### PR TITLE
Don't use locked state as default privacy setting in anywhere

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -247,7 +247,7 @@ class Status < ApplicationRecord
   end
 
   def set_visibility
-    self.visibility = (account.locked? ? :private : :public) if visibility.nil?
+    self.visibility = :public if visibility.nil?
   end
 
   def set_conversation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,7 +76,7 @@ class User < ApplicationRecord
   end
 
   def setting_default_privacy
-    settings.default_privacy || (account.locked? ? 'private' : 'public')
+    settings.default_privacy || 'public'
   end
 
   def setting_boost_modal

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -8,7 +8,7 @@ en:
           one: <span class="name-counter">1</span> character left
           other: <span class="name-counter">%{count}</span> characters left
         header: PNG, GIF or JPG. At most 2MB. Will be downscaled to 700x335px
-        locked: Requires you to manually approve followers and defaults post privacy to followers-only
+        locked: Requires you to manually approve followers
         note:
           one: <span class="note-counter">1</span> character left
           other: <span class="note-counter">%{count}</span> characters left

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -6,7 +6,7 @@ ja:
         avatar: 2MBまでのPNGやGIF、JPGが利用可能です。120x120pxまで縮小されます。
         display_name: あと<span class="name-counter">%{count}</span>文字入力できます。
         header: 2MBまでのPNGやGIF、JPGが利用可能です。 700x335pxまで縮小されます。
-        locked: フォロワーを手動で承認する必要があります。デフォルトではトゥートの公開範囲はフォロワーのみです。
+        locked: フォロワーを手動で承認する必要があります。
         note: あと<span class="note-counter">%{count}</span>文字入力できます。
       imports:
         data: 他の Mastodon インスタンスからエクスポートしたCSVファイルを選択して下さい

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -200,13 +200,8 @@ RSpec.describe User, type: :model do
       expect(user.setting_default_privacy).to eq 'unlisted'
     end
 
-    it "returns 'private' if user has not configured default privacy setting and account is locked" do
-      user = Fabricate(:user, account: Fabricate(:account, locked: true))
-      expect(user.setting_default_privacy).to eq 'private'
-    end
-
-    it "returns 'public' if user has not configured default privacy setting and account is not locked" do
-      user = Fabricate(:user, account: Fabricate(:account, locked: false))
+    it "returns 'public' if user has not configured default privacy setting" do
+      user = Fabricate(:user, account: Fabricate(:account))
       expect(user.setting_default_privacy).to eq 'public'
     end
   end


### PR DESCRIPTION
Currently we set *default post privacy* for locked account to "private". However, it only means:

* default value for `visibility` option on post status API
* default value for default privacy setting for web UI

i.e. it makes no sense if the client specifies (own default) visibility option, or the user already set default privacy setting. This may confuse users.

This removes the hint text about this from Profile page, and current usages for consistency.

Other option: Set default privacy setting for web UI to "private" when the user locked account, and provide this value to clients, although clients may not respect that value.