### PR TITLE
Use GNU libiconv in Nokogiri

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ENV UID=991 GID=991 \
     RAILS_SERVE_STATIC_FILES=true \
     RAILS_ENV=production NODE_ENV=production
 
+ARG LIBICONV_VERSION=1.15
+ARG LIBICONV_DOWNLOAD_SHA256=ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178
+
 EXPOSE 3000 4000
 
 WORKDIR /mastodon
@@ -18,8 +21,7 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
     build-base \
     icu-dev \
     libidn-dev \
-    libxml2-dev \
-    libxslt-dev \
+    libtool \
     postgresql-dev \
     protobuf-dev \
     python \
@@ -32,8 +34,6 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
     imagemagick@edge \
     libidn \
     libpq \
-    libxml2 \
-    libxslt \
     nodejs-npm@edge \
     nodejs@edge \
     protobuf \
@@ -41,11 +41,23 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
     tini \
     yarn@edge \
  && update-ca-certificates \
+ && wget -O libiconv.tar.gz "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-$LIBICONV_VERSION.tar.gz" \
+ && echo "$LIBICONV_DOWNLOAD_SHA256 *libiconv.tar.gz" | sha256sum -c - \
+ && mkdir -p /tmp/src \
+ && tar -xzf libiconv.tar.gz -C /tmp/src \
+ && rm libiconv.tar.gz \
+ && cd /tmp/src/libiconv-$LIBICONV_VERSION \
+ && ./configure --prefix=/usr/local \
+ && make \
+ && make install \
+ && libtool --finish /usr/local/lib \
+ && cd /mastodon \
  && rm -rf /tmp/* /var/cache/apk/*
 
 COPY Gemfile Gemfile.lock package.json yarn.lock /mastodon/
 
-RUN bundle install --deployment --without test development \
+RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include \
+ && bundle install --deployment --without test development \
  && yarn --ignore-optional --pure-lockfile
 
 COPY . /mastodon


### PR DESCRIPTION
System default libiconv of Alpine Linux only supports some charset (e.g. UTF-8). Therefore, the preview card of the page which is not UTF-8 will be broken in the Docker environment.

Solve using GNU libiconv.

before | after
-|-
![before screenshot](https://user-images.githubusercontent.com/12539/28861502-2bc9e8d4-779c-11e7-8577-68d84ec2768a.png) | ![after screenshot](https://user-images.githubusercontent.com/12539/28861504-2be9877a-779c-11e7-9b47-35891a3d3d1f.png)