### PR TITLE
Ignore some locale keys that can but do not need to be translated

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -42,7 +42,9 @@ ignore_missing:
   - 'simple_form.{error_notification,required}.:'
   - 'errors.messages.*'
   - 'activerecord.errors.models.doorkeeper/*'
-
+  - 'sessions.{browsers,platforms}.*'
+  - 'terms.body_html'
+  - 'application_mailer.salutation'
 ignore_unused:
   - 'activemodel.errors.*'
   - 'activerecord.attributes.*'


### PR DESCRIPTION
- Browsers and platforms are brands and do not require translation
- E-mail salutation is valid for most locales
- Default terms text, as a legal text, is hard to translate, and best left alone

Missing translations: 3411