### PR TITLE
Use ws protocol in streaming API base URL (breaking change)

### DIFF
--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -1,17 +1,7 @@
 import WebSocketClient from 'websocket.js';
 
-const createWebSocketURL = (url) => {
-  const a = document.createElement('a');
-
-  a.href     = url;
-  a.href     = a.href;
-  a.protocol = a.protocol.replace('http', 'ws');
-
-  return a.href;
-};
-
 export default function getStream(streamingAPIBaseURL, accessToken, stream, { connected, received, disconnected, reconnected }) {
-  const ws = new WebSocketClient(`${createWebSocketURL(streamingAPIBaseURL)}/api/v1/streaming/?access_token=${accessToken}&stream=${stream}`);
+  const ws = new WebSocketClient(`${streamingAPIBaseURL}/api/v1/streaming/?access_token=${accessToken}&stream=${stream}`);
 
   ws.onopen      = connected;
   ws.onmessage   = e => received(JSON.parse(e.data));

--- a/config/initializers/ostatus.rb
+++ b/config/initializers/ostatus.rb
@@ -12,9 +12,9 @@ Rails.application.configure do
   config.x.use_s3       = ENV['S3_ENABLED'] == 'true'
 
   config.action_mailer.default_url_options = { host: web_host, protocol: https ? 'https://' : 'http://', trailing_slash: false }
-  config.x.streaming_api_base_url          = 'http://localhost:4000'
+  config.x.streaming_api_base_url          = 'ws://localhost:4000'
 
   if Rails.env.production?
-    config.x.streaming_api_base_url = ENV.fetch('STREAMING_API_BASE_URL') { "http#{https ? 's' : ''}://#{web_host}" }
+    config.x.streaming_api_base_url = ENV.fetch('STREAMING_API_BASE_URL') { "ws#{https ? 's' : ''}://#{web_host}" }
   end
 end


### PR DESCRIPTION
This is a breaking change for administrators. Administrators must alter the scheme of `STREAMING_API_BASE_URL` from `http` to `ws`.