### PR TITLE
Fix streaming server worker count

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -19,7 +19,7 @@ dotenv.config({
 if (cluster.isMaster) {
   // cluster master
 
-  const core = +process.env.STREAMING_CLUSTER_NUM || (env === 'development' ? 1 : (os.cpus() > 1 ? os.cpus().length - 1 : 1))
+  const core = +process.env.STREAMING_CLUSTER_NUM || (env === 'development' ? 1 : (os.cpus().length > 1 ? os.cpus().length - 1 : 1))
   const fork = () => {
     const worker = cluster.fork();
     worker.on('exit', (code, signal) => {

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -19,7 +19,7 @@ dotenv.config({
 if (cluster.isMaster) {
   // cluster master
 
-  const core = +process.env.STREAMING_CLUSTER_NUM || (env === 'development' ? 1 : os.cpus().length - 1)
+  const core = +process.env.STREAMING_CLUSTER_NUM || (env === 'development' ? 1 : (os.cpus() > 1 ? os.cpus().length - 1 : 1))
   const fork = () => {
     const worker = cluster.fork();
     worker.on('exit', (code, signal) => {


### PR DESCRIPTION
If you run the streaming cluster on a server (or container) with one CPU in production mode, the worker calculation can end up starting 0 workers. This patch ensures that at least one worker is started, in that case.