### PR TITLE
Add asynchronous emojione-picker (code-splitting)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,6 +12,7 @@
     ]
   ],
   "plugins": [
+    "syntax-dynamic-import",
     "transform-object-rest-spread",
     [
       "react-intl",

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2141,6 +2141,20 @@ button.icon-button.active i.fa-retweet {
   background: radial-gradient(ellipse, rgba($color4, 0.23) 0%, rgba($color4, 0) 60%);
 }
 
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.5;
+  }
+}
+
+.pulse-loading {
+  animation: pulse 1s ease-in-out infinite;
+  animation-direction: alternate;
+}
+
 .emoji-dialog {
   width: 245px;
   height: 270px;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-react-intl": "^2.3.1",
     "babel-plugin-react-transform": "^2.0.2",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-constant-elements": "^6.23.0",
     "babel-plugin-transform-react-inline-elements": "^6.22.0",


### PR DESCRIPTION
This adds Webpack-based code-splitting for the `emojione-picker`, so that the code only needs to be loaded when the user actually clicks the dropdown button.

Since it's easier to explain with a video, here's [a gfycat to show it in action](https://gfycat.com/AcidicPrestigiousBoto). Note that the third JS file is only downloaded when the smiley face is clicked. 

### Bundle size improvements

This has a big impact on the size of the JavaScript that's downloaded and executed on page load. Here's a [webpack-bundle-analyzer view](http://bl.ocks.org/nolanlawson/raw/8e6d858bf3406a5cc74c89f3f0ca44ec/):

![screenshot 2017-05-06 17 12 17](https://cloud.githubusercontent.com/assets/283842/25776883/323744b6-3280-11e7-9d87-b8cce30a40fc.png)

The yellow is `vendor.js`, the blue is `application.js`, and the purple is the new code-split chunk. So this PR removes a huge amount of code that doesn't need to run until the user clicks the little smiley-face button.

In particular, this PR reduces the size of `vendor.js` from 1.5M to 936K (or gzipped: 331K to 237K). The new chunk file is 548K (gzipped: 9.37K).

### Loading state, error state

Since the async chunk may take awhile to download, I added a simple "pulse" animation to show the user that something is happening. It's not super prominent, but it's something at least:

![naivewetbee](https://cloud.githubusercontent.com/assets/283842/25776918/1655616e-3281-11e7-8109-8292cc64e918.gif)

If the request fails entirely then nothing happens; I put that as a TODO. My hunch is we should show the user an error, but I wasn't sure how to do that. Happy to get feedback! :smiley: