### PR TITLE
Use OrderedCollectionPage in followers/following list

### DIFF
--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -17,12 +17,29 @@ class FollowerAccountsController < ApplicationController
 
   private
 
+  def page_url(page)
+    account_followers_url(@account, page: page) unless page.nil?
+  end
+
   def collection_presenter
-    ActivityPub::CollectionPresenter.new(
-      id: account_followers_url(@account),
+    page = ActivityPub::CollectionPresenter.new(
+      id: account_followers_url(@account, page: params.fetch(:page, 1)),
       type: :ordered,
       size: @account.followers_count,
-      items: @follows.map { |f| ActivityPub::TagManager.instance.uri_for(f.account) }
+      items: @follows.map { |f| ActivityPub::TagManager.instance.uri_for(f.account) },
+      part_of: account_followers_url(@account),
+      next: page_url(@follows.next_page),
+      prev: page_url(@follows.prev_page)
     )
+    if params[:page].present?
+      page
+    else
+      ActivityPub::CollectionPresenter.new(
+        id: account_followers_url(@account),
+        type: :ordered,
+        size: @account.followers_count,
+        first: page
+      )
+    end
   end
 end

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -17,12 +17,29 @@ class FollowingAccountsController < ApplicationController
 
   private
 
+  def page_url(page)
+    account_following_index_url(@account, page: page) unless page.nil?
+  end
+
   def collection_presenter
-    ActivityPub::CollectionPresenter.new(
-      id: account_following_index_url(@account),
+    page = ActivityPub::CollectionPresenter.new(
+      id: account_following_index_url(@account, page: params.fetch(:page, 1)),
       type: :ordered,
       size: @account.following_count,
-      items: @follows.map { |f| ActivityPub::TagManager.instance.uri_for(f.target_account) }
+      items: @follows.map { |f| ActivityPub::TagManager.instance.uri_for(f.target_account) },
+      part_of: account_following_index_url(@account),
+      next: page_url(@follows.next_page),
+      prev: page_url(@follows.prev_page)
     )
+    if params[:page].present?
+      page
+    else
+      ActivityPub::CollectionPresenter.new(
+        id: account_following_index_url(@account),
+        type: :ordered,
+        size: @account.following_count,
+        first: page
+      )
+    end
   end
 end

--- a/app/presenters/activitypub/collection_presenter.rb
+++ b/app/presenters/activitypub/collection_presenter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ActivityPub::CollectionPresenter < ActiveModelSerializers::Model
-  attributes :id, :type, :size, :items
+  attributes :id, :type, :size, :items, :part_of, :first, :next, :prev
 end

--- a/app/serializers/activitypub/collection_serializer.rb
+++ b/app/serializers/activitypub/collection_serializer.rb
@@ -3,23 +3,38 @@
 class ActivityPub::CollectionSerializer < ActiveModel::Serializer
   def self.serializer_for(model, options)
     return ActivityPub::ActivitySerializer if model.class.name == 'Status'
+    return ActivityPub::CollectionSerializer if model.class.name == 'ActivityPub::CollectionPresenter'
     super
   end
 
   attributes :id, :type, :total_items
+  attribute :next, if: -> { object.next.present? }
+  attribute :prev, if: -> { object.prev.present? }
+  attribute :part_of, if: -> { object.part_of.present? }
 
-  has_many :items, key: :ordered_items
+  has_one :first, if: -> { object.first.present? }
+  has_many :items, key: :items, if: -> { (object.items.present? || page?) && !ordered? }
+  has_many :items, key: :ordered_items, if: -> { (object.items.present? || page?) && ordered? }
 
   def type
-    case object.type
-    when :ordered
-      'OrderedCollection'
+    if page?
+      ordered? ? 'OrderedCollectionPage' : 'CollectionPage'
     else
-      'Collection'
+      ordered? ? 'OrderedCollection' : 'Collection'
     end
   end
 
   def total_items
     object.size
+  end
+
+  private
+
+  def ordered?
+    object.type == :ordered
+  end
+
+  def page?
+    object.part_of.present?
   end
 end


### PR DESCRIPTION
Currently, `/users/:username/followers` and `/users/:username/following` with the request header `Accept: application/activity+json` (In other words, when you are trying to fetch them in an Activity Streams 2 object's form) return an `OrderedCollection` while they return a part of followers/following collection and it seems they should treat pagination properly through `OrderedCollectionPage`, so I'm trying to implement this modification. However, there are few available examples of `OrderedCollectionPage` and I'm not sure my understanding is correct. So, I want to hear the other people's opinion.

If we can fetch followers/following collection via Activity Streams 2, we can fetch all of the relationships of a remote account in the standard way, and show them in the web UI. I think it's important because the current behavior, in which we can see only the relationships that are concerned with a local account for remote account, is preventing the Mastodon users from remote following the remote accounts which are not in the federated timeline. 

c.f. https://mstdn.jp/@nullkal/40976989