### PR TITLE
Fix db:seed - only run some validations when the field was changed

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -52,13 +52,17 @@ class Account < ApplicationRecord
   has_one :user, inverse_of: :account
 
   validates :username, presence: true
-  validates :username, uniqueness: { scope: :domain, case_sensitive: true }, unless: :local?
+
+  # Remote user validations
+  with_options unless: :local? do
+    validates :username, uniqueness: { scope: :domain, case_sensitive: true }, if: :username_changed?
+  end
 
   # Local user validations
   with_options if: :local? do
-    validates :username, format: { with: /\A[a-z0-9_]+\z/i }, uniqueness: { scope: :domain, case_sensitive: false }, length: { maximum: 30 }, unreserved: true
-    validates :display_name, length: { maximum: 30 }
-    validates :note, length: { maximum: 160 }
+    validates :username, format: { with: /\A[a-z0-9_]+\z/i }, uniqueness: { scope: :domain, case_sensitive: false }, length: { maximum: 30 }, unreserved: true, if: :username_changed?
+    validates :display_name, length: { maximum: 30 }, if: :display_name_changed?
+    validates :note, length: { maximum: 160 }, if: :note_changed?
   end
 
   # Timelines

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,7 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :account
 
   validates :locale, inclusion: I18n.available_locales.map(&:to_s), if: :locale?
-  validates :email, email: true
+  validates :email, email: true, if: :email_changed?
 
   scope :recent,    -> { order(id: :desc) }
   scope :admins,    -> { where(admin: true) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,7 @@ Doorkeeper::Application.create!(name: 'Web', superapp: true, redirect_uri: Doork
 
 if Rails.env.development?
   domain = ENV['LOCAL_DOMAIN'] || Rails.configuration.x.local_domain
-  admin  = Account.where(username: 'admin').first_or_create!(username: 'admin')
+  admin  = Account.where(username: 'admin').first_or_initialize(username: 'admin')
+  admin.save(validate: false)
   User.where(email: "admin@#{domain}").first_or_initialize(email: "admin@#{domain}", password: 'mastodonadmin', password_confirmation: 'mastodonadmin', confirmed_at: Time.now.utc, admin: true, account: admin).save!
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -387,6 +387,12 @@ RSpec.describe Account, type: :model do
       expect(account).to model_have_error_on_field(:username)
     end
 
+    it 'is valid when username is reserved but record has already been created' do
+      account = Fabricate.build(:account, username: 'support')
+      account.save(validate: false)
+      expect(account.valid?).to be true
+    end
+
     context 'when is local' do
       it 'is invalid if the username doesn\'t only contains letters, numbers and underscores' do
         account = Fabricate.build(:account, username: 'the-doctor')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe User, type: :model do
       expect(user).to model_have_error_on_field(:email)
     end
 
+    it 'is valid with an invalid e-mail that has already been saved' do
+      user = Fabricate.build(:user, email: 'invalid-email')
+      user.save(validate: false)
+      expect(user.valid?).to be true
+    end
+
     it 'cleans out empty string from languages' do
       user = Fabricate.build(:user, filtered_languages: [''])
       user.valid?


### PR DESCRIPTION
I'm not 100% sure how to test this. But I believe something like this is good practice, I have seen this pattern in the GitLab codebase. However, correct me if I'm wrong on something.