### PR TITLE
Catch import promise in application.js

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@ if (!window.Intl || !Object.assign || !Number.isNaN ||
     !window.Symbol || !Array.prototype.includes) {
   // load polyfills dynamically
   import('../mastodon/polyfills').then(main).catch(e => {
-    console.log(e)
+    // console.log(e); // no-op
   });
 } else {
   main();

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@ if (!window.Intl || !Object.assign || !Number.isNaN ||
     !window.Symbol || !Array.prototype.includes) {
   // load polyfills dynamically
   import('../mastodon/polyfills').then(main).catch(e => {
-    // console.log(e); // no-op
+    console.log(e); // eslint-disable-line no-console
   });
 } else {
   main();

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@ if (!window.Intl || !Object.assign || !Number.isNaN ||
     !window.Symbol || !Array.prototype.includes) {
   // load polyfills dynamically
   import('../mastodon/polyfills').then(main).catch(e => {
-    console.log(e); // eslint-disable-line no-console
+    console.error(e) // eslint-disable-line no-console
   });
 } else {
   main();

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,7 +3,9 @@ import main from '../mastodon/main';
 if (!window.Intl || !Object.assign || !Number.isNaN ||
     !window.Symbol || !Array.prototype.includes) {
   // load polyfills dynamically
-  import('../mastodon/polyfills').then(main);
+  import('../mastodon/polyfills').then(main).catch(e => {
+    console.log(e)
+  });
 } else {
   main();
 }


### PR DESCRIPTION
Hi -  #2985 changed how polyfills were being imported. This did not work for me in Safari 9 until I made the following changes:

- ~Call `main()` after the import completes.~
- ~Since none of the code in the import was "run", import the intl polyfill.~
- Catch promise error to help determine my error: need to run `yarn update`
- Make import promise catch a noop with commented out console.log for a debugging hint.