### PR TITLE
Fix to completely hide NSFW-tagged images

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1889,7 +1889,6 @@ button.icon-button.active i.fa-retweet {
   }
 }
 
-.media-spoiler,
 .video-error-cover {
   align-items: center;
   background: $color8;
@@ -1900,6 +1899,20 @@ button.icon-button.active i.fa-retweet {
   height: 100%;
   justify-content: center;
   margin-top: 8px;
+  position: relative;
+  text-align: center;
+  z-index: 100;
+}
+
+.media-spoiler {
+  align-items: center;
+  background: $color8;
+  color: $color5;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
   position: relative;
   text-align: center;
   z-index: 100;


### PR DESCRIPTION
fix https://github.com/tootsuite/mastodon/issues/2559

---
before:
![2017-05-03 02 41 46](https://cloud.githubusercontent.com/assets/4888181/25631224/a95fc618-2faa-11e7-8329-a605a0f48b2e.png)
![2017-05-03 02 43 23](https://cloud.githubusercontent.com/assets/4888181/25631229/ae716dc8-2faa-11e7-8f6f-e567e2daca89.png)


after:
![2017-05-03 02 42 00](https://cloud.githubusercontent.com/assets/4888181/25631233/b2d12124-2faa-11e7-864a-3413ecfd0697.png)
![2017-05-03 02 43 37](https://cloud.githubusercontent.com/assets/4888181/25631236/b49dacfc-2faa-11e7-9945-67f464c128da.png)


---
"video-error-cover" needs margin.

![2017-05-03 02 08 22](https://cloud.githubusercontent.com/assets/4888181/25631322/f9bf63c0-2faa-11e7-8ee4-6f69f3ec7985.png)
![2017-05-03 02 10 00](https://cloud.githubusercontent.com/assets/4888181/25631327/fe3de99e-2faa-11e7-978e-bc09c1a5c678.png)


