### PR TITLE
Fix media modal prev button behavior.

### DIFF
--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -35,7 +35,7 @@ export default class MediaModal extends ImmutablePureComponent {
   }
 
   handlePrevClick = () => {
-    this.setState({ index: (this.getIndex() - 1) % this.props.media.size });
+    this.setState({ index: (this.props.media.size + this.getIndex() - 1) % this.props.media.size });
   }
 
   handleKeyUp = (e) => {


### PR DESCRIPTION
When opening first picture of pictures in image loader, prev button works wrong. 