### PR TITLE
Avoid dynamic methods due to processing speed

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -73,7 +73,7 @@ class ApiController < ApplicationController
   end
 
   def current_user
-    super || current_resource_owner
+    current_resource_owner || super
   rescue ActiveRecord::RecordNotFound
     nil
   end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -42,7 +42,7 @@ class Status < ApplicationRecord
   cache_associated :account, :application, :media_attachments, :tags, :stream_entry, mentions: :account, reblog: [:account, :application, :stream_entry, :tags, :media_attachments, mentions: :account], thread: :account
 
   def reply?
-    super || !in_reply_to_id.nil?
+    !in_reply_to_id.nil? || super
   end
 
   def local?


### PR DESCRIPTION
Dynamically generated methods are slow.
I think that it is desirable to replace it with static processing if possible.

### before

```ruby
class Status < ApplicationRecord
  def reply?
    super || !in_reply_to_id.nil?
  end
end
```

```ruby
status = Status.first
Status.benchmark { 1_000_000.times { status.reply? } }
# => Benchmarking (1657.8ms)
```

### after

```ruby
class Status < ApplicationRecord
  def reply?
    !in_reply_to_id.nil? || super
  end
end
```

```ruby
status = Status.first
Status.benchmark { 1_000_000.times { status.reply? } }
# => Benchmarking (528.9ms)
```