### PR TITLE
Use local default for postgres host in node streaming service

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -86,7 +86,6 @@ if (cluster.isMaster) {
   const pgConfigs = {
     development: {
       database: 'mastodon_development',
-      host:     '/var/run/postgresql',
       max:      10,
     },
 


### PR DESCRIPTION
This location varies across postgres installations, and it seems like the pg
package knows how to guess correctly on each system.

Local streaming has been broken for me in local development for a while, and this change fixes that. Someone else should verify that this does not break their local setting before merge.