### PR TITLE
Remove preset-es2015 from babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,13 @@
 {
   "presets": [
-    "es2015",
     "react",
     [
       "env",
       {
         "loose": true,
-        "modules": false
+        "targets": {
+          "browsers": ["last 2 versions", "IE >= 11", "iOS >= 9"]
+        }
       }
     ]
   ],


### PR DESCRIPTION
This PR reduces the size of `application.js` from 740K to 736K.

There's no need to use both `babel-preset-es2015` and `babel-preset-env`, and also by using only `env` we can be explicit about which browsers we're supporting. I've added a fairly conservative target (`["last 2 versions", "IE >= 11", "iOS >= 9"]`), which we are free to toggle up or down depending on exactly which browsers we want to support.

Note: I also turned off `"modules": false`; this was already the case for `babel-preset-es2015` in the old configuration, meaning that effectively we weren't using ES modules anyway. Oddly, using `"modules": false` on `env` actually _increases_ the bundle size, which is the opposite of what I'd expect given that (as I understand it), disabling ES->CJS module transpilation allows Webpack to do tree-shaking. This needs more investigation, but in the meantime I'm just aiming for the smallest possible bundle size.