### PR TITLE
After remote follow worker specs

### DIFF
--- a/app/workers/after_remote_follow_request_worker.rb
+++ b/app/workers/after_remote_follow_request_worker.rb
@@ -5,15 +5,27 @@ class AfterRemoteFollowRequestWorker
 
   sidekiq_options queue: 'pull', retry: 5
 
+  attr_reader :follow_request
+
   def perform(follow_request_id)
-    follow_request  = FollowRequest.find(follow_request_id)
-    updated_account = FetchRemoteAccountService.new.call(follow_request.target_account.remote_url)
-
-    return if updated_account.nil? || updated_account.locked?
-
-    follow_request.destroy
-    FollowService.new.call(follow_request.account, updated_account.acct)
+    @follow_request = FollowRequest.find(follow_request_id)
+    process_follow_service if processing_required?
   rescue ActiveRecord::RecordNotFound
     true
+  end
+
+  private
+
+  def process_follow_service
+    follow_request.destroy
+    FollowService.new.call(follow_request.account, updated_account.acct)
+  end
+
+  def processing_required?
+    !updated_account.nil? && !updated_account.locked?
+  end
+
+  def updated_account
+    @_updated_account ||= FetchRemoteAccountService.new.call(follow_request.target_account.remote_url)
   end
 end

--- a/app/workers/after_remote_follow_worker.rb
+++ b/app/workers/after_remote_follow_worker.rb
@@ -5,15 +5,27 @@ class AfterRemoteFollowWorker
 
   sidekiq_options queue: 'pull', retry: 5
 
+  attr_reader :follow
+
   def perform(follow_id)
-    follow          = Follow.find(follow_id)
-    updated_account = FetchRemoteAccountService.new.call(follow.target_account.remote_url)
-
-    return if updated_account.nil? || !updated_account.locked?
-
-    follow.destroy
-    FollowService.new.call(follow.account, updated_account.acct)
+    @follow = Follow.find(follow_id)
+    process_follow_service if processing_required?
   rescue ActiveRecord::RecordNotFound
     true
+  end
+
+  private
+
+  def process_follow_service
+    follow.destroy
+    FollowService.new.call(follow.account, updated_account.acct)
+  end
+
+  def updated_account
+    @_updated_account ||= FetchRemoteAccountService.new.call(follow.target_account.remote_url)
+  end
+
+  def processing_required?
+    !updated_account.nil? && updated_account.locked?
   end
 end

--- a/spec/workers/after_remote_follow_request_worker_spec.rb
+++ b/spec/workers/after_remote_follow_request_worker_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AfterRemoteFollowRequestWorker do
+  subject { described_class.new }
+  let(:follow_request) { Fabricate(:follow_request) }
+  describe 'perform' do
+    context 'when the follow_request does not exist' do
+      it 'catches a raise and returns true' do
+        allow(FollowService).to receive(:new)
+        result = subject.perform('aaa')
+
+        expect(result).to eq(true)
+        expect(FollowService).not_to have_received(:new)
+      end
+    end
+
+    context 'when the account cannot be updated' do
+      it 'returns nil and does not call service when account is nil' do
+        allow(FollowService).to receive(:new)
+        service = double(call: nil)
+        allow(FetchRemoteAccountService).to receive(:new).and_return(service)
+
+        result = subject.perform(follow_request.id)
+
+        expect(result).to be_nil
+        expect(FollowService).not_to have_received(:new)
+      end
+
+      it 'returns nil and does not call service when account is locked' do
+        allow(FollowService).to receive(:new)
+        service = double(call: double(locked?: true))
+        allow(FetchRemoteAccountService).to receive(:new).and_return(service)
+
+        result = subject.perform(follow_request.id)
+
+        expect(result).to be_nil
+        expect(FollowService).not_to have_received(:new)
+      end
+    end
+
+    context 'when the account is updated' do
+      it 'calls the follow service and destroys the follow' do
+        follow_service = double(call: nil)
+        allow(FollowService).to receive(:new).and_return(follow_service)
+        account = Fabricate(:account, locked: false)
+        service = double(call: account)
+        allow(FetchRemoteAccountService).to receive(:new).and_return(service)
+
+        result = subject.perform(follow_request.id)
+
+        expect(result).to be_nil
+        expect(follow_service).to have_received(:call).with(follow_request.account, account.acct)
+        expect { follow_request.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/workers/after_remote_follow_worker_spec.rb
+++ b/spec/workers/after_remote_follow_worker_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AfterRemoteFollowWorker do
+  subject { described_class.new }
+  let(:follow) { Fabricate(:follow) }
+  describe 'perform' do
+    context 'when the follow does not exist' do
+      it 'catches a raise and returns true' do
+        allow(FollowService).to receive(:new)
+        result = subject.perform('aaa')
+
+        expect(result).to eq(true)
+        expect(FollowService).not_to have_received(:new)
+      end
+    end
+
+    context 'when the account cannot be updated' do
+      it 'returns nil and does not call service when account is nil' do
+        allow(FollowService).to receive(:new)
+        service = double(call: nil)
+        allow(FetchRemoteAccountService).to receive(:new).and_return(service)
+
+        result = subject.perform(follow.id)
+
+        expect(result).to be_nil
+        expect(FollowService).not_to have_received(:new)
+      end
+
+      it 'returns nil and does not call service when account is not locked' do
+        allow(FollowService).to receive(:new)
+        service = double(call: double(locked?: false))
+        allow(FetchRemoteAccountService).to receive(:new).and_return(service)
+
+        result = subject.perform(follow.id)
+
+        expect(result).to be_nil
+        expect(FollowService).not_to have_received(:new)
+      end
+    end
+
+    context 'when the account is updated' do
+      it 'calls the follow service and destroys the follow' do
+        follow_service = double(call: nil)
+        allow(FollowService).to receive(:new).and_return(follow_service)
+        account = Fabricate(:account, locked: true)
+        service = double(call: account)
+        allow(FetchRemoteAccountService).to receive(:new).and_return(service)
+
+        result = subject.perform(follow.id)
+
+        expect(result).to be_nil
+        expect(follow_service).to have_received(:call).with(follow.account, account.acct)
+        expect { follow.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds coverage, refactors those classes.

A question before this is merged:

- In the case of both workers, we skip the processing if the found account is nil, which makes sense
- In the case of the after remote follow worker, we process for locked accounts and skip processing for unlocked accounts
- In the case of the after remote follow request worker, we process for unlocked and skip for locked

I believe that I preserved this behavior in the spec coverage and in the refactor, but I just want to confirm that that is correct, because I did not do a thorough deep dive through the code to wrap my head around all the places this is used.
