### PR TITLE
Apply babel to react-intl to remove prop-types

### DIFF
--- a/config/webpack/loaders/babel.js
+++ b/config/webpack/loaders/babel.js
@@ -1,6 +1,7 @@
 module.exports = {
   test: /\.js$/,
-  exclude: /node_modules/,
+  // include react-intl because transform-react-remove-prop-types needs to apply to it
+  exclude: /node_modules\/(?!react-intl)/,
   loader: 'babel-loader',
   options: {
     forceEnv: process.env.NODE_ENV || 'development',


### PR DESCRIPTION
The `prop-types` package isn't actually being excluded from our build because it's used by `react-intl`. This fixes that, by applying Babel to `react-intl`.

The size of `application.js` is reduced from 670196 bytes to 655841 bytes (14.4kB removed).