### PR TITLE
Changed "reblogs" to "boosts"

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -33,7 +33,7 @@ en:
         follow: Send e-mail when someone follows you
         follow_request: Send e-mail when someone requests to follow you
         mention: Send e-mail when someone mentions you
-        reblog: Send e-mail when someone reblogs your status
+        reblog: Send e-mail when someone boosts your status
     'no': 'No'
     required:
       mark: "*"


### PR DESCRIPTION
As per [issue #783](https://github.com/tootsuite/mastodon/issues/783).