### PR TITLE
Raise an error for remote url in StatusFinder

### DIFF
--- a/app/lib/status_finder.rb
+++ b/app/lib/status_finder.rb
@@ -10,6 +10,8 @@ class StatusFinder
   def status
     verify_action!
 
+    raise ActiveRecord::RecordNotFound unless TagManager.instance.local_url?(url)
+
     case recognized_params[:controller]
     when 'stream_entries'
       StreamEntry.find(recognized_params[:id]).status

--- a/spec/controllers/api/oembed_controller_spec.rb
+++ b/spec/controllers/api/oembed_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Api::OEmbedController, type: :controller do
 
   describe 'GET #show' do
     before do
+      request.host = Rails.configuration.x.local_domain
       get :show, params: { url: account_stream_entry_url(alice, status.stream_entry) }, format: :json
     end
 

--- a/spec/lib/status_finder_spec.rb
+++ b/spec/lib/status_finder_spec.rb
@@ -34,6 +34,16 @@ describe StatusFinder do
       end
     end
 
+    context 'with a remote url even if id exists on local' do
+      let(:status) { Fabricate(:status) }
+      let(:url) { "https://example.com/users/test/statuses/#{status.id}" }
+      subject { described_class.new(url) }
+
+      it 'raises an error' do
+        expect { subject.status }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     context 'with a plausible url' do
       let(:url) { 'https://example.com/users/test/updates/123/embed' }
       subject { described_class.new(url) }


### PR DESCRIPTION
Previous implementation had allowed remote url with status id which also exists on local.

Then that bug leads /api/web/embed to return wrong embed url.