### PR TITLE
Remove ugly blue highlight on Android browsers

### DIFF
--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -11,6 +11,8 @@ body {
   text-rendering: optimizelegibility;
   font-feature-settings: "kern";
   text-size-adjust: none;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  -webkit-tap-highlight-color: transparent;
 
   &.app-body {
     position: fixed;


### PR DESCRIPTION
![screenshot_20170701-234841](https://user-images.githubusercontent.com/11616378/27765374-040f5330-5eb8-11e7-95b2-2541f49a7dfd.png)

It can oftentimes make the web app feel less native and just... ugly. There are enough hints from `:hover` and those applied for desktop uses for this to not make a huge difference in UX.