### PR TITLE
Adjust "signed in as" pages

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1057,6 +1057,8 @@
   strong,
   span {
     display: block;
+    text-overflow: ellipsis; 
+    overflow: hidden;
   }
 
   strong {

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1057,7 +1057,7 @@
   strong,
   span {
     display: block;
-    text-overflow: ellipsis; 
+    text-overflow: ellipsis;
     overflow: hidden;
   }
 

--- a/app/javascript/styles/containers.scss
+++ b/app/javascript/styles/containers.scss
@@ -72,7 +72,7 @@
   margin-bottom: -30px;
   margin-top: 40px;
 
-  @media screen and (max-width: 400px) {
+  @media screen and (max-width: 440px) {
     width: 100%;
     margin: 0;
     margin-bottom: 10px;
@@ -97,10 +97,13 @@
   .name {
     flex: 1 1 auto;
     color: $ui-secondary-color;
+    width: calc(100% - 88px);
 
     .username {
       display: block;
       font-weight: 500;
+      text-overflow: ellipsis;
+      overflow: hidden;
     }
   }
 
@@ -108,5 +111,6 @@
     display: block;
     font-size: 32px;
     line-height: 40px;
+    margin-left: 8px;
   }
 }

--- a/app/javascript/styles/forms.scss
+++ b/app/javascript/styles/forms.scss
@@ -359,6 +359,10 @@ code {
     color: $ui-secondary-color;
     font-weight: 500;
   }
+
+  @media screen and (max-width: 740px) and (min-width: 441px) {
+    margin-top: 40px;
+  }
 }
 
 .qr-wrapper {


### PR DESCRIPTION
- Fix overlapped "signed in as" header (401px ~ 740px).

<details>
<summary>Before and after images</summary>
<img src="https://user-images.githubusercontent.com/27640522/29753963-104e11fa-8bb7-11e7-92fa-566890fb6ee2.png" alt="screenshot1" />
</details>

&#8203;

- Change mobile threshold of "signed in as" header from 400px to 440px in order not to stick to the full width.

<details>
<summary>Before image</summary>
<img src="https://user-images.githubusercontent.com/27640522/29754019-4a12b28c-8bb8-11e7-956a-ee74e2924017.png" alt="screenshot2" />
</details>

&#8203;

- Set `text-overflow: ellipsis;` and `overflow: hidden;` for `display: block;` contents.
This is because text-overflow settings are not inherited in `display: block;`.
- Add margin between "signed in as" and logout button.