### PR TITLE
zh-cn&tw.json: "extended info" -> "about this site"

### DIFF
--- a/app/javascript/mastodon/locales/zh-CN.json
+++ b/app/javascript/mastodon/locales/zh-CN.json
@@ -87,7 +87,7 @@
   "navigation_bar.edit_profile": "修改个人资料",
   "navigation_bar.favourites": "赞的内容",
   "navigation_bar.follow_requests": "关注请求",
-  "navigation_bar.info": "更多信息",
+  "navigation_bar.info": "关于本站",
   "navigation_bar.logout": "注销",
   "navigation_bar.mutes": "被静音的用户",
   "navigation_bar.preferences": "首选项",

--- a/app/javascript/mastodon/locales/zh-CN.json
+++ b/app/javascript/mastodon/locales/zh-CN.json
@@ -87,7 +87,7 @@
   "navigation_bar.edit_profile": "修改个人资料",
   "navigation_bar.favourites": "赞的内容",
   "navigation_bar.follow_requests": "关注请求",
-  "navigation_bar.info": "追加信息",
+  "navigation_bar.info": "更多信息",
   "navigation_bar.logout": "注销",
   "navigation_bar.mutes": "被静音的用户",
   "navigation_bar.preferences": "首选项",

--- a/app/javascript/mastodon/locales/zh-TW.json
+++ b/app/javascript/mastodon/locales/zh-TW.json
@@ -87,7 +87,7 @@
   "navigation_bar.edit_profile": "編輯用戶資訊",
   "navigation_bar.favourites": "最愛",
   "navigation_bar.follow_requests": "關注請求",
-  "navigation_bar.info": "延伸資訊",
+  "navigation_bar.info": "關於本站",
   "navigation_bar.logout": "登出",
   "navigation_bar.mutes": "消音的使用者",
   "navigation_bar.preferences": "偏好設定",


### PR DESCRIPTION
This commit changes the "extended info" (about/more) text to something that translates to "more info", as "additional info" in zh can sound like appending things to the (ugh) navbar, I guess.

Or should I just change it to "about this site" (关于本站)?