### PR TITLE
Lazy load routes and some components

### DIFF
--- a/app/javascript/mastodon/actions/bundles.js
+++ b/app/javascript/mastodon/actions/bundles.js
@@ -1,0 +1,25 @@
+export const BUNDLE_FETCH_REQUEST = 'BUNDLE_FETCH_REQUEST';
+export const BUNDLE_FETCH_SUCCESS = 'BUNDLE_FETCH_SUCCESS';
+export const BUNDLE_FETCH_FAIL = 'BUNDLE_FETCH_FAIL';
+
+export function fetchBundleRequest(skipLoading) {
+  return {
+    type: BUNDLE_FETCH_REQUEST,
+    skipLoading,
+  };
+}
+
+export function fetchBundleSuccess(skipLoading) {
+  return {
+    type: BUNDLE_FETCH_SUCCESS,
+    skipLoading,
+  };
+}
+
+export function fetchBundleFail(error, skipLoading) {
+  return {
+    type: BUNDLE_FETCH_FAIL,
+    error,
+    skipLoading,
+  };
+}

--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -16,33 +16,10 @@ import createBrowserHistory from 'history/lib/createBrowserHistory';
 import applyRouterMiddleware from 'react-router/lib/applyRouterMiddleware';
 import useRouterHistory from 'react-router/lib/useRouterHistory';
 import Router from 'react-router/lib/Router';
-import Route from 'react-router/lib/Route';
-import IndexRedirect from 'react-router/lib/IndexRedirect';
-import IndexRoute from 'react-router/lib/IndexRoute';
 import { useScroll } from 'react-router-scroll';
-import UI from '../features/ui';
-import Status from '../features/status';
-import GettingStarted from '../features/getting_started';
-import PublicTimeline from '../features/public_timeline';
-import CommunityTimeline from '../features/community_timeline';
-import AccountTimeline from '../features/account_timeline';
-import AccountGallery from '../features/account_gallery';
-import HomeTimeline from '../features/home_timeline';
-import Compose from '../features/compose';
-import Followers from '../features/followers';
-import Following from '../features/following';
-import Reblogs from '../features/reblogs';
-import Favourites from '../features/favourites';
-import HashtagTimeline from '../features/hashtag_timeline';
-import Notifications from '../features/notifications';
-import FollowRequests from '../features/follow_requests';
-import GenericNotFound from '../features/generic_not_found';
-import FavouritedStatuses from '../features/favourited_statuses';
-import Blocks from '../features/blocks';
-import Mutes from '../features/mutes';
-import Report from '../features/report';
 import { hydrateStore } from '../actions/store';
 import createStream from '../stream';
+import routes from './routes';
 import { IntlProvider, addLocaleData } from 'react-intl';
 import { getLocale } from '../locales';
 const { localeData, messages } = getLocale();
