### PR TITLE
[WIP] Set unknown attachment type when adding domain blocks

### DIFF
--- a/app/services/block_domain_service.rb
+++ b/app/services/block_domain_service.rb
@@ -39,12 +39,15 @@ class BlockDomainService < BaseService
     blocked_domain_accounts.find_each do |account|
       account.avatar.destroy
       account.header.destroy
+      account.save
     end
   end
 
   def clear_account_attachments
     media_from_blocked_domain.find_each do |attachment|
       attachment.file.destroy
+      attachment.type = :unknown
+      attachment.save
     end
   end
 

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -53,7 +53,17 @@ namespace :mastodon do
     task remove_remote: :environment do
       MediaAttachment.where.not(remote_url: '').where('created_at < ?', 1.week.ago).find_each do |media|
         media.file.destroy
+        media.type = :unknown
+        media.save
       end
+    end
+
+    desc 'Set unknown attachment type for remote-only attachments'
+    task set_unknown: :environment do
+      Rails.logger.debug 'Setting unknown attachment type for remote-only attachments...'
+      # rubocop:disable Rails/SkipsModelValidations
+      MediaAttachment.where(file_file_name: nil).where.not(type: :unknown).in_batches.update_all(type: :unknown)
+      Rails.logger.debug 'Done!'
     end
   end
 


### PR DESCRIPTION
Follow-up to #2599. When a domain block with `reject_media` is added or `rake mastodon:media:remove_remote` is invoked, mastodon deletes the locally cached attachments and avatars but does not reflect that change in the database, causing the `file` fields to still have values. This change persists the deletion in the database and sets the attachment type to unknown.

This also introduces a one-off rake task that sets all attachments without a local file to the "unknown" type. The upgrade notes for the next release should contain a post-upgrade step with `rake mastodon:media:set_unknown`.

**WIP:**
 - The rake task currently doesn't cover the cases that the issue in `BlockDomainService` and the `remove_remote` task caused (i.e. no local file, but `file` columns still have values). As far as I can tell, the only way to fix those files would be to go through all files with a `remote_url` and check if the file exists. **I'm reluctant to add this because of the massive disk and network I/O load it could cause on larger instances. Thoughts? Should we just let them be as-is?**
 - Some test coverage for the `BlockDomainService` issue would be good.