### PR TITLE
Moving things around in the UI

### DIFF
--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -1,22 +1,23 @@
 import React from 'react';
 import ComposeFormContainer from './containers/compose_form_container';
 import NavigationContainer from './containers/navigation_container';
+import ColumnLink from '../ui/components/column_link';
+import ColumnSubheading from '../ui/components/column_subheading';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { mountCompose, unmountCompose } from '../../actions/compose';
 import Link from 'react-router-dom/Link';
-import { injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
 import SearchContainer from './containers/search_container';
 import Motion from 'react-motion/lib/Motion';
 import spring from 'react-motion/lib/spring';
 import SearchResultsContainer from './containers/search_results_container';
 
 const messages = defineMessages({
-  start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
-  public: { id: 'navigation_bar.public_timeline', defaultMessage: 'Federated timeline' },
-  community: { id: 'navigation_bar.community_timeline', defaultMessage: 'Local timeline' },
   preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
   logout: { id: 'navigation_bar.logout', defaultMessage: 'Logout' },
+  settings_subheading: { id: 'column_subheading.settings', defaultMessage: 'Settings' },
+  info: { id: 'navigation_bar.info', defaultMessage: 'Extended information' },
 });
 
 const mapStateToProps = state => ({
@@ -45,23 +46,8 @@ export default class Compose extends React.PureComponent {
   render () {
     const { multiColumn, showSearch, intl } = this.props;
 
-    let header = '';
-
-    if (multiColumn) {
-      header = (
-        <div className='drawer__header'>
-          <Link to='/getting-started' className='drawer__tab' title={intl.formatMessage(messages.start)}><i role='img' aria-label={intl.formatMessage(messages.start)} className='fa fa-fw fa-asterisk' /></Link>
-          <Link to='/timelines/public/local' className='drawer__tab' title={intl.formatMessage(messages.community)}><i role='img' aria-label={intl.formatMessage(messages.community)} className='fa fa-fw fa-users' /></Link>
-          <Link to='/timelines/public' className='drawer__tab' title={intl.formatMessage(messages.public)}><i role='img' aria-label={intl.formatMessage(messages.public)} className='fa fa-fw fa-globe' /></Link>
-          <a href='/settings/preferences' className='drawer__tab' title={intl.formatMessage(messages.preferences)}><i role='img' aria-label={intl.formatMessage(messages.preferences)} className='fa fa-fw fa-cog' /></a>
-          <a href='/auth/sign_out' className='drawer__tab' data-method='delete' title={intl.formatMessage(messages.logout)}><i role='img' aria-label={intl.formatMessage(messages.logout)} className='fa fa-fw fa-sign-out' /></a>
-        </div>
-      );
-    }
-
     return (
       <div className='drawer'>
-        {header}
 
         <SearchContainer />
 
@@ -69,6 +55,25 @@ export default class Compose extends React.PureComponent {
           <div className='drawer__inner'>
             <NavigationContainer />
             <ComposeFormContainer />
+            <ColumnSubheading text={intl.formatMessage(messages.settings_subheading)} />
+            <ColumnLink icon='book' text={intl.formatMessage(messages.info)} href='/about/more' />
+            <ColumnLink icon='cog' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />
+            <ColumnLink icon='sign-out' text={intl.formatMessage(messages.logout)} href='/auth/sign_out' method='delete' />
+
+            <div className='getting-started__footer scrollable optionally-scrollable'>
+              <div className='static-content getting-started'>
+                <p>
+                  <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.faq' defaultMessage='FAQ' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/User-guide.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.userguide' defaultMessage='User Guide' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.appsshort' defaultMessage='Apps' /></a>
+                </p>
+                <p>
+                  <FormattedMessage
+                    id='getting_started.open_source_notice'
+                    defaultMessage='Mastodon is open source software. You can contribute or report issues on GitHub at {github}.'
+                    values={{ github: <a href='https://github.com/tootsuite/mastodon' rel='noopener' target='_blank'>tootsuite/mastodon</a> }}
+                  />
+                </p>
+              </div>
+            </div>
           </div>
 
           <Motion defaultStyle={{ x: -100 }} style={{ x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }) }}>

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1384,6 +1384,9 @@
   &.darker {
     background: $ui-base-color;
   }
+  > .scrollable {
+    background: $ui-base-color;
+  }
 }
 
 .pseudo-drawer {


### PR DESCRIPTION
Hello,

First of all please note the code in the PR is more of a proof of concept than clean code ready to be included.
It was just easier for me to try and code what I had in mind to see if it behaves well.

I identified the following problems with the UI:
- Unused space in the first column below the compose form
- The buttons in the header of the first column act on the last one
- In these buttons some change page instead (settings, logout)
- To access some common features you need to go through the «getting started» page, like to access favorites, or notifications (if they are un-pinned, of course)

So what I did was the following:
- Move the header button par to the last column instead of the first one
- Make it behave like the tabs bar from mobile UI (mobile UI feels way better than desktop UI IMO)
- Remove from it links to getting started, settings, logout
- Move the bottom part of the getting started page below the compose form, to be able to access settings and logout, and have the nice art there at all times

Attached is a screenshot of the result
![mastodon_myui](https://user-images.githubusercontent.com/106382/27555452-0f572d76-5ab2-11e7-97e2-4462fb2532ce.png)

What do you think?
