### PR TITLE
Fix text wrapping in buttons in some translations

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -18,7 +18,7 @@
   font-weight: 500;
   letter-spacing: 0;
   text-transform: uppercase;
-  padding: 0 6px;
+  padding: 0 8px;
   height: 36px;
   cursor: pointer;
   line-height: 36px;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -25,6 +25,8 @@
   border-radius: 4px;
   text-decoration: none;
   transition: all 100ms ease-in;
+  white-space: nowrap;
+  max-width: 75px;
 
   &:hover, &:active, &:focus {
     background-color: lighten($color4, 7%);

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -18,7 +18,7 @@
   font-weight: 500;
   letter-spacing: 0;
   text-transform: uppercase;
-  padding: 0 16px;
+  padding: 0 4px;
   height: 36px;
   cursor: pointer;
   line-height: 36px;
@@ -26,7 +26,6 @@
   text-decoration: none;
   transition: all 100ms ease-in;
   white-space: nowrap;
-  max-width: 75px;
 
   &:hover, &:active, &:focus {
     background-color: lighten($color4, 7%);

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -26,6 +26,7 @@
   text-decoration: none;
   transition: all 100ms ease-in;
   white-space: nowrap;
+  margin-left:-8px;
 
   &:hover, &:active, &:focus {
     background-color: lighten($color4, 7%);

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -18,7 +18,7 @@
   font-weight: 500;
   letter-spacing: 0;
   text-transform: uppercase;
-  padding: 0 4px;
+  padding: 0 6px;
   height: 36px;
   cursor: pointer;
   line-height: 36px;


### PR DESCRIPTION
Fixes https://github.com/tootsuite/mastodon/issues/1686. 
The max-width is not 100% necessary, but makes the button in the translation shown in that issue look better (without the max-width I'm adding, it is too wide to fit in the compose page) and not cause horizontal scrolling issues on small screens. 
Does pose an issue if there are ever any buttons wider than 75px that don't have that max-width overridden with their own class or inline style - but I don't think there currently are any.