### PR TITLE
Improve experience on 4-inch phones

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/navigation_bar.jsx
+++ b/app/assets/javascripts/components/features/compose/components/navigation_bar.jsx
@@ -16,7 +16,7 @@ const NavigationBar = React.createClass({
 
   render () {
     return (
-      <div style={{ padding: '10px', display: 'flex', cursor: 'default' }}>
+      <div style={{ padding: '10px', display: 'flex', flexShrink: '0', cursor: 'default' }}>
         <Permalink href={this.props.account.get('url')} to={`/accounts/${this.props.account.get('id')}`} style={{ textDecoration: 'none' }}><Avatar src={this.props.account.get('avatar')} size={40} /></Permalink>
 
         <div style={{ flex: '1 1 auto', marginLeft: '8px', color: '#9baec8' }}>

--- a/app/assets/javascripts/components/features/getting_started/index.jsx
+++ b/app/assets/javascripts/components/features/getting_started/index.jsx
@@ -43,13 +43,11 @@ const GettingStarted = ({ intl, me }) => {
         {followRequests}
       </div>
 
-      <div className='static-content'>
+      <div className='static-content getting-started'>
         <p><FormattedMessage id='getting_started.about_addressing' defaultMessage='You can follow people if you know their username and the domain they are on by entering an e-mail-esque address into the form at the top of the sidebar.' /></p>
         <p><FormattedMessage id='getting_started.about_shortcuts' defaultMessage='If the target user is on the same domain as you, just the username will work. The same rule applies to mentioning people in statuses.' /></p>
         <p><FormattedMessage id='getting_started.about_developer' defaultMessage='The developer of this project can be followed as Gargron@mastodon.social' /></p>
       </div>
-
-      <div className='getting-started__illustration' />
     </Column>
   );
 };

--- a/app/assets/javascripts/components/features/ui/components/tabs_bar.jsx
+++ b/app/assets/javascripts/components/features/ui/components/tabs_bar.jsx
@@ -10,7 +10,7 @@ const outerStyle = {
 const tabStyle = {
   display: 'block',
   flex: '1 1 auto',
-  padding: '10px',
+  padding: '10px 5px',
   color: '#fff',
   textDecoration: 'none',
   textAlign: 'center',

--- a/app/assets/javascripts/components/features/ui/components/tabs_bar.jsx
+++ b/app/assets/javascripts/components/features/ui/components/tabs_bar.jsx
@@ -3,9 +3,8 @@ import { FormattedMessage } from 'react-intl';
 
 const outerStyle = {
   background: '#373b4a',
-  margin: '10px',
   flex: '0 0 auto',
-  marginBottom: '0'
+  overflowY: 'auto'
 };
 
 const tabStyle = {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -608,12 +608,8 @@
   }
 }
 
-.getting-started__illustration {
-  width: 330px;
-  height: 235px;
-  background: image-url('mastodon-getting-started.png') no-repeat 0 0;
-  position: absolute;
-  pointer-events: none;
-  bottom: 0;
-  left: 0;
+.getting-started {
+  overflow-y: auto;
+  padding-bottom: 235px;
+  background: image-url('mastodon-getting-started.png') no-repeat 0 100% local;
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -331,9 +331,13 @@
 }
 
 .columns-area {
-  margin: 10px;
-  margin-left: 0;
   flex-direction: row;
+}
+
+@media screen and (min-width: 360px) {
+  .columns-area {
+    margin: 10px;
+  }
 }
 
 .column {
@@ -346,9 +350,18 @@
 }
 
 .column, .drawer {
-  margin-left: 10px;
+  margin-left: 5px;
+  margin-right: 5px;
   flex: 0 0 auto;
   overflow: hidden;
+}
+
+.column:first-child, .drawer:first-child {
+  margin-left: 0;
+}
+
+.column:last-child, .drawer:last-child {
+  margin-right: 0;
 }
 
 @media screen and (max-width: 1024px) {
@@ -359,13 +372,19 @@
   }
 
   .columns-area {
-    margin: 10px;
     flex-direction: column;
   }
 }
 
 .tabs-bar {
   display: flex;
+}
+
+@media screen and (min-width: 360px) {
+  .tabs-bar {
+    margin: 10px;
+    margin-bottom: 0;
+  }
 }
 
 @media screen and (min-width: 1025px) {


### PR DESCRIPTION
This makes a few tweaks, mostly to the layout at < 360px wide;
- [x] Removes extra UI margins
- [x] Allows the tab bar to scroll
- [x] Shrinks tab bar padding so that it doesn’t wrap on reasonably-sized phones
- [x] Stops Mastodon friend from overlapping text and UI on the Getting Started tab
- [x] Stops the compose box from overlapping user toolbar in the compose sheet
- [x] Slightly improves horizontal scrolling behaviour on desktop

Some screenshots (before & after - these are sized to the usable area of an iPhone 5, 5s, 5c or SE);
<img width="320" alt="screen shot 2017-01-04 at 5 38 13 pm" src="https://cloud.githubusercontent.com/assets/282113/21666131/af0b57f2-d2a4-11e6-8246-a961c5e7cd76.png"> <img width="320" alt="screen shot 2017-01-04 at 5 38 37 pm" src="https://cloud.githubusercontent.com/assets/282113/21666132/af3f5cf0-d2a4-11e6-8681-f324bffba263.png">

<img width="320" alt="screen shot 2017-01-04 at 5 45 51 pm" src="https://cloud.githubusercontent.com/assets/282113/21666303/b918df70-d2a5-11e6-83b0-53c70ab442ff.png"> <img width="320" alt="screen shot 2017-01-04 at 5 46 12 pm" src="https://cloud.githubusercontent.com/assets/282113/21666304/b93822c2-d2a5-11e6-8b3e-60e3679ac4b8.png">
