### PR TITLE
Make share intent modal to make "signed in as" shown.

### DIFF
--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class SharesController < ApplicationController
-  layout 'public'
+  layout 'modal'
 
   before_action :authenticate_user!
+  before_action :set_body_classes
 
   def show
     serializable_resource = ActiveModelSerializers::SerializableResource.new(InitialStatePresenter.new(initial_state_params), serializer: InitialStateSerializer)
@@ -21,5 +22,9 @@ class SharesController < ApplicationController
       admin: Account.find_local(Setting.site_contact_username),
       text: params[:text],
     }
+  end
+
+  def set_body_classes
+    @body_classes = 'compose-standalone'
   end
 end

--- a/app/javascript/styles/containers.scss
+++ b/app/javascript/styles/containers.scss
@@ -53,6 +53,7 @@
     box-sizing: border-box;
 
     @media screen and (max-width: 400px) {
+      width: 100%;
       margin-top: 0;
       padding: 20px;
     }


### PR DESCRIPTION
Before:
![share](https://user-images.githubusercontent.com/1680550/29360749-506d0cba-82bf-11e7-9082-bfb53c682d76.PNG)

After:
![share_modal](https://user-images.githubusercontent.com/1680550/29360753-5522e5a4-82bf-11e7-9677-53c17c75e109.png)

I guess Gargron simply forgot changing css class for this.