### PR TITLE
Ignore postgres/redis folder while building the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,5 @@ vendor/bundle
 .DS_Store
 *.swp
 *~
+postgres
+redis


### PR DESCRIPTION
Similar to #1645, but they also should be ignored while building container.