### PR TITLE
Allow longer link text on landing page (reduce padding for Mobile)

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -721,6 +721,17 @@
         text-align: center;
       }
 
+      .nav {
+        display: flex;
+        flex-flow: row wrap;
+        justify-content: space-around;
+
+      }
+
+      .links a {
+        padding: 12px 8px;
+      }
+
       .heading h1 {
         padding: 30px 0;
       }

--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -725,7 +725,6 @@
         display: flex;
         flex-flow: row wrap;
         justify-content: space-around;
-
       }
 
       .links a {


### PR DESCRIPTION
Fixes string length problem on #4362.
![iphone5_logout](https://user-images.githubusercontent.com/1680550/28574942-5db6dd10-718a-11e7-8675-36449e4b0dfc.png)
![iphone6_logon](https://user-images.githubusercontent.com/1680550/28574946-60746ef0-718a-11e7-9c55-68198f05ac53.png)

Appearance on iPhone5(logon) isn't fixed. but behave same as English.
![iphone5_logon](https://user-images.githubusercontent.com/1680550/28575072-cb4c439c-718a-11e7-8443-828d675f0b86.png)
![iphone5_logon_en](https://user-images.githubusercontent.com/1680550/28575171-1bb35046-718b-11e7-8e45-61db1bc796a7.png)

I use flexbox to get same appearance with shorter strings. 
![iphone5_logout_en](https://user-images.githubusercontent.com/1680550/28575435-dcaff2e0-718b-11e7-8e80-ec262211b4f2.png)

