### PR TITLE
Add missing back button to "Follow Requests"

### DIFF
--- a/app/assets/javascripts/components/features/follow_requests/index.jsx
+++ b/app/assets/javascripts/components/features/follow_requests/index.jsx
@@ -4,6 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import LoadingIndicator from '../../components/loading_indicator';
 import { ScrollContainer } from 'react-router-scroll';
 import Column from '../ui/components/column';
+import ColumnBackButton from '../../components/column_back_button';
 import AccountAuthorizeContainer from './containers/account_authorize_container';
 import { fetchFollowRequests, expandFollowRequests } from '../../actions/accounts';
 import { defineMessages, injectIntl } from 'react-intl';
@@ -51,6 +52,7 @@ const FollowRequests = React.createClass({
 
     return (
       <Column icon='users' heading={intl.formatMessage(messages.heading)}>
+        <ColumnBackButton />
         <ScrollContainer scrollKey='follow_requests'>
           <div className='scrollable' onScroll={this.handleScroll}>
             {accountIds.map(id =>


### PR DESCRIPTION
Currently we have the problem where the follow request button is missing
from the Follow request tab. This means that when you visit that tab you
either have to press the back button in the browser or re-enter the home
page, which breaks the app flow.

This will resolve that issue by adding a new back button to that tab,
in the same way that the public timeline, and favourites have.

Previously looked like this:
![image](https://cloud.githubusercontent.com/assets/133327/22400723/ff62cfc8-e5b4-11e6-822e-24f057fdadf8.png)

Now looks like this:
![image](https://cloud.githubusercontent.com/assets/133327/22400722/ed66f678-e5b4-11e6-94a2-3e901be0f678.png)
