### PR TITLE
Docker: Smaller image, remove build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,8 @@ ENV UID=991 GID=991 \
 
 EXPOSE 3000 4000
 
-WORKDIR /mastodon
-
 RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
- && apk -U upgrade \
- && apk add -t build-dependencies \
-    build-base \
-    libxml2-dev \
-    libxslt-dev \
-    postgresql-dev \
-    protobuf-dev \
-    python \
- && apk add \
+ && apk add --no-cache \
     ca-certificates \
     ffmpeg \
     file \
@@ -34,14 +24,22 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
     protobuf \
     su-exec \
     tini \
- && npm install -g npm@3 && npm install -g yarn \
  && update-ca-certificates \
- && rm -rf /tmp/* /var/cache/apk/*
+ && npm install -g npm@3 && npm install -g yarn
 
 COPY Gemfile Gemfile.lock package.json yarn.lock /mastodon/
+WORKDIR /mastodon
 
-RUN bundle install --deployment --without test development \
- && yarn --ignore-optional --pure-lockfile
+RUN apk add --no-cache -t build-dependencies \
+    build-base \
+    libxml2-dev \
+    libxslt-dev \
+    postgresql-dev \
+    protobuf-dev \
+    python \
+ && bundle install --clean --no-cache --deployment --without test development \
+ && yarn --ignore-optional --pure-lockfile \
+ && apk del --no-cache build-dependencies
 
 COPY . /mastodon
 


### PR DESCRIPTION
I noticed build-dependencies weren't removed from the the image although a virtual package was created (`apk add -t build-dependencies`). Not sure why and I couldn't find mention of that in the PR where it was introduced (https://github.com/tootsuite/mastodon/pull/3182). So I "fixed" it (`apk del --no-cache build-dependencies`) and split the `apk add RUN` instruction to better leverage build caching following this change.

Image size goes down from 1.41GB to 1.22GB and no more build tools are included in production containers.

I also removed `rm -rf /tmp/* /var/cache/apk/*` because those folders are empty (well, almost: 3 4KB files in /tmp/) at this point.