### PR TITLE
Set the default locale in config

### DIFF
--- a/app/controllers/concerns/localized.rb
+++ b/app/controllers/concerns/localized.rb
@@ -17,11 +17,7 @@ module Localized
   end
 
   def default_locale
-    request_locale || env_locale || I18n.default_locale
-  end
-
-  def env_locale
-    ENV['DEFAULT_LOCALE']
+    request_locale || I18n.default_locale
   end
 
   def request_locale
@@ -29,12 +25,10 @@ module Localized
   end
 
   def preferred_locale
-    http_accept_language.preferred_language_from([env_locale]) ||
-      http_accept_language.preferred_language_from(I18n.available_locales)
+    http_accept_language.preferred_language_from(I18n.available_locales)
   end
 
   def compatible_locale
-    http_accept_language.compatible_language_from([env_locale]) ||
-      http_accept_language.compatible_language_from(I18n.available_locales)
+    http_accept_language.compatible_language_from(I18n.available_locales)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module Mastodon
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
+    # All translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.available_locales = [
       :en,
@@ -61,7 +61,12 @@ module Mastodon
       :'zh-TW',
     ]
 
-    config.i18n.default_locale = :en
+    config.i18n.default_locale = ENV['DEFAULT_LOCALE']&.to_sym
+    if config.i18n.available_locales.include?(config.i18n.default_locale)
+      config.i18n.fallbacks = [config.i18n.default_locale, :en]
+    else
+      config.i18n.default_locale = :en
+    end
 
     # config.paths.add File.join('app', 'api'), glob: File.join('**', '*.rb')
     # config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,6 +47,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.i18n.default_locale = :en
+  config.i18n.fallbacks = true
 end
 
 Paperclip::Attachment.default_options[:path] = "#{Rails.root}/spec/test_files/:class/:id_partition/:style.:extension"

--- a/spec/controllers/concerns/localized_spec.rb
+++ b/spec/controllers/concerns/localized_spec.rb
@@ -16,49 +16,24 @@ describe ApplicationController, type: :controller do
   end
 
   shared_examples 'default locale' do
-    context 'when DEFAULT_LOCALE environment variable is set' do
-      around do |example|
-        ClimateControl.modify 'DEFAULT_LOCALE' => 'ca', &example.method(:run)
-        I18n.locale = I18n.default_locale
-      end
+    after { I18n.locale = I18n.default_locale }
 
-      it 'sets language specified by ENV if preferred' do
-        request.headers['Accept-Language'] = 'ca, fa'
-        get 'success'
-        expect(I18n.locale).to eq :ca
-      end
-
-      it 'sets available and preferred language if language specified by ENV is not preferred' do
-        request.headers['Accept-Language'] = 'ca-ES, fa'
-        get 'success'
-        expect(I18n.locale).to eq :fa
-      end
-
-      it 'sets language specified by ENV if it is compatible and none of available languages are preferred' do
-        request.headers['Accept-Language'] = 'ca-ES, fa-IR'
-        get 'success'
-        expect(I18n.locale).to eq :ca
-      end
-
-      it 'sets available and compatible langauge if language specified by ENV is not compatible none of available languages are preferred' do
-        request.headers['Accept-Language'] = 'fa-IR'
-        get 'success'
-        expect(I18n.locale).to eq :fa
-      end
-
-      it 'sets language specified by ENV if none of available languages are compatible' do
-        request.headers['Accept-Language'] = ''
-        get 'success'
-        expect(I18n.locale).to eq :ca
-      end
+    it 'sets available and preferred language' do
+      request.headers['Accept-Language'] = 'ca-ES, fa'
+      get 'success'
+      expect(I18n.locale).to eq :fa
     end
 
-    context 'when DEFAULT_LOCALE environment variable is not set' do
-      it 'sets default locale if none of available languages are compatible' do
-        request.headers['Accept-Language'] = ''
-        get 'success'
-        expect(I18n.locale).to eq :en
-      end
+    it 'sets available and compatible langauge if none of available languages are preferred' do
+      request.headers['Accept-Language'] = 'fa-IR'
+      get 'success'
+      expect(I18n.locale).to eq :fa
+    end
+
+    it 'sets default locale if none of available languages are compatible' do
+      request.headers['Accept-Language'] = ''
+      get 'success'
+      expect(I18n.locale).to eq :en
     end
   end
 


### PR DESCRIPTION
Previously the default locale was set by `Localized` concern for controllers, but it was not enforced for mailers.

`config` is enforced throughout the application and an appropriate place to set the default locale.

This is succeeding #3696.