### PR TITLE
streaming API: allow env overrides of development pg settings

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -16,8 +16,11 @@ dotenv.config({
 
 const pgConfigs = {
   development: {
-    database: 'mastodon_development',
-    host:     '/var/run/postgresql',
+    user:     process.env.DB_USER || 'mastodon',
+    database: process.env.DB_NAME || 'mastodon_development',
+    password: process.env.DB_PASS || '',
+    host:     process.env.DB_HOST || '/var/run/postgresql',
+    port:     process.env.DB_PORT || 5432,
     max:      10
   },
 


### PR DESCRIPTION
Just like on production.  I had to change the development host to `localhost` in order to run a dev instance on my local machine, but I figure it can't hurt to make everything adjustable.