### PR TITLE
Remove unnecessary message in video player

### DIFF
--- a/app/javascript/mastodon/components/video_player.js
+++ b/app/javascript/mastodon/components/video_player.js
@@ -9,7 +9,6 @@ const messages = defineMessages({
   toggle_sound: { id: 'video_player.toggle_sound', defaultMessage: 'Toggle sound' },
   toggle_visible: { id: 'video_player.toggle_visible', defaultMessage: 'Toggle visibility' },
   expand_video: { id: 'video_player.expand', defaultMessage: 'Expand video' },
-  expand_video: { id: 'video_player.video_error', defaultMessage: 'Video could not be played' }
 });
 
 class VideoPlayer extends React.PureComponent {


### PR DESCRIPTION
Remove unnecessary messages added in #1879. It is duplicated with other keys, causing the correct message not to be displayed.