### PR TITLE
Fix "Could not find actionview-5.0.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ gem 'whatlanguage'
 gem 'react-rails'
 gem 'browserify-rails'
 gem 'autoprefixer-rails'
+gem 'actionview', '>= 5.0.2'
 
 group :development, :test do
   gem 'rspec-rails'


### PR DESCRIPTION
```
==> default: /home/vagrant/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/spec_set.rb:87:in `block in materialize'
==> default: :
==> default: Could not find actionview-5.0.2 in any of the sources
```