### PR TITLE
Perfectly center mastodon logo on mobile landing page

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -455,12 +455,12 @@
       .brand {
         a {
           padding-left: 0;
+          padding-right: 0;
           color: $white;
         }
 
         img {
           height: 32px;
-          margin-right: 10px;
           position: relative;
           top: 4px;
           left: -10px;
@@ -728,7 +728,6 @@
       .links .brand img {
         left: 0;
         top: 0;
-        margin-right: 0;
       }
 
       .hero {


### PR DESCRIPTION
In about.scss .links .brand
- Set padding-right: 0; for Anchor as same as padding-left: 0;
- Quit margin-right: 10px; for IMG, because this setting is no more needed

Setting only padding-left made the logo left-shifted on mobile page.
<details>
<summary>Before &amp After</summary>
<img src="https://user-images.githubusercontent.com/27640522/28528091-b24765fc-70c7-11e7-9836-fc4f33527a1c.png" alt="before-after" />
</details>

Margin-right was old setting for adjusting clearance between old logo and letter "Mastodon".



Thanks @Gargron curing elephant's complexion 😆 #4332