### PR TITLE
Fix an edge case on IntersectionObserver

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -90,7 +90,7 @@ class Status extends ImmutablePureComponent {
   handleIntersection = (entry) => {
     // Edge 15 doesn't support isIntersecting, but we can infer it from intersectionRatio
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12156111/
-    const isIntersecting = entry.intersectionRatio > 0;
+    const isIntersecting = entry.intersectionRatio >= 0.01;
     this.setState((prevState) => {
       if (prevState.isIntersecting && !isIntersecting) {
         scheduleIdleTask(this.hideIfNotIntersecting);

--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -64,8 +64,9 @@ class StatusList extends ImmutablePureComponent {
       root: this.node,
       rootMargin: '300% 0px',
       // Sometimes intersectionRatio will be 0 even on isIntersecting === true.
-      // To avoid this edge case, set a clearly greater value than 0.
-      threshold: 1,
+      // To avoid this edge case, set a greater value than 0.
+      // Note that any value less than lowest threshold will be used as "not intersected".
+      threshold: [0.01],
     });
   }
 

--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -63,6 +63,9 @@ class StatusList extends ImmutablePureComponent {
     this.intersectionObserverWrapper.connect({
       root: this.node,
       rootMargin: '300% 0px',
+      // Sometimes intersectionRatio will be 0 even on isIntersecting === true.
+      // To avoid this edge case, set a clearly greater value than 0.
+      threshold: 1,
     });
   }
 


### PR DESCRIPTION
The default value for the `threshold` option is `0`, which means notify when `intersectionRatio` will be greater than 0. However, it generates the entry which is `intersectionRatio === 0 && isIntersected` sometimes. This causes some toots still being hidden.

![gif](https://cloud.githubusercontent.com/assets/705555/26682385/3e779f14-471b-11e7-8da7-df1c11cb2633.gif)

This issue wouldn't occur if we use `isIntersecting`, but not now for compatibility (#3365). So I've set `threshold` to clearly greater value than `0` to avoid this edge case.

cc @nolanlawson @sorin-davidoi 

### Example

https://codepen.io/unarist/pen/rwBxrQ/

In this example, the element with `intersectionRatio === 0` will be colored pink background. Elements you are seeing should not be colored because it is intersecting, but I can see sometimes while scrolling faster.

I've confirmed this issue on Chrome 61 on Windows.