### PR TITLE
Darkens colour on stream entries meta text

### DIFF
--- a/app/assets/stylesheets/stream_entries.scss
+++ b/app/assets/stylesheets/stream_entries.scss
@@ -43,7 +43,7 @@
         font-size: 14px;
 
         .status__relative-time {
-          color: $color3;
+          color: $color4;
         }
       }
     }
@@ -87,7 +87,7 @@
 
       span {
         font-size: 14px;
-        color: $color3;
+        color: $color4;
       }
     }
 


### PR DESCRIPTION
## Rationale

This PR increases the readability of the username and datetime on stream entires. It's currently a light grey _by default_ but many instances using custom CSS have problems. For example, this is very barely readable:

<img width="689" alt="screen shot 2017-04-29 at 12 47 16 pm" src="https://cloud.githubusercontent.com/assets/498212/25554928/c490e7a0-2cda-11e7-9441-d064395f5d0c.png">

I think this is important enough to go into the main codebase instead of everyone [changing it themselves](https://github.com/ashfurrow/mastodon/commit/43e0b8e271afef89f934b999931c091105f75008). Additionally: these meta texts are links, so changing them to the link colour makes sense.

### Before

<img width="690" alt="screen shot 2017-04-29 at 12 48 57 pm" src="https://cloud.githubusercontent.com/assets/498212/25554921/a0d189e6-2cda-11e7-8b98-59fcd261f87e.png">

### After

<img width="695" alt="screen shot 2017-04-29 at 12 51 29 pm" src="https://cloud.githubusercontent.com/assets/498212/25554922/a4391a90-2cda-11e7-907a-b31ff8e2c98c.png">