### PR TITLE
Improve shouldComponentUpdate for status and status_action_bar

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -44,20 +44,41 @@ class Status extends ImmutablePureComponent {
     isHidden: false,
   }
 
+  // Avoid checking props that are functions (and whose equality will always
+  // evaluate to false. See react-immutable-pure-component for usage.
+  updateOnProps = [
+    'status',
+    'account',
+    'wrapped',
+    'me',
+    'boostModal',
+    'autoPlayGif',
+    'muted',
+  ]
+
+  updateOnStates = []
+
+  shouldComponentUpdate (nextProps, nextState) {
+    if (nextProps.isIntersecting === false && nextState.isHidden) {
+      // It's only if we're not intersecting (i.e. offscreen) and isHidden is true
+      // that either "isIntersecting" or "isHidden" matter, and then they're
+      // the only things that matter.
+      return this.props.isIntersecting !== false || !this.state.isHidden;
+    } else if (nextProps.isIntersecting !== false && this.props.isIntersecting === false) {
+      // If we're going from a non-intersecting state to an intersecting state,
+      // (i.e. offscreen to onscreen), then we definitely need to re-render
+      return true;
+    }
+    // Otherwise, diff based on "updateOnProps" and "updateOnStates"
+    return super.shouldComponentUpdate(nextProps, nextState);
+  }
+
   componentWillReceiveProps (nextProps) {
     if (nextProps.isIntersecting === false && this.props.isIntersecting !== false) {
       requestIdleCallback(() => this.setState({ isHidden: true }));
     } else {
       this.setState({ isHidden: !nextProps.isIntersecting });
     }
-  }
-
-  shouldComponentUpdate (nextProps, nextState) {
-    if (nextProps.isIntersecting === false && this.props.isIntersecting !== false) {
-      return nextState.isHidden;
-    }
-
-    return true;
   }
 
   handleRef = (node) => {

--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import IconButton from './icon_button';
 import DropdownMenu from './dropdown_menu';
 import { defineMessages, injectIntl } from 'react-intl';
+import ImmutablePureComponent from 'react-immutable-pure-component';
 
 const messages = defineMessages({
   delete: { id: 'status.delete', defaultMessage: 'Delete' },
@@ -21,7 +22,7 @@ const messages = defineMessages({
   unmuteConversation: { id: 'status.unmute_conversation', defaultMessage: 'Unmute conversation' },
 });
 
-class StatusActionBar extends React.PureComponent {
+class StatusActionBar extends ImmutablePureComponent {
 
   static contextTypes = {
     router: PropTypes.object,
@@ -42,6 +43,14 @@ class StatusActionBar extends React.PureComponent {
     withDismiss: PropTypes.bool,
     intl: PropTypes.object.isRequired,
   };
+
+  // Avoid checking props that are functions (and whose equality will always
+  // evaluate to false. See react-immutable-pure-component for usage.
+  updateOnProps = [
+    'status',
+    'me',
+    'withDismiss',
+  ]
 
   handleReplyClick = () => {
     this.props.onReply(this.props.status, this.context.router);


### PR DESCRIPTION
This improves the performance of toot rendering, especially while scrolling. To measure the difference, I repeated the same experience twice. The experiment was just to load the page and then scroll down to the bottom of the local timeline once, and then run `ReactPerf.printWasted()` afterwards.

Before (notice all the wasted time in the `Status` and `StatusActionBar` components):

![screenshot 2017-05-25 23 10 14](https://cloud.githubusercontent.com/assets/283842/26483122/44994be8-41a0-11e7-9714-98d6a813a0b3.png)

After (notice that there is much less wasted time overall):

![screenshot 2017-05-25 23 09 46](https://cloud.githubusercontent.com/assets/283842/26483123/449f8aee-41a0-11e7-9268-7d76d319bf79.png)

The main tricks I employed here:

- `ImmutablePureComponent` with custom `updateOnProps` and `updateOnStates` list to decide exactly which props/states to diff.
- don't bother diffing `function` props; these will always be false when you check their equality (apparently because of `mapDispatchToProps`; this is maybe something we want to fix).
- in the case of `status`, it's tricky because of how we're handling `isIntersecting` and `isHidden`. So for this one, I handle those two manually and then defer the rest to `ImmutablePureComponent`.

Scrolling is still a bit jerky, but I'm slowly making progress!