### PR TITLE
Fix media-gallery, overflow is hidden.

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -3433,6 +3433,7 @@ button.icon-button.active i.fa-retweet {
   &,
   img {
     width: 100%;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
Media-gallery can't show 3 or 4 picture correctly, when Responsive images in media gallery (#3963) merged.
Because leakage area infringe other picture. So, this PR sets "overflow: hidden".

Before:
![before](https://user-images.githubusercontent.com/18753048/27717388-b8d403ae-5d7f-11e7-86f2-c1ec21abddd8.png)
After:
![after](https://user-images.githubusercontent.com/18753048/27717391-bc0ad228-5d7f-11e7-8316-4c3d9126d2d0.png)