### PR TITLE
views/about: move about_mastodon below site_description

### DIFF
--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -19,7 +19,9 @@
     = image_tag 'logo.png'
     Mastodon
 
-  %p= t('about.about_mastodon').html_safe
+  - if @instance_presenter.site_description.present?
+    %h3= t('about.description_headline', domain: Rails.configuration.x.local_domain)
+    %p= @instance_presenter.site_description.html_safe
 
   .screenshot-with-signup
     .mascot= image_tag 'fluffy-elephant-friend.png'
@@ -38,6 +40,8 @@
           = link_to t('about.other_instances'), 'https://github.com/tootsuite/mastodon/blob/master/docs/Using-Mastodon/List-of-Mastodon-instances.md'
           ·
           = link_to t('about.about_this'), about_more_path
+
+  %p= t('about.about_mastodon').html_safe
 
   %h3= t('about.features_headline')
 
@@ -70,10 +74,6 @@
         %li
           = fa_icon('li check-square')
           = t 'about.features.api'
-
-  - unless @instance_presenter.site_description.blank?
-    %h3= t('about.description_headline', domain: Rails.configuration.x.local_domain)
-    %p= @instance_presenter.site_description.html_safe
 
   .actions
     .info


### PR DESCRIPTION
Information specific to the instance should be more prominent than
information about Mastodon in general.

Even when `site_description` isn't present, it's probably better to cut right to the chase with the signup form.