### PR TITLE
Enable filtering toots with visibility

### DIFF
--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -60,7 +60,9 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   end
 
   def filter_with_visibility_scope(visibility)
-    Status.where(visibility: Status.visibilities[visibility])
+    permitted_account_statuses.tap do |statuses|
+      statuses.merge!(Status.where(visibility: Status.visibilities[visibility]))
+    end
   end
 
   def pagination_params(core_params)

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -31,6 +31,7 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
     default_statuses.tap do |statuses|
       statuses.merge!(only_media_scope) if params[:only_media]
       statuses.merge!(no_replies_scope) if params[:exclude_replies]
+      statuses.merge!(filter_with_visibility_scope(params[:visibility])) if params[:visibility]
     end
   end
 
@@ -56,6 +57,10 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
 
   def no_replies_scope
     Status.without_replies
+  end
+
+  def filter_with_visibility_scope(visibility)
+    Status.where(visibility: Status.visibilities[visibility])
   end
 
   def pagination_params(core_params)

--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -37,7 +37,7 @@ describe Api::V1::Accounts::StatusesController do
   end
 
   describe 'GET #index with valid visibility' do
-    it 'retures http success' do
+    it 'returns http success' do
       get :index, params: { account_id: user.account.id, visibility: 'public'}
 
       expect(response).to have_http_status(:success)
@@ -45,7 +45,7 @@ describe Api::V1::Accounts::StatusesController do
   end
 
   describe 'GET #index with invalid visibility' do
-    it 'retures http success with empty array' do
+    it 'returns http success with empty array' do
       get :index, params: { account_id: user.account.id, visibility: 'invalid_visibility'}
 
       expect(response).to have_http_status(:success)

--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -35,4 +35,21 @@ describe Api::V1::Accounts::StatusesController do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'GET #index with valid visibility' do
+    it 'retures http success' do
+      get :index, params: { account_id: user.account.id, visibility: 'public'}
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET #index with invalid visibility' do
+    it 'retures http success with empty array' do
+      get :index, params: { account_id: user.account.id, visibility: 'invalid_visibility'}
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to eq '[]'
+    end
+  end
 end


### PR DESCRIPTION
I am a member of developing Naumanni, a kind of mastodon client.

This PR is to filter toots from status API with `visibility` parameter, in order to implement talking on mastodon DM.

Thanks.