### PR TITLE
Show emoji shortname by a tooltip

### DIFF
--- a/app/javascript/mastodon/emoji.js
+++ b/app/javascript/mastodon/emoji.js
@@ -15,7 +15,7 @@ const unicodeToImage = str => {
     const filename = emojione.emojioneList[short].fname;
     const alt      = emojione.convert(unicode.toUpperCase());
 
-    return `<img draggable="false" class="emojione" alt="${alt}" src="/emoji/${filename}.svg" />`;
+    return `<img draggable="false" class="emojione" alt="${alt}" title="${short}" src="/emoji/${filename}.svg" />`;
   });
 };
 
@@ -27,7 +27,7 @@ const shortnameToImage = str => str.replace(emojione.regShortNames, shortname =>
   const unicode = emojione.emojioneList[shortname].unicode[emojione.emojioneList[shortname].unicode.length - 1];
   const alt     = emojione.convert(unicode.toUpperCase());
 
-  return `<img draggable="false" class="emojione" alt="${alt}" src="/emoji/${unicode}.svg" />`;
+  return `<img draggable="false" class="emojione" alt="${alt}" title="${shortname}" src="/emoji/${unicode}.svg" />`;
 });
 
 export default function emojify(text) {


### PR DESCRIPTION
This patch only adds `title` attribute from existing variable.

![image](https://cloud.githubusercontent.com/assets/705555/25697799/5ce6608c-30f7-11e7-9612-cfb332e0e9da.png)

It helps users to know what `:shortname:` they should use.