### PR TITLE
Improve scheduling of requestIdleCallback tasks

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -14,6 +14,7 @@ import { FormattedMessage } from 'react-intl';
 import emojify from '../emoji';
 import escapeTextContentForBrowser from 'escape-html';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+import scheduleIdleTask from '../features/ui/util/schedule_idle_task';
 
 class Status extends ImmutablePureComponent {
 
@@ -92,7 +93,7 @@ class Status extends ImmutablePureComponent {
     const isIntersecting = entry.intersectionRatio > 0;
     this.setState((prevState) => {
       if (prevState.isIntersecting && !isIntersecting) {
-        requestIdleCallback(this.hideIfNotIntersecting);
+        scheduleIdleTask(this.hideIfNotIntersecting);
       }
       return {
         isIntersecting: isIntersecting,

--- a/app/javascript/mastodon/features/ui/util/schedule_idle_task.js
+++ b/app/javascript/mastodon/features/ui/util/schedule_idle_task.js
@@ -1,0 +1,29 @@
+// Wrapper to call requestIdleCallback() to schedule low-priority work.
+// See https://developer.mozilla.org/en-US/docs/Web/API/Background_Tasks_API
+// for a good breakdown of the concepts behind this.
+
+import Queue from 'tiny-queue';
+
+const taskQueue = new Queue();
+let runningRequestIdleCallback = false;
+
+function runTasks(deadline) {
+  while (taskQueue.length && deadline.timeRemaining() > 0) {
+    taskQueue.shift()();
+  }
+  if (taskQueue.length) {
+    requestIdleCallback(runTasks);
+  } else {
+    runningRequestIdleCallback = false;
+  }
+}
+
+function scheduleIdleTask(task) {
+  taskQueue.push(task);
+  if (!runningRequestIdleCallback) {
+    runningRequestIdleCallback = true;
+    requestIdleCallback(runTasks);
+  }
+}
+
+export default scheduleIdleTask;

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "stringz": "^0.2.0",
     "style-loader": "^0.16.1",
     "throng": "^4.0.0",
+    "tiny-queue": "^0.2.1",
     "uuid": "^3.0.1",
     "uws": "^0.14.5",
     "webpack": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5596,12 +5596,6 @@ react-textarea-autosize@^5.0.6:
   dependencies:
     prop-types "^15.5.8"
 
-react-themeable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
-  dependencies:
-    object-assign "^3.0.0"
-
 react-toggle@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/react-toggle/-/react-toggle-4.0.1.tgz#0e83e8c94d94232debfa21a938ff3d2b2106ec72"
@@ -6519,6 +6513,10 @@ timers-browserify@^2.0.2:
 tiny-emitter@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-1.0.2.tgz#8e49470d3f55f89e247210368a6bb9fb51aa1601"
+
+tiny-queue@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tiny-queue/-/tiny-queue-0.2.1.tgz#25a67f2c6e253b2ca941977b5ef7442ef97a6046"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This improves our usage of `requestIdleCallback` for toot de-rendering in a few ways:

1. Instead of just calling `requestIdleCallback()`, we check the [IdleDeadline](https://developer.mozilla.org/en-US/docs/Web/API/IdleDeadline) to see how much time is remaining as described in [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Background_Tasks_API).
2. Tasks are handled within a scheduler which keeps running tasks until the deadline is up.

It's tricky to measure that actual improvement from this, but based on my ad-hoc testing, this removes DOM nodes like the old system while also doing a better job of delaying the cleanup to when the user is actually idle (e.g. not during scrolling, but when the user isn't interacting with the page.)