### PR TITLE
Update react-intl to version 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-dom": "^15.6.1",
     "react-immutable-proptypes": "^2.1.0",
     "react-immutable-pure-component": "^1.0.0",
-    "react-intl": "^2.3.0",
+    "react-intl": "^2.4.0",
     "react-motion": "^0.5.0",
     "react-notification": "^6.7.1",
     "react-redux": "^5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3130,23 +3130,17 @@ intl-messageformat-parser@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.3.0.tgz#c5d26ffb894c7d9c2b9fa444c67f417ab2594268"
 
-intl-messageformat@1.3.0, intl-messageformat@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-1.3.0.tgz#f7d926aded7a3ab19b2dc601efd54e99a4bd4eae"
-  dependencies:
-    intl-messageformat-parser "1.2.0"
-
 intl-messageformat@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-2.0.0.tgz#3d56982583425aee23b76c8b985fb9b0aae5be3c"
   dependencies:
     intl-messageformat-parser "1.2.0"
 
-intl-relativeformat@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/intl-relativeformat/-/intl-relativeformat-1.3.0.tgz#893dc7076fccd380cf091a2300c380fa57ace45b"
+intl-messageformat@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-2.1.0.tgz#1c51da76f02a3f7b360654cdc51bbc4d3fa6c72c"
   dependencies:
-    intl-messageformat "1.3.0"
+    intl-messageformat-parser "1.2.0"
 
 intl-relativeformat@^2.0.0:
   version "2.0.0"
@@ -5312,13 +5306,13 @@ react-intl-translations-manager@^5.0.0:
     json-stable-stringify "^1.0.1"
     mkdirp "^0.5.1"
 
-react-intl@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.3.0.tgz#e1df6af5667fdf01cbe4aab20e137251e2ae5142"
+react-intl@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-2.4.0.tgz#66c14dc9df9a73b2fbbfbd6021726e80a613eb15"
   dependencies:
     intl-format-cache "^2.0.5"
-    intl-messageformat "^1.3.0"
-    intl-relativeformat "^1.3.0"
+    intl-messageformat "^2.1.0"
+    intl-relativeformat "^2.0.0"
     invariant "^2.1.1"
 
 react-motion@^0.5.0:


### PR DESCRIPTION
Update React Intl. [React Intl v2.4.0](https://github.com/yahoo/react-intl/releases/tag/v2.4.0) includes CLDR update (CLDR 28 -> CLDR 31). Defects in many languages have been fixed.

### Japanese case

version | &nbsp;
-|-
CLDR 28 | ![](https://user-images.githubusercontent.com/12539/30114148-edde65d2-9351-11e7-993d-94906bad4b7d.png)
CLDR 31 | ![](https://user-images.githubusercontent.com/12539/30114069-a7870058-9351-11e7-8d5c-cc33299761f0.png)
