### PR TITLE
Redirect to streaming_api_base_url

### DIFF
--- a/app/controllers/api/v1/streaming_controller.rb
+++ b/app/controllers/api/v1/streaming_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::StreamingController < ApiController
     if Rails.configuration.x.streaming_api_base_url != request.host
       uri = URI.parse(request.url)
       uri.host = URI.parse(Rails.configuration.x.streaming_api_base_url).host
-      redirect_to uri.to_s, :status => 301
+      redirect_to uri.to_s, status: 301
     else
       raise ActiveRecord::RecordNotFound
     end

--- a/app/controllers/api/v1/streaming_controller.rb
+++ b/app/controllers/api/v1/streaming_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Api::V1::StreamingController < ApiController
+  respond_to :json
+
+  def index
+    if Rails.configuration.x.streaming_api_base_url != request.host
+      uri = URI.parse(request.url)
+      uri.host = URI.parse(Rails.configuration.x.streaming_api_base_url).host
+      redirect_to uri.to_s, :status => 301
+    else
+      raise ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,7 @@ Rails.application.routes.draw do
         resource :public, only: :show, controller: :public
         resources :tag, only: :show
       end
+      resources :streaming,  only: [:index]
 
       get '/search', to: 'search#index', as: :search
 

--- a/spec/controllers/api/v1/streaming_controller_spec.rb
+++ b/spec/controllers/api/v1/streaming_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::StreamingController do
+  around(:each) do |example|
+    before = Rails.configuration.x.streaming_api_base_url
+    Rails.configuration.x.streaming_api_base_url = Rails.configuration.x.web_domain
+    example.run
+    Rails.configuration.x.streaming_api_base_url = before
+  end
+
+  before(:each) do
+    request.headers.merge! Host: Rails.configuration.x.web_domain
+  end
+
+  context 'with streaming api on same host' do
+    describe 'GET #index' do
+      it 'raises ActiveRecord::RecordNotFound' do
+        get :index
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
+  context 'with streaming api on different host' do
+    before(:each) do
+      Rails.configuration.x.streaming_api_base_url = 'wss://streaming-' + Rails.configuration.x.web_domain
+      @streaming_host = URI.parse(Rails.configuration.x.streaming_api_base_url).host
+    end
+
+    describe 'GET #index' do
+      it 'redirects to streaming host' do
+        get :index, params: {access_token: 'deadbeef', stream: 'public'}
+        expect(response).to have_http_status(301)
+        request_uri = URI.parse(request.url)
+        redirect_to_uri = URI.parse(response.location)
+        [:scheme, :path, :query, :fragment].each do |part|
+          expect(redirect_to_uri.send(part)).to eq(request_uri.send(part)), "redirect target #{part}"
+        end
+        expect(redirect_to_uri.host).to eq(@streaming_host), "redirect target host"
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Alternative solution from #3556 for #2068.

When Rails receives a request to streaming API, it most likely means that there is another host which is configured to respond to it. This is to redirect clients to that host if `STREAMING_API_BASE_URL` is set as another host.