### PR TITLE
Exclude javascript locale file from dup check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,8 @@
 engines:
  duplication:
    enabled: true
+   exclude_paths:
+     - app/assets/javascripts/components/locales/
    config:
      languages:
      - ruby


### PR DESCRIPTION
* Exclude javascript locale files form Code Climate's duplication
  engine. It is silly to have duplication check with locale files.
  They are supposed to look similar.

* Prevent unnecessary blocking for translation updates (like #1661)