### PR TITLE
Remove order prior to .find_in_batches

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -66,7 +66,7 @@ class FeedManager
     timeline_key = key(:home, into_account.id)
     oldest_home_score = redis.zrange(timeline_key, 0, 0, with_scores: true)&.first&.last&.to_i || 0
 
-    from_account.statuses.select('id').where('id > ?', oldest_home_score).find_in_batches do |statuses|
+    from_account.statuses.select('id').where('id > ?', oldest_home_score).reorder(nil).find_in_batches do |statuses|
       redis.pipelined do
         statuses.each do |status|
           redis.zrem(timeline_key, status.id)


### PR DESCRIPTION
The `Status` class has a default order on it, so when this query gets built and
gets all the way to `find_in_batches` there is an order already there.

When `find_in_batches` is run it discards any existing order on the query, and
emits a warning to the logs if there is one there.

This change removes the order prior calling `find_in_batches`, which will stop
the logged warning from occurring as well.

Resolves https://github.com/tootsuite/mastodon/issues/1450