### PR TITLE
fix(scrolling): Center for large screen w/o breaking horiz scroll

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1189,7 +1189,6 @@ a.status__content__spoiler-link {
 @media screen and (min-width: 1025px) {
   .columns-area {
     padding: 0;
-    margin: 0 auto;
   }
 
   .column, .drawer {
@@ -1212,6 +1211,13 @@ a.status__content__spoiler-link {
       padding-left: 5px;
       padding-right: 5px;
     }
+  }
+}
+
+@media screen and (min-width: 1397px) { /* Width of 4 columns with margins */
+  .columns-area {
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 


### PR DESCRIPTION
Adding `margin: 0 auto` to `.columns-area` at sizes greater than 1025px is what does not allow the `columns-area` wrapper to shrink so that scrolling is possible. Instead it's just overflowing because the left and right margins are set to auto.

#2021
#2671 

Since the width of the four columns interface is essentially hardcoded at (3 * 330px) + 407px = 1397, adding a media query and applying the left and right margins of autos at that specific width will allow centering when the browser is larger than that without breaking the scrolling at the small view

Also adding `margin: 0 auto` sets top and bottom margins when it is not necessary. It is best practice to not use shortcuts unless you want to set all the values. This was affecting the margin on the bottom. Since we only want to set left and right margins, don't use the shortcut in this case. 