### PR TITLE
Fix incomplete account records being read

### DIFF
--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -18,7 +18,7 @@ class MediaProxyController < ApplicationController
 
   def redownload!
     @media_attachment.file_remote_url = @media_attachment.remote_url
-    @media_attachment.touch(:created_at)
+    @media_attachment.created_at      = Time.now.utc
     @media_attachment.save!
   end
 

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -8,11 +8,11 @@ class ActivityPub::ProcessAccountService < BaseService
   def call(username, domain, json)
     return if json['inbox'].blank?
 
-    @json           = json
-    @uri            = @json['id']
-    @username       = username
-    @domain         = domain
-    @collections    = {}
+    @json        = json
+    @uri         = @json['id']
+    @username    = username
+    @domain      = domain
+    @collections = {}
 
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?
@@ -20,7 +20,7 @@ class ActivityPub::ProcessAccountService < BaseService
         @old_public_key = @account&.public_key
         @old_protocol   = @account&.protocol
 
-        create_account  if @account.nil?
+        create_account if @account.nil?
         update_account
       end
     end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -8,18 +8,25 @@ class ActivityPub::ProcessAccountService < BaseService
   def call(username, domain, json)
     return if json['inbox'].blank?
 
-    @json        = json
-    @uri         = @json['id']
-    @username    = username
-    @domain      = domain
-    @account     = Account.find_by(uri: @uri)
-    @collections = {}
+    @json           = json
+    @uri            = @json['id']
+    @username       = username
+    @domain         = domain
+    @collections    = {}
 
-    old_public_key = @account&.public_key
-    create_account  if @account.nil?
-    upgrade_account if @account.ostatus?
-    update_account
-    RefollowWorker.perform_async(@account.id) if !old_public_key.nil? && old_public_key != @account.public_key
+    RedisLock.acquire(lock_options) do |lock|
+      if lock.acquired?
+        @account        = Account.find_by(uri: @uri)
+        @old_public_key = @account&.public_key
+        @old_protocol   = @account&.protocol
+
+        create_account  if @account.nil?
+        update_account
+      end
+    end
+
+    after_protocol_change! if protocol_changed?
+    after_key_change! if key_changed?
 
     @account
   rescue Oj::ParseError
@@ -37,31 +44,44 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.suspended   = true if auto_suspend?
     @account.silenced    = true if auto_silence?
     @account.private_key = nil
-    @account.save!
   end
 
   def update_account
     @account.last_webfingered_at = Time.now.utc
     @account.protocol            = :activitypub
-    @account.inbox_url           = @json['inbox'] || ''
-    @account.outbox_url          = @json['outbox'] || ''
-    @account.shared_inbox_url    = (@json['endpoints'].is_a?(Hash) ? @json['endpoints']['sharedInbox'] : @json['sharedInbox']) || ''
-    @account.followers_url       = @json['followers'] || ''
-    @account.url                 = url || @uri
-    @account.display_name        = @json['name'] || ''
-    @account.note                = @json['summary'] || ''
-    @account.avatar_remote_url   = image_url('icon')  unless skip_download?
-    @account.header_remote_url   = image_url('image') unless skip_download?
-    @account.public_key          = public_key || ''
-    @account.locked              = @json['manuallyApprovesFollowers'] || false
-    @account.statuses_count      = outbox_total_items    if outbox_total_items.present?
-    @account.following_count     = following_total_items if following_total_items.present?
-    @account.followers_count     = followers_total_items if followers_total_items.present?
+
+    set_immediate_attributes!
+    set_fetchable_attributes!
+
     @account.save_with_optional_media!
   end
 
-  def upgrade_account
+  def set_immediate_attributes!
+    @account.inbox_url        = @json['inbox'] || ''
+    @account.outbox_url       = @json['outbox'] || ''
+    @account.shared_inbox_url = (@json['endpoints'].is_a?(Hash) ? @json['endpoints']['sharedInbox'] : @json['sharedInbox']) || ''
+    @account.followers_url    = @json['followers'] || ''
+    @account.url              = url || @uri
+    @account.display_name     = @json['name'] || ''
+    @account.note             = @json['summary'] || ''
+    @account.locked           = @json['manuallyApprovesFollowers'] || false
+  end
+
+  def set_fetchable_attributes!
+    @account.avatar_remote_url = image_url('icon')  unless skip_download?
+    @account.header_remote_url = image_url('image') unless skip_download?
+    @account.public_key        = public_key || ''
+    @account.statuses_count    = outbox_total_items    if outbox_total_items.present?
+    @account.following_count   = following_total_items if following_total_items.present?
+    @account.followers_count   = followers_total_items if followers_total_items.present?
+  end
+
+  def after_protocol_change!
     ActivityPub::PostUpgradeWorker.perform_async(@account.domain)
+  end
+
+  def after_key_change!
+    RefollowWorker.perform_async(@account.id)
   end
 
   def image_url(key)
@@ -122,15 +142,27 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def auto_suspend?
-    domain_block && domain_block.suspend?
+    domain_block&.suspend?
   end
 
   def auto_silence?
-    domain_block && domain_block.silence?
+    domain_block&.silence?
   end
 
   def domain_block
     return @domain_block if defined?(@domain_block)
     @domain_block = DomainBlock.find_by(domain: @domain)
+  end
+
+  def key_changed?
+    !@old_public_key.nil? && @old_public_key != @account.public_key
+  end
+
+  def protocol_changed?
+    !@old_protocol.nil? && @old_protocol != @account.protocol
+  end
+
+  def lock_options
+    { redis: Redis.current, key: "process_account:#{@uri}" }
   end
 end


### PR DESCRIPTION
Problem: create_account saves record without public_key, url, and various endpoints, which breaks tasks that rely on those attributes being always present (the record may also appear to end users extremely empty looking)

Ideal solution: Transaction block around create_account and update_account (which fills this data). Impossible because update_account has to fetch some fields from HTTP requests (public key may not be embedded in payload, for example; also avatar, header), so transaction would be held up for up to multiple seconds, therefore decreasing throughput of other processes

Solution:

- Put account processing into redis lock
- Do not save until record is complete

Consequence: Account will not "exist" until it is complete, therefore the code path should take any usage of the account to the redis lock, which will wait until the first processing completes, at which point the record will exist and be complete.