### PR TITLE
fix(getting_started): Scroll on mobile

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1856,7 +1856,7 @@
 
 .getting-started__wrapper {
   position: relative;
-  flex: 0 0 auto;
+  overflow-y: scroll;
 }
 
 .getting-started__footer {


### PR DESCRIPTION
It is currently not possible to scroll the getting started column - on most phones you cannot reach the logout button in landscape mode.