### PR TITLE
Fix spec for #2388

### DIFF
--- a/spec/controllers/well_known/host_meta_controller_spec.rb
+++ b/spec/controllers/well_known/host_meta_controller_spec.rb
@@ -12,7 +12,7 @@ describe WellKnown::HostMetaController, type: :controller do
       expect(response.body).to eq <<XML
 <?xml version="1.0"?>
 <XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
-  <Link rel="lrdd" type="application/xrd+xml" template="http://test.host/.well-known/webfinger?resource={uri}"/>
+  <Link rel="lrdd" type="application/xrd+xml" template="https://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}"/>
 </XRD>
 XML
     end

--- a/spec/controllers/well_known/webfinger_controller_spec.rb
+++ b/spec/controllers/well_known/webfinger_controller_spec.rb
@@ -50,7 +50,7 @@ PEM
 
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq 'application/jrd+json'
-      expect(response.body).to eq "{\"subject\":\"acct:alice@cb6e6126.ngrok.io\",\"aliases\":[\"https://cb6e6126.ngrok.io/@alice\",\"https://cb6e6126.ngrok.io/users/alice\"],\"links\":[{\"rel\":\"http://webfinger.net/rel/profile-page\",\"type\":\"text/html\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"http://schemas.google.com/g/2010#updates-from\",\"type\":\"application/atom+xml\",\"href\":\"http://test.host/users/alice.atom\"},{\"rel\":\"self\",\"type\":\"application/activity+json\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"salmon\",\"href\":\"#{api_salmon_url(alice.id)}\"},{\"rel\":\"magic-public-key\",\"href\":\"data:application/magic-public-key,RSA.x4D6DyZa3zGa1XLhd_VG1bLGvK-Dmyz93WJfWNezIKeSuJkmA0f2NmoOfLUoumq9szN2Xt0GLDX06tDajdYPPXgLtDG0o1qqTrIJ7UTyYhbo94Wotl9iJvEwa5IjP1Mn00YJ_KvFrzKCm15PC7up6r-NtHsqoYS8X1KAqcbnptU=.AQAB\"},{\"rel\":\"http://ostatus.org/schema/1.0/subscribe\",\"template\":\"http://test.host/authorize_follow?acct={uri}\"}]}"
+      expect(response.body).to eq "{\"subject\":\"acct:alice@cb6e6126.ngrok.io\",\"aliases\":[\"https://cb6e6126.ngrok.io/@alice\",\"https://cb6e6126.ngrok.io/users/alice\"],\"links\":[{\"rel\":\"http://webfinger.net/rel/profile-page\",\"type\":\"text/html\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"http://schemas.google.com/g/2010#updates-from\",\"type\":\"application/atom+xml\",\"href\":\"https://cb6e6126.ngrok.io/users/alice.atom\"},{\"rel\":\"self\",\"type\":\"application/activity+json\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"salmon\",\"href\":\"#{api_salmon_url(alice.id)}\"},{\"rel\":\"magic-public-key\",\"href\":\"data:application/magic-public-key,RSA.x4D6DyZa3zGa1XLhd_VG1bLGvK-Dmyz93WJfWNezIKeSuJkmA0f2NmoOfLUoumq9szN2Xt0GLDX06tDajdYPPXgLtDG0o1qqTrIJ7UTyYhbo94Wotl9iJvEwa5IjP1Mn00YJ_KvFrzKCm15PC7up6r-NtHsqoYS8X1KAqcbnptU=.AQAB\"},{\"rel\":\"http://ostatus.org/schema/1.0/subscribe\",\"template\":\"https://cb6e6126.ngrok.io/authorize_follow?acct={uri}\"}]}"
     end
 
     it 'returns JSON when account can be found' do
@@ -65,10 +65,10 @@ PEM
   <Alias>https://cb6e6126.ngrok.io/@alice</Alias>
   <Alias>https://cb6e6126.ngrok.io/users/alice</Alias>
   <Link rel="http://webfinger.net/rel/profile-page" type="text/html" href="https://cb6e6126.ngrok.io/@alice"/>
