### PR TITLE
Add links to project homepage

### DIFF
--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -90,15 +90,7 @@ class GettingStarted extends ImmutablePureComponent {
         <div className='getting-started__footer scrollable optionally-scrollable'>
           <div className='static-content getting-started'>
             <p>
-              <FormattedMessage
-                id='getting_started.support'
-                defaultMessage='{faq} • {userguide} • {apps}'
-                values={{
-                  faq: <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.faq' defaultMessage='FAQ' /></a>,
-                  userguide: <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/User-guide.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.userguide' defaultMessage='User Guide' /></a>,
-                  apps: <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.appsshort' defaultMessage='Apps' /></a>,
-                }}
-              />
+              <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.faq' defaultMessage='FAQ' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/User-guide.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.userguide' defaultMessage='User Guide' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.appsshort' defaultMessage='Apps' /></a>
             </p>
             <p>
               <FormattedMessage

--- a/app/javascript/mastodon/locales/ar.json
+++ b/app/javascript/mastodon/locales/ar.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "أسئلة وأجوبة شائعة",
   "getting_started.heading": "إستعدّ للبدء",
   "getting_started.open_source_notice": "ماستدون برنامج مفتوح المصدر. يمكنك المساهمة، أو الإبلاغ عن تقارير الأخطاء، على جيت هب {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "دليل المستخدم",
   "home.column_settings.advanced": "متقدمة",
   "home.column_settings.basic": "أساسية",

--- a/app/javascript/mastodon/locales/bg.json
+++ b/app/javascript/mastodon/locales/bg.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Първи стъпки",
   "getting_started.open_source_notice": "Mastodon е софтуер с отворен код. Можеш да помогнеш или да докладваш за проблеми в Github: {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Advanced",
   "home.column_settings.basic": "Basic",

--- a/app/javascript/mastodon/locales/ca.json
+++ b/app/javascript/mastodon/locales/ca.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "PMF",
   "getting_started.heading": "Començant",
   "getting_started.open_source_notice": "Mastodon és un programari de codi obert. Pots contribuir o informar de problemes a GitHub de {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "Guia de l'usuari",
   "home.column_settings.advanced": "Avançat",
   "home.column_settings.basic": "Bàsic",

--- a/app/javascript/mastodon/locales/de.json
+++ b/app/javascript/mastodon/locales/de.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Erste Schritte",
   "getting_started.open_source_notice": "Mastodon ist quelloffene Software. Du kannst auf {github} dazu beitragen oder Probleme melden.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Fortgeschritten",
   "home.column_settings.basic": "Einfach",

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -744,10 +744,6 @@
         "id": "navigation_bar.info"
       },
       {
-        "defaultMessage": "{faq} • {userguide} • {apps}",
-        "id": "getting_started.support"
-      },
-      {
         "defaultMessage": "FAQ",
         "id": "getting_started.faq"
       },

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Getting started",
   "getting_started.open_source_notice": "Mastodon is open source software. You can contribute or report issues on GitHub at {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Advanced",
   "home.column_settings.basic": "Basic",

--- a/app/javascript/mastodon/locales/eo.json
+++ b/app/javascript/mastodon/locales/eo.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Por komenci",
   "getting_started.open_source_notice": "Mastodon estas malfermitkoda programo. Vi povas kontribui aŭ raporti problemojn en github je {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Advanced",
   "home.column_settings.basic": "Basic",

--- a/app/javascript/mastodon/locales/es.json
+++ b/app/javascript/mastodon/locales/es.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Primeros pasos",
   "getting_started.open_source_notice": "Mastodon es software libre. Puedes contribuir o reportar errores en {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Advanced",
   "home.column_settings.basic": "Basic",

--- a/app/javascript/mastodon/locales/fa.json
+++ b/app/javascript/mastodon/locales/fa.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "پرسش‌های رایج",
   "getting_started.heading": "آغاز کنید",
   "getting_started.open_source_notice": "ماستدون یک نرم‌افزار آزاد است. می‌توانید در ساخت آن مشارکت کنید یا مشکلاتش را در {github} گزارش دهید.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "راهنمای کاربری",
   "home.column_settings.advanced": "پیشرفته",
   "home.column_settings.basic": "اصلی",

