### PR TITLE
separate queue for RemovalWorker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-worker: bundle exec sidekiq -q default -q push -q pull -q mailers
+worker: bundle exec sidekiq -q default -q push -q pull -q mailers -q remove

--- a/app/workers/removal_worker.rb
+++ b/app/workers/removal_worker.rb
@@ -3,6 +3,8 @@
 class RemovalWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: 'remove'
+
   def perform(status_id)
     RemoveStatusService.new.call(Status.find(status_id))
   rescue ActiveRecord::RecordNotFound

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     build: .
     image: gargron/mastodon
     env_file: .env.production
-    command: bundle exec sidekiq -q default -q mailers -q pull -q push
+    command: bundle exec sidekiq -q default -q mailers -q pull -q push -q remove
     depends_on:
       - db
       - redis


### PR DESCRIPTION
When some user that has many followers remove a status, many RemovalWorker job generated.
It make slow consuming default  queue tasks.