### PR TITLE
Fix some ActivityPub JSON bugs

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -33,7 +33,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def status_params
     {
       uri: @object['id'],
-      url: @object['url'] || @object['id'],
+      url: object_url || @object['id'],
       account: @account,
       text: text_from_content || '',
       language: language_from_content,
@@ -145,6 +145,16 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def language_from_content
     return nil unless language_map?
     @object['contentMap'].keys.first
+  end
+
+  def object_url
+    return if @object['url'].blank?
+
+    value = first_of_value(@object['url'])
+
+    return value if value.is_a?(String)
+
+    value['href']
   end
 
   def language_map?

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -4,7 +4,7 @@ class ActivityPub::ActorSerializer < ActiveModel::Serializer
   include RoutingHelper
 
   attributes :id, :type, :following, :followers,
-             :inbox, :outbox, :shared_inbox,
+             :inbox, :outbox,
              :preferred_username, :name, :summary,
              :url, :manually_approves_followers
 
@@ -23,6 +23,18 @@ class ActivityPub::ActorSerializer < ActiveModel::Serializer
       full_asset_url(object.url(:original))
     end
   end
+
+  class EndpointsSerializer < ActiveModel::Serializer
+    include RoutingHelper
+
+    attributes :shared_inbox
+
+    def shared_inbox
+      inbox_url
+    end
+  end
+
+  has_one :endpoints, serializer: EndpointsSerializer
 
   has_one :icon,  serializer: ImageSerializer, if: :avatar_exists?
   has_one :image, serializer: ImageSerializer, if: :header_exists?
@@ -51,8 +63,8 @@ class ActivityPub::ActorSerializer < ActiveModel::Serializer
     account_outbox_url(object)
   end
 
-  def shared_inbox
-    inbox_url
+  def endpoints
+    object
   end
 
   def preferred_username


### PR DESCRIPTION
- Fix assumption that `url` is always a string. Handle it if it's an
  array of strings, array of objects, object, or string, both for
  accounts and for objects
- `sharedInbox` is actually supposed to be under `endpoints`, handle
  both cases and adjust the serializer