### PR TITLE
Refactor Status#ancestors/descendants

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -122,21 +122,13 @@ class Status < ApplicationRecord
   end
 
   def ancestors(account = nil)
-    ids      = Rails.cache.fetch("ancestors:#{id}") { (Status.find_by_sql(['WITH RECURSIVE search_tree(id, in_reply_to_id, path) AS (SELECT id, in_reply_to_id, ARRAY[id] FROM statuses WHERE id = ? UNION ALL SELECT statuses.id, statuses.in_reply_to_id, path || statuses.id FROM search_tree JOIN statuses ON statuses.id = search_tree.in_reply_to_id WHERE NOT statuses.id = ANY(path)) SELECT id FROM search_tree ORDER BY path DESC', id]) - [self]).pluck(:id) }
-    statuses = Status.where(id: ids).group_by(&:id)
-    results  = ids.map { |id| statuses[id]&.first }.compact
-    results  = results.reject { |status| filter_from_context?(status, account) }
-
-    results
+    ids = Rails.cache.fetch("ancestors:#{id}") { (Status.find_by_sql(['WITH RECURSIVE search_tree(id, in_reply_to_id, path) AS (SELECT id, in_reply_to_id, ARRAY[id] FROM statuses WHERE id = ? UNION ALL SELECT statuses.id, statuses.in_reply_to_id, path || statuses.id FROM search_tree JOIN statuses ON statuses.id = search_tree.in_reply_to_id WHERE NOT statuses.id = ANY(path)) SELECT id FROM search_tree ORDER BY path DESC', id]) - [self]).pluck(:id) }
+    find_statuses_from_tree_path(ids, account)
   end
 
   def descendants(account = nil)
-    ids      = (Status.find_by_sql(['WITH RECURSIVE search_tree(id, path) AS (SELECT id, ARRAY[id] FROM statuses WHERE id = ? UNION ALL SELECT statuses.id, path || statuses.id FROM search_tree JOIN statuses ON statuses.in_reply_to_id = search_tree.id WHERE NOT statuses.id = ANY(path)) SELECT id FROM search_tree ORDER BY path', id]) - [self]).pluck(:id)
-    statuses = Status.where(id: ids).group_by(&:id)
-    results  = ids.map { |id| statuses[id].first }
-    results  = results.reject { |status| filter_from_context?(status, account) }
-
-    results
+    ids = (Status.find_by_sql(['WITH RECURSIVE search_tree(id, path) AS (SELECT id, ARRAY[id] FROM statuses WHERE id = ? UNION ALL SELECT statuses.id, path || statuses.id FROM search_tree JOIN statuses ON statuses.in_reply_to_id = search_tree.id WHERE NOT statuses.id = ANY(path)) SELECT id FROM search_tree ORDER BY path', id]) - [self]).pluck(:id)
+    find_statuses_from_tree_path(ids, account)
   end
 
   def non_sensitive_with_media?
@@ -289,6 +281,14 @@ class Status < ApplicationRecord
     else
       thread.account_id
     end
+  end
+
+  def find_statuses_from_tree_path(ids, account)
+    statuses = Status.where(id: ids).to_a
+    statuses.reject! { |status| filter_from_context?(status, account) }
+
+    # Order ancestors/descendants by tree path
+    statuses.sort_by! { |status| ids.index(status.id) }
   end
 
   def filter_from_context?(status, account)


### PR DESCRIPTION
Fixes error.
It seems that similar with https://github.com/tootsuite/mastodon/pull/3036 .

```
*A* `NoMethodError` *occurred while* `GET </api/v1/statuses/XXX/context>` *was processed by* `statuses#context`
Exception
----------------
undefined method 'first' for nil:NilClass

Hostname
----------------
apa002

Backtrace
----------------
app/models/status.rb:112:in `block in descendants'
```