### PR TITLE
Fix Webpack Bundle Analyzer output for Webpacker

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -34,6 +34,7 @@ module.exports = merge(sharedConfig, {
       analyzerMode: 'static',
       generateStatsFile: true,
       openAnalyzer: false,
+      logLevel: 'silent', // do not bother Webpacker, who runs with --json and parses stdout
     }),
   ],
 });


### PR DESCRIPTION
Webpacker failed to parse output of Webpack when a module requires non-existent module or has similar errors. This commit fixes the bug.