### PR TITLE
Multiple Sidekiq retry adjustments

### DIFF
--- a/app/workers/admin/suspension_worker.rb
+++ b/app/workers/admin/suspension_worker.rb
@@ -3,7 +3,7 @@
 class Admin::SuspensionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'pull', dead: false
 
   def perform(account_id, remove_user = false)
     SuspendAccountService.new.call(Account.find(account_id), remove_user)

--- a/app/workers/after_remote_follow_request_worker.rb
+++ b/app/workers/after_remote_follow_request_worker.rb
@@ -3,7 +3,7 @@
 class AfterRemoteFollowRequestWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: 5
+  sidekiq_options queue: 'pull', retry: 5, dead: false
 
   attr_reader :follow_request
 

--- a/app/workers/after_remote_follow_worker.rb
+++ b/app/workers/after_remote_follow_worker.rb
@@ -3,7 +3,7 @@
 class AfterRemoteFollowWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: 5
+  sidekiq_options queue: 'pull', retry: 5, dead: false
 
   attr_reader :follow
 

--- a/app/workers/block_worker.rb
+++ b/app/workers/block_worker.rb
@@ -3,6 +3,8 @@
 class BlockWorker
   include Sidekiq::Worker
 
+  sidekiq_options dead: false
+
   def perform(account_id, target_account_id)
     AfterBlockService.new.call(Account.find(account_id), Account.find(target_account_id))
   end

--- a/app/workers/digest_mailer_worker.rb
+++ b/app/workers/digest_mailer_worker.rb
@@ -3,7 +3,7 @@
 class DigestMailerWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'mailers'
+  sidekiq_options queue: 'mailers', dead: false
 
   attr_reader :user
 

--- a/app/workers/distribution_worker.rb
+++ b/app/workers/distribution_worker.rb
@@ -3,6 +3,8 @@
 class DistributionWorker
   include Sidekiq::Worker
 
+  sidekiq_options dead: false
+
   def perform(status_id)
     FanOutOnWriteService.new.call(Status.find(status_id))
   rescue ActiveRecord::RecordNotFound

--- a/app/workers/domain_block_worker.rb
+++ b/app/workers/domain_block_worker.rb
@@ -3,6 +3,8 @@
 class DomainBlockWorker
   include Sidekiq::Worker
 
+  sidekiq_options dead: false
+
   def perform(domain_block_id)
     BlockDomainService.new.call(DomainBlock.find(domain_block_id))
   rescue ActiveRecord::RecordNotFound

--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -3,6 +3,8 @@
 class FeedInsertWorker
   include Sidekiq::Worker
 
+  sidekiq_options dead: false
+
   attr_reader :status, :follower
 
   def perform(status_id, follower_id)

--- a/app/workers/merge_worker.rb
+++ b/app/workers/merge_worker.rb
@@ -3,7 +3,7 @@
 class MergeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'pull', dead: false
 
   def perform(from_account_id, into_account_id)
     FeedManager.instance.merge_into_timeline(Account.find(from_account_id), Account.find(into_account_id))

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -3,7 +3,15 @@
 class NotificationWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push', retry: 5
+  sidekiq_options queue: 'push', retry: 10, dead: false
+
+  sidekiq_retry_in do |count|
+    if count < 3
+      5 * (count + 1)
+    else
+      (count ** 4) + 15 + (rand(30) * (count + 1))
+    end
+  end
 
   def perform(xml, source_account_id, target_account_id)
     SendInteractionService.new.call(xml, Account.find(source_account_id), Account.find(target_account_id))

--- a/app/workers/processing_worker.rb
+++ b/app/workers/processing_worker.rb
@@ -3,7 +3,7 @@
 class ProcessingWorker
   include Sidekiq::Worker
 
-  sidekiq_options backtrace: true
+  sidekiq_options backtrace: true, dead: false
 
   def perform(account_id, body)
     ProcessFeedService.new.call(body, Account.find(account_id))

--- a/app/workers/pubsubhubbub/distribution_worker.rb
+++ b/app/workers/pubsubhubbub/distribution_worker.rb
@@ -3,7 +3,7 @@
 class Pubsubhubbub::DistributionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push'
+  sidekiq_options queue: 'push', dead: false
 
   def perform(stream_entry_ids)
     stream_entries = StreamEntry.where(id: stream_entry_ids).includes(:status).reject { |e| e.status&.direct_visibility? }

--- a/app/workers/pubsubhubbub/subscribe_worker.rb
+++ b/app/workers/pubsubhubbub/subscribe_worker.rb
@@ -3,7 +3,7 @@
 class Pubsubhubbub::SubscribeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push', retry: 10, unique: :until_executed
+  sidekiq_options queue: 'push', retry: 10, unique: :until_executed, dead: false
 
   sidekiq_retry_in do |count|
     case count
