### PR TITLE
attach_media should be in transaction of creation status

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -14,15 +14,17 @@ class PostStatusService < BaseService
   # @return [Status]
   def call(account, text, in_reply_to = nil, options = {})
     media  = validate_media!(options[:media_ids])
-    status = account.statuses.create!(text: text,
-                                      thread: in_reply_to,
-                                      sensitive: options[:sensitive],
-                                      spoiler_text: options[:spoiler_text] || '',
-                                      visibility: options[:visibility],
-                                      language: detect_language_for(text, account),
-                                      application: options[:application])
-
-    attach_media(status, media)
+    status = nil
+    ApplicationRecord.transaction do
+      status = account.statuses.create!(text: text,
+                                        thread: in_reply_to,
+                                        sensitive: options[:sensitive],
+                                        spoiler_text: options[:spoiler_text] || '',
+                                        visibility: options[:visibility],
+                                        language: detect_language_for(text, account),
+                                        application: options[:application])
+      attach_media(status, media)
+    end
     process_mentions_service.call(status)
     process_hashtags_service.call(status)
 


### PR DESCRIPTION
if UPDATE "media_attachments" transaction commit delayed, cache_collection cache status row without media_attachments.

that caused followings:

<img width="320" alt="pawoo_ _" src="https://cloud.githubusercontent.com/assets/2655/25369329/fe7cd2dc-29bd-11e7-9c50-952b0e33c364.png">

This item has a media_attachment. But it's cached by cache_collection. So, timeline json return media_attachments to blank.
