### PR TITLE
Fix .information-board style for Safari

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -171,7 +171,7 @@
   }
 
   .section {
-    flex: 1 0 0;
+    flex: 1 0 auto;
     font: 16px/28px 'mastodon-font-sans-serif', sans-serif;
     text-align: right;
     padding: 10px 15px;


### PR DESCRIPTION
Follow-up to #4415.

flex-basis: 0 allows make flexbox smaller than its contents on Safari <10.

c.f. https://github.com/philipwalton/flexbugs#1-minimum-content-sizing-of-flex-items-not-honored

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/705555/29278192-fb9edb80-814e-11e7-9747-336ac1f7a799.png)|![image](https://user-images.githubusercontent.com/705555/29278190-f8c8b8a4-814e-11e7-8b3f-7cf4f43d8480.png)|