### PR TITLE
Avoid using getBoundingClientRect to calculate height

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -17,6 +17,7 @@ import { MediaGallery, VideoPlayer } from '../features/ui/util/async-components'
 // We use the component (and not the container) since we do not want
 // to use the progress bar to show download progress
 import Bundle from '../features/ui/components/bundle';
+import getRectFromEntry from '../features/ui/util/get_rect_from_entry';
 
 export default class Status extends ImmutablePureComponent {
 
@@ -101,6 +102,11 @@ export default class Status extends ImmutablePureComponent {
   }
 
   handleIntersection = (entry) => {
+    if (this.node && this.node.children.length !== 0) {
+      // save the height of the fully-rendered element
+      this.height = getRectFromEntry(entry).height;
+    }
+
     // Edge 15 doesn't support isIntersecting, but we can infer it
     // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12156111/
     // https://github.com/WICG/IntersectionObserver/issues/211
@@ -129,15 +135,8 @@ export default class Status extends ImmutablePureComponent {
     this.setState((prevState) => ({ isHidden: !prevState.isIntersecting }));
   }
 
-  saveHeight = () => {
-    if (this.node && this.node.children.length !== 0) {
-      this.height = this.node.getBoundingClientRect().height;
-    }
-  }
-
   handleRef = (node) => {
     this.node = node;
-    this.saveHeight();
   }
 
   handleClick = () => {
@@ -213,13 +212,13 @@ export default class Status extends ImmutablePureComponent {
 
       } else if (status.getIn(['media_attachments', 0, 'type']) === 'video') {
         media = (
-          <Bundle fetchComponent={VideoPlayer} loading={this.renderLoadingVideoPlayer} onRender={this.saveHeight} >
+          <Bundle fetchComponent={VideoPlayer} loading={this.renderLoadingVideoPlayer} >
             {Component => <Component media={status.getIn(['media_attachments', 0])} sensitive={status.get('sensitive')} onOpenVideo={this.props.onOpenVideo} />}
           </Bundle>
         );
       } else {
         media = (
-          <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery} onRender={this.saveHeight} >
+          <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery} >
             {Component => <Component media={status.get('media_attachments')} sensitive={status.get('sensitive')} height={110} onOpenMedia={this.props.onOpenMedia} autoPlayGif={this.props.autoPlayGif} />}
           </Bundle>
         );
@@ -246,7 +245,7 @@ export default class Status extends ImmutablePureComponent {
           </a>
         </div>
 
-        <StatusContent status={status} onClick={this.handleClick} expanded={isExpanded} onExpandedToggle={this.handleExpandedToggle} onHeightUpdate={this.saveHeight} />
+        <StatusContent status={status} onClick={this.handleClick} expanded={isExpanded} onExpandedToggle={this.handleExpandedToggle} />
 
         {media}
 

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -17,7 +17,6 @@ export default class StatusContent extends React.PureComponent {
     status: ImmutablePropTypes.map.isRequired,
     expanded: PropTypes.bool,
     onExpandedToggle: PropTypes.func,
-    onHeightUpdate: PropTypes.func,
     onClick: PropTypes.func,
   };
 
@@ -56,9 +55,6 @@ export default class StatusContent extends React.PureComponent {
   }
 
   componentDidUpdate () {
-    if (this.props.onHeightUpdate) {
-      this.props.onHeightUpdate();
-    }
     this._updateStatusLinks();
   }
 

--- a/app/javascript/mastodon/features/ui/components/bundle.js
+++ b/app/javascript/mastodon/features/ui/components/bundle.js
@@ -12,7 +12,6 @@ class Bundle extends React.Component {
     error: PropTypes.func,
     children: PropTypes.func.isRequired,
     renderDelay: PropTypes.number,
-    onRender: PropTypes.func,
     onFetch: PropTypes.func,
     onFetchSuccess: PropTypes.func,
     onFetchFail: PropTypes.func,
@@ -22,7 +21,6 @@ class Bundle extends React.Component {
     loading: emptyComponent,
     error: emptyComponent,
     renderDelay: 0,
-    onRender: noop,
     onFetch: noop,
     onFetchSuccess: noop,
     onFetchFail: noop,
@@ -41,10 +39,6 @@ class Bundle extends React.Component {
     if (nextProps.fetchComponent !== this.props.fetchComponent) {
       this.load(nextProps);
     }
-  }
-
-  componentDidUpdate () {
-    this.props.onRender();
   }
 
   componentWillUnmount () {

--- a/app/javascript/mastodon/features/ui/util/get_rect_from_entry.js
+++ b/app/javascript/mastodon/features/ui/util/get_rect_from_entry.js
@@ -1,0 +1,21 @@
+
+// Get the bounding client rect from an IntersectionObserver entry.
+// This is to work around a bug in Chrome: https://crbug.com/737228
+
+let hasBoundingRectBug;
+
+function getRectFromEntry(entry) {
+  if (typeof hasBoundingRectBug !== 'boolean') {
+    const boundingRect = entry.target.getBoundingClientRect();
+    const observerRect = entry.boundingClientRect;
+    hasBoundingRectBug = boundingRect.height !== observerRect.height ||
+      boundingRect.top !== observerRect.top ||
+      boundingRect.width !== observerRect.width ||
+      boundingRect.bottom !== observerRect.bottom ||
+      boundingRect.left !== observerRect.left ||
+      boundingRect.right !== observerRect.right;
+  }
+  return hasBoundingRectBug ? entry.target.getBoundingClientRect() : entry.boundingClientRect;
+}
+
+export default getRectFromEntry;


### PR DESCRIPTION
(This PR is written on top of #3879 to avoid bitrotting myself when that gets merged. So unfortunately if you want to see a good diff you should check out https://github.com/nolanlawson/mastodon/commit/6057d38b10f40ef8cfed95c4782757e565a6ce5a.)

The goal of this PR is to avoid calling `getBoundingClientRect()` because it forces layout and thus can be expensive. In principle there's no need to call gBCR in order to get the height of list items, because that's already calculated within IntersectionObserver, which provides it automatically via [IntersectionObserverEntry.boundingClientRect](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry/boundingClientRect).

Unfortunately it's not quite so easy, because [there's a bug in Chrome](https://crbug.com/737228) that causes this rect to be calculated incorrectly. Luckily the calculation is so inaccurate that we can easily detect it by comparing the two rects, and then fall back to manual `getBoundingClientRect()` calls only for Chrome.

So for browsers with built-in IntersectionObserver and without the bug (e.g. Edge 15+, Firefox 55+), this is a win because we never call gBCR. And for Chrome, it'll be fixed automatically when they fix the bug. As for browsers using the IntersectionObserver polyfill (e.g. Firefox <55, Safari), they are [already calling gBCR](https://github.com/WICG/IntersectionObserver/blob/b8da39911d14e3347f98ba44914378fc19a8786f/polyfill/intersection-observer.js#L622) and so this fix merely ensure they aren't calling it twice.

To show the perf difference, I ran the same scenario in Edge with and without this PR. The scenario was to just click on "local timeline" from the "getting started" page (using a dev build).

![2017-06-29 12_05_35-celadon 06-29-2017 10-53-53 etl - windows performance analyzer](https://user-images.githubusercontent.com/283842/27706011-c67fa0aa-5cc4-11e7-8fe8-78e3b82926a8.png)

In Windows Performance Analyzer, I'm listing the DOM APIs from most to least expensive. If you ignore all the performance.mark/measure/clearMarks calls (which don't appear at all in production), you can see that 72ms of gBCR calls are completely eliminated. (Note this was done on an i5 SurfaceBook.)

/cc @sorin-davidoi 