### PR TITLE
adjust the size of 'column-header__back-button'

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1527,7 +1527,7 @@
   cursor: pointer;
   flex: 0 0 auto;
   font-size: 16px;
-  padding: 15px;
+  padding: 0 5px 0 0;
   z-index: 3;
 
   &:hover {


### PR DESCRIPTION
In Japanese environment, the back button on the community timeline and the public timeline is overlapping with column title ```ローカルタイムライン```.
![ltl-large-button](https://user-images.githubusercontent.com/8458066/26961815-939ca12c-4d1c-11e7-944e-291067a70456.JPG)

I modified the padding size of this button smaller. (```right: 15px, left: 15px``` => ```right: 5px, left: 0px```)
![ltl-smallbutton](https://user-images.githubusercontent.com/8458066/26961827-bf6fa33a-4d1c-11e7-8e5d-2af2eec44164.JPG)
