### PR TITLE
Fix #3550 - Add all missing foreign keys

### DIFF
--- a/db/migrate/20170604144747_add_foreign_keys_for_accounts.rb
+++ b/db/migrate/20170604144747_add_foreign_keys_for_accounts.rb
@@ -1,6 +1,8 @@
 class AddForeignKeysForAccounts < ActiveRecord::Migration[5.1]
   def change
     add_foreign_key :statuses, :accounts, on_delete: :cascade
+    add_foreign_key :statuses, :accounts, column: :in_reply_to_account_id, on_delete: :nullify
+    add_foreign_key :statuses, :statuses, column: :in_reply_to_id, on_delete: :nullify
     add_foreign_key :account_domain_blocks, :accounts, on_delete: :cascade
     add_foreign_key :conversation_mutes, :accounts, on_delete: :cascade
     add_foreign_key :conversation_mutes, :conversations, on_delete: :cascade
@@ -16,12 +18,15 @@ class AddForeignKeysForAccounts < ActiveRecord::Migration[5.1]
     add_foreign_key :mutes, :accounts, column: :target_account_id, on_delete: :cascade
     add_foreign_key :imports, :accounts, on_delete: :cascade
     add_foreign_key :media_attachments, :accounts, on_delete: :nullify
+    add_foreign_key :media_attachments, :statuses, on_delete: :nullify
     add_foreign_key :mentions, :accounts, on_delete: :cascade
     add_foreign_key :mentions, :statuses, on_delete: :cascade
     add_foreign_key :notifications, :accounts, on_delete: :cascade
+    add_foreign_key :notifications, :accounts, column: :from_account_id, on_delete: :cascade
     add_foreign_key :preview_cards, :statuses, on_delete: :cascade
     add_foreign_key :reports, :accounts, on_delete: :cascade
     add_foreign_key :reports, :accounts, column: :target_account_id, on_delete: :cascade
+    add_foreign_key :reports, :accounts, column: :action_taken_by_account_id, on_delete: :nullify
     add_foreign_key :statuses_tags, :statuses, on_delete: :cascade
     add_foreign_key :statuses_tags, :tags, on_delete: :cascade
     add_foreign_key :stream_entries, :accounts, on_delete: :cascade

--- a/db/migrate/20170604144747_add_foreign_keys_for_accounts.rb
+++ b/db/migrate/20170604144747_add_foreign_keys_for_accounts.rb
@@ -1,0 +1,36 @@
+class AddForeignKeysForAccounts < ActiveRecord::Migration[5.1]
+  def change
+    add_foreign_key :statuses, :accounts, on_delete: :cascade
+    add_foreign_key :account_domain_blocks, :accounts, on_delete: :cascade
+    add_foreign_key :conversation_mutes, :accounts, on_delete: :cascade
+    add_foreign_key :conversation_mutes, :conversations, on_delete: :cascade
+    add_foreign_key :favourites, :accounts, on_delete: :cascade
+    add_foreign_key :favourites, :statuses, on_delete: :cascade
+    add_foreign_key :blocks, :accounts, on_delete: :cascade
+    add_foreign_key :blocks, :accounts, column: :target_account_id, on_delete: :cascade
+    add_foreign_key :follow_requests, :accounts, on_delete: :cascade
+    add_foreign_key :follow_requests, :accounts, column: :target_account_id, on_delete: :cascade
+    add_foreign_key :follows, :accounts, on_delete: :cascade
+    add_foreign_key :follows, :accounts, column: :target_account_id, on_delete: :cascade
+    add_foreign_key :mutes, :accounts, on_delete: :cascade
+    add_foreign_key :mutes, :accounts, column: :target_account_id, on_delete: :cascade
+    add_foreign_key :imports, :accounts, on_delete: :cascade
+    add_foreign_key :media_attachments, :accounts, on_delete: :nullify
+    add_foreign_key :mentions, :accounts, on_delete: :cascade
+    add_foreign_key :mentions, :statuses, on_delete: :cascade
+    add_foreign_key :notifications, :accounts, on_delete: :cascade
+    add_foreign_key :preview_cards, :statuses, on_delete: :cascade
+    add_foreign_key :reports, :accounts, on_delete: :cascade
+    add_foreign_key :reports, :accounts, column: :target_account_id, on_delete: :cascade
+    add_foreign_key :statuses_tags, :statuses, on_delete: :cascade
+    add_foreign_key :statuses_tags, :tags, on_delete: :cascade
+    add_foreign_key :stream_entries, :accounts, on_delete: :cascade
+    add_foreign_key :subscriptions, :accounts, on_delete: :cascade
+    add_foreign_key :users, :accounts, on_delete: :cascade
+    add_foreign_key :web_settings, :users, on_delete: :cascade
+    add_foreign_key :oauth_access_grants, :users, column: :resource_owner_id, on_delete: :cascade
+    add_foreign_key :oauth_access_grants, :oauth_applications, column: :application_id, on_delete: :cascade
+    add_foreign_key :oauth_access_tokens, :users, column: :resource_owner_id, on_delete: :cascade
+    add_foreign_key :oauth_access_tokens, :oauth_applications, column: :application_id, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -380,19 +380,24 @@ ActiveRecord::Schema.define(version: 20170604144747) do
   add_foreign_key "follows", "accounts", on_delete: :cascade
   add_foreign_key "imports", "accounts", on_delete: :cascade
   add_foreign_key "media_attachments", "accounts", on_delete: :nullify