@@ -136,36 +113,7 @@ class Mastodon extends React.PureComponent {
     return (
       <IntlProvider locale={locale} messages={messages}>
         <Provider store={store}>
-          <Router history={browserHistory} render={applyRouterMiddleware(useScroll())}>
-            <Route path='/' component={UI}>
-              <IndexRedirect to='/getting-started' />
-              <Route path='getting-started' component={GettingStarted} />
-              <Route path='timelines/home' component={HomeTimeline} />
-              <Route path='timelines/public' component={PublicTimeline} />
-              <Route path='timelines/public/local' component={CommunityTimeline} />
-              <Route path='timelines/tag/:id' component={HashtagTimeline} />
-
-              <Route path='notifications' component={Notifications} />
-              <Route path='favourites' component={FavouritedStatuses} />
-
-              <Route path='statuses/new' component={Compose} />
-              <Route path='statuses/:statusId' component={Status} />
-              <Route path='statuses/:statusId/reblogs' component={Reblogs} />
-              <Route path='statuses/:statusId/favourites' component={Favourites} />
-
-              <Route path='accounts/:accountId' component={AccountTimeline} />
-              <Route path='accounts/:accountId/followers' component={Followers} />
-              <Route path='accounts/:accountId/following' component={Following} />
-              <Route path='accounts/:accountId/media' component={AccountGallery} />
-
-              <Route path='follow_requests' component={FollowRequests} />
-              <Route path='blocks' component={Blocks} />
-              <Route path='mutes' component={Mutes} />
-              <Route path='report' component={Report} />
-
-              <Route path='*' component={GenericNotFound} />
-            </Route>
-          </Router>
+          <Router history={browserHistory} routes={routes} render={applyRouterMiddleware(useScroll())} />
         </Provider>
       </IntlProvider>
     );

--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -25,7 +25,7 @@ import { getLocale } from '../locales';
 const { localeData, messages } = getLocale();
 addLocaleData(localeData);
 
-const store = configureStore();
+export const store = configureStore();
 const initialState = JSON.parse(document.getElementById("initial-state").textContent);
 store.dispatch(hydrateStore(initialState));
 

--- a/app/javascript/mastodon/containers/routes.js
+++ b/app/javascript/mastodon/containers/routes.js
@@ -1,6 +1,16 @@
 import UI from '../features/ui';
+import { store } from './mastodon';
+import { fetchBundleRequest, fetchBundleSuccess, fetchBundleFail } from '../actions/bundles';
 
-const loadRoute = (cb) => module => cb(null, module.default);
+const loadRoute = (cb) => module => {
+  store.dispatch(fetchBundleSuccess());
+  cb(null, module.default);
+};
+
+const failRoute = (cb) => error => {
+  store.dispatch(fetchBundleFail(error));
+  cb(error, null);
+};
 
 export default [
   {
@@ -11,126 +21,146 @@ export default [
       {
         path: 'getting-started',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/getting_started" */ '../features/getting_started').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/getting_started" */ '../features/getting_started').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'timelines/home',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/home_timeline" */ '../features/home_timeline').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/home_timeline" */ '../features/home_timeline').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'timelines/public',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/public_timeline" */ '../features/public_timeline').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/public_timeline" */ '../features/public_timeline').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'timelines/public/local',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/community_timeline" */ '../features/community_timeline').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/community_timeline" */ '../features/community_timeline').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'timelines/tag/:id',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/hashtag_timeline" */ '../features/hashtag_timeline').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/hashtag_timeline" */ '../features/hashtag_timeline').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
 
       {
         path: 'notifications',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/notifications" */ '../features/notifications').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/notifications" */ '../features/notifications').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'favourites',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/favourited_statuses" */ '../features/favourited_statuses').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/favourited_statuses" */ '../features/favourited_statuses').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
 
       {
         path: 'statuses/new',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/compose" */ '../features/compose').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/compose" */ '../features/compose').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'statuses/:statusId',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/status" */ '../features/status').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/status" */ '../features/status').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'statuses/:statusId/reblogs',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/reblogs" */ '../features/reblogs').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/reblogs" */ '../features/reblogs').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'statuses/:statusId/favourites',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/favourites" */ '../features/favourites').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/favourites" */ '../features/favourites').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
 
       {
         path: 'accounts/:accountId',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/account_timeline" */ '../features/account_timeline').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/account_timeline" */ '../features/account_timeline').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'accounts/:accountId/followers',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/followers" */ '../features/followers').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/followers" */ '../features/followers').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'accounts/:accountId/following',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/following" */ '../features/following').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/following" */ '../features/following').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'accounts/:accountId/media',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/account_gallery" */ '../features/account_gallery').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/account_gallery" */ '../features/account_gallery').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
 
       {
         path: 'follow_requests',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/follow_requests" */ '../features/follow_requests').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/follow_requests" */ '../features/follow_requests').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'blocks',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/blocks" */ '../features/blocks').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/blocks" */ '../features/blocks').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'mutes',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/mutes" */ '../features/mutes').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/mutes" */ '../features/mutes').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
       {
         path: 'report',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/report" */ '../features/report').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/report" */ '../features/report').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
 
       {
         path: '*',
         getComponent: (location, cb) => {
-          import(/* webpackChunkName: "features/generic_not_found" */ '../features/generic_not_found').then(loadRoute(cb));
+          store.dispatch(fetchBundleRequest());
+          import(/* webpackChunkName: "features/generic_not_found" */ '../features/generic_not_found').then(loadRoute(cb)).catch(failRoute(cb));
         },
       },
     ],

