### PR TITLE
Optimize Status#permitted_for 24x

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -55,7 +55,7 @@ class Status < ApplicationRecord
   validates_with StatusLengthValidator
   validates :reblog, uniqueness: { scope: :account }, if: 'reblog?'
 
-  default_scope { order('id desc') }
+  default_scope { order(id: :desc) }
 
   scope :remote, -> { where.not(uri: nil) }
   scope :local, -> { where(uri: nil) }

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -202,18 +202,21 @@ class Status < ApplicationRecord
     end
 
     def permitted_for(target_account, account)
-      return where.not(visibility: [:private, :direct]) if account.nil?
+      visibility = [:public, :unlisted]
 
-      if target_account.blocking?(account) # get rid of blocked peeps
+      if account.nil?
+        where(visibility: visibility)
+      elsif target_account.blocking?(account) # get rid of blocked peeps
         none
       elsif account.id == target_account.id # author can see own stuff
         all
-      elsif account.following?(target_account) # followers can see followers-only stuff, but also things they are mentioned in
-        joins('LEFT OUTER JOIN mentions ON statuses.id = mentions.status_id AND mentions.account_id = ' + account.id.to_s)
-          .where('statuses.visibility != ? OR mentions.id IS NOT NULL', Status.visibilities[:direct])
-      else # non-followers can see everything that isn't private/direct, but can see stuff they are mentioned in
-        joins('LEFT OUTER JOIN mentions ON statuses.id = mentions.status_id AND mentions.account_id = ' + account.id.to_s)
-          .where('statuses.visibility NOT IN (?) OR mentions.id IS NOT NULL', [Status.visibilities[:direct], Status.visibilities[:private]])
+      else
+        # followers can see followers-only stuff, but also things they are mentioned in.
+        # non-followers can see everything that isn't private/direct, but can see stuff they are mentioned in.
+        visibility.push(:private) if account.following?(target_account)
+
+        joins("LEFT OUTER JOIN mentions ON statuses.id = mentions.status_id AND mentions.account_id = #{account.id}")
+          .where(arel_table[:visibility].in(visibility).or(Mention.arel_table[:id].not_eq(nil)))
       end
     end
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -217,6 +217,7 @@ class Status < ApplicationRecord
 
         joins("LEFT OUTER JOIN mentions ON statuses.id = mentions.status_id AND mentions.account_id = #{account.id}")
           .where(arel_table[:visibility].in(visibility).or(Mention.arel_table[:id].not_eq(nil)))
+          .order(visibility: :desc)
       end
     end
 

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -439,6 +439,59 @@ RSpec.describe Status, type: :model do
     end
   end
 
+  describe '.permitted_for' do
+    subject { described_class.permitted_for(target_account, account).pluck(:visibility) }
+
+    let(:target_account) { alice }
+    let(:account) { bob }
+    let!(:public_status) { Fabricate(:status, account: target_account, visibility: 'public') }
+    let!(:unlisted_status) { Fabricate(:status, account: target_account, visibility: 'unlisted') }
+    let!(:private_status) { Fabricate(:status, account: target_account, visibility: 'private') }
+
+    let!(:direct_status) do
+      Fabricate(:status, account: target_account, visibility: 'direct').tap do |status|
+        Fabricate(:mention, status: status, account: account)
+      end
+    end
+
+    let!(:other_direct_status) do
+      Fabricate(:status, account: target_account, visibility: 'direct').tap do |status|
+        Fabricate(:mention, status: status)
+      end
+    end
+
+    context 'given nil' do
+      let(:account) { nil }
+      let(:direct_status) { nil }
+      it { is_expected.to eq(%w(unlisted public)) }
+    end
+
+    context 'given blocked account' do
+      before do
+        target_account.block!(account)
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'given same account' do
+      let(:account) { target_account }
+      it { is_expected.to eq(%w(direct direct private unlisted public)) }
+    end
+
+    context 'given followed account' do
+      before do
+        account.follow!(target_account)
+      end
+
+      it { is_expected.to eq(%w(direct private unlisted public)) }
+    end
+
+    context 'given unfollowed account' do
+      it { is_expected.to eq(%w(direct unlisted public)) }
+    end
+  end
+
   describe 'before_create' do
     it 'sets account being replied to correctly over intermediary nodes' do
       first_status = Fabricate(:status, account: bob)


