### PR TITLE
Move force_ssl check to production config

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,8 +5,6 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  force_ssl if: "Rails.env.production? && ENV['LOCAL_HTTPS'] == 'true'"
-
   include Localized
 
   helper_method :current_account

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -108,6 +108,7 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = ENV.fetch('SMTP_DELIVERY_METHOD', 'smtp').to_sym
 
+  config.force_ssl = (ENV['LOCAL_HTTPS'] == 'true')
 
   config.react.variant = :production
 


### PR DESCRIPTION
The force_ssl method from controllers does not add all of the options that the
sitewide configuration in a config block does. For example, HSTS enforcement is
not added by the controller method, but is added by this style.

I see that the exact opposite of this change was done here - https://github.com/tootsuite/mastodon/commit/8459acd1234e9efcbf106e3eaa00ca871717d386 - but I'm not sure why.

Opening this PR to either sort that out, or close if still a concern.