### PR TITLE
WiP: Mark undelivered mentions

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -21,8 +21,8 @@ class Formatter
 
     return reformat(raw_content) unless status.local?
 
-    linkable_accounts = status.mentions.map(&:account)
-    linkable_accounts << status.account
+    linkable_accounts = status.mentions.map { |item| [item.account, item.delivered] }
+    linkable_accounts << [status.account, true]
 
     html = raw_content
     html = "RT @#{prepend_reblog} #{html}" if prepend_reblog
@@ -113,8 +113,8 @@ class Formatter
 
     return link_to_account(acct) unless linkable_accounts
 
-    account = linkable_accounts.find { |item| TagManager.instance.same_acct?(item.acct, acct) }
-    account ? mention_html(account) : "@#{acct}"
+    account = linkable_accounts.find { |(item, _)| TagManager.instance.same_acct?(item.acct, acct) }
+    account ? mention_html(account[0], account[1]) : "@#{acct}"
   end
 
   def link_to_account(acct)
@@ -144,7 +144,8 @@ class Formatter
     "<a href=\"#{tag_url(tag.downcase)}\" class=\"mention hashtag\" rel=\"tag\">#<span>#{tag}</span></a>"
   end
 
-  def mention_html(account)
-    "<span class=\"h-card\"><a href=\"#{TagManager.instance.url_for(account)}\" class=\"u-url mention\">@<span>#{account.username}</span></a></span>"
+  def mention_html(account, delivered = true)
+    delivered_class = delivered == false ? 'undelivered' : ''
+    "<span class=\"h-card\"><a href=\"#{TagManager.instance.url_for(account)}\" class=\"u-url mention #{delivered_class}\">@<span>#{account.username}</span></a></span>"
   end
 end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -8,6 +8,7 @@
 #  status_id  :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  delivered  :boolean
 #
 
 class Mention < ApplicationRecord
@@ -24,4 +25,9 @@ class Mention < ApplicationRecord
     to: :account,
     prefix: true
   )
+
+  def set_delivered(delivery_status)
+    self.delivered = delivery_status
+    save!
+  end
 end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -9,6 +9,7 @@ class NotifyService < BaseService
     return if recipient.user.nil? || blocked?
 
     create_notification
+    activity.set_delivered(true) if activity.respond_to? :set_delivered
     send_email if email_enabled?
   rescue ActiveRecord::RecordInvalid
     return

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -24,7 +24,7 @@ class ProcessMentionsService < BaseService
 
       next if mentioned_account.nil?
 
-      mentioned_account.mentions.where(status: status).first_or_create(status: status)
+      mentioned_account.mentions.where(status: status).first_or_create(status: status, delivered: false)
     end
 
     status.mentions.includes(:account).each do |mention|
@@ -33,7 +33,7 @@ class ProcessMentionsService < BaseService
       if mentioned_account.local?
         NotifyService.new.call(mentioned_account, mention)
       else
-        NotificationWorker.perform_async(stream_entry_to_xml(status.stream_entry), status.account_id, mentioned_account.id)
+        NotificationWorker.perform_async(stream_entry_to_xml(status.stream_entry), status.account_id, mentioned_account.id, mention.id)
       end
     end
   end

--- a/app/services/send_interaction_service.rb
+++ b/app/services/send_interaction_service.rb
@@ -5,7 +5,7 @@ class SendInteractionService < BaseService
   # @param [String] Entry XML
   # @param [Account] source_account
   # @param [Account] target_account
-  def call(xml, source_account, target_account)
+  def call(xml, source_account, target_account, mention_id = nil)
     @xml            = xml
     @source_account = source_account
     @target_account = target_account
@@ -15,6 +15,7 @@ class SendInteractionService < BaseService
     envelope = salmon.pack(@xml, @source_account.keypair)
     delivery = salmon.post(@target_account.salmon_url, envelope)
     raise "Delivery failed for #{target_account.salmon_url}: HTTP #{delivery.code}" unless delivery.code > 199 && delivery.code < 300
+    Mention.find(mention_id).set_delivered(true) unless mention_id.nil?
   end
 
   private

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -5,7 +5,7 @@ class NotificationWorker
 
   sidekiq_options queue: 'push', retry: 5
 
-  def perform(xml, source_account_id, target_account_id)
-    SendInteractionService.new.call(xml, Account.find(source_account_id), Account.find(target_account_id))
+  def perform(xml, source_account_id, target_account_id, mention_id = nil)
+    SendInteractionService.new.call(xml, Account.find(source_account_id), Account.find(target_account_id), mention_id)
   end
 end

--- a/db/migrate/20170625190613_add_delivered_to_mentions.rb
+++ b/db/migrate/20170625190613_add_delivered_to_mentions.rb
@@ -1,0 +1,5 @@
+class AddDeliveredToMentions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :mentions, :delivered, :boolean, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170625140443) do
+ActiveRecord::Schema.define(version: 20170625190613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,6 +153,7 @@ ActiveRecord::Schema.define(version: 20170625140443) do
     t.bigint "status_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "delivered"
     t.index ["account_id", "status_id"], name: "index_mentions_on_account_id_and_status_id", unique: true
     t.index ["status_id"], name: "index_mentions_on_status_id"
   end


### PR DESCRIPTION
This is a work-in-progress attempt to fix #3945.

It does correctly (I hope) mark outgoing mentions as undelivered by default, and mark them delivered whenever it can. It also outputs an “undelivered” class for those mentions' links in the formatted status HTML.

It lacks:
- Some CSS to actually have a visual indicator
- Maybe something else than CSS for accessibility
- Last but not least, some mechanism to refresh the mentions' status

EDIT: Also, I'm not too happy with all the mentions-specific stuff in more general notification code