### PR TITLE
l10n: Improve RTL detection (Stopgap until language detection improves)

### DIFF
--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -54,7 +54,7 @@ module StreamEntriesHelper
       # Remove mentions before counting characters to decide RTL ratio
       justtext = text.gsub(Account::MENTION_RE, '')
       # Remove Email addresses
-      justtext = justtext.gsub(/^([a-z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,6})$/, '')
+      # justtext = justtext.gsub(/^([a-z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,6})$/, '')
       # Naiive catcher for URLs
       justtext = justtext.gsub(/[-A-Za-z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-A-Za-z0-9@:%_\+.~#?&\/=]*)/, '')
 

--- a/app/javascript/mastodon/rtl.js
+++ b/app/javascript/mastodon/rtl.js
@@ -26,9 +26,7 @@ export function isRtl(text) {
   // Remove mentions before counting characters to decide RTL ratio
   text = text.replace(/@[0-9A-Za-z_@]+/g, '');
   // Remove Email addresses
-  text = text.replace(/^([a-z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,6})$/, '');
-  // Naiive catcher for HTML tags
-  text = text.replace(/<[A-Za-z\/]+[^>]*>/g, '');
+  // text = text.replace(/^([a-z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,6})$/, '');
   // Naiive catcher for URLs
   text = text.replace(/[-A-Za-z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-A-Za-z0-9@:%_\+.~#?&//=]*)/g, '');
 

--- a/app/javascript/mastodon/rtl.js
+++ b/app/javascript/mastodon/rtl.js
@@ -23,5 +23,14 @@ export function isRtl(text) {
     return false;
   }
 
+  // Remove mentions before counting characters to decide RTL ratio
+  text = text.replace(/@[0-9A-Za-z_@]+/g, '');
+  // Remove Email addresses
+  text = text.replace(/^([a-z0-9_\.-]+)@([\da-z\.-]+)\.([a-z\.]{2,6})$/, '');
+  // Naiive catcher for HTML tags
+  text = text.replace(/<[A-Za-z\/]+[^>]*>/g, '');
+  // Naiive catcher for URLs
+  text = text.replace(/[-A-Za-z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-A-Za-z0-9@:%_\+.~#?&//=]*)/g, '');
+
   return matches.length / text.trim().length > 0.3;
 };

--- a/spec/helpers/stream_entries_helper_spec.rb
+++ b/spec/helpers/stream_entries_helper_spec.rb
@@ -219,5 +219,9 @@ RSpec.describe StreamEntriesHelper, type: :helper do
     it 'is true if right to left characters are greater than 1/3 of total text' do
       expect(helper).to be_rtl 'aaݟ'
     end
+
+    it 'is true if right to left characters are greater than 1/3 of total text after removing mentions, Emails and HTML' do
+      expect(helper).to be_rtl 'mastodon@something.social <span><a href="https://nothing.org">goooooogle.com</a></span> @u1 @_2 @U3@space @4_fathers עברית שפה יפה, תתעלמו מהלטינית'
+    end
   end
 end


### PR DESCRIPTION
Not too happy with the extra regex lines in JS (makes the compose box quite slower once the first RTL char is typed), but it decides directonality way better in the toot-deck UI

It seems this fixes #2350, however since even more toots are now classified as RTL than before, bug #2588 is happens even more often, which is unfortunate...