### PR TITLE
Add title attribute to URLs in statuses

### DIFF
--- a/app/assets/javascripts/components/components/status_content.jsx
+++ b/app/assets/javascripts/components/components/status_content.jsx
@@ -44,6 +44,7 @@ const StatusContent = React.createClass({
       } else {
         link.setAttribute('target', '_blank');
         link.setAttribute('rel', 'noopener');
+        link.setAttribute('title', link.href);
       }
     }
   },


### PR DESCRIPTION
Since URLs in statuses are truncated, it would be pleasant to see the full URL when hovering the URL (like on twitter, yes).