### PR TITLE
Updates slugignore

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,2 +1,5 @@
 node_modules/
 .cache/
+docs/
+spec/
+storybook/


### PR DESCRIPTION
Based on my work for #1007, I'm trying to reduce the slug size on Heroku. [Their docs](https://devcenter.heroku.com/articles/slug-compiler) suggest removing unused files and assets from the slug, such as unit tests and documentation. Let me know if this is appropriate (I don't _think_ the storybook is used in production, so correct me if I'm wrong).