### PR TITLE
Display native emoji on browsers which support it

### DIFF
--- a/app/assets/javascripts/components/emoji.jsx
+++ b/app/assets/javascripts/components/emoji.jsx
@@ -1,9 +1,18 @@
 import emojione from 'emojione';
+import detectVersion from 'mojibaka';
 
 emojione.imageType    = 'png';
 emojione.sprites      = false;
 emojione.imagePathPNG = '/emoji/';
 
+let emoji_version = detectVersion();
+
 export default function emojify(text) {
-  return emojione.toImage(text);
+  // Browser too old to support native emoji
+  if (emoji_version < 6.1) {
+    return emojione.toImage(text);
+  // Convert short codes into native emoji
+  } else {
+    return emojione.shortnameToUnicode(text);
+  }
 };

--- a/app/assets/javascripts/components/emoji.jsx
+++ b/app/assets/javascripts/components/emoji.jsx
@@ -9,7 +9,7 @@ let emoji_version = detectVersion();
 
 export default function emojify(text) {
   // Browser too old to support native emoji
-  if (emoji_version < 6.1) {
+  if (emoji_version < 9.0) {
     return emojione.toImage(text);
   // Convert short codes into native emoji
   } else {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "intl": "^1.2.5",
     "jsdom": "^9.6.0",
     "mocha": "^3.1.1",
+    "mojibaka": "^0.0.1",
     "node-sass": "^4.0.0",
     "react": "^15.3.2",
     "react-addons-perf": "^15.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2368,7 +2368,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.0.5, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
+glob@7.0.5, glob@^7.0.0, glob@^7.0.3:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
   dependencies:
@@ -2389,7 +2389,7 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@~7.1.1:
+glob@^7.0.5, glob@~7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -3391,6 +3391,10 @@ module-deps@^4.0.2:
     subarg "^1.0.0"
     through2 "^2.0.0"
     xtend "^4.0.0"
+
+mojibaka@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/mojibaka/-/mojibaka-0.0.1.tgz#54b0690d9149bbdf97f13b909f2417c53b8d52e5"
 
 ms@0.7.1:
   version "0.7.1"


### PR DESCRIPTION
I like my OS's native emoji more than EmojiOne; I'd really like to be able to display it where it's supported. This PR adds a check to see if native emoji is available (via the mojibaka npm package), and only use EmojiOne fonts if native emoji isn't available.

Some possible questions / extra features:

* What's the minimum Unicode version we want to gate EmojiOne support on? This uses 6.1, but devices with Unicode 6.1 will lack support for a lot of common emoji. Maybe that should get gated to Unicode 8 or 9?
* If the minimum version is left low, is it okay for unsupported emoji to be left to the OS to render, or would we want to do something else with them?