### PR TITLE
Fix JSON serialization of media_attachment (regression from #4090)

### DIFF
--- a/app/serializers/rest/media_attachment_serializer.rb
+++ b/app/serializers/rest/media_attachment_serializer.rb
@@ -15,7 +15,7 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
   end
 
   def text_url
-    medium_url(object.id)
+    object.local? ? medium_url(object) : nil
   end
 
   def meta


### PR DESCRIPTION
```
{
  "id":20,
  "type":"image",
  "url":"http://localhost:3000/system/media_attachments/files/000/000/020/original/501dc585d56426dd.png?1499464144",
  "preview_url":"http://localhost:3000/system/media_attachments/files/000/000/020/small/501dc585d56426dd.png?1499464144",
  "remote_url":"",
  "text_url":"http://localhost:3000/media/20",
  "meta":{ ... }
}
```

text_url should be `https://.../media/{shortcode}`, not `https://.../media/{id}`. Also it should be `nil` if it's remote resource (it throws Exception due to lack of shortcode).