### PR TITLE
Change to switch signature version for Amazon S3

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -74,6 +74,7 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # S3_PROTOCOL=https
 # S3_HOSTNAME=
 # S3_ENDPOINT=
+# S3_SIGNATURE_VERSION=
 
 # Optional alias for S3 if you want to use Cloudfront or Cloudflare in front
 # S3_CLOUDFRONT_HOST=

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -28,6 +28,7 @@ if ENV['S3_ENABLED'] == 'true'
   unless ENV['S3_ENDPOINT'].blank?
     Paperclip::Attachment.default_options[:s3_options] = {
       endpoint: ENV['S3_ENDPOINT'],
+      signature_version: ENV['S3_SIGNATURE_VERSION'] || 'v4',
       force_path_style: true,
     }
 


### PR DESCRIPTION
Currently it is not possible to upload images to S3 compatible systems that do not correspond to signature v4. (e.g. [Sakura Cloud](http://cloud.sakura.ad.jp/specification/object-storage/)).

I changed it so that I can set a signature version.
