### PR TITLE
Fix overwriting style of extended-video-player

### DIFF
--- a/app/javascript/mastodon/components/extended_video_player.js
+++ b/app/javascript/mastodon/components/extended_video_player.js
@@ -32,7 +32,7 @@ export default class ExtendedVideoPlayer extends React.PureComponent {
 
   render () {
     return (
-      <div className='extended-video-player' style={{ width: this.props.width, height: this.props.height }}>
+      <div className='extended-video-player'>
         <video
           ref={this.setRef}
           src={this.props.src}


### PR DESCRIPTION
<p>
Though size of extended-video-player is already fixed to 80vw*80vh in components.scss, player size was also set to original video size in extended_video_player.js.<br />
Video size is fixed to 80vw*80vh, so video player's size must also be fixed to 80vw*80vh.
</p>

Thank you for your reporting bug @sorin-davidoi on #4220 .
I was not aware about it, because this bug occurred only when video is posted to its own instance. I only checked videos from another instance.