### PR TITLE
Add migration versions

### DIFF
--- a/db/migrate/20160220174730_create_accounts.rb
+++ b/db/migrate/20160220174730_create_accounts.rb
@@ -1,4 +1,4 @@
-class CreateAccounts < ActiveRecord::Migration
+class CreateAccounts < ActiveRecord::Migration[4.2]
   def change
     create_table :accounts do |t|
       t.string :username, null: false, default: ''

--- a/db/migrate/20160220211917_create_statuses.rb
+++ b/db/migrate/20160220211917_create_statuses.rb
@@ -1,4 +1,4 @@
-class CreateStatuses < ActiveRecord::Migration
+class CreateStatuses < ActiveRecord::Migration[4.2]
   def change
     create_table :statuses do |t|
       t.string :uri, null: false, default: ''

--- a/db/migrate/20160221003140_create_users.rb
+++ b/db/migrate/20160221003140_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :email, null: false, default: ''

--- a/db/migrate/20160221003621_create_follows.rb
+++ b/db/migrate/20160221003621_create_follows.rb
@@ -1,4 +1,4 @@
-class CreateFollows < ActiveRecord::Migration
+class CreateFollows < ActiveRecord::Migration[4.2]
   def change
     create_table :follows do |t|
       t.integer :account_id, null: false

--- a/db/migrate/20160222122600_create_stream_entries.rb
+++ b/db/migrate/20160222122600_create_stream_entries.rb
@@ -1,4 +1,4 @@
-class CreateStreamEntries < ActiveRecord::Migration
+class CreateStreamEntries < ActiveRecord::Migration[4.2]
   def change
     create_table :stream_entries do |t|
       t.integer :account_id

--- a/db/migrate/20160222143943_add_profile_fields_to_accounts.rb
+++ b/db/migrate/20160222143943_add_profile_fields_to_accounts.rb
@@ -1,4 +1,4 @@
-class AddProfileFieldsToAccounts < ActiveRecord::Migration
+class AddProfileFieldsToAccounts < ActiveRecord::Migration[4.2]
   def change
     add_column :accounts, :note, :text, null: false, default: ''
     add_column :accounts, :display_name, :string, null: false, default: ''

--- a/db/migrate/20160223162837_add_metadata_to_statuses.rb
+++ b/db/migrate/20160223162837_add_metadata_to_statuses.rb
@@ -1,4 +1,4 @@
-class AddMetadataToStatuses < ActiveRecord::Migration
+class AddMetadataToStatuses < ActiveRecord::Migration[4.2]
   def change
     add_column :statuses, :in_reply_to_id, :integer, null: true
     add_column :statuses, :reblog_of_id, :integer, null: true

--- a/db/migrate/20160223164502_make_uris_nullable_in_statuses.rb
+++ b/db/migrate/20160223164502_make_uris_nullable_in_statuses.rb
@@ -1,4 +1,4 @@
-class MakeUrisNullableInStatuses < ActiveRecord::Migration
+class MakeUrisNullableInStatuses < ActiveRecord::Migration[4.2]
   def change
     change_column :statuses, :uri, :string, null: true, default: nil
   end

--- a/db/migrate/20160223165723_add_url_to_statuses.rb
+++ b/db/migrate/20160223165723_add_url_to_statuses.rb
@@ -1,4 +1,4 @@
-class AddUrlToStatuses < ActiveRecord::Migration
+class AddUrlToStatuses < ActiveRecord::Migration[4.2]
   def change
     add_column :statuses, :url, :string, null: true, default: nil
   end

--- a/db/migrate/20160223165855_add_url_to_accounts.rb
+++ b/db/migrate/20160223165855_add_url_to_accounts.rb
@@ -1,4 +1,4 @@
-class AddUrlToAccounts < ActiveRecord::Migration
+class AddUrlToAccounts < ActiveRecord::Migration[4.2]
   def change
     add_column :accounts, :url, :string, null: true, default: nil
   end

--- a/db/migrate/20160223171800_create_favourites.rb
+++ b/db/migrate/20160223171800_create_favourites.rb
@@ -1,4 +1,4 @@
-class CreateFavourites < ActiveRecord::Migration
+class CreateFavourites < ActiveRecord::Migration[4.2]
   def change
     create_table :favourites do |t|
       t.integer :account_id, null: false

--- a/db/migrate/20160224223247_create_mentions.rb
+++ b/db/migrate/20160224223247_create_mentions.rb
@@ -1,4 +1,4 @@
-class CreateMentions < ActiveRecord::Migration
+class CreateMentions < ActiveRecord::Migration[4.2]
   def change
     create_table :mentions do |t|
       t.integer :account_id

