### PR TITLE
Make timeline scroll position fixed when scrollpos != top (fix regression of #4697) 

### DIFF
--- a/app/javascript/mastodon/components/scrollable_list.js
+++ b/app/javascript/mastodon/components/scrollable_list.js
@@ -5,6 +5,7 @@ import IntersectionObserverArticle from './intersection_observer_article';
 import LoadMore from './load_more';
 import IntersectionObserverWrapper from '../features/ui/util/intersection_observer_wrapper';
 import { throttle } from 'lodash';
+import { List as ImmutableList } from 'immutable';
 
 export default class ScrollableList extends PureComponent {
 
@@ -95,7 +96,12 @@ export default class ScrollableList extends PureComponent {
 
   getFirstChildKey (props) {
     const { children } = props;
-    const firstChild = Array.isArray(children) ? children[0] : children;
+    let firstChild = children;
+    if (children instanceof ImmutableList) {
+      firstChild = children.get(0);
+    } else if (Array.isArray(children)) {
+      firstChild = children[0];
+    }
     return firstChild && firstChild.key;
   }
 


### PR DESCRIPTION
ScrollableList treats children as Array but children is Immutable.List.
So, scroll position fixation logic in ScrollableList does not work properly.
This PR fixes it and make scroll position fixed when new things arrived && scrollpos != top.