### PR TITLE
Add a default LOCAL_DOMAIN=mastodon.dev to .env.vagrant

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -1,1 +1,2 @@
 VAGRANT=true
+LOCAL_DOMAIN=mastodon.dev


### PR DESCRIPTION
Set the LOCAL_DOMAIN by default in Vagrant environments