### PR TITLE
Focus the submit button on boost modal

### DIFF
--- a/app/javascript/mastodon/features/ui/components/boost_modal.js
+++ b/app/javascript/mastodon/features/ui/components/boost_modal.js
@@ -27,6 +27,10 @@ class BoostModal extends ImmutablePureComponent {
     intl: PropTypes.object.isRequired,
   };
 
+  componentDidMount() {
+    this.button.focus();
+  }
+
   handleReblog = () => {
     this.props.onReblog(this.props.status);
     this.props.onClose();
@@ -38,6 +42,10 @@ class BoostModal extends ImmutablePureComponent {
       this.props.onClose();
       this.context.router.push(`/accounts/${this.props.status.getIn(['account', 'id'])}`);
     }
+  }
+
+  setRef = (c) => {
+    this.button = c;
   }
 
   render () {
@@ -67,7 +75,7 @@ class BoostModal extends ImmutablePureComponent {
 
         <div className='boost-modal__action-bar'>
           <div><FormattedMessage id='boost_modal.combo' defaultMessage='You can press {combo} to skip this next time' values={{ combo: <span>Shift + <i className='fa fa-retweet' /></span> }} /></div>
-          <Button text={intl.formatMessage(messages.reblog)} onClick={this.handleReblog} />
+          <Button text={intl.formatMessage(messages.reblog)} onClick={this.handleReblog} ref={this.setRef} />
         </div>
       </div>
     );


### PR DESCRIPTION
Focus the submit button when boost modal is opened, like #3253 on confirmation modal.