### PR TITLE
Add specs for PostStatusService

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -37,11 +37,11 @@ class PostStatusService < BaseService
   def validate_media!(media_ids)
     return if media_ids.nil? || !media_ids.is_a?(Enumerable)
 
-    raise Mastodon::ValidationError, 'Cannot attach more than 4 files' if media_ids.size > 4
+    raise Mastodon::ValidationError, I18n.t('media_attachments.validations.too_many') if media_ids.size > 4
 
     media = MediaAttachment.where(status_id: nil).where(id: media_ids.take(4).map(&:to_i))
 
-    raise Mastodon::ValidationError, 'Cannot attach a video to a toot that already contains images' if media.size > 1 && media.find(&:video?)
+    raise Mastodon::ValidationError, I18n.t('media_attachments.validations.images_and_video') if media.size > 1 && media.find(&:video?)
 
     media
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,3 +163,7 @@ en:
     invalid_otp_token: Invalid two-factor code
   will_paginate:
     page_gap: "&hellip;"
+  media_attachments:
+    validations:
+      too_many: Cannot attach more than 4 files
+      images_and_video: Cannot attach a video to a status that already contains images

--- a/spec/fabricators/media_attachment_fabricator.rb
+++ b/spec/fabricators/media_attachment_fabricator.rb
@@ -1,3 +1,3 @@
 Fabricator(:media_attachment) do
-
+  account
 end

--- a/spec/fabricators/status_fabricator.rb
+++ b/spec/fabricators/status_fabricator.rb
@@ -1,3 +1,4 @@
 Fabricator(:status) do
+  account
   text "Lorem ipsum dolor sit amet"
 end

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe PostStatusService do
       )
     end.to raise_error(
       Mastodon::ValidationError,
-      'Cannot attach more than 4 files',
+      I18n.t('media_attachments.validations.too_many'),
     )
   end
 
@@ -160,7 +160,7 @@ RSpec.describe PostStatusService do
       )
     end.to raise_error(
       Mastodon::ValidationError,
-      'Cannot attach a video to a toot that already contains images',
+      I18n.t('media_attachments.validations.images_and_video'),
     )
   end
 

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -3,27 +3,142 @@ require 'rails_helper'
 RSpec.describe PostStatusService do
   subject { PostStatusService.new }
 
-  it 'creates a new status'
-  it 'creates a new response status'
-  it 'processes mentions'
-  it 'pings PuSH hubs'
+  it 'creates a new status' do
+    account = Fabricate(:account)
+    text = "test status update"
+
+    status = subject.call(account, text)
+
+    expect(status).to be_persisted
+    expect(status.text).to eq text
+  end
+
+  it 'creates a new response status' do
+    in_reply_to_status = Fabricate(:status)
+    account = Fabricate(:account)
+    text = "test status update"
+
+    status = subject.call(account, text, in_reply_to_status)
+
+    expect(status).to be_persisted
+    expect(status.text).to eq text
+    expect(status.thread).to eq in_reply_to_status
+  end
+
+  it 'creates a sensitive status' do
+    status = create_status_with_options(sensitive: true)
+
+    expect(status).to be_persisted
+    expect(status).to be_sensitive
+  end
+
+  it 'creates a status with spoiler text' do
+    spoiler_text = "spoiler text"
+
+    status = create_status_with_options(spoiler_text: spoiler_text)
+
+    expect(status).to be_persisted
+    expect(status.spoiler_text).to eq spoiler_text
+  end
+
+  it 'creates a status with empty default spoiler text' do
+    status = create_status_with_options(spoiler_text: nil)
+
+    expect(status).to be_persisted
+    expect(status.spoiler_text).to eq ''
+  end
+
+  it 'creates a status with the given visibility' do
+    status = create_status_with_options(visibility: :private)
+
+    expect(status).to be_persisted
+    expect(status.visibility).to eq "private"
+  end
+
+  it 'creates a status for the given application' do
+    application = Fabricate(:application)
+
+    status = create_status_with_options(application: application)
+
+    expect(status).to be_persisted
+    expect(status.application).to eq application
+  end
+
+  it 'processes mentions' do
+    mention_service = double(:process_mentions_service)
+    allow(mention_service).to receive(:call)
+    allow(ProcessMentionsService).to receive(:new).and_return(mention_service)
+    account = Fabricate(:account)
+
+    status = subject.call(account, "test status update")
+
+    expect(ProcessMentionsService).to have_received(:new)
+    expect(mention_service).to have_received(:call).with(status)
+  end
+
+  it 'processes hashtags' do
+    hashtags_service = double(:process_hashtags_service)
+    allow(hashtags_service).to receive(:call)
+    allow(ProcessHashtagsService).to receive(:new).and_return(hashtags_service)
+    account = Fabricate(:account)
+
+    status = subject.call(account, "test status update")
+
+    expect(ProcessHashtagsService).to have_received(:new)
+    expect(hashtags_service).to have_received(:call).with(status)
+  end
+
+  it 'pings PuSH hubs' do
+    allow(DistributionWorker).to receive(:perform_async)
+    allow(Pubsubhubbub::DistributionWorker).to receive(:perform_async)
+    account = Fabricate(:account)
+
+    status = subject.call(account, "test status update")
+
+    expect(DistributionWorker).to have_received(:perform_async).with(status.id)
+    expect(Pubsubhubbub::DistributionWorker).
+      to have_received(:perform_async).with(status.stream_entry.id)
+  end
+
+  it 'crawls links' do
+    allow(LinkCrawlWorker).to receive(:perform_async)
+    account = Fabricate(:account)
+
+    status = subject.call(account, "test status update")
+
+    expect(LinkCrawlWorker).to have_received(:perform_async).with(status.id)
+  end
+
+  it 'attaches the given media to the created status' do
+    account = Fabricate(:account)
+    media = Fabricate(:media_attachment)
+
+    status = subject.call(
+      account,
+      "test status update",
+      nil,
+      media_ids: [media.id],
+    )
+
+    expect(media.reload.status).to eq status
+  end
 
   it 'does not allow attaching more than 4 files' do
     account = Fabricate(:account)
 
     expect do
