### PR TITLE
Clean up generation of account webfinger string

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -53,7 +53,7 @@ class AccountsController < ApplicationController
   end
 
   def webfinger_account_url
-    webfinger_url(resource: "acct:#{@account.acct}@#{Rails.configuration.x.local_domain}")
+    webfinger_url(resource: @account.to_webfinger_s)
   end
 
   def check_account_suspension

--- a/app/controllers/remote_follow_controller.rb
+++ b/app/controllers/remote_follow_controller.rb
@@ -25,7 +25,7 @@ class RemoteFollowController < ApplicationController
 
       session[:remote_follow] = @remote_follow.acct
 
-      redirect_to Addressable::Template.new(redirect_url_link.template).expand(uri: "#{@account.username}@#{Rails.configuration.x.local_domain}").to_s
+      redirect_to Addressable::Template.new(redirect_url_link.template).expand(uri: @account.to_webfinger_s).to_s
     else
       render :new
     end

--- a/app/controllers/settings/exports_controller.rb
+++ b/app/controllers/settings/exports_controller.rb
@@ -39,7 +39,7 @@ class Settings::ExportsController < ApplicationController
   def accounts_list_to_csv(list)
     CSV.generate do |csv|
       list.each do |account|
-        csv << [(account.local? ? "#{account.username}@#{Rails.configuration.x.local_domain}" : account.acct)]
+        csv << [(account.local? ? account.local_username_and_domain : account.acct)]
       end
     end
   end

--- a/app/controllers/xrd_controller.rb
+++ b/app/controllers/xrd_controller.rb
@@ -14,7 +14,7 @@ class XrdController < ApplicationController
 
   def webfinger
     @account = Account.find_local!(username_from_resource)
-    @canonical_account_uri = "acct:#{@account.username}@#{Rails.configuration.x.local_domain}"
+    @canonical_account_uri = @account.to_webfinger_s
     @magic_key = pem_to_magic_key(@account.keypair.public_key)
 
     respond_to do |format|

--- a/app/helpers/atom_builder_helper.rb
+++ b/app/helpers/atom_builder_helper.rb
@@ -160,7 +160,7 @@ module AtomBuilderHelper
     object_type      xml, :person
     uri              xml, TagManager.instance.uri_for(account)
     name             xml, account.username
-    email            xml, account.local? ? "#{account.acct}@#{Rails.configuration.x.local_domain}" : account.acct
+    email            xml, account.local? ? account.local_username_and_domain : account.acct
     summary          xml, account.note
     link_alternate   xml, TagManager.instance.url_for(account)
     link_avatar      xml, account

--- a/app/lib/atom_serializer.rb
+++ b/app/lib/atom_serializer.rb
@@ -20,7 +20,7 @@ class AtomSerializer
     append_element(author, 'activity:object-type', TagManager::TYPES[:person])
     append_element(author, 'uri', uri)
     append_element(author, 'name', account.username)
-    append_element(author, 'email', account.local? ? "#{account.acct}@#{Rails.configuration.x.local_domain}" : account.acct)
+    append_element(author, 'email', account.local? ? account.local_username_and_domain : account.acct)
     append_element(author, 'summary', account.note)
     append_element(author, 'link', nil, rel: :alternate, type: 'text/html', href: TagManager.instance.url_for(account))
     append_element(author, 'link', nil, rel: :avatar, type: account.avatar_content_type, 'media:width': 120, 'media:height': 120, href: full_asset_url(account.avatar.url(:original)))

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -120,6 +120,10 @@ class Account < ApplicationRecord
     local? ? username : "#{username}@#{domain}"
   end
 
+  def to_webfinger_s
+    "acct:#{username}@#{Rails.configuration.x.local_domain}"
+  end
+
   def subscribed?
     !subscription_expires_at.blank?
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -120,8 +120,12 @@ class Account < ApplicationRecord
     local? ? username : "#{username}@#{domain}"
   end
 
+  def local_username_and_domain
+    "#{username}@#{Rails.configuration.x.local_domain}"
+  end
+
   def to_webfinger_s
-    "acct:#{username}@#{Rails.configuration.x.local_domain}"
+    "acct:#{local_username_and_domain}"
   end
 
   def subscribed?

--- a/spec/controllers/xrd_controller_spec.rb
+++ b/spec/controllers/xrd_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe XrdController, type: :controller do
     let(:alice) { Fabricate(:account, username: 'alice') }
 
     it 'returns http success when account can be found' do
-      get :webfinger, params: { resource: "acct:#{alice.username}@#{Rails.configuration.x.local_domain}" }
+      get :webfinger, params: { resource: alice.to_webfinger_s }
       expect(response).to have_http_status(:success)
     end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -54,17 +54,27 @@ RSpec.describe Account, type: :model do
     end
   end
 
-  describe '#to_webfinger_s' do
+  describe 'Local domain user methods' do
     around do |example|
       before = Rails.configuration.x.local_domain
       example.run
       Rails.configuration.x.local_domain = before
     end
 
-    it 'returns a webfinger string for the account' do
-      Rails.configuration.x.local_domain = "example.com"
+    describe '#to_webfinger_s' do
+      it 'returns a webfinger string for the account' do
+        Rails.configuration.x.local_domain = 'example.com'
 
-      expect(subject.to_webfinger_s).to eq "acct:alice@example.com"
+        expect(subject.to_webfinger_s).to eq 'acct:alice@example.com'
+      end
+    end
+
+    describe '#local_username_and_domain' do
+      it 'returns the username and local domain for the account' do
+        Rails.configuration.x.local_domain = 'example.com'
+
+        expect(subject.local_username_and_domain).to eq 'alice@example.com'
+      end
     end
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -54,6 +54,20 @@ RSpec.describe Account, type: :model do
     end
   end
 
+  describe '#to_webfinger_s' do
+    around do |example|
+      before = Rails.configuration.x.local_domain
+      example.run
+      Rails.configuration.x.local_domain = before
+    end
+
+    it 'returns a webfinger string for the account' do
+      Rails.configuration.x.local_domain = "example.com"
+
+      expect(subject.to_webfinger_s).to eq "acct:alice@example.com"
+    end
+  end
+
   describe '#acct' do
     it 'returns username for local users' do
       expect(subject.acct).to eql 'alice'


### PR DESCRIPTION
This was being done in more or less the same way in a bunch of places, so this brings it all into a method in `Account`.

I also consolidated a `local_username_and_domain` method because that was useful in a few spots.