### PR TITLE
Fix issue with some Node.js versions not having Array.prototype.includes

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -276,7 +276,7 @@ const startWorker = (workerId) => {
           const targetAccountIds = [unpackedPayload.account.id].concat(unpackedPayload.mentions.map(item => item.id));
           const accountDomain    = unpackedPayload.account.acct.split('@')[1];
 
-          if (Array.isArray(req.filteredLanguages) && req.filteredLanguages.includes(unpackedPayload.language)) {
+          if (Array.isArray(req.filteredLanguages) && req.filteredLanguages.indexOf(unpackedPayload.language) !== -1) {
             log.silly(req.requestId, `Message ${unpackedPayload.id} filtered by language (${unpackedPayload.language})`);
             done();
             return;


### PR DESCRIPTION
by using Array.prototype.indexOf instead

See <https://discourse.joinmastodon.org/t/upgrade-from-v1-3-3-to-v1-4-1-broke-streaming/290>