### PR TITLE
Install Yarn dependencies during setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,6 +17,7 @@ chdir APP_ROOT do
   puts '== Installing dependencies =='
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
+  system!('yarn install')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')


### PR DESCRIPTION
Previously the `bin/setup` script only installed the Ruby dependencies
via Bundler. This is not sufficient to get the test suite to pass. We
also need the JavaScript dependencies.

This commit installs the JavaScript dependencies as part of the
`bin/setup` script via Yarn.

This allows for a successful

    bin/setup && bundle exec rake

on a fresh clone of the repo.