### PR TITLE
Update Japanese translations for landing page (for Mobile). (addition to #4159)

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,7 +2,7 @@
 ja:
   about:
     about_mastodon_html: Mastodon は、オープンなウェブプロトコルを採用した、自由でオープンソースなソーシャルネットワークです。電子メールのような分散型の仕組みを採っています。
-    about_this: このインスタンスについて
+    about_this: 詳細情報
     closed_registrations: 現在このインスタンスでの新規登録は受け付けていません。しかし、他のインスタンスにアカウントを作成しても全く同じネットワークに参加することができます。
     contact: 連絡先
     description_headline: "%{domain} とは？"
@@ -395,7 +395,7 @@ ja:
     title: セッション
   settings:
     authorized_apps: 認証済みアプリ
-    back: 戻る
+    back: Mastodon に戻る
     delete: アカウントの削除
     edit_profile: プロフィールを編集
     export: データのエクスポート


### PR DESCRIPTION
Update translation of 'About' and 'Back to Mastodon'.
'About': 'このインスタンスについて' -> '詳細情報': en-shorten for mobile.
'Back to Mastodon': '戻る' -> 'Mastodon に戻る': only ja and kr translation says 'Back'. fix it to 'Back to Mastodon'. 

![iphone6_logout](https://user-images.githubusercontent.com/1680550/28574379-c6791d7e-7188-11e7-81b9-92693075c3e0.png)

Some string length problem occurs on iPhone5/6(logon) and iPhone5(logout).
I send PR which update css to fix it (#4363).
![iphone6_logon](https://user-images.githubusercontent.com/1680550/28574382-c8321508-7188-11e7-81e2-4c2d74c0980a.png)
![iphone5_logout](https://user-images.githubusercontent.com/1680550/28574388-ca2e2eb4-7188-11e7-9399-ea231efe476e.png)
