### PR TITLE
Add yarn log files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ redis
 # Ignore npm debug log
 npm-debug.log
 
+# Ignore yarn log files
+yarn-error.log
+yarn-debug.log
+
 # Ignore Docker option files
 docker-compose.override.yml
 


### PR DESCRIPTION
This project is using yarn as Javascript package manager.
But yarn log files weren't added to .gitignore, so I add them.