### PR TITLE
Imports controller errors

### DIFF
--- a/app/workers/import_worker.rb
+++ b/app/workers/import_worker.rb
@@ -4,33 +4,41 @@ require 'csv'
 
 class ImportWorker
   include Sidekiq::Worker
-
   sidekiq_options queue: 'pull', retry: false
 
-  def perform(import_id)
-    import = Import.find(import_id)
+  attr_reader :import
 
-    case import.type
+  def perform(import_id)
+    @import = Import.find(import_id)
+
+    case @import.type
     when 'blocking'
-      process_blocks(import)
+      process_blocks
     when 'following'
-      process_follows(import)
+      process_follows
     end
 
-    import.destroy
+    @import.destroy
   end
 
   private
 
-  def process_blocks(import)
-    from_account = import.account
-    contents = Paperclip.io_adapters.for(import.data).read
+  def from_account
+    @import.account
+  end
 
-    CSV.new(contents).each do |row|
-      next if row.size != 1
+  def import_contents
+    Paperclip.io_adapters.for(@import.data).read
+  end
 
+  def import_rows
+    CSV.new(import_contents).reject(&:blank?)
+  end
+
+  def process_blocks
+    import_rows.each do |row|
       begin
-        target_account = FollowRemoteAccountService.new.call(row[0])
+        target_account = FollowRemoteAccountService.new.call(row.first)
         next if target_account.nil?
         BlockService.new.call(from_account, target_account)
       rescue Goldfinger::Error, HTTP::Error, OpenSSL::SSL::SSLError
@@ -39,15 +47,10 @@ class ImportWorker
     end
   end
 
-  def process_follows(import)
-    from_account = import.account
-    contents = Paperclip.io_adapters.for(import.data).read
-
-    CSV.new(contents).each do |row|
-      next if row.size != 1
-
+  def process_follows
+    import_rows.each do |row|
       begin
-        FollowService.new.call(from_account, row[0])
+        FollowService.new.call(from_account, row.first)
       rescue Mastodon::NotPermittedError, ActiveRecord::RecordNotFound, Goldfinger::Error, HTTP::Error, OpenSSL::SSL::SSLError
         next
       end

--- a/app/workers/import_worker.rb
+++ b/app/workers/import_worker.rb
@@ -24,8 +24,9 @@ class ImportWorker
 
   def process_blocks(import)
     from_account = import.account
+    contents = Paperclip.io_adapters.for(import.data).read
 
-    CSV.new(open(import.data.url)).each do |row|
+    CSV.new(contents).each do |row|
       next if row.size != 1
 
       begin
@@ -40,8 +41,9 @@ class ImportWorker
 
   def process_follows(import)
     from_account = import.account
+    contents = Paperclip.io_adapters.for(import.data).read
 
-    CSV.new(open(import.data.url)).each do |row|
+    CSV.new(contents).each do |row|
       next if row.size != 1
 
       begin

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -13,4 +13,11 @@ RSpec.describe Settings::ImportsController, type: :controller do
     end
   end
 
+  describe 'POST #create' do
+    it 'redirects to settings path' do
+      post :create, params: { import: { type: 'following' } }
+
+      expect(response).to be_redirect(settings_import_path)
+    end
+  end
 end

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -14,10 +14,30 @@ RSpec.describe Settings::ImportsController, type: :controller do
   end
 
   describe 'POST #create' do
-    it 'redirects to settings path' do
-      post :create, params: { import: { type: 'following' } }
+    it 'redirects to settings path with successful following import' do
+      service = double(call: nil)
+      allow(FollowRemoteAccountService).to receive(:new).and_return(service)
+      post :create, params: {
+        import: {
+          type: 'following',
+          data: fixture_file_upload('files/imports.txt')
+        }
+      }
 
-      expect(response).to be_redirect(settings_import_path)
+      expect(response).to redirect_to(settings_import_path)
+    end
+
+    it 'redirects to settings path with successful blocking import' do
+      service = double(call: nil)
+      allow(FollowRemoteAccountService).to receive(:new).and_return(service)
+      post :create, params: {
+        import: {
+          type: 'blocking',
+          data: fixture_file_upload('files/imports.txt')
+        }
+      }
+
+      expect(response).to redirect_to(settings_import_path)
     end
   end
 end

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe Settings::ImportsController, type: :controller do
+
+  before do
+    sign_in Fabricate(:user), scope: :user
+  end
+
+  describe "GET #show" do
+    it "returns http success" do
+      get :show
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/fixtures/files/imports.txt
+++ b/spec/fixtures/files/imports.txt
@@ -1,2 +1,3 @@
 user@example.com
+
 user@test.com

--- a/spec/fixtures/files/imports.txt
+++ b/spec/fixtures/files/imports.txt
@@ -1,0 +1,2 @@
+user@example.com
+user@test.com


### PR DESCRIPTION
Resolves https://github.com/tootsuite/mastodon/issues/1540 

The changes in https://github.com/tootsuite/mastodon/commit/e30bbb1cb097ded7db59e905287f85f9f2b5d1b8 broke the import functionality.

This rolls back those changes, and adds a spec which will fail if they are broken again.