### PR TITLE
Add index statuses on account_id and id

### DIFF
--- a/db/migrate/20170610000000_add_statuses_index_on_account_id_id.rb
+++ b/db/migrate/20170610000000_add_statuses_index_on_account_id_id.rb
@@ -1,0 +1,13 @@
+class AddStatusesIndexOnAccountIdId < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    # Statuses queried by account_id are often sorted by id. Querying statuses
+    # of an account to show them in his status page is one of the most
+    # significant examples.
+    # Add this index to improve the performance in such cases.
+    add_index 'statuses', ['account_id', 'id'], algorithm: :concurrently, name: 'index_statuses_on_account_id_id'
+
+    remove_index 'statuses', algorithm: :concurrently, column: 'account_id', name: 'index_statuses_on_account_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170609145826) do
+ActiveRecord::Schema.define(version: 20170610000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -279,7 +279,7 @@ ActiveRecord::Schema.define(version: 20170609145826) do
     t.integer "reblogs_count", default: 0, null: false
     t.string "language"
     t.bigint "conversation_id"
-    t.index ["account_id"], name: "index_statuses_on_account_id"
+    t.index ["account_id", "id"], name: "index_statuses_on_account_id_id"
     t.index ["conversation_id"], name: "index_statuses_on_conversation_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["reblog_of_id"], name: "index_statuses_on_reblog_of_id"


### PR DESCRIPTION
A comment in this change says:
> Statuses queried by `account_id` are often sorted by `id`. Querying statuses of an account to show them in his status page is one of the most significant examples.
> Add this index to improve the performance in such cases.

The following query is similar to those queried when responding with pages of accounts.

Before:
```
> EXPLAIN ANALYZE SELECT  "statuses".* FROM "statuses" WHERE "statuses"."account_id" = 1 AND "statuses"."visibility" IN (0, 1) ORDER BY "statuses"."id" DESC LIMIT 100;
                                                                   QUERY PLAN                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.29..441.07 rows=100 width=432) (actual time=0.043..3.608 rows=100 loops=1)
   ->  Index Scan Backward using statuses_pkey on statuses  (cost=0.29..5179.41 rows=1175 width=432) (actual time=0.041..3.582 rows=100 loops=1)
         Filter: ((visibility = ANY ('{0,1}'::integer[])) AND (account_id = 1))
         Rows Removed by Filter: 4407
 Planning time: 1.007 ms
 Execution time: 3.674 ms
(6 rows)
```

After:
```
> EXPLAIN ANALYZE SELECT  "statuses".* FROM "statuses" WHERE "statuses"."account_id" = 1 AND "statuses"."visibility" IN (0, 1) ORDER BY "statuses"."id" DESC LIMIT 100;
                                                                            QUERY PLAN                                                                
             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.41..314.84 rows=100 width=432) (actual time=0.375..0.695 rows=100 loops=1)
   ->  Index Scan Backward using index_statuses_on_account_id_id on statuses  (cost=0.41..3694.90 rows=1175 width=432) (actual time=0.373..0.669 rows=100 loops=1)
         Index Cond: (account_id = 1)
         Filter: (visibility = ANY ('{0,1}'::integer[]))
         Rows Removed by Filter: 2
 Planning time: 0.361 ms
 Execution time: 0.791 ms
(7 rows)
```

Look at _Filter_ and _Rows Removed by Filter_. The execution time may not be accurate because I have not vacummed the database and not rebooted the server between those two tests.