### PR TITLE
Keep ENV['LOCAL_HTTPS'] with ApplicationControllerSpec (fix random fail)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ end
 
 group :test do
   gem 'capybara', '~> 2.14'
+  gem 'climate_control', '~> 0.2'
   gem 'faker', '~> 1.7'
   gem 'microformats2', '~> 3.0'
   gem 'rails-controller-testing', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -487,6 +487,7 @@ DEPENDENCIES
   capistrano-yarn (~> 2.0)
   capybara (~> 2.14)
   cld3 (~> 3.1)
+  climate_control (~> 0.2)
   devise (~> 4.2)
   devise-two-factor (~> 3.0)
   doorkeeper (~> 4.2)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -37,24 +37,18 @@ describe ApplicationController, type: :controller do
     end
   end
 
-  context do
-    around do |example|
-      original_local_https = ENV['LOCAL_HTTPS']
-      example.run
-      ENV['LOCAL_HTTPS'] = original_local_https
-    end
-
-    it "does not force ssl if LOCAL_HTTPS is not 'true'" do
-      routes.draw { get 'success' => 'anonymous#success' }
-      ENV['LOCAL_HTTPS'] = ''
+  it "does not force ssl if LOCAL_HTTPS is not 'true'" do
+    routes.draw { get 'success' => 'anonymous#success' }
+    ClimateControl.modify LOCAL_HTTPS: '' do
       allow(Rails.env).to receive(:production?).and_return(true)
       get 'success'
       expect(response).to have_http_status(:success)
     end
+  end
 
-    it "forces ssl if LOCAL_HTTPS is 'true'" do
-      routes.draw { get 'success' => 'anonymous#success' }
-      ENV['LOCAL_HTTPS'] = 'true'
+  it "forces ssl if LOCAL_HTTPS is 'true'" do
+    routes.draw { get 'success' => 'anonymous#success' }
+    ClimateControl.modify LOCAL_HTTPS: 'true' do
       allow(Rails.env).to receive(:production?).and_return(true)
       get 'success'
       expect(response).to redirect_to('https://test.host/success')

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -37,20 +37,28 @@ describe ApplicationController, type: :controller do
     end
   end
 
-  it "does not force ssl if LOCAL_HTTPS is not 'true'" do
-    routes.draw { get 'success' => 'anonymous#success' }
-    ENV['LOCAL_HTTPS'] = ''
-    allow(Rails.env).to receive(:production?).and_return(true)
-    get 'success'
-    expect(response).to have_http_status(:success)
-  end
+  context do
+    around do |example|
+      original_local_https = ENV['LOCAL_HTTPS']
+      example.run
+      ENV['LOCAL_HTTPS'] = original_local_https
+    end
 
-  it "forces ssl if LOCAL_HTTPS is 'true'" do
-    routes.draw { get 'success' => 'anonymous#success' }
-    ENV['LOCAL_HTTPS'] = 'true'
-    allow(Rails.env).to receive(:production?).and_return(true)
-    get 'success'
-    expect(response).to redirect_to('https://test.host/success')
+    it "does not force ssl if LOCAL_HTTPS is not 'true'" do
+      routes.draw { get 'success' => 'anonymous#success' }
+      ENV['LOCAL_HTTPS'] = ''
+      allow(Rails.env).to receive(:production?).and_return(true)
+      get 'success'
+      expect(response).to have_http_status(:success)
+    end
+
+    it "forces ssl if LOCAL_HTTPS is 'true'" do
+      routes.draw { get 'success' => 'anonymous#success' }
+      ENV['LOCAL_HTTPS'] = 'true'
+      allow(Rails.env).to receive(:production?).and_return(true)
+      get 'success'
+      expect(response).to redirect_to('https://test.host/success')
+    end
   end
 
   describe 'helper_method :current_account' do

--- a/spec/features/log_in_spec.rb
+++ b/spec/features/log_in_spec.rb
@@ -1,11 +1,14 @@
 require "rails_helper"
 
 feature "Log in" do
-  scenario "A valid email and password user is able to log in" do
-    email = "test@example.com"
-    password = "password"
-    Fabricate(:user, email: email, password: password)
+  given(:email)    { "test@examle.com" }
+  given(:password) { "password" }
 
+  background do
+    Fabricate(:user, email: email, password: password)
+  end
+
+  scenario "A valid email and password user is able to log in" do
     visit new_user_session_path
     fill_in "user_email", with: email
     fill_in "user_password", with: password


### PR DESCRIPTION
This fixes the failure of the random Features Spec that we have suffered for a long time.

### error case

```console
$ ./bin/rspec ./spec/controllers/application_controller_spec.rb[1:1] ./spec/features/log_in_spec.rb[1:1] --seed 26878
[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead.
Run options: include {:ids=>{"./spec/controllers/application_controller_spec.rb"=>["1:1"], "./spec/features/log_in_spec.rb"=>["1:1"]}}                                                  

Randomized with seed 26878
                                                                                                                                                                                        
  1) Log in A valid email and password user is able to log in
     Failure/Error: expect(page).to have_css "div.app-holder"
       expected to find css "div.app-holder" but there were no matches
     # ./spec/features/log_in_spec.rb:17:in `block (2 levels) in <top (required)>'

 2/2 |============================================================================= 100 ==============================================================================>| Time: 00:00:01 

Finished in 1.54 seconds (files took 2.95 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/features/log_in_spec.rb:11 # Log in A valid email and password user is able to log in

Randomized with seed 26878

Coverage report generated for RSpec to /Users/ykzts/works/ykzts/mastodon/coverage. 596 / 8516 LOC (7.0%) covered.
```

### how to find

<details>
<summary><code>$ ./bin/rspec --seed 26878 --bisect</code></summary>
<pre><code>Bisect started using options: "--seed 26878"
Running suite to find failures... (2 minutes 0.5 seconds)
Starting bisect with 1 failing example and 1084 non-failing examples.
Checking that failure(s) are order-dependent... failure appears to be order-dependent

Round 1: bisecting over non-failing examples 1-1084 .. ignoring examples 543-1084 (2 minutes 6.5 seconds)
Round 2: bisecting over non-failing examples 1-542 . ignoring examples 1-271 (27.38 seconds)
Round 3: bisecting over non-failing examples 272-542 .. ignoring examples 408-542 (34.6 seconds)
Round 4: bisecting over non-failing examples 272-407 . ignoring examples 272-339 (11.85 seconds)
Round 5: bisecting over non-failing examples 340-407 .. ignoring examples 374-407 (19.89 seconds)
Round 6: bisecting over non-failing examples 340-373 .. ignoring examples 357-373 (15.36 seconds)
Round 7: bisecting over non-failing examples 340-356 . ignoring examples 340-348 (6.97 seconds)
Round 8: bisecting over non-failing examples 349-356 .. ignoring examples 353-356 (16.2 seconds)
Round 9: bisecting over non-failing examples 349-352 .. ignoring examples 351-352 (14.42 seconds)
Round 10: bisecting over non-failing examples 349-350 . ignoring example 349 (7.94 seconds)
Bisect complete! Reduced necessary non-failing examples from 1084 to 1 in 4 minutes 48.1 seconds.

The minimal reproduction command is:
  rspec ./spec/controllers/application_controller_spec.rb[1:1] ./spec/features/log_in_spec.rb[1:1] --seed 26878</code></pre>
</details