### PR TITLE
Handle resize in a debounce()

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -13,8 +13,6 @@ import { refreshNotifications } from '../../actions/notifications';
 import UploadArea from './components/upload_area';
 import ColumnsAreaContainer from './containers/columns_area_container';
 
-const noOp = () => false;
-
 class UI extends React.PureComponent {
 
   static propTypes = {
@@ -27,9 +25,11 @@ class UI extends React.PureComponent {
     draggingOver: false,
   };
 
-  handleResize = () => {
+  handleResize = debounce(() => {
     this.setState({ width: window.innerWidth });
-  }
+  }, 500, {
+    trailing: true,
+  });
 
   handleDragEnter = (e) => {
     e.preventDefault();


### PR DESCRIPTION
I can't see any reason not to to debounce the `resize` event. There's no reason to spam these events as quickly as possible while the user is resizing the window. Using `trailing: true` also ensures that the function will run after the user is done resizing.