### PR TITLE
Fix nil query_username

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -41,7 +41,7 @@ class AccountSearchService < BaseService
   end
 
   def query_username
-    @_query_username ||= split_query_string.first
+    @_query_username ||= split_query_string.first || ''
   end
 
   def query_domain

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -25,6 +25,18 @@ describe AccountSearchService do
     end
 
     describe 'searching local and remote users' do
+      describe "when only '@'" do
+        before do
+          allow(Account).to receive(:find_remote)
+          allow(Account).to receive(:search_for)
+          subject.call('@', 10)
+        end
+
+        it 'uses find_remote with empty query to look for local accounts' do
+          expect(Account).to have_received(:find_remote).with('', nil)
+        end
+      end
+
       describe 'when no domain' do
         before do
           allow(Account).to receive(:find_remote)


### PR DESCRIPTION
Raise no method error (500 internal server error) when searching with only '@'.
`query_username` will be nil, and raise here https://github.com/tootsuite/mastodon/blob/v1.2/app/models/account.rb#L213