### PR TITLE
Fixes #3388 by moving re-entrant `shared_status_from_xml` before tran…

### DIFF
--- a/app/services/process_feed_service.rb
+++ b/app/services/process_feed_service.rb
@@ -51,6 +51,11 @@ class ProcessFeedService < BaseService
 
       Rails.logger.debug "Creating remote status #{id}"
 
+      if verb == :share
+        original_status = shared_status_from_xml(@xml.at_xpath('.//activity:object', activity: TagManager::AS_XMLNS))
+        return nil if original_status.nil?
+      end
+
       ApplicationRecord.transaction do
         status, just_created = status_from_xml(@xml)
 
@@ -58,14 +63,10 @@ class ProcessFeedService < BaseService
         return status unless just_created
 
         if verb == :share
-          original_status = shared_status_from_xml(@xml.at_xpath('.//activity:object', activity: TagManager::AS_XMLNS))
-          status.reblog   = original_status
-
-          if original_status.nil?
-            status.destroy
-            return nil
-          elsif original_status.reblog?
+          if original_status.reblog?
             status.reblog = original_status.reblog
+          else
+            status.reblog = original_status
           end
         end
 


### PR DESCRIPTION
…saction block

Steps to reproduce the original issue:
1. Have two remote accounts, A that you don't follow, and B that you follow.
2. Have A post a toot and reply to it.
3. Boost A's reply from remote account B.

This used to cause the local instance to get A's reply but fail to link it to
the original post.