### PR TITLE
feat(compose): More space on mobile devices

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -27,6 +27,7 @@ export const COMPOSE_SPOILERNESS_CHANGE = 'COMPOSE_SPOILERNESS_CHANGE';
 export const COMPOSE_SPOILER_TEXT_CHANGE = 'COMPOSE_SPOILER_TEXT_CHANGE';
 export const COMPOSE_VISIBILITY_CHANGE  = 'COMPOSE_VISIBILITY_CHANGE';
 export const COMPOSE_LISTABILITY_CHANGE = 'COMPOSE_LISTABILITY_CHANGE';
+export const COMPOSE_COMPOSING_CHANGE = 'COMPOSE_COMPOSING_CHANGE';
 
 export const COMPOSE_EMOJI_INSERT = 'COMPOSE_EMOJI_INSERT';
 
@@ -278,3 +279,10 @@ export function insertEmojiCompose(position, emoji) {
     emoji,
   };
 };
+
+export function changeComposing(value) {
+  return {
+    type: COMPOSE_COMPOSING_CHANGE,
+    value,
+  };
+}

--- a/app/javascript/mastodon/features/compose/components/navigation_bar.js
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Avatar from '../../../components/avatar';
+import IconButton from '../../../components/icon_button';
 import Permalink from '../../../components/permalink';
 import { FormattedMessage } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
@@ -9,6 +11,7 @@ export default class NavigationBar extends ImmutablePureComponent {
 
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
+    onClose: PropTypes.func.isRequired,
   };
 
   render () {
@@ -25,6 +28,8 @@ export default class NavigationBar extends ImmutablePureComponent {
 
           <a href='/settings/profile' className='navigation-bar__profile-edit'><FormattedMessage id='navigation_bar.edit_profile' defaultMessage='Edit profile' /></a>
         </div>
+
+        <IconButton title='Close' icon='close' onClick={this.props.onClose} />
       </div>
     );
   }

