### PR TITLE
Disable babel-loader cache when development environment

### DIFF
--- a/config/webpack/loaders/babel.js
+++ b/config/webpack/loaders/babel.js
@@ -1,5 +1,7 @@
 const { resolve } = require('path');
 
+const env = process.env.NODE_ENV || 'development';
+
 module.exports = {
   test: /\.js$/,
   // include react-intl because transform-react-remove-prop-types needs to apply to it
@@ -9,7 +11,7 @@ module.exports = {
   },
   loader: 'babel-loader',
   options: {
-    forceEnv: process.env.NODE_ENV || 'development',
-    cacheDirectory: resolve(__dirname, '..', '..', '..', 'tmp', 'cache', 'babel-loader'),
+    forceEnv: env,
+    cacheDirectory: env === 'development' ? false : resolve(__dirname, '..', '..', '..', 'tmp', 'cache', 'babel-loader'),
   },
 };


### PR DESCRIPTION
Since `webpack-dev-server` saves build differences in memory, caching is not necessary.