### PR TITLE
Admin base controller

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -1,51 +1,50 @@
 # frozen_string_literal: true
 
-class Admin::AccountsController < ApplicationController
-  before_action :require_admin!
-  before_action :set_account, except: :index
+module Admin
+  class AccountsController < BaseController
+    before_action :set_account, except: :index
 
-  layout 'admin'
+    def index
+      @accounts = Account.alphabetic.paginate(page: params[:page], per_page: 40)
 
-  def index
-    @accounts = Account.alphabetic.paginate(page: params[:page], per_page: 40)
+      @accounts = @accounts.local                             if params[:local].present?
+      @accounts = @accounts.remote                            if params[:remote].present?
+      @accounts = @accounts.where(domain: params[:by_domain]) if params[:by_domain].present?
+      @accounts = @accounts.silenced                          if params[:silenced].present?
+      @accounts = @accounts.recent                            if params[:recent].present?
+      @accounts = @accounts.suspended                         if params[:suspended].present?
+    end
 
-    @accounts = @accounts.local                             if params[:local].present?
-    @accounts = @accounts.remote                            if params[:remote].present?
-    @accounts = @accounts.where(domain: params[:by_domain]) if params[:by_domain].present?
-    @accounts = @accounts.silenced                          if params[:silenced].present?
-    @accounts = @accounts.recent                            if params[:recent].present?
-    @accounts = @accounts.suspended                         if params[:suspended].present?
-  end
+    def show; end
 
-  def show; end
+    def suspend
+      Admin::SuspensionWorker.perform_async(@account.id)
+      redirect_to admin_accounts_path
+    end
 
-  def suspend
-    Admin::SuspensionWorker.perform_async(@account.id)
-    redirect_to admin_accounts_path
-  end
+    def unsuspend
+      @account.update(suspended: false)
+      redirect_to admin_accounts_path
+    end
 
-  def unsuspend
-    @account.update(suspended: false)
-    redirect_to admin_accounts_path
-  end
+    def silence
+      @account.update(silenced: true)
+      redirect_to admin_accounts_path
+    end
 
-  def silence
-    @account.update(silenced: true)
-    redirect_to admin_accounts_path
-  end
+    def unsilence
+      @account.update(silenced: false)
+      redirect_to admin_accounts_path
+    end
 
-  def unsilence
-    @account.update(silenced: false)
-    redirect_to admin_accounts_path
-  end
+    private
 
-  private
+    def set_account
+      @account = Account.find(params[:id])
+    end
 
-  def set_account
-    @account = Account.find(params[:id])
-  end
-
-  def account_params
-    params.require(:account).permit(:silenced, :suspended)
+    def account_params
+      params.require(:account).permit(:silenced, :suspended)
+    end
   end
 end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Admin
+  class BaseController < ApplicationController
+    before_action :require_admin!
+
+    layout 'admin'
+  end
+end

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -1,32 +1,30 @@
 # frozen_string_literal: true
 
-class Admin::DomainBlocksController < ApplicationController
-  before_action :require_admin!
-
-  layout 'admin'
-
-  def index
-    @blocks = DomainBlock.paginate(page: params[:page], per_page: 40)
-  end
-
-  def new
-    @domain_block = DomainBlock.new
-  end
-
-  def create
-    @domain_block = DomainBlock.new(resource_params)
-
-    if @domain_block.save
-      DomainBlockWorker.perform_async(@domain_block.id)
-      redirect_to admin_domain_blocks_path, notice: 'Domain block is now being processed'
-    else
-      render action: :new
+module Admin
+  class DomainBlocksController < BaseController
+    def index
+      @blocks = DomainBlock.paginate(page: params[:page], per_page: 40)
     end
-  end
 
-  private
+    def new
+      @domain_block = DomainBlock.new
+    end
 
-  def resource_params
-    params.require(:domain_block).permit(:domain, :severity)
+    def create
+      @domain_block = DomainBlock.new(resource_params)
+
+      if @domain_block.save
+        DomainBlockWorker.perform_async(@domain_block.id)
+        redirect_to admin_domain_blocks_path, notice: 'Domain block is now being processed'
+      else
+        render action: :new
+      end
+    end
+
+    private
+
+    def resource_params
+      params.require(:domain_block).permit(:domain, :severity)
+    end
   end
 end

--- a/app/controllers/admin/pubsubhubbub_controller.rb
+++ b/app/controllers/admin/pubsubhubbub_controller.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-class Admin::PubsubhubbubController < ApplicationController
-  before_action :require_admin!
-
-  layout 'admin'
-
-  def index
-    @subscriptions = Subscription.order('id desc').includes(:account).paginate(page: params[:page], per_page: 40)
+module Admin
+  class PubsubhubbubController < BaseController
+    def index
+      @subscriptions = Subscription.order('id desc').includes(:account).paginate(page: params[:page], per_page: 40)
+    end
   end
 end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -1,45 +1,44 @@
 # frozen_string_literal: true
 
