### PR TITLE
Enable HoundCI haml-lint checks

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,12 @@
+eslint:
+  enabled: false
+  config_file: .eslintrc.yml
+haml:
+  enabled: true
+  config_file: .haml-lint.yml
+ruby:
+  enabled: false
+  config_file: .rubocop.yml
+scss:
+  enabled: false
+  config_file: .scss-lint.yml


### PR DESCRIPTION
[*proposal*] [Hound](https://houndci.com/) is code review tool for GitHub pull requests. I have added a configuration file for Hound. We can receive comments on style violations on pull request.

**For maintainer or owner**:

Please activate `tootsuite/mastodon` repo.

## The steps for activation.

![](https://cloud.githubusercontent.com/assets/15371677/25807115/aa90edb0-3440-11e7-92fb-0dbee0fffd5f.png)

![](https://cloud.githubusercontent.com/assets/15371677/25807198/f206c444-3440-11e7-85c3-070821cdb5f0.png)

It will be completed in only this step. And comments of Hound is like this:

![](https://cloud.githubusercontent.com/assets/15371677/25807257/2279e764-3441-11e7-9970-467626a76407.png)

The cost of hound is **unlimitedly $0** (for Open Source). If you don't want to add checkers any more, please close this request (It's no problem for me 🙂 ).