### PR TITLE
Refine CW placeholder in Chinese jsx files

### DIFF
--- a/app/assets/javascripts/components/locales/zh-cn.jsx
+++ b/app/assets/javascripts/components/locales/zh-cn.jsx
@@ -52,7 +52,7 @@ const zh_cn = {
   // Going "toot-toot!" here below.
   "compose_form.publish": "嘟嘟！",
   "compose_form.sensitive": "将媒体文件标示为“敏感内容”",
-  "compose_form.spoiler_placeholder": "敏感内容",
+  "compose_form.spoiler_placeholder": "敏感内容的警告消息",
   "compose_form.spoiler": "将部份文本藏于警告消息之后",
   "compose_form.unlisted": "请勿在公共时间轴显示",
   "emoji_button.label": "加入表情符号",

--- a/app/assets/javascripts/components/locales/zh-hk.jsx
+++ b/app/assets/javascripts/components/locales/zh-hk.jsx
@@ -47,7 +47,7 @@ const zh_hk = {
   "compose_form.private": "標示為「只有關注你的人能看」",
   "compose_form.publish": "發文",
   "compose_form.sensitive": "將媒體檔案標示為「敏感內容」",
-  "compose_form.spoiler_placeholder": "敏感內容",
+  "compose_form.spoiler_placeholder": "敏感警告訊息",
   "compose_form.spoiler": "將部份文字藏於警告訊息之後",
   "compose_form.unlisted": "請勿在公共時間軸顯示",
   "emoji_button.label": "加入表情符號",


### PR DESCRIPTION
Changed placeholder from "sensitive stuff" to "warning message for sensitive stuff" to avoid confusion.