### PR TITLE
Add missing @ to the onboarding modal

### DIFF
--- a/app/javascript/mastodon/features/ui/components/onboarding_modal.js
+++ b/app/javascript/mastodon/features/ui/components/onboarding_modal.js
@@ -30,7 +30,7 @@ const PageOne = ({ acct, domain }) => (
     <div>
       <h1><FormattedMessage id='onboarding.page_one.welcome' defaultMessage='Welcome to Mastodon!' /></h1>
       <p><FormattedMessage id='onboarding.page_one.federation' defaultMessage='Mastodon is a network of independent servers joining up to make one larger social network. We call these servers instances.' /></p>
-      <p><FormattedMessage id='onboarding.page_one.handle' defaultMessage='You are on {domain}, so your full handle is {handle}' values={{ domain, handle: <strong>{acct}@{domain}</strong> }} /></p>
+      <p><FormattedMessage id='onboarding.page_one.handle' defaultMessage='You are on {domain}, so your full handle is {handle}' values={{ domain, handle: <strong>@{acct}@{domain}</strong> }} /></p>
     </div>
   </div>
 );


### PR DESCRIPTION
before
![screenshot_20170808_215547](https://user-images.githubusercontent.com/2041118/29091824-6b091938-7c84-11e7-87f0-7ecb5a9273c4.png)

after
![screenshot_20170808_215612](https://user-images.githubusercontent.com/2041118/29091831-7046fe10-7c84-11e7-8afe-71ef8764c2e9.png)

Without the @, it's kind of confusing because the rest of the tutorial uses the handle with @. Also you need the @ to mention someone, so if a newbie learns their handle is without the @, it could cause some confusion (esp. bc it looks like an e-mail while it's not)