### PR TITLE
Add a new ProfileChange notification type (fixes #4108)

### DIFF
--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -23,6 +23,7 @@ class Api::Web::PushSubscriptionsController < Api::BaseController
       alerts: {
         follow: alerts_enabled,
         favourite: alerts_enabled,
+        profile_change: alerts_enabled,
         reblog: alerts_enabled,
         mention: alerts_enabled,
       },

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -46,6 +46,9 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
       notification,
       account: notification.account,
       status: notification.status,
+      display_name: notification.display_name,
+      avatar: notification.avatar,
+      avatar_static: notification.avatar_static,
       meta: playSound ? { sound: 'boop' } : undefined,
     });
 

--- a/app/javascript/mastodon/components/profile_change.js
+++ b/app/javascript/mastodon/components/profile_change.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import PropTypes from 'prop-types';
+import Avatar from './avatar';
+import DisplayName from './display_name';
+import Permalink from './permalink';
+import { injectIntl } from 'react-intl';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+@injectIntl
+export default class ProfileChange extends ImmutablePureComponent {
+
+  static propTypes = {
+    account: ImmutablePropTypes.map.isRequired,
+    profileChange: ImmutablePropTypes.map.isRequired,
+    intl: PropTypes.object.isRequired,
+    hidden: PropTypes.bool,
+  };
+
+  render () {
+    const { account, profileChange, hidden } = this.props;
+
+    if (!account) {
+      return <div />;
+    }
+
+    if (hidden) {
+      return (
+        <div>
+          {account.get('display_name')}
+          {account.get('username')}
+        </div>
+      );
+    }
+
+    // TODO: better UI and RTL support
+    return (
+      <div className='account'>
+        <div className='account__wrapper'>
+          <Permalink key={account.get('id')+'-old'} className='account__display-name' href={account.get('url')} to={`/accounts/${account.get('id')}`}>
+            <div className='account__avatar-wrapper'><Avatar account={profileChange} size={48} /></div>
+            <DisplayName account={profileChange} />
+          </Permalink>
+
+          <span style={{ margin: 'auto' }}>⇒</span>
+
+          <Permalink key={account.get('id')} className='account__display-name' href={account.get('url')} to={`/accounts/${account.get('id')}`}>
+            <div className='account__avatar-wrapper'><Avatar account={account} size={48} /></div>
+            <DisplayName account={account} />
+          </Permalink>
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/containers/profile_change_container.js
+++ b/app/javascript/mastodon/containers/profile_change_container.js
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+import { injectIntl } from 'react-intl';
+import { makeGetAccount } from '../selectors';
+import ProfileChange from '../components/profile_change';
+
+const makeMapStateToProps = () => {
+  const getAccount = makeGetAccount();
+
+  const mapStateToProps = (state, props) => ({
+    account: getAccount(state, props.id),
+  });
+
+  return mapStateToProps;
+};
+
+export default injectIntl(connect(makeMapStateToProps)(ProfileChange));

--- a/app/javascript/mastodon/features/notifications/components/column_settings.js
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.js
@@ -47,6 +47,17 @@ export default class ColumnSettings extends React.PureComponent {
           </div>
         </div>
 
+        <div role='group' aria-labelledby='notifications-profile_change'>
+          <span id='notifications-follow' className='column-settings__section'><FormattedMessage id='notifications.column_settings.profile_change' defaultMessage='Avatar/name change:' /></span>
+
+          <div className='column-settings__row'>
+            <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'profile_change']} onChange={onChange} label={alertStr} />
+            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'profile_change']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
+            <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'profile_change']} onChange={onChange} label={showStr} />
+            <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'profile_change']} onChange={onChange} label={soundStr} />
+          </div>
+        </div>
+
         <div role='group' aria-labelledby='notifications-favourite'>
           <span id='notifications-favourite' className='column-settings__section'><FormattedMessage id='notifications.column_settings.favourite' defaultMessage='Favourites:' /></span>
 

--- a/app/javascript/mastodon/features/notifications/components/notification.js
+++ b/app/javascript/mastodon/features/notifications/components/notification.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import StatusContainer from '../../../containers/status_container';
 import AccountContainer from '../../../containers/account_container';
+import ProfileChangeContainer from '../../../containers/profile_change_container';
 import { FormattedMessage } from 'react-intl';
 import Permalink from '../../../components/permalink';
 import ImmutablePureComponent from 'react-immutable-pure-component';
