### PR TITLE
Raise an error on getting activity uri for remote status

### DIFF
--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -37,7 +37,7 @@ class ActivityPub::TagManager
   end
 
   def activity_uri_for(target)
-    return nil unless %i(note comment activity).include?(target.object_type) && target.local?
+    raise ArgumentError, 'target must be a local activity' unless %i(note comment activity).include?(target.object_type) && target.local?
 
     activity_account_status_url(target.account, target)
   end


### PR DESCRIPTION
We had returned `nil` for that case, but this raises an error instead, as a wrong usage of the method. This method is currently only used in ActivitySerializer.