### PR TITLE
Use RegExp for require.context to filter custom stylesheets

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -15,12 +15,7 @@ window.Perf = require('react-addons-perf');
 Rails.start();
 
 require.context('../images/', true);
-
-const customContext = require.context('../../assets/stylesheets/', false);
-
-if (customContext.keys().indexOf('./custom.scss') !== -1) {
-  customContext('./custom.scss');
-}
+require.context('../../assets/stylesheets/', false, /custom.*\.scss$/);
 
 document.addEventListener('DOMContentLoaded', () => {
   const mountNode = document.getElementById('mastodon');


### PR DESCRIPTION
ExtractTextWebpackPlugin extracts the content of loaded files, which means it loads files loaded by require.context but not required after that. However the former implementation is not aware of that.

`require.context` can have a `RegExp` to filter files to load. This change gives a `RegExp` which matches with SCSSes with `custom` prefix to `require.context` to take advantage of the feature.