### PR TITLE
Update scroll top state on column mounting

### DIFF
--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -30,8 +30,8 @@ export default class StatusList extends ImmutablePureComponent {
 
   intersectionObserverWrapper = new IntersectionObserverWrapper();
 
-  handleScroll = debounce((e) => {
-    const { scrollTop, scrollHeight, clientHeight } = e.target;
+  handleScroll = debounce(() => {
+    const { scrollTop, scrollHeight, clientHeight } = this.node;
     const offset = scrollHeight - scrollTop - clientHeight;
     this._oldScrollPosition = scrollHeight - scrollTop;
 
@@ -49,6 +49,9 @@ export default class StatusList extends ImmutablePureComponent {
   componentDidMount () {
     this.attachScrollListener();
     this.attachIntersectionObserver();
+
+    // Handle initial scroll posiiton
+    this.handleScroll();
   }
 
   componentDidUpdate (prevProps) {


### PR DESCRIPTION
When you change column after scrolling and back, indicator was still active until you scroll down again. 

![hoge](https://user-images.githubusercontent.com/705555/28381206-f1a0e27c-6cf4-11e7-80dc-f27bf227c283.gif)
