### PR TITLE
Add descriptions of scopes in label

### DIFF
--- a/app/views/settings/applications/_fields.html.haml
+++ b/app/views/settings/applications/_fields.html.haml
@@ -13,6 +13,7 @@
     collection: Doorkeeper.configuration.scopes,
     wrapper: :with_label,
     include_blank: false,
+    label_method: -> (scope) { "#{scope} <span class=\"hint\">#{t("doorkeeper.scopes.#{scope}")}</span>".html_safe },
     selected: f.object.scopes.all,
     required: false,
     as: :check_boxes,


### PR DESCRIPTION
Another solution of #4691. I think the name of the scope (e.g. `read`, `write`, or `follow`) should be displayed because `/oauth/authorize` takes scope as a parameter. 

<img width="442" alt="2017-08-25 17 49 56" src="https://user-images.githubusercontent.com/418982/29706767-f1964764-89bd-11e7-91c2-e972f66b6353.png">