### PR TITLE
Add Scalingo deployment support

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/Scalingo/ruby-buildpack
+https://github.com/Scalingo/nodejs-buildpack

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/Scalingo/ruby-buildpack
 https://github.com/Scalingo/nodejs-buildpack
+https://github.com/Scalingo/ruby-buildpack

--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,2 @@
+node_modules/
+.cache/

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Docker is great for quickly trying out software, but it has its drawbacks too. I
 
 [![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/tootsuite/mastodon#master)
 
+[You can view a guide for deployment on Scalingo here.](docs/Running-Mastodon/Scalingo-guide.md)
+
 ## Deployment on Heroku (experimental)
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Docker is great for quickly trying out software, but it has its drawbacks too. I
 
 ## Deployment on Scalingo
 
-[![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/johnsudaar/mastodon#master)
+[![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/tootsuite/mastodon#master)
 
 ## Deployment on Heroku (experimental)
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Which will re-create the updated containers, leaving databases and data as is. D
 
 Docker is great for quickly trying out software, but it has its drawbacks too. If you prefer to run Mastodon without using Docker, refer to the [production guide](docs/Running-Mastodon/Production-guide.md) for examples, configuration and instructions.
 
+## Deployment on Scalingo
+
+[![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/johnsudaar/mastodon#master)
+
 ## Deployment on Heroku (experimental)
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)

--- a/docs/Running-Mastodon/Scalingo-guide.md
+++ b/docs/Running-Mastodon/Scalingo-guide.md
@@ -1,0 +1,13 @@
+Scalingo guide
+==============
+
+[![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/tootsuite/mastodon#master)
+
+1. Click the above button.
+2. Fill in the options requested.
+  * You can use a .scalingo.io domain, which will be simple to set up, or you can use a custom domain.
+  * You will want Amazon S3 for file storage. The only exception is for development purposes, where you may not care if files are not saved. Follow a guide online for creating a free Amazon S3 bucket and Access Key, then enter the details.
+  * If you want your Mastodon to be able to send emails, configure SMTP settings here (or later). Consider using [Mailgun](https://mailgun.com) or similar, who offer free plans that should suit your interests.
+3. Deploy! The app should be set up, with a working web interface and database. You can change settings and manage versions from the Heroku dashboard.
+
+You may need to use the `scalingo` CLI application to run `USERNAME=yourUsername rails mastodon:make_admin` to make yourself an admin.

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,87 @@
+{
+  "name": "Mastodon",
+  "description": "A GNU Social-compatible microblogging server",
+  "repository": "https://github.com/johnsudaar/mastodon",
+  "logo": "https://github.com/tootsuite/mastodon/raw/master/app/assets/images/logo.png",
+  "env": {
+    "LOCAL_DOMAIN": {
+      "description": "The domain that your Mastodon instance will run on (this can be appname.scalingo.io or a custom domain)",
+      "required": true
+    },
+    "LOCAL_HTTPS": {
+      "description": "Will your domain support HTTPS? (Automatic for *.scalingo.io, requires manual configuration for custom domains)",
+      "value": "true",
+      "required": true
+    },
+    "PAPERCLIP_SECRET": {
+      "description": "The secret key for storing media files",
+      "generator": "secret"
+    },
+    "SECRET_KEY_BASE": {
+      "description": "The secret key base",
+      "generator": "secret"
+    },
+    "SINGLE_USER_MODE": {
+      "description": "Should the instance run in single user mode? (Disable registrations, redirect to front page)",
+      "value": "false",
+      "required": true
+    },
+    "S3_ENABLED": {
+      "description": "Should Mastodon use Amazon S3 for storage? This is highly recommended, as Scalingo does not have persistent file storage (files will be lost).",
+      "value": "true",
+      "required": false
+    },
+    "S3_BUCKET": {
+      "description": "Amazon S3 Bucket",
+      "required": false
+    },
+    "S3_REGION": {
+      "description": "Amazon S3 region that the bucket is located in",
+      "required": false
+    },
+    "AWS_ACCESS_KEY_ID": {
+      "description": "Amazon S3 Access Key",
+      "required": false
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+      "description": "Amazon S3 Secret Key",
+      "required": false
+    },
+    "SMTP_SERVER": {
+      "description": "Hostname for SMTP server, if you want to enable email",
+      "required": false
+    },
+    "SMTP_PORT": {
+      "description": "Port for SMTP server",
+      "required": false
+    },
+    "SMTP_LOGIN": {
+      "description": "Username for SMTP server",
+      "required": false
+    },
+    "SMTP_PASSWORD": {
+      "description": "Password for SMTP server",
+      "required": false
+    },
+    "SMTP_DOMAIN": {
+      "description": "Domain for SMTP server. Will default to instance domain if blank.",
+      "required": false
+    },
+    "SMTP_FROM_ADDRESS": {
+      "description": "Address to send emails from",
+      "required": false
+    },
+    "BUILDPACK_URL": {
+      "description": "Internal scalingo configuration",
+      "required": true,
+      "value": "https://github.com/Scalingo/multi-buildpack.git"
+    }
+  },
+  "scripts": {
+    "postdeploy": "bundle exec rails db:migrate && bundle exec rails db:seed"
+  },
+  "addons": [
+    "scalingo-postgresql",
+    "scalingo-redis"
+  ]
+}


### PR DESCRIPTION
This patch should add everything needed for (relatively) simple deployment to Scalingo.
Scalingo is a cool european PaaS provider.

Changes:

Add a Scalingo one click button to README.
Add an scalingo.json file (used by scalingo to determine the app environment to create).
Add .buildpacks file (used by scalingo to determine which buildpacks should be use).
Add .slugignore file (used by paas providers to prevent build dependencies to be pushed to prod).