### PR TITLE
Fix character/grapheme count stuff

### DIFF
--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -18,6 +18,7 @@ import UploadFormContainer from '../containers/upload_form_container';
 import TextIconButton from './text_icon_button';
 import WarningContainer from '../containers/warning_container';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+import { length } from 'stringz';
 
 const messages = defineMessages({
   placeholder: { id: 'compose_form.placeholder', defaultMessage: 'What is on your mind?' },
@@ -193,7 +194,7 @@ class ComposeForm extends ImmutablePureComponent {
 
           <div className='compose-form__publish'>
             <div className='character-counter__wrapper'><CharacterCounter max={500} text={text} /></div>
-            <div className='compose-form__publish-button-wrapper'><Button text={publishText} onClick={this.handleSubmit} disabled={disabled || this.props.is_uploading || text.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_').length > 500 || (text.length !==0 && text.trim().length === 0)} block /></div>
+            <div className='compose-form__publish-button-wrapper'><Button text={publishText} onClick={this.handleSubmit} disabled={disabled || this.props.is_uploading || length(text) > 500 || (text.length !==0 && text.trim().length === 0)} block /></div>
           </div>
         </div>
       </div>

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -5,6 +5,6 @@ class StatusLengthValidator < ActiveModel::Validator
 
   def validate(status)
     return unless status.local? && !status.reblog?
-    status.errors.add(:text, I18n.t('statuses.over_character_limit', max: MAX_CHARS)) if [status.text, status.spoiler_text].join.length > MAX_CHARS
+    status.errors.add(:text, I18n.t('statuses.over_character_limit', max: MAX_CHARS)) if [status.text, status.spoiler_text].join.mb_chars.grapheme_length > MAX_CHARS
   end
 end


### PR DESCRIPTION
Right now the Mastodon frontend counts characters by grapheme using the package `stringz`. However, the Toot button and Ruby backend count characters by Unicode scalar value. This patch brings the latter two in line (more-or-less) with the provided character count, so that 👌🏽, for example, is considered only one character, despite containing multiple scalar values.

This has been deployed on dev.glitch.social and you can see the result here: https://dev.glitch.social/@kibi/21318

---

**Caveats:** This patch uses the built in Ruby Multibyte `grapheme_length` for the backend grapheme count, which does **not** (afaict) condense Emoji ZWJ sequences (for example: 🏳️‍🌈). The `stringz` package, on the other hand, **does**. So the counts will still differ in this respect, and if someone types 500 pride flags into a toot, they will get an error back saying the toot is too long.

Possible solutions for this are:

1. Find a Ruby package to count Emoji ZWJ sequences as a single character
2. Find a different Javascript package than `stringz` which doesn't
3. Abandon `stringz` altogether and go back to just counting Unicode scalars.