### PR TITLE
Fix broken style when follower has long description

### DIFF
--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -237,13 +237,14 @@
 }
 
 .accounts-grid {
-  clear: both;
   box-shadow: 0 0 15px rgba($color8, 0.2);
   background: $color5;
   border-radius: 0 0 4px 4px;
   padding: 20px 10px;
   padding-bottom: 10px;
   overflow: hidden;
+  display: flex;
+  flex-wrap: wrap;
 
   @media screen and (max-width: 700px) {
     border-radius: 0;
@@ -253,11 +254,9 @@
   .account-grid-card {
     box-sizing: border-box;
     width: 335px;
-    float: left;
     border: 1px solid $color2;
     border-radius: 4px;
     color: $color1;
-    height: 160px;
     margin-bottom: 10px;
 
     &:nth-child(odd) {


### PR DESCRIPTION
Fix broken style when follower has long description.

![d2b37b18-2505-11e7-8dd6-9aa4b1ad01ef](https://cloud.githubusercontent.com/assets/5250706/25191015/17e6ee00-2569-11e7-89cb-cc6f484f022d.png)

It was mainly caused by `float: left` & fixed `height`. I changed it to `display: flex` & `flex-wrap: wrap`.

I also removed unnecessary `clear: both` on the parent element.