### PR TITLE
Enable UniqueRetryJobMiddleware even when called from sidekiq worker

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,6 +9,9 @@ end
 
 Sidekiq.configure_server do |config|
   config.redis = redis_params
+  config.client_middleware do |chain|
+    chain.add Mastodon::UniqueRetryJobMiddleware
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
In #4814 I noticed that it does not work properly when `Pubsubhubbub::SubscribeWorker` is called from `Scheduler::SubscriptionsScheduler`. In this PR, fixed the problem that UniqueRetryJobMiddleware does not work when workers are called from sidekick workers. 