### PR TITLE
Remove final newline in generated locale files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,7 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 2
+
+# ignore generated locale files
+[app/javascript/mastodon/locales/*.json]
+insert_final_newline = false


### PR DESCRIPTION
Running `yarn run manage:tranlation` will delete the last newline. However, editing with a text editor is added by EditorConfig.

I want to suppress unnecessary differences
