### PR TITLE
Params compact deprecation warning

### DIFF
--- a/app/helpers/admin/accounts_helper.rb
+++ b/app/helpers/admin/accounts_helper.rb
@@ -6,10 +6,16 @@ module Admin::AccountsHelper
   end
 
   def filter_link_to(text, more_params)
-    link_to text, filter_params(more_params), class: params.merge(more_params).compact == params.compact ? 'selected' : ''
+    link_to text, filter_params(more_params), class: filtered_link_class(more_params)
   end
 
   def table_link_to(icon, text, path, options = {})
     link_to safe_join([fa_icon(icon), text]), path, options.merge(class: 'table-action-link')
+  end
+
+  private
+
+  def filtered_link_class(more_params)
+    params.merge(more_params).compact == params.compact ? 'selected' : ''
   end
 end

--- a/app/helpers/admin/accounts_helper.rb
+++ b/app/helpers/admin/accounts_helper.rb
@@ -6,7 +6,8 @@ module Admin::AccountsHelper
   end
 
   def filter_link_to(text, more_params)
-    link_to text, filter_params(more_params), class: filtered_link_class(more_params)
+    new_url = filtered_url_for(more_params)
+    link_to text, new_url, class: filter_link_class(new_url)
   end
 
   def table_link_to(icon, text, path, options = {})
@@ -15,7 +16,11 @@ module Admin::AccountsHelper
 
   private
 
-  def filtered_link_class(more_params)
-    params.merge(more_params).compact == params.compact ? 'selected' : ''
+  def filter_link_class(new_url)
+    filtered_url_for(params) == new_url ? 'selected' : ''
+  end
+
+  def filtered_url_for(params)
+    url_for filter_params(params)
   end
 end


### PR DESCRIPTION
The `#compact` method on `ActionController::StrongParameters` is deprecated (strong params is not a `Hash`) and might go away in the future. This change removed that method and swaps in a simpler comparison which has the same effect of highlighting/linking as previous.