### PR TITLE
Fix video having black border on top due to regression from #2608

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -3395,7 +3395,7 @@ button.icon-button.active i.fa-retweet {
   object-fit: cover;
   position: relative;
   top: 50%;
-  transform: translateY(-35%);
+  transform: translateY(-50%);
   width: 100%;
   z-index: 1;
 }


### PR DESCRIPTION
The combination of object-fit, relative position 50% from top and translating it back upwards 50% is what allows us to crop the video properly, so it needs to be +50%-50%