### PR TITLE
Even spacing above and below navigation bar

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/compose_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/compose_form.jsx
@@ -155,7 +155,7 @@ const ComposeForm = React.createClass({
     }
 
     return (
-      <div style={{ padding: '10px' }}>
+      <div style={{ padding: '0 10px' }}>
         <Collapsable isVisible={this.props.spoiler} fullHeight={50}>
           <div className="spoiler-input">
             <input placeholder={intl.formatMessage(messages.spoiler_placeholder)} value={this.props.spoiler_text} onChange={this.handleChangeSpoilerText} onKeyDown={this.handleKeyDown} type="text" className="spoiler-input__input" />


### PR DESCRIPTION
This is a teeny tiny little padding tweak that I think might be quite a good improvement. The left-hand side of the screenshot below shows the spacing around the navigation bar currently. The right-hand side shows it after my changes in this PR.

![screen shot 2017-04-15 at 15 31 44](https://cloud.githubusercontent.com/assets/566159/25064013/a5233d9e-21f1-11e7-9f9f-6262b9cacec9.png)

It just evens out the spacing, so that it's the same above and below the bar. 