### PR TITLE
Use babel-plugin-transform-react-inline-elements

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -44,6 +44,7 @@
             ]
           }
         ],
+        "transform-react-inline-elements",
         [
           "transform-runtime",
           {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-plugin-transform-react-inline-elements": "^6.22.0",
     "babel-plugin-transform-react-jsx-self": "^6.22.0",
     "babel-plugin-transform-react-jsx-source": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,6 +1027,12 @@ babel-plugin-transform-react-display-name@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-react-inline-elements@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-inline-elements/-/babel-plugin-transform-react-inline-elements-6.22.0.tgz#6687211a32b49a52f22c573a2b5504a25ef17c53"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-react-jsx-self@6.22.0, babel-plugin-transform-react-jsx-self@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz#df6d80a9da2612a121e6ddd7558bcbecf06e636e"


### PR DESCRIPTION
This adds [babel-plugin-transform-react-inline-elements](https://babeljs.io/docs/plugins/transform-react-inline-elements/) which is [recommended by Netflix](https://medium.com/netflix-techblog/crafting-a-high-performance-tv-user-interface-using-react-3350e5a6ad3b) and described a bit [here](https://github.com/facebook/react/issues/3228).

I tried to measure the runtime perf benefit, but it's small enough that it's hard to see a huge impact (other than the fact that `ReactElement.createElement()` calls are now gone). On the other hand, it does reduce `application.js` from 510331 bytes to 509402 bytes (~1kB saved), and based on the documentation it doesn't appear to have any downsides.