### PR TITLE
app: Align the breakpoint width for border layout to the one for columns

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1158,7 +1158,8 @@ a.status__content__spoiler-link {
   position: relative;
 }
 
-@media screen and (min-width: 360px) {
+// min-width corresponds to signle-column + nav layout breakpoint
+@media screen and (min-width: 1024px) {
   .columns-area {
     padding: 10px;
   }
@@ -1211,7 +1212,8 @@ a.status__content__spoiler-link {
   overflow: hidden;
 }
 
-@media screen and (min-width: 360px) {
+// min-width corresponds to signle-column + nav layout breakpoint
+@media screen and (min-width: 1024px) {
   .tabs-bar {
     margin: 10px;
     margin-bottom: 0;


### PR DESCRIPTION
Commit 45776b55b0d97d6a6b8b202d3076f19f1d055573 gives 1024px for the
breakpoint width for the layout change of the columns, and but the one for
border layout had a different value (1024px).

The fact that the same layout without the border works means the border is
just a waste of the screen area. This change aligns the breakpoint width
for border layout to the one for columns in order to remove the border also
in such cases.

See also https://github.com/tootsuite/mastodon/commit/3807b0b171d588ccccfc6210c823e5ce87b9b90f#commitcomment-21794176. @ticky, who introduced the previous value, has pointed out the possibility that having borders could be preferred on phablet. I thought it is fine without the border when I resized the browser on desktop to test. However, I do not have any actual phablet or similar device, so I would like to ask opinions.