### PR TITLE
Add empty alt attribute to img elements in landing page

### DIFF
--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -18,13 +18,13 @@
 .landing-page
   .header-wrapper
     .mascot-container
-      = image_tag asset_pack_path('elephant-fren.png'), class: 'mascot'
+      = image_tag asset_pack_path('elephant-fren.png'), alt: '', role: 'presentation', class: 'mascot'
 
     .header
       .container.links
         .brand
           = link_to root_url do
-            = image_tag asset_pack_path('logo.svg')
+            = image_tag asset_pack_path('logo.svg'), alt: '', role: 'presentation'
             Mastodon
 
         %ul.nav
@@ -38,9 +38,9 @@
 
       .container.hero
         .floats
-          = image_tag asset_pack_path('cloud2.png'), class: 'float-1'
-          = image_tag asset_pack_path('cloud3.png'), class: 'float-2'
-          = image_tag asset_pack_path('cloud4.png'), class: 'float-3'
+          = image_tag asset_pack_path('cloud2.png'), alt: '', role: 'presentation', class: 'float-1'
+          = image_tag asset_pack_path('cloud3.png'), alt: '', role: 'presentation', class: 'float-2'
+          = image_tag asset_pack_path('cloud4.png'), alt: '', role: 'presentation', class: 'float-3'
         .heading
           %h1
             = @instance_presenter.site_title
@@ -54,7 +54,7 @@
                 %p= t('about.closed_registrations')
               - else
                 = @instance_presenter.closed_registrations_message.html_safe
-            = link_to t('about.find_another_instance'), 'https://joinmastodon.org', class: 'button button-alternative button--block'
+            = link_to t('about.find_another_instance'), 'https://joinmastodon.org/', class: 'button button-alternative button--block'
 
   .learn-more-cta
     .container
@@ -69,7 +69,7 @@
       .about-mastodon
         %h3= t 'about.what_is_mastodon'
         %p= t 'about.about_mastodon_html'
-        %a.button.button-secondary{ href: 'https://joinmastodon.org' }= t 'about.learn_more'
+        %a.button.button-secondary{ href: 'https://joinmastodon.org/' }= t 'about.learn_more'
         = render 'features'
   .footer-links
     .container


### PR DESCRIPTION
[`image_tag`](https://github.com/rails/rails/blob/v5.1.2/actionview/lib/action_view/helpers/asset_tag_helper.rb#L228-L240) generates the value of the `alt` attribute from the file name when the `alt` attribute is not specified ([`image_alt`](https://github.com/rails/rails/blob/v5.1.2/actionview/lib/action_view/helpers/asset_tag_helper.rb#L259-L261)). Since the screen reader reads the value of the alt attribute, it causes the user to listen to meaningless words.

Explicitly empty the value of the `alt` attribute and make [`role` a `presentation`](https://www.w3.org/TR/2014/REC-wai-aria-20140320/roles#presentation).

### diff

```diff
- <img src="http://127.0.0.1:8080/packs/filename.png" alt="Filename" />
+ <img alt="" role="presentation" src="http://127.0.0.1:8080/packs/filename.png" />
```

