### PR TITLE
Add Vagrant support for easy development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ public/assets
 .env.production
 node_modules/
 neo4j/
+
+# Ignore Vagrant files
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -139,12 +139,11 @@ Running `vagrant up` for the first time will run provisioning, which will:
 - Create a new VirtualBox virtual machine from that image
 - Run the provisioning script (located inside the Vagrantfile), which installs the system packages, Ruby gems, and JS modules required for Mastodon
 
-Once this has completed, the virtual machine will start a rails process. You can then access your development site at http://mastodon.dev (or at http://localhost:3000 if you haven't installed vagrants-hostupdater). Any changes you make should be reflected on the server instantly.
+Once this has completed, the virtual machine will start a rails process. You can then access your development site at http://mastodon.dev (or at http://localhost:3000 if you haven't installed vagrants-hostupdater). Any changes you make should be reflected on the server instantly. To set environment variables, copy `.env.production.sample` to `.env.vagrant` and make changes as required.
 
-When you are finished with your session, run `vagrant halt` to stop the VM. Next time, running `vagrant up` should boot the VM, and skip provsioning.
+When you are finished with your session, run `vagrant halt` to stop the VM. Next time, running `vagrant up` should boot the VM, and skip provisioning.
 
 If you no longer need your environment, or if things have gone terribly wrong, running `vagrant destroy` will delete the virtual machine (after which, running `vagrant up` will create a new one, and run provisioning).
