### PR TITLE
Settings export refactor

### DIFF
--- a/app/controllers/settings/exports/base_controller.rb
+++ b/app/controllers/settings/exports/base_controller.rb
@@ -6,7 +6,7 @@ module Settings
       before_action :authenticate_user!
 
       def index
-        export_data = Export.new(export_accounts).to_csv
+        @export = Export.new(current_account)
 
         respond_to do |format|
           format.csv { send_data export_data, filename: export_filename }

--- a/app/controllers/settings/exports/blocked_accounts_controller.rb
+++ b/app/controllers/settings/exports/blocked_accounts_controller.rb
@@ -5,8 +5,8 @@ module Settings
     class BlockedAccountsController < BaseController
       private
 
-      def export_accounts
-        current_account.blocking
+      def export_data
+        @export.to_blocked_accounts_csv
       end
     end
   end

--- a/app/controllers/settings/exports/following_accounts_controller.rb
+++ b/app/controllers/settings/exports/following_accounts_controller.rb
@@ -5,8 +5,8 @@ module Settings
     class FollowingAccountsController < BaseController
       private
 
-      def export_accounts
-        current_account.following
+      def export_data
+        @export.to_following_accounts_csv
       end
     end
   end

--- a/app/controllers/settings/exports/muted_accounts_controller.rb
+++ b/app/controllers/settings/exports/muted_accounts_controller.rb
@@ -5,8 +5,8 @@ module Settings
     class MutedAccountsController < BaseController
       private
 
-      def export_accounts
-        current_account.muting
+      def export_data
+        @export.to_muted_accounts_csv
       end
     end
   end

--- a/app/controllers/settings/exports_controller.rb
+++ b/app/controllers/settings/exports_controller.rb
@@ -6,9 +6,6 @@ class Settings::ExportsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @total_storage = current_account.media_attachments.sum(:file_file_size)
-    @total_follows = current_account.following.count
-    @total_blocks  = current_account.blocking.count
-    @total_mutes = current_account.muting.count
+    @export = Export.new(current_account)
   end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -2,13 +2,27 @@
 require 'csv'
 
 class Export
-  attr_reader :accounts
+  attr_reader :account
 
-  def initialize(accounts)
-    @accounts = accounts
+  def initialize(account)
+    @account = account
   end
 
-  def to_csv
+  def to_blocked_accounts_csv
+    to_csv @account.blocking
+  end
+
+  def to_muted_accounts_csv
+    to_csv @account.muting
+  end
+
+  def to_following_accounts_csv
+    to_csv @account.following
+  end
+
+  private
+
+  def to_csv(accounts)
     CSV.generate do |csv|
       accounts.each do |account|
         csv << [(account.local? ? account.local_username_and_domain : account.acct)]

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -9,15 +9,31 @@ class Export
   end
 
   def to_blocked_accounts_csv
-    to_csv @account.blocking
+    to_csv account.blocking
   end
 
   def to_muted_accounts_csv
-    to_csv @account.muting
+    to_csv account.muting
   end
 
   def to_following_accounts_csv
-    to_csv @account.following
+    to_csv account.following
+  end
+
+  def total_storage
+    account.media_attachments.sum(:file_file_size)
+  end
+
+  def total_follows
+    account.following.count
+  end
+
+  def total_blocks
+    account.blocking.count
+  end
+
+  def total_mutes
+    account.muting.count
   end
 
   private

--- a/app/views/settings/exports/show.html.haml
+++ b/app/views/settings/exports/show.html.haml
@@ -5,17 +5,17 @@
   %tbody
     %tr
       %th= t('exports.storage')
-      %td= number_to_human_size @total_storage
+      %td= number_to_human_size @export.total_storage
       %td
     %tr
       %th= t('exports.follows')
-      %td= @total_follows
+      %td= @export.total_follows
       %td= table_link_to 'download', t('exports.csv'), settings_exports_follows_path(format: :csv)
     %tr
       %th= t('exports.blocks')
-      %td= @total_blocks
+      %td= @export.total_blocks
       %td= table_link_to 'download', t('exports.csv'), settings_exports_blocks_path(format: :csv)
     %tr
       %th= t('exports.mutes')
-      %td= @total_mutes
+      %td= @export.total_mutes
       %td= table_link_to 'download', t('exports.csv'), settings_exports_mutes_path(format: :csv)

--- a/spec/controllers/settings/exports_controller_spec.rb
+++ b/spec/controllers/settings/exports_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Settings::ExportsController do
+  render_views
+
   before do
     sign_in Fabricate(:user), scope: :user
   end
@@ -8,6 +10,7 @@ describe Settings::ExportsController do
   describe 'GET #show' do
     it 'returns http success' do
       get :show
+
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
In what might be my last change here, I repurpose the `Export` class to be a presenter of sorts around the `current_account` instance we have.

The exports `show` view uses it to get summary info it needs (and removes a bunch of i-vars there), and the various export index views use it to prepare their account collection CSVs.