### PR TITLE
[Account] Skip unreserved validation for existing model.

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -56,7 +56,8 @@ class Account < ApplicationRecord
 
   # Local user validations
   with_options if: :local? do
-    validates :username, format: { with: /\A[a-z0-9_]+\z/i }, uniqueness: { scope: :domain, case_sensitive: false }, length: { maximum: 30 }, unreserved: true
+    validates :username, format: { with: /\A[a-z0-9_]+\z/i }, uniqueness: { scope: :domain, case_sensitive: false }, length: { maximum: 30 }
+    validates :username, unreserved: true, if: :new_record?
     validates :display_name, length: { maximum: 30 }
     validates :note, length: { maximum: 160 }
   end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -362,29 +362,26 @@ RSpec.describe Account, type: :model do
   end
 
   describe 'validations' do
-    it 'has a valid fabricator' do
-      account = Fabricate.build(:account)
-      account.valid?
-      expect(account).to be_valid
+    subject { account }
+    let(:account) { Fabricate.build(:account, username: username) }
+    let(:username) { 'Gargron' }
+
+    it { is_expected.to be_valid }
+
+    describe 'without a username' do
+      let(:username) { nil }
+      it 'should be invalid' do
+        is_expected.not_to be_valid
+        expect(account).to model_have_error_on_field(:username)
+      end
     end
 
-    it 'is invalid without a username' do
-      account = Fabricate.build(:account, username: nil)
-      account.valid?
-      expect(account).to model_have_error_on_field(:username)
-    end
-
-    it 'is invalid if the username already exists' do
-      account_1 = Fabricate(:account, username: 'the_doctor')
-      account_2 = Fabricate.build(:account, username: 'the_doctor')
-      account_2.valid?
-      expect(account_2).to model_have_error_on_field(:username)
-    end
-
-    it 'is invalid if the username is reserved' do
-      account = Fabricate.build(:account, username: 'support')
-      account.valid?
-      expect(account).to model_have_error_on_field(:username)
+    describe 'with an existing username' do
+      before { Fabricate(:account, username: username) }
+      it 'should be invalid' do
+        is_expected.not_to be_valid
+        expect(account).to model_have_error_on_field(:username)
+      end
     end
 
     context 'when is local' do
@@ -398,6 +395,21 @@ RSpec.describe Account, type: :model do
         account = Fabricate.build(:account, username: Faker::Lorem.characters(31))
         account.valid?
         expect(account).to model_have_error_on_field(:username)
+      end
+
+      describe 'reserved username' do
+        let(:username) { 'support' }
+        it 'should be invalid' do
+          is_expected.not_to be_valid
+          expect(account).to model_have_error_on_field(:username)
+        end
+
+        context 'when existing model' do
+          before { account.save(validate: false) }
+          it 'should be valid' do
+            is_expected.to be_valid
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
by #3566, implemented reserved username. 
But it seems to enable validation even for `persisted` account. Is this intentional?

I noticed the issue by running `rails db:seed` , I may have to fix `db:seed` script, not validation :)