### PR TITLE
Skip image length check (regression from #3528)

### DIFF
--- a/spec/lib/atom_serializer_spec.rb
+++ b/spec/lib/atom_serializer_spec.rb
@@ -389,7 +389,6 @@ RSpec.describe AtomSerializer do
 
         enclosure = entry.nodes.find { |node| node.name == 'link' && node[:rel] == 'enclosure' }
         expect(enclosure[:type]).to eq 'image/jpeg'
-        expect(enclosure[:length]).to eq '57822'
         expect(enclosure[:href]).to match /^https:\/\/cb6e6126.ngrok.io\/system\/media_attachments\/files\/.+\/original\/attachment.jpg$/
       end
 


### PR DESCRIPTION
Test fails due to differences in version of ImageMagick.

### pass env

```console
$ convert --version
Version: ImageMagick 6.8.9-9 Q16 x86_64 2017-05-23 http://www.imagemagick.org
Copyright: Copyright (C) 1999-2014 ImageMagick Studio LLC
Features: DPC Modules OpenMP
Delegates: bzlib cairo djvu fftw fontconfig freetype jbig jng jpeg lcms lqr ltdl lzma openexr pangocairo png rsvg tiff wmf x xml zlib
$ ./bin/rspec ./spec/lib/atom_serializer_spec.rb[1:3:2:9]
[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead.
Run options: include {:ids=>{"./spec/lib/atom_serializer_spec.rb"=>["1:3:2:9"]}}                                    

Randomized with seed 43803
 1/1 |=========================================== 100 ============================================>| Time: 00:00:01 

Finished in 1.53 seconds (files took 3.04 seconds to load)
1 example, 0 failures

Randomized with seed 43803

Coverage report generated for RSpec to /home/ykzts/works/ykzts/mastodon/coverage. 695 / 8792 LOC (7.9%) covered.
```

### fail env

```console
$ convert --version
Version: ImageMagick 7.0.5-9 Q16 x86_64 2017-05-29 http://www.imagemagick.org
Copyright: © 1999-2017 ImageMagick Studio LLC
License: http://www.imagemagick.org/script/license.php
Features: Cipher DPC HDRI Modules 
Delegates (built-in): bzlib freetype jng jpeg ltdl lzma png tiff xml zlib
$ ./bin/rspec ./spec/lib/atom_serializer_spec.rb[1:3:2:9]
[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead.
Run options: include {:ids=>{"./spec/lib/atom_serializer_spec.rb"=>["1:3:2:9"]}}                                    

Randomized with seed 42480
                                                                                                                    
  1) AtomSerializer#entry if status is present appends link elements for media attachments
     Failure/Error: expect(enclosure[:length]).to eq '57822'
     
       expected: "57822"
            got: "57818"
     
       (compared using ==)
     # ./spec/lib/atom_serializer_spec.rb:392:in `block (4 levels) in <top (required)>'

 1/1 |=========================================== 100 ============================================>| Time: 00:00:01 

Finished in 1.72 seconds (files took 3.91 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/lib/atom_serializer_spec.rb:383 # AtomSerializer#entry if status is present appends link elements for media attachments

Randomized with seed 42480

Coverage report generated for RSpec to /Users/ykzts/works/ykzts/mastodon/coverage. 695 / 8792 LOC (7.9%) covered.
```
