### PR TITLE
Fix broken embed page

### DIFF
--- a/app/views/layouts/embedded.html.haml
+++ b/app/views/layouts/embedded.html.haml
@@ -3,6 +3,8 @@
   %head
     %meta{ charset: 'utf-8' }/
     = stylesheet_pack_tag 'application', media: 'all'
+    = javascript_pack_tag 'common', integrity: true, crossorigin: 'anonymous'
+    = javascript_pack_tag "locale_#{I18n.locale}", integrity: true, crossorigin: 'anonymous'
     = javascript_pack_tag 'public', integrity: true, crossorigin: 'anonymous'
   %body.embed
     = yield


### PR DESCRIPTION
missing `common.js`.

### screenshot

![](https://cloud.githubusercontent.com/assets/12539/26768279/c3f69514-49e1-11e7-8dd9-92ee3b10758b.png)