### PR TITLE
Add configuration to disable private status federation over PuSH

### DIFF
--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -39,7 +39,7 @@ class ProcessMentionsService < BaseService
 
     if mentioned_account.local?
       NotifyService.new.call(mentioned_account, mention)
-    elsif mentioned_account.ostatus?
+    elsif mentioned_account.ostatus? && (Rails.configuration.x.use_ostatus_privacy || !status.stream_entry.hidden?)
       NotificationWorker.perform_async(stream_entry_to_xml(status.stream_entry), status.account_id, mentioned_account.id)
     elsif mentioned_account.activitypub?
       ActivityPub::DeliveryWorker.perform_async(build_json(mention.status), mention.status.account_id, mentioned_account.inbox_url)

--- a/app/workers/pubsubhubbub/distribution_worker.rb
+++ b/app/workers/pubsubhubbub/distribution_worker.rb
@@ -14,7 +14,7 @@ class Pubsubhubbub::DistributionWorker
     @subscriptions = active_subscriptions.to_a
 
     distribute_public!(stream_entries.reject(&:hidden?))
-    distribute_hidden!(stream_entries.select(&:hidden?))
+    distribute_hidden!(stream_entries.select(&:hidden?)) if Rails.configuration.x.use_ostatus_privacy
   end
 
   private

--- a/config/initializers/ostatus.rb
+++ b/config/initializers/ostatus.rb
@@ -5,7 +5,7 @@ host     = ENV.fetch('LOCAL_DOMAIN') { "localhost:#{port}" }
 web_host = ENV.fetch('WEB_DOMAIN') { host }
 https    = ENV['LOCAL_HTTPS'] == 'true'
 
-alternate_domains = ENV.fetch('ALTERNATE_DOMAINS') { "" }
+alternate_domains = ENV.fetch('ALTERNATE_DOMAINS') { '' }
 
 Rails.application.configure do
   config.x.local_domain = host
@@ -17,6 +17,7 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: web_host, protocol: https ? 'https://' : 'http://', trailing_slash: false }
   config.x.streaming_api_base_url          = 'ws://localhost:4000'
+  config.x.use_ostatus_privacy             = true
 
   if Rails.env.production?
     config.x.streaming_api_base_url = ENV.fetch('STREAMING_API_BASE_URL') { "ws#{https ? 's' : ''}://#{web_host}" }


### PR DESCRIPTION
Follow-up to #4566

Federation of private statuses over Pubsubhubbub was enabled in #2111, with the implementation of ActivityPub with native audience targeting there is no more need to use the less reliable protocol which is implemented by platforms that do not support status privacy.

This would be a **breaking change** in that Mastodon instances that do not upgrade to ActivityPub would stop receiving private statuses. This *might* warrant an overall semver major version bump, once this configuration option is toggled.