### PR TITLE
Rename "favourite" to "boop"

### DIFF
--- a/app/assets/javascripts/components/locales/en.jsx
+++ b/app/assets/javascripts/components/locales/en.jsx
@@ -5,8 +5,8 @@ const en = {
   "status.mention": "Mention",
   "status.delete": "Delete",
   "status.reply": "Reply",
-  "status.reblog": "Boop",
-  "status.favourite": "Favourite",
+  "status.reblog": "Boost",
+  "status.favourite": "Boop",
   "status.reblogged_by": "{name} boosted",
   "status.sensitive_warning": "Sensitive content",
   "status.sensitive_toggle": "Click to view",
@@ -48,7 +48,7 @@ const en = {
   "upload_button.label": "Add media",
   "upload_form.undo": "Undo",
   "notification.follow": "{name} followed you",
-  "notification.favourite": "{name} favourited your status",
+  "notification.favourite": "{name} booped your status",
   "notification.reblog": "{name} boosted your status",
   "notification.mention": "{name} mentioned you"
 };

--- a/app/assets/javascripts/components/locales/en.jsx
+++ b/app/assets/javascripts/components/locales/en.jsx
@@ -5,7 +5,7 @@ const en = {
   "status.mention": "Mention",
   "status.delete": "Delete",
   "status.reply": "Reply",
-  "status.reblog": "Boost",
+  "status.reblog": "Boop",
   "status.favourite": "Favourite",
   "status.reblogged_by": "{name} boosted",
   "status.sensitive_warning": "Sensitive content",


### PR DESCRIPTION
<s>I think "boost" was a fine enough name for reblog/retweet/etc. It's kind of cute, and is something mastodons are effective at doing in some sense or another.

But Mastodon already has "toots" for posts, and "boop" is even cuter than "boost", and also has a certain symmetry both with toot, and a self-symmetry (albeit with parity about the the x-axis with b <=> p).

This proposal has at least some support: https://mastodon.social/users/Iguananaut/updates/237412  An alternate proposal (for which I would update the PR) is to rename "Favourite" to "boop", but I think the main proposal carries more weight.</s>

Originally this proposal was to rename "boost/reblog" to "boop" but it seems like the boost-ship has already sailed in the popular conscience and that's fine--it's a fine name.  But something should be called "boop" and favorite seems like a good choice.