### PR TITLE
Increase color contrast on privacy warning

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -226,7 +226,7 @@
 }
 
 .compose-form__warning {
-  color: darken($ui-secondary-color, 33%);
+  color: darken($ui-secondary-color, 65%);
   margin-bottom: 15px;
   background: $ui-primary-color;
   box-shadow: 0 2px 6px rgba($base-shadow-color, 0.3);


### PR DESCRIPTION
The current text contrast on the privacy warning is a WCAG violation. I didn't notice this because my instance has a custom theme which is better. On default theme I am barely able to read the text with my impaired vision. This patch brings the contrast to Normal Text WCAG AA compliance, and Large Text WCAG AAA compliance.