### PR TITLE
Rescue exceptions related to Goldfinger

### DIFF
--- a/app/services/fetch_remote_account_service.rb
+++ b/app/services/fetch_remote_account_service.rb
@@ -32,7 +32,8 @@ class FetchRemoteAccountService < BaseService
   rescue Nokogiri::XML::XPath::SyntaxError
     Rails.logger.debug 'Invalid XML or missing namespace'
     nil
-  rescue Goldfinger::NotFoundError, Goldfinger::SSLError, Goldfinger::Error
+  rescue Goldfinger::NotFoundError, Goldfinger::Error
+    Rails.logger.debug 'Exceptions related to Goldfinger occurs'
     nil
   end
 end

--- a/app/services/fetch_remote_account_service.rb
+++ b/app/services/fetch_remote_account_service.rb
@@ -32,5 +32,7 @@ class FetchRemoteAccountService < BaseService
   rescue Nokogiri::XML::XPath::SyntaxError
     Rails.logger.debug 'Invalid XML or missing namespace'
     nil
+  rescue Goldfinger::NotFoundError, Goldfinger::SSLError, Goldfinger::Error
+    nil
   end
 end


### PR DESCRIPTION
Exceptions related to Goldfinger occurs when executing `author_from_xml`. So I fixed it to catch exceptions.
