### PR TITLE
Fix multiple-gif display in user page

### DIFF
--- a/app/javascript/styles/stream_entries.scss
+++ b/app/javascript/styles/stream_entries.scss
@@ -263,7 +263,9 @@
     border: medium none;
     display: block;
     flex: 1 1 auto;
+    width: 100%;
     height: 100%;
+    overflow: hidden;
     margin-right: 2px;
 
     &:last-child {


### PR DESCRIPTION
1. Divide media-item elements to equal width. 
Setting  width: 100%; for elements in flexbox is needed, to divide equally regardless of the size of gifs.

2. Hide overlaps.

![beforeafter](https://user-images.githubusercontent.com/27640522/28582208-92c71c76-719f-11e7-9804-ce6d8615ccd8.jpg)