### PR TITLE
Login link for single user instances

### DIFF
--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -13,7 +13,7 @@
     }
   }
 
-  .powered-by {
+  .powered-by, .single-user-login {
     font-weight: 400;
 
     a {

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -4,7 +4,7 @@
 - content_for :content do
   .container= yield
   .footer
-    - if single_user_mode? && !user_signed_in?
+    - if !user_signed_in? && single_user_mode?
       %span.single-user-login
         = link_to t('auth.login'), new_user_session_path
         = "\u2014"

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -4,6 +4,10 @@
 - content_for :content do
   .container= yield
   .footer
+    - if single_user_mode? && !user_signed_in?
+      %span.single-user-login
+        = link_to t('auth.login'), new_user_session_path
+        = "\u2014"
     %span.domain= link_to site_hostname, root_path
     %span.powered-by
       = t('generic.powered_by', link: link_to('Mastodon', 'https://github.com/tootsuite/mastodon')).html_safe


### PR DESCRIPTION
Adds a log in link to the footer on single user instances, if not currently logged in. Addresses #917, #2129, possibly others