### PR TITLE
Experimenting with Preact

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -168,7 +168,7 @@ class MediaGallery extends React.PureComponent {
       );
     } else {
       const size = media.take(4).size;
-      children = media.take(4).map((attachment, i) => <Item key={attachment.get('id')} onClick={this.handleClick} attachment={attachment} autoPlayGif={this.props.autoPlayGif} index={i} size={size} />);
+      children = media.take(4).map((attachment, i) => <Item key={attachment.get('id')} onClick={this.handleClick} attachment={attachment} autoPlayGif={this.props.autoPlayGif} index={i} size={size} />).toArray();
     }
 
     return (

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -81,6 +81,9 @@ class Status extends ImmutablePureComponent {
       // These are managed in notifications/index.js rather than status_list.js
       return;
     }
+
+    this.saveHeight();
+
     this.props.intersectionObserverWrapper.observe(
       this.props.id,
       this.node,
@@ -131,7 +134,6 @@ class Status extends ImmutablePureComponent {
 
   handleRef = (node) => {
     this.node = node;
-    this.saveHeight();
   }
 
   handleClick = () => {

--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -113,10 +113,9 @@ class StatusList extends ImmutablePureComponent {
         <div className='scrollable' ref={this.setRef}>
           <div className='status-list'>
             {prepend}
-
             {statusIds.map((statusId) => {
               return <StatusContainer key={statusId} id={statusId} intersectionObserverWrapper={this.intersectionObserverWrapper} />;
-            })}
+            }).toArray()}
 
             {loadMore}
           </div>

--- a/app/javascript/mastodon/features/notifications/index.js
+++ b/app/javascript/mastodon/features/notifications/index.js
@@ -127,7 +127,7 @@ class Notifications extends React.PureComponent {
           {unread}
 
           <div>
-            {notifications.map(item => <NotificationContainer key={item.get('id')} notification={item} accountId={item.get('account')} />)}
+            {notifications.map(item => <NotificationContainer key={item.get('id')} notification={item} accountId={item.get('account')} />).toArray()}
             {loadMore}
           </div>
         </div>

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -68,6 +68,9 @@ module.exports = {
 
   resolve: {
     alias: {
+      'react': 'preact-compat',
+      'react-dom': 'preact-compat',
+      'create-react-class': 'preact-compat/lib/create-react-class',
       'mastodon-application-style': existsSync(customApplicationStyle) ?
                                     customApplicationStyle : originalApplicationStyle,
     },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "pg": "^6.2.4",
     "postcss-loader": "^2.0.5",
     "postcss-smart-import": "^0.7.4",
+    "preact": "^8.1.0",
+    "preact-compat": "^3.16.0",
     "precss": "^1.4.0",
     "prop-types": "^15.5.10",
     "punycode": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3392,6 +3392,12 @@ ignore@^3.2.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
+immutability-helper@^2.1.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.2.2.tgz#e7e9da728b3de2fad34a216f4157b326dbccc892"
+  dependencies:
+    invariant "^2.2.0"
+
 immutable@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
@@ -5391,6 +5397,30 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
+preact-compat@^3.16.0:
+  version "3.16.0"
+  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.16.0.tgz#cf2bc1b2f8fca14900d68094f9e10b8b329cc41e"
+  dependencies:
+    immutability-helper "^2.1.2"
+    preact-render-to-string "^3.6.0"
+    preact-transition-group "^1.1.0"
+    prop-types "^15.5.8"
+    standalone-react-addons-pure-render-mixin "^0.1.1"
+
+preact-render-to-string@^3.6.0:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.6.3.tgz#481d0d5bdac9192d3347557437d5cd00aa312043"
+  dependencies:
+    pretty-format "^3.5.1"
+
+preact-transition-group@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
+
+preact@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.1.0.tgz#f035b808eebb74e46d56246b02ca0f190b6d6574"
+
 precond@0.2:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/precond/-/precond-0.2.3.tgz#aa9591bcaa24923f1e0f4849d240f47efc1075ac"
@@ -5427,6 +5457,10 @@ prepend-http@^1.0.0:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+pretty-format@^3.5.1:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
 
 private@^0.1.6, private@~0.1.5:
   version "0.1.7"
@@ -6526,6 +6560,10 @@ sshpk@^1.7.0:
     ecc-jsbn "~0.1.1"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+standalone-react-addons-pure-render-mixin@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz#3c7409f4c79c40de9ac72c616cf679a994f37551"
 
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"


### PR DESCRIPTION
I've opened this pull request to **discuss** the tradeoffs that we would get by switching to [Preact](https://preactjs.com/).

To my surprise, only minor changes were needed to make the codebase compatible (we are using `preact-compat`, but I still did not expect the transition to go so smoothly). These are:
 - When mapping over an Immutable list, we need to call `.toArray()` before we render the items
 - The `ref` callback is [not guaranteed to be called after the element is mounted](https://github.com/developit/preact/issues/477#issuecomment-269718643) - this seems to be the case for React as well, so we might be relying on undocumented behavior right now

The main advantage is that we reduce the size of `application.js` by 18% (from 672kB to 552 KB). React is no longer the biggest dependency (Immutable takes its place). If #3879 gets merged, `application.js` will be 387kb.

The only glitch I could find is that when toggling the Emoji picker, the styles of the textarea flash in a weird way for a second or so.

What do you think? If we manage to solve the issue(s), should we switch? Should we also investigate [Inferno](https://www.infernojs.org/)? Should we wait for React 16?