### PR TITLE
Add additional documentation and warnings to the WEB_DOMAIN setting.

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -13,12 +13,8 @@ LOCAL_DOMAIN=example.com
 LOCAL_HTTPS=true
 
 # Use this only if you need to run mastodon on a different domain than the one used for federation.
-# When used, LOCAL_DOMAIN should serve a /.well-known/host-meta directing webfinger requests to WEB_DOMAIN.
-# Do *not* change LOCAL_DOMAIN once WEB_DOMAIN is set or if WEB_DOMAIN is set to a previous LOCAL_DOMAIN value,
-# as that would create *different accounts* (@user@LOCAL_DOMAIN and @user@WEB_DOMAIN) on remote server
-# with conflicting identifiers (https://WEB_DOMAIN/users/user), and *will* break federation for
-# previously-defined users!
-# Do *not* use this unless you know *exactly* what you are doing.
+# You can read more about this option on https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Serving_a_different_domain.md
+# DO *NOT* USE THIS UNLESS YOU KNOW *EXACTLY* WHAT YOU ARE DOING.
 # WEB_DOMAIN=mastodon.example.com
 
 # Application secrets

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -13,7 +13,12 @@ LOCAL_DOMAIN=example.com
 LOCAL_HTTPS=true
 
 # Use this only if you need to run mastodon on a different domain than the one used for federation.
-# Do not use this unless you know exactly what you are doing.
+# When used, LOCAL_DOMAIN should serve a /.well-known/host-meta directing webfinger requests to WEB_DOMAIN.
+# Do *not* change LOCAL_DOMAIN once WEB_DOMAIN is set or if WEB_DOMAIN is set to a previous LOCAL_DOMAIN value,
+# as that would create *different accounts* (@user@LOCAL_DOMAIN and @user@WEB_DOMAIN) on remote server
+# with conflicting identifiers (https://WEB_DOMAIN/users/user), and *will* break federation for
+# previously-defined users!
+# Do *not* use this unless you know *exactly* what you are doing.
 # WEB_DOMAIN=mastodon.example.com
 
 # Application secrets


### PR DESCRIPTION
This feature is largely undocumented, and quite a number of users have
shot them in the feet already despite the warning (e.g. #2375). Added a bit of documentation
and expanded the warning until we have a mechanism for dealing with conflicting
user URIs.