### PR TITLE
Prevent duplicate desktop notifications

### DIFF
--- a/app/assets/javascripts/components/actions/notifications.jsx
+++ b/app/assets/javascripts/components/actions/notifications.jsx
@@ -40,7 +40,7 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
       const title = new IntlMessageFormat(intlMessages[`notification.${notification.type}`], intlLocale).format({ name: notification.account.display_name.length > 0 ? notification.account.display_name : notification.account.username });
       const body  = $('<p>').html(notification.status ? notification.status.content : '').text();
 
-      new Notification(title, { body, icon: notification.account.avatar });
+      new Notification(title, { body, icon: notification.account.avatar, tag: notification.id });
     }
   };
 };


### PR DESCRIPTION
Set the tag property on the HTML5 notification, so that it is never shown more than once. Fixes #407.