### PR TITLE
authorize follow requests after unlocking account

### DIFF
--- a/app/controllers/api/v1/accounts/credentials_controller.rb
+++ b/app/controllers/api/v1/accounts/credentials_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::Accounts::CredentialsController < Api::BaseController
 
   def update
     @account = current_account
-    @account.update!(account_params)
+    UpdateAccountService.new.call(@account, account_params, raise_error: true)
     ActivityPub::UpdateDistributionWorker.perform_async(@account.id)
     render json: @account, serializer: REST::CredentialAccountSerializer
   end

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -14,7 +14,7 @@ class Settings::ProfilesController < ApplicationController
   def show; end
 
   def update
-    if @account.update(account_params)
+    if UpdateAccountService.new.call(@account, account_params)
       ActivityPub::UpdateDistributionWorker.perform_async(@account.id)
       redirect_to settings_profile_path, notice: I18n.t('generic.changes_saved_msg')
     else

--- a/app/services/update_account_service.rb
+++ b/app/services/update_account_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class UpdateAccountService < BaseService
+  def call(account, params, raise_error: false)
+    was_locked = account.locked
+    update_method = raise_error ? :update! : :update
+    account.send(update_method, params).tap do |ret|
+      next unless ret
+      authorize_all_follow_requests(account) if was_locked && !account.locked
+    end
+  end
+
+  private
+
+  def authorize_all_follow_requests(account)
+    follow_requests = FollowRequest.where(target_account: account)
+    AuthorizeFollowWorker.push_bulk(follow_requests) do |req|
+      [req.account_id, req.target_account_id]
+    end
+  end
+end

--- a/app/workers/authorize_follow_worker.rb
+++ b/app/workers/authorize_follow_worker.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AuthorizeFollowWorker
+  include Sidekiq::Worker
+
+  def perform(source_account_id, target_account_id)
+    source_account = Account.find(source_account_id)
+    target_account = Account.find(target_account_id)
+
+    AuthorizeFollowService.new.call(source_account, target_account)
+  rescue ActiveRecord::RecordNotFound
+    true
+  end
+end


### PR DESCRIPTION
1. @A is *locked* account.
2. @B want to follow @A and send follow-request.
3. @A changes his profile to *unlocked*.
4. But record of FollowRequest exists, so @B can't follow @A.
5. Because @A is unlocked, so @A can't see tab of *follow requests*.

I think all follow requests should be accepted automatically when account unlocked.