### PR TITLE
Use immutable list in UploadButton to avoid wasteful re-render

### DIFF
--- a/app/javascript/mastodon/features/compose/components/upload_button.js
+++ b/app/javascript/mastodon/features/compose/components/upload_button.js
@@ -3,6 +3,8 @@ import IconButton from '../../../components/icon_button';
 import PropTypes from 'prop-types';
 import { defineMessages, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 
 const messages = defineMessages({
   upload: { id: 'upload_button.label', defaultMessage: 'Add media' },
@@ -10,7 +12,7 @@ const messages = defineMessages({
 
 const makeMapStateToProps = () => {
   const mapStateToProps = (state, props) => ({
-    acceptContentTypes: state.getIn(['media_attachments', 'accept_content_types']).toArray(),
+    acceptContentTypes: state.getIn(['media_attachments', 'accept_content_types']),
   });
 
   return mapStateToProps;
@@ -21,14 +23,14 @@ const iconStyle = {
   lineHeight: '27px',
 };
 
-class UploadButton extends React.PureComponent {
+class UploadButton extends ImmutablePureComponent {
 
   static propTypes = {
     disabled: PropTypes.bool,
     onSelectFile: PropTypes.func.isRequired,
     style: PropTypes.object,
     resetFileKey: PropTypes.number,
-    acceptContentTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
+    acceptContentTypes: ImmutablePropTypes.listOf(PropTypes.string).isRequired,
     intl: PropTypes.object.isRequired,
   };
 
@@ -58,7 +60,7 @@ class UploadButton extends React.PureComponent {
           ref={this.setRef}
           type='file'
           multiple={false}
-          accept={ acceptContentTypes.join(',')}
+          accept={ acceptContentTypes.toArray().join(',')}
           onChange={this.handleChange}
           disabled={disabled}
           style={{ display: 'none' }}


### PR DESCRIPTION
This is a minor perf improvement to avoid a wasteful re-render in `UploadButton` by using an ImmutableList rather than creating a new Array each time.

To test, I just loaded the home page and ran `ReactPerf.printWasted()`. Before:

![screenshot 2017-05-28 08 39 23](https://cloud.githubusercontent.com/assets/283842/26529998/7454dad6-4381-11e7-9668-c3fd36b2c0c0.png)

After:

![screenshot 2017-05-28 08 42 17](https://cloud.githubusercontent.com/assets/283842/26530005/93ba7a34-4381-11e7-9051-9f4288e33a71.png)
