### PR TITLE
Filter on allowed user language preferences

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -326,3 +326,10 @@ code {
     flex: 0 0 auto;
   }
 }
+
+.user_allowed_languages {
+  li {
+    float: left;
+    width: 50%;
+  }
+}

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -25,7 +25,8 @@ class Settings::PreferencesController < ApplicationController
 
   def user_params
     params.require(:user).permit(
-      :locale
+      :locale,
+      allowed_languages: []
     )
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -82,6 +82,10 @@ class Account < ApplicationRecord
     prefix: true,
     allow_nil: true
 
+  delegate :allowed_languages,
+    to: :user,
+    prefix: false
+
   def follow!(other_account)
     active_relationships.where(target_account: other_account).first_or_create!(target_account: other_account)
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -82,9 +82,7 @@ class Account < ApplicationRecord
     prefix: true,
     allow_nil: true
 
-  delegate :allowed_languages,
-    to: :user,
-    prefix: false
+  delegate :allowed_languages, to: :user, prefix: false, allow_nil: true
 
   def follow!(other_account)
     active_relationships.where(target_account: other_account).first_or_create!(target_account: other_account)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -119,6 +119,10 @@ class Status < ApplicationRecord
   end
 
   class << self
+    def in_allowed_languages(account)
+      where(language: account.allowed_languages)
+    end
+
     def as_home_timeline(account)
       where(account: [account] + account.following)
     end
@@ -198,6 +202,7 @@ class Status < ApplicationRecord
 
     def filter_timeline_for_account(query, account)
       query = query.not_excluded_by_account(account)
+      query = query.in_allowed_languages(account.user)
       query.merge(account_silencing_filter(account))
     end
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -202,7 +202,7 @@ class Status < ApplicationRecord
 
     def filter_timeline_for_account(query, account)
       query = query.not_excluded_by_account(account)
