### PR TITLE
Language detection refactor

### DIFF
--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -8,6 +8,6 @@ class LanguageDetector
   end
 
   def to_iso_s
-    WhatLanguage.new(:all).language_iso(text) || 'en'
+    WhatLanguage.new(:all).language_iso(text) || I18n.default_locale
   end
 end

--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class LanguageDetector
+  attr_reader :text
+
+  def initialize(text)
+    @text = text
+  end
+
+  def to_iso_s
+    WhatLanguage.new(:all).language_iso(text) || 'en'
+  end
+end

--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
 class LanguageDetector
-  attr_reader :text
+  attr_reader :text, :account
 
-  def initialize(text)
+  def initialize(text, account = nil)
     @text = text
+    @account = account
   end
 
   def to_iso_s
-    WhatLanguage.new(:all).language_iso(text) || I18n.default_locale
+    WhatLanguage.new(:all).language_iso(text) || default_locale.to_sym
+  end
+
+  private
+
+  def default_locale
+    account&.user&.locale || I18n.default_locale
   end
 end

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -19,7 +19,7 @@ class PostStatusService < BaseService
                                       sensitive: options[:sensitive],
                                       spoiler_text: options[:spoiler_text] || '',
                                       visibility: options[:visibility],
-                                      language: detect_language(text),
+                                      language: detect_language_for(text, account),
                                       application: options[:application])
 
     attach_media(status, media)
@@ -52,8 +52,8 @@ class PostStatusService < BaseService
     media.update(status_id: status.id)
   end
 
-  def detect_language(text)
-    LanguageDetector.new(text).to_iso_s
+  def detect_language_for(text, account)
+    LanguageDetector.new(text, account).to_iso_s
   end
 
   def process_mentions_service

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -53,7 +53,7 @@ class PostStatusService < BaseService
   end
 
   def detect_language(text)
-    WhatLanguage.new(:all).language_iso(text) || 'en'
+    LanguageDetector.new(text).to_iso_s
   end
 
   def process_mentions_service

--- a/spec/lib/language_detector_spec.rb
+++ b/spec/lib/language_detector_spec.rb
@@ -18,11 +18,31 @@ describe LanguageDetector do
       expect(result).to eq :es
     end
 
-    it 'defaults to `en` for empty string' do
-      string = ''
-      result = described_class.new(string).to_iso_s
+    describe 'when language cant be detected' do
+      describe 'with an `en` default locale' do
+        it 'uses the default locale' do
+          string = ''
+          result = described_class.new(string).to_iso_s
 
-      expect(result).to eq 'en'
+          expect(result).to eq :en
+        end
+      end
+
+      describe 'with a non-`en` default locale' do
+        around(:each) do |example|
+          before = I18n.default_locale
+          I18n.default_locale = :ja
+          example.run
+          I18n.default_locale = before
+        end
+
+        it 'uses the default locale' do
+          string = ''
+          result = described_class.new(string).to_iso_s
+
+          expect(result).to eq :ja
+        end
+      end
     end
   end
 end

--- a/spec/lib/language_detector_spec.rb
+++ b/spec/lib/language_detector_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LanguageDetector do
+  describe 'to_iso_s' do
+    it 'detects english language' do
+      string = 'Hello and welcome to mastadon'
+      result = described_class.new(string).to_iso_s
+
+      expect(result).to eq :en
+    end
+
+    it 'detects spanish language' do
+      string = 'Obtener un Hola y bienvenidos a Mastadon'
+      result = described_class.new(string).to_iso_s
+
+      expect(result).to eq :es
+    end
+
+    it 'defaults to `en` for empty string' do
+      string = ''
+      result = described_class.new(string).to_iso_s
+
+      expect(result).to eq 'en'
+    end
+  end
+end

--- a/spec/lib/language_detector_spec.rb
+++ b/spec/lib/language_detector_spec.rb
@@ -24,6 +24,24 @@ describe LanguageDetector do
         expect(result).to be_nil
       end
 
+      describe 'with an account' do
+        it 'uses the account locale when present' do
+          user = double(:user, locale: 'fr')
+          account = double(:account, user: user)
+          result = described_class.new('', account).to_iso_s
+
+          expect(result).to eq :fr
+        end
+
+        it 'uses default locale when account is present but has no locale' do
+          user = double(:user, locale: nil)
+          account = double(:accunt, user: user)
+          result = described_class.new('', account).to_iso_s
+
+          expect(result).to eq :en
+        end
+      end
+
       describe 'with an `en` default locale' do
         it 'uses the default locale' do
           string = ''

--- a/spec/lib/language_detector_spec.rb
+++ b/spec/lib/language_detector_spec.rb
@@ -19,6 +19,11 @@ describe LanguageDetector do
     end
 
     describe 'when language cant be detected' do
+      it 'confirm language engine cant detect' do
+        result = WhatLanguage.new(:all).language_iso('')
+        expect(result).to be_nil
+      end
+
       describe 'with an `en` default locale' do
         it 'uses the default locale' do
           string = ''

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -64,6 +64,18 @@ RSpec.describe PostStatusService do
     expect(status.application).to eq application
   end
 
+  it 'creates a status with a language set' do
+    detector = double(to_iso_s: :en)
+    allow(LanguageDetector).to receive(:new).and_return(detector)
+
+    account = Fabricate(:account)
+    text = 'test status text'
+
+    subject.call(account, text)
+
+    expect(LanguageDetector).to have_received(:new).with(text, account)
+  end
+
   it 'processes mentions' do
     mention_service = double(:process_mentions_service)
     allow(mention_service).to receive(:call)


### PR DESCRIPTION
Resolves https://github.com/tootsuite/mastodon/issues/2091 and https://github.com/tootsuite/mastodon/pull/2064

This keeps using WhatLanguage (for now), but does so in a way which should make it theoretically easy to swap out when we find something better.

Improvements are:

- If user has locale set, will use that
- If instance has a non-`en` default locale set, will use that instead of `en`

