### PR TITLE
Add styles for small devices to .onboarding-modal

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2827,6 +2827,19 @@ button.icon-button.active i.fa-retweet {
   margin-right: 10px;
 }
 
+@media screen and (max-width: 400px) {
+  .onboarding-modal__page-one {
+    flex-direction: column;
+  }
+
+  .onboarding-modal__page-one__elephant-friend {
+    width: 100%;
+    height: 30vh;
+    max-height: 160px;
+    margin-bottom: 5vh;
+  }
+}
+
 .onboarding-modal__page-two,
 .onboarding-modal__page-three,
 .onboarding-modal__page-four,
@@ -2886,6 +2899,30 @@ button.icon-button.active i.fa-retweet {
 
   .column-header {
     color: $color5;
+  }
+}
+
+@media screen and (max-width: 320px) and (max-height: 600px) {
+  .onboarding-modal__page p {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  .onboarding-modal__page-two .figure,
+  .onboarding-modal__page-three .figure,
+  .onboarding-modal__page-four .figure,
+  .onboarding-modal__page-five .figure {
+    font-size: 12px;
+    margin-bottom: 10px;
+  }
+
+  .onboarding-modal__page-four__columns .row {
+    margin-bottom: 10px;
+  }
+
+  .onboarding-modal__page-four__columns .column-header {
+    padding: 5px;
+    font-size: 12px;
   }
 }
 


### PR DESCRIPTION
Below screenshots are captured on iPhone5s. I can't page from the page 4 since texts on the page overflowed into pager buttons.

![before](https://cloud.githubusercontent.com/assets/705555/25659192/a48cae8e-3041-11e7-8caa-54b9ffab0b7d.png)
![after](https://cloud.githubusercontent.com/assets/705555/25659193/a493a374-3041-11e7-832d-93c96bf2efaf.png)

I've added vertical layout of page 1 for `max-width: 400px` devices, so it also covers iPhone 6.