@@ -16,6 +16,12 @@ class Pubsubhubbub::SubscribeWorker
     else
       24.hours.seconds * (count - 2)
     end
+  end
+
+  sidekiq_retries_exhausted do |msg, e|
+    account = Account.find(msg['args'].first)
+    logger.error "PuSH subscription attempts for #{account.acct} exhausted. Unsubscribing"
+    ::UnsubscribeService.new.call(account)
   end
 
   def perform(account_id)

--- a/app/workers/push_update_worker.rb
+++ b/app/workers/push_update_worker.rb
@@ -3,6 +3,8 @@
 class PushUpdateWorker
   include Sidekiq::Worker
 
+  sidekiq_options dead: false
+
   def perform(account_id, status_id)
     account = Account.find(account_id)
     status  = Status.find(status_id)

--- a/app/workers/regeneration_worker.rb
+++ b/app/workers/regeneration_worker.rb
@@ -3,7 +3,7 @@
 class RegenerationWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', backtrace: true, unique: :until_executed
+  sidekiq_options queue: 'pull', backtrace: true, unique: :until_executed, dead: false
 
   def perform(account_id, _ = :home)
     account = Account.find(account_id)

--- a/app/workers/remote_profile_update_worker.rb
+++ b/app/workers/remote_profile_update_worker.rb
@@ -3,7 +3,7 @@
 class RemoteProfileUpdateWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'pull', dead: false
 
   def perform(account_id, body, resubscribe)
     UpdateRemoteProfileService.new.call(body, Account.find(account_id), resubscribe)

--- a/app/workers/removal_worker.rb
+++ b/app/workers/removal_worker.rb
@@ -3,6 +3,8 @@
 class RemovalWorker
   include Sidekiq::Worker
 
+  sidekiq_options dead: false
+
   def perform(status_id)
     RemoveStatusService.new.call(Status.find(status_id))
   rescue ActiveRecord::RecordNotFound

--- a/app/workers/salmon_worker.rb
+++ b/app/workers/salmon_worker.rb
@@ -3,7 +3,7 @@
 class SalmonWorker
   include Sidekiq::Worker
 
-  sidekiq_options backtrace: true
+  sidekiq_options backtrace: true, dead: false
 
   def perform(account_id, body)
     ProcessInteractionService.new.call(body, Account.find(account_id))

--- a/app/workers/soft_block_domain_followers_worker.rb
+++ b/app/workers/soft_block_domain_followers_worker.rb
@@ -5,7 +5,7 @@ require 'sidekiq-bulk'
 class SoftBlockDomainFollowersWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'pull', dead: false
 
   def perform(account_id, domain)
     followers_id = Account.find(account_id).followers.where(domain: domain).pluck(:id)

--- a/app/workers/soft_block_worker.rb
+++ b/app/workers/soft_block_worker.rb
@@ -3,7 +3,7 @@
 class SoftBlockWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'pull', dead: false
 
   def perform(account_id, target_account_id)
     account        = Account.find(account_id)

--- a/app/workers/unfavourite_worker.rb
+++ b/app/workers/unfavourite_worker.rb
@@ -3,6 +3,8 @@
 class UnfavouriteWorker
   include Sidekiq::Worker
 
+  sidekiq_options dead: false
+
   def perform(account_id, status_id)
     UnfavouriteService.new.call(Account.find(account_id), Status.find(status_id))
   rescue ActiveRecord::RecordNotFound

--- a/app/workers/unmerge_worker.rb
+++ b/app/workers/unmerge_worker.rb
@@ -3,7 +3,7 @@
 class UnmergeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'pull', dead: false
 
   def perform(from_account_id, into_account_id)
     FeedManager.instance.unmerge_from_timeline(Account.find(from_account_id), Account.find(into_account_id))

--- a/app/workers/web_push_notification_worker.rb
+++ b/app/workers/web_push_notification_worker.rb
@@ -3,13 +3,13 @@
 class WebPushNotificationWorker
   include Sidekiq::Worker
 
-  sidekiq_options backtrace: true
+  sidekiq_options backtrace: true, dead: false
 
   def perform(session_activation_id, notification_id)
     session_activation = SessionActivation.find(session_activation_id)
     notification = Notification.find(notification_id)
 
-    return if session_activation.nil? || notification.nil?
+    return if session_activation.web_push_subscription.nil?
 
     begin
       session_activation.web_push_subscription.push(notification)


### PR DESCRIPTION
- Disable dead job queue for all jobs, because the dead job queue is never
  used by anyone except to clear it
- Make Salmon delivery worker a bit better at retrying, at first make it
  behave like the PuSH delivery worker, but after 3 tries go back to
  standard Sidekiq scheduling
- If a subscription job fails all the way through, unsubscribe from
  that user to prevent furter subscription attempts
- Fix WebPushNotificationWorker guarding against impossible conditions,
  make it guard against a real failure condition