### PR TITLE
Remove unnecessary word from Japanese locale

### DIFF
--- a/app/assets/javascripts/components/locales/ja.jsx
+++ b/app/assets/javascripts/components/locales/ja.jsx
@@ -110,7 +110,7 @@ const ja = {
   "report.target": "問題のユーザー",
   "search.placeholder": "検索",
   "search.status_by": "{name}からの投稿",
-  "search_results.total": "{count} {count, plural, one {result} other {results}} 件",
+  "search_results.total": "{count} 件",
   "status.delete": "削除",
   "status.favourite": "お気に入り",
   "status.load_more": "もっと見る",


### PR DESCRIPTION
### Screenshot (from search result)

![](https://cloud.githubusercontent.com/assets/12539/25180601/993f8586-2549-11e7-8abc-13982fe29f15.png)

"5 results 件" is broken Japanese.