### PR TITLE
Support to response of ActivityPub that returns image URL

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -54,9 +54,10 @@ class ActivityPub::ProcessAccountService < BaseService
 
     return if value.nil?
     return @json[key]['url'] if @json[key].is_a?(Hash)
+    return unless value =~ %r{https?://}
 
     image = fetch_resource(value)
-    image['url'] if image
+    image.nil? ? value : image['url']
   end
 
   def public_key


### PR DESCRIPTION
As far as I confirm, I can not fetch the avatar and header of the remote instance account from Mastodon 1.4.7 to 1.5.1.
