### PR TITLE
Fix username of reply message when using `WEB_DOMAIN` env.

### DIFF
--- a/app/lib/atom_serializer.rb
+++ b/app/lib/atom_serializer.rb
@@ -16,7 +16,7 @@ class AtomSerializer
   def author(account)
     author = Ox::Element.new('author')
 
-    uri = TagManager.instance.uri_for(account).gsub(Rails.configuration.x.web_domain, Rails.configuration.x.local_domain)
+    uri = TagManager.instance.uri_for(account)
 
     append_element(author, 'id', uri)
     append_element(author, 'activity:object-type', TagManager::TYPES[:person])

--- a/app/lib/atom_serializer.rb
+++ b/app/lib/atom_serializer.rb
@@ -16,7 +16,7 @@ class AtomSerializer
   def author(account)
     author = Ox::Element.new('author')
 
-    uri = TagManager.instance.uri_for(account)
+    uri = TagManager.instance.uri_for(account).gsub(Rails.configuration.x.web_domain, Rails.configuration.x.local_domain)
 
     append_element(author, 'id', uri)
     append_element(author, 'activity:object-type', TagManager::TYPES[:person])

--- a/app/lib/tag_manager.rb
+++ b/app/lib/tag_manager.rb
@@ -81,7 +81,7 @@ class TagManager
 
     case target.object_type
     when :person
-      account_url(target)
+      account_url(target).gsub(Rails.configuration.x.web_domain, Rails.configuration.x.local_domain)
     when :note, :comment, :activity
       unique_tag(target.created_at, target.id, 'Status')
     else


### PR DESCRIPTION
On v1.2, Mastodon detects account's local-domain from `./xmlns:author/xmlns:uri`.
e.g. )
- https://github.com/tootsuite/mastodon/blob/v1.2/app/services/process_interaction_service.rb#L16-L17
- https://github.com/tootsuite/mastodon/blob/v1.2/app/services/process_feed_service.rb#L271-L277

`./xmlns:author/xmlns:uri` will be created from `RoutingHelper` methods.
c.f.)
- https://github.com/tootsuite/mastodon/blob/v1.2/app/lib/atom_serializer.rb#L19-L23
- https://github.com/tootsuite/mastodon/blob/v1.2/app/lib/tag_manager.rb#L83-L84

Because of that, Mastodon use web-domain as local-domain.
So, username of reply message is mistaken.
(user@local.example.com (correct) -> user@web.example.com (wrong))

We should replace domain name in `./xmlns:author/xmlns:uri` when using `WEB_DOMAIN` env.

-----

NOTE:

Mastodon may use `./xmlns:author/xmlns:email` for detecting local-domain (e.g. when fetching user stream atom). It works correctly on v1.2.
e.g.)
- https://github.com/tootsuite/mastodon/blob/v1.2/app/services/fetch_remote_account_service.rb#L22-L29