### PR TITLE
Use Setting.site_title value for `og:site_name` occurrences

### DIFF
--- a/app/helpers/site_title_helper.rb
+++ b/app/helpers/site_title_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SiteTitleHelper
+  def site_title
+    Setting.site_title.to_s
+  end
+end

--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -5,7 +5,7 @@
   = Rails.configuration.x.local_domain
 
 - content_for :header_tags do
-  %meta{ property: 'og:site_name', content: 'Mastodon' }/
+  %meta{ property: 'og:site_name', content: site_title }/
   %meta{ property: 'og:type', content: 'website' }/
   %meta{ property: 'og:title', content: Rails.configuration.x.local_domain }/
   %meta{ property: 'og:description', content: @description.blank? ? "Mastodon is a free, open-source social network server. A decentralized alternative to commercial platforms, it avoids the risks of a single company monopolizing your communication. Anyone can run Mastodon and participate in the social network seamlessly" : strip_tags(@description) }/

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -5,7 +5,7 @@
   %link{ rel: 'salmon', href: api_salmon_url(@account.id) }/
   %link{ rel: 'alternate', type: 'application/atom+xml', href: account_url(@account, format: 'atom') }/
 
-  %meta{ property: 'og:site_name', content: 'Mastodon' }/
+  %meta{ property: 'og:site_name', content: site_title }/
   %meta{ property: 'og:type', content: 'profile' }/
   %meta{ property: 'og:title', content: "#{@account.username} on #{Rails.configuration.x.local_domain}" }/
   %meta{ property: 'og:description', content: @account.note }/

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,7 +15,7 @@
       - if content_for?(:page_title)
         = yield(:page_title)
         = ' - '
-      = Setting.site_title
+      = site_title
 
     = stylesheet_link_tag 'application', media: 'all'
     = csrf_meta_tags

--- a/app/views/stream_entries/show.html.haml
+++ b/app/views/stream_entries/show.html.haml
@@ -2,7 +2,7 @@
   %link{ rel: 'alternate', type: 'application/atom+xml', href: account_stream_entry_url(@account, @stream_entry, format: 'atom') }/
   %link{ rel: 'alternate', type: 'application/json+oembed', href: api_oembed_url(url: account_stream_entry_url(@account, @stream_entry), format: 'json') }/
 
-  %meta{ property: 'og:site_name', content: 'Mastodon' }/
+  %meta{ property: 'og:site_name', content: site_title }/
   %meta{ property: 'og:type', content: 'article' }/
   %meta{ property: 'og:title', content: "#{@account.username} on #{Rails.configuration.x.local_domain}" }/
 

--- a/spec/helpers/site_title_helper_spec.rb
+++ b/spec/helpers/site_title_helper_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe "site_title" do
+  it "Uses the Setting.site_title value when it exists" do
+    Setting.site_title = "New site title"
+
+    expect(helper.site_title).to eq "New site title"
+  end
+
+  it "returns empty string when Setting.site_title is nil" do
+    Setting.site_title = nil
+
+    expect(helper.site_title).to eq ""
+  end
+end


### PR DESCRIPTION
If someone renames their instance and shares a URL into a place which respects the `og:site_name` value, this is nicer!