### PR TITLE
WIP+RFC: Reduce color count and add more variables

### DIFF
--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -2,7 +2,7 @@
   .wrapper {
     max-width: 600px;
     margin: 0 auto;
-    color: $color3;
+    color: $about-color;
     padding-top: 50px;
     padding-bottom: 50px;
 
@@ -15,7 +15,7 @@
     font: 46px/52px 'Roboto', sans-serif;
     font-weight: 600;
     margin-bottom: 20px;
-    color: $color4;
+    color: $about-title1-color;
     padding: 20px 0;
 
     img {
@@ -32,7 +32,7 @@
     line-height: 28px;
     font-weight: 400;
     margin-bottom: 20px;
-    color: $color5;
+    color: $about-title2-color;
   }
 
   h3 {
@@ -41,7 +41,7 @@
     line-height: 28px;
     font-weight: 400;
     margin-bottom: 20px;
-    color: $lighten20_color3;
+    color: $about-title3-color;
   }
 
   ul, ol {
@@ -67,7 +67,7 @@
     margin-bottom: 12px;
 
     a {
-      color: $color4;
+      color: $about-link-color;
       text-decoration: underline;
     }
   }
@@ -76,14 +76,14 @@
     display: inline-block;
     padding: 7px 7px 5px 7px;
     margin: 0 2px;
-    background: $color3;
-    color: $color1;
+    background: $about-emphasis-background;
+    color: $about-emphasis-color;
     font: 16px/16px 'Montserrat', sans-serif;
     font-weight: 300;
   }
 
   .screenshot {
-    box-shadow: 0 0 15px $color8_alpha04;
+    box-shadow: 0 0 15px $about-screenshot-shadow;
     margin-bottom: 26px;
 
     img {
@@ -103,7 +103,7 @@
       line-height: 36px;
 
       a {
-        color: $color3;
+        color: $about-actions-link-color;
         text-decoration: underline;
       }
     }
@@ -124,8 +124,8 @@
   margin: 20px 0;
   display: flex;
   justify-content: space-between;
-  border-top: 1px solid $lighten10_color1;
-  border-bottom: 1px solid $lighten10_color1;
+  border-top: 1px solid $about-infoboard-border;
+  border-bottom: 1px solid $about-infoboard-border;
   padding-right: 14px;
 
   .section {
@@ -142,7 +142,7 @@
       font-size: 16px;
 
       &:last-child {
-        color: $lighten20_color3;
+        color: $about-infoboard-lastsection;
         font-size: 14px;
       }
     }
@@ -151,7 +151,7 @@
       font-weight: 500;
       font-size: 32px;
       line-height: 48px;
-      color: $color5;
+      color: $about-infoboard-section-strong;
     }
   }
 
@@ -186,7 +186,7 @@
 
     a {
       display: block;
-      color: $color5;
+      color: $owner-link-color;
       text-decoration: none;
 
       &:hover {
@@ -198,7 +198,7 @@
 
     .username {
       display: block;
-      color: $color3;
+      color: $owner-username-color;
     }
   }
 }
@@ -209,7 +209,7 @@
 
   strong {
     display: block;
-    color: $color5;
+    color: $owner-contact-strong;
     word-break: break-word;
   }
 }
@@ -227,14 +227,14 @@
   }
 
   .sidebar {
-    border-left: 1px solid $lighten10_color1;
+    border-left: 1px solid $sidebar-border-color;
     width: 180px;
     flex: 0 0 auto;
   }
 
   .panel {
     .panel-header {
-      background: $lighten10_color1;
+      background: $panel-header-background;
       padding: 7px 14px;
       text-transform: uppercase;
       font-size: 12px;
@@ -259,7 +259,7 @@
           a {
             display: block;
             padding: 7px 14px;
-            color: $color5_alpha07;
+            color: $panel-list-link-color;
             text-decoration: none;
             transition: all 200ms linear;
 
@@ -268,17 +268,17 @@
             }
 
             &:hover {
-              color: $color5;
-              background-color: $darken5_color1;
+              color: $panel-list-link-hover-color;
+              background-color: $panel-list-link-hover-background;
               transition: all 100ms linear;
             }
 
             &.selected {
-              color: $color5;
-              background-color: $color4;
+              color: $panel-list-selected-link-color;
+              background-color: $panel-list-selected-link-background;
 
               &:hover {
-                background-color: $lighten5_color4;
+                background-color: $panel-list-selected-link-hover-background;
               }
             }
           }
@@ -291,7 +291,7 @@
     flex-direction: column;
 
     .sidebar {
-      border: 1px solid $lighten10_color1;
+      border: 1px solid $sidebar-border-color;
       width: auto;
     }
   }
@@ -336,10 +336,10 @@
   .simple_form, .closed-registrations-message {
     width: 300px;
     flex: 0 0 auto;
-    background: $darken_color1_alpha05;
+    background: $signup-background;
     padding: 14px;
     border-radius: 4px;
-    box-shadow: 0 0 15px $color8_alpha04;
+    box-shadow: 0 0 15px $signup-shadow;
 
     .actions {
       margin-bottom: 0;
@@ -349,7 +349,7 @@
       text-align: center;
 
       a {
-        color: $lighten20_color3;
+        color: $signup-info-link-color;
       }
     }
   }

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -41,7 +41,7 @@
     line-height: 28px;
     font-weight: 400;
     margin-bottom: 20px;
-    color: $color2;
+    color: $lighten20_color3;
   }
 
   ul, ol {
@@ -142,7 +142,7 @@
       font-size: 16px;
 
       &:last-child {
-        color: $color2;
+        color: $lighten20_color3;
         font-size: 14px;
       }
     }
