### PR TITLE
fix(web_push_notifications): Send message with welcome notifications

### DIFF
--- a/app/javascript/mastodon/service_worker/web_push_notifications.js
+++ b/app/javascript/mastodon/service_worker/web_push_notifications.js
@@ -9,7 +9,7 @@ const notify = options =>
     if (notifications.length === MAX_NOTIFICATIONS) {
       // Reached the maximum number of notifications, proceed with grouping
       const group = {
-        title: formatGroupTitle(notifications[0].data.message, notifications.length + 1),
+        title: formatGroupTitle(options.data.message, notifications.length + 1),
         body: notifications
           .sort((n1, n2) => n1.timestamp < n2.timestamp)
           .map(notification => notification.title).join('\n'),
@@ -19,7 +19,7 @@ const notify = options =>
         data: {
           url: (new URL('/web/notifications', self.location)).href,
           count: notifications.length + 1,
-          message: notifications[0].data.message,
+          message: options.data.message,
         },
       };
 

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -161,6 +161,7 @@ class Web::PushSubscription < ApplicationRecord
           content: translate('push_notifications.subscribed.body'),
           actions: [],
           url: web_url('notifications'),
+          message: translate('push_notifications.group.title'), # Do not pass count, will be formatted in the ServiceWorker
         }
       ),
       endpoint: endpoint,


### PR DESCRIPTION
Since the format message was not sent with the first notification, grouping would fail. This includes the message in the payload for the welcome notification, but also reads it from the last notification (to avoid reading the misconfigured one).