### PR TITLE
Use srcSet only when know width (regression from #3963)

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -91,8 +91,10 @@ class Item extends React.PureComponent {
       const originalUrl = attachment.get('url');
       const originalWidth = attachment.getIn(['meta', 'original', 'width']);
 
-      const srcSet = `${originalUrl} ${originalWidth}w, ${previewUrl} ${previewWidth}w`;
-      const sizes = `(min-width: 1025px) ${320 * (width / 100)}px, ${width}vw`;
+      const hasSize = typeof originalWidth === 'number' && typeof previewWidth === 'number';
+
+      const srcSet = hasSize && `${originalUrl} ${originalWidth}w, ${previewUrl} ${previewWidth}w`;
+      const sizes = hasSize && `(min-width: 1025px) ${320 * (width / 100)}px, ${width}vw`;
 
       thumbnail = (
         <a


### PR DESCRIPTION
Media Attachment that don't know the width of the image (before #2448) warns.

### screenshot

![](https://user-images.githubusercontent.com/12539/27983293-fe6a5fe2-63f3-11e7-8910-9b13666a3871.png)

### HTML

```html
<a class="media-gallery__item-thumbnail" href="https://files.omanko.porn/media_attachments/files/000/000/398/original/d4ff1f1c334248ca.png" target="_blank">
  <img src="https://files.omanko.porn/media_attachments/files/000/000/398/small/d4ff1f1c334248ca.png" srcset="https://files.omanko.porn/media_attachments/files/000/000/398/original/d4ff1f1c334248ca.png undefinedw, https://files.omanko.porn/media_attachments/files/000/000/398/small/d4ff1f1c334248ca.png undefinedw" sizes="(min-width: 1025px) 320px, 100vw" alt="">
</a>
```

**`https://example.com/image.png undefinedw`** :cry: