### PR TITLE
Streaming API Hashtag bug fixed

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -285,11 +285,11 @@ if (cluster.isMaster) {
   })
 
   app.get('/api/v1/streaming/hashtag', (req, res) => {
-    streamFrom(`timeline:hashtag:${req.params.tag}`, req, streamToHttp(req, res), streamHttpEnd(req), true)
+    streamFrom(`timeline:hashtag:${req.query.tag}`, req, streamToHttp(req, res), streamHttpEnd(req), true)
   })
 
   app.get('/api/v1/streaming/hashtag/local', (req, res) => {
-    streamFrom(`timeline:hashtag:${req.params.tag}:local`, req, streamToHttp(req, res), streamHttpEnd(req), true)
+    streamFrom(`timeline:hashtag:${req.query.tag}:local`, req, streamToHttp(req, res), streamHttpEnd(req), true)
   })
 
   wss.on('connection', ws => {


### PR DESCRIPTION
Fixed a bug where the hashtag could not be specified with the streaming API.

Hash tags are passed in GET queries, but trying to get URL parameters.