### PR TITLE
Revert "Don't attach IntersectionObserver for wrapped statuses"

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -154,10 +154,7 @@ class Status extends ImmutablePureComponent {
   render () {
     let media = null;
     let statusAvatar;
-
-    // Exclude intersectionObserverWrapper from `other` variable
-    // because intersection is managed in here.
-    const { status, account, intersectionObserverWrapper, ...other } = this.props;
+    const { status, account, ...other } = this.props;
     const { isExpanded, isIntersecting, isHidden } = this.state;
 
     if (status === null) {


### PR DESCRIPTION
Reverts tootsuite/mastodon#3863

So we can revert #3851