### PR TITLE
Remove em from onboard federation description

### DIFF
--- a/app/assets/javascripts/components/features/ui/components/onboarding_modal.jsx
+++ b/app/assets/javascripts/components/features/ui/components/onboarding_modal.jsx
@@ -25,7 +25,7 @@ const PageOne = ({ acct, domain }) => (
 
     <div>
       <h1><FormattedMessage id='onboarding.page_one.welcome' defaultMessage='Welcome to Mastodon!' /></h1>
-      <p><FormattedMessage id='onboarding.page_one.federation' defaultMessage='Mastodon is a network of independent servers joining up to make one larger social network. We call these servers: <em>Instances</em>' /></p>
+      <p><FormattedMessage id='onboarding.page_one.federation' defaultMessage='Mastodon is a network of independent servers joining up to make one larger social network. We call these servers instances.' /></p>
       <p><FormattedMessage id='onboarding.page_one.handle' defaultMessage='You are on {domain}, so your full handle is {handle}' values={{ domain, handle: <strong>{acct}@{domain}</strong> }}/></p>
     </div>
   </div>


### PR DESCRIPTION
As suggested in #2519, this PR only aims to remove these `em` tags.