### PR TITLE
Fix response of unreblog/unfavourite APIs

### DIFF
--- a/app/controllers/api/v1/statuses/favourites_controller.rb
+++ b/app/controllers/api/v1/statuses/favourites_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::Statuses::FavouritesController < Api::BaseController
 
     UnfavouriteWorker.perform_async(current_user.account_id, @status.id)
 
-    render json: @status, serializer: REST::StatusSerializer
+    render json: @status, serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new([@status], current_user&.account_id, favourites_map: @favourites_map)
   end
 
   private

--- a/app/controllers/api/v1/statuses/reblogs_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogs_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::Statuses::ReblogsController < Api::BaseController
     authorize status_for_destroy, :unreblog?
     RemovalWorker.perform_async(status_for_destroy.id)
 
-    render json: @status, serializer: REST::StatusSerializer
+    render json: @status, serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new([@status], current_user&.account_id, reblogs_map: @reblogs_map)
   end
 
   private

--- a/app/presenters/status_relationships_presenter.rb
+++ b/app/presenters/status_relationships_presenter.rb
@@ -3,7 +3,7 @@
 class StatusRelationshipsPresenter
   attr_reader :reblogs_map, :favourites_map, :mutes_map
 
-  def initialize(statuses, current_account_id = nil)
+  def initialize(statuses, current_account_id = nil, reblogs_map: {}, favourites_map: {}, mutes_map: {})
     if current_account_id.nil?
       @reblogs_map    = {}
       @favourites_map = {}
@@ -11,9 +11,9 @@ class StatusRelationshipsPresenter
     else
       status_ids       = statuses.compact.flat_map { |s| [s.id, s.reblog_of_id] }.uniq
       conversation_ids = statuses.compact.map(&:conversation_id).compact.uniq
-      @reblogs_map     = Status.reblogs_map(status_ids, current_account_id)
-      @favourites_map  = Status.favourites_map(status_ids, current_account_id)
-      @mutes_map       = Status.mutes_map(conversation_ids, current_account_id)
+      @reblogs_map     = Status.reblogs_map(status_ids, current_account_id).merge(reblogs_map)
+      @favourites_map  = Status.favourites_map(status_ids, current_account_id).merge(favourites_map)
+      @mutes_map       = Status.mutes_map(conversation_ids, current_account_id).merge(mutes_map)
     end
   end
 end


### PR DESCRIPTION
Regression from #4090 

Both APIs process asynchronously, so reblogged/favourited fields in the response should be set to `false` manually.