### PR TITLE
Enable to click/scroll timeline immediately after closing modal

### DIFF
--- a/app/javascript/mastodon/features/ui/components/modal_root.js
+++ b/app/javascript/mastodon/features/ui/components/modal_root.js
@@ -48,9 +48,10 @@ class ModalRoot extends React.PureComponent {
 
   render () {
     const { type, props, onClose } = this.props;
+    const visible = !!type;
     const items = [];
 
-    if (!!type) {
+    if (visible) {
       items.push({
         key: type,
         data: { type, props },
@@ -69,7 +70,7 @@ class ModalRoot extends React.PureComponent {
               const SpecificComponent = MODAL_COMPONENTS[type];
 
               return (
-                <div key={key}>
+                <div key={key} style={{ pointerEvents: visible ? 'auto' : 'none' }}>
                   <div role='presentation' className='modal-root__overlay' style={{ opacity: style.opacity }} onClick={onClose} />
                   <div className='modal-root__container' style={{ opacity: style.opacity, transform: `translateZ(0px) scale(${style.scale})` }}>
                     <SpecificComponent {...props} onClose={onClose} />


### PR DESCRIPTION
Due to the visual effects of TransitionMotion, unable to perform click/scroll on timeline until the modal disappeared completely.

Fixed to allow perform as soon as the modal started to closing.

![](https://i.gyazo.com/561a470e2ca25e8f1bb53cd294b5765b.gif)