### PR TITLE
Center mastodon logo on mobile landing page

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -504,6 +504,7 @@
       .brand {
         a {
           padding-left: 0;
+          padding-right: 0;
           color: $white;
 
           &:hover img {
@@ -513,7 +514,7 @@
 
         img {
           height: 32px;
-          margin-right: 10px;
+          margin-right: -20px;
           position: relative;
           top: 4px;
           left: -10px;


### PR DESCRIPTION
Fix left shifted mastodon logo on mobile landing page.  
Settings for popping out the logo to the left on PC landing page caused this issue.

----

BTW, you set new logo's opacity as "0.8" intentionally? @Gargron  
I think this elephant's complexion looks bad (too transparent)..  
I wonder if it feels like this, because new logo on joinmastodon.org is not transparent :thinking:  

![logo](https://user-images.githubusercontent.com/27640522/28516907-c155aa2e-709d-11e7-82aa-d2bac0de5e90.jpg)

