### PR TITLE
Replace “Unlisted mode” with “Do not show on public timeline”

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/compose_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/compose_form.jsx
@@ -195,7 +195,7 @@ const ComposeForm = React.createClass({
 
         <label style={{ display: 'block', lineHeight: '24px', verticalAlign: 'middle', marginTop: '10px', borderTop: '1px solid #282c37', paddingTop: '10px' }}>
           <Toggle checked={this.props.unlisted} onChange={this.handleChangeVisibility} />
-          <span style={{ display: 'inline-block', verticalAlign: 'middle', marginBottom: '14px', marginLeft: '8px', color: '#9baec8' }}><FormattedMessage id='compose_form.unlisted' defaultMessage='Unlisted mode' /></span>
+          <span style={{ display: 'inline-block', verticalAlign: 'middle', marginBottom: '14px', marginLeft: '8px', color: '#9baec8' }}><FormattedMessage id='compose_form.unlisted' defaultMessage='Do not show on public timeline' /></span>
         </label>
 
         <label style={{ display: 'block', lineHeight: '24px', verticalAlign: 'middle' }}>

--- a/app/assets/javascripts/components/locales/en.jsx
+++ b/app/assets/javascripts/components/locales/en.jsx
@@ -38,7 +38,7 @@ const en = {
   "compose_form.placeholder": "What is on your mind?",
   "compose_form.publish": "Toot",
   "compose_form.sensitive": "Mark content as sensitive",
-  "compose_form.unlisted": "Unlisted mode",
+  "compose_form.unlisted": "Do not show on public timeline",
   "navigation_bar.settings": "Settings",
   "navigation_bar.public_timeline": "Public timeline",
   "navigation_bar.logout": "Logout",


### PR DESCRIPTION
The latter should be clearer as to its purpose.

This patch only touches the English translation. I note however that this actually brings the English locale closer to the existing German text („Öffentlich nicht auflisten“), though not, say, the Spanish text («No listado»).