### PR TITLE
Fix WebPush (regression from #4524)

### DIFF
--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -50,7 +50,7 @@ class Web::PushSubscription < ApplicationRecord
       auth: key_auth,
       ttl: ttl,
       vapid: {
-        subject: "mailto:#{Setting.site_contact_email}",
+        subject: "mailto:#{::Setting.site_contact_email}",
         private_key: Rails.configuration.x.vapid_private_key,
         public_key: Rails.configuration.x.vapid_public_key,
       }

--- a/app/serializers/web/notification_serializer.rb
+++ b/app/serializers/web/notification_serializer.rb
@@ -121,7 +121,7 @@ class Web::NotificationSerializer < ActiveModel::Serializer
   attributes :title, :image, :badge, :tag,
              :timestamp, :icon
 
-  has_one :data
+  has_one :data, serializer: DataSerializer
 
   def title
     case object.type


### PR DESCRIPTION
- In `Web::PushSubscription`, `Setting` refers `Web::Setting` class (/app/models/web/setting.rb) instead of `Setting` class.
-> Specified namespace, `::Setting`
- Since AMS doesn't use inner class `DataSerializer` automatically, it had simply serialized each model.
-> Added `serializer: DataSerializer`