### PR TITLE
Repository field and postversion script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,16 @@
   "name": "mastodon",
   "license": "AGPL-3.0",
   "scripts": {
+    "postversion": "git push --tags",
     "start": "babel-node ./streaming/index.js --presets es2015,stage-2",
     "storybook": "start-storybook -p 9001 -c storybook",
     "test": "npm run test:lint && npm run test:mocha",
     "test:lint": "eslint -c .eslintrc.json --ext=js --ext=jsx app/assets/javascripts/",
     "test:mocha": "mocha --require ./spec/javascript/setup.js --compilers js:babel-register ./spec/javascript/components/*.test.jsx"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tootsuite/mastodon.git"
   },
   "dependencies": {
     "@kadira/storybook": "^2.35.3",


### PR DESCRIPTION
Mastodon currently doesn't reliably know its version. As Mastodon gets more popular and farther removed from the dev community, it's going to be important to be able to notify the admin of the version they are on and what the latest is (#1487).

This PR adds a `repository` field to package.json. Since this is currently hosted on GitHub we can use the [Releases API](https://developer.github.com/v3/repos/releases/#get-the-latest-release) to see what the latest release is, but this URL could be modified to point elsewhere for people that would prefer.

This PR also includes a `postversion` script to release a new version of Mastodon using `npm version <version-number>` which will put `<version-number>` into package.json, commit, and only push a tag.