### PR TITLE
Use envify + NODE_ENV=production for smaller JS bundle

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -3,7 +3,11 @@
 
 window.React    = require('react');
 window.ReactDOM = require('react-dom');
-window.Perf     = require('react-addons-perf');
+
+if (process.env.NODE_ENV !== 'production') {
+  // perf tracking (aka marks/measures) not needed in production mode
+  window.Perf = require('react-addons-perf');
+}
 
 if (!window.Intl) {
   require('intl');

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,7 +74,7 @@ module Mastodon
     config.middleware.use Rack::Deflater
 
     # babel config can be found in .babelrc
-    config.browserify_rails.commandline_options   = '--transform babelify --extension=".jsx"'
+    config.browserify_rails.commandline_options   = '-t babelify -g [ envify --NODE_ENV ' + ENV['RAILS_ENV'] + ' ] --extension=".jsx"'
     config.browserify_rails.evaluate_node_modules = true
 
     config.to_prepare do

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.2.2",
+    "envify": "^4.0.0",
     "eslint": "^3.19.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,6 +2396,13 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+envify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/envify/-/envify-4.0.0.tgz#f791343e3d11cc29cce41150300a8af61c66cab0"
+  dependencies:
+    esprima "~3.1.0"
+    through "~2.3.4"
+
 enzyme@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-2.8.2.tgz#6c8bcb05012abc4aa4bc3213fb23780b9b5b1714"
@@ -6231,7 +6238,7 @@ through2@^2.0.0:
     readable-stream "~2.0.0"
     xtend "~4.0.0"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 


### PR DESCRIPTION
This uses [envify](https://github.com/hughsk/envify) as a global Browserify transform to replace usages of `process.env.NODE_ENV` with `"production"` when `RAILS_ENV` is also set to `"production"`, which allows Uglify to remove non-essential code. It also makes it so `react-addons-perf` is omitted in production mode, since it's not worthwhile in production (it just instruments `performance.mark`/`performance.measure`s in React's APIs).

Before this PR, `application.js` is 2.96 MB (2963246 bytes to be exact, 514 kB gzipped). After, it's 2.95 MB (2952387 bytes to be exact, 512 kB gzipped).