### PR TITLE
Do not emojify ™, ® and © - no more gray on gray

### DIFF
--- a/app/javascript/mastodon/emoji.js
+++ b/app/javascript/mastodon/emoji.js
@@ -3,6 +3,8 @@ import Trie from 'substring-trie';
 
 const trie = new Trie(Object.keys(unicodeMapping));
 
+const excluded = ['™', '©', '®'];
+
 function emojify(str) {
   // This walks through the string from start to end, ignoring any tags (<p>, <br>, etc.)
   // and replacing valid unicode strings
@@ -19,7 +21,7 @@ function emojify(str) {
       insideTag = true;
     } else if (!insideTag && (match = trie.search(str.substring(i)))) {
       const unicodeStr = match;
-      if (unicodeStr in unicodeMapping) {
+      if (unicodeStr in unicodeMapping && excluded.indexOf(unicodeStr) === -1) {
         const [filename, shortCode] = unicodeMapping[unicodeStr];
         const alt      = unicodeStr;
         const replacement =  `<img draggable="false" class="emojione" alt="${alt}" title=":${shortCode}:" src="/emoji/${filename}.svg" />`;


### PR DESCRIPTION
Exclude ™, ® and © from emojifications which makes them unreadable.

Old:
![screenshot_20170731_215141](https://user-images.githubusercontent.com/2041118/28795589-bc04b112-763a-11e7-83c7-9c386b5ae944.png)

New:
![screenshot_20170731_215154](https://user-images.githubusercontent.com/2041118/28795593-bfa8c25e-763a-11e7-9650-108a540a8949.png)

To my knowledge those symbols are supported universally, even on windows.