### PR TITLE
Set column to fluid units

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -727,7 +727,7 @@ a.status__content__spoiler-link {
 }
 
 .column {
-  width: 330px;
+  width: 25%;
   position: relative;
   box-sizing: border-box;
   background: $color1;
@@ -745,7 +745,7 @@ a.status__content__spoiler-link {
 }
 
 .drawer {
-  width: 300px;
+  width: 22%;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -770,7 +770,7 @@ a.status__content__spoiler-link {
   }
 
   .column, .drawer {
-    width: 350px;
+    max-width: 30em;
     border-radius: 4px;
     height: 90vh;
     margin-top: 5vh;


### PR DESCRIPTION
Hi there,

first, thanks for this tool.

I've set up user styles with relative units, and Mastodon takes advantage of it on wider screens ;)

See example on my laptop: 
![mastodon](https://cloud.githubusercontent.com/assets/2578321/24858135/42944f24-1deb-11e7-8e39-8f57505b35de.png)

So here is a PR to improve it.
Cheers,
Nicolas
