### PR TITLE
Fix S3 default settings

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -11,7 +11,7 @@ if ENV['S3_ENABLED'] == 'true'
   Paperclip::Attachment.default_options[:s3_host_name]   = ENV.fetch('S3_HOSTNAME') { "s3-#{ENV.fetch('S3_REGION')}.amazonaws.com" }
   Paperclip::Attachment.default_options[:path]           = '/:class/:attachment/:id_partition/:style/:filename'
   Paperclip::Attachment.default_options[:s3_headers]     = { 'Cache-Control' => 'max-age=315576000', 'Expires' => 10.years.from_now.httpdate }
-  Paperclip::Attachment.default_options[:s3_permissions] = 'public'
+  Paperclip::Attachment.default_options[:s3_permissions] = 'public-read'
   Paperclip::Attachment.default_options[:s3_region]      = ENV.fetch('S3_REGION') { 'us-east-1' }
 
   Paperclip::Attachment.default_options[:s3_credentials] = {


### PR DESCRIPTION
Change default S3 ACL string used by Paperclip from 'public' (which is invalid) to 'public-read'.

This took me a long time to track down, sleep deprivation probably partially to blame.