### PR TITLE
fix(web_push_notification_worker): Guard against deleted notifications

### DIFF
--- a/app/workers/web_push_notification_worker.rb
+++ b/app/workers/web_push_notification_worker.rb
@@ -9,6 +9,8 @@ class WebPushNotificationWorker
     session_activation = SessionActivation.find(session_activation_id)
     notification = Notification.find(notification_id)
 
+    return if session_activation.nil? || notification.nil?
+
     begin
       session_activation.web_push_subscription.push(notification)
     rescue Webpush::InvalidSubscription, Webpush::ExpiredSubscription => e


### PR DESCRIPTION
We do it before creating the worker, but it may be deleted in the meanwhile.