### PR TITLE
Change default bind host to localhost

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,7 +1,7 @@
 threads_count = ENV.fetch('MAX_THREADS') { 5 }.to_i
 threads threads_count, threads_count
 
-port        ENV.fetch('PORT') { 3000 }
+port        ENV.fetch('PORT') { 3000 }, ENV.fetch('HOST') { 'localhost' }
 environment ENV.fetch('RAILS_ENV') { 'development' }
 workers     ENV.fetch('WEB_CONCURRENCY') { 2 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     env_file: .env.production
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     depends_on:
       - db
       - redis
@@ -32,10 +32,12 @@ services:
   streaming:
     restart: always
     build: .
+    environment:
+      HOST: '0.0.0.0'
     env_file: .env.production
     command: npm run start
     ports:
-      - "4000:4000"
+      - "127.0.0.1:4000:4000"
     depends_on:
       - db
       - redis

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -307,7 +307,7 @@ wss.on('connection', ws => {
   })
 })
 
-server.listen(process.env.PORT || 4000, () => {
+server.listen(process.env.PORT || 4000, process.env.HOST || 'localhost', () => {
   log.level = process.env.LOG_LEVEL || 'verbose'
   log.info(`Starting streaming API server on port ${server.address().port}`)
 })


### PR DESCRIPTION
Change the default bind host for web workers and streaming to localhost instead of 0.0.0.0. A new environment variable called HOST allows the bind host to be changed for deployments where load balancers are running on a separate host.

This is a combination/replacement of/for #999 (which seems to have gotten lost in the development branch) and #1536.

Fixes #1283

Note: I used 127.0.0.1 in `docker-compose.yml` because using `localhost` seems to cause docker to listen on `*:3000` instead, whereas `127.0.0.1` makes it bind to `localhost:3000` (as expected), both on IPv4 and IPv6. If someone more knowledgeable in docker thinks `localhost` would be more appropriate here and that this is somehow specific to my docker host (macOS 10.12.4, docker version 17.03.1-ce-mac5 (16048)), let me know.
