### PR TITLE
Ignore DB_NAME for development env on streaming as well as rails side

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -80,7 +80,7 @@ const startWorker = (workerId) => {
     development: {
       user:     process.env.DB_USER || pg.defaults.user,
       password: process.env.DB_PASS || pg.defaults.password,
-      database: process.env.DB_NAME || 'mastodon_development',
+      database: 'mastodon_development',
       host:     process.env.DB_HOST || pg.defaults.host,
       port:     process.env.DB_PORT || pg.defaults.port,
       max:      10,


### PR DESCRIPTION
We don't use `DB_NAME` in database.yml when RAILS_ENV is development, so `streaming/index.js` should follow it, i.e. force `mastodon_development`.