### PR TITLE
Add GitHub Url library

### DIFF
--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -28,6 +28,8 @@ const messages = defineMessages({
 const mapStateToProps = state => ({
   me: state.getIn(['accounts', state.getIn(['meta', 'me'])]),
   columns: state.getIn(['settings', 'columns']),
+  github_url: state.getIn(['meta', 'github_url']),
+  github_name: state.getIn(['meta', 'github_name']),
 });
 
 @connect(mapStateToProps)
@@ -39,10 +41,12 @@ export default class GettingStarted extends ImmutablePureComponent {
     me: ImmutablePropTypes.map.isRequired,
     columns: ImmutablePropTypes.list,
     multiColumn: PropTypes.bool,
+    github_url: PropTypes.string.isRequired,
+    github_name: PropTypes.string.isRequired,
   };
 
   render () {
-    const { intl, me, columns, multiColumn } = this.props;
+    const { intl, me, columns, multiColumn, github_url, github_name } = this.props;
 
     let navItems = [];
 
@@ -97,7 +101,7 @@ export default class GettingStarted extends ImmutablePureComponent {
               <FormattedMessage
                 id='getting_started.open_source_notice'
                 defaultMessage='Mastodon is open source software. You can contribute or report issues on GitHub at {github}.'
-                values={{ github: <a href='https://github.com/tootsuite/mastodon' rel='noopener' target='_blank'>tootsuite/mastodon</a> }}
+                values={{ github: <a href={github_url} rel='noopener' target='_blank'>{github_name}</a> }}
               />
             </p>
           </div>

--- a/app/javascript/mastodon/features/ui/components/onboarding_modal.js
+++ b/app/javascript/mastodon/features/ui/components/onboarding_modal.js
@@ -131,7 +131,7 @@ PageFour.propTypes = {
   intl: PropTypes.object.isRequired,
 };
 
-const PageSix = ({ admin, domain }) => {
+const PageSix = ({ admin, domain, github_url }) => {
   let adminSection = '';
 
   if (admin) {
@@ -148,7 +148,7 @@ const PageSix = ({ admin, domain }) => {
     <div className='onboarding-modal__page onboarding-modal__page-six'>
       <h1><FormattedMessage id='onboarding.page_six.almost_done' defaultMessage='Almost done...' /></h1>
       {adminSection}
-      <p><FormattedMessage id='onboarding.page_six.github' defaultMessage='Mastodon is free open-source software. You can report bugs, request features, or contribute to the code on {github}.' values={{ github: <a href='https://github.com/tootsuite/mastodon' target='_blank' rel='noopener'>GitHub</a> }} /></p>
+      <p><FormattedMessage id='onboarding.page_six.github' defaultMessage='Mastodon is free open-source software. You can report bugs, request features, or contribute to the code on {github}.' values={{ github: <a href={github_url} target='_blank' rel='noopener'>GitHub</a> }} /></p>
       <p><FormattedMessage id='onboarding.page_six.apps_available' defaultMessage='There are {apps} available for iOS, Android and other platforms.' values={{ apps: <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md' target='_blank' rel='noopener'><FormattedMessage id='onboarding.page_six.various_app' defaultMessage='mobile apps' /></a> }} /></p>
       <p><em><FormattedMessage id='onboarding.page_six.appetoot' defaultMessage='Bon Appetoot!' /></em></p>
     </div>
@@ -158,12 +158,14 @@ const PageSix = ({ admin, domain }) => {
 PageSix.propTypes = {
   admin: ImmutablePropTypes.map,
   domain: PropTypes.string.isRequired,
+  github_url: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = state => ({
   me: state.getIn(['accounts', state.getIn(['meta', 'me'])]),
   admin: state.getIn(['accounts', state.getIn(['meta', 'admin'])]),
   domain: state.getIn(['meta', 'domain']),
+  github_url: state.getIn(['meta', 'github_url']),
 });
 
 @connect(mapStateToProps)
@@ -176,6 +178,7 @@ export default class OnboardingModal extends React.PureComponent {
     me: ImmutablePropTypes.map.isRequired,
     domain: PropTypes.string.isRequired,
     admin: ImmutablePropTypes.map,
+    github_url: PropTypes.string.isRequired,
   };
 
   state = {
@@ -183,13 +186,13 @@ export default class OnboardingModal extends React.PureComponent {
   };
 
   componentWillMount() {
-    const { me, admin, domain, intl } = this.props;
+    const { me, admin, domain, intl, github_url } = this.props;
     this.pages = [
       <PageOne acct={me.get('acct')} domain={domain} />,
       <PageTwo me={me} />,
       <PageThree me={me} />,
       <PageFour domain={domain} intl={intl} />,
-      <PageSix admin={admin} domain={domain} />,
+      <PageSix admin={admin} domain={domain} github_url={github_url} />,
     ];
   };
 

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -28,6 +28,10 @@ class InstancePresenter
     Rails.cache.fetch('distinct_domain_count') { Account.distinct.count(:domain) }
   end
 
+  def github_url
+    Mastodon::Github.to_s
+  end
+
   def version_number
     Mastodon::Version
   end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -10,6 +10,8 @@ class InitialStateSerializer < ActiveModel::Serializer
       access_token: object.token,
       locale: I18n.locale,
       domain: Rails.configuration.x.local_domain,
+      github_url: Mastodon::Github.to_s,
+      github_name: Mastodon::Github.link_title,
       admin: object.admin&.id,
     }
 

--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -63,5 +63,5 @@
   .footer-links
     .container
       %p
-        = link_to t('about.source_code'), 'https://github.com/tootsuite/mastodon'
+        = link_to t('about.source_code'), @instance_presenter.github_url
         = " (#{@instance_presenter.version_number})"

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -76,5 +76,5 @@
   .footer-links
     .container
       %p
-        = link_to t('about.source_code'), 'https://github.com/tootsuite/mastodon'
+        = link_to t('about.source_code'), @instance_presenter.github_url
         = " (#{@instance_presenter.version_number})"

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ Bundler.require(*Rails.groups)
 require_relative '../app/lib/exceptions'
 require_relative '../lib/paperclip/gif_transcoder'
 require_relative '../lib/paperclip/video_transcoder'
+require_relative '../lib/mastodon/github'
 require_relative '../lib/mastodon/version'
 
 Dotenv::Railtie.load

--- a/lib/mastodon/github.rb
+++ b/lib/mastodon/github.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Mastodon
+  module Github
+    module_function
+
+    def host
+      'https://github.com'
+    end
+
+    def author
+      'tootsuite'
+    end
+
+    def repository
+      'mastodon'
+    end
+
+    def link_title
+      [author, repository].join('/')
+    end
+
+    def to_s
+      [host, author, repository].join('/')
+    end
+  end
+end

--- a/spec/views/about/show.html.haml_spec.rb
+++ b/spec/views/about/show.html.haml_spec.rb
@@ -14,6 +14,8 @@ describe 'about/show.html.haml', without_verify_partial_doubles: true do
                                 site_description: 'something',
                                 version_number: '1.0',
                                 open_registrations: false,
+                                github_url: 'https://github.com/tootsuite/mastodon',
+                                github_name: 'tootsuite/mastodon',
                                 closed_registrations_message: 'yes')
     assign(:instance_presenter, instance_presenter)
     render


### PR DESCRIPTION
Mastodon Github repository URL replace to dynamic library file.
All other instance need to do is change library file.

(Similar pull request #4643. Sorry, @zunda .)

Thank you.