### PR TITLE
Return force_ssl to the controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  force_ssl if: :https_enabled?
+
   include Localized
 
   helper_method :current_account
@@ -23,6 +25,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def https_enabled?
+    Rails.env.production? && ENV['LOCAL_HTTPS'] == 'true'
+  end
 
   def store_current_location
     store_location_for(:user, request.url)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,14 +35,6 @@ Rails.application.configure do
   # Allow to specify public IP of reverse proxy if it's needed
   config.action_dispatch.trusted_proxies = [IPAddr.new(ENV['TRUSTED_PROXY_IP'])] unless ENV['TRUSTED_PROXY_IP'].blank?
 
-  # When LOCAL_HTTPS is set, force traffic over SSL
-  config.force_ssl = (ENV['LOCAL_HTTPS'] == 'true')
-
-  # When ENABLE_HSTS is also set, turn on Strict-Transport-Security
-  config.ssl_options = {
-    hsts: (ENV['ENABLE_HSTS'] == 'true')
-  }
-
   # By default, use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info').to_sym


### PR DESCRIPTION
I apologize for the churn on this.

This change a few days ago - https://github.com/tootsuite/mastodon/pull/2165 - made it easier/possible to have rails enable hsts in apps. I didn't think through how that might interact with webserver configurations that had good reasons to either want to own that themselves, or want to opt in/out more granularly.

This issue raised that objection - https://github.com/tootsuite/mastodon/issues/2356 - which I fixed partially here - https://github.com/tootsuite/mastodon/pull/2364 - by making it optional.

Unfortunately, the "opt out" option here will had the effect of adding headers to responses, and if they are benign most of the time, I do think it's a reasonable request to not have things like that which force control of something that might be better handled elsewhere into the main app ... and rails doesn't have an option where you can use the  config version (as opposed to controller method version) of `force_ssl` which does not add any HSTS headers to requests.

In any case, this change effectively winds the whole thing back to how it was prior to my changes! I might take a future crack at this, but I'm not sure it's possible to get the opt-in improvements w/out potentially undesirable side effects.
