### PR TITLE
Disable the Rubocop Style/GuardClause cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,9 @@ Style/RegexpLiteral:
 Style/Lambda:
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
 Rails/HasAndBelongsToMany:
   Enabled: false
 


### PR DESCRIPTION
There are many spots throughout the codebase which are showing as covered by
specs in the simplecov output -- but which are not actually run, because they
are on the same line as a guard clause.

I plan on fixing some of these issues, but don't want to keep triggering this
rubocop style violation.

My preference would be that we use the PR review process to identify places
where a guard clause might be appropriate, but that we leave this cop turned off
by default.

(This is partially in place because of the output over here - https://github.com/tootsuite/mastodon/pull/3286 - if you are curious about specific examples of where this cop is suggesting what I believe to be worse code).