### PR TITLE
Tell puma and sidekiq daemons to write pid files

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,6 +1,8 @@
 threads_count = ENV.fetch('MAX_THREADS') { 5 }.to_i
 threads threads_count, threads_count
 
+pidfile 'tmp/mastodon_web.pid'
+
 if ENV['SOCKET'] then
   bind 'unix://' + ENV['SOCKET']
 else

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,6 @@
 ---
 :concurrency: 5
+:pidfile: tmp/mastodon_background.pid
 :queues:
   - default
   - push


### PR DESCRIPTION
Pid files are useful for the rc.d scripts used to start/stop the daemons in the
FreeBSD port/package.