### PR TITLE
Align the back buttons to the right

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1158,7 +1158,8 @@ a.status__content__spoiler-link {
   position: relative;
 }
 
-@media screen and (min-width: 360px) {
+// min-width corresponds to signle-column + nav layout breakpoint
+@media screen and (min-width: 1024px) {
   .columns-area {
     padding: 10px;
   }
@@ -1211,7 +1212,8 @@ a.status__content__spoiler-link {
   overflow: hidden;
 }
 
-@media screen and (min-width: 360px) {
+// min-width corresponds to signle-column + nav layout breakpoint
+@media screen and (min-width: 1024px) {
   .tabs-bar {
     margin: 10px;
     margin-bottom: 0;


### PR DESCRIPTION
The back buttons on the column headers are aligned to the right, so enforce the alignment also for the simple back buttons.

This change is preferred in the sense that the the back button will be far from the follow/unfollow button in the status page.