### PR TITLE
Remove unnecessary status__info-time div

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -100,9 +100,7 @@ class Status extends ImmutablePureComponent {
     return (
       <div className={`status ${this.props.muted ? 'muted' : ''} status-${status.get('visibility')}`}>
         <div className='status__info'>
-          <div className='status__info-time'>
-            <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener'><RelativeTimestamp timestamp={status.get('created_at')} /></a>
-          </div>
+          <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener'><RelativeTimestamp timestamp={status.get('created_at')} /></a>
 
           <a onClick={this.handleAccountClick} data-id={status.getIn(['account', 'id'])} href={status.getIn(['account', 'url'])} className='status__display-name'>
             <div className='status__avatar'>

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -606,6 +606,8 @@
 
 .status__relative-time {
   color: lighten($ui-base-color, 26%);
+  float: right;
+  font-size: 14px;
 }
 
 .status__display-name {
@@ -620,11 +622,6 @@
 
 .status__info {
   font-size: 15px;
-}
-
-.status__info-time {
-  float: right;
-  font-size: 14px;
 }
 
 .status-check-box {

--- a/app/javascript/styles/rtl.scss
+++ b/app/javascript/styles/rtl.scss
@@ -62,7 +62,7 @@ body.rtl {
     left: 0;
   }
 
-  .status__info-time {
+  .status__relative-time {
     float: left;
   }
 


### PR DESCRIPTION
This is a very meager perf improvement to reduce the overall number of DOM nodes, but given https://github.com/tootsuite/mastodon/issues/2900 every bit counts. :smile:

This reduces the number of DOM nodes per status by 1, by removing the extra `<div>` around the `<a>`. I checked that it works both for LTR and RTL:

![screenshot 2017-05-20 07 36 43](https://cloud.githubusercontent.com/assets/283842/26276628/a4e49176-3d2f-11e7-9f2a-5ea500f9664f.png)
![screenshot 2017-05-20 07 37 16](https://cloud.githubusercontent.com/assets/283842/26276629/a4e60952-3d2f-11e7-9752-20b6a385096f.png)
