### PR TITLE
Replace onWheel listener with onScroll

### DIFF
--- a/app/javascript/mastodon/features/ui/components/column.js
+++ b/app/javascript/mastodon/features/ui/components/column.js
@@ -49,11 +49,11 @@ class Column extends React.PureComponent {
     this._interruptScrollAnimation = scrollTop(scrollable);
   }
 
-  handleScroll = () => {
+  handleScroll = debounce(() => {
     if (typeof this._interruptScrollAnimation !== 'undefined') {
       this._interruptScrollAnimation();
     }
-  }
+  }, 200)
 
   setRef = (c) => {
     this.node = c;
@@ -75,7 +75,7 @@ class Column extends React.PureComponent {
         role='region'
         aria-labelledby={columnHeaderId}
         className='column'
-        onScroll={debounce(this.handleScroll, 200)}>
+        onScroll={this.handleScroll}>
         {header}
         {children}
       </div>

--- a/app/javascript/mastodon/features/ui/components/column.js
+++ b/app/javascript/mastodon/features/ui/components/column.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ColumnHeader from './column_header';
 import PropTypes from 'prop-types';
+import { debounce } from 'lodash';
 
 const easingOutQuint = (x, t, b, c, d) => c*((t=t/d-1)*t*t*t*t + 1) + b;
 
@@ -48,7 +49,7 @@ class Column extends React.PureComponent {
     this._interruptScrollAnimation = scrollTop(scrollable);
   }
 
-  handleWheel = () => {
+  handleScroll = () => {
     if (typeof this._interruptScrollAnimation !== 'undefined') {
       this._interruptScrollAnimation();
     }
@@ -74,7 +75,7 @@ class Column extends React.PureComponent {
         role='region'
         aria-labelledby={columnHeaderId}
         className='column'
-        onWheel={this.handleWheel}>
+        onScroll={debounce(this.handleScroll, 200)}>
         {header}
         {children}
       </div>


### PR DESCRIPTION
In general `scroll` listeners are preferred to `wheel` listeners. I wrote [a blog post on this](https://blogs.windows.com/msedgedev/2017/03/08/scrolling-on-the-web/), but basically wheel listeners can block via `event.preventDefault()`, so browsers have to deoptimize off-main-thread scrolling, whereas `scroll` listeners can't `preventDefault()` and so they don't deoptimize.

In our case we're not calling `preventDefault()`, so we could use a passive event listener instead of `onScroll`, but my understanding is that React doesn't support passive event listeners yet (https://github.com/facebook/react/issues/6436) and also if we do `onScroll` then we can get the same effect even for browsers that don't have passive event listeners yet (such as Edge).

This PR also removes a warning Chrome was printing to the console:

    [Violation] Added non-passive event listener to a scroll-blocking 'wheel' event.
    Consider marking event handler as 'passive' to make the page more responsive.

I tested this on the desktop versions of Chrome, Firefox, and Safari, and I can confirm that clicking on the header still results in a smooth scroll animation towards the top. If there are any edge cases I missed, though, please let me know.