### PR TITLE
Add libidn11 to Aptfile

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,8 +1,9 @@
-libpq-dev
-protobuf-compiler
-libprotobuf-dev
 ffmpeg
+libicu-dev
+libidn11
+libidn11-dev
+libpq-dev
+libprotobuf-dev
 libxdamage1
 libxfixes3
-libicu-dev
-libidn11-dev
+protobuf-compiler


### PR DESCRIPTION
Fix builds that fail on Heroku. (and sorting dependencies)

reported by https://mastodon.zunda.ninja/@zundan/137510