### PR TITLE
Add japanese translations for shorten display of large numbers

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -352,6 +352,17 @@ ja:
     reblog:
       body: 'あなたのトゥートが %{name} さんにブーストされました:'
       subject: あなたのトゥートが %{name} さんにブーストされました
+  number:
+    human:
+      decimal_units:
+        format: "%n%u"
+        units:
+          billion: B
+          million: M
+          quadrillion: Q
+          thousand: K
+          trillion: T
+          unit: ''
   pagination:
     next: 次
     prev: 前


### PR DESCRIPTION
Japanese translations for #4711 
Since there is no four digit break units option in Rails, I set same as English units 😭