### PR TITLE
Improve how params from controller are permitted in filter helper

### DIFF
--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -18,14 +18,18 @@ module Admin::FilterHelper
   private
 
   def filter_params(more_params)
-    params.permit(FILTERS).merge(more_params)
+    controller_request_params.merge(more_params)
   end
 
   def filter_link_class(new_url)
-    filtered_url_for(params) == new_url ? 'selected' : ''
+    filtered_url_for(controller_request_params) == new_url ? 'selected' : ''
   end
 
-  def filtered_url_for(params)
-    url_for filter_params(params)
+  def filtered_url_for(url_params)
+    url_for filter_params(url_params)
+  end
+
+  def controller_request_params
+    params.permit(FILTERS)
   end
 end


### PR DESCRIPTION
The `params` variable here was quite overloaded.

It exists via the controller to hold the request params, and was sometimes being
used in this helper as that object, but other times was being used as a local
variable, or to pass to another method, and this was confusing.

This change renames the args for a method away from `params` for more clarity,
and extracts the actual usage of the controller-provided `params` to a
better-named method for clarity.