### PR TITLE
Starting point for "no_reblog" tag federation

### DIFF
--- a/app/assets/javascripts/components/actions/compose.jsx
+++ b/app/assets/javascripts/components/actions/compose.jsx
@@ -68,6 +68,7 @@ export function submitCompose() {
       in_reply_to_id: getState().getIn(['compose', 'in_reply_to'], null),
       media_ids: getState().getIn(['compose', 'media_attachments']).map(item => item.get('id')),
       sensitive: getState().getIn(['compose', 'sensitive']),
+      no_reblog: getState().getIn(['compose', 'no_reblog']),
       unlisted: getState().getIn(['compose', 'unlisted'])
     }).then(function (response) {
       dispatch(submitComposeSuccess({ ...response.data }));

--- a/app/assets/javascripts/components/actions/compose.jsx
+++ b/app/assets/javascripts/components/actions/compose.jsx
@@ -23,6 +23,7 @@ export const COMPOSE_MOUNT   = 'COMPOSE_MOUNT';
 export const COMPOSE_UNMOUNT = 'COMPOSE_UNMOUNT';
 
 export const COMPOSE_SENSITIVITY_CHANGE = 'COMPOSE_SENSITIVITY_CHANGE';
+export const COMPOSE_REBLOGGABILITY_CHANGE = 'COMPOSE_REBLOGGABILITY_CHANGE';
 export const COMPOSE_VISIBILITY_CHANGE  = 'COMPOSE_VISIBILITY_CHANGE';
 
 export function changeCompose(text) {
@@ -216,6 +217,14 @@ export function changeComposeSensitivity(checked) {
     checked
   };
 };
+
+export function changeComposeRebloggability(checked) {
+  return {
+    type: COMPOSE_REBLOGGABILITY_CHANGE,
+    checked
+  };
+};
+
 
 export function changeComposeVisibility(checked) {
   return {

--- a/app/assets/javascripts/components/features/compose/components/compose_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/compose_form.jsx
@@ -23,6 +23,7 @@ const ComposeForm = React.createClass({
     suggestion_token: React.PropTypes.string,
     suggestions: ImmutablePropTypes.list,
     sensitive: React.PropTypes.bool,
+    no_reblog: React.PropTypes.bool,
     unlisted: React.PropTypes.bool,
     is_submitting: React.PropTypes.bool,
     is_uploading: React.PropTypes.bool,
@@ -124,6 +125,11 @@ const ComposeForm = React.createClass({
         <label style={{ display: 'block', lineHeight: '24px', verticalAlign: 'middle', marginTop: '10px', borderTop: '1px solid #282c37', paddingTop: '10px' }}>
           <Toggle checked={this.props.unlisted} onChange={this.handleChangeVisibility} />
           <span style={{ display: 'inline-block', verticalAlign: 'middle', marginBottom: '14px', marginLeft: '8px', color: '#9baec8' }}><FormattedMessage id='compose_form.unlisted' defaultMessage='Do not show on public timeline' /></span>
+        </label>
+        
+        <label style={{ display: 'block', lineHeight: '24px', verticalAlign: 'middle', marginTop: '10px', borderTop: '1px solid #282c37', paddingTop: '10px' }}>
+          <Toggle checked={this.props.no_reblog} onChange={this.handleChangeRebloggability} />
+          <span style={{ display: 'inline-block', verticalAlign: 'middle', marginBottom: '14px', marginLeft: '8px', color: '#9baec8' }}><FormattedMessage id='compose_form.unlisted' defaultMessage='Disable boosting on this instance' /></span>
         </label>
 
         <label style={{ display: 'block', lineHeight: '24px', verticalAlign: 'middle' }}>

--- a/app/assets/javascripts/components/features/compose/components/compose_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/compose_form.jsx
@@ -34,6 +34,7 @@ const ComposeForm = React.createClass({
     onFetchSuggestions: React.PropTypes.func.isRequired,
     onSuggestionSelected: React.PropTypes.func.isRequired,
     onChangeSensitivity: React.PropTypes.func.isRequired,
+    onChangeRebloggability: React.PropTypes.func.isRequired,
     onChangeVisibility: React.PropTypes.func.isRequired
   },
 
@@ -70,6 +71,10 @@ const ComposeForm = React.createClass({
     this.props.onChangeSensitivity(e.target.checked);
   },
 
+  handleChangeRebloggability (e) {
+    this.props.onChangeRebloggability(e.target.checked);
+  },    
+    
   handleChangeVisibility (e) {
     this.props.onChangeVisibility(e.target.checked);
   },

--- a/app/assets/javascripts/components/features/compose/containers/compose_form_container.jsx
+++ b/app/assets/javascripts/components/features/compose/containers/compose_form_container.jsx
@@ -22,6 +22,7 @@ const makeMapStateToProps = () => {
       suggestion_token: state.getIn(['compose', 'suggestion_token']),
       suggestions: state.getIn(['compose', 'suggestions']),
       sensitive: state.getIn(['compose', 'sensitive']),
+      no_reblog: state.getIn(['compose', 'no_reblog']),
       unlisted: state.getIn(['compose', 'unlisted']),
       is_submitting: state.getIn(['compose', 'is_submitting']),
       is_uploading: state.getIn(['compose', 'is_uploading']),

--- a/app/assets/javascripts/components/features/compose/containers/compose_form_container.jsx
+++ b/app/assets/javascripts/components/features/compose/containers/compose_form_container.jsx
@@ -8,6 +8,7 @@ import {
   fetchComposeSuggestions,
   selectComposeSuggestion,
   changeComposeSensitivity,
+  changeComposeRebloggability,
   changeComposeVisibility
 } from '../../../actions/compose';
 import { makeGetStatus } from '../../../selectors';
@@ -61,6 +62,10 @@ const mapDispatchToProps = function (dispatch) {
       dispatch(changeComposeSensitivity(checked));
     },
 
+    onChangeRebloggability (checked) {
+      dispatch(changeComposeRebloggability(checked));
+    },
+    
     onChangeVisibility (checked) {
       dispatch(changeComposeVisibility(checked));
     }

--- a/app/assets/javascripts/components/locales/de.jsx
+++ b/app/assets/javascripts/components/locales/de.jsx
@@ -35,6 +35,7 @@ const en = {
   "compose_form.placeholder": "Worüber möchstest du schreiben?",
   "compose_form.publish": "Veröffentlichen",
   "compose_form.sensitive": "Medien als sensitiv markieren",
+  "compose_form.no_reblog": null,
   "compose_form.unlisted": "Öffentlich nicht auflisten",
   "navigation_bar.settings": "Einstellungen",
   "navigation_bar.public_timeline": "Öffentlich",

--- a/app/assets/javascripts/components/locales/en.jsx
+++ b/app/assets/javascripts/components/locales/en.jsx
@@ -38,6 +38,7 @@ const en = {
   "compose_form.placeholder": "What is on your mind?",
   "compose_form.publish": "Toot",
   "compose_form.sensitive": "Mark content as sensitive",
+  "compose_form.no_reblog": "Disable boosting on this instance",
   "compose_form.unlisted": "Do not show on public timeline",
   "navigation_bar.settings": "Settings",
   "navigation_bar.public_timeline": "Public timeline",

--- a/app/assets/javascripts/components/locales/es.jsx
+++ b/app/assets/javascripts/components/locales/es.jsx
@@ -36,6 +36,7 @@ const es = {
   "compose_form.placeholder": "¿En qué estás pensando?",
   "compose_form.publish": "Publicar",
   "compose_form.sensitive": null,
+  "compose_form.no_reblog": null,
   "compose_form.unlisted": "No listado",
   "navigation_bar.settings": "Ajustes",
   "navigation_bar.public_timeline": "Público",

--- a/app/assets/javascripts/components/locales/fr.jsx
+++ b/app/assets/javascripts/components/locales/fr.jsx
@@ -37,6 +37,7 @@ const fr = {
   "compose_form.placeholder": "Qu’avez-vous en tête ?",
   "compose_form.publish": "Pouet",
   "compose_form.sensitive": "Marquer le contenu comme délicat",
+  "compose_form.no_reblog": null,
   "compose_form.unlisted": "Ne pas apparaître dans le fil public",
   "navigation_bar.settings": "Paramètres",
   "navigation_bar.public_timeline": "Public",

--- a/app/assets/javascripts/components/locales/hu.jsx
+++ b/app/assets/javascripts/components/locales/hu.jsx
@@ -37,6 +37,7 @@ const hu = {
   "compose_form.placeholder": "Mire gondolsz?",
   "compose_form.publish": "Tülk!",
   "compose_form.sensitive": "Tartalom érzékenynek jelölése",
+  "compose_form.no_reblog": null,
   "compose_form.unlisted": "Listázatlan mód",
   "navigation_bar.settings": "Beállítások",
   "navigation_bar.public_timeline": "Nyilvános időfolyam",

--- a/app/assets/javascripts/components/locales/pt.jsx
+++ b/app/assets/javascripts/components/locales/pt.jsx
@@ -35,6 +35,7 @@ const pt = {
   "compose_form.placeholder": "Que estás pensando?",
   "compose_form.publish": "Publicar",
   "compose_form.sensitive": "Marcar conteúdo como sensível",
+  "compose_form.no_reblog": null,
   "compose_form.unlisted": "Modo não-listado",
   "navigation_bar.settings": "Configurações",
   "navigation_bar.public_timeline": "Timeline Pública",

--- a/app/assets/javascripts/components/locales/uk.jsx
+++ b/app/assets/javascripts/components/locales/uk.jsx
@@ -37,6 +37,7 @@ const uk = {
   "compose_form.placeholder": "Що у Вас на думці?",
   "compose_form.publish": "Дмухнути",
   "compose_form.sensitive": "Непристойний зміст",
+  "compose_form.no_reblog": null,
   "compose_form.unlisted": "Таємний режим",
   "navigation_bar.settings": "Налаштування",
   "navigation_bar.public_timeline": "Публічна стіна",

--- a/app/assets/javascripts/components/reducers/compose.jsx
+++ b/app/assets/javascripts/components/reducers/compose.jsx
@@ -17,6 +17,7 @@ import {
   COMPOSE_SUGGESTIONS_READY,
   COMPOSE_SUGGESTION_SELECT,
   COMPOSE_SENSITIVITY_CHANGE,
+  COMPOSE_REBLOGGABILITY_CHANGE,
   COMPOSE_VISIBILITY_CHANGE
 } from '../actions/compose';
 import { TIMELINE_DELETE } from '../actions/timelines';
@@ -91,6 +92,8 @@ export default function compose(state = initialState, action) {
       return state.set('mounted', false);
     case COMPOSE_SENSITIVITY_CHANGE:
       return state.set('sensitive', action.checked);
+    case COMPOSE_REBLOGGABILITY_CHANGE:
+      return state.set('no_reblog', action.checked);
     case COMPOSE_VISIBILITY_CHANGE:
       return state.set('unlisted', action.checked);
     case COMPOSE_CHANGE:

--- a/app/assets/javascripts/components/reducers/compose.jsx
+++ b/app/assets/javascripts/components/reducers/compose.jsx
@@ -27,6 +27,7 @@ import Immutable from 'immutable';
 const initialState = Immutable.Map({
   mounted: false,
   sensitive: false,
+  no_reblog: false,
   unlisted: false,
   text: '',
   in_reply_to: null,

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -52,7 +52,7 @@ class Api::V1::StatusesController < ApiController
   end
 
   def create
-    @status = PostStatusService.new.call(current_user.account, params[:status], params[:in_reply_to_id].blank? ? nil : Status.find(params[:in_reply_to_id]), media_ids: params[:media_ids], sensitive: params[:sensitive], unlisted: params[:unlisted])
+    @status = PostStatusService.new.call(current_user.account, params[:status], params[:in_reply_to_id].blank? ? nil : Status.find(params[:in_reply_to_id]), media_ids: params[:media_ids], sensitive: params[:sensitive], no_reblog: params[:no_reblog], unlisted: params[:unlisted])
     render action: :show
   end
 

--- a/app/helpers/atom_builder_helper.rb
+++ b/app/helpers/atom_builder_helper.rb
@@ -207,6 +207,7 @@ module AtomBuilderHelper
           end
 
           category(xml, 'nsfw') if stream_entry.target.sensitive?
+          category(xml, 'no_reblog') if stream_entry.target.no_reblog?
         end
       end
     end
@@ -228,6 +229,8 @@ module AtomBuilderHelper
     end
 
     category(xml, 'nsfw') if stream_entry.activity.sensitive?
+    category(xml, 'no_reblog') if stream_entry.activity.no_reblog?
+  
   end
 
   private

--- a/app/services/process_hashtags_service.rb
+++ b/app/services/process_hashtags_service.rb
@@ -9,5 +9,6 @@ class ProcessHashtagsService < BaseService
     end
 
     status.update(sensitive: true) if tags.include?('nsfw')
+    status.update(no_reblog: true) if tags.include?('no_reblog')
   end
 end

--- a/app/views/api/v1/statuses/_show.rabl
+++ b/app/views/api/v1/statuses/_show.rabl
@@ -1,4 +1,4 @@
-attributes :id, :created_at, :in_reply_to_id, :sensitive
+attributes :id, :created_at, :in_reply_to_id, :sensitive, :no_reblog
 
 node(:uri)              { |status| TagManager.instance.uri_for(status) }
 node(:content)          { |status| Formatter.instance.format(status) }


### PR DESCRIPTION
I've added a toggle for the no_reblog tag and post status, and set it to propagate just about everywhere the "sensitive" post status can.

Things missing here:

1) actually disabling the boost for posts with this status 
2) any database updates necessary for this schema to function

Any and all questions, comments, concerns, and requests are welcome.