### PR TITLE
Improve style for form in site settings

### DIFF
--- a/app/javascript/styles/forms.scss
+++ b/app/javascript/styles/forms.scss
@@ -9,12 +9,6 @@ code {
   margin: 0 auto;
 }
 
-.admin {
-  input, textarea {
-    width: 100%;
-  }
-}
-
 .simple_form {
   .input {
     margin-bottom: 15px;

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('admin.settings.title')
 
-= form_tag(admin_settings_path, method: :put) do
+= form_tag(admin_settings_path, method: :put, class: 'simple_form', style: 'max-width: 100%') do
   %table.table
     %thead
       %tr


### PR DESCRIPTION
| before | after |
|-|-|
| ![](https://cloud.githubusercontent.com/assets/12539/25716865/9c4b879a-313b-11e7-8bc0-e5670a82a6ed.png) | ![](https://cloud.githubusercontent.com/assets/12539/25716864/9c2ed6e0-313b-11e7-865a-e731e26a3cdf.png) |

Make the style of the form added in #2789 the same as the form of other settings.

In addition, we will correct the display collapse of the checklist of the allowed languages together.

[![](https://cloud.githubusercontent.com/assets/12539/25717010/20fd9618-313c-11e7-8302-f19b8749600e.png)](https://cloud.githubusercontent.com/assets/12539/25716980/059c88ac-313c-11e7-9ebc-e712a4eae6e7.png)
