### PR TITLE
Check @recipient.user at the first

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -6,7 +6,7 @@ class NotifyService < BaseService
     @activity     = activity
     @notification = Notification.new(account: @recipient, activity: @activity)
 
-    return if blocked? || recipient.user.nil?
+    return if recipient.user.nil? || blocked?
 
     create_notification
     send_email if email_enabled?


### PR DESCRIPTION
[L44](https://github.com/tootsuite/mastodon/pull/1939/files#diff-68132e0c7dccf2fc05ee65069a4c469cR44) are not working if `@recepient.user` is nil.

---

Fixes `NoMethodError`.

```
*A* `NoMethodError` *occured in background*
Exception
----------------
undefined method 'settings' for nil:NilClass

Backtrace
----------------
app/services/notify_service.rb:44:in `blocked?'
app/services/notify_service.rb:9:in `call'
app/services/process_interaction_service.rb:123:in `favourite!'
app/services/process_interaction_service.rb:41:in `call'
app/workers/salmon_worker.rb:9:in `perform'
```