### PR TITLE
More status specs

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,6 +46,8 @@ class Account < ApplicationRecord
   # Block relationships
   has_many :block_relationships, class_name: 'Block', foreign_key: 'account_id', dependent: :destroy
   has_many :blocking, -> { order('blocks.id desc') }, through: :block_relationships, source: :target_account
+  has_many :blocked_by_relationships, class_name: 'Block', foreign_key: :target_account_id, dependent: :destroy
+  has_many :blocked_by, -> { order('blocks.id desc') }, through: :blocked_by_relationships, source: :account
 
   # Mute relationships
   has_many :mute_relationships, class_name: 'Mute', foreign_key: 'account_id', dependent: :destroy
@@ -212,7 +214,7 @@ class Account < ApplicationRecord
   end
 
   def excluded_from_timeline_account_ids
-    Rails.cache.fetch("exclude_account_ids_for:#{id}") { Block.where(account: self).pluck(:target_account_id) + Block.where(target_account: self).pluck(:account_id) + Mute.where(account: self).pluck(:target_account_id) }
+    Rails.cache.fetch("exclude_account_ids_for:#{id}") { blocking.pluck(:target_account_id) + blocked_by.pluck(:account_id) + muting.pluck(:target_account_id) }
   end
 
   class << self

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -211,6 +211,10 @@ class Account < ApplicationRecord
     username
   end
 
+  def excluded_from_timeline_account_ids
+    Rails.cache.fetch("exclude_account_ids_for:#{id}") { Block.where(account: self).pluck(:target_account_id) + Block.where(target_account: self).pluck(:account_id) + Mute.where(account: self).pluck(:target_account_id) }
+  end
+
   class << self
     def find_local!(username)
       find_remote!(username, nil)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -39,7 +39,7 @@ class Status < ApplicationRecord
   scope :without_reblogs, -> { where('statuses.reblog_of_id IS NULL') }
   scope :with_public_visibility, -> { where(visibility: :public) }
   scope :tagged_with, -> (tag) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag })}
-  scope :local_only, -> { where(accounts: { domain: nil }) }
+  scope :local_only, -> { left_outer_joins(:account).where(accounts: { domain: nil }) }
   scope :excluding_silenced_accounts, -> { left_outer_joins(:account).where(accounts: { silenced: false }) }
   scope :including_silenced_accounts, -> { left_outer_joins(:account).where(accounts: { silenced: true }) }
   scope :not_excluded_by_account, -> (account) { where.not(account_id: account.excluded_from_timeline_account_ids) }

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -189,7 +189,7 @@ class Status < ApplicationRecord
     private
 
     def filter_timeline(query, account)
-      blocked = Rails.cache.fetch("exclude_account_ids_for:#{account.id}") { Block.where(account: account).pluck(:target_account_id) + Block.where(target_account: account).pluck(:account_id) + Mute.where(account: account).pluck(:target_account_id) }
+      blocked = account.excluded_from_timeline_account_ids
       query   = query.where('statuses.account_id NOT IN (?)', blocked) unless blocked.empty?  # Only give us statuses from people we haven't blocked, or muted, or that have blocked us
       query   = query.where('accounts.silenced = TRUE') if account.silenced?                  # and if we're hellbanned, only people who are also hellbanned
       query

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -38,11 +38,11 @@ class Status < ApplicationRecord
   scope :without_replies, -> { where('statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id') }
   scope :without_reblogs, -> { where('statuses.reblog_of_id IS NULL') }
   scope :with_public_visibility, -> { where(visibility: :public) }
-  scope :tagged_with, -> (tag) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag })}
+  scope :tagged_with, ->(tag) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag }) }
   scope :local_only, -> { left_outer_joins(:account).where(accounts: { domain: nil }) }
   scope :excluding_silenced_accounts, -> { left_outer_joins(:account).where(accounts: { silenced: false }) }
   scope :including_silenced_accounts, -> { left_outer_joins(:account).where(accounts: { silenced: true }) }
-  scope :not_excluded_by_account, -> (account) { where.not(account_id: account.excluded_from_timeline_account_ids) }
+  scope :not_excluded_by_account, ->(account) { where.not(account_id: account.excluded_from_timeline_account_ids) }
 
   cache_associated :account, :application, :media_attachments, :tags, :stream_entry, mentions: :account, reblog: [:account, :application, :stream_entry, :tags, :media_attachments, mentions: :account], thread: :account
 
@@ -124,17 +124,15 @@ class Status < ApplicationRecord
     end
 
     def as_public_timeline(account = nil, local_only = false)
