### PR TITLE
Add .gitattributes file to avoid unwanted CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+*                             text=auto eol=lf
+*.eot                         -text
+*.gif                         -text
+*.gz                          -text
+*.ico                         -text
+*.jpg                         -text
+*.mp3                         -text
+*.ogg                         -text
+*.png                         -text
+*.ttf                         -text
+*.webm                        -text
+*.woff                        -text
+*.woff2                       -text
+spec/fixtures/requests/**     -text !eol


### PR DESCRIPTION
When Windows checks out files, it defaults to changing line endings to CRLF. If these files are then copied to a Linux system to be run, and the endings aren't changed at some point in that process, things break. This file forces git to use LF for all text files on all systems (except the request testing specfiles) to prevent issues everywhere.