### PR TITLE
[nanobox] Adjustments for Nanobox development

### DIFF
--- a/.env.nanobox
+++ b/.env.nanobox
@@ -11,6 +11,8 @@ DB_NAME=gonano
 DB_PASS=$DATA_DB_PASS
 DB_PORT=5432
 
+DATABASE_URL=postgresql://$DATA_DB_USER:$DATA_DB_PASS@$DATA_DB_HOST/gonano
+
 # Federation
 # Note: Changing LOCAL_DOMAIN or LOCAL_HTTPS at a later time will cause unwanted side effects.
 # LOCAL_DOMAIN should *NOT* contain the protocol part of the domain e.g https://example.com.

--- a/boxfile.yml
+++ b/boxfile.yml
@@ -31,7 +31,7 @@ run.config:
     - yarn.lock
 
   extra_steps:
-    - cp .env.nanobox .env
+    - envsubst < .env.nanobox > .env
     - gem install bundler
     - bundle config build.nokogiri --with-iconv-dir=/data/ --with-zlib-dir=/data/
     - bundle config build.nokogumbo --with-iconv-dir=/data/ --with-zlib-dir=/data/
@@ -43,9 +43,8 @@ run.config:
 deploy.config:
   extra_steps:
     - NODE_ENV=production bundle exec rake assets:precompile
-    - "[ -r /app/.env.production ] || sed 's/LOCAL_HTTPS=.*/LOCAL_HTTPS=true/i' /app/.env.nanobox > /app/.env.production"
   transform:
-    - envsubst < /app/.env.production > /tmp/.env.production && mv /tmp/.env.production /app/.env.production
+    - "sed 's/LOCAL_HTTPS=.*/LOCAL_HTTPS=true/i' /app/.env.nanobox | envsubst > /app/.env.production"
     - |-
         if [ -z "$LOCAL_DOMAIN" ]
         then

--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -12,7 +12,7 @@ const devServer = safeLoad(readFileSync(join(configPath, 'development.server.yml
 
 // Compute public path based on environment and CDN_HOST in production
 const ifHasCDN = env.CDN_HOST !== undefined && env.NODE_ENV === 'production';
-const devServerUrl = `http://${devServer.host}:${devServer.port}/${paths.entry}/`;
+const devServerUrl = `http://${env.LOCAL_DOMAIN || devServer.host}:${devServer.port}/${paths.entry}/`;
 const publicUrl = ifHasCDN ? `${env.CDN_HOST}/${paths.entry}/` : `/${paths.entry}/`;
 const publicPath = env.NODE_ENV !== 'production' ? devServerUrl : publicUrl;
 

--- a/config/webpack/development.server.js
+++ b/config/webpack/development.server.js
@@ -1,13 +1,14 @@
 // Note: You must restart bin/webpack-dev-server for changes to take effect
 
 const { resolve } = require('path');
+const { env } = require('process');
 const merge = require('webpack-merge');
 const devConfig = require('./development.js');
 const { devServer, publicPath, paths } = require('./configuration.js');
 
 module.exports = merge(devConfig, {
   devServer: {
-    host: devServer.host,
+    host: env.LOCAL_DOMAIN ? '0.0.0.0' : devServer.host,
     port: devServer.port,
     headers: { "Access-Control-Allow-Origin": "*" },
     compress: true,

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -5,7 +5,10 @@ namespace :db do
     desc 'Setup the db or migrate depending on state of db'
     task setup: :environment do
       begin
-        ActiveRecord::Base.connection
+        if ActiveRecord::Migrator.current_version.zero?
+          Rake::Task['db:migrate'].invoke
+          Rake::Task['db:seed'].invoke
+        end
       rescue ActiveRecord::NoDatabaseError
         Rake::Task['db:setup'].invoke
       else


### PR DESCRIPTION
Because Nanobox doesn't run data components in the same container as the code, there are a few tweaks that need to be made in the configuration to get WebPack to work properly in development mode.

The same differences lead to needing to use `DATABASE_URL` by default in the `.env` file for Rails to work correctly.

Limitations of our `.env` loader for Node.js mean the `.env` file needs to be compiled everywhere in order to work, so we compile it in development, now, too. Also, all the `.env.production` tweaks have been consolidated into a single command.

Finally, since Nanobox actually creates the database when it sets up the database server, using the existence of the database alone to determine whether to migrate or setup is insufficient. So we add a condition to `rake db:migrate:setup` to check whether any migrations have run - if the database doesn't exist yet, `db:setup` will be called; if it does, but no migrations have been run, `db:migrate` and `db:seed` are called instead (the same basic idea as what `db:setup` does, but it skips `db:create`, which will only cause problems with an existing DB); otherwise, only `db:migrate` is called.

None of these changes should affect development, and all are designed not to interfere with existing behaviors in other environments.