### PR TITLE
Fix word-break in account profiles

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -424,7 +424,7 @@ a.status__content__spoiler-link {
 
 .account__header__content {
   word-wrap: break-word;
-  word-break: break-all;
+  word-break: normal;
   font-weight: 400;
   overflow: hidden;
   color: $color3;


### PR DESCRIPTION
word-break:break-all is a surefire way to break things. It should be set
to normal.
This merge just set it back to what it should be.
Tested on Firefox 52.0.2 and Chrome 56.0.2924.87 with no detected
errors.