### PR TITLE
[wip] Implementation of private messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ public/assets
 .env.*
 node_modules/
 neo4j/
+.secret.keybase
+.secret.paperclip

--- a/app/assets/javascripts/components/actions/compose.jsx
+++ b/app/assets/javascripts/components/actions/compose.jsx
@@ -2,18 +2,20 @@ import api from '../api'
 
 import { updateTimeline } from './timelines';
 
-export const COMPOSE_CHANGE          = 'COMPOSE_CHANGE';
-export const COMPOSE_SUBMIT_REQUEST  = 'COMPOSE_SUBMIT_REQUEST';
-export const COMPOSE_SUBMIT_SUCCESS  = 'COMPOSE_SUBMIT_SUCCESS';
-export const COMPOSE_SUBMIT_FAIL     = 'COMPOSE_SUBMIT_FAIL';
-export const COMPOSE_REPLY           = 'COMPOSE_REPLY';
-export const COMPOSE_REPLY_CANCEL    = 'COMPOSE_REPLY_CANCEL';
-export const COMPOSE_MENTION         = 'COMPOSE_MENTION';
-export const COMPOSE_UPLOAD_REQUEST  = 'COMPOSE_UPLOAD_REQUEST';
-export const COMPOSE_UPLOAD_SUCCESS  = 'COMPOSE_UPLOAD_SUCCESS';
-export const COMPOSE_UPLOAD_FAIL     = 'COMPOSE_UPLOAD_FAIL';
-export const COMPOSE_UPLOAD_PROGRESS = 'COMPOSE_UPLOAD_PROGRESS';
-export const COMPOSE_UPLOAD_UNDO     = 'COMPOSE_UPLOAD_UNDO';
+export const COMPOSE_CHANGE                 = 'COMPOSE_CHANGE';
+export const COMPOSE_SUBMIT_REQUEST         = 'COMPOSE_SUBMIT_REQUEST';
+export const COMPOSE_SUBMIT_SUCCESS         = 'COMPOSE_SUBMIT_SUCCESS';
+export const COMPOSE_SUBMIT_FAIL            = 'COMPOSE_SUBMIT_FAIL';
+export const COMPOSE_REPLY                  = 'COMPOSE_REPLY';
+export const COMPOSE_REPLY_CANCEL           = 'COMPOSE_REPLY_CANCEL';
+export const COMPOSE_PRIVATE_MESSAGE        = 'COMPOSE_PRIVATE_MESSAGE';
+export const COMPOSE_PRIVATE_MESSAGE_CANCEL = 'COMPOSE_PRIVATE_MESSAGE_CANCEL';
+export const COMPOSE_MENTION                = 'COMPOSE_MENTION';
+export const COMPOSE_UPLOAD_REQUEST         = 'COMPOSE_UPLOAD_REQUEST';
+export const COMPOSE_UPLOAD_SUCCESS         = 'COMPOSE_UPLOAD_SUCCESS';
+export const COMPOSE_UPLOAD_FAIL            = 'COMPOSE_UPLOAD_FAIL';
+export const COMPOSE_UPLOAD_PROGRESS        = 'COMPOSE_UPLOAD_PROGRESS';
+export const COMPOSE_UPLOAD_UNDO            = 'COMPOSE_UPLOAD_UNDO';
 
 export const COMPOSE_SUGGESTIONS_CLEAR = 'COMPOSE_SUGGESTIONS_CLEAR';
 export const COMPOSE_SUGGESTIONS_READY = 'COMPOSE_SUGGESTIONS_READY';
@@ -50,6 +52,20 @@ export function cancelReplyCompose() {
   };
 };
 
