### PR TITLE
Togglable filter links

### DIFF
--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -6,13 +6,19 @@ module Admin::FilterHelper
 
   FILTERS = ACCOUNT_FILTERS + REPORT_FILTERS
 
-  def filter_link_to(text, more_params)
-    new_url = filtered_url_for(more_params)
-    link_to text, new_url, class: filter_link_class(new_url)
+  def filter_link_to(text, link_to_params, link_class_params = link_to_params)
+    new_url = filtered_url_for(link_to_params)
+    new_class = filtered_url_for(link_class_params)
+    link_to text, new_url, class: filter_link_class(new_class)
   end
 
   def table_link_to(icon, text, path, options = {})
     link_to safe_join([fa_icon(icon), text]), path, options.merge(class: 'table-action-link')
+  end
+
+  def is_selected(more_params)
+    new_url = filtered_url_for(more_params)
+    filter_link_class(new_url) == 'selected' ? true : false
   end
 
   private

--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -16,7 +16,7 @@ module Admin::FilterHelper
     link_to safe_join([fa_icon(icon), text]), path, options.merge(class: 'table-action-link')
   end
 
-  def is_selected(more_params)
+  def selected?(more_params)
     new_url = filtered_url_for(more_params)
     filter_link_class(new_url) == 'selected' ? true : false
   end

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -7,12 +7,12 @@
     %ul
       %li= filter_link_to t('admin.accounts.location.all'), local: nil, remote: nil
       %li
-        - if is_selected local: '1', remote: nil
+        - if selected? local: '1', remote: nil
           = filter_link_to t('admin.accounts.location.local'), {local: nil, remote: nil}, {local: '1', remote: nil}
         - else
           = filter_link_to t('admin.accounts.location.local'), local: '1', remote: nil
       %li
-        - if is_selected remote: '1', local: nil
+        - if selected? remote: '1', local: nil
           = filter_link_to t('admin.accounts.location.remote'), {remote: nil, local: nil}, {remote: '1', local: nil}
         - else
           = filter_link_to t('admin.accounts.location.remote'), remote: '1', local: nil
@@ -21,12 +21,12 @@
     %ul
       %li= filter_link_to t('admin.accounts.moderation.all'), silenced: nil, suspended: nil
       %li
-        - if is_selected silenced: '1'
+        - if selected? silenced: '1'
           = filter_link_to t('admin.accounts.moderation.silenced'), {silenced: nil}, {silenced: '1'}
         - else
           = filter_link_to t('admin.accounts.moderation.silenced'), silenced: '1'
       %li
-        - if is_selected suspended: '1'
+        - if selected? suspended: '1'
           = filter_link_to t('admin.accounts.moderation.suspended'), {suspended: nil}, {suspended: '1'}
         - else
           = filter_link_to t('admin.accounts.moderation.suspended'), suspended: '1'

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -6,14 +6,30 @@
     %strong= t('admin.accounts.location.title')
     %ul
       %li= filter_link_to t('admin.accounts.location.all'), local: nil, remote: nil
-      %li= filter_link_to t('admin.accounts.location.local'), local: '1', remote: nil
-      %li= filter_link_to t('admin.accounts.location.remote'), remote: '1', local: nil
+      %li
+        - if is_selected local: '1', remote: nil
+          = filter_link_to t('admin.accounts.location.local'), {local: nil, remote: nil}, {local: '1', remote: nil}
+        - else
+          = filter_link_to t('admin.accounts.location.local'), local: '1', remote: nil
+      %li
+        - if is_selected remote: '1', local: nil
+          = filter_link_to t('admin.accounts.location.remote'), {remote: nil, local: nil}, {remote: '1', local: nil}
+        - else
+          = filter_link_to t('admin.accounts.location.remote'), remote: '1', local: nil
   .filter-subset
     %strong= t('admin.accounts.moderation.title')
     %ul
       %li= filter_link_to t('admin.accounts.moderation.all'), silenced: nil, suspended: nil
-      %li= filter_link_to t('admin.accounts.moderation.silenced'), silenced: '1'
-      %li= filter_link_to t('admin.accounts.moderation.suspended'), suspended: '1'
+      %li
+        - if is_selected silenced: '1'
+          = filter_link_to t('admin.accounts.moderation.silenced'), {silenced: nil}, {silenced: '1'}
+        - else
+          = filter_link_to t('admin.accounts.moderation.silenced'), silenced: '1'
+      %li
+        - if is_selected suspended: '1'
+          = filter_link_to t('admin.accounts.moderation.suspended'), {suspended: nil}, {suspended: '1'}
+        - else
+          = filter_link_to t('admin.accounts.moderation.suspended'), suspended: '1'
   .filter-subset
     %strong= t('admin.accounts.order.title')
     %ul


### PR DESCRIPTION
Togglable filter links on `/admin/accounts`.

### Before:
![toggle_filter_before](https://user-images.githubusercontent.com/17060801/27761673-ca21833a-5e9b-11e7-99c0-46f272bb0d7f.gif)

### After:
![toggle_filter_after](https://user-images.githubusercontent.com/17060801/27749710-98c9158c-5e0f-11e7-88dc-39f9de364e80.gif)