### PR TITLE
WORK IN PROGRESS Create Ubuntu-guide.md

### DIFF
--- a/docs/Running-Mastodon/Ubuntu-guide.md
+++ b/docs/Running-Mastodon/Ubuntu-guide.md
@@ -1,5 +1,12 @@
-# A guide to installing Mastodon on Ubuntu 16.04 LTS (Intel and ARM).
+# A guide to installing Mastodon on Ubuntu 16.04 LTS (amd64 and arm64).
 
 ## Running under Docker
 
 ### Installing Docker and docker-compose
+
+Issue #869, docker-compose build fails. The package that you get from 
+Docker when you do `apt-get install docker-compose` is too old. 
+
+Install on amd64 machines from the PPA: (instructions)
+
+Docker for arm64 needs to be installed from source: (instructions) 

--- a/docs/Running-Mastodon/Ubuntu-guide.md
+++ b/docs/Running-Mastodon/Ubuntu-guide.md
@@ -1,0 +1,5 @@
+# A guide to installing Mastodon on Ubuntu 16.04 LTS (Intel and ARM).
+
+## Running under Docker
+
+### Installing Docker and docker-compose

--- a/docs/Running-Mastodon/Ubuntu-guide.md
+++ b/docs/Running-Mastodon/Ubuntu-guide.md
@@ -1,5 +1,11 @@
 # A guide to installing Mastodon on Ubuntu 16.04 LTS (amd64 and arm64).
 
+A really good guide is at 
+
+https://github.com/ummjackson/mastodon-guide/blob/master/up-and-running.md
+
+Go read it, I won't repeat myself.
+
 ## Running under Docker
 
 ### Installing Docker and docker-compose


### PR DESCRIPTION
Not ready yet, but when it is ready it will have a guide to running Mastodon on Ubuntu 16.04 LTS on both Intel and ARM servers.