### PR TITLE
Explicitly define attached file of DeprecatedPreviewCard

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -275,8 +275,15 @@ namespace :mastodon do
     task remove_deprecated_preview_cards: :environment do
       return unless ActiveRecord::Base.connection.table_exists? 'deprecated_preview_cards'
 
-      class DeprecatedPreviewCard < PreviewCard
-        self.table_name = 'deprecated_preview_cards'
+      class DeprecatedPreviewCard < ActiveRecord::Base
+        self.inheritance_column = false
+
+        path = '/preview_cards/:attachment/:id_partition/:style/:filename'
+        if ENV['S3_ENABLED'] != 'true'
+          path = (ENV['PAPERCLIP_ROOT_PATH'] || ':rails_root/public/system') + path
+        end
+
+        has_attached_file :image, styles: { original: '280x120>' }, convert_options: { all: '-quality 80 -strip' }, path: path
       end
 
       puts 'Delete records and associated files from deprecated preview cards? [y/N]: '


### PR DESCRIPTION
The `path` template of the attached files must explicitly be defined because it is contradicting to the name of the class.