### PR TITLE
Fix `invisible` CSS class

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -61,8 +61,7 @@
 }
 
 .invisible {
-  font-size: 0;
-  line-height: 0;
+  display: none;
 }
 
 .ellipsis {


### PR DESCRIPTION
Commit 80cefd5b added the `invisible` attribute to parts of the URL by setting the `font-size` and `line-height` to 0; this doesn't actually make the space empty in all browsers, however. In some browsers, like Safari, the text will be rendered invisible but some space will still be taken up. `display: none` has the expected effect in all browsers that I've tested.

Before:
<img width="251" alt="Before" src="https://cloud.githubusercontent.com/assets/780485/22262422/afbe13de-e225-11e6-8da6-262b68032eb2.png">

After:
<img width="249" alt="After" src="https://cloud.githubusercontent.com/assets/780485/22262424/b16c545c-e225-11e6-9a7d-4f721cd65a15.png">