### PR TITLE
Use input type `number` for Two-factor code

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -88,7 +88,7 @@ code {
     }
   }
 
-  input[type=text], input[type=email], input[type=password], textarea {
+  input[type=text], input[type=number], input[type=email], input[type=password], textarea {
     background: transparent;
     box-sizing: border-box;
     border: 0;

--- a/app/views/auth/sessions/two_factor.html.haml
+++ b/app/views/auth/sessions/two_factor.html.haml
@@ -2,7 +2,7 @@
   = t('auth.login')
 
 = simple_form_for(resource, as: resource_name, url: session_path(resource_name), method: :post) do |f|
-  = f.input :otp_attempt, placeholder: t('simple_form.labels.defaults.otp_attempt'), input_html: { 'aria-label' => t('simple_form.labels.defaults.otp_attempt') }, required: true, autofocus: true, autocomplete: 'off'
+  = f.input :otp_attempt, type: :number, placeholder: t('simple_form.labels.defaults.otp_attempt'), input_html: { 'aria-label' => t('simple_form.labels.defaults.otp_attempt') }, required: true, autofocus: true, autocomplete: 'off'
 
   .actions
     = f.button :button, t('auth.login'), type: :submit


### PR DESCRIPTION
Since the two-factor code is always in number, it's better to use `<input type='number'>` instead of `text`.