### PR TITLE
fix remove unnecessary `TEST_DB_ *` variable from `.env`

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -18,10 +18,10 @@ development:
 test:
   <<: *default
   database: mastodon_test<%= ENV['TEST_ENV_NUMBER'] %>
-  username: <%= ENV['TEST_DB_USER'] %>
-  password: <%= ENV['TEST_DB_PASS'] %>
-  host: <%= ENV['TEST_DB_HOST'] %>
-  port: <%= ENV['TEST_DB_PORT'] %>
+  username: <%= ENV['DB_USER'] %>
+  password: <%= ENV['DB_PASS'] %>
+  host: <%= ENV['DB_HOST'] %>
+  port: <%= ENV['DB_PORT'] %>
 
 production:
   <<: *default


### PR DESCRIPTION
This pull request will fix https://github.com/tootsuite/mastodon/pull/3909#issuecomment-310912931

I think TEST_DB_* variables should not separate from DB_* variables, too.

The reason of TEST_DB_* variables is that my misunderstanding hte commnet bellow.

```
# Warning: The database defined as "test" will be erased and
# re-generated from your development database when you run "rake".
# Do not set this db to the same as development or production.
```
My misunderstanding Rails and English causes it.
Please fix it, sorry.

