### PR TITLE
Add ActivityPub serializer for Undo of Announce

### DIFF
--- a/app/serializers/activitypub/undo_announce_serializer.rb
+++ b/app/serializers/activitypub/undo_announce_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ActivityPub::UndoAnnounceSerializer < ActiveModel::Serializer
+  attributes :id, :type, :actor
+
+  has_one :object, serializer: ActivityPub::ActivitySerializer
+
+  def id
+    [ActivityPub::TagManager.instance.uri_for(object.account), '#announces/', object.id, '/undo'].join
+  end
+
+  def type
+    'Undo'
+  end
+
+  def actor
+    ActivityPub::TagManager.instance.uri_for(object.account)
+  end
+end

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -140,7 +140,7 @@ class BatchedRemoveStatusService < BaseService
 
     @activity_json[status.id] = sign_json(status, ActiveModelSerializers::SerializableResource.new(
       status,
-      serializer: ActivityPub::DeleteSerializer,
+      serializer: status.reblog? ? ActivityPub::UndoAnnounceSerializer : ActivityPub::DeleteSerializer,
       adapter: ActivityPub::Adapter
     ).as_json)
   end

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -81,7 +81,7 @@ class RemoveStatusService < BaseService
   def activity_json
     @activity_json ||= ActiveModelSerializers::SerializableResource.new(
       @status,
-      serializer: ActivityPub::DeleteSerializer,
+      serializer: @status.reblog? ? ActivityPub::UndoAnnounceSerializer : ActivityPub::DeleteSerializer,
       adapter: ActivityPub::Adapter
     ).as_json
   end


### PR DESCRIPTION
Since #4687 touches the RemoveStatusService, I do not want to change it here until that one is merged.