### PR TITLE
Fix #1097 When onClick is falsy, do not make status content clickable

### DIFF
--- a/app/assets/javascripts/components/components/status_content.jsx
+++ b/app/assets/javascripts/components/components/status_content.jsx
@@ -125,13 +125,21 @@ const StatusContent = React.createClass({
           <div style={{ display: hidden ? 'none' : 'block', ...directionStyle }} dangerouslySetInnerHTML={content} />
         </div>
       );
-    } else {
+    } else if (this.props.onClick) {
       return (
         <div
           className='status__content'
           style={{ cursor: 'pointer', ...directionStyle }}
           onMouseDown={this.handleMouseDown}
           onMouseUp={this.handleMouseUp}
+          dangerouslySetInnerHTML={content}
+        />
+      );
+    } else {
+      return (
+        <div
+          className='status__content'
+          style={{ ...directionStyle }}
           dangerouslySetInnerHTML={content}
         />
       );


### PR DESCRIPTION
#1097

First PR here. Thanks for making this awesome app.

When a `Status` is expanded and is rendered as a `DetailedStatus`, no `onClick` function prop is passed to `StatusContent`. Within the render method of `StatusContent`, check if `this.props.onClick` is truthy. If so, pass `onMouseUp` handler which invokes `this.props.onClick`. If not, render the status content without a mouse handler and without the pointer cursor.