### PR TITLE
Remove upgrade from docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
     libxml2-dev \
     libxslt-dev \
     build-base" \
- && apk -U upgrade && apk add \
+ && apk --no-cache add \
     $BUILD_DEPS \
     nodejs@edge \
     nodejs-npm@edge \
@@ -33,8 +33,7 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
  && yarn --ignore-optional \
  && yarn cache clean \
  && npm -g cache clean \
- && apk del $BUILD_DEPS \
- && rm -rf /tmp/* /var/cache/apk/*
+ && apk del $BUILD_DEPS
 
 COPY . /mastodon
 


### PR DESCRIPTION
As explained [here](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run) it is not necessary to upgrade the underlying distribution, but better to trust the base underlying alpine ruby docker image.
Also use the `--no-cache` option as a shorter form - see [reference](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache)