### PR TITLE
Set config.cache_store in environments file.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -79,8 +79,6 @@ module Mastodon
     config.middleware.use Rack::Attack
     config.middleware.use Rack::Deflater
 
-    config.cache_store = :redis_store, ENV['REDIS_URL'], REDIS_CACHE_PARAMS if Rails.env.production?
-
     config.to_prepare do
       Doorkeeper::AuthorizationsController.layout 'public'
       Doorkeeper::AuthorizedApplicationsController.layout 'admin'

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ require_relative '../lib/mastodon/version'
 
 Dotenv::Railtie.load
 
+require_relative '../lib/mastodon/redis_config'
+
 module Mastodon
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -76,6 +78,8 @@ module Mastodon
 
     config.middleware.use Rack::Attack
     config.middleware.use Rack::Deflater
+
+    config.cache_store = :redis_store, ENV['REDIS_URL'], REDIS_CACHE_PARAMS if Rails.env.production?
 
     config.to_prepare do
       Doorkeeper::AuthorizationsController.layout 'public'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,6 +50,9 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
+  # Use a different cache store in production.
+  config.cache_store = :redis_store, ENV['REDIS_URL'], REDIS_CACHE_PARAMS
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,30 +1,14 @@
 # frozen_string_literal: true
 
-if ENV['REDIS_URL'].blank?
-  password = ENV.fetch('REDIS_PASSWORD') { '' }
-  host     = ENV.fetch('REDIS_HOST') { 'localhost' }
-  port     = ENV.fetch('REDIS_PORT') { 6379 }
-  db       = ENV.fetch('REDIS_DB') { 0 }
-
-  ENV['REDIS_URL'] = "redis://#{password.blank? ? '' : ":#{password}@"}#{host}:#{port}/#{db}"
-end
-
 redis_connection = Redis.new(
   url: ENV['REDIS_URL'],
   driver: :hiredis
 )
 
-cache_params = { expires_in: 10.minutes }
-
 namespace = ENV.fetch('REDIS_NAMESPACE') { nil }
 
 if namespace
   Redis.current = Redis::Namespace.new(namespace, redis: redis_connection)
-  cache_params[:namespace] = namespace + '_cache'
 else
   Redis.current = redis_connection
-end
-
-Rails.application.configure do
-  config.cache_store = :redis_store, ENV['REDIS_URL'], cache_params
 end

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -9,10 +9,9 @@ if ENV['REDIS_URL'].blank?
   ENV['REDIS_URL'] = "redis://#{password.blank? ? '' : ":#{password}@"}#{host}:#{port}/#{db}"
 end
 
+namespace = ENV.fetch('REDIS_NAMESPACE') { nil }
+cache_namespace = namespace ? namespace + '_cache' : 'cache'
 REDIS_CACHE_PARAMS = {
   expires_in: 10.minutes,
-  namespace: 'cache'
-}
-
-namespace = ENV.fetch('REDIS_NAMESPACE') { nil }
-REDIS_CACHE_PARAMS[:namespace] = namespace + '_cache' if namespace
+  namespace: cache_namespace,
+}.freeze

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+if ENV['REDIS_URL'].blank?
+  password = ENV.fetch('REDIS_PASSWORD') { '' }
+  host     = ENV.fetch('REDIS_HOST') { 'localhost' }
+  port     = ENV.fetch('REDIS_PORT') { 6379 }
+  db       = ENV.fetch('REDIS_DB') { 0 }
+
+  ENV['REDIS_URL'] = "redis://#{password.blank? ? '' : ":#{password}@"}#{host}:#{port}/#{db}"
+end
+
+REDIS_CACHE_PARAMS = {
+  expires_in: 10.minutes,
+  namespace: 'cache'
+}
+
+namespace = ENV.fetch('REDIS_NAMESPACE') { nil }
+REDIS_CACHE_PARAMS[:namespace] = namespace + '_cache' if namespace


### PR DESCRIPTION
In 1.4rc2, Rails.cache is missinitialized and not using Redis.
Because config/initializers/redis.rb is executed after Redis.cache is initialized.
Re-initialize Rails.cache or Setting config.cache_store in application.rb or environments is required.
This PR does config.cache_store setting in environments file.

This is alternative PR of https://github.com/tootsuite/mastodon/pull/3216 .

http://stackoverflow.com/questions/5810289/setting-the-cache-store-in-an-initializer/38619281#38619281