### PR TITLE
Remove Intl polyfill

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -5,11 +5,6 @@ window.React    = require('react');
 window.ReactDOM = require('react-dom');
 window.Perf     = require('react-addons-perf');
 
-if (!window.Intl) {
-  require('intl');
-  require('intl/locale-data/jsonp/en.js');
-}
-
 //= require_tree ./components
 
 window.Mastodon = require('./components/containers/mastodon');

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "express": "^4.14.1",
     "http-link-header": "^0.8.0",
     "immutable": "^3.8.1",
-    "intl": "^1.2.5",
     "jsdom": "^9.11.0",
     "mocha": "^3.2.0",
     "node-sass": "^4.5.2",


### PR DESCRIPTION
Before this change, `application.js` is 2.96 MB (514 kB gzipped). After this change, it's 2.87 MB (494 kB gzipped). So this cuts out a fairly large dependency.

Furthermore, the `window.Intl` API is well-supported by [all modern browsers](http://kangax.github.io/compat-table/esintl/). And currently Mastodon already doesn't work in browsers like IE11 or Android 4.4-5.1 stock browser due to a missing `Object.assign` polyfill and I'm not sure anybody has complained yet. 😃

I checked, and AFAICT based on [the ES6 compatibility table](http://kangax.github.io/compat-table/es6/), the only browser that would lose support after this change is iOS 9, which is already pretty old (released in 2015) and according to [caniuse/statcounter](http://caniuse.com/usage-table) is somewhere around ~0.88% global market share (and undoubtedly much much smaller for Mastodon users). And those iOS users might just be on Amaroq anyway. So it seems pretty safe to drop.