### PR TITLE
Prevent contents of the status placeholder from overflowing

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -95,7 +95,7 @@ class Status extends ImmutablePureComponent {
 
     if (isIntersecting === false && isHidden) {
       return (
-        <div ref={this.handleRef} data-id={status.get('id')} style={{ height: `${this.height}px`, opacity: 0 }}>
+        <div ref={this.handleRef} data-id={status.get('id')} style={{ height: `${this.height}px`, opacity: 0, overflow: 'hidden' }}>
           {status.getIn(['account', 'display_name']) || status.getIn(['account', 'username'])}
           {status.get('content')}
         </div>


### PR DESCRIPTION
Long lines may overflow and cause the status-list horizontally scrollable. It is already prevented by `word-wrap: break-word` for the .status-content, but there is no prevention for the status placeholder (#3191).

![image](https://cloud.githubusercontent.com/assets/705555/26430656/ec342160-4129-11e7-8465-e7cb3f96c7fc.png)

So I added `overflow: hidden` to placeholder contents to prevent it.