### PR TITLE
Remove unused gem: coffee-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'pkg-config'
 gem 'rails', '~> 5.0.2'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
-gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
 gem 'puma'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,13 +111,6 @@ GEM
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.1)
-    coffee-rails (4.1.1)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.1.x)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -482,7 +475,6 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano-yarn
   capybara
-  coffee-rails (~> 4.1.0)
   devise
   devise-two-factor
   doorkeeper


### PR DESCRIPTION
Because I don't see Coffeescript code:

![screenshot from 2017-04-16 02 27 16](https://cloud.githubusercontent.com/assets/1860816/25067695/41d4b4b0-224c-11e7-99f0-bbd56935481b.png)
