### PR TITLE
Add Microformats2 markup

### DIFF
--- a/app/views/accounts/_header.html.haml
+++ b/app/views/accounts/_header.html.haml
@@ -1,4 +1,4 @@
-.card{ style: "background-image: url(#{@account.header.url( :original)})" }
+.card.h-card{ class: [local_assigns[:in_feed] && 'p-author'], style: "background-image: url(#{@account.header.url( :original)})" }
   - if user_signed_in? && current_account.id != @account.id && !current_account.requested?(@account)
     .controls
       - if current_account.following?(@account)
@@ -9,19 +9,19 @@
     .controls
       .remote-follow
         = link_to t('accounts.remote_follow'), account_remote_follow_path(@account), class: 'button'
-  .avatar= image_tag @account.avatar.url(:original)
+  .avatar= image_tag @account.avatar.url(:original), class: 'u-photo'
   %h1.name
-    = display_name(@account)
+    %span.p-name= display_name(@account)
     %small
-      = "@#{@account.username}"
+      %span.p-nickname= "@#{@account.username}"
       = fa_icon('lock') if @account.locked?
   .details
     .bio
-      .account__header__content= Formatter.instance.simplified_format(@account)
+      .account__header__content.p-note= Formatter.instance.simplified_format(@account)
 
     .details-counters
       .counter{ class: active_nav_class(account_url(@account)) }
-        = link_to account_url(@account) do
+        = link_to account_url(@account), class: 'u-url u-uid' do
           %span.counter-label= t('accounts.posts')
           %span.counter-number= number_with_delimiter @account.statuses.count
       .counter{ class: active_nav_class(following_account_url(@account)) }

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -14,15 +14,17 @@
   %meta{ property: 'og:image:height', content: '120' }/
   %meta{ property: 'twitter:card', content: 'summary' }/
 
-= render partial: 'header'
+.h-feed
+  %data.p-name{ value: "#{@account.username} on #{Rails.configuration.x.local_domain}" }
+  = render partial: 'header', locals: {in_feed: true}
 
-- if @statuses.empty?
-  .accounts-grid
-    = render partial: 'nothing_here'
-- else
-  .activity-stream
-    = render partial: 'stream_entries/status', collection: @statuses, as: :status
+  - if @statuses.empty?
+    .accounts-grid
+      = render partial: 'nothing_here'
+  - else
+    .activity-stream
+      = render partial: 'stream_entries/status', collection: @statuses, as: :status
 
-.pagination
-  - if @statuses.size == 20
-    = link_to safe_join([t('pagination.next'), fa_icon('chevron-right')], ' '), account_url(@account, max_id: @statuses.last.id), class: 'next_page', rel: 'next'
+  .pagination
+    - if @statuses.size == 20
+      = link_to safe_join([t('pagination.next'), fa_icon('chevron-right')], ' '), account_url(@account, max_id: @statuses.last.id), class: 'next_page', rel: 'next'

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -1,30 +1,31 @@
 .detailed-status.light
-  = link_to TagManager.instance.url_for(status.account), class: 'detailed-status__display-name', target: @external_links ? '_blank' : nil, rel: 'noopener' do
+  = link_to TagManager.instance.url_for(status.account), class: 'detailed-status__display-name p-author h-card', target: @external_links ? '_blank' : nil, rel: 'noopener' do
     %div
       %div.avatar
-        = image_tag status.account.avatar.url(:original), width: 48, height: 48, alt: ''
+        = image_tag status.account.avatar.url(:original), width: 48, height: 48, alt: '', class: 'u-photo'
     %span.display-name
-      %strong= display_name(status.account)
-      %span= acct(status.account)
+      %strong.p-name= display_name(status.account)
+      %span.p-nickname= acct(status.account)
 
-  .status__content= Formatter.instance.format(status)
+  .status__content.e-content.p-name= Formatter.instance.format(status)
 
   - unless status.media_attachments.empty?
     - if status.media_attachments.first.video?
       .video-player
         - if status.sensitive?
           = render partial: 'stream_entries/content_spoiler'
-        %video{ src: status.media_attachments.first.file.url(:original), loop: true }
+        %video{ src: status.media_attachments.first.file.url(:original), loop: true, class: 'u-video' }
     - else
       .detailed-status__attachments
         - if status.sensitive?
           = render partial: 'stream_entries/content_spoiler'
         - status.media_attachments.each do |media|
           .media-item
-            = link_to '', (media.remote_url.blank? ? media.file.url(:original) : media.remote_url), style: "background-image: url(#{media.file.url(:original)})", target: '_blank', rel: 'noopener'
+            = link_to '', (media.remote_url.blank? ? media.file.url(:original) : media.remote_url), style: "background-image: url(#{media.file.url(:original)})", target: '_blank', rel: 'noopener', class: "u-#{media.video? ? 'video' : 'photo'}"
 
   %div.detailed-status__meta
-    = link_to TagManager.instance.url_for(status), class: 'detailed-status__datetime', target: @external_links ? '_blank' : nil, rel: 'noopener' do
+    %data.dt-published{ value: status.created_at.to_time.iso8601 }
+    = link_to TagManager.instance.url_for(status), class: 'detailed-status__datetime u-url u-uid', target: @external_links ? '_blank' : nil, rel: 'noopener' do
       %span= l(status.created_at)
     ·
     %span

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -1,17 +1,18 @@
 .status.light
   .status__header
     .status__meta
