### PR TITLE
Go to root (home) after login in single user mode

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -35,10 +35,10 @@ class Auth::SessionsController < Devise::SessionsController
     params.require(:user).permit(:email, :password, :otp_attempt)
   end
 
-  def after_sign_in_path_for(_resource)
+  def after_sign_in_path_for(resource)
     last_url = stored_location_for(:user)
 
-    if [about_path].include?(last_url)
+    if home_paths(resource).include?(last_url)
       root_path
     else
       last_url || root_path
@@ -80,5 +80,15 @@ class Auth::SessionsController < Devise::SessionsController
   def prompt_for_two_factor(user)
     session[:otp_user_id] = user.id
     render :two_factor
+  end
+
+  private
+
+  def home_paths(resource)
+    paths = [about_path]
+    if single_user_mode? && resource.is_a?(User)
+      paths << short_account_path(username: resource.account)
+    end
+    paths
   end
 end

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -92,6 +92,30 @@ RSpec.describe Auth::SessionsController, type: :controller do
           expect(flash[:alert]).to eq(I18n.t('devise.failure.unconfirmed', locale: accept_language))
         end
       end
+
+      context "logging in from the user's page" do
+        before do
+          allow(controller).to receive(:single_user_mode?).and_return(single_user_mode)
+          allow(controller).to receive(:stored_location_for).with(:user).and_return("/@#{user.account.username}")
+          post :create, params: { user: { email: user.email, password: user.password } }
+        end
+
+        context "in single user mode" do
+          let(:single_user_mode) { true }
+
+          it 'redirects to home' do
+            expect(response).to redirect_to(root_path)
+          end
+        end
+
+        context "in non-single user mode" do
+          let(:single_user_mode) { false }
+
+          it "redirects back to the user's page" do
+            expect(response).to redirect_to(short_account_path(username: user.account))
+          end
+        end
+      end
     end
 
     context 'using two-factor authentication' do


### PR DESCRIPTION
In single user mode, visitors are redirected to the single user's profile page.  So, if you are the owner without a session, you start from that page, click the login button and authenticate yourself expecting you'll soon get started with the home page, but in reality you'll get redirected back to where you started from -- your own profile page.

This fixes the behavior by redirecting you home after login if you have started from your own profile page.