### PR TITLE
Fix jittery scrolling for Chromium browsers (#3776)

### DIFF
--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -6,6 +6,7 @@ import StatusContainer from '../containers/status_container';
 import LoadMore from './load_more';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import IntersectionObserverWrapper from '../features/ui/util/intersection_observer_wrapper';
+import { debounce } from 'lodash';
 
 class StatusList extends ImmutablePureComponent {
 
@@ -29,7 +30,7 @@ class StatusList extends ImmutablePureComponent {
 
   intersectionObserverWrapper = new IntersectionObserverWrapper();
 
-  handleScroll = (e) => {
+  handleScroll = debounce((e) => {
     const { scrollTop, scrollHeight, clientHeight } = e.target;
     const offset = scrollHeight - scrollTop - clientHeight;
     this._oldScrollPosition = scrollHeight - scrollTop;
@@ -41,7 +42,9 @@ class StatusList extends ImmutablePureComponent {
     } else if (this.props.onScroll) {
       this.props.onScroll();
     }
-  }
+  }, 200, {
+    trailing: true,
+  });
 
   componentDidMount () {
     this.attachScrollListener();
@@ -49,8 +52,16 @@ class StatusList extends ImmutablePureComponent {
   }
 
   componentDidUpdate (prevProps) {
-    if ((prevProps.statusIds.size < this.props.statusIds.size && prevProps.statusIds.first() !== this.props.statusIds.first() && !!this._oldScrollPosition) && this.node.scrollTop > 0) {
-      this.node.scrollTop = this.node.scrollHeight - this._oldScrollPosition;
+    // Reset the scroll position when a new toot comes in in order not to
+    // jerk the scrollbar around if you're already scrolled down the page.
+    if (prevProps.statusIds.size < this.props.statusIds.size &&
+        prevProps.statusIds.first() !== this.props.statusIds.first() &&
+        this._oldScrollPosition &&
+        this.node.scrollTop > 0) {
+      let newScrollTop = this.node.scrollHeight - this._oldScrollPosition;
+      if (this.node.scrollTop !== newScrollTop) {
+        this.node.scrollTop = newScrollTop;
+      }
     }
   }
 


### PR DESCRIPTION
This is a partial fix for #3776 (jiggling/jittery scrolling). This PR only fixes the issue for Chrome/Chromium. Here's why:

The main issue is that `scrollTop` doesn't provide subpixel precision – only integers. So if we set the `scrollTop` to an integer then it will always cause jiggling, because it may be off by a subpixel.

Unfortunately there doesn't seem to be any way to get a subpixel precision for the scroll. So the next best thing is to avoid re-setting an integer `scrollTop` when the `scrollTop` is already that exact same integer. This turns out to work for Chrome because they have [an intervention](https://www.chromestatus.com/feature/5700102471548928) to avoid moving the scroll position when elements are added to the top of a list. So the `scrollTop` is already correct; there's no reason to re-set it.

So by checking the `scrollTop` before setting it, we remove the jitter from Chrome. Unfortunately this PR does not fix Edge, Firefox, or Safari. The only way to fix the jitter in those browser (I believe) would be to avoid adding the elements entirely, e.g. similar to how Twitter does it with the "show more tweets" button.