### PR TITLE
Fix wrong url in scalingo.json

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -1,7 +1,7 @@
 {
   "name": "Mastodon",
   "description": "A GNU Social-compatible microblogging server",
-  "repository": "https://github.com/johnsudaar/mastodon",
+  "repository": "https://github.com/tootsuite/mastodon",
   "logo": "https://github.com/tootsuite/mastodon/raw/master/app/assets/images/logo.png",
   "env": {
     "LOCAL_DOMAIN": {


### PR DESCRIPTION
The url on the scalingo.json is still pointing on johnsudaar/mastodon instead of tootsuite/mastodon