### PR TITLE
Add git and curl as dependencies

### DIFF
--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -88,8 +88,9 @@ It is recommended to create a special user for mastodon on the server (you could
 
 ## General dependencies
 
+    sudo apt-get install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev nodejs file git curl
     curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
-    sudo apt-get install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev nodejs file
+    apt-get intall nodejs
     sudo npm install -g yarn
 
 ## Redis


### PR DESCRIPTION
In some VPS templates, they are not installed by default.