### PR TITLE
Fix Delete activity handling when the status has been reblogged (regression from #4706)

### DIFF
--- a/app/lib/activitypub/activity/delete.rb
+++ b/app/lib/activitypub/activity/delete.rb
@@ -16,8 +16,8 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
   private
 
   def forward_for_reblogs(status)
-    ActivityPub::RawDistributionWorker.push_bulk(status.reblogs.includes(:account).references(:account).merge(Account.local).pluck(:account_id)) do |account|
-      [payload, account.id]
+    ActivityPub::RawDistributionWorker.push_bulk(status.reblogs.includes(:account).references(:account).merge(Account.local).pluck(:account_id)) do |account_id|
+      [payload, account_id]
     end
   end
 

--- a/spec/lib/activitypub/activity/delete_spec.rb
+++ b/spec/lib/activitypub/activity/delete_spec.rb
@@ -25,4 +25,28 @@ RSpec.describe ActivityPub::Activity::Delete do
       expect(Status.find_by(id: status.id)).to be_nil
     end
   end
+
+  context 'when the status has been reblogged' do
+    describe '#perform' do
+      subject { described_class.new(json, sender) }
+      let(:reblogger) { Fabricate(:account) }
+      let(:follower)   { Fabricate(:account, username: 'follower', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
+
+      before do
+        stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
+        follower.follow!(reblogger)
+        Fabricate(:status, account: reblogger, reblog: status)
+        subject.perform
+      end
+
+      it 'deletes sender\'s status' do
+        expect(Status.find_by(id: status.id)).to be_nil
+      end
+
+      it 'sends delete activity to followers of rebloggers' do
+        # one for Delete original post, and one for Undo reblog (normal delivery)
+        expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.twice
+      end
+    end
+  end
 end


### PR DESCRIPTION
```
sidekiq_1    | 2017-08-28T17:55:22.687Z 1 TID-41xbqwa8 WARN: NoMethodError: undefined method `id' for 1:Integer
sidekiq_1    | Did you mean?  i
sidekiq_1    | 2017-08-28T17:55:22.687Z 1 TID-41xbqwa8 WARN: /mastodon/app/lib/activitypub/activity/delete.rb:20:in `block in forward_for_reblogs'
sidekiq_1    | /usr/local/bundle/gems/sidekiq-bulk-0.1.1/lib/sidekiq/bulk.rb:13:in `map'
sidekiq_1    | /usr/local/bundle/gems/sidekiq-bulk-0.1.1/lib/sidekiq/bulk.rb:13:in `push_bulk!'
sidekiq_1    | /usr/local/bundle/gems/sidekiq-bulk-0.1.1/lib/sidekiq/bulk.rb:7:in `block in push_bulk'
sidekiq_1    | /usr/local/bundle/gems/sidekiq-bulk-0.1.1/lib/sidekiq/bulk.rb:6:in `each'
sidekiq_1    | /usr/local/bundle/gems/sidekiq-bulk-0.1.1/lib/sidekiq/bulk.rb:6:in `push_bulk'
sidekiq_1    | /mastodon/app/lib/activitypub/activity/delete.rb:19:in `forward_for_reblogs'
sidekiq_1    | /mastodon/app/lib/activitypub/activity/delete.rb:11:in `perform'
sidekiq_1    | /mastodon/app/services/activitypub/process_collection_service.rb:42:in `process_item'
sidekiq_1    | /mastodon/app/services/activitypub/process_collection_service.rb:33:in `block in process_items'
sidekiq_1    | /mastodon/app/services/activitypub/process_collection_service.rb:33:in `reverse_each'
sidekiq_1    | /mastodon/app/services/activitypub/process_collection_service.rb:33:in `each'
sidekiq_1    | /mastodon/app/services/activitypub/process_collection_service.rb:33:in `map'
sidekiq_1    | /mastodon/app/services/activitypub/process_collection_service.rb:33:in `process_items'
sidekiq_1    | /mastodon/app/services/activitypub/process_collection_service.rb:20:in `call'
sidekiq_1    | /mastodon/app/workers/activitypub/processing_worker.rb:9:in `perform'
```