### PR TITLE
Change Finnish wording of "free" on landing page.

### DIFF
--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -1,7 +1,7 @@
 ---
 fi:
   about:
-    about_mastodon_html: Mastodon on <em>ilmainen, avoimeen lähdekoodiin perustuva</em> sosiaalinen verkosto. <em>Hajautettu</em> vaihtoehto kaupallisille alustoille, se välttää eiskit yhden yrityksen monopolisoinnin sinun viestinnässäsi. Valitse palvelin mihin luotat &mdash; minkä tahansa valitset, voit vuorovaikuttaa muiden kanssa. Kuka tahansa voi luoda Mastodon palvelimen ja ottaa osaa <em>sosiaaliseen verkkoon</em> saumattomasti.
+    about_mastodon_html: Mastodon on <em>vapaa, avoimeen lähdekoodiin perustuva</em> sosiaalinen verkosto. <em>Hajautettu</em> vaihtoehto kaupallisille alustoille, se välttää eiskit yhden yrityksen monopolisoinnin sinun viestinnässäsi. Valitse palvelin mihin luotat &mdash; minkä tahansa valitset, voit vuorovaikuttaa muiden kanssa. Kuka tahansa voi luoda Mastodon palvelimen ja ottaa osaa <em>sosiaaliseen verkkoon</em> saumattomasti.
     about_this: Tietoja tästä palvelimesta
     contact: Ota yhteyttä
     description_headline: Mikä on %{domain}?


### PR DESCRIPTION
"Ilmainen" means "gratis", but Mastodon is free as in freedom, libre – "vapaa".
https://fi.wikipedia.org/wiki/Vapaa_ohjelmisto