### PR TITLE
Fix load more on account timelines (regression from #3311)

### DIFF
--- a/app/javascript/mastodon/actions/accounts.js
+++ b/app/javascript/mastodon/actions/accounts.js
@@ -107,7 +107,9 @@ export function fetchAccountTimeline(id, replace = false) {
     let params = {};
     let skipLoading = false;
 
-    if (newestId !== null && !replace) {
+    replace = replace || newestId === null;
+
+    if (!replace) {
       params.since_id = newestId;
       skipLoading = true;
     }
@@ -131,7 +133,9 @@ export function fetchAccountMediaTimeline(id, replace = false) {
     let params = { only_media: 'true', limit: 12 };
     let skipLoading = false;
 
-    if (newestId !== null && !replace) {
+    replace = replace || newestId === null;
+
+    if (!replace) {
       params.since_id = newestId;
       skipLoading = true;
     }

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -138,7 +138,7 @@ const normalizeAccountTimeline = (state, accountId, statuses, replace, next) => 
   return state.updateIn(['accounts_timelines', accountId], Immutable.Map(), map => map
     .set('isLoading', false)
     .set('loaded', true)
-    .set('next', next)
+    .update('next', null, v => replace ? next : v)
     .update('items', Immutable.List(), list => (replace ? ids : ids.concat(list))));
 };
 
@@ -152,7 +152,7 @@ const normalizeAccountMediaTimeline = (state, accountId, statuses, replace, next
 
   return state.updateIn(['accounts_media_timelines', accountId], Immutable.Map(), map => map
     .set('isLoading', false)
-    .set('next', next)
+    .update('next', null, v => replace ? next : v)
     .update('items', Immutable.List(), list => (replace ? ids : ids.concat(list))));
 };
 


### PR DESCRIPTION
Fixes #3447.

This prevents `next` state from being overridden on the loading *new* statuses.