### PR TITLE
Allow to go home timeline back infinitely

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -10,7 +10,13 @@ class Feed
     if redis.exists("account:#{@account.id}:regeneration")
       from_database(limit, max_id, since_id)
     else
-      from_redis(limit, max_id, since_id)
+      statuses = from_redis(limit, max_id, since_id)
+
+      statuses += from_database(limit - statuses.size,
+                                statuses.last&.id || max_id,
+                                since_id)
+
+      statuses
     end
   end
 

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -10,12 +10,8 @@ class Feed
     if redis.exists("account:#{@account.id}:regeneration")
       from_database(limit, max_id, since_id)
     else
-      statuses = from_redis(limit, max_id, since_id)
-
-      statuses += from_database(limit - statuses.size,
-                                statuses.last&.id || max_id,
-                                since_id)
-
+      statuses  = from_redis(limit, max_id, since_id)
+      statuses += from_database(limit - statuses.size, statuses.last&.id || max_id, since_id) if statuses.size < limit
       statuses
     end
   end

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe FanOutOnWriteService do
   end
 
   it 'delivers status to local followers' do
-    pending 'some sort of problem in test environment causes this to sometimes fail'
-    expect(Feed.new(:home, follower).get(10).map(&:id)).to include status.id
+    expect(Feed.new(:home, follower).get(10, nil, 0).map(&:id)).to include status.id
   end
 
   it 'delivers status to hashtag' do


### PR DESCRIPTION
(~~note: `xit` in 92e95fbec148dd6035aef533b200a878ab077242 could be removed with #4015~~ resolved)

__NOTE: the following description is out of date.__ See https://github.com/tootsuite/mastodon/pull/4016#issuecomment-323997016.

The basic idea is to limit ranges of status id.

The old query to regenerate feed retrieved statuses till it finds the particular number of statuses. It was problematic because:
* Not sustainable; for example, the burden could be twice or more as time passes and statuses are accumulated. (consider about new instances with many statuses such as mstdn.jp for example)
* Vulnerable for DoS attacks; it is easy to trigger the query even though attackers had to wait for 14 days.

Limiting range of ID effectively resolves the issue. (4f0ab569c1923ea7526929fb68d7815ae24103cc and 0c9313449b34b9d648e8c28814895a6caa5578f4)

With ID range limitation, it is safe to relax the limitation of numbers. c78b26eb3730c069bd74b163b6fee7f975a0310b allows to get statuses more than 400 by falling back to database when necessary.

With fallback to database, Redis does no longer have to hold many statuses and not have to be kept up-to-date for a long. 92e95fbec148dd6035aef533b200a878ab077242 changes the accordingly.

As the result, this change would have the following pros and cons.

# Pros
* Infinite status retrieval
* Less load for Redis
* Much less load for PostgreSQL when the old query took too long
* Better response in situations the old query took too long

# Cons
* Unable to get old statuses
* Less cached when getting the 40-100th newest statuses
* More load due to infinite status retrieval