### PR TITLE
Add "Mastodon" to user agent on External HTTP request

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FetchLinkCardService < BaseService
+  USER_AGENT = "#{HTTP::Request::USER_AGENT} (Mastodon; +http://#{Rails.configuration.x.local_domain}/)"
+
   def call(status)
     # Get first http/https URL that isn't local
     url = URI.extract(status.text).reject { |uri| (uri =~ /\Ahttps?:\/\//).nil? || TagManager.instance.local_url?(uri) }.first
@@ -26,7 +28,7 @@ class FetchLinkCardService < BaseService
   private
 
   def http_client
-    HTTP.timeout(:per_operation, write: 10, connect: 10, read: 10).follow
+    HTTP.headers(user_agent: USER_AGENT).timeout(:per_operation, write: 10, connect: 10, read: 10).follow
   end
 
   def meta_property(html, property)


### PR DESCRIPTION
I want to add "Mastodon" to user agent on External HTTP request.

Because I think that the current user agent is unintelligible.
```
http.rb/2.2.1
```

So I want to change user agent to this.
```
http.rb/2.2.1 (Mastodon; +http://mastodon.dev/)
```
