### PR TITLE
FIX: add `patch` method support to CORS

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -64,7 +64,7 @@ module Mastodon
       allow do
         origins  '*'
 
-        resource '/api/*',       headers: :any, methods: [:post, :put, :delete, :get, :options], credentials: false, expose: ['Link', 'X-RateLimit-Reset', 'X-RateLimit-Limit', 'X-RateLimit-Remaining', 'X-Request-Id']
+        resource '/api/*',       headers: :any, methods: [:post, :put, :delete, :get, :patch, :options], credentials: false, expose: ['Link', 'X-RateLimit-Reset', 'X-RateLimit-Limit', 'X-RateLimit-Remaining', 'X-Request-Id']
         resource '/oauth/token', headers: :any, methods: [:post], credentials: false
       end
     end


### PR DESCRIPTION
`/api/v1/accounts/update_credentials` requires `PATCH` request.
But App's Rack::CORS setting lacked `PATCH` method.
