### PR TITLE
Added '(dev)' to the title in development mode

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,6 +20,6 @@ module ApplicationHelper
   end
 
   def title
-     Rails.env.production? ? site_title : "#{site_title} (Dev)"
+    Rails.env.production? ? site_title : "#{site_title} (Dev)"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,8 @@ module ApplicationHelper
     env_suffix = Rails.env.production? ? '' : '-dev'
     asset_path "favicon#{env_suffix}.ico"
   end
+
+  def title
+     Rails.env.production? ? site_title : "#{site_title} (Dev)"
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,7 +17,7 @@
       - if content_for?(:page_title)
         = yield(:page_title)
         = ' - '
-      = site_title
+      = title
 
     = stylesheet_link_tag stylesheet_for_layout, media: 'all'
     = csrf_meta_tags


### PR DESCRIPTION
@LindseyB's PR that added a red favicon to development mode is great (#2470), but it's not especially clear, so I though I might expand it by adding `(Dev)` to the title of the pages as well.

![](https://cloud.githubusercontent.com/assets/13566135/25482084/3cd7d490-2ba4-11e7-8726-dd42bbd3e7cf.png)

I considered using a translatable string instead for this, but thought that it might not be necessary. I'm ok to change it if it is though.