### PR TITLE
Adjust toot button style

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -412,6 +412,13 @@
 .compose-form__publish-button-wrapper {
   overflow: hidden;
   padding-top: 10px;
+
+  .button.button--block {
+    padding: 0 6px !important;
+    min-width: 75px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .emojione {


### PR DESCRIPTION
I think this way is better than #4723 "fix toot button text be hidden when img pasted"

##  Pros

- **Solve ellipsis of toot buttons in some languages whose translation is long**

- Enlarge Formosan toot buttons

##### Before and after images below.
![ba4](https://user-images.githubusercontent.com/27640522/29838157-55d881ea-8d35-11e7-8e89-954550b1750e.png)

## Cons

- **Padding becomes smaller in some languages**
I wonder if we prioritize usual(image is not attached) appearance or not :thinking:
Anyone has good way to solve this cons? Variable padding?
- **Can't solve ellipsis of all languages**
Bulgarian and Ukrainian image is attached.
Spanish and Portuguese image is attached in private or direct toots.
I think there is no way to solve this except increasing column width. :man_shrugging: 

##### Before and after images below.

Padding becomes smaller in some languages
![ba5](https://user-images.githubusercontent.com/27640522/29838166-5d7b5a58-8d35-11e7-8574-5c0e7c94ad91.png) 
To put it the other way around.
![ba8](https://user-images.githubusercontent.com/27640522/29839236-79252b1e-8d38-11e7-98ec-4f3d0a8b45d0.png)

Can't solve
![ws000053](https://user-images.githubusercontent.com/27640522/29840389-d32ae7d0-8d3c-11e7-988c-f98eb7a58489.png)
![ws000054](https://user-images.githubusercontent.com/27640522/29840387-d32109c2-8d3c-11e7-8cdf-30b589743353.png)
![ws000055](https://user-images.githubusercontent.com/27640522/29840388-d322d914-8d3c-11e7-8ace-8f57b2ec5a84.png)


----

The appearance is almost same for languages use "TOOT" as "compose_form.publish".
![ba7](https://user-images.githubusercontent.com/27640522/29838720-f0f9d510-8d36-11e7-8325-6a9ce7eeadbd.png)