### PR TITLE
Parse links in status content on update as well as mount

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -31,10 +31,10 @@ export default class StatusContent extends React.PureComponent {
 
     for (var i = 0; i < links.length; ++i) {
       let link = links[i];
-      if ((' '+link.className+' ').indexOf(' status-link ') >= 0) {
+      if (link.classList.contains('status-link')) {
         continue;
       }
-      link.className += ' status-link';
+      link.classList.add('status-link');
 
       let mention = this.props.status.get('mentions').find(item => link.href === item.get('url'));
 

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -25,12 +25,17 @@ export default class StatusContent extends React.PureComponent {
     hidden: true,
   };
 
-  componentDidMount () {
+  _updateStatusLinks () {
     const node  = this.node;
     const links = node.querySelectorAll('a');
 
     for (var i = 0; i < links.length; ++i) {
-      let link    = links[i];
+      let link = links[i];
+      if ((' '+link.className+' ').indexOf(' status-link ') >= 0) {
+        continue;
+      }
+      link.className += ' status-link';
+
       let mention = this.props.status.get('mentions').find(item => link.href === item.get('url'));
 
       if (mention) {
@@ -46,10 +51,15 @@ export default class StatusContent extends React.PureComponent {
     }
   }
 
+  componentDidMount () {
+    this._updateStatusLinks();
+  }
+
   componentDidUpdate () {
     if (this.props.onHeightUpdate) {
       this.props.onHeightUpdate();
     }
+    this._updateStatusLinks();
   }
 
   onMentionClick = (mention, e) => {


### PR DESCRIPTION
Links in status content were only parsed and had handlers added to them on mount; however, in certain cases the status's content can change without being mounted (e.g.: going back and forth between expanded statuses in the web view with no other pages in between). This resulted in links not getting the necessary handlers and attributes, so mentions and hashtags would wind up opening new windows instead of opening up in the web view like they should.

This moves the link parsing code into a new function and calls it on both mount and update, and also adds a bit of code to check for links that have already been parsed to prevent adding duplicate handlers.