### PR TITLE
Get handle from atom feed's author/email field instead of guessing fr…

### DIFF
--- a/app/services/fetch_remote_account_service.rb
+++ b/app/services/fetch_remote_account_service.rb
@@ -19,11 +19,16 @@ class FetchRemoteAccountService < BaseService
     xml = Nokogiri::XML(body)
     xml.encoding = 'utf-8'
 
-    url_parts = Addressable::URI.parse(url)
-    username  = xml.at_xpath('//xmlns:author/xmlns:name').try(:content)
-    domain    = url_parts.host
+    email = xml.at_xpath('//xmlns:author/xmlns:email').try(:content)
+    if email.nil?
+      url_parts = Addressable::URI.parse(url)
+      username  = xml.at_xpath('//xmlns:author/xmlns:name').try(:content)
+      domain    = url_parts.host
+    else
+      username, domain = email.split('@')
+    end
 
-    return nil if username.nil?
+    return nil if username.nil? || domain.nil?
 
     Rails.logger.debug "Going to webfinger #{username}@#{domain}"
 


### PR DESCRIPTION
…om URL

The goal of this change is to enhance Mastodon's handling of remote domains
for which the APIs reside on a different host (see issue #1032).

Indeed, when a remote user unknown to Mastodon is mentionned, only its profile
URL (e.g. https://social.example.org/users/User) is known, and Mastodon has to
build a @username@domain handle for it. To do so, Mastodon fetches the user's
atom feed (e.g., https://social.example.org/users/User.atom) and uses its
content to get the username part of the handle, and the URL's host part to
build the domain (e.g., @User@social.example.org). This handle is then used
for a Webfinger request.

In the case where example.org serves the Webfinger info for @User@example.org
and all feeds and APIs are hosted at social.example.org, Mastodon will still
build @User@social.example.org and fail at resolving the account's details
through Webfinger.

This patch changes this behaviour by using the author's email address from
the atom feed to build the handle. In Mastodon-generated atom feeds, the
email address is always the handle it expects for federation.