-      public_timeline_query = timeline_scope(local_only).
-        without_replies
+      query = timeline_scope(local_only).without_replies
 
-      apply_timeline_filters(public_timeline_query, account)
+      apply_timeline_filters(query, account)
     end
 
     def as_tag_timeline(tag, account = nil, local_only = false)
-      tag_timeline_query = timeline_scope(local_only).
-        tagged_with(tag)
+      query = timeline_scope(local_only).tagged_with(tag)
 
-      apply_timeline_filters(tag_timeline_query, account)
+      apply_timeline_filters(query, account)
     end
 
     def as_outbox_timeline(account)
@@ -185,9 +183,9 @@ class Status < ApplicationRecord
 
     def timeline_scope(local_only = false)
       starting_scope = local_only ? Status.local_only : Status
-      starting_scope.
-        with_public_visibility.
-        without_reblogs
+      starting_scope
+        .with_public_visibility
+        .without_reblogs
     end
 
     def apply_timeline_filters(query, account)
@@ -200,7 +198,7 @@ class Status < ApplicationRecord
 
     def filter_timeline_for_account(query, account)
       query = query.not_excluded_by_account(account)
-      query = query.merge(account_silencing_filter(account))
+      query.merge(account_silencing_filter(account))
     end
 
     def filter_timeline_default(query)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -120,10 +120,8 @@ class Status < ApplicationRecord
     end
 
     def as_public_timeline(account = nil, local_only = false)
-      query = joins('LEFT OUTER JOIN accounts ON statuses.account_id = accounts.id')
-              .with_public_visibility
-              .without_replies
-              .without_reblogs
+      query = timeline_scope
+        .without_replies
 
       query = query.where('accounts.domain IS NULL') if local_only
 
@@ -131,14 +129,18 @@ class Status < ApplicationRecord
     end
 
     def as_tag_timeline(tag, account = nil, local_only = false)
-      query = joins('LEFT OUTER JOIN accounts ON statuses.account_id = accounts.id')
-              .with_public_visibility
-              .without_reblogs
-              .tagged_with(tag)
+      query = timeline_scope
+        .tagged_with(tag)
 
       query = query.where('accounts.domain IS NULL') if local_only
 
       account.nil? ? filter_timeline_default(query) : filter_timeline_default(filter_timeline(query, account))
+    end
+
+    def timeline_scope
+      joins('LEFT OUTER JOIN accounts ON statuses.account_id = accounts.id')
+        .with_public_visibility
+        .without_reblogs
     end
 
     def as_outbox_timeline(account)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -124,17 +124,17 @@ class Status < ApplicationRecord
     end
 
     def as_public_timeline(account = nil, local_only = false)
-      query = timeline_scope(local_only).
+      public_timeline_query = timeline_scope(local_only).
         without_replies
 
-      account.nil? ? filter_timeline_default(query) : filter_timeline_for_account(query, account)
+      apply_timeline_filters(public_timeline_query, account)
     end
 
     def as_tag_timeline(tag, account = nil, local_only = false)
-      query = timeline_scope(local_only).
+      tag_timeline_query = timeline_scope(local_only).
         tagged_with(tag)
 
-      account.nil? ? filter_timeline_default(query) : filter_timeline_for_account(query, account)
+      apply_timeline_filters(tag_timeline_query, account)
     end
 
     def timeline_scope(local_only = false)
@@ -189,6 +189,14 @@ class Status < ApplicationRecord
     end
 
     private
+
+    def apply_timeline_filters(query, account)
+      if account.nil?
+        filter_timeline_default(query)
+      else
+        filter_timeline_for_account(query, account)
+      end
+    end
 
     def filter_timeline_for_account(query, account)
       query = query.not_excluded_by_account(account)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -121,27 +121,25 @@ class Status < ApplicationRecord
     end
 
     def as_public_timeline(account = nil, local_only = false)
-      query = timeline_scope
-        .without_replies
-
-      query = query.local_only if local_only
+      query = timeline_scope(local_only).
+        without_replies
 
       account.nil? ? filter_timeline_default(query) : filter_timeline_default(filter_timeline(query, account))
     end
 
     def as_tag_timeline(tag, account = nil, local_only = false)
-      query = timeline_scope
-        .tagged_with(tag)
-
-      query = query.local_only if local_only
+      query = timeline_scope(local_only).
+        tagged_with(tag)
 
       account.nil? ? filter_timeline_default(query) : filter_timeline_default(filter_timeline(query, account))
     end
 
