### PR TITLE
Fix visual line-break glitch with .invisible parts of links

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -237,6 +237,8 @@
   line-height: 0;
   display: inline-block;
   width: 0;
+  height: 0;
+  position: absolute;
 }
 
 .ellipsis {


### PR DESCRIPTION
The selecting behaviour still works, but the extra line-break before the link is gone.