### PR TITLE
Fix button overflow on confirmation modal for mobile

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -3499,7 +3499,7 @@ button.icon-button.active i.fa-retweet {
 }
 
 .confirmation-modal {
-  max-width: 280px;
+  max-width: 85vw;
 
   @media screen and (min-width: 480px) {
     max-width: 380px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/705555/28766949-d547d092-760c-11e7-9816-7a0af60e29db.png)
![image](https://user-images.githubusercontent.com/705555/28766968-e7ebb038-760c-11e7-9b92-902e240dfdeb.png)

Note that still button (and text) may overflow on some language or some device width (e.g. iPhone 5s). Reducing horizontal padding from 16px to 8px would helps supporting more (not all) combination, but modifying it requires JS change or `!important`.

However, this change seems reasonable anyway.

---

For the reference, we have below translations for "Hide entire domain" now. I think supporting all sentence in current layout is hard, so changing layout on mobile or change translation would be solution.

```
Negeer alles van deze server
Masquer le domaine entier
Ukryj wszysyko z domeny
Блокировать весь домен
Amagar tot lo domeni
Amagar tot el domini
Skjul alt fra domenet
Sakrij cijelu domenu
ドメイン全体を非表示
Сховати весь домен
도메인 전체를 숨김
Hide entire domain
پنهان‌سازی کل دامین
הסתר קהילה שלמה
隱藏整個網域
```