### PR TITLE
Add more blur to image previews

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1104,7 +1104,7 @@
 
   &.image-loader--loading {
     .image-loader__preview-canvas {
-      filter: blur(2px);
+      filter: blur(10px);
     }
   }
 


### PR DESCRIPTION
Adds more blur to the preview image so that it's clear that it's in a "loading" state, since otherwise it can be hard to tell.

Before: https://gfycat.com/VainCostlyDungenesscrab (throttled to 3G)

After: https://gfycat.com/AthleticSkeletalAlleycat (throttled to 3G)

I think it's debatable whether the entire preview system is an improvement over the browser's built-in loading of images, but personally I find it a bit jarring when an image loads from top-to-bottom, and plus not all images even have a progressive view (it depends how the JPEG is encoded, and PNGs don't have them at all). So I think the blurred approach is nice for consistency.

Fixes #4060