### PR TITLE
Disable sidekiq logging in test mode

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 WebMock.disable_net_connect!
 Sidekiq::Testing.inline!
+Sidekiq::Logging.logger = nil
 
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
Right now it emits some text from one of the `info` level logs in a worker...