### PR TITLE
Block :tm:, :copyright: from emojification

### DIFF
--- a/app/assets/javascripts/components/emoji.jsx
+++ b/app/assets/javascripts/components/emoji.jsx
@@ -2,6 +2,8 @@ import emojione from 'emojione';
 
 const toImage = str => shortnameToImage(unicodeToImage(str));
 
+const blacklistedHex = {"00ae": true, "00a9": true, "2122": true};
+
 const unicodeToImage = str => {
   const mappedUnicode = emojione.mapUnicodeToShort();
 
@@ -13,6 +15,10 @@ const unicodeToImage = str => {
     const unicode  = emojione.jsEscapeMap[unicodeChar];
     const short    = mappedUnicode[unicode];
     const filename = emojione.emojioneList[short].fname;
+    // Blacklisted - these have better font support than images
+    if (blacklistedHex[filename])
+      return unicodeChar;
+    }
     const alt      = emojione.convert(unicode.toUpperCase());
 
     return `<img draggable="false" class="emojione" alt="${alt}" src="/emoji/${filename}.svg" />`;
@@ -26,6 +32,9 @@ const shortnameToImage = str => str.replace(emojione.regShortNames, shortname =>
 
   const unicode = emojione.emojioneList[shortname].unicode[emojione.emojioneList[shortname].unicode.length - 1];
   const alt     = emojione.convert(unicode.toUpperCase());
+  if (blacklistedHex[unicode]) {
+    return alt;
+  }
 
   return `<img draggable="false" class="emojione" alt="${alt}" src="/emoji/${unicode}.svg" />`;
 });

--- a/app/assets/javascripts/components/emoji.jsx
+++ b/app/assets/javascripts/components/emoji.jsx
@@ -17,7 +17,7 @@ const unicodeToImage = str => {
     const short    = mappedUnicode[unicode];
     const filename = emojione.emojioneList[short].fname;
     const alt      = emojione.convert(unicode.toUpperCase());
-    if (useTextList[filename])
+    if (useTextList[filename]) {
       return alt;
     }
 

--- a/app/assets/javascripts/components/emoji.jsx
+++ b/app/assets/javascripts/components/emoji.jsx
@@ -2,7 +2,8 @@ import emojione from 'emojione';
 
 const toImage = str => shortnameToImage(unicodeToImage(str));
 
-const blacklistedHex = {"00ae": true, "00a9": true, "2122": true};
+// Blocked from using iages - these look better as text than as images
+const useTextList = {"00ae": true, "00a9": true, "2122": true};
 
 const unicodeToImage = str => {
   const mappedUnicode = emojione.mapUnicodeToShort();
@@ -15,11 +16,10 @@ const unicodeToImage = str => {
     const unicode  = emojione.jsEscapeMap[unicodeChar];
     const short    = mappedUnicode[unicode];
     const filename = emojione.emojioneList[short].fname;
-    // Blacklisted - these have better font support than images
-    if (blacklistedHex[filename])
-      return unicodeChar;
-    }
     const alt      = emojione.convert(unicode.toUpperCase());
+    if (useTextList[filename])
+      return alt;
+    }
 
     return `<img draggable="false" class="emojione" alt="${alt}" src="/emoji/${filename}.svg" />`;
   });
@@ -32,7 +32,7 @@ const shortnameToImage = str => str.replace(emojione.regShortNames, shortname =>
 
   const unicode = emojione.emojioneList[shortname].unicode[emojione.emojioneList[shortname].unicode.length - 1];
   const alt     = emojione.convert(unicode.toUpperCase());
-  if (blacklistedHex[unicode]) {
+  if (useTextList[unicode]) {
     return alt;
   }
 


### PR DESCRIPTION
Forbid ™ ® © so they don't turn into black-on-black emoji.

I haven't figured out the docker-compose stuff yet so these changes haven't been tested yet. If someone else could make sure this runs that would be nice.