### PR TITLE
Faster emojify() algorithm, avoid regex replace

### DIFF
--- a/app/javascript/mastodon/emoji.js
+++ b/app/javascript/mastodon/emoji.js
@@ -36,7 +36,7 @@ const shortnameToImage = str => {
       if (shortname in emojione.emojioneList) {
         const unicode = emojione.emojioneList[shortname].unicode[emojione.emojioneList[shortname].unicode.length - 1];
         const alt = emojione.convert(unicode.toUpperCase());
-        const replacement = `<img draggable="false" class="emojione" alt="${alt}" title="${shortname}" src="/emoji/${unicode}.svg" />`
+        const replacement = `<img draggable="false" class="emojione" alt="${alt}" title="${shortname}" src="/emoji/${unicode}.svg" />`;
         str = str.substring(0, i) + replacement + str.substring(shortnameEndIndex + 1);
       } else {
         i++; // stray colon, try again

--- a/app/javascript/mastodon/emoji.js
+++ b/app/javascript/mastodon/emoji.js
@@ -19,16 +19,41 @@ const unicodeToImage = str => {
   });
 };
 
-const shortnameToImage = str => str.replace(emojione.regShortNames, shortname => {
-  if (typeof shortname === 'undefined' || shortname === '' || !(shortname in emojione.emojioneList)) {
-    return shortname;
+const shortnameToImage = str => {
+  // This walks through the string from end to start, ignoring any tags (<p>, <br>, etc.)
+  // and replacing valid shortnames like :smile: and :wink: that _aren't_ within
+  // tags with an <img> version.
+  // The goal is to be the same as an emojione.regShortNames replacement, but faster.
+  // The reason we go backwards is because then we can replace substrings as we go.
+  let i = str.length;
+  let insideTag = false;
+  let insideShortname = false;
+  let shortnameEndIndex = -1;
+  while (i--) {
+    const char = str.charAt(i);
+    if (insideShortname && char === ':') {
+      const shortname = str.substring(i, shortnameEndIndex + 1);
+      if (shortname in emojione.emojioneList) {
+        const unicode = emojione.emojioneList[shortname].unicode[emojione.emojioneList[shortname].unicode.length - 1];
+        const alt = emojione.convert(unicode.toUpperCase());
+        const replacement = `<img draggable="false" class="emojione" alt="${alt}" title="${shortname}" src="/emoji/${unicode}.svg" />`
+        str = str.substring(0, i) + replacement + str.substring(shortnameEndIndex + 1);
+      } else {
+        i++; // stray colon, try again
+      }
+      insideShortname = false;
+    } else if (insideTag && char === '<') {
+      insideTag = false;
+    } else if (char === '>') {
+      insideTag = true;
+      insideShortname = false;
+    } else if (!insideTag && char === ':') {
+      insideShortname = true;
+      shortnameEndIndex = i;
+    }
   }
-
-  const unicode = emojione.emojioneList[shortname].unicode[emojione.emojioneList[shortname].unicode.length - 1];
-  const alt     = emojione.convert(unicode.toUpperCase());
-
-  return `<img draggable="false" class="emojione" alt="${alt}" title="${shortname}" src="/emoji/${unicode}.svg" />`;
-});
+  return str;
+};
 
 export default function emojify(text) {
   return toImage(text);

--- a/spec/javascript/components/emojify.test.js
+++ b/spec/javascript/components/emojify.test.js
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import emojify from '../../../app/javascript/mastodon/emoji';
+
+describe('emojify', () => {
+  it('does a basic emojify', () => {
+    expect(emojify(':smile:')).to.equal(
+      '<img draggable="false" class="emojione" alt="😄" title=":smile:" src="/emoji/1f604.svg" />');
+  });
+
+  it('does a double emojify', () => {
+    expect(emojify(':smile: and :wink:')).to.equal(
+      '<img draggable="false" class="emojione" alt="😄" title=":smile:" src="/emoji/1f604.svg" /> and <img draggable="false" class="emojione" alt="😉" title=":wink:" src="/emoji/1f609.svg" />');
+  });
+
+  it('works with random colons', () => {
+    expect(emojify(':smile: : :wink:')).to.equal(
+      '<img draggable="false" class="emojione" alt="😄" title=":smile:" src="/emoji/1f604.svg" /> : <img draggable="false" class="emojione" alt="😉" title=":wink:" src="/emoji/1f609.svg" />');
+    expect(emojify(':smile::::wink:')).to.equal(
+      '<img draggable="false" class="emojione" alt="😄" title=":smile:" src="/emoji/1f604.svg" />::<img draggable="false" class="emojione" alt="😉" title=":wink:" src="/emoji/1f609.svg" />');
+    expect(emojify(':smile:::::wink:')).to.equal(
+      '<img draggable="false" class="emojione" alt="😄" title=":smile:" src="/emoji/1f604.svg" />:::<img draggable="false" class="emojione" alt="😉" title=":wink:" src="/emoji/1f609.svg" />');
+  });
+
+  it('works with tags', () => {
+    expect(emojify('<p>:smile:</p>')).to.equal(
+      '<p><img draggable="false" class="emojione" alt="😄" title=":smile:" src="/emoji/1f604.svg" /></p>');
+    expect(emojify('<p>:smile:</p> and <p>:wink:</p>')).to.equal(
+      '<p><img draggable="false" class="emojione" alt="😄" title=":smile:" src="/emoji/1f604.svg" /></p> and <p><img draggable="false" class="emojione" alt="😉" title=":wink:" src="/emoji/1f609.svg" /></p>');
+  });
+
+  it('ignores unknown shortcodes', () => {
+    expect(emojify(':foobarbazfake:')).to.equal(':foobarbazfake:');
+  });
+
+  it('ignores shortcodes inside of tags', () => {
+    expect(emojify('<p data-foo=":smile:"></p>')).to.equal('<p data-foo=":smile:"></p>');
+  });
+
+  it('works with unclosed tags', () => {
+    expect(emojify('hello>')).to.equal('hello>');
+    expect(emojify('<hello')).to.equal('<hello');
+  });
+
+  it('works with unclosed shortcodes', () => {
+    expect(emojify('smile:')).to.equal('smile:');
+    expect(emojify(':smile')).to.equal(':smile');
+  });
+
+});


### PR DESCRIPTION
After doing some perf analyses on a real device (Nexus 5X), I saw that, when switching from the "getting started" column to the timeline column, the `replace()` function inside of `emoji.js` -> `shortnameToImage()` is very slow (50ms).

This is using a regex replacement using `emojione.regShortNames`, and the regex itself is fairly simple:

![screenshot 2017-06-29 23 23 59](https://user-images.githubusercontent.com/283842/27740930-6a59bc6c-5d68-11e7-9853-51be84ddec11.png)

(Removed all but two shortnames from the regex to make it easier to read.)

Essentially we just need to replace `:strings_like_this:` and avoid `<tagsLikeThis>`. So we can write our own state machine that's faster than regex replacement.

So I wrote it, and can confirm that the speed is much improved:

![out2](https://user-images.githubusercontent.com/283842/27740963-892fc6c2-5d68-11e7-9340-2f2b144c7cc2.png)

I also added some unit tests, and confirmed that the tests pass before my PR and after my PR (so my version has the same behavior as the regex version).

`unicodeToImage()` -> `replace()` is still slow, but that can wait for another PR.

/cc @sorin-davidoi @unarist 