### PR TITLE
Stricter whitelist rules

### DIFF
--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -23,10 +23,9 @@ class EmailValidator < ActiveModel::EachValidator
   def not_on_whitelist?(value)
     return false if Rails.configuration.x.email_domains_whitelist.blank?
 
-    domains = Rails.configuration.x.email_domains_whitelist.gsub('.', '\.').split('|')
-    domains.any? do |domain|
-      regexp = Regexp.new("@(.+\\.)?(#{domain})$", true)
-      value !~ regexp
-    end
+    domains = Rails.configuration.x.email_domains_whitelist.gsub('.', '\.')
+    regexp = Regexp.new("@(.+\\.)?(#{domains})$", true)
+
+    value !~ regexp
   end
 end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -15,7 +15,7 @@ class EmailValidator < ActiveModel::EachValidator
     return false if Rails.configuration.x.email_domains_blacklist.blank?
 
     domains = Rails.configuration.x.email_domains_blacklist.gsub('.', '\.')
-    regexp  = Regexp.new("@(.+\\.)?(#{domains})", true)
+    regexp = Regexp.new("@(.+\\.)?(#{domains})", true)
 
     value =~ regexp
   end
@@ -24,10 +24,9 @@ class EmailValidator < ActiveModel::EachValidator
     return false if Rails.configuration.x.email_domains_whitelist.blank?
 
     domains = Rails.configuration.x.email_domains_whitelist.gsub('.', '\.').split('|')
-    domains.any? { |domain|
-      regexp  = Regexp.new("@(.+\\.)?(#{domain})$", true)
+    domains.any? do |domain|
+      regexp = Regexp.new("@(.+\\.)?(#{domain})$", true)
       value !~ regexp
-    }
-
+    end
   end
 end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -23,9 +23,11 @@ class EmailValidator < ActiveModel::EachValidator
   def not_on_whitelist?(value)
     return false if Rails.configuration.x.email_domains_whitelist.blank?
 
-    domains = Rails.configuration.x.email_domains_whitelist.gsub('.', '\.')
-    regexp  = Regexp.new("@(.+\\.)?(#{domains})", true)
+    domains = Rails.configuration.x.email_domains_whitelist.gsub('.', '\.').split('|')
+    domains.any? { |domain|
+      regexp  = Regexp.new("@(.+\\.)?(#{domain})$", true)
+      value !~ regexp
+    }
 
-    value !~ regexp
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -108,5 +108,15 @@ RSpec.describe User, type: :model do
       user = User.new(email: 'foo@mastodon.space.userdomain.com', account: account, password: password)
       expect(user.valid?).to be_falsey
     end
+
+    it 'should not allow a user to be created with a specific blacklisted subdomain even if the top domain is whitelisted' do
+      old_blacklist = Rails.configuration.x.email_blacklist
+      Rails.configuration.x.email_domains_blacklist = 'blacklisted.mastodon.space'
+
+      user = User.new(email: 'foo@blacklisted.mastodon.space', account: account, password: password)
+      expect(user.valid?).to be_falsey
+
+      Rails.configuration.x.email_domains_blacklist = old_blacklist
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe User, type: :model do
   let(:password) { 'abcd1234' }
 
   describe 'blacklist' do
+    around(:each) do |example|
+      old_blacklist = Rails.configuration.x.email_blacklist
+
+      Rails.configuration.x.email_domains_blacklist = 'mvrht.com'
+
+      example.run
+
+      Rails.configuration.x.email_domains_blacklist = old_blacklist
+    end
+
     it 'should allow a non-blacklisted user to be created' do
       user = User.new(email: 'foo@example.com', account: account, password: password)
 
@@ -62,6 +72,12 @@ RSpec.describe User, type: :model do
 
     it 'should not allow a blacklisted user to be created' do
       user = User.new(email: 'foo@mvrht.com', account: account, password: password)
+
+      expect(user.valid?).to be_falsey
+    end
+
+    it 'should not allow a subdomain blacklisted user to be created' do
+      user = User.new(email: 'foo@mvrht.com.topdomain.tld', account: account, password: password)
 
       expect(user.valid?).to be_falsey
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -87,5 +87,10 @@ RSpec.describe User, type: :model do
       user = User.new(email: 'foo@mastodon.space', account: account, password: password)
       expect(user.valid?).to be_truthy
     end
+
+    it 'should not allow a smart user to be created unless they are whitelisted' do
+      user = User.new(email: 'foo@mastodon.space.userdomain.com', account: account, password: password)
+      expect(user.valid?).to be_falsey
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe User, type: :model do
       expect(user.valid?).to be_truthy
     end
 
-    it 'should not allow a smart user to be created unless they are whitelisted' do
+    it 'should not allow a user with a whitelisted top domain as subdomain in their email address to be created' do
       user = User.new(email: 'foo@mastodon.space.userdomain.com', account: account, password: password)
       expect(user.valid?).to be_falsey
     end


### PR DESCRIPTION
I was browsing an instance where you need a whitelisted email domain, however I figured out you could circumvent the protection by using the whitelisted domain as a subdomain of your email address.