### PR TITLE
 Adjust padding on the public profile page

### DIFF
--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -6,7 +6,7 @@ body {
   line-height: 18px;
   font-weight: 400;
   color: $primary-text-color;
-  padding-bottom: 40px;
+  padding-bottom: 20px;
   text-rendering: optimizelegibility;
   font-feature-settings: "kern";
   text-size-adjust: none;

--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -50,10 +50,6 @@ body {
     height: 100%;
     padding: 0;
   }
-
-  @media screen and (max-width: 400px) {
-    padding-bottom: 0;
-  }
 }
 
 button {


### PR DESCRIPTION
Fixed an issue where padding-bottom was set to 0 and some links were hard to tap on some Android phones.

<details>
<summary>Screenshots</summary>

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/25865313/29930488-70d51fd8-8ea9-11e7-9910-6cae31ad2996.jpg) | ![after](https://user-images.githubusercontent.com/25865313/29930496-74b16ab2-8ea9-11e7-91db-2d7c73ef126c.jpg)

</details>