### PR TITLE
Fix #4058 - Use a long-lived cookie to keep track of user-level sessions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,7 +70,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_session
-    @current_session ||= SessionActivation.find_by(session_id: session['auth_id'])
+    @current_session ||= SessionActivation.find_by(session_id: cookies.signed['_session_id'])
   end
 
   def cache_collection(raw, klass)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,17 +1,29 @@
 Warden::Manager.after_set_user except: :fetch do |user, warden|
-  SessionActivation.deactivate warden.raw_session['auth_id']
-  warden.raw_session['auth_id'] = user.activate_session(warden.request)
+  SessionActivation.deactivate warden.cookies.signed['_session_id']
+
+  warden.cookies.signed['_session_id'] = {
+    value: user.activate_session(warden.request),
+    expires: 1.year.from_now,
+    httponly: true,
+  }
 end
 
 Warden::Manager.after_fetch do |user, warden|
-  unless user.session_active?(warden.raw_session['auth_id'])
+  if user.session_active?(warden.cookies.signed['_session_id'])
+    warden.cookies.signed['_session_id'] = {
+      value: warden.cookies.signed['_session_id'],
+      expires: 1.year.from_now,
+      httponly: true,
+    }
+  else
     warden.logout
     throw :warden, message: :unauthenticated
   end
 end
 
 Warden::Manager.before_logout do |_, warden|
-  SessionActivation.deactivate warden.raw_session['auth_id']
+  SessionActivation.deactivate warden.cookies.signed['_session_id']
+  warden.cookies.delete('_session_id')
 end
 
 Devise.setup do |config|

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,9 +9,9 @@ Warden::Manager.after_set_user except: :fetch do |user, warden|
 end
 
 Warden::Manager.after_fetch do |user, warden|
-  if user.session_active?(warden.cookies.signed['_session_id'])
+  if user.session_active?(warden.cookies.signed['_session_id'] || warden.raw_session['auth_id'])
     warden.cookies.signed['_session_id'] = {
-      value: warden.cookies.signed['_session_id'],
+      value: warden.cookies.signed['_session_id'] || warden.raw_session['auth_id'],
       expires: 1.year.from_now,
       httponly: true,
     }


### PR DESCRIPTION
Reference: <https://gist.github.com/KieranP/9044432>