### PR TITLE
Updated note about 'none' SMTP authentication method in .env.production.sample

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -36,7 +36,8 @@ OTP_SECRET=
 # E-mail configuration
 # Note: Mailgun and SparkPost (https://sparkpo.st/smtp) each have good free tiers
 # If you want to use an SMTP server without authentication (e.g local Postfix relay)
-# then set SMTP_AUTH_METHOD to 'none' and leave SMTP_LOGIN and SMTP_PASSWORD blank
+# then set SMTP_AUTH_METHOD to 'none' and *comment* SMTP_LOGIN and SMTP_PASSWORD.
+# Leaving them blank is not enough for authentication method 'none'.
 SMTP_SERVER=smtp.mailgun.org
 SMTP_PORT=587
 SMTP_LOGIN=


### PR DESCRIPTION
#1597 added 'none' to SMTP authentication. However, I spent some time not understanding why it was still not working. I had to comment SMTP_LOGIN & SMTP_PASSWORD.

Hopefully this will help others not losing time in case it happens for them as well.