--- a/app/javascript/mastodon/containers/routes.js
+++ b/app/javascript/mastodon/containers/routes.js
@@ -1,0 +1,138 @@
+import UI from '../features/ui';
+
+const loadRoute = (cb) => module => cb(null, module.default);
+
+export default [
+  {
+    path: '/',
+    component: UI,
+    // <IndexRedirect to='/getting-started' />
+    childRoutes: [
+      {
+        path: 'getting-started',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/getting_started" */ '../features/getting_started').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'timelines/home',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/home_timeline" */ '../features/home_timeline').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'timelines/public',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/public_timeline" */ '../features/public_timeline').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'timelines/public/local',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/community_timeline" */ '../features/community_timeline').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'timelines/tag/:id',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/hashtag_timeline" */ '../features/hashtag_timeline').then(loadRoute(cb));
+        },
+      },
+
+      {
+        path: 'notifications',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/notifications" */ '../features/notifications').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'favourites',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/favourited_statuses" */ '../features/favourited_statuses').then(loadRoute(cb));
+        },
+      },
+
+      {
+        path: 'statuses/new',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/compose" */ '../features/compose').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'statuses/:statusId',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/status" */ '../features/status').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'statuses/:statusId/reblogs',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/reblogs" */ '../features/reblogs').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'statuses/:statusId/favourites',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/favourites" */ '../features/favourites').then(loadRoute(cb));
+        },
+      },
+
+      {
+        path: 'accounts/:accountId',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/account_timeline" */ '../features/account_timeline').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'accounts/:accountId/followers',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/followers" */ '../features/followers').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'accounts/:accountId/following',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/following" */ '../features/following').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'accounts/:accountId/media',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/account_gallery" */ '../features/account_gallery').then(loadRoute(cb));
+        },
+      },
+
+      {
+        path: 'follow_requests',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/follow_requests" */ '../features/follow_requests').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'blocks',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/blocks" */ '../features/blocks').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'mutes',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/mutes" */ '../features/mutes').then(loadRoute(cb));
+        },
+      },
+      {
+        path: 'report',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/report" */ '../features/report').then(loadRoute(cb));
+        },
+      },
+
+      {
+        path: '*',
+        getComponent: (location, cb) => {
+          import(/* webpackChunkName: "features/generic_not_found" */ '../features/generic_not_found').then(loadRoute(cb));
+        },
+      },
+    ],
+  },
+];

