### PR TITLE
Handle stream_entry URL correctly in ActivityPub

### DIFF
--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -96,12 +96,14 @@ class ActivityPub::TagManager
       when 'Account'
         klass.find_local(uri_to_local_id(uri, :username))
       else
-        klass.find_by(id: uri_to_local_id(uri))
+        StatusFinder.new(uri).status
       end
     elsif ::TagManager.instance.local_id?(uri)
       klass.find_by(id: ::TagManager.instance.unique_tag_to_local_id(uri, klass.to_s))
     else
       klass.find_by(uri: uri.split('#').first)
     end
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 end

--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -91,9 +91,35 @@ RSpec.describe ActivityPub::TagManager do
   end
 
   describe '#uri_to_resource' do
-    it 'returns the local resource' do
+    it 'returns the local account' do
       account = Fabricate(:account)
       expect(subject.uri_to_resource(subject.uri_for(account), Account)).to eq account
+    end
+
+    it 'returns the remote account by matching URI without fragment part' do
+      account = Fabricate(:account, uri: 'https://example.com/123')
+      expect(subject.uri_to_resource('https://example.com/123#456', Account)).to eq account
+    end
+
+    it 'returns the local status for ActivityPub URI' do
+      status = Fabricate(:status)
+      expect(subject.uri_to_resource(subject.uri_for(status), Status)).to eq status
+    end
+
+    it 'returns the local status for OStatus tag: URI' do
+      status = Fabricate(:status)
+      expect(subject.uri_to_resource(::TagManager.instance.uri_for(status), Status)).to eq status
+    end
+
+    it 'returns the local status for OStatus StreamEntry URL' do
+      status = Fabricate(:status)
+      stream_entry_url = account_stream_entry_url(status.account, status.stream_entry)
+      expect(subject.uri_to_resource(stream_entry_url, Status)).to eq status
+    end
+
+    it 'returns the remote status by matching URI without fragment part' do
+      status = Fabricate(:status, uri: 'https://example.com/123')
+      expect(subject.uri_to_resource('https://example.com/123#456', Status)).to eq status
     end
   end
 end


### PR DESCRIPTION
In before, the method uses stream_entry id as status id, so replied status was wrongly selected.

This PR uses StatusFinder which was introduced with `Api::Web::EmbedsController`.