### PR TITLE
Fix column swiping

### DIFF
--- a/app/javascript/mastodon/features/ui/components/columns_area.js
+++ b/app/javascript/mastodon/features/ui/components/columns_area.js
@@ -33,8 +33,22 @@ export default class ColumnsArea extends ImmutablePureComponent {
     children: PropTypes.node,
   };
 
+  state = {
+    shouldAnimate: false,
+  }
+
+  componentWillReceiveProps() {
+    this.setState({ shouldAnimate: false });
+  }
+
+  componentDidMount() {
+    this.lastIndex = getIndex(this.context.router.history.location.pathname);
+    this.setState({ shouldAnimate: true });
+  }
+
   componentDidUpdate() {
     this.lastIndex = getIndex(this.context.router.history.location.pathname);
+    this.setState({ shouldAnimate: true });
   }
 
   handleSwipe = (index) => {
@@ -74,9 +88,10 @@ export default class ColumnsArea extends ImmutablePureComponent {
 
   render () {
     const { columns, children, singleColumn } = this.props;
+    const { shouldAnimate } = this.state;
 
     const columnIndex = getIndex(this.context.router.history.location.pathname);
-    const shouldAnimate = Math.abs(this.lastIndex - columnIndex) === 1;
+    this.pendingIndex = null;
 
     if (singleColumn) {
       return columnIndex !== -1 ? (


### PR DESCRIPTION
This fixes broken behavior and enable animation only on swiping.

* `onTransitionEnd` called before `onChangeIndex` if `animateTransitions` is false. In a result, `location.pathname` won't be updated on swiping.
* Transition depends `animateTransiton` value which is set before transition, i.e. we need to maintain `true` as much as possible to animate swiping. 

This also removes animation from transition caused by location changing.

<details>
<summary>Before</summary>

![before](https://user-images.githubusercontent.com/705555/28240120-2ed192b4-69b6-11e7-84bf-93bbf9e2f29a.gif)
</details>

<details>
<summary>After</summary>

![after](https://user-images.githubusercontent.com/705555/28240121-32edab6c-69b6-11e7-97c2-babb7bdfe5da.gif)
</details>

cc @sorin-davidoi 