### PR TITLE
Fixes #1829 adds full-width toolbar

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/character_counter.jsx
+++ b/app/assets/javascripts/components/features/compose/components/character_counter.jsx
@@ -13,7 +13,7 @@ const CharacterCounter = React.createClass({
     const diff = this.props.max - this.props.text.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "_").length;
 
     return (
-      <span style={{ fontSize: '16px', cursor: 'default' }}>
+      <span style={{ color: 'inherit', fontSize: '16px', cursor: 'default', paddingRight: '5px' }}>
         {diff}
       </span>
     );

--- a/app/assets/javascripts/components/features/compose/components/compose_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/compose_form.jsx
@@ -188,17 +188,16 @@ const ComposeForm = React.createClass({
           <UploadFormContainer />
         </div>
 
-        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <div className='compose-form__buttons'>
+        <div className='compose-form__buttons' style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
             <UploadButtonContainer />
             <PrivacyDropdownContainer />
             <SensitiveButtonContainer />
             <SpoilerButtonContainer />
           </div>
-
-          <div style={{ display: 'flex' }}>
-            <div style={{ paddingTop: '10px', marginRight: '16px', lineHeight: '36px' }}><CharacterCounter max={500} text={[this.props.spoiler_text, this.props.text].join('')} /></div>
-            <div style={{ paddingTop: '10px' }}><Button text={publishText} onClick={this.handleSubmit} disabled={disabled} /></div>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <CharacterCounter max={500} text={[this.props.spoiler_text, this.props.text].join('')} />
+            <Button text={publishText} onClick={this.handleSubmit} disabled={disabled} />
           </div>
         </div>
       </div>

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -210,16 +210,18 @@
   font-family: inherit;
   font-size: 14px;
   background: $color5;
-  border-radius: 0 0 4px 0;
 }
 
 .compose-form__buttons {
-  padding: 10px;
+  padding: 5px;
   background: darken($color5, 8%);
+  color: $color1;
+  border-top: 1px solid rgba($color8, 0.2);
   box-shadow: inset 0 5px 5px rgba($color8, 0.05);
   border-radius: 0 0 4px 4px;
   display: flex;
 
+  .text-icon-button,
   .icon-button {
     box-sizing: content-box;
     padding: 0 3px;


### PR DESCRIPTION
## Before

<img width="301" alt="screen shot 2017-04-15 at 16 05 36" src="https://cloud.githubusercontent.com/assets/176815/25067361/e8ccc89a-21f5-11e7-8f51-f6e25aa8300b.png">
<img width="300" alt="screen shot 2017-04-15 at 16 05 52" src="https://cloud.githubusercontent.com/assets/176815/25067362/e8ccfa7c-21f5-11e7-91f5-1778738a5550.png">

## After

<img width="305" alt="screen shot 2017-04-15 at 16 10 41" src="https://cloud.githubusercontent.com/assets/176815/25067367/237ac0c8-21f6-11e7-9365-73ddf11c0057.png">
<img width="301" alt="screen shot 2017-04-15 at 16 10 52" src="https://cloud.githubusercontent.com/assets/176815/25067368/237c744a-21f6-11e7-8d76-8578263fd518.png">
