### PR TITLE
Remove isRequired from optional prop

### DIFF
--- a/app/assets/javascripts/components/components/permalink.jsx
+++ b/app/assets/javascripts/components/components/permalink.jsx
@@ -7,7 +7,7 @@ const Permalink = React.createClass({
   propTypes: {
     href: React.PropTypes.string.isRequired,
     to: React.PropTypes.string.isRequired,
-    children: React.PropTypes.node.isRequired
+    children: React.PropTypes.node
   },
 
   handleClick (e) {


### PR DESCRIPTION
A `children` propType was recently added to the `<Permalink />` component, and tagged as `isRequired`. However, the `<Notification />` component does not pass any children [when it renders a permalink](https://github.com/tootsuite/mastodon/blob/f4045ba3d962105ae4a7c0ee785a83c678ca2f8a/app/assets/javascripts/components/features/notifications/components/notification.jsx#L79). So if you have > 0 notifications, you get this warning in the console on page load.

```
Warning: Failed prop type: The prop `children` is marked as required in `Permalink`, but its value is `undefined`.
  in Permalink (created by Notification)
```

![screen shot 2017-04-15 at 14 34 13](https://cloud.githubusercontent.com/assets/566159/25063596/ff1e583c-21e8-11e7-8c0f-0472e5eefbd3.png)