### PR TITLE
[css] replace login box shadow with .wrapper background

### DIFF
--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -1,10 +1,10 @@
 .about-body {
   .wrapper {
-    max-width: 600px;
-    margin: 0 auto;
+    background: rgba(darken($color1, 7%), 0.5);
     color: $color3;
-    padding-top: 50px;
-    padding-bottom: 50px;
+    margin: 0 auto;
+    max-width: 600px;
+    padding: 1em 50px;
 
     &.thicc {
       max-width: 700px;
@@ -335,10 +335,7 @@
   .simple_form, .closed-registrations-message {
     width: 300px;
     flex: 0 0 auto;
-    background: rgba(darken($color1, 7%), 0.5);
     padding: 14px;
-    border-radius: 4px;
-    box-shadow: 0 0 15px rgba($color8, 0.4);
 
     .actions {
       margin-bottom: 0;
@@ -352,7 +349,7 @@
       }
     }
   }
-  
+
   @media screen and (max-width: 625px) {
     .mascot {
       display: none;

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -4,9 +4,10 @@ code {
 }
 
 .form-container {
+  background: rgba(darken($color1, 7%), 0.5);
+  margin: 0 auto;
   max-width: 400px;
   padding: 20px;
-  margin: 0 auto;
 }
 
 .simple_form {


### PR DESCRIPTION
This removes the background and drop shadow from the login form and applies the same background (though without the drop shadow) to the `.wrapper` element.  Here's what it looks like:

<img width="841" alt="screen shot 2017-04-10 at 3 37 24 pm" src="https://cloud.githubusercontent.com/assets/985416/24885588/2cd5ec60-1e04-11e7-96d8-f1784a0b34a2.png">

It's much more noticeable on instances with a custom background image.  Without this change, using a lighter image makes for very low contrast between it and the "about" text:
<img width="788" alt="screen shot 2017-04-10 at 3 37 54 pm" src="https://cloud.githubusercontent.com/assets/985416/24885623/5986146a-1e04-11e7-8ae7-30144e5e6a74.png">

But with this change it's perfectly usable:
<img width="811" alt="screen shot 2017-04-10 at 3 38 22 pm" src="https://cloud.githubusercontent.com/assets/985416/24885632/62c1d230-1e04-11e7-84f0-8c56ad0cef2c.png">

The change to the `.form-container` element is also to make light backgrounds usable:
<img width="579" alt="screen shot 2017-04-10 at 3 39 37 pm" src="https://cloud.githubusercontent.com/assets/985416/24885685/bd7e6378-1e04-11e7-9713-6e5dc28bc78b.png">
