### PR TITLE
Fix #1401 Add Instance API Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ redis
 # Ignore vim files
 *~
 *.swp
+
+# Ignore version build file
+.version

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -39,6 +39,12 @@ class Setting < RailsSettings::Base
       records
     end
 
+    def version(fresh: false)
+      file = Rails.root.join('.version')
+      return File.read file if File.exist?(file) && !fresh
+      `git describe --tags`.strip if system('git --version')
+    end
+
     private
 
     def default_settings

--- a/app/views/api/v1/instances/show.rabl
+++ b/app/views/api/v1/instances/show.rabl
@@ -4,3 +4,4 @@ node(:uri)         { Rails.configuration.x.local_domain }
 node(:title)       { Setting.site_title }
 node(:description) { Setting.site_description }
 node(:email)       { Setting.site_contact_email }
+node(:version)     { Setting.version }

--- a/bin/setup
+++ b/bin/setup
@@ -26,6 +26,9 @@ chdir APP_ROOT do
   puts "\n== Preparing database =="
   system! 'bin/rails db:setup'
 
+  puts "\n== Installing front-end dependencies =="
+  system! 'yarn'
+
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'
 

--- a/bin/update
+++ b/bin/update
@@ -21,6 +21,9 @@ chdir APP_ROOT do
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'
 
+  puts "\n== Installing front-end dependencies =="
+  system! 'yarn'
+
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'
 

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -133,4 +133,11 @@ namespace :mastodon do
       Rails.logger.debug 'Done!'
     end
   end
+
+  namespace :version do
+    desc 'Persists the version file prior to building'
+    task write: :environment do
+      File.write Rails.root.join('.version'), Setting.version(fresh: true)
+    end
+  end
 end

--- a/spec/controllers/api/v1/instances_controller_spec.rb
+++ b/spec/controllers/api/v1/instances_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::InstancesController, type: :controller do
+  render_views
+
+  describe 'GET #show' do
+    it 'returns the correct keys' do
+      get :show
+      json = body_as_json
+      expect(json.keys).to match_array %w(
+        description
+        email
+        title
+        uri
+        version
+      ).map(&:to_sym)
+    end
+  end
+end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Setting, type: :model do
+  describe '.version' do
+    version_file = Rails.root.join('.version')
+
+    it "returns the version from filesystem #{version_file} when present" do
+      version = 'foo'
+      expect(File).to receive(:read).with(version_file).and_return version
+      expect(File).to receive(:exist?).with(version_file).and_return true
+      expect(described_class.version).to eq 'foo'
+    end
+
+    it 'reads from git tags if version file is missing' do
+      version = "bar\n"
+      expect(described_class).to receive(:`).and_return version
+      expect(described_class.version).to eq 'bar'
+    end
+
+    it 'returns nil if version file and git executable are missing' do
+      expect(File).to receive(:exist?).with(version_file).and_return false
+      expect(described_class).to receive(:system).and_return false
+      expect(described_class.version).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/tootsuite/mastodon/issues/1401

This PR proposes a way to produce the build artifact `.version` via `rake mastodon:version:write`, and expose it via `/api/v1/instance`. It pulls the version from `git` tags at _build time_, but can fall back to `git` at _runtime_ if the executable is present.

Seems like there are a ton of different deploy options, so I didn't want to prescribe when/where to run that Rake task. Awesome project; hope this helps!

(Also added a few lines to the `bin/` scripts for initial setup.)
