### PR TITLE
[nanobox] Allow Full-size Uploads

### DIFF
--- a/nanobox/nginx-local.conf
+++ b/nanobox/nginx-local.conf
@@ -27,8 +27,8 @@ http {
     }
 
     map $http_upgrade $connection_upgrade {
-      default upgrade;
-      ''      close;
+        default upgrade;
+        ''      close;
     }
 
     # Configuration for Nginx
@@ -37,6 +37,8 @@ http {
         listen 8080;
 
         root /app/public;
+
+        client_max_body_size 8M;
 
         location / {
             try_files $uri @rails;

--- a/nanobox/nginx-stream.conf.erb
+++ b/nanobox/nginx-stream.conf.erb
@@ -22,8 +22,8 @@ http {
     }
 
     map $http_upgrade $connection_upgrade {
-      default upgrade;
-      ''      close;
+        default upgrade;
+        ''      close;
     }
 
     # Configuration for Nginx

--- a/nanobox/nginx-web.conf.erb
+++ b/nanobox/nginx-web.conf.erb
@@ -22,8 +22,8 @@ http {
     }
 
     map $http_upgrade $connection_upgrade {
-      default upgrade;
-      ''      close;
+        default upgrade;
+        ''      close;
     }
 
     # Configuration for Nginx
@@ -35,6 +35,8 @@ http {
         add_header Content-Security-Policy "style-src 'self' 'unsafe-inline'; script-src 'self'; object-src 'self'; img-src data: https:; media-src data: https:; connect-src 'self' wss://<%= ENV["LOCAL_DOMAIN"] %>; upgrade-insecure-requests";
 
         root /app/public;
+
+        client_max_body_size 8M;
 
         location / {
             try_files $uri @rails;


### PR DESCRIPTION
The Nginx configurations used by Nanobox previously neglected to increase the default upload size limit. This PR bumps that value up to the current Mastodon limit of 8MiB.