### PR TITLE
Enhance account filter

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -23,7 +23,11 @@ module Admin
         :by_domain,
         :silenced,
         :recent,
-        :suspended
+        :suspended,
+        :username,
+        :display_name,
+        :email,
+        :ip
       )
     end
   end

--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Admin::FilterHelper
-  ACCOUNT_FILTERS = %i(local remote by_domain silenced suspended recent).freeze
+  ACCOUNT_FILTERS = %i(local remote by_domain silenced suspended recent username display_name email ip).freeze
   REPORT_FILTERS = %i(resolved account_id target_account_id).freeze
 
   FILTERS = ACCOUNT_FILTERS + REPORT_FILTERS

--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -10,27 +10,49 @@ class AccountFilter
   def results
     scope = Account.alphabetic
     params.each do |key, value|
-      scope = scope.merge scope_for(key, value)
+      scope.merge!(scope_for(key, value)) if value.present?
     end
     scope
   end
 
+  private
+
   def scope_for(key, value)
-    case key
-    when /local/
+    accounts = Account.arel_table
+
+    case key.to_s
+    when 'local'
       Account.local
-    when /remote/
+    when 'remote'
       Account.remote
-    when /by_domain/
+    when 'by_domain'
       Account.where(domain: value)
-    when /silenced/
+    when 'silenced'
       Account.silenced
-    when /recent/
+    when 'recent'
       Account.recent
-    when /suspended/
+    when 'suspended'
       Account.suspended
+    when 'username'
+      Account.where(accounts[:username].matches("#{value}%"))
+    when 'display_name'
+      Account.where(accounts[:display_name].matches("#{value}%"))
+    when 'email'
+      users = User.arel_table
+      Account.joins(:user).merge(User.where(users[:email].matches("#{value}%")))
+    when 'ip'
+      return Account.default_scoped unless valid_ip?(value)
+      matches_ip = User.where(current_sign_in_ip: value).or(User.where(last_sign_in_ip: value))
+      Account.joins(:user).merge(matches_ip)
     else
       raise "Unknown filter: #{key}"
     end
+  end
+
+  def valid_ip?(value)
+    IPAddr.new(value)
+    true
+  rescue IPAddr::InvalidAddressError
+    false
   end
 end

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -20,6 +20,21 @@
       %li= filter_link_to t('admin.accounts.order.alphabetic'), recent: nil
       %li= filter_link_to t('admin.accounts.order.most_recent'), recent: '1'
 
+= form_tag(admin_accounts_url, { method: 'GET', class: 'simple_form' }) do
+  .fields-group
+    - Admin::FilterHelper::ACCOUNT_FILTERS.each do |key|
+      - if params[key].present?
+        = hidden_field_tag key, params[key]
+
+    - %i(username display_name email ip).each do |key|
+      .input.string.optional
+        .label_input
+          %label.string.optional= t("admin.accounts.#{key}")
+          = text_field_tag key, params[key], class: 'string optional'
+
+    .actions
+      %button.btn= t('admin.accounts.search')
+
 %table.table
   %thead
     %tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
       feed_url: Feed URL
       followers: Followers
       follows: Follows
+      ip: IP
       location:
         all: All
         local: Local
@@ -86,6 +87,7 @@ en:
       push_subscription_expires: PuSH subscription expires
       reset_password: Reset password
       salmon_url: Salmon URL
+      search: Search
       show:
         created_reports: Reports created by this account
         report: report

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -61,6 +61,7 @@ ja:
       feed_url: フィードURL
       followers: フォロワー数
       follows: フォロー数
+      ip: IP
       location:
         all: すべて
         local: ローカル
@@ -85,6 +86,7 @@ ja:
       push_subscription_expires: PuSH購読期限切れ
       reset_password: パスワード再設定
       salmon_url: Salmon URL
+      search: 検索
       show:
         created_reports: このアカウントで作られたレポート
         report: レポート


### PR DESCRIPTION
I enhance AccountFilter to search by username, display_name, email and ip.
In the daily management work of mastodon, the search form is needed for me.

I have not changed the current behavior, but maybe this PR is a bit complicated.
If you do not like this, please reject. it's okay 😄  👍 

![2017-05-14 1 59 53](https://cloud.githubusercontent.com/assets/1688137/26027488/8adb6a1a-3849-11e7-8930-f2f8d4663fb9.png)

