### PR TITLE
Fix threaded replies to non-federated statuses not being filtered from the timeline

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,9 +106,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    charlock_holmes (0.7.3)
     case_transform (0.2)
       activesupport
+    charlock_holmes (0.7.3)
     chunky_png (1.3.8)
     cld3 (3.1.3)
       ffi (>= 1.1.0, < 1.10.0)

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -117,7 +117,7 @@ class FeedManager
     return true if receiver.muting? check_for_mutes.compact
 
     # filter the status if I'm blocking anyone who was mentioned or the original author
-    check_for_blocks  = status.mentions.pluck(:account_id) + [status.reblog&.account_id]
+    check_for_blocks = status.mentions.pluck(:account_id) + [status.reblog&.account_id]
     return true if receiver.blocking? check_for_blocks.compact
 
     false
@@ -134,7 +134,7 @@ class FeedManager
     return true if receiver.blocking? check_for_blocks.compact
 
     # of if the account is silenced and I'm not following them
-    return true if (status.account.silenced? && !receiver.following?(status.account))
+    return true if status.account.silenced? && !receiver.following?(status.account)
 
     false
   end

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -126,16 +126,16 @@ class FeedManager
   def filter_from_mentions?(status, receiver)
 
     # Filter if I'm mentioning myself
-    should_filter = receiver.id == status.account_id
+    return true if receiver.id == status.account_id
 
     # or it's from someone I blocked, in reply to someone I blocked, or mentioning someone I blocked
-    check_for_blocks  = [status.account_id] + status.mentions.pluck(:account_id)
-    check_for_blocks << status.in_reply_to_account_id
-    should_filter ||= receiver.blocking? check_for_blocks.compact
+    check_for_blocks  = [status.account_id, status.in_reply_to_account_id]
+    check_for_blocks += status.mentions.pluck(:account_id)
+    return true if receiver.blocking? check_for_blocks.compact
 
     # of if the account is silenced and I'm not following them
-    should_filter ||= (status.account.silenced? && !receiver.following?(status.account))
+    return true if (status.account.silenced? && !receiver.following?(status.account))
 
-    should_filter
+    false
   end
 end

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -105,7 +105,11 @@ class FeedManager
 
     return true if Block.where(account_id: receiver_id, target_account_id: check_for_blocks).any?
 
-    if status.reply? && !status.in_reply_to_account_id.nil?                                                              # Filter out if it's a reply
+    # Filter out if it's a reply
+    if status.reply?
+      # it's not a reply to a status we don't know about
+      return true if status.in_reply_to_account_id.nil?
+
       should_filter   = !Follow.where(account_id: receiver_id, target_account_id: status.in_reply_to_account_id).exists? # and I'm not following the person it's a reply to
       should_filter &&= receiver_id != status.in_reply_to_account_id                                                     # and it's not a reply to me
       should_filter &&= status.account_id != status.in_reply_to_account_id                                               # and it's not a self-reply

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -26,7 +26,7 @@ class Feed
   def from_database(limit, max_id, since_id)
     Status.as_home_timeline(@account)
           .paginate_by_max_id(limit, max_id, since_id)
-          .reject { |status| FeedManager.instance.filter?(:home, status, @account.id) }
+          .reject { |status| FeedManager.instance.filter?(:home, status, @account) }
   end
 
   def key

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -48,7 +48,7 @@ class FanOutOnWriteService < BaseService
 
     status.mentions.includes(:account).each do |mention|
       mentioned_account = mention.account
-      next if !mentioned_account.local? || !mentioned_account.following?(status.account) || FeedManager.instance.filter?(:home, status, mention.account_id)
+      next if !mentioned_account.local? || !mentioned_account.following?(status.account) || FeedManager.instance.filter?(:home, status, mention.account)
       FeedManager.instance.push(:home, mentioned_account, status)
     end
   end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -17,7 +17,7 @@ class NotifyService < BaseService
   private
 
   def blocked_mention?
-    FeedManager.instance.filter?(:mentions, @notification.mention.status, @recipient.id)
+    FeedManager.instance.filter?(:mentions, @notification.mention.status, @recipient)
   end
 
   def blocked_favourite?

--- a/app/services/precompute_feed_service.rb
+++ b/app/services/precompute_feed_service.rb
@@ -26,7 +26,7 @@ class PrecomputeFeedService < BaseService
   end
 
   def status_filtered?(status)
-    FeedManager.instance.filter?(:home, status, account.id)
+    FeedManager.instance.filter?(:home, status, account)
   end
 
   def account_home_key

--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -27,7 +27,7 @@ class FeedInsertWorker
   end
 
   def feed_filtered?
-    FeedManager.instance.filter?(:home, status, follower.id)
+    FeedManager.instance.filter?(:home, status, follower)
   end
 
   def perform_push


### PR DESCRIPTION
bug discovered by @vahnj. If someone you follow replies to a status your instance doesn't know about, it gets filtered. but if they continue replying in that thread, further replies don't get filtered. This adds logic to cover that edge case.

This also refactors the feed manager code because it's super out of date, and doens't use the account interaction maps. (lots of Follow.where(target_id: blah, account_id: blah))