### PR TITLE
Fix language selector on preferences page

### DIFF
--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -5,7 +5,12 @@
   = render 'shared/error_messages', object: current_user
 
   .fields-group
-    = f.input :locale, collection: I18n.available_locales, wrapper: :with_label, include_blank: false, label_method: lambda { |locale| human_locale(locale) }
+    = f.input :locale,
+      collection: I18n.available_locales,
+      wrapper: :with_label,
+      include_blank: false,
+      label_method: lambda { |locale| human_locale(locale) },
+      selected: I18n.locale
 
     = f.input :allowed_languages,
       collection: I18n.available_locales,


### PR DESCRIPTION
The user's language is detected automatically.
But the language isn't set in the language selector by default.
So when non-English users change other settings on the Preferences page (e.g. Post privacy)
and save changes, the language setting is changed to English unintentionally.

This commit fixes this issue by set detected language to the selector by default.
And maybe fix #1558.