### PR TITLE
Minor fix in Travis config with bundler call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,10 @@ rvm:
 services:
   - redis-server
 
-bundler_args: --without development production --retry=3 --jobs=16
-
 install:
   - nvm install
   - npm install -g yarn
-  - bundle install
+  - bundle install --without development production --retry=3 --jobs=16
   - yarn install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ services:
 install:
   - nvm install
   - npm install -g yarn
-  - bundle install --without development production --retry=3 --jobs=16
+  - bundle install --path=vendor/bundle --without development production --retry=3 --jobs=16
   - yarn install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ before_script:
 script:
   - bundle exec parallel_test spec/ --group-by filesize --type rspec
   - npm test
-  - i18n-tasks unused
+  - bundle exec i18n-tasks unused

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 cache:
-  bundler: true
+  bundler: false
   yarn: false
 dist: trusty
 sudo: false


### PR DESCRIPTION
* bundler_args is not functional if using custom install script in `.travis.yml`. Directly attach the argument to the install script.
* Parallel to similar scripts in the same travis config. More resiliant to changes in configuration.
* Travis + rvm seems to ignore `.bundle/config` and hence use rvm global vendor directory by default. Adding `--path` will fix this and hence make `cache.bundler = true` really functional.