### PR TITLE
Send short account URL to remote instance (regression from #3844)

### DIFF
--- a/app/views/well_known/webfinger/show.json.rabl
+++ b/app/views/well_known/webfinger/show.json.rabl
@@ -8,9 +8,9 @@ end
 
 node(:links) do
   [
-    { rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: account_url(@account) },
+    { rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: short_account_url(@account) },
     { rel: 'http://schemas.google.com/g/2010#updates-from', type: 'application/atom+xml', href: account_url(@account, format: 'atom') },
-    { rel: 'self', type: 'application/activity+json', href: account_url(@account) },
+    { rel: 'self', type: 'application/activity+json', href: account_url(@account, format: 'json') },
     { rel: 'salmon', href: api_salmon_url(@account.id) },
     { rel: 'magic-public-key', href: "data:application/magic-public-key,#{@magic_key}" },
     { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_follow_url}?acct={uri}" },

--- a/app/views/well_known/webfinger/show.json.rabl
+++ b/app/views/well_known/webfinger/show.json.rabl
@@ -10,7 +10,7 @@ node(:links) do
   [
     { rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: short_account_url(@account) },
     { rel: 'http://schemas.google.com/g/2010#updates-from', type: 'application/atom+xml', href: account_url(@account, format: 'atom') },
-    { rel: 'self', type: 'application/activity+json', href: account_url(@account, format: 'json') },
+    { rel: 'self', type: 'application/activity+json', href: account_url(@account) },
     { rel: 'salmon', href: api_salmon_url(@account.id) },
     { rel: 'magic-public-key', href: "data:application/magic-public-key,#{@magic_key}" },
     { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_follow_url}?acct={uri}" },

--- a/app/views/well_known/webfinger/show.xml.ruby
+++ b/app/views/well_known/webfinger/show.xml.ruby
@@ -5,7 +5,7 @@ Nokogiri::XML::Builder.new do |xml|
     xml.Alias account_url(@account)
     xml.Link(rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: short_account_url(@account))
     xml.Link(rel: 'http://schemas.google.com/g/2010#updates-from', type: 'application/atom+xml', href: account_url(@account, format: 'atom'))
-    xml.Link(rel: 'self', type: 'application/activity+json', href: account_url(@account, format: 'json'))
+    xml.Link(rel: 'self', type: 'application/activity+json', href: account_url(@account))
     xml.Link(rel: 'salmon', href: api_salmon_url(@account.id))
     xml.Link(rel: 'magic-public-key', href: "data:application/magic-public-key,#{@magic_key}")
     xml.Link(rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_follow_url}?acct={uri}")

--- a/app/views/well_known/webfinger/show.xml.ruby
+++ b/app/views/well_known/webfinger/show.xml.ruby
@@ -3,9 +3,9 @@ Nokogiri::XML::Builder.new do |xml|
     xml.Subject @canonical_account_uri
     xml.Alias short_account_url(@account)
     xml.Alias account_url(@account)
-    xml.Link(rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: TagManager.instance.url_for(@account))
+    xml.Link(rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: short_account_url(@account))
     xml.Link(rel: 'http://schemas.google.com/g/2010#updates-from', type: 'application/atom+xml', href: account_url(@account, format: 'atom'))
-    xml.Link(rel: 'self', type: 'application/activity+json', href: account_url(@account))
+    xml.Link(rel: 'self', type: 'application/activity+json', href: account_url(@account, format: 'json'))
     xml.Link(rel: 'salmon', href: api_salmon_url(@account.id))
     xml.Link(rel: 'magic-public-key', href: "data:application/magic-public-key,#{@magic_key}")
     xml.Link(rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_follow_url}?acct={uri}")


### PR DESCRIPTION
Resolve #4347 

```diff
--- /tmp/before.json	2017-07-25 17:12:28.000000000 +0900
+++ /tmp/after.json	2017-07-25 17:12:19.000000000 +0900
@@ -8,7 +8,7 @@
     {
       "rel": "http://webfinger.net/rel/profile-page",
       "type": "text/html",
-      "href": "http://localhost:3000/users/ykzts"
+      "href": "http://localhost:3000/@ykzts"
     },
     {
       "rel": "http://schemas.google.com/g/2010#updates-from",
@@ -18,7 +18,7 @@
     {
       "rel": "self",
       "type": "application/activity+json",
-      "href": "http://localhost:3000/users/ykzts"
+      "href": "http://localhost:3000/users/ykzts.json"
     },
     {
       "rel": "salmon",
```