### PR TITLE
Admin UI for confirming users

### DIFF
--- a/app/controllers/admin/confirmations_controller.rb
+++ b/app/controllers/admin/confirmations_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Admin
-  class ConfirmsController < BaseController
+  class ConfirmationsController < BaseController
     before_action :set_account
 
     def create
-      @account.user.update(confirmed_at: Time.now.utc)
+      @account.user.confirm
       redirect_to admin_accounts_path
     end
 

--- a/app/controllers/admin/confirms_controller.rb
+++ b/app/controllers/admin/confirms_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  class ConfirmsController < BaseController
+    before_action :set_account
+
+    def create
+      @account.user.update(confirmed_at: Time.now.utc)
+      redirect_to admin_accounts_path
+    end
+
+    private
+
+    def set_account
+      @account = Account.find(params[:account_id])
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,10 @@ class User < ApplicationRecord
   scope :admins,    -> { where(admin: true) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
 
+  def confirmed?
+    confirmed_at.present?
+  end
+
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
   end

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -37,7 +37,7 @@
             = link_to account.domain, admin_accounts_path(by_domain: account.domain)
         %td
           - if account.local?
-            - if account.user.present? && account.user.confirmed_at.present?
+            - if account.user.present? && account.user.confirmed?
               %i.fa.fa-check
             - else 
               %i.fa.fa-times

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -25,6 +25,7 @@
     %tr
       %th= t('admin.accounts.username')
       %th= t('admin.accounts.domain')
+      %th= t('admin.accounts.confirmed')
       %th= fa_icon 'paper-plane-o'
       %th
   %tbody
@@ -34,6 +35,12 @@
         %td
           - unless account.local?
             = link_to account.domain, admin_accounts_path(by_domain: account.domain)
+        %td
+          - if account.local?
+            - if account.user.present? && account.user.confirmed_at.present?
+              %i.fa.fa-check
+            - else 
+              %i.fa.fa-times
         %td
           - if account.local?
             = t('admin.accounts.location.local')

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -77,6 +77,9 @@
   - else
     = link_to t('admin.accounts.silence'), admin_account_silence_path(@account.id), method: :post, class: 'button'
 
+  - unless @account.user.confirmed?
+    = link_to t('admin.accounts.confirm'), admin_account_confirm_path(@account.id), method: :post, class: 'button'
+
   - if @account.suspended?
     = link_to t('admin.accounts.undo_suspension'), admin_account_suspension_path(@account.id), method: :delete, class: 'button'
   - else

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -78,7 +78,7 @@
     = link_to t('admin.accounts.silence'), admin_account_silence_path(@account.id), method: :post, class: 'button'
 
   - unless @account.user.confirmed?
-    = link_to t('admin.accounts.confirm'), admin_account_confirm_path(@account.id), method: :post, class: 'button'
+    = link_to t('admin.accounts.confirm'), admin_account_confirmation_path(@account.id), method: :post, class: 'button'
 
   - if @account.suspended?
     = link_to t('admin.accounts.undo_suspension'), admin_account_suspension_path(@account.id), method: :delete, class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,8 @@ en:
   admin:
     accounts:
       are_you_sure: Are you sure?
+      confirm: Confirm
+      confirmed: Confirmed
       display_name: Display name
       domain: Domain
       edit: Edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Rails.application.routes.draw do
       resource :reset, only: [:create]
       resource :silence, only: [:create, :destroy]
       resource :suspension, only: [:create, :destroy]
-      resource :confirm, only: [:create]
+      post '/confirmation', to:'confirmations#create'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,7 @@ Rails.application.routes.draw do
       resource :reset, only: [:create]
       resource :silence, only: [:create, :destroy]
       resource :suspension, only: [:create, :destroy]
+      resource :confirm, only: [:create]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Rails.application.routes.draw do
       resource :reset, only: [:create]
       resource :silence, only: [:create, :destroy]
       resource :suspension, only: [:create, :destroy]
-      post '/confirmation', to:'confirmations#create'
+      resource :confirmation, only: [:create]
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#confirmed?' do
+    it 'returns true when a confirmed_at is set' do
+      user = Fabricate.build(:user, confirmed_at: Time.now.utc)
+      expect(user.confirmed?).to be true
+    end
+
+    it 'returns false if a confirmed_at is nil' do
+      user = Fabricate.build(:user, confirmed_at: nil)
+      expect(user.confirmed?).to be false
+    end
+  end
+
   describe 'whitelist' do
     around(:each) do |example|
       old_whitelist = Rails.configuration.x.email_whitelist


### PR DESCRIPTION
This PR exposes accounts' confirms statuses in the admin list page, and adds a button to the edit page to confirm them. I'm still pretty new at Rails, so please let me know if there are more idiomatic approaches to some of my decisions.

<img width="736" alt="screen shot 2017-04-20 at 8 05 35 pm" src="https://cloud.githubusercontent.com/assets/498212/25257263/c51eb27e-2604-11e7-9ea7-75d8ad7b02a4.png">
<img width="736" alt="screen shot 2017-04-20 at 8 05 41 pm" src="https://cloud.githubusercontent.com/assets/498212/25257265/c660a660-2604-11e7-8dde-2be068a2c36f.png">

Fixes https://github.com/tootsuite/mastodon/issues/1297