### PR TITLE
Fix "Cannot read property" on missing status

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -90,7 +90,7 @@ class Status extends ImmutablePureComponent {
     const { isHidden } = this.state;
 
     if (status === null) {
-      return <div ref={this.handleRef} data-id={status.get('id')} />;
+      return null;
     }
 
     if (isIntersecting === false && isHidden) {


### PR DESCRIPTION
I've found this issue when I open UserA's status which replies to UserB whom I blocked/muted.

Properties I've removed in here were added with lazy loading using IntersectionObserver (8e4d1cba), but those statuses are not need to be tracked anyway because it will be rendered as only empty div.