### PR TITLE
Use CLD2 for language detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'statsd-instrument'
 gem 'twitter-text'
 gem 'tzinfo-data'
 gem 'webpacker', '~>1.2'
-gem 'whatlanguage'
+gem 'cld2'
 
 # For some reason the view specs start failing without this
 gem 'react-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     chunky_png (1.3.8)
+    cld2 (1.0.3)
+      ffi (~> 1.9.3)
     climate_control (0.1.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
@@ -153,6 +155,7 @@ GEM
     faker (1.7.3)
       i18n (~> 0.5)
     fast_blank (1.0.0)
+    ffi (1.9.18)
     fuubar (2.2.0)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
@@ -463,7 +466,6 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    whatlanguage (1.0.6)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -484,6 +486,7 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano-yarn
   capybara
+  cld2
   devise
   devise-two-factor
   doorkeeper
@@ -549,7 +552,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   webmock
   webpacker (~> 1.2)
-  whatlanguage
 
 RUBY VERSION
    ruby 2.4.1p111

--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cld'
+
 class LanguageDetector
   attr_reader :text, :account
 
@@ -9,7 +11,9 @@ class LanguageDetector
   end
 
   def to_iso_s
-    WhatLanguage.new(:all).language_iso(text_without_urls) || default_locale.to_sym
+    cld_lang = CLD.detect_language(text_without_urls)
+    return cld_lang[:code].to_sym if cld_lang[:reliable]
+    default_locale.to_sym
   end
 
   private

--- a/spec/lib/language_detector_spec.rb
+++ b/spec/lib/language_detector_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'rails_helper'
+require 'cld'
 
 describe LanguageDetector do
   describe 'to_iso_s' do
@@ -19,15 +20,15 @@ describe LanguageDetector do
 
     describe 'when language can\'t be detected' do
       it 'confirm language engine cant detect' do
-        result = WhatLanguage.new(:all).language_iso('')
-        expect(result).to be_nil
+        result = CLD.detect_language('')
+        expect(result[:reliable]).to be false
       end
 
       describe 'because of a URL' do
         it 'uses default locale when sent just a URL' do
           string = 'http://example.com/media/2kFTgOJLXhQf0g2nKB4'
-          wl_result = WhatLanguage.new(:all).language_iso(string)
-          expect(wl_result).not_to eq :en
+          cld_result = CLD.detect_language(string)
+          expect(cld_result[:reliable]).to be false
 
           result = described_class.new(string).to_iso_s
 


### PR DESCRIPTION
CLD2 supports more languages and has a 94 % accuracy rate when tested against a dataset of ~70k tweets, compared to 41 % for WhatLanguage.

Fixes #2704