### PR TITLE
Remove rails_12factor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,5 @@ end
 
 group :production do
   gem 'lograge'
-  gem 'rails_12factor'
   gem 'redis-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,11 +325,6 @@ GEM
       railties (~> 5.0)
     rails-settings-cached (0.6.5)
       rails (>= 4.2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.0.2)
       actionpack (= 5.0.2)
       activesupport (= 5.0.2)
@@ -537,7 +532,6 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n
   rails-settings-cached
-  rails_12factor
   redis (~> 3.2)
   redis-namespace
   redis-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,6 +19,11 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
+  ActiveSupport::Logger.new(STDOUT).tap do |logger|
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = Uglifier.new(mangle: false)
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
Currently `public_file_server` can not be disabled because `rails_12factor` is installed. 😕 

---

**from [rails_12factor](https://github.com/heroku/rails_12factor)**

> Rails 5
> 
> We worked with the Rails core team to make Rails 5 work on twelve-factor platforms out of the box.
> 
>## New Rails 5 Apps
> 
> If you are starting a new application with Rails 5, you do not need this gem.
> 
> ## Migrating to Rails 5
> 
> You can remove this gem after making sure the following sections are added in your production.rb file:
>
> ``` 
> config/environments/production.rb
> 
> # Disable serving static files from the `/public` folder by default since
> # Apache or NGINX already handles this.
> config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
> 
> if ENV["RAILS_LOG_TO_STDOUT"].present?
>   logger           = ActiveSupport::Logger.new(STDOUT)
>   logger.formatter = config.log_formatter
>   config.logger = ActiveSupport::TaggedLogging.new(logger)
> end
> Make sure to add both the RAILS_SERVE_STATIC_FILES and RAILS_LOG_TO_STDOUT ENV vars and set them to true. (This is done for you on Heroku)
> ```
