### PR TITLE
rescue HTTP::ConnectionError that occurs in FetchAtomService

### DIFF
--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -20,6 +20,10 @@ class FetchAtomService < BaseService
     process_html(fetch(url))
   rescue OpenSSL::SSL::SSLError => e
     Rails.logger.debug "SSL error: #{e}"
+    nil
+  rescue HTTP::ConnectionError => e
+    Rails.logger.debug "HTTP ConnectionError: #{e}"
+    nil
   end
 
   private


### PR DESCRIPTION
`HTTP::ConnectionError` occurs when name resolution fails with `http_client.head(url)`. So I fixed it to catch exceptions. Also, since the return value when an exception occurred was true which is the return value of `Rails.logger.debug`, it changed to return nil.