### PR TITLE
Add attribute for default privacy to verify credentials

### DIFF
--- a/app/controllers/api/v1/accounts/credentials_controller.rb
+++ b/app/controllers/api/v1/accounts/credentials_controller.rb
@@ -6,13 +6,13 @@ class Api::V1::Accounts::CredentialsController < Api::BaseController
 
   def show
     @account = current_account
-    render json: @account, serializer: REST::AccountSerializer
+    render json: @account, serializer: REST::CredentialAccountSerializer
   end
 
   def update
     current_account.update!(account_params)
     @account = current_account
-    render json: @account, serializer: REST::AccountSerializer
+    render json: @account, serializer: REST::CredentialAccountSerializer
   end
 
   private

--- a/app/serializers/rest/credential_account_serializer.rb
+++ b/app/serializers/rest/credential_account_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class REST::CredentialAccountSerializer < REST::AccountSerializer
+  attributes :default_privacy
+
+  def default_privacy
+    object.user.setting_default_privacy
+  end
+end

--- a/app/serializers/rest/credential_account_serializer.rb
+++ b/app/serializers/rest/credential_account_serializer.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class REST::CredentialAccountSerializer < REST::AccountSerializer
-  attributes :default_privacy
+  attributes :raw_note, :default_privacy
+
+  def raw_note
+    object.note
+  end
 
   def default_privacy
     object.user.setting_default_privacy

--- a/app/serializers/rest/credential_account_serializer.rb
+++ b/app/serializers/rest/credential_account_serializer.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class REST::CredentialAccountSerializer < REST::AccountSerializer
-  attributes :raw_note, :default_privacy
+  attributes :source
 
-  def raw_note
-    object.note
-  end
-
-  def default_privacy
-    object.user.setting_default_privacy
+  def source
+    user = object.user
+    {
+      privacy: user.setting_default_privacy,
+      note: object.note,
+    }
   end
 end


### PR DESCRIPTION
Make the authorized user default privacy information available via the API

### API response

```console
$ curl -sS -H "Authorization: Bearer ${MASTODON_ACCESS_TOKEN}" http://localhost:3000/api/v1/accounts/verify_credentials | jq '.'
{
  "id": 2,
  "username": "ykzts",
  "acct": "ykzts",
  "display_name": "",
  "locked": false,
  "created_at": "2017-06-26T02:05:49.145Z",
  "followers_count": 1,
  "following_count": 0,
  "statuses_count": 10,
  "note": "<p></p>",
  "url": "http://localhost:3000/@ykzts",
  "avatar": "http://localhost:3000/avatars/original/missing.png",
  "avatar_static": "http://localhost:3000/avatars/original/missing.png",
  "header": "http://localhost:3000/headers/original/missing.png",
  "header_static": "http://localhost:3000/headers/original/missing.png",
  "default_privacy": "public"
}
```