### PR TITLE
Give SINGLE_USER a chance to register

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   force_ssl if: "Rails.env.production? && ENV['LOCAL_HTTPS'] == 'true'"
 
   include Localized
-  helper_method :current_account
+  helper_method :current_account, :single_user_mode?
 
   rescue_from ActionController::RoutingError, with: :not_found
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
@@ -67,6 +67,10 @@ class ApplicationController < ActionController::Base
       format.any  { head 422 }
       format.html { render 'errors/422', layout: 'error', status: 422 }
     end
+  end
+
+  def single_user_mode?
+    @single_user_mode ||= Rails.configuration.x.single_user_mode && Account.first
   end
 
   def current_account

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -28,7 +28,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   end
 
   def check_enabled_registrations
-    redirect_to root_path if Rails.configuration.x.single_user_mode || !Setting.open_registrations
+    redirect_to root_path if single_user_mode? || !Setting.open_registrations
   end
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -13,7 +13,7 @@ class HomeController < ApplicationController
   private
 
   def authenticate_user!
-    redirect_to(Rails.configuration.x.single_user_mode ? account_path(Account.first) : about_path) unless user_signed_in?
+    redirect_to(single_user_mode? ? account_path(Account.first) : about_path) unless user_signed_in?
   end
 
   def find_or_create_access_token

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -14,7 +14,7 @@
   %meta{ property: 'og:image:height', content: '120' }/
   %meta{ property: 'twitter:card', content: 'summary' }/
 
-- if !user_signed_in? && !Rails.configuration.x.single_user_mode
+- if !user_signed_in? && !single_user_mode?
   = render partial: 'shared/landing_strip', locals: { account: @account }
 
 .h-feed

--- a/app/views/stream_entries/show.html.haml
+++ b/app/views/stream_entries/show.html.haml
@@ -20,7 +20,7 @@
 
   %meta{ property: 'twitter:card', content: 'summary' }/
 
-- if !user_signed_in? && !Rails.configuration.x.single_user_mode
+- if !user_signed_in? && !single_user_mode?
   = render partial: 'shared/landing_strip', locals: { account: @stream_entry.account }
 
 .activity-stream.activity-stream-headless.h-entry


### PR DESCRIPTION
An attempt to open a brand new Mastodon instance configured
as SINGLE_USER_MODE=true will cause an exception.

Enable temporary registration if we have no users in the database

Fixes #1817