### PR TITLE
Add rspec to further specify FollowRemoteAccountService

### DIFF
--- a/spec/fixtures/requests/redirected.host-meta.txt
+++ b/spec/fixtures/requests/redirected.host-meta.txt
@@ -1,0 +1,15 @@
+HTTP/1.1 200 OK
+Server: nginx/1.6.2
+Date: Sun, 20 Mar 2016 11:11:00 GMT
+Content-Type: application/xrd+xml
+Transfer-Encoding: chunked
+Connection: keep-alive
+Access-Control-Allow-Origin: *
+Vary: Accept-Encoding,Cookie
+Strict-Transport-Security: max-age=31536000; includeSubdomains;
+
+<?xml version="1.0" encoding="UTF-8"?>
+<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+ <Link rel="lrdd" type="application/jrd+json" template="https://redirected.com/.well-known/webfinger?resource={uri}"/>
+ <Link rel="lrdd" type="application/json" template="https://redirected.com/.well-known/webfinger?resource={uri}"/>
+</XRD>

--- a/spec/fixtures/requests/webfinger-hacker1.txt
+++ b/spec/fixtures/requests/webfinger-hacker1.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Server: nginx/1.6.2
+Date: Sun, 20 Mar 2016 11:13:16 GMT
+Content-Type: application/jrd+json
+Transfer-Encoding: chunked
+Connection: keep-alive
+Access-Control-Allow-Origin: *
+Vary: Accept-Encoding,Cookie
+Strict-Transport-Security: max-age=31536000; includeSubdomains;
+
+{"subject":"acct:gargron@quitter.no","aliases":["https:\/\/quitter.no\/user\/7477","https:\/\/quitter.no\/gargron","https:\/\/quitter.no\/index.php\/user\/7477","https:\/\/quitter.no\/index.php\/gargron"],"links":[{"rel":"http:\/\/webfinger.net\/rel\/profile-page","type":"text\/html","href":"https:\/\/quitter.no\/gargron"},{"rel":"http:\/\/gmpg.org\/xfn\/11","type":"text\/html","href":"https:\/\/quitter.no\/gargron"},{"rel":"describedby","type":"application\/rdf+xml","href":"https:\/\/quitter.no\/gargron\/foaf"},{"rel":"http:\/\/apinamespace.org\/atom","type":"application\/atomsvc+xml","href":"https:\/\/quitter.no\/api\/statusnet\/app\/service\/gargron.xml"},{"rel":"http:\/\/apinamespace.org\/twitter","href":"https:\/\/quitter.no\/api\/"},{"rel":"http:\/\/specs.openid.net\/auth\/2.0\/provider","href":"https:\/\/quitter.no\/gargron"},{"rel":"http:\/\/schemas.google.com\/g\/2010#updates-from","type":"application\/atom+xml","href":"https:\/\/quitter.no\/api\/statuses\/user_timeline\/7477.atom"},{"rel":"magic-public-key","href":"data:application\/magic-public-key,RSA.1ZBkHTavLvxH3FzlKv4O6WtlILKRFfNami3_Rcu8EuogtXSYiS-bB6hElZfUCSHbC4uLemOA34PEhz__CDMozax1iI_t8dzjDnh1x0iFSup7pSfW9iXk_WU3Dm74yWWW2jildY41vWgrEstuQ1dJ8vVFfSJ9T_tO4c-T9y8vDI8=.AQAB"},{"rel":"salmon","href":"https:\/\/hacker.com\/main\/salmon\/user\/7477"},{"rel":"http:\/\/salmon-protocol.org\/ns\/salmon-replies","href":"https:\/\/quitter.no\/main\/salmon\/user\/7477"},{"rel":"http:\/\/salmon-protocol.org\/ns\/salmon-mention","href":"https:\/\/quitter.no\/main\/salmon\/user\/7477"},{"rel":"http:\/\/ostatus.org\/schema\/1.0\/subscribe","template":"https:\/\/quitter.no\/main\/ostatussub?profile={uri}"}]}

