### PR TITLE
Prepend reblogs' wrapper content with "RT @original_author"

### DIFF
--- a/app/lib/atom_serializer.rb
+++ b/app/lib/atom_serializer.rb
@@ -337,7 +337,7 @@ class AtomSerializer
 
   def serialize_status_attributes(entry, status)
     append_element(entry, 'summary', Formatter.instance.format(status.proper, :spoiler_text, false).to_str, 'xml:lang': status.language, type: 'html') if status.spoiler_text?
-    append_element(entry, 'content', Formatter.instance.format(status.proper).to_str, type: 'html', 'xml:lang': status.language)
+    append_element(entry, 'content', Formatter.instance.format(status).to_str, type: 'html', 'xml:lang': status.language)
 
     status.mentions.each do |mentioned|
       append_element(entry, 'link', nil, rel: :mentioned, 'ostatus:object-type': TagManager::TYPES[:person], href: TagManager.instance.uri_for(mentioned.account))

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -7,38 +7,56 @@ RSpec.describe Formatter do
   let(:remote_status) { Fabricate(:status, text: '<script>alert("Hello")</script> Beep boop', uri: 'beepboop', account: account) }
 
   let(:local_text_with_mention) { "@#{account.username} @#{account.username}@example.com #{local_text}?x=@#{account.username} #hashtag" }
-  let(:local_status_with_mention) { Fabricate(:status, text: local_text_with_mention,
-                                              account: account, mentions: [Fabricate(:mention, account: account)]) }
+
+  let(:local_status_with_mention) do
+    Fabricate(
+      :status,
+      text: local_text_with_mention,
+      account: account,
+      mentions: [Fabricate(:mention, account: account)]
+    )
+  end
 
   describe '#format' do
     subject { Formatter.instance.format(local_status) }
 
