### PR TITLE
Re-initialize Rails.cache after setting config.cache_store.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'statsd-instrument', '~> 2.1'
 gem 'twitter-text', '~> 1.14'
 gem 'tzinfo-data', '~> 1.2017'
 gem 'webpacker', '~> 1.2'
+gem 'redis-rails', '~> 5.0'
 
 group :development, :test do
   gem 'fabrication', '~> 2.16'
@@ -99,5 +100,4 @@ end
 
 group :production do
   gem 'lograge', '~> 0.5'
-  gem 'redis-rails', '~> 5.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ gem 'statsd-instrument', '~> 2.1'
 gem 'twitter-text', '~> 1.14'
 gem 'tzinfo-data', '~> 1.2017'
 gem 'webpacker', '~> 1.2'
-gem 'redis-rails', '~> 5.0'
 
 group :development, :test do
   gem 'fabrication', '~> 2.16'
@@ -100,4 +99,5 @@ end
 
 group :production do
   gem 'lograge', '~> 0.5'
+  gem 'redis-rails', '~> 5.0'
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -27,5 +27,7 @@ end
 
 Rails.application.configure do
   config.cache_store = :redis_store, ENV['REDIS_URL'], cache_params
-  Rails.cache = ActiveSupport::Cache.lookup_store(Rails.application.config.cache_store)
+  if Rails.env.production?
+    Rails.cache = ActiveSupport::Cache.lookup_store(Rails.application.config.cache_store)
+  end
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -27,4 +27,5 @@ end
 
 Rails.application.configure do
   config.cache_store = :redis_store, ENV['REDIS_URL'], cache_params
+  Rails.cache = ActiveSupport::Cache.lookup_store(Rails.application.config.cache_store)
 end


### PR DESCRIPTION
In 1.4rc2, Rails.cache is missinitialized and not using Redis.
Because config/initializers/redis.rb is executed after Redis.cache is initialized.
Re-initialize Rails.cache or Setting config.cache_store in application.rb or environments is required.
This PR add re-initialize code in config/initializers/redis.rb.

http://stackoverflow.com/questions/5810289/setting-the-cache-store-in-an-initializer/38619281#38619281
