### PR TITLE
About page contact email

### DIFF
--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -3,7 +3,7 @@
 class InstancePresenter
   delegate(
     :closed_registrations_message,
-    :contact_email,
+    :site_contact_email,
     :open_registrations,
     :site_description,
     :site_extended_description,

--- a/app/views/about/_contact.html.haml
+++ b/app/views/about/_contact.html.haml
@@ -1,0 +1,15 @@
+.panel
+  .panel-header= t 'about.contact'
+  .panel-body
+    - if contact.contact_account
+      .owner
+        .avatar= image_tag contact.contact_account.avatar.url
+        .name
+          = link_to TagManager.instance.url_for(contact.contact_account) do
+            %span.display_name.emojify= display_name(contact.contact_account)
+            %span.username= "@#{contact.contact_account.acct}"
+
+    - if contact.site_contact_email
+      .contact-email
+        = t 'about.business_email'
+        %strong= contact.site_contact_email

--- a/app/views/about/_links.html.haml
+++ b/app/views/about/_links.html.haml
@@ -1,0 +1,11 @@
+.panel
+  .panel-header= t 'about.links'
+  .panel-list
+    %ul
+      - if user_signed_in?
+        %li= link_to t('about.get_started'), root_path
+      - else
+        %li= link_to t('about.get_started'), new_user_registration_path
+        %li= link_to t('auth.login'), new_user_session_path
+      %li= link_to t('about.terms'), terms_path
+      %li= link_to t('about.source_code'), 'https://github.com/tootsuite/mastodon'

--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -28,29 +28,5 @@
         .panel= @instance_presenter.site_extended_description.html_safe
 
     .sidebar
-      .panel
-        .panel-header= t 'about.contact'
-        .panel-body
-          - if @instance_presenter.contact_account
-            .owner
-              .avatar= image_tag @instance_presenter.contact_account.avatar.url
-              .name
-                = link_to TagManager.instance.url_for(@instance_presenter.contact_account) do
-                  %span.display_name.emojify= display_name(@instance_presenter.contact_account)
-                  %span.username= "@#{@instance_presenter.contact_account.acct}"
-
-          - unless @instance_presenter.contact_email.blank?
-            .contact-email
-              = t 'about.business_email'
-              %strong= @instance_presenter.contact_email
-      .panel
-        .panel-header= t 'about.links'
-        .panel-list
-          %ul
-            - if user_signed_in?
-              %li= link_to t('about.get_started'), root_path
-            - else
-              %li= link_to t('about.get_started'), new_user_registration_path
-              %li= link_to t('auth.login'), new_user_session_path
-            %li= link_to t('about.terms'), terms_path
-            %li= link_to t('about.source_code'), 'https://github.com/tootsuite/mastodon'
+      = render partial: 'contact', object: @instance_presenter
+      = render 'links'

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -28,9 +28,9 @@ describe InstancePresenter do
   end
 
   it "delegates contact_email to Setting" do
-    Setting.contact_email = "admin@example.com"
+    Setting.site_contact_email = "admin@example.com"
 
-    expect(instance_presenter.contact_email).to eq "admin@example.com"
+    expect(instance_presenter.site_contact_email).to eq "admin@example.com"
   end
 
   describe "contact_account" do

--- a/spec/views/about/_contact.html.haml_spec.rb
+++ b/spec/views/about/_contact.html.haml_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'about/_contact.html.haml' do
+  describe 'the contact account' do
+    it 'shows info when account is present' do
+      account = Account.new(username: 'admin')
+      contact = double(contact_account: account, site_contact_email: '')
+      render 'about/contact', contact: contact
+
+      expect(rendered).to have_content('@admin')
+    end
+
+    it 'does not show info when account is missing' do
+      contact = double(contact_account: nil, site_contact_email: '')
+      render 'about/contact', contact: contact
+
+      expect(rendered).not_to have_content('@')
+    end
+  end
+
+  describe 'the contact email' do
+    it 'show info when email is present' do
+      contact = double(site_contact_email: 'admin@example.com', contact_account: nil)
+      render 'about/contact', contact: contact
+
+      expect(rendered).to have_content('admin@example.com')
+    end
+
+    it 'does not show info when email is missing' do
+      contact = double(site_contact_email: nil, contact_account: nil)
+      render 'about/contact', contact: contact
+
+      expect(rendered).not_to have_content(I18n.t('about.business_email'))
+    end
+  end
+end

--- a/spec/views/about/_links.html.haml_spec.rb
+++ b/spec/views/about/_links.html.haml_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'about/_links.html.haml' do
+  it 'does not show sign in link when signed in' do
+    allow(view).to receive(:user_signed_in?).and_return(true)
+    render
+
+    expect(rendered).to have_content(I18n.t('about.get_started'))
+    expect(rendered).not_to have_content(I18n.t('auth.login'))
+  end
+
+  it 'shows sign in link when signed out' do
+    allow(view).to receive(:user_signed_in?).and_return(false)
+    render
+
+    expect(rendered).to have_content(I18n.t('about.get_started'))
+    expect(rendered).to have_content(I18n.t('auth.login'))
+  end
+end


### PR DESCRIPTION
A previous refactor introduced an error where the site contact email is never shown on the about/more page. This fixes that and hopefully makes it less likely to happen again.