### PR TITLE
Mastodon is not an alternative, it is a solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Mastodon
 [travis]: https://travis-ci.org/tootsuite/mastodon
 [code_climate]: https://codeclimate.com/github/tootsuite/mastodon
 
-Mastodon is a free, open-source social network server. A decentralized alternative to commercial platforms, it avoids the risks of a single company monopolizing your communication. Anyone can run Mastodon and participate in the social network seamlessly.
+Mastodon is a free, open-source social network server. A decentralized solution to commercial platforms, it avoids the risks of a single company monopolizing your communication. Anyone can run Mastodon and participate in the social network seamlessly.
 
 An alternative implementation of the GNU social project. Based on ActivityStreams, Webfinger, PubsubHubbub and Salmon.
 


### PR DESCRIPTION
This month I traveled to Cambridge, Massachusetts with my friends and attended LibrePlanet 2017. At the talk *Technology for direct actions*, Andrew Seeder pointed out that we often call free software an "alternative" to what exists. But an alternative is something that is mostly similar, and differentiated by preference rather than need. For instance, a trackball is an alternative to a mouse, but a jail is not an alternative to a bedroom. Andrew suggested that we start looking at free software as "solutions" rather than alternatives. So I propose boldly proclaiming that Mastodon is not an alternative to Twitter, but rather a solution to it.