### PR TITLE
Fix expandFollowers/expandFollowing typo

### DIFF
--- a/app/assets/javascripts/components/features/followers/index.jsx
+++ b/app/assets/javascripts/components/features/followers/index.jsx
@@ -50,7 +50,7 @@ const Followers = React.createClass({
 
   handleLoadMore (e) {
     e.preventDefault();
-    this.props.dispatch(expandFollowing(Number(this.props.params.accountId)));
+    this.props.dispatch(expandFollowers(Number(this.props.params.accountId)));
   },
 
   render () {


### PR DESCRIPTION
When you click "Load more" in a user's "Followers" list, you get the following error in the console.

```
Uncaught ReferenceError: expandFollowing is not defined
```

It's because the `<Followers />` component has a small typo in the `handleLoadMore` function. Instead of calling `expandFollowers()`, it calls `expandFollowing()`. That's not imported or defined in that file, which causes the error.

![screen_shot_2017-04-15_at_16_17_12](https://cloud.githubusercontent.com/assets/566159/25064270/6ac58228-21f7-11e7-8b17-433d79286a81.png)
