### PR TITLE
Avoid async import if the component is previously loaded

### DIFF
--- a/app/javascript/mastodon/features/ui/components/bundle.js
+++ b/app/javascript/mastodon/features/ui/components/bundle.js
@@ -26,6 +26,8 @@ class Bundle extends React.Component {
     onFetchFail: noop,
   }
 
+  static cache = {}
+
   state = {
     mod: undefined,
     forceRender: false,
@@ -58,8 +60,17 @@ class Bundle extends React.Component {
       this.timeout = setTimeout(() => this.setState({ forceRender: true }), renderDelay);
     }
 
+    if (Bundle.cache[fetchComponent.name]) {
+      const mod = Bundle.cache[fetchComponent.name];
+
+      this.setState({ mod: mod.default });
+      onFetchSuccess();
+      return Promise.resolve();
+    }
+
     return fetchComponent()
       .then((mod) => {
+        Bundle.cache[fetchComponent.name] = mod;
         this.setState({ mod: mod.default });
         onFetchSuccess();
       })


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/705555/27993709-e4006790-64e9-11e7-9add-f0f49e62d5d8.png)

After

![image](https://user-images.githubusercontent.com/705555/27993694-958d0adc-64e9-11e7-9eca-e59c91c5f0cd.png)

This avoids flashing of loading view and slightly reduces total time.

cc @sorin-davidoi 