### PR TITLE
Enlarge font size to avoid autozooming of iPhone

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1203,6 +1203,10 @@ a.status__content__spoiler-link {
   &:focus {
     outline: 0;
   }
+
+  @media screen and (max-width: 600px) {
+    font-size: 16px;
+  }
 }
 
 .spoiler-input__input {
@@ -1266,6 +1270,10 @@ a.status__content__spoiler-link {
   &:focus, &:active {
     color: $color5;
     border-bottom-color: $color4;
+  }
+
+  @media screen and (max-width: 600px) {
+    font-size: 16px;
   }
 }
 
@@ -1905,6 +1913,10 @@ button.icon-button.active i.fa-retweet {
 
   &:focus {
     background: lighten($color1, 4%);
+  }
+
+  @media screen and (max-width: 600px) {
+    font-size: 16px;
   }
 }
 


### PR DESCRIPTION
# problem
Auto-Zooming occurs focusing on textarea in mobile safari.
![](https://i.gyazo.com/e1488efb6f50d3e540614e1b52e36009.gif)

# solution
I changed fontsize.

Mobile safari forces zoom if form input's font size < 16px.  
There are 2 ways to resolve this problem: this way or using `user-scalable=no`.
Latter way affects other browser's usability, so I chose this way.