### PR TITLE
Seed a default, confirmed, admin account on development environments

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,7 @@
 web_app = Doorkeeper::Application.new(name: 'Web', superapp: true, redirect_uri: Doorkeeper.configuration.native_redirect_uri, scopes: 'read write follow')
 web_app.save!
+if Rails.env.development?
+	domain = ENV['LOCAL_DOMAIN'] || Rails.configuration.x.local_domain
+	account = Account.where(username: 'admin').first_or_initialize(username: 'admin').save!
+	user = User.where(email: "admin@#{domain}").first_or_initialize(:email => "admin@#{domain}", :password => 'mastodonadmin', :password_confirmation => 'mastodonadmin', :confirmed_at => Time.now, :admin => true, :account => Account.where(username: 'admin').first).save!
+end


### PR DESCRIPTION
This seeds an account with the username `admin`, and an associated user with the email `admin@LOCAL_DOMAIN || Rails.configuration.x.local_domain`, which is confirmed, and marked as an admin, in development environments.

This should make it quicker and easier for devs to get started (presuming we document it somewhere useful).