### PR TITLE
Fix issue with missing emojify class in views

### DIFF
--- a/app/views/shared/_landing_strip.html.haml
+++ b/app/views/shared/_landing_strip.html.haml
@@ -1,2 +1,5 @@
 .landing-strip
-  = t('landing_strip_html', name: display_name(account), domain: Rails.configuration.x.local_domain, sign_up_path: new_user_registration_path)
+  = t('landing_strip_html',
+    name: content_tag(:span, display_name(account), class: :emojify),
+    domain: Rails.configuration.x.local_domain,
+    sign_up_path: new_user_registration_path)

--- a/app/views/stream_entries/_status.html.haml
+++ b/app/views/stream_entries/_status.html.haml
@@ -13,7 +13,7 @@
         = fa_icon('retweet fw')
       %span
         = link_to TagManager.instance.url_for(status.account), class: 'status__display-name muted' do
-          %strong= display_name(status.account)
+          %strong.emojify= display_name(status.account)
         = t('stream_entries.reblogged')
 
   = render partial: centered ? 'stream_entries/detailed_status' : 'stream_entries/simple_status', locals: { status: status.proper }


### PR DESCRIPTION
I noticed that on the landing strip of user and status pages when signed out, and within the simple status area for the "boosted by" person, users who have `:emoji:` style naming were not being converted to actual emoji, but were just rendering the string as entered.

Before:

![emojify before](https://cloud.githubusercontent.com/assets/225/24874513/ee5b0c2e-1df2-11e7-8fca-e7f28c233fe9.png)

After:

![emojify after](https://cloud.githubusercontent.com/assets/225/24874522/f3722c06-1df2-11e7-98a1-8c9eaf24725a.png)
