### PR TITLE
Spec response for forgery

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,8 +4,6 @@ class ApiController < ApplicationController
   DEFAULT_STATUSES_LIMIT = 20
   DEFAULT_ACCOUNTS_LIMIT = 40
 
-  protect_from_forgery with: :null_session
-
   skip_before_action :verify_authenticity_token
   skip_before_action :store_current_location
 

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ApiController, type: :controller do
+  controller do
+    def success
+      head 200
+    end
+  end
+
+  it 'does not protect from forgery' do
+    ActionController::Base.allow_forgery_protection = true
+    routes.draw { post 'success' => 'api#success' }
+    post 'success'
+    expect(response).to have_http_status(:success)
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -37,6 +37,16 @@ describe ApplicationController, type: :controller do
     end
   end
 
+  context 'forgery' do
+    subject do
+      ActionController::Base.allow_forgery_protection = true
+      routes.draw { post 'success' => 'anonymous#success' }
+      post 'success'
+    end
+
+    include_examples 'respond_with_error', 422
+  end
+
   it "does not force ssl if LOCAL_HTTPS is not 'true'" do
     routes.draw { get 'success' => 'anonymous#success' }
     ENV['LOCAL_HTTPS'] = ''


### PR DESCRIPTION
Remove `protect_from_forgery` in `ApiController`, which is disabled by the following `skip_before_action`, as well.

# Question
Is `protect_from_forgery` really no-op if `verify_authenticity_token` is skipped? I have investigated by looking at the source code and by testing but I could not find any difference.