### PR TITLE
#467 – Making the back button a little smarter

### DIFF
--- a/app/assets/javascripts/components/components/column_back_button.jsx
+++ b/app/assets/javascripts/components/components/column_back_button.jsx
@@ -15,7 +15,8 @@ const ColumnBackButton = React.createClass({
   mixins: [PureRenderMixin],
 
   handleClick () {
-    this.context.router.goBack();
+    if (window.history && window.history.length == 1) this.context.router.push("/");
+    else this.context.router.goBack();
   },
 
   render () {


### PR DESCRIPTION
If the length of `window.history` is `1` then there isn't anywhere to `goBack()` to, and the back button just takes you to `/`.