### PR TITLE
Fix Persian translation (#2428)

### DIFF
--- a/config/locales/simple_form.fa.yml
+++ b/config/locales/simple_form.fa.yml
@@ -1,5 +1,5 @@
 ---
-en:
+fa:
   simple_form:
     hints:
       defaults:


### PR DESCRIPTION
Settings page contained labels in Persian, when I was using English.

This PR was not against master - https://github.com/tootsuite/mastodon/pull/2428/commits/cf5d15e9d22e167e18c79cd5a3642d4c2866f169 