### PR TITLE
Enable useBuiltIns option of transform-object-rest-spread

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -14,7 +14,7 @@
   ],
   "plugins": [
     "syntax-dynamic-import",
-    "transform-object-rest-spread",
+    ["transform-object-rest-spread", { "useBuiltIns": true }],
     "transform-class-properties",
     [
       "react-intl",


### PR DESCRIPTION
### input

```javascript
const object = { ...a, ...b };
```

### before

```javascript
var _extends = Object.assign || function (target) {
  for (var i = 1; i < arguments.length; i++) {
    var source = arguments[i];
    for (var key in source) {
      if (Object.prototype.hasOwnProperty.call(source, key)) {
        target[key] = source[key];
      }
    }
  }
  return target;
};

var object = _extends({}, a, b);
```

### after

```javascript
var object = Object.assign({}, a, b);
```