### PR TITLE
Fix #2680 - Run processes in Docker as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
  && update-ca-certificates \
  && rm -rf /tmp/* /var/cache/apk/*
 
+RUN adduser --disabled-login -gecos 'Mastodon' mastodon
+
+USER mastodon
+
 COPY Gemfile Gemfile.lock package.json yarn.lock /mastodon/
 
 RUN bundle install --deployment --without test development \


### PR DESCRIPTION
This might create issues for existing users where files in volumes are owned by the root user and cannot be used by the non-root one.

cc @Wonderfall 