### PR TITLE
Use puma config for Procfile.dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bundle exec rails s -p 3000
+web: bundle exec puma -C config/puma.rb
 stream: yarn run start
 webpack: ./bin/webpack-dev-server


### PR DESCRIPTION
This mirrors the production `Procfile` which I think makes sense, but also seems harmless. This will also honor whatever PORT settings developers have, if they don't use 3000.