### PR TITLE
Add special oEmbed handling for some providers

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -17,6 +17,9 @@ const getHostname = url => {
   return parser.hostname;
 };
 
+const getProviderName =
+  card => card.get('provider_name') || decodeIDNA(getHostname(card.get('url')));
+
 export default class Card extends React.PureComponent {
 
   static propTypes = {
@@ -27,7 +30,6 @@ export default class Card extends React.PureComponent {
     const { card } = this.props;
 
     let image    = '';
-    let provider = card.get('provider_name');
 
     if (card.get('image')) {
       image = (
@@ -37,8 +39,32 @@ export default class Card extends React.PureComponent {
       );
     }
 
-    if (provider.length < 1) {
-      provider = decodeIDNA(getHostname(card.get('url')));
+    return (
+      <a href={card.get('url')} className='status-card' target='_blank' rel='noopener'>
+        {image}
+
+        <div className='status-card__content'>
+          <div className='status-card__header'>
+            <strong className='status-card__title' title={card.get('title')}>{card.get('title')}</strong>
+          </div>
+          <p className='status-card__description'>{(card.get('description') || '').substring(0, 50)}</p>
+          <span className='status-card__host'>{getProviderName(card)}</span>
+        </div>
+      </a>
+    );
+  }
+
+  renderPost () {
+    const { card } = this.props;
+
+    let image    = '';
+
+    if (card.get('image')) {
+      image = (
+        <div className='status-card__image'>
+          <img src={card.get('image')} alt={card.get('title')} className='status-card__image-image' />
+        </div>
+      );
     }
 
     return (
@@ -46,9 +72,12 @@ export default class Card extends React.PureComponent {
         {image}
 
         <div className='status-card__content'>
-          <strong className='status-card__title' title={card.get('title')}>{card.get('title')}</strong>
-          <p className='status-card__description'>{(card.get('description') || '').substring(0, 50)}</p>
-          <span className='status-card__host'>{provider}</span>
+          <div className='status-card__header'>
+            <strong className='status-card__title'>{card.get('author_name')}</strong>
+            <span className='status-card__author'>{card.get('title')}</span>
+          </div>
+          <p className='status-card__description'>{(card.get('description') || '').substring(0, 200)}</p>
+          <span className='status-card__host'>{getProviderName(card)}</span>
         </div>
       </a>
     );
@@ -90,6 +119,8 @@ export default class Card extends React.PureComponent {
       return this.renderPhoto();
     case 'video':
       return this.renderVideo();
+    case 'post':
+      return this.renderPost();
     case 'rich':
     default:
       return null;

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2024,14 +2024,22 @@ button.icon-button.active i.fa-retweet {
   }
 }
 
-.status-card__title {
+.status-card__header {
   display: block;
-  font-weight: 500;
   margin-bottom: 5px;
-  color: $ui-primary-color;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.status-card__title {
+  font-weight: 500;
+  color: $ui-primary-color;
+  margin-right: 5px;
+}
+
+.status-card__author {
+  color: $ui-primary-color;
 }
 
 .status-card__content {

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -29,7 +29,7 @@ class PreviewCard < ApplicationRecord
 
   self.inheritance_column = false
 
-  enum type: [:link, :photo, :video, :rich]
+  enum type: [:link, :photo, :video, :rich, :post]
 
   belongs_to :status
 


### PR DESCRIPTION
- Supports: Twitter, Facebook, Qvitter
- New card type `post`: shows author_name and allows longer description

I've stored `@Gargron` to `title` field, but it rendered in `.status-card__author` to show `Eugen` in bolder font instead. It seems bad way, and maybe `title` field is not appropriate too.

![image](https://user-images.githubusercontent.com/705555/29818435-4a95a6c0-8cf7-11e7-9a2d-b733bf64198c.png)
