### PR TITLE
Only show upload modal when drag event contains files

### DIFF
--- a/app/assets/javascripts/components/features/ui/components/upload_area.jsx
+++ b/app/assets/javascripts/components/features/ui/components/upload_area.jsx
@@ -4,6 +4,34 @@ import { FormattedMessage } from 'react-intl';
 
 class UploadArea extends React.PureComponent {
 
+  constructor (props, context) {
+    super(props, context);
+
+    this.handleKeyUp = this.handleKeyUp.bind(this);
+  }
+
+  handleKeyUp (e) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const keyCode = e.keyCode
+    if (this.props.active) {
+      switch(keyCode) {
+      case 27:
+        this.props.onClose();
+        break;
+      }
+    }
+  }
+
+  componentDidMount () {
+    window.addEventListener('keyup', this.handleKeyUp, false);
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('keyup', this.handleKeyUp);
+  }
+
   render () {
     const { active } = this.props;
 
@@ -24,7 +52,8 @@ class UploadArea extends React.PureComponent {
 }
 
 UploadArea.propTypes = {
-  active: PropTypes.bool
+  active: PropTypes.bool,
+  onClose: PropTypes.func
 };
 
 export default UploadArea;

--- a/app/assets/javascripts/components/features/ui/index.jsx
+++ b/app/assets/javascripts/components/features/ui/index.jsx
@@ -48,7 +48,7 @@ class UI extends React.PureComponent {
       this.dragTargets.push(e.target);
     }
 
-    if (e.dataTransfer && e.dataTransfer.items.length > 0 && e.dataTransfer.types.includes('Files')) {
+    if (e.dataTransfer && e.dataTransfer.types.includes('Files')) {
       this.setState({ draggingOver: true });
     }
   }

--- a/app/assets/javascripts/components/features/ui/index.jsx
+++ b/app/assets/javascripts/components/features/ui/index.jsx
@@ -28,6 +28,7 @@ class UI extends React.PureComponent {
     this.handleDragOver = this.handleDragOver.bind(this);
     this.handleDrop = this.handleDrop.bind(this);
     this.handleDragLeave = this.handleDragLeave.bind(this);
+    this.handleDragEnd = this.handleDragLeave.bind(this)
     this.setRef = this.setRef.bind(this);
   }
 
@@ -94,6 +95,7 @@ class UI extends React.PureComponent {
     document.addEventListener('dragover', this.handleDragOver, false);
     document.addEventListener('drop', this.handleDrop, false);
     document.addEventListener('dragleave', this.handleDragLeave, false);
+    document.addEventListener('dragend', this.handleDragEnd, false);
 
     this.props.dispatch(refreshTimeline('home'));
     this.props.dispatch(refreshNotifications());
@@ -105,6 +107,7 @@ class UI extends React.PureComponent {
     document.removeEventListener('dragover', this.handleDragOver);
     document.removeEventListener('drop', this.handleDrop);
     document.removeEventListener('dragleave', this.handleDragLeave);
+    document.removeEventListener('dragend', this.handleDragEnd);
   }
 
   setRef (c) {

--- a/app/assets/javascripts/components/features/ui/index.jsx
+++ b/app/assets/javascripts/components/features/ui/index.jsx
@@ -29,6 +29,7 @@ class UI extends React.PureComponent {
     this.handleDrop = this.handleDrop.bind(this);
     this.handleDragLeave = this.handleDragLeave.bind(this);
     this.handleDragEnd = this.handleDragLeave.bind(this)
+    this.closeUploadModal = this.closeUploadModal.bind(this)
     this.setRef = this.setRef.bind(this);
   }
 
@@ -89,6 +90,10 @@ class UI extends React.PureComponent {
     this.setState({ draggingOver: false });
   }
 
+  closeUploadModal() {
+    this.setState({ draggingOver: false });
+  }
+
   componentWillMount () {
     window.addEventListener('resize', this.handleResize, { passive: true });
     document.addEventListener('dragenter', this.handleDragEnter, false);
@@ -146,7 +151,7 @@ class UI extends React.PureComponent {
         <NotificationsContainer />
         <LoadingBarContainer className="loading-bar" />
         <ModalContainer />
-        <UploadArea active={draggingOver} />
+        <UploadArea active={draggingOver} onClose={this.closeUploadModal} />
       </div>
     );
   }

--- a/app/assets/javascripts/components/features/ui/index.jsx
+++ b/app/assets/javascripts/components/features/ui/index.jsx
@@ -47,7 +47,7 @@ class UI extends React.PureComponent {
       this.dragTargets.push(e.target);
     }
 
-    if (e.dataTransfer && e.dataTransfer.items.length > 0) {
+    if (e.dataTransfer && e.dataTransfer.items.length > 0 && e.dataTransfer.types.includes('Files')) {
       this.setState({ draggingOver: true });
     }
   }


### PR DESCRIPTION
Four things here:

1. Fix bug where drag and drop modal isn't dismissed by adding another listener for drag end in addition to drag leave. #687 
2. Only show drag and drop when the dragged item types includes the type of "Files"
3. Removed what I believe is [cruft](https://github.com/tootsuite/mastodon/commit/60ebfa182f944d5803dd6f3d54aa5e9ef24fc922#diff-f3470e6c23e34cc46d6515588f972e8dR50) of the `e.dataTransfer.items.length > 0`. My guess is that this was intended to check if the drag item was a file, but this triggers whenever anything is dragged. If this needs to stay for another reason, lmk and I will add it back. [original commit](https://github.com/tootsuite/mastodon/commit/60ebfa182f944d5803dd6f3d54aa5e9ef24fc922#diff-f3470e6c23e34cc46d6515588f972e8dR50) @Gargron 
4. Add a key listener to the upload modal and, when modal is active, call close function prop when keyCode 27 is hit. (note, using keyCode is more robust than key for key listeners, because Safari does NOT use `e.key`. Instead it using `keyIdentifier` and then, in the case of 'Escape', it is not the same as Chrome or Firefox. [this doesn't work in safari](https://github.com/tootsuite/mastodon/commit/60ebfa182f944d5803dd6f3d54aa5e9ef24fc922#diff-f041ac60855f075c13c45285756f499bR74) #687 

The reason for change 2 is that I would drag a link which would trigger the modal -- not desirable.

I am able to duplicate the bug 4 is addressing which occurs even with all my other changes in Firefox. In Firefox, open the console. Drag a file into the view area then drag it out _over the console_. This does not dismiss the upload modal, and there's no easy way to get rid of it. Hence, adding the escape key listener.