### PR TITLE
don't use a block when #fetching with a default value

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -17,9 +17,9 @@ class AboutController < ApplicationController
     @extended_description = Setting.site_extended_description
     @contact_account      = Account.find_local(Setting.site_contact_username)
     @contact_email        = Setting.site_contact_email
-    @user_count           = Rails.cache.fetch('user_count')            { User.count }
-    @status_count         = Rails.cache.fetch('local_status_count')    { Status.local.count }
-    @domain_count         = Rails.cache.fetch('distinct_domain_count') { Account.distinct.count(:domain) }
+    @user_count           = Rails.cache.fetch('user_count', User.count)
+    @status_count         = Rails.cache.fetch('local_status_count', Status.local.count)
+    @domain_count         = Rails.cache.fetch('distinct_domain_count', Account.distinct.count(:domain))
   end
 
   def terms; end

--- a/app/controllers/concerns/localized.rb
+++ b/app/controllers/concerns/localized.rb
@@ -26,6 +26,6 @@ module Localized
   end
 
   def default_locale
-    ENV.fetch('DEFAULT_LOCALE') { I18n.default_locale }
+    ENV.fetch('DEFAULT_LOCALE', I18n.default_locale)
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch('SMTP_FROM_ADDRESS') { 'notifications@localhost' }
+  default from: ENV.fetch('SMTP_FROM_ADDRESS', 'notifications@localhost')
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserMailer < Devise::Mailer
-  default from: ENV.fetch('SMTP_FROM_ADDRESS') { 'notifications@localhost' }
+  default from: ENV.fetch('SMTP_FROM_ADDRESS', 'notifications@localhost')
   layout 'mailer'
 
   def confirmation_instructions(user, token, _opts = {})

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,4 +82,4 @@ end
 require 'sidekiq/testing'
 Sidekiq::Testing.inline!
 
-ActiveRecordQueryTrace.enabled = ENV.fetch('QUERY_TRACE_ENABLED') { false }
+ActiveRecordQueryTrace.enabled = ENV.fetch('QUERY_TRACE_ENABLED', false)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,9 +59,9 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   config.cache_store = :redis_store, {
-    host: ENV.fetch('REDIS_HOST') { 'localhost' },
-    port: ENV.fetch('REDIS_PORT') { 6379 },
-    password: ENV.fetch('REDIS_PASSWORD') { false },
+    host: ENV.fetch('REDIS_HOST', 'localhost'),
+    port: ENV.fetch('REDIS_PORT', 6379),
+    password: ENV.fetch('REDIS_PASSWORD', false),
     db: 0,
     namespace: 'cache',
     expires_in: 20.minutes,

--- a/config/initializers/blacklists.rb
+++ b/config/initializers/blacklists.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
-  config.x.email_domains_blacklist = ENV.fetch('EMAIL_DOMAIN_BLACKLIST') { 'mvrht.com' }
-  config.x.email_domains_whitelist = ENV.fetch('EMAIL_DOMAIN_WHITELIST') { '' }  
+  config.x.email_domains_blacklist = ENV.fetch('EMAIL_DOMAIN_BLACKLIST', 'mvrht.com')
+  config.x.email_domains_whitelist = ENV.fetch('EMAIL_DOMAIN_WHITELIST', '')
 end

--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-instrumentation_hostname = ENV.fetch('INSTRUMENTATION_HOSTNAME') { 'localhost' }
+instrumentation_hostname = ENV.fetch('INSTRUMENTATION_HOSTNAME', 'localhost')
 
 ActiveSupport::Notifications.subscribe(/process_action.action_controller/) do |*args|
   event      = ActiveSupport::Notifications::Event.new(*args)

--- a/config/initializers/ostatus.rb
+++ b/config/initializers/ostatus.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-port  = ENV.fetch('PORT') { 3000 }
-host  = ENV.fetch('LOCAL_DOMAIN') { "localhost:#{port}" }
+port  = ENV.fetch('PORT', 3000)
+host  = ENV.fetch('LOCAL_DOMAIN', "localhost:#{port}")
 https = ENV['LOCAL_HTTPS'] == 'true'
 
 Rails.application.configure do

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -11,13 +11,13 @@ if ENV['S3_ENABLED'] == 'true'
   Aws.eager_autoload!(services: %w(S3))
 
   Paperclip::Attachment.default_options[:storage]        = :s3
-  Paperclip::Attachment.default_options[:s3_protocol]    = ENV.fetch('S3_PROTOCOL') { 'https' }
+  Paperclip::Attachment.default_options[:s3_protocol]    = ENV.fetch('S3_PROTOCOL', 'https')
   Paperclip::Attachment.default_options[:url]            = ':s3_domain_url'
-  Paperclip::Attachment.default_options[:s3_host_name]   = ENV.fetch('S3_HOSTNAME') { "s3-#{ENV.fetch('S3_REGION')}.amazonaws.com" }
+  Paperclip::Attachment.default_options[:s3_host_name]   = ENV.fetch('S3_HOSTNAME', "s3-#{ENV.fetch('S3_REGION')}.amazonaws.com")
   Paperclip::Attachment.default_options[:path]           = '/:class/:attachment/:id_partition/:style/:filename'
   Paperclip::Attachment.default_options[:s3_headers]     = { 'Cache-Control' => 'max-age=315576000', 'Expires' => 10.years.from_now.httpdate }
   Paperclip::Attachment.default_options[:s3_permissions] = 'public-read'
-  Paperclip::Attachment.default_options[:s3_region]      = ENV.fetch('S3_REGION') { 'us-east-1' }
+  Paperclip::Attachment.default_options[:s3_region]      = ENV.fetch('S3_REGION', 'us-east-1')
 
   Paperclip::Attachment.default_options[:s3_credentials] = {
     bucket: ENV.fetch('S3_BUCKET'),

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 Redis.current = Redis.new(
-  host: ENV.fetch('REDIS_HOST') { 'localhost' },
-  port: ENV.fetch('REDIS_PORT') { 6379 },
-  password: ENV.fetch('REDIS_PASSWORD') { false },
+  host: ENV.fetch('REDIS_HOST', 'localhost'),
+  port: ENV.fetch('REDIS_PORT', 6379),
+  password: ENV.fetch('REDIS_PASSWORD', false),
   driver: :hiredis
 )

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,6 @@
-host = ENV.fetch('REDIS_HOST') { 'localhost' }
-port = ENV.fetch('REDIS_PORT') { 6379 }
-password = ENV.fetch('REDIS_PASSWORD') { false }
+host = ENV.fetch('REDIS_HOST', 'localhost')
+port = ENV.fetch('REDIS_PORT', 6379)
+password = ENV.fetch('REDIS_PASSWORD', false)
 
 Sidekiq.configure_server do |config|
   config.redis = { host: host, port: port, password: password}

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,9 +1,9 @@
-threads_count = ENV.fetch('MAX_THREADS') { 5 }.to_i
+threads_count = ENV.fetch('MAX_THREADS', 5).to_i
 threads threads_count, threads_count
 
-port        ENV.fetch('PORT') { 3000 }
-environment ENV.fetch('RAILS_ENV') { 'development' }
-workers     ENV.fetch('WEB_CONCURRENCY') { 2 }
+port        ENV.fetch('PORT', 3000)
+environment ENV.fetch('RAILS_ENV', 'development')
+workers     ENV.fetch('WEB_CONCURRENCY', 2)
 
 preload_app!
 


### PR DESCRIPTION
When we aren't manipulating the value fetched, it's clearer to use the
default-value parameter instead of passing a block.