### PR TITLE
Fallback from perform_via_activitypub on private posts

### DIFF
--- a/app/lib/ostatus/activity/creation.rb
+++ b/app/lib/ostatus/activity/creation.rb
@@ -8,7 +8,11 @@ class OStatus::Activity::Creation < OStatus::Activity::Base
     end
 
     return [nil, false] if @account.suspended?
-    return perform_via_activitypub if activitypub_uri?
+
+    if activitypub_uri? && [:public, :unlisted].include?(visibility_scope)
+      result = perform_via_activitypub
+      return result if result.first.present?
+    end
 
     Rails.logger.debug "Creating remote status #{id}"
 


### PR DESCRIPTION
Currently, private / direct posts via OStatus from AP compatible instance will be dropped due to failing to fetch AP version.

So this fallbacks to OStatus handling:

* when failed to fetch ActivityPub version
* when status is neither :public nor :unlisted