### PR TITLE
Remove sort in Feed

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -20,8 +20,7 @@ class Feed
     max_id     = '+inf' if max_id.blank?
     since_id   = '-inf' if since_id.blank?
     unhydrated = redis.zrevrangebyscore(key, "(#{max_id}", "(#{since_id}", limit: [0, limit], with_scores: true).map(&:last).map(&:to_i)
-    status_map = Status.where(id: unhydrated).cache_ids.map { |s| [s.id, s] }.to_h
-    unhydrated.map { |id| status_map[id] }.compact
+    Status.where(id: unhydrated).cache_ids
   end
 
   def from_database(limit, max_id, since_id)

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Feed, type: :model do
   describe '#get' do
-    it 'gets statuses with ids in the range, maintining the order from Redis' do
+    it 'gets statuses with ids in the range' do
       account = Fabricate(:account)
       Fabricate(:status, account: account, id: 1)
       Fabricate(:status, account: account, id: 2)


### PR DESCRIPTION
In `from_redis` method, statuses retrieved from the database was mapped to the IDs retrieved from Redis. It was equivalent to order from high to low because those IDs are sorted in the same order.

Statuses are ordered with the ID by default, so we do not have to reorder. Sorting statuses in the database is even faster since the IDs are indexed with B-tree.