### PR TITLE
Use request.remote_ip instead of request.ip

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,7 +124,7 @@ class User < ApplicationRecord
   def activate_session(request)
     session_activations.activate(session_id: SecureRandom.hex,
                                  user_agent: request.user_agent,
-                                 ip: request.ip).session_id
+                                 ip: request.remote_ip).session_id
   end
 
   def exclusive_session(id)


### PR DESCRIPTION
When nginx and puma are run in separate servers, request.ip returns reverse proxy's IP address and thus the session list shows it currently. This PR fixes this problem.