### PR TITLE
Count number of characters, not bytes, in bios/display names

### DIFF
--- a/app/assets/javascripts/extras.jsx
+++ b/app/assets/javascripts/extras.jsx
@@ -40,9 +40,11 @@ $(() => {
 
   // used on /settings/profile
   $('.account_display_name').on('input', e => {
-    $('.name-counter').text(30 - $(e.target).val().length)
+    // Count number of unicode characters, not bytes.
+    $('.name-counter').text(30 - [...$(e.target).val()].length)
   });
   $('.account_note').on('input', e => {
-    $('.note-counter').text(160 - $(e.target).val().length)
+    // Count number of unicode characters, not bytes.
+    $('.note-counter').text(160 - [...$(e.target).val()].length)
   });
 });


### PR DESCRIPTION
I got this solution (using the spread operator to count array length) [from this post](https://mathiasbynens.be/notes/javascript-unicode) but I'm open to suggestions. I see the character count for posts [uses this approach](https://github.com/tootsuite/mastodon/blob/cf845fed3824d3e3587ce9b2ad752c2b3f0a2a76/app/assets/javascripts/components/features/compose/components/character_counter.jsx#L13) so let me know if you'd like it changed.

Fixes https://github.com/tootsuite/mastodon/issues/2156