### PR TITLE
Fix second report (regression from 3b81baaaaf51ff1c70fb1f865eef07fdb33a5950)

### DIFF
--- a/app/javascript/mastodon/reducers/reports.js
+++ b/app/javascript/mastodon/reducers/reports.js
@@ -28,7 +28,7 @@ export default function reports(state = initialState, action) {
       if (state.getIn(['new', 'account_id']) !== action.account.get('id')) {
         map.setIn(['new', 'status_ids'], action.status ? ImmutableSet([action.status.getIn(['reblog', 'id'], action.status.get('id'))]) : ImmutableSet());
         map.setIn(['new', 'comment'], '');
-      } else {
+      } else if (action.status) {
         map.updateIn(['new', 'status_ids'], ImmutableSet(), set => set.add(action.status.getIn(['reblog', 'id'], action.status.get('id'))));
       }
     });


### PR DESCRIPTION
### Steps to reproduce

1. open account detail (`/web/accounts/:account_id`)
2. click to `report @:account_username` in action bar from account header or status
3. one more click to `report @:account_username` in action bar from account header
4. modal can not be opened😢

### stack trace

```plain
Uncaught TypeError: Cannot read property 'getIn' of undefined
    at reports.js:32
    at Rt (immutable.js:1973)
    at Rt (immutable.js:1982)
    at Rt (immutable.js:1982)
    at lt.updateIn (immutable.js:1280)
    at reports.js:32
    at lt.withMutations (immutable.js:1355)
    at r (reports.js:24)
    at combineReducers.js:39
    at Array.forEach (<anonymous>)
```