### PR TITLE
Avoid useless renders

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -49,6 +49,7 @@ rules:
   no-trailing-spaces: warn
 
   react/jsx-wrap-multilines: error
+  react/jsx-no-bind: error
   react/self-closing-comp: error
   react/prop-types: error
   react/no-multi-comp: off

--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -146,7 +146,7 @@ class AutosuggestTextarea extends ImmutablePureComponent {
   }
 
   onSuggestionClick (e) {
-    const suggestion = parseInt(e.currentTarget.getAttribute('data-index'), 10);
+    const suggestion = Number(e.currentTarget.getAttribute('data-index'));
     e.preventDefault();
     this.props.onSuggestionSelected(this.state.tokenStart, this.state.lastToken, suggestion);
     this.textarea.focus();

--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -145,7 +145,8 @@ class AutosuggestTextarea extends ImmutablePureComponent {
     }, 100);
   }
 
-  onSuggestionClick (suggestion, e) {
+  onSuggestionClick (e) {
+    const suggestion = parseInt(e.currentTarget.getAttribute('data-index'), 10);
     e.preventDefault();
     this.props.onSuggestionSelected(this.state.tokenStart, this.state.lastToken, suggestion);
     this.textarea.focus();
@@ -204,8 +205,9 @@ class AutosuggestTextarea extends ImmutablePureComponent {
               role='button'
               tabIndex='0'
               key={suggestion}
+              data-index={suggestion}
               className={`autosuggest-textarea__suggestions__item ${i === selectedSuggestion ? 'selected' : ''}`}
-              onClick={this.onSuggestionClick.bind(this, suggestion)}>
+              onClick={this.onSuggestionClick}>
               <AutosuggestAccountContainer id={suggestion} />
             </div>
           ))}

--- a/app/javascript/mastodon/components/dropdown_menu.js
+++ b/app/javascript/mastodon/components/dropdown_menu.js
@@ -16,6 +16,12 @@ class DropdownMenu extends React.PureComponent {
     ariaLabel: "Menu"
   };
 
+  constructor(props) {
+    super(props);
+
+    this.handleClick = this.handleClick.bind(this);
+  }
+
   state = {
     direction: 'left'
   };
@@ -24,7 +30,8 @@ class DropdownMenu extends React.PureComponent {
     this.dropdown = c;
   }
 
