### PR TITLE
Add aria-controls and aria-expanded to CW button

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/compose_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/compose_form.jsx
@@ -146,7 +146,7 @@ class ComposeForm extends React.PureComponent {
       <div className='compose-form'>
         <Collapsable isVisible={this.props.spoiler} fullHeight={50}>
           <div className="spoiler-input">
-            <input placeholder={intl.formatMessage(messages.spoiler_placeholder)} value={this.props.spoiler_text} onChange={this.handleChangeSpoilerText} onKeyDown={this.handleKeyDown} type="text" className="spoiler-input__input" />
+            <input placeholder={intl.formatMessage(messages.spoiler_placeholder)} value={this.props.spoiler_text} onChange={this.handleChangeSpoilerText} onKeyDown={this.handleKeyDown} type="text" className="spoiler-input__input"  id='cw-spoiler-input'/>
           </div>
         </Collapsable>
 

--- a/app/assets/javascripts/components/features/compose/components/text_icon_button.jsx
+++ b/app/assets/javascripts/components/features/compose/components/text_icon_button.jsx
@@ -13,10 +13,10 @@ class TextIconButton extends React.PureComponent {
   }
 
   render () {
-    const { label, title, active } = this.props;
+    const { label, title, active, ariaControls } = this.props;
 
     return (
-      <button title={title} aria-label={title} className={`text-icon-button ${active ? 'active' : ''}`} onClick={this.handleClick}>
+      <button title={title} aria-label={title} className={`text-icon-button ${active ? 'active' : ''}`} aria-expanded={active} onClick={this.handleClick} aria-controls={ariaControls}>
         {label}
       </button>
     );
@@ -28,7 +28,8 @@ TextIconButton.propTypes = {
   label: PropTypes.string.isRequired,
   title: PropTypes.string,
   active: PropTypes.bool,
-  onClick: PropTypes.func.isRequired
+  onClick: PropTypes.func.isRequired,
+  ariaControls: PropTypes.string
 };
 
 export default TextIconButton;

--- a/app/assets/javascripts/components/features/compose/containers/spoiler_button_container.jsx
+++ b/app/assets/javascripts/components/features/compose/containers/spoiler_button_container.jsx
@@ -10,7 +10,8 @@ const messages = defineMessages({
 const mapStateToProps = (state, { intl }) => ({
   label: 'CW',
   title: intl.formatMessage(messages.title),
-  active: state.getIn(['compose', 'spoiler'])
+  active: state.getIn(['compose', 'spoiler']),
+  ariaControls: 'cw-spoiler-input'
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
~Content warning field appearing above toot reflows the column and is far away from the CW button which triggers the reveal of the field. Move content warning field below the toot box to connect it more directly to the trigger button through proximity.~

~img width="295" alt="cw-below-toot-box" src="https://cloud.githubusercontent.com/assets/6003351/25301091/2dd8ef2a-26e4-11e7-8955-cd3b27386a3e.png"~

#2209
#1807

~NOTE: I removed 'SensitiveButtonContainer' because it was not the button that was triggering the CW input field. I could not identify any way in which that button was being used so I removed the button entirely.~

Update:

Do not remove SensitiveButton, do not move CW field below toot box. What remains of original case:

* Add aria expanded to text icon button, making the CW button show as expanded.
* Add the aria-controls information as well to help JAWS screen reader users jump to the CW input field.