### PR TITLE
[nanobox] Add python for node-gyp

### DIFF
--- a/boxfile.yml
+++ b/boxfile.yml
@@ -14,8 +14,11 @@ run.config:
     # for videos:
     - ffmpeg3
 
-    # to prep the .env file
+    # to prep the .env file:
     - gettext-tools
+
+    # for node-gyp, used in the asset compilation process:
+    - python-2
 
   cache_dirs:
     - node_modules


### PR DESCRIPTION
The node module `node-gyp` - used in asset compilation - requires Python 2. This PR adds `python-2` to the Nanobox package list so it will be installed and available.