-
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -117,6 +117,36 @@ Which will re-create the updated containers, leaving databases and data as is. D
 
 Docker is great for quickly trying out software, but it has its drawbacks too. If you prefer to run Mastodon without using Docker, refer to the [production guide](https://github.com/Gargron/mastodon/wiki/Production-guide) for examples, configuration and instructions.
 
+## Development with Vagrant
+
+A quick way to get a development environment up and running is with Vagrant. You will need recent versions of [Vagrant](https://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/) installed.
+
+Install the latest version for your operating systems, and then run:
+
+    vagrant plugin install vagrant-hostsupdater
+
+This is optional, but will update your 'hosts' file when you start the virtual machine, allowing you to access the site at http://mastodon.dev (instead of http://localhost:3000).
+
+To create and provision a new virtual machine for Mastodon development:
+
+    git clone git@github.com:Gargron/mastodon.git
+    cd mastodon
+    vagrant up
+
+Running `vagrant up` for the first time will run provisioning, which will:
+
+- Download the Ubuntu 14.04 base image, if there isn't already a copy on your machine
+- Create a new VirtualBox virtual machine from that image
+- Run the provisioning script (located inside the Vagrantfile), which installs the system packages, Ruby gems, and JS modules required for Mastodon
+
+Once this has completed, the virtual machine will start a rails process. You can then access your development site at http://mastodon.dev (or at http://localhost:3000 if you haven't installed vagrants-hostupdater). Any changes you make should be reflected on the server instantly.
+
+When you are finished with your session, run `vagrant halt` to stop the VM. Next time, running `vagrant up` should boot the VM, and skip provsioning.
+
+If you no longer need your environment, or if things have gone terribly wrong, running `vagrant destroy` will delete the virtual machine (after which, running `vagrant up` will create a new one, and run provisioning).
+
+
+
 ## Contributing
 
 You can open issues for bugs you've found or features you think are missing. You can also submit pull requests to this repository. This section may be updated with more details in the future.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-$script = <<SCRIPT
+$provision = <<SCRIPT
+
 cd /vagrant # This is where the host folder/repo is mounted
 
 # Add repo for Ruby 2.3 binaries
@@ -52,6 +53,15 @@ bundle exec rails assets:precompile
 
 SCRIPT
 
+$start = <<SCRIPT
+
+cd /vagrant
+export $(cat ".env.vagrant" | xargs)
+killall ruby2.3
+rails s -d -b 0.0.0.0
+
+SCRIPT
+
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -72,15 +82,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if defined?(VagrantPlugins::HostsUpdater)
     config.vm.network :private_network, ip: "192.168.42.42"
     config.hostsupdater.remove_on_suspend = false
-  else
-    # Otherwise, you can access the site at http://localhost:3000
-    config.vm.network :forwarded_port, guest: 80, host: 3000
   end
 
+  # Otherwise, you can access the site at http://localhost:3000
+  config.vm.network :forwarded_port, guest: 80, host: 3000
+
   # Full provisioning script, only runs on first 'vagrant up' or with 'vagrant provision'
-  config.vm.provision :shell, inline: $script, privileged: false
+  config.vm.provision :shell, inline: $provision, privileged: false
 
   # Start up script, runs on every 'vagrant up'
-  config.vm.provision :shell, inline: "cd /vagrant && rails s -d -b 0.0.0.0", run: 'always', privileged: false
+  config.vm.provision :shell, inline: $start, run: 'always', privileged: false
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,86 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script = <<SCRIPT
+cd /vagrant # This is where the host folder/repo is mounted
+
+# Add repo for Ruby 2.3 binaries
+sudo apt-add-repository ppa:brightbox/ruby-ng
+
+# Add repo for NodeJS
+curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
+
+# Add firewall rule to redirect 80 to 3000 and save
+sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 3000
+echo iptables-persistent iptables-persistent/autosave_v4 boolean true | sudo debconf-set-selections
+echo iptables-persistent iptables-persistent/autosave_v6 boolean true | sudo debconf-set-selections
+sudo apt-get install iptables-persistent -y
+
+# Add packages to build and run Mastodon
+sudo apt-get install \
+  git-core \
+  ruby-build \
+  libpq-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  imagemagick \
+  nodejs \
+  ruby2.3 \
+  ruby2.3-dev \
+  ruby-switch \
+  redis-server \
+  redis-tools \
+  postgresql \
+  postgresql-contrib \
+  -y
+
+# Set Ruby 2.3 as 'ruby'
+sudo ruby-switch --set ruby2.3
+
+# Configure database
+sudo -u postgres createuser -U postgres vagrant -s
+sudo -u postgres createdb -U postgres mastodon_development
+
+# Install gems and node modules
+sudo gem install bundler
+bundle install
+yarn install
+
+# Build Mastodon
+bundle exec rails db:setup
+bundle exec rails assets:precompile
+
+SCRIPT
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.name = "mastodon"
+    vb.customize ["modifyvm", :id, "--memory", "1024"]
+  end
+
+  config.vm.hostname = "mastodon.dev"
+
+  # This uses the vagrant-hostsupdater plugin, and lets you
+  # access the development site at http://mastodon.dev.
+  # To install:
+  #   $ vagrant plugin install hostsupdater
+  if defined?(VagrantPlugins::HostsUpdater)
+    config.vm.network :private_network, ip: "192.168.42.42"
+    config.hostsupdater.remove_on_suspend = false
+  else
+    # Otherwise, you can access the site at http://localhost:3000
+    config.vm.network :forwarded_port, guest: 80, host: 3000
+  end
+
+  # Full provisioning script, only runs on first 'vagrant up' or with 'vagrant provision'
+  config.vm.provision :shell, inline: $script, privileged: false
+
+  # Start up script, runs on every 'vagrant up'
+  config.vm.provision :shell, inline: "cd /vagrant && rails s -d -b 0.0.0.0", run: 'always', privileged: false
+
+end


### PR DESCRIPTION
This adds a `Vagrantfile` to the Mastodon repository, which will allow developers to spin up an easy development environment using Vagrant and VirtualBox.

I've included some simple instructions via README (and hopefully can add more in-depth ones to the documentation), but it should be as simple as: install VirtualBox and Vagrant, clone repo, run `vagrant up`, wait a few minutes, go to http://mastodon.dev , and start editing files.

It feels slightly off to be doing this when the project is using Docker, but while in theory Docker should be able to support a good development environment with live-reloading etc, I've never found a good example. Vagrant is a popular choice for dev and I've found it really easy when working on Drupal, WordPress, and other projects.

Note that the provisioning in this is a little crude, since it's shell based (instead of using a provisioning tool such as Chef, Ansible, Puppet). That said, it's all working pretty well, and I've tested on a couple of devices.
