### PR TITLE
Username above toot box UI changes

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/navigation_bar.jsx
+++ b/app/assets/javascripts/components/features/compose/components/navigation_bar.jsx
@@ -15,7 +15,7 @@ class NavigationBar extends React.PureComponent {
 
         <div className='navigation-bar__profile'>
           <Permalink href={this.props.account.get('url')} to={`/accounts/${this.props.account.get('id')}`}>
-            <strong className='navigation-bar__profile-account'>{this.props.account.get('acct')}</strong>
+            <strong className='navigation-bar__profile-account'>@{this.props.account.get('acct')}</strong>
           </Permalink>
           <a href='/settings/profile' className='navigation-bar__profile-edit'><FormattedMessage id='navigation_bar.edit_profile' defaultMessage='Edit profile' /></a>
         </div>

--- a/app/assets/javascripts/components/features/compose/components/navigation_bar.jsx
+++ b/app/assets/javascripts/components/features/compose/components/navigation_bar.jsx
@@ -14,7 +14,9 @@ class NavigationBar extends React.PureComponent {
         <Permalink href={this.props.account.get('url')} to={`/accounts/${this.props.account.get('id')}`}><Avatar src={this.props.account.get('avatar')} animate size={40} /></Permalink>
 
         <div className='navigation-bar__profile'>
-          <strong className='navigation-bar__profile-account'>{this.props.account.get('acct')}</strong>
+          <Permalink href={this.props.account.get('url')} to={`/accounts/${this.props.account.get('id')}`}>
+            <strong className='navigation-bar__profile-account'>{this.props.account.get('acct')}</strong>
+          </Permalink>
           <a href='/settings/profile' className='navigation-bar__profile-edit'><FormattedMessage id='navigation_bar.edit_profile' defaultMessage='Edit profile' /></a>
         </div>
       </div>


### PR DESCRIPTION
This PR makes the username above the new toot box into a link, and prepends the username with an `@`. This makes the username behave and appear consistently with the rest of the app.

Before, not a link:

<img width="298" alt="screen shot 2017-04-25 at 1 11 35 am" src="https://cloud.githubusercontent.com/assets/498212/25362457/4475201a-2954-11e7-8d9b-b4693643536e.png">

After, a link:

<img width="289" alt="screen shot 2017-04-25 at 1 11 20 am" src="https://cloud.githubusercontent.com/assets/498212/25362463/4d7d2fcc-2954-11e7-82fc-4b818d1fd8c3.png">

It's a small thing, but always tripped me up :joy: