### PR TITLE
Add Smartphone screen favourite back button and adjust styles

### DIFF
--- a/app/javascript/mastodon/features/favourited_statuses/index.js
+++ b/app/javascript/mastodon/features/favourited_statuses/index.js
@@ -77,6 +77,7 @@ export default class Favourites extends ImmutablePureComponent {
           onClick={this.handleHeaderClick}
           pinned={pinned}
           multiColumn={multiColumn}
+          showBackButton
         />
 
         <StatusList

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1616,11 +1616,15 @@
   cursor: pointer;
   flex: 0 0 auto;
   font-size: 16px;
-  padding-right: 15px;
+  padding: 0 5px 0 0;
   z-index: 3;
 
   &:hover {
     text-decoration: underline;
+  }
+
+  &:last-child {
+    padding: 0 15px 0 0;
   }
 }
 
@@ -2176,7 +2180,7 @@ button.icon-button.active i.fa-retweet {
   color: $ui-primary-color;
   cursor: pointer;
   font-size: 16px;
-  padding-right: 15px;
+  padding: 0 15px;
 
   &:hover {
     color: lighten($ui-primary-color, 7%);

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1616,7 +1616,7 @@
   cursor: pointer;
   flex: 0 0 auto;
   font-size: 16px;
-  padding: 0 5px 0 0;
+  padding-right: 15px;
   z-index: 3;
 
   &:hover {
@@ -2168,9 +2168,6 @@ button.icon-button.active i.fa-retweet {
   height: 100%;
   display: flex;
   height: 48px;
-  @media screen and (max-width: 1024px) {
-    margin-right: 10px;
-  }
 }
 
 .column-header__button {
@@ -2179,7 +2176,7 @@ button.icon-button.active i.fa-retweet {
   color: $ui-primary-color;
   cursor: pointer;
   font-size: 16px;
-  padding: 0 15px;
+  padding-right: 15px;
 
   &:hover {
     color: lighten($ui-primary-color, 7%);

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2168,6 +2168,9 @@ button.icon-button.active i.fa-retweet {
   height: 100%;
   display: flex;
   height: 48px;
+  @media screen and (max-width: 1024px) {
+    margin-right: 10px;
+  }
 }
 
 .column-header__button {


### PR DESCRIPTION
At first, there was no back button on favourite column.

![screen shot 2017-09-05 at 5 47 26 pm](https://user-images.githubusercontent.com/16035247/30053049-784a0a50-9262-11e7-891e-cf0aff2edd6a.png)

So, I made back button for smart phone screen. but It was not in good shape.

![screen shot 2017-09-05 at 5 46 10 pm](https://user-images.githubusercontent.com/16035247/30053077-8ac1db54-9262-11e7-9df4-d97875ec7419.png)

Therefore I fixed this style issue as well.

![screen shot 2017-09-05 at 5 45 23 pm](https://user-images.githubusercontent.com/16035247/30053113-aa69ea96-9262-11e7-88ef-118cff4ea6f2.png)

**Other Column looks okay as well**
