### PR TITLE
Do not store last visited URL from API controllers

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -7,6 +7,7 @@ class ApiController < ApplicationController
   protect_from_forgery with: :null_session
 
   skip_before_action :verify_authenticity_token
+  skip_before_action :store_current_location
 
   before_action :set_rate_limit_headers
 


### PR DESCRIPTION
Sign-in redirects you back to last visited URL, but in case of API requests,
this sometimes redirected users to an API URL that, of course, greeted them
with an {"error":"The access token is invalid"}