### PR TITLE
Add _:atomUri property for deduplicating OStatus/ActivityPub legacy records

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -4,7 +4,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def perform
     return if delete_arrived_first?(object_uri) || unsupported_object_type?
 
-    status = Status.find_by(uri: object_uri)
+    status = find_existing_status
 
     return status unless status.nil?
 
@@ -22,6 +22,12 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   private
+
+  def find_existing_status
+    status   = Status.find_by(uri: object_uri)
+    status ||= Status.find_by(uri: @object['_:atomUri']) if @object['_:atomUri'].present?
+    status
+  end
 
   def status_params
     {

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -8,6 +8,8 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   has_many :media_attachments, key: :attachment
   has_many :virtual_tags, key: :tag
 
+  attribute :atom_uri, key: '_:atomUri', if: :local?
+
   def id
     ActivityPub::TagManager.instance.uri_for(object)
   end
@@ -50,6 +52,14 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
 
   def virtual_tags
     object.mentions + object.tags
+  end
+
+  def atom_uri
+    ::TagManager.instance.uri_for(object)
+  end
+
+  def local?
+    object.account.local?
   end
 
   class MediaAttachmentSerializer < ActiveModel::Serializer


### PR DESCRIPTION
- For remote records, we can't know the ActivityPub URI post-hoc. The URI is the URI, so the `id` property for such notes will already be OStatus - which is "bad data" as it's unresolvable, but at least it's easy to cross-reference with existing DB entries
- But for local records, we generate URIs on the fly, so we can generate both. So we can add an `_:atomUri` property as an alternative ID. If the status is already in someone's DB under that URI, this allows them to work with the existing DB record without creating a duplicate