### PR TITLE
fix-rails-minor-version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '>= 2.3.0', '< 2.5.0'
 gem 'pkg-config', '~> 1.2'
 
 gem 'puma', '~> 3.8'
-gem 'rails', '~> 5.0'
+gem 'rails', '~> 5.0.0'
 gem 'uglifier', '~> 3.2'
 
 gem 'hamlit-rails', '~> 0.2'


### PR DESCRIPTION
Fix using rails 5.0.x. don't update 5.1.x automatically.