### PR TITLE
Guarantee Subscription service first account has proper URL details

### DIFF
--- a/app/services/subscribe_service.rb
+++ b/app/services/subscribe_service.rb
@@ -42,7 +42,7 @@ class SubscribeService < BaseService
   end
 
   def some_local_account
-    @some_local_account ||= Account.local.where(suspended:false).first
+    @some_local_account ||= Account.local.where(suspended: false).first
   end
 
   # Any response in the 3xx or 4xx range, except for 429 (rate limit)

--- a/app/services/subscribe_service.rb
+++ b/app/services/subscribe_service.rb
@@ -42,7 +42,7 @@ class SubscribeService < BaseService
   end
 
   def some_local_account
-    @some_local_account ||= Account.local.first
+    @some_local_account ||= Account.local.where(suspended:false).first
   end
 
   # Any response in the 3xx or 4xx range, except for 429 (rate limit)


### PR DESCRIPTION
Resolve #4731

Subscription Service potentially could break if the first user suspended
themselves, creating a situation where the urls that populate throughout
subscription service's PuSH request would cause the remote API to throw 503 errors.

Guaranteeing that the first account picked is not suspended prevents this problem.