### PR TITLE
Name the Webpack chunks

### DIFF
--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
@@ -49,7 +49,7 @@ class EmojiPickerDropdown extends React.PureComponent {
     this.setState({active: true});
     if (!EmojiPicker) {
       this.setState({loading: true});
-      import('emojione-picker').then(TheEmojiPicker => {
+      import(/* webpackChunkName: "emojione_picker" */ 'emojione-picker').then(TheEmojiPicker => {
         EmojiPicker = TheEmojiPicker.default;
         this.setState({loading: false});
       }).catch(err => {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -18,13 +18,13 @@ const needsExtraPolyfills = !(
 // This avoids shipping them all the polyfills.
 if (needsBasePolyfills) {
   Promise.all([
-    import('../mastodon/base_polyfills'),
-    import('../mastodon/extra_polyfills'),
+    import(/* webpackChunkName: "base_polyfills" */ '../mastodon/base_polyfills'),
+    import(/* webpackChunkName: "extra_polyfills" */ '../mastodon/extra_polyfills'),
   ]).then(main).catch(e => {
     console.error(e); // eslint-disable-line no-console
   });
 } else if (needsExtraPolyfills) {
-  import('../mastodon/extra_polyfills').then(main).catch(e => {
+  import(/* webpackChunkName: "extra_polyfills" */ '../mastodon/extra_polyfills').then(main).catch(e => {
     console.error(e); // eslint-disable-line no-console
   });
 } else {


### PR DESCRIPTION
There's now a [magic comment](https://webpack.js.org/guides/code-splitting-async/#chunk-names) we can add to name asynchronous Webpack chunks. This just makes it easier to debug; no more chunks with names like `0-*.js`, `1-*.js`, etc.

Before:

![screenshot 2017-05-24 18 21 34](https://cloud.githubusercontent.com/assets/283842/26432064/d9ed81b2-40ad-11e7-8083-456db386b70a.png)


After:

![screenshot 2017-05-24 18 20 04](https://cloud.githubusercontent.com/assets/283842/26432067/e11b7764-40ad-11e7-97d0-a8914e1d4cee.png)