### PR DESCRIPTION
- DRY `#permitted_for`
- Add `order(visibility: desc)`

---

**before**

```
SELECT "statuses"."id", "statuses"."updated_at" FROM "statuses" LEFT OUTER JOIN mentions ON statuses.id = mentions.status_id AND mentions.account_id = X WHERE "statuses"."account_id" = XXX AND (statuses.visibility NOT IN (3,2) OR mentions.id IS NOT NULL) ORDER BY id desc LIMIT 20

Limit  (cost=0.86..1764.33 rows=20 width=16) (actual time=458.269..461.048 rows=20 loops=1)
  ->  Nested Loop Left Join  (cost=0.86..907659.59 rows=10294 width=16) (actual time=458.267..461.039 rows=20 loops=1)
        Join Filter: (statuses.id = mentions.status_id)
        Rows Removed by Join Filter: 2640
        Filter: ((statuses.visibility <> ALL ('{3,2}'::integer[])) OR (mentions.id IS NOT NULL))
        ->  Index Scan Backward using statuses_pkey on statuses  (cost=0.43..885204.23 rows=10294 width=20) (actual time=457.991..459.812 rows=20 loops=1)
              Filter: (account_id = XXX)
              Rows Removed by Filter: 953834
        ->  Materialize  (cost=0.43..477.97 rows=122 width=12) (actual time=0.001..0.033 rows=132 loops=20)
              ->  Index Scan using index_mentions_on_account_id_and_status_id on mentions  (cost=0.43..477.36 rows=122 width=12) (actual time=0.012..0.171 rows=132 loops=1)
                    Index Cond: (account_id = X)
Planning time: 0.283 ms
Execution time: 461.081 ms
```

**after**

```
SELECT "statuses"."id", "statuses"."updated_at" FROM "statuses" LEFT OUTER JOIN mentions ON statuses.id = mentions.status_id AND mentions.account_id = X WHERE "statuses"."account_id" = XXX AND (statuses.visibility NOT IN (3,2) OR mentions.id IS NOT NULL) ORDER BY id desc, "statuses"."visibility" desc LIMIT 20

Limit  (cost=37328.80..37328.85 rows=20 width=20) (actual time=18.820..18.825 rows=20 loops=1)
  ->  Sort  (cost=37328.80..37354.53 rows=10294 width=20) (actual time=18.818..18.823 rows=20 loops=1)
        Sort Key: statuses.id DESC, statuses.visibility DESC
        Sort Method: top-N heapsort  Memory: 26kB
        ->  Hash Right Join  (cost=36577.48..37054.88 rows=10294 width=20) (actual time=13.781..16.643 rows=9070 loops=1)
              Hash Cond: (mentions.status_id = statuses.id)
              Filter: ((statuses.visibility <> ALL ('{3,2}'::integer[])) OR (mentions.id IS NOT NULL))
              Rows Removed by Filter: 31
              ->  Index Scan using index_mentions_on_account_id_and_status_id on mentions  (cost=0.43..477.36 rows=122 width=12) (actual time=0.011..0.153 rows=132 loops=1)
                    Index Cond: (account_id = X)
              ->  Hash  (cost=36448.37..36448.37 rows=10294 width=20) (actual time=13.667..13.667 rows=9101 loops=1)
                    Buckets: 16384  Batches: 1  Memory Usage: 591kB
                    ->  Index Scan using index_statuses_on_account_id on statuses  (cost=0.43..36448.37 rows=10294 width=20) (actual time=0.013..10.439 rows=9101 loops=1)
                          Index Cond: (account_id = XXX)
Planning time: 0.253 ms
Execution time: 18.867 ms
```
