### PR TITLE
Disable ESLint rule jsx/anchor-has-content

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -86,7 +86,7 @@ class Item extends React.PureComponent {
 
     if (attachment.get('type') === 'image') {
       thumbnail = (
-        <a
+        <a // eslint-disable-line jsx-a11y/anchor-has-content
           className='media-gallery__item-thumbnail'
           href={attachment.get('remote_url') || attachment.get('url')}
           onClick={this.handleClick}

--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -52,7 +52,7 @@ class Avatar extends ImmutablePureComponent {
     return (
       <Motion defaultStyle={{ radius: 90 }} style={{ radius: spring(isHovered ? 30 : 90, { stiffness: 180, damping: 12 }) }}>
         {({ radius }) =>
-          <a
+          <a // eslint-disable-line jsx-a11y/anchor-has-content
             href={account.get('url')}
             className='account__header__avatar'
             target='_blank'


### PR DESCRIPTION
```console
$ yarn test:lint
yarn test:lint v0.24.6
$ eslint -c .eslintrc.yml --ext=js app/javascript/ config/webpack/ spec/javascript/ storyboard/ streaming/ 

/Users/ykzts/works/ykzts/mastodon/app/javascript/mastodon/components/media_gallery.js
  89:9  warning  Anchors must have content and the content must be accessible by a screen reader  jsx-a11y/anchor-has-content

/Users/ykzts/works/ykzts/mastodon/app/javascript/mastodon/features/account/components/header.js
  55:11  warning  Anchors must have content and the content must be accessible by a screen reader  jsx-a11y/anchor-has-content

✖ 2 problems (0 errors, 2 warnings)

✨  Done in 5.01s.
```