### PR TITLE
Fix timeline jiggles/jitters

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -124,7 +124,7 @@ export default class Status extends ImmutablePureComponent {
 
   saveHeight = () => {
     if (this.node && this.node.children.length !== 0) {
-      this.height = this.node.clientHeight;
+      this.height = this.node.getBoundingClientRect().height;
     }
   }
 


### PR DESCRIPTION
Hopefully, the final nail in the coffin since this closes #3648 , #3776, #3407.

[About `clientHeight`](https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight):
>
> Note: This property will round the value to an integer. If you need a fractional value, use element.getBoundingClientRect().

This means that the height of the "rendered" toots and the height of the "unrendered" toots is not the same, so switching between them makes the scroll position jump.

![image](https://user-images.githubusercontent.com/2109702/27598997-860381d0-5b67-11e7-878e-de134118d002.png)

![image](https://user-images.githubusercontent.com/2109702/27599001-88e409ce-5b67-11e7-8794-465e9bda1172.png)

A bit concerned about the performance of `getBoundingClientRect`. At first glance, it does not seem to be an issue.