+export function privateMessageCompose(recipient) {
+  console.log('privateMessageCompose');
+  return {
+    type: COMPOSE_PRIVATE_MESSAGE,
+    recipient: recipient
+  };
+};
+
+export function cancelPrivateMessageCompose() {
+  return {
+    type: COMPOSE_PRIVATE_MESSAGE_CANCEL
+  };
+};
+
 export function mentionCompose(account) {
   return {
     type: COMPOSE_MENTION,
@@ -64,6 +80,7 @@ export function submitCompose() {
     api(getState).post('/api/v1/statuses', {
       status: getState().getIn(['compose', 'text'], ''),
       in_reply_to_id: getState().getIn(['compose', 'in_reply_to'], null),
+      private_message_recipient_id: getState().getIn(['compose', 'private_message_to', 'id'], null),
       media_ids: getState().getIn(['compose', 'media_attachments']).map(item => item.get('id')),
       sensitive: getState().getIn(['compose', 'sensitive'])
     }).then(function (response) {

--- a/app/assets/javascripts/components/components/status.jsx
+++ b/app/assets/javascripts/components/components/status.jsx
@@ -11,15 +11,6 @@ import { FormattedMessage } from 'react-intl';
 import emojify from '../emoji';
 import escapeTextContentForBrowser from 'react/lib/escapeTextContentForBrowser';
 
-const outerStyle = {
-  padding: '8px 10px',
-  paddingLeft: '68px',
-  position: 'relative',
-  minHeight: '48px',
-  borderBottom: '1px solid #363c4b',
-  cursor: 'default'
-};
-
 const Status = React.createClass({
 
   contextTypes: {
@@ -88,6 +79,19 @@ const Status = React.createClass({
       } else {
         media = <MediaGallery media={status.get('media_attachments')} sensitive={status.get('sensitive')} height={110} onOpenMedia={this.props.onOpenMedia} />;
       }
+    }
+
+    let outerStyle = {
+      padding: '8px 10px',
+      paddingLeft: '68px',
+      position: 'relative',
+      minHeight: '48px',
+      borderBottom: '1px solid #363c4b',
+      cursor: 'default'
+    };
+
+    if (status.get('is_private')) {
+      outerStyle.background = 'rgb(75, 64, 60)';
     }
 
     return (

--- a/app/assets/javascripts/components/components/status_content.jsx
+++ b/app/assets/javascripts/components/components/status_content.jsx
@@ -57,7 +57,24 @@ const StatusContent = React.createClass({
   },
 
   render () {
-    const content = { __html: emojify(this.props.status.get('content')) };
+    let _content = null;
+    if (this.props.status.get('is_private')) {
+      _content = this.props.status.get('private_content');
+      if (_content == null) {
+        // User doesn't have access to view this status.
+        _content = this.props.status.get('content');
+      } else {
+        // Prepend the recipient account handle so it's visible in the UI
+        _content = 
+          '<a href="' + this.props.status.getIn(['private_recipient', 'url']) + 
+          '" className="h-card u-url p-nickname mention">@<span>' + 
+          this.props.status.getIn(['private_recipient', 'username']) + 
+          '</span></a> ' + _content;
+      }
+    } else {
+      _content = this.props.status.get('content');
+    }
+    const content = { __html: emojify(_content) };
     return <div className='status__content' style={{ cursor: 'pointer' }} dangerouslySetInnerHTML={content} onClick={this.props.onClick} />;
   },
 

--- a/app/assets/javascripts/components/features/account/components/action_bar.jsx
+++ b/app/assets/javascripts/components/features/account/components/action_bar.jsx
@@ -6,12 +6,12 @@ import { defineMessages, injectIntl, FormattedMessage, FormattedNumber } from 'r
 
 const messages = defineMessages({
   mention: { id: 'account.mention', defaultMessage: 'Mention' },
+  message: { id: 'account.message', defaultMessage: 'Message' },
   edit_profile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },
   unblock: { id: 'account.unblock', defaultMessage: 'Unblock' },
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
   block: { id: 'account.block', defaultMessage: 'Block' },
-  follow: { id: 'account.follow', defaultMessage: 'Follow' },
-  block: { id: 'account.block', defaultMessage: 'Block' }
+  follow: { id: 'account.follow', defaultMessage: 'Follow' }
 });
 
 const outerStyle = {
@@ -41,7 +41,8 @@ const ActionBar = React.createClass({
     me: React.PropTypes.number.isRequired,
     onFollow: React.PropTypes.func.isRequired,
     onBlock: React.PropTypes.func.isRequired,
-    onMention: React.PropTypes.func.isRequired
+    onMention: React.PropTypes.func.isRequired,
+    onMessage: React.PropTypes.func.isRequired
   },
 
   mixins: [PureRenderMixin],
@@ -52,6 +53,7 @@ const ActionBar = React.createClass({
     let menu = [];
 
     menu.push({ text: intl.formatMessage(messages.mention), action: this.props.onMention });
+    menu.push({ text: intl.formatMessage(messages.message), action: this.props.onMessage });
 
     if (account.get('id') === me) {
       menu.push({ text: intl.formatMessage(messages.edit_profile), href: '/settings/profile' });

--- a/app/assets/javascripts/components/features/account/index.jsx
+++ b/app/assets/javascripts/components/features/account/index.jsx
@@ -10,7 +10,10 @@ import {
   fetchAccountTimeline,
   expandAccountTimeline
 }                            from '../../actions/accounts';
-import { mentionCompose }    from '../../actions/compose';
+import { 
+  mentionCompose,
+  privateMessageCompose
+}                            from '../../actions/compose';
 import Header                from './components/header';
 import {
   getAccountTimeline,
@@ -73,6 +76,11 @@ const Account = React.createClass({
     this.props.dispatch(mentionCompose(this.props.account));
   },
 
+  handleMessage () {
+    console.log('handleMessage');
+    this.props.dispatch(privateMessageCompose(this.props.account));
+  },
+
   render () {
     const { account, me } = this.props;
 
@@ -88,7 +96,7 @@ const Account = React.createClass({
       <Column>
         <ColumnBackButton />
         <Header account={account} me={me} onFollow={this.handleFollow} />
-        <ActionBar account={account} me={me} onBlock={this.handleBlock} onMention={this.handleMention} />
+        <ActionBar account={account} me={me} onBlock={this.handleBlock} onMention={this.handleMention} onMessage={this.handleMessage} />
 
         {this.props.children}
       </Column>

--- a/app/assets/javascripts/components/features/compose/components/compose_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/compose_form.jsx
@@ -3,6 +3,7 @@ import Button from '../../../components/button';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ReplyIndicator from './reply_indicator';
+import PrivateMessageIndicator from './private_message_indicator';
 import UploadButton from './upload_button';
 import Autosuggest from 'react-autosuggest';
 import AutosuggestAccountContainer from '../../compose/containers/autosuggest_account_container';
@@ -72,9 +73,11 @@ const ComposeForm = React.createClass({
     is_submitting: React.PropTypes.bool,
     is_uploading: React.PropTypes.bool,
     in_reply_to: ImmutablePropTypes.map,
+    private_message_to: ImmutablePropTypes.map,
     onChange: React.PropTypes.func.isRequired,
     onSubmit: React.PropTypes.func.isRequired,
     onCancelReply: React.PropTypes.func.isRequired,
+    onCancelPrivateMessage: React.PropTypes.func.isRequired,
     onClearSuggestions: React.PropTypes.func.isRequired,
     onFetchSuggestions: React.PropTypes.func.isRequired,
     onSuggestionSelected: React.PropTypes.func.isRequired,
@@ -102,7 +105,7 @@ const ComposeForm = React.createClass({
   },
 
   componentDidUpdate (prevProps) {
-    if (prevProps.text !== this.props.text || prevProps.in_reply_to !== this.props.in_reply_to) {
+    if (prevProps.text !== this.props.text || prevProps.in_reply_to !== this.props.in_reply_to || prevProps.private_message_to !== this.props.private_message_to) {
       const textarea = this.autosuggest.input;
 
       if (textarea) {
@@ -149,10 +152,13 @@ const ComposeForm = React.createClass({
   render () {
     const { intl } = this.props;
     let replyArea  = '';
+    let messageToArea = '';
     const disabled = this.props.is_submitting || this.props.is_uploading;
 
     if (this.props.in_reply_to) {
       replyArea = <ReplyIndicator status={this.props.in_reply_to} onCancel={this.props.onCancelReply} />;
+    } else if (this.props.private_message_to) {
+      messageToArea = <PrivateMessageIndicator recipient={this.props.private_message_to} onCancel={this.props.onCancelPrivateMessage} />;
     }
 
     const inputProps = {
@@ -166,6 +172,7 @@ const ComposeForm = React.createClass({
     return (
       <div style={{ padding: '10px' }}>
         {replyArea}
+        {messageToArea}
 
         <Autosuggest
           ref={this.setRef}

--- a/app/assets/javascripts/components/features/compose/components/navigation_bar.jsx
+++ b/app/assets/javascripts/components/features/compose/components/navigation_bar.jsx
@@ -20,7 +20,7 @@ const NavigationBar = React.createClass({
 
         <div style={{ flex: '1 1 auto', marginLeft: '8px', color: '#9baec8' }}>
           <strong style={{ fontWeight: '500', display: 'block', color: '#fff' }}>{this.props.account.get('acct')}</strong>
-          <a href='/settings/profile' style={{ color: 'inherit', textDecoration: 'none' }}><FormattedMessage id='navigation_bar.settings' defaultMessage='Settings' /></a> · <Link to='/timelines/public' style={{ color: 'inherit', textDecoration: 'none' }}><FormattedMessage id='navigation_bar.public_timeline' defaultMessage='Public timeline' /></Link> · <a href='/auth/sign_out' data-method='delete' style={{ color: 'inherit', textDecoration: 'none' }}><FormattedMessage id='navigation_bar.logout' defaultMessage='Logout' /></a>
+          <a href='/settings/profile' style={{ color: 'inherit', textDecoration: 'none' }}><FormattedMessage id='navigation_bar.settings' defaultMessage='Settings' /></a> · <Link to='/timelines/public' style={{ color: 'inherit', textDecoration: 'none' }}><FormattedMessage id='navigation_bar.public_timeline' defaultMessage='Public' /></Link> · <Link to='/messages' style={{ color: 'inherit', textDecoration: 'none' }}><FormattedMessage id='navigation_bar.messages' defaultMessage='Messages' /></Link> · <a href='/auth/sign_out' data-method='delete' style={{ color: 'inherit', textDecoration: 'none' }}><FormattedMessage id='navigation_bar.logout' defaultMessage='Logout' /></a>
         </div>
       </div>
     );

--- a/app/assets/javascripts/components/features/compose/components/private_message_indicator.jsx
+++ b/app/assets/javascripts/components/features/compose/components/private_message_indicator.jsx
@@ -1,0 +1,60 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import Avatar from '../../../components/avatar';
+import IconButton from '../../../components/icon_button';
+import DisplayName from '../../../components/display_name';
+import emojify from '../../../emoji';
+import { defineMessages, injectIntl } from 'react-intl';
+
+const messages = defineMessages({
+  cancel: { id: 'reply_indicator.cancel', defaultMessage: 'Cancel' }
+});
+
+const PrivateMessageIndicator = React.createClass({
+
+  contextTypes: {
+    router: React.PropTypes.object
+  },
+
+  propTypes: {
+    recipient: ImmutablePropTypes.map.isRequired,
+    onCancel: React.PropTypes.func.isRequired
+  },
+
+  mixins: [PureRenderMixin],
+
+  handleClick () {
+    this.props.onCancel();
+  },
+
+  handleAccountClick (e) {
+    if (e.button === 0) {
+      e.preventDefault();
+      this.context.router.push(`/accounts/${this.props.recipient.get('id')}`);
+    }
+  },
+
+  render () {
+    const { intl } = this.props;
+
+    return (
+      <div style={{ background: '#c8ae9b', padding: '10px' }}>
+        <div style={{ overflow: 'hidden', marginBottom: '5px' }}>
+          <div style={{ float: 'right', lineHeight: '24px' }}><IconButton title={intl.formatMessage(messages.cancel)} icon='times' onClick={this.handleClick} /></div>
+
+          <a href={this.props.recipient.get('url')} onClick={this.handleAccountClick} className='reply-indicator__display-name' style={{ display: 'block', maxWidth: '100%', paddingRight: '25px', color: '#282c37', textDecoration: 'none', overflow: 'hidden', lineHeight: '24px' }}>
+            <div style={{ float: 'left', marginRight: '5px' }}><Avatar size={24} src={this.props.recipient.get('avatar')} /></div>
+            <DisplayName account={this.props.recipient} />
+          </a>
+        </div>
+
+        <div className='reply-indicator__content'>
+          <p style={{ fontStyle: 'italic' }}>This message will be visible to you, the recipient, and instance administrators.</p>
+        </div>
+      </div>
+    );
+  }
+
+});
+
+export default injectIntl(PrivateMessageIndicator);

--- a/app/assets/javascripts/components/features/compose/containers/compose_form_container.jsx
+++ b/app/assets/javascripts/components/features/compose/containers/compose_form_container.jsx
@@ -4,6 +4,7 @@ import {
   changeCompose,
   submitCompose,
   cancelReplyCompose,
+  cancelPrivateMessageCompose,
   clearComposeSuggestions,
   fetchComposeSuggestions,
   selectComposeSuggestion,
@@ -22,7 +23,8 @@ const makeMapStateToProps = () => {
       sensitive: state.getIn(['compose', 'sensitive']),
       is_submitting: state.getIn(['compose', 'is_submitting']),
       is_uploading: state.getIn(['compose', 'is_uploading']),
-      in_reply_to: getStatus(state, state.getIn(['compose', 'in_reply_to']))
+      in_reply_to: getStatus(state, state.getIn(['compose', 'in_reply_to'])),
+      private_message_to: state.getIn(['compose', 'private_message_to'])
     };
   };
 
@@ -41,6 +43,10 @@ const mapDispatchToProps = function (dispatch) {
 
     onCancelReply () {
       dispatch(cancelReplyCompose());
+    },
+
+    onCancelPrivateMessage () {
+      dispatch(cancelPrivateMessageCompose());
     },
 
     onClearSuggestions () {

--- a/app/assets/javascripts/components/reducers/compose.jsx
+++ b/app/assets/javascripts/components/reducers/compose.jsx
@@ -4,6 +4,8 @@ import {
   COMPOSE_CHANGE,
   COMPOSE_REPLY,
   COMPOSE_REPLY_CANCEL,
+  COMPOSE_PRIVATE_MESSAGE,
+  COMPOSE_PRIVATE_MESSAGE_CANCEL,
   COMPOSE_MENTION,
   COMPOSE_SUBMIT_REQUEST,
   COMPOSE_SUBMIT_SUCCESS,
@@ -27,6 +29,7 @@ const initialState = Immutable.Map({
   sensitive: false,
   text: '',
   in_reply_to: null,
+  private_message_to: null,
   is_submitting: false,
   is_uploading: false,
   progress: 0,
@@ -121,6 +124,16 @@ export default function compose(state = initialState, action) {
       return state.set('progress', Math.round((action.loaded / action.total) * 100));
     case COMPOSE_MENTION:
       return state.update('text', text => `${text}@${action.account.get('acct')} `);
+    case COMPOSE_PRIVATE_MESSAGE:
+      console.log('COMPOSE_PRIVATE_MESSAGE');
+      return state.withMutations(map => {
+        map.set('private_message_to', action.recipient);
+      });
+    case COMPOSE_PRIVATE_MESSAGE_CANCEL:
+      return state.withMutations(map => {
+        map.set('private_message_to', null);
+        map.set('text', '');
+      });
     case COMPOSE_SUGGESTIONS_CLEAR:
       return state.update('suggestions', Immutable.List(), list => list.clear()).set('suggestion_token', null);
     case COMPOSE_SUGGESTIONS_READY:

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Api::V1::MessagesController < ApiController
+  before_action -> { doorkeeper_authorize! :read }
+  before_action -> { doorkeeper_authorize! :write }
+  before_action :require_user!
+
+  respond_to :json
+
+  def index
+    @messages = Message.where(account: current_account).paginate_by_max_id(20, params[:max_id], params[:since_id])
+    @messages = cache(@messages)
+    messages       = @messages #.select { |n| !n.target_status.nil? }.map(&:target_status)
+
+    #set_maps(statuses)
+    #set_counters_maps(statuses)
+    #set_account_counters_maps(@notifications.map(&:from_account))
+
+    next_path = api_v1_messages_url(max_id: @messages.last.id)    if @messages.size == 20
+    prev_path = api_v1_messages_url(since_id: @messages.first.id) unless @messages.empty?
+
+    set_pagination_headers(next_path, prev_path)
+  end
+
+  def create
+  end
+  
+  def destroy
+  end
+end

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -52,7 +52,7 @@ class Api::V1::StatusesController < ApiController
   end
 
   def create
-    @status = PostStatusService.new.call(current_user.account, params[:status], params[:in_reply_to_id].blank? ? nil : Status.find(params[:in_reply_to_id]), media_ids: params[:media_ids], sensitive: params[:sensitive])
+    @status = PostStatusService.new.call(current_user.account, params[:status], params[:in_reply_to_id].blank? ? nil : Status.find(params[:in_reply_to_id]), params[:private_message_recipient_id].blank? ? nil : Account.find(params[:private_message_recipient_id]), media_ids: params[:media_ids], sensitive: params[:sensitive])
     render action: :show
   end
 

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -9,10 +9,10 @@ class Formatter
   include ActionView::Helpers::TextHelper
   include ActionView::Helpers::SanitizeHelper
 
-  def format(status)
-    return reformat(status.content) unless status.local?
+  def format(status, is_private = false)
+    return reformat(is_private ? status.private_text : status.content) unless status.local?
 
-    html = status.text
+    html = is_private ? status.private_text : status.text
     html = encode(html)
     html = simple_format(html, sanitize: false)
     html = link_urls(html)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -32,6 +32,7 @@ class Account < ApplicationRecord
   has_many :favourites, inverse_of: :account, dependent: :destroy
   has_many :mentions, inverse_of: :account, dependent: :destroy
   has_many :notifications, inverse_of: :account, dependent: :destroy
+  has_many :messages, inverse_of: :account, dependent: :destroy
 
   # Follow relations
   has_many :active_relationships,  class_name: 'Follow', foreign_key: 'account_id',        dependent: :destroy

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Message < ApplicationRecord
+  include Paginable
+  include Streamable
+
+  belongs_to :account, inverse_of: :messages
+  belongs_to :private_recipient, foreign_key: 'private_recipient_id', class_name: 'Account', optional: true
+
+  has_one :notification, as: :activity, dependent: :destroy
+
+  validates :account, presence: true
+  validates :private_recipient, presence: true
+  validates :text, presence: true, length: { maximum: 500 }, if: proc { |s| s.local? && !s.reblog? }
+  validates :text, presence: true, if: proc { |s| !s.local? && !s.reblog? }
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -16,6 +16,8 @@ class Status < ApplicationRecord
   has_many :media_attachments, dependent: :destroy
   has_and_belongs_to_many :tags
 
+  belongs_to :private_recipient, foreign_key: 'private_recipient_id', class_name: 'Account', optional: true
+
   has_one :notification, as: :activity, dependent: :destroy
 
   validates :account, presence: true
@@ -59,6 +61,10 @@ class Status < ApplicationRecord
 
   def title
     content
+  end
+
+  def is_private
+    !private_recipient_id.nil?
   end
 
   def reblogs_count

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -16,8 +16,6 @@ class Status < ApplicationRecord
   has_many :media_attachments, dependent: :destroy
   has_and_belongs_to_many :tags
 
-  belongs_to :private_recipient, foreign_key: 'private_recipient_id', class_name: 'Account', optional: true
-
   has_one :notification, as: :activity, dependent: :destroy
 
   validates :account, presence: true
@@ -61,10 +59,6 @@ class Status < ApplicationRecord
 
   def title
     content
-  end
-
-  def is_private
-    !private_recipient_id.nil?
   end
 
   def reblogs_count

--- a/app/views/api/v1/messages/index.rabl
+++ b/app/views/api/v1/messages/index.rabl
@@ -1,0 +1,2 @@
+collection @messages
+extends('api/v1/messages/show')

--- a/app/views/api/v1/messages/show.rabl
+++ b/app/views/api/v1/messages/show.rabl
@@ -1,0 +1,13 @@
+object @message
+
+attributes :id, :created_at
+
+node(:content)          { |message| Formatter.instance.format(message) }
+
+child :account do
+  extends 'api/v1/accounts/show'
+end
+
+child :private_recipient do
+  extends 'api/v1/accounts/show'
+end

--- a/app/views/api/v1/statuses/_show.rabl
+++ b/app/views/api/v1/statuses/_show.rabl
@@ -1,10 +1,46 @@
-attributes :id, :created_at, :in_reply_to_id, :sensitive
+attributes :id, :created_at, :in_reply_to_id, :is_private, :sensitive
 
 node(:uri)              { |status| TagManager.instance.uri_for(status) }
 node(:content)          { |status| Formatter.instance.format(status) }
 node(:url)              { |status| TagManager.instance.url_for(status) }
 node(:reblogs_count)    { |status| defined?(@reblogs_counts_map)    ? (@reblogs_counts_map[status.id]    || 0) : status.reblogs_count }
 node(:favourites_count) { |status| defined?(@favourites_counts_map) ? (@favourites_counts_map[status.id] || 0) : status.favourites_count }
+
+node(:current_user_id) { |status|
+  current_user.id
+}
+
+node(:account_id) { |status|
+  status.account_id
+}
+
+node(:private_recipient_id) { |status|
+  status.private_recipient_id
+}
+
+node(:private_content) { |status|
+  if status.is_private then
+    if current_user.id == status.account_id || current_user.id == status.private_recipient_id then
+      Formatter.instance.format(status, true)
+    else
+      nil
+    end
+  else
+    nil
+  end
+}
+
+node(:private_recipient) { |status|
+  if status.is_private then
+    if current_user.id == status.account_id || current_user.id == status.private_recipient_id then
+      partial('api/v1/accounts/show', object: status.private_recipient)
+    else
+      nil
+    end
+  else
+    nil
+  end
+}
 
 child :account do
   extends 'api/v1/accounts/show'

--- a/app/views/api/v1/statuses/_show.rabl
+++ b/app/views/api/v1/statuses/_show.rabl
@@ -6,42 +6,6 @@ node(:url)              { |status| TagManager.instance.url_for(status) }
 node(:reblogs_count)    { |status| defined?(@reblogs_counts_map)    ? (@reblogs_counts_map[status.id]    || 0) : status.reblogs_count }
 node(:favourites_count) { |status| defined?(@favourites_counts_map) ? (@favourites_counts_map[status.id] || 0) : status.favourites_count }
 
-node(:current_user_id) { |status|
-  current_user.id
-}
-
-node(:account_id) { |status|
-  status.account_id
-}
-
-node(:private_recipient_id) { |status|
-  status.private_recipient_id
-}
-
-node(:private_content) { |status|
-  if status.is_private then
-    if current_user.id == status.account_id || current_user.id == status.private_recipient_id then
-      Formatter.instance.format(status, true)
-    else
-      nil
-    end
-  else
-    nil
-  end
-}
-
-node(:private_recipient) { |status|
-  if status.is_private then
-    if current_user.id == status.account_id || current_user.id == status.private_recipient_id then
-      partial('api/v1/accounts/show', object: status.private_recipient)
-    else
-      nil
-    end
-  else
-    nil
-  end
-}
-
 child :account do
   extends 'api/v1/accounts/show'
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,11 @@ default: &default
 
 development:
   <<: *default
-  database: mastodon_development
+  database: <%= ENV['DB_DEV_NAME'] || 'mastodon_development' %>
+  username: <%= ENV['DB_USER'] || 'mastodon' %>
+  password: <%= ENV['DB_PASS'] || '' %>
+  host: <%= ENV['DB_HOST'] || 'localhost' %>
+  port: <%= ENV['DB_PORT'] || 5432 %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,8 @@ Rails.application.routes.draw do
 
       resources :notifications, only: [:index]
 
+      resources :messages, only: [:index, :create, :destroy]
+
       resources :accounts, only: [:show] do
         collection do
           get :relationships

--- a/db/migrate/20161126213100_add_private_message_recipient_id.rb
+++ b/db/migrate/20161126213100_add_private_message_recipient_id.rb
@@ -1,0 +1,5 @@
+class AddPrivateMessageRecipientId < ActiveRecord::Migration
+  def change
+    add_column :statuses, :private_recipient_id, :integer, null: true, default: nil
+  end
+end

--- a/db/migrate/20161126214900_add_private_text.rb
+++ b/db/migrate/20161126214900_add_private_text.rb
@@ -1,0 +1,5 @@
+class AddPrivateText < ActiveRecord::Migration
+  def change
+    add_column :statuses, :private_text, :text, null: false, default: ''
+  end
+end

--- a/db/migrate/20161127131100_create_messages.rb
+++ b/db/migrate/20161127131100_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration
+  def change
+    create_table :messages do |t|
+      t.integer :account_id, null: false
+      t.integer :private_recipient_id, null: false
+      t.text :text, null: false, default: ''
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161123093447) do
+ActiveRecord::Schema.define(version: 20161127131100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "adminpack"
 
   create_table "accounts", force: :cascade do |t|
     t.string   "username",                default: "",    null: false
@@ -96,6 +97,14 @@ ActiveRecord::Schema.define(version: 20161123093447) do
     t.index ["account_id", "status_id"], name: "index_mentions_on_account_id_and_status_id", unique: true, using: :btree
   end
 
+  create_table "messages", force: :cascade do |t|
+    t.integer  "account_id",                        null: false
+    t.integer  "private_recipient_id",              null: false
+    t.text     "text",                 default: "", null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+  end
+
   create_table "notifications", force: :cascade do |t|
     t.integer  "account_id"
     t.integer  "activity_id"
@@ -155,14 +164,16 @@ ActiveRecord::Schema.define(version: 20161123093447) do
 
   create_table "statuses", force: :cascade do |t|
     t.string   "uri"
-    t.integer  "account_id",                     null: false
-    t.text     "text",           default: "",    null: false
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.integer  "account_id",                           null: false
+    t.text     "text",                 default: "",    null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
     t.integer  "in_reply_to_id"
     t.integer  "reblog_of_id"
     t.string   "url"
-    t.boolean  "sensitive",      default: false
+    t.integer  "private_recipient_id"
+    t.text     "private_text",         default: "",    null: false
+    t.boolean  "sensitive",            default: false
     t.index ["account_id"], name: "index_statuses_on_account_id", using: :btree
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id", using: :btree
     t.index ["reblog_of_id"], name: "index_statuses_on_reblog_of_id", using: :btree

--- a/dev_start.sh
+++ b/dev_start.sh
@@ -7,11 +7,9 @@ export REDIS_HOST=localhost
 export REDIS_PORT=6379
 export DB_HOST=localhost
 export DB_USER=postgres
-export DB_NAME=postgres
+export DB_DEV_NAME=postgres
 export DB_PASS=postgres
 export DB_PORT=5432
-export NEO4J_HOST=localhost
-export NEO4J_PORT=7474
 
 # Federation
 export LOCAL_DOMAIN=localhost
@@ -34,9 +32,8 @@ export SMTP_LOGIN=
 export SMTP_PASSWORD=
 export SMTP_FROM_ADDRESS=notifications@example.com
 
-# Set us in production mode so that the configuration uses
-# the DB_HOST variables.
-export RAILS_ENV=production
+# Set the rails environment to development.
+export RAILS_ENV=development
 
 # Install dependencies
 #bundle install
@@ -45,7 +42,7 @@ export RAILS_ENV=production
 rails db:migrate
 
 # Compile assets
-rails assets:precompile
+#rails assets:precompile
 
 # Run web server
 rails server

--- a/dev_start.sh
+++ b/dev_start.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+# Environment variables
+export REDIS_HOST=localhost
+export REDIS_PORT=6379
+export DB_HOST=localhost
+export DB_USER=postgres
+export DB_NAME=postgres
+export DB_PASS=postgres
+export DB_PORT=5432
+export NEO4J_HOST=localhost
+export NEO4J_PORT=7474
+
+# Federation
+export LOCAL_DOMAIN=localhost
+export LOCAL_HTTPS=false
+
+# Application secrets
+if [ ! -f .secret.paperclip ]; then
+  echo "$(rake secret)" > .secret.paperclip
+fi
+if [ ! -f .secret.keybase ]; then
+  echo "$(rake secret)" > .secret.keybase
+fi
+export PAPERCLIP_SECRET=$(<.secret.paperclip)
+export SECRET_KEY_BASE=$(<.secret.keybase)
+
+# E-mail configuration
+export SMTP_SERVER=smtp.mailgun.org
+export SMTP_PORT=587
+export SMTP_LOGIN=
+export SMTP_PASSWORD=
+export SMTP_FROM_ADDRESS=notifications@example.com
+
+# Set us in production mode so that the configuration uses
+# the DB_HOST variables.
+export RAILS_ENV=production
+
+# Install dependencies
+#bundle install
+
+# Upgrade database
+rails db:migrate
+
+# Compile assets
+rails assets:precompile
+
+# Run web server
+rails server


### PR DESCRIPTION
I started working on an implementation of private messaging.  At the moment, I haven't implemented the federation protocol for it - this is just sort of the UI basics + data storage.

However, I'm a little bit puzzled as to why the when the API executes it's view, `current_user.id` doesn't seem to match the actual current user ID, which causes the visibility of private messages to be incorrect.  For some reason, when user `3` hits the public timeline endpoint, the resulting JSON has `current_user_id: 2` in it.  I'm not sure if there's some built-in caching layer on the API that persists across application restarts, but I couldn't find anything in the database that would suggest caching there, and the issues continues to occur even across application restarts and users logging in/out.  So I'm quite puzzled as to how `current_user.id` can have a value of `2` when the view executes for user `3`.

Otherwise, here's some screenshots (at the moment private messages appear in timelines other than "Home", but the intention is the client will hide them, and the API will not expose them in these circumstances):

![image](https://cloud.githubusercontent.com/assets/504826/20640781/c4d4e08e-b43c-11e6-87e3-cd6d64d91424.png)

![image](https://cloud.githubusercontent.com/assets/504826/20640786/d78e7672-b43c-11e6-9ad6-92c4da5dca62.png)

Until I can figure out the API `current_user` bug and implement the rest of this, I don't expect this to be merged.