-class Admin::ReportsController < ApplicationController
-  before_action :require_admin!
-  before_action :set_report, except: [:index]
+module Admin
+  class ReportsController < BaseController
+    before_action :set_report, except: [:index]
 
-  layout 'admin'
+    def index
+      @reports = Report.includes(:account, :target_account).order('id desc').paginate(page: params[:page], per_page: 40)
+      @reports = params[:action_taken].present? ? @reports.resolved : @reports.unresolved
+    end
 
-  def index
-    @reports = Report.includes(:account, :target_account).order('id desc').paginate(page: params[:page], per_page: 40)
-    @reports = params[:action_taken].present? ? @reports.resolved : @reports.unresolved
-  end
+    def show
+      @statuses = Status.where(id: @report.status_ids)
+    end
 
-  def show
-    @statuses = Status.where(id: @report.status_ids)
-  end
+    def resolve
+      @report.update(action_taken: true, action_taken_by_account_id: current_account.id)
+      redirect_to admin_report_path(@report)
+    end
 
-  def resolve
-    @report.update(action_taken: true, action_taken_by_account_id: current_account.id)
-    redirect_to admin_report_path(@report)
-  end
+    def suspend
+      Admin::SuspensionWorker.perform_async(@report.target_account.id)
+      Report.unresolved.where(target_account: @report.target_account).update_all(action_taken: true, action_taken_by_account_id: current_account.id)
+      redirect_to admin_report_path(@report)
+    end
 
-  def suspend
-    Admin::SuspensionWorker.perform_async(@report.target_account.id)
-    Report.unresolved.where(target_account: @report.target_account).update_all(action_taken: true, action_taken_by_account_id: current_account.id)
-    redirect_to admin_report_path(@report)
-  end
+    def silence
+      @report.target_account.update(silenced: true)
+      Report.unresolved.where(target_account: @report.target_account).update_all(action_taken: true, action_taken_by_account_id: current_account.id)
+      redirect_to admin_report_path(@report)
+    end
 
-  def silence
-    @report.target_account.update(silenced: true)
-    Report.unresolved.where(target_account: @report.target_account).update_all(action_taken: true, action_taken_by_account_id: current_account.id)
-    redirect_to admin_report_path(@report)
-  end
+    def remove
+      RemovalWorker.perform_async(params[:status_id])
+      redirect_to admin_report_path(@report)
+    end
 
-  def remove
-    RemovalWorker.perform_async(params[:status_id])
-    redirect_to admin_report_path(@report)
-  end
+    private
 
-  private
-
-  def set_report
-    @report = Report.find(params[:id])
+    def set_report
+      @report = Report.find(params[:id])
+    end
   end
 end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,35 +1,33 @@
 # frozen_string_literal: true
 
-class Admin::SettingsController < ApplicationController
-  before_action :require_admin!
-
-  layout 'admin'
-
-  def index
-    @settings = Setting.all_as_records
-  end
-
-  def update
-    @setting = Setting.where(var: params[:id]).first_or_initialize(var: params[:id])
-    value    = settings_params[:value]
-
-    # Special cases
-    value = value == 'true' if @setting.var == 'open_registrations'
-
-    if @setting.value != value
-      @setting.value = value
-      @setting.save
+module Admin
+  class SettingsController < BaseController
+    def index
+      @settings = Setting.all_as_records
     end
 
-    respond_to do |format|
-      format.html { redirect_to admin_settings_path }
-      format.json { respond_with_bip(@setting) }
+    def update
+      @setting = Setting.where(var: params[:id]).first_or_initialize(var: params[:id])
+      value    = settings_params[:value]
+
+      # Special cases
+      value = value == 'true' if @setting.var == 'open_registrations'
+
+      if @setting.value != value
+        @setting.value = value
+        @setting.save
+      end
+
+      respond_to do |format|
+        format.html { redirect_to admin_settings_path }
+        format.json { respond_with_bip(@setting) }
+      end
     end
-  end
 
-  private
+    private
 
-  def settings_params
-    params.require(:setting).permit(:value)
+    def settings_params
+      params.require(:setting).permit(:value)
+    end
   end
 end

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ReportsController, type: :controller do
+  describe 'GET #index' do
+    before do
+      sign_in Fabricate(:user, admin: true), scope: :user
+    end
+
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Admin::SettingsController, type: :controller do
+  describe 'GET #index' do
+    before do
+      sign_in Fabricate(:user, admin: true), scope: :user
+    end
+
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
Adds controller specs for some admin/ controllers which were missing, and then adjusts all admin/ controllers to inherit from a common base class which sets the layout and ensures users are admins.