### PR TITLE
Force UTF8 encoding on generated XML

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq -q default -q mailers -q push
+worker: bundle exec sidekiq -q default -q push -q pull -q mailers

--- a/app/lib/atom_serializer.rb
+++ b/app/lib/atom_serializer.rb
@@ -7,7 +7,7 @@ class AtomSerializer
     def render(element)
       document = Ox::Document.new(version: '1.0')
       document << element
-      "<?xml version=\"1.0\"?>#{Ox.dump(element)}"
+      ('<?xml version="1.0"?>' + Ox.dump(element)).force_encoding('UTF-8')
     end
   end
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,8 +11,10 @@
     %meta{:name => "theme-color", :content => "#282c37"}/
     %meta{:name => "apple-mobile-web-app-capable", :content => "yes"}/
 
-    %title
-      = "#{yield(:page_title)} - " if content_for?(:page_title)
+    %title<
+      - if content_for?(:page_title)
+        = yield(:page_title)
+        = ' - '
       = Setting.site_title
 
     = stylesheet_link_tag 'application', media: 'all'

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ preload_app!
 
 on_worker_boot do
   if ENV['HEROKU'] # Spawn the workers from Puma, to only use one dyno
-    @sidekiq_pid ||= spawn('bundle exec sidekiq -q default -q mailers -q push')
+    @sidekiq_pid ||= spawn('bundle exec sidekiq -q default -q push -q pull -q mailers ')
   end
 
   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)


### PR DESCRIPTION
#1124 has introduced an exception (#1136) that wasn't caught during development and unit testing because testing and development environments use inline Sidekiq instead of enqueue-into-redis-properly Sidekiq.

This marks the generated XML as UTF8 which allows Sidekiq to JSON-encode it properly for the queue