### PR TITLE
Fix padding in hero container of landing page

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -711,7 +711,7 @@
         padding: 0;
 
         .heading {
-          padding: 0 20px 20px 20px;
+          padding: 0 20px 20px;
         }
       }
 

--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -708,6 +708,11 @@
 
       .hero {
         margin-top: 30px;
+        padding: 0;
+      }
+
+      .heading {
+        padding: 0 20px 20px 20px;
       }
 
       .floats {

--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -709,10 +709,10 @@
       .hero {
         margin-top: 30px;
         padding: 0;
-      }
 
-      .heading {
-        padding: 0 20px 20px 20px;
+        .heading {
+          padding: 0 20px 20px 20px;
+        }
       }
 
       .floats {


### PR DESCRIPTION
1. Erase hero container padding to fit registration form to full width.
This space was appeared after #4366 .

2. By 1. setting, heading padding disappears, so I adjust heading padding.
This also fix too long padding under instance name.

![beforeafter2](https://user-images.githubusercontent.com/27640522/28607762-4703ef5c-7218-11e7-97c7-910ee7b4b566.jpg)
