### PR TITLE
Move account header and avatar methods to a concern

### DIFF
--- a/app/models/concerns/account_avatar.rb
+++ b/app/models/concerns/account_avatar.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module AccountAvatar
+  extend ActiveSupport::Concern
+  IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif'].freeze
+
+  class_methods do
+    def avatar_styles(file)
+      styles = { original: '120x120#' }
+      styles[:static] = { format: 'png' } if file.content_type == 'image/gif'
+      styles
+    end
+    private :avatar_styles
+  end
+
+  included do
+    # Avatar upload
+    has_attached_file :avatar, styles: ->(f) { avatar_styles(f) }, convert_options: { all: '-quality 80 -strip' }
+    validates_attachment_content_type :avatar, content_type: IMAGE_MIME_TYPES
+    validates_attachment_size :avatar, less_than: 2.megabytes
+
+    def avatar_original_url
+      avatar.url(:original)
+    end
+
+    def avatar_static_url
+      avatar_content_type == 'image/gif' ? avatar.url(:static) : avatar_original_url
+    end
+
+    def avatar_remote_url=(url)
+      parsed_url = Addressable::URI.parse(url).normalize
+
+      return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[:avatar_remote_url] == url
+
+      self.avatar              = URI.parse(parsed_url.to_s)
+      self[:avatar_remote_url] = url
+    rescue OpenURI::HTTPError => e
+      Rails.logger.debug "Error fetching remote avatar: #{e}"
+    end
+  end
+end

--- a/app/models/concerns/account_header.rb
+++ b/app/models/concerns/account_header.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module AccountHeader
+  extend ActiveSupport::Concern
+  IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif'].freeze
+
+  class_methods do
+    def header_styles(file)
+      styles = { original: '700x335#' }
+      styles[:static] = { format: 'png' } if file.content_type == 'image/gif'
+      styles
+    end
+    private :header_styles
+  end
+
+  included do
+    # Header upload
+    has_attached_file :header, styles: ->(f) { header_styles(f) }, convert_options: { all: '-quality 80 -strip' }
+    validates_attachment_content_type :header, content_type: IMAGE_MIME_TYPES
+    validates_attachment_size :header, less_than: 2.megabytes
+
+    def header_original_url
+      header.url(:original)
+    end
+
+    def header_static_url
+      header_content_type == 'image/gif' ? header.url(:static) : header_original_url
+    end
+
+    def header_remote_url=(url)
+      parsed_url = Addressable::URI.parse(url).normalize
+
+      return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[:header_remote_url] == url
+
+      self.header              = URI.parse(parsed_url.to_s)
+      self[:header_remote_url] = url
+    rescue OpenURI::HTTPError => e
+      Rails.logger.debug "Error fetching remote header: #{e}"
+    end
+  end
+end

--- a/app/services/update_remote_profile_service.rb
+++ b/app/services/update_remote_profile_service.rb
@@ -26,7 +26,7 @@ class UpdateRemoteProfileService < BaseService
     old_hub_url     = account.hub_url
     account.hub_url = hub_link['href'] if !hub_link.nil? && !hub_link['href'].blank? && (hub_link['href'] != old_hub_url)
 
-    account.save_with_optional_avatar!
+    account.save_with_optional_media!
 
     Pubsubhubbub::SubscribeWorker.perform_async(account.id) if resubscribe && (account.hub_url != old_hub_url)
   end


### PR DESCRIPTION
The `Account` class is pretty long!

The avatar and header code in here takes up a lot of LOC, but isn't really that interesting or core to the db model. This moves relevant methods out to concerns.

Additionally, there's a method which was renamed to `save_with_optional_media!` since it's changing both avatar and header, not just avatar.

