### PR TITLE
update emojione-picker for fixed warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "css-loader": "^0.26.2",
     "dotenv": "^4.0.0",
     "emojione": "^2.2.7",
-    "emojione-picker": "^2.0.1",
+    "emojione-picker": "^2.1.2",
     "enzyme": "^2.8.2",
     "es6-promise": "^3.2.1",
     "escape-html": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2341,9 +2341,9 @@ emoji-regex@^6.1.0:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.4.2.tgz#a30b6fee353d406d96cfb9fa765bdc82897eff6e"
 
-emojione-picker@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/emojione-picker/-/emojione-picker-2.0.1.tgz#62e58db67d37a400a883c82d39abb1cc1c8ed65a"
+emojione-picker@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/emojione-picker/-/emojione-picker-2.1.2.tgz#2b12bc74dcb1bd180a8628f7656c09a92ca70e9b"
   dependencies:
     emojione "^2.2.6"
     escape-string-regexp "^1.0.5"
@@ -3898,11 +3898,11 @@ lodash.tail@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^4.15.0, lodash@^4.2.0, lodash@^4.6.1, lodash@~4.16.4:
+lodash@^4.2.0, lodash@^4.6.1, lodash@~4.16.4:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.4.tgz#01ce306b9bad1319f2a5528674f88297aeb70127"
 
@@ -3914,17 +3914,17 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
-  dependencies:
-    js-tokens "^3.0.0"
-
-loose-envify@^1.1.0, loose-envify@^1.2.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.2.0.tgz#69a65aad3de542cf4ee0f4fe74e8e33c709ccb0f"
   dependencies:
     js-tokens "^1.0.1"
+
+loose-envify@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
This commit fixed following warnings.

SEE release of emojione-picker https://github.com/tommoor/emojione-picker/releases

`searchPlaceholder` props is supported after v2.1.0 but mastodon depend on v2.0.1. so upgrade it.

```
warning.js:36 Warning: Unknown prop `searchPlaceholder` on <div> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in div (created by Picker)
    in Picker (created by EmojiPickerDropdown)
    in div (created by DropdownContent)
    in DropdownContent (created by EmojiPickerDropdown)
    in div (created by Dropdown)
    in Dropdown (created by EmojiPickerDropdown)
    in EmojiPickerDropdown (created by InjectIntl(EmojiPickerDropdown))
    in InjectIntl(EmojiPickerDropdown) (created by ComposeForm)
    in div (created by ComposeForm)
    in div (created by ComposeForm)
    in ComposeForm (created by InjectIntl(ComposeForm))
    in InjectIntl(ComposeForm) (created by Connect(InjectIntl(ComposeForm)))
    in Connect(InjectIntl(ComposeForm)) (created by Compose)
    in div (created by Compose)
    in div (created by Compose)
    in div (created by Compose)
    in Compose (created by InjectIntl(Compose))
    in InjectIntl(Compose) (created by Connect(InjectIntl(Compose)))
    in Connect(InjectIntl(Compose)) (created by UI)
    in div (created by ColumnsArea)
    in ColumnsArea (created by UI)
    in div (created by UI)
    in UI (created by Connect(UI))
    in Connect(UI) (created by RouterContext)
    in RouterContext (created by Router)
    in ScrollBehaviorContext (created by Router)
    in Router (created by Mastodon)
    in Provider (created by Mastodon)
    in IntlProvider (created by Mastodon)
    in Mastodon
```