### PR TITLE
Use a fainted text color for <hr> elements in the landing page

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -308,7 +308,7 @@
     font-weight: inherit;
     margin-bottom: 0;
   }
-  
+
   hr {
     border-color: rgba($ui-base-lighter-color, .6);
   }

--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -308,6 +308,10 @@
     font-weight: inherit;
     margin-bottom: 0;
   }
+  
+  hr {
+    border-color: rgba($ui-base-lighter-color, .6);
+  }
 
   .header {
     line-height: 30px;


### PR DESCRIPTION
A simple change but that might make some custom landing pages using `<hr />` elements nicer!

Before:
![screen shot 2017-07-29 at 10 04 10 am](https://user-images.githubusercontent.com/1409924/28746716-693036ba-7445-11e7-9537-31c84d2618c2.png)

After:
![screen shot 2017-07-29 at 10 04 18 am](https://user-images.githubusercontent.com/1409924/28746717-6e0cba8c-7445-11e7-9072-a00ee310ada8.png)
