### PR TITLE
Simplify the way the embed view is created

### DIFF
--- a/app/controllers/stream_entries_controller.rb
+++ b/app/controllers/stream_entries_controller.rb
@@ -27,8 +27,6 @@ class StreamEntriesController < ApplicationController
 
   def embed
     response.headers['X-Frame-Options'] = 'ALLOWALL'
-    @external_links = true
-
     return gone if @stream_entry.activity.nil?
 
     render layout: 'embedded'

--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -5,8 +5,12 @@ module StreamEntriesHelper
     account.display_name.blank? ? account.username : account.display_name
   end
 
+  def stream_link_target
+    embedded_view? ? '_blank' : nil
+  end
+
   def acct(account)
-    "@#{account.acct}#{@external_links && account.local? ? "@#{Rails.configuration.x.local_domain}" : ''}"
+    "@#{account.acct}#{embedded_view? && account.local? ? "@#{Rails.configuration.x.local_domain}" : ''}"
   end
 
   def entry_classes(status, is_predecessor, is_successor, include_threads)
@@ -29,5 +33,11 @@ module StreamEntriesHelper
     ltr_size = text.strip.size.to_f
 
     rtl_size / ltr_size > 0.3
+  end
+
+  private
+
+  def embedded_view?
+    params[:controller] == 'stream_entries' && params[:action] == 'embed'
   end
 end

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -1,5 +1,5 @@
 .detailed-status.light
-  = link_to TagManager.instance.url_for(status.account), class: 'detailed-status__display-name p-author h-card', target: @external_links ? '_blank' : nil, rel: 'noopener' do
+  = link_to TagManager.instance.url_for(status.account), class: 'detailed-status__display-name p-author h-card', target: stream_link_target, rel: 'noopener' do
     %div
       %div.avatar
         = image_tag status.account.avatar.url(:original), width: 48, height: 48, alt: '', class: 'u-photo'
@@ -30,7 +30,7 @@
 
   %div.detailed-status__meta
     %data.dt-published{ value: status.created_at.to_time.iso8601 }
-    = link_to TagManager.instance.url_for(status), class: 'detailed-status__datetime u-url u-uid', target: @external_links ? '_blank' : nil, rel: 'noopener' do
+    = link_to TagManager.instance.url_for(status), class: 'detailed-status__datetime u-url u-uid', target: stream_link_target, rel: 'noopener' do
       %span= l(status.created_at)
     ·
     - if status.application

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -1,10 +1,10 @@
 .status.light
   .status__header
     .status__meta
-      = link_to time_ago_in_words(status.created_at), TagManager.instance.url_for(status), class: 'status__relative-time u-url u-uid', title: l(status.created_at), target: @external_links ? '_blank' : nil, rel: 'noopener'
+      = link_to time_ago_in_words(status.created_at), TagManager.instance.url_for(status), class: 'status__relative-time u-url u-uid', title: l(status.created_at), target: stream_link_target, rel: 'noopener'
       %data.dt-published{ value: status.created_at.to_time.iso8601 }
 
-    = link_to TagManager.instance.url_for(status.account), class: 'status__display-name p-author h-card', target: @external_links ? '_blank' : nil, rel: 'noopener' do
+    = link_to TagManager.instance.url_for(status.account), class: 'status__display-name p-author h-card', target: stream_link_target, rel: 'noopener' do
       .status__avatar
         %div
           = image_tag status.account.avatar(:original), width: 48, height: 48, alt: '', class: 'u-photo'

--- a/spec/controllers/stream_entries_controller_spec.rb
+++ b/spec/controllers/stream_entries_controller_spec.rb
@@ -17,4 +17,14 @@ RSpec.describe StreamEntriesController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'GET #embed' do
+    it 'returns embedded view of status' do
+      get :embed, params: { account_username: alice.username, id: status.stream_entry.id }
+
+      expect(response).to have_http_status(:success)
+      expect(response.headers['X-Frame-Options']).to eq 'ALLOWALL'
+      expect(response).to render_template(layout: 'embedded')
+    end
+  end
 end


### PR DESCRIPTION
The `@external_links` i-var that seemingly came from nowhere was confusing in the views.

This is better, but probably not perfect yet. May do further refactor to that action if this is merged.