### PR TITLE
Attach ReactPerf to window for easier debugging

### DIFF
--- a/app/javascript/mastodon/performance.js
+++ b/app/javascript/mastodon/performance.js
@@ -13,7 +13,9 @@ if (process.env.NODE_ENV === 'development') {
     performance.setResourceTimingBufferSize(Infinity);
   }
   marky = require('marky');
-  require('react-addons-perf').start();
+  // allows us to easily do e.g. ReactPerf.printWasted() while debugging
+  window.ReactPerf = require('react-addons-perf');
+  window.ReactPerf.start();
 }
 
 export function start(name) {


### PR DESCRIPTION
This makes debugging a bit easier, since you can access `ReactPerf` from the console. For those interested, here's the output of `ReactPerf.printWasted()` after scrolling a bit:

![screenshot 2017-05-25 11 48 22](https://cloud.githubusercontent.com/assets/283842/26465527/5ec5eaae-4140-11e7-914d-684521d93759.png)

More resources:

- https://facebook.github.io/react/docs/perf.html
- https://flexport.engineering/optimizing-react-rendering-part-1-9634469dca02