### PR TITLE
Fix Chinese (China) translation availability

### DIFF
--- a/app/assets/javascripts/components/containers/mastodon.jsx
+++ b/app/assets/javascripts/components/containers/mastodon.jsx
@@ -58,6 +58,7 @@ import uk from 'react-intl/locale-data/uk';
 import zh from 'react-intl/locale-data/zh';
 import bg from 'react-intl/locale-data/bg';
 import { localeData as zh_hk } from '../locales/zh-hk';
+import { localeData as zh_cn } from '../locales/zh-cn';
 import pt_br from '../locales/pt-br';
 import getMessagesForLocale from '../locales';
 import { hydrateStore } from '../actions/store';
@@ -89,6 +90,7 @@ addLocaleData([
   ...uk,
   ...zh,
   ...zh_hk,
+  ...zh_cn,
   ...bg,
 ]);
 

--- a/app/assets/javascripts/components/locales/index.jsx
+++ b/app/assets/javascripts/components/locales/index.jsx
@@ -16,6 +16,7 @@ import eo from './eo';
 import ru from './ru';
 import ja from './ja';
 import zh_hk from './zh-hk';
+import zh_cn from './zh-cn';
 import bg from './bg';
 
 const locales = {
@@ -36,6 +37,7 @@ const locales = {
   ru,
   ja,
   'zh-HK': zh_hk,
+  'zh-CN': zh_cn,
   bg,
 };
 


### PR DESCRIPTION
zh-CN is not referenced in the language list so it wouldn't be available to users, ever. This pull request fixes it.

@Artoria2e5 You just forgot... 😉 