### PR TITLE
Ignore empty response in ActivityPub::FetchRemoteStatusService

### DIFF
--- a/app/helpers/jsonld_helper.rb
+++ b/app/helpers/jsonld_helper.rb
@@ -14,7 +14,7 @@ module JsonLdHelper
   end
 
   def supported_context?(json)
-    equals_or_includes?(json['@context'], ActivityPub::TagManager::CONTEXT)
+    !json.nil? && equals_or_includes?(json['@context'], ActivityPub::TagManager::CONTEXT)
   end
 
   def fetch_resource(uri)

--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -7,7 +7,7 @@ class ActivityPub::FetchRemoteStatusService < BaseService
   def call(uri, prefetched_json = nil)
     @json = body_to_json(prefetched_json) || fetch_resource(uri)
 
-    return unless !@json.nil? && supported_context? && expected_type?
+    return unless supported_context? && expected_type?
 
     attributed_to = first_of_value(@json['attributedTo'])
     attributed_to = attributed_to['id'] if attributed_to.is_a?(Hash)

--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -7,7 +7,7 @@ class ActivityPub::FetchRemoteStatusService < BaseService
   def call(uri, prefetched_json = nil)
     @json = body_to_json(prefetched_json) || fetch_resource(uri)
 
-    return unless supported_context? && expected_type?
+    return unless !@json.nil? && supported_context? && expected_type?
 
     attributed_to = first_of_value(@json['attributedTo'])
     attributed_to = attributed_to['id'] if attributed_to.is_a?(Hash)

--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -82,7 +82,7 @@ class FetchAtomService < BaseService
 
   def supported_activity?(body)
     json = body_to_json(body)
-    return false if json.nil? || !supported_context?(json)
+    return false unless supported_context?(json)
     json['type'] == 'Person' ? json['inbox'].present? : true
   end
 end


### PR DESCRIPTION
This fixes `NoMethodError: undefined method [] for nil:NilClass` error (e.g. fetching replied status, which has been deleted)