### PR TITLE
Require stylesheets in common.js

### DIFF
--- a/app/javascript/mastodon/main.js
+++ b/app/javascript/mastodon/main.js
@@ -1,9 +1,5 @@
 const perf = require('./performance');
 
-// import default stylesheet with variables
-require('font-awesome/css/font-awesome.css');
-require('mastodon-application-style');
-
 function onDomContentLoaded(callback) {
   if (document.readyState !== 'loading') {
     callback();

--- a/app/javascript/packs/common.js
+++ b/app/javascript/packs/common.js
@@ -1,2 +1,7 @@
 import { start } from 'rails-ujs';
+
+// import default stylesheet with variables
+require('font-awesome/css/font-awesome.css');
+require('mastodon-application-style');
+
 start();

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,7 +18,7 @@
         = ' - '
       = title
 
-    = stylesheet_pack_tag 'application', media: 'all'
+    = stylesheet_pack_tag 'common', media: 'all'
     = javascript_pack_tag 'common', integrity: true, crossorigin: 'anonymous'
 
     = javascript_pack_tag 'features/getting_started', integrity: true, crossorigin: 'anonymous', rel: 'preload', as: 'script'

--- a/app/views/layouts/embedded.html.haml
+++ b/app/views/layouts/embedded.html.haml
@@ -2,7 +2,7 @@
 %html{ lang: I18n.locale }
   %head
     %meta{ charset: 'utf-8' }/
-    = stylesheet_pack_tag 'application', media: 'all'
+    = stylesheet_pack_tag 'common', media: 'all'
     = javascript_pack_tag 'common', integrity: true, crossorigin: 'anonymous'
     = javascript_pack_tag "locale_#{I18n.locale}", integrity: true, crossorigin: 'anonymous'
     = javascript_pack_tag 'public', integrity: true, crossorigin: 'anonymous'


### PR DESCRIPTION
Require stylesheets in `common.js` because stylesheets are shared by the entry points.