### PR TITLE
Store current locale for sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,5 @@
+require 'sidekiq/middleware/i18n'
+
 host = ENV.fetch('REDIS_HOST') { 'localhost' }
 port = ENV.fetch('REDIS_PORT') { 6379 }
 password = ENV.fetch('REDIS_PASSWORD') { false }


### PR DESCRIPTION
Get stored locale from redis.

related: https://github.com/mperham/sidekiq/blob/7385564bcd2fbded5199b4f549fe924fd816c384/lib/sidekiq/middleware/i18n.rb

```
before
> Sidekiq.client_middleware
<Sidekiq::Middleware::Chain:0x007fa010576ba8 @entries=[
  #<Sidekiq::Middleware::Entry:0x007fa010558ec8 @klass=SidekiqUniqueJobs::Client::Middleware, @args=[]>
]>

after
> Sidekiq.client_middleware
<Sidekiq::Middleware::Chain:0x007fa010576ba8 @entries=[
  #<Sidekiq::Middleware::Entry:0x007fa010558ec8 @klass=SidekiqUniqueJobs::Client::Middleware, @args=[]>,
  #<Sidekiq::Middleware::Entry:0x007fa01114b528 @klass=Sidekiq::Middleware::I18n::Client, @args=[]>
]>
```