### PR TITLE
Add Rake task for generate VAPID key

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -36,7 +36,7 @@ OTP_SECRET=
 # You should only generate this once per instance. If you later decide to change it, all push subscription will
 # be invalidated, requiring the users to access the website again to resubscribe.
 #
-# ruby -e "require 'webpush'; vapid_key = Webpush.generate_key; puts vapid_key.private_key; puts vapid_key.public_key;"
+# Generate with `rake mastodon:webpush:generate_vapid_key` task (`docker-compose run --rm web rake mastodon:webpush:generate_vapid_key` if you use docker compose)
 #
 # For more information visit https://rossta.net/blog/using-the-web-push-api-with-vapid.html
 VAPID_PRIVATE_KEY=

--- a/config/initializers/vapid.rb
+++ b/config/initializers/vapid.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # You should only generate this once per instance. If you later decide to change it, all push subscription will
   # be invalidated, requiring the users to access the website again to resubscribe.
   #
-  # ruby -e "require 'webpush'; vapid_key = Webpush.generate_key; puts vapid_key.private_key; puts vapid_key.public_key;"
+  # Generate with `rake mastodon:webpush:generate_vapid_key` task (`docker-compose run --rm web rake mastodon:webpush:generate_vapid_key` if you use docker compose)
   #
   # For more information visit https://rossta.net/blog/using-the-web-push-api-with-vapid.html
 

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -182,6 +182,15 @@ namespace :mastodon do
     end
   end
 
+  namespace :webpush do
+    desc 'Generate VAPID key'
+    task generate_vapid_key: :environment do
+      vapid_key = Webpush.generate_key
+      puts "VAPID_PRIVATE_KEY=#{vapid_key.private_key}"
+      puts "VAPID_PUBLIC_KEY=#{vapid_key.public_key}"
+    end
+  end
+
   namespace :maintenance do
     desc 'Update counter caches'
     task update_counter_caches: :environment do


### PR DESCRIPTION
ref #3243

### output

```console
$ ./bin/rake mastodon:webpush:generate_vapid_key
VAPID_PRIVATE_KEY=xxxxxxxxx
VAPID_PUBLIC_KEY=xxxxxxxxx
```