### PR TITLE
Make "unfollow" undo pending outgoing follow request too

### DIFF
--- a/app/javascript/mastodon/containers/account_container.js
+++ b/app/javascript/mastodon/containers/account_container.js
@@ -32,7 +32,7 @@ const makeMapStateToProps = () => {
 const mapDispatchToProps = (dispatch, { intl }) => ({
 
   onFollow (account) {
-    if (account.getIn(['relationship', 'following'])) {
+    if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
       if (this.unfollowModal) {
         dispatch(openModal('CONFIRM', {
           message: <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,

--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -11,8 +11,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 const messages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
   follow: { id: 'account.follow', defaultMessage: 'Follow' },
-  requested: { id: 'account.requested', defaultMessage: 'Awaiting approval' },
-  cancel: { id: 'account.cancel_request', defaultMessage: 'Cancel follow request' },
+  requested: { id: 'account.requested', defaultMessage: 'Awaiting approval. Click to cancel follow request' },
 });
 
 const makeMapStateToProps = () => {
@@ -103,8 +102,7 @@ export default class Header extends ImmutablePureComponent {
       if (account.getIn(['relationship', 'requested'])) {
         actionBtn = (
           <div className='account--action-button'>
-            <IconButton size={26} disabled icon='hourglass' title={intl.formatMessage(messages.requested)} />
-            <IconButton size={26} icon='times' title={intl.formatMessage(messages.cancel)} onClick={this.props.onFollow} />
+            <IconButton size={26} active icon='hourglass' title={intl.formatMessage(messages.requested)} onClick={this.props.onFollow} />
           </div>
         );
       } else if (!account.getIn(['relationship', 'blocking'])) {

--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -12,6 +12,7 @@ const messages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
   follow: { id: 'account.follow', defaultMessage: 'Follow' },
   requested: { id: 'account.requested', defaultMessage: 'Awaiting approval' },
+  cancel: { id: 'account.cancel_request', defaultMessage: 'Cancel follow request' },
 });
 
 const makeMapStateToProps = () => {
@@ -103,6 +104,7 @@ export default class Header extends ImmutablePureComponent {
         actionBtn = (
           <div className='account--action-button'>
             <IconButton size={26} disabled icon='hourglass' title={intl.formatMessage(messages.requested)} />
+            <IconButton size={26} icon='times' title={intl.formatMessage(messages.cancel)} onClick={this.props.onFollow} />
           </div>
         );
       } else if (!account.getIn(['relationship', 'blocking'])) {

--- a/app/javascript/mastodon/features/account_timeline/containers/header_container.js
+++ b/app/javascript/mastodon/features/account_timeline/containers/header_container.js
@@ -38,7 +38,7 @@ const makeMapStateToProps = () => {
 const mapDispatchToProps = (dispatch, { intl }) => ({
 
   onFollow (account) {
-    if (account.getIn(['relationship', 'following'])) {
+    if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
       if (this.unfollowModal) {
         dispatch(openModal('CONFIRM', {
           message: <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -436,7 +436,7 @@
         "id": "account.follow"
       },
       {
-        "defaultMessage": "Awaiting approval",
+        "defaultMessage": "Awaiting approval. Click to cancel follow request",
         "id": "account.requested"
       },
       {

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -12,7 +12,7 @@
   "account.mute": "Mute @{name}",
   "account.posts": "Posts",
   "account.report": "Report @{name}",
-  "account.requested": "Awaiting approval",
+  "account.requested": "Awaiting approval. Click to cancel follow request",
   "account.share": "Share @{name}'s profile",
   "account.unblock": "Unblock @{name}",
   "account.unblock_domain": "Unhide {domain}",

--- a/app/lib/activitypub/activity/undo.rb
+++ b/app/lib/activitypub/activity/undo.rb
@@ -33,6 +33,8 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
 
     if @account.following?(target_account)
       @account.unfollow!(target_account)
+    elsif @account.requested?(target_account)
+      FollowRequest.find_by(account: @account, target_account: target_account)&.destroy
     else
       delete_later!(object_uri)
     end

--- a/app/services/process_interaction_service.rb
+++ b/app/services/process_interaction_service.rb
@@ -67,10 +67,13 @@ class ProcessInteractionService < BaseService
 
   def follow!(account, target_account)
     follow = account.follow!(target_account)
+    FollowRequest.find_by(account: account, target_account: target_account)&.destroy
     NotifyService.new.call(target_account, follow)
   end
 
   def follow_request!(account, target_account)
+    return if account.requested?(target_account)
+
     follow_request = FollowRequest.create!(account: account, target_account: target_account)
     NotifyService.new.call(target_account, follow_request)
   end
@@ -88,6 +91,7 @@ class ProcessInteractionService < BaseService
 
   def unfollow!(account, target_account)
     account.unfollow!(target_account)
+    FollowRequest.find_by(account: account, target_account: target_account)&.destroy
   end
 
   def reflect_block!(account, target_account)

--- a/app/services/unfollow_service.rb
+++ b/app/services/unfollow_service.rb
@@ -5,14 +5,34 @@ class UnfollowService < BaseService
   # @param [Account] source_account Where to unfollow from
   # @param [Account] target_account Which to unfollow
   def call(source_account, target_account)
-    follow = source_account.unfollow!(target_account)
-    return unless follow
-    create_notification(follow) unless target_account.local?
-    UnmergeWorker.perform_async(target_account.id, source_account.id)
-    follow
+    @source_account = source_account
+    @target_account = target_account
+
+    unfollow! || undo_follow_request!
   end
 
   private
+
+  def unfollow!
+    follow = Follow.find_by(account: @source_account, target_account: @target_account)
+
+    return unless follow
+
+    follow.destroy!
+    create_notification(follow) unless @target_account.local?
+    UnmergeWorker.perform_async(@target_account.id, @source_account.id)
+    follow
+  end
+
+  def undo_follow_request!
+    follow_request = FollowRequest.find_by(account: @source_account, target_account: @target_account)
+
+    return unless follow_request
+
+    follow_request.destroy!
+    create_notification(follow_request) unless @target_account.local?
+    follow_request
+  end
 
   def create_notification(follow)
     if follow.target_account.ostatus?


### PR DESCRIPTION
- When local user unfollows other user, delete both the follow, and follow_request (if exists)
- When unfollowed user is remote, send "undo follow"/"unfollow" even for cancelled follow_request
- When processing ActivityPub "Undo->Follow", perform unfollow if remote user was following, and remove incoming follow request if the user was not following but had a pending follow request
- In OStatus processing:
  - for incoming follow, clear out any pending follow request from the follower if there was one before
  - ignore double follow requests
  - for incoming unfollow, clear out any pending follow request from the ex-follower

After this, unfollowing should clear out pending follow requests on both ends. A successful follow should also clear out pending follow requests.

Fix #785 

Screenshot of web UI change:

![image](https://user-images.githubusercontent.com/184731/29997225-389a9a60-900e-11e7-85dd-9b8eadc43d03.png)
