### PR TITLE
Admin user listing

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,6 +3,7 @@
 module Admin
   class UsersController < BaseController
     def index
+      @users = User.all.page(params[:page])
     end
 
     def show

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Admin
+  class UsersController < BaseController
+    def index
+    end
+
+    def show
+    end
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,11 +3,25 @@
 module Admin
   class UsersController < BaseController
     def index
-      @users = User.all.page(params[:page])
+      @users = filtered_users.page(params[:page])
     end
 
     def show
       @user = User.find(params[:id])
+    end
+
+    private
+
+    def filtered_users
+      UserFilter.new(filter_params).results
+    end
+
+    def filter_params
+      params.permit(
+        :admin,
+        :confirmed,
+        :unconfirmed
+      )
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,6 +7,7 @@ module Admin
     end
 
     def show
+      @user = User.find(params[:id])
     end
   end
 end

--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
-module Admin::AccountsHelper
-  def filter_params(more_params)
-    params.permit(:local, :remote, :by_domain, :silenced, :suspended, :recent, :resolved).merge(more_params)
-  end
+module Admin::FilterHelper
+  FILTERS = %i[
+    local
+    remote
+    by_domain
+    silenced
+    suspended
+    recent
+    resolved
+    admin
+    confirmed
+    unconfirmed
+  ]
 
   def filter_link_to(text, more_params)
     new_url = filtered_url_for(more_params)
@@ -15,6 +24,10 @@ module Admin::AccountsHelper
   end
 
   private
