### PR TITLE
Add browserslist config for autoprefixer

### DIFF
--- a/.postcssrc.yml
+++ b/.postcssrc.yml
@@ -1,4 +1,8 @@
 plugins:
   postcss-smart-import: {}
   precss: {}
-  autoprefixer: {}
+  autoprefixer:
+    browsers:
+      - last 2 versions
+      - IE >= 11
+      - iOS >= 9


### PR DESCRIPTION
We will reduce the weight of the style sheet by specifying the target web browser of `autoprefixer`.

### before

```plain
public/packs/vendor-6c645ec47343f0ee66da.css 31052 bytes
public/packs/application-6c645ec47343f0ee66da.css 104463 bytes
```

### after

```plain
public/packs/vendor-2d92c3002c107f053ef7.css 30594 bytes
public/packs/application-2d92c3002c107f053ef7.css 98673 bytes
```