### PR TITLE
Revert "Clean up redis configuration. Allow using REDIS_URL to set advanced (#2732)"

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,7 +1,7 @@
 # Service dependencies
-# You may set REDIS_URL instead for more advanced options
 REDIS_HOST=redis
 REDIS_PORT=6379
+# REDIS_DB=0
 # You may set DATABASE_URL instead for more advanced options
 DB_HOST=db
 DB_USER=postgres

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,0 +1,10 @@
+development:
+  adapter: redis
+  url: redis://localhost:6379/1
+
+test:
+  adapter: async
+
+production:
+  adapter: redis
+  url: redis://<%= ENV['REDIS_PASSWORD'] ? ':' + ENV['REDIS_PASSWORD'] + '@' : '' %><%= ENV['REDIS_HOST'] || 'localhost' %>:<%= ENV['REDIS_PORT'] || 6379 %>/1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,6 +50,17 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
+  # Parse and split the REDIS_URL if passed (used with hosting platforms such as Heroku).
+  # Set ENV variables because they are used elsewhere.
+  if ENV['REDIS_URL']
+    redis_url = URI.parse(ENV['REDIS_URL'])
+    ENV['REDIS_HOST'] = redis_url.host
+    ENV['REDIS_PORT'] = redis_url.port.to_s
+    ENV['REDIS_PASSWORD'] = redis_url.password
+    db_num = redis_url.path[1..-1]
+    ENV['REDIS_DB'] = db_num if db_num.present?
+  end
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 

--- a/config/initializers/ostatus.rb
+++ b/config/initializers/ostatus.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-port     = ENV.fetch('PORT') { 3000 }
-host     = ENV.fetch('LOCAL_DOMAIN') { "localhost:#{port}" }
+port  = ENV.fetch('PORT') { 3000 }
+host  = ENV.fetch('LOCAL_DOMAIN') { "localhost:#{port}" }
 web_host = ENV.fetch('WEB_DOMAIN') { host }
-https    = ENV['LOCAL_HTTPS'] == 'true'
+https = ENV['LOCAL_HTTPS'] == 'true'
 
 Rails.application.configure do
   config.x.local_domain = host
@@ -15,6 +15,7 @@ Rails.application.configure do
   config.x.streaming_api_base_url          = 'ws://localhost:4000'
 
   if Rails.env.production?
-    config.x.streaming_api_base_url = ENV.fetch('STREAMING_API_BASE_URL') { "ws#{https ? 's' : ''}://#{web_host}" }
+    config.action_cable.allowed_request_origins = ["http#{https ? 's' : ''}://#{web_host}"]
+    config.x.streaming_api_base_url             = ENV.fetch('STREAMING_API_BASE_URL') { "ws#{https ? 's' : ''}://#{web_host}" }
   end
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
-if ENV['REDIS_URL'].blank?
-  password = ENV.fetch('REDIS_PASSWORD') { '' }
-  host     = ENV.fetch('REDIS_HOST') { 'localhost' }
-  port     = ENV.fetch('REDIS_PORT') { 6379 }
-  db       = ENV.fetch('REDIS_DB') { 0 }
+redis_params = {
+  password: ENV.fetch('REDIS_PASSWORD') { false },
+  host:     ENV.fetch('REDIS_HOST') { 'localhost' },
+  port:     ENV.fetch('REDIS_PORT') { 6379 },
+  db:       ENV.fetch('REDIS_DB') { 0 },
+  driver:   :hiredis
+}
 
-  ENV['REDIS_URL'] = "redis://#{password.blank? ? '' : ":#{password}@"}#{host}:#{port}/#{db}"
-end
-
-redis_connection = Redis.new(
-  url: ENV['REDIS_URL'],
-  driver: :hiredis
-)
+redis_connection = Redis.new(redis_params)
 
 cache_params = { expires_in: 10.minutes }
 
@@ -25,5 +21,5 @@ else
 end
 
 Rails.application.configure do
-  config.cache_store = :redis_store, ENV['REDIS_URL'], cache_params
+  config.cache_store = :redis_store, redis_params, cache_params
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
+host = ENV.fetch('REDIS_HOST') { 'localhost' }
+port = ENV.fetch('REDIS_PORT') { 6379 }
+password = ENV.fetch('REDIS_PASSWORD') { false }
+db = ENV.fetch('REDIS_DB') { 0 }
 
 namespace = ENV.fetch('REDIS_NAMESPACE') { nil }
-redis_params = { url: ENV['REDIS_URL'] }
+redis_params = { host: host, port: port, db: db, password: password }
 
 if namespace
   redis_params [:namespace] = namespace

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -93,7 +93,6 @@ if (cluster.isMaster) {
     host:     process.env.REDIS_HOST     || '127.0.0.1',
     port:     process.env.REDIS_PORT     || 6379,
     password: process.env.REDIS_PASSWORD,
-    url:      process.env.REDIS_URL      || null
   }
 
   if (redisNamespace) {


### PR DESCRIPTION
REDIS_URL was intended to be a single exhaustive configuration for Redis, but it was inappropriate because of incompatibility of Unix socket URLs.

This reverts commit c997091166ba1801eea3a587c913b020b9b84ce4.

The specification of redis scheme does not specify about transporting protocol.
https://www.iana.org/assignments/uri-schemes/prov/redis

Both of redis-rb 3.2 and Node.js redis 2.6.5, which are dependents, assumes the transporting protocol is TCP by default, but they provide different syntax to change the configuration.

redis-rb 3.2 has "unix" scheme to configure Unix socket. The scheme behaves same with redis scheme except the default transporation is Unix socket.
https://github.com/redis/redis-rb/blob/v3.2.2/lib/redis/client.rb#L393

Node.js redis 2.6.5, on the other hand, regards the URL as the path to a Unix socket if the URL lacks the scheme and succeeding two slashes.
https://github.com/NodeRedis/node_redis/blob/v.2.6.5/lib/createClient.js#L29

Because of the difference, using URL is insufficient to add an intended feature, Unix socket support. It is even problematic for environments which have already used the former configuration variables and a user-defined configuration variable for Unix socket support.

This commit reverts the change and maintains the old configuration until we make another change considering the concern.