### PR TITLE
Fix issue in doc with nginx talking to sidekiq on v6 while it is only listening on v4

### DIFF
--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -88,7 +88,7 @@ It is recommended to create a special user for mastodon on the server (you could
 
 ## General dependencies
 
-    sudo apt-get install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev nodejs file git curl
+    sudo apt-get install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev file git curl build-essential
     curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
 
     sudo apt-get install nodejs

--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -52,7 +52,7 @@ server {
 
     proxy_pass_header Server;
 
-    proxy_pass http://localhost:3000;
+    proxy_pass http://127.0.0.1:3000;
     proxy_buffering off;
     proxy_redirect off;
     proxy_http_version 1.1;

--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -88,7 +88,7 @@ It is recommended to create a special user for mastodon on the server (you could
 
 ## General dependencies
 
-    sudo apt-get install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev file git curl build-essential
+    sudo apt-get install imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev nodejs file git curl
     curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
 
     sudo apt-get install nodejs


### PR DESCRIPTION
Sidekiq listens single stack on 127.0.0.1.

The nginx config in the Mastodon documentation proxy passes to sidekiq with the hostname localhost, which resolves dual stack to 127.0.0.1 and ::1. 

This causes timeout errors in the nginx error log as it tries to connect to ::1 fails and fall back to 127.0.0.1. 

To fix this, change your nginx proxy_pass statement to use 127.0.0.1 instead of localhost.