### PR TITLE
Allow connecting to Redis via Unix socket

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -2,6 +2,7 @@
 REDIS_HOST=redis
 REDIS_PORT=6379
 # REDIS_DB=0
+# REDIS_SOCKET=/tmp/redis.sock
 DB_HOST=db
 DB_USER=postgres
 DB_NAME=postgres

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,6 +5,13 @@ development:
 test:
   adapter: async
 
+<% redis_url = if ENV['REDIS_SOCKET']
+  "unix:#{ENV['REDIS_SOCKET']}"
+else
+  "redis://#{ENV['REDIS_PASSWORD'] ? ':' + ENV['REDIS_PASSWORD'] + '@' : ''}#{ENV['REDIS_HOST'] || 'localhost'}:#{ENV['REDIS_PORT'] || 6379}"
+end %>
+
 production:
   adapter: redis
-  url: redis://<%= ENV['REDIS_PASSWORD'] ? ':' + ENV['REDIS_PASSWORD'] + '@' : '' %><%= ENV['REDIS_HOST'] || 'localhost' %>:<%= ENV['REDIS_PORT'] || 6379 %>/1
+  url: <%= redis_url %>
+  db: 1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,15 +59,23 @@ Rails.application.configure do
     ENV['REDIS_DB'] = db_num if db_num.present?
   end
 
+  # Allow connecting via Unix socket
+  redis_config = if ENV['REDIS_SOCKET']
+    { path: ENV['REDIS_SOCKET'] }
+  else
+    {
+      host: ENV.fetch('REDIS_HOST') { 'localhost' },
+      port: ENV.fetch('REDIS_PORT') { 6379 },
+      password: ENV.fetch('REDIS_PASSWORD') { false }
+    }
+  end
+
   # Use a different cache store in production.
-  config.cache_store = :redis_store, {
-    host: ENV.fetch('REDIS_HOST') { 'localhost' },
-    port: ENV.fetch('REDIS_PORT') { 6379 },
-    password: ENV.fetch('REDIS_PASSWORD') { false },
+  config.cache_store = :redis_store, redis_config.merge({
     db: ENV.fetch('REDIS_DB') { 0 },
     namespace: 'cache',
-    expires_in: 10.minutes,
-  }
+    expires_in: 10.minutes
+  })
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
-Redis.current = Redis.new(
-  host: ENV.fetch('REDIS_HOST') { 'localhost' },
-  port: ENV.fetch('REDIS_PORT') { 6379 },
-  password: ENV.fetch('REDIS_PASSWORD') { false },
-  driver: :hiredis
-)
+redis_config = if ENV['REDIS_SOCKET']
+  { path: ENV['REDIS_SOCKET'] }
+else
+  { 
+    host: ENV.fetch('REDIS_HOST') { 'localhost' }, 
+    port: ENV.fetch('REDIS_PORT') { 6379 },
+    password: ENV.fetch('REDIS_PASSWORD') { false },
+  }
+end
+
+redis_config[:driver] = :hiredis
+
+Redis.current = Redis.new(redis_config)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,12 +1,20 @@
-host = ENV.fetch('REDIS_HOST') { 'localhost' }
-port = ENV.fetch('REDIS_PORT') { 6379 }
-password = ENV.fetch('REDIS_PASSWORD') { false }
-db = ENV.fetch('REDIS_DB') { 0 }
+redis_config = if ENV['REDIS_SOCKET']
+  { 
+    url: "unix:#{ENV['REDIS_SOCKET']}" 
+  }
+else
+  { 
+    host: ENV.fetch('REDIS_HOST') { 'localhost' }, 
+    port: ENV.fetch('REDIS_PORT') { '6379' },
+    password: ENV.fetch('REDIS_PASSWORD') { false }
+  }
+end
+redis_config[:db] = ENV.fetch('REDIS_DB') { 0 }
 
 Sidekiq.configure_server do |config|
-  config.redis = { host: host, port: port, db: db, password: password }
+  config.redis = redis_config
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { host: host, port: port, db: db, password: password }
+  config.redis = redis_config
 end

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -56,8 +56,9 @@ if (cluster.isMaster) {
   const wss    = new WebSocket.Server({ server })
 
   const redisClient = redis.createClient({
-    host:     process.env.REDIS_HOST     || '127.0.0.1',
-    port:     process.env.REDIS_PORT     || 6379,
+    host:     process.env.REDIS_HOST     || (process.env.REDIS_SOCKET ? null : '127.0.0.1'),
+    port:     process.env.REDIS_PORT     || (process.env.REDIS_SOCKET ? null : 6379),
+    path:     process.env.REDIS_SOCKET,
     password: process.env.REDIS_PASSWORD
   })
 


### PR DESCRIPTION
Allows admins to specify `REDIS_SOCKET` in their environment as an alternative to `REDIS_HOST` and `REDIS_PORT`, in order to connect to Redis via Unix sockets. Connections via TCP continue to work as well, obviously.

This is a prerequisite for running Mastodon on some shared hosting providers such as Uberspace which many users have requested.

This would fix #1325.
