### PR TITLE
ActiveRecord::NotFound -> ActiveRecord::RecordNotFound

### DIFF
--- a/app/controllers/api/oembed_controller.rb
+++ b/app/controllers/api/oembed_controller.rb
@@ -14,7 +14,7 @@ class Api::OEmbedController < ApiController
   def stream_entry_from_url(url)
     params = Rails.application.routes.recognize_path(url)
 
-    raise ActiveRecord::NotFound unless params[:controller] == 'stream_entries' && params[:action] == 'show'
+    raise ActiveRecord::RecordNotFound unless params[:controller] == 'stream_entries' && params[:action] == 'show'
 
     StreamEntry.find(params[:id])
   end


### PR DESCRIPTION
Fixed bug.

```
uninitialized constant ActiveRecord::NotFound
```

---

BTW, the `Rails.application.routes.recognize_path` is private API so we really shouldn't use it in application. The only reason it's not been removed already is there's a massive amount of legacy controller routing tests of rails that depend on it.