### PR TITLE
Fix references to "v1" API

### DIFF
--- a/docs/Using-the-API/API.md
+++ b/docs/Using-the-API/API.md
@@ -362,15 +362,15 @@ Returns an empty object.
 
 #### Reblogging/unreblogging a status:
 
-    POST /api/vi/statuses/:id/reblog
-    POST /api/vi/statuses/:id/unreblog
+    POST /api/v1/statuses/:id/reblog
+    POST /api/v1/statuses/:id/unreblog
 
 Returns the target [Status](#status).
 
 #### Favouriting/unfavouriting a status:
 
-    POST /api/vi/statuses/:id/favourite
-    POST /api/vi/statuses/:id/unfavourite
+    POST /api/v1/statuses/:id/favourite
+    POST /api/v1/statuses/:id/unfavourite
 
 Returns the target [Status](#status).
 


### PR DESCRIPTION
References to `vi` API version replaced with `v1`