### PR TITLE
Adds git to dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
     libxslt \
     ffmpeg \
     file \
+    git \
     imagemagick@edge \
  && npm install -g npm@3 && npm install -g yarn \
  && bundle install --deployment --without test development \


### PR DESCRIPTION
As discussed [in this issue](https://github.com/tootsuite/mastodon/issues/1789#issuecomment-295304981), we would like to have the output from `git describe --tags` displayed in the UI of the Rails app as a sort of version number. To do so, `git` needs to be installed in the Docker images. This PR adds that.