### PR TITLE
Format datetime of subscriptions on admin UI

### DIFF
--- a/app/views/admin/subscriptions/_subscription.html.haml
+++ b/app/views/admin/subscriptions/_subscription.html.haml
@@ -7,10 +7,12 @@
     - if subscription.confirmed?
       %i.fa.fa-check
   %td{ style: "color: #{subscription.expired? ? 'red' : 'inherit'};" }
-    = precede subscription.expired? ? '-' : '' do
-      = time_ago_in_words(subscription.expires_at)
+    %time.time-ago{ datetime: subscription.expires_at.iso8601, title: l(subscription.expires_at) }
+      = precede subscription.expired? ? '-' : '' do
+        = time_ago_in_words(subscription.expires_at)
   %td
     - if subscription.last_successful_delivery_at?
-      = l subscription.last_successful_delivery_at
+      %time.formatted{ datetime: subscription.last_successful_delivery_at.iso8601, title: l(subscription.last_successful_delivery_at) }
+        = l subscription.last_successful_delivery_at
     - else
       %i.fa.fa-times


### PR DESCRIPTION
It formats the time of the subscription that can be checked from the admin UI. I'm diverting the JavaScript used on the status page on public UI.

### Breaking

- Change time zone to local time from UTC

### Screenshot (`/admin/subscriptions`)

![screenshot on `http://localhost:3000/admin/subscriptions`](https://user-images.githubusercontent.com/12539/27864601-3314f1ca-61ca-11e7-9c9b-75d424f36f8b.png)