### PR TITLE
Link to /about from public page on a single user instance

### DIFF
--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -8,7 +8,9 @@
       %span.single-user-login
         = link_to t('auth.login'), new_user_session_path
         &mdash;
-    %span.domain= link_to site_hostname, root_path
+      %span.domain= link_to site_hostname, about_path
+    - else
+      %span.domain= link_to site_hostname, root_path
     %span.powered-by
       != t('generic.powered_by', link: link_to('Mastodon', 'https://joinmastodon.org'))
 


### PR DESCRIPTION
There was no link for visitors to follow to see the about page.