### PR TITLE
Fix issue where 'sensitive content click to show' item takes up whole screen on public view

### DIFF
--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -218,6 +218,7 @@
       margin-top: 8px;
       height: 300px;
       overflow: hidden;
+      position: relative;
 
       video {
         position: relative;


### PR DESCRIPTION
noticed this when you set a video to nsfw and open that toot in public view, the "sensitive content, click to show" thing takes up the whole screen