### PR TITLE
Do not create empty a element when there is no e-mail

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -147,9 +147,13 @@
       white-space: nowrap;
       overflow: hidden;
 
-      a {
+      a,
+      span {
         font-weight: 400;
         color: lighten($ui-base-color, 34%);
+      }
+
+      a {
         text-decoration: none;
       }
     }

--- a/app/views/about/_contact.html.haml
+++ b/app/views/about/_contact.html.haml
@@ -2,7 +2,10 @@
   .panel-header
     = succeed ':' do
       = t 'about.contact'
-    = mail_to contact.site_contact_email.presence, nil, :title => contact.site_contact_email.presence
+    - if contact.site_contact_email.present?
+      = mail_to contact.site_contact_email, nil, title: contact.site_contact_email
+    - else
+      %span= t 'about.contact_unavailable'
   .panel-body
     - if contact.contact_account
       .owner


### PR DESCRIPTION
Empty a element is created when there is no business e-mail input.

![](https://user-images.githubusercontent.com/12539/28754092-d9dd44fe-7579-11e7-9995-53cee9d4dd74.png)