### PR TITLE
Enable localization fallback to English on Rails side

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,6 +61,7 @@ module Mastodon
     ]
 
     config.i18n.default_locale = :en
+    config.i18n.fallbacks = true
 
     # config.paths.add File.join('app', 'api'), glob: File.join('**', '*.rb')
     # config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]


### PR DESCRIPTION
Of course, we should have translation for all languages, but if we forgot that...

![image](https://user-images.githubusercontent.com/705555/27148412-28e157ca-517b-11e7-8fff-9add346cf72f.png)

...It's should be avoided.