### PR TITLE
feat(web_push_notifications): Group notifications

### DIFF
--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -53,6 +53,7 @@ class Web::PushSubscription < ApplicationRecord
           url: url,
           actions: actions,
           access_token: access_token,
+          message: translate('push_notifications.group.title'), # Do not pass count, will be formatted in the ServiceWorker
         }
       ),
       endpoint: endpoint,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,6 +348,8 @@ en:
       title: "%{name} favourited your status"
     follow:
       title: "%{name} is now following you"
+    group:
+      title: "%{count} notifications"
     mention:
       action_boost: Boost
       action_expand: Show more


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2109702/28665580-5a5792d2-72c4-11e7-8e3e-352cfaa1c2bb.png)

Tradeoffs:
 - Due to the complexity of dealing with locales in the Service Worker, we are sending the message in the payload (`%{count} notifications`) and replacing `%{count}` when the grouping occurs. This is suboptimal, to say the least, but a proper solution is much harder to implement.
 - No actions for the grouped notifications.
 - No ability to customize `MAX_NOTIFICATIONS` - tablet users might want to increase it since they have more space in the notification drawer.
 - If you receive `MAX_NOTIFICATIONS + 1` notifications, this will show the first `MAX_NOTIFICATIONS` individually and group when the last one arrives.
 - Notification body is a concatenation of the original notification titles (most recent on top) - should it be the body instead of the title? Things to consider: line breaks in the message, not enough space in the body...

Related to #4200.