### PR TITLE
We don't need the entire tag model for just the name

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -54,9 +54,9 @@ class FanOutOnWriteService < BaseService
 
     payload = FeedManager.instance.inline_render(nil, 'api/v1/statuses/show', status)
 
-    status.tags.find_each do |tag|
-      FeedManager.instance.broadcast("hashtag:#{tag.name}", event: 'update', payload: payload)
-      FeedManager.instance.broadcast("hashtag:#{tag.name}:local", event: 'update', payload: payload) if status.account.local?
+    status.tags.pluck(:name) do |name|
+      FeedManager.instance.broadcast("hashtag:#{name}", event: 'update', payload: payload)
+      FeedManager.instance.broadcast("hashtag:#{name}:local", event: 'update', payload: payload) if status.account.local?
     end
   end
 


### PR DESCRIPTION
Reduce memory overhead.