### PR TITLE
Add REDIS_DB env variable to configure Redis database

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,6 +1,7 @@
 # Service dependencies
 REDIS_HOST=redis
 REDIS_PORT=6379
+# REDIS_DB=0
 DB_HOST=db
 DB_USER=postgres
 DB_NAME=postgres

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
     host: ENV.fetch('REDIS_HOST') { 'localhost' },
     port: ENV.fetch('REDIS_PORT') { 6379 },
     password: ENV.fetch('REDIS_PASSWORD') { false },
-    db: 0,
+    db: ENV.fetch('REDIS_DB') { 0 },
     namespace: 'cache',
     expires_in: 20.minutes,
   }


### PR DESCRIPTION
Small tweak that seemed make config easier for me on a server with multiple instances - need to have each use a different Redis database for its sidekiq queue