--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
@@ -3,6 +3,9 @@ import Dropdown, { DropdownTrigger, DropdownContent } from 'react-simple-dropdow
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 
+import { store } from '../../../containers/mastodon';
+import { fetchBundleRequest, fetchBundleSuccess, fetchBundleFail } from '../../../actions/bundles';
+
 const messages = defineMessages({
   emoji: { id: 'emoji_button.label', defaultMessage: 'Insert emoji' },
   emoji_search: { id: 'emoji_button.search', defaultMessage: 'Search...' },
@@ -48,12 +51,14 @@ class EmojiPickerDropdown extends React.PureComponent {
   onShowDropdown = () => {
     this.setState({active: true});
     if (!EmojiPicker) {
+      store.dispatch(fetchBundleRequest());
       this.setState({loading: true});
       import(/* webpackChunkName: "emojione_picker" */ 'emojione-picker').then(TheEmojiPicker => {
         EmojiPicker = TheEmojiPicker.default;
+        store.dispatch(fetchBundleSuccess());
         this.setState({loading: false});
       }).catch(err => {
-        // TODO: show the user an error?
+        store.dispatch(fetchBundleFail(err));
         this.setState({loading: false});
       });
     }

--- a/app/javascript/mastodon/features/ui/components/modal_root.js
+++ b/app/javascript/mastodon/features/ui/components/modal_root.js
@@ -3,22 +3,55 @@ import PropTypes from 'prop-types';
 import TransitionMotion from 'react-motion/lib/TransitionMotion';
 import spring from 'react-motion/lib/spring';
 
+import { store } from '../../../containers/mastodon';
+import { fetchBundleRequest, fetchBundleSuccess, fetchBundleFail } from '../../../actions/bundles';
+
 const FETCH_COMPONENTS = {
-  'MEDIA': () =>
+  'MEDIA': () => {
+    store.dispatch(fetchBundleRequest());
     import(/* webpackChunkName: "media_modal" */ './media_modal')
-      .then(Component => MODAL_COMPONENTS.MEDIA = Component.default),
-  'ONBOARDING': () =>
+      .then(Component => {
+        MODAL_COMPONENTS.MEDIA = Component.default;
+        store.dispatch(fetchBundleSuccess());
+      })
+      .catch(error => store.dispatch(fetchBundleFail(error)));
+  },
+  'ONBOARDING': () => {
+    store.dispatch(fetchBundleRequest());
     import(/* webpackChunkName: "onboarding_modal" */ './onboarding_modal')
-      .then(Component => MODAL_COMPONENTS.ONBOARDING = Component.default),
-  'VIDEO': () =>
+      .then(Component => {
+        MODAL_COMPONENTS.ONBOARDING = Component.default;
+        store.dispatch(fetchBundleSuccess());
+      })
+      .catch(error => store.dispatch(fetchBundleFail(error)));
+  },
+  'VIDEO': () => {
+    store.dispatch(fetchBundleRequest());
     import(/* webpackChunkName: "video_modal" */ './video_modal')
-      .then(Component => MODAL_COMPONENTS.VIDEO = Component.default),
-  'BOOST': () =>
+      .then(Component => {
+        MODAL_COMPONENTS.VIDEO = Component.default;
+        store.dispatch(fetchBundleSuccess());
+      })
+      .catch(error => store.dispatch(fetchBundleFail(error)));
+  },
+  'BOOST': () => {
+    store.dispatch(fetchBundleRequest());
     import(/* webpackChunkName: "boost_modal" */ './boost_modal')
-      .then(Component => MODAL_COMPONENTS.BOOST = Component.default),
-  'CONFIRM': () =>
+      .then(Component => {
+        MODAL_COMPONENTS.BOOST = Component.default;
+        store.dispatch(fetchBundleSuccess());
+      })
+      .catch(error => store.dispatch(fetchBundleFail(error)));
+  },
+  'CONFIRM': () => {
+    store.dispatch(fetchBundleRequest());
     import(/* webpackChunkName: "confirmation_modal" */ './confirmation_modal')
-      .then(Component => MODAL_COMPONENTS.CONFIRM = Component.default),
+      .then(Component => {
+        MODAL_COMPONENTS.CONFIRM = Component.default;
+        store.dispatch(fetchBundleSuccess());
+      })
+      .catch(error => store.dispatch(fetchBundleFail(error)));
+  },
 };
 
 const MODAL_COMPONENTS = { };
@@ -40,6 +73,12 @@ class ModalRoot extends React.PureComponent {
 
   componentDidMount () {
     window.addEventListener('keyup', this.handleKeyUp, false);
+  }
+
+  componentWillReceiveProps ({ type }) {
+    if (!!type && !MODAL_COMPONENTS[type]) {
+      FETCH_COMPONENTS[type]();
+    }
   }
 
   componentWillUnmount () {
@@ -77,16 +116,11 @@ class ModalRoot extends React.PureComponent {
             {interpolatedStyles.map(({ key, data: { type, props }, style }) => {
               const SpecificComponent = MODAL_COMPONENTS[type];
 
-              if (!SpecificComponent) {
-                // TODO: Handle error
-                FETCH_COMPONENTS[type]();
-              }
-
               return (
                 <div key={key} style={{ pointerEvents: visible ? 'auto' : 'none' }}>
                   <div role='presentation' className='modal-root__overlay' style={{ opacity: style.opacity }} onClick={onClose} />
                   <div className='modal-root__container' style={{ opacity: style.opacity, transform: `translateZ(0px) scale(${style.scale})` }}>
-                    <SpecificComponent {...props} onClose={onClose} />
+                    {SpecificComponent && <SpecificComponent {...props} onClose={onClose} />}
                   </div>
                 </div>
               );

--- a/app/javascript/mastodon/features/ui/components/modal_root.js
+++ b/app/javascript/mastodon/features/ui/components/modal_root.js
@@ -1,20 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import MediaModal from './media_modal';
-import OnboardingModal from './onboarding_modal';
-import VideoModal from './video_modal';
-import BoostModal from './boost_modal';
-import ConfirmationModal from './confirmation_modal';
 import TransitionMotion from 'react-motion/lib/TransitionMotion';
 import spring from 'react-motion/lib/spring';
 
-const MODAL_COMPONENTS = {
-  'MEDIA': MediaModal,
-  'ONBOARDING': OnboardingModal,
-  'VIDEO': VideoModal,
-  'BOOST': BoostModal,
-  'CONFIRM': ConfirmationModal,
+const FETCH_COMPONENTS = {
+  'MEDIA': () =>
+    import(/* webpackChunkName: "media_modal" */ './media_modal')
+      .then(Component => MODAL_COMPONENTS.MEDIA = Component.default),
+  'ONBOARDING': () =>
+    import(/* webpackChunkName: "onboarding_modal" */ './onboarding_modal')
+      .then(Component => MODAL_COMPONENTS.ONBOARDING = Component.default),
+  'VIDEO': () =>
+    import(/* webpackChunkName: "video_modal" */ './video_modal')
+      .then(Component => MODAL_COMPONENTS.VIDEO = Component.default),
+  'BOOST': () =>
+    import(/* webpackChunkName: "boost_modal" */ './boost_modal')
+      .then(Component => MODAL_COMPONENTS.BOOST = Component.default),
+  'CONFIRM': () =>
+    import(/* webpackChunkName: "confirmation_modal" */ './confirmation_modal')
+      .then(Component => MODAL_COMPONENTS.CONFIRM = Component.default),
 };
+
+const MODAL_COMPONENTS = { };
 
 class ModalRoot extends React.PureComponent {
 
@@ -69,6 +76,11 @@ class ModalRoot extends React.PureComponent {
           <div className='modal-root'>
             {interpolatedStyles.map(({ key, data: { type, props }, style }) => {
               const SpecificComponent = MODAL_COMPONENTS[type];
+
+              if (!SpecificComponent) {
+                // TODO: Handle error
+                FETCH_COMPONENTS[type]();
+              }
 
               return (
                 <div key={key} style={{ pointerEvents: visible ? 'auto' : 'none' }}>

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -3,11 +3,8 @@ import ColumnsArea from './components/columns_area';
 import NotificationsContainer from './containers/notifications_container';
 import PropTypes from 'prop-types';
 import LoadingBarContainer from './containers/loading_bar_container';
-import HomeTimeline from '../home_timeline';
-import Compose from '../compose';
 import TabsBar from './components/tabs_bar';
 import ModalContainer from './containers/modal_container';
-import Notifications from '../notifications';
 import { connect } from 'react-redux';
 import { isMobile } from '../../is_mobile';
 import { debounce } from 'lodash';
@@ -15,6 +12,14 @@ import { uploadCompose } from '../../actions/compose';
 import { refreshTimeline } from '../../actions/timelines';
 import { refreshNotifications } from '../../actions/notifications';
 import UploadArea from './components/upload_area';
+
+const staticColumns = { };
+
+const lazyLoadStaticColumns = () => {
+  import(/* webpackChunkName: "features/home_timeline" */ '../home_timeline').then(Component => staticColumns.HomeTimeline = Component.default);
+  import(/* webpackChunkName: "features/compose" */ '../compose').then(Component => staticColumns.Compose = Component.default);
+  import(/* webpackChunkName: "features/notifications" */ '../notifications').then(Component => staticColumns.Notifications = Component.default);
+};
 
 const noOp = () => false;
 
@@ -128,11 +133,18 @@ class UI extends React.PureComponent {
         </ColumnsArea>
       );
     } else {
+      // TODO: Better check & error handling
+      if (Object.keys(staticColumns).length !== 3) {
+        lazyLoadStaticColumns();
+      }
+
+      const { Compose, HomeTimeline, Notifications } = staticColumns;
+
       mountedColumns = (
         <ColumnsArea>
-          <Compose withHeader={true} />
-          <HomeTimeline shouldUpdateScroll={noOp} />
-          <Notifications shouldUpdateScroll={noOp} />
+          {Compose && <Compose withHeader={true} />}
+          {HomeTimeline && <HomeTimeline shouldUpdateScroll={noOp} />}
+          {Notifications && <Notifications shouldUpdateScroll={noOp} />}
           <div className="column__wrapper">{children}</div>
         </ColumnsArea>
       );


### PR DESCRIPTION
Reduces `application.js` by ~30% (from `648kB` to `455kB`). There are still some things to address like error handling and perhaps show the loading indicator while fetching the bundles.

http://bl.ocks.org/sorin-davidoi/raw/bcce9c6bb4ae822ea8f26f4a5f6eae60/