### PR TITLE
Fix length validator counting things that look like URIs like URLs

### DIFF
--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -33,9 +33,7 @@ class LanguageDetector
 
   def simplified_text
     text.dup.tap do |new_text|
-      URI.extract(new_text).each do |url|
-        new_text.gsub!(url, '')
-      end
+      new_text.gsub!(FetchLinkCardService::URL_PATTERN, '')
       new_text.gsub!(Account::MENTION_RE, '')
       new_text.gsub!(Tag::HASHTAG_RE, '')
       new_text.gsub!(/\s+/, ' ')

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -24,7 +24,7 @@ class StatusLengthValidator < ActiveModel::Validator
 
   def countable_text(status)
     status.text.dup.tap do |new_text|
-      URI.extract(new_text).each { |url| new_text.gsub!(url, 'x' * 23) }
+      new_text.gsub!(FetchLinkCardService::URL_PATTERN, 'x' * 23)
       new_text.gsub!(Account::MENTION_RE, '@\2')
     end
   end


### PR DESCRIPTION
URI.extract is too strong, not limited to URLs, matched real text.
Same issue was present in language detector.