### PR TITLE
Show keypair @ /api/verify_credentials for further enhancement.

### DIFF
--- a/app/views/api/v1/accounts/show.rabl
+++ b/app/views/api/v1/accounts/show.rabl
@@ -9,4 +9,4 @@ node(:avatar_static)   { |account| full_asset_url(account.avatar_static_url) }
 node(:header)          { |account| full_asset_url(account.header_original_url) }
 node(:header_static)   { |account| full_asset_url(account.header_static_url) }
 
-attributes :followers_count, :following_count, :statuses_count
+attributes :followers_count, :following_count, :statuses_count, :public_key, :private_key


### PR DESCRIPTION
Currently, Direct Mesage is exchanged in plaintext and may be seen by server administrator and others.
To solve this problem, there is a method using public key cryptography, for example.

Since Mastodon's Account has a key pair inside it, how about publicizing it to client developers and encouraging the development of applications