+
+  def filter_params(more_params)
+    params.permit(FILTERS).merge(more_params)
+  end
 
   def filter_link_class(new_url)
     filtered_url_for(params) == new_url ? 'selected' : ''

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ApplicationRecord
   scope :recent,    -> { order('id desc') }
   scope :admins,    -> { where(admin: true) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
+  scope :unconfirmed, -> { where(confirmed_at: nil) }
 
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later

--- a/app/models/user_filter.rb
+++ b/app/models/user_filter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class UserFilter
+  attr_reader :params
+
+  def initialize(params)
+    @params = params
+  end
+
+  def results
+    scope = User.all
+    params.each do |key, value|
+      scope = scope.merge scope_for(key, value)
+    end
+    scope
+  end
+
+  def scope_for(key, value)
+    case key
+    when /admin/
+      User.admins
+    when /\Aconfirmed/
+      User.confirmed
+    when /unconfirmed/
+      User.unconfirmed
+    else
+      raise "Unknown filter: #{key}"
+    end
+  end
+end

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,0 +1,20 @@
+- content_for :page_title do
+  = t('admin.users.title')
+
+%table.table
+  %thead
+    %tr
+      %th= t('admin.users.email_address')
+      %th= t('admin.users.is_admin')
+      %th
+  %tbody
+    - @users.each do |user|
+      %tr
+        %td= user.email
+        %td
+          - if user.admin?
+            %i.fa.fa-check
+        %td
+          = table_link_to 'pencil', t('admin.users.edit'), admin_user_path(user.id)
+
+= paginate @users

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,6 +1,19 @@
 - content_for :page_title do
   = t('admin.users.title')
 
+.filters
+  .filter-subset
+    %strong= t('admin.users.user_type.title')
+    %ul
+      %li= filter_link_to t('admin.users.user_type.all'), admin: nil
+      %li= filter_link_to t('admin.users.user_type.admins'), admin: 1
+  .filter-subset
+    %strong= t('admin.users.confirmed_status.title')
+    %ul
+      %li= filter_link_to t('admin.users.confirmed_status.any'), confirmed: nil, unconfirmed: nil
+      %li= filter_link_to t('admin.users.confirmed_status.confirmed'), confirmed: 1, unconfirmed: nil
+      %li= filter_link_to t('admin.users.confirmed_status.unconfirmed'), unconfirmed: 1, confirmed: nil
+
 %table.table
   %thead
     %tr

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -1,0 +1,32 @@
+- content_for :page_title do
+  = @user.email
+
+%table.table
+  %tbody
+    %tr
+      %th= t('admin.users.email_address')
+      %td= @user.email
+    %tr
+      %th= t('admin.users.account')
+      %td= link_to @user.account.username, web_url("accounts/#{@user.account_id}")
+    %tr
+      %th= t('admin.users.is_admin')
+      %td= @user.admin
+    %tr
+      %th= t('admin.users.created_at')
+      %td= @user.created_at
+    %tr
+      %th= t('admin.users.last_sign_in_ip')
+      %td= @user.last_sign_in_ip
+    %tr
+      %th= t('admin.users.confirmed_at')
+      %td= @user.confirmed_at
+    %tr
+      %th= t('admin.users.confirmation_sent_at')
+      %td= @user.confirmation_sent_at
+    %tr
+      %th= t('admin.users.locale')
+      %td= @user.locale
+    %tr
+      %th= t('admin.users.last_emailed_at')
+      %td= @user.last_emailed_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,10 @@ en:
         title: Extended site description
       site_title: Site title
       title: Site Settings
+    users:
+      title: Users
+      email_address: Email Address
+      is_admin: Admin?
     title: Administration
   application_mailer:
     settings: 'Change e-mail preferences: %{link}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,6 +144,15 @@ en:
       title: Users
       email_address: Email Address
       is_admin: Admin?
+      user_type:
+        title: User type
+        all: All users
+        admins: Admins
+      confirmed_status:
+        title: Confirmation status
+        any: Any
+        confirmed: Confirmed
+        unconfirmed: Unconfirmed
     title: Administration
   application_mailer:
     settings: 'Change e-mail preferences: %{link}'

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -17,6 +17,7 @@ SimpleNavigation::Configuration.run do |navigation|
     primary.item :admin, safe_join([fa_icon('cogs fw'), t('admin.title')]), admin_reports_url, if: proc { current_user.admin? } do |admin|
       admin.item :reports, safe_join([fa_icon('flag fw'), t('admin.reports.title')]), admin_reports_url, highlights_on: %r{/admin/reports}
       admin.item :accounts, safe_join([fa_icon('users fw'), t('admin.accounts.title')]), admin_accounts_url, highlights_on: %r{/admin/accounts}
+      admin.item :users, safe_join([fa_icon('users fw'), t('admin.users.title')]), admin_users_url, highlights_on: %r{/admin/users}
       admin.item :pubsubhubbubs, safe_join([fa_icon('paper-plane-o fw'), t('admin.pubsubhubbub.title')]), admin_pubsubhubbub_index_url
       admin.item :domain_blocks, safe_join([fa_icon('lock fw'), t('admin.domain_block.title')]), admin_domain_blocks_url, highlights_on: %r{/admin/domain_blocks}
       admin.item :sidekiq, safe_join([fa_icon('diamond fw'), 'Sidekiq']), sidekiq_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
       resource :silence, only: [:create, :destroy]
       resource :suspension, only: [:create, :destroy]
     end
+    resources :users, only: [:index, :show]
   end
 
   get '/admin', to: redirect('/admin/settings', status: 302)

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::UsersController, type: :controller do

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Admin::UsersController, type: :controller do
+  before do
+    sign_in Fabricate(:user, admin: true), scope: :user
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET #show' do
+    let(:user) { Fabricate(:user) }
+
+    it 'returns http success' do
+      get :show, params: { id: user.id }
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/helpers/admin/accounts_helper_spec.rb
+++ b/spec/helpers/admin/accounts_helper_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Admin::AccountsHelper, type: :helper do
-
-end

--- a/spec/helpers/admin/filter_helper_spec.rb
+++ b/spec/helpers/admin/filter_helper_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe Admin::FilterHelper do
+  it 'Uses table_link_to to create icon links' do
+    result = helper.table_link_to 'icon', 'text', 'path'
+
+    expect(result).to match(/text/)
+  end
+end

--- a/spec/models/user_filter_spec.rb
+++ b/spec/models/user_filter_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe UserFilter do
+  describe 'with empty params' do
+    it 'defaults to alphabetic user list' do
+      filter = UserFilter.new({})
+
+      expect(filter.results).to eq User.all
+    end
+  end
+
+  describe 'with invalid params' do
+    it 'raises with key error' do
+      filter = UserFilter.new(wrong: true)
+
+      expect { filter.results }.to raise_error(/wrong/)
+    end
+  end
+
+  describe 'with valid params' do
+    it 'combines filters on User' do
+      filter = UserFilter.new(admin: true, unconfirmed: true)
+
+      allow(User).to receive(:admins).and_return(User.none)
+      allow(User).to receive(:unconfirmed).and_return(User.none)
+      filter.results
+      expect(User).to have_received(:admins)
+      expect(User).to have_received(:unconfirmed)
+    end
+  end
+end


### PR DESCRIPTION
Adds a user listing to the admin area. Users are filterable by admin status, and confirmed status. User show page has some basic details.

Might be useful for debugging sign up issues.

![screen shot 2017-04-14 at 2 36 18 pm](https://cloud.githubusercontent.com/assets/225/25052451/e36cabbc-211f-11e7-9b6f-4daf732e9ab9.png)
![screen shot 2017-04-14 at 2 36 29 pm](https://cloud.githubusercontent.com/assets/225/25052450/e36b5c30-211f-11e7-82e3-8bda1675e539.png)
![screen shot 2017-04-14 at 2 36 51 pm](https://cloud.githubusercontent.com/assets/225/25052452/e36fcb3a-211f-11e7-829c-dc93f5b81d13.png)
