### PR TITLE
Add tasks for open/close registration

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -86,7 +86,7 @@ namespace :mastodon do
     desc 'Open registrations on this instance'
     task open_registrations: :environment do
       setting = Setting.where(var: 'open_registrations').first
-      setting.value = 'true'
+      setting.value = true
       setting.save
     end
 

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -85,14 +85,14 @@ namespace :mastodon do
   namespace :settings do
     desc 'Open registrations on this instance'
     task open_registrations: :environment do
-      setting = Setting.where(var: 'open_registrations').first()
+      setting = Setting.where(var: 'open_registrations').first
       setting.value = 'true'
       setting.save
     end
 
     desc 'Close registrations on this instance'
     task close_registrations: :environment do
-      setting = Setting.where(var: 'open_registrations').first()
+      setting = Setting.where(var: 'open_registrations').first
       setting.value = false
       setting.save
     end

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -82,6 +82,22 @@ namespace :mastodon do
     end
   end
 
+  namespace :settings do
+    desc 'Open registrations on this instance'
+    task open_registrations: :environment do
+      setting = Setting.where(var: 'open_registrations').first()
+      setting.value = 'true'
+      setting.save
+    end
+
+    desc 'Close registrations on this instance'
+    task close_registrations: :environment do
+      setting = Setting.where(var: 'open_registrations').first()
+      setting.value = false
+      setting.save
+    end
+  end
+
   namespace :maintenance do
     desc 'Update counter caches'
     task update_counter_caches: :environment do


### PR DESCRIPTION
It would be helpful for some server administrators to be able to open and close registrations from the command line. This PR adds two rake tasks, mastodon:settings:open_registrations and mastodon:settings:close_registrations, so that this can be automated easily.