### PR TITLE
ECDH only

### DIFF
--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -23,7 +23,8 @@ server {
   server_name example.com;
 
   ssl_protocols TLSv1.2;
-  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+  ssl_ciphers EECDH+AESGCM:EECDH+AES;
+  ssl_ecdh_curve secp384r1;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
 


### PR DESCRIPTION
Disable DHE ciphers. We don't loose any compatibility as we already use TLS 1.2, and ECDH is faster and safer.
Also, it's better so specify the curve.

This is the conf I use here : https://tls.imirhil.fr/https/mstdn.io