### PR TITLE
Fix AP serialization error when thread is missing

### DIFF
--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -27,7 +27,7 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   end
 
   def in_reply_to
-    return unless object.reply?
+    return unless object.reply? && !object.thread.nil?
 
     if object.thread.uri.nil? || object.thread.uri.start_with?('http')
       ActivityPub::TagManager.instance.uri_for(object.thread)
@@ -67,7 +67,7 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   end
 
   def in_reply_to_atom_uri
-    return unless object.reply?
+    return unless object.reply? && !object.thread.nil?
 
     ::TagManager.instance.uri_for(object.thread)
   end


### PR DESCRIPTION
`Status#reply?` may returns true even if the thread is missing.
e.g. the replied status was deleted or couldn't be fetched.

Then it raises NoMethodError on various AP json serialization.

This issue won't happen on Atom serialization because it checks thread existence using `StreamEntry#threaded?` instead.