### PR TITLE
Ignore implied formats for catch all route requests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,5 +194,8 @@ Rails.application.routes.draw do
 
   root 'home#index'
 
-  match '*unmatched_route', via: :all, to: 'application#raise_not_found'
+  match '*unmatched_route',
+    via: :all,
+    to: 'application#raise_not_found',
+    format: false
 end

--- a/spec/requests/catch_all_route_request_spec.rb
+++ b/spec/requests/catch_all_route_request_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe "The catch all route" do
+  describe "with a simple value" do
+    it "returns a 404 page as html" do
+      get "/test"
+
+      expect(response.status).to eq 404
+      expect(response.content_type).to eq "text/html"
+    end
+  end
+
+  describe "with an implied format" do
+    it "returns a 404 page as html" do
+      get "/test.test"
+
+      expect(response.status).to eq 404
+      expect(response.content_type).to eq "text/html"
+    end
+  end
+end


### PR DESCRIPTION
A request to `/test` would show the custom 404 page, but a request to
`/test.test` would return a 404 with an empty body.

This change ignores the format on incoming catch all route requests, so that the
html 404 page is returned on these requests.

Resolves https://github.com/tootsuite/mastodon/issues/1308