### PR TITLE
Do not assume /xmlns:id is unique accorss domains

### DIFF
--- a/app/lib/atom_serializer.rb
+++ b/app/lib/atom_serializer.rb
@@ -84,6 +84,7 @@ class AtomSerializer
     end
 
     append_element(entry, 'link', nil, rel: :alternate, type: 'text/html', href: account_stream_entry_url(stream_entry.account, stream_entry))
+    append_element(entry, 'link', nil, rel: :related, href: TagManager.instance.url_for(stream_entry.status)) unless stream_entry.status.nil?
     append_element(entry, 'link', nil, rel: :self, type: 'application/atom+xml', href: account_stream_entry_url(stream_entry.account, stream_entry, format: 'atom'))
     append_element(entry, 'thr:in-reply-to', nil, ref: TagManager.instance.uri_for(stream_entry.thread), href: TagManager.instance.url_for(stream_entry.thread)) if stream_entry.threaded?
     append_element(entry, 'ostatus:conversation', nil, ref: conversation_uri(stream_entry.status.conversation)) unless stream_entry&.status&.conversation_id.nil?

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -22,6 +22,7 @@
 #  reblogs_count          :integer          default(0), not null
 #  language               :string
 #  conversation_id        :integer
+#  remote_url             :string
 #
 
 class Status < ApplicationRecord

--- a/db/migrate/20170714010000_add_statuses_index_on_uri_account_id.rb
+++ b/db/migrate/20170714010000_add_statuses_index_on_uri_account_id.rb
@@ -1,0 +1,10 @@
+class AddStatusesIndexOnUriAccountId < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    # URI is not ensured to be unique across accounts, so index with accounts.
+    add_index 'statuses', ['uri', 'account_id'], algorithm: :concurrently, name: 'index_statuses_on_uri_account_id', unique: true
+
+    remove_index 'statuses', algorithm: :concurrently, column: 'uri', name: 'index_statuses_on_uri', unique: true
+  end
+end

--- a/db/migrate/20170714020000_add_remote_url_to_statuses.rb
+++ b/db/migrate/20170714020000_add_remote_url_to_statuses.rb
@@ -1,0 +1,5 @@
+class AddRemoteUrlToStatuses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :statuses, :remote_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170713190709) do
+ActiveRecord::Schema.define(version: 20170714020000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -292,11 +292,12 @@ ActiveRecord::Schema.define(version: 20170713190709) do
     t.integer "reblogs_count", default: 0, null: false
     t.string "language"
     t.bigint "conversation_id"
+    t.string "remote_url"
     t.index ["account_id", "id"], name: "index_statuses_on_account_id_id"
     t.index ["conversation_id"], name: "index_statuses_on_conversation_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["reblog_of_id"], name: "index_statuses_on_reblog_of_id"
-    t.index ["uri"], name: "index_statuses_on_uri", unique: true
+    t.index ["uri", "account_id"], name: "index_statuses_on_uri_account_id", unique: true
   end
 
   create_table "statuses_tags", id: false, force: :cascade do |t|

--- a/spec/fixtures/xml/mastodon.atom
+++ b/spec/fixtures/xml/mastodon.atom
@@ -28,6 +28,7 @@
     <content type="html">localhost started following kat@mastodon.social</content>
     <activity:verb>http://activitystrea.ms/schema/1.0/follow</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/12.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/12"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/12"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/activity</activity:object-type>
     <activity:object>
@@ -53,9 +54,10 @@
     <content type="html">localhost favourited a status by kat@mastodon.social</content>
     <activity:verb>http://activitystrea.ms/schema/1.0/favorite</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/11.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/11"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/11"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/activity</activity:object-type>
-    <thr:in-reply-to ref="tag:mastodon.social,2016-10-10:objectId=22833:objectType=Status" href="https://mastodon.social/users/kat/updates/16543" type="text/html"/>
+    <thr:in-reply-to ref="tag:mastodon.social,2016-10-10:objectId=22833:objectType=Status" href="https://mastodon.social/@kat/16543" type="text/html"/>
     <activity:object>
       <activity:object-type>http://activitystrea.ms/schema/1.0/comment</activity:object-type>
       <id>tag:mastodon.social,2016-10-10:objectId=22833:objectType=Status</id>
@@ -90,9 +92,10 @@
     <content type="html">localhost favourited a status by Gargron@mastodon.social</content>
     <activity:verb>http://activitystrea.ms/schema/1.0/favorite</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/10.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/10"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/10"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/activity</activity:object-type>
-    <thr:in-reply-to ref="tag:mastodon.social,2016-10-10:objectId=22825:objectType=Status" href="https://mastodon.social/users/Gargron/updates/16538" type="text/html"/>
+    <thr:in-reply-to ref="tag:mastodon.social,2016-10-10:objectId=22825:objectType=Status" href="https://mastodon.social/@Gargron/16538" type="text/html"/>
     <activity:object>
       <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
       <id>tag:mastodon.social,2016-10-10:objectId=22825:objectType=Status</id>
@@ -126,6 +129,7 @@
     <content type="html">&lt;p&gt;Social media needs MOAR cats! &lt;a rel="nofollow noopener" href="http://kickass.zone/media/3"&gt;http://kickass.zone/media/3&lt;/a&gt;&lt;/p&gt;</content>
     <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/9.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/9"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/9"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
     <link rel="enclosure" href="http://kickass.zone/system/media_attachments/files/000/000/003/original/gizmo.jpg?1476060065" type="image/jpeg" length="108841"/>
@@ -138,6 +142,7 @@
     <content type="html">&lt;p&gt;&lt;a rel="nofollow noopener" href="http://kickass.zone/media/2"&gt;http://kickass.zone/media/2&lt;/a&gt;&lt;/p&gt;</content>
     <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/8.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/8"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/8"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
     <link rel="enclosure" href="http://kickass.zone/system/media_attachments/files/000/000/002/original/morpheus_linux.jpg?1476059910" type="image/jpeg" length="191816"/>
@@ -149,6 +154,7 @@
     <title/>
     <activity:verb>http://activitystrea.ms/schema/1.0/delete</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/7.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/7"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/7"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/activity</activity:object-type>
   </entry>
@@ -160,6 +166,7 @@
     <content type="html">localhost started following bignimbus@mastodon.social</content>
     <activity:verb>http://activitystrea.ms/schema/1.0/follow</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/6.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/6"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/6"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/activity</activity:object-type>
     <activity:object>
@@ -185,6 +192,7 @@
     <content type="html">localhost started following Gargron@mastodon.social</content>
     <activity:verb>http://activitystrea.ms/schema/1.0/follow</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/5.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/5"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/5"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/activity</activity:object-type>
     <activity:object>
@@ -210,6 +218,7 @@
     <content type="html">localhost started following abc@mastodon.social</content>
     <activity:verb>http://activitystrea.ms/schema/1.0/follow</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/4.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/4"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/4"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/activity</activity:object-type>
     <activity:object>
@@ -232,6 +241,7 @@
     <title/>
     <activity:verb>http://activitystrea.ms/schema/1.0/delete</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/3.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/3"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/3"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/activity</activity:object-type>
   </entry>
@@ -243,9 +253,10 @@
     <content type="html">&lt;p&gt;Yes, that was the obligatory first post. :)&lt;/p&gt;</content>
     <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/2.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/2"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/2"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/comment</activity:object-type>
