### PR TITLE
Improve Activity stream spoiler

### DIFF
--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -53,8 +53,12 @@ function main() {
     }
   });
 
-  delegate(document, '.media-spoiler', 'click', ({ target }) => {
-    target.style.display = 'none';
+  delegate(document, '.activity-stream .media-spoiler-wrapper .media-spoiler', 'click', function() {
+    this.parentNode.classList.add('media-spoiler-wrapper__visible');
+  });
+
+  delegate(document, '.activity-stream .media-spoiler-wrapper .spoiler-button', 'click', function() {
+    this.parentNode.classList.remove('media-spoiler-wrapper__visible');
   });
 
   delegate(document, '.webapp-btn', 'click', ({ target, button }) => {

--- a/app/javascript/styles/stream_entries.scss
+++ b/app/javascript/styles/stream_entries.scss
@@ -330,6 +330,18 @@
     }
   }
 
+  .media-spoiler-wrapper {
+    &.media-spoiler-wrapper__visible {
+      .media-spoiler {
+        display: none;
+      }
+
+      .spoiler-button {
+        display: block;
+      }
+    }
+  }
+
   .pre-header {
     padding: 14px 0;
     padding-left: (48px + 14px * 2);

--- a/app/views/stream_entries/_content_spoiler.html.haml
+++ b/app/views/stream_entries/_content_spoiler.html.haml
@@ -1,3 +1,7 @@
-.media-spoiler
-  %span= t('stream_entries.sensitive_content')
-  %span= t('stream_entries.click_to_show')
+.media-spoiler-wrapper{ class: sensitive == false && 'media-spoiler-wrapper__visible' }
+  .spoiler-button
+    .icon-button.overlayed
+      %i.fa.fa-fw.fa-eye
+  .media-spoiler
+    %span= t('stream_entries.sensitive_content')
+    %span= t('stream_entries.click_to_show')

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -17,13 +17,11 @@
   - unless status.media_attachments.empty?
     - if status.media_attachments.first.video?
       .video-player
-        - if status.sensitive?
-          = render partial: 'stream_entries/content_spoiler'
+        = render partial: 'stream_entries/content_spoiler', locals: { sensitive: status.sensitive? }
         %video.u-video{ src: status.media_attachments.first.file.url(:original), loop: true }
     - else
       .detailed-status__attachments
-        - if status.sensitive?
-          = render partial: 'stream_entries/content_spoiler'
+        = render partial: 'stream_entries/content_spoiler', locals: { sensitive: status.sensitive? }
         .status__attachments__inner
           - status.media_attachments.each do |media|
             = render partial: 'stream_entries/media', locals: { media: media }

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -22,8 +22,7 @@
 
   - unless status.media_attachments.empty?
     .status__attachments
-      - if status.sensitive?
-        = render partial: 'stream_entries/content_spoiler'
+      = render partial: 'stream_entries/content_spoiler', locals: { sensitive: status.sensitive? }
       - if status.media_attachments.first.video?
         .status__attachments__inner
           .video-item


### PR DESCRIPTION
Fixed a problem that images were not displayed when clicking on the spoiler part of the activity stream. In addition, added a hide button just like the media on Timeline.

before:
![spoiler_before](https://user-images.githubusercontent.com/4199439/27918620-782b8b8a-62aa-11e7-8cf0-67570d679548.gif)

after:
![spoiler_after](https://user-images.githubusercontent.com/4199439/27918626-7db8955c-62aa-11e7-8dcd-668bd80ee061.gif)
