### PR TITLE
Use the stable RVM installer

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,7 @@ sudo apt-get install \
 # Install rvm
 read RUBY_VERSION < .ruby-version
 gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-curl -sSL https://get.rvm.io | bash -s stable --ruby=$RUBY_VERSION
+curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer | bash -s stable --ruby=$RUBY_VERSION
 source /home/vagrant/.rvm/scripts/rvm
 
 # Install Ruby


### PR DESCRIPTION
as mentioned by @ElvenSpellmaker here: https://github.com/rvm/rvm/issues/4068

Adds a workaround for the issue mentioned by @abcang here: https://github.com/tootsuite/mastodon/pull/3897#issuecomment-310436668 and makes sure that we're using the stable installer to install the stable version.