### PR TITLE
Update node.js and imagemagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,16 @@ WORKDIR /mastodon
 
 COPY Gemfile Gemfile.lock package.json yarn.lock /mastodon/
 
-RUN BUILD_DEPS=" \
+RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
+ && BUILD_DEPS=" \
     postgresql-dev \
     libxml2-dev \
     libxslt-dev \
     build-base" \
  && apk -U upgrade && apk add \
     $BUILD_DEPS \
-    nodejs \
+    nodejs@edge \
+    nodejs-npm@edge \
     libpq \
     libxml2 \
     libxslt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
     libxslt \
     ffmpeg \
     file \
-    imagemagick \
+    imagemagick@edge \
  && npm install -g npm@3 && npm install -g yarn \
  && bundle install --deployment --without test development \
  && yarn --ignore-optional \


### PR DESCRIPTION
Ruby official alpine image is based on Alpine Linux 3.4. It's okay since Puma won't work with LibreSSL (at the moment) (LibreSSL replaced OpenSSL in Alpine Linux 3.5). But we also have to upgrade other system packages, to patch vulnerabilities, etc. Alpine Linux is nice but it's not well-maintained, unlike Debian. Picking node.js LTS and imagemagick from `edge` is a solution.