### PR TITLE
Add OpenStack Keystone V3 support

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -101,11 +101,19 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # Swift (optional)
 # SWIFT_ENABLED=true
 # SWIFT_USERNAME=
+# For Keystone V3, the value for SWIFT_TENANT should be the project name
 # SWIFT_TENANT=
 # SWIFT_PASSWORD=
+# Keystone V2 and V3 URLs are supported. Use a V3 URL if possible to avoid
+# issues with token rate-limiting during high load.
 # SWIFT_AUTH_URL=
 # SWIFT_CONTAINER=
 # SWIFT_OBJECT_URL=
+# SWIFT_REGION=
+# Defaults to 'default'
+# SWIFT_DOMAIN_NAME=
+# Defaults to 60 seconds. Set to 0 to disable
+# SWIFT_CACHE_TTL=
 
 # Optional alias for S3 if you want to use Cloudfront or Cloudflare in front
 # S3_CLOUDFRONT_HOST=

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -47,9 +47,12 @@ elsif ENV['SWIFT_ENABLED'] == 'true'
     fog_credentials: {
       provider: 'OpenStack',
       openstack_username: ENV.fetch('SWIFT_USERNAME'),
-      openstack_tenant: ENV.fetch('SWIFT_TENANT'),
+      openstack_project_name: ENV.fetch('SWIFT_TENANT'),
       openstack_api_key: ENV.fetch('SWIFT_PASSWORD'),
       openstack_auth_url: ENV.fetch('SWIFT_AUTH_URL'),
+      openstack_domain_name: ENV['SWIFT_DOMAIN_NAME'] || 'default',
+      openstack_region: ENV['SWIFT_REGION'],
+      openstack_cache_ttl: ENV['SWIFT_CACHE_TTL'] || 60,
     },
     fog_directory: ENV.fetch('SWIFT_CONTAINER'),
     fog_host: ENV.fetch('SWIFT_OBJECT_URL'),


### PR DESCRIPTION
Keystone V2 is deprecated in favour of V3. This adds the necessary connection parameters for establishing a V3 connection. Connections to V2 endpoints are still possible and the configuration should remain compatible.

This also introduces a `SWIFT_REGION` variable for multi-region OpenStack environments and a `SWIFT_CACHE_TTL` that controls how long tokens and other meta-data is cached for. Caching tokens avoids rate-limiting errors that would result in media uploads becoming unavailable during high load or when using tasks like `media:remove_remote`. `fog-openstack` only supports token caching for V3 endpoints, so a recommendation for using V3 was added.