-    def timeline_scope
-      joins('LEFT OUTER JOIN accounts ON statuses.account_id = accounts.id')
-        .with_public_visibility
-        .without_reblogs
+    def timeline_scope(local_only = false)
+      starting_scope = local_only ? Status.local_only : Status
+      starting_scope.
+        joins('LEFT OUTER JOIN accounts ON statuses.account_id = accounts.id').
+        with_public_visibility.
+        without_reblogs
     end
 
     def as_outbox_timeline(account)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -37,6 +37,7 @@ class Status < ApplicationRecord
 
   scope :without_replies, -> { where('statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id') }
   scope :without_reblogs, -> { where('statuses.reblog_of_id IS NULL') }
+  scope :with_public_visibility, -> { where(visibility: :public) }
 
   cache_associated :account, :application, :media_attachments, :tags, :stream_entry, mentions: :account, reblog: [:account, :application, :stream_entry, :tags, :media_attachments, mentions: :account], thread: :account
 
@@ -119,7 +120,7 @@ class Status < ApplicationRecord
 
     def as_public_timeline(account = nil, local_only = false)
       query = joins('LEFT OUTER JOIN accounts ON statuses.account_id = accounts.id')
-              .where(visibility: :public)
+              .with_public_visibility
               .without_replies
               .without_reblogs
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -39,6 +39,7 @@ class Status < ApplicationRecord
   scope :without_reblogs, -> { where('statuses.reblog_of_id IS NULL') }
   scope :with_public_visibility, -> { where(visibility: :public) }
   scope :tagged_with, -> (tag) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag })}
+  scope :local_only, -> { where(accounts: { domain: nil }) }
 
   cache_associated :account, :application, :media_attachments, :tags, :stream_entry, mentions: :account, reblog: [:account, :application, :stream_entry, :tags, :media_attachments, mentions: :account], thread: :account
 
@@ -123,7 +124,7 @@ class Status < ApplicationRecord
       query = timeline_scope
         .without_replies
 
-      query = query.where('accounts.domain IS NULL') if local_only
+      query = query.local_only if local_only
 
       account.nil? ? filter_timeline_default(query) : filter_timeline_default(filter_timeline(query, account))
     end
@@ -132,7 +133,7 @@ class Status < ApplicationRecord
       query = timeline_scope
         .tagged_with(tag)
 
-      query = query.where('accounts.domain IS NULL') if local_only
+      query = query.local_only if local_only
 
       account.nil? ? filter_timeline_default(query) : filter_timeline_default(filter_timeline(query, account))
     end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -137,13 +137,6 @@ class Status < ApplicationRecord
       apply_timeline_filters(tag_timeline_query, account)
     end
 
-    def timeline_scope(local_only = false)
-      starting_scope = local_only ? Status.local_only : Status
-      starting_scope.
-        with_public_visibility.
-        without_reblogs
-    end
-
     def as_outbox_timeline(account)
       where(account: account, visibility: :public)
     end
@@ -189,6 +182,13 @@ class Status < ApplicationRecord
     end
 
     private
+
+    def timeline_scope(local_only = false)
+      starting_scope = local_only ? Status.local_only : Status
+      starting_scope.
+        with_public_visibility.
+        without_reblogs
+    end
 
     def apply_timeline_filters(query, account)
       if account.nil?

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -132,7 +132,7 @@ class Status < ApplicationRecord
 
     def as_tag_timeline(tag, account = nil, local_only = false)
       query = joins('LEFT OUTER JOIN accounts ON statuses.account_id = accounts.id')
-              .where(visibility: :public)
+              .with_public_visibility
               .without_reblogs
               .tagged_with(tag)
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -126,14 +126,14 @@ class Status < ApplicationRecord
       query = timeline_scope(local_only).
         without_replies
 
-      account.nil? ? filter_timeline_default(query) : filter_timeline_default(filter_timeline(query, account))
+      account.nil? ? filter_timeline_default(query) : filter_timeline_default(filter_timeline_for_account(query, account))
     end
 
     def as_tag_timeline(tag, account = nil, local_only = false)
       query = timeline_scope(local_only).
         tagged_with(tag)
 
-      account.nil? ? filter_timeline_default(query) : filter_timeline_default(filter_timeline(query, account))
+      account.nil? ? filter_timeline_default(query) : filter_timeline_default(filter_timeline_for_account(query, account))
     end
 
     def timeline_scope(local_only = false)
@@ -189,7 +189,7 @@ class Status < ApplicationRecord
 
     private
 
