### PR TITLE
Expand uploaded thumbnail

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/upload_form.jsx
+++ b/app/assets/javascripts/components/features/compose/components/upload_form.jsx
@@ -18,7 +18,7 @@ class UploadForm extends React.PureComponent {
       <div className='compose-form__upload' key={attachment.get('id')}>
         <Motion defaultStyle={{ scale: 0.8 }} style={{ scale: spring(1, { stiffness: 180, damping: 12 }) }}>
           {({ scale }) =>
-            <div className='compose-form__upload-thumbnail' style={{ transform: `translateZ(0) scale(${scale})`, background: `url(${attachment.get('preview_url')}) no-repeat center` }}>
+            <div className='compose-form__upload-thumbnail' style={{ transform: `translateZ(0) scale(${scale})`, backgroundImage: `url(${attachment.get('preview_url')})` }}>
               <IconButton icon='times' title={intl.formatMessage(messages.undo)} size={36} onClick={this.props.onRemoveFile.bind(this, attachment.get('id'))} />
             </div>
           }

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -274,6 +274,9 @@
 
 .compose-form__upload-thumbnail {
   border-radius: 4px;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
   height: 100px;
   width: 100%;
 }


### PR DESCRIPTION
fixes broken style introduced by https://github.com/tootsuite/mastodon/pull/2338

|before (broken)|after|
|-|-|
|![2017-04-29 13 30 37](https://cloud.githubusercontent.com/assets/1688137/25552901/8dde1498-2ce0-11e7-8f41-e02c584072b9.png)|![2017-04-29 13 31 04](https://cloud.githubusercontent.com/assets/1688137/25552902/8dde9a6c-2ce0-11e7-9c81-dbf1e16919d8.png)|