### PR TITLE
Fix #3462 - Require authentication for search API

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -3,6 +3,9 @@
 class Api::V1::SearchController < Api::BaseController
   RESULTS_LIMIT = 5
 
+  before_action -> { doorkeeper_authorize! :read }
+  before_action :require_user!
+
   respond_to :json
 
   def index


### PR DESCRIPTION
This makes it consistent with /api/v1/accounts/search and
previous behaviour has been an oversight.