### PR TITLE
Use DB connection params in .env even on dev/test environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,9 @@
 default: &default
   adapter: postgresql
+  username: <%= ENV['DB_USER'] || '' %>
+  password: <%= ENV['DB_PASS'] || '' %>
+  host: <%= ENV['DB_HOST'] || '' %>
+  port: <%= ENV['DB_PORT'] || '' %>
   pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>
   timeout: 5000
   encoding: unicode

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -68,8 +68,11 @@ if (cluster.isMaster) {
   // Cluster worker
   const pgConfigs = {
     development: {
+      user:     process.env.DB_USER || null,
+      password: process.env.DB_PASS || null,
       database: 'mastodon_development',
-      host:     '/var/run/postgresql',
+      host:     process.env.DB_HOST || '/var/run/postgresql',
+      port:     process.env.DB_PORT || null,
       max:      10
     },
 


### PR DESCRIPTION
Currently, to avoid unix-domain sockets for DB connection or connect to the DB on another host for development environment, we have to edit `streaming/index.js` and so on. This patch allows those customization for dev/test environment with `.env` flie, like `.env.production` for production environment.

Note that I have left DB_NAME because it should be vary between development and test.