### PR TITLE
Upgrade jQuery to v2.x

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery2
 //= require jquery_ujs
 //= require components

--- a/app/assets/javascripts/application_public.js
+++ b/app/assets/javascripts/application_public.js
@@ -1,4 +1,4 @@
-//= require jquery
+//= require jquery2
 //= require jquery_ujs
 //= require extras
 //= require best_in_place


### PR DESCRIPTION
Fix #2199 and minifying assets file.

jQuery v1.x is supports legacy browsers. But, Mastodon does not support legacy browsers. I think jQuery v1.x is unnecessary.

### fyi

#### before

```shell
$ ls -l public/assets/application-*.js
-rw-r--r--  1 ykzts  staff  9955026  4 21 09:51 public/assets/application-d2ac01466e0bf79e325c4ad3cf123d8d7e617405ab5eddaa27460bed729514de.js
```

#### after

```shell
$ ls -l public/assets/application-*.js
-rw-r--r--  1 ykzts  staff  9919147  4 21 09:53 public/assets/application-e04d3d2e8d11d315e77d2d80efd1e084442303e81146b6cd949917a98ade8692.js
```
