### PR TITLE
Improve RuboCop rules (compatibility to Code Climate)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,11 +17,18 @@ Bundler/OrderedGems:
 Layout/AccessModifierIndentation:
   EnforcedStyle: indent
 
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
 
 Metrics/AbcSize:
   Max: 100
+
+Metrics/BlockLength:
+  Exclude:
+    - 'lib/tasks/**/*'
 
 Metrics/BlockNesting:
   Max: 3
@@ -58,6 +65,9 @@ Rails:
 Rails/HasAndBelongsToMany:
   Enabled: false
 
+Rails/SkipsModelValidations:
+  Enabled: false
+
 Style/ClassAndModuleChildren:
   Enabled: false
 
@@ -81,10 +91,18 @@ Style/GuardClause:
 Style/Lambda:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+    '%w': '()'
+
 Style/PerlBackrefs:
   AutoCorrect: false
 
 Style/RegexpLiteral:
+  Enabled: false
+
+Style/SymbolArray:
   Enabled: false
 
 Style/TrailingCommaInLiteral:

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -51,7 +51,7 @@ class Api::V1::NotificationsController < Api::BaseController
   end
 
   def target_statuses_from_notifications
-    @notifications.select { |notification| !notification.target_status.nil? }.map(&:target_status)
+    @notifications.reject { |notification| notification.target_status.nil? }.map(&:target_status)
   end
 
   def insert_pagination_headers

--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module StreamEntriesHelper
-  EMBEDDED_CONTROLLER = 'stream_entries'.freeze
-  EMBEDDED_ACTION = 'embed'.freeze
+  EMBEDDED_CONTROLLER = 'stream_entries'
+  EMBEDDED_ACTION = 'embed'
 
   def display_name(account)
     account.display_name.presence || account.username

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -109,8 +109,8 @@ class FeedManager
 
     if status.reply? && !status.in_reply_to_account_id.nil?                                                              # Filter out if it's a reply
       should_filter   = !Follow.where(account_id: receiver_id, target_account_id: status.in_reply_to_account_id).exists? # and I'm not following the person it's a reply to
-      should_filter &&= !(receiver_id == status.in_reply_to_account_id)                                                  # and it's not a reply to me
-      should_filter &&= !(status.account_id == status.in_reply_to_account_id)                                            # and it's not a self-reply
+      should_filter &&= receiver_id != status.in_reply_to_account_id                                                     # and it's not a reply to me
+      should_filter &&= status.account_id != status.in_reply_to_account_id                                               # and it's not a self-reply
       return should_filter
     elsif status.reblog?                                                                                                 # Filter out a reblog
       should_filter   = Block.where(account_id: status.reblog.account_id, target_account_id: receiver_id).exists?        # or if the author of the reblogged status is blocking me

--- a/app/models/concerns/paginable.rb
+++ b/app/models/concerns/paginable.rb
@@ -6,8 +6,8 @@ module Paginable
   included do
     scope :paginate_by_max_id, ->(limit, max_id = nil, since_id = nil) {
       query = order(arel_table[:id].desc).limit(limit)
-      query = query.where(arel_table[:id].lt(max_id)) unless max_id.blank?
-      query = query.where(arel_table[:id].gt(since_id)) unless since_id.blank?
+      query = query.where(arel_table[:id].lt(max_id)) if max_id.present?
+      query = query.where(arel_table[:id].gt(since_id)) if since_id.present?
       query
     }
   end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -13,7 +13,7 @@
 #
 
 class Setting < RailsSettings::Base
-  source Rails.root.join('config/settings.yml')
+  source Rails.root.join('config', 'settings.yml')
 
   def to_param
     var

--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -16,7 +16,7 @@ class FetchAtomService < BaseService
 
     return nil if response.code != 200
     return [url, fetch(url)] if response.mime_type == 'application/atom+xml'
-    return process_headers(url, response) unless response['Link'].blank?
+    return process_headers(url, response) if response['Link'].present?
     process_html(fetch(url))
   rescue OpenSSL::SSL::SSLError => e
     Rails.logger.debug "SSL error: #{e}"

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -23,7 +23,7 @@ class SuspendAccountService < BaseService
       @account.notifications,
       @account.favourites,
       @account.active_relationships,
-      @account.passive_relationships
+      @account.passive_relationships,
     ].each do |association|
       destroy_all(association)
     end

--- a/app/services/update_remote_profile_service.rb
+++ b/app/services/update_remote_profile_service.rb
@@ -24,7 +24,7 @@ class UpdateRemoteProfileService < BaseService
     end
 
     old_hub_url     = account.hub_url
