### PR TITLE
Added API for single notification dismissal

### DIFF
--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -30,6 +30,10 @@ class Api::V1::NotificationsController < ApiController
     render_empty
   end
 
+  def dismiss
+    Notification.where(account: current_account, id: params[:id]).delete_all
+  end
+
   private
 
   def exclude_types

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -32,6 +32,7 @@ class Api::V1::NotificationsController < ApiController
 
   def dismiss
     Notification.where(account: current_account, id: params[:id]).delete_all
+    render_empty
   end
 
   private

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::NotificationsController < ApiController
   end
 
   def dismiss
-    Notification.where(account: current_account, id: params[:id]).delete_all
+    Notification.find_by!(account: current_account, id: params[:id]).destroy!
     render_empty
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,7 @@ Rails.application.routes.draw do
       resources :notifications, only: [:index, :show] do
         collection do
           post :clear
+          post :dismiss
         end
       end
 


### PR DESCRIPTION
Adds a `/api/v1/notifications/dismiss` POST route that takes an `id` parameter and removes the notification with that id.

This is a start to solving #686 and #1900.

