### PR TITLE
Adjust background of emoji panel

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1425,7 +1425,7 @@ button.active i.fa-retweet {
 .emoji-dialog {
   width: 280px;
   height: 220px;
-  background: $color2;
+  background: darken($color3, 10%);
   box-sizing: border-box;
   border-radius: 2px;
   overflow: hidden;


### PR DESCRIPTION
Addresses #1451 which notes the emoji picker is too light. I agree, so I submit this adjustment.

Changes:
Changed the background to a darkened version of another system color