### PR TITLE
Convert OStatus tag to ActivityPub id on in_reply_to resolution

### DIFF
--- a/app/lib/ostatus/activity/base.rb
+++ b/app/lib/ostatus/activity/base.rb
@@ -56,6 +56,16 @@ class OStatus::Activity::Base
     Status.find_by(uri: uri)
   end
 
+  def find_activitypub_status(uri, href)
+    tag_matches = /tag:([^,:]+)[^:]*:objectId=([\d]+)/.match(uri)
+    href_matches = %r{/users/([^/]+)}.match(href)
+
+    unless tag_matches.nil? || href_matches.nil?
+      uri = "https://#{tag_matches[1]}/users/#{href_matches[1]}/statuses/#{tag_matches[2]}"
+      Status.find_by(uri: uri)
+    end
+  end
+
   def redis
     Redis.current
   end

--- a/app/lib/ostatus/activity/creation.rb
+++ b/app/lib/ostatus/activity/creation.rb
@@ -32,7 +32,7 @@ class OStatus::Activity::Creation < OStatus::Activity::Base
         language: content_language,
         visibility: visibility_scope,
         conversation: find_or_create_conversation,
-        thread: thread? ? find_status(thread.first) : nil
+        thread: thread? ? find_status(thread.first) || find_activitypub_status(thread.first, thread.second) : nil
       )
 
       save_mentions(status)


### PR DESCRIPTION
This is one of issues described in #4635.

Now we store statuses with ActivityPub id/url, which is not compatible with OStatus tag/url. Although we can fallback to fetching AP url, fetching may be ran after feed insertion, then the status wouldn't inserted into home timeline. This will bug users on upgraded instances while other instances are old.

So I added new fallback: convert OStatus tag and url to ActivityPub id by string manipulation

Of course it only works for Mastodon, so maybe it should be reconsidered when other implementation which supports both of OS / AP appears.