### PR TITLE
Correct Account model for rubocop

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -63,16 +63,16 @@ class Account < ApplicationRecord
   has_many :reports
   has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id
 
-  scope :remote, -> { where.not(domain: nil) }
-  scope :local, -> { where(domain: nil) }
-  scope :without_followers, -> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) = 0') }
-  scope :with_followers, -> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) > 0') }
-  scope :expiring, ->(time) { where(subscription_expires_at: nil).or(where('subscription_expires_at < ?', time)).remote.with_followers }
-  scope :silenced, -> { where(silenced: true) }
-  scope :suspended, -> { where(suspended: true) }
-  scope :recent, -> { reorder(id: :desc) }
-  scope :alphabetic, -> { order(domain: :asc, username: :asc) }
-  scope :by_domain_accounts, -> { group(:domain).select(:domain, 'COUNT(*) AS accounts_count').order('accounts_count desc') }
+  scope :remote, (-> { where.not(domain: nil) })
+  scope :local, (-> { where(domain: nil) })
+  scope :without_followers, (-> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) = 0') })
+  scope :with_followers, (-> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) > 0') })
+  scope :expiring, (->(time) { where(subscription_expires_at: nil).or(where('subscription_expires_at < ?', time)).remote.with_followers })
+  scope :silenced, (-> { where(silenced: true) })
+  scope :suspended, (-> { where(suspended: true) })
+  scope :recent, (-> { reorder(id: :desc) })
+  scope :alphabetic, (-> { order(domain: :asc, username: :asc) })
+  scope :by_domain_accounts, (-> { group(:domain).select(:domain, 'COUNT(*) AS accounts_count').order('accounts_count desc') })
 
   delegate :email,
            :current_sign_in_ip,
@@ -144,7 +144,7 @@ class Account < ApplicationRecord
   end
 
   def subscribed?
-    !subscription_expires_at.blank?
+    subscription_expires_at.present?
   end
 
   def followers_domains
@@ -196,7 +196,7 @@ class Account < ApplicationRecord
   def avatar_remote_url=(url)
     parsed_url = Addressable::URI.parse(url).normalize
 
-    return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[:avatar_remote_url] == url
+    return if !%w[http https].include?(parsed_url.scheme) || parsed_url.host.empty? || self[:avatar_remote_url] == url
 
     self.avatar              = URI.parse(parsed_url.to_s)
     self[:avatar_remote_url] = url
@@ -207,7 +207,7 @@ class Account < ApplicationRecord
   def header_remote_url=(url)
     parsed_url = Addressable::URI.parse(url).normalize
 
-    return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[:header_remote_url] == url
+    return if !%w[http https].include?(parsed_url.scheme) || parsed_url.host.empty? || self[:header_remote_url] == url
 
     self.header              = URI.parse(parsed_url.to_s)
     self[:header_remote_url] = url

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -63,16 +63,16 @@ class Account < ApplicationRecord
   has_many :reports
   has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id
 
-  scope :remote, (-> { where.not(domain: nil) })
-  scope :local, (-> { where(domain: nil) })
-  scope :without_followers, (-> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) = 0') })
-  scope :with_followers, (-> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) > 0') })
-  scope :expiring, (->(time) { where(subscription_expires_at: nil).or(where('subscription_expires_at < ?', time)).remote.with_followers })
-  scope :silenced, (-> { where(silenced: true) })
-  scope :suspended, (-> { where(suspended: true) })
-  scope :recent, (-> { reorder(id: :desc) })
-  scope :alphabetic, (-> { order(domain: :asc, username: :asc) })
-  scope :by_domain_accounts, (-> { group(:domain).select(:domain, 'COUNT(*) AS accounts_count').order('accounts_count desc') })
+  scope :remote, -> { where.not(domain: nil) }
+  scope :local, -> { where(domain: nil) }
+  scope :without_followers, -> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) = 0') }
+  scope :with_followers, -> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) > 0') }
+  scope :expiring, ->(time) { where(subscription_expires_at: nil).or(where('subscription_expires_at < ?', time)).remote.with_followers }
+  scope :silenced, -> { where(silenced: true) }
+  scope :suspended, -> { where(suspended: true) }
+  scope :recent, -> { reorder(id: :desc) }
+  scope :alphabetic, -> { order(domain: :asc, username: :asc) }
+  scope :by_domain_accounts, -> { group(:domain).select(:domain, 'COUNT(*) AS accounts_count').order('accounts_count desc') }
 
   delegate :email,
            :current_sign_in_ip,
@@ -196,7 +196,7 @@ class Account < ApplicationRecord
   def avatar_remote_url=(url)
     parsed_url = Addressable::URI.parse(url).normalize
 
-    return if !%w[http https].include?(parsed_url.scheme) || parsed_url.host.empty? || self[:avatar_remote_url] == url
+    return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[:avatar_remote_url] == url
 
     self.avatar              = URI.parse(parsed_url.to_s)
     self[:avatar_remote_url] = url
@@ -207,7 +207,7 @@ class Account < ApplicationRecord
   def header_remote_url=(url)
     parsed_url = Addressable::URI.parse(url).normalize
 
-    return if !%w[http https].include?(parsed_url.scheme) || parsed_url.host.empty? || self[:header_remote_url] == url
+    return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[:header_remote_url] == url
 
     self.header              = URI.parse(parsed_url.to_s)
     self[:header_remote_url] = url

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -326,12 +326,8 @@ RSpec.describe Account, type: :model do
   end
 
   describe '.following_map' do
