### PR TITLE
Allow "class" attribute on the "a" tag in sanitization

### DIFF
--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -8,7 +8,7 @@ class Sanitize
       elements: %w(p br span a),
 
       attributes: {
-        'a'    => %w(href rel),
+        'a'    => %w(href rel class),
         'span' => %w(class),
       },
 


### PR DESCRIPTION
We use `<a ... class="u-url mention">` for mention links in profiles and statuses, but those classes will be removed if the content are from other Mastodon instances. This may confuses on styling with CSS.

This patch excludes `class` attribute on the `a` tag in sanitization.

Edit: I've found this also has (small) effect even on default CSS.

![image](https://user-images.githubusercontent.com/705555/26875970-1c0f64e0-4bbf-11e7-8a76-a2d1b7c534ae.png)
