### PR TITLE
Fix "TypeError: Cannot read property 'isRequired' of undefined"

### DIFF
--- a/app/assets/javascripts/components/features/notifications/components/column_settings.jsx
+++ b/app/assets/javascripts/components/features/notifications/components/column_settings.jsx
@@ -27,7 +27,7 @@ const ColumnSettings = React.createClass({
 
   propTypes: {
     settings: ImmutablePropTypes.map.isRequired,
-    intl: ImmutablePropTypes.object.isRequired,
+    intl: React.PropTypes.object.isRequired,
     onChange: React.PropTypes.func.isRequired,
     onSave: React.PropTypes.func.isRequired,
   },


### PR DESCRIPTION
Looks like a recent commit introduced a reference to `ImmutablePropTypes.object.isRequired`, which looks absolutely fine on the surface, but turns out not to be a thing. This uncaught TypeError happens immediately on page load.

```
Uncaught TypeError: Cannot read property 'isRequired' of undefined
    at Object.93.../../../components/column_collapsable
```

![screen shot 2017-04-13 at 18 15 31](https://cloud.githubusercontent.com/assets/566159/25013846/8774f79c-2075-11e7-9da8-b0bb269bf91e.png)

All better now though 😄 