### PR TITLE
Merge context hash into final JSON hash after key transform, not before

### DIFF
--- a/app/lib/activitypub/adapter.rb
+++ b/app/lib/activitypub/adapter.rb
@@ -28,7 +28,7 @@ class ActivityPub::Adapter < ActiveModelSerializers::Adapter::Base
 
   def serializable_hash(options = nil)
     options = serialization_options(options)
-    serialized_hash = CONTEXT.merge(ActiveModelSerializers::Adapter::Attributes.new(serializer, instance_options).serializable_hash(options))
-    self.class.transform_key_casing!(serialized_hash, instance_options)
+    serialized_hash = ActiveModelSerializers::Adapter::Attributes.new(serializer, instance_options).serializable_hash(options)
+    CONTEXT.merge(self.class.transform_key_casing!(serialized_hash, instance_options))
   end
 end


### PR DESCRIPTION
Fix #4894 

Sadly, this is the kinda bug that will invalidate LD-signatures between the versions that have this bug and that don't. However, since the sigs are not truly critical yet... What do you do :man_shrugging: 