### PR TITLE
Redirect to PasswordController#new when reset_password_token is invalid

### DIFF
--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
 class Auth::PasswordsController < Devise::PasswordsController
+  before_action :check_validity_of_reset_password_token, only: :edit
+
   layout 'auth'
+
+  private
+
+  def check_validity_of_reset_password_token
+    unless reset_password_token_is_valid?
+      flash[:error] = I18n.t('auth.invalid_reset_password_token')
+      redirect_to new_password_path(resource_name)
+    end
+  end
+
+  def reset_password_token_is_valid?
+    resource_class.with_reset_password_token(params[:reset_password_token]).present?
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,6 +234,7 @@ en:
     resend_confirmation: Resend confirmation instructions
     reset_password: Reset password
     set_new_password: Set new password
+    invalid_reset_password_token: Password reset link is invalid or expired. Please try again.
   authorize_follow:
     error: Unfortunately, there was an error looking up the remote account
     follow: Follow

--- a/spec/controllers/auth/passwords_controller_spec.rb
+++ b/spec/controllers/auth/passwords_controller_spec.rb
@@ -3,11 +3,36 @@
 require 'rails_helper'
 
 describe Auth::PasswordsController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
   describe 'GET #new' do
     it 'returns http success' do
       @request.env['devise.mapping'] = Devise.mappings[:user]
       get :new
       expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'GET #edit' do
+    let(:user) { Fabricate(:user) }
+
+    before do
+      request.env['devise.mapping'] = Devise.mappings[:user]
+      @token = user.send_reset_password_instructions
+    end
+
+    context 'with valid reset_password_token' do
+      it 'returns http success' do
+        get :edit, params: { reset_password_token: @token }
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'with invalid reset_password_token' do
+      it 'redirects to #new' do
+        get :edit, params: { reset_password_token: 'some_invalid_value' }
+        expect(response).to redirect_to subject.new_password_path(subject.send(:resource_name))
+      end
     end
   end
 end


### PR DESCRIPTION
It is more intuitive for users to redirect to PasswordController#new when the token is invalid.

Ref: #4502 