### PR TITLE
Avoid comparing domains when looking for an exact match of a local account

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -59,7 +59,13 @@ class AccountSearchService < BaseService
   end
 
   def exact_match
-    @_exact_match ||= Account.find_remote(query_username, query_domain)
+    @_exact_match ||= begin
+      if domain_is_local?
+        Account.find_local(query_username)
+      else
+        Account.find_remote(query_username, query_domain)
+      end
+    end
   end
 
   def search_results


### PR DESCRIPTION
This is supposed to fix #3064.

When looking for an exact account match, if the search string is in a `user@domain` form, check whether the domain is local before searching the accounts table.
