### PR TITLE
[css] reduce spacing between text elements on about pages

### DIFF
--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -64,7 +64,7 @@
   p, li {
     font: 16px/28px 'Montserrat', sans-serif;
     font-weight: 400;
-    margin-bottom: 26px;
+    margin-bottom: 12px;
 
     a {
       color: $color4;
@@ -352,7 +352,7 @@
       }
     }
   }
-  
+
   @media screen and (max-width: 625px) {
     .mascot {
       display: none;


### PR DESCRIPTION
The current margin is rather too large IMO.  Using awoo.space Guidelines as an example, this is what it's like currently:

<img width="539" alt="screen shot 2017-04-10 at 8 07 53 pm" src="https://cloud.githubusercontent.com/assets/985416/24891321/eb9ff670-1e29-11e7-9080-c404dd281051.png">

With the change, the spacing is more natural but not too tight:

<img width="529" alt="screen shot 2017-04-10 at 8 08 27 pm" src="https://cloud.githubusercontent.com/assets/985416/24891328/fe63c75a-1e29-11e7-922e-e375da477d43.png">