-    it 'returns a string' do
-      expect(subject).to be_a String
+    context 'with standalone status' do
+      it 'returns a string' do
+        expect(subject).to be_a String
+      end
+
+      it 'contains plain text' do
+        expect(subject).to match('Hello world')
+      end
+
+      it 'contains a link' do
+        expect(subject).to match('<a href="http://google.com/" rel="nofollow noopener" target="_blank"><span class="invisible">http://</span><span class="">google.com/</span><span class="invisible"></span></a>')
+      end
+
+      it 'contains a mention' do
+        result = Formatter.instance.format(local_status_with_mention)
+        expect(result).to match "<a href=\"#{TagManager.instance.url_for(account)}\" class=\"u-url mention\">@<span>#{account.username}</span></a></span>"
+        expect(result).to match %r{href=\"http://google.com/\?x=@#{account.username}}
+        expect(result).not_to match "href=\"https://example.com/@#{account.username}"
+      end
+
+      it 'contains a hashtag' do
+        result = Formatter.instance.format(local_status_with_mention)
+        expect(result).to match('/tags/hashtag" class="mention hashtag" rel="tag">#<span>hashtag</span></a>')
+      end
     end
 
-    it 'contains plain text' do
-      expect(subject).to match('Hello world')
-    end
+    context 'with reblog' do
+      let(:local_status) { Fabricate(:status, account: account, reblog: Fabricate(:status, text: 'Hello world', account: account)) }
 
-    it 'contains a link' do
-      expect(subject).to match('<a href="http://google.com/" rel="nofollow noopener" target="_blank"><span class="invisible">http://</span><span class="">google.com/</span><span class="invisible"></span></a>')
-    end
-
-    it 'contains a mention' do
-      result = Formatter.instance.format(local_status_with_mention)
-      expect(result).to match "<a href=\"#{TagManager.instance.url_for(account)}\" class=\"u-url mention\">@<span>#{account.username}</span></a></span>"
-      expect(result).to match %r{href=\"http://google.com/\?x=@#{account.username}}
-      expect(result).not_to match "href=\"https://example.com/@#{account.username}"
-    end
-
-    it 'contains a hashtag' do
-      result = Formatter.instance.format(local_status_with_mention)
-      expect(result).to match("/tags/hashtag\" class=\"mention hashtag\">#<span>hashtag</span></a>")
+      it 'contains credit to original author' do
+        expect(subject).to include("RT <span class=\"h-card\"><a href=\"#{TagManager.instance.url_for(account)}\" class=\"u-url mention\">@<span>#{account.username}</span></a></span> Hello world")
+      end
     end
 
     context 'matches a stand-alone medium URL' do
       let(:local_text) { 'https://hackernoon.com/the-power-to-build-communities-a-response-to-mark-zuckerberg-3f2cac9148a4' }
+
       it 'has valid url' do
         expect(subject).to include('href="https://hackernoon.com/the-power-to-build-communities-a-response-to-mark-zuckerberg-3f2cac9148a4"')
       end
@@ -46,6 +64,7 @@ RSpec.describe Formatter do
 
     context 'matches a stand-alone google URL' do
       let(:local_text) { 'http://google.com' }
+
       it 'has valid url' do
         expect(subject).to include('href="http://google.com/"')
       end
@@ -53,6 +72,7 @@ RSpec.describe Formatter do
 
     context 'matches a stand-alone IDN URL' do
       let(:local_text) { 'https://nic.みんな/' }
+
       it 'has valid url' do
         expect(subject).to include('href="https://nic.xn--q9jyb4c/"')
       end
@@ -64,6 +84,7 @@ RSpec.describe Formatter do
 
     context 'matches a URL without trailing period' do
       let(:local_text) { 'http://www.mcmansionhell.com/post/156408871451/50-states-of-mcmansion-hell-scottsdale-arizona. ' }
+
       it 'has valid url' do
         expect(subject).to include('href="http://www.mcmansionhell.com/post/156408871451/50-states-of-mcmansion-hell-scottsdale-arizona"')
       end
@@ -75,6 +96,7 @@ RSpec.describe Formatter do
 
     context 'matches a URL without exclamation point' do
       let(:local_text) { 'http://www.google.com!' }
+
       it 'has valid url' do
         expect(subject).to include('href="http://www.google.com/"')
       end
@@ -82,6 +104,7 @@ RSpec.describe Formatter do
 
     context 'matches a URL without single quote' do
       let(:local_text) { "http://www.google.com'" }
+
       it 'has valid url' do
         expect(subject).to include('href="http://www.google.com/"')
       end
@@ -89,6 +112,7 @@ RSpec.describe Formatter do
 
     context 'matches a URL without angle brackets' do
       let(:local_text) { 'http://www.google.com>' }
+
       it 'has valid url' do
         expect(subject).to include('href="http://www.google.com/"')
       end
@@ -96,6 +120,7 @@ RSpec.describe Formatter do
 
     context 'matches a URL with a query string' do
       let(:local_text) { 'https://www.ruby-toolbox.com/search?utf8=%E2%9C%93&q=autolink' }
+
       it 'has valid url' do
         expect(subject).to include('href="https://www.ruby-toolbox.com/search?utf8=%E2%9C%93&amp;q=autolink"')
       end
@@ -103,20 +128,23 @@ RSpec.describe Formatter do
 
     context 'matches a URL with parenthesis in it' do
       let(:local_text) { 'https://en.wikipedia.org/wiki/Diaspora_(software)' }
+
       it 'has valid url' do
         expect(subject).to include('href="https://en.wikipedia.org/wiki/Diaspora_(software)"')
       end
     end
 
     context 'contains html (script tag)' do
-        let(:local_text) { '<script>alert("Hello")</script>' }
-        it 'has valid url' do
-            expect(subject).to match '<p>&lt;script&gt;alert(&quot;Hello&quot;)&lt;/script&gt;</p>'
-        end
+      let(:local_text) { '<script>alert("Hello")</script>' }
+
+      it 'has valid url' do
+        expect(subject).to match '<p>&lt;script&gt;alert(&quot;Hello&quot;)&lt;/script&gt;</p>'
+      end
     end
 
     context 'contains html (xss attack)' do
       let(:local_text) { %q{<img src="javascript:alert('XSS');">} }
+
       it 'has valid url' do
         expect(subject).to match '<p>&lt;img src=&quot;javascript:alert(&apos;XSS&apos;);&quot;&gt;</p>'
       end
@@ -124,6 +152,7 @@ RSpec.describe Formatter do
 
     context 'contains invalid URL' do
       let(:local_text) { 'http://www\.google\.com' }
+
       it 'has valid url' do
         expect(subject).to eq '<p>http://www\.google\.com</p>'
       end


### PR DESCRIPTION
So that when a reblog parse fails on another instance, it doesn't look like a misattributed/stolen text.

*Before:*

Reblog content: Hello world
Wrapped status content: Hello world

*After:*

Reblog content: RT @example Hello world
Wrapped status content: Hello world