### PR TITLE
 Allow vertical resizing of the toot textarea

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/compose_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/compose_form.jsx
@@ -55,7 +55,8 @@ const textareaStyle = {
   padding: '10px',
   fontFamily: 'Roboto',
   fontSize: '14px',
-  margin: '0'
+  margin: '0',
+  resize: 'vertical'
 };
 
 const renderInputComponent = inputProps => (


### PR DESCRIPTION
So that users can manually adjust the height depending on how much they write.
(Open question: why are these styles here and not in the CSS?)