### PR TITLE
fix Capfile (remove capistrano/faster_assets)

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -9,7 +9,6 @@ require 'capistrano/rbenv'
 require 'capistrano/bundler'
 require 'capistrano/yarn'
 require 'capistrano/rails/assets'
-require 'capistrano/faster_assets'
 require 'capistrano/rails/migrations'
 
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }


### PR DESCRIPTION
capistrano/faster_assets has been removed from Gemfile, but it remains in Capfile.