-  handleClick = (i, e) => {
+  handleClick = (e) => {
+    const i = parseInt(e.currentTarget.getAttribute('data-index'), 10);
     const { action } = this.props.items[i];
 
     if (typeof action === 'function') {
@@ -43,7 +50,7 @@ class DropdownMenu extends React.PureComponent {
 
     return (
       <li className='dropdown__content-list-item' key={ text + i }>
-        <a href={href} target='_blank' rel='noopener' onClick={this.handleClick.bind(this, i)} className='dropdown__content-list-link'>
+        <a href={href} target='_blank' rel='noopener' onClick={this.handleClick} data-index={i} className='dropdown__content-list-link'>
           {text}
         </a>
       </li>

--- a/app/javascript/mastodon/components/dropdown_menu.js
+++ b/app/javascript/mastodon/components/dropdown_menu.js
@@ -16,12 +16,6 @@ class DropdownMenu extends React.PureComponent {
     ariaLabel: "Menu"
   };
 
-  constructor(props) {
-    super(props);
-
-    this.handleClick = this.handleClick.bind(this);
-  }
-
   state = {
     direction: 'left'
   };
@@ -31,7 +25,7 @@ class DropdownMenu extends React.PureComponent {
   }
 
   handleClick = (e) => {
-    const i = parseInt(e.currentTarget.getAttribute('data-index'), 10);
+    const i = Number(e.currentTarget.getAttribute('data-index'));
     const { action } = this.props.items[i];
 
     if (typeof action === 'function') {

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -38,12 +38,6 @@ class Status extends ImmutablePureComponent {
     muted: PropTypes.bool
   };
 
-  constructor (props) {
-    super(props);
-
-    this.handleAccountClick = this.handleAccountClick.bind(this);
-  }
-
   handleClick = () => {
     const { status } = this.props;
     this.context.router.push(`/statuses/${status.getIn(['reblog', 'id'], status.get('id'))}`);
@@ -51,7 +45,7 @@ class Status extends ImmutablePureComponent {
 
   handleAccountClick = (e) => {
     if (e.button === 0) {
-      const id = parseInt(e.currentTarget.getAttribute('data-id'), 10);
+      const id = Number(e.currentTarget.getAttribute('data-id'));
       e.preventDefault();
       this.context.router.push(`/accounts/${id}`);
     }

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -38,13 +38,20 @@ class Status extends ImmutablePureComponent {
     muted: PropTypes.bool
   };
 
+  constructor (props) {
+    super(props);
+
+    this.handleAccountClick = this.handleAccountClick.bind(this);
+  }
+
   handleClick = () => {
     const { status } = this.props;
     this.context.router.push(`/statuses/${status.getIn(['reblog', 'id'], status.get('id'))}`);
   }
 
-  handleAccountClick = (id, e) => {
+  handleAccountClick = (e) => {
     if (e.button === 0) {
+      const id = parseInt(e.currentTarget.getAttribute('data-id'), 10);
       e.preventDefault();
       this.context.router.push(`/accounts/${id}`);
     }
@@ -72,7 +79,7 @@ class Status extends ImmutablePureComponent {
         <div className='status__wrapper'>
           <div className='status__prepend'>
             <div className='status__prepend-icon-wrapper'><i className='fa fa-fw fa-retweet status__prepend-icon' /></div>
-            <FormattedMessage id='status.reblogged_by' defaultMessage='{name} boosted' values={{ name: <a onClick={this.handleAccountClick.bind(this, status.getIn(['account', 'id']))} href={status.getIn(['account', 'url'])} className='status__display-name muted'><strong dangerouslySetInnerHTML={displayNameHTML} /></a> }} />
+            <FormattedMessage id='status.reblogged_by' defaultMessage='{name} boosted' values={{ name: <a onClick={this.handleAccountClick} data-id={status.getIn(['account', 'id'])} href={status.getIn(['account', 'url'])} className='status__display-name muted'><strong dangerouslySetInnerHTML={displayNameHTML} /></a> }} />
           </div>
 
           <Status {...other} wrapped={true} status={status.get('reblog')} account={status.get('account')} />
@@ -103,7 +110,7 @@ class Status extends ImmutablePureComponent {
             <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener'><RelativeTimestamp timestamp={status.get('created_at')} /></a>
           </div>
 
-          <a onClick={this.handleAccountClick.bind(this, status.getIn(['account', 'id']))} href={status.getIn(['account', 'url'])} className='status__display-name'>
+          <a onClick={this.handleAccountClick} data-id={status.getIn(['account', 'id'])} href={status.getIn(['account', 'url'])} className='status__display-name'>
             <div className='status__avatar'>
               {statusAvatar}
             </div>

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
@@ -36,7 +36,8 @@ class PrivacyDropdown extends React.PureComponent {
     this.setState({ open: !this.state.open });
   }
 
-  handleClick = (value, e) => {
+  handleClick = (e) => {
+    const value = e.currentTarget.getAttribute('data-index');
     e.preventDefault();
     this.setState({ open: false });
     this.props.onChange(value);
@@ -80,7 +81,7 @@ class PrivacyDropdown extends React.PureComponent {
         <div className='privacy-dropdown__value'><IconButton className='privacy-dropdown__value-icon' icon={valueOption.icon} title={intl.formatMessage(messages.change_privacy)} size={18} active={open} inverted onClick={this.handleToggle} style={iconStyle}/></div>
         <div className='privacy-dropdown__dropdown'>
           {options.map(item =>
-            <div role='button' tabIndex='0' key={item.value} onClick={this.handleClick.bind(this, item.value)} className={`privacy-dropdown__option ${item.value === value ? 'active' : ''}`}>
+            <div role='button' tabIndex='0' key={item.value} data-index={item.value} onClick={this.handleClick} className={`privacy-dropdown__option ${item.value === value ? 'active' : ''}`}>
               <div className='privacy-dropdown__option__icon'><i className={`fa fa-fw fa-${item.icon}`} /></div>
               <div className='privacy-dropdown__option__content'>
                 <strong>{item.shortText}</strong>

--- a/app/javascript/mastodon/features/compose/components/upload_form.js
+++ b/app/javascript/mastodon/features/compose/components/upload_form.js
@@ -18,14 +18,8 @@ class UploadForm extends React.PureComponent {
     intl: PropTypes.object.isRequired
   };
 
-  constructor(props) {
-    super(props);
-
-    this.onRemoveFile = this.onRemoveFile.bind(this);
-  }
-
-  onRemoveFile (e) {
-    const id = parseInt(e.currentTarget.parentElement.getAttribute('data-id'), 10);
+  onRemoveFile = (e) => {
+    const id = Number(e.currentTarget.parentElement.getAttribute('data-id'));
     this.props.onRemoveFile(id);
   }
 

--- a/app/javascript/mastodon/features/compose/components/upload_form.js
+++ b/app/javascript/mastodon/features/compose/components/upload_form.js
@@ -18,6 +18,17 @@ class UploadForm extends React.PureComponent {
     intl: PropTypes.object.isRequired
   };
 
+  constructor(props) {
+    super(props);
+
+    this.onRemoveFile = this.onRemoveFile.bind(this);
+  }
+
+  onRemoveFile (e) {
+    const id = parseInt(e.currentTarget.parentElement.getAttribute('data-id'), 10);
+    this.props.onRemoveFile(id);
+  }
+
   render () {
     const { intl, media } = this.props;
 
@@ -25,8 +36,8 @@ class UploadForm extends React.PureComponent {
       <div className='compose-form__upload' key={attachment.get('id')}>
         <Motion defaultStyle={{ scale: 0.8 }} style={{ scale: spring(1, { stiffness: 180, damping: 12 }) }}>
           {({ scale }) =>
-            <div className='compose-form__upload-thumbnail' style={{ transform: `translateZ(0) scale(${scale})`, backgroundImage: `url(${attachment.get('preview_url')})` }}>
-              <IconButton icon='times' title={intl.formatMessage(messages.undo)} size={36} onClick={this.props.onRemoveFile.bind(this, attachment.get('id'))} />
+            <div className='compose-form__upload-thumbnail' data-id={attachment.get('id')} style={{ transform: `translateZ(0) scale(${scale})`, backgroundImage: `url(${attachment.get('preview_url')})` }}>
+              <IconButton icon='times' title={intl.formatMessage(messages.undo)} size={36} onClick={this.onRemoveFile} />
             </div>
           }
         </Motion>

--- a/app/javascript/mastodon/features/notifications/components/setting_toggle.js
+++ b/app/javascript/mastodon/features/notifications/components/setting_toggle.js
@@ -4,6 +4,15 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import Toggle from 'react-toggle';
 
 class SettingToggle extends React.PureComponent {
+
+  static propTypes = {
+    settings: ImmutablePropTypes.map.isRequired,
+    settingKey: PropTypes.array.isRequired,
+    label: PropTypes.node.isRequired,
+    onChange: PropTypes.func.isRequired,
+    htmlFor: PropTypes.string
+  }
+
   onChange = (e) => {
     this.props.onChange(this.props.settingKey, e.target.checked);
   }
@@ -12,20 +21,13 @@ class SettingToggle extends React.PureComponent {
     const { settings, settingKey, label, onChange, htmlFor = '' } = this.props;
 
     return (
-    <label htmlFor={htmlFor} className='setting-toggle__label'>
+      <label htmlFor={htmlFor} className='setting-toggle__label'>
         <Toggle checked={settings.getIn(settingKey)} onChange={this.onChange} />
         <span className='setting-toggle'>{label}</span>
       </label>
-    )
+    );
   }
-}
 
-SettingToggle.propTypes = {
-  settings: ImmutablePropTypes.map.isRequired,
-  settingKey: PropTypes.array.isRequired,
-  label: PropTypes.node.isRequired,
-  onChange: PropTypes.func.isRequired,
-  htmlFor: PropTypes.string
-};
+}
 
 export default SettingToggle;

--- a/app/javascript/mastodon/features/notifications/components/setting_toggle.js
+++ b/app/javascript/mastodon/features/notifications/components/setting_toggle.js
@@ -3,12 +3,28 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Toggle from 'react-toggle';
 
-const SettingToggle = ({ settings, settingKey, label, onChange, htmlFor = '' }) => (
-  <label htmlFor={htmlFor} className='setting-toggle__label'>
-    <Toggle checked={settings.getIn(settingKey)} onChange={(e) => onChange(settingKey, e.target.checked)} />
-    <span className='setting-toggle'>{label}</span>
-  </label>
-);
+class SettingToggle extends React.PureComponent {
+  constructor (props) {
+    super(props);
+
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange (e) {
+    this.props.onChange(this.props.settingKey, e.target.checked);
+  }
+
+  render () {
+    const { settings, settingKey, label, onChange, htmlFor = '' } = this.props;
+
+    return (
+    <label htmlFor={htmlFor} className='setting-toggle__label'>
+        <Toggle checked={settings.getIn(settingKey)} onChange={this.onChange} />
+        <span className='setting-toggle'>{label}</span>
+      </label>
+    )
+  }
+}
 
 SettingToggle.propTypes = {
   settings: ImmutablePropTypes.map.isRequired,

--- a/app/javascript/mastodon/features/notifications/components/setting_toggle.js
+++ b/app/javascript/mastodon/features/notifications/components/setting_toggle.js
@@ -4,13 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import Toggle from 'react-toggle';
 
 class SettingToggle extends React.PureComponent {
-  constructor (props) {
-    super(props);
-
-    this.onChange = this.onChange.bind(this);
-  }
-
-  onChange (e) {
+  onChange = (e) => {
     this.props.onChange(this.props.settingKey, e.target.checked);
   }
 

--- a/app/javascript/mastodon/features/ui/components/onboarding_modal.js
+++ b/app/javascript/mastodon/features/ui/components/onboarding_modal.js
@@ -11,6 +11,8 @@ import NavigationBar from '../../compose/components/navigation_bar';
 import ColumnHeader from './column_header';
 import Immutable from 'immutable';
 
+const noop = () => { };
+
 const messages = defineMessages({
   home_title: { id: 'column.home', defaultMessage: 'Home' },
   notifications_title: { id: 'column.notifications', defaultMessage: 'Notifications' },
@@ -48,14 +50,14 @@ const PageTwo = ({ me }) => (
         suggestions={Immutable.List()}
         mentionedDomains={[]}
         spoiler={false}
-        onChange={() => {}}
-        onSubmit={() => {}}
-        onPaste={() => {}}
-        onPickEmoji={() => {}}
-        onChangeSpoilerText={() => {}}
-        onClearSuggestions={() => {}}
-        onFetchSuggestions={() => {}}
-        onSuggestionSelected={() => {}}
+        onChange={noop}
+        onSubmit={noop}
+        onPaste={noop}
+        onPickEmoji={noop}
+        onChangeSpoilerText={noop}
+        onClearSuggestions={noop}
+        onFetchSuggestions={noop}
+        onSuggestionSelected={noop}
       />
     </div>
 
@@ -72,10 +74,10 @@ const PageThree = ({ me, domain }) => (
     <div className='figure non-interactive'>
       <Search
         value=''
-        onChange={() => {}}
-        onSubmit={() => {}}
-        onClear={() => {}}
-        onShow={() => {}}
+        onChange={noop}
+        onSubmit={noop}
+        onClear={noop}
+        onShow={noop}
       />
 
       <div className='pseudo-drawer'>
@@ -173,6 +175,13 @@ class OnboardingModal extends React.PureComponent {
     admin: ImmutablePropTypes.map
   };
 
+  constructor(props) {
+    super(props);
+
+    this.handleNext = this.handleNext.bind(this);
+    this.handleDot = this.handleDot.bind(this);
+  }
+
   state = {
     currentIndex: 0
   };
@@ -182,12 +191,14 @@ class OnboardingModal extends React.PureComponent {
     this.props.onClose();
   }
 
-  handleDot = (i, e) => {
+  handleDot = (e) => {
+    const i = parseInt(e.currentTarget.getAttribute('data-index'), 10);
     e.preventDefault();
     this.setState({ currentIndex: i });
   }
 
-  handleNext = (maxNum, e) => {
+  handleNext = (e) => {
+    const maxNum = parseInt(e.currentTarget.getAttribute('data-length'), 10);
     e.preventDefault();
 
     if (this.state.currentIndex < maxNum - 1) {
@@ -214,9 +225,9 @@ class OnboardingModal extends React.PureComponent {
     let nextOrDoneBtn;
 
     if(hasMore) {
-      nextOrDoneBtn = <a href='#' onClick={this.handleNext.bind(null, pages.length)} className='onboarding-modal__nav onboarding-modal__next'><FormattedMessage id='onboarding.next' defaultMessage='Next' /></a>;
+      nextOrDoneBtn = <a href='#' data-length={pages.length} onClick={this.handleNext} className='onboarding-modal__nav onboarding-modal__next'><FormattedMessage id='onboarding.next' defaultMessage='Next' /></a>;
     } else {
-      nextOrDoneBtn = <a href='#' onClick={this.handleNext.bind(null, pages.length)} className='onboarding-modal__nav onboarding-modal__done'><FormattedMessage id='onboarding.done' defaultMessage='Done' /></a>;
+      nextOrDoneBtn = <a href='#' data-length={pages.length} onClick={this.handleNext} className='onboarding-modal__nav onboarding-modal__done'><FormattedMessage id='onboarding.done' defaultMessage='Done' /></a>;
     }
 
     const styles = pages.map((page, i) => ({
@@ -242,7 +253,7 @@ class OnboardingModal extends React.PureComponent {
           </div>
 
           <div className='onboarding-modal__dots'>
-            {pages.map((_, i) => <div key={i} role='button' tabIndex='0' onClick={this.handleDot.bind(null, i)} className={`onboarding-modal__dot ${i === currentIndex ? 'active' : ''}`} />)}
+            {pages.map((_, i) => <div key={i} role='button' tabIndex='0' data-index={i} onClick={this.handleDot} className={`onboarding-modal__dot ${i === currentIndex ? 'active' : ''}`} />)}
           </div>
 
           <div>

--- a/app/javascript/mastodon/features/ui/components/onboarding_modal.js
+++ b/app/javascript/mastodon/features/ui/components/onboarding_modal.js
@@ -175,13 +175,6 @@ class OnboardingModal extends React.PureComponent {
     admin: ImmutablePropTypes.map
   };
 
-  constructor(props) {
-    super(props);
-
-    this.handleNext = this.handleNext.bind(this);
-    this.handleDot = this.handleDot.bind(this);
-  }
-
   state = {
     currentIndex: 0
   };
@@ -192,13 +185,13 @@ class OnboardingModal extends React.PureComponent {
   }
 
   handleDot = (e) => {
-    const i = parseInt(e.currentTarget.getAttribute('data-index'), 10);
+    const i = Number(e.currentTarget.getAttribute('data-index'));
     e.preventDefault();
     this.setState({ currentIndex: i });
   }
 
   handleNext = (e) => {
-    const maxNum = parseInt(e.currentTarget.getAttribute('data-length'), 10);
+    const maxNum = Number(e.currentTarget.getAttribute('data-length'));
     e.preventDefault();
 
     if (this.state.currentIndex < maxNum - 1) {


### PR DESCRIPTION
I was using [`why-did-you-update`](https://github.com/garbles/why-did-you-update) to see if there are components whose props do not change but they are still rerendered. A couple of them were being passed anonymous function, which basically were always causing a render (bypassing the checks made by `PureComponent`). The same problem is caused by binding functions when passed as props.

This PR binds the callback functions passed as props **once** (avoiding creating hundreds of functions at each render) and uses `data-` attributes to pass the arguments if necessary.

It also enables [`jsx-no-bind`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) in order to avoid this in the future.