### PR TITLE
Make faster ProcessFeedService

### DIFF
--- a/app/services/process_feed_service.rb
+++ b/app/services/process_feed_service.rb
@@ -209,7 +209,7 @@ class ProcessFeedService < BaseService
       if TagManager.instance.web_domain?(url.host)
         Account.find_local(url.path.gsub('/users/', ''))
       else
-        Account.find_by(uri: href) || Account.find_by(url: href) || FetchRemoteAccountService.new.call(href)
+        Account.where(uri: href).or(Account.where(url: href)).first || FetchRemoteAccountService.new.call(href)
       end
     end
 

--- a/db/migrate/20170516072309_add_index_accounts_on_uri.rb
+++ b/db/migrate/20170516072309_add_index_accounts_on_uri.rb
@@ -1,0 +1,6 @@
+class AddIndexAccountsOnUri < ActiveRecord::Migration[5.0]
+  def change
+    add_index :accounts, :uri
+  end
+end
+

--- a/db/migrate/20170516072309_add_index_accounts_on_uri.rb
+++ b/db/migrate/20170516072309_add_index_accounts_on_uri.rb
@@ -3,4 +3,3 @@ class AddIndexAccountsOnUri < ActiveRecord::Migration[5.0]
     add_index :accounts, :uri
   end
 end
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170508230434) do
+ActiveRecord::Schema.define(version: 20170516072309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20170508230434) do
     t.datetime "last_webfingered_at"
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), lower((domain)::text)", name: "index_accounts_on_username_and_domain_lower", using: :btree
+    t.index ["uri"], name: "index_accounts_on_uri", using: :btree
     t.index ["url"], name: "index_accounts_on_url", using: :btree
     t.index ["username", "domain"], name: "index_accounts_on_username_and_domain", unique: true, using: :btree
   end


### PR DESCRIPTION
In our slow queries I found: 
```
SELECT "accounts".* FROM "accounts" WHERE "accounts"."uri" = '...' LIMIT 1;
```

and the query plan is:
```
paon=> EXPLAIN ANALYZE SELECT "accounts".* FROM "accounts" WHERE "accounts"."uri" = '...' LIMIT 1;
 Limit  (cost=0.00..7710.39 rows=1 width=899) (actual time=202.203..202.203 rows=0 loops=1)
   ->  Seq Scan on accounts  (cost=0.00..46262.32 rows=6 width=899) (actual time=202.201..202.201 rows=0 loops=1)
         Filter: ((uri)::text = '...'::text)
         Rows Removed by Filter: 297178
 Planning time: 1.129 ms
 Execution time: 202.238 ms
(6 rows)
```

It is due to `"accounts"."uri"` have no index.

