### PR TITLE
Fix #2680 - Run processes in Docker as non-root user (alternative)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM ruby:2.4.1-alpine
 LABEL maintainer="https://github.com/tootsuite/mastodon" \
       description="A GNU Social-compatible microblogging server"
 
-ENV RAILS_ENV=production \
-    NODE_ENV=production
+ENV UID=991 GID=991 \
+    RAILS_ENV=production NODE_ENV=production
 
 EXPOSE 3000 4000
 
@@ -31,6 +31,8 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
     imagemagick@edge \
     ca-certificates \
     protobuf \
+    tini \
+    su-exec \
  && npm install -g npm@3 && npm install -g yarn \
  && update-ca-certificates \
  && rm -rf /tmp/* /var/cache/apk/*
@@ -42,4 +44,10 @@ RUN bundle install --deployment --without test development \
 
 COPY . /mastodon
 
+COPY docker_entrypoint.sh /usr/local/bin/run
+
+RUN chmod +x /usr/local/bin/run
+
 VOLUME /mastodon/public/system /mastodon/public/assets /mastodon/public/packs
+
+ENTRYPOINT ["/usr/local/bin/run"]

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+addgroup -g ${GID} mastodon && adduser -h /mastodon -s /bin/sh -D -G mastodon -u ${UID} mastodon
+find /mastodon -path /mastodon/public/system -prune -o -not -user mastodon -not -group mastodon -print0 | xargs -0 chown -f mastodon:mastodon
+su-exec mastodon:mastodon /sbin/tini -- "$@"


### PR DESCRIPTION
Here's an alternative to https://github.com/tootsuite/mastodon/pull/3152.
First, #3152 won't work because it's not using correctly busybox adduser (`--disabled-login` doesn't exist, for example). And another problem is that with #3152, we'll always create a user with the same IDs (`1000`).

This PR was made with flexibility in mind : `UID` and `GID` should be easily set if needed (this can be done using environment variables, defaults are 991). It's also better not to create the user during the build process.

**Suggestion** : do you want to update `docker-compose.yml` or `.env.production`  to show how to configure these environment variables? This is not necessary, but I think it's better for visibility.

That being said, I couldn't make it more "transparent" than https://github.com/tootsuite/mastodon/pull/3152 : this means actual administrators coming from a previous release will have to `chown UID:GID /path/to/public/system`. Otherwise, even with optimisations, this will take too much (and useless) time before the process is run. No problem for new installations though, but this PR will require a release note.