+  add_foreign_key "media_attachments", "statuses", on_delete: :nullify
   add_foreign_key "mentions", "accounts", on_delete: :cascade
   add_foreign_key "mentions", "statuses", on_delete: :cascade
   add_foreign_key "mutes", "accounts", column: "target_account_id", on_delete: :cascade
   add_foreign_key "mutes", "accounts", on_delete: :cascade
+  add_foreign_key "notifications", "accounts", column: "from_account_id", on_delete: :cascade
   add_foreign_key "notifications", "accounts", on_delete: :cascade
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id", on_delete: :cascade
   add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id", on_delete: :cascade
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id", on_delete: :cascade
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id", on_delete: :cascade
   add_foreign_key "preview_cards", "statuses", on_delete: :cascade
+  add_foreign_key "reports", "accounts", column: "action_taken_by_account_id", on_delete: :nullify
   add_foreign_key "reports", "accounts", column: "target_account_id", on_delete: :cascade
   add_foreign_key "reports", "accounts", on_delete: :cascade
+  add_foreign_key "statuses", "accounts", column: "in_reply_to_account_id", on_delete: :nullify
   add_foreign_key "statuses", "accounts", on_delete: :cascade
+  add_foreign_key "statuses", "statuses", column: "in_reply_to_id", on_delete: :nullify
   add_foreign_key "statuses", "statuses", column: "reblog_of_id", on_delete: :cascade
   add_foreign_key "statuses_tags", "statuses", on_delete: :cascade
   add_foreign_key "statuses_tags", "tags", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170601210557) do
+ActiveRecord::Schema.define(version: 20170604144747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -367,5 +367,37 @@ ActiveRecord::Schema.define(version: 20170601210557) do
     t.index ["user_id"], name: "index_web_settings_on_user_id", unique: true
   end
 
+  add_foreign_key "account_domain_blocks", "accounts", on_delete: :cascade
+  add_foreign_key "blocks", "accounts", column: "target_account_id", on_delete: :cascade
+  add_foreign_key "blocks", "accounts", on_delete: :cascade
+  add_foreign_key "conversation_mutes", "accounts", on_delete: :cascade
+  add_foreign_key "conversation_mutes", "conversations", on_delete: :cascade
+  add_foreign_key "favourites", "accounts", on_delete: :cascade
+  add_foreign_key "favourites", "statuses", on_delete: :cascade
+  add_foreign_key "follow_requests", "accounts", column: "target_account_id", on_delete: :cascade
+  add_foreign_key "follow_requests", "accounts", on_delete: :cascade
+  add_foreign_key "follows", "accounts", column: "target_account_id", on_delete: :cascade
+  add_foreign_key "follows", "accounts", on_delete: :cascade
+  add_foreign_key "imports", "accounts", on_delete: :cascade
+  add_foreign_key "media_attachments", "accounts", on_delete: :nullify
+  add_foreign_key "mentions", "accounts", on_delete: :cascade
+  add_foreign_key "mentions", "statuses", on_delete: :cascade
+  add_foreign_key "mutes", "accounts", column: "target_account_id", on_delete: :cascade
+  add_foreign_key "mutes", "accounts", on_delete: :cascade
+  add_foreign_key "notifications", "accounts", on_delete: :cascade
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id", on_delete: :cascade
+  add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id", on_delete: :cascade
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id", on_delete: :cascade
+  add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id", on_delete: :cascade
+  add_foreign_key "preview_cards", "statuses", on_delete: :cascade
+  add_foreign_key "reports", "accounts", column: "target_account_id", on_delete: :cascade
+  add_foreign_key "reports", "accounts", on_delete: :cascade
+  add_foreign_key "statuses", "accounts", on_delete: :cascade
   add_foreign_key "statuses", "statuses", column: "reblog_of_id", on_delete: :cascade
+  add_foreign_key "statuses_tags", "statuses", on_delete: :cascade
+  add_foreign_key "statuses_tags", "tags", on_delete: :cascade
+  add_foreign_key "stream_entries", "accounts", on_delete: :cascade
+  add_foreign_key "subscriptions", "accounts", on_delete: :cascade
+  add_foreign_key "users", "accounts", on_delete: :cascade
+  add_foreign_key "web_settings", "users", on_delete: :cascade
 end


### PR DESCRIPTION
The rule on media attachments table is nullify instead of cascade, because presumably we would want to keep the records so that we have a reference to the files that need to be deleted, otherwise those files would be orphaned.

In fact, this is kind of a concern for accounts table as well, since it keeps references to avatars and headers, which is why you should use `Account#destroy` instead of deleting it directly from the database, but I digress.

Another concern is that the database *will* complain and the migration will fail if there are violations of these constraints, which will require manual intervention from the person doing the upgrade. Suggestions of how to handle this are welcome.