### PR TITLE
Change logo.png to logo.svg for web UI (regression from #4306)

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -6,6 +6,6 @@
 
 .app-holder#mastodon{ data: { props: Oj.dump(default_props) } }
   %noscript
-    = image_tag asset_pack_path('logo.png')
+    = image_tag asset_pack_path('logo.svg')
     %div
       = t('errors.noscript')


### PR DESCRIPTION
```plain
  1) Log in A valid email and password user is able to log in
     Failure/Error: = image_tag asset_pack_path('logo.png')
     
     ActionView::Template::Error:
       Can't find logo.png in /home/travis/build/tootsuite/mastodon/public/packs-test/manifest.json. Is webpack still compiling?
     # ./app/views/home/index.html.haml:9:in `_app_views_home_index_html_haml__1361396113722584969_91733700'
     # ./spec/features/log_in_spec.rb:18:in `block (2 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Webpacker::FileLoader::NotFoundError:
     #   Can't find logo.png in /home/travis/build/tootsuite/mastodon/public/packs-test/manifest.json. Is webpack still compiling?
     #   ./app/views/home/index.html.haml:9:in `_app_views_home_index_html_haml__1361396113722584969_91733700'
```