### PR TITLE
Change account link to admin account link on report page

### DIFF
--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -4,11 +4,11 @@
 .report-accounts
   .report-accounts__item
     %strong= t('admin.reports.reported_account')
-    = render 'authorize_follows/card', account: @report.target_account
+    = render 'authorize_follows/card', account: @report.target_account, admin: true
     = render 'admin/accounts/card', account: @report.target_account
   .report-accounts__item
     %strong= t('admin.reports.reported_by')
-    = render 'authorize_follows/card', account: @report.account
+    = render 'authorize_follows/card', account: @report.account, admin: true
     = render 'admin/accounts/card', account: @report.account
 
 %p

--- a/app/views/authorize_follows/_card.html.haml
+++ b/app/views/authorize_follows/_card.html.haml
@@ -4,7 +4,8 @@
       = image_tag account.avatar.url(:original), alt: '', width: 48, height: 48, class: 'avatar'
 
     %span.display-name
-      = link_to TagManager.instance.url_for(account), class: 'detailed-status__display-name p-author h-card', target: '_blank', rel: 'noopener' do
+      - account_url = local_assigns[:admin] ? admin_account_path(account.id) : TagManager.instance.url_for(account)
+      = link_to account_url, class: 'detailed-status__display-name p-author h-card', target: '_blank', rel: 'noopener' do
         %strong.emojify= display_name(account)
         %span @#{account.acct}
 


### PR DESCRIPTION
I changed the account link of "Reported account" and "Reported by" on the report page to the account link of the admin. It makes it easier to navigate from the report screen to the account page for administrators.

![image](https://user-images.githubusercontent.com/4199439/27986944-41a3161c-6441-11e7-9461-2e9ebad38684.png)
