### PR TITLE
Fixes unknown mime type

### DIFF
--- a/app/models/concerns/attachmentable.rb
+++ b/app/models/concerns/attachmentable.rb
@@ -15,7 +15,7 @@ module Attachmentable
       next if attachment.blank?
       extension = Paperclip::Interpolations.content_type_extension(attachment, :original)
       basename  = Paperclip::Interpolations.basename(attachment, :original)
-      attachment.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
+      attachment.instance_write :file_name, [basename, extension].delete_if(&:blank?).join('.')
     end
   end
 end

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -128,7 +128,7 @@ class MediaAttachment < ApplicationRecord
     self.type = VIDEO_MIME_TYPES.include?(file_content_type) ? :video : :image
     extension = appropriate_extension
     basename  = Paperclip::Interpolations.basename(file, :original)
-    file.instance_write :file_name, [basename, extension].delete_if(&:empty?).join('.')
+    file.instance_write :file_name, [basename, extension].delete_if(&:blank?).join('.')
   end
 
   def set_meta

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -4,7 +4,7 @@ Paperclip.options[:read_timeout] = 60
 
 Paperclip.interpolates :filename do |attachment, style|
   return attachment.original_filename if style == :original
-  [basename(attachment, style), extension(attachment, style)].delete_if(&:empty?).join('.')
+  [basename(attachment, style), extension(attachment, style)].delete_if(&:blank?).join('.')
 end
 
 if ENV['S3_ENABLED'] == 'true'


### PR DESCRIPTION
Fixes `NoMethodError` occurred during uploading unsupported file like `.fla`.

```
A NoMethodError occurred in media#create:

  undefined method `empty?' for nil:NilClass
  app/models/media_attachment.rb:113:in `delete_if'
```