### PR TITLE
fix(boost-icon): Align center for Firefox

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1721,11 +1721,12 @@ a.status__content__spoiler-link {
 @import 'boost';
 
 button.icon-button i.fa-retweet {
-  height: 19px;
-  width: 22px;
   background-position: 0 0;
+  height: 19px;
   transition: background-position 0.9s steps(10);
   transition-duration: 0s;
+  vertical-align: middle;
+  width: 22px;
 
   &::before {
     display: none !important;


### PR DESCRIPTION
#2689

Also, arrange items for selector in alpha order.

Note: this fix also somewhat reduces the space between the toot and the dividing line.

Before:
<img width="306" alt="screen shot 2017-05-01 at 1 43 15 pm" src="https://cloud.githubusercontent.com/assets/6003351/25587947/53f79354-2e74-11e7-972d-1c20b32f20ad.png">


After:
<img width="310" alt="screen shot 2017-05-01 at 1 43 37 pm" src="https://cloud.githubusercontent.com/assets/6003351/25587942/4c577006-2e74-11e7-9a99-63611f33d2b6.png">

