### PR TITLE
Delay unmount of some components

### DIFF
--- a/app/javascript/mastodon/components/column.js
+++ b/app/javascript/mastodon/components/column.js
@@ -41,7 +41,7 @@ export default class Column extends React.PureComponent {
     const visibleClass = visible ? '' : 'column--hidden';
 
     return (
-      <div role='region' className={`column ${visibleClass}`} ref={this.setRef} onWheel={this.handleWheel}>
+      <div role='region' aria-hidden={!visible} className={`column ${visibleClass}`} ref={this.setRef} onWheel={this.handleWheel}>
         {children}
       </div>
     );

--- a/app/javascript/mastodon/components/column.js
+++ b/app/javascript/mastodon/components/column.js
@@ -6,7 +6,12 @@ export default class Column extends React.PureComponent {
 
   static propTypes = {
     children: PropTypes.node,
+    visible: PropTypes.bool,
   };
+
+  static defaultProps = {
+    visible: true,
+  }
 
   scrollTop () {
     const scrollable = this.node.querySelector('.scrollable');
@@ -31,10 +36,12 @@ export default class Column extends React.PureComponent {
   }
 
   render () {
-    const { children } = this.props;
+    const { children, visible } = this.props;
+
+    const visibleClass = visible ? '' : 'column--hidden';
 
     return (
-      <div role='region' className='column' ref={this.setRef} onWheel={this.handleWheel}>
+      <div role='region' className={`column ${visibleClass}`} ref={this.setRef} onWheel={this.handleWheel}>
         {children}
       </div>
     );

--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -22,6 +22,7 @@ export default class StatusList extends ImmutablePureComponent {
     hasMore: PropTypes.bool,
     prepend: PropTypes.node,
     emptyMessage: PropTypes.node,
+    preventUpdate: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -51,6 +52,16 @@ export default class StatusList extends ImmutablePureComponent {
     this.attachIntersectionObserver();
   }
 
+  shouldComponentUpdate (nextProps, nextState) {
+    return !nextProps.preventUpdate && super.shouldComponentUpdate(nextProps, nextState);
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (this.props.preventUpdate !== nextProps.preventUpdate && nextProps.preventUpdate) {
+      this.detachIntersectionObserver();
+    }
+  }
+
   componentDidUpdate (prevProps) {
     // Reset the scroll position when a new toot comes in in order not to
     // jerk the scrollbar around if you're already scrolled down the page.
@@ -62,6 +73,10 @@ export default class StatusList extends ImmutablePureComponent {
       if (this.node.scrollTop !== newScrollTop) {
         this.node.scrollTop = newScrollTop;
       }
+    }
+
+    if (prevProps.preventUpdate !== this.props.preventUpdate && this.props.preventUpdate) {
+      this.attachIntersectionObserver();
     }
   }
 

--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -22,7 +22,7 @@ export default class StatusList extends ImmutablePureComponent {
     hasMore: PropTypes.bool,
     prepend: PropTypes.node,
     emptyMessage: PropTypes.node,
-    preventUpdate: PropTypes.bool,
+    visible: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -53,13 +53,12 @@ export default class StatusList extends ImmutablePureComponent {
   }
 
   shouldComponentUpdate (nextProps, nextState) {
-    return !nextProps.preventUpdate && super.shouldComponentUpdate(nextProps, nextState);
-  }
-
-  componentWillReceiveProps (nextProps) {
-    if (this.props.preventUpdate !== nextProps.preventUpdate && nextProps.preventUpdate) {
-      this.detachIntersectionObserver();
+    // Apply visible changes to child statuses
+    if (this.props.visible !== nextProps.visible) {
+      return true;
     }
+
+    return nextProps.visible && super.shouldComponentUpdate(nextProps, nextState);
   }
 
   componentDidUpdate (prevProps) {
@@ -73,10 +72,6 @@ export default class StatusList extends ImmutablePureComponent {
       if (this.node.scrollTop !== newScrollTop) {
         this.node.scrollTop = newScrollTop;
       }
-    }
-
-    if (prevProps.preventUpdate !== this.props.preventUpdate && this.props.preventUpdate) {
-      this.attachIntersectionObserver();
     }
   }
 
@@ -114,7 +109,7 @@ export default class StatusList extends ImmutablePureComponent {
   }
 
   render () {
-    const { statusIds, scrollKey, trackScroll, shouldUpdateScroll, isLoading, hasMore, prepend, emptyMessage } = this.props;
+    const { statusIds, scrollKey, trackScroll, shouldUpdateScroll, isLoading, hasMore, prepend, emptyMessage, visible } = this.props;
 
     let loadMore       = null;
     let scrollableArea = null;
@@ -130,7 +125,7 @@ export default class StatusList extends ImmutablePureComponent {
             {prepend}
 
             {statusIds.map((statusId) => {
-              return <StatusContainer key={statusId} id={statusId} intersectionObserverWrapper={this.intersectionObserverWrapper} />;
+              return <StatusContainer key={statusId} id={statusId} intersectionObserverWrapper={this.intersectionObserverWrapper} visible={visible} />;
             })}
 
             {loadMore}

--- a/app/javascript/mastodon/features/community_timeline/index.js
+++ b/app/javascript/mastodon/features/community_timeline/index.js
@@ -144,6 +144,7 @@ export default class CommunityTimeline extends React.PureComponent {
           timelineId='community'
           loadMore={this.handleLoadMore}
           emptyMessage={<FormattedMessage id='empty_column.community' defaultMessage='The local timeline is empty. Write something publicly to get the ball rolling!' />}
+          preventUpdate={!visible}
         />
       </Column>
     );

--- a/app/javascript/mastodon/features/community_timeline/index.js
+++ b/app/javascript/mastodon/features/community_timeline/index.js
@@ -144,7 +144,7 @@ export default class CommunityTimeline extends React.PureComponent {
           timelineId='community'
           loadMore={this.handleLoadMore}
           emptyMessage={<FormattedMessage id='empty_column.community' defaultMessage='The local timeline is empty. Write something publicly to get the ball rolling!' />}
-          preventUpdate={!visible}
+          visible={visible}
         />
       </Column>
     );

--- a/app/javascript/mastodon/features/community_timeline/index.js
+++ b/app/javascript/mastodon/features/community_timeline/index.js
@@ -39,7 +39,12 @@ export default class CommunityTimeline extends React.PureComponent {
     accessToken: PropTypes.string.isRequired,
     hasUnread: PropTypes.bool,
     multiColumn: PropTypes.bool,
+    visible: PropTypes.bool,
   };
+
+  static defaultProps = {
+    visible: true,
+  }
 
   handlePin = () => {
     const { columnId, dispatch } = this.props;
@@ -113,11 +118,11 @@ export default class CommunityTimeline extends React.PureComponent {
   }
 
   render () {
-    const { intl, hasUnread, columnId, multiColumn } = this.props;
+    const { intl, hasUnread, columnId, multiColumn, visible } = this.props;
     const pinned = !!columnId;
 
     return (
-      <Column ref={this.setRef}>
+      <Column ref={this.setRef} visible={visible}>
         <ColumnHeader
           icon='users'
           active={hasUnread}

--- a/app/javascript/mastodon/features/community_timeline/index.js
+++ b/app/javascript/mastodon/features/community_timeline/index.js
@@ -40,6 +40,7 @@ export default class CommunityTimeline extends React.PureComponent {
     hasUnread: PropTypes.bool,
     multiColumn: PropTypes.bool,
     visible: PropTypes.bool,
+    shouldUpdateScroll: PropTypes.func,
   };
 
   static defaultProps = {
@@ -118,7 +119,7 @@ export default class CommunityTimeline extends React.PureComponent {
   }
 
   render () {
-    const { intl, hasUnread, columnId, multiColumn, visible } = this.props;
+    const { intl, hasUnread, columnId, multiColumn, visible, shouldUpdateScroll } = this.props;
     const pinned = !!columnId;
 
     return (
@@ -138,6 +139,7 @@ export default class CommunityTimeline extends React.PureComponent {
 
         <StatusListContainer
           trackScroll={!pinned}
+          shouldUpdateScroll={shouldUpdateScroll}
           scrollKey={`community_timeline-${columnId}`}
           timelineId='community'
           loadMore={this.handleLoadMore}

--- a/app/javascript/mastodon/features/home_timeline/index.js
+++ b/app/javascript/mastodon/features/home_timeline/index.js
@@ -30,7 +30,12 @@ export default class HomeTimeline extends React.PureComponent {
     hasFollows: PropTypes.bool,
     columnId: PropTypes.string,
     multiColumn: PropTypes.bool,
+    visible: PropTypes.bool,
   };
+
+  static defaultProps = {
+    visible: true,
+  }
 
   handlePin = () => {
     const { columnId, dispatch } = this.props;
@@ -60,7 +65,7 @@ export default class HomeTimeline extends React.PureComponent {
   }
 
   render () {
-    const { intl, hasUnread, hasFollows, columnId, multiColumn } = this.props;
+    const { intl, hasUnread, hasFollows, columnId, multiColumn, visible } = this.props;
     const pinned = !!columnId;
 
     let emptyMessage;
@@ -72,7 +77,7 @@ export default class HomeTimeline extends React.PureComponent {
     }
 
     return (
-      <Column ref={this.setRef}>
+      <Column ref={this.setRef} visible={visible}>
         <ColumnHeader
           icon='home'
           active={hasUnread}

--- a/app/javascript/mastodon/features/home_timeline/index.js
+++ b/app/javascript/mastodon/features/home_timeline/index.js
@@ -99,7 +99,7 @@ export default class HomeTimeline extends React.PureComponent {
           loadMore={this.handleLoadMore}
           timelineId='home'
           emptyMessage={emptyMessage}
-          preventUpdate={!visible}
+          visible={visible}
         />
       </Column>
     );

--- a/app/javascript/mastodon/features/home_timeline/index.js
+++ b/app/javascript/mastodon/features/home_timeline/index.js
@@ -31,6 +31,7 @@ export default class HomeTimeline extends React.PureComponent {
     columnId: PropTypes.string,
     multiColumn: PropTypes.bool,
     visible: PropTypes.bool,
+    shouldUpdateScroll: PropTypes.func,
   };
 
   static defaultProps = {
@@ -65,7 +66,7 @@ export default class HomeTimeline extends React.PureComponent {
   }
 
   render () {
-    const { intl, hasUnread, hasFollows, columnId, multiColumn, visible } = this.props;
+    const { intl, hasUnread, hasFollows, columnId, multiColumn, visible, shouldUpdateScroll } = this.props;
     const pinned = !!columnId;
 
     let emptyMessage;
@@ -93,6 +94,7 @@ export default class HomeTimeline extends React.PureComponent {
 
         <StatusListContainer
           trackScroll={!pinned}
+          shouldUpdateScroll={shouldUpdateScroll}
           scrollKey={`home_timeline-${columnId}`}
           loadMore={this.handleLoadMore}
           timelineId='home'

--- a/app/javascript/mastodon/features/home_timeline/index.js
+++ b/app/javascript/mastodon/features/home_timeline/index.js
@@ -99,6 +99,7 @@ export default class HomeTimeline extends React.PureComponent {
           loadMore={this.handleLoadMore}
           timelineId='home'
           emptyMessage={emptyMessage}
+          preventUpdate={!visible}
         />
       </Column>
     );

--- a/app/javascript/mastodon/features/public_timeline/index.js
+++ b/app/javascript/mastodon/features/public_timeline/index.js
@@ -39,7 +39,12 @@ export default class PublicTimeline extends React.PureComponent {
     streamingAPIBaseURL: PropTypes.string.isRequired,
     accessToken: PropTypes.string.isRequired,
     hasUnread: PropTypes.bool,
+    visible: PropTypes.bool,
   };
+
+  static defaultProps = {
+    visible: true,
+  }
 
   handlePin = () => {
     const { columnId, dispatch } = this.props;
@@ -113,11 +118,11 @@ export default class PublicTimeline extends React.PureComponent {
   }
 
   render () {
-    const { intl, columnId, hasUnread, multiColumn } = this.props;
+    const { intl, columnId, hasUnread, multiColumn, visible } = this.props;
     const pinned = !!columnId;
 
     return (
-      <Column ref={this.setRef}>
+      <Column ref={this.setRef} visible={visible}>
         <ColumnHeader
           icon='globe'
           active={hasUnread}

--- a/app/javascript/mastodon/features/public_timeline/index.js
+++ b/app/javascript/mastodon/features/public_timeline/index.js
@@ -144,7 +144,7 @@ export default class PublicTimeline extends React.PureComponent {
           shouldUpdateScroll={shouldUpdateScroll}
           scrollKey={`public_timeline-${columnId}`}
           emptyMessage={<FormattedMessage id='empty_column.public' defaultMessage='There is nothing here! Write something publicly, or manually follow users from other instances to fill it up' />}
-          preventUpdate={!visible}
+          visible={visible}
         />
       </Column>
     );

--- a/app/javascript/mastodon/features/public_timeline/index.js
+++ b/app/javascript/mastodon/features/public_timeline/index.js
@@ -144,6 +144,7 @@ export default class PublicTimeline extends React.PureComponent {
           shouldUpdateScroll={shouldUpdateScroll}
           scrollKey={`public_timeline-${columnId}`}
           emptyMessage={<FormattedMessage id='empty_column.public' defaultMessage='There is nothing here! Write something publicly, or manually follow users from other instances to fill it up' />}
+          preventUpdate={!visible}
         />
       </Column>
     );

--- a/app/javascript/mastodon/features/public_timeline/index.js
+++ b/app/javascript/mastodon/features/public_timeline/index.js
@@ -40,6 +40,7 @@ export default class PublicTimeline extends React.PureComponent {
     accessToken: PropTypes.string.isRequired,
     hasUnread: PropTypes.bool,
     visible: PropTypes.bool,
+    shouldUpdateScroll: PropTypes.func,
   };
 
   static defaultProps = {
@@ -118,7 +119,7 @@ export default class PublicTimeline extends React.PureComponent {
   }
 
   render () {
-    const { intl, columnId, hasUnread, multiColumn, visible } = this.props;
+    const { intl, columnId, hasUnread, multiColumn, visible, shouldUpdateScroll } = this.props;
     const pinned = !!columnId;
 
     return (
@@ -140,6 +141,7 @@ export default class PublicTimeline extends React.PureComponent {
           timelineId='public'
           loadMore={this.handleLoadMore}
           trackScroll={!pinned}
+          shouldUpdateScroll={shouldUpdateScroll}
           scrollKey={`public_timeline-${columnId}`}
           emptyMessage={<FormattedMessage id='empty_column.public' defaultMessage='There is nothing here! Write something publicly, or manually follow users from other instances to fill it up' />}
         />

--- a/app/javascript/mastodon/features/ui/components/cached_column.js
+++ b/app/javascript/mastodon/features/ui/components/cached_column.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class CachedColumn extends React.Component {
+
+  static propTypes = {
+    component: PropTypes.func.isRequired,
+    children: PropTypes.node,
+    visible: PropTypes.bool,
+  }
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      mounting: props.visible,
+    };
+  }
+
+  updateMountingState = () => {
+    this.setState((prevState, props) => ({
+      mounting: props.visible,
+    }));
+  }
+
+  setTimer () {
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = setTimeout(this.updateMountingState, 5 * 60 * 1000);
+  }
+
+  clearTimer () {
+    if (this.state.timer) {
+      clearTimeout(this.state.timer);
+      this.timer = null;
+    }
+  }
+
+  componentWillUnmount () {
+    this.clearTimer();
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (this.props.visible !== nextProps.visible) {
+      if (nextProps.visible) {
+        this.clearTimer();
+        this.updateMountingState();
+      } else {
+        this.setTimer();
+      }
+    }
+  }
+
+  render () {
+    const { component: Component, children, visible, ...other } = this.props;
+    const { mounting } = this.state;
+
+    if (visible || mounting) {
+      return <Component visible={visible} {...other}>{children}</Component>;
+    } else {
+      return null;
+    }
+  }
+
+}

--- a/app/javascript/mastodon/features/ui/components/cached_column.js
+++ b/app/javascript/mastodon/features/ui/components/cached_column.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+const preventScrollOnPush = (previous, { history }) => (history && history.action === 'PUSH') ? false : true;
+
 export default class CachedColumn extends React.Component {
 
   static propTypes = {
@@ -54,7 +56,7 @@ export default class CachedColumn extends React.Component {
     const { mounting } = this.state;
 
     if (visible || mounting) {
-      return <Component visible={visible} {...other}>{children}</Component>;
+      return <Component visible={visible} shouldUpdateScroll={preventScrollOnPush} {...other}>{children}</Component>;
     } else {
       return null;
     }

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1266,6 +1266,10 @@
   }
 }
 
+.column--hidden {
+  display: none;
+}
+
 .ui {
   flex: 0 0 auto;
   display: flex;


### PR DESCRIPTION
This brings following benefits:

* Column switching would be bit smoothly. Swipe gesture works well with this.
* Preserve scroll position even if switch column by menu or swipe, not back button.
* In private mode on Safari, react-router-scroll won't work due to unavailability of sessionStorage. This implementation works.

Similar patch (#2271) has been implemented at 1.3.x, but reverted due to the performance and style issues. So I've introduced some improvements.

* Prevent update of status list while the column is hidden.
* No additional container element. This will reduces style regression.
* After some time (currently 5min.), hidden component will be unmounted.

Concerns:

* Performance: I don't know whether no performance issue for all platforms, though this patch and 1.4.x brings many performance improvements.
* Columns: home/local/federated timelines are implemented.
* Unmounting grace period: 5min, 3min, forever, etc...