### PR TITLE
Add effective index to subscriptions

### DIFF
--- a/db/migrate/20170507141759_optimize_index_subscriptions.rb
+++ b/db/migrate/20170507141759_optimize_index_subscriptions.rb
@@ -1,0 +1,11 @@
+class OptimizeIndexSubscriptions < ActiveRecord::Migration[5.0]
+  def up
+    add_index :subscriptions, [:account_id, :callback_url], unique: true
+    remove_index :subscriptions, [:callback_url, :account_id]
+  end
+
+  def down
+    add_index :subscriptions, [:callback_url, :account_id], unique: true
+    remove_index :subscriptions, [:account_id, :callback_url]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170425202925) do
+ActiveRecord::Schema.define(version: 20170507141759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -288,7 +288,7 @@ ActiveRecord::Schema.define(version: 20170425202925) do
     t.datetime "created_at",                                  null: false
     t.datetime "updated_at",                                  null: false
     t.datetime "last_successful_delivery_at"
-    t.index ["callback_url", "account_id"], name: "index_subscriptions_on_callback_url_and_account_id", unique: true, using: :btree
+    t.index ["account_id", "callback_url"], name: "index_subscriptions_on_account_id_and_callback_url", unique: true, using: :btree
   end
 
   create_table "tags", force: :cascade do |t|


### PR DESCRIPTION
Optimize Pubsubhubbub::DistributionWorker

IMO this optimization is not important for most instance owner because Subscription.count is maybe small. However all we have to do is only reverse indexes.

```
SELECT id, callback_url FROM "subscriptions" WHERE "subscriptions"."account_id" = X AND "subscriptions"."confirmed" = 't' AND ("subscriptions"."expires_at" > '2017-05-07 14:16:36.159176')
```

**before**

```
Seq Scan on subscriptions  (cost=0.00..5102.81 rows=342 width=48) (actual time=0.042..21.021 rows=264 loops=1)
  Filter: (confirmed AND (expires_at > '2017-05-07 14:16:36.159176'::timestamp without time zone) AND (account_id = X))
  Rows Removed by Filter: 138723
Planning time: 0.113 ms
Execution time: 21.039 ms
```

**after**

```
Bitmap Heap Scan on subscriptions  (cost=24.92..1497.97 rows=394 width=48) (actual time=0.097..0.461 rows=264 loops=1)
  Recheck Cond: (account_id = X)
  Filter: (confirmed AND (expires_at > '2017-05-07 14:16:36.159176'::timestamp without time zone))
  Rows Removed by Filter: 229
  Heap Blocks: exact=382
  ->  Bitmap Index Scan on index_subscriptions_on_account_id_and_callback_url  (cost=0.00..24.82 rows=587 width=0) (actual time=0.060..0.060 rows=493 loops=1)
        Index Cond: (account_id = X)
Planning time: 0.048 ms
Execution time: 0.488 ms
```