--- a/db/migrate/20160227230233_add_attachment_avatar_to_accounts.rb
+++ b/db/migrate/20160227230233_add_attachment_avatar_to_accounts.rb
@@ -1,4 +1,4 @@
-class AddAttachmentAvatarToAccounts < ActiveRecord::Migration
+class AddAttachmentAvatarToAccounts < ActiveRecord::Migration[4.2]
   def self.up
     change_table :accounts do |t|
       t.attachment :avatar

--- a/db/migrate/20160305115639_add_devise_to_users.rb
+++ b/db/migrate/20160305115639_add_devise_to_users.rb
@@ -1,4 +1,4 @@
-class AddDeviseToUsers < ActiveRecord::Migration
+class AddDeviseToUsers < ActiveRecord::Migration[4.2]
   def self.up
     change_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20160306172223_create_doorkeeper_tables.rb
+++ b/db/migrate/20160306172223_create_doorkeeper_tables.rb
@@ -1,4 +1,4 @@
-class CreateDoorkeeperTables < ActiveRecord::Migration
+class CreateDoorkeeperTables < ActiveRecord::Migration[4.2]
   def change
     create_table :oauth_applications do |t|
       t.string  :name,         null: false

--- a/db/migrate/20160312193225_add_attachment_header_to_accounts.rb
+++ b/db/migrate/20160312193225_add_attachment_header_to_accounts.rb
@@ -1,4 +1,4 @@
-class AddAttachmentHeaderToAccounts < ActiveRecord::Migration
+class AddAttachmentHeaderToAccounts < ActiveRecord::Migration[4.2]
   def self.up
     change_table :accounts do |t|
       t.attachment :header

--- a/db/migrate/20160314164231_add_owner_to_application.rb
+++ b/db/migrate/20160314164231_add_owner_to_application.rb
@@ -1,4 +1,4 @@
-class AddOwnerToApplication < ActiveRecord::Migration
+class AddOwnerToApplication < ActiveRecord::Migration[4.2]
   def change
     add_column :oauth_applications, :owner_id, :integer, null: true
     add_column :oauth_applications, :owner_type, :string, null: true

--- a/db/migrate/20160316103650_add_missing_indices.rb
+++ b/db/migrate/20160316103650_add_missing_indices.rb
@@ -1,4 +1,4 @@
-class AddMissingIndices < ActiveRecord::Migration
+class AddMissingIndices < ActiveRecord::Migration[4.2]
   def change
     add_index :users, :account_id
     add_index :statuses, :account_id

--- a/db/migrate/20160322193748_add_avatar_remote_url_to_accounts.rb
+++ b/db/migrate/20160322193748_add_avatar_remote_url_to_accounts.rb
@@ -1,4 +1,4 @@
-class AddAvatarRemoteUrlToAccounts < ActiveRecord::Migration
+class AddAvatarRemoteUrlToAccounts < ActiveRecord::Migration[4.2]
   def change
     add_column :accounts, :avatar_remote_url, :string, null: true, default: nil
   end

--- a/db/migrate/20160325130944_add_admin_to_users.rb
+++ b/db/migrate/20160325130944_add_admin_to_users.rb
@@ -1,4 +1,4 @@
-class AddAdminToUsers < ActiveRecord::Migration
+class AddAdminToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :admin, :boolean, default: false
   end

--- a/db/migrate/20161006213403_rails_settings_migration.rb
+++ b/db/migrate/20161006213403_rails_settings_migration.rb
@@ -1,7 +1,7 @@
 MIGRATION_BASE_CLASS = if ActiveRecord::VERSION::MAJOR >= 5
   ActiveRecord::Migration[5.0]
 else
-  ActiveRecord::Migration
+  ActiveRecord::Migration[4.2]
 end
 
 class RailsSettingsMigration < MIGRATION_BASE_CLASS

--- a/db/migrate/20170112154826_migrate_settings.rb
+++ b/db/migrate/20170112154826_migrate_settings.rb
@@ -1,4 +1,4 @@
-class MigrateSettings < ActiveRecord::Migration
+class MigrateSettings < ActiveRecord::Migration[4.2]
   def up
     remove_index :settings, [:target_type, :target_id, :var]
     rename_column :settings, :target_id, :thing_id

--- a/db/migrate/20170330164118_add_attachment_data_to_imports.rb
+++ b/db/migrate/20170330164118_add_attachment_data_to_imports.rb
@@ -1,4 +1,4 @@
-class AddAttachmentDataToImports < ActiveRecord::Migration
+class AddAttachmentDataToImports < ActiveRecord::Migration[4.2]
   def self.up
     change_table :imports do |t|
       t.attachment :data


### PR DESCRIPTION
Since Rails 5.1 missing migration version results in following error:

```
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:
```

This PR fixes all migration files.