### PR TITLE
Leave out the "Expires" header from S3 uploads

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -15,7 +15,7 @@ if ENV['S3_ENABLED'] == 'true'
   Paperclip::Attachment.default_options[:url]            = ':s3_domain_url'
   Paperclip::Attachment.default_options[:s3_host_name]   = ENV.fetch('S3_HOSTNAME') { "s3-#{ENV.fetch('S3_REGION')}.amazonaws.com" }
   Paperclip::Attachment.default_options[:path]           = '/:class/:attachment/:id_partition/:style/:filename'
-  Paperclip::Attachment.default_options[:s3_headers]     = { 'Cache-Control' => 'max-age=315576000', 'Expires' => 10.years.from_now.httpdate }
+  Paperclip::Attachment.default_options[:s3_headers]     = { 'Cache-Control' => 'max-age=315576000' }
   Paperclip::Attachment.default_options[:s3_permissions] = 'public-read'
   Paperclip::Attachment.default_options[:s3_region]      = ENV.fetch('S3_REGION') { 'us-east-1' }
 


### PR DESCRIPTION
This pull request leaves out the "Expires" header from S3 uploads to improve compatibility with Google Cloud Storage.

Currently setting `S3_ENDPOINT=https://storage.googleapis.com` and uploading a file yields the following error message:

> The request signature we calculated does not match the signature you provided. Check your Google secret key and signing method.

Based on some trial and error it appears that Google Cloud Storage is having hard time with the "Expires" header, set in `config/initializers/paperclip.rb`. Leaving the header out seems to be enough to convince Cloud Storage to cooperate.