### PR TITLE
Rescue Addressable::URI::InvalidURIError at Remotable

### DIFF
--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -26,8 +26,9 @@ module Remotable
           send("#{attachment_name}_file_name=", filename)
 
           self[attribute_name] = url if has_attribute?(attribute_name)
-        rescue HTTP::TimeoutError, OpenSSL::SSL::SSLError, Paperclip::Errors::NotIdentifiedByImageMagickError => e
+        rescue HTTP::TimeoutError, OpenSSL::SSL::SSLError, Paperclip::Errors::NotIdentifiedByImageMagickError, Addressable::URI::InvalidURIError => e
           Rails.logger.debug "Error fetching remote #{attachment_name}: #{e}"
+          nil
         end
       end
     end


### PR DESCRIPTION
`Addressable::URI::InvalidURIError` is raised when executing `http_client.head` with an illegal URL as an argument. For example, a URL containing consecutive slashes is illegal.

```
http://example.com//hoge
```

So I fixed it to catch exceptions. Also, since the return value when an exception occurred was true which is the return value of Rails.logger.debug, it changed to return nil.

