### PR TITLE
Add favourited toot to favourites column

### DIFF
--- a/app/javascript/mastodon/reducers/status_lists.js
+++ b/app/javascript/mastodon/reducers/status_lists.js
@@ -3,6 +3,7 @@ import {
   FAVOURITED_STATUSES_EXPAND_SUCCESS,
 } from '../actions/favourites';
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+import { FAVOURITE_SUCCESS } from '../actions/interactions';
 
 const initialState = ImmutableMap({
   favourites: ImmutableMap({
@@ -27,12 +28,20 @@ const appendToList = (state, listType, statuses, next) => {
   }));
 };
 
+const appendOneToList = (state, listType, status) => {
+  return state.update(listType, listMap => listMap.withMutations(map => {
+    map.set('items', map.get('items').unshift(status.get('id')));
+  }));
+};
+
 export default function statusLists(state = initialState, action) {
   switch(action.type) {
   case FAVOURITED_STATUSES_FETCH_SUCCESS:
     return normalizeList(state, 'favourites', action.statuses, action.next);
   case FAVOURITED_STATUSES_EXPAND_SUCCESS:
     return appendToList(state, 'favourites', action.statuses, action.next);
+  case FAVOURITE_SUCCESS:
+    return appendOneToList(state, 'favourites', action.status);
   default:
     return state;
   }

--- a/app/javascript/mastodon/reducers/status_lists.js
+++ b/app/javascript/mastodon/reducers/status_lists.js
@@ -28,7 +28,7 @@ const appendToList = (state, listType, statuses, next) => {
   }));
 };
 
-const appendOneToList = (state, listType, status) => {
+const prependOneToList = (state, listType, status) => {
   return state.update(listType, listMap => listMap.withMutations(map => {
     map.set('items', map.get('items').unshift(status.get('id')));
   }));
@@ -41,7 +41,7 @@ export default function statusLists(state = initialState, action) {
   case FAVOURITED_STATUSES_EXPAND_SUCCESS:
     return appendToList(state, 'favourites', action.statuses, action.next);
   case FAVOURITE_SUCCESS:
-    return appendOneToList(state, 'favourites', action.status);
+    return prependOneToList(state, 'favourites', action.status);
   default:
     return state;
   }


### PR DESCRIPTION
The favourites column can be pinned, but its contents don't update, so it's not very useful.

With this change, a favourited status is added to the column after the favourite succeeds.

I deliberately didn't add status removing on un-favourite, because then a mistaken click would chance losing the status forever. Users can hide those statuses by reload, as before.