### PR TITLE
Enable caching dependencies in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 cache:
-  bundler: false
-  yarn: false
+  bundler: true
+  yarn: true
+  directories:
+  - node_modules
 dist: trusty
 sudo: false
 


### PR DESCRIPTION
By caching dependencies, CI will be completed quickly.
