### PR TITLE
Add back button to the hashtag timeline again

### DIFF
--- a/app/javascript/mastodon/components/column_header.js
+++ b/app/javascript/mastodon/components/column_header.js
@@ -14,6 +14,7 @@ class ColumnHeader extends React.PureComponent {
     icon: PropTypes.string.isRequired,
     active: PropTypes.bool,
     multiColumn: PropTypes.bool,
+    showBackButton: PropTypes.bool,
     children: PropTypes.node,
     pinned: PropTypes.bool,
     onPin: PropTypes.func,
@@ -53,7 +54,7 @@ class ColumnHeader extends React.PureComponent {
   }
 
   render () {
-    const { title, icon, active, children, pinned, onPin, multiColumn } = this.props;
+    const { title, icon, active, children, pinned, onPin, multiColumn, showBackButton } = this.props;
     const { collapsed, animating } = this.state;
 
     const buttonClassName = classNames('column-header', {
@@ -90,7 +91,9 @@ class ColumnHeader extends React.PureComponent {
       );
     } else if (multiColumn) {
       pinButton = <button key='pin-button' className='text-btn column-header__setting-btn' onClick={onPin}><i className='fa fa fa-plus' /> <FormattedMessage id='column_header.pin' defaultMessage='Pin' /></button>;
+    }
 
+    if (!pinned && (multiColumn || showBackButton)) {
       backButton = (
         <button onClick={this.handleBackClick} className='column-header__back-button'>
           <i className='fa fa-fw fa-chevron-left column-back-button__icon' />

--- a/app/javascript/mastodon/features/hashtag_timeline/index.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.js
@@ -117,6 +117,7 @@ class HashtagTimeline extends React.PureComponent {
           onClick={this.handleHeaderClick}
           pinned={pinned}
           multiColumn={multiColumn}
+          showBackButton={true}
         />
 
         <StatusListContainer


### PR DESCRIPTION
regression from #3207

Most users access the hashtag timeline from the search result, so back button should be visible even on single column layout to back to the search result.

