### PR TITLE
Fix an error when a user tries to search nonexistent remote user

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -18,7 +18,7 @@ class AccountSearchService < BaseService
     return [] if query_blank_or_hashtag? || limit < 1
 
     if resolving_non_matching_remote_account?
-      [ResolveRemoteAccountService.new.call("#{query_username}@#{query_domain}")]
+      [ResolveRemoteAccountService.new.call("#{query_username}@#{query_domain}")].compact
     else
       search_results_and_exact_match.compact.uniq.slice(0, limit)
     end


### PR DESCRIPTION
Before merging #4275, when a user tries to search an nonexistent remote user, `Goldfinger.finger` raises `Goldfinger::Error` and renders the JSON `{ error: 'Remote account could not be resolved' }` with 422 HTTP status code.

However, after #4275, `Goldfinger::Error` is rescued in ResolveRemoteAccountService#call and it returns `nil` instead of propagating the exception. In such a situation, `AccountSearchService#search_service_results` returns `[nil]` and it causes an error. 