### PR TITLE
Increase breakpoint size for bio on account show

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -149,7 +149,7 @@
     order: 1;
   }
 
-  @media screen and (max-width: 360px) {
+  @media screen and (max-width: 480px) {
     .details {
       display: block;
     }


### PR DESCRIPTION
The 4 column approach to the public account show page gets a little awkward with a long bio in the far right column, and there was already a breakpoint in place for smaller devices .. this increases that breakpoint size.

Before:

![screen shot 2017-04-11 at 1 21 49 pm](https://cloud.githubusercontent.com/assets/225/24921784/0321d9ea-1eba-11e7-8be0-7a1caa7c4f0c.png)

After:

![screen shot 2017-04-11 at 1 22 06 pm](https://cloud.githubusercontent.com/assets/225/24921790/071f3920-1eba-11e7-9621-8e7b806d8bb0.png)
