### PR TITLE
Add SMTP_TLS variable for configuring TLS when server uses non-standard port

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,6 +85,7 @@ Rails.application.configure do
     :ca_file              => ENV['SMTP_CA_FILE'].presence,
     :openssl_verify_mode  => ENV['SMTP_OPENSSL_VERIFY_MODE'],
     :enable_starttls_auto => ENV['SMTP_ENABLE_STARTTLS_AUTO'] || true,
+    :tls                  => ENV['SMTP_TLS'].presence,
   }
 
   config.action_mailer.delivery_method = ENV.fetch('SMTP_DELIVERY_METHOD', 'smtp').to_sym


### PR DESCRIPTION
Reference: <https://stackoverflow.com/questions/26166032/rails-4-netreadtimeout-when-calling-actionmailer#26169280>

Came across this when configuring an instance that didn't use Mailgun.