### PR TITLE
Add Mastodon version to user agent

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FetchLinkCardService < BaseService
-  USER_AGENT = "#{HTTP::Request::USER_AGENT} (Mastodon; +http://#{Rails.configuration.x.local_domain}/)"
+  USER_AGENT = "#{HTTP::Request::USER_AGENT} (Mastodon/#{Mastodon::VERSION}; +http://#{Rails.configuration.x.local_domain}/)"
 
   def call(status)
     # Get first http/https URL that isn't local


### PR DESCRIPTION
I did something I could not do with https://github.com/tootsuite/mastodon/pull/2073 .

I think that the version of Mastodon running on that server will be useful for investigation.

Before
```
http.rb/2.2.1 (Mastodon; +http://mastodon.dev/)
```

After
```
http.rb/2.2.1 (Mastodon/1.2.2; +http://mastodon.dev/)
```