### PR TITLE
Fix console error when scrolling a column with no scrollable content

### DIFF
--- a/app/assets/javascripts/components/features/ui/components/column.jsx
+++ b/app/assets/javascripts/components/features/ui/components/column.jsx
@@ -41,8 +41,11 @@ const Column = React.createClass({
   mixins: [PureRenderMixin],
 
   handleHeaderClick () {
-    let node = ReactDOM.findDOMNode(this);
-    this._interruptScrollAnimation = scrollTop(node.querySelector('.scrollable'));
+    const scrollable = ReactDOM.findDOMNode(this).querySelector('.scrollable');
+    if (!scrollable) {
+      return;
+    }
+    this._interruptScrollAnimation = scrollTop(scrollable);
   },
 
   handleWheel () {


### PR DESCRIPTION
Kind of trying to get my feet wet here, with a fairly low-impact initial PR. Apologies if something this trivial is an unwanted kind of contribution at such a busy time!

The issue addressed by this PR is reproduced by clicking the header of a column that contains no content. For example: when you have no notifications. The lack of a `scrollable` inside the column causes a `TypeError: Cannot read property 'scrollTop' of null` error.

![bug](https://cloud.githubusercontent.com/assets/566159/24927976/11234852-1f01-11e7-84da-e4492548da98.gif)

I've tested this change manually on a column both with and without content. In the long term, would you be at all interested in having unit tests for your front-end code? It's a gorgeous bit of React code and I could see myself having a lot of fun backfilling it with test coverage on some rainy evenings ❤️