### PR TITLE
Remove unused methods

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -100,11 +100,4 @@ class ApiController < ApplicationController
     @reblogs_map    = Status.reblogs_map(status_ids, current_account)
     @favourites_map = Status.favourites_map(status_ids, current_account)
   end
-
-  def set_account_counters_maps(accounts) # rubocop:disable Style/AccessorMethodName
-    account_ids = accounts.compact.map(&:id).uniq
-    @followers_counts_map = Follow.unscoped.select('target_account_id, COUNT(account_id) AS followers_count').group('target_account_id').where(target_account_id: account_ids).map { |f| [f.target_account_id, f.followers_count] }.to_h
-    @following_counts_map = Follow.unscoped.select('account_id, COUNT(target_account_id) AS following_count').group('account_id').where(account_id: account_ids).map { |f| [f.account_id, f.following_count] }.to_h
-    @statuses_counts_map  = Status.unscoped.select('account_id, COUNT(id) AS statuses_count').group('account_id').where(account_id: account_ids).map { |s| [s.account_id, s.statuses_count] }.to_h
-  end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -101,12 +101,6 @@ class ApiController < ApplicationController
     @favourites_map = Status.favourites_map(status_ids, current_account)
   end
 
-  def set_counters_maps(statuses) # rubocop:disable Style/AccessorMethodName
-    status_ids             = statuses.compact.map { |s| s.reblog? ? s.reblog_of_id : s.id }.uniq
-    @favourites_counts_map = Favourite.select('status_id, COUNT(id) AS favourites_count').group('status_id').where(status_id: status_ids).map { |f| [f.status_id, f.favourites_count] }.to_h
-    @reblogs_counts_map    = Status.select('statuses.id, COUNT(reblogs.id) AS reblogs_count').joins('LEFT OUTER JOIN statuses AS reblogs ON statuses.id = reblogs.reblog_of_id').where(id: status_ids).group('statuses.id').map { |r| [r.id, r.reblogs_count] }.to_h
-  end
-
   def set_account_counters_maps(accounts) # rubocop:disable Style/AccessorMethodName
     account_ids = accounts.compact.map(&:id).uniq
     @followers_counts_map = Follow.unscoped.select('target_account_id, COUNT(account_id) AS followers_count').group('target_account_id').where(target_account_id: account_ids).map { |f| [f.target_account_id, f.followers_count] }.to_h

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -227,18 +227,20 @@ class Account < ApplicationRecord
         WITH first_degree AS (
             SELECT target_account_id
             FROM follows
-            WHERE account_id = ?
+            WHERE account_id = :account_id
           )
         SELECT accounts.*
         FROM follows
         INNER JOIN accounts ON follows.target_account_id = accounts.id
-        WHERE account_id IN (SELECT * FROM first_degree) AND target_account_id NOT IN (SELECT * FROM first_degree) AND target_account_id <> ?
+        WHERE account_id IN (SELECT * FROM first_degree) AND target_account_id NOT IN (SELECT * FROM first_degree) AND target_account_id <> :account_id
         GROUP BY target_account_id, accounts.id
         ORDER BY count(account_id) DESC
-        LIMIT ?
+        LIMIT :limit
       SQL
 
-      Account.find_by_sql([sql, account.id, account.id, limit])
+      find_by_sql(
+        [sql, { account_id: account.id, limit: limit }]
+      )
     end
 
     def search_for(terms, limit = 10)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -108,10 +108,6 @@ class Account < ApplicationRecord
     follow_requests.where(target_account: other_account).exists?
   end
 
-  def followers_domains
-    followers.reorder('').select('DISTINCT accounts.domain').map(&:domain)
-  end
-
   def local?
     domain.nil?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,6 @@ class User < ApplicationRecord
   validates :locale, inclusion: I18n.available_locales.map(&:to_s), unless: 'locale.nil?'
   validates :email, email: true
 
-  scope :prolific,  -> { joins('inner join statuses on statuses.account_id = users.account_id').select('users.*, count(statuses.id) as statuses_count').group('users.id').order('statuses_count desc') }
   scope :recent,    -> { order('id desc') }
   scope :admins,    -> { where(admin: true) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -103,6 +103,12 @@ namespace :mastodon do
         User.where(id: batch.map(&:id)).delete_all
       end
     end
+
+    desc 'List all admin users'
+    task admins: :environment do
+      puts 'Admin user emails:'
+      puts User.admins.map(&:email).join("\n")
+    end
   end
 
   namespace :settings do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -245,6 +245,23 @@ RSpec.describe Account, type: :model do
     end
   end
 
+  describe '.triadic_closures' do
+    it 'finds accounts you dont follow which are followed by accounts you do follow' do
+      me = Fabricate(:account)
+      friend = Fabricate(:account)
+      friends_friend = Fabricate(:account)
+      me.follow!(friend)
+      friend.follow!(friends_friend)
+
+      both_follow = Fabricate(:account)
+      me.follow!(both_follow)
+      friend.follow!(both_follow)
+
+      results = Account.triadic_closures(me)
+      expect(results).to eq [friends_friend]
+    end
+  end
+
   describe '.find_local' do
     before do
       Fabricate(:account, username: 'Alice')


### PR DESCRIPTION
Remove unused methods:

- api controller - `set_counters_maps` and `set_accounts_counters_maps`
- `Account#followers_domains`
- `User.prolific`

Also:

- Add coverage for `Account.triadic_closures`
- Add rake task to list all admin users