### PR TITLE
[WIP] Html lang on statuses

### DIFF
--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -9,10 +9,18 @@ class LanguageDetector
   end
 
   def to_iso_s
-    WhatLanguage.new(:all).language_iso(text) || default_locale.to_sym
+    WhatLanguage.new(:all).language_iso(text_without_urls) || default_locale.to_sym
   end
 
   private
+
+  def text_without_urls
+    text.dup.tap do |new_text|
+      URI.extract(new_text).each do |url|
+        new_text.gsub!(url, '')
+      end
+    end
+  end
 
   def default_locale
     account&.user&.locale || I18n.default_locale

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -12,7 +12,7 @@
       %p{ style: 'margin-bottom: 0' }<
         %span.p-summary>= "#{status.spoiler_text} "
         %a.status__content__spoiler-link{ href: '#' }= t('statuses.show_more')
-    %div.e-content{ style: "display: #{status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl?(status.content) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status)
+    %div.e-content{ lang: status.language, style: "display: #{status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl?(status.content) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status)
 
 
   - unless status.media_attachments.empty?

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -17,7 +17,7 @@
       %p{ style: 'margin-bottom: 0' }<
         %span.p-summary>= "#{status.spoiler_text} "
         %a.status__content__spoiler-link{ href: '#' }= t('statuses.show_more')
-    %div.e-content{ style: "display: #{status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl?(status.content) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status)
+    %div.e-content{ lang: status.language, style: "display: #{status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl?(status.content) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status)
 
   - unless status.media_attachments.empty?
     .status__attachments

--- a/spec/lib/language_detector_spec.rb
+++ b/spec/lib/language_detector_spec.rb
@@ -23,6 +23,18 @@ describe LanguageDetector do
         expect(result).to be_nil
       end
 
+      describe 'because of a URL' do
+        it 'uses default locale when sent just a URL' do
+          string = 'http://example.com/media/2kFTgOJLXhQf0g2nKB4'
+          wl_result = WhatLanguage.new(:all).language_iso(string)
+          expect(wl_result).not_to eq :en
+
+          result = described_class.new(string).to_iso_s
+
+          expect(result).to eq :en
+        end
+      end
+
       describe 'with an account' do
         it 'uses the account locale when present' do
           user    = double(:user, locale: 'fr')


### PR DESCRIPTION
Changes to:

- Add html `lang` attribute in stream entries around status
- Update the language detector to ignore urls in strings when detecting language ... should fallback to account or instance default in those scenarios.