### PR TITLE
fix(push-notifications): Refactor how Sidekiq jobs are handled

### DIFF
--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -12,6 +12,9 @@
 #  updated_at :datetime         not null
 #
 
+require 'webpush'
+require_relative '../../models/setting'
+
 class Web::PushSubscription < ApplicationRecord
   include RoutingHelper
   include StreamEntriesHelper
@@ -37,7 +40,6 @@ class Web::PushSubscription < ApplicationRecord
     nsfw = notification.target_status.nil? || notification.target_status.spoiler_text.empty? ? nil : notification.target_status.spoiler_text
 
     # TODO: Make sure that the payload does not exceed 4KB - Webpush::PayloadTooLarge
-    # TODO: Queue the requests - Webpush::TooManyRequests
     Webpush.payload_send(
       message: JSON.generate(
         title: title,
@@ -59,7 +61,7 @@ class Web::PushSubscription < ApplicationRecord
       p256dh: key_p256dh,
       auth: key_auth,
       vapid: {
-        # subject: "mailto:#{Setting.site_contact_email}",
+        subject: "mailto:#{Setting.site_contact_email}",
         private_key: Rails.configuration.x.vapid_private_key,
         public_key: Rails.configuration.x.vapid_public_key,
       },
@@ -166,7 +168,7 @@ class Web::PushSubscription < ApplicationRecord
       p256dh: key_p256dh,
       auth: key_auth,
       vapid: {
-        # subject: "mailto:#{Setting.site_contact_email}",
+        subject: "mailto:#{Setting.site_contact_email}",
         private_key: Rails.configuration.x.vapid_private_key,
         public_key: Rails.configuration.x.vapid_public_key,
       },

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -65,7 +65,11 @@ class NotifyService < BaseService
   end
 
   def send_push_notifications
-    WebPushNotificationWorker.perform_async(@recipient.id, @notification.id)
+    sessions_with_subscriptions_ids = @recipient.user.session_activations.where.not(web_push_subscription: nil).pluck(:id)
+
+    WebPushNotificationWorker.push_bulk(sessions_with_subscriptions_ids) do |session_activation_id|
+      [session_activation_id, @notification.id]
+    end
   end
 
   def send_email


### PR DESCRIPTION
We now send the contact information to the subscription service - I have a suspicion some push requests were refused because this was missing.

Each push subscription now has its own worker - instead of putting N HTTP requests inside a worker (retries did not work properly).

All errors are allowed to bubble up so that they show up in Sidekiq.

cc: @beatrix-bitrot, @nightpool