### PR TITLE
Fix typo

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -48,7 +48,7 @@ class AutosuggestTextarea extends ImmutablePureComponent {
   };
 
   static defaultProps = {
-    autoFucus: true
+    autoFocus: true
   };
 
   constructor (props, context) {


### PR DESCRIPTION
_It adds a shortcut (n) to focus the compose textarea_, **and also fixes autoFucus -> autoFocus in defaultProps**.

**EDIT**: Removed the shortcut, only fixes the typo.