### PR TITLE
Fix npm/yarn cache cleaning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN BUILD_DEPS=" \
  && npm install -g npm@3 && npm install -g yarn \
  && bundle install --deployment --without test development \
  && yarn \
- && npm cache clean \
+ && yarn cache clean \
+ && npm -g cache clean \
  && apk del $BUILD_DEPS \
  && rm -rf /tmp/* /var/cache/apk/*
 


### PR DESCRIPTION
Hello,

Here's a PR for the Dockerfile, to clean the right NPM/Yarn caches and not the wrong one.
This makes the related layer shrink from 932MB to 582MB.