### PR TITLE
Move status reblog authorization into policy

### DIFF
--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -9,12 +9,26 @@ class StatusPolicy
   end
 
   def show?
-    if status.direct_visibility?
+    if direct?
       status.account.id == account&.id || status.mentions.where(account: account).exists?
-    elsif status.private_visibility?
+    elsif private?
       status.account.id == account&.id || account&.following?(status.account) || status.mentions.where(account: account).exists?
     else
       account.nil? || !status.account.blocking?(account)
     end
+  end
+
+  def reblog?
+    !direct? && !private? && show?
+  end
+
+  private
+
+  def direct?
+    status.direct_visibility?
+  end
+
+  def private?
+    status.private_visibility?
   end
 end

--- a/app/services/reblog_service.rb
+++ b/app/services/reblog_service.rb
@@ -11,8 +11,7 @@ class ReblogService < BaseService
   def call(account, reblogged_status)
     reblogged_status = reblogged_status.reblog if reblogged_status.reblog?
 
-    authorize_with account, reblogged_status, :show?
-    raise Mastodon::NotPermittedError if reblogged_status.direct_visibility? || reblogged_status.private_visibility?
+    authorize_with account, reblogged_status, :reblog?
 
     reblog = account.statuses.create!(reblog: reblogged_status, text: '')
 


### PR DESCRIPTION
This PR moves the authorization check for "reblogging" into the `StatusPolicy` class. Currently, this authorization check is only being used in the `ReblogService`.

The specs for `StatusPolicy` have been updated to cover the new `reblog?` predicate method.