### PR TITLE
Added SMTP_FROM_ADDRESS to heroku deploy config

### DIFF
--- a/app.json
+++ b/app.json
@@ -71,6 +71,10 @@
     "SMTP_DOMAIN": {
       "description": "Domain for SMTP server. Will default to instance domain if blank.",
       "required": false
+    },
+    "SMTP_FROM_ADDRESS": {
+      "description": "Address to send emails from",
+      "required": false
     }
   },
   "buildpacks": [


### PR DESCRIPTION
Allows the user to set the address mastodon emails are maraked as being sent from

Addressing issue #638 