### PR TITLE
Fixed bug that timeline can not be displayed by InvalidURIError

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -92,6 +92,8 @@ class Formatter
       rel: 'nofollow noopener',
     }
     Twitter::Autolink.send(:link_to_text, entity, link_html(entity[:url]), normalized_url, html_attrs)
+  rescue Addressable::URI::InvalidURIError
+    encode(entity[:url])
   end
 
   def link_to_mention(entity, mentions)

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -123,6 +123,13 @@ RSpec.describe Formatter do
         expect(subject).to match '<p>&lt;img src=&quot;javascript:alert(&apos;XSS&apos;);&quot;&gt;</p>'
       end
     end
+
+    context 'contains invalid URL' do
+      let(:local_text) { 'http://www\.google\.com' }
+      it 'has valid url' do
+        expect(subject).to eq '<p>http://www\.google\.com</p>'
+      end
+    end
   end
 
   describe '#reformat' do


### PR DESCRIPTION
When InvalidURIError occurs, 500 error occurs.
In this case the user's timeline is not displayed.

I modified to not convert invalid URL.
A URL containing a backslash in its host name is one of invalid URLs.

<img src="https://cloud.githubusercontent.com/assets/4199439/25856864/3b9724f6-3512-11e7-82f7-bb4b0eae6602.png" width=300>
