### PR TITLE
Add close tag of iframe for oEmbed response

### DIFF
--- a/app/serializers/oembed_serializer.rb
+++ b/app/serializers/oembed_serializer.rb
@@ -43,7 +43,7 @@ class OEmbedSerializer < ActiveModel::Serializer
       frameborder: '0',
       scrolling: 'no',
       width: width,
-      height: height
+      height: height,
     }
 
     content_tag :iframe, nil, attributes

--- a/app/serializers/oembed_serializer.rb
+++ b/app/serializers/oembed_serializer.rb
@@ -37,13 +37,16 @@ class OEmbedSerializer < ActiveModel::Serializer
   end
 
   def html
-    tag :iframe,
-        src: embed_short_account_status_url(object.account, object),
-        style: 'width: 100%; overflow: hidden',
-        frameborder: '0',
-        scrolling: 'no',
-        width: width,
-        height: height
+    attributes = {
+      src: embed_short_account_status_url(object.account, object),
+      style: 'width: 100%; overflow: hidden',
+      frameborder: '0',
+      scrolling: 'no',
+      width: width,
+      height: height
+    }
+
+    content_tag :iframe, nil, attributes
   end
 
   def width


### PR DESCRIPTION
`iframe` element is need close tag.

### before

```html
<iframe src="http://localhost:3000/@ykzts/178/embed" style="width: 100%; overflow: hidden" frameborder="0" scrolling="no" width="400" />
```

### after

```html
<iframe src="http://localhost:3000/@ykzts/178/embed" style="width: 100%; overflow: hidden" frameborder="0" scrolling="no" width="400"></iframe>
```