### PR TITLE
Unobserve status on unmount

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -88,6 +88,16 @@ class Status extends ImmutablePureComponent {
     );
   }
 
+  componentWillUnmount () {
+    if (!this.props.intersectionObserverWrapper) {
+      // TODO: enable IntersectionObserver optimization for notification statuses.
+      // These are managed in notifications/index.js rather than status_list.js
+      return;
+    }
+
+    this.props.intersectionObserverWrapper.unobserve(this.props.id, this.node);
+  }
+
   handleIntersection = (entry) => {
     // Edge 15 doesn't support isIntersecting, but we can infer it
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12156111/

--- a/app/javascript/mastodon/features/ui/util/intersection_observer_wrapper.js
+++ b/app/javascript/mastodon/features/ui/util/intersection_observer_wrapper.js
@@ -37,6 +37,13 @@ class IntersectionObserverWrapper {
     }
   }
 
+  unobserve (id, node) {
+    if (this.observer) {
+      delete this.callbacks[id];
+      this.observer.unobserve(node);
+    }
+  }
+
   disconnect () {
     if (this.observer) {
       this.observer.disconnect();


### PR DESCRIPTION
Fixes the following warning

```
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Status component.
```

![ezgif-3-ab639baddd](https://user-images.githubusercontent.com/1688137/27277935-ec815ab6-551a-11e7-9f51-fbce246ea477.gif)