### PR TITLE
Rescue exceptions related to Goldfinger at FetchRemoteStatusService

### DIFF
--- a/app/services/fetch_remote_status_service.rb
+++ b/app/services/fetch_remote_status_service.rb
@@ -33,6 +33,9 @@ class FetchRemoteStatusService < BaseService
   rescue Nokogiri::XML::XPath::SyntaxError
     Rails.logger.debug 'Invalid XML or missing namespace'
     nil
+  rescue Goldfinger::NotFoundError, Goldfinger::Error
+    Rails.logger.debug 'Exceptions related to Goldfinger occurs'
+    nil
   end
 
   def confirmed_domain?(domain, account)


### PR DESCRIPTION
As with #4044, rescue Goldfinger exceptions that occur at FetchRemoteStatusService