### PR TITLE
Allow to listen Unix socket

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,6 +1,10 @@
 threads_count = ENV.fetch('MAX_THREADS') { 5 }.to_i
 threads threads_count, threads_count
 
+if ENV['SOCKET'] then
+  bind 'unix://' + ENV['SOCKET']
+end
+
 port        ENV.fetch('PORT') { 3000 }
 environment ENV.fetch('RAILS_ENV') { 'development' }
 workers     ENV.fetch('WEB_CONCURRENCY') { 2 }

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -328,6 +328,6 @@ if (cluster.isMaster) {
 
   server.listen(process.env.PORT || 4000, () => {
     log.level = process.env.LOG_LEVEL || 'verbose'
-    log.info(`Starting streaming API server worker on port ${server.address().port}`)
+    log.info(`Starting streaming API server worker on ${server.address()}`)
   })
 }

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -330,4 +330,12 @@ if (cluster.isMaster) {
     log.level = process.env.LOG_LEVEL || 'verbose'
     log.info(`Starting streaming API server worker on ${server.address()}`)
   })
+
+  process.on('SIGINT', exit)
+  process.on('SIGTERM', exit)
+  process.on('exit', exit)
+
+  function exit() {
+    server.close()
+  }
 }


### PR DESCRIPTION
One of the significant feature of Mastodon is that it could run anywhere, even on a single computer without a cluster.
Unix socket works better than TCP/IP on such environments. These changes allow puma and streaming server to listen Unix socket. Give `SOCKET` and `PORT` environment value respectively for puma and streaming server.