### PR TITLE
Fix Japanese translation for remote_follow

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -157,7 +157,7 @@ ja:
     prev: 前
     truncate: "&hellip;"
   remote_follow:
-    acct: フォローしたい人の ユーザー名@ドメイン を入力してください
+    acct: あなたの ユーザー名@ドメイン を入力してください
     missing_resource: リダイレクト先が見つかりませんでした
     proceed: フォローする
     prompt: 'フォローしようとしています:'


### PR DESCRIPTION
Current remote_follow.acct translation inappropriate. Users may not input their own acccount. So fix the wording.