### PR TITLE
Replace \u2014 with &mdash; in HAML template for public page on single mode

### DIFF
--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -7,7 +7,7 @@
     - if !user_signed_in? && single_user_mode?
       %span.single-user-login
         = link_to t('auth.login'), new_user_session_path
-        \u2014
+        &mdash;
     %span.domain= link_to site_hostname, root_path
     %span.powered-by
       != t('generic.powered_by', link: link_to('Mastodon', 'https://github.com/tootsuite/mastodon'))


### PR DESCRIPTION
It seems that haml doesn't parse `\u2014` (EM DASH) as expected. It is replaced with an HTML entity reference `&mdash;` here.

Before:

![screen shot 2017-05-24 at 9 26 43 pm](https://cloud.githubusercontent.com/assets/30968/26441105/e8fc79ca-40ca-11e7-99ad-a388cc13c372.png)

After:

![screen shot 2017-05-24 at 9 46 48 pm](https://cloud.githubusercontent.com/assets/30968/26441107/eda6f932-40ca-11e7-9fbd-17277f8da723.png)
