### PR TITLE
Remove status context construction in the React side

### DIFF
--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -91,19 +91,6 @@ const initialState = Immutable.Map({
 });
 
 const normalizeStatus = (state, status) => {
-  const replyToId = status.get('in_reply_to_id');
-  const id        = status.get('id');
-
-  if (replyToId) {
-    if (!state.getIn(['descendants', replyToId], Immutable.List()).includes(id)) {
-      state = state.updateIn(['descendants', replyToId], Immutable.List(), set => set.push(id));
-    }
-
-    if (!state.getIn(['ancestors', id], Immutable.List()).includes(replyToId)) {
-      state = state.updateIn(['ancestors', id], Immutable.List(), set => set.push(replyToId));
-    }
-  }
-
   return state;
 };
 


### PR DESCRIPTION
because it may causes flicker on the conversation when it contains blocked/muted user's status.

![gif](https://cloud.githubusercontent.com/assets/705555/26483223/ed512432-4226-11e7-9b85-a9f1d07c82d0.gif)

We use `/api/v1/statuses/{id}/context` to obtain status ids in the conversation which filters blocked/muted user, but also uses internal cache mainly constructed from `in_reply_to_id` in the `reducers/timelines.js` which doesn't filter.

So if the non-API context cache exists, statuses will appear in conversation even those statuses are from blocked/muted user. Then those statuses will be removed when the context cache are updated with the context API.

I have left the `normalizeStatus()` function itself which is called many functions in the file as a placeholder for now, but maybe it should be removed completely.

Note: This issue won't happen on v1.3 or earlier, because filtering on the context API is fixed with [the domain block feature](https://github.com/tootsuite/mastodon/commit/620d0d80293bef80753ecfcec1c4c5226e67cd6d) in 1.4.