### PR TITLE
Silence more scope order warnings

### DIFF
--- a/app/services/after_block_service.rb
+++ b/app/services/after_block_service.rb
@@ -12,7 +12,7 @@ class AfterBlockService < BaseService
     home_key = FeedManager.instance.key(:home, account.id)
 
     redis.pipelined do
-      target_account.statuses.select('id').find_each do |status|
+      target_account.statuses.select('id').reorder(nil).find_each do |status|
         redis.zrem(home_key, status.id)
       end
     end

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -34,7 +34,7 @@ class FanOutOnWriteService < BaseService
   def deliver_to_followers(status)
     Rails.logger.debug "Delivering status #{status.id} to followers"
 
-    status.account.followers.where(domain: nil).joins(:user).where('users.current_sign_in_at > ?', 14.days.ago).select(:id).find_each do |follower|
+    status.account.followers.where(domain: nil).joins(:user).where('users.current_sign_in_at > ?', 14.days.ago).select(:id).reorder(nil).find_each do |follower|
       FeedInsertWorker.perform_async(status.id, follower.id)
     end
   end

--- a/app/services/mute_service.rb
+++ b/app/services/mute_service.rb
@@ -12,7 +12,7 @@ class MuteService < BaseService
   def clear_home_timeline(account, target_account)
     home_key = FeedManager.instance.key(:home, account.id)
 
-    target_account.statuses.select('id').find_each do |status|
+    target_account.statuses.select('id').reorder(nil).find_each do |status|
       redis.zrem(home_key, status.id)
     end
   end

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -12,7 +12,7 @@ class SuspendAccountService < BaseService
   private
 
   def purge_content
-    @account.statuses.find_each do |status|
+    @account.statuses.reorder(nil).find_each do |status|
       RemoveStatusService.new.call(status)
     end
 


### PR DESCRIPTION
Similar issue to what was cleaned up in https://github.com/tootsuite/mastodon/pull/1470 - but for `find_each` (previous one was `find_in_batches`)