### PR TITLE
Fetch reblogs as Announce activity instead of Note object

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -9,6 +9,7 @@ class StatusesController < ApplicationController
   before_action :set_status
   before_action :set_link_headers
   before_action :check_account_suspension
+  before_action :redirect_to_original, only: [:show]
 
   def show
     respond_to do |format|
@@ -57,5 +58,9 @@ class StatusesController < ApplicationController
 
   def check_account_suspension
     gone if @account.suspended?
+  end
+
+  def redirect_to_original
+    redirect_to ::TagManager.instance.url_for(@status.reblog) if @status.reblog?
   end
 end

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -19,6 +19,7 @@ class ActivityPub::TagManager
     when :person
       short_account_url(target)
     when :note, :comment, :activity
+      return activity_account_status_url(target.account, target) if target.reblog?
       short_account_status_url(target.account, target)
     end
   end
@@ -30,8 +31,15 @@ class ActivityPub::TagManager
     when :person
       account_url(target)
     when :note, :comment, :activity
+      return activity_account_status_url(target.account, target) if target.reblog?
       account_status_url(target.account, target)
     end
+  end
+
+  def activity_uri_for(target)
+    return nil unless %i(note comment activity).include?(target.object_type) && target.local?
+
+    activity_account_status_url(target.account, target)
   end
 
   # Primary audience of a status

--- a/app/serializers/activitypub/activity_serializer.rb
+++ b/app/serializers/activitypub/activity_serializer.rb
@@ -6,7 +6,7 @@ class ActivityPub::ActivitySerializer < ActiveModel::Serializer
   has_one :proper, key: :object, serializer: ActivityPub::NoteSerializer
 
   def id
-    [ActivityPub::TagManager.instance.uri_for(object), '/activity'].join
+    [ActivityPub::TagManager.instance.activity_uri_for(object)].join
   end
 
   def type

--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -7,20 +7,32 @@ class ActivityPub::FetchRemoteStatusService < BaseService
   def call(uri, prefetched_json = nil)
     @json = body_to_json(prefetched_json) || fetch_resource(uri)
 
-    return unless supported_context? && expected_type?
+    return unless supported_context?
 
-    attributed_to = first_of_value(@json['attributedTo'])
-    attributed_to = attributed_to['id'] if attributed_to.is_a?(Hash)
+    activity = activity_json
+    actor_id = value_or_id(activity['actor'])
 
-    return unless trustworthy_attribution?(uri, attributed_to)
+    return unless expected_type?(activity) && trustworthy_attribution?(uri, actor_id)
 
-    actor = ActivityPub::TagManager.instance.uri_to_resource(attributed_to, Account)
-    actor = ActivityPub::FetchRemoteAccountService.new.call(attributed_to) if actor.nil?
+    actor = ActivityPub::TagManager.instance.uri_to_resource(actor_id, Account)
+    actor = ActivityPub::FetchRemoteAccountService.new.call(actor_id) if actor.nil?
 
-    ActivityPub::Activity::Create.new({ 'object' => @json }, actor).perform
+    ActivityPub::Activity.factory(activity, actor).perform
   end
 
   private
+
+  def activity_json
+    if %w(Note Article).include? @json['type']
+      {
+        'type' => 'Create',
+        'actor' => first_of_value(@json['attributedTo']),
+        'object' => @json,
+      }
+    else
+      @json
+    end
+  end
 
   def trustworthy_attribution?(uri, attributed_to)
     Addressable::URI.parse(uri).normalized_host.casecmp(Addressable::URI.parse(attributed_to).normalized_host).zero?
@@ -30,7 +42,7 @@ class ActivityPub::FetchRemoteStatusService < BaseService
     super(@json)
   end
 
-  def expected_type?
-    %w(Note Article).include? @json['type']
+  def expected_type?(json)
+    %w(Create Announce).include? json['type']
   end
 end

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -30,6 +30,18 @@ describe StatusesController do
       end
     end
 
+    context 'status is a reblog' do
+      it 'redirects to the original status' do
+        original_account = Fabricate(:account, domain: 'example.com')
+        original_status = Fabricate(:status, account: original_account, uri: 'tag:example.com,2017:foo', url: 'https://example.com/123')
+        status = Fabricate(:status, reblog: original_status)
+
+        get :show, params: { account_username: status.account.username, id: status.id }
+
+        expect(response).to redirect_to(original_status.url)
+      end
+    end
+
     context 'account is not suspended and status is permitted' do
       it 'assigns @account' do
         status = Fabricate(:status)

--- a/spec/services/activitypub/fetch_remote_status_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_status_service_spec.rb
@@ -1,5 +1,75 @@
 require 'rails_helper'
 
 RSpec.describe ActivityPub::FetchRemoteStatusService do
-  pending
+  let(:sender) { Fabricate(:account) }
+  let(:recipient) { Fabricate(:account) }
+  let(:valid_domain) { Rails.configuration.x.local_domain }
+
+  let(:note) do
+    {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: "https://#{valid_domain}/@foo/1234",
+      type: 'Note',
+      content: 'Lorem ipsum',
+      attributedTo: ActivityPub::TagManager.instance.uri_for(sender),
+    }
+  end
+
+  let(:create) do
+    {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: "https://#{valid_domain}/@foo/1234/activity",
+      type: 'Create',
+      actor: ActivityPub::TagManager.instance.uri_for(sender),
+      object: note,
+    }
+  end
+
+  subject { described_class.new }
+
+  describe '#call' do
+    before do
+      subject.call(object[:id], Oj.dump(object))
+    end
+
+    context 'with Note object' do
+      let(:object) { note }
+
+      it 'creates status' do
+        status = sender.statuses.first
+        
+        expect(status).to_not be_nil
+        expect(status.text).to eq 'Lorem ipsum'
+      end
+    end
+
+    context 'with Create activity' do
+      let(:object) { create }
+
+      it 'creates status' do
+        status = sender.statuses.first
+        
+        expect(status).to_not be_nil
+        expect(status.text).to eq 'Lorem ipsum'
+      end
+    end
+
+    context 'with Announce activity' do
+      let(:status) { Fabricate(:status, account: recipient) }
+
+      let(:object) do
+        {
+          '@context': 'https://www.w3.org/ns/activitystreams',
+          id: "https://#{valid_domain}/@foo/1234/activity",
+          type: 'Announce',
+          actor: ActivityPub::TagManager.instance.uri_for(sender),
+          object: ActivityPub::TagManager.instance.uri_for(status),
+        }
+      end
+
+      it 'creates a reblog by sender of status' do
+        expect(sender.reblogged?(status)).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
We use `/users/:user/statuses/:id` format URL as ActivityPub alternate link in the Atom feed (#4623). This endpoint represents Note object of the status, but it responds with wrong Note object for reblogs since reblogs itself can only be represented as Announce activity,

After this patch, we only use `/users/:user/statuses/:id/activity` for reblogs.

- [x] Process Create / Announce activity in FetchRemoteStatusService
- [x] Change url/uri for the reblog to `/users/.../statuses/.../activity`
- [x] Redirect to (local/remote) original status on non-activity endpoint for reblogs