### PR TITLE
ActivityPub migration procedure

### DIFF
--- a/app/controllers/activitypub/inboxes_controller.rb
+++ b/app/controllers/activitypub/inboxes_controller.rb
@@ -7,6 +7,7 @@ class ActivityPub::InboxesController < Api::BaseController
 
   def create
     if signed_request_account
+      upgrade_account
       process_payload
       head 201
     else
@@ -22,6 +23,11 @@ class ActivityPub::InboxesController < Api::BaseController
 
   def body
     @body ||= request.body.read
+  end
+
+  def upgrade_account
+    return unless signed_request_account.subscribed?
+    Pubsubhubbub::UnsubscribeWorker.perform_async(signed_request_account.id)
   end
 
   def process_payload

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -17,7 +17,7 @@ module Admin
     end
 
     def unsubscribe
-      UnsubscribeService.new.call(@account)
+      Pubsubhubbub::UnsubscribeWorker.perform_async(@account.id)
       redirect_to admin_account_path(@account.id)
     end
 

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -2,7 +2,7 @@
 
 class UnsubscribeService < BaseService
   def call(account)
-    return unless account.ostatus?
+    return if account.hub_url.blank?
 
     @account  = account
     @response = build_request.perform

--- a/app/workers/activitypub/post_upgrade_worker.rb
+++ b/app/workers/activitypub/post_upgrade_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ActivityPub::PostUpgradeWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'pull'
+
+  def perform(domain)
+    Account.where(domain: domain)
+           .where(protocol: :ostatus)
+           .where.not(last_webfingered_at: nil)
+           .in_batches
+           .update_all(last_webfingered_at: nil)
+  end
+end

--- a/app/workers/pubsubhubbub/unsubscribe_worker.rb
+++ b/app/workers/pubsubhubbub/unsubscribe_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Pubsubhubbub::UnsubscribeWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'push', retry: false, unique: :until_executed, dead: false
+
+  def perform(account_id)
+    account = Account.find(account_id)
+    logger.debug "PuSH unsubscribing from #{account.acct}"
+    ::UnsubscribeService.new.call(account)
+  rescue ActiveRecord::RecordNotFound
+    true
+  end
+end

--- a/app/workers/scheduler/subscriptions_scheduler.rb
+++ b/app/workers/scheduler/subscriptions_scheduler.rb
@@ -14,6 +14,6 @@ class Scheduler::SubscriptionsScheduler
   private
 
   def expiring_accounts
-    Account.where(protocol: :ostatus).expiring(1.day.from_now).partitioned
+    Account.expiring(1.day.from_now).partitioned
   end
 end

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -111,10 +111,7 @@ namespace :mastodon do
   namespace :push do
     desc 'Unsubscribes from PuSH updates of feeds nobody follows locally'
     task clear: :environment do
-      Account.remote.without_followers.where.not(subscription_expires_at: nil).find_each do |a|
-        Rails.logger.debug "PuSH unsubscribing from #{a.acct}"
-        UnsubscribeService.new.call(a)
-      end
+      Pubsubhubbub::UnsubscribeWorker.push_bulk(Account.remote.without_followers.where.not(subscription_expires_at: nil).pluck(:id))
     end
 
     desc 'Re-subscribes to soon expiring PuSH subscriptions (deprecated)'


### PR DESCRIPTION
Once one account is detected as going from OStatus to ActivityPub,
unsubscribe from old PuSH subscription, invalidate WebFinger cache
for other accounts from the same domain, and queue up a re-resolve
for all of them.