-      = link_to time_ago_in_words(status.created_at), TagManager.instance.url_for(status), class: 'status__relative-time', title: l(status.created_at), target: @external_links ? '_blank' : nil, rel: 'noopener'
+      = link_to time_ago_in_words(status.created_at), TagManager.instance.url_for(status), class: 'status__relative-time u-url u-uid', title: l(status.created_at), target: @external_links ? '_blank' : nil, rel: 'noopener'
+      %data.dt-published{ value: status.created_at.to_time.iso8601 }
 
-    = link_to TagManager.instance.url_for(status.account), class: 'status__display-name', target: @external_links ? '_blank' : nil, rel: 'noopener' do
+    = link_to TagManager.instance.url_for(status.account), class: 'status__display-name p-author h-card', target: @external_links ? '_blank' : nil, rel: 'noopener' do
       .status__avatar
         %div
-          = image_tag status.account.avatar(:original), width: 48, height: 48, alt: ''
+          = image_tag status.account.avatar(:original), width: 48, height: 48, alt: '', class: 'u-photo'
       %span.display-name
-        %strong= display_name(status.account)
-        %span= acct(status.account)
+        %strong.p-name= display_name(status.account)
+        %span.p-nickname= acct(status.account)
 
-  .status__content= Formatter.instance.format(status)
+  .status__content.e-content.p-name= Formatter.instance.format(status)
 
   - unless status.media_attachments.empty?
     .status__attachments
@@ -19,10 +20,10 @@
         = render partial: 'stream_entries/content_spoiler'
       - if status.media_attachments.first.video?
         .video-item
-          = link_to (status.media_attachments.first.remote_url.blank? ? status.media_attachments.first.file.url(:original) : status.media_attachments.first.remote_url), style: "background-image: url(#{status.media_attachments.first.file.url(:small)})", target: '_blank', rel: 'noopener' do
+          = link_to (status.media_attachments.first.remote_url.blank? ? status.media_attachments.first.file.url(:original) : status.media_attachments.first.remote_url), style: "background-image: url(#{status.media_attachments.first.file.url(:small)})", target: '_blank', rel: 'noopener', class: 'u-video' do
             .video-item__play
               = fa_icon('play')
       - else
         - status.media_attachments.each do |media|
           .media-item
-            = link_to '', (media.remote_url.blank? ? media.file.url(:original) : media.remote_url), style: "background-image: url(#{media.file.url(:original)})", target: '_blank', rel: 'noopener'
+            = link_to '', (media.remote_url.blank? ? media.file.url(:original) : media.remote_url), style: "background-image: url(#{media.file.url(:original)})", target: '_blank', rel: 'noopener', class: "u-#{media.video? ? 'video' : 'photo'}"

--- a/app/views/stream_entries/_status.html.haml
+++ b/app/views/stream_entries/_status.html.haml
@@ -3,20 +3,22 @@
 - is_successor    ||= false
 - centered        ||= include_threads && !is_predecessor && !is_successor
 
-- if status.reply? && include_threads
-  = render partial: 'status', collection: @ancestors, as: :status, locals: { is_predecessor: true }
+%div{ class: [is_predecessor && 'u-in-reply-to h-cite', is_successor && 'u-comment h-cite', !is_predecessor && !is_successor && 'h-entry'] }
+  - if status.reply? && include_threads
+    = render partial: 'status', collection: @ancestors, as: :status, locals: { is_predecessor: true }
 
-.entry{ class: entry_classes(status, is_predecessor, is_successor, include_threads) }
-  - if status.reblog?
-    .pre-header
-      %div.pre-header__icon
-        = fa_icon('retweet fw')
-      %span
-        = link_to TagManager.instance.url_for(status.account), class: 'status__display-name muted' do
-          %strong= display_name(status.account)
-        = t('stream_entries.reblogged')
+  .entry{ class: entry_classes(status, is_predecessor, is_successor, include_threads) }
+    - if status.reblog?
+      .pre-header
+        %div.pre-header__icon
+          = fa_icon('retweet fw')
+        %span
+          = link_to TagManager.instance.url_for(status.account), class: 'status__display-name muted' do
+            %strong= display_name(status.account)
+          = t('stream_entries.reblogged')
 
-  = render partial: centered ? 'stream_entries/detailed_status' : 'stream_entries/simple_status', locals: { status: proper_status(status) }
+    %div{ class: [status.reblog? && 'u-repost-of h-cite'] }
+      = render partial: centered ? 'stream_entries/detailed_status' : 'stream_entries/simple_status', locals: { status: proper_status(status) }
 
-- if include_threads
-  = render partial: 'status', collection: @descendants, as: :status, locals: { is_successor: true }
+  - if include_threads
+    = render partial: 'status', collection: @descendants, as: :status, locals: { is_successor: true }

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -2,7 +2,7 @@
   .accounts-grid
     = render partial: 'accounts/nothing_here'
 - else
-  .activity-stream
+  .activity-stream.h-feed
     = render partial: 'stream_entries/status', collection: @statuses, as: :status, cached: true
 
 .pagination


### PR DESCRIPTION
Continuing #122, this PR adds full microformats2 h-feed, h-card and h-entry markup. This allows e.g. reading feeds in [Woodwind](https://woodwind.xyz) and displaying reply/repost/like contexts in [Sweetroll](https://github.com/myfreeweb/sweetroll).