### PR TITLE
Fix block list 500

### DIFF
--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -13,8 +13,8 @@ class Api::V1::BlocksController < ApiController
                                    .paginate_by_max_id(limit_param(DEFAULT_ACCOUNTS_LIMIT), params[:max_id], params[:since_id]))
                        .to_a
 
-    next_path = api_v1_blocks_url(pagination_params(max_id: @accounts.last.blocked_bies.last.id))     if @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
-    prev_path = api_v1_blocks_url(pagination_params(since_id: @accounts.first.blocked_bies.first.id)) unless @accounts.empty?
+    next_path = api_v1_blocks_url(pagination_params(max_id: @accounts.last.blocked_by_ids.last))     if @accounts.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
+    prev_path = api_v1_blocks_url(pagination_params(since_id: @accounts.first.blocked_by_ids.first)) unless @accounts.empty?
 
     set_pagination_headers(next_path, prev_path)
   end


### PR DESCRIPTION
<details>
<summary><code>23:52:55 web.1     | Started GET "/api/v1/blocks" for 127.0.0.1 at 2017-05-20 23:52:55 +0900</code></summary>
<pre><code>23:52:55 web.1     | Processing by Api::V1::BlocksController#index as HTML
23:52:55 web.1     |   Doorkeeper::AccessToken Load (0.4ms)  SELECT  "oauth_access_tokens".* FROM "oauth_access_tokens" WHERE "oauth_access_tokens"."token" = $1 LIMIT $2  [["token", "c75c9a0e013bee11490ac70ea6a71049935b09f89ccfc001dfbdb4b632132175"], ["LIMIT", 1]]
23:52:55 web.1     |   User Load (0.4ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
23:52:55 web.1     |   Account Load (0.4ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
23:52:55 web.1     |    (0.2ms)  BEGIN
23:52:55 web.1     |   SQL (0.5ms)  UPDATE "users" SET "current_sign_in_at" = $1, "last_sign_in_at" = $2, "sign_in_count" = $3, "updated_at" = $4 WHERE "users"."id" = $5  [["current_sign_in_at", "2017-05-20 14:52:55.656428"], ["last_sign_in_at", "2017-05-20 14:52:52.790256"], ["sign_in_count", 935], ["updated_at", "2017-05-20 14:52:55.659926"], ["id", 1]]
23:52:55 web.1     |    (5.6ms)  COMMIT
23:52:55 web.1     |   SQL (1.4ms)  SELECT  DISTINCT "accounts"."id", "blocks"."id" AS alias_0 FROM "accounts" LEFT OUTER JOIN "blocks" ON "blocks"."target_account_id" = "accounts"."id" LEFT OUTER JOIN "accounts" "blocked_bies_accounts" ON "blocked_bies_accounts"."id" = "blocks"."account_id" WHERE "blocks"."account_id" = 1 ORDER BY "blocks"."id" DESC LIMIT $1  [["LIMIT", 40]]
23:52:55 web.1     |   SQL (2.8ms)  SELECT "accounts"."id" AS t0_r0, "accounts"."username" AS t0_r1, "accounts"."domain" AS t0_r2, "accounts"."secret" AS t0_r3, "accounts"."private_key" AS t0_r4, "accounts"."public_key" AS t0_r5, "accounts"."remote_url" AS t0_r6, "accounts"."salmon_url" AS t0_r7, "accounts"."hub_url" AS t0_r8, "accounts"."created_at" AS t0_r9, "accounts"."updated_at" AS t0_r10, "accounts"."note" AS t0_r11, "accounts"."display_name" AS t0_r12, "accounts"."uri" AS t0_r13, "accounts"."url" AS t0_r14, "accounts"."avatar_file_name" AS t0_r15, "accounts"."avatar_content_type" AS t0_r16, "accounts"."avatar_file_size" AS t0_r17, "accounts"."avatar_updated_at" AS t0_r18, "accounts"."header_file_name" AS t0_r19, "accounts"."header_content_type" AS t0_r20, "accounts"."header_file_size" AS t0_r21, "accounts"."header_updated_at" AS t0_r22, "accounts"."avatar_remote_url" AS t0_r23, "accounts"."subscription_expires_at" AS t0_r24, "accounts"."silenced" AS t0_r25, "accounts"."suspended" AS t0_r26, "accounts"."locked" AS t0_r27, "accounts"."header_remote_url" AS t0_r28, "accounts"."statuses_count" AS t0_r29, "accounts"."followers_count" AS t0_r30, "accounts"."following_count" AS t0_r31, "accounts"."last_webfingered_at" AS t0_r32, "blocked_bies_accounts"."id" AS t1_r0, "blocked_bies_accounts"."username" AS t1_r1, "blocked_bies_accounts"."domain" AS t1_r2, "blocked_bies_accounts"."secret" AS t1_r3, "blocked_bies_accounts"."private_key" AS t1_r4, "blocked_bies_accounts"."public_key" AS t1_r5, "blocked_bies_accounts"."remote_url" AS t1_r6, "blocked_bies_accounts"."salmon_url" AS t1_r7, "blocked_bies_accounts"."hub_url" AS t1_r8, "blocked_bies_accounts"."created_at" AS t1_r9, "blocked_bies_accounts"."updated_at" AS t1_r10, "blocked_bies_accounts"."note" AS t1_r11, "blocked_bies_accounts"."display_name" AS t1_r12, "blocked_bies_accounts"."uri" AS t1_r13, "blocked_bies_accounts"."url" AS t1_r14, "blocked_bies_accounts"."avatar_file_name" AS t1_r15, "blocked_bies_accounts"."avatar_content_type" AS t1_r16, "blocked_bies_accounts"."avatar_file_size" AS t1_r17, "blocked_bies_accounts"."avatar_updated_at" AS t1_r18, "blocked_bies_accounts"."header_file_name" AS t1_r19, "blocked_bies_accounts"."header_content_type" AS t1_r20, "blocked_bies_accounts"."header_file_size" AS t1_r21, "blocked_bies_accounts"."header_updated_at" AS t1_r22, "blocked_bies_accounts"."avatar_remote_url" AS t1_r23, "blocked_bies_accounts"."subscription_expires_at" AS t1_r24, "blocked_bies_accounts"."silenced" AS t1_r25, "blocked_bies_accounts"."suspended" AS t1_r26, "blocked_bies_accounts"."locked" AS t1_r27, "blocked_bies_accounts"."header_remote_url" AS t1_r28, "blocked_bies_accounts"."statuses_count" AS t1_r29, "blocked_bies_accounts"."followers_count" AS t1_r30, "blocked_bies_accounts"."following_count" AS t1_r31, "blocked_bies_accounts"."last_webfingered_at" AS t1_r32 FROM "accounts" LEFT OUTER JOIN "blocks" ON "blocks"."target_account_id" = "accounts"."id" LEFT OUTER JOIN "accounts" "blocked_bies_accounts" ON "blocked_bies_accounts"."id" = "blocks"."account_id" WHERE "blocks"."account_id" = 1 AND "accounts"."id" = 2 ORDER BY "blocks"."id" DESC
23:52:55 web.1     | Completed 500 Internal Server Error in 67ms (ActiveRecord: 11.9ms)
23:52:55 web.1     | 
23:52:55 web.1     | 
23:52:55 web.1     | [StatsD] measure mastodon.performance.Api.V1.BlocksController.index.html.localhost.total_duration:66.952
23:52:55 web.1     | [StatsD] measure mastodon.performance.Api.V1.BlocksController.index.html.localhost.db_time:11.911000000000001
23:52:55 web.1     | [StatsD] measure mastodon.performance.Api.V1.BlocksController.index.html.localhost.view_time:1
23:52:55 web.1     | [StatsD] increment mastodon.performance.Api.V1.BlocksController.index.html.localhost.status.:1
23:52:55 web.1     | 
23:52:55 web.1     | NoMethodError - undefined method `blocked_bies' for #<Account:0x007fbc6f052c78>
23:52:55 web.1     | Did you mean?  blocked_by_ids
23:52:55 web.1     |                blocked_by
23:52:55 web.1     |                blocked_by=:
23:52:55 web.1     |   activemodel (5.0.3) lib/active_model/attribute_methods.rb:433:in `method_missing'
23:52:55 web.1     |   app/controllers/api/v1/blocks_controller.rb:17:in `index'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_controller/metal/basic_implicit_render.rb:4:in `send_action'
23:52:55 web.1     |   actionpack (5.0.3) lib/abstract_controller/base.rb:188:in `process_action'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_controller/metal/rendering.rb:30:in `process_action'
23:52:55 web.1     |   actionpack (5.0.3) lib/abstract_controller/callbacks.rb:20:in `block in process_action'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/callbacks.rb:126:in `call'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/callbacks.rb:506:in `block (2 levels) in compile'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/callbacks.rb:455:in `call'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/callbacks.rb:101:in `__run_callbacks__'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/callbacks.rb:750:in `_run_process_action_callbacks'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/callbacks.rb:90:in `run_callbacks'
23:52:55 web.1     |   actionpack (5.0.3) lib/abstract_controller/callbacks.rb:19:in `process_action'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_controller/metal/rescue.rb:20:in `process_action'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/notifications.rb:164:in `block in instrument'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/notifications/instrumenter.rb:21:in `instrument'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/notifications.rb:164:in `instrument'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_controller/metal/instrumentation.rb:30:in `process_action'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_controller/metal/params_wrapper.rb:248:in `process_action'
23:52:55 web.1     |   activerecord (5.0.3) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
23:52:55 web.1     |   actionpack (5.0.3) lib/abstract_controller/base.rb:126:in `process'
23:52:55 web.1     |   actionview (5.0.3) lib/action_view/rendering.rb:30:in `process'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_controller/metal.rb:190:in `dispatch'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_controller/metal.rb:262:in `dispatch'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/routing/route_set.rb:32:in `serve'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/journey/router.rb:39:in `block in serve'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/journey/router.rb:26:in `serve'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/routing/route_set.rb:725:in `call'
23:52:55 web.1     |   bullet (5.5.1) lib/bullet/rack.rb:12:in `call'
23:52:55 web.1     |   http_accept_language (2.1.0) lib/http_accept_language/middleware.rb:14:in `call'
23:52:55 web.1     |   rack (2.0.3) lib/rack/deflater.rb:34:in `call'
23:52:55 web.1     |   rack-attack (5.0.1) lib/rack/attack.rb:140:in `call'
23:52:55 web.1     |   warden (1.2.7) lib/warden/manager.rb:36:in `block in call'
23:52:55 web.1     |   warden (1.2.7) lib/warden/manager.rb:35:in `call'
23:52:55 web.1     |   rack (2.0.3) lib/rack/etag.rb:25:in `call'
23:52:55 web.1     |   rack (2.0.3) lib/rack/conditional_get.rb:25:in `call'
23:52:55 web.1     |   rack (2.0.3) lib/rack/head.rb:12:in `call'
23:52:55 web.1     |   rack (2.0.3) lib/rack/session/abstract/id.rb:232:in `context'
23:52:55 web.1     |   rack (2.0.3) lib/rack/session/abstract/id.rb:226:in `call'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/middleware/cookies.rb:613:in `call'
23:52:55 web.1     |   activerecord (5.0.3) lib/active_record/migration.rb:553:in `call'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/middleware/callbacks.rb:38:in `block in call'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/callbacks.rb:97:in `__run_callbacks__'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/callbacks.rb:750:in `_run_call_callbacks'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/callbacks.rb:90:in `run_callbacks'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/middleware/callbacks.rb:36:in `call'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/middleware/executor.rb:12:in `call'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
23:52:55 web.1     |   better_errors (2.1.1) lib/better_errors/middleware.rb:84:in `protected_app_call'
23:52:55 web.1     |   better_errors (2.1.1) lib/better_errors/middleware.rb:79:in `better_errors_call'
23:52:55 web.1     |   better_errors (2.1.1) lib/better_errors/middleware.rb:57:in `call'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/middleware/debug_exceptions.rb:49:in `call'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
23:52:55 web.1     |   railties (5.0.3) lib/rails/rack/logger.rb:36:in `call_app'
23:52:55 web.1     |   railties (5.0.3) lib/rails/rack/logger.rb:24:in `block in call'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/tagged_logging.rb:69:in `block in tagged'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/tagged_logging.rb:26:in `tagged'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/tagged_logging.rb:69:in `tagged'
23:52:55 web.1     |   railties (5.0.3) lib/rails/rack/logger.rb:24:in `call'
23:52:55 web.1     |   sprockets-rails (3.2.0) lib/sprockets/rails/quiet_assets.rb:13:in `call'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/middleware/request_id.rb:24:in `call'
23:52:55 web.1     |   rack (2.0.3) lib/rack/method_override.rb:22:in `call'
23:52:55 web.1     |   rack (2.0.3) lib/rack/runtime.rb:22:in `call'
23:52:55 web.1     |   rack-timeout (0.4.2) lib/rack/timeout/core.rb:100:in `call'
23:52:55 web.1     |   activesupport (5.0.3) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/middleware/executor.rb:12:in `call'
23:52:55 web.1     |   actionpack (5.0.3) lib/action_dispatch/middleware/static.rb:136:in `call'
23:52:55 web.1     |   rack (2.0.3) lib/rack/sendfile.rb:111:in `call'
23:52:55 web.1     |   rack-cors (0.4.1) lib/rack/cors.rb:81:in `call'
23:52:55 web.1     |   railties (5.0.3) lib/rails/engine.rb:522:in `call'
23:52:55 web.1     |   puma (3.8.2) lib/puma/configuration.rb:224:in `call'
23:52:55 web.1     |   puma (3.8.2) lib/puma/server.rb:600:in `handle_request'
23:52:55 web.1     |   puma (3.8.2) lib/puma/server.rb:435:in `process_client'
23:52:55 web.1     |   puma (3.8.2) lib/puma/server.rb:299:in `block in run'
23:52:55 web.1     |   puma (3.8.2) lib/puma/thread_pool.rb:120:in `block in spawn_thread'</code></pre>
</details>

It seems to be from #3167.
