### PR TITLE
Fix Japanese translation of ja.yml

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -34,8 +34,8 @@ ja:
     followers: フォロワー
     following: フォロー中
     nothing_here: 何もありません
-    people_followed_by: "%{name} さんをフォロー中のアカウント"
-    people_who_follow: "%{name} さんがフォロー中のアカウント"
+    people_followed_by: "%{name} さんがフォロー中のアカウント"
+    people_who_follow: "%{name} さんをフォロー中のアカウント"
     posts: 投稿
     remote_follow: リモートフォロー
     unfollow: フォロー解除


### PR DESCRIPTION
At the page title, Japanese translation of "following" (https://mstdn.jp/users/Setuu/following) and "followers" (https://mstdn.jp/users/Setuu/followers) replaced each other.