### PR TITLE
Autosuggest Textarea: race condition regarding onBlur

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -124,13 +124,7 @@ class AutosuggestTextarea extends ImmutablePureComponent {
   }
 
   onBlur = () => {
-    // If we hide the suggestions immediately, then this will prevent the
-    // onClick for the suggestions themselves from firing.
-    // Setting a short window for that to take place before hiding the
-    // suggestions ensures that can't happen.
-    setTimeout(() => {
-      this.setState({ suggestionsHidden: true });
-    }, 100);
+    this.setState({ suggestionsHidden: true });
   }
 
   onSuggestionClick = (e) => {
@@ -191,7 +185,7 @@ class AutosuggestTextarea extends ImmutablePureComponent {
               key={suggestion}
               data-index={suggestion}
               className={`autosuggest-textarea__suggestions__item ${i === selectedSuggestion ? 'selected' : ''}`}
-              onClick={this.onSuggestionClick}
+              onMouseDown={this.onSuggestionClick}
             >
               <AutosuggestAccountContainer id={suggestion} />
             </div>


### PR DESCRIPTION
Follows [this advice](https://stackoverflow.com/a/28963938) to solve the race condition. Tested on latest Chrome, Firefox (desktop) and Brave (Android).

Closes #3627 