### PR TITLE
Remove hash from chunk filename when dev env

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -10,7 +10,11 @@ const { publicPath } = require('./configuration.js');
 const path = require('path');
 
 module.exports = merge(sharedConfig, {
-  output: { filename: '[name]-[chunkhash].js' },
+  output: {
+    filename: '[name]-[chunkhash].js',
+    chunkFilename: '[name]-[chunkhash].js',
+  },
+
   devtool: 'source-map', // separate sourcemap file, suitable for production
   stats: 'normal',
 

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -33,7 +33,7 @@ module.exports = {
 
   output: {
     filename: '[name].js',
-    chunkFilename: '[name]-[chunkhash].js',
+    chunkFilename: '[name].js',
     path: output.path,
     publicPath: output.publicPath,
   },


### PR DESCRIPTION
Change the processing of `output.filename` and `output.chunkFilename` the same.
