### PR TITLE
Fix PuSH to instances where WEB_DOMAIN != LOCAL_DOMAIN

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'aws-sdk', '~> 2.9'
 gem 'paperclip', '~> 5.1'
 gem 'paperclip-av-transcoder', '~> 0.6'
 
+gem 'idn-ruby', require: 'idn'
 gem 'addressable', '~> 2.5'
 gem 'bootsnap'
 gem 'browser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
       parser (>= 2.2.3.0)
       rainbow (~> 2.2)
       terminal-table (>= 1.5.1)
+    idn-ruby (0.1.0)
     jmespath (1.3.1)
     json (2.1.0)
     kaminari (1.0.1)
@@ -510,6 +511,7 @@ DEPENDENCIES
   http_accept_language (~> 2.1)
   httplog (~> 0.99)
   i18n-tasks (~> 0.9)
+  idn-ruby
   kaminari (~> 1.0)
   letter_opener (~> 1.4)
   letter_opener_web (~> 1.3)

--- a/app/lib/tag_manager.rb
+++ b/app/lib/tag_manager.rb
@@ -70,7 +70,7 @@ class TagManager
 
     uri = Addressable::URI.new
     uri.host = domain.gsub(/[\/]/, '')
-    uri.normalize.host
+    uri.normalized_host
   end
 
   def same_acct?(canonical, needle)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -160,7 +160,7 @@ class Account < ApplicationRecord
 
   class << self
     def domains
-      reorder(nil).pluck('distinct accounts.domain')
+      reorder(nil).pluck('distinct accounts.domain') + where.not(web_domain: nil).reorder(nil).pluck('distinct accounts.web_domain')
     end
 
     def triadic_closures(account, limit: 5, offset: 0)
@@ -255,5 +255,7 @@ class Account < ApplicationRecord
     return if local?
 
     self.domain = TagManager.instance.normalize_domain(domain)
+    remote_domain = Addressable::URI.parse(remote_url).normalized_host
+    self.web_domain = remote_domain unless domain == remote_domain
   end
 end

--- a/app/services/concerns/author_extractor.rb
+++ b/app/services/concerns/author_extractor.rb
@@ -14,7 +14,7 @@ module AuthorExtractor
 
       return nil if username.blank? || uri.blank?
 
-      domain = Addressable::URI.parse(uri).normalize.host
+      domain = Addressable::URI.parse(uri).normalized_host
       acct   = "#{username}@#{domain}"
     end
 

--- a/app/services/fetch_remote_status_service.rb
+++ b/app/services/fetch_remote_status_service.rb
@@ -24,7 +24,7 @@ class FetchRemoteStatusService < BaseService
     xml.encoding = 'utf-8'
 
     account = author_from_xml(xml.at_xpath('/xmlns:entry', xmlns: TagManager::XMLNS))
-    domain  = Addressable::URI.parse(url).normalize.host
+    domain  = Addressable::URI.parse(url).normalized_host
 
     return nil unless !account.nil? && confirmed_domain?(domain, account)
 
@@ -36,6 +36,6 @@ class FetchRemoteStatusService < BaseService
   end
 
   def confirmed_domain?(domain, account)
-    account.domain.nil? || domain.casecmp(account.domain).zero? || domain.casecmp(Addressable::URI.parse(account.remote_url).normalize.host).zero?
+    account.domain.nil? || domain.casecmp(account.domain).zero? || domain.casecmp(Addressable::URI.parse(account.remote_url).normalized_host).zero?
   end
 end

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -43,7 +43,7 @@ class Pubsubhubbub::DeliveryWorker
   end
 
   def host
-    Addressable::URI.parse(subscription.callback_url).normalize.host
+    Addressable::URI.parse(subscription.callback_url).normalized_host
   end
 
   def headers

--- a/app/workers/pubsubhubbub/distribution_worker.rb
+++ b/app/workers/pubsubhubbub/distribution_worker.rb
@@ -45,6 +45,6 @@ class Pubsubhubbub::DistributionWorker
   end
 
   def allowed_to_receive?(callback_url)
-    @domains.include?(Addressable::URI.parse(callback_url).host)
+    @domains.include?(Addressable::URI.parse(callback_url).normalized_host)
   end
 end

--- a/db/migrate/20170625195017_add_web_domain_to_accounts.rb
+++ b/db/migrate/20170625195017_add_web_domain_to_accounts.rb
@@ -1,0 +1,9 @@
+class AddWebDomainToAccounts < ActiveRecord::Migration[5.0]
+  def up
+    add_column :accounts, :web_domain, :string, null: true, default: nil
+  end
+
+  def down
+    remove_column :accounts, :web_domain
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170624134742) do
+ActiveRecord::Schema.define(version: 20170625195017) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20170624134742) do
     t.integer "followers_count", default: 0, null: false
     t.integer "following_count", default: 0, null: false
     t.datetime "last_webfingered_at"
+    t.string   "web_domain"
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), lower((domain)::text)", name: "index_accounts_on_username_and_domain_lower"
     t.index ["uri"], name: "index_accounts_on_uri"


### PR DESCRIPTION
This is an attempt to fix #2672 and hasn't been tested yet.
This is done in two ways:
- Push public toots without attempting to verify the callback URL against the followers
- Add host part of followers' remote_url to the list of allowed domains. This makes assumptions not in OStatus, but should work with other Mastodon instances
Rspec tests should be added, and the way the followers_domains is built should probably be optimized.