### PR TITLE
Apply white space pre-wrap to `p` instead of surrounding div

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -272,7 +272,6 @@
   word-wrap: break-word;
   font-weight: 400;
   overflow: hidden;
-  white-space: pre-wrap;
 
   .emojione {
     width: 18px;


### PR DESCRIPTION
Resolves https://github.com/tootsuite/mastodon/issues/1609 and https://github.com/tootsuite/mastodon/issues/1628

Before with text like:

```text
Test

This

Testing
```

![pre before separate](https://cloud.githubusercontent.com/assets/225/24974078/115dd0f6-1f8f-11e7-9e20-61424247de08.png)


Before with text like:

```text
test
test

test
```

![pre before together](https://cloud.githubusercontent.com/assets/225/24974107/1ec2e042-1f8f-11e7-960c-41a9c879cc97.png)

After for those cases:

![pre after separate](https://cloud.githubusercontent.com/assets/225/24974124/279850d0-1f8f-11e7-91d7-84086aad079b.png)

![pre after together](https://cloud.githubusercontent.com/assets/225/24974123/2796c2c4-1f8f-11e7-9dc8-792dccc635b0.png)
