### PR TITLE
Fix minor typo in Japanese translation "保村" -> "保存"

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -94,7 +94,7 @@ ja:
           suspend: 停止
         title: 新規ドメインブロック
       reject_media: メディアファイルを拒否
-      reject_media_hint: ローカルに保村されたメディアファイルを削除し、今後のダウンロードを拒否します。停止とは無関係です。
+      reject_media_hint: ローカルに保存されたメディアファイルを削除し、今後のダウンロードを拒否します。停止とは無関係です。
       severities:
         silence: サイレンス
         suspend: 停止


### PR DESCRIPTION
I am a native Japanese speaker.