### PR TITLE
Don't mention default post privacy on hints for locked accounts

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -8,7 +8,7 @@ en:
           one: <span class="name-counter">1</span> character left
           other: <span class="name-counter">%{count}</span> characters left
         header: PNG, GIF or JPG. At most 2MB. Will be downscaled to 700x335px
-        locked: Requires you to manually approve followers and defaults post privacy to followers-only
+        locked: Requires you to manually approve followers
         note:
           one: <span class="note-counter">1</span> character left
           other: <span class="note-counter">%{count}</span> characters left

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -6,7 +6,7 @@ ja:
         avatar: 2MBまでのPNGやGIF、JPGが利用可能です。120x120pxまで縮小されます。
         display_name: あと<span class="name-counter">%{count}</span>文字入力できます。
         header: 2MBまでのPNGやGIF、JPGが利用可能です。 700x335pxまで縮小されます。
-        locked: フォロワーを手動で承認する必要があります。デフォルトではトゥートの公開範囲はフォロワーのみです。
+        locked: フォロワーを手動で承認する必要があります。
         note: あと<span class="note-counter">%{count}</span>文字入力できます。
       imports:
         data: 他の Mastodon インスタンスからエクスポートしたCSVファイルを選択して下さい


### PR DESCRIPTION
"defaults post privacy to followers-only" only means...

* default value of `visibility` param on post API
* default value for web UI privacy setting (i.e. it will be overridden if they once updated)

...so, many users won't see an effect of it.

closes #4082 (this patch same as it, except this doesn't change behaviors)