### PR TITLE
When accessing uncached media attachment, redownload it

### DIFF
--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class MediaProxyController < ApplicationController
+  include RoutingHelper
+
+  def show
+    RedisLock.acquire(lock_options) do |lock|
+      if lock.acquired?
+        @media_attachment = MediaAttachment.remote.find(params[:id])
+        redownload! if @media_attachment.needs_redownload?
+      end
+    end
+
+    redirect_to full_asset_url(@media_attachment.file.url(version))
+  end
+
+  private
+
+  def redownload!
+    @media_attachment.file_remote_url = @media_attachment.remote_url
+    @media_attachment.touch(:created_at)
+    @media_attachment.save!
+  end
+
+  def version
+    if request.path.ends_with?('/small')
+      :small
+    else
+      :original
+    end
+  end
+
+  def lock_options
+    { redis: Redis.current, key: "media_download:#{params[:id]}" }
+  end
+end

--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -7,7 +7,7 @@ class MediaProxyController < ApplicationController
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?
         @media_attachment = MediaAttachment.remote.find(params[:id])
-        redownload! if @media_attachment.needs_redownload?
+        redownload! if @media_attachment.needs_redownload? && !reject_media?
       end
     end
 
@@ -32,5 +32,9 @@ class MediaProxyController < ApplicationController
 
   def lock_options
     { redis: Redis.current, key: "media_download:#{params[:id]}" }
+  end
+
+  def reject_media?
+    DomainBlock.find_by(domain: @media_attachment.account.domain)&.reject_media?
   end
 end

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -56,13 +56,19 @@ class MediaAttachment < ApplicationRecord
 
   validates :account, presence: true
 
-  scope :attached, -> { where.not(status_id: nil) }
+  scope :attached,   -> { where.not(status_id: nil) }
   scope :unattached, -> { where(status_id: nil) }
-  scope :local, -> { where(remote_url: '') }
+  scope :local,      -> { where(remote_url: '') }
+  scope :remote,     -> { where.not(remote_url: '') }
+
   default_scope { order(id: :asc) }
 
   def local?
     remote_url.blank?
+  end
+
+  def needs_redownload?
+    file.blank? && remote_url.present?
   end
 
   def to_param

--- a/app/serializers/rest/media_attachment_serializer.rb
+++ b/app/serializers/rest/media_attachment_serializer.rb
@@ -7,11 +7,19 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
              :remote_url, :text_url, :meta
 
   def url
-    full_asset_url(object.file.url(:original))
+    if object.needs_redownload?
+      media_proxy_url(object.id, :original)
+    else
+      full_asset_url(object.file.url(:original))
+    end
   end
 
   def preview_url
-    full_asset_url(object.file.url(:small))
+    if object.needs_redownload?
+      media_proxy_url(object.id, :small)
+    else
+      full_asset_url(object.file.url(:small))
+    end
   end
 
   def text_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,8 @@ Rails.application.routes.draw do
   resources :media, only: [:show]
   resources :tags,  only: [:show]
 
+  get '/media_proxy/:id/(*any)', to: 'media_proxy#show', as: :media_proxy
+
   # Remote follow
   resource :authorize_follow, only: [:show, :create]
   resource :share, only: [:show, :create]

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -83,7 +83,6 @@ namespace :mastodon do
 
       MediaAttachment.where.not(remote_url: '').where('created_at < ?', time_ago).find_each do |media|
         media.file.destroy
-        media.type = :unknown
         media.save
       end
     end


### PR DESCRIPTION
- When local cache of media attachment is missing, API returns URL of media-proxy instead of static file. When this media-proxy is accessed, the cache is redownloaded from original URL (a lock ensures this only happens once). This is also not done for local or already downloaded attachments. Then the request redirects to the new static URL. The created_at of the media attachment is updated to prevent it to be swiped by mastodon:media:remove_remote again.
- No longer set attachments type to "unknown" during mastodon:media:remove_remote, this means apps can access the media-proxy transparently from image view/video player/etc without having to know the attachment had been uncached