### PR TITLE
Do not set port for puma if it is bound to unix socket

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -3,9 +3,10 @@ threads threads_count, threads_count
 
 if ENV['SOCKET'] then
   bind 'unix://' + ENV['SOCKET']
+else
+  port ENV.fetch('PORT') { 3000 }
 end
 
-port        ENV.fetch('PORT') { 3000 }
 environment ENV.fetch('RAILS_ENV') { 'development' }
 workers     ENV.fetch('WEB_CONCURRENCY') { 2 }
 


### PR DESCRIPTION
Setting port after binding a unix socket puma listen to both of an unix socket and TCP/IP, which is not a desired behavior.

In pull request #2085, I have missed this change which is done on my instance but not on my development environment. It is my fault. I confirmed this works on my instance, m.kagucho.net.