### PR TITLE
Fix deprecation warning for non-pipeline assets

### DIFF
--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -11,7 +11,7 @@ module RoutingHelper
     end
   end
 
-  def full_asset_url(source)
-    Rails.configuration.x.use_s3 ? source : URI.join(root_url, ActionController::Base.helpers.asset_url(source)).to_s
+  def full_asset_url(source, options = {})
+    Rails.configuration.x.use_s3 ? source : URI.join(root_url, ActionController::Base.helpers.asset_url(source, options)).to_s
   end
 end

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -45,7 +45,7 @@ class Web::PushSubscription < ApplicationRecord
         title: title,
         dir: dir,
         image: image,
-        badge: full_asset_url('badge.png'),
+        badge: full_asset_url('badge.png', skip_pipeline: true),
         tag: notification.id,
         timestamp: notification.created_at,
         icon: notification.from_account.avatar_static_url,
@@ -115,7 +115,7 @@ class Web::PushSubscription < ApplicationRecord
       when :mention then [
         {
           title: translate('push_notifications.mention.action_favourite'),
-          icon: full_asset_url('emoji/2764.png'),
+          icon: full_asset_url('emoji/2764.png', skip_pipeline: true),
           todo: 'request',
           method: 'POST',
           action: "/api/v1/statuses/#{notification.target_status.id}/favourite",
@@ -156,8 +156,8 @@ class Web::PushSubscription < ApplicationRecord
     Webpush.payload_send(
       message: JSON.generate(
         title: translate('push_notifications.subscribed.title'),
-        icon: full_asset_url('android-chrome-192x192.png'),
-        badge: full_asset_url('badge.png'),
+        icon: full_asset_url('android-chrome-192x192.png', skip_pipeline: true),
+        badge: full_asset_url('badge.png', skip_pipeline: true),
         data: {
           content: translate('push_notifications.subscribed.body'),
           actions: [],


### PR DESCRIPTION
>DEPRECATION WARNING: The asset "android-chrome-192x192.png" is not present in the asset pipeline.Falling back to an asset that may be in the public folder.
This behavior is deprecated and will be removed.
To bypass the asset pipeline and preserve this behavior,
use the `skip_pipeline: true` option.
 (called from full_asset_url at app/helpers/routing_helper.rb:15)

Added in #1039 