### PR TITLE
Add CHACHA, revert ECDH curve

### DIFF
--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -23,8 +23,7 @@ server {
   server_name example.com;
 
   ssl_protocols TLSv1.2;
-  ssl_ciphers EECDH+AESGCM:EECDH+AES;
-  ssl_ecdh_curve secp384r1;
+  ssl_ciphers EECDH+AES:EECDH+CHACHA20;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
 


### PR DESCRIPTION
After discussing with aeris : https://mstdn.io/@angristan/11291, I'd like to make these changes.

So using secp384r1 can block some users to access Mastodon if their OS does not support this curve. 
It happens on Tusky with Android 7.0.

Not specifying the ECDH curve means that it will use the one the client prefers (`secp256r1` in most cases).

Also, `EECDH+AES` is the same as `EECDH+AESGCM:EECDH+AES`.
I added CHACHA, a nice cipher that is present in most recent version of OpenSSL. If it's not the case, AES will be used anyway.