### PR TITLE
Unobserve status on unmount

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -90,6 +90,10 @@ export default class Status extends ImmutablePureComponent {
   }
 
   componentWillUnmount () {
+    if (this.props.intersectionObserverWrapper) {
+      this.props.intersectionObserverWrapper.unobserve(this.props.id, this.node);
+    }
+
     this.componentMounted = false;
   }
 

--- a/app/javascript/mastodon/features/ui/util/intersection_observer_wrapper.js
+++ b/app/javascript/mastodon/features/ui/util/intersection_observer_wrapper.js
@@ -37,9 +37,18 @@ class IntersectionObserverWrapper {
     }
   }
 
+  unobserve (id, node) {
+    if (this.observer) {
+      delete this.callbacks[id];
+      this.observer.unobserve(node);
+    }
+  }
+
   disconnect () {
     if (this.observer) {
+      this.callbacks = {};
       this.observer.disconnect();
+      this.observer = null;
     }
   }
 


### PR DESCRIPTION
This fixes a warning on status unmounting (e.g. deletion) which mentioned in #3851.

This also resets IntersectionObserverWrapper on disconnect to avoid future `unobserve()` calls which has bug in Edge (#3866).