### PR TITLE
Allow access token in URI for streaming API

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -199,8 +199,9 @@ if (cluster.isMaster) {
     }
 
     const authorization = req.get('Authorization');
+    const accessToken = req.query.access_token;
 
-    if (!authorization) {
+    if (!authorization && !accessToken) {
       const err = new Error('Missing access token');
       err.statusCode = 401;
 
@@ -208,7 +209,7 @@ if (cluster.isMaster) {
       return;
     }
 
-    const token = authorization.replace(/^Bearer /, '');
+    const token = authorization ? authorization.replace(/^Bearer /, '') : accessToken;
 
     accountFromToken(token, req, next);
   };


### PR DESCRIPTION
This is supposed to help with cases like #3119. `EventSource` does not support custom headers, so passing OAuth's bearer token becomes problematic.
Instead, we could support passing the token in a URI query parameter, as it's currently done for web sockets.