### PR TITLE
Specify libicu explicitly in Aptfile

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,4 +1,5 @@
 ffmpeg
+libicu[0-9][0-9]
 libicu-dev
 libidn11
 libidn11-dev


### PR DESCRIPTION
It seems `libicu-dev` no longer installs `libicu55` needed by `charlock_holmes` gem: https://gist.github.com/zunda/181df7ea0e5fba585738e9209eda57da

[This](https://mastodon.social/@Gargron/14057483) might also be related on other platforms.