### PR TITLE
Fix an error on dragging into status_content component

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -65,6 +65,10 @@ class StatusContent extends React.PureComponent {
   }
 
   handleMouseUp = (e) => {
+    if (!this.startXY) {
+      return;
+    }
+
     const [ startX, startY ] = this.startXY;
     const [ deltaX, deltaY ] = [Math.abs(e.clientX - startX), Math.abs(e.clientY - startY)];
 


### PR DESCRIPTION
Reproduce steps:

1. Press mouse button outside of the `.status__content`
2. Move mouse cursor to inside of the `.status__content`, then release button

```
Uncaught TypeError: Cannot read property '0' of undefined
    at StatusContent._this.handleMouseUp (eval at <anonymous> (application.js:1178), <anonymous>:60:33)
    at Object.ReactErrorUtils.invokeGuardedCallback (eval at <anonymous> (application.js:1406), <anonymous>:69:16)
    at executeDispatch (eval at <anonymous> (application.js:1358), <anonymous>:85:21)
    at Object.executeDispatchesInOrder (eval at <anonymous> (application.js:1358), <anonymous>:108:5)
    at executeDispatchesAndRelease (eval at <anonymous> (application.js:812), <anonymous>:43:22)
    at executeDispatchesAndReleaseTopLevel (eval at <anonymous> (application.js:812), <anonymous>:54:10)
    at Array.forEach (<anonymous>)
    at forEachAccumulated (eval at <anonymous> (application.js:2254), <anonymous>:24:9)
    at Object.processEventQueue (eval at <anonymous> (application.js:812), <anonymous>:257:7)
    at runEventQueueInBatch (eval at <anonymous> (application.js:5327), <anonymous>:17:18)
```

(the error was `Uncaught TypeError: Invalid attempt to destructure non-iterable instance` before 1.4)

Since `this.startXY` is undefined or null yet, destructuring assignment will fails.