### PR TITLE
Fix Persian translation

### DIFF
--- a/config/locales/simple_form.fa.yml
+++ b/config/locales/simple_form.fa.yml
@@ -1,5 +1,5 @@
 ---
-en:
+fa:
   simple_form:
     hints:
       defaults:


### PR DESCRIPTION
Settings page labels are using the wrong language file in English. 

Bug introduced in #2405 

![](https://cloud.githubusercontent.com/assets/843787/25362068/0a0f2ddc-2952-11e7-9a18-b27b98985ebe.png)