### PR TITLE
Don't set ASSET_HOST on build:development

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "AGPL-3.0",
   "scripts": {
     "postversion": "git push --tags",
-    "build:development": "cross-env RAILS_ENV=development ASSET_HOST=http://0.0.0.0:8080 ./bin/webpack",
+    "build:development": "cross-env RAILS_ENV=development ./bin/webpack",
     "build:production": "cross-env RAILS_ENV=production ./bin/webpack",
     "manage:translations": "node ./config/webpack/translationRunner.js",
     "start": "rimraf ./tmp/streaming && babel ./streaming/index.js --out-dir ./tmp && node ./tmp/streaming/index.js",


### PR DESCRIPTION
Regression from #3729 

Setting ASSET_HOST to `http://0.0.0.0:8080` makes urls in manifest.json to be invalid, e.g. `http://0.0.0.0:8080/packs/application.js`. Anyway, we don't need set this on build:development because assets would be delivered from same origin in development (and w/o dev-server).