### PR TITLE
Enable to recognize most kinds of characters as URL paths (Mainly for CJK)

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -131,7 +131,7 @@ class Formatter
   end
 
   def link_html(url)
-    url    = Addressable::URI.parse(url).display_uri.to_s
+    url    = Addressable::URI.parse(url).to_s
     prefix = url.match(/\Ahttps?:\/\/(www\.)?/).to_s
     text   = url[prefix.length, 30]
     suffix = url[prefix.length + 30..-1]

--- a/config/initializers/twitter_regex.rb
+++ b/config/initializers/twitter_regex.rb
@@ -1,0 +1,42 @@
+module Twitter
+  class Regex
+
+    REGEXEN[:valid_general_url_path_chars] = /[^\p{White_Space}\(\)\?]/iou
+    REGEXEN[:valid_url_path_ending_chars] = /[^\p{White_Space}\(\)\?!\*';:=\,\.\$%\[\]\p{Pd}_~&\|@]|(?:#{REGEXEN[:valid_url_balanced_parens]})/iou
+    REGEXEN[:valid_url_balanced_parens] = /
+      \(
+        (?:
+          #{REGEXEN[:valid_general_url_path_chars]}+
+          |
+          # allow one nested level of balanced parentheses
+          (?:
+            #{REGEXEN[:valid_general_url_path_chars]}*
+            \(
+              #{REGEXEN[:valid_general_url_path_chars]}+
+            \)
+            #{REGEXEN[:valid_general_url_path_chars]}*
+          )
+        )
+      \)
+    /iox
+    REGEXEN[:valid_url_path] = /(?:
+      (?:
+        #{REGEXEN[:valid_general_url_path_chars]}*
+        (?:#{REGEXEN[:valid_url_balanced_parens]} #{REGEXEN[:valid_general_url_path_chars]}*)*
+        #{REGEXEN[:valid_url_path_ending_chars]}
+      )|(?:#{REGEXEN[:valid_general_url_path_chars]}+\/)
+    )/iox
+    REGEXEN[:valid_url] = %r{
+      (                                                                                     #   $1 total match
+        (#{REGEXEN[:valid_url_preceding_chars]})                                            #   $2 Preceeding chracter
+        (                                                                                   #   $3 URL
+          (https?:\/\/)?                                                                    #   $4 Protocol (optional)
+          (#{REGEXEN[:valid_domain]})                                                       #   $5 Domain(s)
+          (?::(#{REGEXEN[:valid_port_number]}))?                                            #   $6 Port number (optional)
+          (/#{REGEXEN[:valid_url_path]}*)?                                                  #   $7 URL Path and anchor
+          (\?#{REGEXEN[:valid_url_query_chars]}*#{REGEXEN[:valid_url_query_ending_chars]})? #   $8 Query String
+        )
+      )
+    }iox
+  end
+end

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -89,6 +89,38 @@ RSpec.describe Formatter do
       end
     end
 
+    context 'matches a URL with Japanese path string' do
+      let(:text) { 'https://ja.wikipedia.org/wiki/日本' }
+
+      it 'has valid URL' do
+        is_expected.to include 'href="https://ja.wikipedia.org/wiki/%E6%97%A5%E6%9C%AC"'
+      end
+    end
+
+    context 'matches a URL with Korean path string' do
+      let(:text) { 'https://ko.wikipedia.org/wiki/대한민국' }
+
+      it 'has valid URL' do
+        is_expected.to include 'href="https://ko.wikipedia.org/wiki/%EB%8C%80%ED%95%9C%EB%AF%BC%EA%B5%AD"'
+      end
+    end
+
+    context 'matches a URL with Simplified Chinese path string' do
+      let(:text) { 'https://baike.baidu.com/item/中华人民共和国' }
+
+      it 'has valid URL' do
+        is_expected.to include 'href="https://baike.baidu.com/item/%E4%B8%AD%E5%8D%8E%E4%BA%BA%E6%B0%91%E5%85%B1%E5%92%8C%E5%9B%BD"'
+      end
+    end
+
+    context 'matches a URL with Traditional Chinese path string' do
+      let(:text) { 'https://zh.wikipedia.org/wiki/臺灣' }
+
+      it 'has valid URL' do
+        is_expected.to include 'href="https://zh.wikipedia.org/wiki/%E8%87%BA%E7%81%A3"'
+      end
+    end
+
     context 'contains HTML (script tag)' do
       let(:text) { '<script>alert("Hello")</script>' }
 

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe FetchLinkCardService do
     stub_request(:get, 'http://example.com/sjis_with_wrong_charset').to_return(request_fixture('sjis_with_wrong_charset.txt'))
     stub_request(:head, 'http://example.com/koi8-r').to_return(status: 200, headers: { 'Content-Type' => 'text/html' })
     stub_request(:get, 'http://example.com/koi8-r').to_return(request_fixture('koi8-r.txt'))
+    stub_request(:head, 'http://example.com/日本語').to_return(status: 200, headers: { 'Content-Type' => 'text/html' })
+    stub_request(:get, 'http://example.com/日本語').to_return(request_fixture('sjis.txt'))
     stub_request(:head, 'https://github.com/qbi/WannaCry').to_return(status: 404)
 
     subject.call(status)
@@ -50,6 +52,15 @@ RSpec.describe FetchLinkCardService do
       it 'works with koi8-r' do
         expect(a_request(:get, 'http://example.com/koi8-r')).to have_been_made.at_least_once
         expect(status.preview_cards.first.title).to eq("Московя начинаетъ только въ XVI ст. привлекать внимане иностранцевъ.")
+      end
+    end
+
+    context do
+      let(:status) { Fabricate(:status, text: 'テストhttp://example.com/日本語') }
+
+      it 'works with Japanese path string' do
+        expect(a_request(:get, 'http://example.com/日本語')).to have_been_made.at_least_once
+        expect(status.preview_cards.first.title).to eq("SJISのページ")
       end
     end
   end


### PR DESCRIPTION
Related #4837 

Currently, only ASCII (and Cyrillic) characters and several symbols are recognized as URL paths and automatically linked. The behavior is by design of [`twitter-text`](https://github.com/twitter/twitter-text/tree/master/rb) gem. However, [`FetchLinkCardService`](https://github.com/tootsuite/mastodon/blob/1618b68bfa740ed655ac45d7d5f4f46fed6c8c62/app/services/fetch_link_card_service.rb#L4) recognizes non-ASCII paths as a part of the URL.

![linkcard](https://user-images.githubusercontent.com/8458066/30418267-62f44690-996d-11e7-89bd-c2904bf21d92.PNG)
In the above example, `twitter-text` does not recognize "アイドルマスター" as a URL path, but FetchLinkCardService recognizes it and the LinkCard was generated correctly.

This PR solves inconsistency between them. In particular, **this enables to recognize most kinds of characters (of course including Chinese, Japanese, Korean) as URL paths.** The reasons for this change are as follows.

 1. Nowadays, many Japanese websites are using Japanese characters (Hiragana, Katakana and Kanji) in their URL, and I think many Korean or Chinese websites are using their own characters.
2. Usually, **percent-encoding** is used for URLs containing non-ASCII string, but we can not understand the encoded URL. (Can you understand what the following URL refers to? https://ja.wikipedia.org/wiki/%E6%97%A5%E6%9C%AC)
3. Dividing URLs and normal sentences by white-space is not so strange even in the CJK area. 　Unfortunately `twitter-text` does not think so :( Read [Here](https://github.com/twitter/twitter-text/tree/master/rb#urls). I think the design that URLs are not correctly recognized as URLs is a larger problem than `twitter-text` said.

After this change, the URL contains Japanese characters is shown like the following image.
![2017-09-11 2](https://user-images.githubusercontent.com/8458066/30265335-d4070de4-9716-11e7-8654-0e3bd75366bb.png)

The problem that FetchLinkCardService recognizes multiple URLs separated by double-byte space as a single URL has also been resolved.

Also, this modification passes all existing and additional test cases.

If you can read Japanese, please also read [here](https://github.com/imas/mastodon/issues/57).
日本語が読める方は[こちら](https://github.com/imas/mastodon/issues/57)もお読みください。

- [x] Enable to recognize most kinds of characters as URL paths
- [x] Solve the problem in FetchLinkCardService
- [x] Add some test cases