### PR TITLE
Don't attach IntersectionObserver for wrapped statuses

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -154,7 +154,10 @@ class Status extends ImmutablePureComponent {
   render () {
     let media = null;
     let statusAvatar;
-    const { status, account, ...other } = this.props;
+
+    // Exclude intersectionObserverWrapper from `other` variable
+    // because intersection is managed in here.
+    const { status, account, intersectionObserverWrapper, ...other } = this.props;
     const { isExpanded, isIntersecting, isHidden } = this.state;
 
     if (status === null) {


### PR DESCRIPTION
This fixes a bug that sometimes boosted statuses being hidden on scrolling (since #3851).

Previously, we've attached IntersectionObserver twice for boosted statuses: wrapper Status and wrapped Status. This will call intersection handler twice, so this may results race condition...probably.

cc @nolanlawson