### PR TITLE
Apply user timezone for the title attribute of .time-ago

### DIFF
--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -35,6 +35,7 @@ function main() {
 
     [].forEach.call(document.querySelectorAll('time.time-ago'), (content) => {
       const datetime = new Date(content.getAttribute('datetime'));
+      content.title = dateTimeFormat.format(datetime);
       content.textContent = relativeFormat.format(datetime);
     });
   });


### PR DESCRIPTION
We've already done this for `time.formatted` but not yet for `time.time-ago`.