### PR TITLE
Domain block improvements

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -15,16 +15,26 @@ module Admin
 
       if @domain_block.save
         DomainBlockWorker.perform_async(@domain_block.id)
-        redirect_to admin_domain_blocks_path, notice: 'Domain block is now being processed'
+        redirect_to admin_domain_blocks_path, notice: I18n.t('admin.domain_block.created_msg')
       else
         render action: :new
       end
     end
 
+    def show
+      @domain_block = DomainBlock.find(params[:id])
+    end
+
+    def destroy
+      @domain_block = DomainBlock.find(params[:id])
+      UnblockDomainService.new.call(@domain_block, resource_params[:retroactive])
+      redirect_to admin_domain_blocks_path, notice: I18n.t('admin.domain_block.destroyed_msg')
+    end
+
     private
 
     def resource_params
-      params.require(:domain_block).permit(:domain, :severity)
+      params.require(:domain_block).permit(:domain, :severity, :reject_media, :retroactive)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,9 @@ class ApplicationController < ActionController::Base
   force_ssl if: "Rails.env.production? && ENV['LOCAL_HTTPS'] == 'true'"
 
   include Localized
-  helper_method :current_account, :single_user_mode?
+
+  helper_method :current_account
+  helper_method :single_user_mode?
 
   rescue_from ActionController::RoutingError, with: :not_found
   rescue_from ActiveRecord::RecordNotFound, with: :not_found

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -3,6 +3,8 @@
 class DomainBlock < ApplicationRecord
   enum severity: [:silence, :suspend]
 
+  attr_accessor :retroactive
+
   validates :domain, presence: true, uniqueness: true
 
   def self.blocked?(domain)

--- a/app/services/block_domain_service.rb
+++ b/app/services/block_domain_service.rb
@@ -3,12 +3,34 @@
 class BlockDomainService < BaseService
   def call(domain_block)
     if domain_block.silence?
-      Account.where(domain: domain_block.domain).update_all(silenced: true)
+      silence_accounts!(domain_block.domain)
+      clear_media!(domain_block.domain) if domain_block.reject_media?
     else
-      Account.where(domain: domain_block.domain).find_each do |account|
-        account.subscription(api_subscription_url(account.id)).unsubscribe if account.subscribed?
-        SuspendAccountService.new.call(account)
-      end
+      suspend_accounts!(domain_block.domain)
+    end
+  end
+
+  private
+
+  def silence_accounts!(domain)
+    Account.where(domain: domain).update_all(silenced: true)
+  end
+
+  def clear_media!(domain)
+    Account.where(domain: domain).find_each do |account|
+      account.avatar.destroy
+      account.header.destroy
+    end
+
+    MediaAttachment.where(account: Account.where(domain: domain)).find_each do |attachment|
+      attachment.file.destroy
+    end
+  end
+
+  def suspend_accounts!(domain)
+    Account.where(domain: domain).where(suspended: false).find_each do |account|
+      account.subscription(api_subscription_url(account.id)).unsubscribe if account.subscribed?
+      SuspendAccountService.new.call(account)
     end
   end
 end

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -13,6 +13,7 @@ class SuspendAccountService < BaseService
 
   def purge_content
     @account.statuses.reorder(nil).find_each do |status|
+      # This federates out deletes to previous followers
       RemoveStatusService.new.call(status)
     end
 
@@ -29,9 +30,7 @@ class SuspendAccountService < BaseService
     @account.display_name = ''
     @account.note         = ''
     @account.avatar.destroy
-    @account.avatar.clear
     @account.header.destroy
-    @account.header.clear
     @account.save!
   end
 

--- a/app/services/unblock_domain_service.rb
+++ b/app/services/unblock_domain_service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class UnblockDomainService < BaseService
+  def call(domain_block, retroactive)
+    if retroactive
+      if domain_block.silence?
+        Account.where(domain: domain_block.domain).update_all(silenced: false)
+      else
+        Account.where(domain: domain_block.domain).update_all(suspended: false)
+      end
+    end
+
+    domain_block.destroy
+  end
+end

--- a/app/views/admin/domain_blocks/index.html.haml
+++ b/app/views/admin/domain_blocks/index.html.haml
@@ -6,12 +6,19 @@
     %tr
       %th= t('admin.domain_block.domain')
       %th= t('admin.domain_block.severity')
+      %th= t('admin.domain_block.reject_media')
+      %th
   %tbody
     - @blocks.each do |block|
       %tr
         %td
           %samp= block.domain
-        %td= block.severity
+        %td= t("admin.domain_block.severities.#{block.severity}")
+        %td
+          - if block.reject_media? || block.suspend?
+            %i.fa.fa-check
+        %td
+          = table_link_to 'undo', t('admin.domain_block.undo'), admin_domain_block_path(block)
 
 = paginate @blocks
 = link_to t('admin.domain_block.add_new'), new_admin_domain_block_path, class: 'button'

