### PR TITLE
Regression fix for unauthenticated SMTP

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,12 +98,10 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     :port                 => ENV['SMTP_PORT'],
     :address              => ENV['SMTP_SERVER'],
-    :user_name            => ENV['SMTP_LOGIN'],
-    :password             => ENV['SMTP_PASSWORD'],
-
+    :user_name            => ENV['SMTP_LOGIN'].presence,
+    :password             => ENV['SMTP_PASSWORD'].presence,
     :domain               => ENV['SMTP_DOMAIN'] || ENV['LOCAL_DOMAIN'],
     :authentication       => ENV['SMTP_AUTH_METHOD'] == 'none' ? nil : ENV['SMTP_AUTH_METHOD'] || :plain,
-
     :openssl_verify_mode  => ENV['SMTP_OPENSSL_VERIFY_MODE'],
     :enable_starttls_auto => ENV['SMTP_ENABLE_STARTTLS_AUTO'] || true,
   }


### PR DESCRIPTION
A small regression with the fix to send unauthenticated SMTP introduced in https://github.com/tootsuite/mastodon/pull/1597. 

As I suspected (and my original patch fixed), you have to set SMTP_LOGIN and SMTP_PASSWORD to nil, even if blank in the envfile, otherwise brain damage in Ruby will still attempt auth even if SMTP_AUTH_METHOD is none

Do this with .presence so the value is set if it was provided, otherwise nil if blank.