### PR TITLE
Adjust status embeds

### DIFF
--- a/app/controllers/api/web/embeds_controller.rb
+++ b/app/controllers/api/web/embeds_controller.rb
@@ -7,7 +7,7 @@ class Api::Web::EmbedsController < Api::BaseController
 
   def create
     status = StatusFinder.new(params[:url]).status
-    render json: status, serializer: OEmbedSerializer
+    render json: status, serializer: OEmbedSerializer, width: 400
   rescue ActiveRecord::RecordNotFound
     oembed = OEmbed::Providers.get(params[:url])
     render json: Oj.dump(oembed.fields)

--- a/app/controllers/api/web/embeds_controller.rb
+++ b/app/controllers/api/web/embeds_controller.rb
@@ -7,7 +7,7 @@ class Api::Web::EmbedsController < Api::BaseController
 
   def create
     status = StatusFinder.new(params[:url]).status
-    render json: status, serializer: OEmbedSerializer, width: 400
+    render json: status, serializer: OEmbedSerializer
   rescue ActiveRecord::RecordNotFound
     oembed = OEmbed::Providers.get(params[:url])
     render json: Oj.dump(oembed.fields)

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -3966,41 +3966,10 @@ noscript {
   }
 }
 
-.embed-modal__html {
-  color: $ui-secondary-color;
-  outline: 0;
-  box-sizing: border-box;
-  display: block;
-  width: 100%;
-  border: none;
-  padding: 10px;
-  font-family: 'mastodon-font-monospace', monospace;
-  background: $ui-base-color;
-  color: $ui-primary-color;
-  font-size: 14px;
-  margin: 0;
-  margin-bottom: 15px;
-
-  &::-moz-focus-inner {
-    border: 0;
-  }
-
-  &::-moz-focus-inner,
-  &:focus,
-  &:active {
-    outline: 0 !important;
-  }
-
-  &:focus {
-    background: lighten($ui-base-color, 4%);
-  }
-
-  @media screen and (max-width: 600px) {
-    font-size: 16px;
-  }
-}
-
 .embed-modal {
+  max-width: 80vw;
+  max-height: 80vh;
+
   h4 {
     padding: 30px;
     font-weight: 500;
@@ -4008,18 +3977,52 @@ noscript {
     text-align: center;
   }
 
-  .hint {
-    margin-bottom: 15px;
+  .embed-modal__container {
+    padding: 10px;
+
+    .hint {
+      margin-bottom: 15px;
+    }
+
+    .embed-modal__html {
+      color: $ui-secondary-color;
+      outline: 0;
+      box-sizing: border-box;
+      display: block;
+      width: 100%;
+      border: none;
+      padding: 10px;
+      font-family: 'mastodon-font-monospace', monospace;
+      background: $ui-base-color;
+      color: $ui-primary-color;
+      font-size: 14px;
+      margin: 0;
+      margin-bottom: 15px;
+    
+      &::-moz-focus-inner {
+        border: 0;
+      }
+    
+      &::-moz-focus-inner,
+      &:focus,
+      &:active {
+        outline: 0 !important;
+      }
+    
+      &:focus {
+        background: lighten($ui-base-color, 4%);
+      }
+    
+      @media screen and (max-width: 600px) {
+        font-size: 16px;
+      }
+    }
+
+    .embed-modal__iframe {
+      width: 400px;
+      max-width: 100%;
+      overflow: hidden;
+      border: 0;
+    }
   }
-}
-
-.embed-modal__container {
-  padding: 10px;
-}
-
-.embed-modal__iframe {
-  width: 100%;
-  min-width: 400px;
-  overflow: hidden;
-  border: 0;
 }

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -3998,21 +3998,21 @@ noscript {
       font-size: 14px;
       margin: 0;
       margin-bottom: 15px;
-    
+
       &::-moz-focus-inner {
         border: 0;
       }
-    
+
       &::-moz-focus-inner,
       &:focus,
       &:active {
         outline: 0 !important;
       }
-    
+
       &:focus {
         background: lighten($ui-base-color, 4%);
       }
-    
+
       @media screen and (max-width: 600px) {
         font-size: 16px;
       }

--- a/app/javascript/styles/stream_entries.scss
+++ b/app/javascript/styles/stream_entries.scss
@@ -403,51 +403,54 @@
 
 .embed {
   .activity-stream {
-    border-radius: 4px;
     box-shadow: none;
 
     .entry {
-      &:last-child {
-        border-radius: 0 0 4px 4px;
-      }
 
-      &:first-child {
-        border-radius: 4px 4px 0 0;
+      .detailed-status.light {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: flex-start;
 
-        &:last-child {
-          border-radius: 4px;
+        .detailed-status__display-name {
+          flex: 1;
+          margin: 0 5px 15px 0;
+        }
+
+        .button.button-secondary.logo-button {
+          flex: 0 auto;
+          font-size: 14px;
+        
+          svg {
+            width: 20px;
+            height: auto;
+            vertical-align: middle;
+            margin-right: 5px;
+        
+            path:first-child {
+              fill: $ui-primary-color;
+            }
+        
+            path:last-child {
+              fill: $simple-background-color;
+            }
+          }
+        
+          &:active,
+          &:focus,
+          &:hover {
+            svg path:first-child {
+              fill: lighten($ui-primary-color, 4%);
+            }
+          }
+        }
+
+        .status__content,
+        .detailed-status__meta {
+          flex: 100%;
         }
       }
-    }
-  }
-}
-
-.button.button-secondary.logo-button {
-  position: absolute;
-  right: 14px;
-  top: 14px;
-  font-size: 14px;
-
-  svg {
-    width: 20px;
-    height: auto;
-    vertical-align: middle;
-    margin-right: 5px;
-
-    path:first-child {
-      fill: $ui-primary-color;
-    }
-
-    path:last-child {
-      fill: $simple-background-color;
-    }
-  }
-
-  &:active,
-  &:focus,
-  &:hover {
-    svg path:first-child {
-      fill: lighten($ui-primary-color, 4%);
     }
   }
 }

--- a/app/javascript/styles/stream_entries.scss
+++ b/app/javascript/styles/stream_entries.scss
@@ -421,22 +421,22 @@
         .button.button-secondary.logo-button {
           flex: 0 auto;
           font-size: 14px;
-        
+
           svg {
             width: 20px;
             height: auto;
             vertical-align: middle;
             margin-right: 5px;
-        
+
             path:first-child {
               fill: $ui-primary-color;
             }
-        
+
             path:last-child {
               fill: $simple-background-color;
             }
           }
-        
+
           &:active,
           &:focus,
           &:hover {

--- a/app/serializers/oembed_serializer.rb
+++ b/app/serializers/oembed_serializer.rb
@@ -40,8 +40,7 @@ class OEmbedSerializer < ActiveModel::Serializer
     attributes = {
       src: embed_short_account_status_url(object.account, object),
       class: 'mastodon-embed',
-      frameborder: '0',
-      scrolling: 'no',
+      style: 'width: 400px; max-width: 100%; border: none;',
       width: width,
       height: height,
     }

--- a/app/serializers/oembed_serializer.rb
+++ b/app/serializers/oembed_serializer.rb
@@ -40,7 +40,7 @@ class OEmbedSerializer < ActiveModel::Serializer
     attributes = {
       src: embed_short_account_status_url(object.account, object),
       class: 'mastodon-embed',
-      style: 'width: 400px; max-width: 100%; border: none;',
+      style: 'max-width: 100%; border: none;',
       width: width,
       height: height,
     }

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -1,9 +1,4 @@
 .detailed-status.light
-  - if embedded_view?
-    = link_to "web+mastodon://follow?uri=#{status.account.local_username_and_domain}", class: 'button button-secondary logo-button', target: '_new' do
-      = render file: Rails.root.join('app', 'javascript', 'images', 'logo.svg')
-      = t('accounts.follow')
-
   = link_to TagManager.instance.url_for(status.account), class: 'detailed-status__display-name p-author h-card', target: stream_link_target, rel: 'noopener' do
     %div
       .avatar
@@ -11,6 +6,11 @@
     %span.display-name
       %strong.p-name.emojify= display_name(status.account)
       %span= acct(status.account)
+
+  - if embedded_view?
+    = link_to "web+mastodon://follow?uri=#{status.account.local_username_and_domain}", class: 'button button-secondary logo-button', target: '_new' do
+      = render file: Rails.root.join('app', 'javascript', 'images', 'logo.svg')
+      = t('accounts.follow')
 
   .status__content.p-name.emojify<
     - if status.spoiler_text?


### PR DESCRIPTION
## Responsive status embeds

### Permit width under 400px

<details>
<summary>Before and after images</summary>
<img src="https://user-images.githubusercontent.com/27640522/30034166-76e9ea50-91da-11e7-8c07-2250f9c64934.png" alt="screenshot1" />
</details>

### Change style of follow button to support narrow width

<details>
<summary>Before and after images</summary>
<img src="https://user-images.githubusercontent.com/27640522/30034261-25edb54a-91db-11e7-8d34-486cf38321f8.png" alt="screenshot2" />
</details>

## Scrollable status embeds

Since scripts of getting height of iframe is not implemented yet, I remove `scrolling: 'no'` option.
(Scrolling option was obsoleted in HTML5)

<details>
<summary>Before and after images</summary>
<img src="https://user-images.githubusercontent.com/27640522/30034379-e89a51f2-91db-11e7-9a26-a685de1859c2.png" alt="screenshot3" />
</details>

## Fix overflow of embed-modal in narrow devices

<details>
<summary>Before and after images</summary>
<img src="https://user-images.githubusercontent.com/27640522/30034407-231a2456-91dc-11e7-8a19-97db85b4ea23.png" alt="screenshot4" />
</details>

## And some minor adjustments of styles

- **Since frameborder option was obsoleted in HTML5, I change it to `style="border: none;"` .**
- Rearrange style selector according to content order.
- Organize directory level.