--- a/app/views/admin/domain_blocks/new.html.haml
+++ b/app/views/admin/domain_blocks/new.html.haml
@@ -10,5 +10,8 @@
   = f.input :severity, collection: DomainBlock.severities.keys, wrapper: :with_label, include_blank: false, label_method: lambda { |type| I18n.t("admin.domain_block.new.severity.#{type}") }
 
   %p.hint= t('admin.domain_block.new.severity.desc_html')
+
+  = f.input :reject_media, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_block.reject_media'), hint: I18n.t('admin.domain_block.reject_media_hint')
+
   .actions
     = f.button :button, t('admin.domain_block.new.create'), type: :submit

--- a/app/views/admin/domain_blocks/show.html.haml
+++ b/app/views/admin/domain_blocks/show.html.haml
@@ -1,0 +1,9 @@
+- content_for :page_title do
+  = t('admin.domain_block.show.title', domain: @domain_block.domain)
+
+= simple_form_for @domain_block, url: admin_domain_block_path(@domain_block), method: :delete do |f|
+
+  = f.input :retroactive, as: :boolean, wrapper: :with_label, label: I18n.t("admin.domain_block.show.retroactive.#{@domain_block.severity}"), hint: I18n.t('admin.domain_block.show.affected_accounts', count: Account.where(domain: @domain_block.domain).count)
+
+  .actions
+    = f.button :button, t('admin.domain_block.show.undo'), type: :submit

--- a/app/views/api/v1/statuses/_media.rabl
+++ b/app/views/api/v1/statuses/_media.rabl
@@ -1,5 +1,5 @@
 attributes :id, :remote_url, :type
 
-node(:url)         { |media| full_asset_url(media.file.url(:original)) }
-node(:preview_url) { |media| full_asset_url(media.file.url(:small)) }
+node(:url)         { |media| media.file.blank? ? media.remote_url : full_asset_url(media.file.url(:original)) }
+node(:preview_url) { |media| media.file.blank? ? media.remote_url : full_asset_url(media.file.url(:small)) }
 node(:text_url)    { |media| media.local? ? medium_url(media) : nil }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,8 @@ en:
       web: Web
     domain_block:
       add_new: Add new
+      created_msg: Domain block is now being processed
+      destroyed_msg: Domain block has been undone
       domain: Domain
       new:
         create: Create block
@@ -90,8 +92,22 @@ en:
           silence: Silence
           suspend: Suspend
         title: New domain block
+      reject_media: Reject media files
+      reject_media_hint: Removes locally stored media files and refuses to download any in the future. Irrelevant for suspensions
+      severities:
+        silence: Silence
+        suspend: Suspend
       severity: Severity
+      show:
+        affected_accounts:
+          one: One account in the database affected
+          other: "%{count} accounts in the database affected"
+        retroactive:
+          silence: Unsilence all existing accounts from this domain
+          suspend: Unsuspend all existing accounts from this domain
+        title: Undo domain block for %{domain}
       title: Domain Blocks
+      undo: Undo
     pubsubhubbub:
       callback_url: Callback URL
       confirmed: Confirmed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,7 +78,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :pubsubhubbub, only: [:index]
-    resources :domain_blocks, only: [:index, :new, :create]
+    resources :domain_blocks, only: [:index, :new, :create, :show, :destroy]
     resources :settings, only: [:index, :update]
 
     resources :reports, only: [:index, :show, :update] do

--- a/spec/views/accounts/show.html.haml_spec.rb
+++ b/spec/views/accounts/show.html.haml_spec.rb
@@ -2,25 +2,28 @@ require 'rails_helper'
 $LOAD_PATH << '../lib'
 require 'tag_manager'
 
-describe "stream_entries/show.html.haml" do
-
+describe 'stream_entries/show.html.haml' do
   before do
-    double(:api_oembed_url => '')
-    double(:account_stream_entry_url => '')
+    double(api_oembed_url: '')
+    double(account_stream_entry_url: '')
+
+    def view.single_user_mode?
+      false
+    end
   end
 
-  it "has valid author h-card and basic data for a detailed_status" do
-    alice  =  Fabricate(:account, username: 'alice', display_name: 'Alice')
-    bob    =  Fabricate(:account, username: 'bob', display_name: 'Bob')
-    status =  Fabricate(:status, account: alice, text: 'Hello World')
-    reply  =  Fabricate(:status, account: bob, thread: status, text: 'Hello Alice')
+  it 'has valid author h-card and basic data for a detailed_status' do
+    alice  = Fabricate(:account, username: 'alice', display_name: 'Alice')
+    bob    = Fabricate(:account, username: 'bob', display_name: 'Bob')
+    status = Fabricate(:status, account: alice, text: 'Hello World')
+    Fabricate(:status, account: bob, thread: status, text: 'Hello Alice')
 
     assign(:status, status)
     assign(:stream_entry, status.stream_entry)
     assign(:account, alice)
     assign(:type, status.stream_entry.activity_type.downcase)
 
