### PR TITLE
Follow renaming of microformats2 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ group :test do
   gem 'capybara', '~> 2.14'
   gem 'climate_control', '~> 0.2'
   gem 'faker', '~> 1.7'
-  gem 'microformats2', '~> 3.0'
+  gem 'microformats', '~> 4.0'
   gem 'rails-controller-testing', '~> 1.0'
   gem 'rspec-sidekiq', '~> 3.0'
   gem 'simplecov', '~> 0.14', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,9 +106,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    charlock_holmes (0.7.3)
     case_transform (0.2)
       activesupport
+    charlock_holmes (0.7.3)
     chunky_png (1.3.8)
     cld3 (3.1.3)
       ffi (>= 1.1.0, < 1.10.0)
@@ -241,7 +241,7 @@ GEM
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    microformats2 (3.1.0)
+    microformats (4.0.7)
       json
       nokogiri
     mime-types (3.1)
@@ -531,7 +531,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.3)
   link_header (~> 0.0)
   lograge (~> 0.5)
-  microformats2 (~> 3.0)
+  microformats (~> 4.0)
   mime-types (~> 3.1)
   nokogiri (~> 1.7)
   oj (~> 3.0)

--- a/spec/views/stream_entries/show.html.haml_spec.rb
+++ b/spec/views/stream_entries/show.html.haml_spec.rb
@@ -27,7 +27,7 @@ describe 'stream_entries/show.html.haml', without_verify_partial_doubles: true d
 
     render
 
-    mf2 = Microformats2.parse(rendered)
+    mf2 = Microformats.parse(rendered)
 
     expect(mf2.entry.name.to_s).to eq status.text
     expect(mf2.entry.url.to_s).not_to be_empty
@@ -53,7 +53,7 @@ describe 'stream_entries/show.html.haml', without_verify_partial_doubles: true d
 
     render
 
-    mf2 = Microformats2.parse(rendered)
+    mf2 = Microformats.parse(rendered)
 
     expect(mf2.entry.name.to_s).to eq reply.text
     expect(mf2.entry.url.to_s).not_to be_empty


### PR DESCRIPTION
```
$ bundle install

...

Post-install message from microformats2:


The name of the Microformats Ruby Parser is changing from
"microformats2" to "microformats". This is a one time change.
(Thanks to @chrisjpowers for transferring the namespace to us.)

...
```