### PR TITLE
Deduplicate with local status on Create activity

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -25,7 +25,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   private
 
   def find_existing_status
-    status   = Status.find_by(uri: object_uri)
+    status   = status_from_uri(object_uri)
     status ||= Status.find_by(uri: @object['_:atomUri']) if @object['_:atomUri'].present?
     status
   end


### PR DESCRIPTION
This fixes below bug:

1. Bob replies to Alice in remote instance
2. Alice's instance forwards it to followers, including Bob (#4709)
3. **Bob's instance creates that status again** since it doesn't deduplicate with local status