### PR TITLE
Add Japanese translations for #2758, #4506, #4521, #4600 and #4664

### DIFF
--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -35,10 +35,12 @@ en:
         redirect_uri: Use one line per URI
         scopes: Separate scopes with spaces. Leave blank to use the default scopes.
       index:
+        application: Application
         callback_url: Callback URL
         delete: Delete
         name: Name
         new: New application
+        scopes: Scopes
         show: Show
         title: Your applications
       new:

--- a/config/locales/doorkeeper.ja.yml
+++ b/config/locales/doorkeeper.ja.yml
@@ -3,8 +3,10 @@ ja:
   activerecord:
     attributes:
       doorkeeper/application:
-        name: 名前
+        name: アプリの名前
         redirect_uri: リダイレクトURI
+        scopes: アクセス権
+        website: アプリのウェブサイト
     errors:
       models:
         doorkeeper/application:
@@ -33,18 +35,22 @@ ja:
         redirect_uri: 一行に一つのURLを入力してください
         scopes: アクセス権は半角スペースで区切ることができます。 空白のままにするとデフォルトを使用します。
       index:
+        application: アプリ
         callback_url: コールバックURL
+        delete: 削除
         name: 名前
         new: 新規アプリ
+        scopes: アクセス権
+        show: 見る
         title: アプリ
       new:
         title: 新規アプリ
       show:
         actions: アクション
-        application_id: アクションId
-        callback_urls: コールバックurl
+        application_id: クライアントキー
+        callback_urls: コールバックURL
         scopes: アクセス権
-        secret: 非公開
+        secret: クライアントシークレット
         title: 'アプリ: %{name}'
     authorizations:
       buttons:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -232,7 +232,7 @@ ja:
     regenerate_token: アクセストークンの再生成
     token_regenerated: アクセストークンが再生成されました
     warning: このデータは気をつけて取り扱ってください。不特定多数の人と共有しないでください！
-    your_token: あなたのアクセストークン
+    your_token: アクセストークン
   auth:
     agreement_html: 登録すると <a href="%{rules_path}">利用規約</a> と <a href="%{terms_path}">プライバシーポリシー</a> に同意したことになります。
     change_password: セキュリティ

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -61,6 +61,7 @@ ja:
       feed_url: フィードURL
       followers: フォロワー数
       follows: フォロー数
+      inbox_url: インボックスURL
       ip: IP
       location:
         all: すべて
@@ -80,8 +81,10 @@ ja:
         alphabetic: アルファベット順
         most_recent: 直近の活動順
         title: 順序
+      outbox_url: アウトボックスURL
       perform_full_suspension: 完全に活動停止させる
       profile_url: プロフィールURL
+      protocol: プロトコル
       public: パブリック
       push_subscription_expires: PuSH購読期限切れ
       redownload: アバターの更新
@@ -223,7 +226,13 @@ ja:
     signature: Mastodon %{instance} インスタンスからの通知
     view: 'View:'
   applications:
+    created: アプリが作成されました
+    destroyed: アプリが削除されました
     invalid_url: URLが無効です
+    regenerate_token: アクセストークンの再生成
+    token_regenerated: アクセストークンが再生成されました
+    warning: このデータは気をつけて取り扱ってください。不特定多数の人と共有しないでください！
+    your_token: あなたのアクセストークン
   auth:
     agreement_html: 登録すると <a href="%{rules_path}">利用規約</a> と <a href="%{terms_path}">プライバシーポリシー</a> に同意したことになります。
     change_password: セキュリティ
@@ -231,6 +240,7 @@ ja:
     delete_account_html: アカウントを削除したい場合、<a href="%{path}">こちら</a> から手続きが行えます。削除する前に、確認画面があります。
     didnt_get_confirmation: 確認メールを受信できませんか？
     forgot_password: パスワードをお忘れですか？
+    invalid_reset_password_token: パスワードリセットトークンが正しくないか期限切れです。もう一度リクエストしてください。
     login: ログイン
     logout: ログアウト
     register: 登録する
@@ -411,6 +421,7 @@ ja:
     authorized_apps: 認証済みアプリ
     back: Mastodon に戻る
     delete: アカウントの削除
+    development: 開発
     edit_profile: プロフィールを編集
     export: データのエクスポート
     followers: 信頼済みのインスタンス
@@ -418,6 +429,7 @@ ja:
     preferences: ユーザー設定
     settings: 設定
     two_factor_authentication: 二段階認証
+    your_apps: あなたのアプリ
   statuses:
     open_in_web: Webで開く
     over_character_limit: 上限は %{max}文字までです

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -429,7 +429,7 @@ ja:
     preferences: ユーザー設定
     settings: 設定
     two_factor_authentication: 二段階認証
-    your_apps: あなたのアプリ
+    your_apps: アプリ
   statuses:
     open_in_web: Webで開く
     over_character_limit: 上限は %{max}文字までです

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -61,7 +61,7 @@ ja:
       feed_url: フィードURL
       followers: フォロワー数
       follows: フォロー数
-      inbox_url: インボックスURL
+      inbox_url: Inbox URL
       ip: IP
       location:
         all: すべて
@@ -81,7 +81,7 @@ ja:
         alphabetic: アルファベット順
         most_recent: 直近の活動順
         title: 順序
-      outbox_url: アウトボックスURL
+      outbox_url: Outbox URL
       perform_full_suspension: 完全に活動停止させる
       profile_url: プロフィールURL
       protocol: プロトコル


### PR DESCRIPTION
- [Application prefs section #2758](https://github.com/tootsuite/mastodon/pull/2758)
- [Redirect to PasswordController#new when reset_password_token is invalid #4506](https://github.com/tootsuite/mastodon/pull/4506)
- [It makes no sense to try using invalid or expired link again #4521](https://github.com/tootsuite/mastodon/pull/4521)
- [Update /admin/accounts/:id view for ActivityPub #4600](https://github.com/tootsuite/mastodon/pull/4600)
- [Fix up the applications area #4664](https://github.com/tootsuite/mastodon/pull/4664)