### PR TITLE
Add build-essential to dependencies list. Additionally, remove nodejs from the command as we install it afterwards.

### DIFF
--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -88,7 +88,7 @@ It is recommended to create a special user for mastodon on the server (you could
 
 ## General dependencies
 
-    sudo apt-get install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev nodejs file git curl
+    sudo apt-get install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev file git curl build-essential
     curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
 
     sudo apt-get install nodejs


### PR DESCRIPTION
A C compiler is required to compile Ruby.