### PR TITLE
Fix deletion of status which has been reblogged (regression from #4566)

### DIFF
--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -55,8 +55,8 @@ class RemoveStatusService < BaseService
     end
 
     # ActivityPub
-    ActivityPub::DeliveryWorker.push_bulk(target_accounts.select(&:activitypub?).uniq(&:inbox_url)) do |inbox_url|
-      [signed_activity_json, @account.id, inbox_url]
+    ActivityPub::DeliveryWorker.push_bulk(target_accounts.select(&:activitypub?).uniq(&:inbox_url)) do |target_account|
+      [signed_activity_json, @account.id, target_account.inbox_url]
     end
   end
 

--- a/spec/services/remove_status_service_spec.rb
+++ b/spec/services/remove_status_service_spec.rb
@@ -7,17 +7,20 @@ RSpec.describe RemoveStatusService do
   let!(:bob)    { Fabricate(:account, username: 'bob', domain: 'example.com', salmon_url: 'http://example.com/salmon') }
   let!(:jeff)   { Fabricate(:account) }
   let!(:hank)   { Fabricate(:account, username: 'hank', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
+  let!(:bill)   { Fabricate(:account, username: 'bill', protocol: :activitypub, domain: 'example2.com', inbox_url: 'http://example2.com/inbox') }
 
   before do
     stub_request(:post, 'http://example.com/push').to_return(status: 200, body: '', headers: {})
     stub_request(:post, 'http://example.com/salmon').to_return(status: 200, body: '', headers: {})
     stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
+    stub_request(:post, 'http://example2.com/inbox').to_return(status: 200)
 
     Fabricate(:subscription, account: alice, callback_url: 'http://example.com/push', confirmed: true, expires_at: 30.days.from_now)
     jeff.follow!(alice)
     hank.follow!(alice)
 
     @status = PostStatusService.new.call(alice, 'Hello @bob@example.com')
+    Fabricate(:status, account: bill, reblog: @status, uri: 'hoge')
     subject.call(@status)
   end
 
@@ -44,5 +47,9 @@ RSpec.describe RemoveStatusService do
       xml = OStatus2::Salmon.new.unpack(req.body)
       xml.match(TagManager::VERBS[:delete])
     }).to have_been_made.once
+  end
+
+  it 'sends delete activity to rebloggers' do
+    expect(a_request(:post, 'http://example2.com/inbox')).to have_been_made
   end
 end


### PR DESCRIPTION
```
sidekiq_1    | 2017-08-28T17:55:22.401Z 1 TID-4p7j5eec WARN: HTTP::Request::UnsupportedSchemeError: Delivery failed for #<Account:0x0000ab86f2bcf0>: unknown scheme:
sidekiq_1    | 2017-08-28T17:55:22.401Z 1 TID-4p7j5eec WARN: /mastodon/app/workers/activitypub/delivery_worker.rb:19:in `rescue in perform'
sidekiq_1    | /mastodon/app/workers/activitypub/delivery_worker.rb:11:in `perform'
```

Arguments for ActivityPub::DeliveryWorker:

`"{\"@context\":[\"https://www.w3.org/ns/activitystreams\",\"https://w3id.org/security/v1\",\"https://w3id.org/identity/v1\"],...}", 1, "#<Account:0x0000ab86f2bcf0>"`

...last one should be `inbox_url`.