### PR TITLE
Whitelist allowed classes for federated statuses

### DIFF
--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -39,7 +39,7 @@ class Sanitize
       },
 
       transformers: [
-        CLASS_WHITELIST_TRANSFORMER
+        CLASS_WHITELIST_TRANSFORMER,
       ]
     )
 

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -4,6 +4,21 @@ class Sanitize
   module Config
     HTTP_PROTOCOLS ||= ['http', 'https', :relative].freeze
 
+    CLASS_WHITELIST_TRANSFORMER = lambda do |env|
+      node = env[:node]
+      class_list = node['class']&.split(' ')
+
+      return unless class_list
+
+      class_list.keep_if do |e|
+        return true if e =~ /^(h|p|u|dt|e)-/ # microformats classes
+        return true if e =~ /^(mention|hashtag)$/ # semantic classes
+        return true if e =~ /^(ellipsis|invisible)$/ # link formatting classes
+      end
+
+      node['class'] = class_list.join(' ')
+    end
+
     MASTODON_STRICT ||= freeze_config(
       elements: %w(p br span a),
 
@@ -21,7 +36,11 @@ class Sanitize
 
       protocols: {
         'a' => { 'href' => HTTP_PROTOCOLS },
-      }
+      },
+
+      transformers: [
+        CLASS_WHITELIST_TRANSFORMER
+      ]
     )
 
     MASTODON_OEMBED ||= freeze_config merge(

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -204,6 +204,14 @@ RSpec.describe Formatter do
         is_expected.to_not include '<script>alert("Hello")</script>'
       end
     end
+
+    context 'contains malicious classes' do
+      let(:text) { '<span class="status__content__spoiler-link">Show more</span>' }
+
+      it 'strips malicious classes' do
+        is_expected.to_not include 'status__content__spoiler-link'
+      end
+    end
   end
 
   describe '#plaintext' do


### PR DESCRIPTION
Allowed classes are currently:

 - Any microformats class (h/p/u/dt/e-*)
 - the classes `mention`, `hashtag`, `ellipses` and `invisible`.

this last one is somewhat suspect, but Mastodon currently uses it to render truncated links.

Before this pull request gets merged, I would like more input on which classes should be allowed and which should be restricted. For example, I think that fa-spin is fine to be allowed, but I feel weird whitelisting it explicitly. It would be nice to allow some amount of simple formatting (opening the door for things like #853 and #3621 to happen on a federation level), but I don't know what classes we already have that could do similar things.

resolves #3790