### PR TITLE
Don't stream toots from users who have blocked the recipient user

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -245,7 +245,7 @@ if (cluster.isMaster) {
           }
 
           const unpackedPayload  = JSON.parse(payload);
-          const targetAccountIds = [unpackedPayload.account.id].concat(unpackedPayload.mentions.map(item => item.id)).concat(unpackedPayload.reblog ? [unpackedPayload.reblog.account.id] : []);
+          const targetAccountIds = [unpackedPayload.account.id].concat(unpackedPayload.mentions.map(item => item.id));
           const accountDomain    = unpackedPayload.account.acct.split('@')[1];
 
           const queries = [

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -249,7 +249,7 @@ if (cluster.isMaster) {
           const accountDomain    = unpackedPayload.account.acct.split('@')[1];
 
           const queries = [
-            client.query(`SELECT 1 FROM blocks WHERE account_id = $1 AND target_account_id IN (${placeholders(targetAccountIds, 1)}) UNION SELECT 1 FROM mutes WHERE account_id = $1 AND target_account_id IN (${placeholders(targetAccountIds, 1)})`, [req.accountId].concat(targetAccountIds)),
+            client.query(`SELECT 1 FROM blocks WHERE (account_id = $1 AND target_account_id IN (${placeholders(targetAccountIds, 2)})) OR (account_id = $2 AND target_account_id = $1) UNION SELECT 1 FROM mutes WHERE account_id = $1 AND target_account_id IN (${placeholders(targetAccountIds, 2)})`, [req.accountId, unpackedPayload.account.id].concat(targetAccountIds)),
           ];
 
           if (accountDomain) {


### PR DESCRIPTION
This filter was already applied on the `/api/v1/timelines/public` API, but not yet for the Streaming API.