### PR TITLE
Send initial state inside a <script type="application/json"> tag

### DIFF
--- a/app/assets/javascripts/components/containers/mastodon.jsx
+++ b/app/assets/javascripts/components/containers/mastodon.jsx
@@ -60,8 +60,8 @@ import { hydrateStore } from '../actions/store';
 import createStream from '../stream';
 
 const store = configureStore();
-
-store.dispatch(hydrateStore(window.INITIAL_STATE));
+const initialState = JSON.parse(document.getElementById("initial-state").textContent);
+store.dispatch(hydrateStore(initialState));
 
 const browserHistory = useRouterHistory(createBrowserHistory)({
   basename: '/web'
@@ -94,9 +94,10 @@ const Mastodon = React.createClass({
 
   componentDidMount() {
     const { locale }  = this.props;
+    const streamingAPIBaseURL = store.getState().getIn(['meta', 'streaming_api_base_url']);
     const accessToken = store.getState().getIn(['meta', 'access_token']);
 
-    this.subscription = createStream(accessToken, 'user', {
+    this.subscription = createStream(streamingAPIBaseURL, accessToken, 'user', {
 
       connected () {
         store.dispatch(connectTimeline('home'));

--- a/app/assets/javascripts/components/features/community_timeline/index.jsx
+++ b/app/assets/javascripts/components/features/community_timeline/index.jsx
@@ -19,6 +19,7 @@ const messages = defineMessages({
 
 const mapStateToProps = state => ({
   hasUnread: state.getIn(['timelines', 'community', 'unread']) > 0,
+  streamingAPIBaseURL: state.getIn(['meta', 'streaming_api_base_url']),
   accessToken: state.getIn(['meta', 'access_token'])
 });
 
@@ -29,6 +30,7 @@ const CommunityTimeline = React.createClass({
   propTypes: {
     dispatch: React.PropTypes.func.isRequired,
     intl: React.PropTypes.object.isRequired,
+    streamingAPIBaseURL: React.PropTypes.string.isRequired,
     accessToken: React.PropTypes.string.isRequired,
     hasUnread: React.PropTypes.bool
   },
@@ -36,7 +38,7 @@ const CommunityTimeline = React.createClass({
   mixins: [PureRenderMixin],
 
   componentDidMount () {
-    const { dispatch, accessToken } = this.props;
+    const { dispatch, streamingAPIBaseURL, accessToken } = this.props;
 
     dispatch(refreshTimeline('community'));
 
@@ -44,7 +46,7 @@ const CommunityTimeline = React.createClass({
       return;
     }
 
-    subscription = createStream(accessToken, 'public:local', {
+    subscription = createStream(streamingAPIBaseURL, accessToken, 'public:local', {
 
       connected () {
         dispatch(connectTimeline('community'));

--- a/app/assets/javascripts/components/features/hashtag_timeline/index.jsx
+++ b/app/assets/javascripts/components/features/hashtag_timeline/index.jsx
@@ -13,6 +13,7 @@ import createStream from '../../stream';
 
 const mapStateToProps = state => ({
   hasUnread: state.getIn(['timelines', 'tag', 'unread']) > 0,
+  streamingAPIBaseURL: state.getIn(['meta', 'streaming_api_base_url']),
   accessToken: state.getIn(['meta', 'access_token'])
 });
 
@@ -21,6 +22,7 @@ const HashtagTimeline = React.createClass({
   propTypes: {
     params: React.PropTypes.object.isRequired,
     dispatch: React.PropTypes.func.isRequired,
+    streamingAPIBaseURL: React.PropTypes.string.isRequired,
     accessToken: React.PropTypes.string.isRequired,
     hasUnread: React.PropTypes.bool
   },
@@ -28,9 +30,9 @@ const HashtagTimeline = React.createClass({
   mixins: [PureRenderMixin],
 
   _subscribe (dispatch, id) {
-    const { accessToken } = this.props;
+    const { streamingAPIBaseURL, accessToken } = this.props;
 
-    this.subscription = createStream(accessToken, `hashtag&tag=${id}`, {
+    this.subscription = createStream(streamingAPIBaseURL, accessToken, `hashtag&tag=${id}`, {
 
       received (data) {
         switch(data.event) {

--- a/app/assets/javascripts/components/features/public_timeline/index.jsx
+++ b/app/assets/javascripts/components/features/public_timeline/index.jsx
@@ -19,6 +19,7 @@ const messages = defineMessages({
 
 const mapStateToProps = state => ({
   hasUnread: state.getIn(['timelines', 'public', 'unread']) > 0,
+  streamingAPIBaseURL: state.getIn(['meta', 'streaming_api_base_url']),
   accessToken: state.getIn(['meta', 'access_token'])
 });
 
@@ -29,6 +30,7 @@ const PublicTimeline = React.createClass({
   propTypes: {
     dispatch: React.PropTypes.func.isRequired,
     intl: React.PropTypes.object.isRequired,
+    streamingAPIBaseURL: React.PropTypes.string.isRequired,
     accessToken: React.PropTypes.string.isRequired,
     hasUnread: React.PropTypes.bool
   },
@@ -36,7 +38,7 @@ const PublicTimeline = React.createClass({
   mixins: [PureRenderMixin],
 
   componentDidMount () {
-    const { dispatch, accessToken } = this.props;
+    const { dispatch, streamingAPIBaseURL, accessToken } = this.props;
 
     dispatch(refreshTimeline('public'));
 
@@ -44,7 +46,7 @@ const PublicTimeline = React.createClass({
       return;
     }
 
-    subscription = createStream(accessToken, 'public', {
+    subscription = createStream(streamingAPIBaseURL, accessToken, 'public', {
 
       connected () {
         dispatch(connectTimeline('public'));

--- a/app/assets/javascripts/components/reducers/meta.jsx
+++ b/app/assets/javascripts/components/reducers/meta.jsx
@@ -2,6 +2,7 @@ import { STORE_HYDRATE } from '../actions/store';
 import Immutable from 'immutable';
 
 const initialState = Immutable.Map({
+  streaming_api_base_url: null,
   access_token: null,
   me: null
 });

--- a/app/assets/javascripts/components/stream.jsx
+++ b/app/assets/javascripts/components/stream.jsx
@@ -10,8 +10,8 @@ const createWebSocketURL = (url) => {
   return a.href;
 };
 
-export default function getStream(accessToken, stream, { connected, received, disconnected, reconnected }) {
-  const ws = new WebSocketClient(`${createWebSocketURL(STREAMING_API_BASE_URL)}/api/v1/streaming/?access_token=${accessToken}&stream=${stream}`);
+export default function getStream(streamingAPIBaseURL, accessToken, stream, { connected, received, disconnected, reconnected }) {
+  const ws = new WebSocketClient(`${createWebSocketURL(streamingAPIBaseURL)}/api/v1/streaming/?access_token=${accessToken}&stream=${stream}`);
 
   ws.onopen      = connected;
   ws.onmessage   = e => received(JSON.parse(e.data));

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,9 +4,10 @@ class HomeController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @body_classes = 'app-body'
-    @token        = find_or_create_access_token.token
-    @web_settings = Web::Setting.find_by(user: current_user)&.data || {}
+    @body_classes           = 'app-body'
+    @token                  = find_or_create_access_token.token
+    @web_settings           = Web::Setting.find_by(user: current_user)&.data || {}
+    @streaming_api_base_url = Rails.configuration.x.streaming_api_base_url
   end
 
   private

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,7 +1,5 @@
 - content_for :header_tags do
-  :javascript
-    window.STREAMING_API_BASE_URL = '#{Rails.configuration.x.streaming_api_base_url}';
-    window.INITIAL_STATE = #{json_escape(render(file: 'home/initial_state', formats: :json))}
+  %script#initial-state{:type => 'application/json'}!= json_escape(render(file: 'home/initial_state', formats: :json))
 
   = javascript_include_tag 'application', integrity: true
 

--- a/app/views/home/initial_state.json.rabl
+++ b/app/views/home/initial_state.json.rabl
@@ -2,6 +2,7 @@ object false
 
 node(:meta) do
   {
+    streaming_api_base_url: @streaming_api_base_url,
     access_token: @token,
     locale: I18n.locale,
     me: current_account.id,


### PR DESCRIPTION
This pull request is an attempt to fix #1656. It's based on the suggestion @riking's gave in the issue conversation, but instead of a `<div>` tag the state is sent inside a `<script type="application/json">` tag. This allows the state data chunk to be located inside `<head>`, just before the application code bundle.

The STREAMING_API_BASE_URL value is not the window object's attribute anymore, rather it's routed in the store's meta values similarly like access_token.

The json_escape function *should* take care of escaping problematic characters such as `<`, `>` and `&` in the JSON data.