### PR TITLE
Add cursor property to toot user avatar.

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -688,6 +688,7 @@ a.status__content__spoiler-link {
 .account__avatar {
   @include avatar-radius();
   position: relative;
+  cursor: pointer;
 
   &-inline {
     display: inline-block;


### PR DESCRIPTION
<img width="303" alt="screen shot 2017-05-09 at 10 40 39" src="https://cloud.githubusercontent.com/assets/6993514/25832176/012f5c0c-34a4-11e7-8ba1-35c9d2c855d9.png">

## Description 

I added `cursor` property  to toot avator icon.  
By this, It becomes explicit that it is clickable.