### PR TITLE
[Docker] Add multicore support to "make" and "bundler"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
  && rm libiconv.tar.gz \
  && cd /tmp/src/libiconv-$LIBICONV_VERSION \
  && ./configure --prefix=/usr/local \
- && make \
+ && make -j$(getconf _NPROCESSORS_ONLN)\
  && make install \
  && libtool --finish /usr/local/lib \
  && cd /mastodon \
@@ -56,7 +56,7 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
 
 COPY Gemfile Gemfile.lock package.json yarn.lock /mastodon/
 
-RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include \
+RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include --jobs $(getconf _NPROCESSORS_ONLN)\
  && bundle install --deployment --without test development \
  && yarn --ignore-optional --pure-lockfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
 
 COPY Gemfile Gemfile.lock package.json yarn.lock /mastodon/
 
-RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include --jobs $(getconf _NPROCESSORS_ONLN)\
- && bundle install --deployment --without test development \
+RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include \
+ && bundle install -j$(getconf _NPROCESSORS_ONLN) --deployment --without test development \
  && yarn --ignore-optional --pure-lockfile
 
 COPY . /mastodon


### PR DESCRIPTION
These changes add multicore support for ```make``` and ```bundler``` so ```docker-compose build``` time is decreased on multicore machines.