### PR TITLE
Add will-change to improve scrolling perf

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1587,6 +1587,7 @@
   overflow-x: hidden;
   flex: 1 1 auto;
   -webkit-overflow-scrolling: touch;
+  will-change: transform; // improves perf in mobile Chrome
 
   &.optionally-scrollable {
     overflow-y: auto;


### PR DESCRIPTION
This improves the performance of scrolling on mobile browsers, especially mobile Chrome. It adds `will-change: transform`, which provides a hint to the browser to move the scrollable element to the GPU instead of repainting on the main thread.

There is some discussion [on StackOverflow](https://stackoverflow.com/a/41026886/680742). More obviously you can see the difference using the Chrome Dev Tools. Before, the "Scrolling performance issues" feature will warn about "repaints on scroll":

![2017-09-18 12_57_35-developer tools - https___toot cafe_web_statuses_1690410](https://user-images.githubusercontent.com/283842/30563968-51aa9d2c-9c78-11e7-8b2c-fdbd1f5db76b.png)

Afterwards, it doesn't:

![2017-09-18 12_57_24-developer tools - https___toot cafe_web_statuses_1690410](https://user-images.githubusercontent.com/283842/30563976-593c4b94-9c78-11e7-9d3f-e665c1622a81.png)

You can also see the difference in how the FPS is affecting during scroll. Before:

![2017-09-18 12_57_04-developer tools - https___toot cafe_web_statuses_1690410](https://user-images.githubusercontent.com/283842/30563994-67232f5c-9c78-11e7-8d90-e33bd9f9117f.png)

After:

![2017-09-18 12_58_50-developer tools - https___toot cafe_web_statuses_1690410](https://user-images.githubusercontent.com/283842/30564008-6d6d11f2-9c78-11e7-8e7e-ebf2f27583f5.png)

You can also test with your own eyes. 😃 I've pushed the change to https://malfunctioning.technology, (on top of v1.6.1), and if you open it in mobile Chrome (I used Chromium 63 on a Nexus 5), you'll see scrolling the home timeline is way faster than v1.6.1.

### Browsers

I tested in mobile Firefox on Android and didn't see a difference with or without this change. Edge will also not be affected, because Edge doesn't support `will-change`. I didn't have time to test Safari on an iPhone, so somebody should do that first to make sure it's okay.

### TODOs

As for what's causing the scrolling issues in the first place, it seems to me that various `touchstart`/`touchmove` listeners are being added by `react-swipeable-views`, `react-dom`, `is_mobile.js`, and `react-simple-dropdown`. It may be a good idea to audit these and set `passive: true` where we can. (In any situation where we're not calling `event.preventDefault()`, we can set `passive: true`; see [passive event listeners](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners))

BTW this would explain why touch scrolling is affected (mobile), but not mousewheel scrolling (desktop). Our `wheel` listener is passive, so mousewheel should be fine. (Scrolling is horribly complicated and even this `will-change` thing is new to me; I wrote [a blog post on scrolling](https://blogs.windows.com/msedgedev/2017/03/08/scrolling-on-the-web/) in case it's helpful. 😃)