### PR TITLE
Fix conversations (fixes #3869)

### DIFF
--- a/app/services/process_feed_service.rb
+++ b/app/services/process_feed_service.rb
@@ -174,7 +174,7 @@ class ProcessFeedService < BaseService
         return Conversation.find_by(id: local_id)
       end
 
-      Conversation.find_by(uri: uri)
+      Conversation.find_by(uri: uri) || Conversation.create!(uri: uri)
     end
 
     def find_status(uri)

--- a/app/services/process_feed_service.rb
+++ b/app/services/process_feed_service.rb
@@ -66,8 +66,6 @@ class ProcessFeedService < BaseService
           status.reblog = original_status.reblog? ? original_status.reblog : original_status
         end
 
-        status.thread = find_status(thread(@xml).first) if thread?(@xml)
-
         status.save!
       end
 
@@ -155,7 +153,8 @@ class ProcessFeedService < BaseService
         reply: thread?(entry),
         language: content_language(entry),
         visibility: visibility_scope(entry),
-        conversation: find_or_create_conversation(entry)
+        conversation: find_or_create_conversation(entry),
+        thread: thread?(entry) ? find_status(thread(entry).first) : nil
       )
 
       mentions_from_xml(status, entry)


### PR DESCRIPTION
Fix conversations handling by actually creating a `Conversation` object corresponding to unknown remote conversation URIs, and try to keep the same conversation across replies in case of missing `ostatus:conversation` URI. The second part is actually a bit fragile as it will fail for asynchronously fetched parent toots.