### PR TITLE
Fix character images' sizing to make it robust

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1260,7 +1260,7 @@ a.status__content__spoiler-link {
 .getting-started {
   box-sizing: border-box;
   padding-bottom: 235px;
-  background: image-url('mastodon-getting-started.png') no-repeat 0 100% local;
+  background: image-url('mastodon-getting-started.png') no-repeat 0 100%/contain local;
   flex: 1 0 auto;
 
   p {
@@ -2189,7 +2189,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .onboarding-modal__page-one__elephant-friend {
-  background: image-url('elephant-friend.png') no-repeat 0 0;
+  background: image-url('elephant-friend.png') no-repeat center center/contain;
   width: 147px;
   height: 160px;
   margin-right: 10px;


### PR DESCRIPTION
When I tried to theme my instance, I found that the image at bottom right got misaligned if we use different sized images from original ones, like the following.

<img width="511" alt="screen shot 2017-04-23 at 1 13 27 am" src="https://cloud.githubusercontent.com/assets/1580772/25306132/257aad1c-27c2-11e7-8386-b75c94741b45.png">

This PR make it cool for other sizes.

<img width="514" alt="screen shot 2017-04-23 at 1 13 47 am" src="https://cloud.githubusercontent.com/assets/1580772/25306140/6024b386-27c2-11e7-9f04-6f6154842eff.png">

The same issue happens for the onboarding modal, so I will fixed it as well.

**Before:**
<img width="568" alt="screen shot 2017-04-23 at 12 54 30 am" src="https://cloud.githubusercontent.com/assets/1580772/25306150/931b10be-27c2-11e7-974c-31689c20e634.png">

**After:**
<img width="580" alt="screen shot 2017-04-23 at 12 55 02 am" src="https://cloud.githubusercontent.com/assets/1580772/25306155/aa9a3292-27c2-11e7-98d1-49328fd6575f.png">
