### PR TITLE
Fix #2922 - Load stylesheet from "custom.css" entrypoint when present

### DIFF
--- a/app/helpers/style_helper.rb
+++ b/app/helpers/style_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module StyleHelper
+  def stylesheet_for_layout
+    if asset_exist? 'custom.css'
+      'custom'
+    else
+      'application'
+    end
+  end
+
+  def asset_exist?(path)
+    true if Webpacker::Manifest.lookup(path)
+  rescue Webpacker::FileLoader::NotFoundError
+    false
+  end
+end

--- a/app/javascript/mastodon/main.js
+++ b/app/javascript/mastodon/main.js
@@ -1,8 +1,5 @@
 const perf = require('./performance');
 
-// allow override variables here
-require.context('../../assets/stylesheets/', false, /variables.*\.scss$/);
-
 // import default stylesheet with variables
 require('font-awesome/css/font-awesome.css');
 require('../styles/application.scss');
@@ -22,9 +19,6 @@ function main() {
   const ReactDOM = require('react-dom');
 
   require.context('../images/', true);
-
-  // import customization styles
-  require.context('../../assets/stylesheets/', false, /custom.*\.scss$/);
 
   onDomContentLoaded(() => {
     const mountNode = document.getElementById('mastodon');

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,7 +18,7 @@
         = ' - '
       = title
 
-    = stylesheet_pack_tag 'application', media: 'all'
+    = stylesheet_pack_tag stylesheet_for_layout, media: 'all'
     = javascript_pack_tag 'common', integrity: true, crossorigin: 'anonymous'
     = javascript_pack_tag "locale_#{I18n.locale}", integrity: true, crossorigin: 'anonymous'
     = csrf_meta_tags

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,6 +18,7 @@
         = ' - '
       = title
 
+    = stylesheet_pack_tag 'common', media: 'all'
     = stylesheet_pack_tag stylesheet_for_layout, media: 'all'
     = javascript_pack_tag 'common', integrity: true, crossorigin: 'anonymous'
     = javascript_pack_tag "locale_#{I18n.locale}", integrity: true, crossorigin: 'anonymous'

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -53,6 +53,12 @@ module.exports = {
           // be loaded together
           return false;
         }
+
+        if (module.resource && /node_modules\/font-awesome/.test(module.resource)) {
+          // extract vendor css into common module
+          return true;
+        }
+
         return count >= 2;
       },
     }),


### PR DESCRIPTION
This is pretty much the same way it worked as before, albeit with having to create `app/javascript/packs/custom.js` with `require('../styles/custom.scss')` (or whatever you want really), which will be a blank slate for you to import whatever you want