### PR TITLE
fix bottom padding for getting started on mobile

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -357,6 +357,9 @@
     font-size: 13px;
     margin-bottom: 20px;
   }
+  .getting-started {
+    padding-bottom: 235px; 
+  }
 }
 
 .columns-area {


### PR DESCRIPTION
Mobile browsers are reading the css for elements with multiple classes differently from desktop browsers. I think this is causing .getting-started to have a 10px padding-bottom on mobile browsers instead of the 235px it should have, taking the padding value from .static-content instead.