### PR TITLE
Generate ./tmp/streaming on install instead of startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "build:development": "cross-env NODE_ENV=development yarn webpack -- --config config/webpack/development.js",
     "build:production": "cross-env NODE_ENV=production yarn webpack -- --config config/webpack/production.js",
     "manage:translations": "node ./config/webpack/translationRunner.js",
-    "start": "rimraf ./tmp/streaming && babel ./streaming/index.js --out-dir ./tmp && node ./tmp/streaming/index.js",
+    "start": "node ./tmp/streaming/index.js",
     "storybook": "cross-env NODE_ENV=test start-storybook -s ./public -p 9001 -c storybook",
     "test": "npm run test:lint && npm run test:mocha",
     "test:lint": "eslint -c .eslintrc.yml --ext=js app/javascript/ config/webpack/ spec/javascript/ storybook/ streaming/",
     "test:mocha": "cross-env NODE_ENV=test mocha --require ./spec/javascript/setup.js --compilers js:babel-register ./spec/javascript/components/*.test.js",
-    "postinstall": "npm rebuild node-sass"
+    "postinstall": "npm rebuild node-sass && rimraf ./tmp/streaming && babel ./streaming/index.js --out-dir ./tmp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This allows the streaming service to run without write access to the code's directory or one of its subdirectories.

Closes #3486.