### PR TITLE
More narrowly target the admin site settings area with input styles

### DIFF
--- a/app/javascript/styles/forms.scss
+++ b/app/javascript/styles/forms.scss
@@ -9,7 +9,7 @@ code {
   margin: 0 auto;
 }
 
-.admin {
+.site_settings {
   input, textarea {
     width: 100%;
   }

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -2,7 +2,7 @@
   = t('admin.settings.title')
 
 = form_tag(admin_settings_path, method: :put) do
-  %table.table
+  %table.table.site_settings
     %thead
       %tr
         %th{width: '40%'}


### PR DESCRIPTION
A previous change applied styles more broadly than intended. This uses a more
narrow selector to target only the inputs on the relevant page.