### PR TITLE
Optimize account search

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -15,12 +15,12 @@ class AccountSearchService < BaseService
   private
 
   def search_service_results
-    return [] if query_blank_or_hashtag?
+    return [] if query_blank_or_hashtag? || limit < 1
 
     if resolving_non_matching_remote_account?
       [FollowRemoteAccountService.new.call("#{query_username}@#{query_domain}")]
     else
-      search_results_and_exact_match.compact.uniq
+      search_results_and_exact_match.compact.uniq.slice(0, limit)
     end
   end
 
@@ -29,7 +29,9 @@ class AccountSearchService < BaseService
   end
 
   def search_results_and_exact_match
-    [exact_match] + search_results.to_a
+    exact = [exact_match]
+    return exact if !exact[0].nil? && limit == 1
+    exact + search_results.to_a
   end
 
   def query_blank_or_hashtag?

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -13,6 +13,12 @@ describe AccountSearchService do
 
         expect(results).to eq []
       end
+      it 'returns empty array for limit zero' do
+        Fabricate(:account, username: 'match')
+        results = subject.call('match', 0)
+
+        expect(results).to eq []
+      end
     end
 
     describe 'searching for a simple term that is not an exact match' do


### PR DESCRIPTION
* Fixed a bug that returned accounts exceeding limit number will be returned in account search.
* If limit is less than 1, do not access the DB and return an empty array.
* If an account is found by exact_match and limit is 1, the account found by exact_match is returned without performing subsequent DB processing.