### PR TITLE
en.json: change about/more link text to "About this instance"

### DIFF
--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -87,7 +87,7 @@
   "navigation_bar.edit_profile": "Edit profile",
   "navigation_bar.favourites": "Favourites",
   "navigation_bar.follow_requests": "Follow requests",
-  "navigation_bar.info": "Extended information",
+  "navigation_bar.info": "About this instance",
   "navigation_bar.logout": "Logout",
   "navigation_bar.mutes": "Muted users",
   "navigation_bar.preferences": "Preferences",


### PR DESCRIPTION
This change follows #3519, which does the same for the Chinese variants. Or should it be simply "About"?