### PR TITLE
Swap out Roboto font for Droid Sans

### DIFF
--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -12,7 +12,7 @@
   }
 
   h1 {
-    font: 46px/52px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font: 46px/52px -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Droid Sans', sans-serif;
     font-weight: 600;
     margin-bottom: 20px;
     color: $color4;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,6 @@
 @import 'variables';
-@import url(https://fonts.googleapis.com/css?family=Roboto:400,500,400italic);
-@import url(https://fonts.googleapis.com/css?family=Roboto+Mono:400,500);
+@import url(https://fonts.googleapis.com/css?family=Droid+Sans:400,500,400italic);
+@import url(https://fonts.googleapis.com/css?family=Droid+Sans+Mono:400,500);
 @import url(https://fonts.googleapis.com/css?family=Montserrat);
 @import 'font-awesome';
 
@@ -97,7 +97,7 @@ table {
 }
 
 body {
-  font-family: 'Roboto', sans-serif;
+  font-family: 'Droid Sans', sans-serif;
   background: $color1 image-url('background-photo.jpeg');
   background-size: cover;
   background-attachment: fixed;
@@ -199,7 +199,7 @@ body {
       display: block;
       font-size: 12px;
       font-weight: 400;
-      font-family: 'Roboto Mono', monospace;
+      font-family: 'Droid Sans Mono', monospace;
     }
   }
 }

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -1,5 +1,5 @@
 code {
-  font-family: 'Roboto Mono', monospace;
+  font-family: 'Droid Sans Mono', monospace;
   font-weight: 400;
 }
 

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -43,7 +43,7 @@
 }
 
 samp {
-  font-family: 'Roboto Mono', monospace;
+  font-family: 'Droid Sans Mono', monospace;
 }
 
 a.table-action-link {

--- a/app/views/layouts/error.html.haml
+++ b/app/views/layouts/error.html.haml
@@ -5,10 +5,10 @@
     %meta{:charset => "utf-8"}/
     %title= yield :page_title
     %meta{:content => "width=device-width,initial-scale=1", :name => "viewport"}/
-    %link{:href => "https://fonts.googleapis.com/css?family=Roboto:400", :rel => "stylesheet"}/
+    %link{:href => "https://fonts.googleapis.com/css?family=Droid+Sans:400", :rel => "stylesheet"}/
     :css
       body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Droid Sans', sans-serif;
         background: #282c37;
         color: #9baec8;
         text-align: center;
@@ -26,7 +26,7 @@
       }
 
       .dialog h1 {
-        font: 20px/28px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        font: 20px/28px -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Droid Sans', sans-serif;
         font-weight: 400;
       }
   %body

--- a/public/500.html
+++ b/public/500.html
@@ -4,10 +4,10 @@
   <meta charset="utf-8">
   <title>We're sorry, but something went wrong</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:400" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Droid+Sans:400" rel="stylesheet">
   <style>
     body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Droid Sans', sans-serif;
       background: #282c37;
       color: #9baec8;
       text-align: center;
@@ -25,7 +25,7 @@
     }
 
     .dialog h1 {
-      font: 20px/28px -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font: 20px/28px -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Droid Sans', sans-serif;
       font-weight: 400;
     }
   </style>

--- a/storybook/storybook.scss
+++ b/storybook/storybook.scss
@@ -1,8 +1,8 @@
-@import url(https://fonts.googleapis.com/css?family=Roboto:400,500,400italic);
-@import url(https://fonts.googleapis.com/css?family=Roboto+Mono:400,500);
+@import url(https://fonts.googleapis.com/css?family=Droid+Sans:400,500,400italic);
+@import url(https://fonts.googleapis.com/css?family=Droid+Sans+Mono:400,500);
 
 #root {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Droid Sans', sans-serif;
   background: #282c37;
   font-size: 13px;
   line-height: 18px;


### PR DESCRIPTION
Roboto is a lovely font, however it doesn't have a complete set of
symbols. This means that things like Japanese characters, or unicode
symbols frequently don't display.

This change will swap out Robot for Droid Sans, which is a similar
looking font under the same license that does have a full character set.

You can compare the two here:
https://fonts.google.com/specimen/Droid+Sans
https://fonts.google.com/specimen/Roboto

This relates to issue tootsuite/mastodon#531