### PR TITLE
Update nokogumbo to 1.4.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
-    nokogumbo (1.4.12)
+    nokogumbo (1.4.13)
       nokogiri
     oj (3.0.11)
     openssl (2.0.3)
@@ -564,4 +564,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.14.6
+   1.15.1


### PR DESCRIPTION
```
$ bundle update --source nokogumbo
```

nokogumbo 1.4.11 and 1.4.12 don't work on Heroku.