### PR TITLE
Define volume for postgres storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   db:
     restart: always
     image: postgres:alpine
+    volumes:
+      - ./postgres:/var/lib/postgresql/data
   redis:
     restart: always
     image: redis:alpine


### PR DESCRIPTION
As I suggest in [this issue](https://github.com/tootsuite/mastodon/issues/1376), I think it would be a good idea to define a db volume to make sure users don't lose their database if they shut down their server or run `docker-compose down`.

Please be aware I am new to docker and don't know where a "good" place for the volume would be, suggestions welcome.