### PR TITLE
Ignore packs folder when COPY . /mastodon

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .env.*
 public/system
 public/assets
+public/packs
 node_modules
 storybook
 neo4j


### PR DESCRIPTION
public/packs folder is volumed. So don't need copy when building images.