### PR TITLE
Add author/actor URI to the list of webfinger aliases

### DIFF
--- a/app/views/well_known/webfinger/show.json.rabl
+++ b/app/views/well_known/webfinger/show.json.rabl
@@ -3,7 +3,7 @@ object @account
 node(:subject) { @canonical_account_uri }
 
 node(:aliases) do
-  [TagManager.instance.url_for(@account)]
+  [TagManager.instance.url_for(@account), TagManager.instance.uri_for(@account)]
 end
 
 node(:links) do

--- a/app/views/well_known/webfinger/show.xml.ruby
+++ b/app/views/well_known/webfinger/show.xml.ruby
@@ -2,6 +2,7 @@ Nokogiri::XML::Builder.new do |xml|
   xml.XRD(xmlns: 'http://docs.oasis-open.org/ns/xri/xrd-1.0') do
     xml.Subject @canonical_account_uri
     xml.Alias TagManager.instance.url_for(@account)
+    xml.Alias TagManager.instance.uri_for(@account)
     xml.Link(rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: TagManager.instance.url_for(@account))
     xml.Link(rel: 'http://schemas.google.com/g/2010#updates-from', type: 'application/atom+xml', href: account_url(@account, format: 'atom'))
     xml.Link(rel: 'salmon', href: api_salmon_url(@account.id))


### PR DESCRIPTION
This fixes outbound salmon requests to remote GNU Social instances.
Indeed, it appears that GNU Social discovers unknown accounts by doing a webfinger request on the account URI (https://WEB_DOMAIN/users/User), and expects it to be listed in the resulting set of aliases. However, only the short URL (https://WEB_DOMAIN/@User) is currently in the set as an alias for User@LOCAL_DOMAIN, and not the account URI.
This patch fixes that.