### PR TITLE
Fix react-intl/locale-data import issue on production build (regression from #3914)

### DIFF
--- a/config/webpack/loaders/babel.js
+++ b/config/webpack/loaders/babel.js
@@ -1,7 +1,10 @@
 module.exports = {
   test: /\.js$/,
   // include react-intl because transform-react-remove-prop-types needs to apply to it
-  exclude: /node_modules[\/\\](?!react-intl)/,
+  exclude: {
+    test: /node_modules/,
+    exclude: /react-intl[\/\\](?!locale-data)/,
+  },
   loader: 'babel-loader',
   options: {
     forceEnv: process.env.NODE_ENV || 'development',


### PR DESCRIPTION
Webpack seems to fail to import locale-data if those files has been proceed by babel (since #3914).

```
WARNING in ./tmp/packs/locale_ar.js
8:44-54 "export 'default' (imported as 'localeData') was not found in 'react-intl/locale-data/ar.js'

WARNING in ./tmp/packs/locale_bg.js
8:44-54 "export 'default' (imported as 'localeData') was not found in 'react-intl/locale-data/bg.js'

WARNING in ./tmp/packs/locale_ca.js
8:44-54 "export 'default' (imported as 'localeData') was not found in 'react-intl/locale-data/ca.js'

WARNING in ./tmp/packs/locale_de.js
8:44-54 "export 'default' (imported as 'localeData') was not found in 'react-intl/locale-data/de.js'

...
```

and this also breaks applying our translation.

Note that this won't be a problem on English locale, because react-intl includes it as default and works fine without manually added locale-data. Also this issue seems to only occurs on production build (`yarn run build:production`), but I'm not sure about reason.