### PR TITLE
Update webpack-dev-server to v2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "react-intl-translations-manager": "^5.0.0",
     "react-test-renderer": "^15.6.1",
     "sinon": "^2.3.5",
-    "webpack-dev-server": "webpack/webpack-dev-server#047a5954398e67b0a17e6be7d5877d9f55f40cba",
+    "webpack-dev-server": "^2.5.1",
     "yargs": "^8.0.2"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7198,9 +7198,9 @@ webpack-dev-middleware@^1.10.2, webpack-dev-middleware@^1.11.0:
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
 
-webpack-dev-server@webpack/webpack-dev-server#047a5954398e67b0a17e6be7d5877d9f55f40cba:
-  version "2.5.0"
-  resolved "https://codeload.github.com/webpack/webpack-dev-server/tar.gz/047a5954398e67b0a17e6be7d5877d9f55f40cba"
+webpack-dev-server@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.5.1.tgz#a02e726a87bb603db5d71abb7d6d2649bf10c769"
   dependencies:
     ansi-html "0.0.7"
     bonjour "^3.5.0"


### PR DESCRIPTION
- https://github.com/webpack/webpack-dev-server/pull/946#issuecomment-313593956

> So so so sorry about the delay on this all! I have now published as webpack-dev-server@2.5.1 🎉