### PR TITLE
Fixed hungarian translation

### DIFF
--- a/app/assets/javascripts/components/locales/hu.jsx
+++ b/app/assets/javascripts/components/locales/hu.jsx
@@ -18,7 +18,7 @@ const hu = {
   "account.block": "Blokkolás",
   "account.follow": "Követés",
   "account.posts": "Posts",
-  "account.follows": "Követők",
+  "account.follows": "Követve",
   "account.followers": "Követők",
   "account.follows_you": "Követnek téged",
   "getting_started.heading": "Első lépések",


### PR DESCRIPTION
At the moment the followers and follows is the same in hungarian, which is incorrect. I fixed this.