### PR TITLE
Fix first loading of notifications when the column is pinned (regression from #3879)

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -11,10 +11,8 @@ import { isMobile } from '../../is_mobile';
 import { debounce } from 'lodash';
 import { uploadCompose } from '../../actions/compose';
 import { refreshHomeTimeline } from '../../actions/timelines';
-import { refreshNotifications } from '../../actions/notifications';
 import { WrappedSwitch, WrappedRoute } from './util/react_router_helpers';
 import UploadArea from './components/upload_area';
-import { store } from '../../containers/mastodon';
 import ColumnsAreaContainer from './containers/columns_area_container';
 import {
   Compose,
@@ -30,18 +28,13 @@ import {
   Reblogs,
   Favourites,
   HashtagTimeline,
-  Notifications as AsyncNotifications,
+  Notifications,
   FollowRequests,
   GenericNotFound,
   FavouritedStatuses,
   Blocks,
   Mutes,
 } from './util/async-components';
-
-const Notifications = () => AsyncNotifications().then(component => {
-  store.dispatch(refreshNotifications());
-  return component;
-});
 
 // Dummy import, to make sure that <Status /> ends up in the application bundle.
 // Without this it ends up in ~8 very commonly used bundles.

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -1,4 +1,5 @@
 import { store } from '../../../containers/mastodon';
+import { refreshNotifications } from '../../../actions/notifications';
 import { injectAsyncReducer } from '../../../store/configureStore';
 
 // NOTE: When lazy-loading reducers, make sure to add them
@@ -29,6 +30,8 @@ export function Notifications () {
     import(/* webpackChunkName: "reducers/notifications" */'../../../reducers/notifications'),
   ]).then(([component, notificationsReducer]) => {
     injectAsyncReducer(store, 'notifications', notificationsReducer.default);
+
+    store.dispatch(refreshNotifications());
 
     return component;
   });


### PR DESCRIPTION
#3879 changed initial load timing of notifications from `componentWillMount` of the `UI` to after module loading, but it wasn't applied to non-pinned column.

Other option: Load notifications on `componentDid(Will?)Mount` like other column, but this will load on every mounting.

cc @sorin-davidoi 