@@ -129,6 +130,22 @@ export default class Notification extends ImmutablePureComponent {
     );
   }
 
+  renderProfileChange (notification, link) {
+    return (
+      <div className='notification notification-profile_change'>
+        <div className='notification__message'>
+          <div className='notification__favourite-icon-wrapper'>
+            <i className='fa fa-fw fa-pencil' />
+          </div>
+
+          <FormattedMessage id='notification.profile_change' defaultMessage='{name} changed name or avatar' values={{ name: link }} />
+        </div>
+
+        <ProfileChangeContainer id={notification.get('account').get('id')} profileChange={notification} withNote={false} hidden={this.props.hidden} />
+      </div>
+    );
+  }
+
   render () {
     const { notification } = this.props;
     const account          = notification.get('account');
@@ -144,6 +161,8 @@ export default class Notification extends ImmutablePureComponent {
       return this.renderFavourite(notification, link);
     case 'reblog':
       return this.renderReblog(notification, link);
+    case 'profile_change':
+      return this.renderProfileChange(notification, link);
     }
 
     return null;

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -126,6 +126,7 @@
   "notifications.column_settings.favourite": "Favourites:",
   "notifications.column_settings.follow": "New followers:",
   "notifications.column_settings.mention": "Mentions:",
+  "notifications.column_settings.profile_change": "Name/avatar changes:",
   "notifications.column_settings.push": "Push notifications",
   "notifications.column_settings.push_meta": "This device",
   "notifications.column_settings.reblog": "Boosts:",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -118,6 +118,7 @@
   "notification.favourite": "{name} favourited your status",
   "notification.follow": "{name} followed you",
   "notification.mention": "{name} mentioned you",
+  "notification.profile_change": "{name} changed name or avatar",
   "notification.reblog": "{name} boosted your status",
   "notifications.clear": "Clear notifications",
   "notifications.clear_confirmation": "Are you sure you want to permanently clear all your notifications?",

--- a/app/javascript/mastodon/locales/fr.json
+++ b/app/javascript/mastodon/locales/fr.json
@@ -118,6 +118,7 @@
   "notification.favourite": "{name} a ajouté à ses favoris :",
   "notification.follow": "{name} vous suit.",
   "notification.mention": "{name} vous a mentionné⋅e :",
+  "notification.profile_change": "{name} a changé de nom ou d'avatar",
   "notification.reblog": "{name} a partagé votre statut :",
   "notifications.clear": "Nettoyer",
   "notifications.clear_confirmation": "Voulez-vous vraiment supprimer toutes vos notifications ?",

--- a/app/javascript/mastodon/locales/fr.json
+++ b/app/javascript/mastodon/locales/fr.json
@@ -126,6 +126,7 @@
   "notifications.column_settings.favourite": "Favoris :",
   "notifications.column_settings.follow": "Nouveaux⋅elles abonné⋅e⋅s :",
   "notifications.column_settings.mention": "Mentions :",
+  "notifications.column_settings.profile_change": "Changements de nom ou d'avatar :",
   "notifications.column_settings.push": "Notifications push",
   "notifications.column_settings.push_meta": "Cet appareil",
   "notifications.column_settings.reblog": "Partages :",

--- a/app/javascript/mastodon/reducers/notifications.js
+++ b/app/javascript/mastodon/reducers/notifications.js
@@ -14,7 +14,9 @@ import {
   ACCOUNT_MUTE_SUCCESS,
 } from '../actions/accounts';
 import { TIMELINE_DELETE } from '../actions/timelines';
+import emojify from '../features/emoji/emoji';
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+import escapeTextContentForBrowser from 'escape-html';
 
 const initialState = ImmutableMap({
   items: ImmutableList(),
@@ -29,6 +31,10 @@ const notificationToMap = notification => ImmutableMap({
   id: notification.id,
   type: notification.type,
   account: notification.account.id,
+  avatar: notification.avatar,
+  avatar_static: notification.avatar_static,
+  display_name_html: emojify(escapeTextContentForBrowser(notification.display_name)),
+  acct: notification.account.acct,
   status: notification.status ? notification.status.id : null,
 });
 

--- a/app/javascript/mastodon/reducers/push_notifications.js
+++ b/app/javascript/mastodon/reducers/push_notifications.js
@@ -6,6 +6,7 @@ const initialState = Immutable.Map({
   subscription: null,
   alerts: new Immutable.Map({
     follow: false,
+    profile_change: true,
     favourite: false,
     reblog: false,
     mention: false,

--- a/app/javascript/mastodon/reducers/settings.js
+++ b/app/javascript/mastodon/reducers/settings.js
@@ -26,6 +26,7 @@ const initialState = ImmutableMap({
   notifications: ImmutableMap({
     alerts: ImmutableMap({
       follow: true,
+      profile_change: true,
       favourite: true,
       reblog: true,
       mention: true,
@@ -33,6 +34,7 @@ const initialState = ImmutableMap({
 
     shows: ImmutableMap({
       follow: true,
+      profile_change: true,
       favourite: true,
       reblog: true,
       mention: true,
@@ -40,6 +42,7 @@ const initialState = ImmutableMap({
 
     sounds: ImmutableMap({
       follow: true,
+      profile_change: true,
       favourite: true,
       reblog: true,
       mention: true,

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -22,6 +22,7 @@ class Notification < ApplicationRecord
     follow:         'Follow',
     follow_request: 'FollowRequest',
     favourite:      'Favourite',
+    profile_change: 'ProfileChange',
   }.freeze
 
   STATUS_INCLUDES = [:account, :stream_entry, :media_attachments, :tags, mentions: :account, reblog: [:stream_entry, :account, :media_attachments, :tags, mentions: :account]].freeze
@@ -35,6 +36,7 @@ class Notification < ApplicationRecord
   belongs_to :follow,         foreign_type: 'Follow',        foreign_key: 'activity_id'
   belongs_to :follow_request, foreign_type: 'FollowRequest', foreign_key: 'activity_id'
   belongs_to :favourite,      foreign_type: 'Favourite',     foreign_key: 'activity_id'
+  belongs_to :profile_change, foreign_type: 'ProfileChange', foreign_key: 'activity_id'
 
   validates :account_id, uniqueness: { scope: [:activity_type, :activity_id] }
   validates :activity_type, inclusion: { in: TYPE_CLASS_MAP.values }
@@ -46,7 +48,7 @@ class Notification < ApplicationRecord
     where(activity_type: types)
   }
 
-  cache_associated :from_account, status: STATUS_INCLUDES, mention: [status: STATUS_INCLUDES], favourite: [:account, status: STATUS_INCLUDES], follow: :account
+  cache_associated :from_account, status: STATUS_INCLUDES, mention: [status: STATUS_INCLUDES], favourite: [:account, status: STATUS_INCLUDES], follow: :account, profile_change: :account
 
   def type
     @type ||= TYPE_CLASS_MAP.invert[activity_type].to_sym
@@ -94,7 +96,7 @@ class Notification < ApplicationRecord
     return unless new_record?
 
     case activity_type
-    when 'Status', 'Follow', 'Favourite', 'FollowRequest'
+    when 'Status', 'Follow', 'Favourite', 'FollowRequest', 'ProfileChange'
       self.from_account_id = activity&.account_id
     when 'Mention'
       self.from_account_id = activity&.status&.account_id

--- a/app/models/profile_change.rb
+++ b/app/models/profile_change.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: profile_changes
+#
+#  id                  :integer          not null, primary key
+#  account_id          :integer          not null
+#  avatar_file_name    :string
+#  avatar_content_type :string
+#  avatar_file_size    :integer
+#  avatar_updated_at   :datetime
+#  display_name        :string           default(""), not null
+#
+
+class ProfileChange < ApplicationRecord
+  include AccountAvatar
+
+  belongs_to :account, required: true
+
+  has_many :notifications, as: :activity, dependent: :destroy
+
+  validates :account_id, presence: true, uniqueness: true
+end

--- a/app/serializers/rest/notification_serializer.rb
+++ b/app/serializers/rest/notification_serializer.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class REST::NotificationSerializer < ActiveModel::Serializer
+  include RoutingHelper
+
   attributes :id, :type, :created_at
+  attribute :avatar, if: :profile_type?
+  attribute :avatar_static, if: :profile_type?
+  attribute :display_name, if: :profile_type?
 
   belongs_to :from_account, key: :account, serializer: REST::AccountSerializer
   belongs_to :target_status, key: :status, if: :status_type?, serializer: REST::StatusSerializer
@@ -12,5 +17,21 @@ class REST::NotificationSerializer < ActiveModel::Serializer
 
   def status_type?
     [:favourite, :reblog, :mention].include?(object.type)
+  end
+
+  def profile_type?
+    object.type == :profile_change
+  end
+
+  def display_name
+    object.activity.display_name
+  end
+
+  def avatar
+    full_asset_url(object.activity.avatar_original_url)
+  end
+
+  def avatar_static
+    full_asset_url(object.activity.avatar_static_url)
   end
 end

--- a/app/serializers/web/notification_serializer.rb
+++ b/app/serializers/web/notification_serializer.rb
@@ -31,6 +31,8 @@ class Web::NotificationSerializer < ActiveModel::Serializer
         web_url("statuses/#{object.target_status.id}")
       when :follow
         web_url("accounts/#{object.from_account.id}")
+      when :profile_change
+        web_url("accounts/#{object.from_account.id}")
       when :favourite
         web_url("statuses/#{object.target_status.id}")
       when :reblog
@@ -68,6 +70,8 @@ class Web::NotificationSerializer < ActiveModel::Serializer
       when :mention
         object.target_status.text
       when :follow
+        object.from_account.note
+      when :profile_change
         object.from_account.note
       when :favourite
         object.target_status.text
@@ -129,6 +133,8 @@ class Web::NotificationSerializer < ActiveModel::Serializer
       I18n.t('push_notifications.mention.title', name: name)
     when :follow
       I18n.t('push_notifications.follow.title', name: name)
+    when :profile_change
+      I18n.t('push_notifications.profile_change.title', name: name)
     when :favourite
       I18n.t('push_notifications.favourite.title', name: name)
     when :reblog

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -23,12 +23,13 @@ class ActivityPub::ProcessAccountService < BaseService
 
         create_account if @account.nil?
         update_account
+
+        notify_profile_change
       end
     end
 
     after_protocol_change! if protocol_changed?
     after_key_change! if key_changed?
-    notify_profile_change
 
     @account
   rescue Oj::ParseError

--- a/app/services/concerns/profile_change_notifier.rb
+++ b/app/services/concerns/profile_change_notifier.rb
@@ -2,13 +2,18 @@
 
 module ProfileChangeNotifier
   def prepare_profile_change(account)
+    return unless notify_profile_change_recipients(account).exists?
     ProfileChange.where(account: account).destroy_all
     @profile_change = ProfileChange.create!(account: account, avatar: account.avatar, display_name: account.display_name)
   end
 
+  def notify_profile_change_recipients(account)
+    account.followers.local
+  end
+
   def notify_profile_change
     return if @profile_change.nil?
-    @profile_change.account.followers.local.find_each do |follower|
+    notify_profile_change_recipients(@profile_change.account).find_each do |follower|
       NotifyService.new.call(follower, @profile_change)
     end
   end

--- a/app/services/concerns/profile_change_notifier.rb
+++ b/app/services/concerns/profile_change_notifier.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ProfileChangeNotifier
+  def prepare_profile_change(account)
+    ProfileChange.where(account: account).destroy_all
+    @profile_change = ProfileChange.create!(account: account, avatar: account.avatar, display_name: account.display_name)
+  end
+
+  def notify_profile_change
+    return if @profile_change.nil?
+    @profile_change.account.followers.local.find_each do |follower|
+      NotifyService.new.call(follower, @profile_change)
+    end
+  end
+end

--- a/app/services/concerns/profile_change_notifier.rb
+++ b/app/services/concerns/profile_change_notifier.rb
@@ -3,6 +3,7 @@
 module ProfileChangeNotifier
   def prepare_profile_change(account)
     return unless notify_profile_change_recipients(account).exists?
+
     ProfileChange.where(account: account).destroy_all
     @profile_change = ProfileChange.create!(account: account, avatar: account.avatar, display_name: account.display_name)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -457,6 +457,8 @@ en:
       action_expand: Show more
       action_favourite: Favourite
       title: "%{name} mentioned you"
+    profile_change:
+      title: "%{name} changed name or avatar"
     reblog:
       title: "%{name} boosted your status"
   remote_follow:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -436,6 +436,8 @@ fr:
       action_expand: Montrer plus
       action_favourite: Ajouter aux favoris
       title: "%{name} vous a mentionné·e"
+    profile_change:
+      title: "%{name} a changé de nom ou d'avatar"
     reblog:
       title: "%{name} a partagé votre statut"
   remote_follow:

--- a/db/migrate/20171118115432_create_profile_change.rb
+++ b/db/migrate/20171118115432_create_profile_change.rb
@@ -6,6 +6,12 @@ class CreateProfileChange < ActiveRecord::Migration[5.1]
       t.string "display_name", default: "", null: false
     end
 
+    reversible do |dir|
+      dir.down do
+          Notification.where(activity_type: 'ProfileChange').delete_all
+      end
+    end
+
     add_foreign_key :profile_changes, :accounts, column: :account_id, on_delete: :cascade
     add_index :profile_changes, :account_id, unique: true
   end

--- a/db/migrate/20171118115432_create_profile_change.rb
+++ b/db/migrate/20171118115432_create_profile_change.rb
@@ -7,5 +7,6 @@ class CreateProfileChange < ActiveRecord::Migration[5.1]
     end
 
     add_foreign_key :profile_changes, :accounts, column: :account_id, on_delete: :cascade
+    add_index :profile_changes, :account_id, unique: true
   end
 end

--- a/db/migrate/20171118115432_create_profile_change.rb
+++ b/db/migrate/20171118115432_create_profile_change.rb
@@ -1,0 +1,11 @@
+class CreateProfileChange < ActiveRecord::Migration[5.1]
+  def change
+    create_table :profile_changes do |t|
+      t.bigint :account_id, null: false
+      t.attachment :avatar
+      t.string "display_name", default: "", null: false
+    end
+
+    add_foreign_key :profile_changes, :accounts, column: :account_id, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -314,6 +314,7 @@ ActiveRecord::Schema.define(version: 20171118115432) do
     t.integer "avatar_file_size"
     t.datetime "avatar_updated_at"
     t.string "display_name", default: "", null: false
+    t.index ["account_id"], name: "index_profile_changes_on_account_id", unique: true
   end
 
   create_table "reports", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171116161857) do
+ActiveRecord::Schema.define(version: 20171118115432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -307,6 +307,15 @@ ActiveRecord::Schema.define(version: 20171116161857) do
     t.index ["status_id", "preview_card_id"], name: "index_preview_cards_statuses_on_status_id_and_preview_card_id"
   end
 
+  create_table "profile_changes", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.string "avatar_file_name"
+    t.string "avatar_content_type"
+    t.integer "avatar_file_size"
+    t.datetime "avatar_updated_at"
+    t.string "display_name", default: "", null: false
+  end
+
   create_table "reports", force: :cascade do |t|
     t.bigint "status_ids", default: [], null: false, array: true
     t.text "comment", default: "", null: false
@@ -514,6 +523,7 @@ ActiveRecord::Schema.define(version: 20171116161857) do
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id", name: "fk_f5fc4c1ee3", on_delete: :cascade
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id", name: "fk_e84df68546", on_delete: :cascade
   add_foreign_key "oauth_applications", "users", column: "owner_id", name: "fk_b0988c7c0a", on_delete: :cascade
+  add_foreign_key "profile_changes", "accounts", on_delete: :cascade
   add_foreign_key "reports", "accounts", column: "action_taken_by_account_id", name: "fk_bca45b75fd", on_delete: :nullify
   add_foreign_key "reports", "accounts", column: "target_account_id", name: "fk_eb37af34f0", on_delete: :cascade
   add_foreign_key "reports", "accounts", name: "fk_4b81f7522c", on_delete: :cascade


### PR DESCRIPTION
This Pull Request introduces a new notification type for when people you follow change their name or profile picture.

There are still a few things to sort out:
- This is the first notification for transient information, whereas all previous notifications are backed by long-lived activity records that are still meaningful after every notification is discarded. For this reason, I have limited it to one profile change by followed user, but there is no automatic cleanup when all notifications are discarded. This could be improved.
- The UI only shows the new name/profile picture. This is far from ideal, but should be easy to change by someone familiar with Mastodon's web UI (I need help with that!). Ideally, I would like old and new avatar/name couples side by side with an horizontal arrow from the old one to the new one.