### PR TITLE
Fix RemoteFollow behavior

### DIFF
--- a/app/models/remote_follow.rb
+++ b/app/models/remote_follow.rb
@@ -5,11 +5,15 @@ class RemoteFollow
 
   attr_accessor :acct, :addressable_template
 
+  validates :acct, presence: true
+
   def initialize(attrs = {})
     @acct = attrs[:acct].gsub(/\A@/, '').strip unless attrs[:acct].nil?
   end
 
   def valid?
+    return false unless super
+
     populate_template
     errors.empty?
   end
@@ -39,7 +43,6 @@ class RemoteFollow
   def acct_resource
     @_acct_resource ||= Goldfinger.finger("acct:#{acct}")
   rescue Goldfinger::Error
-    missing_resource_error
     nil
   end
 


### PR DESCRIPTION
This reverts UI behavior changes on #2694.

* Invalid acct is an error. not "2 errors".
* Empty input should be different error from invalid acct