### PR TITLE
feat: Use CSS contain to avoid computations

### DIFF
--- a/app/javascript/mastodon/features/notifications/index.js
+++ b/app/javascript/mastodon/features/notifications/index.js
@@ -100,7 +100,9 @@ class Notifications extends React.PureComponent {
       unread = <div className='notifications__unread-indicator' />;
     }
 
-    if (isLoading || notifications.size > 0) {
+    if (isLoading && this.scrollableArea) {
+      scrollableArea = this.scrollableArea;
+    } else if (notifications.size > 0) {
       scrollableArea = (
         <div className='scrollable' onScroll={this.handleScroll} ref={this.setRef}>
           {unread}
@@ -118,6 +120,8 @@ class Notifications extends React.PureComponent {
         </div>
       );
     }
+
+    this.scrollableArea = scrollableArea;
 
     return (
       <Column icon='bell' active={isUnread} heading={intl.formatMessage(messages.title)}>

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1314,6 +1314,7 @@
 .drawer {
   flex: 1 1 100%;
   overflow: hidden;
+  contain: strict;
 }
 
 @media screen and (min-width: 360px) {
@@ -1488,6 +1489,7 @@
   flex: 1 1 auto;
   backface-visibility: hidden;
   -webkit-overflow-scrolling: touch;
+  contain: strict;
 
   &.optionally-scrollable {
     overflow-y: auto;
@@ -2234,6 +2236,7 @@ button.icon-button.active i.fa-retweet {
   flex: 1 1 auto;
   align-items: center;
   justify-content: center;
+  contain: strict;
 
   a {
     color: $ui-highlight-color;


### PR DESCRIPTION
We use the [`contain`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain) to avoid repaints. [Browser support](http://caniuse.com/#search=contain) is limited to Chrome and Opera (hopefully Edge at some point).

To see what this does, enable Paint Flashing in the Chrome Dev Tools and perform the following on the latest `master`:
- Toggle the Column settings for the Home column - observe that it triggers repaints of the whole page
- Wait for the timer that fetches notifications to fire - two observations:
  - it triggers repaint of elements outside the notification column
  - if there are no notifications, it swaps the "empty view" with the "list view" for a moment (while `isLoading` is true)

This PR limits repaints to the column that triggered them and avoids the fast swapping of the view in the notification column (instead of displaying the "list view" if `isLoading`, we keep the same view that is currently displayed).