### PR TITLE
Redirect to short_account_path when accessing /web/accounts/:id without signed in

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -14,7 +14,10 @@ class HomeController < ApplicationController
   private
 
   def authenticate_user!
-    redirect_to(single_user_mode? ? account_path(Account.first) : about_path) unless user_signed_in?
+    return if user_signed_in?
+    md = request.original_fullpath.match(/\A\/web\/accounts\/(\d+)/)
+    return redirect_to(short_account_path(Account.find(md[1].to_i))) if md
+    redirect_to(single_user_mode? ? account_path(Account.first) : about_path)
   end
 
   def find_or_create_access_token

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,11 +2,21 @@ require 'rails_helper'
 
 RSpec.describe HomeController, type: :controller do
   render_views
+  let(:user) { Fabricate(:user) }
+  let(:alice) { Fabricate(:account, id: 1, username: 'alica') }
 
   describe 'GET #index' do
     it 'redirects to about page' do
       get :index
       expect(response).to redirect_to(about_path)
+    end
+
+    context 'GET /web/accounts/:id' do
+      before { controller.request.env['ORIGINAL_FULLPATH'] = "/web/accounts/#{alice.id}" }
+      it 'redirects to @username page' do
+        get :index
+        expect(response).to redirect_to(short_account_path(alice))
+      end
     end
   end
 end


### PR DESCRIPTION
Would like to be redirected.
I think it would be more convenient.