### PR TITLE
Fix incorrect visibility setter in StatusPolicySpec

### DIFF
--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe StatusPolicy, type: :model do
   permissions :show? do
     it 'grants access when direct and account is viewer' do
       status.visibility = :direct
+
       expect(subject).to permit(status.account, status)
     end
 
@@ -42,7 +43,7 @@ RSpec.describe StatusPolicy, type: :model do
     end
 
     it 'grants access when private and account is viewer' do
-      status.visibility = :direct
+      status.visibility = :private
 
       expect(subject).to permit(status.account, status)
     end


### PR DESCRIPTION
This was a mistake introduced in one of my previous PRs (#3150), where the spec for viewing a private status incorrectly specced the behavior of a direct status.