### PR TITLE
Detect extension for preview card

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -21,7 +21,7 @@ class Account < ApplicationRecord
   validates_attachment_content_type :header, content_type: IMAGE_MIME_TYPES
   validates_attachment_size :header, less_than: 2.megabytes
 
-  before_post_process :set_file_extensions
+  include Attachmentable
 
   # Local user profile validations
   validates :display_name, length: { maximum: 30 }, if: 'local?'
@@ -362,19 +362,5 @@ class Account < ApplicationRecord
     return if local?
 
     self.domain = TagManager.instance.normalize_domain(domain)
-  end
-
-  def set_file_extensions
-    unless avatar.blank?
-      extension = Paperclip::Interpolations.content_type_extension(avatar, :original)
-      basename  = Paperclip::Interpolations.basename(avatar, :original)
-      avatar.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
-    end
-
-    unless header.blank?
-      extension = Paperclip::Interpolations.content_type_extension(header, :original)
-      basename  = Paperclip::Interpolations.basename(header, :original)
-      header.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
-    end
   end
 end

--- a/app/models/concerns/attachmentable.rb
+++ b/app/models/concerns/attachmentable.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Attachmentable
+  extend ActiveSupport::Concern
+
+  included do
+    before_post_process :set_file_extensions
+  end
+
+  private
+
+  def set_file_extensions
+    self.class.attachment_definitions.each_key do |attachment_name|
+      attachment = send(attachment_name)
+      unless attachment.blank?
+        extension = Paperclip::Interpolations.content_type_extension(attachment, :original)
+        basename  = Paperclip::Interpolations.basename(attachment, :original)
+        attachment.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
+      end
+    end
+  end
+end

--- a/app/models/concerns/attachmentable.rb
+++ b/app/models/concerns/attachmentable.rb
@@ -12,11 +12,10 @@ module Attachmentable
   def set_file_extensions
     self.class.attachment_definitions.each_key do |attachment_name|
       attachment = send(attachment_name)
-      unless attachment.blank?
-        extension = Paperclip::Interpolations.content_type_extension(attachment, :original)
-        basename  = Paperclip::Interpolations.basename(attachment, :original)
-        attachment.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
-      end
+      next if attachment.blank?
+      extension = Paperclip::Interpolations.content_type_extension(attachment, :original)
+      basename  = Paperclip::Interpolations.basename(attachment, :original)
+      attachment.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
     end
   end
 end

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -11,6 +11,8 @@ class PreviewCard < ApplicationRecord
 
   has_attached_file :image, styles: { original: '120x120#' }, convert_options: { all: '-quality 80 -strip' }
 
+  include Attachmentable
+
   validates :url, presence: true
   validates_attachment_content_type :image, content_type: IMAGE_MIME_TYPES
   validates_attachment_size :image, less_than: 1.megabytes


### PR DESCRIPTION
Image URLs without extensions (e.g. https://avatars2.githubusercontent.com/u/12539?v=3&s=400) will be uploaded with no extension.

![](https://cloud.githubusercontent.com/assets/12539/25578518/8103348a-2eaa-11e7-8033-fe72d12ba7ed.png)
