### PR TITLE
Unify the method of extracting tags

### DIFF
--- a/app/lib/extractor.rb
+++ b/app/lib/extractor.rb
@@ -30,4 +30,30 @@ module Extractor
     end
     possible_entries
   end
+
+  def extract_hashtags_with_indices(text, _options = {})
+    return [] unless text =~ /#/
+
+    tags = []
+    text.scan(Tag::HASHTAG_RE) do |hash_text, _|
+      match_data = $LAST_MATCH_INFO
+      start_position = match_data.char_begin(1) - 1
+      end_position = match_data.char_end(1)
+      after = $'
+      if after =~ %r{\A://}
+        hash_text.match(/(.+)(https?\Z)/) do |matched|
+          hash_text = matched[1]
+          end_position -= matched[2].char_length
+        end
+      end
+
+      tags << {
+        hashtag: hash_text,
+        indices: [start_position, end_position],
+      }
+    end
+
+    tags.each { |tag| yield tag[:hashtag], tag[:indices].first, tag[:indices].last } if block_given?
+    tags
+  end
 end

--- a/app/services/process_hashtags_service.rb
+++ b/app/services/process_hashtags_service.rb
@@ -2,7 +2,7 @@
 
 class ProcessHashtagsService < BaseService
   def call(status, tags = [])
-    tags = status.text.scan(Tag::HASHTAG_RE).map(&:first) if status.local?
+    tags = Extractor.extract_hashtags(status.text) if status.local?
 
     tags.map { |str| str.mb_chars.downcase }.uniq(&:to_s).each do |tag|
       status.tags << Tag.where(name: tag).first_or_initialize(name: tag)


### PR DESCRIPTION
The tag extracting method is different between tag link generation and tag generation.
For example, in the case of the tag `#テスト・テスト`, it was saved in the database as `#テスト`.
So you may not be able to search tags with tag links.

This problem can be solved by unifying the method of extracting tags.
I changed to use Mastodon's regular expression.
