### PR TITLE
fix(status_list): Update scroll position after toots are appended

### DIFF
--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -57,13 +57,14 @@ export default class StatusList extends ImmutablePureComponent {
   componentDidUpdate (prevProps) {
     // Reset the scroll position when a new toot comes in in order not to
     // jerk the scrollbar around if you're already scrolled down the page.
-    if (prevProps.statusIds.size < this.props.statusIds.size &&
-        prevProps.statusIds.first() !== this.props.statusIds.first() &&
-        this._oldScrollPosition &&
-        this.node.scrollTop > 0) {
-      let newScrollTop = this.node.scrollHeight - this._oldScrollPosition;
-      if (this.node.scrollTop !== newScrollTop) {
-        this.node.scrollTop = newScrollTop;
+    if (prevProps.statusIds.size < this.props.statusIds.size && this._oldScrollPosition && this.node.scrollTop > 0) {
+      if (prevProps.statusIds.first() !== this.props.statusIds.first()) {
+        let newScrollTop = this.node.scrollHeight - this._oldScrollPosition;
+        if (this.node.scrollTop !== newScrollTop) {
+          this.node.scrollTop = newScrollTop;
+        }
+      } else {
+        this._oldScrollPosition = this.node.scrollHeight - this.node.scrollTop;
       }
     }
   }


### PR DESCRIPTION
The following sequence of events would lead to the scroll position being update using stale values:
 - Scroll to the bottom of the column
 - Toots are appended
 - Toots are prepended

This is because we were updating `_oldScrollPosition` after the user scrolled, but not after toots were appended. If the user scrolled after step 2 this bug would not manifest itself.