### PR TITLE
Add explit admin actions to (re)subscribe/unsubscribe remote accounts

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -2,15 +2,42 @@
 
 module Admin
   class AccountsController < BaseController
+    before_action :set_account, only: [:show, :subscribe, :unsubscribe, :redownload]
+    before_action :require_remote_account!, only: [:subscribe, :unsubscribe, :redownload]
+
     def index
       @accounts = filtered_accounts.page(params[:page])
     end
 
-    def show
-      @account = Account.find(params[:id])
+    def show; end
+
+    def subscribe
+      Pubsubhubbub::SubscribeWorker.perform_async(@account.id)
+      redirect_to admin_account_path(@account.id)
+    end
+
+    def unsubscribe
+      UnsubscribeService.new.call(@account)
+      redirect_to admin_account_path(@account.id)
+    end
+
+    def redownload
+      @account.avatar = @account.avatar_remote_url
+      @account.header = @account.header_remote_url
+      @account.save!
+
+      redirect_to admin_account_path(@account.id)
     end
 
     private
+
+    def set_account
+      @account = Account.find(params[:id])
+    end
+
+    def require_remote_account!
+      redirect_to admin_account_path(@account.id) if @account.local?
+    end
 
     def filtered_accounts
       AccountFilter.new(filter_params).results

