### PR TITLE
CSS Variables for Sass $colors 💅

### DIFF
--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -2,7 +2,7 @@
   .wrapper {
     max-width: 600px;
     margin: 0 auto;
-    color: $color3;
+    color: var(--color3, $color3);
     padding-top: 50px;
     padding-bottom: 50px;
 
@@ -15,7 +15,7 @@
     font: 46px/52px 'Roboto', sans-serif;
     font-weight: 600;
     margin-bottom: 20px;
-    color: $color4;
+    color: var(--color4, $color4);
     padding: 20px 0;
 
     img {
@@ -32,7 +32,7 @@
     line-height: 28px;
     font-weight: 400;
     margin-bottom: 20px;
-    color: $color5;
+    color: var(--color5, $color5);
   }
 
   h3 {
@@ -41,7 +41,7 @@
     line-height: 28px;
     font-weight: 400;
     margin-bottom: 20px;
-    color: $color2;
+    color: var(--color2, $color2);
   }
 
   ul, ol {
@@ -67,7 +67,7 @@
     margin-bottom: 26px;
 
     a {
-      color: $color4;
+      color: var(--color4, $color4);
       text-decoration: underline;
     }
   }
@@ -76,14 +76,14 @@
     display: inline-block;
     padding: 7px 7px 5px 7px;
     margin: 0 2px;
-    background: $color3;
-    color: $color1;
+    background: var(--color3, $color3);
+    color: var(--color1, $color1);
     font: 16px/16px 'Montserrat', sans-serif;
     font-weight: 300;
   }
 
   .screenshot {
-    box-shadow: 0 0 15px rgba($color8, 0.4);
+    box-shadow: 0 0 15px rgba(var(--color8, $color8), 0.4);
     margin-bottom: 26px;
 
     img {
@@ -103,7 +103,7 @@
       line-height: 36px;
 
       a {
-        color: $color3;
+        color: var(--color3, $color3);
         text-decoration: underline;
       }
     }
@@ -126,6 +126,7 @@
   justify-content: space-between;
   border-top: 1px solid lighten($color1, 10%);
   border-bottom: 1px solid lighten($color1, 10%);
+  border-color: var(--color1, $color1);
   padding-right: 14px;
 
   .section {
@@ -142,7 +143,7 @@
       font-size: 16px;
 
       &:last-child {
-        color: $color2;
+        color: var(--color2, $color2);
         font-size: 14px;
       }
     }
@@ -151,7 +152,7 @@
       font-weight: 500;
       font-size: 32px;
       line-height: 48px;
-      color: $color5;
+      color: var(--color5, $color5);
     }
   }
 
@@ -186,7 +187,7 @@
 
     a {
       display: block;
-      color: $color5;
+      color: var(--color5, $color5);
       text-decoration: none;
 
       &:hover {
@@ -198,7 +199,7 @@
 
     .username {
       display: block;
-      color: $color3;
+      color: var(--color3, $color3);
     }
   }
 }
@@ -209,7 +210,7 @@
 
   strong {
     display: block;
-    color: $color5;
+    color: var(--color5, $color5);
   }
 }
 
@@ -258,7 +259,7 @@
           a {
             display: block;
             padding: 7px 14px;
-            color: rgba($color5, 0.7);
+            color: rgba(var(--color5, $color5), 0.7);
             text-decoration: none;
             transition: all 200ms linear;
 
@@ -267,14 +268,14 @@
             }
 
             &:hover {
-              color: $color5;
-              background-color: darken($color1, 5%);
+              color: var(--color5, $color5);
+              background-color: darken(var(--color1, $color1), 5%);
               transition: all 100ms linear;
             }
 
             &.selected {
-              color: $color5;
-              background-color: $color4;
+              color: var(--color5, $color5);
+              background-color: var(--color4, $color4);
 
               &:hover {
                 background-color: lighten($color4, 5%);
@@ -335,10 +336,10 @@
   .simple_form, .closed-registrations-message {
     width: 300px;
     flex: 0 0 auto;
-    background: rgba(darken($color1, 7%), 0.5);
+    background: rgba(darken(var(--color1, $color1), 7%), 0.5);
     padding: 14px;
     border-radius: 4px;
-    box-shadow: 0 0 15px rgba($color8, 0.4);
+    box-shadow: 0 0 15px rgba(var(--color8, $color8), 0.4);
 
     .actions {
       margin-bottom: 0;
@@ -348,7 +349,7 @@
       text-align: center;
 
       a {
-        color: $color2;
+        color: var(--color2, $color2);
       }
     }
   }

--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -4,7 +4,7 @@
   padding: 60px 0;
   padding-bottom: 0;
   border-radius: 4px 4px 0 0;
-  box-shadow: 0 0 15px rgba($color8, 0.2);
+  box-shadow: 0 0 15px rgba(var(--color8, $color8), 0.2);
   overflow: hidden;
   position: relative;
 
@@ -14,7 +14,7 @@
   }
 
   &:after {
-    background: rgba($color8, 0.5);
+    background: rgba(var(--color8, $color8), 0.5);
     display: block;
     content: "";
     position: absolute;
@@ -29,7 +29,7 @@
     display: block;
     font-size: 20px;
     line-height: 18px * 1.5;
-    color: $color5;
+    color: var(--color5, $color5);
     font-weight: 500;
     text-align: center;
     position: relative;
@@ -39,7 +39,7 @@
     small {
       display: block;
       font-size: 14px;
-      color: $color4;
+      color: var(--color4, $color4);
       font-weight: 400;
     }
   }
@@ -82,7 +82,7 @@
 
   .counter {
     width: 80px;
-    color: $color3;
+    color: var(--color3, $color3);
     padding: 0 10px;
     margin-bottom: 10px;
     border-right: 1px solid $color3;
@@ -100,14 +100,14 @@
       bottom: -10px;
       left: 0;
       width: 100%;
-      border-bottom: 4px solid $color3;
+      border-bottom: 4px solid var(--color3, $color3);
       opacity: 0.5;
       transition: all 0.8s ease;
     }
 
     &.active {
       &:after {
-        border-bottom: 4px solid $color4;
+        border-bottom: 4px solid var(--color4, $color4);
         opacity: 1;
       }
     }
@@ -129,13 +129,13 @@
       text-transform: uppercase;
       display: block;
       margin-bottom: 5px;
-      text-shadow: 0 0 2px $color8;
+      text-shadow: 0 0 2px var(--color8, $color8);
     }
 
     .counter-number {
       font-weight: 500;
       font-size: 18px;
-      color: $color5;
+      color: var(--color5, $color5);
     }
   }
 
