### PR TITLE
travis: Add yarn and nodejs caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
-cache: bundler
+cache:
+  bundler: true
+  yarn: true
+  directories:
+    - node_modules
 dist: trusty
 sudo: false
 


### PR DESCRIPTION
Also cache node_module and yarn cache in Travis test process.
Improves speed for Travis tests.