### PR TITLE
Add scheduled worker to purge old user IPs

### DIFF
--- a/app/workers/scheduler/ip_cleanup_scheduler.rb
+++ b/app/workers/scheduler/ip_cleanup_scheduler.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'sidekiq-scheduler'
+
+class Scheduler::IpCleanupScheduler
+  include Sidekiq::Worker
+
+  def perform
+    time_ago = 5.years.ago
+    SessionActivation.where('updated_at < ?', time_ago).destroy_all
+    User.where('last_sign_in_at < ?', time_ago).update_all(:last_sign_in_ip => nil)
+  end
+end

--- a/app/workers/scheduler/ip_cleanup_scheduler.rb
+++ b/app/workers/scheduler/ip_cleanup_scheduler.rb
@@ -7,6 +7,6 @@ class Scheduler::IpCleanupScheduler
   def perform
     time_ago = 5.years.ago
     SessionActivation.where('updated_at < ?', time_ago).destroy_all
-    User.where('last_sign_in_at < ?', time_ago).update_all(:last_sign_in_ip => nil)
+    User.where('last_sign_in_at < ?', time_ago).update_all(last_sign_in_ip: nil)
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -24,3 +24,6 @@
   subscriptions_cleanup_scheduler:
     cron: '2 2 * * 0'
     class: Scheduler::SubscriptionsCleanupScheduler
+  ip_cleanup_scheduler:
+    cron: '0 4 * * *'
+    class: Scheduler::IpCleanupScheduler


### PR DESCRIPTION
Partially fixes #4886. We still need to update the deployment guides with info on setting up logrotate to purge old server logs.