### PR TITLE
Convenient colour palettes

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,8 +1,12 @@
-$color1: #282c37; // darkest
-$color2: #d9e1e8; // lightest
-$color3: #9baec8; // lighter
-$color4: #2b90d9; // vibrant
-$color5: #ffffff; // white
-$color6: #df405a; // error red
-$color7: #79bd9a; // succ green
-$color8: #000000; // black
+@import 'variables/palettes';
+
+//  For some colour palettes to chose from, see `variables/palettes.scss`!!
+
+$color1: $mastodon-color1; // darkest
+$color2: $mastodon-color2; // lightest
+$color3: $mastodon-color3; // lighter
+$color4: $mastodon-color4; // vibrant
+$color5: $mastodon-color5; // white
+$color6: $mastodon-color6; // error red
+$color7: $mastodon-color7; // succ green
+$color8: $mastodon-color8; // black

--- a/app/assets/stylesheets/variables/palettes.scss
+++ b/app/assets/stylesheets/variables/palettes.scss
@@ -1,0 +1,223 @@
+/*
+  This stylesheet contains a few default colour palettes you can use
+  when customizing your server for a consistent appearance.
+*/
+
+///////////////////////////////////////////////////////////////////////
+
+/*  TANGO COLOR PALETTE  */
+/*  by: Tango Desktop Project  */
+
+/*
+  The Tango icon theme's goal is to make applications not seem alien on any desktop. Having a common color palette is required to have a consistent look across all icons. The Tango color palette consists of 27 RGB colors.
+*/
+
+//  BUTTER  //
+
+$tango-butter_1: #fce94f;
+$tango-butter_2: #edd400;
+$tango-butter_3: #c4a000;
+
+//  CHAMELEON  //
+
+$tango-chameleon_1: #8ae234;
+$tango-chameleon_2: #73d216;
+$tango-chameleon_3: #4e9a06;
+
+//  ORANGE  //
+
+$tango-orange_1: #fcaf3e;
+$tango-orange_2: #f57900;
+$tango-orange_3: #ce5c00;
+
+//  SKY BLUE  //
+
+$tango-sky_blue_1: #729fcf;
+$tango-sky_blue_2: #3465a4;
+$tango-sky_blue_3: #204a87;
+
+//  PLUM  //
+
+$tango-plum_1: #ad7fa8;
+$tango-plum_2: #75507b;
+$tango-plum_3: #5c3566;
+
+//  CHOCOLATE  //
+
+$tango-chocolate_1: #e9b96e;
+$tango-chocolate_2: #c17d11;
+$tango-chocolate_3: #8f5902;
+
+//  SCARLET RED  //
+
+$tango-scarlet_red_1: #ef2929;
+$tango-scarlet_red_2: #cc0000;
+$tango-scarlet_red_3: #a40000;
+
+//  ALUMINIUM  //
+
+$tango-aluminium_1: #eeeeec;
+$tango-aluminium_2: #d3d7cf;
+$tango-aluminium_3: #babdb6;
+$tango-aluminium_4: #888a85;
+$tango-aluminium_5: #555753;
+$tango-aluminium_6: #2e3436;
+
+///////////////////////////////////////////////////////////////////////
+
+/*  SOLARIZED  */
+/*  by: Ethan Schoonover  */
+
+/*
+  Precision colors for machines and people. Solarized is a sixteen color palette (eight monotones, eight accent colors) designed for use with terminal and gui applications.
+*/
+
+$solarized-base03:  #002b36;
+$solarized-base02:  #073642;
+$solarized-base01:  #586e75;
+$solarized-base00:  #657b83;
+$solarized-base0:   #839496;
+$solarized-base1:   #93a1a1;
+$solarized-base2:   #eee8d5;
+$solarized-base3:   #fdf6e3;
+$solarized-yellow:  #b58900;
+$solarized-orange:  #cb4b16;
+$solarized-red:     #dc322f;
+$solarized-magenta: #d33682;
+$solarized-violet:  #6c71c4;
+$solarized-blue:    #268bd2;
+$solarized-cyan:    #2aa198;
+$solarized-green:   #859900;
+
+///////////////////////////////////////////////////////////////////////
+
+/*  PRINT + PASTELS  */
+/*  by: Kibigo!      */
+
+/*
+  This theme combines offwhite greys with bright pastels for a faded
+  yet distinctive look.
+*/
+
+//  PRINT  //
+
+$print-white:   #faf8f7;
+$print-bright:  #dedbd9;
+$print-light:   #b8b3b0;
+$print-regular: #948d87;
+$print-medium:  #75706a;
+$print-dark:    #57534c;
+$print-dim:     #302f2b;
+$print-black:   #1f1a14;
+
+//  PASTELS  //
+
+$pastel-red:    #b01c1c;
+$pastel-orange: #d15919;
+$pastel-gold:   #eb9100;
+$pastel-yellow: #fae13e;
+$pastel-green:  #50d952;
+$pastel-cyan:   #1aaceb;
+$pastel-blue:   #4b2df7;
+$pastel-pink:   #f56e97;
+
+///////////////////////////////////////////////////////////////////////
+
+/*  RAINBOW.TXT  */
+/*  by: Kibigo!  */
+
+/*
+  This theme contains eight colours and eight greys. Each colour comes
+  in standard, light, and dark variants.
+*/
+
+//  RED  //
+
+$rainbow-red:       #e83f2c;
+$rainbow-red_light: #f9a59b;
+$rainbow-red_dark:  #5d2721;
+
+//  YELLOW  //
+
+$rainbow-yellow:       #f6d037;
+$rainbow-yellow_light: #fcf0be;
+$rainbow-yellow_dark:  #4f420d;
+
+//  GREEN  //
+
+$rainbow-green:       #6ad622;
+$rainbow-green_light: #d5fcbb;
+$rainbow-green_dark:  #1f4505;
+
+//  CYAN  //
+
+$rainbow-cyan:       #31b9db;
+$rainbow-cyan_light: #bfe7f2;
+$rainbow-cyan_dark:  #00495c;
+
+//  BLUE  //
+
+$rainbow-blue:       #7476fc;
+$rainbow-blue_light: #d0d1f6;
+$rainbow-blue_dark:  #383966;
+
+//  PURPLE  //
+
+$rainbow-purple:       #c258f2;
+$rainbow-purple_light: #eabdff;
+$rainbow-purple_dark:  #4c3159;
+
+//  MAGENTA  //
+
+$rainbow-magenta:       #e63ca4;
+$rainbow-magenta_light: #f0b2d8;
+$rainbow-magenta_dark:  #592846;
+
+//  GREY  //
+
+$rainbow-grey_white:  #f5f5f5;
+$rainbow-grey_bright: #cccccc;
+$rainbow-grey_light:  #a3a3a3;
+$rainbow-grey:        #828282;
+$rainbow-grey_medium: #636363;
+$rainbow-grey_dark:   #3b3b3b;
+$rainbow-grey_dim:    #1c1c1c;
+$rainbow-grey_black:  #0c0c0c;
+
+///////////////////////////////////////////////////////////////////////
+
+/*  MOTHER MINT                  */
+/*  from the Mother video games  */
+
+/*
+  This palette contains a mint theme inspired by the Mother series of
+  video games.
+*/
+
+$mother-mint00: #000000; // black
+$mother-mint01: #50f0b0; // light
+$mother-mint02: #30c088; // medium
+$mother-mint03: #209868; // dark
+$mother-mint04: #106078; // blue
+$mother-mint05: #78f8d0; // bright
+$mother-mint06: #f8f0e8; // white
+
+///////////////////////////////////////////////////////////////////////
+
+/*  MASTODON     */
+/*  by: Gargron  */
+
+/*
+  This theme contains the original eight-colour palette used by
+  https://mastodon.social. Use it to obtain that old-school Mastodon
+  vibe.
+*/
+
+$mastodon-color1: #282c37; // darkest
+$mastodon-color2: #d9e1e8; // lightest
+$mastodon-color3: #9baec8; // lighter
+$mastodon-color4: #2b90d9; // vibrant
+$mastodon-color5: #ffffff; // white
+$mastodon-color6: #df405a; // error red
+$mastodon-color7: #79bd9a; // succ green
+$mastodon-color8: #000000; // black


### PR DESCRIPTION
This doesn't change *anything* about the site, but it does add some handy colour palettes (Tango, Solarized, etc) in `variables/palettes.scss` to make customizing your instance as easy as substituting one variable name for another.