### PR TITLE
ActivityPub: Add ActivityStreams 2.0 Actor id to WebFinger JSON.

### DIFF
--- a/app/views/well_known/webfinger/show.json.rabl
+++ b/app/views/well_known/webfinger/show.json.rabl
@@ -10,6 +10,7 @@ node(:links) do
   [
     { rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: TagManager.instance.url_for(@account) },
     { rel: 'http://schemas.google.com/g/2010#updates-from', type: 'application/atom+xml', href: account_url(@account, format: 'atom') },
+    { rel: 'self', type: 'application/activity+json', href: TagManager.instance.url_for(@account) },
     { rel: 'salmon', href: api_salmon_url(@account.id) },
     { rel: 'magic-public-key', href: "data:application/magic-public-key,#{@magic_key}" },
     { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_follow_url}?acct={uri}" },


### PR DESCRIPTION
The quest for [ActivityPub support on Mastodon](https://github.com/tootsuite/mastodon/issues/1557) continues.

This *very simple* PR adds support for the AS2 representation of a user in their WebFinger response, allowing applications to use WF-style identifiers (`evan@example.social`) for discovery and tagging, then hand off the actual AS2 URL to handle federation via AP.

I used a `rel` value of `self` as recommended in [this ActivityPub issue](https://github.com/w3c/activitypub/issues/194).