### PR TITLE
Don't attach IntersectionObserver for wrapped statuses (again)

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -154,7 +154,10 @@ class Status extends ImmutablePureComponent {
   render () {
     let media = null;
     let statusAvatar;
-    const { status, account, ...other } = this.props;
+
+    // Exclude intersectionObserverWrapper from `other` variable
+    // because intersection is managed in here.
+    const { status, account, intersectionObserverWrapper, ...other } = this.props;
     const { isExpanded, isIntersecting, isHidden } = this.state;
 
     if (status === null) {


### PR DESCRIPTION
(This patch has been merged as bugfix at #3863 and reverted, but still valuable as improvement)

Previously, we've attached IntersectionObserver twice for boosted statuses: wrapper Status and wrapped Status. but wrapped Status don't need to manage intersection and visibility by itself, because it's a part of wrapper Status.