### PR TITLE
Fix #2922 - Change how customizations are saved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ yarn-debug.log
 # Ignore Docker option files
 docker-compose.override.yml
 
+app/javascript/styles/custom_variables.scss
+app/javascript/styles/customizations.scss

--- a/app/javascript/mastodon/main.js
+++ b/app/javascript/mastodon/main.js
@@ -1,8 +1,5 @@
 const perf = require('./performance');
 
-// allow override variables here
-require.context('../../assets/stylesheets/', false, /variables.*\.scss$/);
-
 // import default stylesheet with variables
 require('font-awesome/css/font-awesome.css');
 require('../styles/application.scss');
@@ -22,9 +19,6 @@ function main() {
   const ReactDOM = require('react-dom');
 
   require.context('../images/', true);
-
-  // import customization styles
-  require.context('../../assets/stylesheets/', false, /custom.*\.scss$/);
 
   onDomContentLoaded(() => {
     const mountNode = document.getElementById('mastodon');

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -1,5 +1,6 @@
 @import 'mixins';
 @import 'variables';
+@import 'custom_variables';
 @import 'fonts/roboto';
 @import 'fonts/roboto-mono';
 @import 'fonts/montserrat';
@@ -19,3 +20,4 @@
 @import 'tables';
 @import 'admin';
 @import 'rtl';
+@import 'customizations';

--- a/app/javascript/styles/custom_variables.scss
+++ b/app/javascript/styles/custom_variables.scss
@@ -1,0 +1,1 @@
+// This file allows you to change variable definitions

--- a/app/javascript/styles/customizations.scss
+++ b/app/javascript/styles/customizations.scss
@@ -1,0 +1,1 @@
+// Your own custom SCSS here


### PR DESCRIPTION
- Files are now present in the git repository but .gitignore'd
- All loaded through Sass, so variable re-definitions work as expected

You will need to move your code out of `app/assets/stylesheets/custom.scss` into `app/javascript/styles/customizations.scss` and/or `app/javascript/styles/custom_variables.scss`, your code also no longer needs to explicitly re-import application SCSS, as it simply precedes yours