### PR TITLE
Improve scrolling behaviour

### DIFF
--- a/app/assets/javascripts/components/features/notifications/components/clear_column_button.jsx
+++ b/app/assets/javascripts/components/features/notifications/components/clear_column_button.jsx
@@ -4,16 +4,6 @@ const messages = defineMessages({
   clear: { id: 'notifications.clear', defaultMessage: 'Clear notifications' }
 });
 
-const iconStyle = {
-  fontSize: '16px',
-  padding: '15px',
-  position: 'absolute',
-  right: '48px',
-  top: '0',
-  cursor: 'pointer',
-  zIndex: '2'
-};
-
 const ClearColumnButton = React.createClass({
 
   propTypes: {
@@ -25,7 +15,7 @@ const ClearColumnButton = React.createClass({
     const { intl } = this.props;
 
     return (
-      <div title={intl.formatMessage(messages.clear)} className='column-icon' tabIndex='0' style={iconStyle} onClick={this.props.onClick}>
+      <div title={intl.formatMessage(messages.clear)} className='column-icon column-icon-clear' tabIndex='0' onClick={this.props.onClick}>
         <i className='fa fa-eraser' />
       </div>
     );

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -49,6 +49,22 @@
   }
 }
 
+.column-icon-clear {
+  font-size: 16px;
+  padding: 15px;
+  position: absolute;
+  right: 48px;
+  top: 0;
+  cursor: pointer;
+  z-index: 2;
+}
+
+@media screen and (min-width: 1024px) {
+  .column-icon-clear {
+    top: 10px;
+  }
+}
+
 .icon-button {
   display: inline-block;
   padding: 0;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -714,15 +714,7 @@ a.status__content__spoiler-link {
 
 @media screen and (min-width: 360px) {
   .columns-area {
-    margin: 0;
-  }
-
-  .column:first-child, .drawer:first-child {
-    margin-left: 0;
-  }
-
-  .column:last-child, .drawer:last-child {
-    margin-right: 0;
+    padding: 10px;
   }
 }
 
@@ -730,9 +722,12 @@ a.status__content__spoiler-link {
   width: 330px;
   position: relative;
   box-sizing: border-box;
-  background: $color1;
   display: flex;
   flex-direction: column;
+
+  > .scrollable {
+    background: $color1;
+  }
 }
 
 .ui {
@@ -762,6 +757,58 @@ a.status__content__spoiler-link {
   text-align: center;
   font-size: 16px;
   border-bottom: 2px solid transparent;
+}
+
+.column, .drawer {
+  flex: 1 1 100%;
+  overflow: hidden;
+}
+
+@media screen and (min-width: 360px) {
+  .tabs-bar {
+    margin: 10px;
+    margin-bottom: 0;
+  }
+
+  .search {
+    margin-bottom: 10px;
+  }
+}
+
+@media screen and (max-width: 1024px) {
+  .column, .drawer {
+    width: 100%;
+    padding: 0;
+  }
+
+  .columns-area {
+    flex-direction: column;
+  }
+
+  .search__input, .autosuggest-textarea__textarea {
+    font-size: 16px;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns-area {
+    padding: 0;
+  }
+
+  .column, .drawer {
+    flex: 0 0 auto;
+    padding: 10px;
+    padding-left: 5px;
+    padding-right: 5px;
+
+    &:first-child {
+      padding-left: 10px;
+    }
+
+    &:last-child {
+      padding-right: 10px;
+    }
+  }
 }
 
 @media screen and (min-width: 2560px) {
@@ -823,38 +870,6 @@ a.status__content__spoiler-link {
   }
 }
 
-.column, .drawer {
-  margin: 10px;
-  margin-left: 5px;
-  margin-right: 5px;
-  flex: 0 0 auto;
-  overflow: hidden;
-}
-
-.column:first-child, .drawer:first-child {
-  margin-left: 10px;
-}
-
-.column:last-child, .drawer:last-child {
-  margin-right: 10px;
-}
-
-@media screen and (max-width: 1024px) {
-  .column, .drawer {
-    width: 100%;
-    margin: 0;
-    flex: 1 1 100%;
-  }
-
-  .columns-area {
-    flex-direction: column;
-  }
-
-  .search__input, .autosuggest-textarea__textarea {
-    font-size: 16px;
-  }
-}
-
 .tabs-bar {
   display: flex;
   background: lighten($color1, 8%);
@@ -890,27 +905,6 @@ a.status__content__spoiler-link {
 
   span {
     display: none;
-  }
-}
-
-@media screen and (min-width: 360px) {
-  .columns-area {
-    margin: 10px;
-  }
-
-  .tabs-bar {
-    margin: 10px;
-    margin-bottom: 0;
-  }
-
-  .search {
-    margin-bottom: 10px;
-  }
-}
-
-@media screen and (min-width: 1024px) {
-  .columns-area {
-    margin: 0;
   }
 }
 
@@ -1381,12 +1375,15 @@ button.active i.fa-retweet {
 
 .empty-column-indicator {
   color: lighten($color1, 20%);
+  background: $color1;
   text-align: center;
   padding: 20px;
-  padding-top: 100px;
   font-size: 15px;
   font-weight: 400;
   cursor: default;
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
 
   a {
     color: $color4;


### PR DESCRIPTION
- This switches from using `margin` to using `padding`.
  - This means column backgrounds need to be painted *inside* the scrollable area rather than on the background of the `column`.
  - As a side-effect, it seems to provide a _very minor_ boost to drawing performance, at the cost of a small amount of obviousness!
  - The padding also means the UI can scroll right to the end horizontally.
- This also fixes an issue where small browsers would encounter ~10px of horizontal scrolling.
- A few duplicate/overloaded CSS specifications were removed.
  - The ones that the browser used are the ones which stayed!
- The empty column indicator’s contents were set to flex to the centre so it can have a background applied, and could be squashed correctly by the column settings.
- Fixes #1412 

**Screenshots:**
320px wide:
<img width="320" alt="screen shot 2017-04-10 at 8 45 39 pm" src="https://cloud.githubusercontent.com/assets/282113/24858280/f8561f8e-1e2e-11e7-8722-abe19980109e.png">

340px wide:
<img width="341" alt="screen shot 2017-04-10 at 8 46 43 pm" src="https://cloud.githubusercontent.com/assets/282113/24858282/f895154a-1e2e-11e7-8a84-b33c69bd28c9.png">

Desktop:
<img width="484" alt="screen shot 2017-04-10 at 8 47 14 pm" src="https://cloud.githubusercontent.com/assets/282113/24858283/f8971390-1e2e-11e7-92f0-92a9b67742e9.png">

P.S. The “clear notifications” button remains in the right spot on mobile screens (it required the addition of a breakpoint-aware CSS class)
<img width="341" alt="screen shot 2017-04-10 at 8 47 37 pm" src="https://cloud.githubusercontent.com/assets/282113/24858281/f894c90a-1e2e-11e7-8bed-7373218fe823.png">

**To-do:**
- [x] Fix horizontal scrolling margin
- [x] Make sure “clear column” button is still in the right place
  - [x] On desktop
  - [x] On mobile
- [x] Check column settings opening behaviour isn’t adversely affected