### PR TITLE
Fix avatar scaling on high-DPI displays

### DIFF
--- a/app/assets/javascripts/components/components/avatar.jsx
+++ b/app/assets/javascripts/components/components/avatar.jsx
@@ -25,7 +25,7 @@ const Avatar = React.createClass({
   },
 
   handleLoad () {
-    this.canvas.getContext('2d').drawImage(this.image, 0, 0, this.props.size, this.props.size);
+    this.canvas.getContext('2d').drawImage(this.image, 0, 0, this.props.size * window.devicePixelRatio, this.props.size * window.devicePixelRatio);
   },
 
   setImageRef (c) {
@@ -42,7 +42,7 @@ const Avatar = React.createClass({
     return (
       <div onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} style={{ ...this.props.style, width: `${this.props.size}px`, height: `${this.props.size}px`, position: 'relative' }}>
         <img ref={this.setImageRef} onLoad={this.handleLoad} src={this.props.src} width={this.props.size} height={this.props.size} alt='' style={{ position: 'absolute', top: '0', left: '0', visibility: hovering ? 'visible' : 'hidden', borderRadius: '4px' }} />
-        <canvas ref={this.setCanvasRef} width={this.props.size} height={this.props.size} style={{ borderRadius: '4px' }} />
+        <canvas ref={this.setCanvasRef} width={this.props.size * window.devicePixelRatio} height={this.props.size * window.devicePixelRatio} style={{ borderRadius: '4px', width: this.props.size, height: this.props.size }} />
       </div>
     );
   }


### PR DESCRIPTION
Commit 00fa850bdc8e98dfb3e3772ec2b9a55e8538cadc updated the avatars to only play when hovered. This has led to a few display bugs with avatars.

The larger bug is that the width and height being set don't take into account that the resolution in CSS pixels and physical pixels might not align; for example, on the retina/high-DPI screens used on most modern laptops, phones, and tablets, these two things differ by a factor of 2 or more. The [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) property provides a way to request the ratio to convert between them. The result of this was that the canvas element was being told to render in "CSS pixels", which is significantly lower than the actual size on screen; this led to avatars being rendered very pixelated on high-DPI devices.

This PR updates the styles so that the canvas element renders at the real physical resolution using `window.devicePixelRatio`, while the size in CSS is set using CSS pixels.

Before:

<img width="124" alt="Pixelated avatar" src="https://cloud.githubusercontent.com/assets/780485/22402640/81cfcf1c-e5b3-11e6-8a04-e1d6b25d7359.png">

After:

<img width="121" alt="Clean avatar" src="https://cloud.githubusercontent.com/assets/780485/22402641/8493e972-e5b3-11e6-8480-9d307c35d73e.png">

This leaves a couple of bugs that still need to get addressed after this:

1) Because the browser's native scaling is different than what we're doing here, the avatars will still look different after you hover over them. This isn't desirable. It's probably better to use a different method of handling this, and maybe to avoid invoking this logic on non-animated avatars.
2) On devices without hover, e.g. touch devices, there's no way to get the "hover" version of an avatar.