-    render(:template => 'stream_entries/show.html.haml')
+    render(template: 'stream_entries/show.html.haml')
 
     mf2 = Microformats2.parse(rendered)
 
@@ -31,22 +34,22 @@ describe "stream_entries/show.html.haml" do
     expect(mf2.entry.author.format.url.to_s).not_to be_empty
   end
 
-  it "has valid h-cites for p-in-reply-to and p-comment" do
-    alice   =  Fabricate(:account, username: 'alice', display_name: 'Alice')
-    bob     =  Fabricate(:account, username: 'bob', display_name: 'Bob')
-    carl    =  Fabricate(:account, username: 'carl', display_name: 'Carl')
-    status  =  Fabricate(:status, account: alice, text: 'Hello World')
-    reply   =  Fabricate(:status, account: bob, thread: status, text: 'Hello Alice')
-    comment =  Fabricate(:status, account: carl, thread: reply, text: 'Hello Bob')
+  it 'has valid h-cites for p-in-reply-to and p-comment' do
+    alice  = Fabricate(:account, username: 'alice', display_name: 'Alice')
+    bob    = Fabricate(:account, username: 'bob', display_name: 'Bob')
+    carl   = Fabricate(:account, username: 'carl', display_name: 'Carl')
+    status = Fabricate(:status, account: alice, text: 'Hello World')
+    reply  = Fabricate(:status, account: bob, thread: status, text: 'Hello Alice')
+    Fabricate(:status, account: carl, thread: reply, text: 'Hello Bob')
 
     assign(:status, reply)
     assign(:stream_entry, reply.stream_entry)
     assign(:account, alice)
     assign(:type, reply.stream_entry.activity_type.downcase)
-    assign(:ancestors, reply.stream_entry.activity.ancestors(bob) )
+    assign(:ancestors, reply.stream_entry.activity.ancestors(bob))
     assign(:descendants, reply.stream_entry.activity.descendants(bob))
 
-    render(:template => 'stream_entries/show.html.haml')
+    render(template: 'stream_entries/show.html.haml')
 
     mf2 = Microformats2.parse(rendered)
 
@@ -61,7 +64,4 @@ describe "stream_entries/show.html.haml" do
     expect(mf2.entry.in_reply_to.format.author.format.name.to_s).to eq alice.display_name
     expect(mf2.entry.in_reply_to.format.author.format.url.to_s).not_to be_empty
   end
-
 end
-
-

--- a/spec/views/stream_entries/show.html.haml_spec.rb
+++ b/spec/views/stream_entries/show.html.haml_spec.rb
@@ -1,22 +1,23 @@
 require 'rails_helper'
 
-describe "accounts/show.html.haml" do
+describe 'accounts/show.html.haml' do
+  before do
+    def view.single_user_mode?
+      false
+    end
+  end
 
-  it "has an h-feed with correct number of h-entry objects in it" do
-    alice   =  Fabricate(:account, username: 'alice', display_name: 'Alice')
-    status  =  Fabricate(:status, account: alice, text: 'Hello World')
-    status2 =  Fabricate(:status, account: alice, text: 'Hello World Again')
-    status3 =  Fabricate(:status, account: alice, text: 'Are You Still There World?')
+  it 'has an h-feed with correct number of h-entry objects in it' do
+    alice = Fabricate(:account, username: 'alice', display_name: 'Alice')
+    Fabricate(:status, account: alice, text: 'Hello World')
+    Fabricate(:status, account: alice, text: 'Hello World Again')
+    Fabricate(:status, account: alice, text: 'Are You Still There World?')
 
     assign(:account, alice)
     assign(:statuses, alice.statuses)
 
-    render(:template => 'accounts/show.html.haml')
+    render(template: 'accounts/show.html.haml')
 
     expect(Nokogiri::HTML(rendered).search('.h-feed .h-entry').size).to eq 3
-
   end
-
 end
-
-


### PR DESCRIPTION
* Make file attachment on MediaAttachment optional
* Create MediaAttachment but without actual file download when domain is blocked with reject_media set to true
* Clean up old media files when creating a new domain block with reject_media set to true
* Return remote_url in media attachments API if local file is not present
* Undo domain block action in admin UI
* Ability to enable reject_media from admin UI