### PR TITLE
Allows setting log level in env variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,9 +38,13 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = false
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  if ENV['RAILS_LOG_LEVEL']
+    config.log_level = ENV['RAILS_LOG_LEVEL'].to_sym
+  else
+    # Use the lowest log level to ensure availability of diagnostic information
+    # when problems arise.
+    config.log_level = :debug
+  end
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,13 +38,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = false
 
-  if ENV['RAILS_LOG_LEVEL']
-    config.log_level = ENV['RAILS_LOG_LEVEL'].to_sym
-  else
-    # Use the lowest log level to ensure availability of diagnostic information
-    # when problems arise.
-    config.log_level = :debug
-  end
+  # By default, use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'debug').to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
I used `RAILS_LOG_LEVEL` to avoid conflicting with [the NPM logging level](https://github.com/tootsuite/mastodon/blob/9acdb166e8871632f592bfcd2386dfc288d81a07/streaming/index.js#L306).