### PR TITLE
Assign user locale on signup

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -10,6 +10,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
 
   def build_resource(hash = nil)
     super(hash)
+    resource.locale = I18n.locale
     resource.build_account if resource.account.nil?
   end
 

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -16,9 +16,12 @@ RSpec.describe Auth::RegistrationsController, type: :controller do
   end
 
   describe 'POST #create' do
+    let(:accept_language) { Rails.application.config.i18n.available_locales.sample.to_s }
+
     before do
       Setting.open_registrations = true
       request.env["devise.mapping"] = Devise.mappings[:user]
+      request.headers["Accept-Language"] = accept_language
       post :create, params: { user: { account_attributes: { username: 'test' }, email: 'test@example.com', password: '12345678', password_confirmation: '12345678' } }
     end
 
@@ -27,7 +30,9 @@ RSpec.describe Auth::RegistrationsController, type: :controller do
     end
 
     it 'creates user' do
-      expect(User.find_by(email: 'test@example.com')).to_not be_nil
+      user = User.find_by(email: 'test@example.com')
+      expect(user).to_not be_nil
+      expect(user.locale).to eq(accept_language)
     end
   end
 end


### PR DESCRIPTION
https://mastodon.social/about shows me Japanese page for my browser with `Accept-Language: ja`. But after registration I receive email written in English. I fixed that email honors `Accept-Language`.
