### PR TITLE
reduce unneed query when post without attachements.

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -39,7 +39,8 @@ class PostStatusService < BaseService
 
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.too_many') if media_ids.size > 4
 
-    media = MediaAttachment.where(status_id: nil).where(id: media_ids.take(4).map(&:to_i))
+    target_media_ids = media_ids.take(4).map(&:to_i)
+    media = target_media_ids.blank? ? [] : MediaAttachment.where(status_id: nil).where(id: target_media_ids)
 
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.images_and_video') if media.size > 1 && media.find(&:video?)
 
@@ -47,7 +48,7 @@ class PostStatusService < BaseService
   end
 
   def attach_media(status, media)
-    return if media.nil?
+    return if media.nil? || media.empty?
     media.update(status_id: status.id)
   end
 

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -35,12 +35,11 @@ class PostStatusService < BaseService
   private
 
   def validate_media!(media_ids)
-    return if media_ids.nil? || !media_ids.is_a?(Enumerable)
+    return if media_ids.blank? || !media_ids.is_a?(Enumerable)
 
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.too_many') if media_ids.size > 4
 
-    target_media_ids = media_ids.take(4).map(&:to_i)
-    media = target_media_ids.blank? ? [] : MediaAttachment.where(status_id: nil).where(id: target_media_ids)
+    media = MediaAttachment.where(status_id: nil).where(id: media_ids.take(4).map(&:to_i))
 
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.images_and_video') if media.size > 1 && media.find(&:video?)
 
@@ -48,7 +47,7 @@ class PostStatusService < BaseService
   end
 
   def attach_media(status, media)
-    return if media.nil? || media.empty?
+    return if media.nil?
     media.update(status_id: status.id)
   end
 


### PR DESCRIPTION
This commit reduce following query:

```
 MediaAttachment Load (0.9ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status
_id" IS NULL AND 1=0 ORDER BY id asc
```