### PR TITLE
Required foreign keys

### DIFF
--- a/app/models/favourite.rb
+++ b/app/models/favourite.rb
@@ -3,8 +3,8 @@
 class Favourite < ApplicationRecord
   include Paginable
 
-  belongs_to :account, inverse_of: :favourites
-  belongs_to :status,  inverse_of: :favourites, counter_cache: true
+  belongs_to :account, inverse_of: :favourites, required: true
+  belongs_to :status,  inverse_of: :favourites, counter_cache: true, required: true
 
   has_one :notification, as: :activity, dependent: :destroy
 

--- a/app/models/favourite.rb
+++ b/app/models/favourite.rb
@@ -11,6 +11,6 @@ class Favourite < ApplicationRecord
   validates :status_id, uniqueness: { scope: :account_id }
 
   before_validation do
-    self.status = status.reblog if status.reblog?
+    self.status = status.reblog if status&.reblog?
   end
 end

--- a/app/models/mute.rb
+++ b/app/models/mute.rb
@@ -3,9 +3,8 @@
 class Mute < ApplicationRecord
   include Paginable
 
-  belongs_to :account
-  belongs_to :target_account, class_name: 'Account'
+  belongs_to :account, required: true
+  belongs_to :target_account, class_name: 'Account', required: true
 
-  validates :account, :target_account, presence: true
   validates :account_id, uniqueness: { scope: :target_account_id }
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -10,7 +10,7 @@ class Status < ApplicationRecord
 
   belongs_to :application, class_name: 'Doorkeeper::Application'
 
-  belongs_to :account, inverse_of: :statuses, counter_cache: true
+  belongs_to :account, inverse_of: :statuses, counter_cache: true, required: true
   belongs_to :in_reply_to_account, foreign_key: 'in_reply_to_account_id', class_name: 'Account'
 
   belongs_to :thread, foreign_key: 'in_reply_to_id', class_name: 'Status', inverse_of: :replies
@@ -26,7 +26,6 @@ class Status < ApplicationRecord
   has_one :notification, as: :activity, dependent: :destroy
   has_one :preview_card, dependent: :destroy
 
-  validates :account, presence: true
   validates :uri, uniqueness: true, unless: 'local?'
   validates :text, presence: true, unless: 'reblog?'
   validates_with StatusLengthValidator

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -4,7 +4,7 @@ class Subscription < ApplicationRecord
   MIN_EXPIRATION = 3600 * 24 * 7
   MAX_EXPIRATION = 3600 * 24 * 30
 
-  belongs_to :account
+  belongs_to :account, required: true
 
   validates :callback_url, presence: true
   validates :callback_url, uniqueness: { scope: :account_id }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,10 +9,9 @@ class User < ApplicationRecord
          otp_secret_encryption_key: ENV['OTP_SECRET'],
          otp_number_of_backup_codes: 10
 
-  belongs_to :account, inverse_of: :user
+  belongs_to :account, inverse_of: :user, required: true
   accepts_nested_attributes_for :account
 
-  validates :account, presence: true
   validates :locale, inclusion: I18n.available_locales.map(&:to_s), unless: 'locale.nil?'
   validates :email, email: true
 


### PR DESCRIPTION
Added missing `required: true` option.

```
# Listing of required foreign keys
conn = ApplicationRecord.connection

conn.tables.each do |table_name|
  foreign_keys = conn.columns(table_name).select { |column| column.name =~ /_id$/ }

  foreign_keys.each do |column|
    puts "#{table_name}.#{column.name}" unless column.null
  end
end

#=> 
blocks.account_id
blocks.target_account_id
favourites.account_id
favourites.status_id
follow_requests.account_id
follow_requests.target_account_id
follows.account_id
follows.target_account_id
imports.account_id
mutes.account_id
mutes.target_account_id
oauth_access_grants.resource_owner_id
oauth_access_grants.application_id
reports.account_id
reports.target_account_id
statuses_tags.status_id
statuses_tags.tag_id
subscriptions.account_id
users.account_id
statuses.account_id
```
