### PR TITLE
More controller specs

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -72,6 +72,14 @@ class Account < ApplicationRecord
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }
   scope :by_domain_accounts, -> { group(:domain).select(:domain, 'COUNT(*) AS accounts_count').order('accounts_count desc') }
 
+  delegate :email,
+    :current_sign_in_ip,
+    :current_sign_in_at,
+    :confirmed?,
+    to: :user,
+    prefix: true,
+    allow_nil: true
+
   def follow!(other_account)
     active_relationships.where(target_account: other_account).first_or_create!(target_account: other_account)
   end

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -16,15 +16,15 @@
     - if @account.local?
       %tr
         %th= t('admin.accounts.email')
-        %td= @account.user.email
+        %td= @account.user_email
       %tr
         %th= t('admin.accounts.most_recent_ip')
-        %td= @account.user.current_sign_in_ip
+        %td= @account.user_current_sign_in_ip
       %tr
         %th= t('admin.accounts.most_recent_activity')
         %td
-          - if @account.user.current_sign_in_at
-            = l @account.user.current_sign_in_at
+          - if @account.user_current_sign_in_at
+            = l @account.user_current_sign_in_at
           - else
             Never
     - else
@@ -78,7 +78,7 @@
     = link_to t('admin.accounts.silence'), admin_account_silence_path(@account.id), method: :post, class: 'button'
 
   - if @account.local?
-    - unless @account.user.confirmed?
+    - unless @account.user_confirmed?
       = link_to t('admin.accounts.confirm'), admin_account_confirmation_path(@account.id), method: :post, class: 'button'
 
   - if @account.suspended?

--- a/spec/controllers/account_follow_controller_spec.rb
+++ b/spec/controllers/account_follow_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe AccountFollowController do
   render_views
+
   let(:user) { Fabricate(:user) }
   let(:alice) { Fabricate(:account, username: 'alice') }
 

--- a/spec/controllers/account_unfollow_controller_spec.rb
+++ b/spec/controllers/account_unfollow_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe AccountUnfollowController do
   render_views
+
   let(:user) { Fabricate(:user) }
   let(:alice) { Fabricate(:account, username: 'alice') }
 

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Admin::AccountsController, type: :controller do
+  render_views
+
   before do
     sign_in Fabricate(:user, admin: true), scope: :user
   end

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Admin::DomainBlocksController, type: :controller do
+  render_views
+
   before do
     sign_in Fabricate(:user, admin: true), scope: :user
   end

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Admin::InstancesController, type: :controller do
+  render_views
+
   before do
     sign_in Fabricate(:user, admin: true), scope: :user
   end

--- a/spec/controllers/admin/pubsubhubbub_controller_spec.rb
+++ b/spec/controllers/admin/pubsubhubbub_controller_spec.rb
@@ -2,6 +2,8 @@
 require 'rails_helper'
 
 RSpec.describe Admin::PubsubhubbubController, type: :controller do
+  render_views
+
   describe 'GET #index' do
     before do
       sign_in Fabricate(:user, admin: true), scope: :user

--- a/spec/controllers/admin/reported_statuses_controller_spec.rb
+++ b/spec/controllers/admin/reported_statuses_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Admin::ReportedStatusesController do
+  render_views
+
   let(:user) { Fabricate(:user, admin: true) }
   before do
     sign_in user, scope: :user

--- a/spec/controllers/admin/resets_controller_spec.rb
+++ b/spec/controllers/admin/resets_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Admin::ResetsController do
+  render_views
+
   let(:account) { Fabricate(:account, user: Fabricate(:user)) }
   before do
     sign_in Fabricate(:user, admin: true), scope: :user

--- a/spec/controllers/admin/silences_controller_spec.rb
+++ b/spec/controllers/admin/silences_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Admin::SilencesController do
+  render_views
+
   let(:account) { Fabricate(:account) }
   before do
     sign_in Fabricate(:user, admin: true), scope: :user

