### PR TITLE
Add og:url tags

### DIFF
--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -6,6 +6,7 @@
 
 - content_for :header_tags do
   %meta{ property: 'og:site_name', content: site_title }/
+  %meta{ property: 'og:url', content: about_url }/
   %meta{ property: 'og:type', content: 'website' }/
   %meta{ property: 'og:title', content: site_hostname }/
   %meta{ property: 'og:description', content: strip_tags(@instance_presenter.site_description.presence || t('about.about_mastodon')) }/

--- a/app/views/accounts/_og.html.haml
+++ b/app/views/accounts/_og.html.haml
@@ -1,3 +1,4 @@
+%meta{ property: 'og:url', content: url }/
 %meta{ property: 'og:site_name', content: site_title }/
 %meta{ property: 'og:title', content: [yield(:page_title).strip.presence, site_title].compact.join(' - ') }/
 %meta{ property: 'og:description', content: account.note }/

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -6,7 +6,7 @@
   %link{ rel: 'alternate', type: 'application/atom+xml', href: account_url(@account, format: 'atom') }/
 
   %meta{ property: 'og:type', content: 'profile' }/
-  = render 'og', account: @account
+  = render 'og', account: @account, url: account_url(@account, only_path: false)
 
 - if show_landing_strip?
   = render partial: 'shared/landing_strip', locals: { account: @account }

--- a/app/views/follower_accounts/index.html.haml
+++ b/app/views/follower_accounts/index.html.haml
@@ -2,7 +2,7 @@
   = t('accounts.people_who_follow', name: display_name(@account))
 
 - content_for :header_tags do
-  = render 'accounts/og', account: @account
+  = render 'accounts/og', account: @account, url: account_followers_url(@account, only_path: false)
 
 = render 'accounts/header', account: @account
 

--- a/app/views/following_accounts/index.html.haml
+++ b/app/views/following_accounts/index.html.haml
@@ -2,7 +2,7 @@
   = t('accounts.people_followed_by', name: display_name(@account))
 
 - content_for :header_tags do
-  = render 'accounts/og', account: @account
+  = render 'accounts/og', account: @account, url: account_followers_url(@account, only_path: false)
 
 = render 'accounts/header', account: @account
 

--- a/app/views/stream_entries/show.html.haml
+++ b/app/views/stream_entries/show.html.haml
@@ -5,6 +5,7 @@
   %meta{ property: 'og:site_name', content: site_title }/
   %meta{ property: 'og:type', content: 'article' }/
   %meta{ property: 'og:title', content: "#{@account.username} on #{site_hostname}" }/
+  %meta{ property: 'og:url', content: account_stream_entry_url(@account, @stream_entry) }/
 
   = render 'stream_entries/og_description', activity: @stream_entry.activity
   = render 'stream_entries/og_image', activity: @stream_entry.activity, account: @account

--- a/spec/views/about/show.html.haml_spec.rb
+++ b/spec/views/about/show.html.haml_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+$LOAD_PATH << '../lib'
+require 'tag_manager'
+
+describe 'about/show.html.haml' do
+  before do
+  end
+
+  it 'has valid open graph tags' do
+    instance_presenter = double(:instance_presenter,
+				site_description: 'something',
+				open_registrations: false,
+				closed_registrations_message: 'yes',
+			       )
+    assign(:instance_presenter, instance_presenter)
+    render
+
+    header_tags = view.content_for(:header_tags)
+
+    expect(header_tags).to match(%r{<meta content='.+' property='og:title'>})
+    expect(header_tags).to match(%r{<meta content='website' property='og:type'>})
+    expect(header_tags).to match(%r{<meta content='.+' property='og:image'>})
+    expect(header_tags).to match(%r{<meta content='http://.+' property='og:url'>})
+  end
+end

--- a/spec/views/accounts/show.html.haml_spec.rb
+++ b/spec/views/accounts/show.html.haml_spec.rb
@@ -20,4 +20,23 @@ describe 'accounts/show.html.haml' do
 
     expect(Nokogiri::HTML(rendered).search('.h-feed .h-entry').size).to eq 3
   end
+
+  it 'has valid opengraph tags' do
+    alice   =  Fabricate(:account, username: 'alice', display_name: 'Alice')
+    status  =  Fabricate(:status, account: alice, text: 'Hello World')
+
+    assign(:account, alice)
+    assign(:statuses, alice.statuses)
+    assign(:stream_entry, status.stream_entry)
+    assign(:type, status.stream_entry.activity_type.downcase)
+
+    render
+
+    header_tags = view.content_for(:header_tags)
+
+    expect(header_tags).to match(%r{<meta content='.+' property='og:title'>})
+    expect(header_tags).to match(%r{<meta content='profile' property='og:type'>})
+    expect(header_tags).to match(%r{<meta content='.+' property='og:image'>})
+    expect(header_tags).to match(%r{<meta content='http://.+' property='og:url'>})
+  end
 end

--- a/spec/views/stream_entries/show.html.haml_spec.rb
+++ b/spec/views/stream_entries/show.html.haml_spec.rb
@@ -61,4 +61,23 @@ describe 'stream_entries/show.html.haml' do
     expect(mf2.entry.in_reply_to.format.author.format.name.to_s).to eq alice.display_name
     expect(mf2.entry.in_reply_to.format.author.format.url.to_s).not_to be_empty
   end
+
+  it 'has valid opengraph tags' do
+    alice   =  Fabricate(:account, username: 'alice', display_name: 'Alice')
+    status  =  Fabricate(:status, account: alice, text: 'Hello World')
+
+    assign(:status, status)
+    assign(:stream_entry, status.stream_entry)
+    assign(:account, alice)
+    assign(:type, status.stream_entry.activity_type.downcase)
+
+    render
+
+    header_tags = view.content_for(:header_tags)
+
+    expect(header_tags).to match(%r{<meta content='.+' property='og:title'>})
+    expect(header_tags).to match(%r{<meta content='article' property='og:type'>})
+    expect(header_tags).to match(%r{<meta content='.+' property='og:image'>})
+    expect(header_tags).to match(%r{<meta content='http://.+' property='og:url'>})
+  end
 end


### PR DESCRIPTION
According [The Open Graph Protocol](https://ogp.me/)

> The four required properties for every page are:
>  og:title - The title of your object as it should appear within the graph, e.g., "The Rock".
>   og:type - The type of your object, e.g., "video.movie". Depending on the type you specify, other properties may also be required.
>   og:image - An image URL which should represent your object within the graph.
 >  og:url - The canonical URL of your object that will be used as its permanent ID in the graph, e.g., "http://www.imdb.com/title/tt0117500/".

This adds those urls to all the pages that I could find that had the other opengraph tags.

One thing I'm not sure about is which value to return for a user's profile page. It seems that both `/@user` and `/users/user` render the correct page but only one can be the canonical url. I went with `/users/user` because it was easier to get to, but that could be change.

I'm also not sure what kind of testing you prefer on the project. The ones I wrote are pretty 'loose' in that they basically just check that all the tags are present, but it doesn't check to see if the values make any sense for fear of making the tests too brittle.