### PR TITLE
Fix Nokogiri::HTML at FetchLinkCardService

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'nkf'
 
 class FetchLinkCardService < BaseService
   include HttpHelper
@@ -84,7 +85,8 @@ class FetchLinkCardService < BaseService
 
     return if response.code != 200 || response.mime_type != 'text/html'
 
-    page = Nokogiri::HTML(response.to_s)
+    html = response.to_s
+    page = Nokogiri::HTML(html, nil, NKF.guess(html).to_s)
 
     card.type             = :link
     card.title            = meta_property(page, 'og:title') || page.at_xpath('//title')&.content

--- a/spec/fixtures/requests/sjis.txt
+++ b/spec/fixtures/requests/sjis.txt
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx/1.11.10
+Date: Tue, 04 Jul 2017 16:43:39 GMT
+Content-Type: text/html
+Content-Length: 273
+Connection: keep-alive
+Last-Modified: Tue, 04 Jul 2017 16:41:34 GMT
+Accept-Ranges: bytes
+
+<HTML>
+<HEAD>
+  <META NAME="GENERATOR" CONTENT="Adobe PageMill 3.0J Mac">
+  <META HTTP-EQUIV="Content-Type" CONTENT="text/html;CHARSET=x-sjis">
+  <TITLE>JSISのページ</TITLE>
+</HEAD>
+<BODY>
+<P><CENTER><B><FONT SIZE="+2">SJISのページ</FONT></B><BR>
+<HR><BR>
+</BODY>
+</HTML>

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe FetchLinkCardService do
   before do
     stub_request(:head, 'http://example.xn--fiqs8s/').to_return(status: 200, headers: { 'Content-Type' => 'text/html' })
     stub_request(:get, 'http://example.xn--fiqs8s/').to_return(request_fixture('idn.txt'))
+    stub_request(:head, 'http://example.com/sjis').to_return(status: 200, headers: { 'Content-Type' => 'text/html' })
+    stub_request(:get, 'http://example.com/sjis').to_return(request_fixture('sjis.txt'))
     stub_request(:head, 'https://github.com/qbi/WannaCry').to_return(status: 404)
 
     subject.call(status)
@@ -17,6 +19,14 @@ RSpec.describe FetchLinkCardService do
 
       it 'works with IDN URLs' do
         expect(a_request(:get, 'http://example.xn--fiqs8s/')).to have_been_made.at_least_once
+      end
+    end
+
+    context do
+      let(:status) { Fabricate(:status, text: 'Check out http://example.com/sjis') }
+
+      it 'works with SJIS' do
+        expect(a_request(:get, 'http://example.com/sjis')).to have_been_made.at_least_once
       end
     end
   end


### PR DESCRIPTION
Since `ArgumentError: invalid byte sequence in UTF-8` occurred in the case of SJIS page, I fix to specify encoding at parsing.