### PR TITLE
Fix partial path in admin/reports

### DIFF
--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -4,11 +4,11 @@
 .report-accounts
   .report-accounts__item
     %strong= t('admin.reports.reported_account')
-    = render partial: 'authorize_follow/card', locals: { account: @report.target_account }
+    = render partial: 'authorize_follows/card', locals: { account: @report.target_account }
     = render partial: 'admin/accounts/card', locals: { account: @report.target_account }
   .report-accounts__item
     %strong= t('admin.reports.reported_by')
-    = render partial: 'authorize_follow/card', locals: { account: @report.account }
+    = render partial: 'authorize_follows/card', locals: { account: @report.account }
     = render partial: 'admin/accounts/card', locals: { account: @report.account }
 
 %p


### PR DESCRIPTION
In #2505, the authorize_follow views were renamed to authorize_follows. This change was not applied in the show view of admin/reports, which causes a 500 when reports are viewed.