@@ -144,7 +144,7 @@
     font-size: 14px;
     line-height: 18px;
     padding: 5px 10px;
-    color: $color2;
+    color: var(--color2, $color2);
     order: 1;
   }
 
@@ -175,7 +175,7 @@
 
   a, .current, .next_page, .previous_page, .gap {
     font-size: 14px;
-    color: $color5;
+    color: var(--color5, $color5);
     font-weight: 500;
     display: inline-block;
     padding: 6px 10px;
@@ -183,9 +183,9 @@
   }
 
   .current {
-    background: $color5;
+    background: var(--$color5, $color5);
     border-radius: 100px;
-    color: $color1;
+    color: var(--color1, $color1);
     cursor: default;
   }
 
@@ -195,7 +195,7 @@
 
   .previous_page, .next_page {
     text-transform: uppercase;
-    color: $color2;
+    color: var(--color2, $color2);
   }
 
   .previous_page {
@@ -239,7 +239,7 @@
 .accounts-grid {
   clear: both;
   box-shadow: 0 0 15px rgba($color8, 0.2);
-  background: $color5;
+  background: var(--color5, $color5);
   border-radius: 0 0 4px 4px;
   padding: 20px 10px;
   padding-bottom: 10px;
@@ -254,9 +254,9 @@
     box-sizing: border-box;
     width: 335px;
     float: left;
-    border: 1px solid $color2;
+    border: 1px solid var(--color2, $color2);
     border-radius: 4px;
-    color: $color1;
+    color: var(--color1, $color1);
     height: 160px;
     margin-bottom: 10px;
 
@@ -267,7 +267,7 @@
     .account-grid-card__header {
       overflow: hidden;
       padding: 10px;
-      border-bottom: 1px solid $color2;
+      border-bottom: 1px solid var(--color2, $color2);
     }
 
     .avatar {
@@ -289,7 +289,7 @@
 
       a {
         display: block;
-        color: $color1;
+        color: var(--color1, $color1);
         text-decoration: none;
 
         &:hover {
@@ -306,20 +306,20 @@
     }
 
     .username {
-      color: $color4;
+      color: var(--color4, $color4);
     }
 
     .note {
       padding: 10px;
       padding-top: 15px;
-      color: $color3;
+      color: var(--color3, $color3);
       word-wrap: break-word;
     }
   }
 }
 
 .nothing-here {
-  color: $color3;
+  color: var(--color3, $color3);
   font-size: 14px;
   font-weight: 500;
   text-align: center;
@@ -330,7 +330,7 @@
 
 .account-card {
   padding: 14px 10px;
-  background: $color5;
+  background: var(--color5, $color5);
   border-radius: 4px;
   text-align: left;
   box-shadow: 0 0 15px rgba($color8, 0.2);
@@ -366,12 +366,12 @@
 
       strong {
         font-weight: 500;
-        color: $color1;
+        color: var(--color1, $color1);
       }
 
       span {
         font-size: 14px;
-        color: $color3;
+        color: var(--color3, $color3);
       }
     }
 
@@ -387,6 +387,6 @@
   .account__header__content {
     font-size: 14px;
     color: $color1;
-    text-shadow: 0 0 2px $color8;
+    text-shadow: 0 0 2px var(--color8, $color8);
   }
 }

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -6,7 +6,7 @@
   .sidebar-wrapper {
     flex: 1;
     height: 100%;
-    background: $color1;
+    background: var(--color1, $color1);
     display: flex;
     justify-content: flex-end;
   }
@@ -31,7 +31,7 @@
       a {
         display: block;
         padding: 15px 25px;
-        color: rgba($color5, 0.7);
+        color: rgba(var(--color5, $color5), 0.7);
         text-decoration: none;
         transition: all 200ms linear;
         border-radius: 4px 0 0 4px;
@@ -41,26 +41,26 @@
         }
 
         &:hover {
-          color: $color5;
-          background-color: darken($color1, 5%);
+          color: var(--color5, $color5);
+          background-color: darken(var(--color1, $color1), 5%);
           transition: all 100ms linear;
         }
 
         &.selected {
-          background: darken($color1, 2%);
+          background: darken(var(--color1, $color1), 2%);
           border-radius: 4px 0 0 0;
         }
       }
 
       ul {
-        background: darken($color1, 4%);
+        background: darken(var(--color1, $color1), 4%);
         border-radius: 0 0 0 4px;
 
         a {
           border: 0;
 
           &.selected {
-            color: $color5;
+            color: var(--color5, $color5);
             background-color: $color4;
             border-bottom: 0;
             border-radius: 0;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -66,7 +66,7 @@ table {
 
 ::-webkit-scrollbar-thumb {
   background: lighten($color1, 4%);
-  border: 0px none $color5;
+  border: 0px none var(--color5, $color5);
   border-radius: 50px;
 }
 
@@ -81,15 +81,15 @@ table {
 ::-webkit-scrollbar-track {
   border: 0px none $color5;
   border-radius: 0;
-  background: rgba($color8, 0.1);
+  background: rgba(var(--color8, $color8), 0.1);
 }
 
 ::-webkit-scrollbar-track:hover {
-  background: $color1;
+  background: var(--color1, $color1);
 }
 
 ::-webkit-scrollbar-track:active {
-  background: $color1;
+  background: var(--color1, $color1);
 }
 
 ::-webkit-scrollbar-corner {
@@ -98,7 +98,7 @@ table {
 
 body {
   font-family: 'Roboto', sans-serif;
-  background: $color1 image-url('background-photo.jpeg');
+  background: var(--color1, $color1) image-url('background-photo.jpeg');
   background-size: cover;
   background-attachment: fixed;
   font-size: 13px;
@@ -115,7 +115,7 @@ body {
     width: 100%;
     height: 100%;
     padding: 0;
-    background: $color1;
+    background: var(--color1, $color1);
   }
 
   &.embed {
@@ -131,7 +131,7 @@ body {
   }
 
   &.admin {
-    background: darken($color1, 4%);
+    background: darken(var(--color1, $color1), 4%);
     position: fixed;
     width: 100%;
     height: 100%;
@@ -179,7 +179,7 @@ button:focus {
   h1 {
     display: block;
     text-align: center;
-    color: $color5;
+    color: var(--color5, $color5);
     font-size: 48px;
     font-weight: 500;
 
@@ -230,7 +230,7 @@ button:focus {
   text-align: center;
   margin-top: 30px;
   font-size: 12px;
-  color: darken($color2, 25%);
+  color: darken(var(--color2, $color2), 25%);
 
   .domain {
     font-weight: 500;
@@ -260,7 +260,7 @@ button:focus {
   h1 {
     font-size: 24px;
     line-height: 28px;
-    color: $color3;
+    color: var(--color3, $color3);
     overflow: hidden;
     font-weight: 500;
     margin-bottom: 20px;
@@ -272,7 +272,7 @@ button:focus {
 
     small {
       font-weight: 400;
-      color: $color2;
+      color: var(--color2, $color2);
     }
 
     img {
@@ -286,8 +286,8 @@ button:focus {
 }
 
 .landing-strip {
-  background: rgba(darken($color1, 7%), 0.8);
-  color: $color3;
+  background: rgba(darken(var(--color1, $color1), 7%), 0.8);
+  color: var(--color3, $color3);
   font-weight: 400;
   padding: 14px;
   border-radius: 4px;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -12,7 +12,7 @@
   box-sizing: border-box;
   text-align: center;
   border: 10px none;
-  color: $color5;
+  color: var(--color5, $color5);
   font-size: 14px;
   font-weight: 500;
   letter-spacing: 0;
@@ -31,7 +31,7 @@
   }
 
   &:disabled {
-    background-color: $color3;
+    background-color: var(--color3, $color3);
     cursor: default;
   }
 
@@ -41,25 +41,25 @@
 }
 
 .column-icon {
-  color: $color3;
-  background: lighten($color1, 4%);
+  color: var(--color3, $color3);
+  background: lighten($color1);
 
   &:hover {
-    color: lighten($color3, 7%);
+    color: lighten($color3);
   }
 }
 
 .icon-button {
   display: inline-block;
   padding: 0;
-  color: lighten($color1, 26%);
+  color: lighten($color1);
   border: none;
   background: transparent;
   cursor: pointer;
   transition: all 100ms ease-in;
 
   &:hover, &:active, &:focus {
-    color: lighten($color1, 33%);
+    color: lighten($color1);
     transition: all 200ms ease-out;
   }
 
@@ -69,7 +69,7 @@
   }
 
   &.active {
-    color: $color4;
+    color: var(--color4, $color4);
   }
 
   &::-moz-focus-inner {
@@ -233,11 +233,11 @@
   border-radius: 4px 4px 0 0;
   position: relative;
   bottom: -2px;
-  background: $color3;
+  background: var(--color3, $color3);
   padding: 10px;
 
   .reply-indicator__display-name {
-    color: $color1;
+    color: var(--color1, $color1);
   }
 }
 
@@ -263,7 +263,7 @@
   }
 
   a {
-    color: $color2;
+    color: var(--color2, $color2);
     text-decoration: none;
 
     &:hover {
@@ -379,7 +379,7 @@ a.status__content__spoiler-link {
 }
 
 .reply-indicator__content {
-  color: $color1;
+  color: var(--color1, $color1);
   font-size: 14px;
 
   a {
@@ -394,7 +394,7 @@ a.status__content__spoiler-link {
   .account__display-name {
     flex: 1 1 auto;
     display: block;
-    color: $color3;
+    color: var(--color3, $color3);
     overflow: hidden;
     text-decoration: none;
     font-size: 14px;
@@ -414,15 +414,15 @@ a.status__content__spoiler-link {
   }
 
   .account__header__content {
-    color: $color2;
+    color: var(--color2, $color2);
   }
 
   .account__header__display-name {
-    color: $color5;
+    color: var(--color5, $color5);
   }
 
   .account__header__username {
-    color: $color4;
+    color: var(--color4, $color4);
   }
 }
 
@@ -431,7 +431,7 @@ a.status__content__spoiler-link {
   word-break: normal;
   font-weight: 400;
   overflow: hidden;
-  color: $color3;
+  color: var(--color3, $color3);
 
   p {
     margin-bottom: 20px;
@@ -478,14 +478,14 @@ a.status__content__spoiler-link {
     display: block;
     text-transform: uppercase;
     font-size: 11px;
-    color: $color3;
+    color: var(--color3, $color3);
   }
 
   strong {
     display: block;
     font-size: 15px;
     font-weight: 500;
-    color: $color5;
+    color: var(--color5, $color5);
   }
 
   abbr {
@@ -499,7 +499,7 @@ a.status__content__spoiler-link {
 
 .status__display-name, .account__display-name {
   strong {
-    color: $color5;
+    color: var(--color5, $color5);
   }
 
   &.muted {
@@ -524,7 +524,7 @@ a.status__content__spoiler-link {
 }
 
 .detailed-status__display-name {
-  color: $color2;
+  color: var(--color2, $color2);
   line-height: 24px;
 
   strong, span {
@@ -533,7 +533,7 @@ a.status__content__spoiler-link {
 
   strong {
     font-size: 16px;
-    color: $color5;
+    color: var(--color5, $color5);
   }
 }
 
@@ -566,12 +566,12 @@ a.status__content__spoiler-link {
   padding: 8px 0;
   padding-bottom: 0;
   cursor: default;
-  color: $color3;
+  color: var(--color3, $color3);
   font-size: 15px;
   position: relative;
 
   .fa {
-    color: $color4;
+    color: var(--color4, $color4);
   }
 }
 
@@ -580,7 +580,7 @@ a.status__content__spoiler-link {
   text-decoration: none;
 
   &:hover {
-    color: $color5;
+    color: var(--color5, $color5);
     text-decoration: underline;
   }
 }
@@ -604,10 +604,10 @@ a.status__content__spoiler-link {
   display: flex;
   flex-shrink: 0;
   cursor: default;
-  color: $color3;
+  color: var(--color3, $color3);
 
   strong {
-    color: $color5;
+    color: var(--color5, $color5);
   }
 }
 
@@ -672,8 +672,8 @@ a.status__content__spoiler-link {
     box-sizing: border-box;
     width: 140px;
     text-decoration: none;
-    background: $color2;
-    color: $color1;
+    background: var(--color2, $color2);
+    color: var(--color1, $color1);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -683,8 +683,8 @@ a.status__content__spoiler-link {
     }
 
     &:hover {
-      background: $color4;
-      color: $color2;
+      background: var(--color4, $color4);
+      color: var(--color2, $color2);
     }
   }
 }
@@ -730,7 +730,7 @@ a.status__content__spoiler-link {
   width: 330px;
   position: relative;
   box-sizing: border-box;
-  background: $color1;
+  background: var(--color1, $color1);
   display: flex;
   flex-direction: column;
 }
@@ -757,7 +757,7 @@ a.status__content__spoiler-link {
   flex: 1 1 auto;
   padding: 15px;
   padding-bottom: 13px;
-  color: $color3;
+  color: var(--color3, $color3);
   text-decoration: none;
   text-align: center;
   font-size: 16px;
@@ -801,7 +801,7 @@ a.status__content__spoiler-link {
   height: 100%;
 
   &.darker {
-    background: $color1;
+    background: var(--color1, $color1);
   }
 }
 
@@ -866,7 +866,7 @@ a.status__content__spoiler-link {
   display: block;
   flex: 1 1 auto;
   padding: 15px 10px;
-  color: $color5;
+  color: var(--color5, $color5);
   text-decoration: none;
   text-align: center;
   font-size: 14px;
@@ -880,8 +880,8 @@ a.status__content__spoiler-link {
   }
 
   &.active {
-    border-bottom: 2px solid $color4;
-    color: $color4;
+    border-bottom: 2px solid var(--color4, $color4);
+    color: var(--color4, $color4);
   }
 
   &:hover, &:focus, &:active {
@@ -939,22 +939,22 @@ a.status__content__spoiler-link {
   top: 100%;
   width: 100%;
   z-index: 99;
-  box-shadow: 0 0 15px rgba($color8, 0.4);
+  box-shadow: 0 0 15px rgba(var(--color8, $color8), 0.4);
 }
 
 .react-autosuggest__section-title {
-  background: $color3;
+  background: var(--color3, $color3);
   padding: 4px 10px;
   font-weight: 500;
   cursor: default;
-  color: $color1;
+  color: var(--color1, $color1);
   text-transform: uppercase;
   font-size: 11px;
 }
 
 .react-autosuggest__suggestions-list {
-  background: $color2;
-  color: $color1;
+  background: var(--color2, $color2);
+  color: var(--color1, $color1);
   font-size: 14px;
 }
 
@@ -964,8 +964,8 @@ a.status__content__spoiler-link {
 }
 
 .react-autosuggest__suggestion--focused {
-  background: $color4;
-  color: $color5;
+  background: var(--color4, $color4);
+  color: var(--color5, $color5);
 }
 
 .scrollable {
@@ -985,7 +985,7 @@ a.status__content__spoiler-link {
   background: lighten($color1, 4%);
   flex: 0 0 auto;
   cursor: pointer;
-  color: $color4;
+  color: var(--color4, $color4);
   z-index: 3;
 
   &:hover {
@@ -1001,7 +1001,7 @@ a.status__content__spoiler-link {
   border: 0;
   padding: 0;
   user-select: none;
-  -webkit-tap-highlight-color: rgba($color8, 0);
+  -webkit-tap-highlight-color: rgba(var(--color8, $color8), 0);
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -1027,16 +1027,16 @@ a.status__content__spoiler-link {
   height: 24px;
   padding: 0;
   border-radius: 30px;
-  background-color: $color1;
+  background-color: var(--color1, $color1);
   transition: all 0.2s ease;
 }
 
 .react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {
-  background-color: darken($color1, 10%);
+  background-color: darken(var(--color1, $color1), 10%);
 }
 
 .react-toggle--checked .react-toggle-track {
-  background-color: $color4;
+  background-color: var(--color1, $color1);
 }
 
 .react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-track {
@@ -1087,7 +1087,7 @@ a.status__content__spoiler-link {
   left: 1px;
   width: 22px;
   height: 22px;
-  border: 1px solid $color1;
+  border: 1px solid var(--color1, $color1);
   border-radius: 50%;
   background-color: darken($color5, 2%);
   box-sizing: border-box;
@@ -1163,8 +1163,8 @@ a.status__content__spoiler-link {
   }
 
   &.selected {
-    background: $color4;
-    color: $color5;
+    background: var(--color4, $color4);
+    color: var(--color5, $color5);
   }
 }
 
@@ -1175,7 +1175,7 @@ a.status__content__spoiler-link {
   flex: 1 0 auto;
 
   p {
-    color: $color2;
+    color: var(--color2, $color2);
   }
 
   a {
@@ -1184,14 +1184,14 @@ a.status__content__spoiler-link {
 }
 
 .setting-text {
-  color: $color3;
+  color: var(--color3, $color3);
   background: transparent;
   border: none;
-  border-bottom: 2px solid $color3;
+  border-bottom: 2px solid var(--color3, $color3);
 
   &:focus, &:active {
-    color: $color5;
-    border-bottom-color: $color4;
+    color: var(--color5, $color5);
+    border-bottom-color: var(--color4, $color4);
   }
 }
 
@@ -1234,14 +1234,14 @@ button.active i.fa-retweet {
   display: block;
   font-weight: 500;
   margin-bottom: 5px;
-  color: $color3;
+  color: var(--color3, $color3);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .status-card__description {
-  color: $color3;
+  color: var(--color3, $color3);
 }
 
 .status-card__image {
@@ -1285,33 +1285,33 @@ button.active i.fa-retweet {
   }
 
   &.active .fa {
-    color: $color4;
-    text-shadow: 0 0 10px rgba($color4, 0.4);
+    color: var(--color4, $color4);
+    text-shadow: 0 0 10px rgba(var(--color4, $color4), 0.4);
   }
 }
 
 .loading-indicator {
-  color: $color2;
+  color: var(--color2, $color2);
 }
 
 .collapsable-collapsed {
-  color: $color3;
+  color: var(--color3, $color3);
   background: lighten($color1, 4%);
 }
 
 .collapsable {
-  color: $color5;
+  color: var(--color5, $color5);
   background: lighten($color1, 8%);
 
   &:hover {
-    color: $color5;
+    color: var(--color5, $color5);
     background: lighten($color1, 8%);
   }
 }
 
 .media-spoiler {
-  background: $color8;
-  color: $color5;
+  background: var(--color8, $color8);
+  color: var(--color5, $color5);
 }
 
 .modal-container--preloader {
@@ -1329,29 +1329,29 @@ button.active i.fa-retweet {
 }
 
 .column-settings--section {
-  color: $color3;
+  color: var(--color3, $color3);
 }
 
 .modal-container__nav {
-  color: $color5;
+  color: var(--color5, $color5);
 }
 
 .account--follows-info {
-  color: $color5;
+  color: var(--color5, $color5);
 }
 
 .setting-toggle {
-  color: $color3;
+  color: var(--color3, $color3);
 }
 
 .report__target {
   border-bottom: 1px solid lighten($color1, 4%);
-  color: $color2;
+  color: var(--color2, $color2);
   padding-bottom: 10px;
 
   strong {
     display: block;
-    color: $color5;
+    color: var(--color5, $color5);
     font-weight: 500;
   }
 }
@@ -1364,7 +1364,7 @@ button.active i.fa-retweet {
   border-radius: 2px 2px 0 0;
   padding: 7px 4px;
   font-size: 14px;
-  color: $color5;
+  color: var(--color5, $color5);
   display: block;
   width: 100%;
   outline: 0;
@@ -1372,8 +1372,8 @@ button.active i.fa-retweet {
   resize: vertical;
 
   &:active, &:focus {
-    border-bottom-color: $color4;
-    background: rgba($color8, 0.1);
+    border-bottom-color: var(--color4, $color4);
+    background: rgba(var(--color8, $color8), 0.1);
   }
 }
 
@@ -1387,7 +1387,7 @@ button.active i.fa-retweet {
   cursor: default;
 
   a {
-    color: $color4;
+    color: var(--color4, $color4);
     text-decoration: none;
 
     &:hover {
@@ -1412,12 +1412,12 @@ button.active i.fa-retweet {
 .emoji-dialog {
   width: 280px;
   height: 220px;
-  background: $color2;
+  background: var(--color2, $color2);
   box-sizing: border-box;
   border-radius: 2px;
   overflow: hidden;
   position: relative;
-  box-shadow: 0 0 15px rgba($color8, 0.4);
+  box-shadow: 0 0 15px rgba(var(--color8, $color8), 0.4);
 
   .emojione {
     margin: 0;
@@ -1427,7 +1427,7 @@ button.active i.fa-retweet {
 
   .emoji-dialog-header {
     padding: 0 10px;
-    background-color: $color3;
+    background-color: var(--color3, $color3);
 
     ul {
       padding: 0;
@@ -1486,7 +1486,7 @@ button.active i.fa-retweet {
     font-size: 14px;
     font-family: sans-serif;
     font-weight: normal;
-    color: $color1;
+    color: var(--color1, $color1);
     cursor: default;
   }
 
@@ -1589,7 +1589,7 @@ button.active i.fa-retweet {
   width: 100%;
   height: 100%;
   visibility: hidden;
-  background: rgba($color8, 0.8);
+  background: rgba(var(--color8, $color8), 0.8);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1618,8 +1618,8 @@ button.active i.fa-retweet {
   left: 0;
   z-index: -1;
   border-radius: 4px;
-  background: $color1;
-  box-shadow: 0 0 5px rgba($color8, 0.2);
+  background: var(--color1, $color1);
+  box-shadow: 0 0 5px rgba(var(--color8, $color8), 0.2);
 }
 
 .upload-area__content {
@@ -1627,7 +1627,7 @@ button.active i.fa-retweet {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: $color2;
+  color: var(--color2, $color2);
   font-size: 18px;
   font-weight: 500;
   border: 2px dashed lighten($color1, 26%);
@@ -1711,27 +1711,27 @@ button.active i.fa-retweet {
   left: 0;
   top: 27px;
   width: 230px;
-  background: $color5;
+  background: var(--color5, $color5);
   border-radius: 0 4px 4px 4px;
   z-index: 2;
   overflow: hidden;
 }
 
 .privacy-dropdown__option {
-  color: $color1;
+  color: var(--color1, $color1);
   padding: 10px;
   cursor: pointer;
   display: flex;
 
   &:hover, &.active {
-    background: $color4;
-    color: $color5;
+    background: var(--color4, $color4);
+    color: var(--color5, $color5);
 
     .privacy-dropdown__option__content {
-      color: $color5;
+      color: var(--color5, $color5);
 
       strong {
-        color: $color5;
+        color: var(--color5, $color5);
       }
     }
   }
@@ -1755,20 +1755,20 @@ button.active i.fa-retweet {
   strong {
     font-weight: 500;
     display: block;
-    color: $color1;
+    color: var(--color1, $color1);
   }
 }
 
 .privacy-dropdown.active {
   .privacy-dropdown__value {
-    background: $color5;
+    background: var(--color5, $color5);
     border-radius: 4px 4px 0 0;
-    box-shadow: 0 -4px 4px rgba($color8, 0.1);
+    box-shadow: 0 -4px 4px rgba(var(--color8, $color8), 0.1);
   }
 
   .privacy-dropdown__dropdown {
     display: block;
-    box-shadow: 2px 4px 6px rgba($color8, 0.1);
+    box-shadow: 2px 4px 6px rgba(var(--color8, $color8), 0.1);
   }
 }
 
@@ -1778,7 +1778,7 @@ button.active i.fa-retweet {
 
 .search__input {
   padding-right: 30px;
-  color: $color2;
+  color: var(--color2, $color2);
   outline: 0;
   box-sizing: border-box;
   display: block;
@@ -1787,8 +1787,8 @@ button.active i.fa-retweet {
   padding: 10px;
   padding-right: 30px;
   font-family: inherit;
-  background: $color1;
-  color: $color3;
+  background: var(--color1, $color1);
+  color: var(--color3, $color3);
   font-size: 14px;
   margin: 0;
 
@@ -1817,7 +1817,7 @@ button.active i.fa-retweet {
     font-size: 18px;
     width: 18px;
     height: 18px;
-    color: $color2;
+    color: var(--color2, $color2);
     cursor: default;
     pointer-events: none;
 
@@ -1846,7 +1846,7 @@ button.active i.fa-retweet {
     }
 
     &:hover {
-      color: $color5;
+      color: var(--color5, $color5);
     }
   }
 }
@@ -1863,7 +1863,7 @@ button.active i.fa-retweet {
 .search-results__hashtag {
   display: block;
   padding: 10px;
-  color: $color2;
+  color: var(--color2, $color2);
   text-decoration: none;
 
   &:hover, &:active, &:focus {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -16,7 +16,7 @@ code {
 
   span.hint {
     display: block;
-    color: $color3;
+    color: var(--color3, $color3);
     font-size: 12px;
     margin-top: 4px;
   }
@@ -49,7 +49,7 @@ code {
     label {
       font-family: inherit;
       font-size: 16px;
-      color: $color5;
+      color: var(--color5, $color5);
       display: block;
       padding-top: 5px;
     }
@@ -96,7 +96,7 @@ code {
     border-radius: 2px 2px 0 0;
     padding: 7px 4px;
     font-size: 16px;
-    color: $color5;
+    color: var(--color5, $color5);
     display: block;
     width: 100%;
     outline: 0;
@@ -108,32 +108,32 @@ code {
     }
 
     &:focus:invalid {
-      border-bottom-color: $color6;
+      border-bottom-color: var(--color6, $color6);
     }
 
     &:required:valid {
-      border-bottom-color: $color7;
+      border-bottom-color: var(--color7, $color7);
     }
 
     &:active, &:focus {
-      border-bottom-color: $color4;
-      background: rgba($color8, 0.1);
+      border-bottom-color: var(--color4, $color4);
+      background: rgba(var(--color8, $color8), 0.1);
     }
   }
 
   .input.field_with_errors {
     label {
-      color: $color6;
+      color: var(--color6, $color6);
     }
 
     input[type=text], input[type=email], input[type=password] {
-      border-bottom-color: $color6;
+      border-bottom-color: var(--color6, $color6);
     }
 
     .error {
       display: block;
       font-weight: 500;
-      color: $color6;
+      color: var(--color6, $color6);
       margin-top: 4px;
     }
   }
@@ -147,8 +147,8 @@ code {
     width: 100%;
     border: 0;
     border-radius: 4px;
-    background: $color4;
-    color: $color5;
+    background: var(--color4, $color4);
+    color: var(--color5, $color5);
     font-size: 18px;
     padding: 10px;
     text-transform: uppercase;
@@ -171,7 +171,7 @@ code {
     }
 
     &.negative {
-      background: $color6;
+      background: var(--color6, $color6);
 
       &:hover {
         background-color: lighten($color6, 5%);
@@ -185,12 +185,12 @@ code {
 }
 
 .flash-message {
-  background: $color1;
-  color: $color3;
+  background: var(--color1, $color1);
+  color: var(--color3, $color3);
   border-radius: 4px;
   padding: 15px 10px;
   margin-bottom: 30px;
-  box-shadow: 0 0 5px rgba($color8, 0.2);
+  box-shadow: 0 0 5px rgba(var(--color8, $color8), 0.2);
   text-align: center;
 
   strong {
@@ -203,7 +203,7 @@ code {
   text-align: center;
 
   a {
-    color: $color5;
+    color: var(--color5, $color5);
     text-decoration: none;
 
     &:hover {
@@ -215,7 +215,7 @@ code {
 .oauth-prompt, .follow-prompt {
   margin-bottom: 30px;
   text-align: center;
-  color: $color3;
+  color: var(--color3, $color3);
 
   h2 {
     font-size: 16px;
@@ -223,7 +223,7 @@ code {
   }
 
   strong {
-    color: $color2;
+    color: var(--color2, $color2);
     font-weight: 500;
   }
 }
@@ -237,7 +237,7 @@ code {
   background: #fff;
   padding: 4px;
   margin-bottom: 20px;
-  box-shadow: 0 0 15px rgba($color8, 0.2);
+  box-shadow: 0 0 15px rgba(var(--color8, $color8), 0.2);
   display: inline-block;
 
   svg {
@@ -248,7 +248,7 @@ code {
 
 .qr-alternative {
   margin-left: 10px;
-  color: $color3;
+  color: var(--color3, $color3);
 
   samp {
     display: block;

--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -1,12 +1,12 @@
 .activity-stream {
   clear: both;
-  box-shadow: 0 0 15px rgba($color8, 0.2);
+  box-shadow: 0 0 15px rgba(var(--color8, $color8), 0.2);
 
   .entry {
-    background: $color5;
+    background: var(--color5, $color5);
 
     .detailed-status.light, .status.light {
-      border-bottom: 1px solid $color2;
+      border-bottom: 1px solid var(--color2, $color2);
     }
 
     &:last-child {
@@ -43,7 +43,7 @@
         font-size: 14px;
 
         .status__relative-time {
-          color: $color3;
+          color: var(--color3, $color3);
         }
       }
     }
@@ -52,7 +52,7 @@
       display: block;
       max-width: 100%;
       padding-right: 25px;
-      color: $color1;
+      color: var(--color1, $color1);
     }
 
     .status__avatar {
@@ -82,25 +82,25 @@
 
       strong {
         font-weight: 500;
-        color: $color1;
+        color: var(--color1, $color1);
       }
 
       span {
         font-size: 14px;
-        color: $color3;
+        color: var(--color3, $color3);
       }
     }
 
     .status__content {
-      color: $color1;
+      color: var(--color1, $color1);
 
       a {
-        color: $color4;
+        color: var(--color4, $color4);
       }
 
       a.status__content__spoiler-link {
-        color: $color5;
-        background: $color3;
+        color: var(--color5, $color5);
+        background: var(--color3, $color3);
 
         &:hover {
           background: lighten($color3, 8%);
@@ -124,7 +124,7 @@
 
   .detailed-status.light {
     padding: 14px;
-    background: $color5;
+    background: var(--color5, $color5);
     cursor: default;
 
     .detailed-status__display-name {
@@ -146,12 +146,12 @@
 
         strong {
           font-weight: 500;
-          color: $color1;
+          color: var(--color1, $color1);
         }
 
         span {
           font-size: 14px;
-          color: $color3;
+          color: var(--color3, $color3);
         }
       }
     }
@@ -167,15 +167,15 @@
     }
 
     .status__content {
-      color: $color1;
+      color: var(--color1, $color1);
 
       a {
-        color: $color4;
+        color: var(--color4, $color4);
       }
 
       a.status__content__spoiler-link {
-        color: $color5;
-        background: $color3;
+        color: var(--color5, $color5);
+        background: var(--color3, $color3);
 
         &:hover {
           background: lighten($color3, 8%);
@@ -185,7 +185,7 @@
 
     .detailed-status__meta {
       margin-top: 15px;
-      color: $color3;
+      color: var(--color3, $color3);
       font-size: 14px;
       line-height: 18px;
 
@@ -282,13 +282,13 @@
       transform: translate(-50%, -50%);
       padding: 5px;
       border-radius: 100px;
-      color: rgba($color5, 0.8);
+      color: rgba(var(--color5, $color5), 0.8);
       z-index: 1;
     }
   }
 
   .media-spoiler {
-    background: $color3;
+    background: var(--color3, $color3);
     width: 100%;
     height: 100%;
     cursor: pointer;
@@ -326,7 +326,7 @@
     padding-left: (48px + 14px*2);
     padding-bottom: 0;
     margin-bottom: -4px;
-    color: $color3;
+    color: var(--color3, $color3);
     font-size: 14px;
     position: relative;
 
@@ -336,7 +336,7 @@
     }
 
     .status__display-name.muted strong {
-      color: $color3;
+      color: var(--color3, $color3);
     }
   }
 

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -9,13 +9,13 @@
     padding: 8px;
     line-height: 18px;
     vertical-align: top;
-    border-top: 1px solid $color1;
+    border-top: 1px solid var(--color1, $color1);
     text-align: left;
   }
 
   & > thead > tr > th {
     vertical-align: bottom;
-    border-bottom: 2px solid $color1;
+    border-bottom: 2px solid var(--color1, $color1);
     border-top: 0;
     font-weight: 500;
   }
@@ -25,11 +25,11 @@
   }
 
   & > tbody > tr:nth-child(odd) > td, & > tbody > tr:nth-child(odd) > th {
-    background: $color1;
+    background: var(--color1, $color1);
   }
 
   a {
-    color: $color4;
+    color: var(--color4, $color4);
     text-decoration: underline;
 
     &:hover {
@@ -51,11 +51,11 @@ a.table-action-link {
   display: inline-block;
   margin-right: 5px;
   padding: 0 10px;
-  color: rgba($color5, 0.7);
+  color: rgba(var(--color5, $color5), 0.7);
   font-weight: 500;
 
   &:hover {
-    color: $color5;
+    color: var(--color5, $color5);
   }
 
   i.fa {


### PR DESCRIPTION
One step closer to supporting “theming”. This would allow user agents and theme designers to customize the colors of the UI with very little CSS and no knowledge of the CSS selectors.
This is particularly useful for [supporting themes that respond to High Contrast Media queries](https://github.com/jpdevries/eureka#-accessible-themes).

CSS Variables aren’t completely safe to use. I’m not familiar with how the Sass is built, but thinking we’d need to:
- [ ] add a postcss plugin for CSS Variables fallbacks

CSS Tricks has a write up on [using CSS Custom Properties for Theming](https://css-tricks.com/css-custom-properties-theming/?utm_campaign=CSS%2BLayout%2BNews&utm_medium=email&utm_source=CSS_Layout_News_92)

<details open>
  <summary>Screenshots</summary >
  <div>
    <img src="http://j4p.us/1q0e2P231N0S/Screen%20Shot%202017-04-12%20at%201.54.58%20AM.png" />
    <img src="http://j4p.us/0V0x0B2A0i1R/Screen%20Shot%202017-04-12%20at%201.54.54%20AM.png" />
    <img src="http://j4p.us/3Y2Q2c2A070i/Screen%20Shot%202017-04-12%20at%201.54.46%20AM.png" />
  </div>
</details>