### PR TITLE
Fix mangling of ##tag matches (#2194)

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -109,7 +109,7 @@ class Formatter
   end
 
   def hashtag_html(match)
-    prefix, affix = match.split('#')
+    prefix, _, affix = match.rpartition('#')
     "#{prefix}<a href=\"#{tag_url(affix.downcase)}\" class=\"mention hashtag\">#<span>#{affix}</span></a>"
   end
 


### PR DESCRIPTION
This commit fixes hashtag_html so it correctly handles matches with multiple hash-signs.

Bug located by @over9001, initial fix suggested by @nightpool.