### PR TITLE
Fix a typo and give CW'd statuses the right cursor

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -135,7 +135,7 @@ export default class StatusContent extends React.PureComponent {
       }
 
       return (
-        <div className='status__content status__content--with_action' ref={this.setRef} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp}>
+        <div className='status__content status__content--with-action' ref={this.setRef} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp}>
           <p style={{ marginBottom: hidden && status.get('mentions').isEmpty() ? '0px' : null }}>
             <span dangerouslySetInnerHTML={spoilerContent} />
             {' '}


### PR DESCRIPTION
Currently, since 1.4.4 (more specifically, PR #3857), a small typo in a JS file has left CW'd statuses with the `default` cursor, even when not expanded. Fixing the typo fixes the issue. This PR fixes the typo.