### PR TITLE
Add status destroy authorization to policy

### DIFF
--- a/app/controllers/admin/reported_statuses_controller.rb
+++ b/app/controllers/admin/reported_statuses_controller.rb
@@ -2,6 +2,8 @@
 
 module Admin
   class ReportedStatusesController < BaseController
+    include Authorization
+
     before_action :set_report
     before_action :set_status
 
@@ -11,6 +13,7 @@ module Admin
     end
 
     def destroy
+      authorize @status, :destroy?
       RemovalWorker.perform_async(@status.id)
       redirect_to admin_report_path(@report)
     end

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -79,7 +79,10 @@ class Api::V1::StatusesController < ApiController
 
   def destroy
     @status = Status.where(account_id: current_user.account).find(params[:id])
+    authorize @status, :destroy?
+
     RemovalWorker.perform_async(@status.id)
+
     render_empty
   end
 
@@ -92,6 +95,8 @@ class Api::V1::StatusesController < ApiController
     reblog       = Status.where(account_id: current_user.account, reblog_of_id: params[:id]).first!
     @status      = reblog.reblog
     @reblogs_map = { @status.id => false }
+
+    authorize reblog, :destroy?
 
     RemovalWorker.perform_async(reblog.id)
 

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -96,7 +96,7 @@ class Api::V1::StatusesController < ApiController
     @status      = reblog.reblog
     @reblogs_map = { @status.id => false }
 
-    authorize reblog, :destroy?
+    authorize reblog, :unreblog?
 
     RemovalWorker.perform_async(reblog.id)
 

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -26,6 +26,8 @@ class StatusPolicy
     admin? || owned?
   end
 
+  alias unreblog? destroy?
+
   private
 
   def admin?

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -10,9 +10,9 @@ class StatusPolicy
 
   def show?
     if direct?
-      status.account.id == account&.id || status.mentions.where(account: account).exists?
+      owned? || status.mentions.where(account: account).exists?
     elsif private?
-      status.account.id == account&.id || account&.following?(status.account) || status.mentions.where(account: account).exists?
+      owned? || account&.following?(status.account) || status.mentions.where(account: account).exists?
     else
       account.nil? || !status.account.blocking?(account)
     end
@@ -22,10 +22,22 @@ class StatusPolicy
     !direct? && !private? && show?
   end
 
+  def destroy?
+    admin? || owned?
+  end
+
   private
+
+  def admin?
+    account&.user&.admin?
+  end
 
   def direct?
     status.direct_visibility?
+  end
+
+  def owned?
+    status.account.id == account&.id
   end
 
   def private?

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe StatusPolicy, type: :model do
     end
   end
 
-  permissions :destroy? do
+  permissions :destroy?, :unreblog? do
     it 'grants access when account is deleter' do
       expect(subject).to permit(status.account, status)
     end

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -4,7 +4,9 @@ require 'pundit/rspec'
 RSpec.describe StatusPolicy, type: :model do
   subject { described_class }
 
+  let(:admin) { Fabricate(:user, admin: true) }
   let(:alice) { Fabricate(:account, username: 'alice') }
+  let(:bob) { Fabricate(:account, username: 'bob') }
   let(:status) { Fabricate(:status, account: alice) }
 
   permissions :show?, :reblog? do
@@ -83,6 +85,24 @@ RSpec.describe StatusPolicy, type: :model do
       status.visibility = :direct
 
       expect(subject).to_not permit(viewer, status)
+    end
+  end
+
+  permissions :destroy? do
+    it 'grants access when account is deleter' do
+      expect(subject).to permit(status.account, status)
+    end
+
+    it 'grants access when account is admin' do
+      expect(subject).to permit(admin.account, status)
+    end
+
+    it 'denies access when account is not deleter' do
+      expect(subject).to_not permit(bob, status)
+    end
+
+    it 'denies access when no deleter' do
+      expect(subject).to_not permit(nil, status)
     end
   end
 end


### PR DESCRIPTION
The PR adds a `destroy?` authorization check for statuses. Only admin users or the account that is connected to a status is authorized to destroy.

I've also (in a separate commit) added an explicit `unreblog?` check that is an alias for `destroy?`.

I have also added a spec for `ProcessInteractionService` for incoming delete "slaps". I'd appreciate a review on the spec code here.