### PR TITLE
Make sure email is case insensitive on all places

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -27,7 +27,7 @@ class Auth::SessionsController < Devise::SessionsController
     if session[:otp_user_id]
       User.find(session[:otp_user_id])
     elsif user_params[:email]
-      User.find_by(email: user_params[:email])
+      User.find_for_authentication(email: user_params[:email])
     end
   end
 

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe Auth::SessionsController, type: :controller do
         end
       end
 
+      context 'using email with uppercase letters' do
+        before do
+          post :create, params: { user: { email: user.email.upcase, password: user.password } }
+        end
+
+        it 'redirects to home' do
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'logs the user in' do
+          expect(controller.current_user).to eq user
+        end
+      end
+
       context 'using an invalid password' do
         before do
           post :create, params: { user: { email: user.email, password: 'wrongpw' } }
@@ -127,6 +141,26 @@ RSpec.describe Auth::SessionsController, type: :controller do
         codes = user.generate_otp_backup_codes!
         user.save
         return codes
+      end
+
+      context 'using email and password' do
+        before do
+          post :create, params: { user: { email: user.email, password: user.password } }
+        end
+
+        it 'renders two factor authentication page' do
+          expect(controller).to render_template("two_factor")
+        end
+      end
+
+      context 'using upcase email and password' do
+        before do
+          post :create, params: { user: { email: user.email.upcase, password: user.password } }
+        end
+
+        it 'renders two factor authentication page' do
+          expect(controller).to render_template("two_factor")
+        end
       end
 
       context 'using a valid OTP' do


### PR DESCRIPTION
When case insensitivity is enabled via devise's `config.case_insensitive_keys` then `.find_for_authentication` method needs to be used instead of `.find_by` because second mentioned returns `nil` when valid email with different cases is passed.

More info https://github.com/plataformatec/devise/wiki/How-To:-Use-case-insensitive-emails

Closes #3325