### PR TITLE
Remove unnecessary Buffer polyfill

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -55,5 +55,11 @@ module.exports = {
 
   resolveLoader: {
     modules: [paths.node_modules]
+  },
+
+  node: {
+    // Called by http-link-header in an API we never use, increases
+    // bundle size unnecessarily
+    Buffer: false
   }
 }


### PR DESCRIPTION
This PR reduces the size of `vendor.js` from 2089022 bytes to 2055270 bytes (i.e. 33.8 kB removed, a 1.6% total improvement). It removes an unnecessary [Buffer polyfill](https://github.com/feross/buffer), which is being required solely by `http-link-header` in [a part of the API we don't use](https://github.com/jhermsmeier/node-http-link-header/blob/e317e7717223080c45dac151e1ca8610e9b10986/lib/link.js#L55).

It's extremely uncommon IME for a JS library to _actually_ want to include the Buffer polyfill, so this is pretty safe to remove.