### PR TITLE
Add a 'Back to Mastodon' link to footer of settings pages

### DIFF
--- a/app/views/settings/shared/_links.html.haml
+++ b/app/views/settings/shared/_links.html.haml
@@ -5,3 +5,4 @@
     %li= link_to t('settings.preferences'), settings_preferences_path
   - if controller_name != 'registrations'
     %li= link_to t('auth.change_password'), edit_user_registration_path
+  %li= link_to t('settings.back'), root_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,7 @@ en:
   settings:
     edit_profile: Edit profile
     preferences: Preferences
+    back: Back to Mastodon
   stream_entries:
     click_to_show: Click to show
     favourited: favourited a post by


### PR DESCRIPTION
Resolves #162 