### PR TITLE
"Reblog" -> "boost" in more places

### DIFF
--- a/app/assets/javascripts/components/features/notifications/components/notification.jsx
+++ b/app/assets/javascripts/components/features/notifications/components/notification.jsx
@@ -71,7 +71,7 @@ const Notification = React.createClass({
             <i className='fa fa-fw fa-retweet' style={{ color: '#2b90d9' }} />
           </div>
 
-          <FormattedMessage id='notification.reblog' defaultMessage='{name} reblogged your status' values={{ name: link }} />
+          <FormattedMessage id='notification.reblog' defaultMessage='{name} boosted your status' values={{ name: link }} />
         </div>
 
         <StatusContainer id={notification.get('status')} muted={true} />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,8 +67,8 @@ en:
       body: 'You were mentioned by %{name} in:'
       subject: You were mentioned by %{name}
     reblog:
-      body: 'Your status was reblogged by %{name}:'
-      subject: "%{name} reblogged your status"
+      body: 'Your status was boosted by %{name}:'
+      subject: "%{name} boosted your status"
   pagination:
     next: Next
     prev: Prev

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe NotificationMailer, type: :mailer do
     let(:mail) { NotificationMailer.reblog(own_status.account, Notification.create!(account: receiver.account, activity: reblog)) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("bob reblogged your status")
+      expect(mail.subject).to eq("bob boosted your status")
       expect(mail.to).to eq([receiver.email])
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("Your status was reblogged by bob")
+      expect(mail.body.encoded).to match("Your status was boosted by bob")
     end
   end
 


### PR DESCRIPTION
A couple of places were using "reblog" rather than "boost" - this updates them to match the web UI