### PR TITLE
Fixes problem with showing non-local accounts.

### DIFF
--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -77,8 +77,9 @@
   - else
     = link_to t('admin.accounts.silence'), admin_account_silence_path(@account.id), method: :post, class: 'button'
 
-  - unless @account.user.confirmed?
-    = link_to t('admin.accounts.confirm'), admin_account_confirmation_path(@account.id), method: :post, class: 'button'
+  - if @account.local?
+    - unless @account.user.confirmed?
+      = link_to t('admin.accounts.confirm'), admin_account_confirmation_path(@account.id), method: :post, class: 'button'
 
   - if @account.suspended?
     = link_to t('admin.accounts.undo_suspension'), admin_account_suspension_path(@account.id), method: :delete, class: 'button'


### PR DESCRIPTION
Apologies for introducing this bug in #2245. I know I can short-circuit with `&&` to avoid the nested conditional statement but I felt being more explicit would be better. Happy to amend.

Fixes #2366.