### PR TITLE
Upgrade react-immutable-pure-component to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-addons-shallow-compare": "^15.5.2",
     "react-dom": "^15.6.0",
     "react-immutable-proptypes": "^2.1.0",
-    "react-immutable-pure-component": "^0.0.5",
+    "react-immutable-pure-component": "^1.0.0",
     "react-intl": "^2.3.0",
     "react-motion": "^0.5.0",
     "react-notification": "^6.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5537,9 +5537,9 @@ react-immutable-proptypes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz#023d6f39bb15c97c071e9e60d00d136eac5fa0b4"
 
-react-immutable-pure-component@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/react-immutable-pure-component/-/react-immutable-pure-component-0.0.5.tgz#5ef9bea0ce670c041e6ae5d689b59aea8983384a"
+react-immutable-pure-component@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-immutable-pure-component/-/react-immutable-pure-component-1.0.0.tgz#761d27b1497c5af64d2d2454e17b26ce7c9cda88"
 
 react-inspector@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
ImmutablePureComponent v1.0.0 has been released. This release is React v16 ready.

There is no change in API due to internal change only.

- [Change React.PureComponent to React.Component (Monar/react-immutable-pure-component#3)](https://github.com/Monar/react-immutable-pure-component/pull/3)
- [Add support Universal Module Definition (UMD) using rollup.js - (Monar/react-immutable-pure-component#6)](https://github.com/Monar/react-immutable-pure-component/pull/6)

There are two major changes in this release.