-  <Link rel="http://schemas.google.com/g/2010#updates-from" type="application/atom+xml" href="http://test.host/users/alice.atom"/>
+  <Link rel="http://schemas.google.com/g/2010#updates-from" type="application/atom+xml" href="https://cb6e6126.ngrok.io/users/alice.atom"/>
   <Link rel="salmon" href="#{api_salmon_url(alice.id)}"/>
   <Link rel="magic-public-key" href="data:application/magic-public-key,RSA.x4D6DyZa3zGa1XLhd_VG1bLGvK-Dmyz93WJfWNezIKeSuJkmA0f2NmoOfLUoumq9szN2Xt0GLDX06tDajdYPPXgLtDG0o1qqTrIJ7UTyYhbo94Wotl9iJvEwa5IjP1Mn00YJ_KvFrzKCm15PC7up6r-NtHsqoYS8X1KAqcbnptU=.AQAB"/>
-  <Link rel="http://ostatus.org/schema/1.0/subscribe" template="http://test.host/authorize_follow?acct={uri}"/>
+  <Link rel="http://ostatus.org/schema/1.0/subscribe" template="https://cb6e6126.ngrok.io/authorize_follow?acct={uri}"/>
 </XRD>
 XML
     end
@@ -87,7 +87,7 @@ XML
 
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq 'application/jrd+json'
-      expect(response.body).to eq "{\"subject\":\"acct:alice@cb6e6126.ngrok.io\",\"aliases\":[\"https://cb6e6126.ngrok.io/@alice\",\"https://cb6e6126.ngrok.io/users/alice\"],\"links\":[{\"rel\":\"http://webfinger.net/rel/profile-page\",\"type\":\"text/html\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"http://schemas.google.com/g/2010#updates-from\",\"type\":\"application/atom+xml\",\"href\":\"http://test.host/users/alice.atom\"},{\"rel\":\"self\",\"type\":\"application/activity+json\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"salmon\",\"href\":\"#{api_salmon_url(alice.id)}\"},{\"rel\":\"magic-public-key\",\"href\":\"data:application/magic-public-key,RSA.x4D6DyZa3zGa1XLhd_VG1bLGvK-Dmyz93WJfWNezIKeSuJkmA0f2NmoOfLUoumq9szN2Xt0GLDX06tDajdYPPXgLtDG0o1qqTrIJ7UTyYhbo94Wotl9iJvEwa5IjP1Mn00YJ_KvFrzKCm15PC7up6r-NtHsqoYS8X1KAqcbnptU=.AQAB\"},{\"rel\":\"http://ostatus.org/schema/1.0/subscribe\",\"template\":\"http://test.host/authorize_follow?acct={uri}\"}]}"
+      expect(response.body).to eq "{\"subject\":\"acct:alice@cb6e6126.ngrok.io\",\"aliases\":[\"https://cb6e6126.ngrok.io/@alice\",\"https://cb6e6126.ngrok.io/users/alice\"],\"links\":[{\"rel\":\"http://webfinger.net/rel/profile-page\",\"type\":\"text/html\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"http://schemas.google.com/g/2010#updates-from\",\"type\":\"application/atom+xml\",\"href\":\"https://cb6e6126.ngrok.io/users/alice.atom\"},{\"rel\":\"self\",\"type\":\"application/activity+json\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"salmon\",\"href\":\"#{api_salmon_url(alice.id)}\"},{\"rel\":\"magic-public-key\",\"href\":\"data:application/magic-public-key,RSA.x4D6DyZa3zGa1XLhd_VG1bLGvK-Dmyz93WJfWNezIKeSuJkmA0f2NmoOfLUoumq9szN2Xt0GLDX06tDajdYPPXgLtDG0o1qqTrIJ7UTyYhbo94Wotl9iJvEwa5IjP1Mn00YJ_KvFrzKCm15PC7up6r-NtHsqoYS8X1KAqcbnptU=.AQAB\"},{\"rel\":\"http://ostatus.org/schema/1.0/subscribe\",\"template\":\"https://cb6e6126.ngrok.io/authorize_follow?acct={uri}\"}]}"
     end
 
     it 'returns http not found when account can not be found with alternate domains' do


