### PR TITLE
Fix all icons in the column header being hilighted

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2029,7 +2029,7 @@ button.icon-button.active i.fa-retweet {
     box-shadow: 0 1px 0 rgba($ui-highlight-color, 0.3);
   }
 
-  &.active .fa {
+  &.active .column-header__icon {
     color: $ui-highlight-color;
     text-shadow: 0 0 10px rgba($ui-highlight-color, 0.4);
   }


### PR DESCRIPTION
regression from #3207 

![image](https://cloud.githubusercontent.com/assets/705555/26761400/324124c2-4969-11e7-89c6-17285165ca31.png)

After this patch:

![image](https://cloud.githubusercontent.com/assets/705555/26761407/56b89dda-4969-11e7-96d0-99489857b588.png)
