### PR TITLE
fix(push_subscription): Use star icon for favourite action

### DIFF
--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -117,7 +117,7 @@ class Web::PushSubscription < ApplicationRecord
       when :mention then [
         {
           title: translate('push_notifications.mention.action_favourite'),
-          icon: full_asset_url('emoji/2764.png', skip_pipeline: true),
+          icon: full_asset_url('emoji/2b50.png', skip_pipeline: true),
           todo: 'request',
           method: 'POST',
           action: "/api/v1/statuses/#{notification.target_status.id}/favourite",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2109702/28662769-9a633434-72bb-11e7-9cb1-62d55d77f935.png)
![image](https://user-images.githubusercontent.com/2109702/28662785-a2fd1114-72bb-11e7-80ee-1b87dec27e93.png)

Would like to change to boost icon to something that is not circle-shaped (Android makes the icons gray, so the boost icon becomes a gray circle - not recognizable), but couldn't find an emoji for it.