### PR TITLE
Enable to choose OpenStack object storage

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -90,3 +90,13 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # Cluster number setting for streaming API server.
 # If you comment out following line, cluster number will be `numOfCpuCores - 1`.
 STREAMING_CLUSTER_NUM=1
+
+# OpenStack object storage (optional)
+# S3 settings overrides OpenStack object storage settings
+# OPEN_STACK_OBJECT_STORAGE_ENABLED=true
+# OPEN_STACK_OBJECT_STORAGE_USERNAME=
+# OPEN_STACK_OBJECT_STORAGE_PASSWORD=
+# OPEN_STACK_OBJECT_STORAGE_AUTH_URL=
+# OPEN_STACK_OBJECT_STORAGE_TENANT=
+# OPEN_STACK_OBJECT_STORAGE_DIRECTORY=
+# OPEN_STACK_OBJECT_STORAGE_HOST=

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'best_in_place', '~> 3.0.1'
 gem 'paperclip', '~> 5.1'
 gem 'paperclip-av-transcoder'
 gem 'aws-sdk', '>= 2.0'
+gem 'fog-openstack'
 
 gem 'addressable'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,13 +152,26 @@ GEM
       thread_safe
     encryptor (3.0.0)
     erubis (2.7.0)
+    excon (0.55.0)
     execjs (2.7.0)
     fabrication (2.16.1)
     faker (1.7.3)
       i18n (~> 0.5)
     fast_blank (1.0.0)
+    fog-core (1.43.0)
+      builder
+      excon (~> 0.49)
+      formatador (~> 0.2)
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-openstack (0.1.20)
+      fog-core (>= 1.40)
+      fog-json (>= 1.0)
+      ipaddress (>= 0.8)
     font-awesome-rails (4.7.0.1)
       railties (>= 3.2, < 5.1)
+    formatador (0.2.5)
     fuubar (2.2.0)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
@@ -204,6 +217,7 @@ GEM
       parser (>= 2.2.3.0)
       rainbow (~> 2.2)
       terminal-table (>= 1.5.1)
+    ipaddress (0.8.3)
     jmespath (1.3.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -252,6 +266,7 @@ GEM
     mimemagic (0.3.2)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    multi_json (1.12.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
@@ -494,6 +509,7 @@ DEPENDENCIES
   fabrication
   faker
   fast_blank
+  fog-openstack
   font-awesome-rails
   fuubar
   goldfinger

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -12,6 +12,6 @@ module RoutingHelper
   end
 
   def full_asset_url(source)
-    Rails.configuration.x.use_s3 ? source : File.join(root_url, ActionController::Base.helpers.asset_url(source))
+    (Rails.configuration.x.use_s3 || Rails.configuration.x.use_open_stack_object_storage) ? source : File.join(root_url, ActionController::Base.helpers.asset_url(source))
   end
 end

--- a/config/initializers/ostatus.rb
+++ b/config/initializers/ostatus.rb
@@ -9,7 +9,11 @@ Rails.application.configure do
   config.x.local_domain = host
   config.x.web_domain   = web_host
   config.x.use_https    = https
-  config.x.use_s3       = ENV['S3_ENABLED'] == 'true'
+  if ENV['S3_ENABLED'] == 'true'
+    config.x.use_s3 = true
+  else
+    config.x.use_open_stack_object_storage = ENV['OPEN_STACK_OBJECT_STORAGE_ENABLED'] == 'true'
+  end
 
   config.action_mailer.default_url_options = { host: web_host, protocol: https ? 'https://' : 'http://', trailing_slash: false }
   config.x.streaming_api_base_url          = 'http://localhost:4000'

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -40,6 +40,18 @@ if ENV['S3_ENABLED'] == 'true'
     Paperclip::Attachment.default_options[:url]           = ':s3_alias_url'
     Paperclip::Attachment.default_options[:s3_host_alias] = ENV['S3_CLOUDFRONT_HOST']
   end
+elsif ENV['OPEN_STACK_OBJECT_STORAGE_ENABLED'] == 'true'
+  Paperclip::Attachment.default_options[:storage]         = :fog
+  Paperclip::Attachment.default_options[:fog_public]      = true
+  Paperclip::Attachment.default_options[:fog_directory]   = ENV.fetch('OPEN_STACK_OBJECT_STORAGE_DIRECTORY')
+  Paperclip::Attachment.default_options[:fog_host]        = ENV.fetch('OPEN_STACK_OBJECT_STORAGE_HOST')
+  Paperclip::Attachment.default_options[:fog_credentials] = {
+    provider: 'OpenStack',
+    openstack_username: ENV.fetch('OPEN_STACK_OBJECT_STORAGE_USERNAME'),
+    openstack_api_key:  ENV.fetch('OPEN_STACK_OBJECT_STORAGE_PASSWORD'),
+    openstack_auth_url: ENV.fetch('OPEN_STACK_OBJECT_STORAGE_AUTH_URL'),
+    openstack_tenant:   ENV.fetch('OPEN_STACK_OBJECT_STORAGE_TENANT')
+  }
 else
   Paperclip::Attachment.default_options[:path] = (ENV['PAPERCLIP_ROOT_PATH'] || ':rails_root/public/system') + '/:class/:attachment/:id_partition/:style/:filename'
   Paperclip::Attachment.default_options[:url]  = (ENV['PAPERCLIP_ROOT_URL'] || '/system') + '/:class/:attachment/:id_partition/:style/:filename'


### PR DESCRIPTION
Since the object storage I use is not S3 compatible, I made it enable to use Openstack Object Storage instead of S3.