### PR TITLE
Set margin between character-counter and compose-form__buttons

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1872,7 +1872,7 @@
 
 .character-counter__wrapper {
   line-height: 36px;
-  margin-right: 16px;
+  margin: 0 16px 0 8px;
   padding-top: 10px;
 }
 

--- a/app/javascript/styles/rtl.scss
+++ b/app/javascript/styles/rtl.scss
@@ -8,7 +8,7 @@ body.rtl {
   }
 
   .character-counter__wrapper {
-    margin-right: 0;
+    margin-right: 8px;
     margin-left: 16px;
   }
 


### PR DESCRIPTION
Since some languages, whose translation of "compose_form.publish" is long, have no gaps between toot counts and buttons, I add margin for counter.
I set margin as 8px so that this change increase omission at most only one letter in all languages.
There is no change for languages use "TOOT" as "compose_form.publish".

Before and After images below.
![ba](https://user-images.githubusercontent.com/27640522/29723463-ad1d3006-89ff-11e7-85e2-c7ff495c2ac0.png)
