### PR TITLE
Fix timeline height on landing page for Safari

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -547,6 +547,7 @@
   }
 
   #mastodon-timeline {
+    display: flex;
     -webkit-overflow-scrolling: touch;
     -ms-overflow-style: -ms-autohiding-scrollbar;
     font-family: 'mastodon-font-sans-serif', sans-serif;
@@ -565,7 +566,6 @@
       padding: 0;
       border-radius: 4px;
       overflow: hidden;
-      height: 100%;
     }
 
     .scrollable {


### PR DESCRIPTION
resolves #4390

Currently, we're using styles like below to make timeline to have full height.

```css
#mastodon-timeline { align-self: stretch /* as default style */ }
#mastodon-timeline .column { height: 100% }
```

However, `height: 100%` in `align-self: stretch` box doesn't stretch as we expected on Safari < 11.

https://bugs.webkit.org/show_bug.cgi?id=137730

This workaround uses flexbox instead of `height: 100%` to stretch height.

|Before|After|
|-------|------|
|![image](https://user-images.githubusercontent.com/705555/28657289-5a70f944-72e1-11e7-87e1-4f1355258ce9.png)|![image](https://user-images.githubusercontent.com/705555/28657284-57b1bd88-72e1-11e7-9713-b40366009dd3.png)|
