### PR TITLE
Fix bugs which OStatus accounts may detected as ActivityPub ready

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -68,7 +68,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
   def process_mention(tag, status)
     account = account_from_uri(tag['href'])
-    account = ActivityPub::FetchRemoteAccountService.new.call(tag['href']) if account.nil?
+    account = FetchRemoteAccountService.new.call(tag['href']) if account.nil?
     return if account.nil?
     account.mentions.create(status: status)
   end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -6,6 +6,8 @@ class ActivityPub::ProcessAccountService < BaseService
   # Should be called with confirmed valid JSON
   # and WebFinger-resolved username and domain
   def call(username, domain, json)
+    return unless json['inbox'].present?
+
     @json     = json
     @uri      = @json['id']
     @username = username

--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 class FetchAtomService < BaseService
+  include JsonLdHelper
+
   def call(url)
     return if url.blank?
 
-    @url = url
+    result = process(url)
 
-    perform_request
-    process_response
+    # retry without ActivityPub
+    result ||= process(url) if @unsupported_activity
+
+    result
   rescue OpenSSL::SSL::SSLError => e
     Rails.logger.debug "SSL error: #{e}"
     nil
@@ -18,9 +22,18 @@ class FetchAtomService < BaseService
 
   private
 
+  def process(url, terminal = false)
+    @url = url
+    perform_request
+    process_response(terminal)
+  end
+
   def perform_request
+    accept = 'text/html'
+    accept = 'application/activity+json, application/ld+json, application/atom+xml, ' + accept unless @unsupported_activity
+
     @response = Request.new(:get, @url)
-                       .add_headers('Accept' => 'application/activity+json, application/ld+json, application/atom+xml, text/html')
+                       .add_headers('Accept' => accept)
                        .perform
   end
 
@@ -30,7 +43,12 @@ class FetchAtomService < BaseService
     if @response.mime_type == 'application/atom+xml'
       [@url, @response.to_s, :ostatus]
     elsif ['application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'].include?(@response.mime_type)
-      [@url, @response.to_s, :activitypub]
+      if supported_activity?(@response.to_s)
+        [@url, @response.to_s, :activitypub]
+      else
+        @unsupported_activity = true
+        nil
+      end
     elsif @response['Link'] && !terminal
       process_headers
     elsif @response.mime_type == 'text/html' && !terminal
@@ -44,15 +62,10 @@ class FetchAtomService < BaseService
     json_link = page.xpath('//link[@rel="alternate"]').find { |link| ['application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'].include?(link['type']) }
     atom_link = page.xpath('//link[@rel="alternate"]').find { |link| link['type'] == 'application/atom+xml' }
 
-    if !json_link.nil?
-      @url = json_link['href']
-      perform_request
-      process_response(true)
-    elsif !atom_link.nil?
-      @url = atom_link['href']
-      perform_request
-      process_response(true)
-    end
+    result ||= process(json_link.href, terminal: true) unless json_link.nil? || @unsupported_activity
+    result ||= process(atom_link.href, terminal: true) unless atom_link.nil?
+
+    result
   end
 
   def process_headers
@@ -61,14 +74,15 @@ class FetchAtomService < BaseService
     json_link = link_header.find_link(%w(rel alternate), %w(type application/activity+json)) || link_header.find_link(%w(rel alternate), ['type', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'])
     atom_link = link_header.find_link(%w(rel alternate), %w(type application/atom+xml))
 
-    if !json_link.nil?
-      @url = json_link.href
-      perform_request
-      process_response(true)
-    elsif !atom_link.nil?
-      @url = atom_link.href
-      perform_request
-      process_response(true)
-    end
+    result ||= process(json_link.href, terminal: true) unless json_link.nil? || @unsupported_activity
+    result ||= process(atom_link.href, terminal: true) unless atom_link.nil?
+
+    result
+  end
+
+  def supported_activity?(body)
+    json = body_to_json(body)
+    return false if json.nil? || !supported_context?(json)
+    json['type'] == 'Person' ? json['inbox'].present? : true
   end
 end


### PR DESCRIPTION
This patch fixes fallback handling on FetchAtomService, which is called from FetchRemoteAccountService

* Skip activity+json link if that activity is Person without inbox
* If unsupported activity was detected and all other URLs failed, retry with ActivityPub-less Accept header

then use FetchRemoteAccountService from ActivityPub::Activity::Create.