### PR TITLE
#3649 Added option return note in plain text (enoded HTML) in verify_credentials API.

### DIFF
--- a/app/controllers/api/v1/accounts/credentials_controller.rb
+++ b/app/controllers/api/v1/accounts/credentials_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::Accounts::CredentialsController < Api::BaseController
 
   def show
     @account = current_account
+    @plain_text_note = query_params[:note_format] == 'plain'
     render 'api/v1/accounts/show'
   end
 
@@ -19,5 +20,9 @@ class Api::V1::Accounts::CredentialsController < Api::BaseController
 
   def account_params
     params.permit(:display_name, :note, :avatar, :header)
+  end
+
+  def query_params
+    params.permit(:note_format)
   end
 end

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -52,6 +52,11 @@ class Formatter
     html.html_safe # rubocop:disable Rails/OutputSafety
   end
 
+  def simplified_plain_text_format(account)
+    raise Mastodon::ValidationError, 'Local account needed to get note in plain text. Got remote account.' unless account.local?
+    encode(account.note)
+  end
+
   def sanitize(html, config)
     Sanitize.fragment(html, config)
   end

--- a/app/views/api/v1/accounts/show.rabl
+++ b/app/views/api/v1/accounts/show.rabl
@@ -2,7 +2,11 @@ object @account
 
 attributes :id, :username, :acct, :display_name, :locked, :created_at
 
-node(:note)            { |account| Formatter.instance.simplified_format(account) }
+node(:note) do |account|
+    @plain_text_note ?
+        Formatter.instance.simplified_plain_text_format(account) :
+        Formatter.instance.simplified_format(account)
+end
 node(:url)             { |account| TagManager.instance.url_for(account) }
 node(:avatar)          { |account| full_asset_url(account.avatar_original_url) }
 node(:avatar_static)   { |account| full_asset_url(account.avatar_static_url) }

--- a/spec/controllers/api/v1/accounts/credentials_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/credentials_controller_spec.rb
@@ -15,6 +15,26 @@ describe Api::V1::Accounts::CredentialsController do
       get :show
       expect(response).to have_http_status(:success)
     end
+    
+    context 'with note_format=plain' do
+      let(:params) { {note_format: 'plain'} }
+
+      it do
+        get :show, params: params
+        expect(response).to have_http_status(:success) 
+      end
+
+      context 'and remote account' do
+        before do
+          allow_any_instance_of(Account).to receive(:local?).and_return false
+        end
+
+        it do
+          get :show, params: params
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
   end
 
   describe 'PATCH #update' do


### PR DESCRIPTION
In `simplified_format` function (which is used to format HTML note) there is following condition at the beginning:

`return reformat(account.note) unless account.local?`

I have kept the same condition in new `simplified_plain_text_format` function too.

Issue link: https://github.com/tootsuite/mastodon/issues/3649