### PR TITLE
Improved Japanese translation in devise.ja.yml

### DIFF
--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -7,7 +7,7 @@ ja:
       send_paranoid_instructions: もしあなたのメールアドレスが登録されていれば、まもなくメールアドレスの確認の方法が記載されたメールが送信されます。
     failure:
       already_authenticated: 既にログイン済みです。
-      inactive: あなたのアカウントはまだアクティベートされていません。
+      inactive: あなたのアカウントはまだ有効化されていません。
       invalid: '%{authentication_keys}かパスワードが誤っています'
       last_attempt: あと1回失敗するとアカウントがロックされます。
       locked: アカウントはロックされました。


### PR DESCRIPTION
'有効化' has the same meaning as 'アクティベート', but more natural.

'有効化' is already used In other lines in devise.ja.yml. 

```
$ git grep 有効化
config/locales/devise.ja.yml:      signed_up_but_inactive: アカウントの作成が完了しました。しかし、アカウントが有効化されていないためログインできませんでした。
config/locales/devise.ja.yml:      signed_up_but_unconfirmed: メールアドレスの確認用のリンクが入力したメールアドレスに送信されました。メール内のリンクをクリックしてアカウントを有効化してください。
```