### PR TITLE
Add Content-Type header on throttled response to fix mojibake

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -33,6 +33,7 @@ class Rack::Attack
     match_data = env['rack.attack.match_data']
 
     headers = {
+      'Content-Type'          => 'application/json',
       'X-RateLimit-Limit'     => match_data[:limit].to_s,
       'X-RateLimit-Remaining' => '0',
       'X-RateLimit-Reset'     => (now + (match_data[:period] - now.to_i % match_data[:period])).iso8601(6),


### PR DESCRIPTION
application/json only allows Unicode, so this prevents from wrong charset detection.

### Before

![image](https://user-images.githubusercontent.com/705555/29072394-631cd040-7c82-11e7-8a99-22c9da56f56a.png)

### After

![image](https://user-images.githubusercontent.com/705555/29072426-8339c9fa-7c82-11e7-833b-f2d8cb5d8b2d.png)
