### PR TITLE
Fixed the URL

### DIFF
--- a/docs/Running-Mastodon/Heroku-guide.md
+++ b/docs/Running-Mastodon/Heroku-guide.md
@@ -1,7 +1,7 @@
 Heroku guide
 ============
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?button-url=https://github.com/tootsuite/mastodon&template=https://github.com/tootsuite/mastodon)
 
 Mastodon can theoretically run indefinitely on a free [Heroku](https://heroku.com) app. It should be noted this has limited testing and could have unpredictable results.
 


### PR DESCRIPTION
Heroku uses the referrer URL to point at the repo that should be deployed; from this page that includes part of a path that breaks the deployment (specifically /blob/master/docs/Running-Mastodon/Heroku-guide.md).

I've replaced the vanilla address with one that includes a specific reference to the root of the repo