### PR TITLE
Add .env.test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,3 @@
-# Service dependencies
-NEO4J_PORT=7575
-
 # Federation
 LOCAL_DOMAIN=cb6e6126.ngrok.io
 LOCAL_HTTPS=true

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,6 @@
+# Service dependencies
+NEO4J_PORT=7575
+
+# Federation
+LOCAL_DOMAIN=cb6e6126.ngrok.io
+LOCAL_HTTPS=true

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,6 @@ coverage
 public/system
 public/assets
 .env
-.env.*
+.env.production
 node_modules/
 neo4j/


### PR DESCRIPTION
It took me ages to get Mastodon set up with the tests passing because the environment variables I needed to define weren't documented and I had to work them out one at a time.

This change adds a .env.test file, and makes it so it isn't ignored by git. I think it makes sense for the .env.test file to be in git, since there's nothing secret in it, but other approaches would be to have a .env.test.sample (like the corresponding one for production), or to set these values in a test helper, or to adapt the tests to work with environments other than this one. I'd be happy to make these changes if that would be preferred.

Being able to get set up and run the tests is a pretty important part of being able to contribute to Mastodon (or your test coverage with suffer!), so having some sort of solution like this one is vital.