### PR TITLE
Use locale of the receiver on push notifications

### DIFF
--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -25,6 +25,8 @@
 #
 
 class SessionActivation < ApplicationRecord
+  belongs_to :user, inverse_of: :session_activations, required: true
+
   belongs_to :access_token, class_name: 'Doorkeeper::AccessToken', dependent: :destroy
   belongs_to :web_push_subscription, class_name: 'Web::PushSubscription', dependent: :destroy
 


### PR DESCRIPTION
Currently, web push notification is not localized because current locale is not set on Sidekiq.

This patch set locale from `user.locale` like we do for emails.