### PR TITLE
Move babel-plugin-lodash to dependencies from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-cli": "^6.23.0",
     "babel-core": "^6.24.1",
     "babel-loader": "7.x",
+    "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-react-intl": "^2.3.1",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
@@ -108,7 +109,6 @@
   "devDependencies": {
     "@kadira/storybook": "^2.35.3",
     "babel-eslint": "^7.2.2",
-    "babel-plugin-lodash": "^3.2.11",
     "chai": "^3.5.0",
     "chai-enzyme": "^0.6.1",
     "enzyme": "^2.8.2",


### PR DESCRIPTION
Failed build for an assets when using the Docker.

<details>
<summary><code>$ docker run --env-file .env.production --rm -v /public/assets:/mastodon/public/assets -v /public/packs:/mastodon/public/packs gargron/mastodon:latest rails assets:precompile</code></summary>
<pre><code>Webpacker is installed 🎉 🍰
Using /mastodon/config/webpack/paths.yml file for setting up webpack paths
Compiling webpacker assets 🎉
./app/javascript/packs/application.js
Module build failed: Error: Plugin 0 specified in "/mastodon/.babelrc.env.production" provided an invalid property of "__wrapped__"
    at Plugin.init (/mastodon/node_modules/babel-core/lib/transformation/plugin.js:131:13)
    at Function.normalisePlugin (/mastodon/node_modules/babel-core/lib/transformation/file/options/option-manager.js:152:12)
    at /mastodon/node_modules/babel-core/lib/transformation/file/options/option-manager.js:184:30
    at Array.map (native)
    at Function.normalisePlugins (/mastodon/node_modules/babel-core/lib/transformation/file/options/option-manager.js:158:20)
    at OptionManager.mergeOptions (/mastodon/node_modules/babel-core/lib/transformation/file/options/option-manager.js:234:36)
    at OptionManager.init (/mastodon/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at File.initOptions (/mastodon/node_modules/babel-core/lib/transformation/file/index.js:212:65)
    at new File (/mastodon/node_modules/babel-core/lib/transformation/file/index.js:135:24)
    at Pipeline.transform (/mastodon/node_modules/babel-core/lib/transformation/pipeline.js:46:16)
    at transpile (/mastodon/node_modules/babel-loader/lib/index.js:48:20)
    at Object.module.exports (/mastodon/node_modules/babel-loader/lib/index.js:163:20)</code></pre>
</details>

This has failed because bock-plugin-lodash is not installed in Docker. We will also install babel-plugin-lodash even in production environment.
