### PR TITLE
Don't show business e-mail on /about/more if it's blank

### DIFF
--- a/app/views/about/_contact.html.haml
+++ b/app/views/about/_contact.html.haml
@@ -9,7 +9,7 @@
             %span.display_name.emojify= display_name(contact.contact_account)
             %span.username @#{contact.contact_account.acct}
 
-    - if contact.site_contact_email
+    - unless contact.site_contact_email.blank?
       .contact-email
         = t 'about.business_email'
         %strong= contact.site_contact_email


### PR DESCRIPTION
One line change; it looks like this was supposed to happen already, but the condition being checked was wrong.