--- a/app/javascript/styles/admin.scss
+++ b/app/javascript/styles/admin.scss
@@ -245,19 +245,13 @@
 
 .report-status__actions {
   flex: 0 0 auto;
-  position: relative;
+  display: flex;
+  flex-direction: column;
 
-  .nsfw-button {
-    color: $white;
-    font-size: 11px;
-    width: 11px;
-    display: block;
-  }
-
-  .trash-button {
-    position: absolute;
-    bottom: 10px;
+  .icon-button {
     font-size: 24px;
     width: 24px;
+    text-align: center;
+    margin-bottom: 10px;
   }
 }

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -67,11 +67,17 @@
       %th= t('.targeted_reports')
       %td= link_to pluralize(@account.targeted_reports.count, t('.report')), admin_reports_path(target_account_id: @account.id)
 
-- if @account.local?
-  %div{ style: 'float: right' }
+
+%div{ style: 'float: right' }
+  - if @account.local?
     = link_to t('admin.accounts.reset_password'), admin_account_reset_path(@account.id), method: :create, class: 'button'
     - if @account.user&.otp_required_for_login?
       = link_to t('admin.accounts.disable_two_factor_authentication'), admin_user_two_factor_authentication_path(@account.user.id), method: :delete, class: 'button'
+  - else
+    = link_to @account.subscribed? ? t('admin.accounts.resubscribe') : t('admin.accounts.subscribe'), subscribe_admin_account_path(@account.id), method: :post, class: 'button'
+    - if @account.subscribed?
+      = link_to t('admin.accounts.unsubscribe'), unsubscribe_admin_account_path(@account.id), method: :post, class: 'button negative'
+    = link_to t('admin.accounts.redownload'), redownload_admin_account_path(@account.id), method: :post, class: 'button'
 
 %div{ style: 'float: left' }
   - if @account.silenced?

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -25,8 +25,8 @@
         .entry= render partial: 'stream_entries/simple_status', locals: { status: status }
       .report-status__actions
         - unless status.media_attachments.empty?
-          = link_to admin_report_reported_status_path(@report, status, status: { sensitive: !status.sensitive }), method: :patch, class: 'nsfw-button', title: t("admin.reports.nsfw.#{!status.sensitive}") do
-            = t("admin.reports.nsfw.#{!status.sensitive}")
+          = link_to admin_report_reported_status_path(@report, status, status: { sensitive: !status.sensitive }), method: :patch, class: 'icon-button nsfw-button', title: t("admin.reports.nsfw.#{!status.sensitive}") do
+            = fa_icon status.sensitive? ? 'eye' : 'eye-slash'
         = link_to admin_report_reported_status_path(@report, status), method: :delete, class: 'icon-button trash-button', title: t('admin.reports.delete'), data: { confirm: t('admin.reports.are_you_sure') } do
           = fa_icon 'trash'
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -134,13 +134,6 @@ ca:
       account_count: Comptes coneguts
       domain_name: Domini
       title: Instàncies conegudes
-    subscriptions:
-      callback_url: Callback URL
-      confirmed: Confirmat
-      expires_in: Expira en
-      last_delivery: Últim lliurament
-      title: PubSubHubbub
-      topic: Tòpic
     reports:
       are_you_sure: Estàs segur?
       comment:
@@ -186,6 +179,13 @@ ca:
         title: Descripció estesa del lloc
       site_title: Títol del lloc
       title: Configuració del lloc
+    subscriptions:
+      callback_url: Callback URL
+      confirmed: Confirmat
+      expires_in: Expira en
+      last_delivery: Últim lliurament
+      title: PubSubHubbub
+      topic: Tòpic
     title: Administració
   application_mailer:
     settings: 'Canviar preferències de correu: %{link}'
@@ -263,7 +263,7 @@ ca:
       following: Llista de seguits
       muting: Llista d'apagats
     upload: Carregar
-  landing_strip_html: <strong>%{name}</strong> és un usuari/a de %{link_to_root_path}. Pots seguir-lo/la o interactuar amb ell/a si tens un compte a qualsevol node del fediverse.
+  landing_strip_html: "<strong>%{name}</strong> és un usuari/a de %{link_to_root_path}. Pots seguir-lo/la o interactuar amb ell/a si tens un compte a qualsevol node del fediverse."
   landing_strip_signup_html: Si no en tens, pots <a href="%{sign_up_path}">registrar-te aquí</a>.
   media_attachments:
     validations:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -119,13 +119,6 @@ de:
       account_count: Bekannte Konten
       domain_name: Domain
       title: Bekannte Instanzen
-    subscriptions:
-      callback_url: Callback-URL
-      confirmed: Bestätigt
-      expires_in: Verfällt in
-      last_delivery: Letzte Zustellung
-      title: PubSubHubbub
-      topic: Thema
     reports:
       comment:
         label: Kommentar
@@ -133,7 +126,7 @@ de:
       delete: Löschen
       id: ID
       mark_as_resolved: Als gelöst markieren
-      report: '#%{id} melden'
+      report: "#%{id} melden"
       reported_account: Gemeldetes Konto
       reported_by: Gemeldet von
       resolved: Gelöst
@@ -166,6 +159,13 @@ de:
         title: Erweiterte Seitenbeschreibung
       site_title: Seitentitel
       title: Seiteneinstellungen
+    subscriptions:
+      callback_url: Callback-URL
+      confirmed: Bestätigt
+      expires_in: Verfällt in
+      last_delivery: Letzte Zustellung
+      title: PubSubHubbub
+      topic: Thema
     title: Administration
   application_mailer:
     settings: 'E-Mail-Einstellungen ändern: %{link}'
@@ -229,7 +229,7 @@ de:
       following: Folgeliste
       muting: Stummschaltungsliste
     upload: Hochladen
-  landing_strip_html: <strong>%{name}</strong> ist ein Benutzer auf %{link_to_root_path}. Du kannst ihm folgen oder mit ihm interagieren, sofern du ein Konto irgendwo in der Fediverse hast.
+  landing_strip_html: "<strong>%{name}</strong> ist ein Benutzer auf %{link_to_root_path}. Du kannst ihm folgen oder mit ihm interagieren, sofern du ein Konto irgendwo in der Fediverse hast."
   landing_strip_signup_html: Wenn nicht, kannst du dich <a href="%{sign_up_path}">hier anmelden</a>.
   media_attachments:
     validations:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,8 +39,8 @@ en:
     people_who_follow: People who follow %{name}
     posts: Posts
     remote_follow: Remote follow
-    unfollow: Unfollow
     reserved_username: The username is reserved
+    unfollow: Unfollow
   activitypub:
     activity:
       announce:
@@ -86,8 +86,10 @@ en:
       profile_url: Profile URL
       public: Public
       push_subscription_expires: PuSH subscription expires
+      redownload: Refresh avatar
       reset: Reset
       reset_password: Reset password
+      resubscribe: Resubscribe
       salmon_url: Salmon URL
       search: Search
       show:
@@ -96,9 +98,11 @@ en:
         targeted_reports: Reports made about this account
       silence: Silence
       statuses: Statuses
+      subscribe: Subscribe
       title: Accounts
       undo_silenced: Undo silence
       undo_suspension: Undo suspension
+      unsubscribe: Unsubscribe
       username: Username
       web: Web
     domain_blocks:
@@ -135,20 +139,17 @@ en:
       account_count: Known accounts
       domain_name: Domain
       title: Known Instances
-    subscriptions:
-      callback_url: Callback URL
-      confirmed: Confirmed
-      expires_in: Expires in
-      last_delivery: Last delivery
-      title: PubSubHubbub
-      topic: Topic
     reports:
+      are_you_sure: Are you sure?
       comment:
         label: Comment
         none: None
       delete: Delete
       id: ID
       mark_as_resolved: Mark as resolved
+      nsfw:
+        'false': NSFW OFF
+        'true': NSFW ON
       report: 'Report #%{id}'
       report_contents: Contents
       reported_account: Reported account
@@ -161,10 +162,6 @@ en:
       title: Reports
       unresolved: Unresolved
       view: View
-      nsfw:
-        'true': NSFW ON
-        'false': NSFW OFF
-      are_you_sure: Are you sure?
     settings:
       contact_information:
         email: Enter a public e-mail address
@@ -187,6 +184,13 @@ en:
         title: Extended site description
       site_title: Site title
       title: Site Settings
+    subscriptions:
+      callback_url: Callback URL
+      confirmed: Confirmed
+      expires_in: Expires in
+      last_delivery: Last delivery
+      title: PubSubHubbub
+      topic: Topic
     title: Administration
   application_mailer:
     settings: 'Change e-mail preferences: %{link}'
@@ -265,7 +269,7 @@ en:
       following: Following list
       muting: Muting list
     upload: Upload
-  landing_strip_html: <strong>%{name}</strong> is a user on %{link_to_root_path}. You can follow them or interact with them if you have an account anywhere in the fediverse.
+  landing_strip_html: "<strong>%{name}</strong> is a user on %{link_to_root_path}. You can follow them or interact with them if you have an account anywhere in the fediverse."
   landing_strip_signup_html: If you don't, you can <a href="%{sign_up_path}">sign up here</a>.
   media_attachments:
     validations:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,8 +148,8 @@ en:
       id: ID
       mark_as_resolved: Mark as resolved
       nsfw:
-        'false': NSFW OFF
-        'true': NSFW ON
+        'false': Unhide media attachments
+        'true': Hide media attachments
       report: 'Report #%{id}'
       report_contents: Contents
       reported_account: Reported account

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -5,7 +5,7 @@ fa:
     about_this: دربارهٔ این سرور
     apps: برنامه‌ها
     business_email: 'ایمیل کاری:'
-    closed_registrations: "امکان ثبت نام روی این سرور هم‌اینک فعال نیست."
+    closed_registrations: امکان ثبت نام روی این سرور هم‌اینک فعال نیست.
     contact: تماس
     description_headline: "%{domain} چیست؟"
     domain_count_after: سرور دیگر
@@ -47,8 +47,8 @@ fa:
       create:
         name: "%{account_name} یادداشتی نوشت."
     outbox:
-      name: "صندوق خروجی %{account_name}"
-      summary: "مجموعه‌ای از فعالیت‌های کاربر %{account_name}."
+      name: صندوق خروجی %{account_name}
+      summary: مجموعه‌ای از فعالیت‌های کاربر %{account_name}.
   admin:
     accounts:
       are_you_sure: آیا مطمئن هستید؟
@@ -118,7 +118,7 @@ fa:
       show:
         affected_accounts:
           one: روی یک حساب در پایگاه داده تأثیر گذاشت
-          other: "روی %{count} حساب در پایگاه داده تأثیر گذاشت"
+          other: روی %{count} حساب در پایگاه داده تأثیر گذاشت
         retroactive:
           silence: بی‌صداشدن همهٔ حساب‌های این دامین را لغو کن
           suspend: معلق‌شدن همهٔ حساب‌های این دامین را لغو کن
@@ -130,13 +130,6 @@ fa:
       account_count: حساب‌های شناخته‌شده
       domain_name: دامین
       title: سرورهای شناخته‌شده
-    subscriptions:
-      callback_url: نشانی Callback
-      confirmed: تأییدشده
-      expires_in: مهلت انقضا
-      last_delivery: آخرین ارسال
-      title: PubSubHubbub
-      topic: موضوع
     reports:
       comment:
         label: توضیح
@@ -178,6 +171,13 @@ fa:
         title: اطلاعات بیشتر دربارهٔ سایت
       site_title: نام سایت
       title: تنظیمات سایت
+    subscriptions:
+      callback_url: نشانی Callback
+      confirmed: تأییدشده
+      expires_in: مهلت انقضا
+      last_delivery: آخرین ارسال
+      title: PubSubHubbub
+      topic: موضوع
     title: مدیریت
   application_mailer:
     settings: 'تغییر تنظیمات ایمیل: %{link}'
@@ -255,7 +255,7 @@ fa:
       following: فهرست پی‌گیری‌ها
       muting: فهرست بی‌صداشده‌ها
     upload: بارگذاری
-  landing_strip_html: <strong>%{name}</strong> کاربری روی %{link_to_root_path} است. شما با داشتن حساب روی هر سروری می‌توانید نوشته‌های او را پیگیری کرده یا با او ارتباط داشته باشید.
+  landing_strip_html: "<strong>%{name}</strong> کاربری روی %{link_to_root_path} است. شما با داشتن حساب روی هر سروری می‌توانید نوشته‌های او را پیگیری کرده یا با او ارتباط داشته باشید."
   landing_strip_signup_html: اگر هنوز حسابی ندارید <a href="%{sign_up_path}">این‌جا حساب باز کنید</a>.
   media_attachments:
     validations:
@@ -272,7 +272,7 @@ fa:
         one: "یک اعلان تازه از زمان آخرین بازدید شما \U0001F418"
         other: "%{count} اعلان تازه از زمان آخرین بازدید شما \U0001F418"
     favourite:
-      body: '%{name} این نوشتهٔ شما را پسندید:'
+      body: "%{name} این نوشتهٔ شما را پسندید:"
       subject: "%{name} نوشتهٔ شما را پسندید"
     follow:
       body: "%{name} هم‌اینک پیگیر شماست!"
@@ -281,10 +281,10 @@ fa:
       body: "%{name} می‌خواهد پیگیر نوشته‌های شما باشد"
       subject: 'منتظر پیگیری: %{name}'
     mention:
-      body: '%{name} در این‌جا از شما نام برد:'
-      subject: '%{name} از شما نام برد'
+      body: "%{name} در این‌جا از شما نام برد:"
+      subject: "%{name} از شما نام برد"
     reblog:
-      body: '%{name} نوشتهٔ شما را بازبوقید:'
+      body: "%{name} نوشتهٔ شما را بازبوقید:"
       subject: "%{name} نوشتهٔ شما را بازبوقید"
   pagination:
     next: بعدی

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -110,13 +110,6 @@ fr:
         undo: Annuler
       title: Blocage de domaines
       undo: Annuler
-    subscriptions:
-      callback_url: URL de rappel
-      confirmed: Confirmé
-      expires_in: Expire dans
-      last_delivery: Dernière livraison
-      title: PubSubHubbub
-      topic: Sujet
     reports:
       comment:
         label: Commentaire
@@ -157,6 +150,13 @@ fr:
         title: Description étendue du site
       site_title: Titre du site
       title: Paramètres du site
+    subscriptions:
+      callback_url: URL de rappel
+      confirmed: Confirmé
+      expires_in: Expire dans
+      last_delivery: Dernière livraison
+      title: PubSubHubbub
+      topic: Sujet
     title: Administration
   application_mailer:
     settings: 'Changer les préférences courriel : %{link}'
@@ -298,7 +298,7 @@ fr:
     generate_recovery_codes: Générer les codes de récupération
     instructions_html: "<strong>Scannez ce QR code grâce à Google Authenticator, Authy ou une application similaire sur votre téléphone</strong>. Désormais, cette application générera des jetons que vous devrez saisir à chaque connexion."
     lost_recovery_codes: Les codes de récupération vous permettent de retrouver les accès à votre comptre si vous perdez votre téléphone. Si vous perdez vos codes de récupération, vous pouvez les générer à nouveau ici. Vos anciens codes de récupération seront invalidés.
-    manual_instructions: "Si vous ne pouvez pas scanner ce QR code et devez l'entrer manuellement, voici le secret en clair :"
+    manual_instructions: 'Si vous ne pouvez pas scanner ce QR code et devez l''entrer manuellement, voici le secret en clair :'
     recovery_codes_regenerated: Codes de récupération régénérés avec succès
     recovery_instructions: Si vous perdez l'accès à votre téléphone, vous pouvez utiliser un des codes de récupération ci-dessous pour récupérer l'accès à votre compte. Conservez les codes de récupération en toute sécurité, par exemple, en les imprimant et en les stockant avec vos autres documents importants.
     setup: Installer

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -134,20 +134,17 @@ he:
       account_count: חשבונות מוכרים
       domain_name: שם מתחם
       title: שרתים מוכרים
-    subscriptions:
-      callback_url: קישורית Callback
-      confirmed: מאושר
-      expires_in: פג תוקף ב-
-      last_delivery: משלוח אחרון
-      title: PubSubHubbub
-      topic: נושא
     reports:
+      are_you_sure: 100% על בטוח?
       comment:
         label: הערה
         none: ללא
       delete: מחיקה
       id: ID
       mark_as_resolved: סימון כפתור
+      nsfw:
+        'false': לכל המשפחה
+        'true': תוכן רגיש
       report: 'דווח על #%{id}'
       report_contents: תוכן
       reported_account: חשבון מדווח
@@ -160,10 +157,6 @@ he:
       title: דיווחים
       unresolved: לא פתור
       view: תצוגה
-      nsfw:
-        'true': תוכן רגיש
-        'false': לכל המשפחה
-      are_you_sure: 100% על בטוח?
     settings:
       contact_information:
         email: נא להקליד כתובת דוא"ל פומבית
@@ -186,6 +179,13 @@ he:
         title: תיאור אתר מורחב
       site_title: כותרת האתר
       title: הגדרות אתר
+    subscriptions:
+      callback_url: קישורית Callback
+      confirmed: מאושר
+      expires_in: פג תוקף ב-
+      last_delivery: משלוח אחרון
+      title: PubSubHubbub
+      topic: נושא
     title: ניהול
   application_mailer:
     settings: 'שינוי הגדרות דוא"ל: %{link}'
@@ -263,7 +263,7 @@ he:
       following: רשימת נעקבים
       muting: רשימת השתקות
     upload: יבוא
-  landing_strip_html: <strong>%{name}</strong> מזהה משתמש(ת) מהקהילה %{link_to_root_path}. ניתן לעקוב אחריהם או לדבר איתם בעזרת חשבון על כל שרת קהילה ברחבי הפדרציה.
+  landing_strip_html: "<strong>%{name}</strong> מזהה משתמש(ת) מהקהילה %{link_to_root_path}. ניתן לעקוב אחריהם או לדבר איתם בעזרת חשבון על כל שרת קהילה ברחבי הפדרציה."
   landing_strip_signup_html: לחלופין , ניתן <a href="%{sign_up_path}">להרשם מקומית כאן</a>.
   media_attachments:
     validations:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -48,7 +48,7 @@ id:
         name: "%{account_name} membuat catatan."
     outbox:
       name: "%{account_name} Outbox"
-      summary: "Koleksi aktivitas dari pengguna %{account_name}."
+      summary: Koleksi aktivitas dari pengguna %{account_name}.
   admin:
     accounts:
       are_you_sure: Anda yakin?
@@ -129,13 +129,6 @@ id:
       account_count: Akun yang diketahui
       domain_name: Domain
       title: Server yang diketahui
-    subscriptions:
-      callback_url: Callback URL
-      confirmed: Dikonfirmasi
-      expires_in: Kadaluarsa dalam
-      last_delivery: Terakhir dikirim
-      title: PubSubHubbub
-      topic: Topik
     reports:
       comment:
         label: Komentar
@@ -177,6 +170,13 @@ id:
         title: Deskripsi situs tambahan
       site_title: Judul Situs
       title: Pengaturan situs
+    subscriptions:
+      callback_url: Callback URL
+      confirmed: Dikonfirmasi
+      expires_in: Kadaluarsa dalam
+      last_delivery: Terakhir dikirim
+      title: PubSubHubbub
+      topic: Topik
     title: Administrasi
   application_mailer:
     settings: 'Ubah pilihan email: %{link}'
@@ -253,7 +253,7 @@ id:
       following: Daftar diikuti
       muting: Daftar didiamkan
     upload: Unggah
-  landing_strip_html: <strong>%{name}</strong> adalah pengguna di %{link_to_root_path}.Anda dapat mengikuti mereka atau berinteraksi dengan mereka jika anda memiliki akun di fediverse.
+  landing_strip_html: "<strong>%{name}</strong> adalah pengguna di %{link_to_root_path}.Anda dapat mengikuti mereka atau berinteraksi dengan mereka jika anda memiliki akun di fediverse."
   landing_strip_signup_html: Jika anda tidak punya, anda bisa <a href="%{sign_up_path}">daftar disini</a>.
   media_attachments:
     validations:
@@ -312,7 +312,6 @@ id:
       private_long: Hanya tampilkan ke pengikut
       public: Publik
       public_long: Bisa dilihat semua orang
-      unlisted: Tidak Tercantum
       unlisted: Bisa dilihat semua orang, tapi tidak ditampilkan di linimasa publik
   stream_entries:
     click_to_show: Klik untuk menampilkan

--- a/config/locales/io.yml
+++ b/config/locales/io.yml
@@ -118,13 +118,6 @@ io:
       account_count: Known accounts
       domain_name: Domain
       title: Known Instances
-    subscriptions:
-      callback_url: Callback URL
-      confirmed: Confirmed
-      expires_in: Expires in
-      last_delivery: Last delivery
-      title: PubSubHubbub
-      topic: Topic
     reports:
       comment:
         label: Comment
@@ -165,6 +158,13 @@ io:
         title: Extended site description
       site_title: Site title
       title: Site Settings
+    subscriptions:
+      callback_url: Callback URL
+      confirmed: Confirmed
+      expires_in: Expires in
+      last_delivery: Last delivery
+      title: PubSubHubbub
+      topic: Topic
     title: Administration
   application_mailer:
     settings: 'Chanjar la retpost-mesajala preferi: %{link}'
@@ -228,7 +228,7 @@ io:
       following: Listo de sequati
       muting: Muting list
     upload: Kargar
-  landing_strip_html: <strong>%{name}</strong> esas uzero en %{link_to_root_path}. Tu povas sequar lu o komunikar kun lu, se tu havas konto irgaloke en la Fediverse.
+  landing_strip_html: "<strong>%{name}</strong> esas uzero en %{link_to_root_path}. Tu povas sequar lu o komunikar kun lu, se tu havas konto irgaloke en la Fediverse."
   landing_strip_signup_html: Se tu ne havas, tu povas <a href="%{sign_up_path}">membreskar hike</a>.
   media_attachments:
     validations:
@@ -245,19 +245,19 @@ io:
         one: "1 nova savigo depos tua lasta vizito \U0001F418"
         other: "%{count} nova savigi depos tua lasta vizito \U0001F418"
     favourite:
-      body: '%{name} favoris tua mesajo:'
+      body: "%{name} favoris tua mesajo:"
       subject: "%{name} favoris tua mesajo"
     follow:
       body: "%{name} sequeskas tu!"
       subject: "%{name} sequeskas tu"
     follow_request:
       body: "%{name} demandis sequar tu"
-      subject: '%{name} demandis sequar tu'
+      subject: "%{name} demandis sequar tu"
     mention:
-      body: '%{name} mencionis tu en:'
-      subject: '%{name} mencionis tu'
+      body: "%{name} mencionis tu en:"
+      subject: "%{name} mencionis tu"
     reblog:
-      body: '%{name} diskonocigis tua mesajo:'
+      body: "%{name} diskonocigis tua mesajo:"
       subject: "%{name} diskonocigis tua mesajo"
   pagination:
     next: Sequanta

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -135,13 +135,6 @@ ja:
       account_count: 既知のアカウント数
       domain_name: ドメイン名
       title: 既知のインスタンス
-    subscriptions:
-      callback_url: コールバックURL
-      confirmed: 確認済み
-      expires_in: 期限
-      last_delivery: 最終配送
-      title: PubSubHubbub
-      topic: トピック
     reports:
       are_you_sure: 本当に実行しますか？
       comment:
@@ -187,6 +180,13 @@ ja:
         title: サイトの詳細な説明
       site_title: サイトのタイトル
       title: サイト設定
+    subscriptions:
+      callback_url: コールバックURL
+      confirmed: 確認済み
+      expires_in: 期限
+      last_delivery: 最終配送
+      title: PubSubHubbub
+      topic: トピック
     title: 管理
   application_mailer:
     settings: 'メール設定の変更: %{link}'
@@ -265,7 +265,7 @@ ja:
       following: フォロー中のアカウントリスト
       muting: ミュートしたアカウントリスト
     upload: アップロード
-  landing_strip_html: <strong>%{name}</strong> さんはインスタンス %{link_to_root_path} のユーザーです。アカウントさえ持っていればフォローしたり会話したりできます。
+  landing_strip_html: "<strong>%{name}</strong> さんはインスタンス %{link_to_root_path} のユーザーです。アカウントさえ持っていればフォローしたり会話したりできます。"
   landing_strip_signup_html: もしお持ちでないなら <a href="%{sign_up_path}">こちら</a> からサインアップできます。
   media_attachments:
     validations:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -131,13 +131,6 @@
       account_count: Kjente kontoer
       domain_name: Domene
       title: Kjente instanser
-    subscriptions:
-      callback_url: Callback-URL
-      confirmed: Bekreftet
-      expires_in: Utløper om
-      last_delivery: Siste levering
-      title: PubSubHubbub
-      topic: Emne
     reports:
       comment:
         label: Kommentar
@@ -179,6 +172,13 @@
         title: Utvidet nettstedsinformasjon
       site_title: Nettstedstittel
       title: Nettstedsinnstillinger
+    subscriptions:
+      callback_url: Callback-URL
+      confirmed: Bekreftet
+      expires_in: Utløper om
+      last_delivery: Siste levering
+      title: PubSubHubbub
+      topic: Emne
     title: Administrasjon
   application_mailer:
     settings: 'Endre foretrukne e-postinnstillinger: %{link}'
@@ -256,7 +256,7 @@
       following: Følgeliste
       muting: Dempeliste
     upload: Opplastning
-  landing_strip_html: <strong>%{name}</strong> er en bruker på %{link_to_root_path}. Du kan følge dem eller kommunisere med dem hvis du har en konto hvor som helst i fediverset.
+  landing_strip_html: "<strong>%{name}</strong> er en bruker på %{link_to_root_path}. Du kan følge dem eller kommunisere med dem hvis du har en konto hvor som helst i fediverset."
   landing_strip_signup_html: Hvis du ikke har en konto så kan du <a href="%{sign_up_path}">registrere deg her</a>.
   media_attachments:
     validations:

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -134,20 +134,17 @@ oc:
       account_count: Comptes coneguts
       domain_name: Domeni
       title: Instàncias conegudas
-    subscriptions:
-      callback_url: URL de rapèl
-      confirmed: Confirmat
-      expires_in: S’acaba dins
-      last_delivery: Darrièra distribucion
-      title: PubSubHubbub
-      topic: Subjècte
     reports:
+      are_you_sure: Es segur ?
       comment:
         label: Comentari
         none: Pas cap
       delete: Suprimir
       id: ID
       mark_as_resolved: Marcat coma resolgut
+      nsfw:
+        'false': Sens contengut sensible
+        'true': Contengut sensible activat
       report: 'enhalament #%{id}'
       report_contents: Contenguts
       reported_account: Compte senhalat
@@ -160,10 +157,6 @@ oc:
       title: Senhalament
       unresolved: Pas resolguts
       view: Veire
-      nsfw:
-        'true': Contengut sensible activat
-        'false': Sens contengut sensible
-      are_you_sure: Es segur ?
     settings:
       contact_information:
         email: Picatz una adreça de corrièl
@@ -186,6 +179,13 @@ oc:
         title: Descripcion espandida del site
       site_title: Títol del site
       title: Paramètres del site
+    subscriptions:
+      callback_url: URL de rapèl
+      confirmed: Confirmat
+      expires_in: S’acaba dins
+      last_delivery: Darrièra distribucion
+      title: PubSubHubbub
+      topic: Subjècte
     title: Administracion
   application_mailer:
     settings: 'Cambiar las preferéncias de corrièl : %{link}'
@@ -218,7 +218,7 @@ oc:
     - dv
     - ds
     abbr_month_names:
-    -
+    - 
     - gen
     - feb
     - mar
@@ -241,48 +241,47 @@ oc:
     - dissabte
     formats:
       default: "%d/%m/%Y"
-      long: "Lo %B %d de %Y"
+      long: Lo %B %d de %Y
       short: "%b %d"
     month_names:
-      -
-      - de genièr
-      - de febrièr
-      - de març
-      - d’abrial
-      - de mai
-      - de junh
-      - de julhet
-      - d’agost
-      - de setembre
-      - d’octòbre
-      - de novembre
-      - de decembre
+    - 
+    - de genièr
+    - de febrièr
+    - de març
+    - d’abrial
+    - de mai
+    - de junh
+    - de julhet
+    - d’agost
+    - de setembre
+    - d’octòbre
+    - de novembre
+    - de decembre
     order:
-      - :day
-      - :month
-      - :year
+    - :day
+    - :month
+    - :year
   datetime:
     distance_in_words:
-      about_x_hours: "Fa %{count} oras"
-      about_x_months: "Fa %{count} meses"
+      about_x_hours: Fa %{count} oras
+      about_x_months: Fa %{count} meses
       about_x_years:
         one: Fa un an
-        other: "Fa %{count} ans"
+        other: Fa %{count} ans
       almost_x_years:
         one: Fa un an
-        other: "Fa %{count} ans"
+        other: Fa %{count} ans
       half_a_minute: Ara
-      less_than_x_minutes: "Fa %{count} minutas"
+      less_than_x_minutes: Fa %{count} minutas
       less_than_x_seconds: Ara
       over_x_years:
         one: Fa un an
-        other: "Fa %{count} ans"
-      x_days: "Fa %{count} jorns"
-      x_minutes: "Fa %{count} minutas"
-      x_months: "Fa %{count} meses"
-      x_seconds: "Fa %{count} segondas"
+        other: Fa %{count} ans
+      x_days: Fa %{count} jorns
+      x_minutes: Fa %{count} minutas
+      x_months: Fa %{count} meses
+      x_seconds: Fa %{count} segondas
   errors:
-    '404': Avètz pas la permission per veire aquesta pagina.
     '404': La pagina que recercatz existís pas.
     '410': La pagina que cercatz existís pas mai.
     '422':
@@ -322,7 +321,7 @@ oc:
       following: Lista de mond que seguètz
       muting: Lista de mond que volètz pas legir
     upload: Importar
-  landing_strip_html: <strong>%{name}</strong> es un utilizaire de %{link_to_root_path}. Podètz lo/la sègre o interagir amb el o ela s’avètz un compte ont que siasgue sul fediverse.
+  landing_strip_html: "<strong>%{name}</strong> es un utilizaire de %{link_to_root_path}. Podètz lo/la sègre o interagir amb el o ela s’avètz un compte ont que siasgue sul fediverse."
   landing_strip_signup_html: S’es pas lo cas, podètz <a href="%{sign_up_path}">vos marcar aquí</a>.
   media_attachments:
     validations:
@@ -389,7 +388,7 @@ oc:
     sensitive_content: Contengut sensible
   time:
     formats:
-      default: "Lo %d %b de %Y a %Ho%M"
+      default: Lo %d %b de %Y a %Ho%M
   two_factor_authentication:
     code_hint: Picatz lo còdi generat per vòstra aplicacion d’autentificacion per confirmar
     description_html: S’activatz <strong> l’autentificacion two-factor</strong>, vos caldrà vòstre mobil per vos connectar perque generarà un geton per vos daissar dintrar.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -39,8 +39,8 @@ pl:
     people_who_follow: Osoby, które śledzą konto %{name}
     posts: Wpisy
     remote_follow: Zdalne śledzenie
-    unfollow: Przestań śledzić
     reserved_username: Ta nazwa użytkownika jest zarezerwowana.
+    unfollow: Przestań śledzić
   activitypub:
     activity:
       announce:
@@ -135,20 +135,17 @@ pl:
       account_count: Znane konta
       domain_name: Domena
       title: Znane instancje
-    subscriptions:
-      callback_url: URL zwrotny
-      confirmed: Potwierdzono
-      expires_in: Wygasa
-      last_delivery: Ostatnio doręczono
-      title: PubSubHubbub
-      topic: Temat
     reports:
+      are_you_sure: Czy na pewno?
       comment:
         label: Komentarz
         none: Brak
       delete: Usuń
       id: Identyfikator
       mark_as_resolved: Oznacz jako rozwiązane
+      nsfw:
+        'false': NSFW nie będzie wyświetlane
+        'true': NSFW będzie wyświetlane
       report: 'Zgłoszenie #%{id}'
       report_contents: Zawartość
       reported_account: Zgłoszone konto
@@ -161,10 +158,6 @@ pl:
       title: Zgłoszenia
       unresolved: Nierozwiązane
       view: Wyświetl
-      nsfw:
-        'true': NSFW będzie wyświetlane
-        'false': NSFW nie będzie wyświetlane
-      are_you_sure: Czy na pewno?
     settings:
       contact_information:
         email: Wprowadź publiczny adres e-mail
@@ -187,6 +180,13 @@ pl:
         title: Extended site description
       site_title: Tytuł strony
       title: Ustawienia strony
+    subscriptions:
+      callback_url: URL zwrotny
+      confirmed: Potwierdzono
+      expires_in: Wygasa
+      last_delivery: Ostatnio doręczono
+      title: PubSubHubbub
+      topic: Temat
     title: Administracja
   application_mailer:
     settings: 'Zmień ustawienia powiadamiania: %{link}'
@@ -265,7 +265,7 @@ pl:
       following: Lista śledzonych
       muting: Lista wyciszonych
     upload: Załaduj
-  landing_strip_html: <strong>%{name}</strong> ma konto na %{link_to_root_path}. Możesz je śledzić i wejść z nim w interakcję jeśli masz konto gdziekolwiek w Fediwersie.
+  landing_strip_html: "<strong>%{name}</strong> ma konto na %{link_to_root_path}. Możesz je śledzić i wejść z nim w interakcję jeśli masz konto gdziekolwiek w Fediwersie."
   landing_strip_signup_html: Jeśli jeszcze go nie masz, możesz <a href="%{sign_up_path}">stworzyć konto</a>.
   media_attachments:
     validations:
@@ -276,14 +276,14 @@ pl:
       body: 'Oto krótkie podsumowanie co Cię ominęło na %{instance} od Twojej ostatniej wizyty (%{since}):'
       mention: "%{name} wspomniał o Tobie w:"
       new_followers_summary:
+        few: "(%{count}) nowe osoby śledzą Cię!"
+        many: "(%{count}) nowych osób Cię śledzi! Wspaniale!"
         one: Śledzi Cię nowa osoba! Gratulacje!
-        few: (%{count}) nowe osoby śledzą Cię!
-        many: (%{count}) nowych osób Cię śledzi! Wspaniale!
-        other: (%{count}) nowych osób Cię śledzi! Wspaniale!
+        other: "(%{count}) nowych osób Cię śledzi! Wspaniale!"
       subject:
-        one: "1 nowe powiadomienie od Twojej ostatniej wizyty \U0001F418"
         few: "%{count} nowe powiadomienia od Twojej ostatniej wizyty \U0001F418"
         many: "%{count} nowych powiadomień od Twojej ostatniej wizyty \U0001F418"
+        one: "1 nowe powiadomienie od Twojej ostatniej wizyty \U0001F418"
         other: "%{count} nowych powiadomień od Twojej ostatniej wizyty \U0001F418"
     favourite:
       body: 'Twój wpis został polubiony przez %{name}:'

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -130,13 +130,6 @@ pt-BR:
       account_count: Contas conhecidas
       domain_name: Domínio
       title: Instâncias conhecidas
-    subscriptions:
-      callback_url: URL de Callback
-      confirmed: Confirmado
-      expires_in: Expira em
-      last_delivery: Última entrega
-      title: PubSubHubbub
-      topic: Tópico
     reports:
       comment:
         label: Commentário
@@ -178,6 +171,13 @@ pt-BR:
         title: Descrição extendida do site
       site_title: Título do site
       title: Preferências do site
+    subscriptions:
+      callback_url: URL de Callback
+      confirmed: Confirmado
+      expires_in: Expira em
+      last_delivery: Última entrega
+      title: PubSubHubbub
+      topic: Tópico
     title: Administração
   application_mailer:
     settings: 'Mudar preferências de email: %{link}'
@@ -254,7 +254,7 @@ pt-BR:
       following: Lista de seguidos
       muting: Lista de silenciados
     upload: Carregar
-  landing_strip_html: <strong>%{name}</strong> is a user on %{link_to_root_path}. You can follow them or interact with them if you have an account anywhere in the fediverse.
+  landing_strip_html: "<strong>%{name}</strong> is a user on %{link_to_root_path}. You can follow them or interact with them if you have an account anywhere in the fediverse."
   landing_strip_signup_html: If you don't, you can <a href="%{sign_up_path}">sign up here</a>.
   media_attachments:
     validations:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -126,13 +126,6 @@ pt:
       account_count: Contas conhecidas
       domain_name: Domínio
       title: Instâncias conhecidas
-    subscriptions:
-      callback_url: URL de Callback
-      confirmed: Confirmado
-      expires_in: Expira em
-      last_delivery: Última entrega
-      title: PubSubHubbub
-      topic: Tópico
     reports:
       comment:
         label: Comentário
@@ -173,6 +166,13 @@ pt:
         title: Página de mais informações
       site_title: Título do site
       title: Preferências do site
+    subscriptions:
+      callback_url: URL de Callback
+      confirmed: Confirmado
+      expires_in: Expira em
+      last_delivery: Última entrega
+      title: PubSubHubbub
+      topic: Tópico
     title: Administração
   application_mailer:
     settings: 'Alterar preferências de email: %{link}'
@@ -196,7 +196,7 @@ pt:
     validation_errors:
       one: Algo não está correcto. Por favor vê o erro abaixo
       other: Algo não está correto. Por favor vê os %{count} erros abaixo
-  landing_strip_html: <strong>%{name}</strong> is a user on %{link_to_root_path}. You can follow them or interact with them if you have an account anywhere in the fediverse.
+  landing_strip_html: "<strong>%{name}</strong> is a user on %{link_to_root_path}. You can follow them or interact with them if you have an account anywhere in the fediverse."
   landing_strip_signup_html: If you don't, you can <a href="%{sign_up_path}">sign up here</a>.
   notification_mailer:
     favourite:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -113,13 +113,6 @@ ru:
         undo: Отменить
       title: Доменные блокировки
       undo: Отемнить
-    subscriptions:
-      callback_url: Callback URL
-      confirmed: Подтверждено
-      expires_in: Истекает через
-      last_delivery: Последняя доставка
-      title: PubSubHubbub
-      topic: Тема
     reports:
       comment:
         label: Комментарий
@@ -160,6 +153,13 @@ ru:
         title: Расширенное описание сайта
       site_title: Название сайта
       title: Настройки сайта
+    subscriptions:
+      callback_url: Callback URL
+      confirmed: Подтверждено
+      expires_in: Истекает через
+      last_delivery: Последняя доставка
+      title: PubSubHubbub
+      topic: Тема
     title: Администрирование
   application_mailer:
     settings: 'Изменить настройки e-mail: %{link}'
@@ -236,7 +236,7 @@ ru:
       following: Подписки
       muting: Список глушения
     upload: Загрузить
-  landing_strip_html: <strong>%{name}</strong> - пользователь на %{link_to_root_path}. Вы можете подписаться на него/нее и общаться с ним/ней, если у Вас есть аккаунт на любом узле общей сети.
+  landing_strip_html: "<strong>%{name}</strong> - пользователь на %{link_to_root_path}. Вы можете подписаться на него/нее и общаться с ним/ней, если у Вас есть аккаунт на любом узле общей сети."
   landing_strip_signup_html: Если у Вас его нет, вы можете <a href="%{sign_up_path}">зарегистрироваться здесь</a>.
   media_attachments:
     validations:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -5,13 +5,13 @@ en:
       defaults:
         avatar: PNG, GIF or JPG. At most 2MB. Will be downscaled to 120x120px
         display_name:
-          one: '<span class="name-counter">1</span> character left'
-          other: '<span class="name-counter">%{count}</span> characters left'
+          one: <span class="name-counter">1</span> character left
+          other: <span class="name-counter">%{count}</span> characters left
         header: PNG, GIF or JPG. At most 2MB. Will be downscaled to 700x335px
         locked: Requires you to manually approve followers and defaults post privacy to followers-only
         note:
-          one: '<span class="note-counter">1</span> character left'
-          other: '<span class="note-counter">%{count}</span> characters left'
+          one: <span class="note-counter">1</span> character left
+          other: <span class="note-counter">%{count}</span> characters left
       imports:
         data: CSV file exported from another Mastodon instance
       sessions:
@@ -36,8 +36,8 @@ en:
         password: Password
         setting_auto_play_gif: Auto-play animated GIFs
         setting_boost_modal: Show confirmation dialog before boosting
-        setting_delete_modal: Show confirmation dialog before deleting a toot
         setting_default_privacy: Post privacy
+        setting_delete_modal: Show confirmation dialog before deleting a toot
         severity: Severity
         type: Import type
         username: Username

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -33,8 +33,8 @@ ja:
         password: パスワード
         setting_auto_play_gif: アニメーションGIFを自動再生する
         setting_boost_modal: ブーストする前に確認ダイアログを表示する
-        setting_delete_modal: トゥートを削除する前に確認ダイアログを表示する
         setting_default_privacy: 投稿の公開範囲
+        setting_delete_modal: トゥートを削除する前に確認ダイアログを表示する
         severity: 重大性
         type: インポートする項目
         username: ユーザー名

--- a/config/locales/simple_form.oc.yml
+++ b/config/locales/simple_form.oc.yml
@@ -5,13 +5,13 @@ oc:
       defaults:
         avatar: PNG, GIF o JPG. Maximum 2 Mo. Serà retalhat en 120x120px
         display_name:
-          one: 'Demòra encara <span class="name-counter">1</span> caractèr'
-          other: 'Demòran encara <span class="name-counter">%{count}</span> caractèrs'
+          one: Demòra encara <span class="name-counter">1</span> caractèr
+          other: Demòran encara <span class="name-counter">%{count}</span> caractèrs
         header: PNG, GIF o JPG. Maximum 2 Mo. Serà retalhada en 700x335px
         locked: Demanda qu’acceptetz manualament lo mond que vos sègon e botarà la visibilitat de vòstras publicacions coma accessiblas a vòstres seguidors solament
         note:
-          one: 'Demòra encara <span class="name-counter">1</span> caractèr'
-          other: 'Demòran encara <span class="name-counter">%{count}</span> caractèrs'
+          one: Demòra encara <span class="name-counter">1</span> caractèr
+          other: Demòran encara <span class="name-counter">%{count}</span> caractèrs
       imports:
         data: Fichièr CSV exportat d’una autra instància Mastodon
       sessions:
@@ -36,8 +36,8 @@ oc:
         password: Senhal
         setting_auto_play_gif: Lectura automatica dels GIFS animats
         setting_boost_modal: Afichar una fenèstra de confirmacion abans de partejar un estatut
-        setting_delete_modal: Afichar una fenèstra de confirmacion abans de suprimir un estatut
         setting_default_privacy: Confidencialitat de las publicacions
+        setting_delete_modal: Afichar una fenèstra de confirmacion abans de suprimir un estatut
         severity: Severitat
         type: Tip d’impòrt
         username: Nom d’utilizaire
@@ -51,8 +51,8 @@ oc:
         follow_request: Enviar un corrièl quand qualqu’un demanda de vos sègre
         mention: Enviar un corrièl quand qualqu’un vos menciona
         reblog: Enviar un corrièl quand qualqu’un tòrna partejar vòstre estatut
-    'no': 'Non'
+    'no': Non
     required:
       mark: "*"
       text: requesit
-    'yes': 'Òc'
+    'yes': Òc

--- a/config/locales/simple_form.pl.yml
+++ b/config/locales/simple_form.pl.yml
@@ -5,17 +5,17 @@ pl:
       defaults:
         avatar: PNG, GIF lub JPG. Maksymalnie 2MB. Zostanie zmniejszony do 120x120px
         display_name:
-          one: 'Pozostał <span class="name-counter">1</span> znak.'
-          few: 'Pozostały <span class="name-counter">%{count}</span> znaki.'
-          many: 'Pozostało <span class="name-counter">%{count}</span> znaków'
-          other: 'Pozostało <span class="name-counter">%{count}</span> znaków'
+          few: Pozostały <span class="name-counter">%{count}</span> znaki.
+          many: Pozostało <span class="name-counter">%{count}</span> znaków
+          one: Pozostał <span class="name-counter">1</span> znak.
+          other: Pozostało <span class="name-counter">%{count}</span> znaków
         header: PNG, GIF lub JPG. Maksymalnie 2MB. Zostanie zmniejszony do 700x335px
         locked: Musisz akceptować obserwacje; Twoje wpisy są domyślnie widoczne tylko dla Twoich obserwujących
         note:
-          one: 'Pozostał <span class="name-counter">1</span> znak.'
-          few: 'Pozostały <span class="name-counter">%{count}</span> znaki.'
-          many: 'Pozostało <span class="name-counter">%{count}</span> znaków'
-          other: 'Pozostało <span class="name-counter">%{count}</span> znaków'
+          few: Pozostały <span class="name-counter">%{count}</span> znaki.
+          many: Pozostało <span class="name-counter">%{count}</span> znaków
+          one: Pozostał <span class="name-counter">1</span> znak.
+          other: Pozostało <span class="name-counter">%{count}</span> znaków
       imports:
         data: Plik CSV wyeksportowany z innej instancji Mastodona
       sessions:
@@ -40,8 +40,8 @@ pl:
         password: Hasło
         setting_auto_play_gif: Automatycznie odtwarzaj animowane GIFy
         setting_boost_modal: Pytaj o potwierdzenie przed podbiciem
-        setting_delete_modal: Pytaj o potwierdzenie przed usunięciem postu
         setting_default_privacy: Widoczność posta
+        setting_delete_modal: Pytaj o potwierdzenie przed usunięciem postu
         severity: Priorytet
         type: Typ importu
         username: Nazwa użytkownika
@@ -55,8 +55,8 @@ pl:
         follow_request: Powiadom mnie e-mailem gdy ktoś poprosi o pozwolenie śledzenia mnie.
         mention: Powiadom mnie e-mailem gdy ktoś mnie wspomni.
         reblog: Powiadom mnie e-mailem gdy ktoś podbije mój status.
-    'no': 'Nie'
+    'no': Nie
     required:
       mark: "*"
       text: pole wymagane
-    'yes': 'Tak'
+    'yes': Tak

--- a/config/locales/simple_form.ru.yml
+++ b/config/locales/simple_form.ru.yml
@@ -5,17 +5,17 @@ ru:
       defaults:
         avatar: PNG, GIF или JPG. Максимально 2MB. Будет уменьшено до 120x120px
         display_name:
-          one: 'Остался <span class="name-counter">1</span> символ'
-          few: 'Осталось <span class="name-counter">%{count}</span> символа'
-          many: 'Осталось <span class="name-counter">%{count}</span> символов'
-          other: 'Осталось <span class="name-counter">%{count}</span> символов'
+          few: Осталось <span class="name-counter">%{count}</span> символа
+          many: Осталось <span class="name-counter">%{count}</span> символов
+          one: Остался <span class="name-counter">1</span> символ
+          other: Осталось <span class="name-counter">%{count}</span> символов
         header: PNG, GIF или JPG. Максимально 2MB. Будет уменьшено до 700x335px
         locked: Потребует от Вас ручного подтверждения подписчиков, изменит приватность постов по умолчанию на "только для подписчиков"
         note:
-          one: 'Остался <span class="name-counter">1</span> символ'
-          few: 'Осталось <span class="name-counter">%{count}</span> символа'
-          many: 'Осталось <span class="name-counter">%{count}</span> символов'
-          other: 'Осталось <span class="name-counter">%{count}</span> символов'
+          few: Осталось <span class="name-counter">%{count}</span> символа
+          many: Осталось <span class="name-counter">%{count}</span> символов
+          one: Остался <span class="name-counter">1</span> символ
+          other: Осталось <span class="name-counter">%{count}</span> символов
       imports:
         data: Файл CSV, экспортированный с другого узла Mastodon
       sessions:
@@ -55,8 +55,8 @@ ru:
         follow_request: Уведомлять по e-mail, когда кто-то запрашивает разрешение на подписку
         mention: Уведомлять по e-mail, когда кто-то упомянул Вас
         reblog: Уведомлять по e-mail, когда кто-то продвинул Ваш статус
-    'no': 'Нет'
+    'no': Нет
     required:
       mark: "*"
       text: обязательно
-    'yes': 'Да'
+    'yes': Да

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -131,13 +131,6 @@ th:
       account_count: Known accounts
       domain_name: ชื่อโดเมน
       title: Known Instances
-    subscriptions:
-      callback_url: Callback URL
-      confirmed: ยืนยัน
-      expires_in: หมดอายุภายใน
-      last_delivery: จัดส่งครั้งล่าสุด
-      title: PubSubHubbub
-      topic: ชื่อเรื่อง
     reports:
       comment:
         label: คอมเม้นต์
@@ -179,6 +172,13 @@ th:
         title: คำอธิบายไซต์เพิ่มเติม
       site_title: ชื่อไซต์
       title: ตั้งค่าไซต์
+    subscriptions:
+      callback_url: Callback URL
+      confirmed: ยืนยัน
+      expires_in: หมดอายุภายใน
+      last_delivery: จัดส่งครั้งล่าสุด
+      title: PubSubHubbub
+      topic: ชื่อเรื่อง
     title: แอดมิน
   application_mailer:
     settings: 'เปลี่ยนอีเมล์ preferences: %{link}'
@@ -256,7 +256,7 @@ th:
       following: Following list
       muting: Muting list
     upload: Upload
-  landing_strip_html: <strong>%{name}</strong> is a user on %{link_to_root_path}. You can follow them or interact with them if you have an account anywhere in the fediverse.
+  landing_strip_html: "<strong>%{name}</strong> is a user on %{link_to_root_path}. You can follow them or interact with them if you have an account anywhere in the fediverse."
   landing_strip_signup_html: If you don't, you can <a href="%{sign_up_path}">sign up here</a>.
   media_attachments:
     validations:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -118,7 +118,7 @@ tr:
       show:
         affected_accounts:
           one: Veritabanındaki bir hesap etkilendi
-          other: "Veritabanındaki %{count} hesap etkilendi"
+          other: Veritabanındaki %{count} hesap etkilendi
         retroactive:
           silence: Bu domaindeki tüm hesapların üzerindeki susturulma işlemini kaldır.
           suspend: Bu domaindeki tüm hesapların üzerindeki uzaklaştırma işlemini kaldır.
@@ -130,13 +130,6 @@ tr:
       account_count: Bilinen hesaplar
       domain_name: Domain
       title: Bilinen Sunucular
-    subscriptions:
-      callback_url: Callback linki
-      confirmed: Onaylandı
-      expires_in: Bitiş Tarihi
-      last_delivery: Son gönderim
-      title: PubSubHubbub
-      topic: Konu
     reports:
       comment:
         label: Yorum
@@ -178,6 +171,13 @@ tr:
         title: Sunucu hakkında detaylı bilgi
       site_title: Site başlığı
       title: Site Ayarları
+    subscriptions:
+      callback_url: Callback linki
+      confirmed: Onaylandı
+      expires_in: Bitiş Tarihi
+      last_delivery: Son gönderim
+      title: PubSubHubbub
+      topic: Konu
     title: Yönetim
   application_mailer:
     settings: 'E-mail tercihlerini değiştir: %{link}'
@@ -236,7 +236,7 @@ tr:
     success:
       one: Domaindeki takipçilerin engellenmesi sürüyor...
       other: "%{count} domaindeki takipçilerin engellenmesi sürüyor..."
-    true_privacy_html: "Lütfen aklınızda bulundurun: <strong>gerçek gizlilik yalnızca uçtan-uca şifreleme ile sağlanır</strong>."
+    true_privacy_html: 'Lütfen aklınızda bulundurun: <strong>gerçek gizlilik yalnızca uçtan-uca şifreleme ile sağlanır</strong>.'
     unlocked_warning_html: Herhangi bir kişi sizi takip edebilir ve paylaştığınız gizli gönderilerinizi görebilir. %{lock_link}'e tıklayarak takipçilerinizi gözden geçirebilir ve reddedebilirsiniz.
     unlocked_warning_title: Hesabınız kilitlendi
   generic:
@@ -254,7 +254,7 @@ tr:
       following: Takip edilenler listesi
       muting: Susturulanlar listesi
     upload: Yükle
-  landing_strip_html: <strong>%{name}</strong>, %{link_to_root_path} sunucusundaki bir kullanıcıdır. Onu takip edebilir, veya Mastodon ağındaki bir hesabınızı kullanarak etkileşime geçebilirsiniz.
+  landing_strip_html: "<strong>%{name}</strong>, %{link_to_root_path} sunucusundaki bir kullanıcıdır. Onu takip edebilir, veya Mastodon ağındaki bir hesabınızı kullanarak etkileşime geçebilirsiniz."
   landing_strip_signup_html: Eğer hesabınız yoksa <a href="%{sign_up_path}">buradan kaydolabilirsiniz</a>.
   media_attachments:
     validations:
@@ -262,7 +262,7 @@ tr:
       too_many: 4'ten fazla dosya ekleyemezsiniz
   notification_mailer:
     digest:
-      body: "Son ziyaretiniz olan %{since}'den beri %{instance}'da kaçırdığınız şeylerin özeti:"
+      body: 'Son ziyaretiniz olan %{since}''den beri %{instance}''da kaçırdığınız şeylerin özeti:'
       mention: "%{name} senden bahsetti:"
       new_followers_summary:
         one: Yeni bir takipçiniz var!
@@ -271,7 +271,7 @@ tr:
         one: "Son ziyaretinizden beri 1 yeni bildiriminiz var \U0001F418"
         other: "Son ziyaretinizden beri %{count} yeni bildiriminiz var \U0001F418"
     favourite:
-      body: '%{name} durumunuzu favorilere ekledi:'
+      body: "%{name} durumunuzu favorilere ekledi:"
       subject: "%{name} favorilere ekledi"
     follow:
       body: "%{name} sizi takip etmeye başladı!"
@@ -280,10 +280,10 @@ tr:
       body: "%{name} size takip isteği gönderdi"
       subject: 'Takip isteği: %{name}'
     mention:
-      body: '%{name} sizden bahsetti:'
+      body: "%{name} sizden bahsetti:"
       subject: "%{name} sizden bahsetti"
     reblog:
-      body: '%{name} durumunuzu boost etti:'
+      body: "%{name} durumunuzu boost etti:"
       subject: "%{name} durumunuzu boost etti"
   pagination:
     next: Sonraki
@@ -293,7 +293,7 @@ tr:
     acct: Takip edeceğiniz kişiyi kullaniciadi@sunuculinki şeklinde giriniz
     missing_resource: Hesabınız için yönlendirme linki bulunamadı
     proceed: Takip onayı
-    prompt: 'Bu kullanıcıyı takip etmek istediğinize emin misiniz?'
+    prompt: Bu kullanıcıyı takip etmek istediğinize emin misiniz?
   settings:
     authorized_apps: Yetkilendirilen uygulamalar
     back: Mastodon'a geri dön
@@ -329,7 +329,7 @@ tr:
     enable: Aktifleştir
     enabled_success: İki-faktörlü kimlik doğrulama başarıyla aktif edildi.
     generate_recovery_codes: Kurtarma Kodlarını Oluştur
-    instructions_html: '<strong>Bu QR kodunu, telefonunuzdaki <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2">Google Authenticator</a> veya benzer bir TOTP uygulamasıyla taratınız</strong>. Bundan sonra giriş yaparken uygulamanın ürettiği kodu kullanarak giriş yapacaksınız.'
+    instructions_html: <strong>Bu QR kodunu, telefonunuzdaki <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2">Google Authenticator</a> veya benzer bir TOTP uygulamasıyla taratınız</strong>. Bundan sonra giriş yaparken uygulamanın ürettiği kodu kullanarak giriş yapacaksınız.
     lost_recovery_codes: Kurtarma kodları telefonunuzu kaybettiğiniz durumlarda hesabınıza erişim yapabilmenize olanak tanır. Eğer kurtarma kodlarınızı kaybettiyseniz burada tekrar oluşturabilirsiniz. Eski kurtarma kodlarınız geçersiz hale gelecektir.
     manual_instructions: 'Eğer QR kodunu taratamıyorsanız ve elle giriş yapmanız gerekiyorsa buradaki gizli düz metni girebilirsiniz:'
     recovery_codes_regenerated: Kurtarma kodları başarıyla oluşturuldu
@@ -339,4 +339,3 @@ tr:
   users:
     invalid_email: E-posta adresiniz geçersiz
     invalid_otp_token: İki-faktörlü kodunuz geçersiz
-

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -113,13 +113,6 @@ uk:
         undo: Відмінити
       title: Доменні блокування
       undo: Відмінити
-    subscriptions:
-      callback_url: Callback URL
-      confirmed: Підтверджено
-      expires_in: Спливає через
-      last_delivery: Остання доставка
-      title: PubSubHubbub
-      topic: Тема
     reports:
       comment:
         label: Коментар
@@ -160,6 +153,13 @@ uk:
         title: Розширений опис сайту
       site_title: Назва сайту
       title: Налаштування сайту
+    subscriptions:
+      callback_url: Callback URL
+      confirmed: Підтверджено
+      expires_in: Спливає через
+      last_delivery: Остання доставка
+      title: PubSubHubbub
+      topic: Тема
     title: Адміністрування
   application_mailer:
     settings: 'Змінити налаштування email: %{link}'
@@ -236,7 +236,7 @@ uk:
       following: Підписки
       muting: Список глушення
     upload: Завантажити
-  landing_strip_html: <strong>%{name}</strong> - користувач на %{link_to_root_path}. Ви можете підписатися на нього/неї та спілкуватися з ним/нею, якщо у Вас є акаунт на будь-якій інстанції загальної мережі.
+  landing_strip_html: "<strong>%{name}</strong> - користувач на %{link_to_root_path}. Ви можете підписатися на нього/неї та спілкуватися з ним/нею, якщо у Вас є акаунт на будь-якій інстанції загальної мережі."
   landing_strip_signup_html: Якщо його у Вас немає, Ви можете <a href="%{sign_up_path}">зареєструватися тут</a>.
   media_attachments:
     validations:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -134,20 +134,17 @@ zh-CN:
       account_count: 已知帐号
       domain_name: 域名
       title: 已知实例
-    subscriptions:
-      callback_url: 回调 URL
-      confirmed: 确定
-      expires_in: 期限
-      last_delivery: 数据最后送抵时间
-      title: PubSubHubbub 订阅
-      topic: 所订阅资源
     reports:
+      are_you_sure: 你确定吗?
       comment:
         label: 备注
         none: 没有
       delete: 删除
       id: ID
       mark_as_resolved: 标示为「已处理」
+      nsfw:
+        'false': NSFW无效
+        'true': NSFW有效
       report: '举报 #%{id}'
       reported_account: 举报用户
       reported_by: 举报者
@@ -159,10 +156,6 @@ zh-CN:
       title: 举报
       unresolved: 未处理
       view: 查看
-      nsfw:
-        'true': NSFW有效
-        'false': NSFW无效
-      are_you_sure: 你确定吗?
     settings:
       contact_information:
         email: 输入一个公开的电邮地址
@@ -185,6 +178,13 @@ zh-CN:
         title: 本站详细信息
       site_title: 本站名称
       title: 网站设置
+    subscriptions:
+      callback_url: 回调 URL
+      confirmed: 确定
+      expires_in: 期限
+      last_delivery: 数据最后送抵时间
+      title: PubSubHubbub 订阅
+      topic: 所订阅资源
     title: 管理
   application_mailer:
     settings: 更改电邮设置︰%{link}
@@ -260,7 +260,7 @@ zh-CN:
       following: 关注名单
       muting: 静音名单
     upload: 上载
-  landing_strip_html: <strong>%{name}</strong> 是一个在 %{link_to_root_path} 的用户。只要你是象毛世界里（Mastodon、GNU social）任一服务器实例的用户，便可以跨站关注此站用户并与其沟通。
+  landing_strip_html: "<strong>%{name}</strong> 是一个在 %{link_to_root_path} 的用户。只要你是象毛世界里（Mastodon、GNU social）任一服务器实例的用户，便可以跨站关注此站用户并与其沟通。"
   landing_strip_signup_html: 如果你没有这类账户，欢迎在<a href="%{sign_up_path}">此处登记</a>。
   media_attachments:
     validations:

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -130,13 +130,6 @@ zh-HK:
       account_count: 已知帳號
       domain_name: 域名
       title: 已知服務站
-    subscriptions:
-      callback_url: 回傳 URL
-      confirmed: 確定
-      expires_in: 期限
-      last_delivery: 資料最後送抵時間
-      title: PuSH 訂閱
-      topic: 所訂閱資源
     reports:
       comment:
         label: 詳細解釋
@@ -178,6 +171,13 @@ zh-HK:
         title: 本站詳細資訊
       site_title: 本站名稱
       title: 網站設定
+    subscriptions:
+      callback_url: 回傳 URL
+      confirmed: 確定
+      expires_in: 期限
+      last_delivery: 資料最後送抵時間
+      title: PuSH 訂閱
+      topic: 所訂閱資源
     title: 管理
   application_mailer:
     settings: 修改電郵設定︰%{link}
@@ -255,7 +255,7 @@ zh-HK:
       following: 你所關注的用戶名單
       muting: 靜音名單
     upload: 上載
-  landing_strip_html: <strong>%{name}</strong> 是一個在 %{link_to_root_path} 的用戶。只要你有任何 Mastodon 服務站、或者聯盟網站的用戶，便可以跨站關注此站用戶，或者與他們互動。
+  landing_strip_html: "<strong>%{name}</strong> 是一個在 %{link_to_root_path} 的用戶。只要你有任何 Mastodon 服務站、或者聯盟網站的用戶，便可以跨站關注此站用戶，或者與他們互動。"
   landing_strip_signup_html: 如果你沒有這類用戶，歡迎在<a href="%{sign_up_path}">此處登記</a>。
   media_attachments:
     validations:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -34,7 +34,7 @@ zh-TW:
     followers: 關注者
     following: 正在關注
     nothing_here: 暫時沒有內容可供顯示
-    people_followed_by: '%{name} 關注的人'
+    people_followed_by: "%{name} 關注的人"
     people_who_follow: 關注 %{name} 的人
     posts: 文章
     remote_follow: 跨站關注
@@ -92,13 +92,6 @@ zh-TW:
         title: 新封鎖網域
       severity: 嚴重度
       title: 網域封鎖
-    subscriptions:
-      callback_url: Callback URL
-      confirmed: 已確認
-      expires_in: 期限
-      last_delivery: 最後遞送
-      title: PubSubHubbub
-      topic: 主題
     reports:
       comment:
         label: 留言
@@ -139,11 +132,18 @@ zh-TW:
         title: 長版網站描述
       site_title: 網站標題
       title: 網站設定
+    subscriptions:
+      callback_url: Callback URL
+      confirmed: 已確認
+      expires_in: 期限
+      last_delivery: 最後遞送
+      title: PubSubHubbub
+      topic: 主題
     title: 管理介面
   application_mailer:
-    settings: '修改信箱設定︰ %{link}'
+    settings: 修改信箱設定︰ %{link}
     signature: 來自 %{instance} 的 Mastodon 通知
-    view: '進入瀏覽︰'
+    view: 進入瀏覽︰
   applications:
     invalid_url: 網址不正確
   auth:
@@ -159,16 +159,16 @@ zh-TW:
   authorize_follow:
     error: 對不起，尋找這個跨站使用者的過程發生錯誤
     follow: 關注
-    prompt_html: '您 (<strong>%{self}</strong>) 正準備關注︰'
+    prompt_html: 您 (<strong>%{self}</strong>) 正準備關注︰
     title: 關注 %{acct}
   datetime:
     distance_in_words:
       about_x_hours: "%{count}小時前"
       about_x_months: "%{count}個月前"
       about_x_years: "%{count}年前"
-      almost_x_years: "接近%{count}年前"
+      almost_x_years: 接近%{count}年前
       half_a_minute: 剛剛
-      less_than_x_minutes: "小於%{count}分鐘前"
+      less_than_x_minutes: 小於%{count}分鐘前
       less_than_x_seconds: 剛剛
       over_x_years: "%{count}y"
       x_days: "%{count}天"
@@ -200,7 +200,7 @@ zh-TW:
       blocking: 您封鎖的使用者名單
       following: 您關注的使用者名單
     upload: 上傳
-  landing_strip_html: <strong>%{name}</strong> 是一個在 %{link_to_root_path} 的使用者。只要您有任何 Mastodon 服務站、或者聯盟網站的帳號，便可以跨站關注此站使用者，或者與他們互動。
+  landing_strip_html: "<strong>%{name}</strong> 是一個在 %{link_to_root_path} 的使用者。只要您有任何 Mastodon 服務站、或者聯盟網站的帳號，便可以跨站關注此站使用者，或者與他們互動。"
   landing_strip_signup_html: 如果您沒有這些帳號，歡迎在<a href="%{sign_up_path}">這裡註冊</a>。
   media_attachments:
     validations:
@@ -208,7 +208,7 @@ zh-TW:
       too_many: 無法加入超過 4 個檔案
   notification_mailer:
     digest:
-      body: '這是自從您在%{since}使用%{instance}以後，您錯過的訊息︰'
+      body: 這是自從您在%{since}使用%{instance}以後，您錯過的訊息︰
       mention: "%{name} 在此提及了您︰"
       new_followers_summary:
         one: 您新獲得了 1 位關注者！恭喜！
@@ -217,19 +217,19 @@ zh-TW:
         one: "自從上次登入以來，您收到 1 則新的通知 \U0001F418"
         other: "自從上次登入以來，您收到 %{count} 則新的通知 \U0001F418"
     favourite:
-      body: '您的文章被 %{name} 喜歡'
+      body: 您的文章被 %{name} 喜歡
       subject: "%{name} 喜歡您的文章"
     follow:
       body: "%{name} 開始關注您！"
       subject: "%{name} 開始關注您"
     follow_request:
       body: "%{name} 要求關注您"
-      subject: '等待關注您的使用者︰ %{name}'
+      subject: 等待關注您的使用者︰ %{name}
     mention:
-      body: '%{name} 在文章中提及您︰'
-      subject: '%{name} 在文章中提及您'
+      body: "%{name} 在文章中提及您︰"
+      subject: "%{name} 在文章中提及您"
     reblog:
-      body: '您的文章被 %{name} 轉推'
+      body: 您的文章被 %{name} 轉推
       subject: "%{name} 轉推了您的文章"
   pagination:
     next: 下一頁
@@ -239,7 +239,7 @@ zh-TW:
     acct: 請輸入您的︰使用者名稱@服務點網域
     missing_resource: 無法找到資源
     proceed: 下一步
-    prompt: '您希望關注︰'
+    prompt: 您希望關注︰
   settings:
     authorized_apps: 已授權應用程式
     back: 回到 Mastodon
@@ -270,7 +270,7 @@ zh-TW:
     disable: 停用
     enable: 啟用
     enabled_success: 已成功啟用雙因子認證
-    instructions_html: <strong>請用您手機的認證器應用程式（如 Google Authenticator、Authy），掃描這裡的 QR 圖形碼</strong>。在雙因子認證啟用後，您登入時將須要使用此應用程式產生的認證碼。
+    instructions_html: "<strong>請用您手機的認證器應用程式（如 Google Authenticator、Authy），掃描這裡的 QR 圖形碼</strong>。在雙因子認證啟用後，您登入時將須要使用此應用程式產生的認證碼。"
     manual_instructions: 如果您無法掃描 QR 圖形碼，請手動輸入︰
     setup: 設定
     wrong_code: 您輸入的認證碼並不正確！可能伺服器時間和您手機不一致，請檢查您手機的時間，或與本站管理員聯絡。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,12 @@ Rails.application.routes.draw do
     end
 
     resources :accounts, only: [:index, :show] do
+      member do
+        post :subscribe
+        post :unsubscribe
+        post :redownload
+      end
+
       resource :reset, only: [:create]
       resource :silence, only: [:create, :destroy]
       resource :suspension, only: [:create, :destroy]


### PR DESCRIPTION
and re-download avatar/header

Also I've run `i18n-tasks normalize` and apparently it hasn't been run by anyone submitting locales for a while so that's a huge update -_-