### PR TITLE
Add transform-runtime for smaller Babel helpers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -32,7 +32,15 @@
     },
     "production": {
       "plugins": [
-        "lodash"
+        "lodash",
+        [
+          "transform-runtime",
+          {
+            "helpers": true,
+            "polyfill": false,
+            "regenerator": false
+          }
+        ]
       ]
     },
     "test": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx-self": "^6.22.0",
     "babel-plugin-transform-react-jsx-source": "^6.22.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.4.0",
     "babel-preset-react": "^6.11.1",
     "coffee-loader": "^0.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,6 +984,12 @@ babel-plugin-transform-runtime@6.15.0:
   dependencies:
     babel-runtime "^6.9.0"
 
+babel-plugin-transform-runtime@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
This reduces the size of `application.js` from 1049385 bytes (~1.05M) to 1023583 bytes (~1.02M) by adding `babel-plugin-transform-runtime` with `{helpers: true}`. The size of the other packs are unchanged.

The [babel-plugin-runtime-transform](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime) page explains how this works, but basically this takes a lot of inline helpers that Babel inserts for things like class-to-function transforms and externalizes them to a single module, so it cuts down on the overall code size.

(I chose to disable `polyfills` and `regenerator` to avoid the increase in bundle size, but if we want to support IE11 we can turn on `polyfills: true` and it will add ~8KB to `common.js` due to the `Promise`/`Map` polyfills. I haven't tested yet to see if it actually fixes IE11, but in any case we can do that in another PR.)