### PR TITLE
Add "private: true" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "type": "git",
     "url": "https://github.com/tootsuite/mastodon.git"
   },
+  "private": true,
   "dependencies": {
     "array-includes": "^3.0.3",
     "autoprefixer": "^7.1.0",


### PR DESCRIPTION
> If you set `"private": true` in your package.json, then npm will refuse to publish it.
> 
> This is a way to prevent accidental publication of private repositories. If you would like to ensure that a given package is only ever published to a specific registry (for example, an internal registry), then use the `publishConfig` dictionary described below to override the `registry` config param at publish-time.

cite: https://docs.npmjs.com/files/package.json#private