### PR TITLE
fix js error: add scrollTop to ui/components/column

### DIFF
--- a/app/javascript/mastodon/features/ui/components/column.js
+++ b/app/javascript/mastodon/features/ui/components/column.js
@@ -25,6 +25,17 @@ export default class Column extends React.PureComponent {
     this._interruptScrollAnimation = scrollTop(scrollable);
   }
 
+  scrollTop () {
+    const scrollable = this.node.querySelector('.scrollable');
+
+    if (!scrollable) {
+      return;
+    }
+
+    this._interruptScrollAnimation = scrollTop(scrollable);
+  }
+
+
   handleScroll = debounce(() => {
     if (typeof this._interruptScrollAnimation !== 'undefined') {
       this._interruptScrollAnimation();


### PR DESCRIPTION
The error happens when user clicks the header of a favourites column (and possibly others, like blocks and mutes), because the copy of `Column` in the `features/ui/components` folder lacks the  `scrollTop()` method.
