### PR TITLE
fix(dropdowns): Allow for dropdowns to fill full column

### DIFF
--- a/app/assets/javascripts/components/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/assets/javascripts/components/features/compose/components/emoji_picker_dropdown.jsx
@@ -97,7 +97,7 @@ class EmojiPickerDropdown extends React.PureComponent {
           <img draggable="false" className="emojione" alt="🙂" src="/emoji/1f602.svg" />
         </DropdownTrigger>
 
-        <DropdownContent className='dropdown__left light'>
+        <DropdownContent className='dropdown__left'>
           <EmojiPicker emojione={settings} onChange={this.handleChange} searchPlaceholder={intl.formatMessage(messages.emoji_search)} categories={categories} search={true} />
         </DropdownContent>
       </Dropdown>

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -330,6 +330,12 @@
 
 .compose-form__autosuggest-wrapper {
   position: relative;
+
+  .dropdown--active:after {
+    border-color: transparent transparent $color5 transparent;
+    bottom: -1px;
+    right: 8px;
+  }
 }
 
 .compose-form__publish {
@@ -1039,12 +1045,6 @@ a.status__content__spoiler-link {
   right: 0;
   text-align: left;
   z-index: 9999;
-
-  &.light {
-    &:before {
-      border-color: transparent transparent $color5 transparent;
-    }
-  }
 
   & > ul {
     list-style: none;

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -181,6 +181,19 @@
   color: $color4;
 }
 
+.dropdown--active:after {
+  content: "";
+  display: block;
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 4.5px 7.8px 4.5px;
+  border-color: transparent transparent $color2 transparent;
+  bottom: 8px;
+  right: 104px;
+}
+
 .invisible {
   font-size: 0;
   line-height: 0;
@@ -563,7 +576,6 @@ a.status__content__spoiler-link {
   align-items: center;
   display: flex;
   margin-top: 10px;
-  overflow: hidden;
 }
 
 .status__action-bar-button-wrapper {
@@ -737,6 +749,20 @@ a.status__content__spoiler-link {
 .account__action-bar-dropdown {
   flex: 1 1 auto;
   padding: 10px;
+
+  .dropdown--active {
+    .dropdown__content.dropdown__right {
+      left: 6px;
+      right: initial;
+    }
+
+    &:after {
+      bottom: initial;
+      margin-left: 11px;
+      margin-top: -7px;
+      right: initial;
+    }
+  }
 }
 
 .account__action-bar-links {
@@ -1009,21 +1035,10 @@ a.status__content__spoiler-link {
 .dropdown--active .dropdown__content {
   display: block;
   line-height: 18px;
+  max-width: 311px;
+  right: 0;
   text-align: left;
   z-index: 9999;
-
-  &:before {
-    content: "";
-    display: block;
-    position: absolute;
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-width: 0 4.5px 7.8px 4.5px;
-    border-color: transparent transparent $color2 transparent;
-    top: -7px;
-    left: 8px;
-  }
 
   &.light {
     &:before {
@@ -1039,16 +1054,15 @@ a.status__content__spoiler-link {
     box-shadow: 0 0 15px rgba($color8, 0.4);
     min-width: 140px;
     position: relative;
-    left: -10px;
+  }
+
+  &.dropdown__right {
+    right: 0;
   }
 
   &.dropdown__left {
     & > ul {
       left: -98px;
-    }
-
-    & > .emoji-dialog {
-      left: -210px;
     }
   }
 
@@ -1058,7 +1072,6 @@ a.status__content__spoiler-link {
     display: block;
     padding: 4px 14px;
     box-sizing: border-box;
-    width: 140px;
     text-decoration: none;
     background: $color2;
     color: $color1;


### PR DESCRIPTION
When the text inside a dropdown is longer than it is for English, the text is truncated which can result in a less-than-usable experience for languages such as German with longer words. This commit addresses the following:

* Allow the dropdown to expand to the entire width of the column based on the length of the text in the dropdown
* Align active dropdown arrow in relation to the trigger rather than the dropdown
* Show the right hand side of the dropdown which was previously hidden (could not see border radius)
* Ensure the three places dropdowns of status, account, and emoji appear well in Chrome, Firefox, Safari

#2643 

Screenshots (Chrome):
Old emoji dropdown:
<img width="298" alt="old_emoji" src="https://cloud.githubusercontent.com/assets/6003351/25580962/a4cd6b72-2e52-11e7-86d7-c9859ce344e2.png">

New emoji dropdown:
<img width="305" alt="screen shot 2017-05-01 at 9 54 38 am" src="https://cloud.githubusercontent.com/assets/6003351/25581200/5368f826-2e54-11e7-8b23-dad97497df18.png">

Old status dropdown:
<img width="336" alt="right_dropdown_english" src="https://cloud.githubusercontent.com/assets/6003351/25580976/bac71da6-2e52-11e7-8765-47b67deb5f9f.png">

New status dropdown:
<img width="333" alt="right_dropdown_new_english" src="https://cloud.githubusercontent.com/assets/6003351/25580982/c6ac9dda-2e52-11e7-9399-7cc25fd926c4.png">

Status dropdown full column width:
<img width="335" alt="full_text_new" src="https://cloud.githubusercontent.com/assets/6003351/25580985/ce48a64c-2e52-11e7-8897-ea0d33e0e70f.png">

Old user dropdown:
<img width="172" alt="live_user_dropdown" src="https://cloud.githubusercontent.com/assets/6003351/25580987/d2bc2e1a-2e52-11e7-85c1-2904ad591033.png">

New user dropdown:
<img width="184" alt="new_user_dropdown" src="https://cloud.githubusercontent.com/assets/6003351/25580996/db265e5e-2e52-11e7-8c75-a99498d28fd0.png">
