### PR TITLE
Fix locale key for account card

### DIFF
--- a/app/views/admin/accounts/_card.html.haml
+++ b/app/views/admin/accounts/_card.html.haml
@@ -11,6 +11,6 @@
         %td= t('admin.accounts.moderation.title')
         %td
           - if account.silenced?
-            %p= t('admin.moderation.silenced')
+            %p= t('admin.accounts.moderation.silenced')
           - if account.suspended?
-            %p= t('admin.moderation.suspended')
+            %p= t('admin.accounts.moderation.suspended')


### PR DESCRIPTION
```plain
$ bundle exec i18n-tasks missing -l ja
warning: parser/current is loading parser/ruby24, which recognizes
warning: 2.4.0-compliant syntax, but you are running 2.4.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Missing translations (3) | i18n-tasks v0.9.15
+--------+--------------------------------------------------+---------------------------------------------+
| Locale | Key                                              | Value in other locales or source            |
+--------+--------------------------------------------------+---------------------------------------------+
|   ja   | admin.accounts.disable_two_factor_authentication | en Disable 2FA                              |
|   ja   | admin.moderation.silenced                        | app/views/admin/accounts/_card.html.haml:14 |
|   ja   | admin.moderation.suspended                       | app/views/admin/accounts/_card.html.haml:16 |
+--------+--------------------------------------------------+---------------------------------------------+
```