### PR TITLE
Limit total subscribe retries to 10, but space them out more

### DIFF
--- a/app/workers/pubsubhubbub/subscribe_worker.rb
+++ b/app/workers/pubsubhubbub/subscribe_worker.rb
@@ -3,7 +3,20 @@
 class Pubsubhubbub::SubscribeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push'
+  sidekiq_options queue: 'push', retry: 10, unique: :until_executed
+
+  sidekiq_retry_in do |count|
+    case count
+    when 0
+      30.minutes.seconds
+    when 1
+      2.hours.seconds
+    when 2
+      12.hours.seconds
+    else
+      24.hours.seconds * (count - 2)
+    end
+  end
 
   def perform(account_id)
     account = Account.find(account_id)


### PR DESCRIPTION
Since there is little point in retrying so often when a service is down
or does not exist anymore. Subscriptions are renewed 1 day before they
should expire, so retrying in 30 minutes, then 2 hours, then 12 hours
is fine. If even after that, the remote server does not work, there is
little sense in retrying more often than once a day

Also, uniqueness of the job should ensure that failed retries will
not result in multiple retries for the same endpoint when the next
resubscription cycle comes