### PR TITLE
Remove uneeded `ORDER BY` query

### DIFF
--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -4,12 +4,6 @@ class FollowerAccountsController < ApplicationController
   include AccountControllerConcern
 
   def index
-    @accounts = ordered_accounts.page(params[:page]).per(FOLLOW_PER_PAGE)
-  end
-
-  private
-
-  def ordered_accounts
-    @account.followers.order('follows.created_at desc')
+    @accounts = @account.followers.page(params[:page]).per(FOLLOW_PER_PAGE)
   end
 end

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -4,12 +4,6 @@ class FollowingAccountsController < ApplicationController
   include AccountControllerConcern
 
   def index
-    @accounts = ordered_accounts.page(params[:page]).per(FOLLOW_PER_PAGE)
-  end
-
-  private
-
-  def ordered_accounts
-    @account.following.order('follows.created_at desc')
+    @accounts = @account.following.page(params[:page]).per(FOLLOW_PER_PAGE)
   end
 end


### PR DESCRIPTION
1. already added `order by follows.id desc` as default. `follows.created_at desc` is not needed.
2. `follows.id desc, follows.created_at desc` is too slow. Only `follows.id desc` is fast.

---

The results of the optimization.

```
Account.find(X).following_count #=> 187053
```

**before**

```
EXPLAIN ANALYZE SELECT  "accounts".* FROM "accounts" INNER JOIN "follows" ON "accounts"."id" = "follows"."target_account_id" WHERE "follows"."account_id" = X ORDER BY follows.id desc, follows.created_at LIMIT 25 OFFSET 300
```

```
Limit  (cost=158229.25..158229.31 rows=25 width=905) (actual time=1171.888..1171.902 rows=25 loops=1)
  ->  Sort  (cost=158228.50..158660.37 rows=172751 width=905) (actual time=1171.681..1171.832 rows=325 loops=1)
        Sort Key: follows.id DESC, follows.created_at
        Sort Method: top-N heapsort  Memory: 410kB
        ->  Hash Join  (cost=65124.60..150157.31 rows=172751 width=905) (actual time=478.949..982.550 rows=186710 loops=1)
              Hash Cond: (follows.target_account_id = accounts.id)
              ->  Bitmap Heap Scan on follows  (cost=4715.25..62317.64 rows=172751 width=16) (actual time=24.447..141.505 rows=187053 loops=1)
                    Recheck Cond: (account_id = 112251)
                    Heap Blocks: exact=16279
                    ->  Bitmap Index Scan on index_follows_on_account_id_and_target_account_id  (cost=0.00..4672.06 rows=172751 width=0) (actual time=21.474..21.474 rows=187296 loops=1)
                          Index Cond: (account_id = 112251)
              ->  Hash  (cost=34441.60..34441.60 rows=208060 width=893) (actual time=454.045..454.045 rows=208046 loops=1)
                    Buckets: 8192  Batches: 64  Memory Usage: 2708kB
                    ->  Seq Scan on accounts  (cost=0.00..34441.60 rows=208060 width=893) (actual time=0.004..80.224 rows=208046 loops=1)
Planning time: 0.660 ms
Execution time: 1172.533 ms
```

**after**

remove `follows.created_at desc`

```
EXPLAIN ANALYZE SELECT  "accounts".* FROM "accounts" INNER JOIN "follows" ON "accounts"."id" = "follows"."target_account_id" WHERE "follows"."account_id" = X ORDER BY follows.id desc LIMIT 25 OFFSET 300
```

```
Limit  (cost=909.49..985.21 rows=25 width=897) (actual time=24.419..24.704 rows=25 loops=1)
  ->  Nested Loop  (cost=0.85..523229.75 rows=172751 width=897) (actual time=2.342..24.636 rows=325 loops=1)
        ->  Index Scan Backward using follows_pkey on follows  (cost=0.43..310931.68 rows=172751 width=8) (actual time=2.316..22.074 rows=325 loops=1)
              Filter: (account_id = 112251)
              Rows Removed by Filter: 49877
        ->  Index Scan using accounts_pkey on accounts  (cost=0.42..1.22 rows=1 width=893) (actual time=0.006..0.006 rows=1 loops=325)
              Index Cond: (id = follows.target_account_id)
Planning time: 1.346 ms
Execution time: 24.838 ms
```