### PR TITLE
Implement hash tag completion

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -30,6 +30,10 @@ export const COMPOSE_SPOILER_TEXT_CHANGE = 'COMPOSE_SPOILER_TEXT_CHANGE';
 export const COMPOSE_VISIBILITY_CHANGE  = 'COMPOSE_VISIBILITY_CHANGE';
 export const COMPOSE_LISTABILITY_CHANGE = 'COMPOSE_LISTABILITY_CHANGE';
 
+export const COMPOSE_HASH_TAG_CLEAR = 'COMPOSE_HASH_TAG_CLEAR';
+export const COMPOSE_HASH_TAG_READY = 'COMPOSE_HASH_TAG_READY';
+export const COMPOSE_HASH_TAG_SELECT = 'COMPOSE_HASH_TAG_SELECT';
+
 export const COMPOSE_EMOJI_INSERT = 'COMPOSE_EMOJI_INSERT';
 
 export function changeCompose(text) {
@@ -103,6 +107,24 @@ export function submitCompose() {
         if (getState().getIn(['timelines', 'public', 'loaded'])) {
           dispatch(updateTimeline('public', { ...response.data }));
         }
+      }
+
+      const statusTags = response.data.tags.map(it => it.name);
+      let tags = JSON.parse(localStorage.getItem('hash_tag_history'));
+      if (tags === null) {
+        tags = statusTags;
+      } else {
+        tags = tags.filter(it => !statusTags.includes(it));
+        tags.unshift(...statusTags);
+      }
+      const maxSize = 1000;
+      tags = tags.slice(0, maxSize);
+
+      const data = JSON.stringify(tags);
+      try {
+        localStorage.setItem('hash_tag_history', data);
+      } catch (e) {
+        //ignore
       }
     }).catch(function (error) {
       dispatch(submitComposeFail(error));
@@ -275,5 +297,37 @@ export function insertEmojiCompose(position, emoji) {
     type: COMPOSE_EMOJI_INSERT,
     position,
     emoji,
+  };
+};
+
+export function clearComposeHashTagSuggestions() {
+  return {
+    type: COMPOSE_HASH_TAG_CLEAR,
+  };
+};
+
+export function fetchComposeHashTagSuggestions(token) {
+  return (dispatch, _) => {
+    const tags = JSON.parse(localStorage.getItem('hash_tag_history')) || [];
+    const suggestionMaxSize = 4;
+    const suggestions = tags.filter(it => it.startsWith(token)).slice(0, suggestionMaxSize);
+    dispatch(readyComposeHashTagSuggestions(token, suggestions));
+  };
+};
+
+export function readyComposeHashTagSuggestions(token, tags) {
+  return {
+    type: COMPOSE_HASH_TAG_READY,
+    token,
+    tags,
+  };
+}
+
+export function selectComposeHashTagSuggestion(position, token, tag) {
+  return {
+    type: COMPOSE_HASH_TAG_SELECT,
+    position,
+    token,
+    completion: tag,
   };
 };

--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -22,7 +22,7 @@ const textAtCursorMatchesToken = (str, caretPosition, prefix) => {
     return [null, null];
   }
 
-  word = word.trim().slice(1);
+  word = word.trim().toLowerCase().slice(1);
 
   if (word.length > 0) {
     return [left + 1, word];
@@ -38,7 +38,7 @@ const textAtCursorMatchesHashToken = (str, caretPosition) => {
 const textAtCursorMatchesMentionToken = (str, caretPosition) => {
   const token = textAtCursorMatchesToken(str, caretPosition, '@');
   const start = token[0];
-  const word = token[1] === null ? null : token[1].toLowerCase();
+  const word = token[1] === null ? null : token[1];
   return [start, word];
 };
 

--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -72,7 +72,7 @@ class AutosuggestTextarea extends ImmutablePureComponent {
     selectedSuggestion: 0,
     lastToken: null,
     tokenStart: 0,
-    ashTagSuggestionsHidden: false,
+    hashTagSuggestionsHidden: false,
     selectedHashTagSuggestion: 0,
     lastHashTagToken: null,
     hashTagTokenStart: 0,
@@ -194,7 +194,7 @@ class AutosuggestTextarea extends ImmutablePureComponent {
     this.textarea.focus();
   }
 
-  onHashTagSuggestionClick(tag, e) {
+  onHashTagSuggestionClick = (tag, e) => {
     e.preventDefault();
     this.props.onHashTagSuggestionsSelected(this.state.hashTagTokenStart, this.state.lastHashTagToken, tag);
     this.textarea.focus();

--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -6,7 +6,7 @@ import { isRtl } from '../rtl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import Textarea from 'react-textarea-autosize';
 
-const textAtCursorMatchesToken = (str, caretPosition) => {
+const textAtCursorMatchesToken = (str, caretPosition, prefix) => {
   let word;
 
   let left  = str.slice(0, caretPosition).search(/\S+$/);
@@ -18,11 +18,11 @@ const textAtCursorMatchesToken = (str, caretPosition) => {
     word = str.slice(left, right + caretPosition);
   }
 
-  if (!word || word.trim().length < 2 || word[0] !== '@') {
+  if (!word || word.trim().length < 2 || word[0] !== prefix) {
     return [null, null];
   }
 
-  word = word.trim().toLowerCase().slice(1);
+  word = word.trim().slice(1);
 
   if (word.length > 0) {
     return [left + 1, word];
@@ -31,16 +31,31 @@ const textAtCursorMatchesToken = (str, caretPosition) => {
   }
 };
 
+const textAtCursorMatchesHashToken = (str, caretPosition) => {
+  return textAtCursorMatchesToken(str, caretPosition, '#');
+};
+
+const textAtCursorMatchesMentionToken = (str, caretPosition) => {
+  const token = textAtCursorMatchesToken(str, caretPosition, '@');
+  const start = token[0];
+  const word = token[1] === null ? null : token[1].toLowerCase();
+  return [start, word];
+};
+
 class AutosuggestTextarea extends ImmutablePureComponent {
 
   static propTypes = {
     value: PropTypes.string,
     suggestions: ImmutablePropTypes.list,
+    hash_tag_suggestions: ImmutablePropTypes.list,
     disabled: PropTypes.bool,
     placeholder: PropTypes.string,
     onSuggestionSelected: PropTypes.func.isRequired,
     onSuggestionsClearRequested: PropTypes.func.isRequired,
     onSuggestionsFetchRequested: PropTypes.func.isRequired,
+    onHashTagSuggestionsSelected: PropTypes.func.isRequired,
+    onHashTagSuggestionsClearRequested: PropTypes.func.isRequired,
+    onHashTagSuggestionsFetchRequested: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
     onKeyUp: PropTypes.func,
     onKeyDown: PropTypes.func,
@@ -57,10 +72,14 @@ class AutosuggestTextarea extends ImmutablePureComponent {
     selectedSuggestion: 0,
     lastToken: null,
     tokenStart: 0,
+    ashTagSuggestionsHidden: false,
+    selectedHashTagSuggestion: 0,
+    lastHashTagToken: null,
+    hashTagTokenStart: 0,
   };
 
   onChange = (e) => {
-    const [ tokenStart, token ] = textAtCursorMatchesToken(e.target.value, e.target.selectionStart);
+    const [ tokenStart, token ] = textAtCursorMatchesMentionToken(e.target.value, e.target.selectionStart);
 
     if (token !== null && this.state.lastToken !== token) {
       this.setState({ lastToken: token, selectedSuggestion: 0, tokenStart });
@@ -70,12 +89,20 @@ class AutosuggestTextarea extends ImmutablePureComponent {
       this.props.onSuggestionsClearRequested();
     }
 
+    const [hashTagTokenStart, hashToken] = textAtCursorMatchesHashToken(e.target.value, e.target.selectionStart);
+    if (hashToken !== null && this.state.lastHashTagToken !== hashToken) {
+      this.setState({lastHashTagToken: hashToken, selectedHashTagSuggestion: 0, hashTagTokenStart});
+      this.props.onHashTagSuggestionsFetchRequested(hashToken);
+    } else if (hashToken === null) {
+      this.setState({lastHashTagToken: null});
+      this.props.onHashTagSuggestionsClearRequested();
+    }
     this.props.onChange(e);
   }
 
   onKeyDown = (e) => {
-    const { suggestions, disabled } = this.props;
-    const { selectedSuggestion, suggestionsHidden } = this.state;
+    const { suggestions, disabled, hash_tag_suggestions } = this.props;
+    const { selectedSuggestion, suggestionsHidden, hashTagSuggestionsHidden, selectedHashTagSuggestion } = this.state;
 
     if (disabled) {
       e.preventDefault();
@@ -89,11 +116,21 @@ class AutosuggestTextarea extends ImmutablePureComponent {
         this.setState({ suggestionsHidden: true });
       }
 
+      if (!hashTagSuggestionsHidden) {
+        e.preventDefault();
+        this.setState({ hashTagSuggestionsHidden: true });
+      }
+
       break;
     case 'ArrowDown':
       if (suggestions.size > 0 && !suggestionsHidden) {
         e.preventDefault();
         this.setState({ selectedSuggestion: Math.min(selectedSuggestion + 1, suggestions.size - 1) });
+      }
+
+      if (hash_tag_suggestions.size > 0 && !hashTagSuggestionsHidden) {
+        e.preventDefault();
+        this.setState({ selectedHashTagSuggestion: Math.min(selectedHashTagSuggestion + 1, hash_tag_suggestions.size - 1)});
       }
 
       break;
@@ -103,14 +140,31 @@ class AutosuggestTextarea extends ImmutablePureComponent {
         this.setState({ selectedSuggestion: Math.max(selectedSuggestion - 1, 0) });
       }
 
+      if (hash_tag_suggestions.size > 0 && !hashTagSuggestionsHidden) {
+        e.preventDefault();
+        this.setState({ selectedHashTagSuggestion: Math.max(selectedHashTagSuggestion -1, 0)});
+      }
+
       break;
     case 'Enter':
     case 'Tab':
+      // Note: Ignore the event of Confirm Conversion of IME
+      if (e.keyCode === 229) {
+        break;
+      }
+
       // Select suggestion
       if (this.state.lastToken !== null && suggestions.size > 0 && !suggestionsHidden) {
         e.preventDefault();
         e.stopPropagation();
         this.props.onSuggestionSelected(this.state.tokenStart, this.state.lastToken, suggestions.get(selectedSuggestion));
+      }
+
+      if (this.state.lastHashTagToken !== null && hash_tag_suggestions.size > 0 && !hashTagSuggestionsHidden) {
+        e.preventDefault();
+        e.stopPropagation();
+        this.props.onHashTagSuggestionsSelected(this.state.hashTagTokenStart,
+          this.state.lastHashTagToken, hash_tag_suggestions.get(selectedHashTagSuggestion));
       }
 
       break;
@@ -140,9 +194,20 @@ class AutosuggestTextarea extends ImmutablePureComponent {
     this.textarea.focus();
   }
 
+  onHashTagSuggestionClick(tag, e) {
+    e.preventDefault();
+    this.props.onHashTagSuggestionsSelected(this.state.hashTagTokenStart, this.state.lastHashTagToken, tag);
+    this.textarea.focus();
+  }
+
   componentWillReceiveProps (nextProps) {
     if (nextProps.suggestions !== this.props.suggestions && nextProps.suggestions.size > 0 && this.state.suggestionsHidden) {
       this.setState({ suggestionsHidden: false });
+    }
+
+    if (nextProps.hash_tag_suggestions !== this.props.hash_tag_suggestions &&
+      nextProps.hash_tag_suggestions.size > 0 && this.state.hashTagSuggestionsHidden) {
+      this.setState({hashTagSuggestionsHidden: false});
     }
   }
 
@@ -157,10 +222,27 @@ class AutosuggestTextarea extends ImmutablePureComponent {
     }
   }
 
+  renderHashTagSuggestion(tag, i) {
+    const {selectedHashTagSuggestion} = this.state;
+    const onClick = this.onHashTagSuggestionClick.bind(this, tag);
+
+    return (
+      <div
+        role='button'
+        tabIndex='0'
+        key={tag}
+        className={`autosuggest-textarea__suggestions__item ${i === selectedHashTagSuggestion ? 'selected' : ''}`}
+        onClick={onClick}>
+        #{tag}
+      </div>
+    );
+  }
+
   render () {
-    const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus } = this.props;
-    const { suggestionsHidden, selectedSuggestion } = this.state;
+    const { value, suggestions, hash_tag_suggestions, disabled, placeholder, onKeyUp, autoFocus } = this.props;
+    const { suggestionsHidden, selectedSuggestion, hashTagSuggestionsHidden } = this.state;
     const style = { direction: 'ltr' };
+    const renderHashTagSuggestion = (tag, i) => this.renderHashTagSuggestion(tag, i);
 
     if (isRtl(value)) {
       style.direction = 'rtl';
@@ -195,6 +277,11 @@ class AutosuggestTextarea extends ImmutablePureComponent {
               <AutosuggestAccountContainer id={suggestion} />
             </div>
           ))}
+        </div>
+
+        <div style={{display: (hash_tag_suggestions.size > 0 && !hashTagSuggestionsHidden) ? 'block' : 'none'}}
+             className='autosuggest-textarea__suggestions'>
+          {hash_tag_suggestions.map(renderHashTagSuggestion)}
         </div>
       </div>
     );

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -33,6 +33,8 @@ class ComposeForm extends ImmutablePureComponent {
     text: PropTypes.string.isRequired,
     suggestion_token: PropTypes.string,
     suggestions: ImmutablePropTypes.list,
+    hash_tag_suggestions: ImmutablePropTypes.list,
+    hash_tag_token: PropTypes.string,
     spoiler: PropTypes.bool,
     privacy: PropTypes.string,
     spoiler_text: PropTypes.string,
@@ -50,6 +52,9 @@ class ComposeForm extends ImmutablePureComponent {
     onPaste: PropTypes.func.isRequired,
     onPickEmoji: PropTypes.func.isRequired,
     showSearch: PropTypes.bool,
+    onHashTagSuggestionsClearRequested: PropTypes.func.isRequired,
+    onHashTagSuggestionsFetchRequested: PropTypes.func.isRequired,
+    onHashTagSuggestionsSelected: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -81,6 +86,19 @@ class ComposeForm extends ImmutablePureComponent {
   onSuggestionSelected = (tokenStart, token, value) => {
     this._restoreCaret = null;
     this.props.onSuggestionSelected(tokenStart, token, value);
+  }
+
+  onHashTagSuggestionsClearRequested = () => {
+    this.props.onHashTagSuggestionsClearRequested();
+  }
+
+  onHashTagSuggestionsFetchRequested = (token) => {
+    this.props.onHashTagSuggestionsFetchRequested(token);
+  }
+
+  onHashTagSuggestionsSelected = (tokenStart, token, value) => {
+    this._restoreCaret = null;
+    this.props.onHashTagSuggestionsSelected(tokenStart, token, value);
   }
 
   handleChangeSpoilerText = (e) => {
@@ -145,7 +163,6 @@ class ComposeForm extends ImmutablePureComponent {
     } else {
       publishText = this.props.privacy !== 'unlisted' ? intl.formatMessage(messages.publishLoud, { publish: intl.formatMessage(messages.publish) }) : intl.formatMessage(messages.publish);
     }
-
     return (
       <div className='compose-form'>
         <Collapsable isVisible={this.props.spoiler} fullHeight={50}>
@@ -164,12 +181,16 @@ class ComposeForm extends ImmutablePureComponent {
             placeholder={intl.formatMessage(messages.placeholder)}
             disabled={disabled}
             value={this.props.text}
+            hash_tag_suggestions={this.props.hash_tag_suggestions}
             onChange={this.handleChange}
             suggestions={this.props.suggestions}
             onKeyDown={this.handleKeyDown}
             onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
             onSuggestionsClearRequested={this.onSuggestionsClearRequested}
             onSuggestionSelected={this.onSuggestionSelected}
+            onHashTagSuggestionsFetchRequested={this.onHashTagSuggestionsFetchRequested}
+            onHashTagSuggestionsClearRequested={this.onHashTagSuggestionsClearRequested}
+            onHashTagSuggestionsSelected={this.onHashTagSuggestionsSelected}
             onPaste={onPaste}
             autoFocus={!showSearch}
           />

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -9,12 +9,17 @@ import {
   selectComposeSuggestion,
   changeComposeSpoilerText,
   insertEmojiCompose,
+  clearComposeHashTagSuggestions,
+  fetchComposeHashTagSuggestions,
+  selectComposeHashTagSuggestion,
 } from '../../../actions/compose';
 
 const mapStateToProps = state => ({
   text: state.getIn(['compose', 'text']),
   suggestion_token: state.getIn(['compose', 'suggestion_token']),
   suggestions: state.getIn(['compose', 'suggestions']),
+  hash_tag_suggestions: state.getIn(['compose', 'hash_tag_suggestions']),
+  hash_tag_token: state.getIn(['compose', 'hash_tag_token']),
   spoiler: state.getIn(['compose', 'spoiler']),
   spoiler_text: state.getIn(['compose', 'spoiler_text']),
   privacy: state.getIn(['compose', 'privacy']),
@@ -46,6 +51,18 @@ const mapDispatchToProps = (dispatch) => ({
 
   onSuggestionSelected (position, token, accountId) {
     dispatch(selectComposeSuggestion(position, token, accountId));
+  },
+
+  onHashTagSuggestionsClearRequested() {
+    dispatch(clearComposeHashTagSuggestions());
+  },
+
+  onHashTagSuggestionsFetchRequested(token) {
+    dispatch(fetchComposeHashTagSuggestions(token));
+  },
+
+  onHashTagSuggestionsSelected(tokenStart, token, value) {
+    dispatch(selectComposeHashTagSuggestion(tokenStart, token, value));
   },
 
   onChangeSpoilerText (checked) {

--- a/app/javascript/mastodon/features/ui/components/onboarding_modal.js
+++ b/app/javascript/mastodon/features/ui/components/onboarding_modal.js
@@ -49,6 +49,7 @@ const PageTwo = ({ me }) => (
       <ComposeForm
         text='Awoo! #introductions'
         suggestions={Immutable.List()}
+        hash_tag_suggestions={Immutable.List()}
         mentionedDomains={[]}
         spoiler={false}
         onChange={noop}
@@ -59,6 +60,9 @@ const PageTwo = ({ me }) => (
         onClearSuggestions={noop}
         onFetchSuggestions={noop}
         onSuggestionSelected={noop}
+        onHashTagSuggestionsClearRequested={noop}
+        onHashTagSuggestionsFetchRequested={noop}
+        onHashTagSuggestionsSelected={noop}
       />
     </div>
 


### PR DESCRIPTION
This PR implements completion of hashtags.
The tooted hashtag is included in the candidate.
Candidates are stored localStorage.

<img width="285" alt="2017-05-21 15 23 35" src="https://cloud.githubusercontent.com/assets/2792624/26281766/1b462da4-3e3c-11e7-9c9b-ec29371bdce3.png">
