### PR TITLE
Include pkg-config as a gem dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source 'https://rubygems.org'
 ruby '2.4.1'
 
+gem 'pkg-config'
+
 gem 'rails', '~> 5.0.2'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,7 @@ GEM
     pg (0.20.0)
     pghero (1.6.4)
       activerecord
+    pkg-config (1.1.7)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -496,6 +497,7 @@ DEPENDENCIES
   paperclip-av-transcoder
   pg
   pghero
+  pkg-config
   pry-rails
   puma
   rabl


### PR DESCRIPTION
The pkg-config gem was necessary in order for nokogiri to find the system
libraries when building on OpenBSD.

Closes #1637

Signed-off-by: Bryce Chidester <bryce@cobryce.com>