### PR TITLE
Don't unconditionally call `preventDefault` and `stopPropagation` on all keyup events

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/setting_toggle.js
+++ b/app/javascript/mastodon/features/notifications/components/setting_toggle.js
@@ -18,12 +18,6 @@ export default class SettingToggle extends React.PureComponent {
     this.props.onChange(this.props.settingKey, target.checked);
   }
 
-  onKeyDown = e => {
-    if (e.key === ' ') {
-      this.props.onChange(this.props.settingKey, !e.target.checked);
-    }
-  }
-
   render () {
     const { prefix, settings, settingKey, label, meta } = this.props;
     const id = ['setting-toggle', prefix, ...settingKey].filter(Boolean).join('-');

--- a/app/javascript/mastodon/features/ui/components/upload_area.js
+++ b/app/javascript/mastodon/features/ui/components/upload_area.js
@@ -12,13 +12,12 @@ export default class UploadArea extends React.PureComponent {
   };
 
   handleKeyUp = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-
     const keyCode = e.keyCode;
     if (this.props.active) {
       switch(keyCode) {
       case 27:
+        e.preventDefault();
+        e.stopPropagation();
         this.props.onClose();
         break;
       }


### PR DESCRIPTION
The `UploadArea` component (used when dragging and dropping a file onto Mastodon to upload it) registers an event handler on `onkeyup` on `window` when mounted that watches for the escape key and closes the UploadArea if it's pressed. Regardless of whether the key was the escape key, it calls `e.stopPropagation()` and `e.preventDefault()`.  This is perhaps not a big deal when the `UploadArea` is active, but the component remains mounted even when it isn't active. As a result, no `keyup` event in the main web UI ever performs its default actions unless something prevents it from propagating up to the `UploadArea`'s handler.

This sometimes poses accessibility problems, since activating some elements/components using the keyboard happens in the default action on keyup. In at least one place (the `SettingToggle` component) we've added a workaround to manually trigger what would normally be the default behavior on pressing the space key. But this would not be necessary if we just don't unnecessarily prevent the default behavior; the element would be usable via the keyboard without any special effort. There's also at least one place where we haven't yet added a workaround whose accessibility to keyboard navigation is being compromised by the `preventDefault` calls: the toggles in the report modal (try toggling them using the space key).

This PR modifies `UploadArea`'s event handler to only call `e.stopPropagation()` and `e.preventDefault()` when the key is the escape key. It also removes the workaround for the old behavior from `SettingToggle` (otherwise pressing space would trigger the workaround onkeydown handler and toggle it and then the default onkeyup behavior would toggle it back to its previous state again). If there are other such workarounds elsewhere, we may need to remove them for the behavior to work properly. It's possible that we should also only be doing anything in the `UploadArea` onkeyup handler when the `UploadArea` is actually active, but that seemed a more invasive of a change and I was uncertain if that would be the appropriate behavior.