### PR TITLE
Call uniq on the string version of mb_chars tags - fixes #503

### DIFF
--- a/app/services/process_hashtags_service.rb
+++ b/app/services/process_hashtags_service.rb
@@ -4,7 +4,7 @@ class ProcessHashtagsService < BaseService
   def call(status, tags = [])
     tags = status.text.scan(Tag::HASHTAG_RE).map(&:first) if status.local?
 
-    tags.map { |str| str.mb_chars.downcase }.uniq.each do |tag|
+    tags.map { |str| str.mb_chars.downcase }.uniq{ |t| t.to_s }.each do |tag|
       status.tags << Tag.where(name: tag).first_or_initialize(name: tag)
     end
 


### PR DESCRIPTION
Not sure if there's a neater way to do this, but this works.

.uniq was not removing duplicates, as they're Multibyte::Chars objects (introduced in #950312ba), causing issue #503 

Fixed by passing it a block, so that it compares the to_s version.