### PR TITLE
Use REDIS_DB in streaming

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -92,6 +92,7 @@ if (cluster.isMaster) {
   const redisParams = {
     host:     process.env.REDIS_HOST     || '127.0.0.1',
     port:     process.env.REDIS_PORT     || 6379,
+    db:       process.env.REDIS_DB       || 0,
     password: process.env.REDIS_PASSWORD,
     url:      process.env.REDIS_URL      || null
   }


### PR DESCRIPTION
According to c997091166ba1801eea3a587c913b020b9b84ce4, REDIS_DB is still used in web/sidekiq (`config/initializers/redis.rb`).
But seems to be not used in streaming.