### PR TITLE
Update Capistrano lock version in config/deploy.rb

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lock '3.8.1'
+lock '3.8.2'
 
 set :repo_url, ENV.fetch('REPO', 'https://github.com/tootsuite/mastodon.git')
 set :branch, ENV.fetch('BRANCH', 'master')


### PR DESCRIPTION
Deployment with Capistrano was failing due to a mismatch between the loaded
version of Capistrano and the one specified in the deployment
configuration. Bumping the version in config/deploy.rb fixes this issue.