### PR TITLE
Fix limit_param in favourites_controller.rb

### DIFF
--- a/app/controllers/api/v1/favourites_controller.rb
+++ b/app/controllers/api/v1/favourites_controller.rb
@@ -65,7 +65,7 @@ class Api::V1::FavouritesController < ApiController
   end
 
   def records_continue?
-    results.size == limit_param(DEFAULT_ACCOUNTS_LIMIT)
+    results.size == limit_param(DEFAULT_STATUSES_LIMIT)
   end
 
   def pagination_params(core_params)


### PR DESCRIPTION
In current master, /web/favourites/ can't load many more statuses.
Because records_countinue? formula always be false.

See l.33, statuses taken from db 'DEFAULT_STATUSES_LIMIT' pieces,
but records_continue? formula see 'DEFAULT_ACCOUNTS_LIMIT'.