### PR TITLE
Increase color contrast on getting started text

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -656,6 +656,7 @@
   padding-bottom: 235px;
   background: image-url('mastodon-getting-started.png') no-repeat 0 100% local;
   height: 100%;
+  p {font-color: $color2;}
 }
 
 .dropdown__content.dropdown__left {


### PR DESCRIPTION
Currently, the getting started text fails WCAG standards for color contrast by a lot. Especially on the part overlapping with the elephant graphic which is nearly unreadable even for users with 20|20 vision. This change doesn't fix the elephant overlap but at least makes the text meet AAA WCAG Small Text color contrast standards, making it easier to read.