### PR TITLE
Adjust public profile pages

### DIFF
--- a/app/javascript/styles/accounts.scss
+++ b/app/javascript/styles/accounts.scss
@@ -306,7 +306,7 @@
   box-shadow: 0 0 15px rgba($base-shadow-color, 0.2);
   background: darken($simple-background-color, 8%);
   border-radius: 0 0 4px 4px;
-  padding: 20px 10px;
+  padding: 20px 5px;
   padding-bottom: 10px;
   overflow: hidden;
   display: flex;
@@ -325,11 +325,12 @@
     background: $simple-background-color;
     border-radius: 4px;
     color: $ui-base-color;
-    margin-bottom: 10px;
+    margin: 0 5px 10px;
     position: relative;
+    word-wrap: break-word;
 
-    &:nth-child(odd) {
-      margin-right: 10px;
+    @media screen and (max-width: 740px) {
+      width: calc(100% - 10px);
     }
 
     .account-grid-card__header {
@@ -413,7 +414,6 @@
       padding-top: 15px;
       box-sizing: border-box;
       color: lighten($ui-base-color, 26%);
-      word-wrap: break-word;
       min-height: 80px;
     }
   }

--- a/app/javascript/styles/accounts.scss
+++ b/app/javascript/styles/accounts.scss
@@ -329,7 +329,6 @@
     color: $ui-base-color;
     margin: 0 5px 10px;
     position: relative;
-    word-wrap: break-word;
 
     @media screen and (max-width: 740px) {
       width: calc(100% - 10px);
@@ -416,6 +415,7 @@
       padding-top: 15px;
       box-sizing: border-box;
       color: lighten($ui-base-color, 26%);
+      word-wrap: break-word;
       min-height: 80px;
     }
   }

--- a/app/javascript/styles/accounts.scss
+++ b/app/javascript/styles/accounts.scss
@@ -402,6 +402,8 @@
     .display_name {
       font-size: 16px;
       display: block;
+      text-overflow: ellipsis;
+      overflow: hidden;
     }
 
     .username {

--- a/app/javascript/styles/accounts.scss
+++ b/app/javascript/styles/accounts.scss
@@ -296,7 +296,9 @@
     }
 
     .next,
-    .prev {
+    .prev,
+    .next a,
+    .prev a {
       display: inline-block;
     }
   }

--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -6,7 +6,7 @@ body {
   line-height: 18px;
   font-weight: 400;
   color: $primary-text-color;
-  padding-bottom: 140px;
+  padding-bottom: 40px;
   text-rendering: optimizelegibility;
   font-feature-settings: "kern";
   text-size-adjust: none;


### PR DESCRIPTION
- Adjust account-grid in public profiles pages
  - Full-width card on the mobile UI
  - ~~Set break-word for long name and ID~~
  - Fix margin of odd-child card
<details>
<summary>Before and after images</summary>
<img src="https://user-images.githubusercontent.com/27640522/29746154-44068d34-8b0c-11e7-9a71-6ea4eefeedbd.png" alt="screenshot1" />
<img src="https://user-images.githubusercontent.com/27640522/29746156-51e2896c-8b0c-11e7-9c57-e3d4f0890909.png" alt="screenshot2" />
</details>

&#8203;

- Revive next and prev buttons in followers and followees mobile pages
- Reduce padding-bottom of public profiles pages

You can also know the details at [profiles pages of my instance running with this commit](https://mstdn.sanin.link/users/lynx/followers) .