### PR TITLE
:wrench: S3 protocol  from ENV

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -39,6 +39,8 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
 # S3_REGION=
+# S3_PROTOCOL=http
+# S3_HOSTNAME=192.168.1.123:9000
 
 # Optional alias for S3 if you want to use Cloudfront or Cloudflare in front
 # S3_CLOUDFRONT_HOST=

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -11,7 +11,7 @@ if ENV['S3_ENABLED'] == 'true'
   Aws.eager_autoload!(services: %w(S3))
 
   Paperclip::Attachment.default_options[:storage]        = :s3
-  Paperclip::Attachment.default_options[:s3_protocol]    = 'https'
+  Paperclip::Attachment.default_options[:s3_protocol]    = ENV.fetch('S3_PROTOCOL') { 'https' }
   Paperclip::Attachment.default_options[:url]            = ':s3_domain_url'
   Paperclip::Attachment.default_options[:s3_host_name]   = ENV.fetch('S3_HOSTNAME') { "s3-#{ENV.fetch('S3_REGION')}.amazonaws.com" }
   Paperclip::Attachment.default_options[:path]           = '/:class/:attachment/:id_partition/:style/:filename'


### PR DESCRIPTION
Add support for reading S3 protocol from ENV
Also add S3_HOSTNAME in .env.production.sample
I used [minio](https://minio.io/) in my test environment(without `https`) and part of production. So I add no-ssl environment support for this great software.