### PR TITLE
Add callback_url/acct information for Sidekiq PuSH workers Exception(alternative)

### DIFF
--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -5,6 +5,7 @@ module Mastodon
   class NotPermittedError < Error; end
   class ValidationError < Error; end
   class RaceConditionError < Error; end
+  class WorkerError < Error; end
 
   class UnexpectedResponseError < Error
     def initialize(response = nil)

--- a/app/services/process_interaction_service.rb
+++ b/app/services/process_interaction_service.rb
@@ -47,7 +47,7 @@ class ProcessInteractionService < BaseService
         reflect_unblock!(account, target_account)
       end
     end
-  rescue HTTP::Error, OStatus2::BadSalmonError, Mastodon::NotPermittedError
+  rescue HTTP::Error, OStatus2::BadSalmonError, Mastodon::NotPermittedError, Mastodon::WorkerError
     nil
   end
 

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -18,7 +18,7 @@ class Pubsubhubbub::DeliveryWorker
     begin
       process_delivery unless blocked_domain?
     rescue => e
-      raise "Delivery failed for #{subscription&.account_id}, #{subscription&.callback_url}: #{e.class}: #{e.message}"
+      raise "Delivery failed for #{subscription&.callback_url}: #{e.class}: #{e.message}"
     end
   end
 

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -15,7 +15,11 @@ class Pubsubhubbub::DeliveryWorker
   def perform(subscription_id, payload)
     @subscription = Subscription.find(subscription_id)
     @payload = payload
-    process_delivery unless blocked_domain?
+    begin
+      process_delivery unless blocked_domain?
+    rescue => e
+      raise "Delivery failed for #{subscription&.account_id}, #{subscription&.callback_url}: #{e.class}: #{e.message}"
+    end
   end
 
   private

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -15,11 +15,9 @@ class Pubsubhubbub::DeliveryWorker
   def perform(subscription_id, payload)
     @subscription = Subscription.find(subscription_id)
     @payload = payload
-    begin
-      process_delivery unless blocked_domain?
-    rescue => e
-      raise "Delivery failed for #{subscription&.callback_url}: #{e.class}: #{e.message}"
-    end
+    process_delivery unless blocked_domain?
+  rescue => e
+    raise Mastodon::WorkerError, "Delivery failed for #{subscription&.callback_url}: #{e.class}: #{e.message}"
   end
 
   private

--- a/app/workers/pubsubhubbub/subscribe_worker.rb
+++ b/app/workers/pubsubhubbub/subscribe_worker.rb
@@ -21,10 +21,8 @@ class Pubsubhubbub::SubscribeWorker
   def perform(account_id)
     account = Account.find(account_id)
     logger.debug "PuSH re-subscribing to #{account.acct}"
-    begin
-      ::SubscribeService.new.call(account)
-    rescue => e
-      raise "Subscribe failed for #{account.acct}: #{e.class}: #{e.message}"
-    end
+    ::SubscribeService.new.call(account)
+  rescue => e
+    raise Mastodon::WorkerError, "Subscribe failed for #{account&.acct}: #{e.class}: #{e.message}"
   end
 end

--- a/app/workers/pubsubhubbub/subscribe_worker.rb
+++ b/app/workers/pubsubhubbub/subscribe_worker.rb
@@ -21,6 +21,10 @@ class Pubsubhubbub::SubscribeWorker
   def perform(account_id)
     account = Account.find(account_id)
     logger.debug "PuSH re-subscribing to #{account.acct}"
-    ::SubscribeService.new.call(account)
+    begin
+      ::SubscribeService.new.call(account)
+    rescue => e
+      raise "Subscribe failed for #{account.acct}: #{e.class}: #{e.message}"
+    end
   end
 end


### PR DESCRIPTION
This is alternative implementation of https://github.com/tootsuite/mastodon/pull/4281.
![sidekiq_fixx](https://user-images.githubusercontent.com/1680550/28432949-e81a3c96-6dc4-11e7-8815-276550fbbcc4.PNG)
