### PR TITLE
WIP - Remove in place editor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'hamlit-rails'
 gem 'pg'
 gem 'pghero'
 gem 'dotenv-rails'
-gem 'best_in_place', '~> 3.0.1'
 
 gem 'aws-sdk', '>= 2.0'
 gem 'paperclip', '~> 5.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,9 +65,6 @@ GEM
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
     bcrypt (3.1.11)
-    best_in_place (3.0.3)
-      actionpack (>= 3.2)
-      railties (>= 3.2)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -478,7 +475,6 @@ DEPENDENCIES
   addressable
   annotate
   aws-sdk (>= 2.0)
-  best_in_place (~> 3.0.1)
   better_errors
   binding_of_caller
   bullet

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -1,0 +1,12 @@
+- content_for :page_title do
+  = t('settings.preferences')
+
+= simple_form_for @setting, url: admin_setting_path(@setting.var), html: { method: :put } do |f|
+  .fields-group
+    %label
+      = t("admin.settings.#{@setting.var}.title")
+    = f.input :value,
+      as: typecast_setting(@setting.var)
+
+  .actions
+    = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/settings/index.html.haml
+++ b/app/views/admin/settings/index.html.haml
@@ -7,34 +7,11 @@
   %thead
     %tr
       %th= t('admin.settings.setting')
-      %th= t('admin.settings.click_to_edit')
+      %th= t('admin.settings.description')
+      %th
   %tbody
-    %tr
-      %td{ rowspan: 2 }
-        %strong= t('admin.settings.contact_information.label')
-      %td= best_in_place @settings['site_contact_username'], :value, url: admin_setting_path(@settings['site_contact_username']), place_holder: t('admin.settings.contact_information.username')
-    %tr
-      %td= best_in_place @settings['site_contact_email'], :value, url: admin_setting_path(@settings['site_contact_email']), place_holder: t('admin.settings.contact_information.email')
-    %tr
-      %td
-        %strong= t('admin.settings.site_title')
-      %td= best_in_place @settings['site_title'], :value, url: admin_setting_path(@settings['site_title'])
-    %tr
-      %td
-        %strong= t('admin.settings.site_description.title')
-        %p= t('admin.settings.site_description.desc_html')
-      %td= best_in_place @settings['site_description'], :value, as: :textarea, url: admin_setting_path(@settings['site_description'])
-    %tr
-      %td
-        %strong= t('admin.settings.site_description_extended.title')
-        %p= t('admin.settings.site_description_extended.desc_html')
-      %td= best_in_place @settings['site_extended_description'], :value, as: :textarea, url: admin_setting_path(@settings['site_extended_description'])
-    %tr
-      %td
-        %strong= t('admin.settings.registrations.open.title')
-      %td= best_in_place @settings['open_registrations'], :value, as: :checkbox, collection: { false: t('admin.settings.registrations.open.disabled'), true: t('admin.settings.registrations.open.enabled')}, url: admin_setting_path(@settings['open_registrations'])
-    %tr
-      %td
-        %strong= t('admin.settings.registrations.closed_message.title')
-        %p= t('admin.settings.registrations.closed_message.desc_html')
-      %td= best_in_place @settings['closed_registrations_message'], :value, as: :textarea, url: admin_setting_path(@settings['closed_registrations_message'])
+    - @settings.each do |key|
+      %tr
+        %td= key.to_s.humanize
+        %td= t("admin.settings.#{key}.desc_html")
+        %td= link_to t('admin.accounts.edit'), edit_admin_setting_path(key)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,27 +158,29 @@ en:
       unresolved: Unresolved
       view: View
     settings:
-      click_to_edit: Click to edit
-      contact_information:
-        email: Enter a public e-mail address
-        label: Contact information
-        username: Enter a username
-      registrations:
-        closed_message:
-          desc_html: Displayed on frontpage when registrations are closed<br>You can use HTML tags
-          title: Closed registration message
-        open:
-          disabled: Disabled
-          enabled: Enabled
-          title: Open registration
+      closed_registrations_message:
+        desc_html: Displayed on frontpage when registrations are closed. You can use HTML tags.
+        title: Closed registration message
+      description: Where is this used?
+      open_registrations:
+        title: Open registration
+        desc_html: Boolean value which determines if new account creation is allowed.
       setting: Setting
+      site_contact_email:
+        desc_html: The email address to contact with instance questions.
+        title: Public email address
+      site_contact_username:
+        desc_html: The account username to contact with instance questions.
+        title: Public account username
       site_description:
-        desc_html: Displayed as a paragraph on the frontpage and used as a meta tag.<br>You can use HTML tags, in particular <code>&lt;a&gt;</code> and <code>&lt;em&gt;</code>.
+        desc_html: Displayed as a paragraph on the frontpage and used as a meta tag. You can use HTML tags, in particular <code>&lt;a&gt;</code> and <code>&lt;em&gt;</code>.
         title: Site description
-      site_description_extended:
-        desc_html: Displayed on extended information page<br>You can use HTML tags
+      site_extended_description:
+        desc_html: Displayed on extended information page. You can use HTML tags.
         title: Extended site description
-      site_title: Site title
+      site_title:
+        title: Site title
+        desc_html: The name for this instance, shown on page titles.
       title: Site Settings
     title: Administration
   application_mailer:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :pubsubhubbub, only: [:index]
     resources :domain_blocks, only: [:index, :new, :create, :show, :destroy]
-    resources :settings, only: [:index, :update]
+    resources :settings, only: [:index, :edit, :update]
     resources :instances, only: [:index]
 
     resources :reports, only: [:index, :show, :update] do

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe Admin::SettingsController, type: :controller do
       end
     end
 
+    describe 'GET #edit' do
+      it 'finds the setting value' do
+        get :edit, params: { id: 'open_registrations' }
+
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template(:edit)
+      end
+    end
+
     describe 'PUT #update' do
 
       describe 'for a record that doesnt exist' do
@@ -43,7 +52,7 @@ RSpec.describe Admin::SettingsController, type: :controller do
 
       it 'typecasts open_registrations to boolean' do
         Setting.open_registrations = false
-        patch :update, params: { id: 'open_registrations', setting: { value: 'true' } }
+        patch :update, params: { id: 'open_registrations', setting: { value: '1' } }
 
         expect(response).to redirect_to(admin_settings_path)
         expect(Setting.open_registrations).to eq true


### PR DESCRIPTION
This removes the best_in_place gem, which no longer works post-webpack-changes.

So far I have done this stuff:

- Change admin/settings#index to list relevant settings, instead of in-place editing
- Link to edit for each one
- An edit view to update settings

![screen shot 2017-05-03 at 4 32 24 pm](https://cloud.githubusercontent.com/assets/225/25680306/577e8504-301e-11e7-81f4-612e52a9547f.png)
![screen shot 2017-05-03 at 4 32 49 pm](https://cloud.githubusercontent.com/assets/225/25680305/577e7f3c-301e-11e7-86fd-46c5dae11ecf.png)
![screen shot 2017-05-03 at 4 33 01 pm](https://cloud.githubusercontent.com/assets/225/25680307/577fb6a4-301e-11e7-949f-97a44491f827.png)

This is good, because it's better than not working.

This feels incomplete, because the actual edit pages are a little empty. It might be nicer to have one big form on the admin settings page, similar to user prefs page, but that's a bigger change here and I was shooting for "make it not broken" as a first pass.

This build will likely break because there is a lot of missing i18n now ... but I didn't want to go fixing those until we were sure of the approach here.

Let me know if this is "good enough" for now, or if you'd prefer to go the other route (full page form) right away...

