### PR TITLE
Slim down tabs and section headers

### DIFF
--- a/app/assets/javascripts/components/features/ui/components/column_header.jsx
+++ b/app/assets/javascripts/components/features/ui/components/column_header.jsx
@@ -22,7 +22,7 @@ const ColumnHeader = React.createClass({
     }
 
     return (
-      <div onClick={this.handleClick} style={{ padding: '15px', fontSize: '16px', background: '#2f3441', flex: '0 0 auto', cursor: 'pointer' }}>
+      <div onClick={this.handleClick} style={{ padding: '5px', fontSize: '16px', background: '#2f3441', flex: '0 0 auto', cursor: 'pointer' }}>
         {icon}
         {this.props.type}
       </div>

--- a/app/assets/javascripts/components/features/ui/components/tabs_bar.jsx
+++ b/app/assets/javascripts/components/features/ui/components/tabs_bar.jsx
@@ -12,7 +12,7 @@ const outerStyle = {
 const tabStyle = {
   display: 'block',
   flex: '1 1 auto',
-  padding: '10px',
+  padding: '5px',
   color: '#fff',
   textDecoration: 'none',
   textAlign: 'center',


### PR DESCRIPTION
This reduces the `padding` on the tabs and the section headers. This makes for a surprisingly large increase in screen space for content on mobile (iPhone SE form factor in Safari's responsive design mode pictured), and I think it also looks nicer:
![before](https://cloud.githubusercontent.com/assets/579774/20579726/5c1d2ee8-b1c6-11e6-85a9-b007523f05ff.png) ![after](https://cloud.githubusercontent.com/assets/579774/20579731/5dad9c84-b1c6-11e6-8d1c-3719c577e695.png)