-      query = query.in_allowed_languages(account.user)
+      query = query.in_allowed_languages(account) if account.allowed_languages.present?
       query.merge(account_silencing_filter(account))
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,10 @@ class User < ApplicationRecord
   scope :admins,    -> { where(admin: true) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
 
+  def allowed_languages
+    ['en', 'es']
+  end
+
   def confirmed?
     confirmed_at.present?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,10 +19,6 @@ class User < ApplicationRecord
   scope :admins,    -> { where(admin: true) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
 
-  def allowed_languages
-    ['en', 'es']
-  end
-
   def confirmed?
     confirmed_at.present?
   end

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -7,6 +7,16 @@
   .fields-group
     = f.input :locale, collection: I18n.available_locales, wrapper: :with_label, include_blank: false, label_method: lambda { |locale| human_locale(locale) }
 
+    = f.input :allowed_languages,
+      collection: I18n.available_locales,
+      wrapper: :with_label,
+      include_blank: false,
+      label_method: lambda { |locale| human_locale(locale) },
+      required: false,
+      as: :check_boxes,
+      collection_wrapper_tag: 'ul',
+      item_wrapper_tag: 'li'
+
     = f.input :setting_default_privacy, collection: Status.visibilities.keys - ['direct'], wrapper: :with_label, include_blank: false, label_method: lambda { |visibility| safe_join([I18n.t("statuses.visibilities.#{visibility}"), content_tag(:span, I18n.t("statuses.visibilities.#{visibility}_long"), class: 'hint')]) }, required: false, as: :radio_buttons, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
 
   .fields-group

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -12,6 +12,8 @@ en:
         data: CSV file exported from another Mastodon instance
       sessions:
         otp: Enter the Two-factor code from your phone or use one of your recovery codes.
+      user:
+        allowed_languages: These languages will be allowed in your public timelines. Languages that are not selected will be filtered out.
     labels:
       defaults:
         avatar: Avatar

--- a/db/migrate/20170423005413_add_allowed_languages_to_user.rb
+++ b/db/migrate/20170423005413_add_allowed_languages_to_user.rb
@@ -1,6 +1,6 @@
 class AddAllowedLanguagesToUser < ActiveRecord::Migration[5.0]
   def change
-    add_column :users, :allowed_languages, :string, array: true
+    add_column :users, :allowed_languages, :string, array: true, default: [], null: false
     add_index :users, :allowed_languages, using: :gin
   end
 end

--- a/db/migrate/20170423005413_add_allowed_languages_to_user.rb
+++ b/db/migrate/20170423005413_add_allowed_languages_to_user.rb
@@ -1,0 +1,6 @@
+class AddAllowedLanguagesToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :allowed_languages, :string, array: true
+    add_index :users, :allowed_languages, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,7 +326,9 @@ ActiveRecord::Schema.define(version: 20170425202925) do
     t.boolean  "otp_required_for_login"
     t.datetime "last_emailed_at"
     t.string   "otp_backup_codes",                                       array: true
+    t.string   "allowed_languages",                                      array: true
     t.index ["account_id"], name: "index_users_on_account_id", using: :btree
+    t.index ["allowed_languages"], name: "index_users_on_allowed_languages", using: :gin
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,7 +326,7 @@ ActiveRecord::Schema.define(version: 20170425202925) do
     t.boolean  "otp_required_for_login"
     t.datetime "last_emailed_at"
     t.string   "otp_backup_codes",                                       array: true
-    t.string   "allowed_languages",                                      array: true
+    t.string   "allowed_languages",         default: [],    null: false, array: true
     t.index ["account_id"], name: "index_users_on_account_id", using: :btree
     t.index ["allowed_languages"], name: "index_users_on_allowed_languages", using: :gin
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/spec/controllers/settings/preferences_controller_spec.rb
+++ b/spec/controllers/settings/preferences_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Settings::PreferencesController do
   render_views
 
-  let(:user) { Fabricate(:user) }
+  let(:user) { Fabricate(:user, allowed_languages: []) }
 
   before do
     sign_in user, scope: :user
@@ -18,10 +18,12 @@ describe Settings::PreferencesController do
 
   describe 'PUT #update' do
     it 'updates the user record' do
-      put :update, params: { user: { locale: 'en' } }
+      put :update, params: { user: { locale: 'en', allowed_languages: ['es', 'fr'] } }
 
       expect(response).to redirect_to(settings_preferences_path)
-      expect(user.reload.locale).to eq 'en'
+      user.reload
+      expect(user.locale).to eq 'en'
+      expect(user.allowed_languages).to eq ['es', 'fr']
     end
 
     it 'updates user settings' do

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -251,6 +251,31 @@ RSpec.describe Status, type: :model do
         expect(results).not_to include(muted_status)
       end
 
+      context 'with language preferences' do
+        it 'excludes statuses in languages not allowed by the account user' do
+          user = Fabricate(:user, allowed_languages: [:en, :es])
+          @account.update(user: user)
+          en_status = Fabricate(:status, language: 'en')
+          es_status = Fabricate(:status, language: 'es')
+          fr_status = Fabricate(:status, language: 'fr')
+
+          results = Status.as_public_timeline(@account)
+          expect(results).to include(en_status)
+          expect(results).to include(es_status)
+          expect(results).not_to include(fr_status)
+        end
+
+        it 'includes all languages when account does not have a user' do
+          expect(@account.user).to be_nil
+          en_status = Fabricate(:status, language: 'en')
+          es_status = Fabricate(:status, language: 'es')
+
+          results = Status.as_public_timeline(@account)
+          expect(results).to include(en_status)
+          expect(results).to include(es_status)
+        end
+      end
+
       context 'where that account is silenced' do
         it 'includes statuses from other accounts that are silenced' do
           @account.update(silenced: true)


### PR DESCRIPTION
Related to https://github.com/tootsuite/mastodon/issues/691

This adds an `allowed_languages` array column to `User` which is meant to hold the iso codes for languages that user wants to see in their feed.

The prefs screen gets a list like this:

![screen shot 2017-04-28 at 11 29 44 am](https://cloud.githubusercontent.com/assets/225/25536054/46ddee12-2c07-11e7-98bc-174c6e00f3ec.png)


Once the options are selected, there's a new filter that gets added to the timelines.

The Home timeline is not changed at all ... it makes sense to me that if you have chosen to follow someone you see all of their statuses regardless of which language they are posting in. The local and federated timelines are both filtered using language, so that you only see statuses that have a language which in the list you have selected.

Feedback I'm looking for:

- Are there other places we need to filter this beyond just those few places in the timeline creation?
- I don't think there are any federation concerns here ... everything will still be sent and received as before, this is purely a filter on what a person sees in their timeline, not on what their instance receives. If account X on instance B creates only `es` statuses, and is followed by account Y on instance A, instance A will continue to receive all their statuses. Account Y will see those statuses in their home timeline (and in others, if they have `es` turned on), but if no other users on instance A are allowing `es` into their feed, they just won't see those. If they turned `es` back on and refreshed their feed, they would immediately see what had previously been hidden.
- Performance concerns?

Also, this is not directly related to adding the filter, but will be relevant to how it actually works --
 statuses that get posted which are only a URL with no surrounding text will currently get created as either the locale selected by the person who created them, or as the instance default wherever they came from. This means that on the filtering side, users will only see URL-only statuses created by people who have selected a locale which is a language they allow through. This is *probably* ok, but I could be persuaded in either direction on it. We might also want to reconsider whether setting a locale at all on URL-only statuses makes sense? ... or we might want to just strip all URLs out of statuses when we choose their language?
