### PR TITLE
Add IPv6 column in list and remove dead instance

### DIFF
--- a/docs/Using-Mastodon/List-of-Mastodon-instances.md
+++ b/docs/Using-Mastodon/List-of-Mastodon-instances.md
@@ -1,21 +1,20 @@
 List of Known Mastodon instances
 ==========================
 
-| Name | Theme/Notes, if applicable | Open Registrations |
-| -------------|-------------|---|
-| [mastodon.social](https://mastodon.social) |Flagship, quick updates|Yes|
-| [awoo.space](https://awoo.space) |Intentionally moderated, only federates with mastodon.social|Yes|
-| [social.tchncs.de](https://social.tchncs.de)|N/A|Yes|
-| [animalliberation.social](https://animalliberation.social) |Animal Rights|Yes|
-| [socially.constructed.space](https://socially.constructed.space) |Single user|No|
-| [epiktistes.com](https://epiktistes.com) |N/A|Yes|
-| [on.vu](https://on.vu) | Appears defunct|No|
-| [gay.crime.team](https://gay.crime.team) |N/A|Yes(?)|
-| [icosahedron.website](https://icosahedron.website/) |Icosahedron-themed (well, visually), open registration.|Yes|
-| [memetastic.space](https://memetastic.space) |Memes|Yes|
-| [social.diskseven.com](https://social.diskseven.com) |Single user|No|
-| [social.gestaltzerfall.net](https://social.gestaltzerfall.net) |Single user|No|
-| [mastodon.xyz](https://mastodon.xyz) |N/A|Yes|
-| [social.targaryen.house](https://social.targaryen.house) |N/A|Yes|
+| Name | Theme/Notes, if applicable | Open Registrations | IPv6 |
+| -------------|-------------|---|---|
+| [mastodon.social](https://mastodon.social) |Flagship, quick updates|Yes|No|
+| [awoo.space](https://awoo.space) |Intentionally moderated, only federates with mastodon.social|Yes|No|
+| [social.tchncs.de](https://social.tchncs.de)|N/A|Yes|No|
+| [animalliberation.social](https://animalliberation.social) |Animal Rights|Yes|No|
+| [socially.constructed.space](https://socially.constructed.space) |Single user|No|No|
+| [epiktistes.com](https://epiktistes.com) |N/A|Yes|No|
+| [gay.crime.team](https://gay.crime.team) |N/A|Yes(?)|No|
+| [icosahedron.website](https://icosahedron.website/) |Icosahedron-themed (well, visually), open registration.|Yes|No|
+| [memetastic.space](https://memetastic.space) |Memes|Yes|No|
+| [social.diskseven.com](https://social.diskseven.com) |Single user|No|No (DNS entry but no response)|
+| [social.gestaltzerfall.net](https://social.gestaltzerfall.net) |Single user|No|No|
+| [mastodon.xyz](https://mastodon.xyz) |N/A|Yes|Yes|
+| [social.targaryen.house](https://social.targaryen.house) |N/A|Yes|No|
 
 Let me know if you start running one so I can add it to the list! (Alternatively, add it yourself as a pull request).


### PR DESCRIPTION
This is done after some complaints I saw on Twitter about the lack of IPv6 support on Mastodon instances.
Also, seeing this may encourage instances owner to add IPv6 support to their own.