### PR TITLE
Add index to statuses_tags#status_id

### DIFF
--- a/db/migrate/20170424112722_add_status_id_index_to_statuses_tags.rb
+++ b/db/migrate/20170424112722_add_status_id_index_to_statuses_tags.rb
@@ -1,0 +1,5 @@
+class AddStatusIdIndexToStatusesTags < ActiveRecord::Migration[5.0]
+  def change
+    add_index :statuses_tags, :status_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170418160728) do
+ActiveRecord::Schema.define(version: 20170424112722) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -255,6 +255,7 @@ ActiveRecord::Schema.define(version: 20170418160728) do
   create_table "statuses_tags", id: false, force: :cascade do |t|
     t.bigint  "status_id", null: false
     t.integer "tag_id",    null: false
+    t.index ["status_id"], name: "index_statuses_tags_on_status_id", using: :btree
     t.index ["tag_id", "status_id"], name: "index_statuses_tags_on_tag_id_and_status_id", unique: true, using: :btree
   end
 


### PR DESCRIPTION
Optimized statuses_tags.

```
# pawoo.net
./bin/rails c production
$ class StatusesTag < ApplicationRecord; end
$ StatusesTag.count 
#=> 276146
```

```
EXPLAIN ANALYZE SELECT "statuses_tags".* FROM "statuses_tags"."status_id" IN (938537, 576666, 295882, 221478);

**before**
 Seq Scan on statuses_tags  (cost=0.00..5826.19 rows=11 width=12) (actual time=30.804..30.804 rows=0 loops=1)
   Filter: (status_id = ANY ('{938537,576666,295882,221478}'::bigint[]))
   Rows Removed by Filter: 276146
 Planning time: 110.067 ms
 Execution time: 30.880 ms
(5 rows)


**after**
 Index Scan using index_statuses_tags_on_status_id on statuses_tags  (cost=0.42..21.91 rows=11 width=12) (actual time=0.053..0.053 rows=0 loops=1)
   Index Cond: (status_id = ANY ('{938537,576666,295882,221478}'::bigint[]))
 Planning time: 0.199 ms
 Execution time: 0.087 ms
(4 rows)
```