### PR TITLE
l10n: Fix Japanese translation

### DIFF
--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -146,7 +146,7 @@
   "status.delete": "削除",
   "status.favourite": "お気に入り",
   "status.load_more": "もっと見る",
-  "status.media_hidden": "非表示のメデイア",
+  "status.media_hidden": "非表示のメディア",
   "status.mention": "返信",
   "status.mute_conversation": "会話をミュート",
   "status.open": "詳細を表示",


### PR DESCRIPTION
**media** is not **メデイア** in Japanese, it's **メディア**.