### PR TITLE
Clicking on the CW text should expand the status

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -81,7 +81,7 @@ class StatusContent extends React.PureComponent {
     const [ startX, startY ] = this.startXY;
     const [ deltaX, deltaY ] = [Math.abs(e.clientX - startX), Math.abs(e.clientY - startY)];
 
-    if (e.target.localName === 'button' || e.target.localName === 'span' || e.target.localName === 'a' || (e.target.parentNode && e.target.parentNode.localName === 'a')) {
+    if (e.target.localName === 'button' || e.target.localName === 'a' || (e.target.parentNode && (e.target.parentNode.localName === 'button' || e.target.parentNode.localName === 'a'))) {
       return;
     }
 


### PR DESCRIPTION
fixes #3826 

Note that this doesn't covers  `button > span > span`, `a > span > span` and other case. Mastodon won't generate these structure, but we don't know for other OStatus servers. So I think below code may be needed:

```
let element = e.target;
do {
  if (element.localName === 'button' || element.localName === 'a') {
    return;
  }
  element = e.parentNode;
} while(element !== undefined && element !== this.node);
```

but it doesn't look efficient. So I only did quick fix on this patch.