### PR TITLE
l10n OC - Added  #4523 “signed in as”

### DIFF
--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -580,3 +580,4 @@ oc:
   users:
     invalid_email: L’adreça de corrièl es invalida
     invalid_otp_token: Còdi d’autentificacion en dos temps invalid
+    signed_in_as: 'Session a'


### PR DESCRIPTION
Neutral form used.