### PR TITLE
Make instance names in `/admin/instances` into links to user list in the instance

### DIFF
--- a/app/views/admin/instances/_instance.html.haml
+++ b/app/views/admin/instances/_instance.html.haml
@@ -1,6 +1,6 @@
 %tr
   %td.domain
-    = instance.domain
+    = link_to instance.domain, admin_accounts_path(by_domain: instance.domain)
   %td.count
     = instance.accounts_count
   %td


### PR DESCRIPTION
<img width="748" alt="2017-09-13 17 58 06" src="https://user-images.githubusercontent.com/418982/30368746-24f72fbc-98ad-11e7-9ed9-d341ea1d23f4.png">

With this PR merged, you can see all users in the specific instnace by clicking instance's domain.