### PR TITLE
Small Changes for Promotion of Other Instances

### DIFF
--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -32,6 +32,7 @@
       = link_to t('about.learn_more'), about_more_path
       = link_to t('about.terms'), terms_path
       = link_to t('about.source_code'), 'https://github.com/tootsuite/mastodon'
+      = link_to t('about.other_instances'), 'https://github.com/tootsuite/mastodon/blob/master/docs/Using-Mastodon/List-of-Mastodon-instances.md'
 
     = link_to t('about.get_started'), new_user_registration_path, class: 'button webapp-btn'
     = link_to t('auth.login'), new_user_session_path, class: 'button webapp-btn'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
     get_started: Get started
     learn_more: Learn more
     links: Links
+    other_instances: Other Instances
     source_code: Source code
     status_count_after: statuses
     status_count_before: Who authored

--- a/docs/Using-Mastodon/List-of-Mastodon-instances.md
+++ b/docs/Using-Mastodon/List-of-Mastodon-instances.md
@@ -2,17 +2,17 @@ List of Known Mastodon instances
 ==========================
 
 
-| Name        | Theme/Notes, if applicable           | Open Registrations  |
-| ------------- |:-------------:| -----:|
-| [mastodon.social](https://mastodon.social)      | Flagship, quick updates | $Yes |
-| [awoo.space](https://awoo.space)      | Intentionally moderated, only federates with mastodon.social | $Yes |
-| [social.tchncs.de](https://social.tchncs.de)      | Technology      |   $Yes |
-| [animalliberation.social](https://animalliberation.social) | Animal Rights      |    $Yes |
-| [socially.constructed.space](https://socially.constructed.space) | Single user      |    $No |
-| [epiktistes.com](https://epiktistes.com) | N/A      |    $Yes |
-| [toot.zone](https://toot.zone) | N/A      |    $Yes |
-| [on.vu](https://on.vu) | Appears defunct      |    $No |
-| [gay.crime.team](https://gay.crime.team) | N/A      |    $Yes(?) |
+| Name | Theme/Notes, if applicable | Open Registrations |
+| -------------|-------------|---|
+| [mastodon.social](https://mastodon.social) |Flagship, quick updates|Yes|
+| [awoo.space](https://awoo.space) |Intentionally moderated, only federates with mastodon.social|Yes|
+| [social.tchncs.de](https://social.tchncs.de)|N/A|Yes|
+| [animalliberation.social](https://animalliberation.social) |Animal Rights|Yes|
+| [socially.constructed.space](https://socially.constructed.space) |Single user|No|
+| [epiktistes.com](https://epiktistes.com) |N/A|Yes|
+| [toot.zone](https://toot.zone) |N/A|Yes|
+| [on.vu](https://on.vu) | Appears defunct|No|
+| [gay.crime.team](https://gay.crime.team) |N/A|Yes(?)|
 
 
 Let me know if you start running one so I can add it to the list! (Alternatively, add it yourself as a pull request).

--- a/docs/Using-Mastodon/List-of-Mastodon-instances.md
+++ b/docs/Using-Mastodon/List-of-Mastodon-instances.md
@@ -1,12 +1,18 @@
-List of Mastodon instances
+List of Known Mastodon instances
 ==========================
 
-* [mastodon.social](https://mastodon.social)
-* [social.tchncs.de](https://social.tchncs.de)
-* [on.vu](https://on.vu)
-* [animalliberation.social](https://animalliberation.social)
-* [socially.constructed.space](https://socially.constructed.space)
-* [epiktistes.com](https://epiktistes.com)
-* [toot.zone](https://toot.zone)
 
-Let me know if you start running one so I can add it to the list!
+| Name        | Theme/Notes, if applicable           | Open Registrations  |
+| ------------- |:-------------:| -----:|
+| [mastodon.social](https://mastodon.social)      | Flagship, quick updates | $Yes |
+| [awoo.space](https://awoo.space)      | Intentionally moderated, only federates with mastodon.social | $Yes |
+| [social.tchncs.de](https://social.tchncs.de)      | Technology      |   $Yes |
+| [animalliberation.social](https://animalliberation.social) | Animal Rights      |    $Yes |
+| [socially.constructed.space](https://socially.constructed.space) | Single user      |    $No |
+| [epiktistes.com](https://epiktistes.com) | N/A      |    $Yes |
+| [toot.zone](https://toot.zone) | N/A      |    $Yes |
+| [on.vu](https://on.vu) | Appears defunct      |    $No |
+| [gay.crime.team](https://gay.crime.team) | N/A      |    $Yes(?) |
+
+
+Let me know if you start running one so I can add it to the list! (Alternatively, add it yourself as a pull request).


### PR DESCRIPTION
This PR is a series of updates to further promote the existence of instances other than mastodon.social. The list of other instances on GitHub is now more robust and provides information about each instance. I have also added more instances to the list, such as awoo.space and gay.crime.team.

I have added a link on the front page while logged out, next to the source code link, which goes to the list of other instances, so new users are invited to explore their options. Right now it's in a subtle location since this is a change for mastodon the software. I think that for mastodon.social the link could be made more prominent. Though that's something gargron would have to do.