### PR TITLE
Set cursor:pointer only when necessary

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -136,7 +136,7 @@ class StatusContent extends React.PureComponent {
       }
 
       return (
-        <div className='status__content' ref={this.setRef} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp}>
+        <div className='status__content status__content--with_action' ref={this.setRef} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp}>
           <p style={{ marginBottom: hidden && status.get('mentions').isEmpty() ? '0px' : null }}>
             <span dangerouslySetInnerHTML={spoilerContent} />
             {' '}
@@ -152,7 +152,7 @@ class StatusContent extends React.PureComponent {
       return (
         <div
           ref={this.setRef}
-          className='status__content'
+          className='status__content status__content--with-action'
           style={directionStyle}
           onMouseDown={this.handleMouseDown}
           onMouseUp={this.handleMouseUp}
@@ -163,7 +163,7 @@ class StatusContent extends React.PureComponent {
       return (
         <div
           ref={this.setRef}
-          className='status__content status__content--no-action'
+          className='status__content'
           style={directionStyle}
           dangerouslySetInnerHTML={content}
         />

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -436,12 +436,8 @@
   margin-right: 5px;
 }
 
-.status__content {
+.status__content--with-action {
   cursor: pointer;
-}
-
-.status__content--no-action {
-  cursor: default;
 }
 
 .status__content,


### PR DESCRIPTION
fixes #3437 

This fixes `.status__content` being styled with `cursor: pointer` even if it's in detailed view and public view.

Before: `.status__content` has `cursor: pointer` by default, disabled by `.status__content--no-action`
After: Set `cursor: pointer` by `.status__content--with-action`, only when necessary