### PR TITLE
Separate .babelrc for prod/dev, add babel-plugin-lodash

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,8 +11,6 @@
     ]
   ],
   "plugins": [
-    "transform-react-jsx-source",
-    "transform-react-jsx-self",
     "transform-decorators-legacy",
     "transform-object-rest-spread",
     [
@@ -21,5 +19,18 @@
         "messagesDir": "./build/messages"
       }
     ]
-  ]
+  ],
+  "env": {
+    "development": {
+      "plugins": [
+        "transform-react-jsx-source",
+        "transform-react-jsx-self"
+      ]
+    },
+    "production": {
+      "plugins": [
+        "lodash"
+      ]
+    }
+  }
 }

--- a/config/webpack/loaders/babel.js
+++ b/config/webpack/loaders/babel.js
@@ -1,5 +1,8 @@
 module.exports = {
   test: /\.js(\.erb)?$/,
   exclude: /node_modules/,
-  loader: 'babel-loader'
+  loader: 'babel-loader',
+  options: {
+    forceEnv: process.env.NODE_ENV || 'development'
+  }
 }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   "devDependencies": {
     "@kadira/storybook": "^2.35.3",
     "babel-eslint": "^7.2.2",
+    "babel-plugin-lodash": "^3.2.11",
     "chai": "^3.5.0",
     "chai-enzyme": "^0.6.1",
     "enzyme": "^2.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,6 +627,13 @@ babel-plugin-check-es2015-constants@^6.22.0, babel-plugin-check-es2015-constants
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-lodash@^3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.2.11.tgz#21c8fdec9fe1835efaa737873e3902bdd66d5701"
+  dependencies:
+    glob "^7.1.1"
+    lodash "^4.17.2"
+
 babel-plugin-react-docgen@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.4.2.tgz#04c02133b84b6cc182d35de2162f15764da03e7c"


### PR DESCRIPTION
This reduces the size of `application.js` from 814133 bytes to 756256 bytes (7.1% improvement) or gzipped 125656 to 120398 (4.2% improvement).

There's no need for `transform-react-jsx-source` or `transform-react-jsx-self` in production, since they just add debugging metadata, and also `babel-plugin-lodash` helps reduce the size of lodash, which is only needed for production.