### PR TITLE
[Perf] Implement shouldComponentUpdate for relative_timestamp

### DIFF
--- a/app/javascript/mastodon/components/relative_timestamp.js
+++ b/app/javascript/mastodon/components/relative_timestamp.js
@@ -2,19 +2,40 @@ import React from 'react';
 import { injectIntl, FormattedRelative } from 'react-intl';
 import PropTypes from 'prop-types';
 
-const RelativeTimestamp = ({ intl, timestamp }) => {
-  const date = new Date(timestamp);
-
-  return (
-    <time dateTime={timestamp} title={intl.formatDate(date, { hour12: false, year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' })}>
-      <FormattedRelative value={date} />
-    </time>
-  );
+const dateFormatOptions = {
+  hour12: false,
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
 };
 
-RelativeTimestamp.propTypes = {
-  intl: PropTypes.object.isRequired,
-  timestamp: PropTypes.string.isRequired,
-};
+class RelativeTimestamp extends React.Component {
+
+  static propTypes = {
+    intl: PropTypes.object.isRequired,
+    timestamp: PropTypes.string.isRequired,
+  };
+
+  shouldComponentUpdate (nextProps) {
+    // As of right now the locale doesn't change without a new page load,
+    // but we might as well check in case that ever changes.
+    return this.props.timestamp !== nextProps.timestamp ||
+      this.props.intl.locale !== nextProps.intl.locale;
+  }
+
+  render () {
+    const { timestamp, intl } = this.props;
+    const date = new Date(timestamp);
+
+    return (
+      <time dateTime={timestamp} title={intl.formatDate(date, dateFormatOptions)}>
+        <FormattedRelative value={date} />
+      </time>
+    );
+  }
+
+}
 
 export default injectIntl(RelativeTimestamp);


### PR DESCRIPTION
This improves performance of toot rendering by ensuring we only update the relative timestamp (e.g. "12 minutes ago") when it's actually changed.

Before this change, we might see lots of little update operations for `InjectIntl(RelativeTimestamp`. Below you can see it taking ~4ms several times, as I scroll:

![screenshot 2017-05-25 17 58 32](https://cloud.githubusercontent.com/assets/283842/26476582/b4d04aaa-4174-11e7-9420-efb30f34a596.png)

Afterwards those are eliminated thanks to `shouldComponentUpdate()`:

![screenshot 2017-05-25 17 59 25](https://cloud.githubusercontent.com/assets/283842/26476583/b4debb26-4174-11e7-9888-61b7bd7b8b3a.png)