### PR TITLE
Automatically position cursor when writing a reply toot

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/compose_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/compose_form.jsx
@@ -86,6 +86,13 @@ const ComposeForm = React.createClass({
 
   componentDidUpdate (prevProps) {
     if (prevProps.in_reply_to !== this.props.in_reply_to) {
+      // If replying to zero or one users, places the cursor at the end of the textbox.
+      // If replying to more than one user, selects any usernames past the first;
+      // this provides a convenient shortcut to drop everyone else from the conversation.
+      let selectionStart = this.props.text.search(/\s/) + 1;
+      let selectionEnd = this.props.text.length;
+      this.autosuggestTextarea.textarea.setSelectionRange(selectionStart, selectionEnd);
+
       this.autosuggestTextarea.textarea.focus();
     }
   },


### PR DESCRIPTION
When creating a new reply toot, this positions the cursor at the end of the textbox - I find that a lot more useful for writing new toots.

This mimics Tweetbot's behaviour of selecting any usernames past the first when replying. This makes it a lot easier to drop people from a conversation when replying, which I find encourages good reply etiquette.

Before:

<img width="271" alt="screen shot 2017-01-04 at 8 17 22 pm" src="https://cloud.githubusercontent.com/assets/780485/21668881/0379812c-d2bb-11e6-86d4-0c9530ce0f75.png">
<img width="271" alt="screen shot 2017-01-04 at 8 17 58 pm" src="https://cloud.githubusercontent.com/assets/780485/21668885/056381f4-d2bb-11e6-8a17-29b9b1659cad.png">

After:
<img width="273" alt="screen shot 2017-01-04 at 8 18 38 pm" src="https://cloud.githubusercontent.com/assets/780485/21668886/097da7f6-d2bb-11e6-8420-5eeca94d4fdb.png">
<img width="271" alt="screen shot 2017-01-04 at 8 11 33 pm" src="https://cloud.githubusercontent.com/assets/780485/21668889/0d082c5c-d2bb-11e6-9433-ca50441e9ed2.png">
