### PR TITLE
Change the content warning placeholder

### DIFF
--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -45,7 +45,7 @@
   "compose_form.publish_loud": "{publish}!",
   "compose_form.sensitive": "Mark media as sensitive",
   "compose_form.spoiler": "Hide text behind warning",
-  "compose_form.spoiler_placeholder": "Content warning",
+  "compose_form.spoiler_placeholder": "Write your warning here",
   "confirmation_modal.cancel": "Cancel",
   "confirmations.block.confirm": "Block",
   "confirmations.block.message": "Are you sure you want to block {name}?",

--- a/app/javascript/mastodon/locales/fr.json
+++ b/app/javascript/mastodon/locales/fr.json
@@ -45,7 +45,7 @@
   "compose_form.publish_loud": "{publish}!",
   "compose_form.sensitive": "Marquer le média comme délicat",
   "compose_form.spoiler": "Masquer le texte derrière un avertissement",
-  "compose_form.spoiler_placeholder": "Avertissement",
+  "compose_form.spoiler_placeholder": "Écrivez ici votre avertissement",
   "confirmation_modal.cancel": "Annuler",
   "confirmations.block.confirm": "Bloquer",
   "confirmations.block.message": "Confirmez vous le blocage de {name} ?",


### PR DESCRIPTION
- Change the placeholder used in the content warning field from "Content warning" to "Write your warning here". This change should make it easier to understand what the field is about. See #2310.
- Update the French translation accordingly.