### PR TITLE
Hide get started link when register closed

### DIFF
--- a/app/views/about/_links.html.haml
+++ b/app/views/about/_links.html.haml
@@ -5,7 +5,8 @@
       - if user_signed_in?
         %li= link_to t('about.get_started'), root_path
       - else
-        %li= link_to t('about.get_started'), new_user_registration_path
+        - if @instance_presenter.open_registrations
+          %li= link_to t('about.get_started'), new_user_registration_path
         %li= link_to t('auth.login'), new_user_session_path
       %li= link_to t('about.terms'), terms_path
       %li= link_to t('about.source_code'), 'https://github.com/tootsuite/mastodon'


### PR DESCRIPTION
in `/about/more`

| | before | after |
|-|-|-|
| register opened | ![](https://cloud.githubusercontent.com/assets/12539/25530643/f4067302-2c61-11e7-99d4-952c9ac7452d.png) | ![](https://cloud.githubusercontent.com/assets/12539/25530643/f4067302-2c61-11e7-99d4-952c9ac7452d.png) |
| register closed | ![](https://cloud.githubusercontent.com/assets/12539/25530643/f4067302-2c61-11e7-99d4-952c9ac7452d.png) | ![](https://cloud.githubusercontent.com/assets/12539/25530644/f408d282-2c61-11e7-871b-340100e05a46.png) |