### PR DESCRIPTION
spec is failed from #2388.

```console
$ ./bin/rspec
[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead.
[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead.

Randomized with seed 49626
                                                                                                                                                                                       
  1) WellKnown::HostMetaController GET #show returns http success
     Failure/Error:
             expect(response.body).to eq <<XML
       <?xml version="1.0"?>
       <XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
         <Link rel="lrdd" type="application/xrd+xml" template="http://test.host/.well-known/webfinger?resource={uri}"/>
       </XRD>
       XML
     
       expected: "<?xml version=\"1.0\"?>\n<XRD xmlns=\"http://docs.oasis-open.org/ns/xri/xrd-1.0\">\n  <Link rel=\"lr...pplication/xrd+xml\" template=\"http://test.host/.well-known/webfinger?resource={uri}\"/>\n</XRD>\n"
            got: "<?xml version=\"1.0\"?>\n<XRD xmlns=\"http://docs.oasis-open.org/ns/xri/xrd-1.0\">\n  <Link rel=\"lr...n/xrd+xml\" template=\"https://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}\"/>\n</XRD>\n"
     
       (compared using ==)
     
       Diff:
       @@ -1,5 +1,5 @@
        <?xml version="1.0"?>
        <XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
       -  <Link rel="lrdd" type="application/xrd+xml" template="http://test.host/.well-known/webfinger?resource={uri}"/>
       +  <Link rel="lrdd" type="application/xrd+xml" template="https://cb6e6126.ngrok.io/.well-known/webfinger?resource={uri}"/>
        </XRD>
       
     # ./spec/controllers/well_known/host_meta_controller_spec.rb:12:in `block (3 levels) in <top (required)>'

                                                                                                                                                                                       
  2) WellKnown::WebfingerController GET #show returns JSON when account can be found with alternate domains
     Failure/Error: expect(response.body).to eq "{\"subject\":\"acct:alice@cb6e6126.ngrok.io\",\"aliases\":[\"https://cb6e6126.ngrok.io/@alice\",\"https://cb6e6126.ngrok.io/users/alice\"],\"links\":[{\"rel\":\"http://webfinger.net/rel/profile-page\",\"type\":\"text/html\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"http://schemas.google.com/g/2010#updates-from\",\"type\":\"application/atom+xml\",\"href\":\"http://test.host/users/alice.atom\"},{\"rel\":\"self\",\"type\":\"application/activity+json\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"salmon\",\"href\":\"#{api_salmon_url(alice.id)}\"},{\"rel\":\"magic-public-key\",\"href\":\"data:application/magic-public-key,RSA.x4D6DyZa3zGa1XLhd_VG1bLGvK-Dmyz93WJfWNezIKeSuJkmA0f2NmoOfLUoumq9szN2Xt0GLDX06tDajdYPPXgLtDG0o1qqTrIJ7UTyYhbo94Wotl9iJvEwa5IjP1Mn00YJ_KvFrzKCm15PC7up6r-NtHsqoYS8X1KAqcbnptU=.AQAB\"},{\"rel\":\"http://ostatus.org/schema/1.0/subscribe\",\"template\":\"http://test.host/authorize_follow?acct={uri}\"}]}"
     
       expected: "{\"subject\":\"acct:alice@cb6e6126.ngrok.io\",\"aliases\":[\"https://cb6e6126.ngrok.io/@alice\",\"ht...ostatus.org/schema/1.0/subscribe\",\"template\":\"http://test.host/authorize_follow?acct={uri}\"}]}"
            got: "{\"subject\":\"acct:alice@cb6e6126.ngrok.io\",\"aliases\":[\"https://cb6e6126.ngrok.io/@alice\",\"ht...rg/schema/1.0/subscribe\",\"template\":\"https://cb6e6126.ngrok.io/authorize_follow?acct={uri}\"}]}"
     
       (compared using ==)
     # ./spec/controllers/well_known/webfinger_controller_spec.rb:90:in `block (3 levels) in <top (required)>'
     # ./spec/controllers/well_known/webfinger_controller_spec.rb:44:in `block (3 levels) in <top (required)>'

                                                                                                                                                                                       
  3) WellKnown::WebfingerController GET #show returns JSON when account can be found
     Failure/Error:
             expect(response.body).to eq <<"XML"
       <?xml version="1.0"?>
       <XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
         <Subject>acct:alice@cb6e6126.ngrok.io</Subject>
         <Alias>https://cb6e6126.ngrok.io/@alice</Alias>
         <Alias>https://cb6e6126.ngrok.io/users/alice</Alias>
         <Link rel="http://webfinger.net/rel/profile-page" type="text/html" href="https://cb6e6126.ngrok.io/@alice"/>
         <Link rel="http://schemas.google.com/g/2010#updates-from" type="application/atom+xml" href="http://test.host/users/alice.atom"/>
         <Link rel="salmon" href="#{api_salmon_url(alice.id)}"/>
         <Link rel="magic-public-key" href="data:application/magic-public-key,RSA.x4D6DyZa3zGa1XLhd_VG1bLGvK-Dmyz93WJfWNezIKeSuJkmA0f2NmoOfLUoumq9szN2Xt0GLDX06tDajdYPPXgLtDG0o1qqTrIJ7UTyYhbo94Wotl9iJvEwa5IjP1Mn00YJ_KvFrzKCm15PC7up6r-NtHsqoYS8X1KAqcbnptU=.AQAB"/>
     
       expected: "<?xml version=\"1.0\"?>\n<XRD xmlns=\"http://docs.oasis-open.org/ns/xri/xrd-1.0\">\n  <Subject>acct:...us.org/schema/1.0/subscribe\" template=\"http://test.host/authorize_follow?acct={uri}\"/>\n</XRD>\n"
            got: "<?xml version=\"1.0\"?>\n<XRD xmlns=\"http://docs.oasis-open.org/ns/xri/xrd-1.0\">\n  <Subject>acct:...hema/1.0/subscribe\" template=\"https://cb6e6126.ngrok.io/authorize_follow?acct={uri}\"/>\n</XRD>\n"
     
       (compared using ==)
     
       Diff:
       
       @@ -4,9 +4,9 @@
          <Alias>https://cb6e6126.ngrok.io/@alice</Alias>
          <Alias>https://cb6e6126.ngrok.io/users/alice</Alias>
          <Link rel="http://webfinger.net/rel/profile-page" type="text/html" href="https://cb6e6126.ngrok.io/@alice"/>
       -  <Link rel="http://schemas.google.com/g/2010#updates-from" type="application/atom+xml" href="http://test.host/users/alice.atom"/>
       +  <Link rel="http://schemas.google.com/g/2010#updates-from" type="application/atom+xml" href="https://cb6e6126.ngrok.io/users/alice.atom"/>
          <Link rel="salmon" href="https://cb6e6126.ngrok.io/api/salmon/253"/>
          <Link rel="magic-public-key" href="data:application/magic-public-key,RSA.x4D6DyZa3zGa1XLhd_VG1bLGvK-Dmyz93WJfWNezIKeSuJkmA0f2NmoOfLUoumq9szN2Xt0GLDX06tDajdYPPXgLtDG0o1qqTrIJ7UTyYhbo94Wotl9iJvEwa5IjP1Mn00YJ_KvFrzKCm15PC7up6r-NtHsqoYS8X1KAqcbnptU=.AQAB"/>
       -  <Link rel="http://ostatus.org/schema/1.0/subscribe" template="http://test.host/authorize_follow?acct={uri}"/>
       +  <Link rel="http://ostatus.org/schema/1.0/subscribe" template="https://cb6e6126.ngrok.io/authorize_follow?acct={uri}"/>
        </XRD>
       
     # ./spec/controllers/well_known/webfinger_controller_spec.rb:61:in `block (3 levels) in <top (required)>'
     # ./spec/controllers/well_known/webfinger_controller_spec.rb:44:in `block (3 levels) in <top (required)>'

                                                                                                                                                                                       
  4) WellKnown::WebfingerController GET #show returns JSON when account can be found
     Failure/Error: expect(response.body).to eq "{\"subject\":\"acct:alice@cb6e6126.ngrok.io\",\"aliases\":[\"https://cb6e6126.ngrok.io/@alice\",\"https://cb6e6126.ngrok.io/users/alice\"],\"links\":[{\"rel\":\"http://webfinger.net/rel/profile-page\",\"type\":\"text/html\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"http://schemas.google.com/g/2010#updates-from\",\"type\":\"application/atom+xml\",\"href\":\"http://test.host/users/alice.atom\"},{\"rel\":\"self\",\"type\":\"application/activity+json\",\"href\":\"https://cb6e6126.ngrok.io/@alice\"},{\"rel\":\"salmon\",\"href\":\"#{api_salmon_url(alice.id)}\"},{\"rel\":\"magic-public-key\",\"href\":\"data:application/magic-public-key,RSA.x4D6DyZa3zGa1XLhd_VG1bLGvK-Dmyz93WJfWNezIKeSuJkmA0f2NmoOfLUoumq9szN2Xt0GLDX06tDajdYPPXgLtDG0o1qqTrIJ7UTyYhbo94Wotl9iJvEwa5IjP1Mn00YJ_KvFrzKCm15PC7up6r-NtHsqoYS8X1KAqcbnptU=.AQAB\"},{\"rel\":\"http://ostatus.org/schema/1.0/subscribe\",\"template\":\"http://test.host/authorize_follow?acct={uri}\"}]}"
     
       expected: "{\"subject\":\"acct:alice@cb6e6126.ngrok.io\",\"aliases\":[\"https://cb6e6126.ngrok.io/@alice\",\"ht...ostatus.org/schema/1.0/subscribe\",\"template\":\"http://test.host/authorize_follow?acct={uri}\"}]}"
            got: "{\"subject\":\"acct:alice@cb6e6126.ngrok.io\",\"aliases\":[\"https://cb6e6126.ngrok.io/@alice\",\"ht...rg/schema/1.0/subscribe\",\"template\":\"https://cb6e6126.ngrok.io/authorize_follow?acct={uri}\"}]}"
     
       (compared using ==)
     # ./spec/controllers/well_known/webfinger_controller_spec.rb:53:in `block (3 levels) in <top (required)>'
     # ./spec/controllers/well_known/webfinger_controller_spec.rb:44:in `block (3 levels) in <top (required)>'

                                                                                                                                                                                       
  5) Api::V1::NotificationsController GET #index with excluded mentions includes reblog
     Failure/Error: expect(assigns(:notifications).map(&:activity)).to include(@reblog_of_first_status)
     
       expected [#<Follow id: 43, account_id: 286, target_account_id: 285, created_at: "2017-06-03 02:07:28", updated_at: "2017-06-03 02:07:28">] to include #<Status id: 118, uri: nil, account_id: 286, text: "", created_at: "2017-06-03 02:07:28", updated_at:...text: "", reply: false, favourites_count: 0, reblogs_count: 0, language: "en", conversation_id: 111>
       Diff:
       @@ -1,2 +1,2 @@
       -[#<Status id: 118, uri: nil, account_id: 286, text: "", created_at: "2017-06-03 02:07:28", updated_at: "2017-06-03 02:07:28", in_reply_to_id: nil, reblog_of_id: 117, url: nil, sensitive: false, visibility: "public", in_reply_to_account_id: nil, application_id: nil, spoiler_text: "", reply: false, favourites_count: 0, reblogs_count: 0, language: "en", conversation_id: 111>]
       +[#<Follow id: 43, account_id: 286, target_account_id: 285, created_at: "2017-06-03 02:07:28", updated_at: "2017-06-03 02:07:28">]
       
     # ./spec/controllers/api/v1/notifications_controller_spec.rb:89:in `block (4 levels) in <top (required)>'

 1117/1117 |========================================================================== 100 ==========================================================================>| Time: 00:01:40 

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Account MENTION_RE does not match URL querystring
     # Temporarily skipped with xit
     # ./spec/models/account_spec.rb:359

  2) Formatter#format matches a URL without closing paranthesis
     # Temporarily skipped with xit
     # ./spec/lib/formatter_spec.rb:101

  3) FanOutOnWriteService delivers status to local followers
     # some sort of problem in test environment causes this to sometimes fail
     Failure/Error: expect(Feed.new(:home, follower).get(10).map(&:id)).to include status.id
       expected [] to include 148
     # ./spec/services/fan_out_on_write_service_spec.rb:27:in `block (2 levels) in <top (required)>'

  4) Api::V1::MediaController POST #create video/webm creates a media attachment
     # Temporarily skipped with xit
     # ./spec/controllers/api/v1/media_controller_spec.rb:91

  5) Api::V1::MediaController POST #create video/webm returns http success
     # Temporarily skipped with xit
     # ./spec/controllers/api/v1/media_controller_spec.rb:87

  6) Api::V1::MediaController POST #create video/webm uploads a file
     # Temporarily skipped with xit
     # ./spec/controllers/api/v1/media_controller_spec.rb:95

  7) Api::V1::MediaController POST #create video/webm returns media ID in JSON
     # Temporarily skipped with xit
     # ./spec/controllers/api/v1/media_controller_spec.rb:99

  8) AtomSerializer#reject_follow_request_salmon returns dumpable XML
     # Not yet implemented
     # ./spec/lib/atom_serializer_spec.rb:203

  9) AtomSerializer#reject_follow_request_salmon deletes follow request when processed
     # Not yet implemented
     # ./spec/lib/atom_serializer_spec.rb:204

  10) AtomSerializer#entry with reblog of 3rd party user creates a reblog with correct author
     # Not yet implemented
     # ./spec/lib/atom_serializer_spec.rb:67

  11) AtomSerializer#entry with reblog of 3rd party user returns dumpable XML
     # Not yet implemented
     # ./spec/lib/atom_serializer_spec.rb:66

  12) AtomSerializer#entry with reblog of local user returns dumpable XML
     # Not yet implemented
     # ./spec/lib/atom_serializer_spec.rb:61

  13) AtomSerializer#entry with reblog of local user creates a reblog
     # Not yet implemented
     # ./spec/lib/atom_serializer_spec.rb:62

  14) AtomSerializer#authorize_follow_request_salmon returns dumpable XML
     # Not yet implemented
     # ./spec/lib/atom_serializer_spec.rb:198

  15) AtomSerializer#authorize_follow_request_salmon creates follow from follow request when processed
     # Not yet implemented
     # ./spec/lib/atom_serializer_spec.rb:199

  16) AtomSerializer#follow_request_salmon triggers follow request when processed
     # Not yet implemented
     # ./spec/lib/atom_serializer_spec.rb:194

  17) AtomSerializer#follow_request_salmon returns dumpable XML
     # Not yet implemented
     # ./spec/lib/atom_serializer_spec.rb:193

  18) Notification#from_account 
     # Not yet implemented
     # ./spec/models/notification_spec.rb:5

  19) SendInteractionService sends an XML envelope to the Salmon end point of remote user
     # Not yet implemented
     # ./spec/services/send_interaction_service_spec.rb:6

  20) User settings does not mutate defaults via the cache
     # Temporarily skipped with xit
     # ./spec/models/user_spec.rb:63


Finished in 1 minute 40.84 seconds (files took 8.57 seconds to load)
1117 examples, 5 failures, 20 pending

Failed examples:

rspec ./spec/controllers/well_known/host_meta_controller_spec.rb:7 # WellKnown::HostMetaController GET #show returns http success
rspec ./spec/controllers/well_known/webfinger_controller_spec.rb:82 # WellKnown::WebfingerController GET #show returns JSON when account can be found with alternate domains
rspec ./spec/controllers/well_known/webfinger_controller_spec.rb:56 # WellKnown::WebfingerController GET #show returns JSON when account can be found
rspec ./spec/controllers/well_known/webfinger_controller_spec.rb:48 # WellKnown::WebfingerController GET #show returns JSON when account can be found
rspec ./spec/controllers/api/v1/notifications_controller_spec.rb:88 # Api::V1::NotificationsController GET #index with excluded mentions includes reblog

Randomized with seed 49626

Coverage report generated for RSpec to /Users/ykzts/works/ykzts/mastodon/coverage. 4805 / 5011 LOC (95.89%) covered.
```