### PR TITLE
Silence Devise deprecation warning about TestHelpers

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include Devise::Test::ControllerHelpers, type: :controller
-  config.include Devise::TestHelpers, type: :view
+  config.include Devise::Test::ControllerHelpers, type: :view
   config.include Paperclip::Shoulda::Matchers
 
   config.before :each, type: :feature do


### PR DESCRIPTION
Devise changed their approach -
https://github.com/plataformatec/devise/commit/3f3ec236bb50a2ae8b0eede90d8f7ecd201d7dbb

This change silences a deprecation warning about `TestHelpers`