### PR TITLE
Fix for #626

### DIFF
--- a/app/assets/javascripts/components/actions/statuses.jsx
+++ b/app/assets/javascripts/components/actions/statuses.jsx
@@ -103,8 +103,12 @@ export function fetchContext(id) {
       dispatch(fetchContextSuccess(id, response.data.ancestors, response.data.descendants));
       dispatch(fetchStatusCard(id));
     }).catch(error => {
-      dispatch(deleteStatusSuccess(id));
-      dispatch(deleteFromTimelines(id));
+      if (error.response.status == 404){
+        dispatch(deleteStatusSuccess(id));
+        dispatch(deleteFromTimelines(id));
+      }else{
+        dispatch(fetchContextFail(id, error));
+      }
     });
   };
 };

--- a/app/assets/javascripts/components/actions/statuses.jsx
+++ b/app/assets/javascripts/components/actions/statuses.jsx
@@ -28,7 +28,6 @@ export function fetchStatus(id) {
     const skipLoading = getState().getIn(['statuses', id], null) !== null;
 
     dispatch(fetchContext(id));
-    dispatch(fetchStatusCard(id));
 
     if (skipLoading) {
       return;
@@ -102,7 +101,10 @@ export function fetchContext(id) {
 
     api(getState).get(`/api/v1/statuses/${id}/context`).then(response => {
       dispatch(fetchContextSuccess(id, response.data.ancestors, response.data.descendants));
+      dispatch(fetchStatusCard(id));
     }).catch(error => {
+      dispatch(deleteStatusSuccess(id));
+      dispatch(deleteFromTimelines(id));
       dispatch(fetchContextFail(id, error));
     });
   };

--- a/app/assets/javascripts/components/actions/statuses.jsx
+++ b/app/assets/javascripts/components/actions/statuses.jsx
@@ -105,7 +105,6 @@ export function fetchContext(id) {
     }).catch(error => {
       dispatch(deleteStatusSuccess(id));
       dispatch(deleteFromTimelines(id));
-      dispatch(fetchContextFail(id, error));
     });
   };
 };

--- a/app/assets/javascripts/components/components/status_not_found.jsx
+++ b/app/assets/javascripts/components/components/status_not_found.jsx
@@ -1,0 +1,16 @@
+import { FormattedMessage } from 'react-intl';
+
+const style = {
+  textAlign: 'center',
+  fontSize: '16px',
+  fontWeight: '500',
+  paddingTop: '120px'
+};
+
+const StatusNotFound = () => (
+  <div className='status-not-found-indicator' style={style}>
+    <FormattedMessage id='status_not_found_indicator.label' defaultMessage='Status Not Found' />
+  </div>
+);
+
+export default StatusNotFound;

--- a/app/assets/javascripts/components/features/status/index.jsx
+++ b/app/assets/javascripts/components/features/status/index.jsx
@@ -117,7 +117,7 @@ const Status = React.createClass({
     if (status === null) {
       return (
         <Column>
-          <LoadingIndicator />
+          <ColumnBackButton />
         </Column>
       );
     }

--- a/app/assets/javascripts/components/features/status/index.jsx
+++ b/app/assets/javascripts/components/features/status/index.jsx
@@ -4,7 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { fetchStatus } from '../../actions/statuses';
 import Immutable from 'immutable';
 import EmbeddedStatus from '../../components/status';
-import LoadingIndicator from '../../components/loading_indicator';
+import StatusNotFound from '../../components/status_not_found';
 import DetailedStatus from './components/detailed_status';
 import ActionBar from './components/action_bar';
 import Column from '../ui/components/column';
@@ -118,6 +118,7 @@ const Status = React.createClass({
       return (
         <Column>
           <ColumnBackButton />
+          <StatusNotFound />
         </Column>
       );
     }


### PR DESCRIPTION
If `fetchStatus` gets an error while sending sending request to `/api/v1/statuses/${id}/context`, then it will check if the error status is 404 and delete the status from the timeline if it is.  I created a new React class called `StatusNotFound`. In `status/indiex.jsx`, if status is null, then it will render the new React class with a back button on top.