### PR TITLE
Fix "Edit profile" on the account action bar

### DIFF
--- a/app/javascript/mastodon/components/dropdown_menu.js
+++ b/app/javascript/mastodon/components/dropdown_menu.js
@@ -33,11 +33,14 @@ class DropdownMenu extends React.PureComponent {
     const i = Number(e.currentTarget.getAttribute('data-index'));
     const { action, to } = this.props.items[i];
 
-    e.preventDefault();
+    // Don't call e.preventDefault() when the item uses 'href' property.
+    // ex. "Edit profile" on the account action bar
 
     if (typeof action === 'function') {
+      e.preventDefault();
       action();
     } else if (to) {
+      e.preventDefault();
       this.context.router.push(to);
     }
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/705555/26305352/e0f9d3c8-3f29-11e7-9eb5-bdf7e403bbf8.png)

Clicking the "Edit profile" button should open `/settings/profile`, but it doesn't work since #3120.