### PR TITLE
Do not add image size without meta to OGP (regression from #4901)

### DIFF
--- a/app/views/stream_entries/_og_image.html.haml
+++ b/app/views/stream_entries/_og_image.html.haml
@@ -3,17 +3,20 @@
     - if media.image?
       = opengraph 'og:image', full_asset_url(media.file.url(:original))
       = opengraph 'og:image:type', media.file_content_type
-      = opengraph 'og:image:width', media.file.meta['original']['width']
-      = opengraph 'og:image:height', media.file.meta['original']['height']
+      - unless media.file.meta.nil?
+        = opengraph 'og:image:width', media.file.meta['original']['width']
+        = opengraph 'og:image:height', media.file.meta['original']['height']
     - elsif media.video?
       = opengraph 'og:image', full_asset_url(media.file.url(:small))
       = opengraph 'og:image:type', 'image/png'
-      = opengraph 'og:image:width', media.file.meta['small']['width']
-      = opengraph 'og:image:height', media.file.meta['small']['height']
+      - unless media.file.meta.nil?
+        = opengraph 'og:image:width', media.file.meta['small']['width']
+        = opengraph 'og:image:height', media.file.meta['small']['height']
       = opengraph 'og:video', full_asset_url(media.file.url(:original))
       = opengraph 'og:video:type', media.file_content_type
-      = opengraph 'og:video:width', media.file.meta['small']['width']
-      = opengraph 'og:video:height', media.file.meta['small']['height']
+      - unless media.file.meta.nil?
+        = opengraph 'og:video:width', media.file.meta['small']['width']
+        = opengraph 'og:video:height', media.file.meta['small']['height']
 - else
   = opengraph 'og:image', full_asset_url(account.avatar.url(:original))
   = opengraph 'og:image:width', '120'


### PR DESCRIPTION
Resolve #4994

### error log

```plain
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1] method=GET path=/@ykzts/5102 format=html controller=StatusesController action=show status=500 error='ActionView::Template::Error: undefined method `[]' for nil:NilClass' duration=60.38 view=0.00 db=8.51
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1]   
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1] ActionView::Template::Error (undefined method `[]' for nil:NilClass):
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1]     3:     - if media.image?
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1]     4:       = opengraph 'og:image', full_asset_url(media.file.url(:original))
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1]     5:       = opengraph 'og:image:type', media.file_content_type
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1]     6:       = opengraph 'og:image:width', media.file.meta['original']['width']
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1]     7:       = opengraph 'og:image:height', media.file.meta['original']['height']
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1]     8:     - elsif media.video?
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1]     9:       = opengraph 'og:image', full_asset_url(media.file.url(:small))
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1]   
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1] app/views/stream_entries/_og_image.html.haml:6:in `block in _app_views_stream_entries__og_image_html_haml__1277959569481662249_47255615500100'
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1] app/views/stream_entries/_og_image.html.haml:2:in `_app_views_stream_entries__og_image_html_haml__1277959569481662249_47255615500100'
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1] app/views/stream_entries/show.html.haml:15:in `block in _app_views_stream_entries_show_html_haml___3903030558903062391_47255538873740'
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1] app/views/stream_entries/show.html.haml:1:in `_app_views_stream_entries_show_html_haml___3903030558903062391_47255538873740'
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1] app/controllers/statuses_controller.rb:20:in `block (2 levels) in show'
web_1        | [8ca0ddde-60bd-45de-8543-1ccb0f3dcae1] app/controllers/statuses_controller.rb:15:in `show'
```