### PR TITLE
Try fixing ThreadResolveWorker calls

### DIFF
--- a/app/services/process_feed_service.rb
+++ b/app/services/process_feed_service.rb
@@ -72,6 +72,12 @@ class ProcessFeedService < BaseService
         status.save!
       end
 
+      if thread?(@xml)
+        Rails.logger.debug "Trying to attach #{status.id} (#{id(@xml)}) to #{thread(@xml).first}"
+        status.thread = find_or_resolve_status(status, *thread(@xml))
+        status.save!
+      end
+
       notify_about_mentions!(status) unless status.reblog?
       notify_about_reblog!(status) if status.reblog? && status.reblog.account.local?
 
@@ -153,11 +159,6 @@ class ProcessFeedService < BaseService
         visibility: visibility_scope(entry),
         conversation: find_or_create_conversation(entry)
       )
-
-      if thread?(entry)
-        Rails.logger.debug "Trying to attach #{status.id} (#{id(entry)}) to #{thread(entry).first}"
-        status.thread = find_or_resolve_status(status, *thread(entry))
-      end
 
       mentions_from_xml(status, entry)
       hashtags_from_xml(status, entry)

--- a/app/services/process_feed_service.rb
+++ b/app/services/process_feed_service.rb
@@ -69,13 +69,14 @@ class ProcessFeedService < BaseService
           end
         end
 
+        status.thread = find_status(thread(@xml).first) if thread?(@xml)
+
         status.save!
       end
 
-      if thread?(@xml)
+      if thread?(@xml) && status.thread.nil?
         Rails.logger.debug "Trying to attach #{status.id} (#{id(@xml)}) to #{thread(@xml).first}"
-        status.thread = find_or_resolve_status(status, *thread(@xml))
-        status.save!
+        ThreadResolveWorker.perform_async(status.id, thread(@xml).second)
       end
 
       notify_about_mentions!(status) unless status.reblog?
@@ -165,14 +166,6 @@ class ProcessFeedService < BaseService
       media_from_xml(status, entry)
 
       [status, true]
-    end
-
-    def find_or_resolve_status(parent, uri, url)
-      status = find_status(uri)
-
-      ThreadResolveWorker.perform_async(parent.id, url) if status.nil?
-
-      status
     end
 
     def find_or_create_conversation(xml)


### PR DESCRIPTION
This is an attempt at fixing #3388.

From my understanding of ActiveRecord, a transaction is commited as soon as
the exit of the outmost ActiveRecord.transaction block. However, inner
transaction blocks will exit without the transaction being commited.

In this case, ThreadResolveWorker were fired *within* a transaction block,
so moving the call out of it should do the trick. However, this is somewhat
fragile, as this whole codepath could be called within yet another transaction.