### PR TITLE
Fix color contrast some more in privacy warning

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -236,7 +236,7 @@
   font-weight: 400;
 
   strong {
-    color: darken($primary-text-color, 33%);
+    color: $primary-text-color;
     font-weight: 500;
   }
 

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -236,7 +236,7 @@
   font-weight: 400;
 
   strong {
-    color: darken($ui-secondary-color, 65%)
+    color: darken($ui-secondary-color, 65%);
     font-weight: 500;
   }
 

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -236,7 +236,7 @@
   font-weight: 400;
 
   strong {
-    color: $primary-text-color;
+    color: darken($ui-secondary-color, 65%)
     font-weight: 500;
   }
 


### PR DESCRIPTION
Latest master appears to have changed the `<strong>` to this unreadable grey color. 

![capture](https://cloud.githubusercontent.com/assets/12243190/26008870/8a3b566e-3714-11e7-9c24-6af9cad7d5e2.JPG)

So this PR makes it look like this:

![capture 2](https://cloud.githubusercontent.com/assets/12243190/26008909/aaeaceb2-3714-11e7-8aa7-26572f26fa1f.JPG)

If you want that to be white then it should be pure white. If someone would rather revert this to that strong dark blue color it was before that would be good too.


