### PR TITLE
Show what protocol is used for accounts in admin/accounts#index

### DIFF
--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -1,0 +1,12 @@
+module AccountHelper
+  def protocol_for_display(protocol)
+    case protocol
+    when 'activitypub'
+      'ActivityPub'
+    when 'ostatus'
+      'OStatus'
+    else
+      protocol
+    end
+  end
+end

--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AccountHelper
   def protocol_for_display(protocol)
     case protocol

--- a/app/views/admin/accounts/_account.html.haml
+++ b/app/views/admin/accounts/_account.html.haml
@@ -4,6 +4,9 @@
   %td.domain
     - unless account.local?
       = link_to account.domain, admin_accounts_path(by_domain: account.domain)
+  %td.protocol
+    - unless account.local?
+      = protocol_for_display(account.protocol)
   %td.confirmed
     - if account.local?
       - if account.user_confirmed?

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -55,6 +55,7 @@
     %tr
       %th= t('admin.accounts.username')
       %th= t('admin.accounts.domain')
+      %th= t('admin.accounts.protocol')
       %th= t('admin.accounts.confirmed')
       %th= fa_icon 'paper-plane-o'
       %th

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -33,7 +33,7 @@
         %td= link_to @account.url, @account.url
       %tr
         %th= t('admin.accounts.protocol')
-        %td= @account.protocol
+        %td= protocol_for_display(@account.protocol)
 
       - if @account.ostatus?
         %tr

--- a/spec/helpers/account_helper_spec.rb
+++ b/spec/helpers/account_helper_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the AccountHelper. For example:
+#
+# describe AccountHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe AccountHelper, type: :helper do
+  describe '#protocol_for_display' do
+    it "returns OStatus when the protocol is 'ostatus'" do
+      protocol = 'ostatus'
+      expect(protocol_for_display(protocol)).to eq 'OStatus'
+    end
+
+    it "returns ActivityPub when the protocol is 'activitypub'" do
+      protocol = 'activitypub'
+      expect(protocol_for_display(protocol)).to eq 'ActivityPub'
+    end
+
+    it "returns the same string when the protocol is unknown" do
+      protocol = 'wave'
+      expect(protocol_for_display(protocol)).to eq protocol
+    end
+  end
+end


### PR DESCRIPTION
What this PR looks like: 
<img width="743" src="https://user-images.githubusercontent.com/418982/29419083-1f75f64a-83a9-11e7-934d-f00fef28eda8.png">

This PR adds "protocol" colomn to account list for admin. In addition to it, I added a helper to show protocol names like "OStatus", or "ActivityPub", not "ostatus", nor "activitypub".