### PR TITLE
Hide scrollbars in Edge instead of showing white ones

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -96,6 +96,13 @@ table {
   background: transparent;
 }
 
+* {
+  -ms-overflow-style: none;
+}
+#if-supports::webkit-scrollbar, * {
+  -ms-overflow-style: unset;
+}
+
 body {
   font-family: 'Roboto', sans-serif;
   background: $color1 image-url('background-photo.jpeg');


### PR DESCRIPTION
Hey there,

I am a Microsoft Edge user but the use of light scrollbars on dark content is somewhat bothering me. 

I wanted to discuss the possibility to accomodate the experience in Edge by using -ms-overflow-style, at least as long as Edge does not add support for the non-standards ::-webkit-scrollbar your app is currently using.

Hiding scrollbars (while retaining both scrolling and accessibility access to scrolling) seems fine to me in this case, for the following reasons:

- Scrollbars in the app aren't really useful since most lists are infinite anyway. 
- Even if you don't have touch or mouse wheel, you can use the keyboard accessiblity to scroll (click in the scrollable list, then use up/down or page up/down). 
- Using the provided scrollbar doesn't work if you scroll down too much because the scroll speed keeps getting faster. As a result it is only used as a positional indicator but this is not critical information either.

Opinions?
