### PR TITLE
Fixes slow query in notifications api

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -16,6 +16,16 @@ class Notification < ApplicationRecord
   include Paginable
   include Cacheable
 
+  TYPE_CLASS_MAP = {
+    mention:        'Mention',
+    reblog:         'Status',
+    follow:         'Follow',
+    follow_request: 'FollowRequest',
+    favourite:      'Favourite',
+  }.freeze
+
+  STATUS_INCLUDES = [:account, :stream_entry, :media_attachments, :tags, mentions: :account, reblog: [:stream_entry, :account, :media_attachments, :tags, mentions: :account]].freeze
+
   belongs_to :account
   belongs_to :from_account, class_name: 'Account'
   belongs_to :activity, polymorphic: true
@@ -27,16 +37,7 @@ class Notification < ApplicationRecord
   belongs_to :favourite,      foreign_type: 'Favourite',     foreign_key: 'activity_id'
 
   validates :account_id, uniqueness: { scope: [:activity_type, :activity_id] }
-
-  TYPE_CLASS_MAP = {
-    mention:        'Mention',
-    reblog:         'Status',
-    follow:         'Follow',
-    follow_request: 'FollowRequest',
-    favourite:      'Favourite',
-  }.freeze
-
-  STATUS_INCLUDES = [:account, :stream_entry, :media_attachments, :tags, mentions: :account, reblog: [:stream_entry, :account, :media_attachments, :tags, mentions: :account]].freeze
+  validates :activity_type, inclusion: { in: TYPE_CLASS_MAP.values }
 
   scope :cache_ids, -> { select(:id, :updated_at, :activity_type, :activity_id) }
 

--- a/spec/fabricators/notification_fabricator.rb
+++ b/spec/fabricators/notification_fabricator.rb
@@ -1,4 +1,4 @@
 Fabricator(:notification) do
   activity_id   1
-  activity_type "MyString"
+  activity_type 'Favourite'
 end


### PR DESCRIPTION
In the case of user disables all types, the query is very slow because It search all rows.
This optimization is using `where(activity_type: [])` instead of `where.not(activity_type: ['Status', 'Follow', 'Favourite', 'Mention', 'FollowRequest', 'FollowRequest'])`.

![2017-05-07 2 42 38](https://cloud.githubusercontent.com/assets/1688137/25774710/e8ca4620-32cf-11e7-82bc-145bd924f93d.png)

**Changes**

- Use named_scope because `.browserable` is chainable.
- Use `WHERE IN` instead of `WHERE NOT IN`.
- Add inclusion validation to assure the result of `WHERE IN()`.

**before**

```
EXPLAIN ANALYZE SELECT  "notifications".* FROM "notifications" WHERE "notifications"."account_id" = X AND ("notifications"."activity_type" NOT IN ('Status', 'Follow', 'Favourite', 'Mention', 'FollowRequest', 'FollowRequest')) ORDER BY "notifications"."id" DESC LIMIT 15

Limit  (cost=0.43..3.12 rows=15 width=45) (actual time=857.818..857.818 rows=0 loops=1)
  ->  Index Scan Backward using notifications_pkey on notifications  (cost=0.43..134168.43 rows=748192 width=45) (actual time=857.817..857.817 rows=0 loops=1)
        Filter: ((account_id = X) AND ((activity_type)::text <> ALL ('{Status,Follow,Favourite,Mention,FollowRequest,FollowRequest}'::text[])))
        Rows Removed by Filter: 3000000
Planning time: 0.085 ms
Execution time: 857.833 ms
```

**after**

```
SELECT  "notifications".* FROM "notifications" WHERE "notifications"."account_id" = X AND 1=0 ORDER BY "notifications"."id" DESC LIMIT 15

Limit  (cost=0.01..0.02 rows=1 width=68) (actual time=0.006..0.006 rows=0 loops=1)
  ->  Sort  (cost=0.01..0.02 rows=0 width=68) (actual time=0.005..0.005 rows=0 loops=1)
        Sort Key: id DESC
        Sort Method: quicksort  Memory: 25kB
        ->  Result  (cost=0.00..0.00 rows=0 width=68) (actual time=0.000..0.000 rows=0 loops=1)
              One-Time Filter: false
Planning time: 0.049 ms
Execution time: 0.019 ms
```
