### PR TITLE
Prevent pinned columns from scroll to top on URL changing

### DIFF
--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -15,6 +15,7 @@ class StatusList extends ImmutablePureComponent {
     onScrollToBottom: PropTypes.func,
     onScrollToTop: PropTypes.func,
     onScroll: PropTypes.func,
+    trackScroll: PropTypes.bool,
     shouldUpdateScroll: PropTypes.func,
     isLoading: PropTypes.bool,
     isUnread: PropTypes.bool,
@@ -88,7 +89,7 @@ class StatusList extends ImmutablePureComponent {
   }
 
   render () {
-    const { statusIds, onScrollToBottom, scrollKey, shouldUpdateScroll, isLoading, isUnread, hasMore, prepend, emptyMessage } = this.props;
+    const { statusIds, onScrollToBottom, scrollKey, trackScroll, shouldUpdateScroll, isLoading, isUnread, hasMore, prepend, emptyMessage } = this.props;
 
     let loadMore       = null;
     let scrollableArea = null;
@@ -126,11 +127,15 @@ class StatusList extends ImmutablePureComponent {
       );
     }
 
-    return (
-      <ScrollContainer scrollKey={scrollKey} shouldUpdateScroll={shouldUpdateScroll}>
-        {scrollableArea}
-      </ScrollContainer>
-    );
+    if (trackScroll) {
+      return (
+        <ScrollContainer scrollKey={scrollKey} shouldUpdateScroll={shouldUpdateScroll}>
+          {scrollableArea}
+        </ScrollContainer>
+      );
+    } else {
+      return scrollableArea;
+    }
   }
 
 }

--- a/app/javascript/mastodon/features/community_timeline/index.js
+++ b/app/javascript/mastodon/features/community_timeline/index.js
@@ -124,6 +124,7 @@ class CommunityTimeline extends React.PureComponent {
 
         <StatusListContainer
           {...this.props}
+          trackScroll={!pinned}
           scrollKey={`community_timeline-${columnId}`}
           type='community'
           emptyMessage={<FormattedMessage id='empty_column.community' defaultMessage='The local timeline is empty. Write something publicly to get the ball rolling!' />}

--- a/app/javascript/mastodon/features/hashtag_timeline/index.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.js
@@ -120,6 +120,7 @@ class HashtagTimeline extends React.PureComponent {
         />
 
         <StatusListContainer
+          trackScroll={!pinned}
           scrollKey={`hashtag_timeline-${columnId}`}
           type='tag'
           id={id}

--- a/app/javascript/mastodon/features/home_timeline/index.js
+++ b/app/javascript/mastodon/features/home_timeline/index.js
@@ -81,6 +81,7 @@ class HomeTimeline extends React.PureComponent {
 
         <StatusListContainer
           {...this.props}
+          trackScroll={!pinned}
           scrollKey={`home_timeline-${columnId}`}
           type='home'
           emptyMessage={emptyMessage}

--- a/app/javascript/mastodon/features/notifications/index.js
+++ b/app/javascript/mastodon/features/notifications/index.js
@@ -119,6 +119,7 @@ class Notifications extends React.PureComponent {
     let loadMore       = '';
     let scrollableArea = '';
     let unread         = '';
+    let scrollContainer = '';
 
     if (!isLoading && notifications.size > 0) {
       loadMore = <LoadMore onClick={this.handleLoadMore} />;
@@ -149,6 +150,16 @@ class Notifications extends React.PureComponent {
       );
     }
 
+    if (pinned) {
+      scrollContainer = scrollableArea;
+    } else {
+      scrollContainer = (
+        <ScrollContainer scrollKey={`notifications-${columnId}`} shouldUpdateScroll={shouldUpdateScroll}>
+          {scrollableArea}
+        </ScrollContainer>
+      );
+    }
+
     this.scrollableArea = scrollableArea;
 
     return (
@@ -166,9 +177,7 @@ class Notifications extends React.PureComponent {
           <ColumnSettingsContainer />
         </ColumnHeader>
 
-        <ScrollContainer scrollKey={`notifications-${columnId}`} shouldUpdateScroll={shouldUpdateScroll}>
-          {scrollableArea}
-        </ScrollContainer>
+        {scrollContainer}
       </Column>
     );
   }

--- a/app/javascript/mastodon/features/public_timeline/index.js
+++ b/app/javascript/mastodon/features/public_timeline/index.js
@@ -125,6 +125,7 @@ class PublicTimeline extends React.PureComponent {
         <StatusListContainer
           {...this.props}
           type='public'
+          trackScroll={!pinned}
           scrollKey={`public_timeline-${columnId}`}
           emptyMessage={<FormattedMessage id='empty_column.public' defaultMessage='There is nothing here! Write something publicly, or manually follow users from other instances to fill it up' />}
         />


### PR DESCRIPTION
Regression in #3207.

We have also pinned columns in the Router component now, so we should prevent those columns from ScrollContainer behavior.

This can be resolved by one of following:

- Remove ScrollContainer
- Set a function which returns falsy value to `shouldUpdateScroll` property

and I choose first one in this patch to avoid declaring those functions and simplify component tree.