### PR TITLE
Adjust css for user detail page

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -72,6 +72,7 @@
     position: relative;
     z-index: 2;
     flex-direction: row;
+    background: rgba(0,0,0,0.5);
   }
 
   .details-counters {
@@ -83,7 +84,7 @@
   .counter {
     width: 80px;
     color: $color3;
-    padding: 0 10px;
+    padding: 5px 10px 0px;
     margin-bottom: 10px;
     border-right: 1px solid $color3;
     cursor: default;


### PR DESCRIPTION
Addresses a suggestion in #1430.

- givess the `details` element a background for contrast (tried it with a couple different colours/backgrounds, seems ok at 0.5)
- add 5px padding to the top of the `details-counters` children to line them up with the bio to the right (Which has a 5px padding on the top)