### PR TITLE
refactor: Import from react-router/lib

### DIFF
--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -13,14 +13,12 @@ import {
 import { showOnboardingOnce } from '../actions/onboarding';
 import { updateNotifications, refreshNotifications } from '../actions/notifications';
 import createBrowserHistory from 'history/lib/createBrowserHistory';
-import {
-  applyRouterMiddleware,
-  useRouterHistory,
-  Router,
-  Route,
-  IndexRedirect,
-  IndexRoute
-} from 'react-router';
+import applyRouterMiddleware from 'react-router/lib/applyRouterMiddleware';
+import useRouterHistory from 'react-router/lib/useRouterHistory';
+import Router from 'react-router/lib/Router';
+import Route from 'react-router/lib/Route';
+import IndexRedirect from 'react-router/lib/IndexRedirect';
+import IndexRoute from 'react-router/lib/IndexRoute';
 import { useScroll } from 'react-router-scroll';
 import UI from '../features/ui';
 import Status from '../features/status';

--- a/app/javascript/mastodon/features/account/components/action_bar.js
+++ b/app/javascript/mastodon/features/account/components/action_bar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
 import DropdownMenu from '../../../components/dropdown_menu';
-import { Link } from 'react-router';
+import Link from 'react-router/lib/Link';
 import { defineMessages, injectIntl, FormattedMessage, FormattedNumber } from 'react-intl';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/compose/components/navigation_bar.js
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.js
@@ -5,7 +5,7 @@ import IconButton from '../../../components/icon_button';
 import DisplayName from '../../../components/display_name';
 import Permalink from '../../../components/permalink';
 import { FormattedMessage } from 'react-intl';
-import { Link } from 'react-router';
+import Link from 'react-router/lib/Link';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 class NavigationBar extends ImmutablePureComponent {

--- a/app/javascript/mastodon/features/compose/components/search_results.js
+++ b/app/javascript/mastodon/features/compose/components/search_results.js
@@ -3,7 +3,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import AccountContainer from '../../../containers/account_container';
 import StatusContainer from '../../../containers/status_container';
-import { Link } from 'react-router';
+import Link from 'react-router/lib/Link';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 class SearchResults extends ImmutablePureComponent {

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -5,7 +5,7 @@ import NavigationContainer from './containers/navigation_container';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { mountCompose, unmountCompose } from '../../actions/compose';
-import { Link } from 'react-router';
+import Link from 'react-router/lib/Link';
 import { injectIntl, defineMessages } from 'react-intl';
 import SearchContainer from './containers/search_container';
 import { Motion, spring } from 'react-motion';

--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Column from '../ui/components/column';
 import ColumnLink from '../ui/components/column_link';
 import ColumnSubheading from '../ui/components/column_subheading';
-import { Link } from 'react-router';
+import Link from 'react-router/lib/Link';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';

--- a/app/javascript/mastodon/features/home_timeline/index.js
+++ b/app/javascript/mastodon/features/home_timeline/index.js
@@ -5,7 +5,7 @@ import StatusListContainer from '../ui/containers/status_list_container';
 import Column from '../ui/components/column';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import ColumnSettingsContainer from './containers/column_settings_container';
-import { Link } from 'react-router';
+import Link from 'react-router/lib/Link';
 
 const messages = defineMessages({
   title: { id: 'column.home', defaultMessage: 'Home' }

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -7,7 +7,7 @@ import StatusContent from '../../../components/status_content';
 import MediaGallery from '../../../components/media_gallery';
 import VideoPlayer from '../../../components/video_player';
 import AttachmentList from '../../../components/attachment_list';
-import { Link } from 'react-router';
+import Link from 'react-router/lib/Link';
 import { FormattedDate, FormattedNumber } from 'react-intl';
 import CardContainer from '../containers/card_container';
 import ImmutablePureComponent from 'react-immutable-pure-component';

--- a/app/javascript/mastodon/features/ui/components/column_link.js
+++ b/app/javascript/mastodon/features/ui/components/column_link.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
+import Link from 'react-router/lib/Link';
 
 const ColumnLink = ({ icon, text, to, href, method, hideOnMobile }) => {
   if (href) {

--- a/app/javascript/mastodon/features/ui/components/tabs_bar.js
+++ b/app/javascript/mastodon/features/ui/components/tabs_bar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router';
+import Link from 'react-router/lib/Link';
 import { FormattedMessage } from 'react-intl';
 
 class TabsBar extends React.Component {


### PR DESCRIPTION
Instead of importing the entire library, cherry-pick the components we use. This is [supported and encouraged](https://github.com/ReactTraining/react-router/blob/v3/docs/guides/MinimizingBundleSize.md) by `react-router`, reducing the bundle size. Some more information [here](https://github.com/react-boilerplate/react-boilerplate/pull/1608/).

Before:

```bash
> $ ls -l --block-size=KB public/packs | grep 'application.*.js'
-rw-r--r-- 1 sorin sorin 1050kB May 18 18:36 application-93f93183b8bdeebdd845.js
-rw-r--r-- 1 sorin sorin  239kB May 18 18:36 application-93f93183b8bdeebdd845.js.gz
-rw-r--r-- 1 sorin sorin 6286kB May 18 18:36 application-93f93183b8bdeebdd845.js.map
```

After:
```bash
> $ ls -l --block-size=KB public/packs | grep 'application.*.js'
-rw-r--r-- 1 sorin sorin 1041kB May 18 18:37 application-fc40a9bde77c0b630973.js
-rw-r--r-- 1 sorin sorin  236kB May 18 18:37 application-fc40a9bde77c0b630973.js.gz
-rw-r--r-- 1 sorin sorin 6220kB May 18 18:37 application-fc40a9bde77c0b630973.js.map
```