### PR TITLE
Change webpack-dev-server repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "react-intl-translations-manager": "^5.0.0",
     "react-test-renderer": "^15.6.1",
     "sinon": "^2.3.5",
-    "webpack-dev-server": "lencioni/webpack-dev-server#patch-1",
+    "webpack-dev-server": "webpack/webpack-dev-server#047a5954398e67b0a17e6be7d5877d9f55f40cba",
     "yargs": "^8.0.2"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3011,10 +3011,6 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-readdir-recursive@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -7202,9 +7198,9 @@ webpack-dev-middleware@^1.10.2, webpack-dev-middleware@^1.11.0:
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
 
-webpack-dev-server@lencioni/webpack-dev-server#patch-1:
+webpack-dev-server@webpack/webpack-dev-server#047a5954398e67b0a17e6be7d5877d9f55f40cba:
   version "2.5.0"
-  resolved "https://codeload.github.com/lencioni/webpack-dev-server/tar.gz/8978059d9b880c6c28908a6ed4608e27d40f2f69"
+  resolved "https://codeload.github.com/webpack/webpack-dev-server/tar.gz/047a5954398e67b0a17e6be7d5877d9f55f40cba"
   dependencies:
     ansi-html "0.0.7"
     bonjour "^3.5.0"


### PR DESCRIPTION
`lencioni/webpack-dev-server#patch-1` has been deleted.

```console
$ node -v
v6.11.0
$ npm -v
3.10.10
$ npm i
npm ERR! git rev-list -n1 patch-1: fatal: ambiguous argument 'patch-1': unknown revision or path not in the working tree.
npm ERR! git rev-list -n1 patch-1: Use '--' to separate paths from revisions, like this:
npm ERR! git rev-list -n1 patch-1: 'git <command> [<revision>...] -- [<file>...]'
npm ERR! git rev-list -n1 patch-1: 
npm ERR! git rev-list -n1 patch-1: fatal: ambiguous argument 'patch-1': unknown revision or path not in the working tree.
npm ERR! git rev-list -n1 patch-1: Use '--' to separate paths from revisions, like this:
npm ERR! git rev-list -n1 patch-1: 'git <command> [<revision>...] -- [<file>...]'
npm ERR! git rev-list -n1 patch-1: 
npm ERR! git rev-list -n1 patch-1: fatal: ambiguous argument 'patch-1': unknown revision or path not in the working tree.
npm ERR! git rev-list -n1 patch-1: Use '--' to separate paths from revisions, like this:
npm ERR! git rev-list -n1 patch-1: 'git <command> [<revision>...] -- [<file>...]'
npm ERR! git rev-list -n1 patch-1: 
npm ERR! Darwin 16.6.0
npm ERR! argv "/Users/ykzts/.nodenv/versions/6.11.0/bin/node" "/Users/ykzts/.nodenv/versions/6.11.0/bin/npm" "i"
npm ERR! node v6.11.0
npm ERR! npm  v3.10.10
npm ERR! code 128

npm ERR! Command failed: git rev-list -n1 patch-1
npm ERR! fatal: ambiguous argument 'patch-1': unknown revision or path not in the working tree.
npm ERR! Use '--' to separate paths from revisions, like this:
npm ERR! 'git <command> [<revision>...] -- [<file>...]'
npm ERR! 
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /private/tmp/mastodon/npm-debug.log
```