### PR TITLE
Feat add validation for report comment: characters under 1000 valid

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -22,6 +22,8 @@ class Report < ApplicationRecord
   scope :unresolved, -> { where(action_taken: false) }
   scope :resolved,   -> { where(action_taken: true) }
 
+  validates :comment, length: { maximum: 1000 }
+
   def statuses
     Status.where(id: status_ids).includes(:account, :media_attachments, :mentions)
   end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -21,4 +21,18 @@ describe Report do
       expect(report.media_attachments).to eq [media_attachment]
     end
   end
+
+  describe 'validatiions' do
+    it 'has a valid fabricator' do
+      report = Fabricate(:report)
+      report.valid?
+      expect(report).to be_valid
+    end
+
+    it 'is invalid if comment is longer than 1000 characters' do
+      report = Fabricate.build(:report, comment: Faker::Lorem.characters(1001))
+      report.valid?
+      expect(report).to model_have_error_on_field(:comment)
+    end
+  end
 end


### PR DESCRIPTION
Currently, the report has no restriction on comment length. So, I added characters validation(until 1000 characters) with tests

related #4725 