### PR TITLE
added "https://" to the CDN_HOST variable in .env.production.sample

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -65,7 +65,7 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # PAPERCLIP_ROOT_URL=/system
 
 # Optional asset host for multi-server setups
-# CDN_HOST=assets.example.com
+# CDN_HOST=https://assets.example.com
 
 # S3 (optional)
 # S3_ENABLED=true


### PR DESCRIPTION
Incredibly small PR. As of v1.4 the CDN_HOST variable needs to contain the protocol - adding that to the example URL should help to avoid confusion in the future.