### PR TITLE
Allow columns to be wider on large screen.

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1364,6 +1364,7 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
 
   > .scrollable {
     background: $ui-base-color;


### PR DESCRIPTION
This line make the columns take full width on large screen but still allow horizontal scrollbar on small screens or when there is to much of them.