### PR TITLE
Remove unused methods from StreamEntriesHelper

### DIFF
--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -9,10 +9,6 @@ module StreamEntriesHelper
     "@#{account.acct}#{@external_links && account.local? ? "@#{Rails.configuration.x.local_domain}" : ''}"
   end
 
-  def avatar_for_status_url(status)
-    status.reblog? ? status.reblog.account.avatar.url(:original) : status.account.avatar.url(:original)
-  end
-
   def entry_classes(status, is_predecessor, is_successor, include_threads)
     classes = ['entry']
     classes << 'entry-reblog u-repost-of h-cite' if status.reblog?
@@ -20,18 +16,6 @@ module StreamEntriesHelper
     classes << 'entry-successor u-comment h-cite' if is_successor
     classes << 'entry-center h-entry' if include_threads
     classes.join(' ')
-  end
-
-  def relative_time(date)
-    date < 5.days.ago ? date.strftime('%d.%m.%Y') : "#{time_ago_in_words(date)} ago"
-  end
-
-  def reblogged_by_me_class(status)
-    user_signed_in? && @reblogged.key?(status.id) ? 'reblogged' : ''
-  end
-
-  def favourited_by_me_class(status)
-    user_signed_in? && @favourited.key?(status.id) ? 'favourited' : ''
   end
 
   def rtl?(text)

--- a/spec/helpers/stream_entries_helper_spec.rb
+++ b/spec/helpers/stream_entries_helper_spec.rb
@@ -15,23 +15,7 @@ RSpec.describe StreamEntriesHelper, type: :helper do
     end
   end
 
-  describe '#avatar_for_status_url' do
-    pending
-  end
-
   describe '#entry_classes' do
-    pending
-  end
-
-  describe '#relative_time' do
-    pending
-  end
-
-  describe '#reblogged_by_me_class' do
-    pending
-  end
-
-  describe '#favourited_by_me_class' do
     pending
   end
 end


### PR DESCRIPTION
Removes:

- avatar_for_status_url
- relative_time
- reblogged_by_me_class
- favourited_by_me_class