### PR TITLE
Toggle sensitive from admin page

### DIFF
--- a/app/controllers/admin/reported_statuses_controller.rb
+++ b/app/controllers/admin/reported_statuses_controller.rb
@@ -2,17 +2,31 @@
 
 module Admin
   class ReportedStatusesController < BaseController
-    def destroy
-      status = Status.find params[:id]
+    before_action :set_report
+    before_action :set_status
 
-      RemovalWorker.perform_async(status.id)
-      redirect_to admin_report_path(report)
+    def update
+      @status.update(status_params)
+      redirect_to admin_report_path(@report)
+    end
+
+    def destroy
+      RemovalWorker.perform_async(@status.id)
+      redirect_to admin_report_path(@report)
     end
 
     private
 
-    def report
-      Report.find(params[:report_id])
+    def status_params
+      params.require(:status).permit(:sensitive)
+    end
+
+    def set_report
+      @report = Report.find(params[:report_id])
+    end
+
+    def set_status
+      @status = @report.statuses.find(params[:id])
     end
   end
 end

--- a/app/javascript/styles/admin.scss
+++ b/app/javascript/styles/admin.scss
@@ -245,4 +245,19 @@
 
 .report-status__actions {
   flex: 0 0 auto;
+  position: relative;
+
+  .nsfw-button {
+    color: $white;
+    font-size: 11px;
+    width: 11px;
+    display: block;
+  }
+
+  .trash-button {
+    position: absolute;
+    bottom: 10px;
+    font-size: 24px;
+    width: 24px;
+  }
 }

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -24,7 +24,10 @@
       .activity-stream.activity-stream-headless
         .entry= render partial: 'stream_entries/simple_status', locals: { status: status }
       .report-status__actions
-        = link_to admin_report_reported_status_path(@report, status), method: :delete, class: 'icon-button', style: 'font-size: 24px; width: 24px; height: 24px', title: t('admin.reports.delete') do
+        - unless status.media_attachments.empty?
+          = link_to admin_report_reported_status_path(@report, status, status: { sensitive: !status.sensitive }), method: :patch, class: 'nsfw-button', title: t("admin.reports.nsfw.#{!status.sensitive}") do
+            = t("admin.reports.nsfw.#{!status.sensitive}")
+        = link_to admin_report_reported_status_path(@report, status), method: :delete, class: 'icon-button trash-button', title: t('admin.reports.delete'), data: { confirm: t('admin.reports.are_you_sure') } do
           = fa_icon 'trash'
 
 - if !@report.action_taken?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,10 @@ en:
       title: Reports
       unresolved: Unresolved
       view: View
+      nsfw:
+        'true': NSFW ON
+        'false': NSFW OFF
+      are_you_sure: Are you sure?
     settings:
       contact_information:
         email: Enter a public e-mail address

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,7 @@ Rails.application.routes.draw do
     resources :instances, only: [:index]
 
     resources :reports, only: [:index, :show, :update] do
-      resources :reported_statuses, only: :destroy
+      resources :reported_statuses, only: [:update, :destroy]
     end
 
     resources :accounts, only: [:index, :show] do

--- a/spec/controllers/admin/reported_statuses_controller_spec.rb
+++ b/spec/controllers/admin/reported_statuses_controller_spec.rb
@@ -4,14 +4,47 @@ describe Admin::ReportedStatusesController do
   render_views
 
   let(:user) { Fabricate(:user, admin: true) }
+  let(:report) { Fabricate(:report, status_ids: [status.id]) }
+  let(:status) { Fabricate(:status) }
+
   before do
     sign_in user, scope: :user
   end
 
+  describe 'PATCH #update' do
+    subject do
+      -> { patch :update, params: { report_id: report, id: status, status: { sensitive: sensitive } } }
+    end
+
+    let(:status) { Fabricate(:status, sensitive: !sensitive) }
+    let(:sensitive) { true }
+
+    context 'updates sensitive column to true' do
+      it 'updates sensitive column' do
+        is_expected.to change {
+          status.reload.sensitive
+        }.from(false).to(true)
+      end
+    end
+
+    context 'updates sensitive column to false' do
+      let(:sensitive) { false }
+
+      it 'updates sensitive column' do
+        is_expected.to change {
+          status.reload.sensitive
+        }.from(true).to(false)
+      end
+    end
+
+    it 'redirects to report page' do
+      subject.call
+      expect(response).to redirect_to(admin_report_path(report))
+    end
+  end
+
   describe 'DELETE #destroy' do
     it 'removes a status' do
-      report = Fabricate(:report)
-      status = Fabricate(:status)
       allow(RemovalWorker).to receive(:perform_async)
 
       delete :destroy, params: { report_id: report, id: status }


### PR DESCRIPTION
Administrator can change sensitive column from admin page.
If sensitive status was reported, we can enable nsfw flag instead of deleting it.'

- Added `Admin::ReportedStatusesController#update` to update `sensitive` column.
- Added `confirm` option to link of trash to prevent wrong click.

---

screenshot:

![1](https://cloud.githubusercontent.com/assets/1688137/26357528/8421c0de-400a-11e7-8e5f-5b03a6342f1a.png)
![2](https://cloud.githubusercontent.com/assets/1688137/26357529/86ef69ba-400a-11e7-9178-14cfc2aa8661.png)
