### PR TITLE
Add hasMore field to account timeline to block large amount of XHR

### DIFF
--- a/app/assets/javascripts/components/actions/accounts.jsx
+++ b/app/assets/javascripts/components/actions/accounts.jsx
@@ -126,7 +126,8 @@ export function expandAccountTimeline(id) {
         max_id: lastId
       }
     }).then(response => {
-      dispatch(expandAccountTimelineSuccess(id, response.data));
+      const next = getLinks(response).refs.find(link => link.rel === 'next');
+      dispatch(expandAccountTimelineSuccess(id, response.data, next));
     }).catch(error => {
       dispatch(expandAccountTimelineFail(id, error));
     });
@@ -257,11 +258,12 @@ export function expandAccountTimelineRequest(id) {
   };
 };
 
-export function expandAccountTimelineSuccess(id, statuses) {
+export function expandAccountTimelineSuccess(id, statuses, next) {
   return {
     type: ACCOUNT_TIMELINE_EXPAND_SUCCESS,
     id,
-    statuses
+    statuses,
+    next
   };
 };
 

--- a/app/assets/javascripts/components/features/account_timeline/index.jsx
+++ b/app/assets/javascripts/components/features/account_timeline/index.jsx
@@ -46,7 +46,9 @@ const AccountTimeline = React.createClass({
   },
 
   handleScrollToBottom () {
-    this.props.dispatch(expandAccountTimeline(Number(this.props.params.accountId)));
+    if (!this.props.isLoading && this.props.hasMore) {
+      this.props.dispatch(expandAccountTimeline(Number(this.props.params.accountId)));
+    }
   },
 
   render () {

--- a/app/assets/javascripts/components/reducers/timelines.jsx
+++ b/app/assets/javascripts/components/reducers/timelines.jsx
@@ -144,10 +144,11 @@ const normalizeAccountTimeline = (state, accountId, statuses, replace = false) =
   return state.updateIn(['accounts_timelines', accountId], Immutable.Map(), map => map
     .set('isLoading', false)
     .set('loaded', true)
+    .set('next', true)
     .update('items', Immutable.List(), list => (replace ? ids : list.unshift(...ids))));
 };
 
-const appendNormalizedAccountTimeline = (state, accountId, statuses) => {
+const appendNormalizedAccountTimeline = (state, accountId, statuses, next) => {
   let moreIds = Immutable.List([]);
 
   statuses.forEach((status, i) => {
@@ -157,6 +158,7 @@ const appendNormalizedAccountTimeline = (state, accountId, statuses) => {
 
   return state.updateIn(['accounts_timelines', accountId], Immutable.Map(), map => map
     .set('isLoading', false)
+    .set('next', next)
     .update('items', list => list.push(...moreIds)));
 };
 
@@ -299,7 +301,7 @@ export default function timelines(state = initialState, action) {
   case ACCOUNT_TIMELINE_FETCH_SUCCESS:
     return normalizeAccountTimeline(state, action.id, Immutable.fromJS(action.statuses), action.replace);
   case ACCOUNT_TIMELINE_EXPAND_SUCCESS:
-    return appendNormalizedAccountTimeline(state, action.id, Immutable.fromJS(action.statuses));
+    return appendNormalizedAccountTimeline(state, action.id, Immutable.fromJS(action.statuses), action.next);
   case ACCOUNT_BLOCK_SUCCESS:
   case ACCOUNT_MUTE_SUCCESS:
     return filterTimelines(state, action.relationship, action.statuses);


### PR DESCRIPTION
Fixed a problem that large amount of XHR request occurred when scrolling to the bottom of the account timeline because account timeline reducer ignores `hasMore` field.

![8764e097067077b3b72597bbc3d6d599](https://cloud.githubusercontent.com/assets/665440/25123499/87f943de-2463-11e7-845c-291726285dfd.gif)