-      PostStatusService.new.call(
-      account,
-      "test status update",
-      nil,
-      media_ids: [
-        Fabricate(:media_attachment, account: account),
-        Fabricate(:media_attachment, account: account),
-        Fabricate(:media_attachment, account: account),
-        Fabricate(:media_attachment, account: account),
-        Fabricate(:media_attachment, account: account),
-      ].map(&:id),
-    )
+      subject.call(
+        account,
+        "test status update",
+        nil,
+        media_ids: [
+          Fabricate(:media_attachment, account: account),
+          Fabricate(:media_attachment, account: account),
+          Fabricate(:media_attachment, account: account),
+          Fabricate(:media_attachment, account: account),
+          Fabricate(:media_attachment, account: account),
+        ].map(&:id),
+      )
     end.to raise_error(
       Mastodon::ValidationError,
       'Cannot attach more than 4 files',
@@ -34,18 +149,22 @@ RSpec.describe PostStatusService do
     account = Fabricate(:account)
 
     expect do
-      PostStatusService.new.call(
-      account,
-      "test status update",
-      nil,
-      media_ids: [
-        Fabricate(:media_attachment, type: :video, account: account),
-        Fabricate(:media_attachment, type: :image, account: account),
-      ].map(&:id),
-    )
+      subject.call(
+        account,
+        "test status update",
+        nil,
+        media_ids: [
+          Fabricate(:media_attachment, type: :video, account: account),
+          Fabricate(:media_attachment, type: :image, account: account),
+        ].map(&:id),
+      )
     end.to raise_error(
       Mastodon::ValidationError,
       'Cannot attach a video to a toot that already contains images',
     )
+  end
+
+  def create_status_with_options(options = {})
+    subject.call(Fabricate(:account), "test", nil, options)
   end
 end

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -7,4 +7,45 @@ RSpec.describe PostStatusService do
   it 'creates a new response status'
   it 'processes mentions'
   it 'pings PuSH hubs'
+
+  it 'does not allow attaching more than 4 files' do
+    account = Fabricate(:account)
+
+    expect do
+      PostStatusService.new.call(
+      account,
+      "test status update",
+      nil,
+      media_ids: [
+        Fabricate(:media_attachment, account: account),
+        Fabricate(:media_attachment, account: account),
+        Fabricate(:media_attachment, account: account),
+        Fabricate(:media_attachment, account: account),
+        Fabricate(:media_attachment, account: account),
+      ].map(&:id),
+    )
+    end.to raise_error(
+      Mastodon::ValidationError,
+      'Cannot attach more than 4 files',
+    )
+  end
+
+  it 'does not allow attaching both videos and images' do
+    account = Fabricate(:account)
+
+    expect do
+      PostStatusService.new.call(
+      account,
+      "test status update",
+      nil,
+      media_ids: [
+        Fabricate(:media_attachment, type: :video, account: account),
+        Fabricate(:media_attachment, type: :image, account: account),
+      ].map(&:id),
+    )
+    end.to raise_error(
+      Mastodon::ValidationError,
+      'Cannot attach a video to a toot that already contains images',
+    )
+  end
 end


### PR DESCRIPTION
This implements all pending specs for `PostStatusService`, and adds additional coverage for the
following functionality:

* Normal status creation
* Creating a reply status
* Creating a sensitive status
* Creating a status with spoiler text
* A status with no spoiler text gets an empty string for spoiler text
* Creating a status with custom visibility
* Creating a status for an application
* Processing mentions
* Processing Hashtags
* Pinging PuSH hubs
* Crawling links
* Attaching media

Additionally, the user-facing error text for the media validation errors was extracted to a localized string, to allow them to be localized.