### PR TITLE
Fix isIntersecting in Chrome

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -88,9 +88,11 @@ class Status extends ImmutablePureComponent {
   }
 
   handleIntersection = (entry) => {
-    // Edge 15 doesn't support isIntersecting, but we can infer it from intersectionRatio
+    // Edge 15 doesn't support isIntersecting, but we can infer it
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12156111/
-    const isIntersecting = entry.intersectionRatio > 0;
+    // https://github.com/WICG/IntersectionObserver/issues/211
+    const isIntersecting = (typeof entry.isIntersecting === 'boolean') ?
+      entry.isIntersecting : entry.intersectionRect.height > 0;
     this.setState((prevState) => {
       if (prevState.isIntersecting && !isIntersecting) {
         scheduleIdleTask(this.hideIfNotIntersecting);


### PR DESCRIPTION
Another way to fix #3502. If `entry.isIntersecting` is a boolean, then use it. Otherwise fall back to `entry.intersectionRect.height > 0`.

I have tested this on https://malfunctioning.technology (where it is live) and it seems to work in Edge 15, Chrome 58, and Firefox 54 on Windows 10. If anyone can still reproduce the bug on any browser please let me know. :smile: