### PR TITLE
Fixed issue that the NSFW image is not hidden on detail page

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -183,6 +183,12 @@ export default class MediaGallery extends React.PureComponent {
     visible: !this.props.sensitive,
   };
 
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.sensitive !== this.props.sensitive) {
+      this.setState({ visible: !nextProps.sensitive });
+    }
+  }
+
   handleOpen = () => {
     this.setState({ visible: !this.state.visible });
   }


### PR DESCRIPTION
When NSFW image is opened after opening non-NSFW image on detail page, image is not hidden. This pull request fixes this problem.