### PR TITLE
Add improved performance marks for development mode

### DIFF
--- a/app/javascript/mastodon/main.js
+++ b/app/javascript/mastodon/main.js
@@ -1,3 +1,5 @@
+const perf = require('./performance');
+
 // allow override variables here
 require.context('../../assets/stylesheets/', false, /variables.*\.scss$/);
 
@@ -14,10 +16,10 @@ function onDomContentLoaded(callback) {
 }
 
 function main() {
+  perf.start('main()');
   const Mastodon = require('mastodon/containers/mastodon').default;
   const React = require('react');
   const ReactDOM = require('react-dom');
-  window.Perf = require('react-addons-perf');
 
   require.context('../images/', true);
 
@@ -29,6 +31,7 @@ function main() {
     const props = JSON.parse(mountNode.getAttribute('data-props'));
 
     ReactDOM.render(<Mastodon {...props} />, mountNode);
+    perf.stop('main()');
   });
 }
 

--- a/app/javascript/mastodon/performance.js
+++ b/app/javascript/mastodon/performance.js
@@ -1,0 +1,24 @@
+//
+// Tools for performance debugging, only enabled in development mode.
+// Open up Chrome Dev Tools, then Timeline, then User Timing to see output.
+// Also see config/webpack/loaders/mark.js for the webpack loader marks.
+//
+
+let marky;
+
+if (process.env.NODE_ENV === 'development') {
+  marky = require('marky');
+  require('react-addons-perf').start();
+}
+
+export function start(name) {
+  if (process.env.NODE_ENV === 'development') {
+    marky.mark(name);
+  }
+}
+
+export function stop(name) {
+  if (process.env.NODE_ENV === 'development') {
+    marky.stop(name);
+  }
+}

--- a/config/webpack/loaders/mark.js
+++ b/config/webpack/loaders/mark.js
@@ -1,0 +1,8 @@
+if (process.env.NODE_ENV === 'production') {
+  module.exports = {};
+} else {
+  module.exports = {
+    test: /\.js$/,
+    loader: 'mark-loader',
+  };
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "is-nan": "^1.2.1",
     "js-yaml": "^3.8.3",
     "lodash": "^4.17.4",
+    "mark-loader": "^0.1.6",
+    "marky": "^1.2.0",
     "mkdirp": "^0.5.1",
     "node-sass": "^4.5.2",
     "npmlog": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4022,6 +4022,14 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+mark-loader@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/mark-loader/-/mark-loader-0.1.6.tgz#0abb477dca7421d70e20128ff6489f5cae8676d5"
+
+marky@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.0.tgz#9617ed647bbbea8f45d19526da33dec70606df42"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.14.tgz#39511771ed9602405fba9affff17eb4d2a3843ab"


### PR DESCRIPTION
All this does is add performance marks in development mode, to make it easier to debug JavaScript runtime performance. On production builds, it adds nothing.

I added
 * [react-addons-perf](https://facebook.github.io/react/docs/perf.html): React performance marks, i.e. tells us how long it takes each component to render (this was already in the build but wasn't doing anything because we needed to call `start()`)
 * [mark-loader](https://github.com/statianzo/mark-loader): Webpack performance marks, i.e. tells us how long it takes each module to load
  * a custom measure for the `main()` function using [marky](https://github.com/nolanlawson/marky)

This is what it looks like in the Chrome Dev Tools. Here's page load:

![screenshot 2017-05-24 22 25 48](https://cloud.githubusercontent.com/assets/283842/26437632/17f318bc-40d3-11e7-8eb9-14265b977a75.png)

And here's scrolling:

![screenshot 2017-05-24 22 42 42](https://cloud.githubusercontent.com/assets/283842/26437644/224629ee-40d3-11e7-9bfe-5a1799bd709d.png)

The idea is that this gives us better tools to analyze runtime performance, because otherwise the React/Webpack stack traces are pretty opaque.