### PR TITLE
Update fabricator for MediaAttachment to attach a file according to type

### DIFF
--- a/spec/fabricators/media_attachment_fabricator.rb
+++ b/spec/fabricators/media_attachment_fabricator.rb
@@ -1,4 +1,16 @@
 Fabricator(:media_attachment) do
   account
-  file { [attachment_fixture(['attachment.gif', 'attachment.jpg', 'attachment.webm'].sample), nil].sample }
+  file do |attrs|
+    [
+      case attrs[:type]
+      when :gifv
+        attachment_fixture ['attachment.gif', 'attachment.webm'].sample
+      when :image
+        attachment_fixture 'attachment.jpg'
+      when nil
+        attachment_fixture ['attachment.gif', 'attachment.jpg', 'attachment.webm'].sample
+      end,
+      nil
+    ].sample
+  end
 end


### PR DESCRIPTION
This fixes a random spec failures since commit d55f207274648369cba30ff001aa3e354fa30dca.