### PR TITLE
Set default From address in config

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch('SMTP_FROM_ADDRESS') { 'notifications@localhost' }
   layout 'mailer'
   helper :instance
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class UserMailer < Devise::Mailer
-  default from: ENV.fetch('SMTP_FROM_ADDRESS') { 'notifications@localhost' }
   layout 'mailer'
 
   helper :instance

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,6 +62,8 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  config.action_mailer.default_options = { from: 'notifications@localhost' }
+
   # If using a Heroku, Vagrant or generic remote development environment,
   # use letter_opener_web, accessible at  /letter_opener.
   # Otherwise, use letter_opener, which launches a browser window to view sent mail.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,6 +73,8 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # E-mails
+  config.action_mailer.default_options = { from: ENV.fetch('SMTP_FROM_ADDRESS') }
+
   config.action_mailer.smtp_settings = {
     :port                 => ENV['SMTP_PORT'],
     :address              => ENV['SMTP_SERVER'],

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,6 +30,8 @@ Rails.application.configure do
   config.action_controller.allow_forgery_protection = false
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_options = { from: 'notifications@localhost' }
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.


### PR DESCRIPTION
The old implementation sets default `From` address in mailers. It sets the address from `SMTP_FROM_ADDRESS`, or `notifications@localhost`. The behavior is occasionally undesired results.

In production environment, `notifications@localhost` is likely to be incorrect.
In testing environment, the email address should not be varied by a environment variable.

After appling this change,

In production environment, it will throw an exception when launching Mastodon.
In testing environment, the address will be fixed with `notifications@localhost`.