### PR TITLE
Allow alternate domains for mastodon handlers

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -20,6 +20,11 @@ LOCAL_HTTPS=true
 # DO *NOT* USE THIS UNLESS YOU KNOW *EXACTLY* WHAT YOU ARE DOING.
 # WEB_DOMAIN=mastodon.example.com
 
+# Use this if you want to have several aliases handler@example1.com
+# handler@example2.com etc. for the same user. LOCAL_DOMAIN should not
+# be added. Comma separated values
+# ALTERNATE_DOMAINS=example1.com,example2.com
+
 # Application secrets
 # Generate each with the `rake secret` task (`docker-compose run --rm web rake secret` if you use docker compose)
 PAPERCLIP_SECRET=

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -23,7 +23,14 @@ module WellKnown
     private
 
     def username_from_resource
-      WebfingerResource.new(resource_param).username
+      resource_user = resource_param
+
+      username, domain = resource_user.split('@')
+      if Rails.configuration.x.alternate_domains.include?(domain)
+        resource_user = "#{username}@#{Rails.configuration.x.local_domain}"
+      end
+
+      WebfingerResource.new(resource_user).username
     end
 
     def pem_to_magic_key(public_key)

--- a/config/initializers/ostatus.rb
+++ b/config/initializers/ostatus.rb
@@ -5,11 +5,15 @@ host     = ENV.fetch('LOCAL_DOMAIN') { "localhost:#{port}" }
 web_host = ENV.fetch('WEB_DOMAIN') { host }
 https    = ENV['LOCAL_HTTPS'] == 'true'
 
+alternate_domains = ENV.fetch('ALTERNATE_DOMAINS') { "" }
+
 Rails.application.configure do
   config.x.local_domain = host
   config.x.web_domain   = web_host
   config.x.use_https    = https
   config.x.use_s3       = ENV['S3_ENABLED'] == 'true'
+
+  config.x.alternate_domains = alternate_domains.split(/\s*,\s*/)
 
   config.action_mailer.default_url_options = { host: web_host, protocol: https ? 'https://' : 'http://', trailing_slash: false }
   config.x.streaming_api_base_url          = 'ws://localhost:4000'

--- a/spec/controllers/well_known/webfinger_controller_spec.rb
+++ b/spec/controllers/well_known/webfinger_controller_spec.rb
@@ -6,6 +6,12 @@ describe WellKnown::WebfingerController, type: :controller do
   describe 'GET #show' do
     let(:alice) { Fabricate(:account, username: 'alice') }
 
+    around(:each) do |example|
+      before = Rails.configuration.x.alternate_domains
+      example.run
+      Rails.configuration.x.alternate_domains = before
+    end
+
     it 'returns http success when account can be found' do
       get :show, params: { resource: alice.to_webfinger_s }, format: :json
 
@@ -14,6 +20,24 @@ describe WellKnown::WebfingerController, type: :controller do
 
     it 'returns http not found when account cannot be found' do
       get :show, params: { resource: 'acct:not@existing.com' }, format: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns http success when account can be found with alternate domains' do
+      Rails.configuration.x.alternate_domains = ["foo.org"]
+      username, domain = alice.to_webfinger_s.split("@")
+
+      get :show, params: { resource: "#{username}@foo.org" }, format: :json
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'returns http not found when account can not be found with alternate domains' do
+      Rails.configuration.x.alternate_domains = ["foo.org"]
+      username, domain = alice.to_webfinger_s.split("@")
+
+      get :show, params: { resource: "#{username}@bar.org" }, format: :json
 
       expect(response).to have_http_status(:not_found)
     end


### PR DESCRIPTION
This PR allows to have several alternate domains when looking for a user.

For instance, you may want to have handlers like foo@mastodon.verylongbar.com but allow users to give foo@b.ar as handler as a shorthand.