--- a/app/javascript/mastodon/locales/fi.json
+++ b/app/javascript/mastodon/locales/fi.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Aloitus",
   "getting_started.open_source_notice": "Mastodon Mastodon on avoimen lähdekoodin ohjelma. Voit avustaa tai raportoida ongelmia GitHub palvelussa {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Advanced",
   "home.column_settings.basic": "Basic",

--- a/app/javascript/mastodon/locales/fr.json
+++ b/app/javascript/mastodon/locales/fr.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Pour commencer",
   "getting_started.open_source_notice": "Mastodon est un logiciel libre. Vous pouvez contribuer et envoyer vos commentaires et rapports de bogues via {github} sur GitHub.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "Guide d'utilisation",
   "home.column_settings.advanced": "Avancé",
   "home.column_settings.basic": "Basique",

--- a/app/javascript/mastodon/locales/he.json
+++ b/app/javascript/mastodon/locales/he.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "שאלות ותשובות",
   "getting_started.heading": "בואו נתחיל",
   "getting_started.open_source_notice": "מסטודון היא תוכנה חופשית (בקוד פתוח). ניתן לתרום או לדווח על בעיות בגיטהאב: {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "מדריך למשתמשים",
   "home.column_settings.advanced": "למתקדמים",
   "home.column_settings.basic": "למתחילים",

--- a/app/javascript/mastodon/locales/hr.json
+++ b/app/javascript/mastodon/locales/hr.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Počnimo",
   "getting_started.open_source_notice": "Mastodon je softver otvorenog koda. Možeš pridonijeti ili prijaviti probleme na GitHubu  {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "Vodič za korisnike",
   "home.column_settings.advanced": "Napredno",
   "home.column_settings.basic": "Osnovno",

--- a/app/javascript/mastodon/locales/hu.json
+++ b/app/javascript/mastodon/locales/hu.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Első lépések",
   "getting_started.open_source_notice": "Mastodon is open source software. You can contribute or report issues on GitHub at {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Advanced",
   "home.column_settings.basic": "Basic",

--- a/app/javascript/mastodon/locales/id.json
+++ b/app/javascript/mastodon/locales/id.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Mulai",
   "getting_started.open_source_notice": "Mastodon adalah perangkat lunak yang bersifat open source. Anda dapat berkontribusi atau melaporkan permasalahan/bug di Github {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Tingkat Lanjut",
   "home.column_settings.basic": "Dasar",

--- a/app/javascript/mastodon/locales/io.json
+++ b/app/javascript/mastodon/locales/io.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Debuto",
   "getting_started.open_source_notice": "Mastodon esas programaro kun apertita kodexo. Tu povas kontributar o signalar problemi en GitHub ye {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Komplexa",
   "home.column_settings.basic": "Simpla",

--- a/app/javascript/mastodon/locales/it.json
+++ b/app/javascript/mastodon/locales/it.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Come iniziare",
   "getting_started.open_source_notice": "Mastodon è un software open source. Puoi contribuire o segnalare errori su GitHub all'indirizzo {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Avanzato",
   "home.column_settings.basic": "Semplice",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "よくある質問",
   "getting_started.heading": "スタート",
   "getting_started.open_source_notice": "Mastodonはオープンソースソフトウェアです。誰でもGitHub（{github}）から開発に参加したり、問題を報告したりできます。",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "ユーザーガイド",
   "home.column_settings.advanced": "上級者向け",
   "home.column_settings.basic": "基本設定",

--- a/app/javascript/mastodon/locales/nl.json
+++ b/app/javascript/mastodon/locales/nl.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Beginnen",
   "getting_started.open_source_notice": "Mastodon is open-sourcesoftware. Je kunt bijdragen of problemen melden op GitHub via {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "Gebruikersgids",
   "home.column_settings.advanced": "Geavanceerd",
   "home.column_settings.basic": "Basic",

