### PR TITLE
Update es5-ext to avoid CSP violation

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2512,8 +2512,8 @@ es-to-primitive@^1.1.1:
     is-symbol "^1.0.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.23"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.23.tgz#7578b51be974207a5487821b56538c224e4e7b38"
+  version "0.10.24"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.24.tgz#a55877c9924bc0c8d9bd3c2cbe17495ac1709b14"
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"


### PR DESCRIPTION
Since es5-ext used `new Function("...")`, it caused CSP violation unless "unsafe-eval" included. So this patch updates it to the version which fixes it.

Note that this package is used in polyfills (e.g. Symbol), so loaded only if needed. I've encountered this issue on iOS9.

cf. medikoo/es5-ext@d3864493