### PR TITLE
Simplify browserify+babelify config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -72,7 +72,8 @@ module Mastodon
     config.middleware.use Rack::Attack
     config.middleware.use Rack::Deflater
 
-    config.browserify_rails.commandline_options   = '--transform [ babelify --presets [ es2015 react ] --plugins [ transform-decorators-legacy ] ] --extension=".jsx"'
+    # babel config can be found in .babelrc
+    config.browserify_rails.commandline_options   = '--transform babelify --extension=".jsx"'
     config.browserify_rails.evaluate_node_modules = true
 
     config.to_prepare do


### PR DESCRIPTION
AFAICT these command-line options are completely ignored by babel/babelify. Since there is a `.babelrc` file, this takes precedence and so there's no need to pass in any arguments here.

The CLI config here is subtly different from the `.babelrc` config and thus could also be a source of confusion.