### PR TITLE
Change label arrangement vertically

### DIFF
--- a/app/javascript/styles/admin.scss
+++ b/app/javascript/styles/admin.scss
@@ -121,12 +121,18 @@
 
     .label_input {
       label.select {
+        display: inline;
         width: 50%;
       }
 
       select {
         width: 50%;
         float: right;
+      }
+
+      label.file {
+        display: inline-block;
+        width: 100px;
       }
     }
   }

--- a/app/javascript/styles/forms.scss
+++ b/app/javascript/styles/forms.scss
@@ -29,19 +29,6 @@ code {
     font-weight: 500;
   }
 
-  .label_input {
-    display: flex;
-
-    label {
-      flex: 0 0 auto;
-      width: 100px;
-    }
-
-    input {
-      flex: 1 1 auto;
-    }
-  }
-
   .input.file,
   .input.select,
   .input.radio_buttons {
@@ -54,6 +41,7 @@ code {
       color: $color5;
       display: block;
       padding-top: 5px;
+      padding-bottom: 5px;
     }
   }
 


### PR DESCRIPTION
I changed the layout vertically because the label was broken in the middle.
This problem also occurs in other languages such as Chinese.

The selection and file placement are not changed from landscape orientation.

### /settings/preferences
Before:
<img width="391" alt="before" src="https://cloud.githubusercontent.com/assets/4199439/25952565/fc3b5062-369b-11e7-8a71-214f7a0eafec.png">

After:
<img width="391" alt="after" src="https://cloud.githubusercontent.com/assets/4199439/25952610/1c84754c-369c-11e7-99dc-1194e7034c47.png">

### /settings/import
Before:
![image](https://cloud.githubusercontent.com/assets/4199439/25952772/8bc54710-369c-11e7-9b50-8b26c0f11315.png)

After:
![image](https://cloud.githubusercontent.com/assets/4199439/25952700/58e1104a-369c-11e7-8838-52a0cccbffaf.png)
