### PR TITLE
Fix og:url in account page

### DIFF
--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -6,7 +6,7 @@
   %link{ rel: 'alternate', type: 'application/atom+xml', href: account_url(@account, format: 'atom') }/
 
   %meta{ property: 'og:type', content: 'profile' }/
-  = render 'og', account: @account, url: account_url(@account, only_path: false)
+  = render 'og', account: @account, url: short_account_url(@account, only_path: false)
 
 - if show_landing_strip?
   = render partial: 'shared/landing_strip', locals: { account: @account }


### PR DESCRIPTION
in account page (e.g: https://pawoo.net/@harukasan)

```
<meta content='https://pawoo.net/users/harukasan' property='og:url'>
```

should be

```
<meta content='https://pawoo.net/@harukasan' property='og:url'>
```
