### PR TITLE
Always add nsfw tag when sensitive toot

### DIFF
--- a/app/lib/ostatus/atom_serializer.rb
+++ b/app/lib/ostatus/atom_serializer.rb
@@ -358,8 +358,6 @@ class OStatus::AtomSerializer
       append_element(entry, 'category', nil, term: tag.name)
     end
 
-    append_element(entry, 'category', nil, term: 'nsfw') if status.sensitive?
-
     status.media_attachments.each do |media|
       append_element(entry, 'link', nil, rel: :enclosure, type: media.file_content_type, length: media.file_file_size, href: full_asset_url(media.file.url(:original, false)))
     end

--- a/app/services/process_hashtags_service.rb
+++ b/app/services/process_hashtags_service.rb
@@ -4,6 +4,8 @@ class ProcessHashtagsService < BaseService
   def call(status, tags = [])
     tags = Extractor.extract_hashtags(status.text) if status.local?
 
+    tags << 'nsfw' if status.sensitive?
+
     tags.map { |str| str.mb_chars.downcase }.uniq(&:to_s).each do |tag|
       status.tags << Tag.where(name: tag).first_or_initialize(name: tag)
     end

--- a/spec/lib/ostatus/atom_serializer_spec.rb
+++ b/spec/lib/ostatus/atom_serializer_spec.rb
@@ -374,12 +374,6 @@ RSpec.describe OStatus::AtomSerializer do
         expect(entry.category[:term]).to eq 'tag'
       end
 
-      it 'appends category element for NSFW if status is sensitive' do
-        status = Fabricate(:status, sensitive: true)
-        entry = OStatus::AtomSerializer.new.entry(status.stream_entry)
-        expect(entry.category[:term]).to eq 'nsfw'
-      end
-
       it 'appends link elements for media attachments' do
         file = attachment_fixture('attachment.jpg')
         media_attachment = Fabricate(:media_attachment, file: file)


### PR DESCRIPTION
Close #4610

Mastodon implicitly adds an NSFW tag to a sensitive toot. This is only for Federates case (e90fcb46e3e5bc4144d8777c2267bec638e327a0). I think that similar behaviors are better for local instances as well.
