### PR TITLE
Parse OStatus tag URIs in ActivityPub handlers when those are local

### DIFF
--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -87,6 +87,8 @@ class ActivityPub::TagManager
       else
         klass.find_by(id: uri_to_local_id(uri))
       end
+    elsif ::TagManager.instance.local_id?(uri)
+      klass.find_by(id: ::TagManager.instance.unique_tag_to_local_id(uri, klass.to_s))
     else
       klass.find_by(uri: uri)
     end


### PR DESCRIPTION
Use case:

Local-Alice favourites a status by remote-Bob. The status was created when Bob was using OStatus. But Bob is now upgraded to ActivityPub. So Bob will receive an ActivityPub Like activity about this status. This is where Bob's server must realize that the status being favourited is his, despite different URI format.