### PR TITLE
Fix #2619 - When redis feed is empty, fall back to database

### DIFF
--- a/app/controllers/concerns/user_tracking_concern.rb
+++ b/app/controllers/concerns/user_tracking_concern.rb
@@ -17,7 +17,7 @@ module UserTrackingConcern
     current_user.update_tracked_fields!(request)
 
     # Regenerate feed if needed
-    RegenerationWorker.perform_async(current_user.account_id) if user_needs_feed_update?
+    regenerate_feed! if user_needs_feed_update?
   end
 
   def user_needs_sign_in_update?
@@ -26,5 +26,10 @@ module UserTrackingConcern
 
   def user_needs_feed_update?
     current_user.last_sign_in_at < REGENERATE_FEED_DAYS.days.ago
+  end
+
+  def regenerate_feed!
+    Redis.current.setnx("account:#{current_user.account_id}:regeneration", 3_600 * 24, true)
+    RegenerationWorker.perform_async(current_user.account_id)
   end
 end

--- a/app/controllers/concerns/user_tracking_concern.rb
+++ b/app/controllers/concerns/user_tracking_concern.rb
@@ -29,7 +29,7 @@ module UserTrackingConcern
   end
 
   def regenerate_feed!
-    Redis.current.setnx("account:#{current_user.account_id}:regeneration", 3_600 * 24, true)
+    Redis.current.setnx("account:#{current_user.account_id}:regeneration", true) == 1 && Redis.current.expire("account:#{current_user.account_id}:regeneration", 3_600 * 24)
     RegenerationWorker.perform_async(current_user.account_id)
   end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -7,7 +7,7 @@ class Feed
   end
 
   def get(limit, max_id = nil, since_id = nil)
-    if redis.zcard(key).zero?
+    if redis.exists("account:#{@account.id}:regeneration")
       from_database(limit, max_id, since_id)
     else
       from_redis(limit, max_id, since_id)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -7,15 +7,28 @@ class Feed
   end
 
   def get(limit, max_id = nil, since_id = nil)
+    if redis.zcard(key).zero?
+      from_database(limit, max_id, since_id)
+    else
+      from_redis(limit, max_id, since_id)
+    end
+  end
+
+  private
+
+  def from_redis(limit, max_id, since_id)
     max_id     = '+inf' if max_id.blank?
     since_id   = '-inf' if since_id.blank?
     unhydrated = redis.zrevrangebyscore(key, "(#{max_id}", "(#{since_id}", limit: [0, limit], with_scores: true).map(&:last).map(&:to_i)
     status_map = Status.where(id: unhydrated).cache_ids.map { |s| [s.id, s] }.to_h
-
     unhydrated.map { |id| status_map[id] }.compact
   end
 
-  private
+  def from_database(limit, max_id, since_id)
+    results = Status.as_home_timeline(@account).paginate_by_max_id(limit, max_id, since_id).to_a
+    results.reject! { |status| FeedManager.instance.filter?(:home, status, @account.id) }
+    results
+  end
 
   def key
     FeedManager.instance.key(@type, @account.id)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -25,9 +25,9 @@ class Feed
   end
 
   def from_database(limit, max_id, since_id)
-    results = Status.as_home_timeline(@account).paginate_by_max_id(limit, max_id, since_id).to_a
-    results.reject! { |status| FeedManager.instance.filter?(:home, status, @account.id) }
-    results
+    Status.as_home_timeline(@account)
+          .paginate_by_max_id(limit, max_id, since_id)
+          .reject { |status| FeedManager.instance.filter?(:home, status, @account.id) }
   end
 
   def key

--- a/app/services/precompute_feed_service.rb
+++ b/app/services/precompute_feed_service.rb
@@ -17,6 +17,8 @@ class PrecomputeFeedService < BaseService
       statuses.each do |status|
         process_status(status)
       end
+
+      redis.del("account:#{@account.id}:regeneration")
     end
   end
 

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -2,20 +2,20 @@ require 'rails_helper'
 
 RSpec.describe Feed, type: :model do
   describe '#get' do
-    it "gets statuses with ids in the range, maintining the order from Redis" do
+    it 'gets statuses with ids in the range, maintining the order from Redis' do
       account = Fabricate(:account)
       Fabricate(:status, account: account, id: 1)
       Fabricate(:status, account: account, id: 2)
       Fabricate(:status, account: account, id: 3)
       Fabricate(:status, account: account, id: 10)
-      redis = double(zrevrangebyscore: [["val2", 2.0], ["val1", 1.0], ["val3", 3.0], ["deleted", 4.0]])
+      redis = double(zrevrangebyscore: [['val2', 2.0], ['val1', 1.0], ['val3', 3.0], ['deleted', 4.0]], exists: false)
       allow(Redis).to receive(:current).and_return(redis)
 
-      feed = Feed.new("type", account)
+      feed = Feed.new(:home, account)
       results = feed.get(3)
 
       expect(results.map(&:id)).to eq [2, 1, 3]
-      expect(results.first.attributes.keys).to eq ["id", "updated_at"]
+      expect(results.first.attributes.keys).to eq %w(id updated_at)
     end
   end
 end


### PR DESCRIPTION
Home feeds are normally stored in redis. But removed for users inactive for > 14 days.

When user logs back in, a background worker starts to regenerate the feed. However, before that job completes, the user is greeted with a blank home timeline.

This change will fallback to database queries if RegenerationWorker has been queued up but hasn't finished running.