### PR TITLE
Adjust mobile landing page

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -689,9 +689,9 @@
     .header-wrapper {
       padding-top: 0;
 
-        &.compact .hero .heading {
-          padding-bottom: 20px;
-        }
+      &.compact .hero .heading {
+        padding-bottom: 20px;
+      }
     }
 
     .header .container,

--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -646,7 +646,7 @@
     }
   }
 
-  @media screen and (max-width: 800px) {
+  @media screen and (max-width: 840px) {
     .container {
       padding: 0 20px;
     }
@@ -688,6 +688,10 @@
   @media screen and (max-width: 675px) {
     .header-wrapper {
       padding-top: 0;
+
+        &.compact .hero .heading {
+          padding-bottom: 20px;
+        }
     }
 
     .header .container,
@@ -701,15 +705,9 @@
     }
 
     .header {
-      padding-top: 0;
 
       .hero {
         margin-top: 30px;
-        padding: 0;
-
-        .heading {
-          padding-bottom: 20px;
-        }
       }
 
       .floats {


### PR DESCRIPTION
### Change mobile viewport threshold from 800px to 840px

In consideration of padding left 20px + right 20px, we need 40px more than container width 800px.

<details>
<summary>Before and after</summary>
<img src="https://user-images.githubusercontent.com/27640522/28588786-a61a939a-71b6-11e7-95cb-fb1e4b5d3087.jpg" alt="beforeafter" />
</details>

### Fix loss of "container hero" padding in about/more under 675px.

padding: 0 20px; is already set in "media screen and (max-width: 800px) .landing-page .container".  
There is no meaning to set padding-top: 0; in max-width: 675px.

<details>
<summary>Before and after</summary>
<img src="https://user-images.githubusercontent.com/27640522/28588887-f45e19dc-71b6-11e7-955f-8845bb223361.png" alt="beforeafter" />
</details>

### Minor adjustments in about.scss

1. Strictly change padding-bottom of description 30px to 20px in about/more
We should specify element STRICTLY to change previous setting. (ref. second image)

2. ".landing-page .header" is already "padding: 0;" even without setting "padding-top: 0;"
