### PR TITLE
Gracefully stop streaming server

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -467,6 +467,7 @@ const startWorker = (workerId) => {
   const onExit = () => {
     log.info(`Worker ${workerId} exiting, bye bye`);
     server.close();
+    process.exit(0);
   };
 
   const onError = (err) => {


### PR DESCRIPTION
Before this change: if you run `foreman start` and then Ctrl-C it (e.g. on MacOS), the streaming server would still be running (`ps -ef | grep streaming`).

After this change: doing Ctrl-C on `foreman start` will cause the streaming server to gracefully shut down.