-    <thr:in-reply-to ref="tag:kickass.zone,2016-10-10:objectId=1:objectType=Status" href="http://kickass.zone/users/localhost/updates/1" type="text/html"/>
+    <thr:in-reply-to ref="tag:kickass.zone,2016-10-10:objectId=1:objectType=Status" href="http://kickass.zone/@localhost/1" type="text/html"/>
   </entry>
   <entry>
     <id>tag:kickass.zone,2016-10-10:objectId=1:objectType=Status</id>
@@ -255,6 +266,7 @@
     <content type="html">&lt;p&gt;Hello, world!&lt;/p&gt;</content>
     <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
     <link rel="self" type="application/atom+xml" href="http://kickass.zone/users/localhost/updates/1.atom"/>
+    <link rel="related" href="http://kickass.zone/@localhost/1"/>
     <link rel="alternate" type="text/html" href="http://kickass.zone/users/localhost/updates/1"/>
     <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
   </entry>

--- a/spec/lib/atom_serializer_spec.rb
+++ b/spec/lib/atom_serializer_spec.rb
@@ -534,6 +534,16 @@ RSpec.describe AtomSerializer do
       expect(link[:href]).to eq "https://cb6e6126.ngrok.io/users/username/updates/#{status.stream_entry.id}"
     end
 
+    it 'appends link element for related' do
+      account = Fabricate(:account, username: 'username')
+      status = Fabricate(:status, account: account)
+
+      entry = AtomSerializer.new.entry(status.stream_entry)
+
+      link = entry.nodes.find { |node| node.name == 'link' && node[:rel] == 'related' }
+      expect(link[:href]).to eq TagManager.instance.url_for(status)
+    end
+
     it 'appends link element for itself' do
       account = Fabricate(:account, username: 'username')
       status = Fabricate(:status, account: account)


### PR DESCRIPTION
The uniqueness of `/xmlns:id` across accounts is not ensured by any means and it could collide intentionally or unintentionally, so do not rely on the assumption.

~~Now URLs ensure the uniqueness and they should be in the same domains with corresponding accounts. That may be, however, problematic because specifications does not say they should have the same domains, and it does not prevent an account in a domain from crafting a URL colliding with a URL of another account in the same domain.~~