### PR TITLE
Enable disableHostCheck option of webpack-dev-server

### DIFF
--- a/config/webpack/development.server.js
+++ b/config/webpack/development.server.js
@@ -13,6 +13,7 @@ module.exports = merge(devConfig, {
     compress: true,
     historyApiFallback: true,
     contentBase: resolve(paths.output, paths.entry),
-    publicPath
+    publicPath,
+    disableHostCheck: true
   }
 })


### PR DESCRIPTION
When accessing http://mastodon.dev using Vagrant, the websocket of webpack-dev-server fails to connect and it is displayed as "Invalid Host header".
This problem can be solved by enabling disableHostCheck.