### PR TITLE
Better remote dev mail debugging

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -1,0 +1,1 @@
+VAGRANT=true

--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'letter_opener'
+  gem 'letter_opener_web'
   gem 'bullet'
   gem 'active_record_query_trace'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,10 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.4.1)
       launchy (~> 2.2)
+    letter_opener_web (1.3.0)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     link_header (0.0.8)
     lograge (0.4.1)
       actionpack (>= 4, < 5.1)
@@ -432,6 +436,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   letter_opener
+  letter_opener_web
   link_header
   lograge
   nokogiri
@@ -474,4 +479,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,7 +62,15 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.action_mailer.delivery_method = :letter_opener
+  # If usng a Heroku, Vagrant or generic remote development environment,
+  # use letter_opener_web, accessible at  /letter_opener.
+  #
+  # Otherwise, use letter_opener, which launches a browser window to view sent mail.
+  if (ENV['HEROKU'] || ENV['VAGRANT'] || ENV['REMOTE_DEV'])
+    config.action_mailer.delivery_method = :letter_opener_web
+  else
+    config.action_mailer.delivery_method = :letter_opener
+  end
 
   config.after_initialize do
     Bullet.enable        = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,12 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+
+  # Development-only routes
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
+
   mount ActionCable.server, at: 'cable'
 
   authenticate :user, lambda { |u| u.admin? } do


### PR DESCRIPTION
Set development environments that are remote (identified by presence of VAGRANT, HEROKU, or REMOTE_DEV environment variables) to use letter_opener_web for mail debugging.

Create a default .env.vagrant file to set VAGRANT=true.