### PR TITLE
Use in_batches.destroy_all instead of destroy_all

### DIFF
--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -17,12 +17,16 @@ class SuspendAccountService < BaseService
       RemoveStatusService.new.call(status)
     end
 
-    @account.media_attachments.destroy_all
-    @account.stream_entries.destroy_all
-    @account.notifications.destroy_all
-    @account.favourites.destroy_all
-    @account.active_relationships.destroy_all
-    @account.passive_relationships.destroy_all
+    [
+      @account.media_attachments,
+      @account.stream_entries,
+      @account.notifications,
+      @account.favourites,
+      @account.active_relationships,
+      @account.passive_relationships
+    ].each do |association|
+      destroy_all(association)
+    end
   end
 
   def purge_profile
@@ -35,6 +39,10 @@ class SuspendAccountService < BaseService
   end
 
   def unsubscribe_push_subscribers
-    @account.subscriptions.destroy_all
+    destroy_all(@account.subscriptions)
+  end
+
+  def destroy_all(association)
+    association.in_batches.destroy_all
   end
 end

--- a/spec/fabricators/favourite_fabricator.rb
+++ b/spec/fabricators/favourite_fabricator.rb
@@ -1,3 +1,4 @@
 Fabricator(:favourite) do
-
+  account
+  status
 end

--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SuspendAccountService do
+  describe '#call' do
+    subject do
+      -> { described_class.new.call(account) }
+    end
+
+    let!(:account) { Fabricate(:account) }
+    let!(:status) { Fabricate(:status, account: account) }
+    let!(:media_attachment) { Fabricate(:media_attachment, account: account) }
+    let!(:notification) { Fabricate(:notification, account: account) }
+    let!(:favourite) { Fabricate(:favourite, account: account) }
+    let!(:active_relationship) { Fabricate(:follow, account: account) }
+    let!(:passive_relationship) { Fabricate(:follow, target_account: account) }
+    let!(:subscription) { Fabricate(:subscription, account: account) }
+
+    it 'deletes associated records' do
+      is_expected.to change {
+        [
+          account.statuses,
+          account.media_attachments,
+          account.stream_entries,
+          account.notifications,
+          account.favourites,
+          account.active_relationships,
+          account.passive_relationships,
+          account.subscriptions
+        ].map(&:count)
+      }.from([1, 1, 1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0, 0, 0])
+    end
+  end
+end


### PR DESCRIPTION
What is different?
Example for suspending account with huge follows.

- `destroy_all` 
  - It locks all of associated records until complete deleting them. Therefore associated followers can not update `Account` of themselves for a while. 
  - It loads all records at the first. It is very heavy.
- `in_batches.destroy_all` 
  - It locks and releases for each record while saving.
  - It works with a batch of records.

## Before `association.destroy_all`

```
SELECT "follows".* FROM "follows" WHERE "follows"."account_id" = $1  [["account_id", 2]]

BEGIN
  SELECT  "notifications".* FROM "notifications" WHERE "notifications"."activity_id" = $1 AND "notifications"."activity_type" = $2 LIMIT $3  [["activity_id", 1], ["activity_type", "Follow"], ["LIMIT", 1]]
  DELETE FROM "follows" WHERE "follows"."id" = $1  [["id", 1]]
  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  UPDATE "accounts" SET "following_count" = COALESCE("following_count", 0) - 1 WHERE "accounts"."id" = $1  [["id", 2]]
  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 3], ["LIMIT", 1]]
  UPDATE "accounts" SET "followers_count" = COALESCE("followers_count", 0) - 1 WHERE "accounts"."id" = $1  [["id", 3]]

  SELECT  "notifications".* FROM "notifications" WHERE "notifications"."activity_id" = $1 AND "notifications"."activity_type" = $2 LIMIT $3  [["activity_id", 2], ["activity_type", "Follow"], ["LIMIT", 1]]
  DELETE FROM "follows" WHERE "follows"."id" = $1  [["id", 2]]
  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  UPDATE "accounts" SET "following_count" = COALESCE("following_count", 0) - 1 WHERE "accounts"."id" = $1  [["id", 2]]
  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 4], ["LIMIT", 1]]
  UPDATE "accounts" SET "followers_count" = COALESCE("followers_count", 0) - 1 WHERE "accounts"."id" = $1  [["id", 4]]

  ...
COMMIT
```

## After `association.in_batches.destroy_all`

```
SELECT  "follows"."id" FROM "follows" WHERE "follows"."account_id" = $1 ORDER BY "follows"."id" ASC LIMIT $2  [["account_id", 2], ["LIMIT", 1000]]
SELECT "follows".* FROM "follows" WHERE "follows"."account_id" = $1 AND "follows"."id" IN (1, 2, ...)  [["account_id", 2]]

BEGIN
  SELECT  "notifications".* FROM "notifications" WHERE "notifications"."activity_id" = $1 AND "notifications"."activity_type" = $2 LIMIT $3  [["activity_id", 1], ["activity_type", "Follow"], ["LIMIT", 1]]
  DELETE FROM "follows" WHERE "follows"."id" = $1  [["id", 1]]
  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  UPDATE "accounts" SET "following_count" = COALESCE("following_count", 0) - 1 WHERE "accounts"."id" = $1  [["id", 2]]
  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 3], ["LIMIT", 1]]
  UPDATE "accounts" SET "followers_count" = COALESCE("followers_count", 0) - 1 WHERE "accounts"."id" = $1  [["id", 3]]
COMMIT

BEGIN
  SELECT  "notifications".* FROM "notifications" WHERE "notifications"."activity_id" = $1 AND "notifications"."activity_type" = $2 LIMIT $3  [["activity_id", 2], ["activity_type", "Follow"], ["LIMIT", 1]]
  DELETE FROM "follows" WHERE "follows"."id" = $1  [["id", 2]]
  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  UPDATE "accounts" SET "following_count" = COALESCE("following_count", 0) - 1 WHERE "accounts"."id" = $1  [["id", 2]]
  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 4], ["LIMIT", 1]]
  UPDATE "accounts" SET "followers_count" = COALESCE("followers_count", 0) - 1 WHERE "accounts"."id" = $1  [["id", 4]]
COMMIT
...
```
