### PR TITLE
Fetch remote image using http.rb

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -44,6 +44,7 @@ class Account < ApplicationRecord
   include AccountAvatar
   include AccountHeader
   include Attachmentable
+  include Remotable
   include Targetable
 
   # Local users

--- a/app/models/concerns/account_avatar.rb
+++ b/app/models/concerns/account_avatar.rb
@@ -26,16 +26,5 @@ module AccountAvatar
     def avatar_static_url
       avatar_content_type == 'image/gif' ? avatar.url(:static) : avatar_original_url
     end
-
-    def avatar_remote_url=(url)
-      parsed_url = Addressable::URI.parse(url).normalize
-
-      return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[:avatar_remote_url] == url
-
-      self.avatar              = URI.parse(parsed_url.to_s)
-      self[:avatar_remote_url] = url
-    rescue OpenURI::HTTPError, OpenSSL::SSL::SSLError, Paperclip::Errors::NotIdentifiedByImageMagickError => e
-      Rails.logger.debug "Error fetching remote avatar: #{e}"
-    end
   end
 end

--- a/app/models/concerns/account_header.rb
+++ b/app/models/concerns/account_header.rb
@@ -26,16 +26,5 @@ module AccountHeader
     def header_static_url
       header_content_type == 'image/gif' ? header.url(:static) : header_original_url
     end
-
-    def header_remote_url=(url)
-      parsed_url = Addressable::URI.parse(url).normalize
-
-      return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[:header_remote_url] == url
-
-      self.header              = URI.parse(parsed_url.to_s)
-      self[:header_remote_url] = url
-    rescue OpenURI::HTTPError, OpenSSL::SSL::SSLError, Paperclip::Errors::NotIdentifiedByImageMagickError => e
-      Rails.logger.debug "Error fetching remote header: #{e}"
-    end
   end
 end

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Remotable
+  include HttpHelper
+  extend ActiveSupport::Concern
+
+  included do
+    attachment_definitions.each_key do |attachment_name|
+      attribute_name = "#{attachment_name}_remote_url".to_sym
+      method_name = "#{attribute_name}=".to_sym
+
+      define_method method_name do |url|
+        parsed_url = Addressable::URI.parse(url).normalize
+
+        return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[attribute_name] == url
+
+        begin
+          response = http_client.get(url)
+
+          return if response.code != 200
+
+          matches  = response.headers['content-disposition']&.match(/filename="([^"]*)"/)
+          filename = matches.nil? ? parsed_url.path.split('/').last : matches[1]
+
+          send("#{attachment_name}=", StringIO.new(response.to_s))
+          send("#{attachment_name}_file_name=", filename)
+
+          self[attribute_name] = url if has_attribute?(attribute_name)
+        rescue HTTP::TimeoutError, OpenSSL::SSL::SSLError, Paperclip::Errors::NotIdentifiedByImageMagickError => e
+          Rails.logger.debug "Error fetching remote #{attachment_name}: #{e}"
+        end
+      end
+    end
+  end
+end

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -46,6 +46,9 @@ class MediaAttachment < ApplicationRecord
                     styles: ->(f) { file_styles f },
                     processors: ->(f) { file_processors f },
                     convert_options: { all: '-quality 90 -strip' }
+
+  include Remotable
+
   validates_attachment_content_type :file, content_type: IMAGE_MIME_TYPES + VIDEO_MIME_TYPES
   validates_attachment_size :file, less_than: 8.megabytes
 
@@ -57,10 +60,6 @@ class MediaAttachment < ApplicationRecord
 
   def local?
     remote_url.blank?
-  end
-
-  def file_remote_url=(url)
-    self.file = URI.parse(Addressable::URI.parse(url).normalize.to_s)
   end
 
   def to_param

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -36,6 +36,7 @@ class PreviewCard < ApplicationRecord
   has_attached_file :image, styles: { original: '120x120#' }, convert_options: { all: '-quality 80 -strip' }
 
   include Attachmentable
+  include Remotable
 
   validates :url, presence: true
   validates_attachment_content_type :image, content_type: IMAGE_MIME_TYPES

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -84,10 +84,10 @@ class FetchLinkCardService < BaseService
 
     page = Nokogiri::HTML(response.to_s)
 
-    card.type        = :link
-    card.title       = meta_property(page, 'og:title') || page.at_xpath('//title')&.content
-    card.description = meta_property(page, 'og:description') || meta_property(page, 'description')
-    card.image       = URI.parse(Addressable::URI.parse(meta_property(page, 'og:image')).normalize.to_s) if meta_property(page, 'og:image')
+    card.type             = :link
+    card.title            = meta_property(page, 'og:title') || page.at_xpath('//title')&.content
+    card.description      = meta_property(page, 'og:description') || meta_property(page, 'description')
+    card.image_remote_url = meta_property(page, 'og:image') if meta_property(page, 'og:image')
 
     return if card.title.blank?
 

--- a/app/services/process_feed_service.rb
+++ b/app/services/process_feed_service.rb
@@ -239,8 +239,8 @@ class ProcessFeedService < BaseService
 
         begin
           media.file_remote_url = link['href']
-          media.save
-        rescue OpenURI::HTTPError, OpenSSL::SSL::SSLError, Paperclip::Errors::NotIdentifiedByImageMagickError
+          media.save!
+        rescue ActiveRecord::RecordInvalid
           next
         end
       end


