### PR TITLE
Set contact address in about/more as mailto link 

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -147,9 +147,10 @@
       white-space: nowrap;
       overflow: hidden;
 
-      span {
+      a {
         font-weight: 400;
         color: lighten($ui-base-color, 34%);
+        text-decoration: none;
       }
     }
   }

--- a/app/views/about/_contact.html.haml
+++ b/app/views/about/_contact.html.haml
@@ -2,7 +2,7 @@
   .panel-header
     = succeed ':' do
       = t 'about.contact'
-    %span{ title: contact.site_contact_email.presence }= contact.site_contact_email.presence
+    = mail_to contact.site_contact_email.presence, nil, :title => contact.site_contact_email.presence
   .panel-body
     - if contact.contact_account
       .owner


### PR DESCRIPTION
In current style, long contact email address is hidden. This is applicable to mastodon.social.
As address is spanned with title , we can know address by mouseover it (only on PCs), but there is no way to know address on phones, and copy address.

If we change spanned address to mailto link, we can know address on phones, copy address, and send email easily.
I continue to set title in anchor, so we can know address by mouseover it as before.