### PR TITLE
Activity stream background should use $color5

### DIFF
--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -3,7 +3,7 @@
   box-shadow: 0 0 15px rgba($color8, 0.2);
 
   .entry {
-    background: lighten($color2, 8%);
+    background: $color5;
 
     .detailed-status.light, .status.light {
       border-bottom: 1px solid $color2;


### PR DESCRIPTION
Right now, it uses a lightened color3, which gives very weird results when you have a colour that isn't very desaturated set as color3. It should probably always be white instead - on the flagship instance, it practically is (#f2f5f7).