### PR TITLE
Fix webpack-dev-server on Windows

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: PORT=3000 bundle exec puma -C config/puma.rb
 sidekiq: PORT=3000 bundle exec sidekiq
 stream: PORT=4000 yarn run start
-webpack: ./bin/webpack-dev-server --host 127.0.0.1
+webpack: ./bin/webpack-dev-server --host 0.0.0.0

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: PORT=3000 bundle exec puma -C config/puma.rb
 sidekiq: PORT=3000 bundle exec sidekiq
 stream: PORT=4000 yarn run start
-webpack: ./bin/webpack-dev-server --host 0.0.0.0
+webpack: ./bin/webpack-dev-server --host 127.0.0.1

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -23,7 +23,7 @@ end
 begin
   dev_server = YAML.load_file(CONFIG_FILE)["development"]["dev_server"]
 
-  DEV_SERVER_HOST = "http#{"s" if args('--https') || dev_server["https"]}://#{args('--host') || dev_server["host"]}:#{args('--port') || dev_server["port"]}"
+  DEV_SERVER_HOST = "http#{"s" if args('--https') || dev_server["https"]}://#{dev_server["host"]}:#{args('--port') || dev_server["port"]}"
 
 rescue Errno::ENOENT, NoMethodError
   puts "Webpack dev_server configuration not found in #{CONFIG_FILE}."

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -19,7 +19,7 @@ development:
   <<: *default
 
   dev_server:
-    host: 0.0.0.0
+    host: 127.0.0.1
     port: 8080
     https: false
 


### PR DESCRIPTION
Using 0.0.0.0 to bind to 127.0.0.1/localhost is unfortunately one of those things that just doesn't work on Windows. This fixes that, so that you can run webpack-dev-server on Windows, e.g. in Bash on Ubuntu on Windows.