### PR TITLE
Remote following success page

### DIFF
--- a/app/controllers/authorize_follows_controller.rb
+++ b/app/controllers/authorize_follows_controller.rb
@@ -15,7 +15,7 @@ class AuthorizeFollowsController < ApplicationController
     if @account.nil?
       render :error
     else
-      redirect_to web_url("accounts/#{@account.id}")
+      render :success
     end
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     render :error

--- a/app/javascript/styles/forms.scss
+++ b/app/javascript/styles/forms.scss
@@ -375,3 +375,12 @@ code {
     width: 50%;
   }
 }
+
+.post-follow-actions {
+  text-align: center;
+  color: $ui-primary-color;
+
+  div {
+    margin-bottom: 4px;
+  }
+}

--- a/app/views/authorize_follows/success.html.haml
+++ b/app/views/authorize_follows/success.html.haml
@@ -4,9 +4,9 @@
 .form-container
   .follow-prompt
     - if @account.locked?
-      %h2= t('authorize_follow.follow_request_html', self: current_account.username)
+      %h2= t('authorize_follow.follow_request')
     - else
-      %h2= t('authorize_follow.following_html', self: current_account.username)
+      %h2= t('authorize_follow.following')
 
     = render 'card', account: @account
 

--- a/app/views/authorize_follows/success.html.haml
+++ b/app/views/authorize_follows/success.html.haml
@@ -1,0 +1,16 @@
+- content_for :page_title do
+  = t('authorize_follow.title', acct: @account.acct)
+
+.form-container
+  .follow-prompt
+    - if @account.locked?
+      %h2= t('authorize_follow.follow_request_html', self: current_account.username)
+    - else
+      %h2= t('authorize_follow.following_html', self: current_account.username)
+
+    = render 'card', account: @account
+
+  .post-follow-actions
+    %div= link_to t('authorize_follow.post_follow.web'), web_url("accounts/#{@account.id}"), class: 'button button--block'
+    %div= link_to t('authorize_follow.post_follow.return'), @account.url, class: 'button button--block'
+    %div= t('authorize_follow.post_follow.close')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,8 +218,8 @@ en:
   authorize_follow:
     error: Unfortunately, there was an error looking up the remote account
     follow: Follow
-    following_html: 'Success! You (<strong>%{self}</strong>) are now following:'
-    follow_request_html: 'You (<strong>%{self}</strong>) have sent a follow request to:'
+    following: 'Success! You are now following:'
+    follow_request: 'You have sent a follow request to:'
     post_follow:
       web: Go to web
       return: Return to the user's profile

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,6 +218,12 @@ en:
   authorize_follow:
     error: Unfortunately, there was an error looking up the remote account
     follow: Follow
+    following_html: 'Success! You (<strong>%{self}</strong>) are now following:'
+    follow_request_html: 'You (<strong>%{self}</strong>) have sent a follow request to:'
+    post_follow:
+      web: Go to web
+      return: Return to the user's profile
+      close: Or, you can just close this window.
     prompt_html: 'You (<strong>%{self}</strong>) have requested to follow:'
     title: Follow %{acct}
   datetime:

--- a/spec/controllers/authorize_follows_controller_spec.rb
+++ b/spec/controllers/authorize_follows_controller_spec.rb
@@ -103,7 +103,7 @@ describe AuthorizeFollowsController do
         post :create, params: { acct: 'acct:user@hostname' }
 
         expect(service).to have_received(:call).with(account, 'user@hostname')
-        expect(response).to redirect_to(web_url('accounts/123'))
+        expect(response).to render_template(:success)
       end
     end
   end

--- a/spec/controllers/authorize_follows_controller_spec.rb
+++ b/spec/controllers/authorize_follows_controller_spec.rb
@@ -94,7 +94,7 @@ describe AuthorizeFollowsController do
       end
 
       it 'follows account when found' do
-        target_account = Account.new
+        target_account = Fabricate(:account)
         result_account = double(target_account: target_account)
         service = double
         allow(FollowService).to receive(:new).and_return(service)

--- a/spec/controllers/authorize_follows_controller_spec.rb
+++ b/spec/controllers/authorize_follows_controller_spec.rb
@@ -94,7 +94,7 @@ describe AuthorizeFollowsController do
       end
 
       it 'follows account when found' do
-        target_account = double(id: '123')
+        target_account = Account.new
         result_account = double(target_account: target_account)
         service = double
         allow(FollowService).to receive(:new).and_return(service)


### PR DESCRIPTION
Instead of immediately redirecting to web upon doing a remote follow, show an interstitial success page with links to web (the same redirect as before), and a link back to the remote user's profile, while also saying it's safe to close the page.

Personally, I keep my instance open in a pinned tab all the time but I prefer using the remote follow button to follow people over copying and pasting URLs around. Having remote follows automatically redirect to web was rather annoying since I would already have it open somewhere else.

Preview of how it looks:
![rfconfirm](https://user-images.githubusercontent.com/539749/27999762-428ec8f2-64d5-11e7-85bf-054bedda2257.PNG)
