### PR TITLE
a11y: Improve icon button component regarding semantics, screen reader usage

### DIFF
--- a/app/assets/javascripts/components/components/icon_button.jsx
+++ b/app/assets/javascripts/components/components/icon_button.jsx
@@ -35,9 +35,9 @@ const IconButton = React.createClass({
     };
 
     return (
-      <a href='#' title={this.props.title} className={`icon-button ${this.props.active ? 'active' : ''}`} onClick={this.handleClick} style={style}>
-        <i className={`fa fa-fw fa-${this.props.icon}`}></i>
-      </a>
+      <button aria-label={this.props.title} title={this.props.title} className={`icon-button ${this.props.active ? 'active' : ''}`} onClick={this.handleClick} style={style}>
+        <i className={`fa fa-fw fa-${this.props.icon}`} aria-hidden='true'></i>
+      </button>
     );
   }
 

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -42,7 +42,8 @@
 
 .icon-button {
   color: #616b86;
-  cursor: pointer;
+  border: none;
+  background: transparent;
 
   &:hover {
     color: #717b98;


### PR DESCRIPTION
* Improve font awesome icon accessibility, see: http://fontawesome.io/accessibility/
* Add aria-label, since title attribute has no effect on screen readers, see: https://www.w3.org/TR/html/dom.html#the-title-attribute
* Semantics: `<button>`-element instead of `<a href="#" />`