### PR TITLE
Remove unused React Storybook addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "minimist": "^1.2.0",
     "mocha": "^3.4.1",
     "react-intl-translations-manager": "^5.0.0",
-    "react-storybook-addon-intl": "^0.1.0",
     "react-test-renderer": "^15.5.4",
     "sinon": "^2.2.0",
     "webpack-dev-server": "^2.4.5"

--- a/storybook/config.js
+++ b/storybook/config.js
@@ -1,5 +1,4 @@
 import { configure, setAddon } from '@kadira/storybook';
-import IntlAddon from 'react-storybook-addon-intl';
 import React from 'react';
 import { storiesOf, action } from '@kadira/storybook';
 import { addLocaleData } from 'react-intl';
@@ -7,7 +6,6 @@ import en from 'react-intl/locale-data/en';
 import '../app/javascript/styles/application.scss';
 import './storybook.scss';
 
-setAddon(IntlAddon);
 addLocaleData(en);
 
 let req = require.context('./stories/', true, /.story.js$/);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5573,10 +5573,6 @@ react-simple-dropdown@^3.0.0:
     classnames "^2.1.2"
     prop-types "^15.5.8"
 
-react-storybook-addon-intl@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/react-storybook-addon-intl/-/react-storybook-addon-intl-0.1.0.tgz#4d46c9e6c7be0ad4e4f7de72d907ec764743dee8"
-
 react-stubber@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-stubber/-/react-stubber-1.0.0.tgz#41ee2cac72d4d4fd70a63896da98e13739b84628"
@@ -5595,12 +5591,6 @@ react-textarea-autosize@^5.0.6:
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.0.6.tgz#a3742e0a319484021b4dbfa1519df287768f2133"
   dependencies:
     prop-types "^15.5.8"
-
-react-themeable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
-  dependencies:
-    object-assign "^3.0.0"
 
 react-toggle@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
`react-storybook-addon-intl` has not been updated for a long time. It does not correspond to a new `storybook`.

And it is not used.
