### PR TITLE
feat: Enable push subscription for mobile devices by default

### DIFF
--- a/app/javascript/mastodon/web_push_subscription.js
+++ b/app/javascript/mastodon/web_push_subscription.js
@@ -37,7 +37,7 @@ const unsubscribe = ({ registration, subscription }) =>
 
 const sendSubscriptionToBackend = (subscription) =>
   axios.post('/api/web/push_subscriptions', {
-    data: subscription,
+    subscription,
   }).then(response => response.data);
 
 // Last one checks for payload support: https://web-push-book.gauntface.com/chapter-06/01-non-standards-browsers/#no-payload

--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -9,7 +9,7 @@ describe Api::Web::PushSubscriptionsController do
 
   let(:create_payload) do
     {
-      data: {
+      subscription: {
         endpoint: 'https://fcm.googleapis.com/fcm/send/fiuH06a27qE:APA91bHnSiGcLwdaxdyqVXNDR9w1NlztsHb6lyt5WDKOC_Z_Q8BlFxQoR8tWFSXUIDdkyw0EdvxTu63iqamSaqVSevW5LfoFwojws8XYDXv_NRRLH6vo2CdgiN4jgHv5VLt2A8ah6lUX',
         keys: {
           p256dh: 'BEm_a0bdPDhf0SOsrnB2-ategf1hHoCnpXgQsFj5JCkcoMrMt2WHoPfEYOYPzOIs9mZE8ZUaD7VA5vouy0kEkr8=',
@@ -36,25 +36,17 @@ describe Api::Web::PushSubscriptionsController do
     it 'saves push subscriptions' do
       sign_in(user)
 
-      stub_request(:post, create_payload[:data][:endpoint]).to_return(status: 200)
+      stub_request(:post, create_payload[:subscription][:endpoint]).to_return(status: 200)
 
       post :create, format: :json, params: create_payload
 
       user.reload
 
-      push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:data][:endpoint])
+      push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint])
 
-      expect(push_subscription['endpoint']).to eq(create_payload[:data][:endpoint])
-      expect(push_subscription['key_p256dh']).to eq(create_payload[:data][:keys][:p256dh])
-      expect(push_subscription['key_auth']).to eq(create_payload[:data][:keys][:auth])
-    end
-
-    it 'sends welcome notification' do
-      sign_in(user)
-
-      stub_request(:post, create_payload[:data][:endpoint]).to_return(status: 200)
-
-      post :create, format: :json, params: create_payload
+      expect(push_subscription['endpoint']).to eq(create_payload[:subscription][:endpoint])
+      expect(push_subscription['key_p256dh']).to eq(create_payload[:subscription][:keys][:p256dh])
+      expect(push_subscription['key_auth']).to eq(create_payload[:subscription][:keys][:auth])
     end
   end
 
@@ -62,15 +54,15 @@ describe Api::Web::PushSubscriptionsController do
     it 'changes alert settings' do
       sign_in(user)
 
-      stub_request(:post, create_payload[:data][:endpoint]).to_return(status: 200)
+      stub_request(:post, create_payload[:subscription][:endpoint]).to_return(status: 200)
 
       post :create, format: :json, params: create_payload
 
-      alerts_payload[:id] = Web::PushSubscription.find_by(endpoint: create_payload[:data][:endpoint]).id
+      alerts_payload[:id] = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint]).id
 
       put :update, format: :json, params: alerts_payload
 
-      push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:data][:endpoint])
+      push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint])
 
       expect(push_subscription.data['follow']).to eq(alerts_payload[:data][:follow])
       expect(push_subscription.data['favourite']).to eq(alerts_payload[:data][:favourite])


### PR DESCRIPTION
Mobile devices do not support regular notifications. So we enable push notifications by default for these devices. I wish there was a better way to detect this, but it is impossible to reliably feature-detect this in the browsers (e.g. Chrome exposes the Notification API but throws errors when invoked).