### PR TITLE
Fix width of .confirmation-modal on narrow screens

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2947,7 +2947,11 @@ button.icon-button.active i.fa-retweet {
 }
 
 .confirmation-modal {
-  max-width: 380px;
+  max-width: 280px;
+
+  @media screen and (min-width: 480px) {
+    max-width: 380px;
+  }
 }
 
 .confirmation-modal__action-bar {


### PR DESCRIPTION
Example (320px):

![image](https://cloud.githubusercontent.com/assets/705555/25653788/648aa560-3029-11e7-9aa7-e78c29310717.png) ![image](https://cloud.githubusercontent.com/assets/705555/25653804/792c7afc-3029-11e7-8a7c-15c03599a0f4.png)