### PR TITLE
Update Dockerfile to Alpine 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.1-alpine
+FROM ruby:2.4.1-alpine3.6
 
 LABEL maintainer="https://github.com/tootsuite/mastodon" \
       description="A GNU Social-compatible microblogging server"
@@ -14,9 +14,7 @@ EXPOSE 3000 4000
 
 WORKDIR /mastodon
 
-RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
- && echo "@edge https://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
- && apk -U upgrade \
+RUN apk -U upgrade \
  && apk add -t build-dependencies \
     build-base \
     icu-dev \
@@ -31,15 +29,15 @@ RUN echo "@edge https://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/reposit
     file \
     git \
     icu-libs \
-    imagemagick@edge \
+    imagemagick \
     libidn \
     libpq \
-    nodejs-npm@edge \
-    nodejs@edge \
+    nodejs-npm \
+    nodejs \
     protobuf \
     su-exec \
     tini \
-    yarn@edge \
+    yarn \
  && update-ca-certificates \
  && wget -O libiconv.tar.gz "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-$LIBICONV_VERSION.tar.gz" \
  && echo "$LIBICONV_DOWNLOAD_SHA256 *libiconv.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
Alpine Linux 3.6 was released months ago, and the previous Alpine Linux image on which Mastodon was based was out-of-date and had some vulnerabilities (the `alpine` tag currently redirects to `alpine3.4`).

This PR updates the system to Alpine Linux 3.6, which is the latest version available. This PR defines the Alpine Linux version in the `FROM` directive, which is a good practice. Edge depositories are now removed, they were previously used to avoid some vulnerabilities on Alpine 3.4.

Theses changes, while they should work, should be tested. I'm not using the official Dockerfile, so I can't try it in production, but I can try locally later if no one does.