### PR TITLE
Fix column buttons overflow in Japanese

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1534,7 +1534,7 @@
   cursor: pointer;
   flex: 0 0 auto;
   font-size: 16px;
-  padding: 15px;
+  padding: 0 15px;
   z-index: 3;
 
   &:hover {
@@ -2050,6 +2050,7 @@ button.icon-button.active i.fa-retweet {
   position: absolute;
   right: 0;
   top: 0;
+  height: 100%;
   display: flex;
 }
 
@@ -2059,7 +2060,7 @@ button.icon-button.active i.fa-retweet {
   color: $ui-primary-color;
   cursor: pointer;
   font-size: 16px;
-  padding: 15px;
+  padding: 0 15px;
 
   &:hover {
     color: lighten($ui-primary-color, 7%);


### PR DESCRIPTION
regression from #3207

### before

![](https://cloud.githubusercontent.com/assets/12539/26761053/70c6fcfe-4963-11e7-9451-7a78a8dce8ef.png)

### after

![](https://cloud.githubusercontent.com/assets/12539/26761055/74b9f21c-4963-11e7-89a0-836923f67887.png)