### PR TITLE
CDN_HOST routing_helper fix

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -36,8 +36,8 @@ SMTP_LOGIN=
 SMTP_PASSWORD=
 SMTP_FROM_ADDRESS=notifications@example.com
 
-# Optional asset host for multi-server setups
-# CDN_HOST=assets.example.com
+# Optional asset host for multi-server setups (inc. protocol)
+# CDN_HOST=http://assets.example.com
 
 # S3 (optional)
 # S3_ENABLED=true

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -12,6 +12,6 @@ module RoutingHelper
   end
 
   def full_asset_url(source)
-    Rails.configuration.x.use_s3 ? source : File.join(root_url, ActionController::Base.helpers.asset_url(source))
+    Rails.configuration.x.use_s3 ? source : Rails.configuration.action_controller.asset_host ? ActionController::Base.helpers.asset_url(source) : File.join(root_url, ActionController::Base.helpers.asset_url(source))
   end
 end

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -12,6 +12,12 @@ module RoutingHelper
   end
 
   def full_asset_url(source)
-    Rails.configuration.x.use_s3 ? source : Rails.configuration.action_controller.asset_host ? ActionController::Base.helpers.asset_url(source) : File.join(root_url, ActionController::Base.helpers.asset_url(source))
+    if Rails.configuration.x.use_s3
+      source
+    elsif Rails.configuration.action_controller.asset_host
+      ActionController::Base.helpers.asset_url(source)
+    else
+      File.join(root_url, ActionController::Base.helpers.asset_url(source))
+    end
   end
 end


### PR DESCRIPTION
Two minor fixes to the behaviour of CDN_HOST:

- Currently, if you enter a CDN_HOST and build the Docker image, the application will throw the following error:

```
method=GET path=/web/accounts/166 format=html controller=HomeController action=index status=500 error='ActionView::Template::Error: undefined method 'protocol' for nil:NilClass' duration=35.83 view=0.00 db=27.18

 ActionView::Template::Error (undefined method 'protocol' for nil:NilClass):
     1: object false
     2:
     3: node(:meta) do
     4:   {
     5:     access_token: @token,
     6:     locale: I18n.locale,

 app/helpers/routing_helper.rb:15:in 'full_asset_url'
 app/views/api/v1/accounts/show.rabl:7:in 'block in eval_source'
 app/views/home/initial_state.json.rabl:3:in '_app_views_home_initial_state_json_rabl___4241867769042566489_47336508132160'
 app/views/home/index.html.haml:4:in 'block in _app_views_home_index_html_haml__1697788668079016006_47336538039340'
 app/views/home/index.html.haml:1:in '_app_views_home_index_html_haml__1697788668079016006_47336538039340'
 app/controllers/concerns/localized.rb:24:in 'block in set_locale'
 app/controllers/concerns/localized.rb:23:in 'set_locale'
```


This does not occur if the provided CDN_HOST has a protocol specified, so I've added one to .env.production.sample.

- In addition, once the page loads, assets which are loaded with full_asset_path such as avatars will have an incorrect URL, e.g. http://mastodon.social/http://static.mastodon.social/assets/avatar.png. I've tweaked routing_helper.rb in a way which appears to fix this on my instance.

Apologies if I've made any obvious slip-ups.

resolves issue #1044 