--- a/spec/fixtures/requests/webfinger-hacker2.txt
+++ b/spec/fixtures/requests/webfinger-hacker2.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Server: nginx/1.6.2
+Date: Sun, 20 Mar 2016 11:13:16 GMT
+Content-Type: application/jrd+json
+Transfer-Encoding: chunked
+Connection: keep-alive
+Access-Control-Allow-Origin: *
+Vary: Accept-Encoding,Cookie
+Strict-Transport-Security: max-age=31536000; includeSubdomains;
+
+{"subject":"acct:catsrgr8@quitter.no","aliases":["https:\/\/quitter.no\/user\/7477","https:\/\/quitter.no\/gargron","https:\/\/quitter.no\/index.php\/user\/7477","https:\/\/quitter.no\/index.php\/gargron"],"links":[{"rel":"http:\/\/webfinger.net\/rel\/profile-page","type":"text\/html","href":"https:\/\/quitter.no\/gargron"},{"rel":"http:\/\/gmpg.org\/xfn\/11","type":"text\/html","href":"https:\/\/quitter.no\/gargron"},{"rel":"describedby","type":"application\/rdf+xml","href":"https:\/\/quitter.no\/gargron\/foaf"},{"rel":"http:\/\/apinamespace.org\/atom","type":"application\/atomsvc+xml","href":"https:\/\/quitter.no\/api\/statusnet\/app\/service\/gargron.xml"},{"rel":"http:\/\/apinamespace.org\/twitter","href":"https:\/\/quitter.no\/api\/"},{"rel":"http:\/\/specs.openid.net\/auth\/2.0\/provider","href":"https:\/\/quitter.no\/gargron"},{"rel":"http:\/\/schemas.google.com\/g\/2010#updates-from","type":"application\/atom+xml","href":"https:\/\/quitter.no\/api\/statuses\/user_timeline\/7477.atom"},{"rel":"magic-public-key","href":"data:application\/magic-public-key,RSA.1ZBkHTavLvxH3FzlKv4O6WtlILKRFfNami3_Rcu8EuogtXSYiS-bB6hElZfUCSHbC4uLemOA34PEhz__CDMozax1iI_t8dzjDnh1x0iFSup7pSfW9iXk_WU3Dm74yWWW2jildY41vWgrEstuQ1dJ8vVFfSJ9T_tO4c-T9y8vDI8=.AQAB"},{"rel":"salmon","href":"https:\/\/quitter.no\/main\/salmon\/user\/7477"},{"rel":"http:\/\/salmon-protocol.org\/ns\/salmon-replies","href":"https:\/\/quitter.no\/main\/salmon\/user\/7477"},{"rel":"http:\/\/salmon-protocol.org\/ns\/salmon-mention","href":"https:\/\/quitter.no\/main\/salmon\/user\/7477"},{"rel":"http:\/\/ostatus.org\/schema\/1.0\/subscribe","template":"https:\/\/quitter.no\/main\/ostatussub?profile={uri}"}]}

--- a/spec/services/follow_remote_account_service_spec.rb
+++ b/spec/services/follow_remote_account_service_spec.rb
@@ -6,8 +6,12 @@ RSpec.describe FollowRemoteAccountService do
   before do
     stub_request(:get, "https://quitter.no/.well-known/host-meta").to_return(request_fixture('.host-meta.txt'))
     stub_request(:get, "https://example.com/.well-known/webfinger?resource=acct:catsrgr8@example.com").to_return(status: 404)
+    stub_request(:get, "https://redirected.com/.well-known/host-meta").to_return(request_fixture('redirected.host-meta.txt'))
     stub_request(:get, "https://example.com/.well-known/host-meta").to_return(status: 404)
     stub_request(:get, "https://quitter.no/.well-known/webfinger?resource=acct:gargron@quitter.no").to_return(request_fixture('webfinger.txt'))
+    stub_request(:get, "https://redirected.com/.well-known/webfinger?resource=acct:gargron@redirected.com").to_return(request_fixture('webfinger.txt'))
+    stub_request(:get, "https://redirected.com/.well-known/webfinger?resource=acct:hacker1@redirected.com").to_return(request_fixture('webfinger-hacker1.txt'))
+    stub_request(:get, "https://redirected.com/.well-known/webfinger?resource=acct:hacker2@redirected.com").to_return(request_fixture('webfinger-hacker2.txt'))
     stub_request(:get, "https://quitter.no/.well-known/webfinger?resource=acct:catsrgr8@quitter.no").to_return(status: 404)
     stub_request(:get, "https://quitter.no/api/statuses/user_timeline/7477.atom").to_return(request_fixture('feed.txt'))
     stub_request(:get, "https://quitter.no/avatar/7477-300-20160211190340.png").to_return(request_fixture('avatar.txt'))
@@ -34,5 +38,22 @@ RSpec.describe FollowRemoteAccountService do
     expect(account.username).to eq 'gargron'
     expect(account.domain).to eq 'quitter.no'
     expect(account.remote_url).to eq 'https://quitter.no/api/statuses/user_timeline/7477.atom'
+  end
+
+  it 'follows a legitimate account redirection' do
+    account = subject.call('gargron@redirected.com')
+
+    expect(account.username).to eq 'gargron'
+    expect(account.domain).to eq 'quitter.no'
+    expect(account.remote_url).to eq 'https://quitter.no/api/statuses/user_timeline/7477.atom'
+  end
+
+  it 'prevents hijacking existing accounts' do
+    account = subject.call('hacker1@redirected.com')
+    expect(account.salmon_url).to_not eq 'https://hacker.com/main/salmon/user/7477'
+  end
+
+  it 'prevents hijacking inexisting accounts' do
+    expect { subject.call('hacker2@redirected.com') }.to raise_error Goldfinger::Error
   end
 end


### PR DESCRIPTION
This pull request is a follow-up to #2147 to further specify the intended behavior of FollowRemoteAccountService and make sure it prevents hijacking remote accounts using webfinger, while still following legitimate redirections.

To give a bit more background, webfinger queries for an “acct:” URI are not required to return a response with the same “acct:” URI as subject. This allows some form of redirection (user a@example.com is now called b@example.com, or has moved to a@example.org).

However, until #2147 was merged, Mastodon would take the returned subject “acct:” URI as the actual ID of the remote account, even if it didn't match the requested “acct:” URI, making it possible for attackers to create or overwrite a remote account for a domain they do not control.