### PR TITLE
Fix require_user! behavior when not logged in

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -62,10 +62,11 @@ class Api::BaseController < ApplicationController
   end
 
   def require_user!
-    current_resource_owner
-    set_user_activity
-  rescue ActiveRecord::RecordNotFound
-    render json: { error: 'This method requires an authenticated user' }, status: 422
+    if current_user
+      set_user_activity
+    else
+      render json: { error: 'This method requires an authenticated user' }, status: 422
+    end
   end
 
   def render_empty


### PR DESCRIPTION
If you run require_user! when you are not logged in, set_user_activity raises an exception.

```
> undefined method `update_tracked_fields!' for nil:NilClass

app/controllers/concerns/user_tracking_concern.rb, line 17
----------------------------------------------------------

``` ruby
   12   
   13     private
   14   
   15     def set_user_activity
   16       # Mark as signed-in today
>  17       current_user.update_tracked_fields!(request)
   18   
   19       # Regenerate feed if needed
   20       regenerate_feed! if user_needs_feed_update?
   21     end
   22   
```

Therefore, I changed to execute set_user_activity only when current_user is not nil.
