### PR TITLE
DRYing out icon code

### DIFF
--- a/app/assets/javascripts/components/components/column_back_button.jsx
+++ b/app/assets/javascripts/components/components/column_back_button.jsx
@@ -1,5 +1,6 @@
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { FormattedMessage } from 'react-intl';
+import Icon from './icon';
 
 const iconStyle = {
   display: 'inline-block',
@@ -22,7 +23,7 @@ const ColumnBackButton = React.createClass({
   render () {
     return (
       <div onClick={this.handleClick} className='column-back-button'>
-        <i className='fa fa-fw fa-chevron-left' style={iconStyle} />
+        <Icon icon='chevron-left' style={iconStyle} fixedWidth={true} />
         <FormattedMessage id='column_back_button.label' defaultMessage='Back' />
       </div>
     );

--- a/app/assets/javascripts/components/components/column_back_button_slim.jsx
+++ b/app/assets/javascripts/components/components/column_back_button_slim.jsx
@@ -1,5 +1,6 @@
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { FormattedMessage } from 'react-intl';
+import Icon from './icon';
 
 const outerStyle = {
   position: 'absolute',
@@ -32,7 +33,7 @@ const ColumnBackButtonSlim = React.createClass({
     return (
       <div style={{ position: 'relative' }}>
         <div style={outerStyle} onClick={this.handleClick} className='column-back-button'>
-          <i className='fa fa-fw fa-chevron-left' style={iconStyle} />
+          <Icon icon='chevron-left' style={iconStyle} fixedWidth={true} />
           <FormattedMessage id='column_back_button.label' defaultMessage='Back' />
         </div>
       </div>

--- a/app/assets/javascripts/components/components/column_collapsable.jsx
+++ b/app/assets/javascripts/components/components/column_collapsable.jsx
@@ -1,5 +1,6 @@
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { Motion, spring } from 'react-motion';
+import Icon from './icon';
 
 const iconStyle = {
   fontSize: '16px',
@@ -46,7 +47,7 @@ const ColumnCollapsable = React.createClass({
 
     return (
       <div style={{ position: 'relative' }}>
-        <div title={`${title}`} style={{...iconStyle }} className={`column-icon ${collapsedClassName}`} onClick={this.handleToggleCollapsed}><i className={`fa fa-${icon}`} /></div>
+        <div title={`${title}`} style={{...iconStyle }} className={`column-icon ${collapsedClassName}`} onClick={this.handleToggleCollapsed}><Icon icon={icon} /></div>
 
         <Motion defaultStyle={{ opacity: 0, height: 0 }} style={{ opacity: spring(collapsed ? 0 : 100), height: spring(collapsed ? 0 : fullHeight, collapsed ? undefined : { stiffness: 150, damping: 9 }) }}>
           {({ opacity, height }) =>

--- a/app/assets/javascripts/components/components/dropdown_menu.jsx
+++ b/app/assets/javascripts/components/components/dropdown_menu.jsx
@@ -1,5 +1,6 @@
 import Dropdown, { DropdownTrigger, DropdownContent } from 'react-simple-dropdown';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
+import Icon from './icon';
 
 const DropdownMenu = React.createClass({
 
@@ -55,7 +56,7 @@ const DropdownMenu = React.createClass({
     return (
       <Dropdown ref={this.setRef}>
         <DropdownTrigger className='icon-button' style={{ fontSize: `${size}px`, width: `${size}px`, lineHeight: `${size}px` }}>
-          <i className={`fa fa-fw fa-${icon}`} style={{ verticalAlign: 'middle' }} />
+          <Icon icon={icon} style={{ verticalAlign: 'middle' }} fixedWidth={true} />
         </DropdownTrigger>
 
         <DropdownContent className={directionClass} style={{ lineHeight: '18px', textAlign: 'left' }}>

--- a/app/assets/javascripts/components/components/icon.jsx
+++ b/app/assets/javascripts/components/components/icon.jsx
@@ -1,0 +1,36 @@
+import PureRenderMixin from 'react-addons-pure-render-mixin';
+
+const Icon = React.createClass({
+
+  propTypes: {
+    icon: React.PropTypes.string.isRequired,
+    active: React.PropTypes.bool,
+    fixedWidth: React.PropTypes.bool,
+    className: React.PropTypes.string,
+    iconPrefix: React.PropTypes.string,
+    ariaLabel: React.PropTypes.string,
+    style: React.PropTypes.object
+  },
+
+  getDefaultProps () {
+    return {
+      active: false,
+      fixedWidth: false,
+      iconPrefix: 'fa'
+    };
+  },
+
+  mixins: [PureRenderMixin],
+
+  render () {
+    const active = (this.props.active) ? ' active' : '',
+    fixedWidth = (this.props.fixedWidth) ? ` ${this.props.iconPrefix}-fw` : '';
+
+    return (
+      <i className={`${this.props.iconPrefix}${fixedWidth} ${this.props.iconPrefix}-${this.props.icon}${active}`} {...props} />
+    );
+  }
+
+});
+
+export default Icon;

--- a/app/assets/javascripts/components/components/icon_button.jsx
+++ b/app/assets/javascripts/components/components/icon_button.jsx
@@ -1,5 +1,6 @@
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { Motion, spring } from 'react-motion';
+import Icon from './icon';
 
 const IconButton = React.createClass({
 
@@ -57,7 +58,7 @@ const IconButton = React.createClass({
             className={`icon-button ${this.props.active ? 'active' : ''} ${this.props.disabled ? 'disabled' : ''} ${this.props.inverted ? 'inverted' : ''}`}
             onClick={this.handleClick}
             style={style}>
-            <i style={{ transform: `rotate(${rotate}deg)` }} className={`fa fa-fw fa-${this.props.icon}`} aria-hidden='true' />
+            <Icon style={{ transform: `rotate(${rotate}deg)` }} icon={this.props.icon} aria-hidden='true' />
           </button>
         }
       </Motion>

--- a/app/assets/javascripts/components/components/status.jsx
+++ b/app/assets/javascripts/components/components/status.jsx
@@ -10,6 +10,7 @@ import StatusActionBar from './status_action_bar';
 import { FormattedMessage } from 'react-intl';
 import emojify from '../emoji';
 import escapeTextContentForBrowser from 'escape-html';
+import Icon from './icon';
 
 const Status = React.createClass({
 
@@ -64,7 +65,7 @@ const Status = React.createClass({
       return (
         <div style={{ cursor: 'default' }}>
           <div className='status__prepend'>
-            <div style={{ position: 'absolute', 'left': '-26px'}}><i className='fa fa-fw fa-retweet' /></div>
+            <div style={{ position: 'absolute', 'left': '-26px'}}><Icon icon="retweet" fixedWidth={true} /></div>
             <FormattedMessage id='status.reblogged_by' defaultMessage='{name} reblogged' values={{ name: <a onClick={this.handleAccountClick.bind(this, status.getIn(['account', 'id']))} href={status.getIn(['account', 'url'])} className='status__display-name muted'><strong dangerouslySetInnerHTML={displayNameHTML} /></a> }} />
           </div>
 

--- a/app/assets/javascripts/components/components/status_content.jsx
+++ b/app/assets/javascripts/components/components/status_content.jsx
@@ -5,6 +5,7 @@ import emojify from '../emoji';
 import { isRtl } from '../rtl';
 import { FormattedMessage } from 'react-intl';
 import Permalink from './permalink';
+import Icon from './icon';
 
 const StatusContent = React.createClass({
 
@@ -39,7 +40,7 @@ const StatusContent = React.createClass({
       } else if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
         link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
       } else if (media) {
-        link.innerHTML = '<i class="fa fa-fw fa-photo"></i>';
+        link.innerHTML = '<Icon icon="photo" />';
       } else {
         link.setAttribute('target', '_blank');
         link.setAttribute('rel', 'noopener');

--- a/app/assets/javascripts/components/components/status_content.jsx
+++ b/app/assets/javascripts/components/components/status_content.jsx
@@ -40,7 +40,7 @@ const StatusContent = React.createClass({
       } else if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
         link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
       } else if (media) {
-        link.innerHTML = '<Icon icon="photo" />';
+        link.innerHTML = '<i class="fa fa-fw fa-photo"></i>';
       } else {
         link.setAttribute('target', '_blank');
         link.setAttribute('rel', 'noopener');

--- a/app/assets/javascripts/components/components/video_player.jsx
+++ b/app/assets/javascripts/components/components/video_player.jsx
@@ -3,6 +3,7 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 import IconButton from './icon_button';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { isIOS } from '../is_mobile';
+import Icon from './icon';
 
 const messages = defineMessages({
   toggle_sound: { id: 'video_player.toggle_sound', defaultMessage: 'Toggle sound' },
@@ -193,7 +194,7 @@ const VideoPlayer = React.createClass({
       return (
         <div style={{ cursor: 'pointer', position: 'relative', marginTop: '8px', width: `${width}px`, height: `${height}px`, background: `url(${media.get('preview_url')}) no-repeat center`, backgroundSize: 'cover' }} onClick={this.handleOpen}>
           {spoilerButton}
-          <div style={{ position: 'absolute', top: '50%', left: '50%', fontSize: '36px', transform: 'translate(-50%, -50%)', padding: '5px', borderRadius: '100px', color: 'rgba(255, 255, 255, 0.8)' }}><i className='fa fa-play' /></div>
+          <div style={{ position: 'absolute', top: '50%', left: '50%', fontSize: '36px', transform: 'translate(-50%, -50%)', padding: '5px', borderRadius: '100px', color: 'rgba(255, 255, 255, 0.8)' }}><Icon icon='play' /></div>
         </div>
       );
     }

--- a/app/assets/javascripts/components/features/account/components/header.jsx
+++ b/app/assets/javascripts/components/features/account/components/header.jsx
@@ -3,6 +3,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import emojify from '../../../emoji';
 import escapeTextContentForBrowser from 'escape-html';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import Icon from '../../../components/icon';
 import IconButton from '../../../components/icon_button';
 import { Motion, spring } from 'react-motion';
 
@@ -101,7 +102,7 @@ const Header = React.createClass({
     }
 
     if (account.get('locked')) {
-      lockedIcon = <i className='fa fa-lock' />;
+      lockedIcon = <Icon icon='lock' />;
     }
 
     const content         = { __html: emojify(account.get('note')) };

--- a/app/assets/javascripts/components/features/compose/components/compose_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/compose_form.jsx
@@ -1,5 +1,6 @@
 import CharacterCounter from './character_counter';
 import Button from '../../../components/button';
+import Icon from '../../../components/icon';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ReplyIndicatorContainer from '../containers/reply_indicator_container';
@@ -137,7 +138,7 @@ const ComposeForm = React.createClass({
     }
 
     if (this.props.privacy === 'private' || this.props.privacy === 'direct') {
-      publishText = <span><i className='fa fa-lock' /> {intl.formatMessage(messages.publish)}</span>;
+      publishText = <span><Icon icon='lock' /> {intl.formatMessage(messages.publish)}</span>;
     } else {
       publishText = intl.formatMessage(messages.publish) + (this.props.privacy !== 'unlisted' ? '!' : '');
     }

--- a/app/assets/javascripts/components/features/compose/components/privacy_dropdown.jsx
+++ b/app/assets/javascripts/components/features/compose/components/privacy_dropdown.jsx
@@ -1,5 +1,6 @@
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { injectIntl, defineMessages } from 'react-intl';
+import Icon from '../../../components/icon';
 import IconButton from '../../../components/icon_button';
 
 const messages = defineMessages({
@@ -84,7 +85,7 @@ const PrivacyDropdown = React.createClass({
         <div className='privacy-dropdown__dropdown'>
           {options.map(item =>
             <div key={item.value} onClick={this.handleClick.bind(this, item.value)} className={`privacy-dropdown__option ${item.value === value ? 'active' : ''}`}>
-              <div className='privacy-dropdown__option__icon'><i className={`fa fa-fw fa-${item.icon}`} /></div>
+              <div className='privacy-dropdown__option__icon'><Icon icon={item.icon} fixedWidth={true} /></div>
               <div className='privacy-dropdown__option__content'>
                 <strong>{item.shortText}</strong>
                 {item.longText}

--- a/app/assets/javascripts/components/features/compose/components/search.jsx
+++ b/app/assets/javascripts/components/features/compose/components/search.jsx
@@ -1,6 +1,7 @@
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import Icon from '../../../components/icon';
 
 const messages = defineMessages({
   placeholder: { id: 'search.placeholder', defaultMessage: 'Search' }
@@ -57,8 +58,8 @@ const Search = React.createClass({
         />
 
         <div className='search__icon'>
-          <i className={`fa fa-search ${hasValue ? '' : 'active'}`} />
-          <i className={`fa fa-times-circle ${hasValue ? 'active' : ''}`} onClick={this.handleClear} />
+          <Icon icon="search" active={hasValue} />
+          <Icon icon="times-circle" active={hasValue} onClick={this.handleClear} />
         </div>
       </div>
     );

--- a/app/assets/javascripts/components/features/compose/components/upload_progress.jsx
+++ b/app/assets/javascripts/components/features/compose/components/upload_progress.jsx
@@ -1,6 +1,7 @@
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { Motion, spring } from 'react-motion';
 import { FormattedMessage } from 'react-intl';
+import Icon from '../../../components/icon';
 
 const UploadProgress = React.createClass({
 
@@ -21,7 +22,7 @@ const UploadProgress = React.createClass({
     return (
       <div className='upload-progress'>
         <div>
-          <i className='fa fa-upload' />
+          <Icon icon='upload' />
         </div>
 
         <div style={{ flex: '1 1 auto' }}>

--- a/app/assets/javascripts/components/features/compose/index.jsx
+++ b/app/assets/javascripts/components/features/compose/index.jsx
@@ -9,6 +9,7 @@ import { injectIntl, defineMessages } from 'react-intl';
 import SearchContainer from './containers/search_container';
 import { Motion, spring } from 'react-motion';
 import SearchResultsContainer from './containers/search_results_container';
+import Icon from '../../components/icon';
 
 const messages = defineMessages({
   start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
@@ -49,11 +50,11 @@ const Compose = React.createClass({
     if (withHeader) {
       header = (
         <div className='drawer__header'>
-          <Link title={intl.formatMessage(messages.start)} className='drawer__tab' to='/getting-started'><i className='fa fa-fw fa-asterisk' /></Link>
-          <Link title={intl.formatMessage(messages.community)} className='drawer__tab' to='/timelines/public/local'><i className='fa fa-fw fa-users' /></Link>
-          <Link title={intl.formatMessage(messages.public)} className='drawer__tab' to='/timelines/public'><i className='fa fa-fw fa-globe' /></Link>
-          <a title={intl.formatMessage(messages.preferences)} className='drawer__tab' href='/settings/preferences'><i className='fa fa-fw fa-cog' /></a>
-          <a title={intl.formatMessage(messages.logout)} className='drawer__tab' href='/auth/sign_out' data-method='delete'><i className='fa fa-fw fa-sign-out' /></a>
+          <Link title={intl.formatMessage(messages.start)} className='drawer__tab' to='/getting-started'><Icon icon='asterisk' fixedWidth={true} /></Link>
+          <Link title={intl.formatMessage(messages.community)} className='drawer__tab' to='/timelines/public/local'><Icon icon='users' fixedWidth={true} /></Link>
+          <Link title={intl.formatMessage(messages.public)} className='drawer__tab' to='/timelines/public'><Icon icon='globe'  fixedWidth={true} /></Link>
+          <a title={intl.formatMessage(messages.preferences)} className='drawer__tab' href='/settings/preferences'><Icon icon='cog' fixedWidth={true} /></a>
+          <a title={intl.formatMessage(messages.logout)} className='drawer__tab' href='/auth/sign_out' data-method='delete'><Icon icon='sign-out' fixedWidth={true} /></a>
         </div>
       );
     }

--- a/app/assets/javascripts/components/features/notifications/components/clear_column_button.jsx
+++ b/app/assets/javascripts/components/features/notifications/components/clear_column_button.jsx
@@ -1,4 +1,5 @@
 import { defineMessages, injectIntl } from 'react-intl';
+import Icon from '../../../components/icon';
 
 const messages = defineMessages({
   clear: { id: 'notifications.clear', defaultMessage: 'Clear notifications' }
@@ -26,7 +27,7 @@ const ClearColumnButton = React.createClass({
 
     return (
       <div title={intl.formatMessage(messages.clear)} className='column-icon' tabIndex='0' style={iconStyle} onClick={this.props.onClick}>
-        <i className='fa fa-eraser' />
+        <Icon icon='eraser' />
       </div>
     );
   }

--- a/app/assets/javascripts/components/features/notifications/components/notification.jsx
+++ b/app/assets/javascripts/components/features/notifications/components/notification.jsx
@@ -3,6 +3,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import StatusContainer from '../../../containers/status_container';
 import AccountContainer from '../../../containers/account_container';
 import { FormattedMessage } from 'react-intl';
+import Icon from '../../../components/icon';
 import Permalink from '../../../components/permalink';
 import emojify from '../../../emoji';
 import escapeTextContentForBrowser from 'escape-html';
@@ -24,7 +25,7 @@ const Notification = React.createClass({
       <div className='notification'>
         <div className='notification__message'>
           <div style={{ position: 'absolute', 'left': '-26px'}}>
-            <i className='fa fa-fw fa-user-plus' />
+            <Icon icon='user-plus' fixedWidth={true} />
           </div>
 
           <FormattedMessage id='notification.follow' defaultMessage='{name} followed you' values={{ name: link }} />
@@ -44,7 +45,7 @@ const Notification = React.createClass({
       <div className='notification'>
         <div className='notification__message'>
           <div style={{ position: 'absolute', 'left': '-26px'}}>
-            <i className='fa fa-fw fa-star' style={{ color: '#ca8f04' }} />
+            <Icon icon='star' fixedWidth={true} style={{ color: '#ca8f04' }} />
           </div>
 
           <FormattedMessage id='notification.favourite' defaultMessage='{name} favourited your status' values={{ name: link }} />
@@ -60,7 +61,7 @@ const Notification = React.createClass({
       <div className='notification'>
         <div className='notification__message'>
           <div style={{ position: 'absolute', 'left': '-26px'}}>
-            <i className='fa fa-fw fa-retweet' />
+            <Icon icon='retweet' />
           </div>
 
           <FormattedMessage id='notification.reblog' defaultMessage='{name} boosted your status' values={{ name: link }} />

--- a/app/assets/javascripts/components/features/status/components/detailed_status.jsx
+++ b/app/assets/javascripts/components/features/status/components/detailed_status.jsx
@@ -2,6 +2,7 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Avatar from '../../../components/avatar';
 import DisplayName from '../../../components/display_name';
+import Icon from '../../../components/icon';
 import StatusContent from '../../../components/status_content';
 import MediaGallery from '../../../components/media_gallery';
 import VideoPlayer from '../../../components/video_player';
@@ -63,7 +64,7 @@ const DetailedStatus = React.createClass({
         {media}
 
         <div className='detailed-status__meta'>
-          <a className='detailed-status__datetime' style={{ color: 'inherit' }} href={status.get('url')} target='_blank' rel='noopener'><FormattedDate value={new Date(status.get('created_at'))} hour12={false} year='numeric' month='short' day='2-digit' hour='2-digit' minute='2-digit' /></a>{applicationLink} · <Link to={`/statuses/${status.get('id')}/reblogs`} style={{ color: 'inherit', textDecoration: 'none' }}><i className='fa fa-retweet' /><span style={{ fontWeight: '500', fontSize: '12px', marginLeft: '6px', display: 'inline-block' }}><FormattedNumber value={status.get('reblogs_count')} /></span></Link> · <Link to={`/statuses/${status.get('id')}/favourites`} style={{ color: 'inherit', textDecoration: 'none' }}><i className='fa fa-star' /><span style={{ fontWeight: '500', fontSize: '12px', marginLeft: '6px', display: 'inline-block' }}><FormattedNumber value={status.get('favourites_count')} /></span></Link>
+          <a className='detailed-status__datetime' style={{ color: 'inherit' }} href={status.get('url')} target='_blank' rel='noopener'><FormattedDate value={new Date(status.get('created_at'))} hour12={false} year='numeric' month='short' day='2-digit' hour='2-digit' minute='2-digit' /></a>{applicationLink} · <Link to={`/statuses/${status.get('id')}/reblogs`} style={{ color: 'inherit', textDecoration: 'none' }}><Icon icon='retweet' /><span style={{ fontWeight: '500', fontSize: '12px', marginLeft: '6px', display: 'inline-block' }}><FormattedNumber value={status.get('reblogs_count')} /></span></Link> · <Link to={`/statuses/${status.get('id')}/favourites`} style={{ color: 'inherit', textDecoration: 'none' }}><Icon icon='star' /><span style={{ fontWeight: '500', fontSize: '12px', marginLeft: '6px', display: 'inline-block' }}><FormattedNumber value={status.get('favourites_count')} /></span></Link>
         </div>
       </div>
     );

--- a/app/assets/javascripts/components/features/ui/components/column_header.jsx
+++ b/app/assets/javascripts/components/features/ui/components/column_header.jsx
@@ -1,4 +1,5 @@
 import PureRenderMixin from 'react-addons-pure-render-mixin';
+import Icon from '../../../components/icon';
 
 const ColumnHeader = React.createClass({
 
@@ -21,7 +22,7 @@ const ColumnHeader = React.createClass({
     let icon = '';
 
     if (this.props.icon) {
-      icon = <i className={`fa fa-fw fa-${this.props.icon}`} style={{ display: 'inline-block', marginRight: '5px' }} />;
+      icon = <Icon icon={this.props.icon} style={{ display: 'inline-block', marginRight: '5px' }} />;
     }
 
     return (

--- a/app/assets/javascripts/components/features/ui/components/column_link.jsx
+++ b/app/assets/javascripts/components/features/ui/components/column_link.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router';
+import Icon from '../../../components/icon';
 
 const outerStyle = {
   display: 'block',
@@ -16,14 +17,14 @@ const ColumnLink = ({ icon, text, to, href, method }) => {
   if (href) {
     return (
       <a href={href} style={outerStyle} className='column-link' data-method={method}>
-        <i className={`fa fa-fw fa-${icon}`} style={iconStyle} />
+        <Icon icon={icon} style={iconStyle} />
         {text}
       </a>
     );
   } else {
     return (
       <Link to={to} style={outerStyle} className='column-link'>
-        <i className={`fa fa-fw fa-${icon}`} style={iconStyle} />
+        <Icon icon={icon} style={iconStyle} />
         {text}
       </Link>
     );

--- a/app/assets/javascripts/components/features/ui/components/media_modal.jsx
+++ b/app/assets/javascripts/components/features/ui/components/media_modal.jsx
@@ -4,6 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ExtendedVideoPlayer from '../../../components/extended_video_player';
 import ImageLoader from 'react-imageloader';
 import { defineMessages, injectIntl } from 'react-intl';
+import Icon from '../../../components/icon';
 import IconButton from '../../../components/icon_button';
 
 const messages = defineMessages({
@@ -104,8 +105,8 @@ const MediaModal = React.createClass({
     leftNav = rightNav = content = '';
 
     if (media.size > 1) {
-      leftNav  = <div style={leftNavStyle} className='modal-container__nav' onClick={this.handlePrevClick}><i className='fa fa-fw fa-chevron-left' /></div>;
-      rightNav = <div style={rightNavStyle} className='modal-container__nav' onClick={this.handleNextClick}><i className='fa fa-fw fa-chevron-right' /></div>;
+      leftNav  = <div style={leftNavStyle} className='modal-container__nav' onClick={this.handlePrevClick}><Icon icon='chevron-left' fixedWidth={true} /></div>;
+      rightNav = <div style={rightNavStyle} className='modal-container__nav' onClick={this.handleNextClick}><Icon icon='chevron-right' fixedWidth={true} /></div>;
     }
 
     if (attachment.get('type') === 'image') {

--- a/app/assets/javascripts/components/features/ui/components/tabs_bar.jsx
+++ b/app/assets/javascripts/components/features/ui/components/tabs_bar.jsx
@@ -1,19 +1,20 @@
 import { Link } from 'react-router';
 import { FormattedMessage } from 'react-intl';
+import Icon from '../../../components/icon';
 
 const TabsBar = React.createClass({
 
   render () {
     return (
       <div className='tabs-bar'>
-        <Link className='tabs-bar__link primary' activeClassName='active' to='/statuses/new'><i className='fa fa-fw fa-pencil' /><FormattedMessage id='tabs_bar.compose' defaultMessage='Compose' /></Link>
-        <Link className='tabs-bar__link primary' activeClassName='active' to='/timelines/home'><i className='fa fa-fw fa-home' /><FormattedMessage id='tabs_bar.home' defaultMessage='Home' /></Link>
-        <Link className='tabs-bar__link primary' activeClassName='active' to='/notifications'><i className='fa fa-fw fa-bell' /><FormattedMessage id='tabs_bar.notifications' defaultMessage='Notifications' /></Link>
+        <Link className='tabs-bar__link primary' activeClassName='active' to='/statuses/new'><Icon icon='pencil' fixedWidth={true} /><FormattedMessage id='tabs_bar.compose' defaultMessage='Compose' /></Link>
+        <Link className='tabs-bar__link primary' activeClassName='active' to='/timelines/home'><Icon icon='home' fixedWidth={true} /><FormattedMessage id='tabs_bar.home' defaultMessage='Home' /></Link>
+        <Link className='tabs-bar__link primary' activeClassName='active' to='/notifications'><Icon icon='bell' fixedWidth={true} /><FormattedMessage id='tabs_bar.notifications' defaultMessage='Notifications' /></Link>
 
-        <Link className='tabs-bar__link secondary' activeClassName='active' to='/timelines/public/local'><i className='fa fa-fw fa-users' /><FormattedMessage id='tabs_bar.local_timeline' defaultMessage='Local' /></Link>
-        <Link className='tabs-bar__link secondary' activeClassName='active' to='/timelines/public'><i className='fa fa-fw fa-globe' /><FormattedMessage id='tabs_bar.federated_timeline' defaultMessage='Federated' /></Link>
+        <Link className='tabs-bar__link secondary' activeClassName='active' to='/timelines/public/local'><Icon icon='users' fixedWidth={true} /><FormattedMessage id='tabs_bar.local_timeline' defaultMessage='Local' /></Link>
+        <Link className='tabs-bar__link secondary' activeClassName='active' to='/timelines/public'><Icon icon='globe' fixedWidth={true} /><FormattedMessage id='tabs_bar.federated_timeline' defaultMessage='Federated' /></Link>
 
-        <Link className='tabs-bar__link primary' activeClassName='active' style={{ flexGrow: '0', flexBasis: '30px' }} to='/getting-started'><i className='fa fa-fw fa-bars' /></Link>
+        <Link className='tabs-bar__link primary' activeClassName='active' style={{ flexGrow: '0', flexBasis: '30px' }} to='/getting-started'><Icon icon='bars' fixedWidth={true} /></Link>
       </div>
     );
   }


### PR DESCRIPTION
This PR creates a component for icons so that changes to icons in the future can be made in just one&nbsp;place 💯 

Just removes duplication for now but does so as a step
towards #1469

also see #1349 which proposes adding descriptive text to icons (for the toolbar but eventually would be great across the board)



### Usage
The Icon component just takes the name of the icon now:
```js
  <Icon icon={this.props.icon} />
```

You can pass an `active` property which will add an `.active` class to the icon.
```js
  <Icon icon={this.props.icon} active={true} />
```

You can also pass a `fixedWidth` property which will add a `fa-fw` class to the icon:
```js
  <Icon icon={this.props.icon} fixedWidth={true} />
```

or override the `iconPrefix`:
```js
  <Icon icon={this.props.icon} iconPrefix="foo" />
```

The Icon component sets the `className` for you. If for some reason you want to override this, pass a `className` property.
```js
  <Icon icon={this.props.icon} className={`foo foo-${this.props.icon} foo-bar`} />
```