### PR TITLE
Edit nginx config to add extra security headers.

### DIFF
--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -39,6 +39,9 @@ server {
   root /home/mastodon/live/public;
 
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  add_header Content-Security-Policy "default-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://example.com/ wss://example.com/; upgrade-insecure-requests";
+  add_header X-Content-Type-Options nosniff;
+  add_header X-Frame-Options DENY;
 
   location / {
     try_files $uri @proxy;
@@ -81,6 +84,8 @@ server {
   error_page 500 501 502 503 504 /500.html;
 }
 ```
+
+Make sure you remplace all instances of `example.com`.
 
 ## Running in production without Docker
 

--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -85,7 +85,7 @@ server {
 }
 ```
 
-Make sure you remplace all instances of `example.com`.
+Make sure you replace all instances of `example.com`.
 
 ## Running in production without Docker
 

--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -39,7 +39,7 @@ server {
   root /home/mastodon/live/public;
 
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
-  add_header Content-Security-Policy "default-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://example.com/ wss://example.com/; upgrade-insecure-requests";
+  add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' wss://example.com;; upgrade-insecure-requests";
 
   location / {
     try_files $uri @proxy;

--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -40,8 +40,6 @@ server {
 
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
   add_header Content-Security-Policy "default-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://example.com/ wss://example.com/; upgrade-insecure-requests";
-  add_header X-Content-Type-Options nosniff;
-  add_header X-Frame-Options DENY;
 
   location / {
     try_files $uri @proxy;


### PR DESCRIPTION
Content-Security-Policy to mitigate XSS.
X-Content-Type-Options to prevent use of forged media to exploit browsers
X-Frame-Options because I don't see how it could be a good idea to allow embedding Mastodon in an iframe.

I have been using this config on my 1k users instance for a week now; everything looks fine.