### PR TITLE
Fix style settings for images in media modal

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2969,6 +2969,7 @@ button.icon-button.active i.fa-retweet {
     max-height: 80vh;
     width: auto;
     height: auto;
+    margin: auto;
   }
 
   .extended-video-player,

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1143,8 +1143,8 @@
     top: 0;
     left: 0;
     right: 0;
-    width: 100%;
-    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
     background-image: none;
   }
 
@@ -2967,7 +2967,7 @@ button.icon-button.active i.fa-retweet {
   video {
     max-width: 80vw;
     max-height: 80vh;
-    width: 100%;
+    width: auto;
     height: auto;
   }
 
@@ -2983,6 +2983,10 @@ button.icon-button.active i.fa-retweet {
     display: block;
     background: url('../images/void.png') repeat;
     object-fit: contain;
+  }
+
+  .react-swipeable-view-container {
+    max-width: 80vw;
   }
 }
 


### PR DESCRIPTION
Fix issues described by @sorin-davidoi on #4187 

### Shrink too wide single-image media modal.

This makes it easy to close single image.

### Centering images in media modal.

Set margin:auto to center left sided images in multiple-image media modal.