### PR TITLE
Fixes #3605 by returning account from database in case of race condition

### DIFF
--- a/app/services/follow_remote_account_service.rb
+++ b/app/services/follow_remote_account_service.rb
@@ -61,8 +61,13 @@ class FollowRemoteAccountService < BaseService
     account.uri     = get_account_uri(xml)
     account.hub_url = hubs.first.attribute('href').value
 
-    account.save!
-    get_profile(body, account)
+    begin
+      account.save!
+      get_profile(body, account)
+    rescue ActiveRecord::RecordNotUnique
+      # The account has been added by another worker!
+      return Account.find_remote(confirmed_username, confirmed_domain)
+    end
 
     account
   end


### PR DESCRIPTION
A better solution would probably be to ensure that there are no concurrent `FollowRemoteAccountService` calls in the first place, but this should do the trick.

I haven't properly tested it, as it is a bit of pain to reproduce.