### PR TITLE
Accessible Search Form Submit

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/search.jsx
+++ b/app/assets/javascripts/components/features/compose/components/search.jsx
@@ -47,6 +47,7 @@ const Search = React.createClass({
         <input
           className='search__input'
           type='text'
+          required={true}
           placeholder={intl.formatMessage(messages.placeholder)}
           value={value}
           onChange={this.handleChange}

--- a/app/assets/javascripts/components/features/compose/components/search.jsx
+++ b/app/assets/javascripts/components/features/compose/components/search.jsx
@@ -29,15 +29,13 @@ const Search = React.createClass({
     this.props.onClear();
   },
 
-  handleKeyDown (e) {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      this.props.onSubmit();
-    }
-  },
-
   handleFocus () {
     this.props.onShow();
+  },
+
+  handleSubmit (e) {
+    e.preventDefault();
+    this.props.onSubmit();
   },
 
   render () {
@@ -45,22 +43,21 @@ const Search = React.createClass({
     const hasValue = value.length > 0 || submitted;
 
     return (
-      <div className='search'>
+      <form role='search' className='search' onSubmit={this.handleSubmit}>
         <input
           className='search__input'
           type='text'
           placeholder={intl.formatMessage(messages.placeholder)}
           value={value}
           onChange={this.handleChange}
-          onKeyUp={this.handleKeyDown}
           onFocus={this.handleFocus}
         />
 
-        <div className='search__icon'>
+        <button type='submit' className='search__icon'>
           <i className={`fa fa-search ${hasValue ? '' : 'active'}`} />
           <i className={`fa fa-times-circle ${hasValue ? 'active' : ''}`} onClick={this.handleClear} />
-        </div>
-      </div>
+        </button>
+      </form>
     );
   }
 

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1806,6 +1806,13 @@ button.active i.fa-retweet {
 }
 
 .search__icon {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 36px;
+  border: none;
+  cursor: pointer;
   .fa {
     position: absolute;
     top: 10px;


### PR DESCRIPTION
Does
 - Wraps the input.search__input in a form
 - Removes now unnecessary handleKeyDown (automatically triggered now by capturing the form onSubmit)
 - Turns div.search__icon into a button[type=“submit”]
   - add a little styling for the button
 - Adds role=‘search’ to new form (ARIA)
 - allow us to leverage the HTML5 Form Validation API down the line

Does Not
 - add a label or aria-label to the input or button

Assistive Technology may tap into standard `<form>` elements in various ways. Rather than explicitly listening to a keyUp for ENTER in the input, now listening to a generic form submit event.