### PR DESCRIPTION
Preview Card cannot be saved if image acquisition fails. Use http.rb to fetch image URL.

### stack trace

```plain
19:06:23 sidekiq.1 | [httplog] GET http://dic.pixiv.net/a/%E3%81%91%E3%82%82%E3%81%AE%E3%83%95%E3%83%AC%E3%83%B3%E3%82%BA completed with status code 200 in 0.1636550000112038 seconds
19:06:23 sidekiq.1 | [httplog] GET http://i.pximg.net:443/c/150x150/img-master/img/2017/04/02/23/09/55/62225052_p0_master1200.jpg completed with status code 403 in 0.007223000007797964 seconds
19:06:23 sidekiq.1 | 2017-05-18T10:06:23.901Z 23760 TID-owvjbrlog LinkCrawlWorker JID-204eed2139d1b876c0341384 INFO: fail: 1.036 sec
19:06:23 sidekiq.1 | 2017-05-18T10:06:23.901Z 23760 TID-owvjbrlog WARN: {"context":"Job raised exception","job":{"class":"LinkCrawlWorker","args":[60],"retry":false,"queue":"pull","jid":"204eed2139d1b876c0341384","created_at":1495101982.86397,"enqueued_at":1495101982.864059},"jobstr":"{\"class\":\"LinkCrawlWorker\",\"args\":[60],\"retry\":false,\"queue\":\"pull\",\"jid\":\"204eed2139d1b876c0341384\",\"created_at\":1495101982.86397,\"enqueued_at\":1495101982.864059}"}
19:06:23 sidekiq.1 | 2017-05-18T10:06:23.901Z 23760 TID-owvjbrlog WARN: OpenURI::HTTPError: 403 Forbidden
19:06:23 sidekiq.1 | 2017-05-18T10:06:23.901Z 23760 TID-owvjbrlog WARN: /Users/ykzts/.rbenv/versions/2.4.1/lib/ruby/2.4.0/open-uri.rb:363:in `open_http'
19:06:23 sidekiq.1 | /Users/ykzts/.rbenv/versions/2.4.1/lib/ruby/2.4.0/open-uri.rb:741:in `buffer_open'
19:06:23 sidekiq.1 | /Users/ykzts/.rbenv/versions/2.4.1/lib/ruby/2.4.0/open-uri.rb:212:in `block in open_loop'
19:06:23 sidekiq.1 | /Users/ykzts/.rbenv/versions/2.4.1/lib/ruby/2.4.0/open-uri.rb:210:in `catch'
19:06:23 sidekiq.1 | /Users/ykzts/.rbenv/versions/2.4.1/lib/ruby/2.4.0/open-uri.rb:210:in `open_loop'
19:06:23 sidekiq.1 | /Users/ykzts/.rbenv/versions/2.4.1/lib/ruby/2.4.0/open-uri.rb:151:in `open_uri'
19:06:23 sidekiq.1 | /Users/ykzts/.rbenv/versions/2.4.1/lib/ruby/2.4.0/open-uri.rb:721:in `open'
19:06:23 sidekiq.1 | /Users/ykzts/.rbenv/versions/2.4.1/lib/ruby/2.4.0/open-uri.rb:31:in `open'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/paperclip-5.1.0/lib/paperclip/io_adapters/uri_adapter.rb:48:in `download_content'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/paperclip-5.1.0/lib/paperclip/io_adapters/uri_adapter.rb:9:in `initialize'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/paperclip-5.1.0/lib/paperclip/io_adapters/registry.rb:29:in `new'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/paperclip-5.1.0/lib/paperclip/io_adapters/registry.rb:29:in `for'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/paperclip-5.1.0/lib/paperclip/attachment.rb:100:in `assign'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/paperclip-5.1.0/lib/paperclip/has_attached_file.rb:66:in `block in define_setter'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/app/services/fetch_link_card_service.rb:90:in `attempt_opengraph'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/app/services/fetch_link_card_service.rb:20:in `call'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/app/workers/link_crawl_worker.rb:9:in `perform'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:204:in `execute_job'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:175:in `block (2 levels) in process'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/middleware/chain.rb:128:in `block in invoke'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-unique-jobs-5.0.8/lib/sidekiq_unique_jobs/server/middleware.rb:17:in `call'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/middleware/chain.rb:133:in `invoke'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:174:in `block in process'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:146:in `block (6 levels) in dispatch'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/job_retry.rb:97:in `local'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:145:in `block (5 levels) in dispatch'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/rails.rb:43:in `block in call'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.3/lib/active_support/execution_wrapper.rb:85:in `wrap'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.3/lib/active_support/reloader.rb:68:in `block in wrap'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.3/lib/active_support/execution_wrapper.rb:85:in `wrap'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.3/lib/active_support/reloader.rb:67:in `wrap'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/rails.rb:42:in `call'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:141:in `block (4 levels) in dispatch'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:220:in `stats'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:136:in `block (3 levels) in dispatch'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/job_logger.rb:8:in `call'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:135:in `block (2 levels) in dispatch'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/job_retry.rb:72:in `global'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:134:in `block in dispatch'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/logging.rb:32:in `with_context'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:133:in `dispatch'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:173:in `process'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:85:in `process_one'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/processor.rb:73:in `run'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/util.rb:17:in `watchdog'
19:06:23 sidekiq.1 | /Users/ykzts/works/ykzts/mastodon/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.0/lib/sidekiq/util.rb:26:in `block in safe_thread'
```