### PR TITLE
Add option to disable two factor auth in admin accounts panel.

### DIFF
--- a/app/controllers/admin/two_factor_authentications_controller.rb
+++ b/app/controllers/admin/two_factor_authentications_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Admin
+  class TwoFactorAuthenticationsController < BaseController
+    before_action :set_account
+
+    def destroy
+      @account.user.otp_required_for_login = false
+      @account.user.otp_backup_codes.clear
+      @account.user.save!
+      redirect_to admin_accounts_path
+    end
+
+    private
+
+    def set_account
+      @account = Account.find(params[:account_id])
+    end
+  end
+end

--- a/app/controllers/admin/two_factor_authentications_controller.rb
+++ b/app/controllers/admin/two_factor_authentications_controller.rb
@@ -2,19 +2,17 @@
 
 module Admin
   class TwoFactorAuthenticationsController < BaseController
-    before_action :set_account
+    before_action :set_user
 
     def destroy
-      @account.user.otp_required_for_login = false
-      @account.user.otp_backup_codes.clear
-      @account.user.save!
+      @user.disable_two_factor!
       redirect_to admin_accounts_path
     end
 
     private
 
-    def set_account
-      @account = Account.find(params[:account_id])
+    def set_user
+      @user = User.find(params[:user_id])
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,12 @@ class User < ApplicationRecord
     confirmed_at.present?
   end
 
+  def disable_two_factor!
+    self.otp_required_for_login = false
+    otp_backup_codes&.clear
+    save!
+  end
+
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
   end

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -71,7 +71,7 @@
   %div{ style: 'float: right' }
     = link_to t('admin.accounts.reset_password'), admin_account_reset_path(@account.id), method: :create, class: 'button'
     - if @account.user&.otp_required_for_login?
-      = link_to t('admin.accounts.disable_two_factor_authentication'), admin_account_two_factor_authentication_path(@account.id), method: :delete, class: 'button'
+      = link_to t('admin.accounts.disable_two_factor_authentication'), admin_user_two_factor_authentication_path(@account.user.id), method: :delete, class: 'button'
 
 %div{ style: 'float: left' }
   - if @account.silenced?

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -70,6 +70,8 @@
 - if @account.local?
   %div{ style: 'float: right' }
     = link_to t('admin.accounts.reset_password'), admin_account_reset_path(@account.id), method: :create, class: 'button'
+    - if @account.user&.otp_required_for_login?
+      = link_to t('admin.accounts.disable_two_factor_authentication'), admin_account_two_factor_authentication_path(@account.id), method: :delete, class: 'button'
 
 %div{ style: 'float: left' }
   - if @account.silenced?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
       public: Public
       push_subscription_expires: PuSH subscription expires
       reset_password: Reset password
+      disable_two_factor_authentication: Disable 2FA
       salmon_url: Salmon URL
       show:
         created_reports: Reports created by this account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
       resource :silence, only: [:create, :destroy]
       resource :suspension, only: [:create, :destroy]
       resource :confirmation, only: [:create]
+      resource :two_factor_authentication, only: [:destroy]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,9 @@ Rails.application.routes.draw do
       resource :silence, only: [:create, :destroy]
       resource :suspension, only: [:create, :destroy]
       resource :confirmation, only: [:create]
+    end
+
+    resources :users, only: [] do
       resource :two_factor_authentication, only: [:destroy]
     end
   end

--- a/spec/controllers/admin/two_factor_authentications_controller_spec.rb
+++ b/spec/controllers/admin/two_factor_authentications_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Admin::TwoFactorAuthenticationsController do
+  render_views
+
+  let(:user) { Fabricate(:user) }
+  before do
+    sign_in Fabricate(:user, admin: true), scope: :user
+  end
+
+  describe 'DELETE #destroy' do
+    it 'redirects to admin accounts page' do
+      delete :destroy, params: { user_id: user.id }
+      expect(response).to redirect_to(admin_accounts_path)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -126,6 +126,20 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#disable_two_factor!' do
+    it 'sets otp_required_for_login to false' do
+      user = Fabricate.build(:user, otp_required_for_login: true)
+      user.disable_two_factor!
+      expect(user.otp_required_for_login).to be false
+    end
+
+    it 'clears otp_backup_codes' do
+      user = Fabricate.build(:user, otp_backup_codes: %w[dummy dummy])
+      user.disable_two_factor!
+      expect(user.otp_backup_codes.empty?).to be true
+    end
+  end
+
   describe 'whitelist' do
     around(:each) do |example|
       old_whitelist = Rails.configuration.x.email_whitelist


### PR DESCRIPTION
Closes #2578, adds an option to disable 2FA in the accounts panel. UI change displayed below.

This will require updated translations, if anyone can help translate that would be awesome.

![UI Change](https://cloud.githubusercontent.com/assets/27916112/25530761/54fd653c-2c1f-11e7-947d-b511511cbf8c.png)