### PR TITLE
Remove unused will_paginate.page_gap key from i18n

### DIFF
--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -165,5 +165,3 @@ bg:
   users:
     invalid_email: E-mail адресът е невалиден
     invalid_otp_token: Невалиден код
-  will_paginate:
-    page_gap: "&hellip;"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,5 +298,3 @@ en:
   users:
     invalid_email: The e-mail address is invalid
     invalid_otp_token: Invalid two-factor code
-  will_paginate:
-    page_gap: "&hellip;"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -293,5 +293,3 @@ fr:
   users:
     invalid_email: L'adresse courriel est invalide
     invalid_otp_token: Le code d'authentification à deux facteurs est invalide
-  will_paginate:
-    page_gap: "&hellip;"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -161,5 +161,3 @@ hr:
   users:
     invalid_email: E-mail adresa nije valjana
     invalid_otp_token: Nevaljani dvo-faktorski kod
-  will_paginate:
-    page_gap: "&hellip;"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -298,5 +298,3 @@ ja:
   users:
     invalid_email: メールアドレスが無効です
     invalid_otp_token: 二段階認証コードが間違っています
-  will_paginate:
-    page_gap: "&hellip;"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -161,5 +161,3 @@ nl:
   users:
     invalid_email: Het e-mailadres is ongeldig
     invalid_otp_token: Ongeldige twe-factor code
-  will_paginate:
-    page_gap: "&hellip;"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -164,5 +164,3 @@ ru:
   users:
     invalid_email: Введенный e-mail неверен
     invalid_otp_token: Введен неверный код
-  will_paginate:
-    page_gap: "&hellip;"


### PR DESCRIPTION
This value was changed recently, and every locale which had it set was using the
same value as the default. This value is still the default in the new location.