### PR TITLE
Fix 500 errors on searching invalid URLs

### DIFF
--- a/app/services/fetch_remote_resource_service.rb
+++ b/app/services/fetch_remote_resource_service.rb
@@ -5,7 +5,7 @@ class FetchRemoteResourceService < BaseService
 
   def call(url)
     @url = url
-    process_url unless atom_url.nil?
+    process_url unless fetched_atom_feed.nil?
   end
 
   private

--- a/spec/services/fetch_remote_resource_service_spec.rb
+++ b/spec/services/fetch_remote_resource_service_spec.rb
@@ -10,7 +10,7 @@ describe FetchRemoteResourceService do
       url = 'http://example.com/missing-atom'
       service = double
       allow(FetchAtomService).to receive(:new).and_return service
-      allow(service).to receive(:call).with(url).and_return([nil, 'body'])
+      allow(service).to receive(:call).with(url).and_return(nil)
 
       result = subject.call(url)
       expect(result).to be_nil


### PR DESCRIPTION
Fixes #3461

Searching invalid feed URLs causes 500 error from #2812. It should returns empty results without error.

For example:

- not contains feed URL: http://example.com/
- non-200 responses: https://mstdn.maud.io/@unarist/2346775 (you can't see because it's a "direct" toot)

Actually, FetchAtomService returns `nil` when [the specified URL returns non-200 responses](https://github.com/tootsuite/mastodon/blob/master/app/services/fetch_atom_service.rb#L17) or when [it doesn't have any atom links](https://github.com/tootsuite/mastodon/blob/master/app/services/fetch_atom_service.rb#L33), not `[nil, ...]`.

cc @mjankowski