### PR TITLE
Fix #4059 - Remove ModuleConcatenationPlugin

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -12,7 +12,6 @@ module.exports = merge(sharedConfig, {
   stats: 'normal',
 
   plugins: [
-    new webpack.optimize.ModuleConcatenationPlugin(),
     new webpack.optimize.UglifyJsPlugin({
       sourceMap: true,
       mangle: true,


### PR DESCRIPTION
It increased memory usage of Webpack 1.5x fold with little benefits