### PR TITLE
gnusocial.me doesn't use Mastodon anymore

### DIFF
--- a/docs/Using-Mastodon/List-of-Mastodon-instances.md
+++ b/docs/Using-Mastodon/List-of-Mastodon-instances.md
@@ -11,7 +11,6 @@ List of Known Mastodon instances
 | [epiktistes.com](https://epiktistes.com) |N/A|Yes|
 | [on.vu](https://on.vu) | Appears defunct|No|
 | [gay.crime.team](https://gay.crime.team) |N/A|Yes(?)|
-| [gnusocial.me](https://gnusocial.me) |Yes, it's a mastodon instance now|Yes|
 | [icosahedron.website](https://icosahedron.website/) |Icosahedron-themed (well, visually), open registration.|Yes|
 | [memetastic.space](https://memetastic.space) |Memes|Yes|
 | [social.diskseven.com](https://social.diskseven.com) |Single user|No|


### PR DESCRIPTION
The host uses postActiv now.