### PR TITLE
Fix count numbers from ActivityPub not being saved

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -172,6 +172,10 @@ class Account < ApplicationRecord
   end
 
   class << self
+    def readonly_attributes
+      super - %w(statuses_count following_count followers_count)
+    end
+
     def domains
       reorder(nil).pluck('distinct accounts.domain')
     end

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -90,9 +90,9 @@ namespace :mastodon do
 
     desc 'Set unknown attachment type for remote-only attachments'
     task set_unknown: :environment do
-      Rails.logger.debug 'Setting unknown attachment type for remote-only attachments...'
+      puts 'Setting unknown attachment type for remote-only attachments...'
       MediaAttachment.where(file_file_name: nil).where.not(type: :unknown).in_batches.update_all(type: :unknown)
-      Rails.logger.debug 'Done!'
+      puts 'Done!'
     end
 
     desc 'Redownload avatars/headers of remote users. Optionally limit to a particular domain with DOMAIN'
@@ -188,24 +188,24 @@ namespace :mastodon do
   namespace :maintenance do
     desc 'Update counter caches'
     task update_counter_caches: :environment do
-      Rails.logger.debug 'Updating counter caches for accounts...'
+      puts 'Updating counter caches for accounts...'
 
-      Account.unscoped.select('id').find_in_batches do |batch|
+      Account.unscoped.where.not(protocol: :activitypub).select('id').find_in_batches do |batch|
         Account.where(id: batch.map(&:id)).update_all('statuses_count = (select count(*) from statuses where account_id = accounts.id), followers_count = (select count(*) from follows where target_account_id = accounts.id), following_count = (select count(*) from follows where account_id = accounts.id)')
       end
 
-      Rails.logger.debug 'Updating counter caches for statuses...'
+      puts 'Updating counter caches for statuses...'
 
       Status.unscoped.select('id').find_in_batches do |batch|
         Status.where(id: batch.map(&:id)).update_all('favourites_count = (select count(*) from favourites where favourites.status_id = statuses.id), reblogs_count = (select count(*) from statuses as reblogs where reblogs.reblog_of_id = statuses.id)')
       end
 
-      Rails.logger.debug 'Done!'
+      puts 'Done!'
     end
 
     desc 'Generate static versions of GIF avatars/headers'
     task add_static_avatars: :environment do
-      Rails.logger.debug 'Generating static avatars/headers for GIF ones...'
+      puts 'Generating static avatars/headers for GIF ones...'
 
       Account.unscoped.where(avatar_content_type: 'image/gif').or(Account.unscoped.where(header_content_type: 'image/gif')).find_each do |account|
         begin
@@ -217,7 +217,7 @@ namespace :mastodon do
         end
       end
 
-      Rails.logger.debug 'Done!'
+      puts 'Done!'
     end
 
     desc 'Ensure referencial integrity'


### PR DESCRIPTION
They are marked as read-only by Rails, but we know what we are doing,
so we are un-marking them as such.

The mastodon:maintenance:update_counter_caches task is not really
supposed to be run anymore (it was a one-time thing during an upgrade)
however, just in case, I have modified it to not touch ActivityPub
accounts.

Also, no point writing to logger from these rake tasks, since they
are not to be run from cron. Better to give stdout feedback.