### PR TITLE
Lazy load toots using IntersectionObserver

### DIFF
--- a/app/javascript/mastodon/base_polyfills.js
+++ b/app/javascript/mastodon/base_polyfills.js
@@ -1,8 +1,6 @@
 import 'intl';
 import 'intl/locale-data/jsonp/en.js';
 import 'es6-symbol/implement';
-import 'intersection-observer';
-import 'requestidlecallback';
 import includes from 'array-includes';
 import assign from 'object-assign';
 import isNaN from 'is-nan';

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -32,11 +32,21 @@ class Status extends ImmutablePureComponent {
     onOpenMedia: PropTypes.func,
     onOpenVideo: PropTypes.func,
     onBlock: PropTypes.func,
+    onRef: PropTypes.func,
+    isIntersecting: PropTypes.bool,
     me: PropTypes.number,
     boostModal: PropTypes.bool,
     autoPlayGif: PropTypes.bool,
     muted: PropTypes.bool,
   };
+
+  handleRef = (node) => {
+    this.props.onRef(node);
+
+    if (node && node.children.length !== 0) {
+      this.height = node.clientHeight;
+    }
+  }
 
   handleClick = () => {
     const { status } = this.props;
@@ -52,12 +62,21 @@ class Status extends ImmutablePureComponent {
   }
 
   render () {
-    let media = '';
+    let media = null;
     let statusAvatar;
-    const { status, account, ...other } = this.props;
+    const { status, account, isIntersecting, onRef, ...other } = this.props;
 
     if (status === null) {
-      return <div />;
+      return <div ref={this.handleRef} data-id={status.get('id')} />;
+    }
+
+    if (!isIntersecting) {
+      return (
+        <div ref={this.handleRef} data-id={status.get('id')} style={{ height: `${this.height}px`, opacity: 0 }}>
+          {status.getIn(['account', 'display_name']) || status.getIn(['account', 'username'])}
+          {status.get('content')}
+        </div>
+      );
     }
 
     if (status.get('reblog', null) !== null && typeof status.get('reblog') === 'object') {
@@ -70,7 +89,7 @@ class Status extends ImmutablePureComponent {
       const displayNameHTML = { __html: emojify(escapeTextContentForBrowser(displayName)) };
 
       return (
-        <div className='status__wrapper'>
+        <div className='status__wrapper' ref={this.handleRef} data-id={status.get('id')} >
           <div className='status__prepend'>
             <div className='status__prepend-icon-wrapper'><i className='fa fa-fw fa-retweet status__prepend-icon' /></div>
             <FormattedMessage id='status.reblogged_by' defaultMessage='{name} boosted' values={{ name: <a onClick={this.handleAccountClick} data-id={status.getIn(['account', 'id'])} href={status.getIn(['account', 'url'])} className='status__display-name muted'><strong dangerouslySetInnerHTML={displayNameHTML} /></a> }} />
@@ -98,7 +117,7 @@ class Status extends ImmutablePureComponent {
     }
 
     return (
-      <div className={`status ${this.props.muted ? 'muted' : ''} status-${status.get('visibility')}`}>
+      <div className={`status ${this.props.muted ? 'muted' : ''} status-${status.get('visibility')}`} data-id={status.get('id')} ref={this.handleRef}>
         <div className='status__info'>
           <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener'><RelativeTimestamp timestamp={status.get('created_at')} /></a>
 

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -17,8 +17,6 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 class Status extends ImmutablePureComponent {
 
-  static RECYCLE_TIMEOUT = 2000
-
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -48,7 +46,7 @@ class Status extends ImmutablePureComponent {
 
   componentWillReceiveProps (nextProps) {
     if (nextProps.isIntersecting === false && this.props.isIntersecting !== false) {
-      setTimeout(() => this.setState({ isHidden: true }), this.RECYCLE_TIMEOUT);
+      requestIdleCallback(() => this.setState({ isHidden: true }));
     } else {
       this.setState({ isHidden: !nextProps.isIntersecting });
     }

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -17,6 +17,8 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 class Status extends ImmutablePureComponent {
 
+  static RECYCLE_TIMEOUT = 2000
+
   static contextTypes = {
     router: PropTypes.object,
   };
@@ -39,6 +41,26 @@ class Status extends ImmutablePureComponent {
     autoPlayGif: PropTypes.bool,
     muted: PropTypes.bool,
   };
+
+  state = {
+    isHidden: false,
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.isIntersecting === false && this.props.isIntersecting !== false) {
+      setTimeout(() => this.setState({ isHidden: true }), this.RECYCLE_TIMEOUT);
+    } else {
+      this.setState({ isHidden: !nextProps.isIntersecting });
+    }
+  }
+
+  shouldComponentUpdate (nextProps, nextState) {
+    if (nextProps.isIntersecting === false && this.props.isIntersecting !== false) {
+      return nextState.isHidden;
+    }
+
+    return true;
+  }
 
   handleRef = (node) => {
     this.props.onRef(node);
@@ -65,12 +87,13 @@ class Status extends ImmutablePureComponent {
     let media = null;
     let statusAvatar;
     const { status, account, isIntersecting, onRef, ...other } = this.props;
+    const { isHidden } = this.state;
 
     if (status === null) {
       return <div ref={this.handleRef} data-id={status.get('id')} />;
     }
 
-    if (isIntersecting === false) {
+    if (isIntersecting === false && isHidden) {
       return (
         <div ref={this.handleRef} data-id={status.get('id')} style={{ height: `${this.height}px`, opacity: 0 }}>
           {status.getIn(['account', 'display_name']) || status.getIn(['account', 'username'])}

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -70,7 +70,7 @@ class Status extends ImmutablePureComponent {
       return <div ref={this.handleRef} data-id={status.get('id')} />;
     }
 
-    if (!isIntersecting) {
+    if (isIntersecting === false) {
       return (
         <div ref={this.handleRef} data-id={status.get('id')} style={{ height: `${this.height}px`, opacity: 0 }}>
           {status.getIn(['account', 'display_name']) || status.getIn(['account', 'username'])}

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -61,10 +61,12 @@ class Status extends ImmutablePureComponent {
   }
 
   handleRef = (node) => {
-    this.props.onRef(node);
+    if (this.props.onRef) {
+      this.props.onRef(node);
 
-    if (node && node.children.length !== 0) {
-      this.height = node.clientHeight;
+      if (node && node.children.length !== 0) {
+        this.height = node.clientHeight;
+      }
     }
   }
 

--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -64,16 +64,16 @@ class StatusList extends ImmutablePureComponent {
 
   attachIntersectionObserver () {
     const onIntersection = (entries) => {
-      const isIntersecting = { };
-
       this.setState(state => {
+        const isIntersecting = { };
+
         entries.forEach(entry => {
           const statusId = entry.target.getAttribute('data-id');
 
           state.isIntersecting[0][statusId] = entry.isIntersecting;
         });
 
-        return [state.isIntersecting[0]];
+        return { isIntersecting: [state.isIntersecting[0]] };
       });
     };
 

--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -79,7 +79,7 @@ class StatusList extends ImmutablePureComponent {
 
     const options = {
       root: this.node,
-      rootMargin: '100% 0px',
+      rootMargin: '300% 0px',
     };
 
     this.intersectionObserver = new IntersectionObserver(onIntersection, options);

--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -27,7 +27,7 @@ class StatusList extends ImmutablePureComponent {
   };
 
   state = {
-    isIntersecting: { },
+    isIntersecting: [{ }],
   }
 
   statusRefQueue = []
@@ -66,15 +66,15 @@ class StatusList extends ImmutablePureComponent {
     const onIntersection = (entries) => {
       const isIntersecting = { };
 
-      entries.forEach(entry => {
-        const statusId = entry.target.getAttribute('data-id');
+      this.setState(state => {
+        entries.forEach(entry => {
+          const statusId = entry.target.getAttribute('data-id');
 
-        isIntersecting[statusId] = entry.isIntersecting;
+          state.isIntersecting[0][statusId] = entry.isIntersecting;
+        });
+
+        return [state.isIntersecting[0]];
       });
-
-      this.setState(state => ({
-        isIntersecting: Object.assign({ }, state.isIntersecting, isIntersecting),
-      }));
     };
 
     const options = {
@@ -122,7 +122,7 @@ class StatusList extends ImmutablePureComponent {
 
   render () {
     const { statusIds, onScrollToBottom, scrollKey, shouldUpdateScroll, isLoading, isUnread, hasMore, prepend, emptyMessage } = this.props;
-    const { isIntersecting } = this.state;
+    const isIntersecting = this.state.isIntersecting[0];
 
     let loadMore       = null;
     let scrollableArea = null;

--- a/app/javascript/mastodon/extra_polyfills.js
+++ b/app/javascript/mastodon/extra_polyfills.js
@@ -1,0 +1,2 @@
+import 'intersection-observer';
+import 'requestidlecallback';

--- a/app/javascript/mastodon/polyfills.js
+++ b/app/javascript/mastodon/polyfills.js
@@ -1,6 +1,7 @@
 import 'intl';
 import 'intl/locale-data/jsonp/en.js';
 import 'es6-symbol/implement';
+import 'intersection-observer';
 import includes from 'array-includes';
 import assign from 'object-assign';
 import isNaN from 'is-nan';

--- a/app/javascript/mastodon/polyfills.js
+++ b/app/javascript/mastodon/polyfills.js
@@ -2,6 +2,7 @@ import 'intl';
 import 'intl/locale-data/jsonp/en.js';
 import 'es6-symbol/implement';
 import 'intersection-observer';
+import 'requestidlecallback';
 import includes from 'array-includes';
 import assign from 'object-assign';
 import isNaN from 'is-nan';

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,7 +1,8 @@
 import main from '../mastodon/main';
 
 if (!window.Intl || !Object.assign || !Number.isNaN ||
-    !window.Symbol || !Array.prototype.includes) {
+    !window.Symbol || !Array.prototype.includes ||
+    !window.IntersectionObserver) {
   // load polyfills dynamically
   import('../mastodon/polyfills').then(main).catch(e => {
     console.error(e); // eslint-disable-line no-console

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -2,7 +2,8 @@ import main from '../mastodon/main';
 
 if (!window.Intl || !Object.assign || !Number.isNaN ||
     !window.Symbol || !Array.prototype.includes ||
-    !window.IntersectionObserver) {
+    !window.IntersectionObserver ||
+    !window.requestIdleCallback) {
   // load polyfills dynamically
   import('../mastodon/polyfills').then(main).catch(e => {
     console.error(e); // eslint-disable-line no-console

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,11 +1,27 @@
 import main from '../mastodon/main';
 
-if (!window.Intl || !Object.assign || !Number.isNaN ||
-    !window.Symbol || !Array.prototype.includes ||
-    !window.IntersectionObserver ||
-    !window.requestIdleCallback) {
-  // load polyfills dynamically
-  import('../mastodon/polyfills').then(main).catch(e => {
+const needsBasePolyfills = !(
+  window.Intl &&
+  Object.assign &&
+  Number.isNaN &&
+  window.Symbol &&
+  Array.prototype.includes
+);
+
+const needsExtraPolyfills = !(
+  window.IntersectionObserver &&
+  window.requestIdleCallback
+);
+
+if (needsBasePolyfills) {
+  Promise.all([
+    import('../mastodon/base_polyfills'),
+    import('../mastodon/extra_polyfills'),
+  ]).then(main).catch(e => {
+    console.error(e); // eslint-disable-line no-console
+  });
+} else if (needsExtraPolyfills) {
+  import('../mastodon/extra_polyfills').then(main).catch(e => {
     console.error(e); // eslint-disable-line no-console
   });
 } else {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,6 +13,9 @@ const needsExtraPolyfills = !(
   window.requestIdleCallback
 );
 
+// Latest version of Firefox and Safari do not have IntersectionObserver.
+// Edge does not have requestIdleCallback.
+// This avoids shipping them all the polyfills.
 if (needsBasePolyfills) {
   Promise.all([
     import('../mastodon/base_polyfills'),

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -554,6 +554,14 @@
   border-bottom: 1px solid lighten($ui-base-color, 8%);
   cursor: default;
 
+  @keyframes fade {
+    0% { opacity: 0; }
+    100% { opacity: 1; }
+  }
+
+  opacity: 1;
+  animation: fade 1s linear;
+
   &.status-direct {
     background: lighten($ui-base-color, 8%);
 

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -560,7 +560,7 @@
   }
 
   opacity: 1;
-  animation: fade 1s linear;
+  animation: fade 0.5s linear;
 
   &.status-direct {
     background: lighten($ui-base-color, 8%);

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -560,7 +560,7 @@
   }
 
   opacity: 1;
-  animation: fade 0.5s linear;
+  animation: fade 0.3s linear;
 
   &.status-direct {
     background: lighten($ui-base-color, 8%);

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "redux": "^3.6.0",
     "redux-immutable": "^3.1.0",
     "redux-thunk": "^2.2.0",
+    "requestidlecallback": "^0.3.0",
     "reselect": "^2.5.4",
     "rimraf": "^2.6.1",
     "sass-loader": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "glob": "^7.1.1",
     "http-link-header": "^0.8.0",
     "immutable": "^3.8.1",
+    "intersection-observer": "^0.2.1",
     "intl": "^1.2.5",
     "is-nan": "^1.2.1",
     "js-yaml": "^3.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,6 +3341,10 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
+intersection-observer@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.2.1.tgz#cb55175f4eebef6436d957a7d1774d39a9248e5e"
+
 intl:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5836,6 +5836,10 @@ request@2, request@2.x, request@^2.74.0, request@^2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
+requestidlecallback@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/requestidlecallback/-/requestidlecallback-0.3.0.tgz#6fb74e0733f90df3faa4838f9f6a2a5f9b742ac5"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"


### PR DESCRIPTION
An attempt at fixing #2900 using  [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) instead of scroll listeners and libraries.

Workflow:
 - Render all the toots and save their height
 - Use `IntersectionObserver` to compute which toots are in the viewport. Toots that are outside get replaced with a `div` containing the author and status content (in order for browser search to continue working). The `div` has the original height, maintaining the list scrolling.
 - Render toots that are visible in the scrolling container plus a few more before and after. This avoids displaying the empty `div` (which has `opacity: 0`).

In case swapping between the actual toot and the placeholder `div` is not fast enough, I have  added a fade-in effect to make the loading appear smoother. You may see this on mobile or if you are scrolling fast.

[Browser support](http://caniuse.com/#feat=intersectionobserver): Chrome and Edge 15. Firefox and WebKit are currently implementing it - the [official WICG polyfill](https://github.com/WICG/IntersectionObserver/tree/gh-pages/polyfill) is used meanwhile.