### PR TITLE
Fix target blank on "open_in_web" link

### DIFF
--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -49,4 +49,4 @@
 
     - if user_signed_in?
       ·
-      = link_to t('statuses.open_in_web'), web_url("statuses/#{status.id}"), class: 'open-in-web-link'
+      = link_to t('statuses.open_in_web'), web_url("statuses/#{status.id}"), class: 'open-in-web-link', target: '_blank'


### PR DESCRIPTION
When you render the "embed" view in an iframe, this link bugs when clicked, due to missing target blank.