### PR TITLE
Fix #2027 - Accept own ID for remote follow with and without preceding @

### DIFF
--- a/app/models/remote_follow.rb
+++ b/app/models/remote_follow.rb
@@ -6,7 +6,7 @@ class RemoteFollow
   attr_accessor :acct, :addressable_template
 
   def initialize(attrs = {})
-    @acct = attrs[:acct].strip unless attrs[:acct].nil?
+    @acct = attrs[:acct].gsub(/\A@/, '').strip unless attrs[:acct].nil?
   end
 
   def valid?
@@ -15,7 +15,7 @@ class RemoteFollow
   end
 
   def subscribe_address_for(account)
-    addressable_template.expand(uri: account.to_webfinger_s).to_s
+    addressable_template.expand(uri: account.local_username_and_domain).to_s
   end
 
   private

--- a/spec/controllers/remote_follow_controller_spec.rb
+++ b/spec/controllers/remote_follow_controller_spec.rb
@@ -66,7 +66,7 @@ describe RemoteFollowController do
         end
 
         it 'redirects to the remote location' do
-          address = "http://example.com/follow_me?acct=acct%3Atest_user%40#{Rails.configuration.x.local_domain}"
+          address = "http://example.com/follow_me?acct=test_user%40#{Rails.configuration.x.local_domain}"
 
           expect(response).to redirect_to(address)
         end


### PR DESCRIPTION
Fix #2177 - Omit leading "acct:" in remote follow redirect template expansion