### PR TITLE
Fix regression from #3842

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -131,15 +131,7 @@ class Status < ApplicationRecord
     end
 
     def as_home_timeline(account)
-      # 'references' is a workaround for the following issue:
-      # Inconsistent results with #or in ActiveRecord::Relation with respect to documentation Issue #24055 rails/rails
-      # https://github.com/rails/rails/issues/24055
-      references(:mentions)
-        .where.not(visibility: :direct)
-        .or(where(mentions: { account: account }))
-        .where(follows: { account_id: account })
-        .or(references(:mentions, :follows).where(account: account))
-        .left_outer_joins(account: :followers).left_outer_joins(:mentions).group(:id)
+      where(account: [account] + account.following).where(visibility: [:public, :unlisted, :private])
     end
 
     def as_public_timeline(account = nil, local_only = false)

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -201,17 +201,17 @@ RSpec.describe Status, type: :model do
       expect(@results).to include(@self_status)
     end
 
-    it 'includes direct statuses from self' do
-      expect(@results).to include(@self_direct_status)
+    it 'does not include direct statuses from self' do
+      expect(@results).to_not include(@self_direct_status)
     end
 
     it 'includes statuses from followed' do
       expect(@results).to include(@followed_status)
     end
 
-    it 'includes direct statuses mentioning recipient from followed' do
+    it 'does not include direct statuses mentioning recipient from followed' do
       Fabricate(:mention, account: account, status: @followed_direct_status)
-      expect(@results).to include(@followed_direct_status)
+      expect(@results).to_not include(@followed_direct_status)
     end
 
     it 'does not include direct statuses not mentioning recipient from followed' do


### PR DESCRIPTION
Simplify the query by omitting all direct statuses. Private statuses
are allowed because they are from accounts we are following (so
by definition)

Resolves #3887 (alternative)