### PR TITLE
Enable cache for babel-loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   - node_modules
   - public/assets
   - public/packs-test
+  - tmp/cache/babel-loader
 dist: trusty
 sudo: required
 

--- a/config/webpack/loaders/babel.js
+++ b/config/webpack/loaders/babel.js
@@ -1,3 +1,5 @@
+const { resolve } = require('path');
+
 module.exports = {
   test: /\.js$/,
   // include react-intl because transform-react-remove-prop-types needs to apply to it
@@ -8,5 +10,6 @@ module.exports = {
   loader: 'babel-loader',
   options: {
     forceEnv: process.env.NODE_ENV || 'development',
+    cacheDirectory: resolve(__dirname, '..', '..', '..', 'tmp', 'cache', 'babel-loader'),
   },
 };


### PR DESCRIPTION
### without cache

```console
$ rm -rf tmp/cache/babel-loader
$ rm -rf public/assets public/packs
$ time ./bin/rails assets:precompile RAILS_ENV=production > /dev/null

real	0m58.440s
user	1m1.308s
sys	0m2.217s
```

### with cache

```console
$ rm -rf public/assets public/packs
$ time ./bin/rails assets:precompile RAILS_ENV=production > /dev/null

real	0m49.067s
user	0m51.141s
sys	0m2.080s
```
