### PR TITLE
Fix #1642, fix #1912 - Dictate content-type file extension

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -21,6 +21,8 @@ class Account < ApplicationRecord
   validates_attachment_content_type :header, content_type: IMAGE_MIME_TYPES
   validates_attachment_size :header, less_than: 2.megabytes
 
+  before_post_process :set_file_extensions
+
   # Local user profile validations
   validates :display_name, length: { maximum: 30 }, if: 'local?'
   validates :note, length: { maximum: 160 }, if: 'local?'
@@ -326,5 +328,17 @@ class Account < ApplicationRecord
       self.private_key = keypair.to_pem
       self.public_key  = keypair.public_key.to_pem
     end
+  end
+
+  private
+
+  def set_file_extensions
+    extension = Paperclip::Interpolations.content_type_extension(avatar, :original)
+    basename  = Paperclip::Interpolations.basename(avatar, :original)
+    avatar.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
+
+    extension = Paperclip::Interpolations.content_type_extension(header, :original)
+    basename  = Paperclip::Interpolations.basename(header, :original)
+    header.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -333,12 +333,16 @@ class Account < ApplicationRecord
   private
 
   def set_file_extensions
-    extension = Paperclip::Interpolations.content_type_extension(avatar, :original)
-    basename  = Paperclip::Interpolations.basename(avatar, :original)
-    avatar.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
+    unless avatar.blank?
+      extension = Paperclip::Interpolations.content_type_extension(avatar, :original)
+      basename  = Paperclip::Interpolations.basename(avatar, :original)
+      avatar.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
+    end
 
-    extension = Paperclip::Interpolations.content_type_extension(header, :original)
-    basename  = Paperclip::Interpolations.basename(header, :original)
-    header.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
+    unless header.blank?
+      extension = Paperclip::Interpolations.content_type_extension(header, :original)
+      basename  = Paperclip::Interpolations.basename(header, :original)
+      header.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
+    end
   end
 end

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -106,8 +106,10 @@ class MediaAttachment < ApplicationRecord
   def set_type_and_extension
     self.type = VIDEO_MIME_TYPES.include?(file_content_type) ? :video : :image
 
-    extension = Paperclip::Interpolations.content_type_extension(file, :original)
-    basename  = Paperclip::Interpolations.basename(file, :original)
-    file.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
+    unless file.blank?
+      extension = Paperclip::Interpolations.content_type_extension(file, :original)
+      basename  = Paperclip::Interpolations.basename(file, :original)
+      file.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
+    end
   end
 end

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -50,7 +50,7 @@ class MediaAttachment < ApplicationRecord
   end
 
   before_create :set_shortcode
-  before_post_process :set_type
+  before_post_process :set_type_and_extension
 
   class << self
     private
@@ -103,7 +103,11 @@ class MediaAttachment < ApplicationRecord
     end
   end
 
-  def set_type
+  def set_type_and_extension
     self.type = VIDEO_MIME_TYPES.include?(file_content_type) ? :video : :image
+
+    extension = Paperclip::Interpolations.content_type_extension(file, :original)
+    basename  = Paperclip::Interpolations.basename(file, :original)
+    file.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
   end
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -4,7 +4,7 @@ Paperclip.options[:read_timeout] = 60
 
 Paperclip.interpolates :filename do |attachment, style|
   return attachment.original_filename if style == :original
-  [basename(attachment, style), content_type_extension(attachment, style)].delete_if(&:empty?).join('.')
+  [basename(attachment, style), extension(attachment, style)].delete_if(&:empty?).join('.')
 end
 
 if ENV['S3_ENABLED'] == 'true'
@@ -39,6 +39,6 @@ if ENV['S3_ENABLED'] == 'true'
     Paperclip::Attachment.default_options[:s3_host_alias] = ENV['S3_CLOUDFRONT_HOST']
   end
 else
-  Paperclip::Attachment.default_options[:path]           = (ENV['PAPERCLIP_ROOT_PATH'] || ':rails_root/public/system') + '/:class/:attachment/:id_partition/:style/:filename'
-  Paperclip::Attachment.default_options[:url]            = (ENV['PAPERCLIP_ROOT_URL'] || '/system') + '/:class/:attachment/:id_partition/:style/:filename'
+  Paperclip::Attachment.default_options[:path] = (ENV['PAPERCLIP_ROOT_PATH'] || ':rails_root/public/system') + '/:class/:attachment/:id_partition/:style/:filename'
+  Paperclip::Attachment.default_options[:url]  = (ENV['PAPERCLIP_ROOT_URL'] || '/system') + '/:class/:attachment/:id_partition/:style/:filename'
 end


### PR DESCRIPTION
Previous change (#1718) did not modify how original file was saved on upload