### PR TITLE
Refactor UpdateRemoteProfileService

### DIFF
--- a/app/models/remote_profile.rb
+++ b/app/models/remote_profile.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class RemoteProfile
+  include ActiveModel::Model
+
+  attr_reader :document
+
+  def initialize(body)
+    @document = Nokogiri::XML.parse(body, nil, 'utf-8')
+  end
+
+  def root
+    @root ||= document.at_xpath('/atom:feed|/atom:entry', atom: TagManager::XMLNS)
+  end
+
+  def author
+    @author ||= root.at_xpath('./atom:author|./dfrn:owner', atom: TagManager::XMLNS, dfrn: TagManager::DFRN_XMLNS)
+  end
+
+  def hub_link
+    @hub_link ||= link_href_from_xml(root, 'hub')
+  end
+
+  def display_name
+    @display_name ||= author.at_xpath('./poco:displayName', poco: TagManager::POCO_XMLNS)&.content
+  end
+
+  def note
+    @note ||= author.at_xpath('./atom:summary|./poco:note', atom: TagManager::XMLNS, poco: TagManager::POCO_XMLNS)&.content
+  end
+
+  def scope
+    @scope ||= author.at_xpath('./mastodon:scope', mastodon: TagManager::MTDN_XMLNS)&.content
+  end
+
+  def avatar
+    @avatar ||= link_href_from_xml(author, 'avatar')
+  end
+
+  def header
+    @header ||= link_href_from_xml(author, 'header')
+  end
+
+  def locked?
+    scope == 'private'
+  end
+
+  private
+
+  def link_href_from_xml(xml, type)
+    xml.at_xpath(%(./atom:link[@rel="#{type}"]/@href), atom: TagManager::XMLNS)&.content
+  end
+end

--- a/app/services/update_remote_profile_service.rb
+++ b/app/services/update_remote_profile_service.rb
@@ -1,43 +1,34 @@
 # frozen_string_literal: true
 
 class UpdateRemoteProfileService < BaseService
+  attr_reader :account, :remote_profile
+
   def call(body, account, resubscribe = false)
-    xml = Nokogiri::XML(body)
-    xml.encoding = 'utf-8'
+    @account        = account
+    @remote_profile = RemoteProfile.new(body)
 
-    xml = xml.at_xpath('/xmlns:feed', xmlns: TagManager::XMLNS) || xml.at_xpath('/xmlns:entry', xmlns: TagManager::XMLNS)
+    return if remote_profile.root.nil?
 
-    return if xml.nil?
-
-    author_xml = xml.at_xpath('./xmlns:author', xmlns: TagManager::XMLNS) || xml.at_xpath('./dfrn:owner', dfrn: TagManager::DFRN_XMLNS)
-    hub_link   = xml.at_xpath('./xmlns:link[@rel="hub"]', xmlns: TagManager::XMLNS)
-
-    unless author_xml.nil?
-      account.display_name = author_xml.at_xpath('./poco:displayName', poco: TagManager::POCO_XMLNS)&.content || ''
-      account.note         = author_xml.at_xpath('./xmlns:summary', xmlns: TagManager::XMLNS)&.content || author_xml.at_xpath('./poco:note', poco: TagManager::POCO_XMLNS)&.content || ''
-      account.locked       = author_xml.at_xpath('./mastodon:scope', mastodon: TagManager::MTDN_XMLNS)&.content == 'private'
-
-      if !account.suspended? && !DomainBlock.find_by(domain: account.domain)&.reject_media?
-        account.avatar_remote_url = link_href_from_xml(author_xml, 'avatar') if link_has_href?(author_xml, 'avatar')
-        account.header_remote_url = link_href_from_xml(author_xml, 'header') if link_has_href?(author_xml, 'header')
-      end
-    end
+    update_account unless remote_profile.author.nil?
 
     old_hub_url     = account.hub_url
-    account.hub_url = hub_link['href'] if !hub_link.nil? && hub_link['href'].present? && (hub_link['href'] != old_hub_url)
+    account.hub_url = remote_profile.hub_link if remote_profile.hub_link.present? && remote_profile.hub_link != old_hub_url
 
     account.save_with_optional_media!
 
-    Pubsubhubbub::SubscribeWorker.perform_async(account.id) if resubscribe && (account.hub_url != old_hub_url)
+    Pubsubhubbub::SubscribeWorker.perform_async(account.id) if resubscribe && account.hub_url != old_hub_url
   end
 
   private
 
-  def link_href_from_xml(xml, type)
-    xml.at_xpath('./xmlns:link[@rel="' + type + '"]', xmlns: TagManager::XMLNS)['href']
-  end
+  def update_account
+    account.display_name = remote_profile.display_name || ''
+    account.note         = remote_profile.note         || ''
+    account.locked       = remote_profile.locked?
 
-  def link_has_href?(xml, type)
-    !(xml.at_xpath('./xmlns:link[@rel="' + type + '"]', xmlns: TagManager::XMLNS).nil? || xml.at_xpath('./xmlns:link[@rel="' + type + '"]', xmlns: TagManager::XMLNS)['href'].blank?)
+    if !account.suspended? && !DomainBlock.find_by(domain: account.domain)&.reject_media?
+      account.avatar_remote_url = remote_profile.avatar if remote_profile.avatar.present?
+      account.header_remote_url = remote_profile.header if remote_profile.header.present?
+    end
   end
 end


### PR DESCRIPTION
### before

```console
$ bundle exec rubocop app/services/update_remote_profile_service.rb 
Inspecting 1 file
C

Offenses:

app/services/update_remote_profile_service.rb:4:3: C: Cyclomatic complexity for call is too high. [17/15]
  def call(body, account, resubscribe = false)
  ^^^
app/services/update_remote_profile_service.rb:4:3: C: Perceived complexity for call is too high. [17/10]
  def call(body, account, resubscribe = false)
  ^^^

1 file inspected, 2 offenses detected
```

### after

```console
$ bundle exec rubocop app/services/update_remote_profile_service.rb 
Inspecting 1 file
.

1 file inspected, no offenses detected
```