### PR TITLE
Include requested URL into the message on network errors

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -31,6 +31,8 @@ class Request
 
   def perform
     http_client.headers(headers).public_send(@verb, @url.to_s, @options)
+  rescue => e
+    raise e.class, "#{e.message} on #{@url}"
   end
 
   def headers


### PR DESCRIPTION
For ProcessingWorker, we need to read stacktrace and arguments to know where the network error was occurred. Also in NotificationWorker, we can't know it from Sidekiq web UI because that worker doesn't log stacktrace.

So this PR adds requested URL into the error message like we did at #4281. This will pretty helps admin to check overview and details of those errors.

Before

![image](https://user-images.githubusercontent.com/705555/30432514-decc8c08-999c-11e7-906c-bc854fef204a.png)

After

![image](https://user-images.githubusercontent.com/705555/30432480-cae7a9d4-999c-11e7-80f3-7eead2354604.png)