### PR TITLE
Make FeedInsertWorker to perform with followers in batches.

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -23,8 +23,8 @@ class FeedManager
 
   def push(timeline_type, accounts, status)
     accounts = Array.wrap(accounts)
-    accounts = accounts.reject do |account|
-      filter?(timeline_type, status, account.id) || !insert_and_check(timeline_type, status, account)
+    accounts = accounts.select do |account|
+      insert_and_check(timeline_type, status, account)
     end
 
     PushUpdateWorker.perform_async(accounts.map(&:id), status.id) unless accounts.empty?

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -21,20 +21,29 @@ class FeedManager
     end
   end
 
-  def push(timeline_type, account, status)
-    timeline_key = key(timeline_type, account.id)
+  def push(timeline_type, accounts, status)
+    accounts = Array.wrap(accounts)
+    accounts = accounts.reject do |account|
+      filter?(timeline_type, status, account.id) || !insert_and_check(timeline_type, status, account)
+    end
+
+    PushUpdateWorker.perform_async(accounts.map(&:id), status.id) unless accounts.empty?
+  end
+
+  def insert_and_check(type, status, account)
+    timeline_key = key(type, account.id)
 
     if status.reblog?
       # If the original status is within 40 statuses from top, do not re-insert it into the feed
       rank = redis.zrevrank(timeline_key, status.reblog_of_id)
-      return if !rank.nil? && rank < 40
+      return false if !rank.nil? && rank < 40
       redis.zadd(timeline_key, status.id, status.reblog_of_id)
     else
       redis.zadd(timeline_key, status.id, status.id)
-      trim(timeline_type, account.id)
+      trim(type, account.id)
     end
 
-    PushUpdateWorker.perform_async(account.id, status.id)
+    true
   end
 
   def trim(type, account_id)

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -34,8 +34,19 @@ class FanOutOnWriteService < BaseService
   def deliver_to_followers(status)
     Rails.logger.debug "Delivering status #{status.id} to followers"
 
-    status.account.followers.where(domain: nil).joins(:user).where('users.current_sign_in_at > ?', 14.days.ago).select(:id).reorder(nil).find_each do |follower|
-      FeedInsertWorker.perform_async(status.id, follower.id)
+    followers = status.account.followers.where(domain: nil).joins(:user).where('users.current_sign_in_at > ?', 14.days.ago).select(:id).reorder(nil)
+
+    batch_size = Rails.configuration.x.fan_out_job_batch_size
+    if batch_size > 1
+      followers.find_in_batches do |group|
+        group.each_slice(batch_size) do |batch|
+          FeedInsertWorker.perform_async(status.id, batch.map(&:id))
+        end
+      end
+    else
+      followers.find_each do |follower|
+        FeedInsertWorker.perform_async(status.id, follower.id)
+      end
     end
   end
 

--- a/app/workers/push_update_worker.rb
+++ b/app/workers/push_update_worker.rb
@@ -3,12 +3,13 @@
 class PushUpdateWorker
   include Sidekiq::Worker
 
-  def perform(account_id, status_id)
-    account = Account.find(account_id)
-    status  = Status.find(status_id)
-    message = InlineRenderer.render(status, account, 'api/v1/statuses/show')
+  def perform(account_ids, status_id)
+    status = Status.find(status_id)
+    Account.where(id: account_ids).each do |account|
+      message = InlineRenderer.render(status, account, 'api/v1/statuses/show')
 
-    Redis.current.publish("timeline:#{account.id}", Oj.dump(event: :update, payload: message, queued_at: (Time.now.to_f * 1000.0).to_i))
+      Redis.current.publish("timeline:#{account.id}", Oj.dump(event: :update, payload: message, queued_at: (Time.now.to_f * 1000.0).to_i))
+    end
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/config/initializers/fan_out_on_write_service.rb
+++ b/config/initializers/fan_out_on_write_service.rb
@@ -1,0 +1,1 @@
+Rails.configuration.x.fan_out_job_batch_size = ENV.fetch('FAN_OUT_JOB_BATCH_SIZE') { 1 }.to_i

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -138,7 +138,6 @@ RSpec.describe FeedManager do
     let(:instance) { FeedManager.instance }
 
     it 'performs pushing updates into home timelines' do
-      allow(instance).to receive(:filter?).and_return false
       allow(instance).to receive(:insert_and_check).and_return true
       expect(PushUpdateWorker).to receive(:perform_async).with(accounts.map(&:id), status.id)
 
@@ -151,13 +150,6 @@ RSpec.describe FeedManager do
 
       reblog = Fabricate(:status, reblog: status)
       instance.push(:home, accounts, reblog)
-    end
-
-    it 'skips pushing update if the accounts are filtered' do
-      allow(instance).to receive(:filter?).and_return true
-      expect(PushUpdateWorker).to_not receive(:perform_async)
-
-      instance.push(:home, accounts, status)
     end
   end
 end

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -131,4 +131,33 @@ RSpec.describe FeedManager do
       end
     end
   end
+
+  describe 'push' do
+    let(:accounts) { [Fabricate(:account), Fabricate(:account)] }
+    let(:status) { Fabricate(:status) }
+    let(:instance) { FeedManager.instance }
+
+    it 'performs pushing updates into home timelines' do
+      allow(instance).to receive(:filter?).and_return false
+      allow(instance).to receive(:insert_and_check).and_return true
+      expect(PushUpdateWorker).to receive(:perform_async).with(accounts.map(&:id), status.id)
+
+      instance.push(:home, accounts, status)
+    end
+
+    it 'skips pushing update if the status is reblog and within top 40 statuses' do
+      allow(instance).to receive(:insert_and_check).and_return false
+      expect(PushUpdateWorker).to_not receive(:perform_async)
+
+      reblog = Fabricate(:status, reblog: status)
+      instance.push(:home, accounts, reblog)
+    end
+
+    it 'skips pushing update if the accounts are filtered' do
+      allow(instance).to receive(:filter?).and_return true
+      expect(PushUpdateWorker).to_not receive(:perform_async)
+
+      instance.push(:home, accounts, status)
+    end
+  end
 end


### PR DESCRIPTION
This PR is a feature request for performance.

FeedInsertWorker and PushUpdateWorker spawn for each followers when the toot is post.
It causes request N+1 queries by each toots.

This PR reduces the number of queries by processing followers in batches.
By default, the feature is disabled, and enabled by setting `FAN_OUT_BATCH_JOB_SIZE` to 2 or more.

In Pawoo, the number of Sidekiq jobs became 1/3 and CPU utilization decreased in the both RDB and Application (`FAN_OUT_BATCH_JOB_SIZE=4`).

How do you like it?