### PR TITLE
User settings mutation

### DIFF
--- a/spec/controllers/settings/preferences_controller_spec.rb
+++ b/spec/controllers/settings/preferences_controller_spec.rb
@@ -24,8 +24,8 @@ describe Settings::PreferencesController do
 
     it 'updates user settings' do
       user.settings['boost_modal'] = false
-      user.settings['notification_emails']['follow'] = false
-      user.settings['interactions']['must_be_follower'] = true
+      user.settings['notification_emails'] = user.settings['notification_emails'].merge('follow' => false)
+      user.settings['interactions'] = user.settings['interactions'].merge('must_be_follower' => true)
 
       put :update, params: {
         user: {

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,6 +24,37 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'settings' do
+    it 'inherits default settings from default yml' do
+      expect(Setting.boost_modal).to eq false
+      expect(Setting.interactions['must_be_follower']).to eq false
+
+      user = User.new
+      expect(user.settings.boost_modal).to eq false
+      expect(user.settings.interactions['must_be_follower']).to eq false
+    end
+
+    it 'can update settings' do
+      user = Fabricate(:user)
+      expect(user.settings['interactions']['must_be_follower']).to eq false
+      user.settings['interactions'] = user.settings['interactions'].merge('must_be_follower' => true)
+      user.reload
+
+      expect(user.settings['interactions']['must_be_follower']).to eq true
+    end
+
+    xit 'does not mutate defaults via the cache' do
+      user = Fabricate(:user)
+      user.settings['interactions']['must_be_follower'] = true
+      # TODO
+      # This mutates the global settings default such that future user
+      # instances will inherit the incorrect starting values
+
+      other = Fabricate(:user)
+      expect(other.settings['interactions']['must_be_follower']).to eq false
+    end
+  end
+
   describe 'scopes' do
     describe 'recent' do
       it 'returns an array of recent users ordered by id' do


### PR DESCRIPTION
There was a setting assignment in the settings/preferences controller which had a side effect of mutating the global setting defaults, which then caused an issue in the api notifications spec, but only when the preferences spec ran first, which is why the failure was intermittent.

This should fix what have been intermittent CI failures like https://travis-ci.org/tootsuite/mastodon/jobs/224311789

I left an `xit` spec in here with a note about whats happening, because I don't know how to resolve this. It seems like that assignment style should not be mutating the setting defaults, but that's probably happening in the `rails-settings-cached` gem itself, or in our interaction with it.

Steps to replicate the failure, prior to these changes:

    rspec ./spec/controllers/api/v1/media_controller_spec.rb[1:1:3:4] ./spec/controllers/api/v1/notifications_controller_spec.rb[1:1:1:2,1:1:1:3,1:1:1:4,1:1:2:2,1:1:2:4] ./spec/controllers/settings/preferences_controller_spec.rb[1:2:2] ./spec/services/fan_out_on_write_service_spec.rb[1:1] --seed 2887