### PR TITLE
fixed error of Uncaught ReferenceError: outerStyle is not defined

### DIFF
--- a/app/assets/javascripts/components/features/ui/components/column_link.jsx
+++ b/app/assets/javascripts/components/features/ui/components/column_link.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 const ColumnLink = ({ icon, text, to, href, method, hideOnMobile }) => {
   if (href) {
     return (
-      <a href={href} style={outerStyle} className={`column-link ${hideOnMobile ? 'hidden-on-mobile' : ''}`} data-method={method}>
+      <a href={href} className={`column-link ${hideOnMobile ? 'hidden-on-mobile' : ''}`} data-method={method}>
         <i className={`fa fa-fw fa-${icon} column-link__icon`} />
         {text}
       </a>


### PR DESCRIPTION
This fix error followings:

```
components.self-b903296….js?body=1:13765 Uncaught ReferenceError: outerStyle is not defined
    at ColumnLink (components.self-b903296….js?body=1:13765)
    at components.self-b903296….js?body=1:52271
    at measureLifeCyclePerf (components.self-b903296….js?body=1:52040)
    at ReactCompositeComponentWrapper._constructComponentWithoutOwner (components.self-b903296….js?body=1:52270)
    at ReactCompositeComponentWrapper._constructComponent (components.self-b903296….js?body=1:52245)
    at ReactCompositeComponentWrapper.mountComponent (components.self-b903296….js?body=1:52153)
    at Object.mountComponent (components.self-b903296….js?body=1:59023)
    at ReactDOMComponent.mountChildren (components.self-b903296….js?body=1:57910)
    at ReactDOMComponent._createInitialChildren (components.self-b903296….js?body=1:53675)
    at ReactDOMComponent.mountComponent (components.self-b903296….js?body=1:53494)
```

It maybe started by #2338
