### PR TITLE
Add heroku's APT buildpack for scalingo.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
+https://github.com/heroku/heroku-buildpack-apt
 https://github.com/Scalingo/nodejs-buildpack
 https://github.com/Scalingo/ruby-buildpack


### PR DESCRIPTION
Commit 83138697 made it impossible to deploy new versions on Scalingo due to introducing dependencies on the package manager.  As such, pull in Heroku's APT buildpack for Scalingo too, so that builds on Scalingo also invoke the package manager.