### PR TITLE
Allow Symbol keyed Hash in LinkedDataSignature

### DIFF
--- a/app/lib/activitypub/linked_data_signature.rb
+++ b/app/lib/activitypub/linked_data_signature.rb
@@ -6,7 +6,7 @@ class ActivityPub::LinkedDataSignature
   CONTEXT = 'https://w3id.org/identity/v1'
 
   def initialize(json)
-    @json = json
+    @json = json.with_indifferent_access
   end
 
   def verify_account!


### PR DESCRIPTION
SerializarbleResource#as_json serializes to Symbol keyed Hash, but current
implementation of LinkedDataSignature expects String keyed Hash.

Then it failed to merge `@context`.

```json
{
  "@context": [
    null,
    "https://w3id.org/identity/v1"
  ],
  ...
}
```

- [ ] add spec?
- [ ] raise Error if `@context` is missing?