### PR TITLE
Allow webfinger controller to reply to user@WEB_DOMAIN in addition to…

### DIFF
--- a/app/lib/webfinger_resource.rb
+++ b/app/lib/webfinger_resource.rb
@@ -61,6 +61,6 @@ class WebfingerResource
   end
 
   def domain_matches_local?
-    TagManager.instance.local_domain?(local_domain)
+    TagManager.instance.local_domain?(local_domain) || TagManager.instance.web_domain?(local_domain)
   end
 end


### PR DESCRIPTION
… user@LOCAL_DOMAIN

This provides a hotfix for outbound salmon requests to other Mastodon instances
as they currently will try to resovle user@WEB_DOMAIN instead of user@LOCAL_DOMAIN
(see #2012 and #20312).

Furthermore, this should ease transition from users switching from
LOCAL_DOMAIN = WEB_DOMAIN to another LOCAL_DOMAIN when WEB_DOMAIN does not change.