### PR TITLE
Fix Devise destroy method being available to delete user record

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -6,6 +6,10 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   before_action :check_enabled_registrations, only: [:new, :create]
   before_action :configure_sign_up_params, only: [:create]
 
+  def destroy
+    not_found
+  end
+
   protected
 
   def build_resource(hash = nil)

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -35,4 +35,22 @@ RSpec.describe Auth::RegistrationsController, type: :controller do
       expect(user.locale).to eq(accept_language)
     end
   end
+
+  describe 'DELETE #destroy' do
+    let(:user) { Fabricate(:user) }
+
+    before do
+      request.env['devise.mapping'] = Devise.mappings[:user]
+      sign_in(user, scope: :user)
+      delete :destroy
+    end
+
+    it 'returns http not found' do
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'does not delete user' do
+      expect(User.find(user.id)).to_not be_nil
+    end
+  end
 end


### PR DESCRIPTION
(You may think that we need account deletions, but this way would've just orphaned the db records)