### PR TITLE
Fix locale related specs

### DIFF
--- a/spec/controllers/concerns/localized_spec.rb
+++ b/spec/controllers/concerns/localized_spec.rb
@@ -19,6 +19,7 @@ describe ApplicationController, type: :controller do
     context 'when DEFAULT_LOCALE environment variable is set' do
       around do |example|
         ClimateControl.modify 'DEFAULT_LOCALE' => 'ca', &example.method(:run)
+        I18n.locale = I18n.default_locale
       end
 
       it 'sets language specified by ENV if preferred' do

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe HomeHelper, type: :helper do
   describe 'default_props' do
     it 'returns default properties according to the context' do
-      expect(helper.default_props).to eq locale: :en
+      expect(helper.default_props).to eq locale: I18n.locale
     end
   end
 end

--- a/spec/requests/localization_spec.rb
+++ b/spec/requests/localization_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 describe 'Localization' do
+  after(:all) do
+    I18n.locale = I18n.default_locale
+  end
+  
   it 'uses a specific region when provided' do
     headers = { 'Accept-Language' => 'zh-HK' }
 


### PR DESCRIPTION
* Use I18n.locale instead of ":en"
* Reset I18n.locale value after locale changing tests

This fixes below random fails:

`rspec spec/requests/localization_spec.rb[1:1] spec/helpers/home_helper_spec.rb[1:1]  --seed 37117`

```
  1) HomeHelper default_props returns default properties according to the context
     Failure/Error: expect(helper.default_props).to eq locale: :en

       expected: {:locale=>:en}
            got: {:locale=>:"zh-HK"}

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -:locale => :en,
       +:locale => :"zh-HK",

     # ./spec/helpers/home_helper_spec.rb:6:in `block (3 levels) in <top (required)>'
```

`rspec spec/controllers/concerns/localized_spec.rb[1:1] spec/helpers/home_helper_spec.rb[1:1] --seed 21698`

```
  1) HomeHelper default_props returns default properties according to the context
     Failure/Error: expect(helper.default_props).to eq locale: :en #I18n.locale

       expected: {:locale=>:en}
            got: {:locale=>:ca}

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -:locale => :en,
       +:locale => :ca,

     # ./spec/helpers/home_helper_spec.rb:6:in `block (3 levels) in <top (required)>'
```