### PR TITLE
Catch more errors in process_follows so it doesn't fail

### DIFF
--- a/app/workers/import_worker.rb
+++ b/app/workers/import_worker.rb
@@ -46,7 +46,7 @@ class ImportWorker
 
       begin
         FollowService.new.call(from_account, row[0])
-      rescue Goldfinger::Error, HTTP::Error, OpenSSL::SSL::SSLError
+      rescue Mastodon::NotPermittedError, ActiveRecord::RecordNotFound, Goldfinger::Error, HTTP::Error, OpenSSL::SSL::SSLError
         next
       end
     end


### PR DESCRIPTION
FollowService throws these two errors if something about the requested account is bad (for example, it's your account) and because they're not catched the import process aborts halfway through