-    def filter_timeline(query, account)
+    def filter_timeline_for_account(query, account)
       blocked = account.excluded_from_timeline_account_ids
       query   = query.where('statuses.account_id NOT IN (?)', blocked) unless blocked.empty?  # Only give us statuses from people we haven't blocked, or muted, or that have blocked us
       query   = query.including_silenced_accounts if account.silenced?                  # and if we're hellbanned, only people who are also hellbanned

--- a/spec/fabricators/mute_fabricator.rb
+++ b/spec/fabricators/mute_fabricator.rb
@@ -1,3 +1,4 @@
 Fabricator(:mute) do
-
+  account
+  target_account { Fabricate(:account) }
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -190,6 +190,21 @@ RSpec.describe Account, type: :model do
     end
   end
 
+  describe '#excluded_from_timeline_account_ids' do
+    it 'includes account ids of blockings, blocked_bys and mutes' do
+      account = Fabricate(:account)
+      block = Fabricate(:block, account: account)
+      mute = Fabricate(:mute, account: account)
+      block_by = Fabricate(:block, target_account: account)
+
+      results = account.excluded_from_timeline_account_ids
+      expect(results.size).to eq 3
+      expect(results).to include(block.target_account.id)
+      expect(results).to include(mute.target_account.id)
+      expect(results).to include(block_by.account.id)
+    end
+  end
+
   describe '.search_for' do
     before do
       @match = Fabricate(

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -194,7 +194,16 @@ RSpec.describe Status, type: :model do
     end
 
     context 'with a local_only option set' do
-      it 'does not include remote instances statuses'
+      it 'does not include remote instances statuses' do
+        local_account = Fabricate(:account, domain: nil)
+        remote_account = Fabricate(:account, domain: 'test.com')
+        local_status = Fabricate(:status, account: local_account)
+        remote_status = Fabricate(:status, account: remote_account)
+
+        results = Status.as_public_timeline(nil, true)
+        expect(results).to include(local_status)
+        expect(results).not_to include(remote_status)
+      end
     end
 
     describe 'with an account passed in' do

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -153,4 +153,30 @@ RSpec.describe Status, type: :model do
       expect(@results).not_to include(@not_followed_status)
     end
   end
+
+  describe '.as_public_timeline' do
+    it 'only includes statuses with public visibility'
+
+    it 'does not include replies'
+
+    it 'does not include boosts'
+
+    it 'filters out silenced accounts'
+
+    context 'with a local_only option set' do
+      it 'does not include remote instances statuses'
+    end
+
+    describe 'with an account passed in' do
+      it 'excludes statuses from accounts blocked by the account'
+
+      it 'excludes statuses from accounts who have blocked the account'
+
+      it 'excludes statuses from accounts muted by the account'
+
+      context 'where that account is silenced' do
+        it 'includes statuses from other accounts that are silenced'
+      end
+    end
+  end
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -182,7 +182,16 @@ RSpec.describe Status, type: :model do
       expect(results).not_to include(boost)
     end
 
-    it 'filters out silenced accounts'
+    it 'filters out silenced accounts' do
+      account = Fabricate(:account)
+      silenced_account = Fabricate(:account, silenced: true)
+      status = Fabricate(:status, account: account)
+      silenced_status = Fabricate(:status, account: silenced_account)
+
+      results = Status.as_public_timeline
+      expect(results).to include(status)
+      expect(results).not_to include(silenced_status)
+    end
 
     context 'with a local_only option set' do
       it 'does not include remote instances statuses'

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -261,5 +261,14 @@ RSpec.describe Status, type: :model do
       expect(results).to include(status)
       expect(results).not_to include(other)
     end
+
+    it 'allows replies to be included' do
+      original = Fabricate(:status)
+      tag = Fabricate(:tag)
+      status = Fabricate(:status, tags: [tag], in_reply_to_id: original.id)
+
+      results = Status.as_tag_timeline(tag)
+      expect(results).to include(status)
+    end
   end
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -239,7 +239,7 @@ RSpec.describe Status, type: :model do
       end
 
       context 'where that account is silenced' do
-        xit 'includes statuses from other accounts that are silenced' do
+        it 'includes statuses from other accounts that are silenced' do
           @account.update(silenced: true)
           other_silenced_account = Fabricate(:account, silenced: true)
           other_status = Fabricate(:status, account: other_silenced_account)

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -207,11 +207,36 @@ RSpec.describe Status, type: :model do
     end
 
     describe 'with an account passed in' do
-      it 'excludes statuses from accounts blocked by the account'
+      before do
+        @account = Fabricate(:account)
+      end
 
-      it 'excludes statuses from accounts who have blocked the account'
+      it 'excludes statuses from accounts blocked by the account' do
+        blocked = Fabricate(:account)
+        Fabricate(:block, account: @account, target_account: blocked)
+        blocked_status = Fabricate(:status, account: blocked)
 
-      it 'excludes statuses from accounts muted by the account'
+        results = Status.as_public_timeline(@account)
+        expect(results).not_to include(blocked_status)
+      end
+
+      it 'excludes statuses from accounts who have blocked the account' do
+        blocked = Fabricate(:account)
+        Fabricate(:block, account: blocked, target_account: @account)
+        blocked_status = Fabricate(:status, account: blocked)
+
+        results = Status.as_public_timeline(@account)
+        expect(results).not_to include(blocked_status)
+      end
+
+      it 'excludes statuses from accounts muted by the account' do
+        muted = Fabricate(:account)
+        Fabricate(:mute, account: @account, target_account: muted)
+        muted_status = Fabricate(:status, account: muted)
+
+        results = Status.as_public_timeline(@account)
+        expect(results).not_to include(muted_status)
+      end
 
       context 'where that account is silenced' do
         it 'includes statuses from other accounts that are silenced'

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -250,4 +250,16 @@ RSpec.describe Status, type: :model do
       end
     end
   end
+
+  describe '.as_tag_timeline' do
+    it 'includes statuses with a tag' do
+      tag = Fabricate(:tag)
+      status = Fabricate(:status, tags: [tag])
+      other = Fabricate(:status)
+
+      results = Status.as_tag_timeline(tag)
+      expect(results).to include(status)
+      expect(results).not_to include(other)
+    end
+  end
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -127,6 +127,19 @@ RSpec.describe Status, type: :model do
     pending
   end
 
+  describe '.local_only' do
+    it 'returns only statuses from local accounts' do
+      local_account = Fabricate(:account, domain: nil)
+      remote_account = Fabricate(:account, domain: 'test.com')
+      local_status = Fabricate(:status, account: local_account)
+      remote_status = Fabricate(:status, account: remote_account)
+
+      results = described_class.local_only
+      expect(results).to include(local_status)
+      expect(results).not_to include(remote_status)
+    end
+  end
+
   describe '.as_home_timeline' do
     before do
       account = Fabricate(:account)

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -155,11 +155,32 @@ RSpec.describe Status, type: :model do
   end
 
   describe '.as_public_timeline' do
-    it 'only includes statuses with public visibility'
+    it 'only includes statuses with public visibility' do
+      public_status = Fabricate(:status, visibility: :public)
+      private_status = Fabricate(:status, visibility: :private)
 
-    it 'does not include replies'
+      results = Status.as_public_timeline
+      expect(results).to include(public_status)
+      expect(results).not_to include(private_status)
+    end
 
-    it 'does not include boosts'
+    it 'does not include replies' do
+      status = Fabricate(:status)
+      reply = Fabricate(:status, in_reply_to_id: status.id)
+
+      results = Status.as_public_timeline
+      expect(results).to include(status)
+      expect(results).not_to include(reply)
+    end
+
+    it 'does not include boosts' do
+      status = Fabricate(:status)
+      boost = Fabricate(:status, reblog_of_id: status.id)
+
+      results = Status.as_public_timeline
+      expect(results).to include(status)
+      expect(results).not_to include(boost)
+    end
 
     it 'filters out silenced accounts'
 

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -239,7 +239,14 @@ RSpec.describe Status, type: :model do
       end
 
       context 'where that account is silenced' do
-        it 'includes statuses from other accounts that are silenced'
+        xit 'includes statuses from other accounts that are silenced' do
+          @account.update(silenced: true)
+          other_silenced_account = Fabricate(:account, silenced: true)
+          other_status = Fabricate(:status, account: other_silenced_account)
+
+          results = Status.as_public_timeline(@account)
+          expect(results).to include(other_status)
+        end
       end
     end
   end


### PR DESCRIPTION
More prep work for https://github.com/tootsuite/mastodon/pull/2361

- Adds a `blocked_by` relationship to `Account` to find accounts which have blocked the record in question
- Moves the method to find excluded accounts ids out of status and into account
- Add a bunch of scopes to account to assist in building timeline queries
- Pretty big refactor to timeline query code
- Lots of specs added for public and tag timeline methods
- Fixed a bug where silenced accounts were not returning statuses of other silenced accounts
