### PR TITLE
Disable mouse-based pause from #4859

### DIFF
--- a/app/javascript/mastodon/components/scrollable_list.js
+++ b/app/javascript/mastodon/components/scrollable_list.js
@@ -74,7 +74,7 @@ export default class ScrollableList extends PureComponent {
 
     // Reset the scroll position when a new child comes in in order not to
     // jerk the scrollbar around if you're already scrolled down the page.
-    if (someItemInserted && this._oldScrollPosition && (this.node.scrollTop > 0 || this._recentlyMoved())) {
+    if (someItemInserted && this._oldScrollPosition && this.node.scrollTop > 0) {
       const newScrollTop = this.node.scrollHeight - this._oldScrollPosition;
 
       if (this.node.scrollTop !== newScrollTop) {


### PR DESCRIPTION
It wasn't working ideally and introduced some annoying false positivies

Sorry @lmorchard, looks like not in 1.6 :cry: 