### PR TITLE
Re-add outline

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -466,10 +466,6 @@
   overflow: hidden;
   white-space: pre-wrap;
 
-  &:focus {
-    outline: rgba($ui-highlight-color, 0.7) solid 2px;
-  }
-
   .emojione {
     width: 18px;
     height: 18px;
@@ -569,11 +565,6 @@
     .icon-button.disabled {
       color: lighten($ui-base-color, 16%);
     }
-  }
-
-  &:focus,
-  &.status-direct:focus {
-    outline: rgba($ui-highlight-color, 0.7) solid 2px;
   }
 
   &.light {

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -573,8 +573,7 @@
 
   &:focus,
   &.status-direct:focus {
-    outline: 0;
-    background-color: lighten($ui-base-color, 10%);
+    outline: rgba($ui-highlight-color, 0.7) solid 2px;
   }
 
   &.light {


### PR DESCRIPTION
ref #4448

I actually tried it and felt that the style with DM was confusing. This Pull Request rewinds the previous change, making Google Chrome and Firefox look the same.

### before (Firefox v54)

![](https://user-images.githubusercontent.com/12539/28801527-f080e238-768c-11e7-874e-ce95e359757a.png)

### after

![](https://user-images.githubusercontent.com/12539/28801528-f086c040-768c-11e7-85dc-bbde2e68b095.png)