### PR TITLE
rescue HTTP::ConnectionError in RemoteFollowController#create

### DIFF
--- a/app/models/remote_follow.rb
+++ b/app/models/remote_follow.rb
@@ -42,7 +42,7 @@ class RemoteFollow
 
   def acct_resource
     @_acct_resource ||= Goldfinger.finger("acct:#{acct}")
-  rescue Goldfinger::Error
+  rescue Goldfinger::Error, HTTP::ConnectionError
     nil
   end
 

--- a/spec/controllers/remote_follow_controller_spec.rb
+++ b/spec/controllers/remote_follow_controller_spec.rb
@@ -87,6 +87,14 @@ describe RemoteFollowController do
         expect(response).to render_template(:new)
         expect(response.body).to include(I18n.t('remote_follow.missing_resource'))
       end
+
+      it 'renders new when occur HTTP::ConnectionError' do
+        allow(Goldfinger).to receive(:finger).with('acct:user@unknown').and_raise(HTTP::ConnectionError)
+        post :create, params: { account_username: @account.to_param, remote_follow: { acct: 'user@unknown' } }
+
+        expect(response).to render_template(:new)
+        expect(response.body).to include(I18n.t('remote_follow.missing_resource'))
+      end
     end
   end
 


### PR DESCRIPTION
`HTTP::ConnectionError` occurred when I entered an account on a host that does not exist on the remote follow page. For example, if you make a mistake like typing `abcang@pawoo`, an error will occur. In Pawoo, this error often occurs on the remote follow page.