### PR TITLE
Enable and fill in JSON response test in API::AccountsController

### DIFF
--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -234,8 +234,23 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
         expect(response).to have_http_status(:success)
       end
 
-      xit 'returns JSON with correct data' do
-        # todo
+      it 'returns JSON with correct data' do
+        json = body_as_json
+
+        expect(json).to be_a Enumerable
+        expect(json.first[:id]).to be simon.id
+        expect(json.first[:following]).to be true
+        expect(json.first[:followed_by]).to be false
+        expect(json.first[:muting]).to be false
+        expect(json.first[:requested]).to be false
+        expect(json.first[:domain_blocking]).to be false
+
+        expect(json.second[:id]).to be lewis.id
+        expect(json.second[:following]).to be false
+        expect(json.second[:followed_by]).to be true
+        expect(json.second[:muting]).to be false
+        expect(json.second[:requested]).to be false
+        expect(json.second[:domain_blocking]).to be false
       end
     end
   end


### PR DESCRIPTION
This PR just fills in a single test that was marked as `TODO` in the `API::AccountsController` spec.