### PR TITLE
terms: remove redundant words

### DIFF
--- a/app/views/about/terms.en.html.haml
+++ b/app/views/about/terms.en.html.haml
@@ -51,7 +51,7 @@
   %h3#coppa Children's Online Privacy Protection Act Compliance
 
   %p
-    Our site, products and services are all directed to people who are at least 13 years old or older. If this server is in the USA, and you are under the age of 13, per the requirements of COPPA
+    Our site, products and services are all directed to people who are at least 13 years old. If this server is in the USA, and you are under the age of 13, per the requirements of COPPA
     = surround '(', '),' do
       = link_to 'Children\'s Online Privacy Protection Act', 'https://en.wikipedia.org/wiki/Children%27s_Online_Privacy_Protection_Act'
     do not use this site.


### PR DESCRIPTION
"at least X" and "X or older" have identical meanings. Using both together feels a little jarring, so I've removed one of them.