### PR TITLE
Do not execute the job with the same arguments as the retry job

### DIFF
--- a/app/workers/pubsubhubbub/subscribe_worker.rb
+++ b/app/workers/pubsubhubbub/subscribe_worker.rb
@@ -3,7 +3,7 @@
 class Pubsubhubbub::SubscribeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push', retry: 10, unique: :until_executed, dead: false
+  sidekiq_options queue: 'push', retry: 10, unique: :until_executed, dead: false, unique_retry: true
 
   sidekiq_retry_in do |count|
     case count

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ require_relative '../app/lib/exceptions'
 require_relative '../lib/paperclip/gif_transcoder'
 require_relative '../lib/paperclip/video_transcoder'
 require_relative '../lib/mastodon/version'
+require_relative '../lib/mastodon/unique_retry_job_middleware'
 
 Dotenv::Railtie.load
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -13,4 +13,7 @@ end
 
 Sidekiq.configure_client do |config|
   config.redis = redis_params
+  config.client_middleware do |chain|
+    chain.add Mastodon::UniqueRetryJobMiddleware
+  end
 end

--- a/lib/mastodon/unique_retry_job_middleware.rb
+++ b/lib/mastodon/unique_retry_job_middleware.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Mastodon::UniqueRetryJobMiddleware
+  def call(_worker_class, item, _queue, _redis_pool)
+    return if item['unique_retry'] && retried?(item)
+    yield
+  end
+
+  private
+
+  def retried?(item)
+    # Use unique digest key of SidekiqUniqueJobs
+    unique_key = SidekiqUniqueJobs::UNIQUE_DIGEST_KEY
+    unique_digest = item[unique_key]
+    class_name = item['class']
+    retries = Sidekiq::RetrySet.new
+
+    retries.any? { |job| job.item['class'] == class_name && job.item[unique_key] == unique_digest }
+  end
+end


### PR DESCRIPTION
Since `sidekiq-unique-jobs` does not check the retry queue, new jobs are pushed even though there is a unique job in the retry queue. So, Mastodon runs `Pubsubhubbub::SubscribeWorker` many times. In Pawoo, there were only 5000 unique jobs out of 60,000 `Pubsubhubbub::SubscribeWorker` retry jobs.
In this PR, check the retry queue when queuing a job to Sidekiq. At this time, confirmation of uniqueness is done by using the digest key of `sidekiq-unique-jobs`.