### PR TITLE
Change to returns nil when Account.find_local is given blank username (regression from #3485)

### DIFF
--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -30,7 +30,7 @@ module AccountFinderConcern
     end
 
     def account
-      scoped_accounts.take
+      scoped_accounts.take unless username.blank?
     end
 
     private
@@ -43,7 +43,6 @@ module AccountFinderConcern
     end
 
     def matching_username
-      raise(ActiveRecord::RecordNotFound) if username.blank?
       Account.where(Account.arel_table[:username].lower.eq username.downcase)
     end
 

--- a/spec/models/concerns/account_finder_concern_spec.rb
+++ b/spec/models/concerns/account_finder_concern_spec.rb
@@ -24,6 +24,10 @@ describe AccountFinderConcern do
       it 'returns nil for regex style username value' do
         expect(Account.find_local('al%')).to be_nil
       end
+
+      it 'returns nil with blank username' do
+        expect(Account.find_local('')).to be_nil
+      end
     end
 
     describe '.find_local!' do


### PR DESCRIPTION
`HomeController#index` returns "404 Not Found" when no value is specified for `Setting.site_contact_username`.
