### PR TITLE
adjust the size of 'column-header__back-button' (fix regression #3654)

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1527,7 +1527,7 @@
   cursor: pointer;
   flex: 0 0 auto;
   font-size: 16px;
-  padding: 0 5px 0 0;
+  padding: 15px;
   z-index: 3;
 
   &:hover {
@@ -1543,7 +1543,7 @@
   cursor: pointer;
   flex: 0 0 auto;
   font-size: 16px;
-  padding: 0 15px;
+  padding: 0 5px 0 0;
   z-index: 3;
 
   &:hover {


### PR DESCRIPTION
This PR fixes regression of #3654 and change proper 'column-header__back-button' style.

![r3654_local](https://user-images.githubusercontent.com/1680550/26978988-5288d236-4d68-11e7-8adb-8772514dd1db.png)
![r3654_profile](https://user-images.githubusercontent.com/1680550/26978995-57b62010-4d68-11e7-9727-c316b0104669.png)

I also checked local/global timeline display of other non-RTL languages. (RTL language has other issue https://github.com/tootsuite/mastodon/issues/3658)
Some languages have long global/local name.

Català (too long..)
![r3654_catala](https://user-images.githubusercontent.com/1680550/26979237-0e634306-4d69-11e7-8c80-8c11a3924945.png)

Deutsch (OK)
![r3654_deutsch](https://user-images.githubusercontent.com/1680550/26979266-2a7346a4-4d69-11e7-929d-1d19b55b0811.png)

Suomi (OK)
![r3654_suomi](https://user-images.githubusercontent.com/1680550/26979279-387ecff2-4d69-11e7-8a81-0ea485d41eae.png)

Bahasa Indonesia (has difference between  tooltip and title)
![r3654_indonesia](https://user-images.githubusercontent.com/1680550/26979303-49f74020-4d69-11e7-89b5-97cd02541451.png)

Occitan (has difference between tooltip and title)
![r3654_occitan](https://user-images.githubusercontent.com/1680550/26979377-858b2ed0-4d69-11e7-9594-ce0543d9736a.png)
