### PR TITLE
Post status idempotency - prevent duplicates from network failures

### DIFF
--- a/app/assets/javascripts/components/actions/compose.jsx
+++ b/app/assets/javascripts/components/actions/compose.jsx
@@ -85,6 +85,10 @@ export function submitCompose() {
       sensitive: getState().getIn(['compose', 'sensitive']),
       spoiler_text: getState().getIn(['compose', 'spoiler_text'], ''),
       visibility: getState().getIn(['compose', 'privacy'])
+    }, {
+      headers: {
+        'Idempotency-Key': getState().getIn(['compose', 'idempotencyKey'])
+      }
     }).then(function (response) {
       dispatch(submitComposeSuccess({ ...response.data }));
 

--- a/app/assets/javascripts/components/uuid.jsx
+++ b/app/assets/javascripts/components/uuid.jsx
@@ -1,0 +1,3 @@
+export default function uuid(a) {
+  return a ? (a^Math.random() * 16 >> a / 4).toString(16) : ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, uuid);
+};

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -57,11 +57,16 @@ class Api::V1::StatusesController < ApiController
   end
 
   def create
-    @status = PostStatusService.new.call(current_user.account, status_params[:status], status_params[:in_reply_to_id].blank? ? nil : Status.find(status_params[:in_reply_to_id]), media_ids: status_params[:media_ids],
-                                                                                                                                                                                  sensitive: status_params[:sensitive],
-                                                                                                                                                                                  spoiler_text: status_params[:spoiler_text],
-                                                                                                                                                                                  visibility: status_params[:visibility],
-                                                                                                                                                                                  application: doorkeeper_token.application)
+    @status = PostStatusService.new.call(current_user.account,
+                                         status_params[:status],
+                                         status_params[:in_reply_to_id].blank? ? nil : Status.find(status_params[:in_reply_to_id]),
+                                         media_ids: status_params[:media_ids],
+                                         sensitive: status_params[:sensitive],
+                                         spoiler_text: status_params[:spoiler_text],
+                                         visibility: status_params[:visibility],
+                                         application: doorkeeper_token.application,
+                                         idempotency: request.headers['Idempotency-Key'])
+
     render :show
   end
 

--- a/config/locales/simple_form.fa.yml
+++ b/config/locales/simple_form.fa.yml
@@ -1,5 +1,5 @@
 ---
-en:
+fa:
   simple_form:
     hints:
       defaults:
@@ -35,7 +35,7 @@ en:
         type: نوع درون‌ریزی
         username: نام کاربری
       interactions:
-        must_be_follower: مسدودکردن اعلان‌های همه به جز پیگیران 
+        must_be_follower: مسدودکردن اعلان‌های همه به جز پیگیران
         must_be_following: مسدودکردن اعلان‌های کسانی که شما پی نمی‌گیرید
       notification_emails:
         digest: خلاصه‌کردن چند اعلان در یک ایمیل

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -176,7 +176,14 @@ RSpec.describe PostStatusService do
     )
   end
 
+  it 'returns existing status when used twice with idempotency key' do
+    account = Fabricate(:account)
+    status1 = subject.call(account, 'test', nil, idempotency: 'meepmeep')
+    status2 = subject.call(account, 'test', nil, idempotency: 'meepmeep')
+    expect(status2.id).to eq status1.id
+  end
+
   def create_status_with_options(options = {})
-    subject.call(Fabricate(:account), "test", nil, options)
+    subject.call(Fabricate(:account), 'test', nil, options)
   end
 end


### PR DESCRIPTION
Fix #2402 - Add Idempotency-Key header to PostStatusService that prevents duplicates. Web UI regenerates UUID for that header every time the compose form is changed or successfully submitted 

Also, fix Farsi i18n overwriting the English one