### PR TITLE
Moves from hamburger icon to asterisk.

### DIFF
--- a/app/assets/javascripts/components/features/ui/components/tabs_bar.jsx
+++ b/app/assets/javascripts/components/features/ui/components/tabs_bar.jsx
@@ -13,7 +13,7 @@ const TabsBar = React.createClass({
         <Link className='tabs-bar__link secondary' activeClassName='active' to='/timelines/public/local'><i className='fa fa-fw fa-users' /><FormattedMessage id='tabs_bar.local_timeline' defaultMessage='Local' /></Link>
         <Link className='tabs-bar__link secondary' activeClassName='active' to='/timelines/public'><i className='fa fa-fw fa-globe' /><FormattedMessage id='tabs_bar.federated_timeline' defaultMessage='Federated' /></Link>
 
-        <Link className='tabs-bar__link primary' activeClassName='active' style={{ flexGrow: '0', flexBasis: '30px' }} to='/getting-started'><i className='fa fa-fw fa-bars' /></Link>
+        <Link className='tabs-bar__link primary' activeClassName='active' style={{ flexGrow: '0', flexBasis: '30px' }} to='/getting-started'><i className='fa fa-fw fa-asterisk' /></Link>
       </div>
     );
   }


### PR DESCRIPTION
Before:

<img width="379" alt="screen shot 2017-04-18 at 8 38 31 pm" src="https://cloud.githubusercontent.com/assets/498212/25158503/01edd9e4-2477-11e7-9549-ed8857cc4834.png">

After:

<img width="374" alt="screen shot 2017-04-18 at 8 38 14 pm" src="https://cloud.githubusercontent.com/assets/498212/25158511/0f81bc4c-2477-11e7-8898-706bc89e91fc.png">

The hamburger menu icon has been replaced with the getting-started asterisk.

Fixes https://github.com/tootsuite/mastodon/issues/2072