### PR TITLE
Make vagrant HTTP port configurable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+ENV["PORT"] ||= "3000"
+
 $provision = <<SCRIPT
 
 cd /vagrant # This is where the host folder/repo is mounted
@@ -12,8 +14,8 @@ sudo apt-add-repository 'deb https://dl.yarnpkg.com/debian/ stable main'
 # Add repo for NodeJS
 curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
 
-# Add firewall rule to redirect 80 to 3000 and save
-sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 3000
+# Add firewall rule to redirect 80 to PORT and save
+sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port #{ENV["PORT"]}
 echo iptables-persistent iptables-persistent/autosave_v4 boolean true | sudo debconf-set-selections
 echo iptables-persistent iptables-persistent/autosave_v6 boolean true | sudo debconf-set-selections
 sudo apt-get install iptables-persistent -y
@@ -62,7 +64,7 @@ $start = <<SCRIPT
 
 cd /vagrant
 export $(cat ".env.vagrant" | xargs)
-rails s -d -b 0.0.0.0
+rails s -d -b 0.0.0.0 -p #{ENV["PORT"]}
 
 SCRIPT
 
@@ -105,7 +107,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   # Otherwise, you can access the site at http://localhost:3000
-  config.vm.network :forwarded_port, guest: 80, host: 3000
+  config.vm.network :forwarded_port, guest: 80, host: ENV["PORT"]
 
   # Full provisioning script, only runs on first 'vagrant up' or with 'vagrant provision'
   config.vm.provision :shell, inline: $provision, privileged: false


### PR DESCRIPTION
port 3000 is tied up by something else on my development machine. This changes `Vagrantfile` to default to 3000 but accept a different port on the command line when booting.