### PR TITLE
Redirect user profile page to short URL when HTML format (regression from #3844)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
     confirmations:      'auth/confirmations',
   }
 
-  get '/users/:username', to: redirect('/@%{username}'), constraints: lambda { |req| req.format.nil? }
+  get '/users/:username', to: redirect('/@%{username}'), constraints: lambda { |req| req.format.nil? || req.format.html? }
 
   resources :accounts, path: 'users', only: [:show], param: :username do
     resources :stream_entries, path: 'updates', only: [:show] do


### PR DESCRIPTION
### v1.4.7

```console
$ curl -H 'Accept: text/html' -sSI http://localhost:3000/users/user1 | grep Location
Location: http://localhost:3000/@user1
```

### master (`4b4ea1f`)

```console
$ curl -H 'Accept: text/html' -sSI http://localhost:3000/users/user1 | grep Location
```