### PR TITLE
Fix account delete form not accepting password

### DIFF
--- a/app/controllers/settings/deletes_controller.rb
+++ b/app/controllers/settings/deletes_controller.rb
@@ -22,6 +22,6 @@ class Settings::DeletesController < ApplicationController
   private
 
   def delete_params
-    params.permit(:password)
+    params.require(:form_delete_confirmation).permit(:password)
   end
 end

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -5,8 +5,8 @@ class SuspendAccountService < BaseService
     @account = account
 
     purge_user if remove_user
-    purge_content
     purge_profile
+    purge_content
     unsubscribe_push_subscribers
   end
 

--- a/spec/controllers/settings/deletes_controller_spec.rb
+++ b/spec/controllers/settings/deletes_controller_spec.rb
@@ -35,7 +35,7 @@ describe Settings::DeletesController do
 
       context 'with correct password' do
         before do
-          delete :destroy, params: { password: 'petsmoldoggos' }
+          delete :destroy, params: { form_delete_confirmation: { password: 'petsmoldoggos' } }
         end
 
         it 'redirects to sign in page' do
@@ -53,7 +53,7 @@ describe Settings::DeletesController do
 
       context 'with incorrect password' do
         before do
-          delete :destroy, params: { password: 'blaze420' }
+          delete :destroy, params: { form_delete_confirmation: { password: 'blaze420' } }
         end
 
         it 'redirects back to confirmation page' do


### PR DESCRIPTION
And update suspended account before removing content for quicker feedback to end-users