### PR TITLE
columns header pin/unpin

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -40,6 +40,7 @@ class Settings::PreferencesController < ApplicationController
       :setting_delete_modal,
       :setting_auto_play_gif,
       :setting_system_font_ui,
+      :setting_system_hdr_pin,
       :setting_noindex,
       notification_emails: %i(follow follow_request reblog favourite mention digest),
       interactions: %i(must_be_follower must_be_following)

--- a/app/javascript/mastodon/components/column_header.js
+++ b/app/javascript/mastodon/components/column_header.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
+import {connect} from 'react-redux';
 
 const messages = defineMessages({
   show: { id: 'column_header.show_settings', defaultMessage: 'Show settings' },
@@ -10,6 +11,15 @@ const messages = defineMessages({
   moveRight: { id: 'column_header.moveRight_settings', defaultMessage: 'Move column to the right' },
 });
 
+const makeMapStateToProps = () => {
+    const mapStateToProps = state => ({
+	systemHdrPin: state.getIn(['meta', 'system_hdr_pin']),
+    });
+
+    return mapStateToProps;
+};
+
+@connect(makeMapStateToProps)
 @injectIntl
 export default class ColumnHeader extends React.PureComponent {
 
@@ -30,7 +40,9 @@ export default class ColumnHeader extends React.PureComponent {
     onPin: PropTypes.func,
     onMove: PropTypes.func,
     onClick: PropTypes.func,
+    systemHdrPin: PropTypes.bool.isRequired,
   };
+
 
   static defaultProps = {
     focusable: true,
@@ -68,7 +80,7 @@ export default class ColumnHeader extends React.PureComponent {
   }
 
   render () {
-    const { title, icon, active, children, pinned, onPin, multiColumn, focusable, showBackButton, intl: { formatMessage } } = this.props;
+    const { title, icon, active, children, pinned, onPin, multiColumn, focusable, showBackButton, systemHdrPin, intl : { formatMessage } } = this.props;
     const { collapsed, animating } = this.state;
 
     const wrapperClassName = classNames('column-header__wrapper', {
@@ -88,7 +100,7 @@ export default class ColumnHeader extends React.PureComponent {
       'active': !collapsed,
     });
 
-    let extraContent, pinButton, moveButtons, backButton, collapseButton;
+    let extraContent, pinButton, pinButtonHdr, moveButtons, backButton, collapseButton;
 
     if (children) {
       extraContent = (
@@ -101,6 +113,9 @@ export default class ColumnHeader extends React.PureComponent {
     if (multiColumn && pinned) {
       pinButton = <button key='pin-button' className='text-btn column-header__setting-btn' onClick={onPin}><i className='fa fa fa-times' /> <FormattedMessage id='column_header.unpin' defaultMessage='Unpin' /></button>;
 
+      if(systemHdrPin)
+          pinButtonHdr = <button key='pin-button' className='column-header__button' onClick={onPin}><i className='fa fa fa-times' /></button>;
+
       moveButtons = (
         <div key='move-buttons' className='column-header__setting-arrows'>
           <button title={formatMessage(messages.moveLeft)} aria-label={formatMessage(messages.moveLeft)} className='text-btn column-header__setting-btn' onClick={this.handleMoveLeft}><i className='fa fa-chevron-left' /></button>
@@ -109,6 +124,8 @@ export default class ColumnHeader extends React.PureComponent {
       );
     } else if (multiColumn) {
       pinButton = <button key='pin-button' className='text-btn column-header__setting-btn' onClick={onPin}><i className='fa fa fa-plus' /> <FormattedMessage id='column_header.pin' defaultMessage='Pin' /></button>;
+      if(systemHdrPin)
+        pinButtonHdr = <button key='pin-button' className='column-header__button' onClick={onPin}><i className='fa fa fa-thumb-tack' /></button>;
     }
 
     if (!pinned && (multiColumn || showBackButton)) {
@@ -141,6 +158,7 @@ export default class ColumnHeader extends React.PureComponent {
 
           <div className='column-header__buttons'>
             {backButton}
+            {pinButtonHdr}
             {collapseButton}
           </div>
         </h1>

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -24,6 +24,7 @@ class UserSettingsDecorator
     user.settings['delete_modal'] = delete_modal_preference
     user.settings['auto_play_gif'] = auto_play_gif_preference
     user.settings['system_font_ui'] = system_font_ui_preference
+    user.settings['system_hdr_pin'] = system_hdr_pin_preference
     user.settings['noindex'] = noindex_preference
   end
 
@@ -57,6 +58,10 @@ class UserSettingsDecorator
 
   def system_font_ui_preference
     boolean_cast_setting 'setting_system_font_ui'
+  end
+
+  def system_hdr_pin_preference
+    boolean_cast_setting 'setting_system_hdr_pin'
   end
 
   def auto_play_gif_preference

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,6 +106,10 @@ class User < ApplicationRecord
     settings.system_font_ui
   end
 
+  def setting_system_hdr_pin
+    settings.system_hdr_pin
+  end
+
   def setting_noindex
     settings.noindex
   end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -20,6 +20,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:delete_modal]   = object.current_account.user.setting_delete_modal
       store[:auto_play_gif]  = object.current_account.user.setting_auto_play_gif
       store[:system_font_ui] = object.current_account.user.setting_system_font_ui
+      store[:system_hdr_pin] = object.current_account.user.setting_system_hdr_pin
     end
 
     store

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -51,6 +51,7 @@
   .fields-group
     = f.input :setting_auto_play_gif, as: :boolean, wrapper: :with_label
     = f.input :setting_system_font_ui, as: :boolean, wrapper: :with_label
+    = f.input :setting_system_hdr_pin, as: :boolean, wrapper: :with_label
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -43,6 +43,7 @@ en:
         setting_delete_modal: Show confirmation dialog before deleting a toot
         setting_noindex: Opt-out of search engine indexing
         setting_system_font_ui: Use system's default font
+        setting_system_hdr_pin: Show pin/unpin in column header
         setting_unfollow_modal: Show confirmation dialog before unfollowing someone
         severity: Severity
         type: Import type

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,7 @@ defaults: &defaults
   delete_modal: true
   auto_play_gif: false
   system_font_ui: false
+  system_hdr_pin: true
   noindex: false
   notification_emails:
     follow: false

--- a/spec/controllers/settings/preferences_controller_spec.rb
+++ b/spec/controllers/settings/preferences_controller_spec.rb
@@ -38,6 +38,7 @@ describe Settings::PreferencesController do
           setting_delete_modal: '0',
           notification_emails: { follow: '1' },
           interactions: { must_be_follower: '0' },
+          setting_system_hdr_pin: '1' },
         }
       }
 

--- a/spec/lib/user_settings_decorator_spec.rb
+++ b/spec/lib/user_settings_decorator_spec.rb
@@ -69,5 +69,15 @@ describe UserSettingsDecorator do
       settings.update(values)
       expect(user.settings['system_font_ui']).to eq false
     end
+    
+    it 'updates the user settings value for showing pnning in header' do
+      values = { 'setting_system_hdr_pin' => '0' }
+
+      settings.update(values)
+      expect(user.settings['system_hdr_pin']).to eq false
+    end
+    
+    
+
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -193,6 +193,14 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#setting_system_hdr_pin' do
+    it 'returns system hdr pinning setting' do
+      user = Fabricate(:user)
+      user.settings[:system_hdr_pin] = false
+      expect(user.setting_system_hdr_pin).to eq false
+    end
+  end
+
   describe '#setting_boost_modal' do
     it 'returns boost modal setting' do
       user = Fabricate(:user)


### PR DESCRIPTION
I got asked for our Mastodon instance to introduce the pin/unpin being directly in the header of the columns, so I added this option to our instance and thought that it's a good idea to share it, perhaps someone else would like it too.