### PR TITLE
Fix getting started commands out of order

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,6 @@ The project now includes a `Dockerfile` and a `docker-compose.yml` file (which r
 Review the settings in `docker-compose.yml`. Note that it is not default to store the postgresql database and redis databases in a persistent storage location,
 so you may need or want to adjust the settings there.
 
-Before running the first time, you need to build the images:
-
-    docker-compose build
-
 Then, you need to fill in the `.env.production` file:
 
     cp .env.production.sample .env.production
@@ -84,6 +80,11 @@ Then, you need to fill in the `.env.production` file:
 Do NOT change the `REDIS_*` or `DB_*` settings when running with the default docker configurations.
 
 You will need to fill in, at least: `LOCAL_DOMAIN`, `LOCAL_HTTPS`, `PAPERCLIP_SECRET`, `SECRET_KEY_BASE`, `OTP_SECRET`, and the `SMTP_*` settings.  To generate the `PAPERCLIP_SECRET`, `SECRET_KEY_BASE`, and `OTP_SECRET`, you may use:
+
+Before running the first time, you need to build the images:
+
+    docker-compose build
+
 
     docker-compose run --rm web rake secret
 


### PR DESCRIPTION
In current order, docker-compose build results in
ERROR: Couldn't find env file: /a/hopt/mastodon/.env.production