### PR TITLE
Hotfix convert string from symbol

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -54,7 +54,7 @@ class NotifyService < BaseService
   end
 
   def send_email
-    NotificationMailer.send(@notification.type, @recipient, @notification).deliver_later
+    NotificationMailer.public_send(@notification.type, @recipient, @notification).deliver_later
   end
 
   def email_enabled?

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -58,6 +58,6 @@ class NotifyService < BaseService
   end
 
   def email_enabled?
-    @recipient.user.settings.notification_emails[@notification.type]
+    @recipient.user.settings.notification_emails[@notification.type.to_s]
   end
 end

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe NotifyService do
+  subject do
+    -> { described_class.new.call(recipient, activity) }
+  end
+
+  let(:user) { Fabricate(:user) }
+  let(:recipient) { user.account }
+  let(:activity) { Fabricate(:follow, target_account: recipient) }
+
+  it { is_expected.to change(Notification, :count).by(1) }
+
+  describe 'email' do
+    before do
+      ActionMailer::Base.deliveries.clear
+
+      notification_emails = user.settings.notification_emails
+      user.settings.notification_emails = notification_emails.merge('follow' => enabled)
+    end
+
+    context 'when email notification is enabled' do
+      let(:enabled) { true }
+
+      it 'sends email' do
+        is_expected.to change(ActionMailer::Base.deliveries, :count).by(1)
+      end
+    end
+
+    context 'when email notification is disabled' do
+      let(:enabled) { false }
+
+      it "doesn't send email" do
+        is_expected.to_not change(ActionMailer::Base.deliveries, :count).from(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`#email_enabled?` is broken because the keys of notification_emails are string instead of symbol.
[Notification#type returns symbol](https://github.com/tootsuite/mastodon/blob/05b72368ed56f23e247d28c2798789f91bb096c5/app/models/notification.rb#L56)