### PR TITLE
Fix #1426 - Trim long usernames in public follower/following lists

### DIFF
--- a/app/javascript/styles/accounts.scss
+++ b/app/javascript/styles/accounts.scss
@@ -302,6 +302,8 @@
         display: block;
         color: $ui-base-color;
         text-decoration: none;
+        text-overflow: ellipsis;
+        overflow: hidden;
 
         &:hover {
           .display_name {

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -8,7 +8,7 @@ class Sanitize
       elements: %w(p br span a),
 
       attributes: {
-        'a'    => %w(href),
+        'a'    => %w(href rel),
         'span' => %w(class),
       },
 

--- a/app/models/concerns/account_avatar.rb
+++ b/app/models/concerns/account_avatar.rb
@@ -34,7 +34,7 @@ module AccountAvatar
 
       self.avatar              = URI.parse(parsed_url.to_s)
       self[:avatar_remote_url] = url
-    rescue OpenURI::HTTPError => e
+    rescue OpenURI::HTTPError, OpenSSL::SSL::SSLError, Paperclip::Errors::NotIdentifiedByImageMagickError => e
       Rails.logger.debug "Error fetching remote avatar: #{e}"
     end
   end

--- a/app/models/concerns/account_header.rb
+++ b/app/models/concerns/account_header.rb
@@ -34,7 +34,7 @@ module AccountHeader
 
       self.header              = URI.parse(parsed_url.to_s)
       self[:header_remote_url] = url
-    rescue OpenURI::HTTPError => e
+    rescue OpenURI::HTTPError, OpenSSL::SSL::SSLError, Paperclip::Errors::NotIdentifiedByImageMagickError => e
       Rails.logger.debug "Error fetching remote header: #{e}"
     end
   end

--- a/app/services/process_feed_service.rb
+++ b/app/services/process_feed_service.rb
@@ -223,7 +223,7 @@ class ProcessFeedService < BaseService
         begin
           media.file_remote_url = link['href']
           media.save
-        rescue OpenURI::HTTPError, Paperclip::Errors::NotIdentifiedByImageMagickError
+        rescue OpenURI::HTTPError, OpenSSL::SSL::SSLError, Paperclip::Errors::NotIdentifiedByImageMagickError
           next
         end
       end


### PR DESCRIPTION
Fix #2221 - Catch OpenSSL exceptions when loading remote avatars/headers/attachments
Don't strip "rel" attribute from `<a>` tags when sanitizing (microformats)