### PR TITLE
Automatically change the size of textarea

### DIFF
--- a/app/assets/javascripts/components/components/autosuggest_textarea.jsx
+++ b/app/assets/javascripts/components/components/autosuggest_textarea.jsx
@@ -63,6 +63,10 @@ const AutosuggestTextarea = React.createClass({
       this.props.onSuggestionsClearRequested();
     }
 
+    // auto-resize textarea
+    e.target.style.height = 'auto';
+    e.target.style.height = `${e.target.scrollHeight}px`;
+
     this.props.onChange(e);
   },
 

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1196,7 +1196,6 @@ a.status__content__spoiler-link {
   display: block;
   box-sizing: border-box;
   width: 100%;
-  resize: none;
   margin: 0;
   color: $color1;
   padding: 10px;
@@ -1220,11 +1219,17 @@ a.status__content__spoiler-link {
 }
 
 .autosuggest-textarea__textarea {
-  height: 100px;
+  min-height: 100px;
   background: $color5;
   border-radius: 4px 4px 0 0;
   padding-bottom: 0;
   padding-right: 10px + 22px;
+  resize: none;
+
+  @media screen and (max-width: 600px) {
+    height: 100px !important; // prevent auto-resize textarea
+    resize: vertical;
+  }
 }
 
 .autosuggest-textarea__suggestions {


### PR DESCRIPTION
The height of the textarea is automatically changed according to the entered text.

It applied only when the screen width is narrower than 600px for the touch device where the keyboard appears from the bottom. (prevent keyboard from hiding icons such as `CW`)

`>= 600px` | `< 600px`
-------------|------------
![pc](https://cloud.githubusercontent.com/assets/665440/25167685/65059acc-251b-11e7-8911-9a4c55cb5abd.gif) | ![sp](https://cloud.githubusercontent.com/assets/665440/25167688/69940c5e-251b-11e7-8e3e-1384ff52cc0e.gif)