### PR TITLE
further updates to Docker instructions in README and docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     image: postgres:alpine
 ### Uncomment to enable DB persistance
 #    volumes:
-#      - ./postgres:/var/lib/postgresql/data
+#      - mastodon-postgres:/var/lib/postgresql/data # Windows -- make sure you check volumes section at bottom of file!
+#      - ./postgres:/var/lib/postgresql/data # Unix/Mac
 
   redis:
     restart: always
@@ -50,3 +51,7 @@ services:
       - redis
     volumes:
       - ./public/system:/mastodon/public/system
+
+#volumes: # Windows - Uncomment if you uncomment the postgres volume above
+#  mastodon-postgres:
+#    external: true


### PR DESCRIPTION
Update Docker instructions to make sure that .env.production is created
before running rake secret
Add Windows-specific instructions for persisting postgres to README and
associated comments in docker-compose.yml
Add steps for validating first account and making it admin