### PR TITLE
Enable stats.json analysis with Webpack Visualizer

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -33,6 +33,10 @@ module.exports = merge(sharedConfig, {
     new BundleAnalyzerPlugin({ // generates report.html and stats.json
       analyzerMode: 'static',
       generateStatsFile: true,
+      statsOptions: {
+        // allows usage with http://chrisbateman.github.io/webpack-visualizer/
+        chunkModules: true,
+      },
       openAnalyzer: false,
       logLevel: 'silent', // do not bother Webpacker, who runs with --json and parses stdout
     }),


### PR DESCRIPTION
[Webpack Visualizer](http://chrisbateman.github.io/webpack-visualizer/) is another nice tool we can use to inspect bundle size, and this fix allows `stats.json` to work with it.

![screenshot 2017-06-01 16 45 57](https://cloud.githubusercontent.com/assets/283842/26705261/efc2a656-46e9-11e7-9848-975db0416412.png)
