### PR TITLE
Fix the position of the Mastodon mascot in the UI

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1149,10 +1149,9 @@ a.status__content__spoiler-link {
 
 .getting-started {
   box-sizing: border-box;
-  overflow-y: auto;
   padding-bottom: 235px;
   background: image-url('mastodon-getting-started.png') no-repeat 0 100% local;
-  height: 100%;
+  flex: 1 0 auto;
 
   p {
     color: $color2;


### PR DESCRIPTION
The Mastodon mascot was previously anchored to the bottom, and that was since broken. This restores that behaviour!

It also fixes the double-scrollbar behaviour that was caused by this area allowing overflow-y in addition to its parent doing so.

**Before:**
<img width="343" alt="screen shot 2017-04-03 at 1 17 25 pm" src="https://cloud.githubusercontent.com/assets/282113/24594377/f2a8efa4-186f-11e7-9f7f-b93d5ea09127.png">

**After:**
<img width="342" alt="screen shot 2017-04-03 at 1 17 36 pm" src="https://cloud.githubusercontent.com/assets/282113/24594378/f2e66780-186f-11e7-84f8-1429d5c28c1a.png">