@@ -349,7 +349,7 @@
       text-align: center;
 
       a {
-        color: $color2;
+        color: $lighten20_color3;
       }
     }
   }

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -83,7 +83,7 @@
   }
 
   .screenshot {
-    box-shadow: 0 0 15px $forty_alpha_color8;
+    box-shadow: 0 0 15px $color8_alpha04;
     margin-bottom: 26px;
 
     img {
@@ -339,7 +339,7 @@
     background: $darken_transparent5_color1;
     padding: 14px;
     border-radius: 4px;
-    box-shadow: 0 0 15px $forty_alpha_color8;
+    box-shadow: 0 0 15px $color8_alpha04;
 
     .actions {
       margin-bottom: 0;

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -259,7 +259,7 @@
           a {
             display: block;
             padding: 7px 14px;
-            color: $transparent7_color5;
+            color: $color5_alpha07;
             text-decoration: none;
             transition: all 200ms linear;
 
@@ -336,7 +336,7 @@
   .simple_form, .closed-registrations-message {
     width: 300px;
     flex: 0 0 auto;
-    background: $darken_transparent5_color1;
+    background: $darken_color1_alpha05;
     padding: 14px;
     border-radius: 4px;
     box-shadow: 0 0 15px $color8_alpha04;

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -124,8 +124,8 @@
   margin: 20px 0;
   display: flex;
   justify-content: space-between;
-  border-top: 1px solid lighten($color1, 10%);
-  border-bottom: 1px solid lighten($color1, 10%);
+  border-top: 1px solid $lighten_color1;
+  border-bottom: 1px solid $lighten_color1;
   padding-right: 14px;
 
   .section {
@@ -227,14 +227,14 @@
   }
 
   .sidebar {
-    border-left: 1px solid lighten($color1, 10%);
+    border-left: 1px solid $lighten_color1;
     width: 180px;
     flex: 0 0 auto;
   }
 
   .panel {
     .panel-header {
-      background: lighten($color1, 10%);
+      background: $lighten_color1;
       padding: 7px 14px;
       text-transform: uppercase;
       font-size: 12px;
@@ -269,7 +269,7 @@
 
             &:hover {
               color: $color5;
-              background-color: darken($color1, 5%);
+              background-color: $darken_color1;
               transition: all 100ms linear;
             }
 
@@ -291,7 +291,7 @@
     flex-direction: column;
 
     .sidebar {
-      border: 1px solid lighten($color1, 10%);
+      border: 1px solid $lighten_color1;
       width: auto;
     }
   }
@@ -336,7 +336,7 @@
   .simple_form, .closed-registrations-message {
     width: 300px;
     flex: 0 0 auto;
-    background: rgba(darken($color1, 7%), 0.5);
+    background: $darken_transparent_color1;
     padding: 14px;
     border-radius: 4px;
     box-shadow: 0 0 15px rgba($color8, 0.4);

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -259,7 +259,7 @@
           a {
             display: block;
             padding: 7px 14px;
-            color: rgba($color5, 0.7);
+            color: $seventy_alpha_color5;
             text-decoration: none;
             transition: all 200ms linear;
 

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -278,7 +278,7 @@
               background-color: $color4;
 
               &:hover {
-                background-color: lighten($color4, 5%);
+                background-color: $five_lighten_color4;
               }
             }
           }

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -124,8 +124,8 @@
   margin: 20px 0;
   display: flex;
   justify-content: space-between;
-  border-top: 1px solid $lighten_color1;
-  border-bottom: 1px solid $lighten_color1;
+  border-top: 1px solid $lighten10_color1;
+  border-bottom: 1px solid $lighten10_color1;
   padding-right: 14px;
 
   .section {
@@ -227,14 +227,14 @@
   }
 
   .sidebar {
-    border-left: 1px solid $lighten_color1;
+    border-left: 1px solid $lighten10_color1;
     width: 180px;
     flex: 0 0 auto;
   }
 
   .panel {
     .panel-header {
-      background: $lighten_color1;
+      background: $lighten10_color1;
       padding: 7px 14px;
       text-transform: uppercase;
       font-size: 12px;
@@ -269,7 +269,7 @@
 
             &:hover {
               color: $color5;
-              background-color: $darken_color1;
+              background-color: $darken5_color1;
               transition: all 100ms linear;
             }
 
@@ -291,7 +291,7 @@
     flex-direction: column;
 
     .sidebar {
-      border: 1px solid $lighten_color1;
+      border: 1px solid $lighten10_color1;
       width: auto;
     }
   }
@@ -336,7 +336,7 @@
   .simple_form, .closed-registrations-message {
     width: 300px;
     flex: 0 0 auto;
-    background: $darken_transparent_color1;
+    background: $darken_transparent5_color1;
     padding: 14px;
     border-radius: 4px;
     box-shadow: 0 0 15px $forty_alpha_color8;

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -259,7 +259,7 @@
           a {
             display: block;
             padding: 7px 14px;
-            color: $seventy_alpha_color5;
+            color: $transparent7_color5;
             text-decoration: none;
             transition: all 200ms linear;
 
@@ -278,7 +278,7 @@
               background-color: $color4;
 
               &:hover {
-                background-color: $five_lighten_color4;
+                background-color: $lighten5_color4;
               }
             }
           }

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -83,7 +83,7 @@
   }
 
   .screenshot {
-    box-shadow: 0 0 15px rgba($color8, 0.4);
+    box-shadow: 0 0 15px $forty_alpha_color8;
     margin-bottom: 26px;
 
     img {
@@ -339,7 +339,7 @@
     background: $darken_transparent_color1;
     padding: 14px;
     border-radius: 4px;
-    box-shadow: 0 0 15px rgba($color8, 0.4);
+    box-shadow: 0 0 15px $forty_alpha_color8;
 
     .actions {
       margin-bottom: 0;

--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -144,7 +144,7 @@
     font-size: 14px;
     line-height: 18px;
     padding: 5px 10px;
-    color: $color2;
+    color: $lighten20_color3;
     order: 1;
   }
 
@@ -196,7 +196,7 @@
 
   .prev, .next {
     text-transform: uppercase;
-    color: $color2;
+    color: $lighten20_color3;
   }
 
   .prev {
@@ -255,7 +255,7 @@
   .account-grid-card {
     box-sizing: border-box;
     width: 335px;
-    border: 1px solid $color2;
+    border: 1px solid $lighten20_color3;
     border-radius: 4px;
     color: $color1;
     margin-bottom: 10px;
@@ -267,7 +267,7 @@
     .account-grid-card__header {
       overflow: hidden;
       padding: 10px;
-      border-bottom: 1px solid $color2;
+      border-bottom: 1px solid $lighten20_color3;
     }
 
     .avatar {

--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -4,7 +4,7 @@
   padding: 60px 0;
   padding-bottom: 0;
   border-radius: 4px 4px 0 0;
-  box-shadow: 0 0 15px rgba($color8, 0.2);
+  box-shadow: 0 0 15px $twenty_alpha_color8;
   overflow: hidden;
   position: relative;
 
@@ -14,7 +14,7 @@
   }
 
   &:after {
-    background: linear-gradient(rgba($color8, 0.5), rgba($color8, 0.8));
+    background: linear-gradient($fifty_alpha_color8, $eighty_alpha_color8);
     display: block;
     content: "";
     position: absolute;
@@ -238,7 +238,7 @@
 }
 
 .accounts-grid {
-  box-shadow: 0 0 15px rgba($color8, 0.2);
+  box-shadow: 0 0 15px $twenty_alpha_color8;
   background: $color5;
   border-radius: 0 0 4px 4px;
   padding: 20px 10px;
@@ -333,7 +333,7 @@
   background: $color5;
   border-radius: 4px;
   text-align: left;
-  box-shadow: 0 0 15px rgba($color8, 0.2);
+  box-shadow: 0 0 15px $twenty_alpha_color8;
 
   .detailed-status__display-name {
     display: block;

--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -221,7 +221,7 @@
 
   .disabled {
     cursor: default;
-    color: lighten($color1, 10%);
+    color: $lighten_color1;
   }
 
   @media screen and (max-width: 360px) {

--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -4,7 +4,7 @@
   padding: 60px 0;
   padding-bottom: 0;
   border-radius: 4px 4px 0 0;
-  box-shadow: 0 0 15px $twenty_alpha_color8;
+  box-shadow: 0 0 15px $color8_alpha02;
   overflow: hidden;
   position: relative;
 
@@ -14,7 +14,7 @@
   }
 
   &:after {
-    background: linear-gradient($fifty_alpha_color8, $eighty_alpha_color8);
+    background: linear-gradient($color8_alpha05, $color8_alpha08);
     display: block;
     content: "";
     position: absolute;
@@ -238,7 +238,7 @@
 }
 
 .accounts-grid {
-  box-shadow: 0 0 15px $twenty_alpha_color8;
+  box-shadow: 0 0 15px $color8_alpha02;
   background: $color5;
   border-radius: 0 0 4px 4px;
   padding: 20px 10px;
@@ -333,7 +333,7 @@
   background: $color5;
   border-radius: 4px;
   text-align: left;
-  box-shadow: 0 0 15px $twenty_alpha_color8;
+  box-shadow: 0 0 15px $color8_alpha02;
 
   .detailed-status__display-name {
     display: block;

--- a/app/assets/stylesheets/accounts.scss
+++ b/app/assets/stylesheets/accounts.scss
@@ -221,7 +221,7 @@
 
   .disabled {
     cursor: default;
-    color: $lighten_color1;
+    color: $lighten10_color1;
   }
 
   @media screen and (max-width: 360px) {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -89,7 +89,7 @@
     padding-left: 25px;
 
     h2 {
-      color: $color2;
+      color: $lighten20_color3;
       font-size: 24px;
       line-height: 28px;
       font-weight: 400;
@@ -99,7 +99,7 @@
     & > p {
       font-size: 14px;
       line-height: 18px;
-      color: $color2;
+      color: $lighten20_color3;
       margin-bottom: 20px;
 
       strong {
@@ -218,7 +218,7 @@
     font-weight: 500;
     font-size: 14px;
     line-height: 18px;
-    color: $color2;
+    color: $lighten20_color3;
   }
 
   &:first-child {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -16,7 +16,7 @@
     height: 100%;
     padding: 0;
     overflow-y: auto;
-    
+
     .logo {
       display: block;
       margin: 40px auto;
@@ -44,18 +44,18 @@
 
         &:hover {
           color: $color5;
-          background-color: $darken_color1;
+          background-color: $darken5_color1;
           transition: all 100ms linear;
         }
 
         &.selected {
-          background: $lighter_darken_color1;
+          background: $darken5_color1;
           border-radius: 4px 0 0 0;
         }
       }
 
       ul {
-        background: $light_darken_color1;
+        background: $darken5_color1;
         border-radius: 0 0 0 4px;
         margin: 0;
 
@@ -191,7 +191,7 @@
 
       &:hover {
         color: $color5;
-        border-bottom: 2px solid $light_lighten_color1;
+        border-bottom: 2px solid $lighten5_color1;
       }
 
       &.selected {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -33,7 +33,7 @@
       a {
         display: block;
         padding: 15px 25px;
-        color: $seventy_alpha_color5;
+        color: $transparent7_color5;
         text-decoration: none;
         transition: all 200ms linear;
         border-radius: 4px 0 0 4px;
@@ -69,7 +69,7 @@
             border-radius: 0;
 
             &:hover {
-              background-color: $five_lighten_color4;
+              background-color: $lighten5_color4;
             }
           }
         }
@@ -182,7 +182,7 @@
 
     a {
       display: inline-block;
-      color: $seventy_alpha_color5;
+      color: $transparent7_color5;
       text-decoration: none;
       text-transform: uppercase;
       font-size: 12px;

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -69,7 +69,7 @@
             border-radius: 0;
 
             &:hover {
-              background-color: lighten($color4, 5%);
+              background-color: $five_lighten_color4;
             }
           }
         }

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -33,7 +33,7 @@
       a {
         display: block;
         padding: 15px 25px;
-        color: rgba($color5, 0.7);
+        color: $seventy_alpha_color5;
         text-decoration: none;
         transition: all 200ms linear;
         border-radius: 4px 0 0 4px;
@@ -182,7 +182,7 @@
 
     a {
       display: inline-block;
-      color: rgba($color5, 0.7);
+      color: $seventy_alpha_color5;
       text-decoration: none;
       text-transform: uppercase;
       font-size: 12px;

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -44,18 +44,18 @@
 
         &:hover {
           color: $color5;
-          background-color: darken($color1, 5%);
+          background-color: $darken_color1;
           transition: all 100ms linear;
         }
 
         &.selected {
-          background: darken($color1, 2%);
+          background: $lighter_darken_color1;
           border-radius: 4px 0 0 0;
         }
       }
 
       ul {
-        background: darken($color1, 4%);
+        background: $light_darken_color1;
         border-radius: 0 0 0 4px;
         margin: 0;
 
@@ -191,7 +191,7 @@
 
       &:hover {
         color: $color5;
-        border-bottom: 2px solid lighten($color1, 5%);
+        border-bottom: 2px solid $light_lighten_color1;
       }
 
       &.selected {

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -33,7 +33,7 @@
       a {
         display: block;
         padding: 15px 25px;
-        color: $transparent7_color5;
+        color: $color5_alpha07;
         text-decoration: none;
         transition: all 200ms linear;
         border-radius: 4px 0 0 4px;
@@ -182,7 +182,7 @@
 
     a {
       display: inline-block;
-      color: $transparent7_color5;
+      color: $color5_alpha07;
       text-decoration: none;
       text-transform: uppercase;
       font-size: 12px;

--- a/app/assets/stylesheets/basics.scss
+++ b/app/assets/stylesheets/basics.scss
@@ -1,6 +1,6 @@
 body {
   font-family: 'Roboto', sans-serif;
-  background: $color1 image-url('background-photo.jpeg');
+  background: $body-background-color image-url('background-photo.jpeg');
   background-size: cover;
   background-attachment: fixed;
   font-size: 13px;
@@ -17,7 +17,7 @@ body {
     width: 100%;
     height: 100%;
     padding: 0;
-    background: $color1;
+    background: $body-background-color;
   }
 
   &.embed {
@@ -33,7 +33,7 @@ body {
   }
 
   &.admin {
-    background: $darken5_color1;
+    background: $admin-background;
     position: fixed;
     width: 100%;
     height: 100%;

--- a/app/assets/stylesheets/basics.scss
+++ b/app/assets/stylesheets/basics.scss
@@ -33,7 +33,7 @@ body {
   }
 
   &.admin {
-    background: $light_darken_color1;
+    background: $darken5_color1;
     position: fixed;
     width: 100%;
     height: 100%;

--- a/app/assets/stylesheets/basics.scss
+++ b/app/assets/stylesheets/basics.scss
@@ -33,7 +33,7 @@ body {
   }
 
   &.admin {
-    background: darken($color1, 4%);
+    background: $light_darken_color1;
     position: fixed;
     width: 100%;
     height: 100%;

--- a/app/assets/stylesheets/compact_header.scss
+++ b/app/assets/stylesheets/compact_header.scss
@@ -14,7 +14,7 @@
 
     small {
       font-weight: 400;
-      color: $color2;
+      color: $lighten20_color3;
     }
 
     img {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -308,7 +308,7 @@
   background: $color5;
 
   &:disabled {
-    background: $color2;
+    background: $lighten20_color3;
   }
 }
 
@@ -403,7 +403,7 @@
   }
 
   a {
-    color: $color2;
+    color: $lighten20_color3;
     text-decoration: none;
 
     &:hover {
@@ -502,11 +502,11 @@ a.status__content__spoiler-link {
 }
 
 .status__relative-time {
-  color: $lighten25_color1;
+  color: $darken16_color3;
 }
 
 .status__display-name {
-  color: $lighten25_color1;
+  color: $darken16_color3;
 }
 
 .status__info .status__display-name {
@@ -675,7 +675,7 @@ a.status__content__spoiler-link {
   }
 
   .account__header__content {
-    color: $color2;
+    color: $lighten20_color3;
   }
 
   .account__header__display-name {
@@ -831,7 +831,7 @@ a.status__content__spoiler-link {
 }
 
 .detailed-status__display-name {
-  color: $color2;
+  color: $lighten20_color3;
   display: block;
   line-height: 24px;
   margin-bottom: 15px;
@@ -996,7 +996,7 @@ a.status__content__spoiler-link {
 }
 
 .dropdown__sep {
-  border-bottom: 1px solid $darken8_color2;
+  border-bottom: 1px solid $lighten12_color3;
   margin: 5px 7px 6px;
   padding-top: 1px;
 }
@@ -1015,7 +1015,7 @@ a.status__content__spoiler-link {
     height: 0;
     border-style: solid;
     border-width: 0 4.5px 7.8px 4.5px;
-    border-color: transparent transparent $color2 transparent;
+    border-color: transparent transparent $lighten20_color3 transparent;
     top: -7px;
     left: 8px;
   }
@@ -1028,7 +1028,7 @@ a.status__content__spoiler-link {
 
   & > ul {
     list-style: none;
-    background: $color2;
+    background: $lighten20_color3;
     padding: 4px 0;
     border-radius: 4px;
     box-shadow: 0 0 15px $color8_alpha04;
@@ -1055,7 +1055,7 @@ a.status__content__spoiler-link {
     box-sizing: border-box;
     width: 140px;
     text-decoration: none;
-    background: $color2;
+    background: $lighten20_color3;
     color: $color1;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1067,7 +1067,7 @@ a.status__content__spoiler-link {
 
     &:hover {
       background: $color4;
-      color: $color2;
+      color: $lighten20_color3;
     }
   }
 }
@@ -1344,7 +1344,7 @@ a.status__content__spoiler-link {
 }
 
 .react-autosuggest__suggestions-list {
-  background: $color2;
+  background: $lighten20_color3;
   color: $color1;
   font-size: 14px;
 }
@@ -1585,7 +1585,7 @@ a.status__content__spoiler-link {
   width: 100%;
   z-index: 99;
   box-shadow: 0 0 15px $color8_alpha04;
-  background: $color2;
+  background: $lighten20_color3;
   color: $color1;
   font-size: 14px;
 }
@@ -1595,7 +1595,7 @@ a.status__content__spoiler-link {
   cursor: pointer;
 
   &:hover {
-    background: $darken8_color2;
+    background: $lighten12_color3;
   }
 
   &.selected {
@@ -1649,7 +1649,7 @@ a.status__content__spoiler-link {
   flex: 1 0 auto;
 
   p {
-    color: $color2;
+    color: $lighten20_color3;
   }
 
   a {
@@ -1805,7 +1805,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .loading-indicator {
-  color: $color2;
+  color: $lighten20_color3;
   font-size: 16px;
   font-weight: 500;
   padding-top: 120px;
@@ -1941,7 +1941,7 @@ button.icon-button.active i.fa-retweet {
 
 .report__target {
   border-bottom: 1px solid $lighten5_color1;
-  color: $color2;
+  color: $lighten20_color3;
   flex: 0 0 auto;
   padding: 10px;
 
@@ -2114,7 +2114,7 @@ button.icon-button.active i.fa-retweet {
     font-size: 12px;
     text-transform: uppercase;
     font-weight: 500;
-    color: $darken16_color2;
+    color: $lighten4_color3;
     cursor: default;
   }
 
@@ -2163,7 +2163,7 @@ button.icon-button.active i.fa-retweet {
 
   .emoji-search-wrapper {
     padding: 10px;
-    border-bottom: 1px solid $lighten4_color2;
+    border-bottom: 1px solid $lighten24_color3;
   }
 
   .emoji-search {
@@ -2173,9 +2173,9 @@ button.icon-button.active i.fa-retweet {
     font-family: inherit;
     display: block;
     width: 100%;
-    background: $color2_alpha03;
-    color: $darken16_color2;
-    border: 1px solid $color2;
+    background: $lighten28_color3;
+    color: $lighten4_color3;
+    border: 1px solid $lighten20_color3;
     border-radius: 4px;
   }
 
@@ -2197,7 +2197,7 @@ button.icon-button.active i.fa-retweet {
     }
 
     &:hover {
-      background: $lighten4_color2;
+      background: $lighten24_color3;
 
       img, svg {
         transform: translateZ(0) scale(1.2);
@@ -2261,7 +2261,7 @@ button.icon-button.active i.fa-retweet {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: $color2;
+  color: $lighten20_color3;
   font-size: 18px;
   font-weight: 500;
   border: 2px dashed $lighten25_color1;
@@ -2416,7 +2416,7 @@ button.icon-button.active i.fa-retweet {
 
 .search__input {
   padding-right: 30px;
-  color: $color2;
+  color: $lighten20_color3;
   outline: 0;
   box-sizing: border-box;
   display: block;
@@ -2459,7 +2459,7 @@ button.icon-button.active i.fa-retweet {
     font-size: 18px;
     width: 18px;
     height: 18px;
-    color: $color2;
+    color: $lighten20_color3;
     cursor: default;
     pointer-events: none;
 
@@ -2505,11 +2505,11 @@ button.icon-button.active i.fa-retweet {
 .search-results__hashtag {
   display: block;
   padding: 10px;
-  color: $color2;
+  color: $lighten20_color3;
   text-decoration: none;
 
   &:hover, &:active, &:focus {
-    color: $lighten4_color2;
+    color: $lighten24_color3;
     text-decoration: underline;
   }
 }
@@ -2568,7 +2568,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .onboarding-modal {
-  background: $color2;
+  background: $lighten20_color3;
   color: $color1;
   border-radius: 8px;
   overflow: hidden;
@@ -2619,7 +2619,7 @@ button.icon-button.active i.fa-retweet {
 
 .onboarding-modal__paginator {
   flex: 0 0 auto;
-  background: $darken8_color2;
+  background: $lighten12_color3;
   display: flex;
   padding: 25px;
 
@@ -2628,13 +2628,13 @@ button.icon-button.active i.fa-retweet {
   }
 
   a {
-    color: $darken36_color2;
+    color: $darken16_color3;
     text-decoration: none;
     font-size: 14px;
     font-weight: 500;
 
     &:hover, &:focus, &:active {
-      color: $darken36_color2;
+      color: $darken16_color3;
     }
 
     &.onboarding-modal__done, &.onboarding-modal__next {
@@ -2654,17 +2654,17 @@ button.icon-button.active i.fa-retweet {
   width: 14px;
   height: 14px;
   border-radius: 14px;
-  background: $darken16_color2;
+  background: $lighten4_color3;
   margin: 0 3px;
   cursor: pointer;
 
   &:hover {
-    background: $darken16_color2;
+    background: $lighten4_color3;
   }
 
   &.active {
     cursor: default;
-    background: $darken24_color2;
+    background: $darken4_color3;
   }
 }
 
@@ -2700,7 +2700,7 @@ button.icon-button.active i.fa-retweet {
     strong {
       font-weight: 500;
       background: $color1;
-      color: $color2;
+      color: $lighten20_color3;
       border-radius: 4px;
       font-size: 14px;
       padding: 3px 6px;
@@ -2729,7 +2729,7 @@ button.icon-button.active i.fa-retweet {
 
   .figure {
     background: $darken10_color1;
-    color: $color2;
+    color: $lighten20_color3;
     margin-bottom: 20px;
     border-radius: 4px;
     padding: 10px;
@@ -2799,7 +2799,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .boost-modal, .confirmation-modal {
-  background: $lighten8_color2;
+  background: $lighten28_color3;
   color: $color1;
   border-radius: 8px;
   overflow: hidden;
@@ -2835,7 +2835,7 @@ button.icon-button.active i.fa-retweet {
 
 .boost-modal__action-bar, .confirmation-modal__action-bar {
   display: flex;
-  background: $color2;
+  background: $lighten20_color3;
   padding: 10px;
   line-height: 36px;
 
@@ -2871,13 +2871,13 @@ button.icon-button.active i.fa-retweet {
   }
 
   a {
-    color: $darken36_color2;
+    color: $darken16_color3;
     text-decoration: none;
     font-size: 14px;
     font-weight: 500;
 
     &:hover, &:focus, &:active {
-      color: $darken36_color2;
+      color: $darken16_color3;
     }
   }
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -502,11 +502,11 @@ a.status__content__spoiler-link {
 }
 
 .status__relative-time {
-  color: $darken16_color3;
+  color: $lighten35_color1;
 }
 
 .status__display-name {
-  color: $darken16_color3;
+  color: $lighten35_color1;
 }
 
 .status__info .status__display-name {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -2024,7 +2024,7 @@ button.icon-button.active i.fa-retweet {
   pointer-events: none;
   height: 28px;
   z-index: 1;
-  background: radial-gradient(ellipse, $twentythree_alpha_color4 0%, $color 60%);
+  background: radial-gradient(ellipse, $twentythree_alpha_color4 0%, transparent 60%);
 }
 
 .emoji-dialog {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -996,7 +996,7 @@ a.status__content__spoiler-link {
 }
 
 .dropdown__sep {
-  border-bottom: 1px solid $eight_darken_color2;
+  border-bottom: 1px solid $darken8_color2;
   margin: 5px 7px 6px;
   padding-top: 1px;
 }
@@ -1595,7 +1595,7 @@ a.status__content__spoiler-link {
   cursor: pointer;
 
   &:hover {
-    background: $ten_darken_color2;
+    background: $darken8_color2;
   }
 
   &.selected {
@@ -2114,7 +2114,7 @@ button.icon-button.active i.fa-retweet {
     font-size: 12px;
     text-transform: uppercase;
     font-weight: 500;
-    color: $eighteen_darken_color2;
+    color: $darken16_color2;
     cursor: default;
   }
 
@@ -2163,7 +2163,7 @@ button.icon-button.active i.fa-retweet {
 
   .emoji-search-wrapper {
     padding: 10px;
-    border-bottom: 1px solid $four_lighten_color2;
+    border-bottom: 1px solid $lighten4_color22;
   }
 
   .emoji-search {
@@ -2174,7 +2174,7 @@ button.icon-button.active i.fa-retweet {
     display: block;
     width: 100%;
     background: $transparent_color2;
-    color: $eighteen_darken_color2;
+    color: $darken16_color2;
     border: 1px solid $color2;
     border-radius: 4px;
   }
@@ -2197,7 +2197,7 @@ button.icon-button.active i.fa-retweet {
     }
 
     &:hover {
-      background: $three_lighten_color2;
+      background: $lighten4_color22;
 
       img, svg {
         transform: translateZ(0) scale(1.2);
@@ -2375,7 +2375,7 @@ button.icon-button.active i.fa-retweet {
   }
 
   &.active:hover {
-    background: $four_lighten_color4;
+    background: $lighten4_color24;
   }
 }
 
@@ -2509,7 +2509,7 @@ button.icon-button.active i.fa-retweet {
   text-decoration: none;
 
   &:hover, &:active, &:focus {
-    color: $four_lighten_color2;
+    color: $lighten4_color22;
     text-decoration: underline;
   }
 }
@@ -2619,7 +2619,7 @@ button.icon-button.active i.fa-retweet {
 
 .onboarding-modal__paginator {
   flex: 0 0 auto;
-  background: $eight_darken_color2;
+  background: $darken8_color2;
   display: flex;
   padding: 25px;
 
@@ -2628,13 +2628,13 @@ button.icon-button.active i.fa-retweet {
   }
 
   a {
-    color: $thirtyfour_darken_color2;
+    color: $darken36_color2;
     text-decoration: none;
     font-size: 14px;
     font-weight: 500;
 
     &:hover, &:focus, &:active {
-      color: $thirtyeight_darken_color2;
+      color: $darken36_color2;
     }
 
     &.onboarding-modal__done, &.onboarding-modal__next {
@@ -2654,17 +2654,17 @@ button.icon-button.active i.fa-retweet {
   width: 14px;
   height: 14px;
   border-radius: 14px;
-  background: $sixteen_darken_color2;
+  background: $darken16_color2;
   margin: 0 3px;
   cursor: pointer;
 
   &:hover {
-    background: $eighteen_darken_color2;
+    background: $darken16_color2;
   }
 
   &.active {
     cursor: default;
-    background: $twentyfour_darken_color2;
+    background: $darken24_color2;
   }
 }
 
@@ -2683,7 +2683,7 @@ button.icon-button.active i.fa-retweet {
     color: $color4;
 
     &:hover, &:focus, &:active {
-      color: $four_lighten_color4;
+      color: $lighten4_color24;
     }
   }
 
@@ -2799,7 +2799,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .boost-modal, .confirmation-modal {
-  background: $eight_lighten_color2;
+  background: $lighten8_color2;
   color: $color1;
   border-radius: 8px;
   overflow: hidden;
@@ -2871,13 +2871,13 @@ button.icon-button.active i.fa-retweet {
   }
 
   a {
-    color: $thirtyfour_darken_color2;
+    color: $darken36_color2;
     text-decoration: none;
     font-size: 14px;
     font-weight: 500;
 
     &:hover, &:focus, &:active {
-      color: $thirtyeight_darken_color2;
+      color: $darken36_color2;
     }
   }
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -2024,7 +2024,7 @@ button.icon-button.active i.fa-retweet {
   pointer-events: none;
   height: 28px;
   z-index: 1;
-  background: radial-gradient(ellipse, $twentythree_alpha_color4 0%, rgba($color4, 0) 60%);
+  background: radial-gradient(ellipse, $twentythree_alpha_color4 0%, $color 60%);
 }
 
 .emoji-dialog {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -62,7 +62,7 @@
   z-index: 3;
 
   &:hover {
-    color: lighten($color3, 7%);
+    color: $seven_lighten_color3;
   }
 }
 
@@ -203,7 +203,7 @@
 }
 
 .compose-form__warning {
-  color: darken($color3, 33%);
+  color: $thirtythree_darken_color3;
   margin-bottom: 15px;
   background: $color3;
   box-shadow: 0 2px 6px rgba($color8, 0.3);
@@ -213,12 +213,12 @@
   font-weight: 400;
 
   strong {
-    color: darken($color3, 33%);
+    color: $thirtythree_darken_color3;
     font-weight: 500;
   }
 
   a {
-    color: darken($color3, 33%);
+    color: $thirtythree_darken_color3;
     font-weight: 500;
     text-decoration: underline;
 
@@ -494,7 +494,7 @@ a.status__content__spoiler-link {
         background: $color3;
 
         &:hover {
-          background: lighten($color3, 8%);
+          background: $eight_lighten_color3;
         }
       }
     }
@@ -2389,7 +2389,7 @@ button.icon-button.active i.fa-retweet {
 
 .privacy-dropdown__option__content {
   flex: 1 1 auto;
-  color: darken($color3, 24%);
+  color: $twenty_darken_color3;
 
   strong {
     font-weight: 500;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -2163,7 +2163,7 @@ button.icon-button.active i.fa-retweet {
 
   .emoji-search-wrapper {
     padding: 10px;
-    border-bottom: 1px solid $lighten4_color22;
+    border-bottom: 1px solid $lighten4_color2;
   }
 
   .emoji-search {
@@ -2197,7 +2197,7 @@ button.icon-button.active i.fa-retweet {
     }
 
     &:hover {
-      background: $lighten4_color22;
+      background: $lighten4_color2;
 
       img, svg {
         transform: translateZ(0) scale(1.2);
@@ -2509,7 +2509,7 @@ button.icon-button.active i.fa-retweet {
   text-decoration: none;
 
   &:hover, &:active, &:focus {
-    color: $lighten4_color22;
+    color: $lighten4_color2;
     text-decoration: underline;
   }
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -131,13 +131,13 @@
 
   &.overlayed {
     box-sizing: content-box;
-    background: $sixty_alpha_color8;
+    background: $color8_alpha06;
     color: $transparent7_color5;
     border-radius: 4px;
     padding: 2px;
 
     &:hover {
-      background: $ninety_alpha_color8;
+      background: $color8_alpha09;
     }
   }
 }
@@ -206,7 +206,7 @@
   color: $darken30_color3;
   margin-bottom: 15px;
   background: $color3;
-  box-shadow: 0 2px 6px $thirty_alpha_color8;
+  box-shadow: 0 2px 6px $color8_alpha03;
   padding: 8px 10px;
   border-radius: 4px;
   font-size: 13px;
@@ -244,7 +244,7 @@
 .compose-form__buttons {
   padding: 10px;
   background: $darken8_color5;
-  box-shadow: inset 0 5px 5px $fifty_alpha_color8;
+  box-shadow: inset 0 5px 5px $color8_alpha05;
   border-radius: 0 0 4px 4px;
   display: flex;
 
@@ -1031,7 +1031,7 @@ a.status__content__spoiler-link {
     background: $color2;
     padding: 4px 0;
     border-radius: 4px;
-    box-shadow: 0 0 15px $forty_alpha_color8;
+    box-shadow: 0 0 15px $color8_alpha04;
     min-width: 140px;
     position: relative;
     left: -10px;
@@ -1330,7 +1330,7 @@ a.status__content__spoiler-link {
   top: 100%;
   width: 100%;
   z-index: 99;
-  box-shadow: 0 0 15px $forty_alpha_color8;
+  box-shadow: 0 0 15px $color8_alpha04;
 }
 
 .react-autosuggest__section-title {
@@ -1584,7 +1584,7 @@ a.status__content__spoiler-link {
   top: 100%;
   width: 100%;
   z-index: 99;
-  box-shadow: 0 0 15px $forty_alpha_color8;
+  box-shadow: 0 0 15px $color8_alpha04;
   background: $color2;
   color: $color1;
   font-size: 14px;
@@ -1979,7 +1979,7 @@ button.icon-button.active i.fa-retweet {
 
   &:active, &:focus {
     border-bottom-color: $color4;
-    background: $ten_alpha_color8;
+    background: $color8_alpha01;
   }
 }
 
@@ -2035,7 +2035,7 @@ button.icon-button.active i.fa-retweet {
   border-radius: 4px;
   overflow: hidden;
   position: relative;
-  box-shadow: 0 0 8px $twenty_alpha_color8;
+  box-shadow: 0 0 8px $color8_alpha02;
 
   .emojione {
     margin: 0;
@@ -2218,7 +2218,7 @@ button.icon-button.active i.fa-retweet {
 
 .upload-area {
   align-items: center;
-  background: $eighty_alpha_color8;
+  background: $color8_alpha08;
   display: flex;
   height: 100%;
   justify-content: center;
@@ -2253,7 +2253,7 @@ button.icon-button.active i.fa-retweet {
   z-index: -1;
   border-radius: 4px;
   background: $color1;
-  box-shadow: 0 0 5px $twenty_alpha_color8;
+  box-shadow: 0 0 5px $color8_alpha02;
 }
 
 .upload-area__content {
@@ -2401,12 +2401,12 @@ button.icon-button.active i.fa-retweet {
   .privacy-dropdown__value {
     background: $color5;
     border-radius: 4px 4px 0 0;
-    box-shadow: 0 -4px 4px $ten_alpha_color8;
+    box-shadow: 0 -4px 4px $color8_alpha01;
   }
 
   .privacy-dropdown__dropdown {
     display: block;
-    box-shadow: 2px 4px 6px $ten_alpha_color8;
+    box-shadow: 2px 4px 6px $color8_alpha01;
   }
 }
 
@@ -2522,7 +2522,7 @@ button.icon-button.active i.fa-retweet {
   bottom: 0;
   z-index: 9999;
   opacity: 0;
-  background: $seventy_alpha_color8;
+  background: $color8_alpha07;
   transform: translateZ(0px);
 }
 
@@ -2735,7 +2735,7 @@ button.icon-button.active i.fa-retweet {
     padding: 10px;
     text-align: center;
     font-size: 14px;
-    box-shadow: 1px 2px 6px $thirty_alpha_color8;
+    box-shadow: 1px 2px 6px $color8_alpha03;
 
     .onboarding-modal__image {
       border-radius: 4px;
@@ -2904,7 +2904,7 @@ button.icon-button.active i.fa-retweet {
   display: block;
   position: absolute;
   color: $color5;
-  background: $fifty_alpha_color8;
+  background: $color8_alpha05;
   bottom: 6px;
   left: 6px;
   padding: 2px 6px;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1780,12 +1780,12 @@ button.icon-button.active i.fa-retweet {
   outline: 0;
 
   &.active {
-    box-shadow: 0 1px 0 $transparent3_color4;
+    box-shadow: 0 1px 0 $color4_alpha03;
   }
 
   &.active .fa {
     color: $color4;
-    text-shadow: 0 0 10px $transparent3_color4;
+    text-shadow: 0 0 10px $color4_alpha03;
   }
 
   &.hidden-on-mobile {
@@ -2024,7 +2024,7 @@ button.icon-button.active i.fa-retweet {
   pointer-events: none;
   height: 28px;
   z-index: 1;
-  background: radial-gradient(ellipse, $transparent3_color4 0%, transparent 60%);
+  background: radial-gradient(ellipse, $color4_alpha03 0%, transparent 60%);
 }
 
 .emoji-dialog {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -131,13 +131,13 @@
 
   &.overlayed {
     box-sizing: content-box;
-    background: rgba($color8, 0.6);
+    background: $sixty_alpha_color8;
     color: $seventy_alpha_color5;
     border-radius: 4px;
     padding: 2px;
 
     &:hover {
-      background: rgba($color8, 0.9);
+      background: $ninety_alpha_color8;
     }
   }
 }
@@ -206,7 +206,7 @@
   color: $thirtythree_darken_color3;
   margin-bottom: 15px;
   background: $color3;
-  box-shadow: 0 2px 6px rgba($color8, 0.3);
+  box-shadow: 0 2px 6px $thirty_alpha_color8;
   padding: 8px 10px;
   border-radius: 4px;
   font-size: 13px;
@@ -244,7 +244,7 @@
 .compose-form__buttons {
   padding: 10px;
   background: $eight_darken_color5;
-  box-shadow: inset 0 5px 5px rgba($color8, 0.05);
+  box-shadow: inset 0 5px 5px $fifty_alpha_color8;
   border-radius: 0 0 4px 4px;
   display: flex;
 
@@ -1031,7 +1031,7 @@ a.status__content__spoiler-link {
     background: $color2;
     padding: 4px 0;
     border-radius: 4px;
-    box-shadow: 0 0 15px rgba($color8, 0.4);
+    box-shadow: 0 0 15px $forty_alpha_color8;
     min-width: 140px;
     position: relative;
     left: -10px;
@@ -1330,7 +1330,7 @@ a.status__content__spoiler-link {
   top: 100%;
   width: 100%;
   z-index: 99;
-  box-shadow: 0 0 15px rgba($color8, 0.4);
+  box-shadow: 0 0 15px $forty_alpha_color8;
 }
 
 .react-autosuggest__section-title {
@@ -1412,7 +1412,6 @@ a.status__content__spoiler-link {
   border: 0;
   padding: 0;
   user-select: none;
-  -webkit-tap-highlight-color: rgba($color8, 0);
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -1585,7 +1584,7 @@ a.status__content__spoiler-link {
   top: 100%;
   width: 100%;
   z-index: 99;
-  box-shadow: 0 0 15px rgba($color8, 0.4);
+  box-shadow: 0 0 15px $forty_alpha_color8;
   background: $color2;
   color: $color1;
   font-size: 14px;
@@ -1980,7 +1979,7 @@ button.icon-button.active i.fa-retweet {
 
   &:active, &:focus {
     border-bottom-color: $color4;
-    background: rgba($color8, 0.1);
+    background: $ten_alpha_color8;
   }
 }
 
@@ -2036,7 +2035,7 @@ button.icon-button.active i.fa-retweet {
   border-radius: 4px;
   overflow: hidden;
   position: relative;
-  box-shadow: 0 0 8px rgba($color8, 0.2);
+  box-shadow: 0 0 8px $twenty_alpha_color8;
 
   .emojione {
     margin: 0;
@@ -2219,7 +2218,7 @@ button.icon-button.active i.fa-retweet {
 
 .upload-area {
   align-items: center;
-  background: rgba($color8, 0.8);
+  background: $eighty_alpha_color8;
   display: flex;
   height: 100%;
   justify-content: center;
@@ -2254,7 +2253,7 @@ button.icon-button.active i.fa-retweet {
   z-index: -1;
   border-radius: 4px;
   background: $color1;
-  box-shadow: 0 0 5px rgba($color8, 0.2);
+  box-shadow: 0 0 5px $twenty_alpha_color8;
 }
 
 .upload-area__content {
@@ -2402,12 +2401,12 @@ button.icon-button.active i.fa-retweet {
   .privacy-dropdown__value {
     background: $color5;
     border-radius: 4px 4px 0 0;
-    box-shadow: 0 -4px 4px rgba($color8, 0.1);
+    box-shadow: 0 -4px 4px $ten_alpha_color8;
   }
 
   .privacy-dropdown__dropdown {
     display: block;
-    box-shadow: 2px 4px 6px rgba($color8, 0.1);
+    box-shadow: 2px 4px 6px $ten_alpha_color8;
   }
 }
 
@@ -2523,7 +2522,7 @@ button.icon-button.active i.fa-retweet {
   bottom: 0;
   z-index: 9999;
   opacity: 0;
-  background: rgba($color8, 0.7);
+  background: $seventy_alpha_color8;
   transform: translateZ(0px);
 }
 
@@ -2736,7 +2735,7 @@ button.icon-button.active i.fa-retweet {
     padding: 10px;
     text-align: center;
     font-size: 14px;
-    box-shadow: 1px 2px 6px rgba($color8, 0.3);
+    box-shadow: 1px 2px 6px $thirty_alpha_color8;
 
     .onboarding-modal__image {
       border-radius: 4px;
@@ -2905,7 +2904,7 @@ button.icon-button.active i.fa-retweet {
   display: block;
   position: absolute;
   color: $color5;
-  background: rgba($color8, 0.5);
+  background: $fifty_alpha_color8;
   bottom: 6px;
   left: 6px;
   padding: 2px 6px;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -132,7 +132,7 @@
   &.overlayed {
     box-sizing: content-box;
     background: $color8_alpha06;
-    color: $transparent7_color5;
+    color: $color5_alpha07;
     border-radius: 4px;
     padding: 2px;
 
@@ -2173,7 +2173,7 @@ button.icon-button.active i.fa-retweet {
     font-family: inherit;
     display: block;
     width: 100%;
-    background: $transparent_color2;
+    background: $color2_alpha03;
     color: $darken16_color2;
     border: 1px solid $color2;
     border-radius: 4px;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -996,7 +996,7 @@ a.status__content__spoiler-link {
 }
 
 .dropdown__sep {
-  border-bottom: 1px solid darken($color2, 8%);
+  border-bottom: 1px solid $eight_darken_color2;
   margin: 5px 7px 6px;
   padding-top: 1px;
 }
@@ -1596,7 +1596,7 @@ a.status__content__spoiler-link {
   cursor: pointer;
 
   &:hover {
-    background: darken($color2, 10%);
+    background: $ten_darken_color2;
   }
 
   &.selected {
@@ -2115,7 +2115,7 @@ button.icon-button.active i.fa-retweet {
     font-size: 12px;
     text-transform: uppercase;
     font-weight: 500;
-    color: darken($color2, 18%);
+    color: $eighteen_darken_color2;
     cursor: default;
   }
 
@@ -2164,7 +2164,7 @@ button.icon-button.active i.fa-retweet {
 
   .emoji-search-wrapper {
     padding: 10px;
-    border-bottom: 1px solid lighten($color2, 4%);
+    border-bottom: 1px solid $four_lighten_color2;
   }
 
   .emoji-search {
@@ -2174,8 +2174,8 @@ button.icon-button.active i.fa-retweet {
     font-family: inherit;
     display: block;
     width: 100%;
-    background: rgba($color2, 0.3);
-    color: darken($color2, 18%);
+    background: $transparent_color2;
+    color: $eighteen_darken_color2;
     border: 1px solid $color2;
     border-radius: 4px;
   }
@@ -2198,7 +2198,7 @@ button.icon-button.active i.fa-retweet {
     }
 
     &:hover {
-      background: lighten($color2, 3%);
+      background: $three_lighten_color2;
 
       img, svg {
         transform: translateZ(0) scale(1.2);
@@ -2510,7 +2510,7 @@ button.icon-button.active i.fa-retweet {
   text-decoration: none;
 
   &:hover, &:active, &:focus {
-    color: lighten($color2, 4%);
+    color: $four_lighten_color2;
     text-decoration: underline;
   }
 }
@@ -2620,7 +2620,7 @@ button.icon-button.active i.fa-retweet {
 
 .onboarding-modal__paginator {
   flex: 0 0 auto;
-  background: darken($color2, 8%);
+  background: $eight_darken_color2;
   display: flex;
   padding: 25px;
 
@@ -2629,13 +2629,13 @@ button.icon-button.active i.fa-retweet {
   }
 
   a {
-    color: darken($color2, 34%);
+    color: $thirtyfour_darken_color2;
     text-decoration: none;
     font-size: 14px;
     font-weight: 500;
 
     &:hover, &:focus, &:active {
-      color: darken($color2, 38%);
+      color: $thirtyeight_darken_color2;
     }
 
     &.onboarding-modal__done, &.onboarding-modal__next {
@@ -2655,17 +2655,17 @@ button.icon-button.active i.fa-retweet {
   width: 14px;
   height: 14px;
   border-radius: 14px;
-  background: darken($color2, 16%);
+  background: $sixteen_darken_color2;
   margin: 0 3px;
   cursor: pointer;
 
   &:hover {
-    background: darken($color2, 18%);
+    background: $eighteen_darken_color2;
   }
 
   &.active {
     cursor: default;
-    background: darken($color2, 24%);
+    background: $twentyfour_darken_color2;
   }
 }
 
@@ -2800,7 +2800,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .boost-modal, .confirmation-modal {
-  background: lighten($color2, 8%);
+  background: $eight_lighten_color2;
   color: $color1;
   border-radius: 8px;
   overflow: hidden;
@@ -2872,13 +2872,13 @@ button.icon-button.active i.fa-retweet {
   }
 
   a {
-    color: darken($color2, 34%);
+    color: $thirtyfour_darken_color2;
     text-decoration: none;
     font-size: 14px;
     font-weight: 500;
 
     &:hover, &:focus, &:active {
-      color: darken($color2, 38%);
+      color: $thirtyeight_darken_color2;
     }
   }
 }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -51,7 +51,7 @@
 }
 
 .column-icon {
-  background: lighten($color1, 4%);
+  background: $lighter_lighten_color1;
   color: $color3;
   cursor: pointer;
   font-size: 16px;
@@ -85,19 +85,19 @@
 .icon-button {
   display: inline-block;
   padding: 0;
-  color: lighten($color1, 26%);
+  color: $quarter_lighten_color1;
   border: none;
   background: transparent;
   cursor: pointer;
   transition: color 100ms ease-in;
 
   &:hover, &:active, &:focus {
-    color: lighten($color1, 33%);
+    color: $third_lighten_color1;
     transition: color 200ms ease-out;
   }
 
   &.disabled {
-    color: lighten($color1, 13%);
+    color: $eigth_lighten_color1;
     cursor: default;
   }
 
@@ -114,10 +114,10 @@
   }
 
   &.inverted {
-    color: lighten($color1, 33%);
+    color: $third_lighten_color1;
 
     &:hover, &:active, &:focus {
-      color: lighten($color1, 26%);
+      color: $quarter_lighten_color1;
     }
 
     &.active {
@@ -143,7 +143,7 @@
 }
 
 .text-icon-button {
-  color: lighten($color1, 33%);
+  color: $third_lighten_color1;
   border: none;
   background: transparent;
   cursor: pointer;
@@ -155,12 +155,12 @@
   transition: color 100ms ease-in;
 
   &:hover, &:active, &:focus {
-    color: lighten($color1, 26%);
+    color: $quarter_lighten_color1;
     transition: color 200ms ease-out;
   }
 
   &.disabled {
-    color: lighten($color1, 13%);
+    color: $eigth_lighten_color1;
     cursor: default;
   }
 
@@ -410,7 +410,7 @@
       text-decoration: underline;
 
       .fa {
-        color: lighten($color1, 40%);
+        color: $forty_lighten_color1;
       }
     }
 
@@ -425,15 +425,15 @@
     }
 
     .fa {
-      color: lighten($color1, 30%);
+      color: $thirty_lighten_color1;
     }
   }
 
   .status__content__spoiler-link {
-    background: lighten($color1, 30%);
+    background: $thirty_lighten_color1;
 
     &:hover {
-      background: lighten($color1, 33%);
+      background: $third_lighten_color1;
       text-decoration: none;
     }
   }
@@ -442,7 +442,7 @@
 a.status__content__spoiler-link {
   display: inline-block;
   border-radius: 2px;
-  color: lighten($color1, 8%);
+  color: $eight_lighten_color1;
   font-weight: 500;
   font-size: 11px;
   padding: 0px 6px;
@@ -460,7 +460,7 @@ a.status__content__spoiler-link {
   padding-left: 68px;
   position: relative;
   min-height: 48px;
-  border-bottom: 1px solid lighten($color1, 8%);
+  border-bottom: 1px solid $eight_lighten_color1;
   cursor: default;
 
   &.light {
@@ -502,11 +502,11 @@ a.status__content__spoiler-link {
 }
 
 .status__relative-time {
-  color: lighten($color1, 26%);
+  color: $quarter_lighten_color1;
 }
 
 .status__display-name {
-  color: lighten($color1, 26%);
+  color: $quarter_lighten_color1;
 }
 
 .status__info .status__display-name {
@@ -525,11 +525,11 @@ a.status__content__spoiler-link {
 }
 
 .status-check-box {
-  border-bottom: 1px solid lighten($color1, 8%);
+  border-bottom: 1px solid $eight_lighten_color1;
   display: flex;
 
   .status__content {
-    background: lighten($color1, 4%);
+    background: $lighter_lighten_color1;
     flex: 1 1 auto;
     padding: 10px;
   }
@@ -545,14 +545,14 @@ a.status__content__spoiler-link {
 
 .status__prepend {
   margin-left: 68px;
-  color: lighten($color1, 26%);
+  color: $quarter_lighten_color1;
   padding: 8px 0;
   padding-bottom: 2px;
   font-size: 14px;
   position: relative;
 
   .status__display-name strong {
-    color: lighten($color1, 26%);
+    color: $quarter_lighten_color1;
   }
 }
 
@@ -573,7 +573,7 @@ a.status__content__spoiler-link {
 }
 
 .detailed-status {
-  background: lighten($color1, 4%);
+  background: $lighter_lighten_color1;
   padding: 14px 10px;
 
   .status__content {
@@ -589,17 +589,17 @@ a.status__content__spoiler-link {
 
 .detailed-status__meta {
   margin-top: 15px;
-  color: lighten($color1, 26%);
+  color: $quarter_lighten_color1;
   font-size: 14px;
   line-height: 18px;
 }
 
 .detailed-status__action-bar {
-  background: lighten($color1, 4%);
+  background: $lighter_lighten_color1;
   display: flex;
   flex-direction: row;
-  border-top: 1px solid lighten($color1, 8%);
-  border-bottom: 1px solid lighten($color1, 8%);
+  border-top: 1px solid $eight_lighten_color1;
+  border-bottom: 1px solid $eight_lighten_color1;
   padding: 10px 0;
 }
 
@@ -621,13 +621,13 @@ a.status__content__spoiler-link {
   font-size: 14px;
 
   a {
-    color: lighten($color1, 20%);
+    color: $twenty_lighten_color1;
   }
 }
 
 .account {
   padding: 10px;
-  border-bottom: 1px solid lighten($color1, 8%);
+  border-bottom: 1px solid $eight_lighten_color1;
 
   .account__display-name {
     flex: 1 1 auto;
@@ -664,14 +664,14 @@ a.status__content__spoiler-link {
 
 .account__header {
   flex: 0 0 auto;
-  background: lighten($color1, 4%);
+  background: $lighter_lighten_color1;
   text-align: center;
   background-size: cover;
   background-position: center;
   position: relative;
 
   & > div {
-    background: rgba(lighten($color1, 4%), 0.9);
+    background: rgba($lighter_lighten_color1, 0.9);
   }
 
   .account__header__content {
@@ -721,8 +721,8 @@ a.status__content__spoiler-link {
 }
 
 .account__action-bar {
-  border-top: 1px solid lighten($color1, 8%);
-  border-bottom: 1px solid lighten($color1, 8%);
+  border-top: 1px solid $eight_lighten_color1;
+  border-bottom: 1px solid $eight_lighten_color1;
   line-height: 36px;
   overflow: hidden;
   flex: 0 0 auto;
@@ -744,7 +744,7 @@ a.status__content__spoiler-link {
   text-decoration: none;
   overflow: hidden;
   width: 80px;
-  border-left: 1px solid lighten($color1, 8%);
+  border-left: 1px solid $eight_lighten_color1;
   padding: 10px 5px;
 
   & > span {
@@ -762,7 +762,7 @@ a.status__content__spoiler-link {
   }
 
   abbr {
-    color: lighten($color1, 26%);
+    color: $quarter_lighten_color1;
   }
 }
 
@@ -864,11 +864,11 @@ a.status__content__spoiler-link {
 .muted {
   .status__content p,
   .status__content a {
-    color: lighten($color1, 26%);
+    color: $quarter_lighten_color1;
   }
 
   .status__display-name strong {
-    color: lighten($color1, 26%);
+    color: $quarter_lighten_color1;
   }
 
   .status__avatar {
@@ -876,11 +876,11 @@ a.status__content__spoiler-link {
   }
 
   a.status__content__spoiler-link {
-    background: lighten($color1, 26%);
-    color: lighten($color1, 4%);
+    background: $quarter_lighten_color1;
+    color: $lighter_lighten_color1;
 
     &:hover {
-      background: lighten($color1, 29%);
+      background: $twentynine_lighten_color1;
       text-decoration: none;
     }
   }
@@ -1079,7 +1079,7 @@ a.status__content__spoiler-link {
 .static-content {
   padding: 10px;
   padding-top: 20px;
-  color: lighten($color1, 26%);
+  color: $quarter_lighten_color1;
 
   h1 {
     font-size: 16px;
@@ -1127,7 +1127,7 @@ a.status__content__spoiler-link {
   flex-direction: column;
   width: 100%;
   height: 100%;
-  background: darken($color1, 7%);
+  background: $seven_darken_color1;
 }
 
 .drawer {
@@ -1228,7 +1228,7 @@ a.status__content__spoiler-link {
   position: absolute;
   top: 0;
   left: 0;
-  background: lighten($color1, 13%);
+  background: $eigth_lighten_color1;
   box-sizing: border-box;
   padding: 0;
   display: flex;
@@ -1244,7 +1244,7 @@ a.status__content__spoiler-link {
 }
 
 .pseudo-drawer {
-  background: lighten($color1, 13%);
+  background: $eigth_lighten_color1;
   font-size: 13px;
   text-align: left;
 }
@@ -1252,7 +1252,7 @@ a.status__content__spoiler-link {
 .drawer__header {
   flex: 0 0 auto;
   font-size: 16px;
-  background: lighten($color1, 8%);
+  background: $eight_lighten_color1;
   margin-bottom: 10px;
   display: flex;
   flex-direction: row;
@@ -1261,7 +1261,7 @@ a.status__content__spoiler-link {
     transition: background 100ms ease-in;
 
     &:hover {
-      background: lighten($color1, 3%);
+      background: $three_lighten_color1;
       transition: background 200ms ease-out;
     }
   }
@@ -1269,7 +1269,7 @@ a.status__content__spoiler-link {
 
 .tabs-bar {
   display: flex;
-  background: lighten($color1, 8%);
+  background: $eight_lighten_color1;
   flex: 0 0 auto;
   overflow-y: auto;
 }
@@ -1283,7 +1283,7 @@ a.status__content__spoiler-link {
   text-align: center;
   font-size: 14px;
   font-weight: 500;
-  border-bottom: 2px solid lighten($color1, 8%);
+  border-bottom: 2px solid $eight_lighten_color1;
   transition: all 200ms linear;
 
   .fa {
@@ -1297,7 +1297,7 @@ a.status__content__spoiler-link {
   }
 
   &:hover, &:focus, &:active {
-    background: lighten($color1, 14%);
+    background: $fourteen_lighten_color1;
     transition: all 100ms linear;
   }
 
@@ -1372,7 +1372,7 @@ a.status__content__spoiler-link {
 }
 
 .column-back-button {
-  background: lighten($color1, 4%);
+  background: $lighter_lighten_color1;
   color: $color4;
   cursor: pointer;
   flex: 0 0 auto;
@@ -1443,7 +1443,7 @@ a.status__content__spoiler-link {
 }
 
 .react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {
-  background-color: darken($color1, 10%);
+  background-color: $ten_darken_color1;
 }
 
 .react-toggle--checked .react-toggle-track {
@@ -1511,7 +1511,7 @@ a.status__content__spoiler-link {
 }
 
 .column-link {
-  background: lighten($color1, 8%);
+  background: $eight_lighten_color1;
   color: $color5;
   display: block;
   font-size: 16px;
@@ -1519,7 +1519,7 @@ a.status__content__spoiler-link {
   text-decoration: none;
 
   &:hover {
-    background: lighten($color1, 11%);
+    background: $eleven_lighten_color1;
   }
 
   &.hidden-on-mobile {
@@ -1654,7 +1654,7 @@ a.status__content__spoiler-link {
   }
 
   a {
-    color: lighten($color1, 26%);
+    color: $quarter_lighten_color1;
   }
 }
 
@@ -1703,15 +1703,15 @@ button.icon-button.active i.fa-retweet {
   display: flex;
   cursor: pointer;
   font-size: 14px;
-  border: 1px solid lighten($color1, 8%);
+  border: 1px solid $eight_lighten_color1;
   border-radius: 4px;
-  color: lighten($color1, 26%);
+  color: $quarter_lighten_color1;
   margin-top: 14px;
   text-decoration: none;
   overflow: hidden;
 
   &:hover {
-    background: lighten($color1, 8%);
+    background: $eight_lighten_color1;
   }
 }
 
@@ -1737,7 +1737,7 @@ button.icon-button.active i.fa-retweet {
 
 .status-card__image {
   flex: 0 0 100px;
-  background: lighten($color1, 8%);
+  background: $eight_lighten_color1;
 }
 
 .status-card__image-image {
@@ -1750,13 +1750,13 @@ button.icon-button.active i.fa-retweet {
 
 .load-more {
   display: block;
-  color: lighten($color1, 26%);
+  color: $quarter_lighten_color1;
   text-align: center;
   padding: 15px;
   text-decoration: none;
 
   &:hover {
-    background: lighten($color1, 2%);
+    background: $two_lighten_color1;
   }
 }
 
@@ -1764,7 +1764,7 @@ button.icon-button.active i.fa-retweet {
   text-align: center;
   font-size: 16px;
   font-weight: 500;
-  color: lighten($color1, 16%);
+  color: $sixteen_lighten_color1;
   padding-top: 210px;
   background: image-url('mastodon-not-found.png') no-repeat center -50px;
   cursor: default;
@@ -1773,7 +1773,7 @@ button.icon-button.active i.fa-retweet {
 .column-header {
   padding: 15px;
   font-size: 16px;
-  background: lighten($color1, 4%);
+  background: $lighter_lighten_color1;
   flex: 0 0 auto;
   cursor: pointer;
   position: relative;
@@ -1815,16 +1815,16 @@ button.icon-button.active i.fa-retweet {
 
 .collapsable-collapsed {
   color: $color3;
-  background: lighten($color1, 4%);
+  background: $lighter_lighten_color1;
 }
 
 .collapsable {
   color: $color5;
-  background: lighten($color1, 8%);
+  background: $eight_lighten_color1;
 
   &:hover {
     color: $color5;
-    background: lighten($color1, 8%);
+    background: $eight_lighten_color1;
   }
 }
 
@@ -1862,13 +1862,13 @@ button.icon-button.active i.fa-retweet {
 }
 
 .modal-container--preloader {
-  background: lighten($color1, 8%);
+  background: $eight_lighten_color1;
 }
 
 .account--panel {
-  background: lighten($color1, 4%);
-  border-top: 1px solid lighten($color1, 8%);
-  border-bottom: 1px solid lighten($color1, 8%);
+  background: $lighter_lighten_color1;
+  border-top: 1px solid $eight_lighten_color1;
+  border-bottom: 1px solid $eight_lighten_color1;
   display: flex;
   flex-direction: row;
   padding: 10px 0px;
@@ -1881,7 +1881,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .column-settings__outer {
-  background: lighten($color1, 8%);
+  background: $eight_lighten_color1;
   padding: 15px;
 }
 
@@ -1941,7 +1941,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .report__target {
-  border-bottom: 1px solid lighten($color1, 4%);
+  border-bottom: 1px solid $lighter_lighten_color1;
   color: $color2;
   flex: 0 0 auto;
   padding: 10px;
@@ -1994,7 +1994,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .empty-column-indicator {
-  color: lighten($color1, 20%);
+  color: $twenty_lighten_color1;
   background: $color1;
   text-align: center;
   padding: 20px;
@@ -2265,13 +2265,13 @@ button.icon-button.active i.fa-retweet {
   color: $color2;
   font-size: 18px;
   font-weight: 500;
-  border: 2px dashed lighten($color1, 26%);
+  border: 2px dashed $quarter_lighten_color1;
   border-radius: 4px;
 }
 
 .upload-progress {
   padding: 10px;
-  color: lighten($color1, 26%);
+  color: $quarter_lighten_color1;
   overflow: hidden;
   display: flex;
 
@@ -2296,7 +2296,7 @@ button.icon-button.active i.fa-retweet {
   width: 100%;
   height: 6px;
   border-radius: 6px;
-  background: lighten($color1, 26%);
+  background: $quarter_lighten_color1;
   position: relative;
   margin-top: 5px;
 }
@@ -2440,7 +2440,7 @@ button.icon-button.active i.fa-retweet {
   }
 
   &:focus {
-    background: lighten($color1, 4%);
+    background: $lighter_lighten_color1;
   }
 
   @media screen and (max-width: 600px) {
@@ -2495,9 +2495,9 @@ button.icon-button.active i.fa-retweet {
 }
 
 .search-results__header {
-  color: lighten($color1, 26%);
-  background: lighten($color1, 2%);
-  border-bottom: 1px solid darken($color1, 4%);
+  color: $quarter_lighten_color1;
+  background: $two_lighten_color1;
+  border-bottom: 1px solid $light_darken_color1;
   padding: 15px 10px;
   font-size: 14px;
   font-weight: 500;
@@ -2690,7 +2690,7 @@ button.icon-button.active i.fa-retweet {
 
   p {
     font-size: 16px;
-    color: lighten($color1, 8%);
+    color: $eight_lighten_color1;
     margin-top: 10px;
     margin-bottom: 10px;
 
@@ -2729,7 +2729,7 @@ button.icon-button.active i.fa-retweet {
   }
 
   .figure {
-    background: darken($color1, 8%);
+    background: $eight_darken_color1;
     color: $color2;
     margin-bottom: 20px;
     border-radius: 4px;
@@ -2843,7 +2843,7 @@ button.icon-button.active i.fa-retweet {
   & > div {
     flex: 1 1 auto;
     text-align: right;
-    color: lighten($color1, 33%);
+    color: $third_lighten_color1;
     padding-right: 10px;
   }
 
@@ -2935,7 +2935,7 @@ button.icon-button.active i.fa-retweet {
 .attachment-list {
   display: flex;
   font-size: 14px;
-  border: 1px solid lighten($color1, 8%);
+  border: 1px solid $eight_lighten_color1;
   border-radius: 4px;
   margin-top: 14px;
   overflow: hidden;
@@ -2943,10 +2943,10 @@ button.icon-button.active i.fa-retweet {
 
 .attachment-list__icon {
   flex: 0 0 auto;
-  color: lighten($color1, 26%);
+  color: $quarter_lighten_color1;
   padding: 8px 18px;
   cursor: default;
-  border-right: 1px solid lighten($color1, 8%);
+  border-right: 1px solid $eight_lighten_color1;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2973,7 +2973,7 @@ button.icon-button.active i.fa-retweet {
 
   a {
     text-decoration: none;
-    color: lighten($color1, 26%);
+    color: $quarter_lighten_color1;
     font-weight: 500;
 
     &:hover {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -6,7 +6,7 @@
 }
 
 .button {
-  background-color: darken($color4, 3%);
+  background-color: $three_darken_color4;
   border: 10px none;
   border-radius: 4px;
   box-sizing: border-box;
@@ -32,7 +32,7 @@
   &:active,
   &:focus,
   &:hover {
-    background-color: lighten($color4, 7%);
+    background-color: $seven_lighten_color4;
     transition: all 200ms ease-out;
   }
 
@@ -1451,7 +1451,7 @@ a.status__content__spoiler-link {
 }
 
 .react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-track {
-  background-color: lighten($color4, 10%);
+  background-color: $ten_lighten_color4;
 }
 
 .react-toggle-track-check {
@@ -1781,12 +1781,12 @@ button.icon-button.active i.fa-retweet {
   outline: 0;
 
   &.active {
-    box-shadow: 0 1px 0 rgba($color4, 0.3);
+    box-shadow: 0 1px 0 $thirty_alpha_color4;
   }
 
   &.active .fa {
     color: $color4;
-    text-shadow: 0 0 10px rgba($color4, 0.4);
+    text-shadow: 0 0 10px $fourty_alpha_color4;
   }
 
   &.hidden-on-mobile {
@@ -2025,7 +2025,7 @@ button.icon-button.active i.fa-retweet {
   pointer-events: none;
   height: 28px;
   z-index: 1;
-  background: radial-gradient(ellipse, rgba($color4, 0.23) 0%, rgba($color4, 0) 60%);
+  background: radial-gradient(ellipse, $twentythree_alpha_color4 0%, rgba($color4, 0) 60%);
 }
 
 .emoji-dialog {
@@ -2376,7 +2376,7 @@ button.icon-button.active i.fa-retweet {
   }
 
   &.active:hover {
-    background: lighten($color4, 4%);
+    background: $four_lighten_color4;
   }
 }
 
@@ -2684,7 +2684,7 @@ button.icon-button.active i.fa-retweet {
     color: $color4;
 
     &:hover, &:focus, &:active {
-      color: lighten($color4, 4%);
+      color: $four_lighten_color4;
     }
   }
 

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -6,7 +6,7 @@
 }
 
 .button {
-  background-color: $three_darken_color4;
+  background-color: $darken5_color4;
   border: 10px none;
   border-radius: 4px;
   box-sizing: border-box;
@@ -32,7 +32,7 @@
   &:active,
   &:focus,
   &:hover {
-    background-color: $seven_lighten_color4;
+    background-color: $lighten5_color4;
     transition: all 200ms ease-out;
   }
 
@@ -132,7 +132,7 @@
   &.overlayed {
     box-sizing: content-box;
     background: $sixty_alpha_color8;
-    color: $seventy_alpha_color5;
+    color: $transparent7_color5;
     border-radius: 4px;
     padding: 2px;
 
@@ -243,7 +243,7 @@
 
 .compose-form__buttons {
   padding: 10px;
-  background: $eight_darken_color5;
+  background: $darken8_color5;
   box-shadow: inset 0 5px 5px $fifty_alpha_color8;
   border-radius: 0 0 4px 4px;
   display: flex;
@@ -1450,7 +1450,7 @@ a.status__content__spoiler-link {
 }
 
 .react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-track {
-  background-color: $ten_lighten_color4;
+  background-color: $lighten10_color4;
 }
 
 .react-toggle-track-check {
@@ -1499,7 +1499,7 @@ a.status__content__spoiler-link {
   height: 22px;
   border: 1px solid $color1;
   border-radius: 50%;
-  background-color: $two_darken_color5;
+  background-color: $darken2_color5;
   box-sizing: border-box;
   transition: all 0.25s ease;
 }
@@ -1780,12 +1780,12 @@ button.icon-button.active i.fa-retweet {
   outline: 0;
 
   &.active {
-    box-shadow: 0 1px 0 $thirty_alpha_color4;
+    box-shadow: 0 1px 0 $transparent3_color4;
   }
 
   &.active .fa {
     color: $color4;
-    text-shadow: 0 0 10px $fourty_alpha_color4;
+    text-shadow: 0 0 10px $transparent3_color4;
   }
 
   &.hidden-on-mobile {
@@ -2024,7 +2024,7 @@ button.icon-button.active i.fa-retweet {
   pointer-events: none;
   height: 28px;
   z-index: 1;
-  background: radial-gradient(ellipse, $twentythree_alpha_color4 0%, transparent 60%);
+  background: radial-gradient(ellipse, $transparent3_color4 0%, transparent 60%);
 }
 
 .emoji-dialog {
@@ -2375,7 +2375,7 @@ button.icon-button.active i.fa-retweet {
   }
 
   &.active:hover {
-    background: $lighten4_color24;
+    background: $lighten5_color4;
   }
 }
 
@@ -2683,7 +2683,7 @@ button.icon-button.active i.fa-retweet {
     color: $color4;
 
     &:hover, &:focus, &:active {
-      color: $lighten4_color24;
+      color: $lighten5_color4;
     }
   }
 

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -62,7 +62,7 @@
   z-index: 3;
 
   &:hover {
-    color: $seven_lighten_color3;
+    color: $lighten8_color3;
   }
 }
 
@@ -203,7 +203,7 @@
 }
 
 .compose-form__warning {
-  color: $thirtythree_darken_color3;
+  color: $darken30_color3;
   margin-bottom: 15px;
   background: $color3;
   box-shadow: 0 2px 6px $thirty_alpha_color8;
@@ -213,12 +213,12 @@
   font-weight: 400;
 
   strong {
-    color: $thirtythree_darken_color3;
+    color: $darken30_color3;
     font-weight: 500;
   }
 
   a {
-    color: $thirtythree_darken_color3;
+    color: $darken30_color3;
     font-weight: 500;
     text-decoration: underline;
 
@@ -494,7 +494,7 @@ a.status__content__spoiler-link {
         background: $color3;
 
         &:hover {
-          background: $eight_lighten_color3;
+          background: $lighten8_color3;
         }
       }
     }
@@ -2388,7 +2388,7 @@ button.icon-button.active i.fa-retweet {
 
 .privacy-dropdown__option__content {
   flex: 1 1 auto;
-  color: $twenty_darken_color3;
+  color: $darken30_color3;
 
   strong {
     font-weight: 500;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -51,7 +51,7 @@
 }
 
 .column-icon {
-  background: $lighter_lighten_color1;
+  background: $lighten5_color1;
   color: $color3;
   cursor: pointer;
   font-size: 16px;
@@ -85,19 +85,19 @@
 .icon-button {
   display: inline-block;
   padding: 0;
-  color: $quarter_lighten_color1;
+  color: $lighten25_color1;
   border: none;
   background: transparent;
   cursor: pointer;
   transition: color 100ms ease-in;
 
   &:hover, &:active, &:focus {
-    color: $third_lighten_color1;
+    color: $lighten35_color1;
     transition: color 200ms ease-out;
   }
 
   &.disabled {
-    color: $eigth_lighten_color1;
+    color: $lighten15_color1;
     cursor: default;
   }
 
@@ -114,10 +114,10 @@
   }
 
   &.inverted {
-    color: $third_lighten_color1;
+    color: $lighten35_color1;
 
     &:hover, &:active, &:focus {
-      color: $quarter_lighten_color1;
+      color: $lighten25_color1;
     }
 
     &.active {
@@ -143,7 +143,7 @@
 }
 
 .text-icon-button {
-  color: $third_lighten_color1;
+  color: $lighten35_color1;
   border: none;
   background: transparent;
   cursor: pointer;
@@ -155,12 +155,12 @@
   transition: color 100ms ease-in;
 
   &:hover, &:active, &:focus {
-    color: $quarter_lighten_color1;
+    color: $lighten25_color1;
     transition: color 200ms ease-out;
   }
 
   &.disabled {
-    color: $eigth_lighten_color1;
+    color: $lighten15_color1;
     cursor: default;
   }
 
@@ -410,7 +410,7 @@
       text-decoration: underline;
 
       .fa {
-        color: $forty_lighten_color1;
+        color: $lighten40_color1;
       }
     }
 
@@ -425,15 +425,15 @@
     }
 
     .fa {
-      color: $thirty_lighten_color1;
+      color: $lighten30_color1;
     }
   }
 
   .status__content__spoiler-link {
-    background: $thirty_lighten_color1;
+    background: $lighten30_color1;
 
     &:hover {
-      background: $third_lighten_color1;
+      background: $lighten35_color1;
       text-decoration: none;
     }
   }
@@ -442,7 +442,7 @@
 a.status__content__spoiler-link {
   display: inline-block;
   border-radius: 2px;
-  color: $eight_lighten_color1;
+  color: $lighten10_color1;
   font-weight: 500;
   font-size: 11px;
   padding: 0px 6px;
@@ -460,7 +460,7 @@ a.status__content__spoiler-link {
   padding-left: 68px;
   position: relative;
   min-height: 48px;
-  border-bottom: 1px solid $eight_lighten_color1;
+  border-bottom: 1px solid $lighten10_color1;
   cursor: default;
 
   &.light {
@@ -502,11 +502,11 @@ a.status__content__spoiler-link {
 }
 
 .status__relative-time {
-  color: $quarter_lighten_color1;
+  color: $lighten25_color1;
 }
 
 .status__display-name {
-  color: $quarter_lighten_color1;
+  color: $lighten25_color1;
 }
 
 .status__info .status__display-name {
@@ -525,11 +525,11 @@ a.status__content__spoiler-link {
 }
 
 .status-check-box {
-  border-bottom: 1px solid $eight_lighten_color1;
+  border-bottom: 1px solid $lighten10_color1;
   display: flex;
 
   .status__content {
-    background: $lighter_lighten_color1;
+    background: $lighten5_color1;
     flex: 1 1 auto;
     padding: 10px;
   }
@@ -545,14 +545,14 @@ a.status__content__spoiler-link {
 
 .status__prepend {
   margin-left: 68px;
-  color: $quarter_lighten_color1;
+  color: $lighten25_color1;
   padding: 8px 0;
   padding-bottom: 2px;
   font-size: 14px;
   position: relative;
 
   .status__display-name strong {
-    color: $quarter_lighten_color1;
+    color: $lighten25_color1;
   }
 }
 
@@ -573,7 +573,7 @@ a.status__content__spoiler-link {
 }
 
 .detailed-status {
-  background: $lighter_lighten_color1;
+  background: $lighten5_color1;
   padding: 14px 10px;
 
   .status__content {
@@ -589,17 +589,17 @@ a.status__content__spoiler-link {
 
 .detailed-status__meta {
   margin-top: 15px;
-  color: $quarter_lighten_color1;
+  color: $lighten25_color1;
   font-size: 14px;
   line-height: 18px;
 }
 
 .detailed-status__action-bar {
-  background: $lighter_lighten_color1;
+  background: $lighten5_color1;
   display: flex;
   flex-direction: row;
-  border-top: 1px solid $eight_lighten_color1;
-  border-bottom: 1px solid $eight_lighten_color1;
+  border-top: 1px solid $lighten10_color1;
+  border-bottom: 1px solid $lighten10_color1;
   padding: 10px 0;
 }
 
@@ -621,13 +621,13 @@ a.status__content__spoiler-link {
   font-size: 14px;
 
   a {
-    color: $twenty_lighten_color1;
+    color: $lighten20_color1;
   }
 }
 
 .account {
   padding: 10px;
-  border-bottom: 1px solid $eight_lighten_color1;
+  border-bottom: 1px solid $lighten10_color1;
 
   .account__display-name {
     flex: 1 1 auto;
@@ -664,14 +664,14 @@ a.status__content__spoiler-link {
 
 .account__header {
   flex: 0 0 auto;
-  background: $lighter_lighten_color1;
+  background: $lighten5_color1;
   text-align: center;
   background-size: cover;
   background-position: center;
   position: relative;
 
   & > div {
-    background: rgba($lighter_lighten_color1, 0.9);
+    background: rgba($lighten5_color1, 0.9);
   }
 
   .account__header__content {
@@ -721,8 +721,8 @@ a.status__content__spoiler-link {
 }
 
 .account__action-bar {
-  border-top: 1px solid $eight_lighten_color1;
-  border-bottom: 1px solid $eight_lighten_color1;
+  border-top: 1px solid $lighten10_color1;
+  border-bottom: 1px solid $lighten10_color1;
   line-height: 36px;
   overflow: hidden;
   flex: 0 0 auto;
@@ -744,7 +744,7 @@ a.status__content__spoiler-link {
   text-decoration: none;
   overflow: hidden;
   width: 80px;
-  border-left: 1px solid $eight_lighten_color1;
+  border-left: 1px solid $lighten10_color1;
   padding: 10px 5px;
 
   & > span {
@@ -762,7 +762,7 @@ a.status__content__spoiler-link {
   }
 
   abbr {
-    color: $quarter_lighten_color1;
+    color: $lighten25_color1;
   }
 }
 
@@ -864,11 +864,11 @@ a.status__content__spoiler-link {
 .muted {
   .status__content p,
   .status__content a {
-    color: $quarter_lighten_color1;
+    color: $lighten25_color1;
   }
 
   .status__display-name strong {
-    color: $quarter_lighten_color1;
+    color: $lighten25_color1;
   }
 
   .status__avatar {
@@ -876,11 +876,11 @@ a.status__content__spoiler-link {
   }
 
   a.status__content__spoiler-link {
-    background: $quarter_lighten_color1;
-    color: $lighter_lighten_color1;
+    background: $lighten25_color1;
+    color: $lighten5_color1;
 
     &:hover {
-      background: $twentynine_lighten_color1;
+      background: $lighten30_color1;
       text-decoration: none;
     }
   }
@@ -1079,7 +1079,7 @@ a.status__content__spoiler-link {
 .static-content {
   padding: 10px;
   padding-top: 20px;
-  color: $quarter_lighten_color1;
+  color: $lighten25_color1;
 
   h1 {
     font-size: 16px;
@@ -1127,7 +1127,7 @@ a.status__content__spoiler-link {
   flex-direction: column;
   width: 100%;
   height: 100%;
-  background: $seven_darken_color1;
+  background: $darken5_color1;
 }
 
 .drawer {
@@ -1228,7 +1228,7 @@ a.status__content__spoiler-link {
   position: absolute;
   top: 0;
   left: 0;
-  background: $eigth_lighten_color1;
+  background: $lighten15_color1;
   box-sizing: border-box;
   padding: 0;
   display: flex;
@@ -1244,7 +1244,7 @@ a.status__content__spoiler-link {
 }
 
 .pseudo-drawer {
-  background: $eigth_lighten_color1;
+  background: $lighten15_color1;
   font-size: 13px;
   text-align: left;
 }
@@ -1252,7 +1252,7 @@ a.status__content__spoiler-link {
 .drawer__header {
   flex: 0 0 auto;
   font-size: 16px;
-  background: $eight_lighten_color1;
+  background: $lighten10_color1;
   margin-bottom: 10px;
   display: flex;
   flex-direction: row;
@@ -1261,7 +1261,7 @@ a.status__content__spoiler-link {
     transition: background 100ms ease-in;
 
     &:hover {
-      background: $three_lighten_color1;
+      background: $lighten5_color1;
       transition: background 200ms ease-out;
     }
   }
@@ -1269,7 +1269,7 @@ a.status__content__spoiler-link {
 
 .tabs-bar {
   display: flex;
-  background: $eight_lighten_color1;
+  background: $lighten10_color1;
   flex: 0 0 auto;
   overflow-y: auto;
 }
@@ -1283,7 +1283,7 @@ a.status__content__spoiler-link {
   text-align: center;
   font-size: 14px;
   font-weight: 500;
-  border-bottom: 2px solid $eight_lighten_color1;
+  border-bottom: 2px solid $lighten10_color1;
   transition: all 200ms linear;
 
   .fa {
@@ -1297,7 +1297,7 @@ a.status__content__spoiler-link {
   }
 
   &:hover, &:focus, &:active {
-    background: $fourteen_lighten_color1;
+    background: $lighten15_color1;
     transition: all 100ms linear;
   }
 
@@ -1372,7 +1372,7 @@ a.status__content__spoiler-link {
 }
 
 .column-back-button {
-  background: $lighter_lighten_color1;
+  background: $lighten5_color1;
   color: $color4;
   cursor: pointer;
   flex: 0 0 auto;
@@ -1442,7 +1442,7 @@ a.status__content__spoiler-link {
 }
 
 .react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {
-  background-color: $ten_darken_color1;
+  background-color: $darken10_color1;
 }
 
 .react-toggle--checked .react-toggle-track {
@@ -1510,7 +1510,7 @@ a.status__content__spoiler-link {
 }
 
 .column-link {
-  background: $eight_lighten_color1;
+  background: $lighten10_color1;
   color: $color5;
   display: block;
   font-size: 16px;
@@ -1518,7 +1518,7 @@ a.status__content__spoiler-link {
   text-decoration: none;
 
   &:hover {
-    background: $eleven_lighten_color1;
+    background: $lighten10_color1;
   }
 
   &.hidden-on-mobile {
@@ -1653,7 +1653,7 @@ a.status__content__spoiler-link {
   }
 
   a {
-    color: $quarter_lighten_color1;
+    color: $lighten25_color1;
   }
 }
 
@@ -1702,15 +1702,15 @@ button.icon-button.active i.fa-retweet {
   display: flex;
   cursor: pointer;
   font-size: 14px;
-  border: 1px solid $eight_lighten_color1;
+  border: 1px solid $lighten10_color1;
   border-radius: 4px;
-  color: $quarter_lighten_color1;
+  color: $lighten25_color1;
   margin-top: 14px;
   text-decoration: none;
   overflow: hidden;
 
   &:hover {
-    background: $eight_lighten_color1;
+    background: $lighten10_color1;
   }
 }
 
@@ -1736,7 +1736,7 @@ button.icon-button.active i.fa-retweet {
 
 .status-card__image {
   flex: 0 0 100px;
-  background: $eight_lighten_color1;
+  background: $lighten10_color1;
 }
 
 .status-card__image-image {
@@ -1749,13 +1749,13 @@ button.icon-button.active i.fa-retweet {
 
 .load-more {
   display: block;
-  color: $quarter_lighten_color1;
+  color: $lighten25_color1;
   text-align: center;
   padding: 15px;
   text-decoration: none;
 
   &:hover {
-    background: $two_lighten_color1;
+    background: $lighten5_color1;
   }
 }
 
@@ -1763,7 +1763,7 @@ button.icon-button.active i.fa-retweet {
   text-align: center;
   font-size: 16px;
   font-weight: 500;
-  color: $sixteen_lighten_color1;
+  color: $lighten15_color1;
   padding-top: 210px;
   background: image-url('mastodon-not-found.png') no-repeat center -50px;
   cursor: default;
@@ -1772,7 +1772,7 @@ button.icon-button.active i.fa-retweet {
 .column-header {
   padding: 15px;
   font-size: 16px;
-  background: $lighter_lighten_color1;
+  background: $lighten5_color1;
   flex: 0 0 auto;
   cursor: pointer;
   position: relative;
@@ -1814,16 +1814,16 @@ button.icon-button.active i.fa-retweet {
 
 .collapsable-collapsed {
   color: $color3;
-  background: $lighter_lighten_color1;
+  background: $lighten5_color1;
 }
 
 .collapsable {
   color: $color5;
-  background: $eight_lighten_color1;
+  background: $lighten10_color1;
 
   &:hover {
     color: $color5;
-    background: $eight_lighten_color1;
+    background: $lighten10_color1;
   }
 }
 
@@ -1861,13 +1861,13 @@ button.icon-button.active i.fa-retweet {
 }
 
 .modal-container--preloader {
-  background: $eight_lighten_color1;
+  background: $lighten10_color1;
 }
 
 .account--panel {
-  background: $lighter_lighten_color1;
-  border-top: 1px solid $eight_lighten_color1;
-  border-bottom: 1px solid $eight_lighten_color1;
+  background: $lighten5_color1;
+  border-top: 1px solid $lighten10_color1;
+  border-bottom: 1px solid $lighten10_color1;
   display: flex;
   flex-direction: row;
   padding: 10px 0px;
@@ -1880,7 +1880,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .column-settings__outer {
-  background: $eight_lighten_color1;
+  background: $lighten10_color1;
   padding: 15px;
 }
 
@@ -1940,7 +1940,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .report__target {
-  border-bottom: 1px solid $lighter_lighten_color1;
+  border-bottom: 1px solid $lighten5_color1;
   color: $color2;
   flex: 0 0 auto;
   padding: 10px;
@@ -1993,7 +1993,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .empty-column-indicator {
-  color: $twenty_lighten_color1;
+  color: $lighten20_color1;
   background: $color1;
   text-align: center;
   padding: 20px;
@@ -2264,13 +2264,13 @@ button.icon-button.active i.fa-retweet {
   color: $color2;
   font-size: 18px;
   font-weight: 500;
-  border: 2px dashed $quarter_lighten_color1;
+  border: 2px dashed $lighten25_color1;
   border-radius: 4px;
 }
 
 .upload-progress {
   padding: 10px;
-  color: $quarter_lighten_color1;
+  color: $lighten25_color1;
   overflow: hidden;
   display: flex;
 
@@ -2295,7 +2295,7 @@ button.icon-button.active i.fa-retweet {
   width: 100%;
   height: 6px;
   border-radius: 6px;
-  background: $quarter_lighten_color1;
+  background: $lighten25_color1;
   position: relative;
   margin-top: 5px;
 }
@@ -2439,7 +2439,7 @@ button.icon-button.active i.fa-retweet {
   }
 
   &:focus {
-    background: $lighter_lighten_color1;
+    background: $lighten5_color1;
   }
 
   @media screen and (max-width: 600px) {
@@ -2494,9 +2494,9 @@ button.icon-button.active i.fa-retweet {
 }
 
 .search-results__header {
-  color: $quarter_lighten_color1;
-  background: $two_lighten_color1;
-  border-bottom: 1px solid $light_darken_color1;
+  color: $lighten25_color1;
+  background: $lighten5_color1;
+  border-bottom: 1px solid $darken5_color1;
   padding: 15px 10px;
   font-size: 14px;
   font-weight: 500;
@@ -2689,7 +2689,7 @@ button.icon-button.active i.fa-retweet {
 
   p {
     font-size: 16px;
-    color: $eight_lighten_color1;
+    color: $lighten10_color1;
     margin-top: 10px;
     margin-bottom: 10px;
 
@@ -2728,7 +2728,7 @@ button.icon-button.active i.fa-retweet {
   }
 
   .figure {
-    background: $eight_darken_color1;
+    background: $darken10_color1;
     color: $color2;
     margin-bottom: 20px;
     border-radius: 4px;
@@ -2842,7 +2842,7 @@ button.icon-button.active i.fa-retweet {
   & > div {
     flex: 1 1 auto;
     text-align: right;
-    color: $third_lighten_color1;
+    color: $lighten35_color1;
     padding-right: 10px;
   }
 
@@ -2934,7 +2934,7 @@ button.icon-button.active i.fa-retweet {
 .attachment-list {
   display: flex;
   font-size: 14px;
-  border: 1px solid $eight_lighten_color1;
+  border: 1px solid $lighten10_color1;
   border-radius: 4px;
   margin-top: 14px;
   overflow: hidden;
@@ -2942,10 +2942,10 @@ button.icon-button.active i.fa-retweet {
 
 .attachment-list__icon {
   flex: 0 0 auto;
-  color: $quarter_lighten_color1;
+  color: $lighten25_color1;
   padding: 8px 18px;
   cursor: default;
-  border-right: 1px solid $eight_lighten_color1;
+  border-right: 1px solid $lighten10_color1;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2972,7 +2972,7 @@ button.icon-button.active i.fa-retweet {
 
   a {
     text-decoration: none;
-    color: $quarter_lighten_color1;
+    color: $lighten25_color1;
     font-weight: 500;
 
     &:hover {

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -132,7 +132,7 @@
   &.overlayed {
     box-sizing: content-box;
     background: rgba($color8, 0.6);
-    color: rgba($color5, 0.7);
+    color: $seventy_alpha_color5;
     border-radius: 4px;
     padding: 2px;
 
@@ -243,7 +243,7 @@
 
 .compose-form__buttons {
   padding: 10px;
-  background: darken($color5, 8%);
+  background: $eight_darken_color5;
   box-shadow: inset 0 5px 5px rgba($color8, 0.05);
   border-radius: 0 0 4px 4px;
   display: flex;
@@ -1500,7 +1500,7 @@ a.status__content__spoiler-link {
   height: 22px;
   border: 1px solid $color1;
   border-radius: 50%;
-  background-color: darken($color5, 2%);
+  background-color: $two_darken_color5;
   box-sizing: border-box;
   transition: all 0.25s ease;
 }

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -2,7 +2,7 @@
   text-align: center;
   margin-top: 30px;
   font-size: 12px;
-  color: $darken24_color2;
+  color: $darken4_color3;
 
   .domain {
     font-weight: 500;

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,3 +1,4 @@
+.footer {
   text-align: center;
   margin-top: 30px;
   font-size: 12px;

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -1,8 +1,7 @@
-.footer {
   text-align: center;
   margin-top: 30px;
   font-size: 12px;
-  color: $twentyfive_darken_color2;
+  color: $darken24_color2;
 
   .domain {
     font-weight: 500;

--- a/app/assets/stylesheets/footer.scss
+++ b/app/assets/stylesheets/footer.scss
@@ -2,7 +2,7 @@
   text-align: center;
   margin-top: 30px;
   font-size: 12px;
-  color: darken($color2, 25%);
+  color: $twentyfive_darken_color2;
 
   .domain {
     font-weight: 500;

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -16,7 +16,7 @@ code {
 
   span.hint {
     display: block;
-    color: $color3;
+    color: $form-hint-color;
     font-size: 12px;
     margin-top: 4px;
   }
@@ -49,7 +49,7 @@ code {
     label {
       font-family: inherit;
       font-size: 16px;
-      color: $color5;
+      color: $form-text-color;
       display: block;
       padding-top: 5px;
     }
@@ -102,11 +102,11 @@ code {
     background: transparent;
     box-sizing: border-box;
     border: 0;
-    border-bottom: 2px solid $color3;
+    border-bottom: 2px solid $form-input-border-bottom-color;
     border-radius: 2px 2px 0 0;
     padding: 7px 4px;
     font-size: 16px;
-    color: $color5;
+    color: $form-text-color;
     display: block;
     width: 100%;
     outline: 0;
@@ -118,32 +118,32 @@ code {
     }
 
     &:focus:invalid {
-      border-bottom-color: $color6;
+      border-bottom-color: $form-input-border-bottom-color-invalid;
     }
 
     &:required:valid {
-      border-bottom-color: $color7;
+      border-bottom-color: $form-input-border-bottom-color-valid;
     }
 
     &:active, &:focus {
-      border-bottom-color: $color4;
-      background: $color8_alpha01;
+      border-bottom-color: $form-input-border-bottom-color-active;
+      background: $form-input-background-active;
     }
   }
 
   .input.field_with_errors {
     label {
-      color: $color6;
+      color: $form-text-error;
     }
 
     input[type=text], input[type=email], input[type=password] {
-      border-bottom-color: $color6;
+      border-bottom-color: $form-input-border-bottom-color-invalid;
     }
 
     .error {
       display: block;
       font-weight: 500;
-      color: $color6;
+      color: $form-text-error;
       margin-top: 4px;
     }
   }
@@ -157,8 +157,8 @@ code {
     width: 100%;
     border: 0;
     border-radius: 4px;
-    background: $color4;
-    color: $color5;
+    background: $form-button-background;
+    color: $form-button-color;
     font-size: 18px;
     padding: 10px;
     text-transform: uppercase;
@@ -171,24 +171,24 @@ code {
     margin-bottom: 10px;
 
     &:hover {
-      background-color: $lighten5_color4;
+      background-color: $form-button-background-hover;
     }
 
     &:active, &:focus {
       position: relative;
       top: 1px;
-      background-color: $darken5_color4;
+      background-color: $form-button-background-active;
     }
 
     &.negative {
-      background: $color6;
+      background: $form-button-negative-background;
 
       &:hover {
-        background-color: $lighten_color6;
+        background-color: $form-button-negative-background-hover;
       }
 
       &:active, &:focus {
-        background-color: $darken_color6;
+        background-color: $form-button-negative-background-active;
       }
     }
   }
@@ -199,12 +199,12 @@ code {
 }
 
 .flash-message {
-  background: $color1;
-  color: $color3;
+  background: $flash-background;
+  color: $flash-color;
   border-radius: 4px;
   padding: 15px 10px;
   margin-bottom: 30px;
-  box-shadow: 0 0 5px $color8_alpha02;
+  box-shadow: 0 0 5px $flash-shadow;
   text-align: center;
 
   strong {
@@ -217,7 +217,7 @@ code {
   text-align: center;
 
   a {
-    color: $color5;
+    color: $form-text-color;
     text-decoration: none;
 
     &:hover {
@@ -229,7 +229,7 @@ code {
 .oauth-prompt, .follow-prompt {
   margin-bottom: 30px;
   text-align: center;
-  color: $color3;
+  color: $prompt-color;
 
   h2 {
     font-size: 16px;
@@ -237,7 +237,7 @@ code {
   }
 
   strong {
-    color: $lighten20_color3;
+    color: $prompt-strong-color;
     font-weight: 500;
   }
 }
@@ -251,7 +251,7 @@ code {
   background: #fff;
   padding: 4px;
   margin-bottom: 20px;
-  box-shadow: 0 0 15px $color8_alpha02;
+  box-shadow: 0 0 15px $qrcode-shadow;
   display: inline-block;
 
   svg {
@@ -262,7 +262,7 @@ code {
 
 .qr-alternative {
   margin-left: 10px;
-  color: $color3;
+  color: $qr-alternative-color;
 
   samp {
     display: block;
@@ -283,16 +283,16 @@ code {
   .warning {
     max-width: 400px;
     box-sizing: border-box;
-    background: $color6_alpha05;
-    color: $color5;
-    text-shadow: 1px 1px 0 $color8_alpha03;
-    box-shadow: 0 2px 6px $color8_alpha04;
+    background: $form-warning-background;
+    color: $form-text-color;
+    text-shadow: 1px 1px 0 $form-warning-text-shadow;
+    box-shadow: 0 2px 6px $form-warning-shadow;
     border-radius: 4px;
     padding: 10px;
     margin-bottom: 15px;
 
     a {
-      color: $color5;
+      color: $form-warning-color;
       text-decoration: underline;
 
       &:hover, &:focus, &:active {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -237,7 +237,7 @@ code {
   }
 
   strong {
-    color: $color2;
+    color: $lighten20_color3;
     font-weight: 500;
   }
 }

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -127,7 +127,7 @@ code {
 
     &:active, &:focus {
       border-bottom-color: $color4;
-      background: rgba($color8, 0.1);
+      background: $ten_alpha_color8;
     }
   }
 
@@ -204,7 +204,7 @@ code {
   border-radius: 4px;
   padding: 15px 10px;
   margin-bottom: 30px;
-  box-shadow: 0 0 5px rgba($color8, 0.2);
+  box-shadow: 0 0 5px $twenty_alpha_color8;
   text-align: center;
 
   strong {
@@ -251,7 +251,7 @@ code {
   background: #fff;
   padding: 4px;
   margin-bottom: 20px;
-  box-shadow: 0 0 15px rgba($color8, 0.2);
+  box-shadow: 0 0 15px $twenty_alpha_color8;
   display: inline-block;
 
   svg {
@@ -285,8 +285,8 @@ code {
     box-sizing: border-box;
     background: $fifty_alpha_color6;
     color: $color5;
-    text-shadow: 1px 1px 0 rgba($color8, 0.3);
-    box-shadow: 0 2px 6px rgba($color8, 0.4);
+    text-shadow: 1px 1px 0 $thirty_alpha_color8;
+    box-shadow: 0 2px 6px $forty_alpha_color8;
     border-radius: 4px;
     padding: 10px;
     margin-bottom: 15px;

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -171,13 +171,13 @@ code {
     margin-bottom: 10px;
 
     &:hover {
-      background-color: lighten($color4, 5%);
+      background-color: $five_lighten_color4;
     }
 
     &:active, &:focus {
       position: relative;
       top: 1px;
-      background-color: darken($color4, 5%);
+      background-color: $five_darken_color4;
     }
 
     &.negative {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -127,7 +127,7 @@ code {
 
     &:active, &:focus {
       border-bottom-color: $color4;
-      background: $ten_alpha_color8;
+      background: $color8_alpha01;
     }
   }
 
@@ -204,7 +204,7 @@ code {
   border-radius: 4px;
   padding: 15px 10px;
   margin-bottom: 30px;
-  box-shadow: 0 0 5px $twenty_alpha_color8;
+  box-shadow: 0 0 5px $color8_alpha02;
   text-align: center;
 
   strong {
@@ -251,7 +251,7 @@ code {
   background: #fff;
   padding: 4px;
   margin-bottom: 20px;
-  box-shadow: 0 0 15px $twenty_alpha_color8;
+  box-shadow: 0 0 15px $color8_alpha02;
   display: inline-block;
 
   svg {
@@ -285,8 +285,8 @@ code {
     box-sizing: border-box;
     background: $transparent_color6;
     color: $color5;
-    text-shadow: 1px 1px 0 $thirty_alpha_color8;
-    box-shadow: 0 2px 6px $forty_alpha_color8;
+    text-shadow: 1px 1px 0 $color8_alpha03;
+    box-shadow: 0 2px 6px $color8_alpha04;
     border-radius: 4px;
     padding: 10px;
     margin-bottom: 15px;

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -171,13 +171,13 @@ code {
     margin-bottom: 10px;
 
     &:hover {
-      background-color: $five_lighten_color4;
+      background-color: $lighten5_color4;
     }
 
     &:active, &:focus {
       position: relative;
       top: 1px;
-      background-color: $five_darken_color4;
+      background-color: $darken5_color4;
     }
 
     &.negative {

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -283,7 +283,7 @@ code {
   .warning {
     max-width: 400px;
     box-sizing: border-box;
-    background: $transparent_color6;
+    background: $color6_alpha05;
     color: $color5;
     text-shadow: 1px 1px 0 $color8_alpha03;
     box-shadow: 0 2px 6px $color8_alpha04;

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -184,11 +184,11 @@ code {
       background: $color6;
 
       &:hover {
-        background-color: lighten($color6, 5%);
+        background-color: $five_lighten_color6;
       }
 
       &:active, &:focus {
-        background-color: darken($color6, 5%);
+        background-color: $five_darken_color6;
       }
     }
   }
@@ -283,7 +283,7 @@ code {
   .warning {
     max-width: 400px;
     box-sizing: border-box;
-    background: rgba($color6, 0.5);
+    background: $fifty_alpha_color6;
     color: $color5;
     text-shadow: 1px 1px 0 rgba($color8, 0.3);
     box-shadow: 0 2px 6px rgba($color8, 0.4);

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -184,11 +184,11 @@ code {
       background: $color6;
 
       &:hover {
-        background-color: $five_lighten_color6;
+        background-color: $lighten_color6;
       }
 
       &:active, &:focus {
-        background-color: $five_darken_color6;
+        background-color: $darken_color6;
       }
     }
   }
@@ -283,7 +283,7 @@ code {
   .warning {
     max-width: 400px;
     box-sizing: border-box;
-    background: $fifty_alpha_color6;
+    background: $transparent_color6;
     color: $color5;
     text-shadow: 1px 1px 0 $thirty_alpha_color8;
     box-shadow: 0 2px 6px $forty_alpha_color8;

--- a/app/assets/stylesheets/landing_strip.scss
+++ b/app/assets/stylesheets/landing_strip.scss
@@ -1,5 +1,5 @@
 .landing-strip {
-  background: $darken_transparent8_color1;
+  background: $darken_color1_alpha08;
   color: $color3;
   font-weight: 400;
   padding: 14px;

--- a/app/assets/stylesheets/landing_strip.scss
+++ b/app/assets/stylesheets/landing_strip.scss
@@ -1,5 +1,5 @@
 .landing-strip {
-  background: $light_transparent_darken_color1;
+  background: $$darken_transparent8_color1;
   color: $color3;
   font-weight: 400;
   padding: 14px;

--- a/app/assets/stylesheets/landing_strip.scss
+++ b/app/assets/stylesheets/landing_strip.scss
@@ -1,5 +1,5 @@
 .landing-strip {
-  background: $$darken_transparent8_color1;
+  background: $darken_transparent8_color1;
   color: $color3;
   font-weight: 400;
   padding: 14px;

--- a/app/assets/stylesheets/landing_strip.scss
+++ b/app/assets/stylesheets/landing_strip.scss
@@ -1,5 +1,5 @@
 .landing-strip {
-  background: rgba(darken($color1, 7%), 0.8);
+  background: $light_transparent_darken_color1;
   color: $color3;
   font-weight: 400;
   padding: 14px;

--- a/app/assets/stylesheets/reset.scss
+++ b/app/assets/stylesheets/reset.scss
@@ -59,17 +59,17 @@ table {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: lighten($color1, 4%);
+  background: $lighter_lighten_color1;
   border: 0px none $color5;
   border-radius: 50px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: lighten($color1, 6%);
+  background: $six_lighten_color1;
 }
 
 ::-webkit-scrollbar-thumb:active {
-  background: lighten($color1, 4%);
+  background: $lighter_lighten_color1;
 }
 
 ::-webkit-scrollbar-track {

--- a/app/assets/stylesheets/reset.scss
+++ b/app/assets/stylesheets/reset.scss
@@ -59,17 +59,17 @@ table {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: $lighter_lighten_color1;
+  background: $lighten5_color1;
   border: 0px none $color5;
   border-radius: 50px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: $six_lighten_color1;
+  background: $lighten5_color1;
 }
 
 ::-webkit-scrollbar-thumb:active {
-  background: $lighter_lighten_color1;
+  background: $lighten5_color1;
 }
 
 ::-webkit-scrollbar-track {

--- a/app/assets/stylesheets/reset.scss
+++ b/app/assets/stylesheets/reset.scss
@@ -75,7 +75,7 @@ table {
 ::-webkit-scrollbar-track {
   border: 0px none $color5;
   border-radius: 0;
-  background: $ten_alpha_color8;
+  background: $color8_alpha01;
 }
 
 ::-webkit-scrollbar-track:hover {

--- a/app/assets/stylesheets/reset.scss
+++ b/app/assets/stylesheets/reset.scss
@@ -75,7 +75,7 @@ table {
 ::-webkit-scrollbar-track {
   border: 0px none $color5;
   border-radius: 0;
-  background: rgba($color8, 0.1);
+  background: $ten_alpha_color8;
 }
 
 ::-webkit-scrollbar-track:hover {

--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -6,7 +6,7 @@
     background: $color5;
 
     .detailed-status.light, .status.light {
-      border-bottom: 1px solid $color2;
+      border-bottom: 1px solid $lighten20_color3;
     }
 
     &:last-child {
@@ -305,7 +305,7 @@
     z-index: 2;
 
     &:hover {
-      background: $darken5_color3;
+      background: $darken4_color3;
     }
 
     span {

--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -283,7 +283,7 @@
       transform: translate(-50%, -50%);
       padding: 5px;
       border-radius: 100px;
-      color: $eighty_alpha_color5;
+      color: $transparent7_color5;
       z-index: 1;
     }
   }

--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -283,7 +283,7 @@
       transform: translate(-50%, -50%);
       padding: 5px;
       border-radius: 100px;
-      color: $transparent7_color5;
+      color: $color5_alpha07;
       z-index: 1;
     }
   }

--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -1,6 +1,6 @@
 .activity-stream {
   clear: both;
-  box-shadow: 0 0 15px rgba($color8, 0.2);
+  box-shadow: 0 0 15px $twenty_alpha_color8;
 
   .entry {
     background: $color5;

--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -103,7 +103,7 @@
         background: $color3;
 
         &:hover {
-          background: lighten($color3, 8%);
+          background: $eight_lighten_color3;
         }
       }
     }
@@ -178,7 +178,7 @@
         background: $color3;
 
         &:hover {
-          background: lighten($color3, 8%);
+          background: $eight_lighten_color3;
         }
       }
     }

--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -305,7 +305,7 @@
     z-index: 2;
 
     &:hover {
-      background: darken($color3, 5%);
+      background: $five_darken_color3;
     }
 
     span {

--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -1,6 +1,6 @@
 .activity-stream {
   clear: both;
-  box-shadow: 0 0 15px $twenty_alpha_color8;
+  box-shadow: 0 0 15px $color8_alpha02;
 
   .entry {
     background: $color5;

--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -103,7 +103,7 @@
         background: $color3;
 
         &:hover {
-          background: $eight_lighten_color3;
+          background: $lighten8_color3;
         }
       }
     }
@@ -178,7 +178,7 @@
         background: $color3;
 
         &:hover {
-          background: $eight_lighten_color3;
+          background: $lighten8_color3;
         }
       }
     }
@@ -305,7 +305,7 @@
     z-index: 2;
 
     &:hover {
-      background: $five_darken_color3;
+      background: $darken5_color3;
     }
 
     span {

--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -283,7 +283,7 @@
       transform: translate(-50%, -50%);
       padding: 5px;
       border-radius: 100px;
-      color: rgba($color5, 0.8);
+      color: $eighty_alpha_color5;
       z-index: 1;
     }
   }

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -51,7 +51,7 @@ a.table-action-link {
   display: inline-block;
   margin-right: 5px;
   padding: 0 10px;
-  color: $seventy_alpha_color5;
+  color: $transparent7_color5;
   font-weight: 500;
 
   &:hover {

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -51,7 +51,7 @@ a.table-action-link {
   display: inline-block;
   margin-right: 5px;
   padding: 0 10px;
-  color: rgba($color5, 0.7);
+  color: $seventy_alpha_color5;
   font-weight: 500;
 
   &:hover {

--- a/app/assets/stylesheets/tables.scss
+++ b/app/assets/stylesheets/tables.scss
@@ -51,7 +51,7 @@ a.table-action-link {
   display: inline-block;
   margin-right: 5px;
   padding: 0 10px;
-  color: $transparent7_color5;
+  color: $color5_alpha07;
   font-weight: 500;
 
   &:hover {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -14,23 +14,16 @@ $darken10_color1:       darken($color1, 10%) !default;
 $darken_color1_alpha05: rgba(darken($color1, 7%), 0.5) !default;
 $darken_color1_alpha08: rgba(darken($color1, 7%), 0.8) !default;
 
-/* $color2 is the default text color
-    and the light background of non-connected view */
-$color2:                #d9e1e8 !default; // lightest
-$lighten4_color2:       lighten($color2, 4%) !default;
-$lighten8_color2:       lighten($color2, 8%) !default;
-$darken8_color2:        darken($color2, 8%) !default;
-$darken16_color2:       darken($color2, 16%) !default;
-$darken24_color2:       darken($color2, 24%) !default;
-$darken36_color2:       darken($color2, 36%) !default;
-$color2_alpha03:        rgba($color2, 0.3) !default;
-
-
-/* $color3 is the base color for muted colors
-(text or bg on dark or light backgrounds) */
-$color3:                #9baec8 !default; // lighter
+/* $color3 is for muted text-color or backgrounds */
+$color3:                #9baec8 !default; // muted text on light bg
+$lighten4_color3:       lighten($color3, 4%) !default;
 $lighten8_color3:       lighten($color3, 8%) !default;
-$darken5_color3:        darken($color3, 5%) !default;
+$lighten12_color3:      lighten($color3, 12%) !default;
+$lighten20_color3:      lighten($color3, 20%) !default;
+$lighten24_color3:      lighten($color3, 24%) !default;
+$lighten28_color3:      lighten($color3, 28%) !default;
+$darken4_color3:        darken($color3, 4%) !default;
+$darken16_color3:       darken($color3, 16%) !default; // muted text on dark bg
 $darken30_color3:       darken($color3, 30%) !default;
 
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -65,6 +65,10 @@ $color8_alpha07:        rgba($color8, 0.7) !default;
 $color8_alpha08:        rgba($color8, 0.8) !default;
 $color8_alpha09:        rgba($color8, 0.9) !default;
 
+// BASICS
+$body-background-color: $color1 !default;
+$admin-background: $darken5_color1 !default;
+
 // FORMS
 $form-hint-color: $color3 !default;
 $form-text-color: $color5 !default;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -64,3 +64,38 @@ $color8_alpha06:        rgba($color8, 0.6) !default;
 $color8_alpha07:        rgba($color8, 0.7) !default;
 $color8_alpha08:        rgba($color8, 0.8) !default;
 $color8_alpha09:        rgba($color8, 0.9) !default;
+
+// FORMS
+$form-hint-color: $color3 !default;
+$form-text-color: $color5 !default;
+$form-text-error: $color6 !default;
+
+$form-input-border-bottom-color: $color3 !default;
+$form-input-border-bottom-color-invalid: $color6 !default;
+$form-input-border-bottom-color-valid: $color7 !default;
+$form-input-border-bottom-color-active: $color4 !default;
+$form-input-background-active: $color8_alpha01 !default;
+
+$form-button-background: $color4 !default;
+$form-button-background-hover: $lighten5_color4 !default;
+$form-button-background-active: $darken5_color4 !default;
+$form-button-color: $color5 !default;
+
+$form-button-negative-background: $color6 !default;
+$form-button-negative-background-hover: $lighten_color6 !default;
+$form-button-negative-background-active: $darken_color6 !default;
+
+$flash-background: $color1 !default;
+$flash-color: $color3 !default;
+$flash-shadow: $color8_alpha02 !default;
+
+$prompt-color: $color3 !default;
+$prompt-strong-color: $lighten20_color3 !default;
+
+$qrcode-shadow: $color8_alpha02 !default;
+$qr-alternative-color: $color3 !default;
+
+$form-warning-background: $color6_alpha05 !default;
+$form-warning-color: $color5 !default;
+$form-warning-text-shadow: $color8_alpha03 !default;
+$form-warning-shadow: $color8_alpha04 !default;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -7,14 +7,14 @@ $lighten15_color1:      lighten($color1, 15%) !default;
 $lighten20_color1:      lighten($color1, 20%) !default;
 $lighten25_color1:      lighten($color1, 25%) !default;
 $lighten30_color1:      lighten($color1, 30%) !default;
-$lighten35_color1:      lighten($color1, 35%) !default;
+$lighten35_color1:      lighten($color1, 35%) !default; // muted text or icons on dark bg
 $lighten40_color1:      lighten($color1, 40%) !default;
 $darken5_color1:        darken($color1, 5%) !default;
 $darken10_color1:       darken($color1, 10%) !default;
 $darken_color1_alpha05: rgba(darken($color1, 7%), 0.5) !default;
 $darken_color1_alpha08: rgba(darken($color1, 7%), 0.8) !default;
 
-/* $color3 is for muted text-color or backgrounds */
+/* $color3 is the secondary color */
 $color3:                #9baec8 !default; // muted text on light bg
 $lighten4_color3:       lighten($color3, 4%) !default;
 $lighten8_color3:       lighten($color3, 8%) !default;
@@ -23,7 +23,7 @@ $lighten20_color3:      lighten($color3, 20%) !default;
 $lighten24_color3:      lighten($color3, 24%) !default;
 $lighten28_color3:      lighten($color3, 28%) !default;
 $darken4_color3:        darken($color3, 4%) !default;
-$darken16_color3:       darken($color3, 16%) !default; // muted text on dark bg
+$darken16_color3:       darken($color3, 16%) !default;
 $darken30_color3:       darken($color3, 30%) !default;
 
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -99,3 +99,34 @@ $form-warning-background: $color6_alpha05 !default;
 $form-warning-color: $color5 !default;
 $form-warning-text-shadow: $color8_alpha03 !default;
 $form-warning-shadow: $color8_alpha04 !default;
+
+// ABOUT
+$about-color: $color3 !default;
+$about-link-color: $color4 !default;
+$about-title1-color: $color4 !default;
+$about-title2-color: $color5 !default;
+$about-title3-color: $lighten20_color3 !default;
+$about-emphasis-color: $color1 !default;
+$about-emphasis-background: $color3 !default;
+$about-screenshot-shadow: $color8_alpha04 !default;
+$about-actions-link-color: $color3 !default;
+$about-infoboard-border: $lighten10_color1 !default;
+$about-infoboard-lastsection: $lighten20_color3 !default;
+$about-infoboard-section-strong: $color5 !default;
+
+$owner-username-color: $color3 !default;
+$owner-link-color: $color5 !default;
+$owner-contact-strong: $color5 !default;
+
+$sidebar-border-color: $lighten10_color1 !default;
+$panel-header-background: $lighten10_color1 !default;
+$panel-list-link-color: $color5_alpha07 !default;
+$panel-list-link-hover-color: $color5 !default;
+$panel-list-link-hover-background: $darken5_color1 !default;
+$panel-list-selected-link-color: $color5 !default;
+$panel-list-selected-link-background: $color4 !default;
+$panel-list-selected-link-hover-background: $lighten5_color4 !default;
+
+$signup-background: $darken_color1_alpha05 !default;
+$signup-shadow: $color8_alpha04 !default;
+$signup-info-link-color: $lighten20_color3 !default;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -55,6 +55,7 @@ $transparent_color2: rgba($color2, 0.3);
 $seven_lighten_color3: lighten($color3, 7%);
 $eight_lighten_color3: lighten($color3, 8%);
 
+$five_darken_color3: darken($color3, 5%);
 $twenty_darken_color3: darken($color3, 24%);
 $thirtythree_darken_color3: darken($color3, 33%);
 
@@ -67,6 +68,7 @@ $ten_lighten_color4: lighten($color4, 10%);
 $three_darken_color4: darken($color4, 3%);
 $five_darken_color4: darken($color4, 5%);
 
+$zero_alpha_color4: rgba($color4, 0);
 $thirty_alpha_color4: rgba($color4, 0.3);
 $fourty_alpha_color4: rgba($color4, 0.4);
 $twentythree_alpha_color4: rgba($color4, 0.23);

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -50,3 +50,9 @@ $thirtyfour_darken_color2: darken($color2, 34%);
 $thirtyeight_darken_color2: darken($color2, 38%);
 
 $transparent_color2: rgba($color2, 0.3);
+
+$seven_lighten_color3: lighten($color3, 7%);
+$thirtythree_darken_color3: darken($color3, 33%);
+$eight_lighten_color3: lighten($color3, 8%);
+$twenty_darken_color3: darken($color3, 24%);
+

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,4 +1,3 @@
-$color1: #282c37 !default; // darkest
 $color2: #d9e1e8 !default; // lightest
 $color3: #9baec8 !default; // lighter
 $color4: #2b90d9 !default; // vibrant
@@ -7,35 +6,22 @@ $color6: #df405a !default; // error red
 $color7: #79bd9a !default; // succ green
 $color8: #000000 !default; // black
 
-$two_lighten_color1: lighten($color1, 2%) !default;
-$three_lighten_color1: lighten($color1, 3%) !default;
-$lighter_lighten_color1: lighten($color1, 4%) !default;
-$light_lighten_color1: lighten($color1, 5%) !default;
-$six_lighten_color1: lighten($color1, 6%) !default;
-$eight_lighten_color1: lighten($color1, 8%) !default;
-$lighten_color1: lighten($color1, 10%) !default;
-$eleven_lighten_color1: lighten($color1, 11%) !default;
-$eigth_lighten_color1: lighten($color1, 13%) !default;
-$fourteen_lighten_color1: lighten($color1, 14%) !default;
-$sixteen_lighten_color1: lighten($color1, 16%) !default;
-$twenty_lighten_color1: lighten($color1, 20%) !default;
-$quarter_lighten_color1: lighten($color1, 26%) !default;
-$twentynine_lighten_color1: lighten($color1, 29%) !default;
-$thirty_lighten_color1: lighten($color1, 30%) !default;
-$third_lighten_color1: lighten($color1, 33%) !default;
-$forty_lighten_color1: lighten($color1, 40%) !default;
+/* $color1 is the default body background-color */
+$color1:            #282c37 !default; // darkest
+$lighten5_color1:   lighten($color1, 5%) !default;
+$lighten10_color1:  lighten($color1, 10%) !default;
+$lighten15_color1:  lighten($color1, 15%) !default;
+$lighten20_color1:  lighten($color1, 20%) !default;
+$lighten25_color1:  lighten($color1, 25%) !default;
+$lighten30_color1:  lighten($color1, 29%) !default;
+$lighten35_color1:  lighten($color1, 33%) !default;
+$lighten40_color1:  lighten($color1, 40%) !default;
+$darken5_color1:    darken($color1, 5%) !default;
+$darken10_color1:   darken($color1, 10%) !default;
+$darken_transparent5_color1: rgba(darken($color1, 7%), 0.5) !default;
+$darken_transparent8_color1: rgba(darken($color1, 7%), 0.8) !default;
 
-$lighter_darken_color1: darken($color1, 2%) !default;
-$light_darken_color1: darken($color1, 4%) !default;
-$darken_color1: darken($color1, 5%) !default;
-$seven_darken_color1: darken($color1, 7%) !default;
-$eight_darken_color1: darken($color1, 8%) !default;
-$ten_darken_color1: darken($color1, 10%) !default;
-
-$darken_transparent_color1: rgba(darken($color1, 7%), 0.5) !default;
-$light_transparent_darken_color1: rgba(darken($color1, 7%), 0.8) !default;
-
-
+/* $color2 is the default text color */
 $three_lighten_color2: lighten($color2, 3%) !default;
 $four_lighten_color2: lighten($color2, 4%) !default;
 $eight_lighten_color2: lighten($color2, 8%) !default;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,72 +1,72 @@
 /* $color1 is the default body background-color */
-$color1:            #282c37 !default; // darkest
-$lighten5_color1:   lighten($color1, 5%) !default;
-$lighten10_color1:  lighten($color1, 10%) !default;
-$lighten15_color1:  lighten($color1, 15%) !default;
-$lighten20_color1:  lighten($color1, 20%) !default;
-$lighten25_color1:  lighten($color1, 25%) !default;
-$lighten30_color1:  lighten($color1, 29%) !default;
-$lighten35_color1:  lighten($color1, 33%) !default;
-$lighten40_color1:  lighten($color1, 40%) !default;
-$darken5_color1:    darken($color1, 5%) !default;
-$darken10_color1:   darken($color1, 10%) !default;
+$color1:                #282c37 !default; // darkest
+$lighten5_color1:       lighten($color1, 5%) !default;
+$lighten10_color1:      lighten($color1, 10%) !default;
+$lighten15_color1:      lighten($color1, 15%) !default;
+$lighten20_color1:      lighten($color1, 20%) !default;
+$lighten25_color1:      lighten($color1, 25%) !default;
+$lighten30_color1:      lighten($color1, 29%) !default;
+$lighten35_color1:      lighten($color1, 33%) !default;
+$lighten40_color1:      lighten($color1, 40%) !default;
+$darken5_color1:        darken($color1, 5%) !default;
+$darken10_color1:       darken($color1, 10%) !default;
 $darken_color1_alpha05: rgba(darken($color1, 7%), 0.5) !default;
 $darken_color1_alpha08: rgba(darken($color1, 7%), 0.8) !default;
 
 /* $color2 is the default text color
     and the light background of non-connected view */
-$color2:              #d9e1e8 !default; // lightest
-$lighten4_color2:     lighten($color2, 4%) !default;
-$lighten8_color2:     lighten($color2, 8%) !default;
-$darken8_color2:      darken($color2, 8%) !default;
-$darken16_color2:     darken($color2, 16%) !default;
-$darken24_color2:     darken($color2, 24%) !default;
-$darken36_color2:     darken($color2, 36%) !default;
-$color2_alpha03:      rgba($color2, 0.3) !default;
+$color2:                #d9e1e8 !default; // lightest
+$lighten4_color2:       lighten($color2, 4%) !default;
+$lighten8_color2:       lighten($color2, 8%) !default;
+$darken8_color2:        darken($color2, 8%) !default;
+$darken16_color2:       darken($color2, 16%) !default;
+$darken24_color2:       darken($color2, 24%) !default;
+$darken36_color2:       darken($color2, 36%) !default;
+$color2_alpha03:        rgba($color2, 0.3) !default;
 
 
 /* $color3 is the base color for muted colors
 (text or bg on dark or light backgrounds) */
-$color3:              #9baec8 !default; // lighter
-$lighten8_color3:     lighten($color3, 8%) !default;
-$darken5_color3:      darken($color3, 5%) !default;
-$darken30_color3:     darken($color3, 30%) !default;
+$color3:                #9baec8 !default; // lighter
+$lighten8_color3:       lighten($color3, 8%) !default;
+$darken5_color3:        darken($color3, 5%) !default;
+$darken30_color3:       darken($color3, 30%) !default;
 
 
 /* $color4 is the accent color */
-$color4:              #2b90d9 !default; // vibrant
-$lighten5_color4:     lighten($color4, 5%) !default;
-$lighten10_color4:    lighten($color4, 10%) !default;
-$darken5_color4:      darken($color4, 5%) !default;
-$transparent3_color4: rgba($color4, 0.3) !default;
+$color4:                #2b90d9 !default; // vibrant
+$lighten5_color4:       lighten($color4, 5%) !default;
+$lighten10_color4:      lighten($color4, 10%) !default;
+$darken5_color4:        darken($color4, 5%) !default;
+$color4_alpha03:        rgba($color4, 0.3) !default;
 
 
 /* $color5 (actually white) is used to enlight text
 like username, title, strong… and for inverted bg */
-$color5:              #ffffff !default; // white
-$darken2_color5:      darken($color5, 2%) !default;
-$darken8_color5:      darken($color5, 8%) !default;
-$color5_alpha07:      rgba($color5, 0.7) !default;
+$color5:                #ffffff !default; // white
+$darken2_color5:        darken($color5, 2%) !default;
+$darken8_color5:        darken($color5, 8%) !default;
+$color5_alpha07:        rgba($color5, 0.7) !default;
 
 
 /* $color6 (error) and $color7 (success) are for
 messages in forms */
-$color6:              #df405a !default; // error red
-$lighten_color6:      lighten($color6, 5%) !default;
-$darken_color6:       darken($color6, 5%) !default;
-$color6_alpha05:      rgba($color6, 0.5) !default;
+$color6:                #df405a !default; // error red
+$lighten_color6:        lighten($color6, 5%) !default;
+$darken_color6:         darken($color6, 5%) !default;
+$color6_alpha05:        rgba($color6, 0.5) !default;
 
-$color7:              #79bd9a !default; // succ green
+$color7:                #79bd9a !default; // succ green
 
 
 /* $color8 (black) is for shadows and alpha backgrounds */
-$color8:              #000000 !default; // black
-$color8_alpha01:      rgba($color8, 0.1) !default;
-$color8_alpha02:      rgba($color8, 0.2) !default;
-$color8_alpha03:      rgba($color8, 0.3) !default;
-$color8_alpha04:      rgba($color8, 0.4) !default;
-$color8_alpha05:      rgba($color8, 0.5) !default;
-$color8_alpha06:      rgba($color8, 0.6) !default;
-$color8_alpha07:      rgba($color8, 0.7) !default;
-$color8_alpha08:      rgba($color8, 0.8) !default;
-$color8_alpha09:      rgba($color8, 0.9) !default;
+$color8:                #000000 !default; // black
+$color8_alpha01:        rgba($color8, 0.1) !default;
+$color8_alpha02:        rgba($color8, 0.2) !default;
+$color8_alpha03:        rgba($color8, 0.3) !default;
+$color8_alpha04:        rgba($color8, 0.4) !default;
+$color8_alpha05:        rgba($color8, 0.5) !default;
+$color8_alpha06:        rgba($color8, 0.6) !default;
+$color8_alpha07:        rgba($color8, 0.7) !default;
+$color8_alpha08:        rgba($color8, 0.8) !default;
+$color8_alpha09:        rgba($color8, 0.9) !default;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -70,3 +70,11 @@ $five_darken_color4: darken($color4, 5%);
 $thirty_alpha_color4: rgba($color4, 0.3);
 $fourty_alpha_color4: rgba($color4, 0.4);
 $twentythree_alpha_color4: rgba($color4, 0.23);
+
+
+$two_darken_color5: darken($color5, 2%);
+$eight_darken_color5: darken($color5, 8%);
+
+$seventy_alpha_color5: rgba($color5, 0.7);
+$eighty_alpha_color5: rgba($color5, 0.8);
+

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -84,3 +84,17 @@ $five_lighten_color6: lighten($color6, 5%);
 $five_darken_color6: darken($color6, 5%);
 
 $fifty_alpha_color6: rgba($color6, 0.5);
+
+
+$ten_alpha_color8: rgba($color8, 0.1);
+$twenty_alpha_color8: rgba($color8, 0.2);
+$thirty_alpha_color8: rgba($color8, 0.3);
+$forty_alpha_color8: rgba($color8, 0.4);
+$fifty_alpha_color8: rgba($color8, 0.5);
+$sixty_alpha_color8: rgba($color8, 0.6);
+$seventy_alpha_color8: rgba($color8, 0.7);
+$eighty_alpha_color8: rgba($color8, 0.8);
+$ninety_alpha_color8: rgba($color8, 0.9);
+
+
+

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,6 +1,3 @@
-$color3: #9baec8 !default; // lighter
-$color4: #2b90d9 !default; // vibrant
-$color5: #ffffff !default; // white
 $color6: #df405a !default; // error red
 $color7: #79bd9a !default; // succ green
 $color8: #000000 !default; // black
@@ -40,31 +37,25 @@ $darken5_color3:      darken($color3, 5%) !default;
 $darken30_color3:     darken($color3, 30%) !default;
 
 
-$lighten4_color24: lighten($color4, 4%) !default;
-$five_lighten_color4: lighten($color4, 5%) !default;
-$seven_lighten_color4: lighten($color4, 7%) !default;
-$ten_lighten_color4: lighten($color4, 10%) !default;
-
-$three_darken_color4: darken($color4, 3%) !default;
-$five_darken_color4: darken($color4, 5%) !default;
-
-$zero_alpha_color4: rgba($color4, 0) !default;
-$thirty_alpha_color4: rgba($color4, 0.3) !default;
-$fourty_alpha_color4: rgba($color4, 0.4) !default;
-$twentythree_alpha_color4: rgba($color4, 0.23) !default;
+/* $color4 is the accent color */
+$color4:              #2b90d9 !default; // vibrant
+$lighten5_color4:     lighten($color4, 5%) !default;
+$lighten10_color4:    lighten($color4, 10%) !default;
+$darken5_color4:      darken($color4, 5%) !default;
+$transparent3_color4: rgba($color4, 0.3) !default;
 
 
-$two_darken_color5: darken($color5, 2%) !default;
-$eight_darken_color5: darken($color5, 8%) !default;
+/* $color5 (actually white) is used to enlight text
+like username, title, strong… and for inverted bg */
+$color5:              #ffffff !default; // white
+$darken2_color5:      darken($color5, 2%) !default;
+$darken8_color5:      darken($color5, 8%) !default;
+$transparent7_color5: rgba($color5, 0.7) !default;
 
-$seventy_alpha_color5: rgba($color5, 0.7) !default;
-$eighty_alpha_color5: rgba($color5, 0.8) !default;
 
 
 $five_lighten_color6: lighten($color6, 5%) !default;
-
 $five_darken_color6: darken($color6, 5%) !default;
-
 $fifty_alpha_color6: rgba($color6, 0.5) !default;
 
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -6,3 +6,32 @@ $color5: #ffffff !default; // white
 $color6: #df405a !default; // error red
 $color7: #79bd9a !default; // succ green
 $color8: #000000 !default; // black
+
+$two_lighten_color1: lighten($color1, 2%) !default;
+$three_lighten_color1: lighten($color1, 3%) !default;
+$lighter_lighten_color1: lighten($color1, 4%) !default;
+$light_lighten_color1: lighten($color1, 5%) !default;
+$six_lighten_color1: lighten($color1, 6%) !default;
+$eight_lighten_color1: lighten($color1, 8%) !default;
+$lighten_color1: lighten($color1, 10%) !default;
+$eleven_lighten_color1: lighten($color1, 11%) !default;
+$eigth_lighten_color1: lighten($color1, 13%) !default;
+$fourteen_lighten_color1: lighten($color1, 14%) !default;
+$sixteen_lighten_color1: lighten($color1, 16%) !default;
+$twenty_lighten_color1: lighten($color1, 20%) !default;
+$quarter_lighten_color1: lighten($color1, 26%) !default;
+$twentynine_lighten_color1: lighten($color1, 29%) !default;
+$thirty_lighten_color1: lighten($color1, 30%) !default;
+$third_lighten_color1: lighten($color1, 33%) !default;
+$forty_lighten_color1: lighten($color1, 40%) !default;
+
+$lighter_darken_color1: darken($color1, 2%) !default;
+$light_darken_color1: darken($color1, 4%) !default;
+$darken_color1: darken($color1, 5%) !default;
+$seven_darken_color1: darken($color1, 7%) !default;
+$eight_darken_color1: darken($color1, 8%) !default;
+$ten_darken_color1: darken($color1, 10%) !default;
+
+$darken_transparent_color1: rgba(darken($color1, 7%), 0.5) !default;
+$light_transparent_darken_color1: rgba(darken($color1, 7%), 0.8) !default;
+

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -51,8 +51,22 @@ $thirtyeight_darken_color2: darken($color2, 38%);
 
 $transparent_color2: rgba($color2, 0.3);
 
-$seven_lighten_color3: lighten($color3, 7%);
-$thirtythree_darken_color3: darken($color3, 33%);
-$eight_lighten_color3: lighten($color3, 8%);
-$twenty_darken_color3: darken($color3, 24%);
 
+$seven_lighten_color3: lighten($color3, 7%);
+$eight_lighten_color3: lighten($color3, 8%);
+
+$twenty_darken_color3: darken($color3, 24%);
+$thirtythree_darken_color3: darken($color3, 33%);
+
+
+$four_lighten_color4: lighten($color4, 4%);
+$five_lighten_color4: lighten($color4, 5%);
+$seven_lighten_color4: lighten($color4, 7%);
+$ten_lighten_color4: lighten($color4, 10%);
+
+$three_darken_color4: darken($color4, 3%);
+$five_darken_color4: darken($color4, 5%);
+
+$thirty_alpha_color4: rgba($color4, 0.3);
+$fourty_alpha_color4: rgba($color4, 0.4);
+$twentythree_alpha_color4: rgba($color4, 0.23);

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -20,7 +20,8 @@ $darken10_color1:   darken($color1, 10%) !default;
 $darken_transparent5_color1: rgba(darken($color1, 7%), 0.5) !default;
 $darken_transparent8_color1: rgba(darken($color1, 7%), 0.8) !default;
 
-/* $color2 is the default text color */
+/* $color2 is the default text color
+    and the light background of non-connected view */
 $color2:              #d9e1e8 !default; // lightest
 $lighten4_color2:     lighten($color2, 4%) !default;
 $lighten8_color2:     lighten($color2, 8%) !default;
@@ -31,12 +32,12 @@ $darken36_color2:     darken($color2, 36%) !default;
 $transparent_color2:  rgba($color2, 0.3) !default;
 
 
-$seven_lighten_color3: lighten($color3, 7%) !default;
-$eight_lighten_color3: lighten($color3, 8%) !default;
-
-$five_darken_color3: darken($color3, 5%) !default;
-$twenty_darken_color3: darken($color3, 24%) !default;
-$thirtythree_darken_color3: darken($color3, 33%) !default;
+/* $color3 is the base color for muted colors
+(text or bg on dark or light backgrounds) */
+$color3:              #9baec8 !default; // lighter
+$lighten8_color3:     lighten($color3, 8%) !default;
+$darken5_color3:      darken($color3, 5%) !default;
+$darken30_color3:     darken($color3, 30%) !default;
 
 
 $lighten4_color24: lighten($color4, 4%) !default;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,12 +1,13 @@
-/* $color1 is the default body background-color */
+/* $color1 is the default body background-color
+  and the column-scrollable background-color */
 $color1:                #282c37 !default; // darkest
 $lighten5_color1:       lighten($color1, 5%) !default;
 $lighten10_color1:      lighten($color1, 10%) !default;
 $lighten15_color1:      lighten($color1, 15%) !default;
 $lighten20_color1:      lighten($color1, 20%) !default;
 $lighten25_color1:      lighten($color1, 25%) !default;
-$lighten30_color1:      lighten($color1, 29%) !default;
-$lighten35_color1:      lighten($color1, 33%) !default;
+$lighten30_color1:      lighten($color1, 30%) !default;
+$lighten35_color1:      lighten($color1, 35%) !default;
 $lighten40_color1:      lighten($color1, 40%) !default;
 $darken5_color1:        darken($color1, 5%) !default;
 $darken10_color1:       darken($color1, 10%) !default;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -35,3 +35,18 @@ $ten_darken_color1: darken($color1, 10%) !default;
 $darken_transparent_color1: rgba(darken($color1, 7%), 0.5) !default;
 $light_transparent_darken_color1: rgba(darken($color1, 7%), 0.8) !default;
 
+
+$three_lighten_color2: lighten($color2, 3%);
+$four_lighten_color2: lighten($color2, 4%);
+$eight_lighten_color2: lighten($color2, 8%);
+
+$eight_darken_color2: darken($color2, 8%);
+$ten_darken_color2: darken($color2, 10%);
+$sixteen_darken_color2: darken($color2, 16%);
+$eighteen_darken_color2: darken($color2, 18%);
+$twentyfour_darken_color2: darken($color2, 24%);
+$twentyfive_darken_color2: darken($color2, 25%);
+$thirtyfour_darken_color2: darken($color2, 34%);
+$thirtyeight_darken_color2: darken($color2, 38%);
+
+$transparent_color2: rgba($color2, 0.3);

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,4 +1,3 @@
-$color2: #d9e1e8 !default; // lightest
 $color3: #9baec8 !default; // lighter
 $color4: #2b90d9 !default; // vibrant
 $color5: #ffffff !default; // white
@@ -22,20 +21,14 @@ $darken_transparent5_color1: rgba(darken($color1, 7%), 0.5) !default;
 $darken_transparent8_color1: rgba(darken($color1, 7%), 0.8) !default;
 
 /* $color2 is the default text color */
-$three_lighten_color2: lighten($color2, 3%) !default;
-$four_lighten_color2: lighten($color2, 4%) !default;
-$eight_lighten_color2: lighten($color2, 8%) !default;
-
-$eight_darken_color2: darken($color2, 8%) !default;
-$ten_darken_color2: darken($color2, 10%) !default;
-$sixteen_darken_color2: darken($color2, 16%) !default;
-$eighteen_darken_color2: darken($color2, 18%) !default;
-$twentyfour_darken_color2: darken($color2, 24%) !default;
-$twentyfive_darken_color2: darken($color2, 25%) !default;
-$thirtyfour_darken_color2: darken($color2, 34%) !default;
-$thirtyeight_darken_color2: darken($color2, 38%) !default;
-
-$transparent_color2: rgba($color2, 0.3) !default;
+$color2:              #d9e1e8 !default; // lightest
+$lighten4_color2:     lighten($color2, 4%) !default;
+$lighten8_color2:     lighten($color2, 8%) !default;
+$darken8_color2:      darken($color2, 8%) !default;
+$darken16_color2:     darken($color2, 16%) !default;
+$darken24_color2:     darken($color2, 24%) !default;
+$darken36_color2:     darken($color2, 36%) !default;
+$transparent_color2:  rgba($color2, 0.3) !default;
 
 
 $seven_lighten_color3: lighten($color3, 7%) !default;
@@ -46,7 +39,7 @@ $twenty_darken_color3: darken($color3, 24%) !default;
 $thirtythree_darken_color3: darken($color3, 33%) !default;
 
 
-$four_lighten_color4: lighten($color4, 4%) !default;
+$lighten4_color24: lighten($color4, 4%) !default;
 $five_lighten_color4: lighten($color4, 5%) !default;
 $seven_lighten_color4: lighten($color4, 7%) !default;
 $ten_lighten_color4: lighten($color4, 10%) !default;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -10,8 +10,8 @@ $lighten35_color1:  lighten($color1, 33%) !default;
 $lighten40_color1:  lighten($color1, 40%) !default;
 $darken5_color1:    darken($color1, 5%) !default;
 $darken10_color1:   darken($color1, 10%) !default;
-$darken_transparent5_color1: rgba(darken($color1, 7%), 0.5) !default;
-$darken_transparent8_color1: rgba(darken($color1, 7%), 0.8) !default;
+$darken_color1_alpha05: rgba(darken($color1, 7%), 0.5) !default;
+$darken_color1_alpha08: rgba(darken($color1, 7%), 0.8) !default;
 
 /* $color2 is the default text color
     and the light background of non-connected view */
@@ -22,7 +22,7 @@ $darken8_color2:      darken($color2, 8%) !default;
 $darken16_color2:     darken($color2, 16%) !default;
 $darken24_color2:     darken($color2, 24%) !default;
 $darken36_color2:     darken($color2, 36%) !default;
-$transparent_color2:  rgba($color2, 0.3) !default;
+$color2_alpha03:      rgba($color2, 0.3) !default;
 
 
 /* $color3 is the base color for muted colors
@@ -46,7 +46,7 @@ like username, title, strong… and for inverted bg */
 $color5:              #ffffff !default; // white
 $darken2_color5:      darken($color5, 2%) !default;
 $darken8_color5:      darken($color5, 8%) !default;
-$transparent7_color5: rgba($color5, 0.7) !default;
+$color5_alpha07:      rgba($color5, 0.7) !default;
 
 
 /* $color6 (error) and $color7 (success) are for
@@ -54,7 +54,7 @@ messages in forms */
 $color6:              #df405a !default; // error red
 $lighten_color6:      lighten($color6, 5%) !default;
 $darken_color6:       darken($color6, 5%) !default;
-$transparent_color6:  rgba($color6, 0.5) !default;
+$color6_alpha05:      rgba($color6, 0.5) !default;
 
 $color7:              #79bd9a !default; // succ green
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -36,67 +36,67 @@ $darken_transparent_color1: rgba(darken($color1, 7%), 0.5) !default;
 $light_transparent_darken_color1: rgba(darken($color1, 7%), 0.8) !default;
 
 
-$three_lighten_color2: lighten($color2, 3%);
-$four_lighten_color2: lighten($color2, 4%);
-$eight_lighten_color2: lighten($color2, 8%);
+$three_lighten_color2: lighten($color2, 3%) !default;
+$four_lighten_color2: lighten($color2, 4%) !default;
+$eight_lighten_color2: lighten($color2, 8%) !default;
 
-$eight_darken_color2: darken($color2, 8%);
-$ten_darken_color2: darken($color2, 10%);
-$sixteen_darken_color2: darken($color2, 16%);
-$eighteen_darken_color2: darken($color2, 18%);
-$twentyfour_darken_color2: darken($color2, 24%);
-$twentyfive_darken_color2: darken($color2, 25%);
-$thirtyfour_darken_color2: darken($color2, 34%);
-$thirtyeight_darken_color2: darken($color2, 38%);
+$eight_darken_color2: darken($color2, 8%) !default;
+$ten_darken_color2: darken($color2, 10%) !default;
+$sixteen_darken_color2: darken($color2, 16%) !default;
+$eighteen_darken_color2: darken($color2, 18%) !default;
+$twentyfour_darken_color2: darken($color2, 24%) !default;
+$twentyfive_darken_color2: darken($color2, 25%) !default;
+$thirtyfour_darken_color2: darken($color2, 34%) !default;
+$thirtyeight_darken_color2: darken($color2, 38%) !default;
 
-$transparent_color2: rgba($color2, 0.3);
-
-
-$seven_lighten_color3: lighten($color3, 7%);
-$eight_lighten_color3: lighten($color3, 8%);
-
-$five_darken_color3: darken($color3, 5%);
-$twenty_darken_color3: darken($color3, 24%);
-$thirtythree_darken_color3: darken($color3, 33%);
+$transparent_color2: rgba($color2, 0.3) !default;
 
 
-$four_lighten_color4: lighten($color4, 4%);
-$five_lighten_color4: lighten($color4, 5%);
-$seven_lighten_color4: lighten($color4, 7%);
-$ten_lighten_color4: lighten($color4, 10%);
+$seven_lighten_color3: lighten($color3, 7%) !default;
+$eight_lighten_color3: lighten($color3, 8%) !default;
 
-$three_darken_color4: darken($color4, 3%);
-$five_darken_color4: darken($color4, 5%);
-
-$zero_alpha_color4: rgba($color4, 0);
-$thirty_alpha_color4: rgba($color4, 0.3);
-$fourty_alpha_color4: rgba($color4, 0.4);
-$twentythree_alpha_color4: rgba($color4, 0.23);
+$five_darken_color3: darken($color3, 5%) !default;
+$twenty_darken_color3: darken($color3, 24%) !default;
+$thirtythree_darken_color3: darken($color3, 33%) !default;
 
 
-$two_darken_color5: darken($color5, 2%);
-$eight_darken_color5: darken($color5, 8%);
+$four_lighten_color4: lighten($color4, 4%) !default;
+$five_lighten_color4: lighten($color4, 5%) !default;
+$seven_lighten_color4: lighten($color4, 7%) !default;
+$ten_lighten_color4: lighten($color4, 10%) !default;
 
-$seventy_alpha_color5: rgba($color5, 0.7);
-$eighty_alpha_color5: rgba($color5, 0.8);
+$three_darken_color4: darken($color4, 3%) !default;
+$five_darken_color4: darken($color4, 5%) !default;
+
+$zero_alpha_color4: rgba($color4, 0) !default;
+$thirty_alpha_color4: rgba($color4, 0.3) !default;
+$fourty_alpha_color4: rgba($color4, 0.4) !default;
+$twentythree_alpha_color4: rgba($color4, 0.23) !default;
 
 
-$five_lighten_color6: lighten($color6, 5%);
+$two_darken_color5: darken($color5, 2%) !default;
+$eight_darken_color5: darken($color5, 8%) !default;
 
-$five_darken_color6: darken($color6, 5%);
+$seventy_alpha_color5: rgba($color5, 0.7) !default;
+$eighty_alpha_color5: rgba($color5, 0.8) !default;
 
-$fifty_alpha_color6: rgba($color6, 0.5);
+
+$five_lighten_color6: lighten($color6, 5%) !default;
+
+$five_darken_color6: darken($color6, 5%) !default;
+
+$fifty_alpha_color6: rgba($color6, 0.5) !default;
 
 
-$ten_alpha_color8: rgba($color8, 0.1);
-$twenty_alpha_color8: rgba($color8, 0.2);
-$thirty_alpha_color8: rgba($color8, 0.3);
-$forty_alpha_color8: rgba($color8, 0.4);
-$fifty_alpha_color8: rgba($color8, 0.5);
-$sixty_alpha_color8: rgba($color8, 0.6);
-$seventy_alpha_color8: rgba($color8, 0.7);
-$eighty_alpha_color8: rgba($color8, 0.8);
-$ninety_alpha_color8: rgba($color8, 0.9);
+$ten_alpha_color8: rgba($color8, 0.1) !default;
+$twenty_alpha_color8: rgba($color8, 0.2) !default;
+$thirty_alpha_color8: rgba($color8, 0.3) !default;
+$forty_alpha_color8: rgba($color8, 0.4) !default;
+$fifty_alpha_color8: rgba($color8, 0.5) !default;
+$sixty_alpha_color8: rgba($color8, 0.6) !default;
+$seventy_alpha_color8: rgba($color8, 0.7) !default;
+$eighty_alpha_color8: rgba($color8, 0.8) !default;
+$ninety_alpha_color8: rgba($color8, 0.9) !default;
 
 
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,5 +1,3 @@
-$color8: #000000 !default; // black
-
 /* $color1 is the default body background-color */
 $color1:            #282c37 !default; // darkest
 $lighten5_color1:   lighten($color1, 5%) !default;
@@ -61,16 +59,14 @@ $transparent_color6:  rgba($color6, 0.5) !default;
 $color7:              #79bd9a !default; // succ green
 
 
-
-$ten_alpha_color8: rgba($color8, 0.1) !default;
-$twenty_alpha_color8: rgba($color8, 0.2) !default;
-$thirty_alpha_color8: rgba($color8, 0.3) !default;
-$forty_alpha_color8: rgba($color8, 0.4) !default;
-$fifty_alpha_color8: rgba($color8, 0.5) !default;
-$sixty_alpha_color8: rgba($color8, 0.6) !default;
-$seventy_alpha_color8: rgba($color8, 0.7) !default;
-$eighty_alpha_color8: rgba($color8, 0.8) !default;
-$ninety_alpha_color8: rgba($color8, 0.9) !default;
-
-
-
+/* $color8 (black) is for shadows and alpha backgrounds */
+$color8:              #000000 !default; // black
+$color8_alpha01:      rgba($color8, 0.1) !default;
+$color8_alpha02:      rgba($color8, 0.2) !default;
+$color8_alpha03:      rgba($color8, 0.3) !default;
+$color8_alpha04:      rgba($color8, 0.4) !default;
+$color8_alpha05:      rgba($color8, 0.5) !default;
+$color8_alpha06:      rgba($color8, 0.6) !default;
+$color8_alpha07:      rgba($color8, 0.7) !default;
+$color8_alpha08:      rgba($color8, 0.8) !default;
+$color8_alpha09:      rgba($color8, 0.9) !default;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -78,3 +78,9 @@ $eight_darken_color5: darken($color5, 8%);
 $seventy_alpha_color5: rgba($color5, 0.7);
 $eighty_alpha_color5: rgba($color5, 0.8);
 
+
+$five_lighten_color6: lighten($color6, 5%);
+
+$five_darken_color6: darken($color6, 5%);
+
+$fifty_alpha_color6: rgba($color6, 0.5);

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,5 +1,3 @@
-$color6: #df405a !default; // error red
-$color7: #79bd9a !default; // succ green
 $color8: #000000 !default; // black
 
 /* $color1 is the default body background-color */
@@ -53,10 +51,15 @@ $darken8_color5:      darken($color5, 8%) !default;
 $transparent7_color5: rgba($color5, 0.7) !default;
 
 
+/* $color6 (error) and $color7 (success) are for
+messages in forms */
+$color6:              #df405a !default; // error red
+$lighten_color6:      lighten($color6, 5%) !default;
+$darken_color6:       darken($color6, 5%) !default;
+$transparent_color6:  rgba($color6, 0.5) !default;
 
-$five_lighten_color6: lighten($color6, 5%) !default;
-$five_darken_color6: darken($color6, 5%) !default;
-$fifty_alpha_color6: rgba($color6, 0.5) !default;
+$color7:              #79bd9a !default; // succ green
+
 
 
 $ten_alpha_color8: rgba($color8, 0.1) !default;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3898,11 +3898,11 @@ lodash.tail@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^4.2.0, lodash@^4.6.1, lodash@~4.16.4:
+lodash@^4.15.0, lodash@^4.2.0, lodash@~4.16.4:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.4.tgz#01ce306b9bad1319f2a5528674f88297aeb70127"
 
@@ -3914,17 +3914,17 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.2.0.tgz#69a65aad3de542cf4ee0f4fe74e8e33c709ccb0f"
-  dependencies:
-    js-tokens "^1.0.1"
-
-loose-envify@^1.3.0:
+loose-envify@^1.0.0, loose-envify@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.1.0, loose-envify@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.2.0.tgz#69a65aad3de542cf4ee0f4fe74e8e33c709ccb0f"
+  dependencies:
+    js-tokens "^1.0.1"
 
 loud-rejection@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
The aim of this pull request is to reduce the number of colors used throughout the default css of mastodon (near a hundred colors!).

This is a work in progress but I'm opening the pull request now for comments.

- [x] Moving all colors used to variable.scss
- [x] Reduce color count
- [ ] Rename colors according to their usage(e.g.: `$link-color` or `$link-color-hover`)

I propose also that we change the name of `$color1`to `$color8` to relevant names while customisation is still not heavy on current mastodon instances.