--- a/app/javascript/mastodon/features/compose/components/navigation_bar.js
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.js
@@ -29,7 +29,7 @@ export default class NavigationBar extends ImmutablePureComponent {
           <a href='/settings/profile' className='navigation-bar__profile-edit'><FormattedMessage id='navigation_bar.edit_profile' defaultMessage='Edit profile' /></a>
         </div>
 
-        <IconButton title='Close' icon='close' onClick={this.props.onClose} />
+        <IconButton title='' icon='close' onClick={this.props.onClose} />
       </div>
     );
   }

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -91,7 +91,7 @@ export default class Compose extends React.PureComponent {
         <SearchContainer />
 
         <div className='drawer__pager'>
-          <div className='drawer__inner' onFocus={this.onFocus} onBlur={this.onBlur}>
+          <div className='drawer__inner' onFocus={this.onFocus}>
             <NavigationContainer onClose={this.onBlur} />
             <ComposeFormContainer />
           </div>

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -11,6 +11,7 @@ import SearchContainer from './containers/search_container';
 import Motion from 'react-motion/lib/Motion';
 import spring from 'react-motion/lib/spring';
 import SearchResultsContainer from './containers/search_results_container';
+import { changeComposing } from '../../actions/compose';
 
 const messages = defineMessages({
   start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
@@ -45,6 +46,14 @@ export default class Compose extends React.PureComponent {
 
   componentWillUnmount () {
     this.props.dispatch(unmountCompose());
+  }
+
+  onFocus = () => {
+    this.props.dispatch(changeComposing(true));
+  }
+
+  onBlur = () => {
+    this.props.dispatch(changeComposing(false));
   }
 
   render () {
@@ -82,8 +91,8 @@ export default class Compose extends React.PureComponent {
         <SearchContainer />
 
         <div className='drawer__pager'>
-          <div className='drawer__inner'>
-            <NavigationContainer />
+          <div className='drawer__inner' onFocus={this.onFocus} onBlur={this.onBlur}>
+            <NavigationContainer onClose={this.onBlur} />
             <ComposeFormContainer />
           </div>
 

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -43,6 +43,7 @@ import '../../components/status';
 
 const mapStateToProps = state => ({
   systemFontUi: state.getIn(['meta', 'system_font_ui']),
+  isComposing: state.getIn(['compose', 'is_composing']),
 });
 
 @connect(mapStateToProps)
@@ -52,6 +53,7 @@ export default class UI extends React.PureComponent {
     dispatch: PropTypes.func.isRequired,
     children: PropTypes.node,
     systemFontUi: PropTypes.bool,
+    isComposing: PropTypes.bool,
   };
 
   state = {
@@ -131,6 +133,19 @@ export default class UI extends React.PureComponent {
 
     this.props.dispatch(refreshHomeTimeline());
     this.props.dispatch(refreshNotifications());
+  }
+
+  shouldComponentUpdate (nextProps) {
+    if (nextProps.isComposing !== this.props.isComposing) {
+      // Avoid expensive update just to toggle a class
+      this.node.classList.toggle('is-composing', nextProps.isComposing);
+
+      return false;
+    }
+
+    // Why isn't this working?!?
+    // return super.shouldComponentUpdate(nextProps, nextState);
+    return true;
   }
 
   componentWillUnmount () {

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -20,6 +20,7 @@ import {
   COMPOSE_SPOILERNESS_CHANGE,
   COMPOSE_SPOILER_TEXT_CHANGE,
   COMPOSE_VISIBILITY_CHANGE,
+  COMPOSE_COMPOSING_CHANGE,
   COMPOSE_EMOJI_INSERT,
 } from '../actions/compose';
 import { TIMELINE_DELETE } from '../actions/timelines';
@@ -37,6 +38,7 @@ const initialState = ImmutableMap({
   focusDate: null,
   preselectDate: null,
   in_reply_to: null,
+  is_composing: false,
   is_submitting: false,
   is_uploading: false,
   progress: 0,
@@ -146,7 +148,9 @@ export default function compose(state = initialState, action) {
   case COMPOSE_MOUNT:
     return state.set('mounted', true);
   case COMPOSE_UNMOUNT:
-    return state.set('mounted', false);
+    return state
+      .set('mounted', false)
+      .set('is_composing', false);
   case COMPOSE_SENSITIVITY_CHANGE:
     return state
       .set('sensitive', !state.get('sensitive'))
@@ -169,6 +173,8 @@ export default function compose(state = initialState, action) {
     return state
       .set('text', action.text)
       .set('idempotencyKey', uuid());
+  case COMPOSE_COMPOSING_CHANGE:
+    return state.set('is_composing', action.value);
   case COMPOSE_REPLY:
     return state.withMutations(map => {
       map.set('in_reply_to', action.status.get('id'));

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -3729,7 +3729,7 @@ noscript {
   }
 }
 
-@media screen and (max-width: 1024px) and (max-height: 400px) {
+@media screen and (max-width: 1024px) and (max-height: 600px) {
   $duration: 400ms;
   $delay: 100ms;
 

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1177,6 +1177,10 @@
   .permalink {
     text-decoration: none;
   }
+
+  .icon-button {
+    display: none;
+  }
 }
 
 .navigation-bar__profile {
@@ -3721,5 +3725,24 @@ noscript {
   div {
     font-size: 20px;
     margin: 20px 0;
+  }
+}
+
+@media screen and (max-width: 1024px) and (max-height: 400px) {
+  .tabs-bar,
+  .search {
+    will-change: margin;
+    transition: margin 600ms 100ms;
+  }
+
+  .is-composing {
+    .tabs-bar,
+    .search {
+      margin-top: -50px;
+    }
+
+    .navigation-bar .icon-button {
+      display: block;
+    }
   }
 }

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -3730,7 +3730,7 @@ noscript {
 }
 
 @media screen and (max-width: 1024px) and (max-height: 400px) {
-  $duration: 600ms;
+  $duration: 400ms;
   $delay: 100ms;
 
   .tabs-bar,

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1179,7 +1179,8 @@
   }
 
   .icon-button {
-    display: none;
+    pointer-events: none;
+    opacity: 0;
   }
 }
 
@@ -3729,10 +3730,35 @@ noscript {
 }
 
 @media screen and (max-width: 1024px) and (max-height: 400px) {
+  $duration: 600ms;
+  $delay: 100ms;
+
   .tabs-bar,
   .search {
-    will-change: margin;
-    transition: margin 600ms 100ms;
+    will-change: margin-top;
+    transition: margin-top $duration $delay;
+  }
+
+  .navigation-bar {
+    will-change: padding-bottom;
+    transition: padding-bottom $duration $delay;
+  }
+
+  .navigation-bar {
+    & > a:first-child {
+      will-change: margin-top, margin-left, width;
+      transition: margin-top $duration $delay, margin-left $duration ($duration + $delay);
+    }
+
+    & > .navigation-bar__profile-edit {
+      will-change: margin-top;
+      transition: margin-top $duration $delay;
+    }
+
+    & > .icon-button {
+      will-change: opacity;
+      transition: opacity $duration $delay;
+    }
   }
 
   .is-composing {
@@ -3741,8 +3767,27 @@ noscript {
       margin-top: -50px;
     }
 
-    .navigation-bar .icon-button {
-      display: block;
+    .navigation-bar {
+      padding-bottom: 0;
+
+      & > a:first-child {
+        margin-top: -50px;
+        margin-left: -40px;
+      }
+
+      .navigation-bar__profile {
+        padding-top: 2px;
+      }
+
+      .navigation-bar__profile-edit {
+        position: absolute;
+        margin-top: -50px;
+      }
+
+      .icon-button {
+        pointer-events: auto;
+        opacity: 1;
+      }
     }
   }
 }


### PR DESCRIPTION
Writing toots on mobile devices is a sub par experience due to the lack of space in the compose column - when the virtual keyboard covers the screen you don't see what you are typing and have to scroll to tap any of the buttons. This PR hides the tabs and search bar if the compose area is focused.

I would prefer to hide the navigation bar (avatar, username, edit profile) as well, but I don't really know where to place the "close" button then - it would be too close to the emoji picker. `react-motion` is not used because that could mean we have to connect more components to the state (plus we need media queries). We could probably improve the performance of the animation, but I don't really know how - changing `margin-top` is pretty computationally expensive since it triggers re-layout.

This also raises the problem of auto focusing the `textarea`, which implies that switching to the compose column automatically triggers the hiding of the two bars.

# Before
<img src="https://user-images.githubusercontent.com/2109702/28429528-5444dfcc-6d7d-11e7-9612-d41b4ed29c8a.png" width=200 />

# After
<img src="https://user-images.githubusercontent.com/2109702/28429529-54481aac-6d7d-11e7-9c69-5cff0217e546.png" width=250 />

# Animation
<img src="https://user-images.githubusercontent.com/2109702/28429423-e96c956e-6d7c-11e7-921f-a7b73788b380.gif" width=250 />