### PR TITLE
Fix JavaScript error

### DIFF
--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -46,7 +46,7 @@ const parseFormat = (format) => format.replace(/%(\w)/g, (_, modifier) => {
 });
 
 document.addEventListener('DOMContentLoaded', () => {
-  for (const content of document.getElementsByClassName('emojify')) {
+  for (const content of document.querySelectorAll('.emojify')) {
     content.innerHTML = emojify(content.innerHTML);
   }
 


### PR DESCRIPTION
JavaScript error at Safari 10.1(macOS 10.12.4) / iPhone Safari(iOS 10.3.2)

By the way, IE11 also had an error. But I ignored it.
ref.
https://github.com/tootsuite/mastodon/pull/2913
