### PR TITLE
Add ffmpeg and dependent packages as well as LD_LIBRARY_PATHs

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,1 @@
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/app/.apt/lib/x86_64-linux-gnu:/app/.apt/usr/lib/x86_64-linux-gnu/mesa:/app/.apt/usr/lib/x86_64-linux-gnu/pulseaudio

--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,5 @@
 protobuf-compiler
 libprotobuf-dev
+ffmpeg
+libxdamage1
+libxfixes3


### PR DESCRIPTION
This change adds mp4 support confirmed on Heroku-16 stack.

This is a similar pull request as #3274 but makes use of `ffmpeg` instead of `avprobe`. [An article in Japanese](https://kledgeb.blogspot.jp/2015/11/ubuntu-1510-12-libavffmpeg.html) suggests ffmpeg is currently better supported than avprobe/libav.