### PR TITLE
Add Japanese translation of terms and flash

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -24,7 +24,7 @@ module Admin
         setting.update(value: value_for_update(key, value))
       end
 
-      flash[:notice] = 'Success!'
+      flash[:notice] = I18n.t('generic.changes_saved_msg')
       redirect_to edit_admin_settings_path
     end
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -183,6 +183,9 @@ ja:
       site_description_extended:
         desc_html: インスタンスについてのページに表示されます。<br>HTMLタグが利用可能です。
         title: サイトの詳細な説明
+      site_terms:
+        desc_html: プライバシーポリシーのページに表示されます。<br>HTMLタグが利用可能です。
+        title: サイトのプライバシーポリシー
       site_title: サイトのタイトル
       title: サイト設定
     subscriptions:


### PR DESCRIPTION
Translated site privacy policy and flash message on `/admin/settings/edit` into Japanese.

### Before:
![admin_settings_terms_before](https://user-images.githubusercontent.com/17060801/28009607-f4cc59fa-6596-11e7-9bcf-38398cdfd7f8.png)
![admin_settings_flash_before](https://user-images.githubusercontent.com/17060801/28009619-fb582452-6596-11e7-9eac-3987e09c2a34.png)

### After:
![admin_settings_terms_after](https://user-images.githubusercontent.com/17060801/28009623-01160d28-6597-11e7-9c97-1ab8f04c36fb.png)
![admin_settings_flash_after](https://user-images.githubusercontent.com/17060801/28009628-0523c7ac-6597-11e7-9105-4a9ca84c02ab.png)