### PR TITLE
Fix column-back-button style for some browsers (regression #4457)

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1590,8 +1590,9 @@
   flex: 0 0 auto;
   font-size: 16px;
   border: 0;
-  text-align: start;
+  text-align: unset;
   padding: 15px;
+  margin: 0;
   z-index: 3;
 
   &:hover {


### PR DESCRIPTION
Use `text-align: unset` instead of `text-align: start` which Edge doesn't support for now.

![image](https://user-images.githubusercontent.com/705555/28835902-f14decd4-7721-11e7-856d-55ec05c25c6e.png) ![image](https://user-images.githubusercontent.com/705555/28835777-86fedda2-7721-11e7-94b1-2f59d7cc1bfc.png)


Also remove default margin on Safari.

![image](https://user-images.githubusercontent.com/705555/28835929-0ff23276-7722-11e7-877d-c44ff35f514e.png) ![image](https://user-images.githubusercontent.com/705555/28835600-e6aa6e16-7720-11e7-814f-71e48903996d.png)
