### PR TITLE
gemfile: lock capistrano to 3.7.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ group :development do
   gem 'bullet'
   gem 'active_record_query_trace'
 
-  gem 'capistrano'
+  gem 'capistrano', '3.8.0'
   gem 'capistrano-rails'
   gem 'capistrano-rbenv'
   gem 'capistrano-yarn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
-    airbrussh (1.1.2)
+    airbrussh (1.2.0)
       sshkit (>= 1.6.1, != 1.7.0)
     arel (7.1.4)
     ast (2.3.0)
@@ -469,7 +469,7 @@ DEPENDENCIES
   binding_of_caller
   browserify-rails
   bullet
-  capistrano
+  capistrano (= 3.8.0)
   capistrano-faster-assets (~> 1.0)
   capistrano-rails
   capistrano-rbenv

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,4 +1,7 @@
-lock '3.7.2'
+# frozen_string_literal: true
+
+lock '3.8.0'
+
 set :repo_url, ENV.fetch('REPO', 'https://github.com/tootsuite/mastodon.git')
 set :branch, ENV.fetch('BRANCH', 'master')
 


### PR DESCRIPTION
Since that's what the `deploy.rb` is locked to.