--- a/app/javascript/mastodon/locales/no.json
+++ b/app/javascript/mastodon/locales/no.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Kom i gang",
   "getting_started.open_source_notice": "Mastodon er fri programvare. Du kan bidra eller rapportere problemer på GitHub på {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "Brukerguide",
   "home.column_settings.advanced": "Avansert",
   "home.column_settings.basic": "Enkel",

--- a/app/javascript/mastodon/locales/oc.json
+++ b/app/javascript/mastodon/locales/oc.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Per començar",
   "getting_started.open_source_notice": "Mastodon es un logicial liure. Podètz contribuir e mandar vòstres comentaris e rapòrt de bug via{github} sus GitHub.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "Guida d’utilizacion",
   "home.column_settings.advanced": "Avançat",
   "home.column_settings.basic": "Basic",

--- a/app/javascript/mastodon/locales/pl.json
+++ b/app/javascript/mastodon/locales/pl.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Naucz się korzystać",
   "getting_started.open_source_notice": "Mastodon jest oprogramowaniem o otwartym źródle. Możesz pomóc w rozwoju lub zgłaszać błędy na GitHubie tutaj {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "Podręcznik użytkownika",
   "home.column_settings.advanced": "Zaawansowane",
   "home.column_settings.basic": "Podstawowe",

--- a/app/javascript/mastodon/locales/pt.json
+++ b/app/javascript/mastodon/locales/pt.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Primeiros passos",
   "getting_started.open_source_notice": "Mastodon é software de fonte aberta. Podes contribuir ou repostar problemas no GitHub do projecto: {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Avançado",
   "home.column_settings.basic": "Básico",

--- a/app/javascript/mastodon/locales/ru.json
+++ b/app/javascript/mastodon/locales/ru.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Добро пожаловать",
   "getting_started.open_source_notice": "Mastodon - программа с открытым исходным кодом. Вы можете помочь проекту или сообщить о проблемах на GitHub по адресу {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "Руководство",
   "home.column_settings.advanced": "Дополнительные",
   "home.column_settings.basic": "Основные",

--- a/app/javascript/mastodon/locales/th.json
+++ b/app/javascript/mastodon/locales/th.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Getting started",
   "getting_started.open_source_notice": "Mastodon is open source software. You can contribute or report issues on GitHub at {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Advanced",
   "home.column_settings.basic": "Basic",

--- a/app/javascript/mastodon/locales/tr.json
+++ b/app/javascript/mastodon/locales/tr.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Başlangıç",
   "getting_started.open_source_notice": "Mastodon açık kaynaklı bir yazılımdır. Github {github}. {apps} üzerinden katkıda bulunabilir, hata raporlayabilirsiniz.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "User Guide",
   "home.column_settings.advanced": "Gelişmiş",
   "home.column_settings.basic": "Temel",

--- a/app/javascript/mastodon/locales/uk.json
+++ b/app/javascript/mastodon/locales/uk.json
@@ -72,7 +72,6 @@
   "getting_started.faq": "FAQ",
   "getting_started.heading": "Ласкаво просимо",
   "getting_started.open_source_notice": "Mastodon - програма з відкритим вихідним кодом. Ви можете допомогти проекту, або повідомити про проблеми на GitHub за адресою {github}.",
-  "getting_started.support": "{faq} • {userguide} • {apps}",
   "getting_started.userguide": "Посібник",
   "home.column_settings.advanced": "Додаткові",
   "home.column_settings.basic": "Основні",

--- a/app/javascript/mastodon/locales/whitelist_ja.json
+++ b/app/javascript/mastodon/locales/whitelist_ja.json
@@ -1,3 +1,2 @@
 [
-  "getting_started.support"
 ]

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -10,6 +10,6 @@
         &mdash;
     %span.domain= link_to site_hostname, root_path
     %span.powered-by
-      != t('generic.powered_by', link: link_to('Mastodon', 'https://github.com/tootsuite/mastodon'))
+      != t('generic.powered_by', link: link_to('Mastodon', 'https://joinmastodon.org'))
 
 = render template: 'layouts/application'


### PR DESCRIPTION
- Link Mastodon in "Powered by Mastodon" to joinmastodon.org

Where else should we put the link? Should I replace all "Source code" links leading to GitHub to lead to joinmastodon.org instead?