### PR TITLE
Export .env.vagrant before Vagrant provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,6 +63,7 @@ bundle install
 yarn install
 
 # Build Mastodon
+export $(cat ".env.vagrant" | xargs)
 bundle exec rails db:setup
 bundle exec rails assets:precompile
 


### PR DESCRIPTION
Fixes an issue where LOCAL_DOMAIN is not set, causing the database seeds to create the admin user as `admin@localhost:3000` instead of `admin@mastodon.dev` (or the other custom domain set by developer).