### PR TITLE
unify short description styling

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -484,7 +484,7 @@
     padding: 0;
   }
 
-  .learn-more-cta {
+  .about-short {
     background: darken($ui-base-color, 4%);
     padding: 50px 0;
   }

--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -35,9 +35,10 @@
               %i.fa.fa-external-link{ style: 'padding-left: 5px;' }
 
       .container.hero
-        .heading
-          %h3= t('about.description_headline', domain: site_hostname)
-          %p= @instance_presenter.site_description.html_safe.presence || t('about.generic_description', domain: site_hostname)
+        .about-short
+          .heading
+            %h3= t('about.description_headline', domain: site_hostname)
+            %p= @instance_presenter.site_description.html_safe.presence || t('about.generic_description', domain: site_hostname)
 
   .information-board
     .container

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -58,7 +58,7 @@
                 = @instance_presenter.closed_registrations_message.html_safe
             = link_to t('about.find_another_instance'), 'https://joinmastodon.org/', class: 'button button-alternative button--block'
 
-  .learn-more-cta
+  .about-short
     .container
       %h3= t('about.description_headline', domain: site_hostname)
       %p= @instance_presenter.site_description.html_safe.presence || t('about.generic_description', domain: site_hostname)


### PR DESCRIPTION
Applies the same style class to the About description on both the landing page
and the about/more page.

This allows more consistent and simpler customization of instances.