### PR TITLE
Multiple lines of Content Warning area

### DIFF
--- a/app/javascript/mastodon/components/collapsable.js
+++ b/app/javascript/mastodon/components/collapsable.js
@@ -3,10 +3,10 @@ import Motion from 'react-motion/lib/Motion';
 import spring from 'react-motion/lib/spring';
 import PropTypes from 'prop-types';
 
-const Collapsable = ({ fullHeight, isVisible, children }) => (
-  <Motion defaultStyle={{ opacity: !isVisible ? 0 : 100, height: isVisible ? fullHeight : 0 }} style={{ opacity: spring(!isVisible ? 0 : 100), height: spring(!isVisible ? 0 : fullHeight) }}>
-    {({ opacity, height }) =>
-      <div style={{ height: `${height}px`, overflow: 'hidden', opacity: opacity / 100, display: Math.floor(opacity) === 0 ? 'none' : 'block' }}>
+const Collapsable = ({ isVisible, children }) => (
+  <Motion defaultStyle={{ opacity: !isVisible ? 0 : 100 }} style={{ opacity: spring(!isVisible ? 0 : 100) }}>
+    {({ opacity }) =>
+      <div style={{ opacity: opacity / 100, display: Math.floor(opacity) === 0 ? 'none' : 'block', marginBottom: '15px' }}>
         {children}
       </div>
     }
@@ -14,7 +14,6 @@ const Collapsable = ({ fullHeight, isVisible, children }) => (
 );
 
 Collapsable.propTypes = {
-  fullHeight: PropTypes.number.isRequired,
   isVisible: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
 };

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -68,6 +68,7 @@ class ComposeForm extends ImmutablePureComponent {
 
   handleSubmit = () => {
     this.autosuggestTextarea.reset();
+    this.refs.spoilerTextarea.style.height = '100px';
     this.props.onSubmit();
   }
 
@@ -85,6 +86,8 @@ class ComposeForm extends ImmutablePureComponent {
   }
 
   handleChangeSpoilerText = (e) => {
+    e.target.style.height = 'auto';
+    e.target.style.height = `${e.target.scrollHeight}px`;
     this.props.onChangeSpoilerText(e.target.value);
   }
 
@@ -149,9 +152,9 @@ class ComposeForm extends ImmutablePureComponent {
 
     return (
       <div className='compose-form'>
-        <Collapsable isVisible={this.props.spoiler} fullHeight={50}>
+        <Collapsable isVisible={this.props.spoiler}>
           <div className="spoiler-input">
-            <input placeholder={intl.formatMessage(messages.spoiler_placeholder)} value={this.props.spoiler_text} onChange={this.handleChangeSpoilerText} onKeyDown={this.handleKeyDown} type="text" className="spoiler-input__input"  id='cw-spoiler-input'/>
+            <textarea placeholder={intl.formatMessage(messages.spoiler_placeholder)} value={this.props.spoiler_text} onChange={this.handleChangeSpoilerText} onKeyDown={this.handleKeyDown} className="spoiler-textarea__textarea" id='cw-spoiler-textarea' ref='spoilerTextarea' />
           </div>
         </Collapsable>
 

--- a/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
@@ -11,7 +11,7 @@ const mapStateToProps = (state, { intl }) => ({
   label: 'CW',
   title: intl.formatMessage(messages.title),
   active: state.getIn(['compose', 'spoiler']),
-  ariaControls: 'cw-spoiler-input',
+  ariaControls: 'cw-spoiler-textarea',
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1686,7 +1686,7 @@
 }
 
 .autosuggest-textarea__textarea,
-.spoiler-input__input {
+.spoiler-textarea__textarea {
   display: block;
   box-sizing: border-box;
   width: 100%;
@@ -1698,6 +1698,7 @@
   resize: vertical;
   border: 0;
   outline: 0;
+  resize: none;
 
   &:focus {
     outline: 0;
@@ -1708,7 +1709,8 @@
   }
 }
 
-.spoiler-input__input {
+.spoiler-textarea__textarea {
+  min-height: 100px;
   border-radius: 4px;
 }
 


### PR DESCRIPTION
Added change the Content Warning area from Input tag to Textarea tag.
The purpose is to enrich the user's toot expression more.

![cw](https://cloud.githubusercontent.com/assets/28813809/26419676/73cd60a2-40fb-11e7-90ed-62f471712cb3.jpg)
