### PR TITLE
Language detection defaults to nil

### DIFF
--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -10,7 +10,7 @@ class LanguageDetector
   end
 
   def to_iso_s
-    detected_language_code || default_locale.to_sym
+    detected_language_code || default_locale
   end
 
   def prepared_text
@@ -43,6 +43,6 @@ class LanguageDetector
   end
 
   def default_locale
-    account&.user_locale || I18n.default_locale
+    account&.user_locale&.to_sym || nil
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -20,7 +20,7 @@
 #  reply                  :boolean          default(FALSE)
 #  favourites_count       :integer          default(0), not null
 #  reblogs_count          :integer          default(0), not null
-#  language               :string           default("en"), not null
+#  language               :string
 #  conversation_id        :integer
 #
 

--- a/db/migrate/20170609145826_remove_default_language_from_statuses.rb
+++ b/db/migrate/20170609145826_remove_default_language_from_statuses.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultLanguageFromStatuses < ActiveRecord::Migration[5.1]
+  def change
+    change_column :statuses, :language, :string, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170606113804) do
+ActiveRecord::Schema.define(version: 20170609145826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -277,7 +277,7 @@ ActiveRecord::Schema.define(version: 20170606113804) do
     t.boolean "reply", default: false
     t.integer "favourites_count", default: 0, null: false
     t.integer "reblogs_count", default: 0, null: false
-    t.string "language", default: "en", null: false
+    t.string "language"
     t.bigint "conversation_id"
     t.index ["account_id"], name: "index_statuses_on_account_id"
     t.index ["conversation_id"], name: "index_statuses_on_conversation_id"

--- a/spec/lib/language_detector_spec.rb
+++ b/spec/lib/language_detector_spec.rb
@@ -43,7 +43,7 @@ describe LanguageDetector do
   describe 'to_iso_s' do
     it 'detects english language for basic strings' do
       strings = [
-        "Hello and welcome to mastodon",
+        "Hello and welcome to mastodon how are you today?",
         "I'd rather not!",
         "a lot of people just want to feel righteous all the time and that's all that matters",
       ]
@@ -62,20 +62,20 @@ describe LanguageDetector do
     end
 
     describe 'when language can\'t be detected' do
-      it 'uses default locale when sent an empty document' do
+      it 'uses nil when sent an empty document' do
         result = described_class.new('').to_iso_s
-        expect(result).to eq :en
+        expect(result).to eq nil
       end
 
       describe 'because of a URL' do
-        it 'uses default locale when sent just a URL' do
+        it 'uses nil when sent just a URL' do
           string = 'http://example.com/media/2kFTgOJLXhQf0g2nKB4'
           cld_result = CLD3::NNetLanguageIdentifier.new(0, 2048).find_language(string)
           expect(cld_result).not_to eq :en
 
           result = described_class.new(string).to_iso_s
 
-          expect(result).to eq :en
+          expect(result).to eq nil
         end
       end
 
@@ -87,20 +87,20 @@ describe LanguageDetector do
           expect(result).to eq :fr
         end
 
-        it 'uses default locale when account is present but has no locale' do
+        it 'uses nil when account is present but has no locale' do
           account = double(user_locale: nil)
           result  = described_class.new('', account).to_iso_s
 
-          expect(result).to eq :en
+          expect(result).to eq nil
         end
       end
 
       describe 'with an `en` default locale' do
-        it 'uses the default locale' do
+        it 'uses nil for undetectable string' do
           string = ''
           result = described_class.new(string).to_iso_s
 
-          expect(result).to eq :en
+          expect(result).to eq nil
         end
       end
 
@@ -112,11 +112,11 @@ describe LanguageDetector do
           I18n.default_locale = before
         end
 
-        it 'uses the default locale' do
+        it 'uses nil for undetectable string' do
           string = ''
           result = described_class.new(string).to_iso_s
 
-          expect(result).to eq :ja
+          expect(result).to eq nil
         end
       end
     end


### PR DESCRIPTION
I believe these code changes are sufficient to change the behavior if we want to, here's some background...

- Prior to this change, the language detection would "fall back" to the default locale setting for the UI of the instance.
- This seemed reasonable as a language guess ... but has proven not to be so, especially for highly diverse instances where many languages are used.
- In those cases, when the language cannot be detected and we have fall back to the instance default, the statuses wind up having a WRONG language applied to them, rather than no language at all applied to them, which seems worse.

Example: prior to this change, a status written in farsi might be undetectable by CLD3 (or at least not reliably detected), so that part would bail out, and if the user did not have a locale set in the UI it would skip that - so then it would fall back to the instance default, which might be `en`.

This leads to a bunch of statuses in farsi being tagged as `en`, which is wrong, and which makes it impossible to either a) ignore them by adding a "filter all undetectable languages" setting, b) re-process them with improved language detection in the future.

It seems more accurate to just not tag things when we aren't sure, which is what this change would do.

I'm open to counterargument before merge here ... I THINK that the in-feed and in-html-page `lang` attributes we have in various places will just wind up being blank, and that that's fine, but I have not thoroughly examined those places yet.