### PR TITLE
Refresh webfinger

### DIFF
--- a/app/services/follow_remote_account_service.rb
+++ b/app/services/follow_remote_account_service.rb
@@ -28,21 +28,30 @@ class FollowRemoteAccountService < BaseService
 
     return Account.find_local(confirmed_username) if TagManager.instance.local_domain?(confirmed_domain)
 
-    confirmed_account = Account.find_remote(confirmed_username, confirmed_domain)
-    return confirmed_account unless confirmed_account.nil?
+    remote_url  = data.link('http://schemas.google.com/g/2010#updates-from').href
+    salmon_url  = data.link('salmon').href
+    url         = data.link('http://webfinger.net/rel/profile-page').href
+    public_key  = magic_key_to_pem(data.link('magic-public-key').href)
 
-    Rails.logger.debug "Creating new remote account for #{uri}"
+    account = Account.find_remote(confirmed_username, confirmed_domain)
+    return account unless account.nil? || remote_url != account.remote_url || salmon_url != account.salmon_url || url != account.url || public_key != account.public_key
 
-    domain_block = DomainBlock.find_by(domain: domain)
+    if account.nil?
+        Rails.logger.debug "Creating new remote account for #{uri}"
 
-    account = Account.new(username: confirmed_username, domain: confirmed_domain)
-    account.remote_url  = data.link('http://schemas.google.com/g/2010#updates-from').href
-    account.salmon_url  = data.link('salmon').href
-    account.url         = data.link('http://webfinger.net/rel/profile-page').href
-    account.public_key  = magic_key_to_pem(data.link('magic-public-key').href)
-    account.private_key = nil
-    account.suspended   = true if domain_block && domain_block.suspend?
-    account.silenced    = true if domain_block && domain_block.silence?
+        domain_block = DomainBlock.find_by(domain: domain)
+        account = Account.new(username: confirmed_username, domain: confirmed_domain)
+        account.suspended   = true if domain_block && domain_block.suspend?
+        account.silenced    = true if domain_block && domain_block.silence?
+        account.private_key = nil
+    else
+        Rails.logger.debug "Updating remote account #{uri}"
+    end
+
+    account.remote_url  = remote_url
+    account.salmon_url  = salmon_url
+    account.url         = url
+    account.public_key  = public_key
 
     body, xml = get_feed(account.remote_url)
     hubs      = get_hubs(xml)

--- a/app/services/follow_remote_account_service.rb
+++ b/app/services/follow_remote_account_service.rb
@@ -16,7 +16,7 @@ class FollowRemoteAccountService < BaseService
     return Account.find_local(username) if TagManager.instance.local_domain?(domain)
 
     account = Account.find_remote(username, domain)
-    return account unless account.nil?
+    return account unless account.nil? || !account.subscribed?
 
     Rails.logger.debug "Looking up webfinger for #{uri}"
 

--- a/db/migrate/20170409170753_add_last_webfingered_at_to_accounts.rb
+++ b/db/migrate/20170409170753_add_last_webfingered_at_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddLastWebfingeredAtToAccounts < ActiveRecord::Migration[5.0]
+  def change
+    add_column :accounts, :last_webfingered_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 20170406215816) do
     t.datetime "header_updated_at"
     t.string   "avatar_remote_url"
     t.datetime "subscription_expires_at"
+    t.datetime "last_webfingered_at"
     t.boolean  "silenced",                default: false, null: false
     t.boolean  "suspended",               default: false, null: false
     t.boolean  "locked",                  default: false, null: false

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -1,3 +1,4 @@
 Fabricator(:account) do
   username { Faker::Internet.user_name(nil, %w(_)) }
+  last_webfingered_at { Time.now.utc }
 end


### PR DESCRIPTION
This is an attempt to fix #1276 that I've been running on my instance without any ill effect (that I noticed),
but I couldn't verify that it fixes my particular issue, as the instances having incorrect information about my account are remote ones on which I could not try those changes.

This is split in two commits:
* The first one allows to refresh some existing account if webfinger returns new information. This only performs additional requests if one of the URLs or the public key did actually change. This is essentially dead code in the absence of the second patch, as local information on the remote account will be returned if it exists, without querying webfinger.
* The second patch performs the webfinger query whenever we are looking up at a remote account we are not subscribed to. The rationale is that the most important aspect of a remote account is the ability to be subscribed to, and if that fails, the account info may need updating. On the other hand, we may miss things like the user's web-facing profile URL changing. Furthermore, it may generate additional unwanted requests, and may probably be restricted to remote users we tried to subscribe to but failed.

As evidenced by the second patch, I am not too sure *when* we should re-query webfinger, any input on this would be appreciated.