### PR TITLE
Prevent wasted render in load_more.js

### DIFF
--- a/app/javascript/mastodon/components/load_more.js
+++ b/app/javascript/mastodon/components/load_more.js
@@ -2,14 +2,20 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 
-const LoadMore = ({ onClick }) => (
-  <button className='load-more' onClick={onClick}>
-    <FormattedMessage id='status.load_more' defaultMessage='Load more' />
-  </button>
-);
+class LoadMore extends React.PureComponent {
 
-LoadMore.propTypes = {
-  onClick: PropTypes.func,
-};
+  static propTypes = {
+    onClick: PropTypes.func,
+  }
+
+  render() {
+    return (
+      <button className='load-more' onClick={this.props.onClick}>
+        <FormattedMessage id='status.load_more' defaultMessage='Load more' />
+      </button>
+    );
+  }
+
+}
 
 export default LoadMore;


### PR DESCRIPTION
Minor perf improvement. Makes this component a PureComponent to avoid unnecessary re-renders.

Tested by loading the home page and then calling `ReactPerf.printWasted()`. Before:

![screenshot 2017-05-28 15 37 21](https://cloud.githubusercontent.com/assets/283842/26532667/0dda5b60-43bc-11e7-9841-83fde24ac348.png)

After ("LoadMore" is gone from the list):

![screenshot 2017-05-28 15 37 40](https://cloud.githubusercontent.com/assets/283842/26532668/1b9a3068-43bc-11e7-8561-e99cd16df8d2.png)
