### PR TITLE
Fix broken oEmbed provider

### DIFF
--- a/app/lib/provider_discovery.rb
+++ b/app/lib/provider_discovery.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProviderDiscovery < OEmbed::ProviderDiscovery
-  include HttpHelper
+  extend HttpHelper
 
   class << self
     def discover_provider(url, options = {})


### PR DESCRIPTION
oEmbed is not working.

```plain
[12] pry(main)> ProviderDiscovery.get('https://www.youtube.com/watch?v=Jt1h1MinlLI')
NameError: undefined local variable or method `http_client' for ProviderDiscovery:Class
Did you mean?  http_get
from /Users/ykzts/works/ykzts/mastodon/app/lib/provider_discovery.rb:8:in `discover_provider'
```