### PR TITLE
Remove unused registrations: key from PT yml locale

### DIFF
--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -145,7 +145,6 @@ pt:
           disabled: Desabilitado
           enabled: Habilitado
           title: Aberto para registro
-      registrations:
       setting: Preferências
       site_description:
         desc_html: Mostrar como parágrafo e usado como meta tag.<br/>Vôce pode usar tags HTML, em particular <code>&lt;a&gt;</code> e <code>&lt;em&gt;</code>.


### PR DESCRIPTION
This change must have slipped in from a merge after I started my i18n work, but before mine was merged. This change fixes `i18n-tasks unused` which should fix travis.