-    account.hub_url = hub_link['href'] if !hub_link.nil? && !hub_link['href'].blank? && (hub_link['href'] != old_hub_url)
+    account.hub_url = hub_link['href'] if !hub_link.nil? && hub_link['href'].present? && (hub_link['href'] != old_hub_url)
 
     account.save_with_optional_media!
 

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 if Rails.env.development?
   task :set_annotation_options do
     Annotate.set_defaults(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe User, type: :model do
     end
 
     it 'saves cleared otp_backup_codes' do
-      user = Fabricate.build(:user, otp_backup_codes: %w[dummy dummy])
+      user = Fabricate.build(:user, otp_backup_codes: %w(dummy dummy))
       user.disable_two_factor!
       expect(user.reload.otp_backup_codes.empty?).to be true
     end

--- a/spec/requests/link_headers_spec.rb
+++ b/spec/requests/link_headers_spec.rb
@@ -14,14 +14,14 @@ describe 'Link headers' do
       link_header = link_header_with_type('application/xrd+xml')
 
       expect(link_header.href).to match 'http://www.example.com/.well-known/webfinger?resource=acct%3Atest%40cb6e6126.ngrok.io'
-      expect(link_header.attr_pairs.first).to eq %w[rel lrdd]
+      expect(link_header.attr_pairs.first).to eq %w(rel lrdd)
     end
 
     it 'contains atom url in link header' do
       link_header = link_header_with_type('application/atom+xml')
 
       expect(link_header.href).to eq 'http://www.example.com/users/test.atom'
-      expect(link_header.attr_pairs.first).to eq %w[rel alternate]
+      expect(link_header.attr_pairs.first).to eq %w(rel alternate)
     end
 
     def link_header_with_type(type)


### PR DESCRIPTION
Code Climate is using [RuboCop v0.46.0](https://github.com/codeclimate/codeclimate-rubocop/blob/08f8de84ebfb39caa96391e23816877278f6441c/Gemfile.lock#L38).

Change several rules to maintain compatibility.

### before

```console
$ bundle exec rubocop
Inspecting 251 files
CC.C......C..C.C.......C..........C.........C..C........C.CC.....C..............CC...CC....CC......C.C..C.....CC........C.CC..C......CC..CCCCC.CC.C.CCCCC.C.CCC.CCC........C.....CC...C.....C.C.C.......CC.....C....C....C.........C.......CC..........C.CC

Offenses:

# ...

251 files inspected, 131 offenses detected
```

### after

```console
$ bundle exec rubocop
Inspecting 251 files
.....................................................................................................C..C.....C...................................................................C...C.....C.C................C...........................................

Offenses:

app/lib/atom_serializer.rb:3:1: C: Class has too many lines. [257/200]
class AtomSerializer ...
^^^^^^^^^^^^^^^^^^^^
app/lib/feed_manager.rb:97:3: C: Perceived complexity for filter_from_home? is too high. [11/10]
  def filter_from_home?(status, receiver_id)
  ^^^
app/lib/provider_discovery.rb:7:5: C: Perceived complexity for discover_provider is too high. [11/10]
    def discover_provider(url, options = {})
    ^^^
app/services/fetch_link_card_service.rb:47:3: C: Cyclomatic complexity for attempt_oembed is too high. [16/15]
  def attempt_oembed(card, url)
  ^^^
app/services/fetch_link_card_service.rb:47:3: C: Perceived complexity for attempt_oembed is too high. [14/10]
  def attempt_oembed(card, url)
  ^^^
app/services/follow_remote_account_service.rb:14:3: C: Cyclomatic complexity for call is too high. [16/15]
  def call(uri, redirected = nil)
  ^^^
app/services/follow_remote_account_service.rb:14:3: C: Perceived complexity for call is too high. [17/10]
  def call(uri, redirected = nil)
  ^^^
app/services/process_feed_service.rb:22:3: C: Class has too many lines. [209/200]
  class ProcessEntry ...
  ^^^^^^^^^^^^^^^^^^
app/services/process_feed_service.rb:44:5: C: Perceived complexity for create_status is too high. [15/10]
    def create_status
    ^^^
app/services/process_interaction_service.rb:10:3: C: Cyclomatic complexity for call is too high. [25/15]
  def call(envelope, target_account)
  ^^^
app/services/process_interaction_service.rb:10:3: C: Perceived complexity for call is too high. [16/10]
  def call(envelope, target_account)
  ^^^
app/services/update_remote_profile_service.rb:4:3: C: Cyclomatic complexity for call is too high. [16/15]
  def call(body, account, resubscribe = false)
  ^^^
app/services/update_remote_profile_service.rb:4:3: C: Perceived complexity for call is too high. [16/10]
  def call(body, account, resubscribe = false)
  ^^^

251 files inspected, 13 offenses detected
```