### PR TITLE
Downgrade rubocop 0.48.1 => 0.46.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -88,3 +88,4 @@ AllCops:
   - 'Rakefile'
   - 'node_modules/**/*'
   - 'Vagrantfile'
+  - 'vendor/**/*'

--- a/Capfile
+++ b/Capfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'capistrano/setup'
 require 'capistrano/deploy'
 require 'capistrano/scm/git'

--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ group :test do
 end
 
 group :development do
-  gem 'rubocop', require: false
+  gem 'rubocop', '0.46.0', require: false
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'letter_opener'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,8 +394,8 @@ GEM
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.5.0)
-    rubocop (0.48.1)
-      parser (>= 2.3.3.1, < 3.0)
+    rubocop (0.46.0)
+      parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -547,7 +547,7 @@ DEPENDENCIES
   rqrcode
   rspec-rails
   rspec-sidekiq
-  rubocop
+  rubocop (= 0.46.0)
   ruby-oembed
   sanitize
   sass-rails (~> 5.0)

--- a/app/controllers/authorize_follows_controller.rb
+++ b/app/controllers/authorize_follows_controller.rb
@@ -44,7 +44,7 @@ class AuthorizeFollowsController < ApplicationController
   end
 
   def acct_param_is_url?
-    parsed_uri.path && %w[http https].include?(parsed_uri.scheme)
+    parsed_uri.path && %w(http https).include?(parsed_uri.scheme)
   end
 
   def parsed_uri

--- a/app/controllers/well_known/host_meta_controller.rb
+++ b/app/controllers/well_known/host_meta_controller.rb
@@ -1,4 +1,4 @@
-  # frozen_string_literal: true
+# frozen_string_literal: true
 
 module WellKnown
   class HostMetaController < ApplicationController

--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Admin::FilterHelper
-  ACCOUNT_FILTERS = %i[local remote by_domain silenced suspended recent].freeze
-  REPORT_FILTERS = %i[resolved account_id target_account_id].freeze
+  ACCOUNT_FILTERS = %i(local remote by_domain silenced suspended recent).freeze
+  REPORT_FILTERS = %i(resolved account_id target_account_id).freeze
 
   FILTERS = ACCOUNT_FILTERS + REPORT_FILTERS
 

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -63,10 +63,12 @@ class AccountSearchService < BaseService
   end
 
   def search_results
-    @_search_results ||= if account
-      advanced_search_results
-    else
-      simple_search_results
+    @_search_results ||= begin
+      if account
+        advanced_search_results
+      else
+        simple_search_results
+      end
     end
   end
 

--- a/app/services/process_feed_service.rb
+++ b/app/services/process_feed_service.rb
@@ -205,7 +205,7 @@ class ProcessFeedService < BaseService
         media = MediaAttachment.where(status: parent, remote_url: link['href']).first_or_initialize(account: parent.account, status: parent, remote_url: link['href'])
         parsed_url = Addressable::URI.parse(link['href']).normalize
 
-        next if !%w[http https].include?(parsed_url.scheme) || parsed_url.host.empty?
+        next if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty?
 
         media.save
 

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -61,7 +61,6 @@ namespace :mastodon do
     desc 'Set unknown attachment type for remote-only attachments'
     task set_unknown: :environment do
       Rails.logger.debug 'Setting unknown attachment type for remote-only attachments...'
-      # rubocop:disable Rails/SkipsModelValidations
       MediaAttachment.where(file_file_name: nil).where.not(type: :unknown).in_batches.update_all(type: :unknown)
       Rails.logger.debug 'Done!'
     end


### PR DESCRIPTION
### Problems

- [Code climate use rubocop version `0.46.0`](https://docs.codeclimate.com/v1.0/docs/rubocop), but this project use `0.48.1`. 
- Different versions, different warnings, so I think we should use the same version.

### Resolved

- Downgraded rubocop version to `0.46.0` from `0.48.1`.
- Add `vendor/**/*` to Excludes of Allcops in `.rubocop.yml`.
- Fix several styles:
    - Added `frozen_string_literal`.
    - Changed percent literal delimiter from `[]` to `()`.
    - Modified Alignment.