### PR TITLE
[WIP] fix(status_list): Hide column header when scrolling down

### DIFF
--- a/app/javascript/mastodon/components/status_list.js
+++ b/app/javascript/mastodon/components/status_list.js
@@ -33,6 +33,17 @@ export default class StatusList extends ImmutablePureComponent {
   handleScroll = debounce(() => {
     const { scrollTop, scrollHeight, clientHeight } = this.node;
     const offset = scrollHeight - scrollTop - clientHeight;
+
+    if (this._oldScrollPosition) {
+      const isScrollingDown = this._oldScrollPosition > scrollHeight - scrollTop;
+
+      if (scrollTop >= 250 || (!isScrollingDown)) {
+        window.requestAnimationFrame(() => {
+          document.querySelector('div[aria-hidden="false"][data-swipeable="true"]').classList.toggle('collapsed', isScrollingDown);
+        });
+      }
+    }
+
     this._oldScrollPosition = scrollHeight - scrollTop;
 
     if (250 > offset && this.props.onScrollToBottom && !this.props.isLoading) {
@@ -72,6 +83,10 @@ export default class StatusList extends ImmutablePureComponent {
   componentWillUnmount () {
     this.detachScrollListener();
     this.detachIntersectionObserver();
+
+    window.requestAnimationFrame(() => {
+      document.querySelector('div[aria-hidden="false"][data-swipeable="true"]').classList.toggle('collapsed', false);
+    });
   }
 
   attachIntersectionObserver () {

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2069,6 +2069,32 @@ button.icon-button.active i.fa-retweet {
   }
 }
 
+@media screen and (max-width: 1024px) and (max-height: 800px) {
+  div[aria-hidden="false"][data-swipeable="true"] {
+    .columns-area {
+      will-change: margin-top, padding-top, height;
+      transition: margin-top 200ms, padding-top 200ms, height 200ms;
+    }
+
+    .column-header__wrapper {
+      will-change: margin-top;
+      transition: margin-top 200ms;
+    }
+
+    &.collapsed {
+      .columns-area {
+        margin-top: -10px;
+        padding-top: 0;
+        height: 100% !important;
+      }
+
+      .column-header__wrapper {
+        margin-top: -50px;
+      }
+    }
+  }
+}
+
 .column-header__wrapper {
   position: relative;
   flex: 0 0 auto;


### PR DESCRIPTION
Collapses the header to make more space for the actual content. This is very poorly implemented right now, opened the PR to see if there is interest in this feature.

<img src="https://user-images.githubusercontent.com/2109702/28486074-b8398ac6-6e7e-11e7-9fd9-90117de5cfd3.gif" width=250 />
