### PR TITLE
Improve handling of HTTP_ACCEPT for webfinger

### DIFF
--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -8,8 +8,13 @@ module WellKnown
       @magic_key = pem_to_magic_key(@account.keypair.public_key)
 
       respond_to do |format|
-        format.xml  { render content_type: 'application/xrd+xml' }
-        format.json { render content_type: 'application/jrd+json' }
+        format.any(:json, :html) do
+          render formats: :json, content_type: 'application/jrd+json'
+        end
+
+        format.xml do
+          render content_type: 'application/xrd+xml'
+        end
       end
     rescue ActiveRecord::RecordNotFound
       head 404

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   end
 
   get '.well-known/host-meta', to: 'well_known/host_meta#show', as: :host_meta, defaults: { format: 'xml' }
-  get '.well-known/webfinger', to: 'well_known/webfinger#show', as: :webfinger, defaults: { format: 'json' }
+  get '.well-known/webfinger', to: 'well_known/webfinger#show', as: :webfinger
 
   devise_for :users, path: 'auth', controllers: {
     sessions:           'auth/sessions',

--- a/spec/requests/webfinger_request_spec.rb
+++ b/spec/requests/webfinger_request_spec.rb
@@ -1,33 +1,48 @@
-require "rails_helper"
+require 'rails_helper'
 
-describe "The webfinger route" do
+describe 'The webfinger route' do
   let(:alice) { Fabricate(:account, username: 'alice') }
 
-  describe "requested without accepts headers" do
-    it "returns a json response" do
-      get webfinger_url, params: { resource: alice.to_webfinger_s }
+  describe 'requested with standard accepts headers' do
+    it 'returns a json response' do
+      get webfinger_url(resource: alice.to_webfinger_s)
 
       expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq "application/jrd+json"
+      expect(response.content_type).to eq 'application/jrd+json'
     end
   end
 
-  describe "requested with html in accepts headers" do
-    it "returns a json response" do
-      headers = { 'HTTP_ACCEPT' => 'text/html' }
-      get webfinger_url, params: { resource: alice.to_webfinger_s }, headers: headers
-
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq "application/jrd+json"
-    end
-  end
-
-  describe "requested with xml format" do
-    it "returns an xml response" do
+  describe 'asking for xml format' do
+    it 'returns an xml response for xml format' do
       get webfinger_url(resource: alice.to_webfinger_s, format: :xml)
 
       expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq "application/xrd+xml"
+      expect(response.content_type).to eq 'application/xrd+xml'
+    end
+
+    it 'returns an xml response for xml accept header' do
+      headers = { 'HTTP_ACCEPT' => 'application/xrd+xml' }
+      get webfinger_url(resource: alice.to_webfinger_s), headers: headers
+
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq 'application/xrd+xml'
+    end
+  end
+
+  describe 'asking for json format' do
+    it 'returns a json response for json format' do
+      get webfinger_url(resource: alice.to_webfinger_s, format: :json)
+
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq 'application/jrd+json'
+    end
+
+    it 'returns a json response for json accept header' do
+      headers = { 'HTTP_ACCEPT' => 'application/jrd+json' }
+      get webfinger_url(resource: alice.to_webfinger_s), headers: headers
+
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq 'application/jrd+json'
     end
   end
 end

--- a/spec/routing/well_known_routes_spec.rb
+++ b/spec/routing/well_known_routes_spec.rb
@@ -10,6 +10,6 @@ end
 describe 'the webfinger route' do
   it 'routes to correct place with json format' do
     expect(get('/.well-known/webfinger')).
-      to route_to('well_known/webfinger#show', format: 'json')
+      to route_to('well_known/webfinger#show')
   end
 end


### PR DESCRIPTION
This change includes:

- Improve the spec coverage for incoming request to the webfinger action
- For requests without an accept header (ie, what a browser might look like),
  return a JSON response.
- For requests with an explicit format of xml or json, return that format.
- For requests using an accept header, return that format.

Also adds failing spec showing webfinger does not return xml, which covers the
issue described in: #1983