### PR TITLE
about page : use slightly more space

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -7,7 +7,7 @@
     padding-bottom: 50px;
 
     &.thicc {
-      max-width: 700px;
+      max-width: 800px;
     }
   }
 
@@ -228,7 +228,7 @@
 
   .sidebar {
     border-left: 1px solid lighten($color1, 10%);
-    width: 180px;
+    width: 200px;
     flex: 0 0 auto;
   }
 


### PR DESCRIPTION
Everything is said in the title of this PR. I think `/about/more` can use more space. Most email addresses are displayed on two lines, which is not visually optimal.

Before : ![](https://social.targaryen.house/system/media_attachments/files/000/130/122/original/9d4a3f66d6fc007f.jpg)

After : 
![](https://social.targaryen.house/system/media_attachments/files/000/130/123/original/15ea198370ca1fe7.jpg)