### PR TITLE
Change language detection method to user account locale setting.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ gem 'sprockets-rails', :require => 'sprockets/railtie'
 gem 'statsd-instrument'
 gem 'twitter-text'
 gem 'tzinfo-data'
-gem 'whatlanguage'
 
 gem 'react-rails'
 gem 'browserify-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,7 +455,6 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    whatlanguage (1.0.6)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -542,7 +541,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   webmock
-  whatlanguage
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -19,7 +19,7 @@ class PostStatusService < BaseService
                                       sensitive: options[:sensitive],
                                       spoiler_text: options[:spoiler_text] || '',
                                       visibility: options[:visibility],
-                                      language: account.user.locale || 'en',
+                                      language: account&.user&.locale || 'en',
                                       application: options[:application])
 
     attach_media(status, media)

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -19,7 +19,7 @@ class PostStatusService < BaseService
                                       sensitive: options[:sensitive],
                                       spoiler_text: options[:spoiler_text] || '',
                                       visibility: options[:visibility],
-                                      language: detect_language(text),
+                                      language: account.user.locale,
                                       application: options[:application])
 
     attach_media(status, media)

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -19,7 +19,7 @@ class PostStatusService < BaseService
                                       sensitive: options[:sensitive],
                                       spoiler_text: options[:spoiler_text] || '',
                                       visibility: options[:visibility],
-                                      language: account.user.locale,
+                                      language: account.user.locale || 'en',
                                       application: options[:application])
 
     attach_media(status, media)

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -52,10 +52,6 @@ class PostStatusService < BaseService
     media.update(status_id: status.id)
   end
 
-  def detect_language(text)
-    WhatLanguage.new(:all).language_iso(text) || 'en'
-  end
-
   def process_mentions_service
     @process_mentions_service ||= ProcessMentionsService.new
   end


### PR DESCRIPTION
related: #2091 

whatlanguage gem cannot handle to detect some langauge.
https://github.com/peterc/whatlanguage/blob/master/lib/whatlanguage.rb#L10

It maybe good to write patch whatlanguage to handling CJK languages. But it take some time for writing it.

https://instances.mastodon.xyz/list There are already many instances whoes almost people toot on japanese.

This PR detect language by user account's locale setting.
This change maybe not  acceptable for user that toot in English on sometimes and toot in Japanese sometime.

How about it?
