### PR TITLE
Fix repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ If you would like, you can [support the development of this project on Patreon][
 
 ## Resources
 
-- [List of Mastodon instances](https://github.com/Gargron/mastodon/wiki/List-of-Mastodon-instances)
+- [List of Mastodon instances](https://github.com/tootsuite/mastodon/wiki/List-of-Mastodon-instances)
 - [Use this tool to find Twitter friends on Mastodon](https://mastodon-bridge.herokuapp.com)
-- [API overview](https://github.com/Gargron/mastodon/wiki/API)
-- [How to use the API via cURL/oAuth](https://github.com/Gargron/mastodon/wiki/Testing-with-cURL)
-- [Frequently Asked Questions](https://github.com/Gargron/mastodon/wiki/FAQ)
+- [API overview](https://github.com/tootsuite/mastodon/wiki/API)
+- [How to use the API via cURL/oAuth](https://github.com/tootsuite/mastodon/wiki/Testing-with-cURL)
+- [Frequently Asked Questions](https://github.com/tootsuite/mastodon/wiki/FAQ)
 - [List of apps](https://github.com/tootsuite/mastodon/wiki/Apps)
 
 ## Features
@@ -116,7 +116,7 @@ Which will re-create the updated containers, leaving databases and data as is. D
 
 ## Deployment without Docker
 
-Docker is great for quickly trying out software, but it has its drawbacks too. If you prefer to run Mastodon without using Docker, refer to the [production guide](https://github.com/Gargron/mastodon/wiki/Production-guide) for examples, configuration and instructions.
+Docker is great for quickly trying out software, but it has its drawbacks too. If you prefer to run Mastodon without using Docker, refer to the [production guide](https://github.com/tootsuite/mastodon/wiki/Production-guide) for examples, configuration and instructions.
 
 ## Development with Vagrant
 
@@ -130,7 +130,7 @@ This is optional, but will update your 'hosts' file when you start the virtual m
 
 To create and provision a new virtual machine for Mastodon development:
 
-    git clone git@github.com:Gargron/mastodon.git
+    git clone git@github.com:tootsuite/mastodon.git
     cd mastodon
     vagrant up
 

--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -27,7 +27,7 @@
   .actions
     .info
       = link_to t('about.terms'), terms_path
-      = link_to t('about.source_code'), 'https://github.com/Gargron/mastodon'
+      = link_to t('about.source_code'), 'https://github.com/tootsuite/mastodon'
 
     = link_to t('about.get_started'), new_user_registration_path, class: 'button webapp-btn'
     = link_to t('auth.login'), new_user_session_path, class: 'button webapp-btn'

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -6,6 +6,6 @@
   .footer
     %span.domain= link_to Rails.configuration.x.local_domain, root_path
     %span.powered-by
-      = t('generic.powered_by', link: link_to('Mastodon', 'https://github.com/Gargron/mastodon')).html_safe
+      = t('generic.powered_by', link: link_to('Mastodon', 'https://github.com/tootsuite/mastodon')).html_safe
 
 = render template: "layouts/application"

--- a/spec/fixtures/xml/mastodon.atom
+++ b/spec/fixtures/xml/mastodon.atom
@@ -107,14 +107,14 @@
         <uri>https://mastodon.social/users/Gargron</uri>
         <name>Gargron</name>
         <email>Gargron@mastodon.social</email>
-        <summary>Developer of Mastodon, a GNU social alternative: https://github.com/Gargron/mastodon</summary>
+        <summary>Developer of Mastodon, a GNU social alternative: https://github.com/tootsuite/mastodon</summary>
         <link rel="alternate" type="text/html" href="https://mastodon.social/users/Gargron"/>
         <link rel="avatar" type="image/png" media:width="300" media:height="300" href="http://kickass.zone/system/accounts/avatars/000/000/003/large/4375_eugencommish.png"/>
         <link rel="avatar" type="image/png" media:width="96" media:height="96" href="http://kickass.zone/system/accounts/avatars/000/000/003/medium/4375_eugencommish.png"/>
         <link rel="avatar" type="image/png" media:width="48" media:height="48" href="http://kickass.zone/system/accounts/avatars/000/000/003/small/4375_eugencommish.png"/>
         <poco:preferredUsername>Gargron</poco:preferredUsername>
         <poco:displayName>Eugen</poco:displayName>
-        <poco:note>Developer of Mastodon, a GNU social alternative: https://github.com/Gargron/mastodon</poco:note>
+        <poco:note>Developer of Mastodon, a GNU social alternative: https://github.com/tootsuite/mastodon</poco:note>
       </author>
     </activity:object>
   </entry>
@@ -192,14 +192,14 @@
       <uri>https://mastodon.social/users/Gargron</uri>
       <name>Gargron</name>
       <email>Gargron@mastodon.social</email>
-      <summary>Developer of Mastodon, a GNU social alternative: https://github.com/Gargron/mastodon</summary>
+      <summary>Developer of Mastodon, a GNU social alternative: https://github.com/tootsuite/mastodon</summary>
       <link rel="alternate" type="text/html" href="https://mastodon.social/users/Gargron"/>
       <link rel="avatar" type="image/png" media:width="300" media:height="300" href="http://kickass.zone/system/accounts/avatars/000/000/003/large/4375_eugencommish.png"/>
       <link rel="avatar" type="image/png" media:width="96" media:height="96" href="http://kickass.zone/system/accounts/avatars/000/000/003/medium/4375_eugencommish.png"/>
       <link rel="avatar" type="image/png" media:width="48" media:height="48" href="http://kickass.zone/system/accounts/avatars/000/000/003/small/4375_eugencommish.png"/>
       <poco:preferredUsername>Gargron</poco:preferredUsername>
       <poco:displayName>Eugen</poco:displayName>
-      <poco:note>Developer of Mastodon, a GNU social alternative: https://github.com/Gargron/mastodon</poco:note>
+      <poco:note>Developer of Mastodon, a GNU social alternative: https://github.com/tootsuite/mastodon</poco:note>
     </activity:object>
   </entry>
   <entry>


### PR DESCRIPTION
Update the Mastodon repository URL from Gargron/ to tootsuite/ in various places.