### PR TITLE
Fix sidekiq "port" being wrong

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: PORT=3000 bundle exec puma -C config/puma.rb
-sidekiq: bundle exec sidekiq
+sidekiq: PORT=3000 bundle exec sidekiq
 stream: PORT=4000 yarn run start
 webpack: ./bin/webpack-dev-server --host 0.0.0.0


### PR DESCRIPTION
Sidekiq doesn't need a port, however that env var is used for generating URLs
in development, so when foreman sets it wrong, you get bad URLs from the
streaming API during development