### PR TITLE
Fix merge default columns

### DIFF
--- a/app/javascript/mastodon/reducers/settings.js
+++ b/app/javascript/mastodon/reducers/settings.js
@@ -7,12 +7,6 @@ import uuid from '../uuid';
 const initialState = Immutable.Map({
   onboarded: false,
 
-  columns: Immutable.fromJS([
-    { id: 'COMPOSE', uuid: uuid(), params: {} },
-    { id: 'HOME', uuid: uuid(), params: {} },
-    { id: 'NOTIFICATIONS', uuid: uuid(), params: {} },
-  ]),
-
   home: Immutable.Map({
     shows: Immutable.Map({
       reblog: true,
@@ -60,6 +54,19 @@ const initialState = Immutable.Map({
   }),
 });
 
+const defaultColumns = Immutable.fromJS([
+  { id: 'COMPOSE', uuid: uuid(), params: {} },
+  { id: 'HOME', uuid: uuid(), params: {} },
+  { id: 'NOTIFICATIONS', uuid: uuid(), params: {} },
+]);
+
+const hydrate = (settings) => {
+  return initialState.withMutations((state) => {
+    state.mergeDeep(settings);
+    state.update('columns', defaultColumns, val => val);
+  });
+};
+
 const moveColumn = (state, uuid, direction) => {
   const columns  = state.get('columns');
   const index    = columns.findIndex(item => item.get('uuid') === uuid);
@@ -76,7 +83,7 @@ const moveColumn = (state, uuid, direction) => {
 export default function settings(state = initialState, action) {
   switch(action.type) {
   case STORE_HYDRATE:
-    return state.mergeDeep(action.state.get('settings'));
+    return hydrate(action.state.get('settings'));
   case SETTING_CHANGE:
     return state.setIn(action.key, action.value);
   case COLUMN_ADD:


### PR DESCRIPTION
`mergeDeep` also merges columns, but it should be replaced simply.

So in the new function, first apply `mergeDeep` except columns, and set default columns if columns unset.