--- a/spec/controllers/admin/suspensions_controller_spec.rb
+++ b/spec/controllers/admin/suspensions_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Admin::SuspensionsController do
+  render_views
+
   let(:account) { Fabricate(:account) }
   before do
     sign_in Fabricate(:user, admin: true), scope: :user

--- a/spec/controllers/authorize_follows_controller_spec.rb
+++ b/spec/controllers/authorize_follows_controller_spec.rb
@@ -40,7 +40,7 @@ describe AuthorizeFollowsController do
       end
 
       it 'sets account from url' do
-        account = double
+        account = Account.new
         service = double
         allow(FetchRemoteAccountService).to receive(:new).and_return(service)
         allow(service).to receive(:call).with('http://example.com').and_return(account)
@@ -52,7 +52,7 @@ describe AuthorizeFollowsController do
       end
 
       it 'sets account from acct uri' do
-        account = double
+        account = Account.new
         service = double
         allow(FollowRemoteAccountService).to receive(:new).and_return(service)
         allow(service).to receive(:call).with('found@hostname').and_return(account)

--- a/spec/controllers/authorize_follows_controller_spec.rb
+++ b/spec/controllers/authorize_follows_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe AuthorizeFollowsController do
+  render_views
+
   describe 'GET #show' do
     describe 'when signed out' do
       it 'redirects to sign in page' do

--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe FollowerAccountsController do
   render_views
+
   let(:alice) { Fabricate(:account, username: 'alice') }
 
   describe 'GET #index' do

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe FollowingAccountsController do
   render_views
+
   let(:alice) { Fabricate(:account, username: 'alice') }
 
   describe 'GET #index' do

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe MediaController do
+  render_views
+
   describe '#show' do
     it 'redirects to the file url when attached to a status' do
       status = Fabricate(:status)

--- a/spec/controllers/oauth/authorizations_controller_spec.rb
+++ b/spec/controllers/oauth/authorizations_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Oauth::AuthorizationsController, type: :controller do

--- a/spec/controllers/settings/exports/blocked_accounts_controller_spec.rb
+++ b/spec/controllers/settings/exports/blocked_accounts_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Settings::Exports::BlockedAccountsController do
+  render_views
+
   before do
     sign_in Fabricate(:user), scope: :user
   end

--- a/spec/controllers/settings/exports/following_accounts_controller_spec.rb
+++ b/spec/controllers/settings/exports/following_accounts_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Settings::Exports::FollowingAccountsController do
+  render_views
+
   before do
     sign_in Fabricate(:user), scope: :user
   end

--- a/spec/controllers/settings/exports/muted_accounts_controller_spec.rb
+++ b/spec/controllers/settings/exports/muted_accounts_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Settings::Exports::MutedAccountsController do
+  render_views
+
   before do
     sign_in Fabricate(:user), scope: :user
   end

--- a/spec/controllers/settings/follower_domains_controller_spec.rb
+++ b/spec/controllers/settings/follower_domains_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Settings::FollowerDomainsController do
+  render_views
+
   let(:user) { Fabricate(:user) }
 
   before do

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Settings::ImportsController, type: :controller do
+  render_views
 
   before do
     sign_in Fabricate(:user), scope: :user

--- a/spec/controllers/settings/preferences_controller_spec.rb
+++ b/spec/controllers/settings/preferences_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Settings::PreferencesController do
+  render_views
+
   let(:user) { Fabricate(:user) }
 
   before do

--- a/spec/controllers/settings/profiles_controller_spec.rb
+++ b/spec/controllers/settings/profiles_controller_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Settings::ProfilesController, type: :controller do
+  render_views
 
   before do
     sign_in Fabricate(:user), scope: :user


### PR DESCRIPTION
Following on recent regression issues, adds render_views in more places.

This is a good holdover until a fuller feature spec suite or similar can be added.

While I was doing this, I found two bugs: a) admin accounts show page had errors when the account did not have a user record, b) authorize follows controller spec needed a proper Account object to render views. Both of those are fixed here.