### PR TITLE
Fix #1010 - When spoiler text is set, enforce sensitivity too

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -124,6 +124,7 @@ class Status < ApplicationRecord
   before_validation :set_reblog
   before_validation :set_visibility
   before_validation :set_conversation
+  before_validation :set_sensitivity
 
   class << self
     def not_in_filtered_languages(account)
@@ -248,6 +249,10 @@ class Status < ApplicationRecord
 
   def set_visibility
     self.visibility = (account.locked? ? :private : :public) if visibility.nil?
+  end
+
+  def set_sensitivity
+    self.sensitive = sensitive || spoiler_text.present?
   end
 
   def set_conversation


### PR DESCRIPTION
There is a thing that can be done in web UI about connecting the visible/hidden state between the "show more" and the media spoiler, but this resolves the crux of the issue.

Resolves #3979