### PR TITLE
Use travis_retry to reduce spurious test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,6 @@ before_script:
   - ln -s /usr/bin/x86_64-linux-gnu-g++-6 "$HOME/g++"
 
 script:
-  - bundle exec parallel_test spec/ --group-by filesize --type rspec
+  - travis_retry bundle exec parallel_test spec/ --group-by filesize --type rspec
   - npm test
   - bundle exec i18n-tasks unused


### PR DESCRIPTION
The Travis tests seem a bit flaky. This will make it so that it tries the tests 3 times, and only fails if it fails all 3 times.