### PR TITLE
Add callback_url/acct information for Sidekiq PuSH workers Exception.

### DIFF
--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -8,11 +8,11 @@ module Mastodon
 
   class UnexpectedResponseError < Error
     def initialize(response = nil)
-      @response = response
-    end
-
-    def to_s
-      "#{@response.uri} returned code #{@response.code}"
+      if response.respond_to? :url
+        super("#{response.uri} returned code #{response.code}")
+      else
+        super
+      end
     end
   end
 end

--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -8,7 +8,7 @@ module Mastodon
 
   class UnexpectedResponseError < Error
     def initialize(response = nil)
-      if response.respond_to? :url
+      if response.respond_to? :uri
         super("#{response.uri} returned code #{response.code}")
       else
         super

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -18,7 +18,7 @@ class Pubsubhubbub::DeliveryWorker
     begin
       process_delivery unless blocked_domain?
     rescue => e
-      raise "Delivery failed for #{subscription&.account_id}, #{subscription&.callback_url}: #{e.class}: #{e.message}"
+      raise "Delivery failed for #{subscription&.callback_url}: #{e.class}: #{e.message}"
     end
   end
 

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -15,7 +15,11 @@ class Pubsubhubbub::DeliveryWorker
   def perform(subscription_id, payload)
     @subscription = Subscription.find(subscription_id)
     @payload = payload
-    process_delivery unless blocked_domain?
+    begin
+      process_delivery unless blocked_domain?
+    rescue => e
+      raise "Delivery failed for #{subscription&.account_id}, #{subscription&.callback_url}: #{e.class}: #{e.message}"
+    end
   end
 
   private

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -15,11 +15,9 @@ class Pubsubhubbub::DeliveryWorker
   def perform(subscription_id, payload)
     @subscription = Subscription.find(subscription_id)
     @payload = payload
-    begin
-      process_delivery unless blocked_domain?
-    rescue => e
-      raise "Delivery failed for #{subscription&.callback_url}: #{e.class}: #{e.message}"
-    end
+    process_delivery unless blocked_domain?
+  rescue => e
+    raise e.class, "Delivery failed for #{subscription&.callback_url}: #{e.message}"
   end
 
   private

--- a/app/workers/pubsubhubbub/subscribe_worker.rb
+++ b/app/workers/pubsubhubbub/subscribe_worker.rb
@@ -21,10 +21,8 @@ class Pubsubhubbub::SubscribeWorker
   def perform(account_id)
     account = Account.find(account_id)
     logger.debug "PuSH re-subscribing to #{account.acct}"
-    begin
-      ::SubscribeService.new.call(account)
-    rescue => e
-      raise "Subscribe failed for #{account.acct}: #{e.class}: #{e.message}"
-    end
+    ::SubscribeService.new.call(account)
+  rescue => e
+    raise e.class, "Subscribe failed for #{account&.acct}: #{e.message}"
   end
 end

--- a/app/workers/pubsubhubbub/subscribe_worker.rb
+++ b/app/workers/pubsubhubbub/subscribe_worker.rb
@@ -21,6 +21,10 @@ class Pubsubhubbub::SubscribeWorker
   def perform(account_id)
     account = Account.find(account_id)
     logger.debug "PuSH re-subscribing to #{account.acct}"
-    ::SubscribeService.new.call(account)
+    begin
+      ::SubscribeService.new.call(account)
+    rescue => e
+      raise "Subscribe failed for #{account.acct}: #{e.class}: #{e.message}"
+    end
   end
 end


### PR DESCRIPTION
Some exception does not report hostname in exception message.
So, hostname does not shown in Sidekiq error console.
You need check database tables to know which host returns error.
With this PR, you can easily see which server is in trouble...
![sidekiq_fix3](https://user-images.githubusercontent.com/1680550/28429873-4f25b35e-6db9-11e7-9a38-c12ce9d00980.PNG)

