### PR TITLE
Do not call setState from unmounted component

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -86,6 +86,8 @@ class Status extends ImmutablePureComponent {
       this.node,
       this.handleIntersection
     );
+
+    this.componentMounted = true;
   }
 
   componentWillUnmount () {
@@ -96,6 +98,8 @@ class Status extends ImmutablePureComponent {
     }
 
     this.props.intersectionObserverWrapper.unobserve(this.props.id, this.node);
+
+    this.componentMounted = false;
   }
 
   handleIntersection = (entry) => {
@@ -116,6 +120,10 @@ class Status extends ImmutablePureComponent {
   }
 
   hideIfNotIntersecting = () => {
+    if (!this.componentMounted) {
+      return;
+    }
+
     // When the browser gets a chance, test if we're still not intersecting,
     // and if so, set our isHidden to true to trigger an unrender. The point of
     // this is to save DOM nodes and avoid using up too much memory.


### PR DESCRIPTION
Stop an executing task by `scheduleIdleTask` if the component already unmounted.

Fixes the following warning.

```
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Status component.
```