### PR TITLE
Introduce RecentOrderable concern for models

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -6,12 +6,12 @@ class AccountsController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        @statuses = @account.statuses.permitted_for(@account, current_account).paginate_by_max_id(20, params[:max_id], params[:since_id])
+        @statuses = @account.statuses.permitted_for(@account, current_account).paginate_by_recent(20, params[:max_id], params[:since_id])
         @statuses = cache_collection(@statuses, Status)
       end
 
       format.atom do
-        @entries = @account.stream_entries.where(hidden: false).with_includes.paginate_by_max_id(20, params[:max_id], params[:since_id])
+        @entries = @account.stream_entries.where(hidden: false).with_includes.paginate_by_recent(20, params[:max_id], params[:since_id])
         render xml: AtomSerializer.render(AtomSerializer.new.feed(@account, @entries.to_a))
       end
 

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -49,7 +49,7 @@ module Admin
     end
 
     def filtered_reports
-      ReportFilter.new(filter_params).results.order(id: :desc).includes(
+      ReportFilter.new(filter_params).results.recent.includes(
         :account,
         :target_account
       )

--- a/app/controllers/admin/subscriptions_controller.rb
+++ b/app/controllers/admin/subscriptions_controller.rb
@@ -9,7 +9,7 @@ module Admin
     private
 
     def ordered_subscriptions
-      Subscription.order(id: :desc).includes(:account)
+      Subscription.recent.includes(:account)
     end
 
     def requested_page

--- a/app/controllers/api/activitypub/outbox_controller.rb
+++ b/app/controllers/api/activitypub/outbox_controller.rb
@@ -28,7 +28,7 @@ class Api::ActivityPub::OutboxController < Api::BaseController
 
   def show_outbox_page
     all_statuses = Status.as_outbox_timeline(@account)
-    @statuses = all_statuses.paginate_by_max_id(limit_param(DEFAULT_STATUSES_LIMIT), params[:max_id], params[:since_id])
+    @statuses = all_statuses.paginate_by_recent(limit_param(DEFAULT_STATUSES_LIMIT), params[:max_id], params[:since_id])
 
     all_statuses = cache_collection(all_statuses)
     @statuses = cache_collection(@statuses)

--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
   end
 
   def paginated_follows
-    Follow.where(target_account: @account).paginate_by_max_id(
+    Follow.where(target_account: @account).paginate_by_recent(
       limit_param(DEFAULT_ACCOUNTS_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
   end
 
   def paginated_follows
-    Follow.where(account: @account).paginate_by_max_id(
+    Follow.where(account: @account).paginate_by_recent(
       limit_param(DEFAULT_ACCOUNTS_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -35,7 +35,7 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   end
 
   def default_statuses
-    permitted_account_statuses.paginate_by_max_id(
+    permitted_account_statuses.paginate_by_recent(
       limit_param(DEFAULT_STATUSES_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::BlocksController < Api::BaseController
   end
 
   def paginated_blocks
-    Block.where(account: current_account).paginate_by_max_id(
+    Block.where(account: current_account).paginate_by_recent(
       limit_param(DEFAULT_ACCOUNTS_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/domain_blocks_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::DomainBlocksController < Api::BaseController
   private
 
   def load_domain_blocks
-    account_domain_blocks.paginate_by_max_id(
+    account_domain_blocks.paginate_by_recent(
       limit_param(BLOCK_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/favourites_controller.rb
+++ b/app/controllers/api/v1/favourites_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::FavouritesController < Api::BaseController
   end
 
   def results
-    @_results ||= account_favourites.paginate_by_max_id(
+    @_results ||= account_favourites.paginate_by_recent(
       limit_param(DEFAULT_STATUSES_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/follow_requests_controller.rb
+++ b/app/controllers/api/v1/follow_requests_controller.rb
@@ -34,7 +34,7 @@ class Api::V1::FollowRequestsController < Api::BaseController
   end
 
   def paginated_follow_requests
-    FollowRequest.where(target_account: current_account).paginate_by_max_id(
+    FollowRequest.where(target_account: current_account).paginate_by_recent(
       limit_param(DEFAULT_ACCOUNTS_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/mutes_controller.rb
+++ b/app/controllers/api/v1/mutes_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::MutesController < Api::BaseController
   end
 
   def paginated_mutes
-    Mute.where(account: current_account).paginate_by_max_id(
+    Mute.where(account: current_account).paginate_by_recent(
       limit_param(DEFAULT_ACCOUNTS_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -35,7 +35,7 @@ class Api::V1::NotificationsController < Api::BaseController
   end
 
   def paginated_notifications
-    browserable_account_notifications.paginate_by_max_id(
+    browserable_account_notifications.paginate_by_recent(
       limit_param(DEFAULT_NOTIFICATIONS_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::Statuses::FavouritedByAccountsController < Api::BaseController
   end
 
   def paginated_favourites
-    Favourite.paginate_by_max_id(
+    Favourite.paginate_by_recent(
       limit_param(DEFAULT_ACCOUNTS_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::Statuses::RebloggedByAccountsController < Api::BaseController
   end
 
   def paginated_statuses
-    Status.where(reblog_of_id: @status.id).paginate_by_max_id(
+    Status.where(reblog_of_id: @status.id).paginate_by_recent(
       limit_param(DEFAULT_ACCOUNTS_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::Timelines::PublicController < Api::BaseController
   end
 
   def public_statuses
-    public_timeline_statuses.paginate_by_max_id(
+    public_timeline_statuses.paginate_by_recent(
       limit_param(DEFAULT_STATUSES_LIMIT),
       params[:max_id],
       params[:since_id]

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::Timelines::TagController < Api::BaseController
     if @tag.nil?
       []
     else
-      tag_timeline_statuses.paginate_by_max_id(
+      tag_timeline_statuses.paginate_by_recent(
         limit_param(DEFAULT_STATUSES_LIMIT),
         params[:max_id],
         params[:since_id]

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -5,7 +5,7 @@ class TagsController < ApplicationController
 
   def show
     @tag      = Tag.find_by!(name: params[:id].downcase)
-    @statuses = @tag.nil? ? [] : Status.as_tag_timeline(@tag, current_account, params[:local]).paginate_by_max_id(20, params[:max_id])
+    @statuses = @tag.nil? ? [] : Status.as_tag_timeline(@tag, current_account, params[:local]).paginate_by_recent(20, params[:max_id])
     @statuses = cache_collection(@statuses, Status)
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,6 +46,7 @@ class Account < ApplicationRecord
   include AccountHeader
   include AccountInteractions
   include Attachmentable
+  include RecentOrderable
   include Remotable
 
   # Local users
@@ -87,7 +88,6 @@ class Account < ApplicationRecord
   scope :partitioned, -> { order('row_number() over (partition by domain)') }
   scope :silenced, -> { where(silenced: true) }
   scope :suspended, -> { where(suspended: true) }
-  scope :recent, -> { reorder(id: :desc) }
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }
   scope :by_domain_accounts, -> { group(:domain).select(:domain, 'COUNT(*) AS accounts_count').order('accounts_count desc') }
   scope :matches_username, ->(value) { where(arel_table[:username].matches("#{value}%")) }

--- a/app/models/account_domain_block.rb
+++ b/app/models/account_domain_block.rb
@@ -11,7 +11,7 @@
 #
 
 class AccountDomainBlock < ApplicationRecord
-  include Paginable
+  include RecentOrderable
 
   belongs_to :account, required: true
   validates :domain, presence: true, uniqueness: { scope: :account_id }

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -11,7 +11,7 @@
 #
 
 class Block < ApplicationRecord
-  include Paginable
+  include RecentOrderable
 
   belongs_to :account, required: true
   belongs_to :target_account, class_name: 'Account', required: true

--- a/app/models/concerns/recent_orderable.rb
+++ b/app/models/concerns/recent_orderable.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-module Paginable
+module RecentOrderable
   extend ActiveSupport::Concern
 
   included do
-    scope :paginate_by_max_id, ->(limit, max_id = nil, since_id = nil) {
-      query = order(arel_table[:id].desc).limit(limit)
+    scope :recent, -> { order(arel_table[:id].desc) }
+    scope :paginate_by_recent, ->(limit, max_id = nil, since_id = nil) {
+      query = recent.limit(limit)
       query = query.where(arel_table[:id].lt(max_id)) if max_id.present?
       query = query.where(arel_table[:id].gt(since_id)) if since_id.present?
       query

--- a/app/models/favourite.rb
+++ b/app/models/favourite.rb
@@ -11,7 +11,7 @@
 #
 
 class Favourite < ApplicationRecord
-  include Paginable
+  include RecentOrderable
 
   belongs_to :account, inverse_of: :favourites, required: true
   belongs_to :status,  inverse_of: :favourites, counter_cache: true, required: true

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -26,7 +26,7 @@ class Feed
 
   def from_database(limit, max_id, since_id)
     Status.as_home_timeline(@account)
-          .paginate_by_max_id(limit, max_id, since_id)
+          .paginate_by_recent(limit, max_id, since_id)
           .reject { |status| FeedManager.instance.filter?(:home, status, @account.id) }
   end
 

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -11,7 +11,7 @@
 #
 
 class Follow < ApplicationRecord
-  include Paginable
+  include RecentOrderable
 
   belongs_to :account, counter_cache: :following_count, required: true
 
@@ -23,6 +23,4 @@ class Follow < ApplicationRecord
   has_one :notification, as: :activity, dependent: :destroy
 
   validates :account_id, uniqueness: { scope: :target_account_id }
-
-  scope :recent, -> { reorder(id: :desc) }
 end

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -11,7 +11,7 @@
 #
 
 class FollowRequest < ApplicationRecord
-  include Paginable
+  include RecentOrderable
 
   belongs_to :account, required: true
   belongs_to :target_account, class_name: 'Account', required: true

--- a/app/models/mute.rb
+++ b/app/models/mute.rb
@@ -11,7 +11,7 @@
 #
 
 class Mute < ApplicationRecord
-  include Paginable
+  include RecentOrderable
 
   belongs_to :account, required: true
   belongs_to :target_account, class_name: 'Account', required: true

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -13,7 +13,7 @@
 #
 
 class Notification < ApplicationRecord
-  include Paginable
+  include RecentOrderable
   include Cacheable
 
   TYPE_CLASS_MAP = {

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -15,6 +15,8 @@
 #
 
 class Report < ApplicationRecord
+  include RecentOrderable
+
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
   belongs_to :action_taken_by_account, class_name: 'Account'

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -25,7 +25,7 @@
 #
 
 class Status < ApplicationRecord
-  include Paginable
+  include RecentOrderable
   include Streamable
   include Cacheable
   include StatusThreadingConcern
@@ -58,7 +58,6 @@ class Status < ApplicationRecord
 
   default_scope { recent }
 
-  scope :recent, -> { reorder(id: :desc) }
   scope :remote, -> { where.not(uri: nil) }
   scope :local, -> { where(uri: nil) }
 

--- a/app/models/stream_entry.rb
+++ b/app/models/stream_entry.rb
@@ -14,7 +14,7 @@
 #
 
 class StreamEntry < ApplicationRecord
-  include Paginable
+  include RecentOrderable
 
   belongs_to :account, inverse_of: :stream_entries
   belongs_to :activity, polymorphic: true
@@ -25,7 +25,6 @@ class StreamEntry < ApplicationRecord
   STATUS_INCLUDES = [:account, :stream_entry, :conversation, :media_attachments, :tags, mentions: :account, reblog: [:stream_entry, :account, :conversation, :media_attachments, :tags, mentions: :account], thread: [:stream_entry, :account]].freeze
 
   default_scope { where(activity_type: 'Status') }
-  scope :recent, -> { reorder(id: :desc) }
   scope :with_includes, -> { includes(:account, status: STATUS_INCLUDES) }
 
   delegate :target, :title, :content, :thread,

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -16,6 +16,8 @@
 #
 
 class Subscription < ApplicationRecord
+  include RecentOrderable
+
   MIN_EXPIRATION = 7.days.seconds.to_i
   MAX_EXPIRATION = 30.days.seconds.to_i
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,7 @@
 #
 
 class User < ApplicationRecord
+  include RecentOrderable
   include Settings::Extend
   ACTIVE_DURATION = 14.days
 
@@ -49,7 +50,6 @@ class User < ApplicationRecord
   validates :locale, inclusion: I18n.available_locales.map(&:to_s), if: :locale?
   validates_with BlacklistedEmailValidator, if: :email_changed?
 
-  scope :recent,    -> { order(id: :desc) }
   scope :admins,    -> { where(admin: true) }
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :inactive, -> { where(arel_table[:current_sign_in_at].lt(ACTIVE_DURATION.ago)) }

--- a/spec/controllers/stream_entries_controller_spec.rb
+++ b/spec/controllers/stream_entries_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe StreamEntriesController, type: :controller do
     context 'when activity is nil' do
       it 'raises ActiveRecord::RecordNotFound' do
         account = Fabricate(:account)
-        stream_entry = Fabricate.build(:stream_entry, account: account, activity: nil, activity_type: 'Status')
+        stream_entry = StreamEntry.new(account: account)
         stream_entry.save!(validate: false)
 
         get route, params: { account_username: account.username, id: stream_entry.id }

--- a/spec/fabricators/notification_fabricator.rb
+++ b/spec/fabricators/notification_fabricator.rb
@@ -1,4 +1,5 @@
 Fabricator(:notification) do
+  account
   activity_id   1
   activity_type 'Favourite'
 end

--- a/spec/fabricators/stream_entry_fabricator.rb
+++ b/spec/fabricators/stream_entry_fabricator.rb
@@ -1,5 +1,3 @@
 Fabricator(:stream_entry) do
-  account
-  activity { Fabricate(:status) }
-  hidden { [true, false].sample }
+  initialize_with { Fabricate(:status).stream_entry }
 end

--- a/spec/models/account_domain_block_spec.rb
+++ b/spec/models/account_domain_block_spec.rb
@@ -19,4 +19,6 @@ RSpec.describe AccountDomainBlock, type: :model do
 
     expect(Rails.cache.exist?("exclude_domains_for:#{account.id}")).to eq false
   end
+
+  it_behaves_like 'RecentOrderable', :account_domain_block
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -695,13 +695,6 @@ RSpec.describe Account, type: :model do
       end
     end
 
-    describe 'recent' do
-      it 'returns a relation of accounts sorted by recent creation' do
-        matches = 2.times.map { Fabricate(:account) }
-        expect(Account.recent).to match_array(matches)
-      end
-    end
-
     describe 'silenced' do
       it 'returns an array of accounts who are silenced' do
         account_1 = Fabricate(:account, silenced: true)
@@ -758,4 +751,5 @@ RSpec.describe Account, type: :model do
   end
 
   include_examples 'AccountAvatar', :account
+  it_behaves_like 'RecentOrderable', :account
 end

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -44,4 +44,6 @@ RSpec.describe Block, type: :model do
     expect(Rails.cache.exist?("exclude_account_ids_for:#{account.id}")).to eq false
     expect(Rails.cache.exist?("exclude_account_ids_for:#{target_account.id}")).to eq false
   end
+
+  it_behaves_like 'RecentOrderable', :block
 end

--- a/spec/models/favourite_spec.rb
+++ b/spec/models/favourite_spec.rb
@@ -26,4 +26,6 @@ RSpec.describe Favourite, type: :model do
       expect(favourite.status).to eq status
     end
   end
+
+  it_behaves_like 'RecentOrderable', :favourite
 end

--- a/spec/models/follow_request_spec.rb
+++ b/spec/models/follow_request_spec.rb
@@ -22,4 +22,6 @@ RSpec.describe FollowRequest, type: :model do
       expect(follow_request).to model_have_error_on_field(:target_account)      
     end
   end
+
+  it_behaves_like 'RecentOrderable', :follow_request
 end

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -25,16 +25,5 @@ RSpec.describe Follow, type: :model do
     end
   end
 
-  describe 'recent' do
-    it 'sorts so that more recent follows comes earlier' do
-      follow0 = Follow.create!(account: alice, target_account: bob)
-      follow1 = Follow.create!(account: bob, target_account: alice)
-
-      a = Follow.recent.to_a
-
-      expect(a.size).to eq 2
-      expect(a[0]).to eq follow1
-      expect(a[1]).to eq follow0
-    end
-  end
+  it_behaves_like 'RecentOrderable', :follow
 end

--- a/spec/models/mute_spec.rb
+++ b/spec/models/mute_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Mute, type: :model do
-
+  it_behaves_like 'RecentOrderable', :mute
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -26,4 +26,6 @@ RSpec.describe Notification, type: :model do
       expect(notification.type).to eq :follow
     end
   end
+
+  it_behaves_like 'RecentOrderable', :notification
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -21,4 +21,6 @@ describe Report do
       expect(report.media_attachments).to eq [media_attachment]
     end
   end
+
+  it_behaves_like 'RecentOrderable', :report
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -513,4 +513,6 @@ RSpec.describe Status, type: :model do
       expect(Status.create(account: alice, thread: parent, text: 'Response').conversation_id).to eq parent.conversation_id
     end
   end
+
+  it_behaves_like 'RecentOrderable', :status
 end

--- a/spec/models/stream_entry_spec.rb
+++ b/spec/models/stream_entry_spec.rb
@@ -74,4 +74,6 @@ RSpec.describe StreamEntry, type: :model do
       end
     end
   end
+
+  it_behaves_like 'RecentOrderable', :stream_entry
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -64,4 +64,6 @@ RSpec.describe Subscription, type: :model do
       expect(subscription.expires_at).to be_within(1.0).of(expected)
     end
   end
+
+  it_behaves_like 'RecentOrderable', :subscription
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,14 +48,6 @@ RSpec.describe User, type: :model do
   end
 
   describe 'scopes' do
-    describe 'recent' do
-      it 'returns an array of recent users ordered by id' do
-        user_1 = Fabricate(:user)
-        user_2 = Fabricate(:user)
-        expect(User.recent).to eq [user_2, user_1]
-      end
-    end
-
     describe 'admins' do
       it 'returns an array of users who are admin' do
         user_1 = Fabricate(:user, admin: false)
@@ -260,6 +252,8 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  it_behaves_like 'RecentOrderable', :user
 
   it_behaves_like 'Settings-extended' do
     def create!

--- a/spec/support/examples/models/recent_orderable.rb
+++ b/spec/support/examples/models/recent_orderable.rb
@@ -1,0 +1,48 @@
+shared_examples 'RecentOrderable' do |fabricator|
+  describe 'paginate_by_recent' do
+    it 'limits by number' do
+      Fabricate(fabricator)
+      specified = Fabricate(fabricator)
+
+      a = described_class.paginate_by_recent(1).to_a
+
+      expect(a.size).to eq 1
+      expect(a[0]).to eq specified
+    end
+
+    it 'limits by max ID' do
+      min = Fabricate(fabricator)
+      max = Fabricate(fabricator)
+
+      a = described_class.paginate_by_recent(2, max.id).to_a
+
+      expect(a.size).to eq 1
+      expect(a[0]).to eq min
+    end
+
+    it 'limits by min ID' do
+      min = Fabricate(fabricator)
+      max = Fabricate(fabricator)
+
+      a = described_class.paginate_by_recent(2, nil, min.id).to_a
+
+      expect(a.size).to eq 1
+      expect(a[0]).to eq max
+    end
+  end
+
+  describe 'recent' do
+    it 'sorts so that more recent follows comes earlier' do
+      old = Fabricate(fabricator)
+      recent = Fabricate(fabricator)
+      old.save!
+      recent.save!
+
+      a = described_class.recent.to_a
+
+      expect(a.size).to eq 2
+      expect(a[0]).to eq recent
+      expect(a[1]).to eq old
+    end
+  end
+end


### PR DESCRIPTION
`ID`concern has scopes dealing with IDs, namely `recent`, which were common for some models, and `paginate_by_max_id`, which were provided `Paginable` concern and included `recent` scope.

This pull request also includes `ID` to `Subscription`.