### PR TITLE
api/instances: Include the stats from the /about/more page

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -2,7 +2,7 @@
 
 class REST::InstanceSerializer < ActiveModel::Serializer
   attributes :uri, :title, :description, :email,
-             :version, :urls
+             :version, :urls, :stats
 
   def uri
     Rails.configuration.x.local_domain
@@ -24,7 +24,21 @@ class REST::InstanceSerializer < ActiveModel::Serializer
     Mastodon::Version.to_s
   end
 
+  def stats
+    {
+      user_count: instance_presenter.user_count,
+      status_count: instance_presenter.status_count,
+      domain_count: instance_presenter.domain_count,
+    }
+  end
+
   def urls
     { streaming_api: Rails.configuration.x.streaming_api_base_url }
+  end
+
+  private
+
+  def instance_presenter
+    @instance_presenter ||= InstancePresenter.new
   end
 end


### PR DESCRIPTION
To be able to pull some basic statistics from a Mastodon instance, include the user, status and connected domain counters in the `/api/v1/instance` response.

Fixes #3570.