### PR TITLE
ActiveRecord::Relation does not respond to `#id`

### DIFF
--- a/app/services/pubsubhubbub/unsubscribe_service.rb
+++ b/app/services/pubsubhubbub/unsubscribe_service.rb
@@ -4,7 +4,7 @@ class Pubsubhubbub::UnsubscribeService < BaseService
   def call(account, callback)
     return ['Invalid topic URL', 422] if account.nil?
 
-    subscription = Subscription.where(account: account, callback_url: callback)
+    subscription = Subscription.find_by(account: account, callback_url: callback)
 
     unless subscription.nil?
       Pubsubhubbub::ConfirmationWorker.perform_async(subscription.id, 'unsubscribe')


### PR DESCRIPTION
Fixed undefined method error.

```
L:10 `subscription.id`
undefined method 'id' for #<Subscription::ActiveRecord_Relation:0x007f7dfc782478>
```