### PR TITLE
Don't need to include ActiveModel::Validations

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Status < ApplicationRecord
-  include ActiveModel::Validations
   include Paginable
   include Streamable
   include Cacheable


### PR DESCRIPTION
Already extends `ApplicationRecord`