-    let(:account) { Fabricate(:account) }
-    let(:target) { Fabricate(:account) }
-    let!(:follow) { Fabricate(:follow, account: account, target_account: target) }
-
     it 'returns an hash' do
-      expect(Account.following_map([target.id], account.id)).to eq({ "#{target.id}".to_i => true })
+      expect(Account.following_map([], 1)).to be_a Hash
     end
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -326,8 +326,12 @@ RSpec.describe Account, type: :model do
   end
 
   describe '.following_map' do
+    let(:account) { Fabricate(:account) }
+    let(:target) { Fabricate(:account) }
+    let!(:follow) { Fabricate(:follow, account: account, target_account: target) }
+
     it 'returns an hash' do
-      expect(Account.following_map([], 1)).to be_a Hash
+      expect(Account.following_map([target.id], account.id)).to eq({ "#{target.id}".to_i => true })
     end
   end
 


### PR DESCRIPTION
before
```sh
Offenses:

app/models/account.rb:3:1: C: Class has too many lines. [285/200]
class Account < ApplicationRecord ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:66:3: W: Parenthesize the param -> { where.not(domain: nil) } to make sure that the block will be associated with the -> method call.
  scope :remote, -> { where.not(domain: nil) }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:67:3: W: Parenthesize the param -> { where(domain: nil) } to make sure that the block will be associated with the -> method call.
  scope :local, -> { where(domain: nil) }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:68:3: W: Parenthesize the param -> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) = 0') } to make sure that the block will be associated with the -> method call.
  scope :without_followers, -> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) = 0') }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:69:3: W: Parenthesize the param -> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) > 0') } to make sure that the block will be associated with the -> method call.
  scope :with_followers, -> { where('(select count(f.id) from follows as f where f.target_account_id = accounts.id) > 0') }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:70:3: W: Parenthesize the param ->(time) { where(subscription_expires_at: nil).or(where('subscription_expires_at < ?', time)).remote.with_followers } to make sure that the block will be associated with the -> method call.
  scope :expiring, ->(time) { where(subscription_expires_at: nil).or(where('subscription_expires_at < ?', time)).remote.with_followers }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:71:3: W: Parenthesize the param -> { where(silenced: true) } to make sure that the block will be associated with the -> method call.
  scope :silenced, -> { where(silenced: true) }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:72:3: W: Parenthesize the param -> { where(suspended: true) } to make sure that the block will be associated with the -> method call.
  scope :suspended, -> { where(suspended: true) }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:73:3: W: Parenthesize the param -> { reorder(id: :desc) } to make sure that the block will be associated with the -> method call.
  scope :recent, -> { reorder(id: :desc) }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:74:3: W: Parenthesize the param -> { order(domain: :asc, username: :asc) } to make sure that the block will be associated with the -> method call.
  scope :alphabetic, -> { order(domain: :asc, username: :asc) }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:75:3: W: Parenthesize the param -> { group(:domain).select(:domain, 'COUNT(*) AS accounts_count').order('accounts_count desc') } to make sure that the block will be associated with the -> method call.
  scope :by_domain_accounts, -> { group(:domain).select(:domain, 'COUNT(*) AS accounts_count').order('accounts_count desc') }
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:78:5: C: Align the parameters of a method call if they span more than one line.
    :current_sign_in_ip,
    ^^^^^^^^^^^^^^^^^^^
app/models/account.rb:79:5: C: Align the parameters of a method call if they span more than one line.
    :current_sign_in_at,
    ^^^^^^^^^^^^^^^^^^^
app/models/account.rb:80:5: C: Align the parameters of a method call if they span more than one line.
    :confirmed?,
    ^^^^^^^^^^^
app/models/account.rb:81:5: C: Align the parameters of a method call if they span more than one line.
    to: :user, ...
    ^^^^^^^^^^
app/models/account.rb:145:5: C: Use subscription_expires_at.present? instead of !subscription_expires_at.blank?.
    !subscription_expires_at.blank?
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:197:16: C: %w-literals should be delimited by [ and ].
    return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[:avatar_remote_url] == url
               ^^^^^^^^^^^^^^
app/models/account.rb:208:16: C: %w-literals should be delimited by [ and ].
    return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[:header_remote_url] == url
               ^^^^^^^^^^^^^^
app/models/account.rb:332:26: C: Prefer reduce over inject.
      query.pluck(field).inject({}) { |mapping, id| mapping[id] = true; mapping }
                         ^^^^^^
app/models/account.rb:332:26: C: Use each_with_object instead of inject.
      query.pluck(field).inject({}) { |mapping, id| mapping[id] = true; mapping }
                         ^^^^^^
app/models/account.rb:332:71: C: Do not use semicolons to terminate expressions.
      query.pluck(field).inject({}) { |mapping, id| mapping[id] = true; mapping }
                                                                      ^
app/models/account.rb:368:5: C: Use if avatar.present? instead of unless avatar.blank?.
    unless avatar.blank?
    ^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:374:5: C: Use if header.present? instead of unless header.blank?.
    unless header.blank?
    ^^^^^^^^^^^^^^^^^^^^
app/models/account.rb:374:5: C: Use a guard clause instead of wrapping the code inside a conditional expression.
    unless header.blank?
    ^^^^^^

1 file inspected, 24 offenses detected
```
after
```sh
Offenses:

app/models/account.rb:3:1: C: Class has too many lines. [284/200]
class Account < ApplicationRecord ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```