### PR TITLE
Fix ogp url

### DIFF
--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -10,7 +10,7 @@
   %meta{ property: 'og:type', content: 'website' }/
   %meta{ property: 'og:title', content: site_hostname }/
   %meta{ property: 'og:description', content: strip_tags(@instance_presenter.site_description.presence || t('about.about_mastodon')) }/
-  %meta{ property: 'og:image', content: asset_pack_path('mastodon_small.jpg') }/
+  %meta{ property: 'og:image', content: asset_pack_path('mastodon_small.jpg', protocol: :request) }/
   %meta{ property: 'og:image:width', content: '400' }/
   %meta{ property: 'og:image:height', content: '400' }/
   %meta{ property: 'twitter:card', content: 'summary' }/


### PR DESCRIPTION
If assets packed with webpacker are on the same domain, OGP will not display properly. OGP must be specified as an absolute path, but asset_pack_path returns a relative path if it is the same domain.

`asset_pack_path` returns an absolute path by specifying `{protocol: :request}` as an option. Also `assets_path` is called inside `assets_url`, and `{protocol: :request}` option is specified in `asset_path`.

asset_pack_path:
https://github.com/rails/webpacker/blob/master/lib/webpacker/helper.rb#L11-L13

assets_url:
https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/asset_url_helper.rb#L225-L227