### PR TITLE
Fix #4794 - Fake instant follow in API response when account is believed unlocked

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -14,6 +14,16 @@ class Api::V1::AccountsController < Api::BaseController
 
   def follow
     FollowService.new.call(current_user.account, @account.acct)
+
+    unless @account.locked?
+      relationships = AccountRelationshipsPresenter.new(
+        [@account.id],
+        current_user.account_id,
+        following_map: { @account.id => true },
+        requested_map: { @account.id => false }
+      )
+    end
+
     render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships
   end
 

--- a/app/presenters/account_relationships_presenter.rb
+++ b/app/presenters/account_relationships_presenter.rb
@@ -4,12 +4,12 @@ class AccountRelationshipsPresenter
   attr_reader :following, :followed_by, :blocking,
               :muting, :requested, :domain_blocking
 
-  def initialize(account_ids, current_account_id)
-    @following       = Account.following_map(account_ids, current_account_id)
-    @followed_by     = Account.followed_by_map(account_ids, current_account_id)
-    @blocking        = Account.blocking_map(account_ids, current_account_id)
-    @muting          = Account.muting_map(account_ids, current_account_id)
-    @requested       = Account.requested_map(account_ids, current_account_id)
-    @domain_blocking = Account.domain_blocking_map(account_ids, current_account_id)
+  def initialize(account_ids, current_account_id, options = {})
+    @following       = Account.following_map(account_ids, current_account_id).merge(options[:following_map] || {})
+    @followed_by     = Account.followed_by_map(account_ids, current_account_id).merge(options[:followed_by_map] || {})
+    @blocking        = Account.blocking_map(account_ids, current_account_id).merge(options[:blocking_map] || {})
+    @muting          = Account.muting_map(account_ids, current_account_id).merge(options[:muting_map] || {})
+    @requested       = Account.requested_map(account_ids, current_account_id).merge(options[:requested_map] || {})
+    @domain_blocking = Account.domain_blocking_map(account_ids, current_account_id).merge(options[:domain_blocking_map] || {})
   end
 end

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
       expect(response).to have_http_status(:success)
     end
 
+    it 'returns JSON with following=true and requested=false' do
+      json = body_as_json
+
+      expect(json[:following]).to be true
+      expect(json[:requested]).to be false
+    end
+
     it 'creates a following relation between user and target user' do
       expect(user.account.following?(other_account)).to be true
     end


### PR DESCRIPTION
See https://github.com/tootsuite/mastodon/issues/4794#issuecomment-326830374