### PR TITLE
Disabled auto focus on toot form after returning from other tab during search result shown.

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -153,7 +153,7 @@ class AutosuggestTextarea extends ImmutablePureComponent {
   }
 
   render () {
-    const { value, suggestions, disabled, placeholder, onKeyUp } = this.props;
+    const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus } = this.props;
     const { suggestionsHidden, selectedSuggestion } = this.state;
     const style = { direction: 'ltr' };
 
@@ -168,7 +168,7 @@ class AutosuggestTextarea extends ImmutablePureComponent {
           className='autosuggest-textarea__textarea'
           disabled={disabled}
           placeholder={placeholder}
-          autoFocus={true}
+          autoFocus={autoFocus}
           value={value}
           onChange={this.onChange}
           onKeyDown={this.onKeyDown}
@@ -208,6 +208,11 @@ AutosuggestTextarea.propTypes = {
   onKeyUp: PropTypes.func,
   onKeyDown: PropTypes.func,
   onPaste: PropTypes.func.isRequired,
+  autoFocus: PropTypes.bool
+};
+
+AutosuggestTextarea.defaultProps = {
+  autoFucus: true,
 };
 
 export default AutosuggestTextarea;

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -118,7 +118,7 @@ class ComposeForm extends ImmutablePureComponent {
   }
 
   render () {
-    const { intl, onPaste } = this.props;
+    const { intl, onPaste, showSearch } = this.props;
     const disabled = this.props.is_submitting;
     const text = [this.props.spoiler_text, this.props.text].join('');
 
@@ -156,6 +156,7 @@ class ComposeForm extends ImmutablePureComponent {
             onSuggestionsClearRequested={this.onSuggestionsClearRequested}
             onSuggestionSelected={this.onSuggestionSelected}
             onPaste={onPaste}
+            autoFocus={!showSearch}
           />
 
           <EmojiPickerDropdown onPickEmoji={this.handleEmojiPick} />
@@ -204,7 +205,12 @@ ComposeForm.propTypes = {
   onSuggestionSelected: PropTypes.func.isRequired,
   onChangeSpoilerText: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
-  onPickEmoji: PropTypes.func.isRequired
+  onPickEmoji: PropTypes.func.isRequired,
+  showSearch: PropTypes.bool,
+};
+
+ComposeForm.defaultProps = {
+  showSearch: false
 };
 
 export default injectIntl(ComposeForm);

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -22,7 +22,8 @@ const mapStateToProps = state => ({
   preselectDate: state.getIn(['compose', 'preselectDate']),
   is_submitting: state.getIn(['compose', 'is_submitting']),
   is_uploading: state.getIn(['compose', 'is_uploading']),
-  me: state.getIn(['compose', 'me'])
+  me: state.getIn(['compose', 'me']),
+  showSearch: state.getIn(['search', 'submitted']) && !state.getIn(['search', 'hidden'])
 });
 
 const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
On mobile safari browser, the cursor focus appears out of the search box after returning from other tab during search results are shown (see below image). To fix this, I disabled auto focus on toot form only when search result is shown.
![image](https://cloud.githubusercontent.com/assets/8464231/25846820/50f5c43e-34ee-11e7-92f7-ae36aac7d99f.png)
