### PR TITLE
Added external-link icons to joinmastodon navbar buttons

### DIFF
--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -29,7 +29,10 @@
             - else
               = link_to t('auth.login'), new_user_session_path, class: 'webapp-btn'
           %li= link_to t('about.about_this'), about_more_path
-          %li= link_to t('about.other_instances'), 'https://joinmastodon.org/'
+          %li
+            = link_to 'https://joinmastodon.org/' do
+              = "#{t('about.other_instances')}"
+              %i.fa.fa-external-link{ style: 'padding-left: 5px;' }
 
       .container.hero
         .heading

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -33,7 +33,10 @@
             - else
               = link_to t('auth.login'), new_user_session_path, class: 'webapp-btn'
           %li= link_to t('about.about_this'), about_more_path
-          %li= link_to t('about.other_instances'), 'https://joinmastodon.org/'
+          %li
+            = link_to 'https://joinmastodon.org/' do
+              = "#{t('about.other_instances')}"
+              %i.fa.fa-external-link{ style: 'padding-left: 5px;' }
 
       .container.hero
         .floats


### PR DESCRIPTION
The "Instance list" button can deceive users into going to an external site unknowingly, and as joinmastodon has almost the same CSS, one is easily fooled.

This PR adds external-link icons there to make the distinction obvious.

![screenshot_20170726_000133](https://user-images.githubusercontent.com/2041118/28595847-0d1f5d62-7196-11e7-8b6c-4cffea8cf61b.png)

![screenshot_20170726_000143](https://user-images.githubusercontent.com/2041118/28595851-1019f400-7196-11e7-8d9d-a0c4c551cdca.png)
