### PR TITLE
add Mathjax support in your toots to enjoy pretty mathematical formulae in toots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem 'react-rails'
 gem 'browserify-rails'
 gem 'autoprefixer-rails'
 
+gem 'mathjax-rails'
+
 group :development, :test do
   gem 'rspec-rails'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,8 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    mathjax-rails (2.6.1)
+      railties (>= 3.0)
     method_source (0.8.2)
     microformats2 (2.1.0)
       activesupport
@@ -501,6 +503,7 @@ DEPENDENCIES
   letter_opener_web
   link_header
   lograge
+  mathjax-rails
   microformats2
   nokogiri
   oj

--- a/app/views/layouts/_mathjax.html
+++ b/app/views/layouts/_mathjax.html
@@ -1,0 +1,9 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+     tex2jax: {
+       inlineMath: [ ['$','$'] ],
+       skipTags: ["script","noscript","style","textarea","pre","code","annotation","annotation-xml","p"],
+       processEscapes: true
+     }
+    });
+</script>

--- a/app/views/layouts/_setinterval.html
+++ b/app/views/layouts/_setinterval.html
@@ -1,0 +1,7 @@
+<script type="text/javascript">
+    window.setInterval( function() { 
+      $('div.status__content p:contains("#math")').addClass('tex2jax_process');
+      $('div.status__content p:contains("#math")').siblings().addClass('tex2jax_process');
+      MathJax.Hub.Queue(["Typeset",MathJax.Hub]); 
+    }, 5000 ) ;
+</script>

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -22,8 +22,12 @@
     = csrf_meta_tags
 
     = yield :header_tags
+    = render 'layouts/mathjax'
+    = mathjax_tag
+    = render 'layouts/setinterval'
 
   - body_classes ||= @body_classes
 
   %body{ class: body_classes }
     = content_for?(:content) ? yield(:content) : yield
+

--- a/app/views/layouts/embedded.html.haml
+++ b/app/views/layouts/embedded.html.haml
@@ -4,5 +4,8 @@
     %meta{:charset => 'utf-8'}/
     = stylesheet_link_tag 'application', media: 'all'
     = javascript_include_tag 'application_public', integrity: true, crossorigin: 'anonymous'
+    = render 'layouts/mathjax'
+    = mathjax_tag
+    = render 'layouts/setinterval'
   %body.embed
     = yield

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -1,5 +1,8 @@
 - content_for :header_tags do
   = javascript_include_tag 'application_public', integrity: true, crossorigin: 'anonymous'
+  = render 'layouts/mathjax'
+  = mathjax_tag
+  = render 'layouts/setinterval'
 
 - content_for :content do
   .container= yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  mathjax 'mathjax'
   mount LetterOpenerWeb::Engine, at: 'letter_opener' if Rails.env.development?
 
   authenticate :user, lambda { |u| u.admin? } do
@@ -191,4 +192,7 @@ Rails.application.routes.draw do
     via: :all,
     to: 'application#raise_not_found',
     format: false
+
 end
+
+


### PR DESCRIPTION
Using 'mathjax-rails' gem, every mastodon toots can contain beautiful mathematical formulae inside.
This PR has some of small codes to include mathjax-rails gem and apply that only when you write #math hashtag in your toots. I used setInterval() javascript to make new #math toots rendered periodically. 

Example screenshot:
https://m.okadajp.org/system/media_attachments/files/000/000/065/original/ba49c476fce42601.png?1492705908

One of Japanese mastodon community enjoyed this feature so much. They even innovated many new smileys using mathematical signs and fonts. The ideas of this PR were given from @EzoeRyou@friends.nico , @h_okumura@mstdn.jp , and other many community members.
