### PR TITLE
Update capistrano lock version to 3.8.1

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lock '3.8.0'
+lock '3.8.1'
 
 set :repo_url, ENV.fetch('REPO', 'https://github.com/tootsuite/mastodon.git')
 set :branch, ENV.fetch('BRANCH', 'master')


### PR DESCRIPTION
> $ bundle exec cap -T
> (Backtrace restricted to imported tasks)
> cap aborted!
> Capfile locked at 3.8.0, but 3.8.1 is loaded

