### PR TITLE
Add a setting allowing the use of system's default font in Web UI

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -37,6 +37,7 @@ class Settings::PreferencesController < ApplicationController
       :setting_boost_modal,
       :setting_delete_modal,
       :setting_auto_play_gif,
+      :setting_system_font_ui,
       notification_emails: %i(follow follow_request reblog favourite mention digest),
       interactions: %i(must_be_follower must_be_following)
     )

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -184,7 +184,7 @@ export default class UI extends React.PureComponent {
     const classNames = ['ui'];
 
     if (this.props.systemFontUi)
-      classNames.push('has-system-font');
+      classNames.push('system-font');
 
     return (
       <div className={classNames.join(' ')} ref={this.setRef}>

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -72,12 +72,17 @@ class WrappedRoute extends React.Component {
 
 }
 
-@connect()
+const mapStateToProps = state => ({
+  systemFontUi: state.getIn(['meta', 'system_font_ui']),
+});
+
+@connect(mapStateToProps)
 export default class UI extends React.PureComponent {
 
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     children: PropTypes.node,
+    systemFontUi: PropTypes.bool,
   };
 
   state = {
@@ -176,8 +181,13 @@ export default class UI extends React.PureComponent {
     const { width, draggingOver } = this.state;
     const { children } = this.props;
 
+    let className = 'ui';
+
+    if (this.props.systemFontUi)
+      className += ' has-system-font';
+
     return (
-      <div className='ui' ref={this.setRef}>
+      <div className={className} ref={this.setRef}>
         <TabsBar />
         <ColumnsAreaContainer singleColumn={isMobile(width)}>
           <WrappedSwitch>

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -181,13 +181,13 @@ export default class UI extends React.PureComponent {
     const { width, draggingOver } = this.state;
     const { children } = this.props;
 
-    let className = 'ui';
+    const classNames = ['ui'];
 
     if (this.props.systemFontUi)
-      className += ' has-system-font';
+      classNames.push('has-system-font');
 
     return (
-      <div className={className} ref={this.setRef}>
+      <div className={classNames.join(' ')} ref={this.setRef}>
         <TabsBar />
         <ColumnsAreaContainer singleColumn={isMobile(width)}>
           <WrappedSwitch>

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import Switch from 'react-router-dom/Switch';
 import Route from 'react-router-dom/Route';
 import Redirect from 'react-router-dom/Redirect';
@@ -181,13 +182,12 @@ export default class UI extends React.PureComponent {
     const { width, draggingOver } = this.state;
     const { children } = this.props;
 
-    const classNames = ['ui'];
-
-    if (this.props.systemFontUi)
-      classNames.push('system-font');
+    const className = classNames('ui', {
+      'system-font': this.props.systemFontUi,
+    });
 
     return (
-      <div className={classNames.join(' ')} ref={this.setRef}>
+      <div className={className} ref={this.setRef}>
         <TabsBar />
         <ColumnsAreaContainer singleColumn={isMobile(width)}>
           <WrappedSwitch>

--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -62,7 +62,7 @@ button {
   justify-content: center;
 }
 
-.has-system-font {
+.system-font {
   // system-ui => standard property (Chrome/Android WebView 56+, Opera 43+, Safari 11+)
   font-family: system-ui, 
     // -apple-system => Safari <11 specific

--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -63,5 +63,5 @@ button {
 }
 
 .has-system-font {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Roboto, sans-serif;
 }

--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -63,5 +63,26 @@ button {
 }
 
 .has-system-font {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Roboto, sans-serif;
+  // system-ui => standard property (Chrome/Android WebView 56+, Opera 43+, Safari 11+)
+  font-family: system-ui, 
+    // -apple-system => Safari <11 specific
+    -apple-system,
+    // BlinkMacSystemFont => Chrome <56 on macOS specific
+    BlinkMacSystemFont, 
+    // Segoe UI => Windows 7/8/10
+    "Segoe UI",
+    // Oxygen => KDE
+    "Oxygen", 
+    // Ubuntu => Unity/Ubuntu
+    "Ubuntu",
+    // Cantarell => GNOME
+    "Cantarell",
+    // Fira Sans => Firefox OS
+    "Fira Sans", 
+    // Droid Sans => Older Androids (<4.0)
+    "Droid Sans",
+    // Helvetica Neue => Older macOS <10.11
+    "Helvetica Neue",
+    // Roboto => web-font fallback and newer Androids (>=4.0)
+    "Roboto", sans-serif;
 }

--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -64,25 +64,15 @@ button {
 
 .system-font {
   // system-ui => standard property (Chrome/Android WebView 56+, Opera 43+, Safari 11+)
-  font-family: system-ui, 
-    // -apple-system => Safari <11 specific
-    -apple-system,
-    // BlinkMacSystemFont => Chrome <56 on macOS specific
-    BlinkMacSystemFont, 
-    // Segoe UI => Windows 7/8/10
-    "Segoe UI",
-    // Oxygen => KDE
-    "Oxygen", 
-    // Ubuntu => Unity/Ubuntu
-    "Ubuntu",
-    // Cantarell => GNOME
-    "Cantarell",
-    // Fira Sans => Firefox OS
-    "Fira Sans", 
-    // Droid Sans => Older Androids (<4.0)
-    "Droid Sans",
-    // Helvetica Neue => Older macOS <10.11
-    "Helvetica Neue",
-    // Roboto => web-font fallback and newer Androids (>=4.0)
-    "Roboto", sans-serif;
+  // -apple-system => Safari <11 specific
+  // BlinkMacSystemFont => Chrome <56 on macOS specific
+  // Segoe UI => Windows 7/8/10
+  // Oxygen => KDE
+  // Ubuntu => Unity/Ubuntu
+  // Cantarell => GNOME
+  // Fira Sans => Firefox OS 
+  // Droid Sans => Older Androids (<4.0)
+  // Helvetica Neue => Older macOS <10.11
+  // Roboto => web-font fallback and newer Androids (>=4.0)
+  font-family: system-ui, -apple-system,BlinkMacSystemFont, "Segoe UI","Oxygen", "Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue","Roboto", sans-serif;
 }

--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -61,3 +61,7 @@ button {
   align-items: center;
   justify-content: center;
 }
+
+.has-system-font {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}

--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -73,6 +73,6 @@ button {
   // Fira Sans => Firefox OS
   // Droid Sans => Older Androids (<4.0)
   // Helvetica Neue => Older macOS <10.11
-  // Roboto => web-font fallback and newer Androids (>=4.0)
-  font-family: system-ui, -apple-system,BlinkMacSystemFont, "Segoe UI","Oxygen", "Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue","Roboto", sans-serif;
+  // mastodon-font-sans-serif => web-font (Roboto) fallback and newer Androids (>=4.0)
+  font-family: system-ui, -apple-system,BlinkMacSystemFont, "Segoe UI","Oxygen", "Ubuntu","Cantarell","Fira Sans","Droid Sans","Helvetica Neue",mastodon-font-sans-serif, sans-serif;
 }

--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -70,7 +70,7 @@ button {
   // Oxygen => KDE
   // Ubuntu => Unity/Ubuntu
   // Cantarell => GNOME
-  // Fira Sans => Firefox OS 
+  // Fira Sans => Firefox OS
   // Droid Sans => Older Androids (<4.0)
   // Helvetica Neue => Older macOS <10.11
   // Roboto => web-font fallback and newer Androids (>=4.0)

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -21,6 +21,7 @@ class UserSettingsDecorator
     user.settings['boost_modal'] = boost_modal_preference
     user.settings['delete_modal'] = delete_modal_preference
     user.settings['auto_play_gif'] = auto_play_gif_preference
+    user.settings['system_font_ui'] = system_font_ui_preference
   end
 
   def merged_notification_emails
@@ -41,6 +42,10 @@ class UserSettingsDecorator
 
   def delete_modal_preference
     boolean_cast_setting 'setting_delete_modal'
+  end
+  
+  def system_font_ui_preference
+    boolean_cast_setting 'setting_system_font_ui'
   end
 
   def auto_play_gif_preference

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -43,7 +43,7 @@ class UserSettingsDecorator
   def delete_modal_preference
     boolean_cast_setting 'setting_delete_modal'
   end
-  
+
   def system_font_ui_preference
     boolean_cast_setting 'setting_system_font_ui'
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,6 +90,10 @@ class User < ApplicationRecord
   def setting_auto_play_gif
     settings.auto_play_gif
   end
+  
+  def setting_system_font_ui
+    settings.system_font_ui
+  end
 
   def activate_session(request)
     session_activations.activate(session_id: SecureRandom.hex,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < ApplicationRecord
   def setting_auto_play_gif
     settings.auto_play_gif
   end
-  
+
   def setting_system_font_ui
     settings.system_font_ui
   end

--- a/app/views/home/initial_state.json.rabl
+++ b/app/views/home/initial_state.json.rabl
@@ -11,6 +11,7 @@ node(:meta) do
     boost_modal: current_account.user.setting_boost_modal,
     delete_modal: current_account.user.setting_delete_modal,
     auto_play_gif: current_account.user.setting_auto_play_gif,
+    system_font_ui: current_account.user.setting_system_font_ui,
   }
 end
 

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -44,6 +44,7 @@
 
   .fields-group
     = f.input :setting_auto_play_gif, as: :boolean, wrapper: :with_label
+    = f.input :setting_system_font_ui, as: :boolean, wrapper: :with_label
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -38,6 +38,7 @@ en:
         setting_boost_modal: Show confirmation dialog before boosting
         setting_default_privacy: Post privacy
         setting_delete_modal: Show confirmation dialog before deleting a toot
+        setting_system_font_ui: Use system's default font
         severity: Severity
         type: Import type
         username: Username

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -28,6 +28,7 @@ fr:
         password: Mot de passe
         setting_boost_modal: Afficher un dialogue de confirmation avant de partager
         setting_default_privacy: Confidentialité des statuts
+        setting_system_font_ui: Utiliser la police par défaut du système
         severity: Séverité
         type: Type d'import
         username: Identifiant

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,6 +18,7 @@ defaults: &defaults
   boost_modal: false
   auto_play_gif: true
   delete_modal: true
+  system_font_ui: false
   notification_emails:
     follow: false
     reblog: false

--- a/spec/lib/user_settings_decorator_spec.rb
+++ b/spec/lib/user_settings_decorator_spec.rb
@@ -48,5 +48,12 @@ describe UserSettingsDecorator do
       settings.update(values)
       expect(user.settings['auto_play_gif']).to eq false
     end
+    
+    it 'updates the user settings value for system font in UI' do
+      values = { 'setting_system_font_ui' => '0' }
+
+      settings.update(values)
+      expect(user.settings['system_font_ui']).to eq false
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe User, type: :model do
     it 'returns system font ui setting' do
       user = Fabricate(:user)
       user.settings[:system_font_ui] = false
-      expect(user.setting_auto_play_gif).to eq false
+      expect(user.system_font_ui).to eq false
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe User, type: :model do
     it 'returns system font ui setting' do
       user = Fabricate(:user)
       user.settings[:system_font_ui] = false
-      expect(user.system_font_ui).to eq false
+      expect(user.setting_system_font_ui).to eq false
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -184,6 +184,14 @@ RSpec.describe User, type: :model do
       expect(user.setting_auto_play_gif).to eq false
     end
   end
+  
+  describe '#setting_system_font_ui' do
+    it 'returns system font ui setting' do
+      user = Fabricate(:user)
+      user.settings[:system_font_ui] = false
+      expect(user.setting_auto_play_gif).to eq false
+    end
+  end
 
   describe '#setting_boost_modal' do
     it 'returns boost modal setting' do


### PR DESCRIPTION
![screen shot 2017-07-02 at 12 08 35 am](https://user-images.githubusercontent.com/1409924/27767905-9d84ff5e-5eba-11e7-80e1-16996e6ae619.png)

**Disabled by default**

This will use the following font stack:
```scss
.system-font {
  // system-ui => standard property (Chrome/Android WebView 56+, Opera 43+, Safari 11+)
  font-family: system-ui, 
    // -apple-system => Safari <11 specific
    -apple-system,
    // BlinkMacSystemFont => Chrome <56 on macOS specific
    BlinkMacSystemFont, 
    // Segoe UI => Windows 7/8/10
    "Segoe UI",
    // Oxygen => KDE
    "Oxygen", 
    // Ubuntu => Unity/Ubuntu
    "Ubuntu",
    // Cantarell => GNOME
    "Cantarell",
    // Fira Sans => Firefox OS
    "Fira Sans", 
    // Droid Sans => Older Androids (<4.0)
    "Droid Sans",
    // Helvetica Neue => Older macOS <10.11
    "Helvetica Neue",
    // Roboto => web-font fallback and newer Androids (>=4.0)
    "Roboto", sans-serif;
}
```