### PR TITLE
Add REDIS_DB env variable to configure Redis database

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,6 +1,7 @@
 # Service dependencies
 REDIS_HOST=redis
 REDIS_PORT=6379
+# REDIS_DB=0
 DB_HOST=db
 DB_USER=postgres
 DB_NAME=postgres

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,6 +55,8 @@ Rails.application.configure do
     ENV['REDIS_HOST'] = redis_url.host
     ENV['REDIS_PORT'] = redis_url.port.to_s
     ENV['REDIS_PASSWORD'] = redis_url.password
+    db_num = redis_url.path[1..-1]
+    ENV['REDIS_DB'] = db_num if db_num.present?
   end
 
   # Use a different cache store in production.
@@ -62,7 +64,7 @@ Rails.application.configure do
     host: ENV.fetch('REDIS_HOST') { 'localhost' },
     port: ENV.fetch('REDIS_PORT') { 6379 },
     password: ENV.fetch('REDIS_PASSWORD') { false },
-    db: 0,
+    db: ENV.fetch('REDIS_DB') { 0 },
     namespace: 'cache',
     expires_in: 20.minutes,
   }

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,11 +1,12 @@
 host = ENV.fetch('REDIS_HOST') { 'localhost' }
 port = ENV.fetch('REDIS_PORT') { 6379 }
 password = ENV.fetch('REDIS_PASSWORD') { false }
+db = ENV.fetch('REDIS_DB') { 0 }
 
 Sidekiq.configure_server do |config|
-  config.redis = { host: host, port: port, password: password}
+  config.redis = { host: host, port: port, db: db, password: password }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { host: host, port: port, password: password }
+  config.redis = { host: host, port: port, db: db, password: password }
 end


### PR DESCRIPTION
Small tweak that seemed make config easier for me on a server with multiple instances - need to have each use a different Redis database for caching & sidekiq queue. (Kind of a Rails & Ruby newb, but hopefully this does the trick.)