### PR TITLE
Add reserved usernames

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,6 +46,9 @@ class Account < ApplicationRecord
   include Attachmentable
   include Targetable
 
+  word_data = ReservedUsernameList.all
+  VALID_RESERVED_WORDS = word_data.map{ |word| word.word }
+
   # Local users
   has_one :user, inverse_of: :account
 
@@ -54,7 +57,7 @@ class Account < ApplicationRecord
 
   # Local user validations
   with_options if: 'local?' do
-    validates :username, format: { with: /\A[a-z0-9_]+\z/i }, uniqueness: { scope: :domain, case_sensitive: false }, length: { maximum: 30 }
+    validates :username, format: { with: /\A[a-z0-9_]+\z/i }, uniqueness: { scope: :domain, case_sensitive: false }, length: { maximum: 30 }, exclusion: {in: VALID_RESERVED_WORDS}
     validates :display_name, length: { maximum: 30 }
     validates :note, length: { maximum: 160 }
   end

--- a/app/models/reserved_username_list.rb
+++ b/app/models/reserved_username_list.rb
@@ -1,0 +1,2 @@
+class ReservedUsernameList < ApplicationRecord
+end

--- a/db/migrate/20170514034222_create_reserved_username_lists.rb
+++ b/db/migrate/20170514034222_create_reserved_username_lists.rb
@@ -1,0 +1,7 @@
+class CreateReservedUsernameLists < ActiveRecord::Migration[5.0]
+  def change
+    create_table :reserved_username_lists do |t|
+      t.string :word
+    end
+  end
+end

--- a/db/reserved_username.json
+++ b/db/reserved_username.json
@@ -1,0 +1,14 @@
+[
+  "admin",
+  "administrator",
+  "root",
+  "master",
+  "webmaster",
+  "system",
+  "owner",
+  "register",
+  "official",
+  "staff",
+  "support",
+  "help"
+]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,15 @@
+require 'json'
+
 Doorkeeper::Application.create!(name: 'Web', superapp: true, redirect_uri: Doorkeeper.configuration.native_redirect_uri, scopes: 'read write follow')
 
 if Rails.env.development?
   domain = ENV['LOCAL_DOMAIN'] || Rails.configuration.x.local_domain
   admin  = Account.where(username: 'admin').first_or_create!(username: 'admin')
   User.where(email: "admin@#{domain}").first_or_initialize(email: "admin@#{domain}", password: 'mastodonadmin', password_confirmation: 'mastodonadmin', confirmed_at: Time.now.utc, admin: true, account: admin).save!
+end
+
+reserved_words = JSON.parse(File.read('db/reserved_username.json'))
+
+reserved_words.each do |word|
+  ReservedUsernameList.create(word: word)
 end


### PR DESCRIPTION
I suggest reserving these words "system, official, owner, master, register, staff, support, admin, etc.".
At least, I added them as reserved usernames in developing another service.
Please let me know your opinions on this.