### PR TITLE
Fixed NoMethodError in UnfollowService

### DIFF
--- a/app/services/unfollow_service.rb
+++ b/app/services/unfollow_service.rb
@@ -6,6 +6,7 @@ class UnfollowService < BaseService
   # @param [Account] target_account Which to unfollow
   def call(source_account, target_account)
     follow = source_account.unfollow!(target_account)
+    return unless follow
     NotificationWorker.perform_async(build_xml(follow), source_account.id, target_account.id) unless target_account.local?
     UnmergeWorker.perform_async(target_account.id, source_account.id)
   end


### PR DESCRIPTION
Fixed NoMethodError. It occurred when `:account_id` is already unfollowed.

```
*A* `NoMethodError` *occurred while* `POST </api/v1/accounts/:account_id/unfollow>` *was processed by* `accounts#unfollow`

Backtrace
----------------
app/lib/atom_serializer.rb:206:in `unfollow_salmon'
app/services/unfollow_service.rb:16:in `build_xml'
app/services/unfollow_service.rb:9:in `call'
app/controllers/api/v1/accounts_controller.rb:90:in `unfollow'
```