### PR TITLE
feat(babel): Strip prop types

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -33,13 +33,16 @@
     "production": {
       "plugins": [
         "lodash",
-        ["transform-react-remove-prop-types", {
-          "mode": "remove",
-          "removeImport": true,
-          "additionalLibraries": [
-            "react-immutable-proptypes"
-          ]
-        }],
+        [
+          "transform-react-remove-prop-types",
+          {
+            "mode": "remove",
+            "removeImport": true,
+            "additionalLibraries": [
+              "react-immutable-proptypes"
+            ]
+          }
+        ],
         [
           "transform-runtime",
           {

--- a/.babelrc
+++ b/.babelrc
@@ -33,6 +33,13 @@
     "production": {
       "plugins": [
         "lodash",
+        ["transform-react-remove-prop-types", {
+          "mode": "remove",
+          "removeImport": true,
+          "additionalLibraries": [
+            "react-immutable-proptypes"
+          ]
+        }],
         [
           "transform-runtime",
           {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx-self": "^6.22.0",
     "babel-plugin-transform-react-jsx-source": "^6.22.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.5",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.4.0",
     "babel-preset-react": "^6.11.1",
@@ -104,7 +105,6 @@
   "devDependencies": {
     "@kadira/storybook": "^2.35.3",
     "babel-eslint": "^7.2.2",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.5",
     "chai": "^3.5.0",
     "chai-enzyme": "^0.6.1",
     "enzyme": "^2.8.2",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   "devDependencies": {
     "@kadira/storybook": "^2.35.3",
     "babel-eslint": "^7.2.2",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.5",
     "chai": "^3.5.0",
     "chai-enzyme": "^0.6.1",
     "enzyme": "^2.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -964,6 +964,12 @@ babel-plugin-transform-react-jsx@^6.3.13:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.0.0"
 
+babel-plugin-transform-react-remove-prop-types@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.5.tgz#79d1958437ae23d4fbc0b11d1a041498ddb23877"
+  dependencies:
+    babel-traverse "^6.24.1"
+
 babel-plugin-transform-regenerator@6.16.1:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz#a75de6b048a14154aae14b0122756c5bed392f59"


### PR DESCRIPTION
No need to ship our `propTypes`. Unfortunately this does not strip them from imported modules and does not remove the two modules from the bundle.

Before:
```bash
> ls -l --block-size=KB public/packs | grep 'application.*.js'
-rw-r--r-- 1 sorin sorin 1015kB May 19 01:22 application-e2333eb5abd97b680820.js
-rw-r--r-- 1 sorin sorin  241kB May 19 01:22 application-e2333eb5abd97b680820.js.gz
-rw-r--r-- 1 sorin sorin 6357kB May 19 01:22 application-e2333eb5abd97b680820.js.map
```

After:
```bash
> ls -l --block-size=KB public/packs | grep 'application.*.js'
-rw-r--r-- 1 sorin sorin 1007kB May 19 01:26 application-4cc778a2892b9ed4f620.js
-rw-r--r-- 1 sorin sorin  240kB May 19 01:26 application-4cc778a2892b9ed4f620.js.gz
-rw-r--r-- 1 sorin sorin 6305kB May 19 01:26 application-4cc778a2892b9ed4f620.js.map
```