### PR TITLE
Fixed only 7/8 emoji being displayed in a row in the emoji picker

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -2064,7 +2064,7 @@ button.icon-button.active i.fa-retweet {
 
     .emoji {
       display: inline-block;
-      padding: 5px;
+      padding: 2.5px;
       border-radius: 4px;
     }
   }


### PR DESCRIPTION
This fixes #1921. The [emojione-picker](https://github.com/tommoor/emojione-picker) has 8 emoji on a line, but Mastodon's css only shows 7 of these. By lowering the padding between emoji I managed to fit all of them on a line.

**Before:**

![before](https://cloud.githubusercontent.com/assets/13566135/25310898/096a5964-2845-11e7-96b8-19d0bbc9a6bb.png)

**After:**

![after](https://cloud.githubusercontent.com/assets/13566135/25310899/124e8532-2845-11e7-8653-5f3078529a5e.png)
