### PR TITLE
Remove react-imageloader

### DIFF
--- a/app/javascript/mastodon/features/ui/components/image_loader.js
+++ b/app/javascript/mastodon/features/ui/components/image_loader.js
@@ -2,8 +2,6 @@ import React from 'react';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import PropTypes from 'prop-types';
 
-import notFoundPng from '../../../../images/mastodon-not-found.png';
-
 class ImageLoader extends ImmutablePureComponent {
 
   static propTypes = {

--- a/app/javascript/mastodon/features/ui/components/image_loader.js
+++ b/app/javascript/mastodon/features/ui/components/image_loader.js
@@ -12,9 +12,8 @@ class ImageLoader extends React.PureComponent {
     error: false,
   }
 
-  constructor(props) {
-    super(props);
-    this.loadImage(props.src);
+  componentWillMount() {
+    this.loadImage(this.props.src);
   }
 
   componentWillReceiveProps(props) {

--- a/app/javascript/mastodon/features/ui/components/image_loader.js
+++ b/app/javascript/mastodon/features/ui/components/image_loader.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import PropTypes from 'prop-types';
+
+import notFoundPng from '../../../../images/mastodon-not-found.png';
+
+class ImageLoader extends ImmutablePureComponent {
+
+  static propTypes = {
+    src: PropTypes.string.isRequired,
+  }
+
+  state = {
+    loading: true,
+    error: false,
+  }
+
+  constructor(props) {
+    super(props);
+    this.loadImage(props.src);
+  }
+
+  componentWillReceiveProps(props) {
+    this.loadImage(props.src);
+  }
+
+  loadImage(src) {
+    const image = new Image();
+    image.onerror = () => this.setState({loading: false, error: true});
+    image.onload = () => this.setState({loading: false, error: false});
+    image.src = src;
+    this.lastSrc = src;
+    this.setState({loading: true});
+  }
+
+  render() {
+    const { src } = this.props;
+    const { loading, error } = this.state;
+
+    // TODO: handle image error state
+
+    const imageClass = `image-loader__img ${loading ? 'image-loader__img-loading' : ''}`;
+
+    return <img className={imageClass} src={src} />; // eslint-disable-line jsx-a11y/img-has-alt
+  }
+
+}
+
+export default ImageLoader;

--- a/app/javascript/mastodon/features/ui/components/image_loader.js
+++ b/app/javascript/mastodon/features/ui/components/image_loader.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 import PropTypes from 'prop-types';
 
-class ImageLoader extends ImmutablePureComponent {
+class ImageLoader extends React.PureComponent {
 
   static propTypes = {
     src: PropTypes.string.isRequired,

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -3,7 +3,6 @@ import LoadingIndicator from '../../../components/loading_indicator';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
 import ExtendedVideoPlayer from '../../../components/extended_video_player';
-import ImageLoader from 'react-imageloader';
 import { defineMessages, injectIntl } from 'react-intl';
 import IconButton from '../../../components/icon_button';
 import ImmutablePureComponent from 'react-immutable-pure-component';
@@ -73,7 +72,7 @@ class MediaModal extends ImmutablePureComponent {
     }
 
     if (attachment.get('type') === 'image') {
-      content = <ImageLoader src={url} imgProps={{ style: { display: 'block' } }} />;
+      content = <img src={url} />;
     } else if (attachment.get('type') === 'gifv') {
       content = <ExtendedVideoPlayer src={url} muted={true} controls={false} />;
     }

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -72,7 +72,7 @@ class MediaModal extends ImmutablePureComponent {
     }
 
     if (attachment.get('type') === 'image') {
-      content = <img src={url} />;
+      content = <img src={url} />; // eslint-disable-line jsx-a11y/img-has-alt
     } else if (attachment.get('type') === 'gifv') {
       content = <ExtendedVideoPlayer src={url} muted={true} controls={false} />;
     }

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -6,6 +6,7 @@ import ExtendedVideoPlayer from '../../../components/extended_video_player';
 import { defineMessages, injectIntl } from 'react-intl';
 import IconButton from '../../../components/icon_button';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+import ImageLoader from './image_loader';
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
@@ -72,7 +73,7 @@ class MediaModal extends ImmutablePureComponent {
     }
 
     if (attachment.get('type') === 'image') {
-      content = <img src={url} />; // eslint-disable-line jsx-a11y/img-has-alt
+      content = <ImageLoader src={url} />;
     } else if (attachment.get('type') === 'gifv') {
       content = <ExtendedVideoPlayer src={url} muted={true} controls={false} />;
     }

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1137,6 +1137,15 @@
   }
 }
 
+.image-loader__img {
+  transition: opacity 0.3s linear;
+  opacity: 1;
+}
+
+.image-loader__img-loading {
+  opacity: 0.7;
+}
+
 .navigation-bar {
   padding: 10px;
   display: flex;

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1137,15 +1137,6 @@
   }
 }
 
-.transparent-background,
-.imageloader {
-  background: url('../images/void.png');
-}
-
-.imageloader {
-  display: block;
-}
-
 .navigation-bar {
   padding: 10px;
   display: flex;
@@ -2851,6 +2842,11 @@ button.icon-button.active i.fa-retweet {
   video {
     max-width: 80vw;
     max-height: 80vh;
+  }
+
+  img {
+    display: block;
+    background: url('../images/void.png') repeat;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "react-addons-perf": "^15.4.2",
     "react-addons-shallow-compare": "^15.5.2",
     "react-dom": "^15.5.4",
-    "react-imageloader": "^2.1.0",
     "react-immutable-proptypes": "^2.1.0",
     "react-immutable-pure-component": "^0.0.4",
     "react-intl": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5436,10 +5436,6 @@ react-fuzzy@^0.3.3:
     classnames "^2.2.3"
     fuse.js "^2.2.0"
 
-react-imageloader@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-imageloader/-/react-imageloader-2.1.0.tgz#a58401970b3282386aeb810c43175165634f6308"
-
 react-immutable-proptypes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz#023d6f39bb15c97c071e9e60d00d136eac5fa0b4"
@@ -5595,12 +5591,6 @@ react-textarea-autosize@^5.0.6:
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.0.6.tgz#a3742e0a319484021b4dbfa1519df287768f2133"
   dependencies:
     prop-types "^15.5.8"
-
-react-themeable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
-  dependencies:
-    object-assign "^3.0.0"
 
 react-toggle@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
`react-imageloader` is causing a warning in the console:

    Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.

Furthermore, its last version was released 2 years ago and [appears to be inactive](https://github.com/hzdg/react-imageloader/graphs/contributors). And we're not really using it for much; an `<img>` tag works just fine instead.

Here's a screenshot before this PR (note the transparent white-and-gray checkerboard background):

![screenshot 2017-05-29 11 29 06](https://cloud.githubusercontent.com/assets/283842/26559225/27fbac5e-4463-11e7-9cc1-ac9e4f784e44.png)

And after:

![screenshot 2017-05-29 11 29 32](https://cloud.githubusercontent.com/assets/283842/26559229/308f2fee-4463-11e7-93a8-7476b56cb824.png)

(The point is that they look exactly the same. :smiley:)