### PR TITLE
Fix yaml parse error uk.yml

### DIFF
--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -138,8 +138,7 @@ uk:
       title: Скарги
       unresolved: Невирішені
       view: Подивитися
-
-  settings:
+    settings:
       contact_information:
         email: Введіть публічний email
         label: Контактна інформація
@@ -222,8 +221,7 @@ uk:
     true_privacy_html: Будь ласка, помітьте, що <strong>справжняя конфіденційність може бути досягнена тільки за допомогою end-to-end шифрування</strong>.
     unlocked_warning_html: Хто завгодно може підписатися на Вас та отримати доступ до перегляду Ваших приватних статусів. %{lock_link}, щоб отримати можливість роздивлятися та вручну підтверджувати запити щодо підписки.
     unlocked_warning_title: Ваш аккаунт не закритий для підписки
-
-generic:
+  generic:
     changes_saved_msg: Зміни успішно збережені!
     powered_by: працює на %{link}
     save_changes: Зберегти зміни


### PR DESCRIPTION
```
$ bundle exec i18n-tasks health
i18n-tasks: yaml parse error: ({}): did not find expected key while parsing a block mapping at line 3 column 3
```