### PR TITLE
Store JSON in HTML attribute to avoid <script> embedding problems

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,6 +1,7 @@
 - content_for :header_tags do
+  %meta{name: 'initial-state', content: render(file: 'home/initial_state', formats: :json)}
   :javascript
-    window.INITIAL_STATE = #{render(file: 'home/initial_state', formats: :json)}
+    window.INITIAL_STATE = JSON.parse(document.querySelector('meta[name=initial-state]').content);
 
   = javascript_include_tag 'application'
 


### PR DESCRIPTION
JSON isn’t quite JavaScript-in-HTML, so a user setting a display name of `</script><script>alert(1)//` will see an alert on their dashboard. (Only on their own dashboard, though, so it isn’t really a vulnerability.) A more likely scenario is that invisible U+2028s or U+2029s might sneak in at some point and cause a mysterious blank page.