### PR TITLE
Small style fixes

### DIFF
--- a/app/javascript/mastodon/components/load_more.js
+++ b/app/javascript/mastodon/components/load_more.js
@@ -6,11 +6,18 @@ export default class LoadMore extends React.PureComponent {
 
   static propTypes = {
     onClick: PropTypes.func,
+    visible: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    visible: true,
   }
 
   render() {
+    const { visible } = this.props;
+
     return (
-      <button className='load-more' onClick={this.props.onClick}>
+      <button className='load-more' disabled={!visible} style={{ opacity: visible ? 1 : 0 }} onClick={this.props.onClick}>
         <FormattedMessage id='status.load_more' defaultMessage='Load more' />
       </button>
     );

--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -101,12 +101,8 @@ export default class StatusList extends ImmutablePureComponent {
   render () {
     const { statusIds, scrollKey, trackScroll, shouldUpdateScroll, isLoading, hasMore, prepend, emptyMessage } = this.props;
 
-    let loadMore       = null;
+    const loadMore     = <LoadMore visible={!isLoading && statusIds.size > 0 && hasMore} onClick={this.handleLoadMore} />;
     let scrollableArea = null;
-
-    if (!isLoading && statusIds.size > 0 && hasMore) {
-      loadMore = <LoadMore onClick={this.handleLoadMore} />;
-    }
 
     if (isLoading || statusIds.size > 0 || !emptyMessage) {
       scrollableArea = (

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1314,6 +1314,7 @@
 .react-swipeable-view-container > * {
   display: flex;
   align-items: center;
+  justify-content: center;
   height: 100%;
 }
 


### PR DESCRIPTION
Removing and readding the load more button when loading causes the content to jump up-and-down. We hide and disable it. This also improves slightly the situation when you open the dropdown menu of the last toot and you cannot click on any of the buttons because they are displayed "below" the screen.