### PR TITLE
clarify the intended use of the oauth api call

### DIFF
--- a/docs/Using-the-API/API.md
+++ b/docs/Using-the-API/API.md
@@ -212,6 +212,8 @@ Form data:
 
 Creates a new OAuth app. Returns `id`, `client_id` and `client_secret` which can be used with [OAuth authentication in your 3rd party app](Testing-with-cURL.md).
 
+These values should be requested in the app itself from the API for each new app install + mastodon domain combo, and stored in the app for future requests.
+
 ___
 
 ## Entities


### PR DESCRIPTION
The docs on the oauth api call didn't make it quite clear what the intended usage for it is, so this adds a bit of an explanation based on the comments in this issue:

https://github.com/alin-rautoiu/mastodroid/issues/23