### PR TITLE
Make the getting started ui more intuitive

### DIFF
--- a/app/assets/javascripts/components/features/getting_started/index.jsx
+++ b/app/assets/javascripts/components/features/getting_started/index.jsx
@@ -1,5 +1,6 @@
 import Column from '../ui/components/column';
 import ColumnLink from '../ui/components/column_link';
+import ColumnSubheading from '../ui/components/column_subheading';
 import { Link } from 'react-router';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
@@ -9,6 +10,8 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 const messages = defineMessages({
   heading: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
   public_timeline: { id: 'navigation_bar.public_timeline', defaultMessage: 'Federated timeline' },
+  navigation_subheading: { id: 'column_subheading.navigation', defaultMessage: 'Navigation'},
+  settings_subheading: { id: 'column_subheading.settings', defaultMessage: 'Settings'},
   community_timeline: { id: 'navigation_bar.community_timeline', defaultMessage: 'Local timeline' },
   preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
   follow_requests: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
@@ -33,14 +36,16 @@ const GettingStarted = ({ intl, me }) => {
   return (
     <Column icon='asterisk' heading={intl.formatMessage(messages.heading)} hideHeadingOnMobile={true}>
       <div className='getting-started__wrapper'>
+        <ColumnSubheading text={intl.formatMessage(messages.navigation_subheading)}/>
         <ColumnLink icon='users' hideOnMobile={true} text={intl.formatMessage(messages.community_timeline)} to='/timelines/public/local' />
         <ColumnLink icon='globe' hideOnMobile={true} text={intl.formatMessage(messages.public_timeline)} to='/timelines/public' />
-        <ColumnLink icon='cog' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />
         <ColumnLink icon='star' text={intl.formatMessage(messages.favourites)} to='/favourites' />
         {followRequests}
-        <ColumnLink icon='ban' text={intl.formatMessage(messages.blocks)} to='/blocks' />
         <ColumnLink icon='volume-off' text={intl.formatMessage(messages.mutes)} to='/mutes' />
+        <ColumnLink icon='ban' text={intl.formatMessage(messages.blocks)} to='/blocks' />
+        <ColumnSubheading text={intl.formatMessage(messages.settings_subheading)}/>
         <ColumnLink icon='book' text={intl.formatMessage(messages.info)} href='/about/more' />
+        <ColumnLink icon='cog' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />
         <ColumnLink icon='sign-out' text={intl.formatMessage(messages.sign_out)} href='/auth/sign_out' method='delete' />
       </div>
 

--- a/app/assets/javascripts/components/features/ui/components/column_subheading.jsx
+++ b/app/assets/javascripts/components/features/ui/components/column_subheading.jsx
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types';
+
+const ColumnSubheading = ({ text }) => {
+    return (
+      <div className='column-subheading'>
+        {text}
+      </div>
+    );
+  };
+
+ColumnSubheading.propTypes = {
+  text: PropTypes.string.isRequired,
+};
+
+export default ColumnSubheading;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1534,6 +1534,12 @@ a.status__content__spoiler-link {
   margin-right: 5px;
 }
 
+.column-subheading {
+  background: lighten($color1, 20%);
+  padding: 8px 20px;
+  font-size: 16px;
+}
+
 .autosuggest-textarea,
 .spoiler-input {
   position: relative;


### PR DESCRIPTION
**Context**
* Some of the links in the `Getting started` tab change the context of the third column, while others leave the page entirely. 
* The ordering of the links makes the tab even less intuitive for a new user - the `Preferences` link navigates away from the page, while several of the links below it navigate within the column.

**Changes**
* Re-orders the links in the `Getting started` tab, grouping links which only change the context of the column together, and separating them visually from links which leave the page.
* Adds subheadings to clarify the distinction between the two groups of links.