### PR TITLE
Rebuild node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "storybook": "start-storybook -p 9001 -c storybook",
     "test": "npm run test:lint && npm run test:mocha",
     "test:lint": "eslint -c .eslintrc.yml --ext=js --ext=jsx app/javascript/",
-    "test:mocha": "mocha --require ./spec/javascript/setup.js --compilers js:babel-register ./spec/javascript/components/*.test.jsx"
+    "test:mocha": "mocha --require ./spec/javascript/setup.js --compilers js:babel-register ./spec/javascript/components/*.test.jsx",
+    "postinstall": "npm rebuild node-sass"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Got an error in asset precompile on Heroku deploying second time:

```
Module build failed: Error: ENOENT: no such file or directory, scandir '/tmp/.../node_modules/node-sass/vendor'
```

This could be avoided with rebuilding the module in the `postinstall` hook: https://github.com/rails/webpacker#troubleshooting . `node-sass` module seems to have some files missing when it is built in a directory for the second time: