### PR TITLE
Reject revoked access_token on Streaming API.

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -168,7 +168,7 @@ if (cluster.isMaster) {
         return;
       }
 
-      client.query('SELECT oauth_access_tokens.resource_owner_id, users.account_id, users.filtered_languages FROM oauth_access_tokens INNER JOIN users ON oauth_access_tokens.resource_owner_id = users.id WHERE oauth_access_tokens.token = $1 LIMIT 1', [token], (err, result) => {
+      client.query('SELECT oauth_access_tokens.resource_owner_id, users.account_id, users.filtered_languages FROM oauth_access_tokens INNER JOIN users ON oauth_access_tokens.resource_owner_id = users.id WHERE oauth_access_tokens.token = $1 AND oauth_access_tokens.revoked_at IS NULL LIMIT 1', [token], (err, result) => {
         done();
 
         if (err) {


### PR DESCRIPTION
Currently Streaming API does not check presented access_token is revoked or not.
So, Someone who has access token can use Streaming API after revoking access token.
This PR add a condition to SQL, and Streaming API  will reject revoked access token.

Doorkeeper gem also checks when expire and revoke and compare with current time, but I think we don't need this check.

Revocation check is done at connect time, and does not kill connection remains connected when revoke access token. Need some additional work to do that.
