### PR TITLE
Textarea: fix clicking on name suggestions

### DIFF
--- a/app/assets/javascripts/components/components/autosuggest_textarea.jsx
+++ b/app/assets/javascripts/components/components/autosuggest_textarea.jsx
@@ -118,12 +118,19 @@ const AutosuggestTextarea = React.createClass({
   },
 
   onBlur () {
-    this.setState({ suggestionsHidden: true });
+    // If we hide the suggestions immediately, then this will prevent the
+    // onClick for the suggestions themselves from firing.
+    // Setting a short window for that to take place before hiding the
+    // suggestions ensures that can't happen.
+    setTimeout(() => {
+      this.setState({ suggestionsHidden: true });
+    }, 100);
   },
 
   onSuggestionClick (suggestion, e) {
     e.preventDefault();
     this.props.onSuggestionSelected(this.state.tokenStart, this.state.lastToken, suggestion);
+    this.textarea.focus();
   },
 
   componentWillReceiveProps (nextProps) {


### PR DESCRIPTION
This was broken in c3e9ba6a, which added an onBlur to hide the suggestions when the textarea loses focus. Unfortunately, this fired even when the textarea lost focus to its own suggestions box, and that meant that onSuggestionClick is never called.

Setting a short window in which onSuggestionClick can still happen before hiding the suggestion area ensures that clicking still works, while still hiding the suggestions if the user clicks on something else.