### PR TITLE
Add filename extension to paperclip

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -4,7 +4,7 @@ Paperclip.options[:read_timeout] = 60
 
 Paperclip.interpolates :filename do |attachment, style|
   return attachment.original_filename if style == :original
-  [basename(attachment, style), extension(attachment, style)].delete_if(&:empty?).join('.')
+  [basename(attachment, style), content_type_extension(attachment, style)].delete_if(&:empty?).join('.')
 end
 
 if ENV['S3_ENABLED'] == 'true'


### PR DESCRIPTION
#1705 
Replaced `extension` with [content_type_extension](http://www.rubydoc.info/gems/paperclip/Paperclip/Interpolations#content_type_extension-instance_method) which enables to add filename extension.