### PR TITLE
Show pinned statuses only in the top of the profile page

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -14,7 +14,7 @@ class AccountsController < ApplicationController
           return
         end
 
-        @pinned_statuses = cache_collection(@account.pinned_statuses, Status) unless media_requested?
+        @pinned_statuses = cache_collection(@account.pinned_statuses, Status) if show_pinned_statuses?
         @statuses        = filtered_statuses.paginate_by_max_id(20, params[:max_id], params[:since_id])
         @statuses        = cache_collection(@statuses, Status)
         @next_url        = next_url unless @statuses.empty?
@@ -32,6 +32,10 @@ class AccountsController < ApplicationController
   end
 
   private
+
+  def show_pinned_statuses?
+    !(replies_requested? || media_requested? || params[:max_id].present? || params[:since_id].present?)
+  end
 
   def filtered_statuses
     default_statuses.tap do |statuses|

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -34,7 +34,7 @@ class AccountsController < ApplicationController
   private
 
   def show_pinned_statuses?
-    !(replies_requested? || media_requested? || params[:max_id].present? || params[:since_id].present?)
+    [replies_requested?, media_requested?, params[:max_id].present?, params[:since_id].present?].none?
   end
 
   def filtered_statuses

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -61,7 +61,29 @@ RSpec.describe AccountsController, type: :controller do
       end
     end
 
-    context 'html' do
+    context 'html without since_id nor max_id' do
+      before do
+        get :show, params: { username: alice.username }
+      end
+
+      it 'assigns @account' do
+        expect(assigns(:account)).to eq alice
+      end
+
+      it 'assigns @pinned_statuses' do
+        pinned_statuses = assigns(:pinned_statuses).to_a
+        expect(pinned_statuses.size).to eq 3
+        expect(pinned_statuses[0]).to eq status7
+        expect(pinned_statuses[1]).to eq status5
+        expect(pinned_statuses[2]).to eq status6
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'html with since_id and max_id' do
       before do
         get :show, params: { username: alice.username, max_id: status4.id, since_id: status1.id }
       end
@@ -77,12 +99,9 @@ RSpec.describe AccountsController, type: :controller do
         expect(statuses[1]).to eq status2
       end
 
-      it 'assigns @pinned_statuses' do
+      it 'assigns an empty array to @pinned_statuses' do
         pinned_statuses = assigns(:pinned_statuses).to_a
-        expect(pinned_statuses.size).to eq 3
-        expect(pinned_statuses[0]).to eq status7
-        expect(pinned_statuses[1]).to eq status5
-        expect(pinned_statuses[2]).to eq status6
+        expect(pinned_statuses.size).to eq 0
       end
 
       it 'returns http success' do


### PR DESCRIPTION
Currently, pinned toot is shown even in page 2, and so on, and I think it will be annoying when the user pinned a lot of statuses.

This PR modifies that pinned toot is shown only in the first page of the profile. It also hide the pinned toot when the user specifies `/with_replies` in URL, because most users who visit `/@(screen_name)/with_replies` come from `/@(screen_name)` and they might think pinned statuses redundant.