### PR TITLE
Fix search (regression from #4589)

### DIFF
--- a/app/services/fetch_remote_resource_service.rb
+++ b/app/services/fetch_remote_resource_service.rb
@@ -31,7 +31,7 @@ class FetchRemoteResourceService < BaseService
   end
 
   def body
-    fetched_atom_feed.last
+    fetched_atom_feed.second
   end
 
   def xml_root


### PR DESCRIPTION
I had overlooked the search:cry:

### stacktrace

```
TypeError: no implicit conversion of Symbol into String
	from app/services/fetch_remote_resource_service.rb:42:in `xml_data'
	from app/services/fetch_remote_resource_service.rb:38:in `xml_root'
	from app/services/fetch_remote_resource_service.rb:17:in `process_url'
	from app/services/fetch_remote_resource_service.rb:11:in `call'
```