### PR TITLE
Use "source-map" in development mode

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -4,7 +4,7 @@ const merge = require('webpack-merge');
 const sharedConfig = require('./shared.js');
 
 module.exports = merge(sharedConfig, {
-  devtool: 'cheap-module-eval-source-map',
+  devtool: 'source-map',
 
   stats: {
     errorDetails: true,


### PR DESCRIPTION
I've spent awhile testing in Chrome and Firefox and reading https://github.com/webpack/webpack/issues/2145 and [the Webpack docs](https://webpack.js.org/configuration/devtool/#components/sidebar/sidebar.jsx), and this seems to be the only option that consistently works in both browsers.

My needs for sourcemaps are:

1. Shows the original source
2. Breakpoints work
3. Clicking a link in a stacktrace in the console works
4. "Continue to next" etc. work in the console
5. Works in at least Chrome and Firefox

I don't really care how "fast" it is if it doesn't work, and none of the `cheap-*` ones actually seem to work for all these use cases. `source-map` may take a bit longer to recompile, but to me I've tested and it's an acceptable delay (~3-5 seconds on my 2013 MacBook Air). As a bonus, `source-map` ought to work fine in Edge and Safari since it's the "standard" sourcemap option.