### PR TITLE
Fix protruded infomation board section in about/more page

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -121,7 +121,7 @@
 
 .information-board {
   background: darken($ui-base-color, 4%);
-  padding: 30px 0;
+  padding: 20px 0;
 
   .panel {
     position: absolute;
@@ -642,10 +642,6 @@
   @media screen and (max-width: 840px) {
     .container {
       padding: 0 20px;
-    }
-
-    .information-board {
-      padding-bottom: 20px;
     }
 
     .information-board .container {

--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -121,7 +121,7 @@
 
 .information-board {
   background: darken($ui-base-color, 4%);
-  padding: 40px 0;
+  padding: 30px 0;
 
   .panel {
     position: absolute;
@@ -162,13 +162,14 @@
   .information-board-sections {
     display: flex;
     justify-content: space-between;
+    flex-wrap: wrap;
   }
 
   .section {
     flex: 1 0 0;
     font: 16px/28px 'mastodon-font-sans-serif', sans-serif;
     text-align: right;
-    padding: 0 15px;
+    padding: 10px 15px;
 
     span,
     strong {
@@ -188,14 +189,6 @@
       font-size: 32px;
       line-height: 48px;
       color: $primary-text-color;
-    }
-  }
-
-  @media screen and (max-width: 500px) {
-    flex-direction: column;
-
-    .section {
-      text-align: left;
     }
   }
 }
@@ -660,7 +653,7 @@
 
       .panel {
         position: static;
-        margin-top: 30px;
+        margin-top: 20px;
         width: 100%;
         border-radius: 4px;
 


### PR DESCRIPTION
### Set "flex-wrap: wrap" for information-board-sections

To prevent protruded information board section.

### Set upper and lower padding for each section

To make clearance between each information-board section, for when sections are wrapped.
I also reduce padding and margin of elements around sections, in order not to change styles.

### Delete settings for viewport maximum 500px

These settings have no meaning in current styles. They are made for old information-board.

#### References

1. [about/more page of my instance running with this commit](https://mstdn.sanin.link/about/more)

2. Before and after images below
All images are 320px width
![beforeafter](https://user-images.githubusercontent.com/27640522/28709872-fd9529ca-73bc-11e7-8fd4-ab835d3a3d6a.jpg)
