### PR TITLE
Update Gemfile for using Rails5.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '>= 2.3.0', '< 2.5.0'
 gem 'pkg-config', '~> 1.2'
 
 gem 'puma', '~> 3.8'
-gem 'rails', '~> 5.0.0'
+gem 'rails', '~> 5.1.0'
 gem 'uglifier', '~> 3.2'
 
 gem 'hamlit-rails', '~> 0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,7 +528,7 @@ DEPENDENCIES
   rack-attack (~> 5.0)
   rack-cors (~> 0.4)
   rack-timeout (~> 0.4)
-  rails (~> 5.0.0)
+  rails (~> 5.1.0)
   rails-controller-testing (~> 1.0)
   rails-i18n (~> 5.0)
   rails-settings-cached (~> 0.6)


### PR DESCRIPTION
In #3121, only Gemfile.lock is updated.
But #3403 locks Rails minor version to 5.0.x.
It is conflicted and cause problem in my environment (because I added some gems. and 'bundle install' complains version difference.)

This PR changes Rails lock minor version to 5.1.x.
