### PR TITLE
Fix race condition when receiving an ActivityPub Create multiple times

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -4,31 +4,30 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def perform
     return if delete_arrived_first?(object_uri) || unsupported_object_type?
 
-    status = find_existing_status
-
-    return status unless status.nil?
-
-    begin
-      ApplicationRecord.transaction do
-        status = Status.create!(status_params)
-
-        process_tags(status)
-        process_attachments(status)
+    RedisLock.acquire(lock_options) do |lock|
+      if lock.acquired?
+        @status = find_existing_status
+        process_status if @status.nil?
       end
-    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-      status = find_existing_status
-      raise e unless status
-      return status
     end
 
-    resolve_thread(status)
-    distribute(status)
-    forward_for_reply if status.public_visibility? || status.unlisted_visibility?
-
-    status
+    @status
   end
 
   private
+
+  def process_status
+    ApplicationRecord.transaction do
+      @status = Status.create!(status_params)
+
+      process_tags(@status)
+      process_attachments(@status)
+    end
+
+    resolve_thread(@status)
+    distribute(@status)
+    forward_for_reply if @status.public_visibility? || @status.unlisted_visibility?
+  end
 
   def find_existing_status
     status   = status_from_uri(object_uri)
@@ -187,5 +186,9 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def forward_for_reply
     return unless @json['signature'].present? && reply_to_local?
     ActivityPub::RawDistributionWorker.perform_async(Oj.dump(@json), replied_to_status.account_id)
+  end
+
+  def lock_options
+    { redis: Redis.current, key: "create:#{@object['id']}" }
   end
 end


### PR DESCRIPTION
Fixes #4905. The issue is that a same Create activity can be delivered multiple times to the same instance, and will be processed in concurrent tasks. The time from status processing to commit in the database is relatively long, which makes things worse and a race condition more likely to occur.

This proposed looks up the toot locally if an ActiveRecord exception is raised by the transaction. The reasoning behind the `raise e unless status` pattern is that we want to catch issues arising from the race condition, and not other issues, as I fear `ActiveRecord::RecordInvalid` might be too broad and catch unrelated exceptions.

(Or of course we may also use locks, but I have no experience with these in RoR)