### PR TITLE
Add `flex: 0 0 auto` to some components to avoid bugs on iOS9

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -60,6 +60,7 @@
 
 .column-collapsable {
   position: relative;
+  flex: 0 0 auto;
 
   .column-collapsable__content {
     overflow: auto;
@@ -1792,6 +1793,7 @@
 
 .getting-started__wrapper {
   position: relative;
+  flex: 0 0 auto;
 }
 
 .getting-started__footer {


### PR DESCRIPTION
See https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored

|Before|After|
|-------|-----|
|![image](https://cloud.githubusercontent.com/assets/705555/26459173/91210a18-41b0-11e7-98a9-3e15957adca7.png)|![image](https://cloud.githubusercontent.com/assets/705555/26459192/9b591ade-41b0-11e7-98d0-1a43ddedd609.png)|
|![image](https://cloud.githubusercontent.com/assets/705555/26459197/9e4726b4-41b0-11e7-9a93-323ae7af22ea.png)|![image](https://cloud.githubusercontent.com/assets/705555/26459200/a0f37142-41b0-11e7-81fb-bda7ab4f6fd0.png)|
