### PR TITLE
Improve example env file for local Postfix relay

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -38,8 +38,8 @@ OTP_SECRET=
 # E-mail configuration
 # Note: Mailgun and SparkPost (https://sparkpo.st/smtp) each have good free tiers
 # If you want to use an SMTP server without authentication (e.g local Postfix relay)
-# then set SMTP_AUTH_METHOD to 'none' and *comment* SMTP_LOGIN and SMTP_PASSWORD.
-# Leaving them blank is not enough for authentication method 'none'.
+# then set SMTP_AUTH_METHOD and SMTP_OPENSSL_VERIFY_MODE to 'none' and 
+# *comment* SMTP_LOGIN and SMTP_PASSWORD (leaving them blank is not enough).
 SMTP_SERVER=smtp.mailgun.org
 SMTP_PORT=587
 SMTP_LOGIN=


### PR DESCRIPTION
From my tests when connecting to local SMTP server, which will be usually unencrypted, it's necessary to set SMTP_OPENSSL_VERIFY_MODE to 'none' as well. 

Please let me know if you'd like to rephrase the comment to be more precise (mention encryption, etc.)