### PR TITLE
Define missing JSON-LD properties

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -26,7 +26,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
   def find_existing_status
     status   = status_from_uri(object_uri)
-    status ||= Status.find_by(uri: @object['_:atomUri']) if @object['_:atomUri'].present?
+    status ||= Status.find_by(uri: @object['atomUri']) if @object['atomUri'].present?
     status
   end
 
@@ -43,7 +43,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       sensitive: @object['sensitive'] || false,
       visibility: visibility_from_audience,
       thread: replied_to_status,
-      conversation: conversation_from_uri(@object['_:conversation']),
+      conversation: conversation_from_uri(@object['conversation']),
     }
   end
 
@@ -125,7 +125,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       @replied_to_status = nil
     else
       @replied_to_status   = status_from_uri(in_reply_to_uri)
-      @replied_to_status ||= status_from_uri(@object['_:inReplyToAtomUri']) if @object['_:inReplyToAtomUri'].present?
+      @replied_to_status ||= status_from_uri(@object['inReplyToAtomUri']) if @object['inReplyToAtomUri'].present?
       @replied_to_status
     end
   end

--- a/app/lib/activitypub/activity/delete.rb
+++ b/app/lib/activitypub/activity/delete.rb
@@ -17,7 +17,7 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
 
   def delete_note
     status   = Status.find_by(uri: object_uri, account: @account)
-    status ||= Status.find_by(uri: @object['_:atomUri'], account: @account) if @object.is_a?(Hash) && @object['_:atomUri'].present?
+    status ||= Status.find_by(uri: @object['atomUri'], account: @account) if @object.is_a?(Hash) && @object['atomUri'].present?
 
     delete_later!(object_uri)
 

--- a/app/lib/activitypub/adapter.rb
+++ b/app/lib/activitypub/adapter.rb
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 
 class ActivityPub::Adapter < ActiveModelSerializers::Adapter::Base
+  CONTEXT = {
+    '@context': [
+      'https://www.w3.org/ns/activitystreams',
+      'https://w3id.org/security/v1',
+
+      {
+        'locked'    => 'as:locked',
+        'sensitive' => 'as:sensitive',
+        'Hashtag'   => 'as:Hashtag',
+
+        'ostatus'          => 'http://ostatus.org#',
+        'atomUri'          => 'ostatus:atomUri',
+        'inReplyToAtomUri' => 'ostatus:inReplyToAtomUri',
+        'conversation'     => 'ostatus:conversation',
+      },
+    ],
+  }.freeze
+
   def self.default_key_transform
     :camel_lower
   end
@@ -11,7 +29,7 @@ class ActivityPub::Adapter < ActiveModelSerializers::Adapter::Base
 
   def serializable_hash(options = nil)
     options = serialization_options(options)
-    serialized_hash = { '@context': [ActivityPub::TagManager::CONTEXT, 'https://w3id.org/security/v1'] }.merge(ActiveModelSerializers::Adapter::Attributes.new(serializer, instance_options).serializable_hash(options))
+    serialized_hash = CONTEXT.merge(ActiveModelSerializers::Adapter::Attributes.new(serializer, instance_options).serializable_hash(options))
     self.class.transform_key_casing!(serialized_hash, instance_options)
   end
 end

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -6,11 +6,9 @@ class ActivityPub::ActorSerializer < ActiveModel::Serializer
   attributes :id, :type, :following, :followers,
              :inbox, :outbox, :shared_inbox,
              :preferred_username, :name, :summary,
-             :url
+             :url, :locked
 
   has_one :public_key, serializer: ActivityPub::PublicKeySerializer
-
-  attribute :locked, key: '_:locked'
 
   class ImageSerializer < ActiveModel::Serializer
     include RoutingHelper

--- a/app/serializers/activitypub/delete_serializer.rb
+++ b/app/serializers/activitypub/delete_serializer.rb
@@ -2,8 +2,7 @@
 
 class ActivityPub::DeleteSerializer < ActiveModel::Serializer
   class TombstoneSerializer < ActiveModel::Serializer
-    attributes :id, :type
-    attribute :atom_uri, key: '_:atomUri'
+    attributes :id, :type, :atom_uri
 
     def id
       ActivityPub::TagManager.instance.uri_for(object)

--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -25,8 +25,8 @@ class ActivityPub::FetchRemoteStatusService < BaseService
   def activity_json
     if %w(Note Article).include? @json['type']
       {
-        'type' => 'Create',
-        'actor' => first_of_value(@json['attributedTo']),
+        'type'   => 'Create',
+        'actor'  => first_of_value(@json['attributedTo']),
         'object' => @json,
       }
     else

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -50,7 +50,7 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.avatar_remote_url   = image_url('icon')
     @account.header_remote_url   = image_url('image')
     @account.public_key          = public_key || ''
-    @account.locked              = @json['_:locked'] || false
+    @account.locked              = @json['locked'] || false
     @account.save!
   end
 


### PR DESCRIPTION
Using _: property names is discouraged, as in the future,
canonicalization may throw an error when encountering that instead
of discarding it silently like it does now.

We are defining some ActivityStreams properties which we expect
to land in ActivityStreams eventually, to ensure that future versions
of Mastodon will remain compatible with this even once that happens.
Those would be `locked`, `sensitive` and `Hashtag`

We are defining a custom context inline for some properties which we
do not expect to land in any other context. `atomUri`, `inReplyToAtomUri`
and `conversation` are part of the custom defined OStatus context.