### PR TITLE
Handle ActivityPub follows correctly

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -39,6 +39,10 @@ class ActivityPub::Activity
         ActivityPub::Activity::Update
       when 'Undo'
         ActivityPub::Activity::Undo
+      when 'Accept'
+        ActivityPub::Activity::Accept
+      when 'Reject'
+        ActivityPub::Activity::Reject
       end
     end
   end

--- a/app/lib/activitypub/activity/accept.rb
+++ b/app/lib/activitypub/activity/accept.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ActivityPub::Activity::Accept < ActivityPub::Activity
+  def perform
+    case @object['type']
+    when 'Follow'
+      accept_follow
+    end
+  end
+
+  private
+
+  def accept_follow
+    target_account = account_from_uri(target_uri)
+
+    return if target_account.nil? || !target_account.local?
+
+    follow_request = FollowRequest.find_by(account: target_account, target_account: @account)
+    follow_request&.authorize!
+  end
+
+  def target_uri
+    @target_uri ||= @object['object'].is_a?(String) ? @object['object'] : @object['object']['id']
+  end
+end

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -12,7 +12,7 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
       NotifyService.new.call(target_account, follow_request)
     else
       AuthorizeFollowService.new.call(@account, target_account)
-      NotifyService.new.call(target_account, Follow.find_by(account: @account, target_account: target_account))
+      NotifyService.new.call(target_account, ::Follow.find_by(account: @account, target_account: target_account))
     end
   end
 end

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -6,7 +6,13 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
 
     return if target_account.nil? || !target_account.local? || delete_arrived_first?(@json['id'])
 
-    follow = @account.follow!(target_account)
-    NotifyService.new.call(target_account, follow)
+    follow_request = FollowRequest.create!(account: @account, target_account: target_account)
+
+    if target_account.locked?
+      NotifyService.new.call(target_account, follow_request)
+    else
+      AuthorizeFollowService.new.call(@account, target_account)
+      NotifyService.new.call(target_account, Follow.find_by!(account: @account, target_account: target_account))
+    end
   end
 end

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -12,7 +12,7 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
       NotifyService.new.call(target_account, follow_request)
     else
       AuthorizeFollowService.new.call(@account, target_account)
-      NotifyService.new.call(target_account, Follow.find_by!(account: @account, target_account: target_account))
+      NotifyService.new.call(target_account, Follow.find_by(account: @account, target_account: target_account))
     end
   end
 end

--- a/app/lib/activitypub/activity/reject.rb
+++ b/app/lib/activitypub/activity/reject.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ActivityPub::Activity::Reject < ActivityPub::Activity
+  def perform
+    case @object['type']
+    when 'Follow'
+      reject_follow
+    end
+  end
+
+  private
+
+  def reject_follow
+    target_account = account_from_uri(target_uri)
+
+    return if target_account.nil? || !target_account.local?
+
+    follow_request = FollowRequest.find_by(account: target_account, target_account: @account)
+    follow_request&.reject!
+  end
+
+  def target_uri
+    @target_uri ||= @object['object'].is_a?(String) ? @object['object'] : @object['object']['id']
+  end
+end


### PR DESCRIPTION
ActivityPub follows are follow-requests. Always require an Accept.
If account is not locked, auto-accept.