### PR TITLE
Adjust tags and accounts page

### DIFF
--- a/app/javascript/styles/accounts.scss
+++ b/app/javascript/styles/accounts.scss
@@ -9,7 +9,7 @@
   overflow: hidden;
   position: relative;
 
-  @media screen and (max-width: 700px) {
+  @media screen and (max-width: 740px) {
     border-radius: 0;
     box-shadow: none;
   }
@@ -272,7 +272,7 @@
   display: flex;
   flex-wrap: wrap;
 
-  @media screen and (max-width: 700px) {
+  @media screen and (max-width: 740px) {
     border-radius: 0;
     box-shadow: none;
   }

--- a/app/javascript/styles/compact_header.scss
+++ b/app/javascript/styles/compact_header.scss
@@ -3,9 +3,15 @@
     font-size: 24px;
     line-height: 28px;
     color: $ui-primary-color;
-    overflow: hidden;
     font-weight: 500;
     margin-bottom: 20px;
+    padding: 0px 10px;
+    overflow-wrap: break-word;
+
+    @media screen and (max-width: 740px) {
+      text-align: center;
+      padding: 20px 10px 0px;
+    }
 
     a {
       color: inherit;

--- a/app/javascript/styles/compact_header.scss
+++ b/app/javascript/styles/compact_header.scss
@@ -5,12 +5,12 @@
     color: $ui-primary-color;
     font-weight: 500;
     margin-bottom: 20px;
-    padding: 0px 10px;
+    padding: 0 10px;
     overflow-wrap: break-word;
 
     @media screen and (max-width: 740px) {
       text-align: center;
-      padding: 20px 10px 0px;
+      padding: 20px 10px 0;
     }
 
     a {

--- a/app/javascript/styles/containers.scss
+++ b/app/javascript/styles/containers.scss
@@ -3,7 +3,7 @@
   margin: 0 auto;
   margin-top: 40px;
 
-  @media screen and (max-width: 700px) {
+  @media screen and (max-width: 740px) {
     width: 100%;
     margin: 0;
   }

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -4,6 +4,7 @@
 .compact-header
   %h1<
     = link_to site_title, root_path
+    %br
     %small ##{@tag.name}
 
 - if @statuses.empty?


### PR DESCRIPTION
- Set padding for compact-header, header of the tag page. <details><summary>Before and After</summary>
![beforeafter1](https://user-images.githubusercontent.com/27640522/29002171-943787a8-7ad7-11e7-8229-229adfb14ba9.jpg)
</details>

- Change mobile threshold from 700px to 740px, in order not to remain too wide padding-top when left and side paddings are narrow. <details><summary>Before and After</summary>
![beforeafter2](https://user-images.githubusercontent.com/27640522/29002174-a22ca302-7ad7-11e7-8a19-6b41d4b26488.jpg)
</details>

- Change treatment of long tags from `overflow: hidden;` to `overflow-wrap: break-word;`, because a name of the tag is important in the tag page.