### PR TITLE
Optimize MuteService and AfterBlockService

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -76,6 +76,14 @@ class FeedManager
     end
   end
 
+  def clear_from_timeline(account, target_account)
+    timeline_key = key(:home, account.id)
+    timeline_status_ids = redis.zrange(timeline_key, 0, -1)
+    target_status_ids = Status.where(id: timeline_status_ids, account: target_account).ids
+
+    redis.zrem(timeline_key, target_status_ids) if target_status_ids.present?
+  end
+
   private
 
   def redis

--- a/app/services/after_block_service.rb
+++ b/app/services/after_block_service.rb
@@ -2,30 +2,16 @@
 
 class AfterBlockService < BaseService
   def call(account, target_account)
-    clear_timelines(account, target_account)
+    FeedManager.instance.clear_from_timeline(account, target_account)
     clear_notifications(account, target_account)
   end
 
   private
-
-  def clear_timelines(account, target_account)
-    home_key = FeedManager.instance.key(:home, account.id)
-
-    redis.pipelined do
-      target_account.statuses.select('id').reorder(nil).find_each do |status|
-        redis.zrem(home_key, status.id)
-      end
-    end
-  end
 
   def clear_notifications(account, target_account)
     Notification.where(account: account).joins(:follow).where(activity_type: 'Follow', follows: { account_id: target_account.id }).delete_all
     Notification.where(account: account).joins(mention: :status).where(activity_type: 'Mention', statuses: { account_id: target_account.id }).delete_all
     Notification.where(account: account).joins(:favourite).where(activity_type: 'Favourite', favourites: { account_id: target_account.id }).delete_all
     Notification.where(account: account).joins(:status).where(activity_type: 'Status', statuses: { account_id: target_account.id }).delete_all
-  end
-
-  def redis
-    Redis.current
   end
 end

--- a/app/services/mute_service.rb
+++ b/app/services/mute_service.rb
@@ -3,21 +3,7 @@
 class MuteService < BaseService
   def call(account, target_account)
     return if account.id == target_account.id
-    clear_home_timeline(account, target_account)
+    FeedManager.instance.clear_from_timeline(account, target_account)
     account.mute!(target_account)
-  end
-
-  private
-
-  def clear_home_timeline(account, target_account)
-    home_key = FeedManager.instance.key(:home, account.id)
-
-    target_account.statuses.select('id').reorder(nil).find_each do |status|
-      redis.zrem(home_key, status.id)
-    end
-  end
-
-  def redis
-    Redis.current
   end
 end

--- a/spec/services/after_block_service_spec.rb
+++ b/spec/services/after_block_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe MuteService do
+RSpec.describe AfterBlockService do
   subject do
     -> { described_class.new.call(account, target_account) }
   end
@@ -25,11 +25,5 @@ RSpec.describe MuteService do
         Redis.current.zrange(home_timeline_key, 0, -1)
       }.from([status.id.to_s, other_account_status.id.to_s]).to([other_account_status.id.to_s])
     end
-  end
-
-  it 'mutes account' do
-    is_expected.to change {
-      account.muting?(target_account)
-    }.from(false).to(true)
   end
 end


### PR DESCRIPTION
- Find target statuses by id from home timeline
- Call `zrem` with multiple keys

```
Example for account with 13_000 statuses.

puts Benchmark.measure {
  MuteService.new.call(account, target_account)
}

**before**

`0.600000   0.060000   0.660000 (  2.150312)`

**after**

`0.010000   0.000000   0.010000 (  0.034723)`
```