### PR TITLE
Switch uglify to compress:true, mangle:true

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -12,22 +12,8 @@ module.exports = merge(sharedConfig, {
 
   plugins: [
     new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        unused: true,
-        evaluate: true,
-        booleans: true,
-        drop_debugger: true,
-        dead_code: true,
-        pure_getters: true,
-        negate_iife: true,
-        conditionals: true,
-        loops: true,
-        cascade: true,
-        keep_fargs: false,
-        warnings: true
-      },
-
-      mangle: false,
+      compress: true,
+      mangle: true,
 
       output: {
         comments: false


### PR DESCRIPTION
This has a fairly enormous impact on the JS bundle size:

| file | bytes before | bytes after | improvement |
| --- | --- | ---- | --- |
| application.js | 740K | 564K | 23.98% |
| vendor.js | 2.0M | 1.5M | 25.46% |
| application.js.gz | 112K | 100K | 10.8% |
| vendor.js.gz | 380K | 320K | 16.19% |

Both `mangle:true` and `compress:true` are safe options, although it's true they make debugging more difficult (we can always enable source maps if we really care about this; there's no cost to shipping source maps in production because it only activates when the Dev Tools are open). 

I also tinkered with using Babili in conjunction with Uglify, but I found that Uglify alone produced the same results as Babili+Uglify, so it doesn't seem worth it to use both.