### PR TITLE
Fix HTML format of account note

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -35,6 +35,8 @@ class Formatter
     return reformat(account.note) unless account.local?
 
     html = encode_and_link_urls(account.note)
+    html = simple_format(html, {}, sanitize: false)
+    html = html.delete("\n")
     html = link_accounts(html)
     html = link_hashtags(html)
 


### PR DESCRIPTION
Currently, line breaks in notes are not reflected in HTML.
I think that it is better to reflect line breaks in HTML.