### PR TITLE
Fix #4548 short description in about/more page

### DIFF
--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -35,10 +35,9 @@
               %i.fa.fa-external-link{ style: 'padding-left: 5px;' }
 
       .container.hero
-        .about-short
-          .heading
-            %h3= t('about.description_headline', domain: site_hostname)
-            %p= @instance_presenter.site_description.html_safe.presence || t('about.generic_description', domain: site_hostname)
+        .heading
+          %h3= t('about.description_headline', domain: site_hostname)
+          %p= @instance_presenter.site_description.html_safe.presence || t('about.generic_description', domain: site_hostname)
 
   .information-board
     .container


### PR DESCRIPTION
Style settings of short description in about/more page are broken after #4548 .

The about description on the landing page and the about/more page are NOT same style class.