### PR TITLE
Fix an error in ReplyDistributionWorker when replied status was deleted

### DIFF
--- a/app/workers/activitypub/reply_distribution_worker.rb
+++ b/app/workers/activitypub/reply_distribution_worker.rb
@@ -7,9 +7,9 @@ class ActivityPub::ReplyDistributionWorker
 
   def perform(status_id)
     @status  = Status.find(status_id)
-    @account = @status.thread.account
+    @account = @status.thread&.account
 
-    return if skip_distribution?
+    return if @account.nil? || skip_distribution?
 
     ActivityPub::DeliveryWorker.push_bulk(inboxes) do |inbox_url|
       [signed_payload, @status.account_id, inbox_url]


### PR DESCRIPTION
Similar to #4970 

Since reply distribution is proceed by Sidekiq, replied status may be deleted before this, then it raises "NoMethodError: undefined method `account' for nil:NilClass".

