### PR TITLE
Do not fail to create access token if superapp was never created

### DIFF
--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -69,9 +69,7 @@ class SessionActivation < ApplicationRecord
   def assign_access_token
     superapp = Doorkeeper::Application.find_by(superapp: true)
 
-    return if superapp.nil?
-
-    self.access_token = Doorkeeper::AccessToken.create!(application_id: superapp.id,
+    self.access_token = Doorkeeper::AccessToken.create!(application_id: superapp&.id,
                                                         resource_owner_id: user_id,
                                                         scopes: 'read write follow',
                                                         expires_in: Doorkeeper.configuration.access_token_expires_in,


### PR DESCRIPTION
This is a really small fix.