### PR TITLE
Minor performance improvement for test suite

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -268,7 +268,7 @@ class Account < ApplicationRecord
   def generate_keys
     return unless local?
 
-    keypair = OpenSSL::PKey::RSA.new(Rails.env.test? ? 1024 : 2048)
+    keypair = OpenSSL::PKey::RSA.new(Rails.env.test? ? 512 : 2048)
     self.private_key = keypair.to_pem
     self.public_key  = keypair.public_key.to_pem
   end

--- a/spec/controllers/api/v1/accounts/relationships_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/relationships_controller_spec.rb
@@ -50,14 +50,14 @@ describe Api::V1::Accounts::RelationshipsController do
         json = body_as_json
 
         expect(json).to be_a Enumerable
-        expect(json.first[:id]).to be simon.id
+        expect(json.first[:id]).to eq simon.id
         expect(json.first[:following]).to be true
         expect(json.first[:followed_by]).to be false
         expect(json.first[:muting]).to be false
         expect(json.first[:requested]).to be false
         expect(json.first[:domain_blocking]).to be false
 
-        expect(json.second[:id]).to be lewis.id
+        expect(json.second[:id]).to eq lewis.id
         expect(json.second[:following]).to be false
         expect(json.second[:followed_by]).to be true
         expect(json.second[:muting]).to be false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,14 @@
 require 'simplecov'
 
+GC.disable
+
 SimpleCov.start 'rails' do
   add_group 'Services', 'app/services'
   add_group 'Presenters', 'app/presenters'
   add_group 'Validators', 'app/validators'
 end
+
+gc_counter = -1
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
@@ -22,7 +26,20 @@ RSpec.configure do |config|
   end
 
   config.after :suite do
+    gc_counter = 0
     FileUtils.rm_rf(Dir["#{Rails.root}/spec/test_files/"])
+  end
+
+  config.after :each do
+    gc_counter += 1
+
+    if gc_counter > 19
+      GC.enable
+      GC.start
+      GC.disable
+
+      gc_counter = 0
+    end
   end
 end
 


### PR DESCRIPTION
Before: 1 minute 36.18 seconds
After: 1 minute 18.8 seconds

Explanation:

- I believe most time of the tests is spent in OpenSSL because of private key generation in Account#generate_keys. In most parts of the test code, the private key is never used, actually, whereas Fabricate(:account) is in every single test. However, the private key is used in every integration test where cryptography is involved, so it cannot be cut out completely. Given that we are using SHA256 for the signature digest, a 512 bit key should suffice, 1024 bit is not necessary.
- The tests allocate (and throw away) a lot of objects. Garbage collection does a lot of work, which takes time. At the expense of more memory usage, we can speed up the tests by disabling garbage collection. However, completely without GC the test process consumes about 4GB by the end of the test suite. By making GC run on each 20th test, we get some speed improvement while keeping memory usage around 500MB