### PR TITLE
Localize with i18n for Devise::FailureApp

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -115,8 +115,7 @@ class ApplicationController < ActionController::Base
   end
 
   def respond_with_error(code)
-    set_locale do
-      render "errors/#{code}", layout: 'error', status: code
-    end
+    set_locale
+    render "errors/#{code}", layout: 'error', status: code
   end
 end

--- a/app/controllers/concerns/localized.rb
+++ b/app/controllers/concerns/localized.rb
@@ -4,25 +4,16 @@ module Localized
   extend ActiveSupport::Concern
 
   included do
-    around_action :set_locale
+    before_action :set_locale
   end
 
   private
 
   def set_locale
-    locale = default_locale
-
-    if user_signed_in?
-      begin
-        locale = current_user.try(:locale) || default_locale
-      rescue I18n::InvalidLocale
-        locale = default_locale
-      end
-    end
-
-    I18n.with_locale(locale) do
-      yield
-    end
+    I18n.locale = default_locale
+    I18n.locale = current_user.locale if user_signed_in?
+  rescue I18n::InvalidLocale
+    I18n.locale = default_locale
   end
 
   def default_locale

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe Auth::SessionsController, type: :controller do
           expect(controller.current_user).to be_nil
         end
       end
+
+      context 'using an unconfirmed password' do
+        before do
+          request.headers['Accept-Language'] = accept_language
+          post :create, params: { user: { email: unconfirmed_user.email, password: unconfirmed_user.password } }
+        end
+
+        let(:unconfirmed_user) { user.tap { |u| u.update!(confirmed_at: nil) } }
+        let(:accept_language) { 'fr' }
+
+        it 'shows a translated login error' do
+          expect(flash[:alert]).to eq(I18n.t('devise.failure.unconfirmed', locale: accept_language))
+        end
+      end
     end
 
     context 'using two-factor authentication' do


### PR DESCRIPTION
Currently I18n.locale is changed inside the controller. Therefore, I18n.locale in
Devise::FailureApp always uses the default locale because it is called from outside of the controller.

side effect:

- Controller
  - If the controller doesn't include Localized, I18n.locale remains from previous request.
- Worker
  - No side effects because Redis does not store current locale.
- Mailer
  - No side effects because it uses `I18n.with_locale` every time.
