### PR TITLE
Add dev_start.sh to let people get a development environment started quickly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ public/assets
 .env.*
 node_modules/
 neo4j/
+.secret.keybase
+.secret.paperclip

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,11 @@ default: &default
 
 development:
   <<: *default
-  database: mastodon_development
+  database: <%= ENV['DB_DEV_NAME'] || 'mastodon_development' %>
+  username: <%= ENV['DB_USER'] || 'mastodon' %>
+  password: <%= ENV['DB_PASS'] || '' %>
+  host: <%= ENV['DB_HOST'] || 'localhost' %>
+  port: <%= ENV['DB_PORT'] || 5432 %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/dev_start.sh
+++ b/dev_start.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+# Environment variables
+export REDIS_HOST=localhost
+export REDIS_PORT=6379
+export DB_HOST=localhost
+export DB_USER=postgres
+export DB_DEV_NAME=postgres
+export DB_PASS=postgres
+export DB_PORT=5432
+
+# Federation
+export LOCAL_DOMAIN=localhost
+export LOCAL_HTTPS=false
+
+# Application secrets
+if [ ! -f .secret.paperclip ]; then
+  echo "$(rake secret)" > .secret.paperclip
+fi
+if [ ! -f .secret.keybase ]; then
+  echo "$(rake secret)" > .secret.keybase
+fi
+export PAPERCLIP_SECRET=$(<.secret.paperclip)
+export SECRET_KEY_BASE=$(<.secret.keybase)
+
+# E-mail configuration
+export SMTP_SERVER=smtp.mailgun.org
+export SMTP_PORT=587
+export SMTP_LOGIN=
+export SMTP_PASSWORD=
+export SMTP_FROM_ADDRESS=notifications@example.com
+
+# Set the rails environment to development.
+export RAILS_ENV=development
+
+# Install dependencies
+#bundle install
+
+# Install Node.js dependencies
+if [ ! -d node_modules ]; then
+  yarn
+fi
+
+# Upgrade database
+rails db:migrate
+
+# Compile assets; if you set RAILS_ENV to production, you 
+# need to uncomment this line.
+#rails assets:precompile
+
+# Run web server
+rails server


### PR DESCRIPTION
When I was first setting up a development environment for this, and attempting to get the application to connect to the database, it was confusing that `.env.production` wasn't something that the application was loading it, but rather dictated a list of environment variables that are required for the app to run.

This adds a `dev_start.sh` script which basically sets up all the required environment variables (including generating secrets if needed), installs any dependencies, runs migrations and then starts the rails server.  As long as the developer has PostgreSQL and has run `bundle install`, this should basically work out of the box.