### PR TITLE
Fix ActionMailer SMTP domain fallback

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,7 +98,7 @@ Rails.application.configure do
     :address              => ENV['SMTP_SERVER'],
     :user_name            => ENV['SMTP_LOGIN'],
     :password             => ENV['SMTP_PASSWORD'],
-    :domain               => ENV['SMTP_DOMAIN'] || config.x.local_domain,
+    :domain               => ENV['SMTP_DOMAIN'] || ENV['LOCAL_DOMAIN'],
     :authentication       => ENV['SMTP_AUTH_METHOD'] || :plain,
     :openssl_verify_mode  => ENV['SMTP_OPENSSL_VERIFY_MODE'],
     :enable_starttls_auto => ENV['SMTP_ENABLE_STARTTLS_AUTO'] || true,


### PR DESCRIPTION
Modify ActionMailer configuration to default to ENV['LOCAL_DOMAIN'] if ENV['SMTP_DOMAIN'] is not set. The previous fallback, config.x.local_domain, is undefined when the code is called.

Fixes an issue mentioned in #772, fixes #1130 as long as LOCAL_DOMAIN is set.

Related to #1738 