### PR TITLE
Make contents of boost confirmation dialog scroll

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -2031,6 +2031,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .boost-modal__container {
+  overflow-x: scroll;
   padding: 10px;
 
   .status {


### PR DESCRIPTION
Addresses https://github.com/tootsuite/mastodon/issues/1703 
This is necessary for boosting long posts on small screens - see this post for video: https://slime.global/@masklayer/102308