### PR TITLE
change suggested cipher for nginx

### DIFF
--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -24,7 +24,7 @@ server {
 
   ssl_protocols TLSv1.2;
   ssl_ciphers EECDH+AESGCM:EECDH+AES;
-  ssl_ecdh_curve secp384r1;
+  ssl_ecdh_curve prime256v1;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
 


### PR DESCRIPTION
The current value of secp384r1 for ssl_ecdh_curve in the suggested nginx configuration causes problems for Android 7.0 devices connecting with an app. Changing the value to prime256v1 fixes the issue.

See section 4.2.1 https://datatracker.ietf.org/doc/rfc7525/?include_text=1