### PR TITLE
fix text position of NSFW in Safari

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2315,19 +2315,11 @@ button.icon-button.active i.fa-retweet {
 }
 
 .media-spoiler {
-  align-items: center;
   background: $base-overlay-background;
   color: $primary-text-color;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
   border: 0;
   width: 100%;
   height: 100%;
-  justify-content: center;
-  position: relative;
-  text-align: center;
-  z-index: 100;
 }
 
 .media-spoiler__warning {


### PR DESCRIPTION
`button` + `display: flex;` not work in Safari (Mac/iPhone).

![cw](https://user-images.githubusercontent.com/28813809/29128236-3e88d990-7d5e-11e7-8f9e-33d2f34462bc.jpg)
