### PR TITLE
Order by symbol value

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -53,7 +53,7 @@ class MediaAttachment < ApplicationRecord
 
   scope :attached, -> { where.not(status_id: nil) }
   scope :local, -> { where(remote_url: '') }
-  default_scope { order('id asc') }
+  default_scope { order(id: :asc) }
 
   def local?
     remote_url.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ApplicationRecord
   validates :locale, inclusion: I18n.available_locales.map(&:to_s), unless: 'locale.nil?'
   validates :email, email: true
 
-  scope :recent,    -> { order('id desc') }
+  scope :recent,    -> { order(id: :desc) }
   scope :admins,    -> { where(admin: true) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
 


### PR DESCRIPTION
arel can not build node from string.
Use symbol instead of string is better way.

---

```
users = User.unscoped

users.order('id desc').to_sql
#=> SELECT "users".* FROM "users" ORDER BY id desc

users.order(id: :desc).to_sql
SELECT "users".* FROM "users" ORDER BY "users"."id" DESC

---

users.order('id desc').arel.orders
#=> ["id desc"]

users.order(id: :desc).arel.orders
#=> [#<Arel::Nodes::Descending:0x007f95a3172830 ..., name=:id>>]
```