### PR TITLE
Increase color contrast on buttons

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,7 +1,7 @@
 $color1: #282c37; // darkest
 $color2: #d9e1e8; // lightest
 $color3: #9baec8; // lighter
-$color4: #2b90d9; // vibrant
+$color4: #2584c7; // vibrant
 $color5: #fff; // white
 $color6: #df405a; // error red
 $color7: #79bd9a; // succ green


### PR DESCRIPTION
Currently, the buttons on the login page fail WCAG color contrast standards for text. Someone with low vision may not be able to read these buttons. This change slightly darkens the blue so that it passes AA WCAG for Large Text (the most minimal amount you need to do to not be failing accessibility).