### PR TITLE
Add japanese translations for custom emoji.

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -111,7 +111,7 @@ ja:
     custom_emojis:
       created_msg: 絵文字の作成に成功しました
       delete: 削除
-      destroyed_msg: 絵文字の削除に成功しました
+      destroyed_msg: Emojoは消滅しました！
       emoji: 絵文字
       image_hint: 50KBまでのPNG画像を利用できます
       new:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -111,7 +111,7 @@ ja:
     custom_emojis:
       created_msg: 絵文字の作成に成功しました
       delete: 削除
-      destroyed_msg: Emojoは消滅しました！
+      destroyed_msg: 絵文字の削除に成功しました
       emoji: 絵文字
       image_hint: 50KBまでのPNG画像を利用できます
       new:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -108,6 +108,18 @@ ja:
       unsubscribe: 購読の解除
       username: ユーザー名
       web: Web
+    custom_emojis:
+      created_msg: 絵文字の作成に成功しました
+      delete: 削除
+      destroyed_msg: 絵文字の削除に成功しました
+      emoji: 絵文字
+      image_hint: 50KB までの PNG 画像を利用できます
+      new:
+        title: 新規カスタム絵文字の追加
+      shortcode: ショートコード
+      shortcode_hint: 2 文字以上の半角英数字とアンダースコアのみ利用できます
+      title: カスタム絵文字
+      upload: アップロード
     domain_blocks:
       add_new: 新規追加
       created_msg: ドメインブロック処理を完了しました

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -113,11 +113,11 @@ ja:
       delete: 削除
       destroyed_msg: 絵文字の削除に成功しました
       emoji: 絵文字
-      image_hint: 50KB までの PNG 画像を利用できます
+      image_hint: 50KBまでのPNG画像を利用できます
       new:
         title: 新規カスタム絵文字の追加
       shortcode: ショートコード
-      shortcode_hint: 2 文字以上の半角英数字とアンダースコアのみ利用できます
+      shortcode_hint: 2文字以上の半角英数字とアンダースコアのみ利用できます
       title: カスタム絵文字
       upload: アップロード
     domain_blocks:


### PR DESCRIPTION
Add japanese translations for Custom emoji.

"alphanumeric" is translated "英数字" in Japanese.
But I adopted "半角英数字" meaning "Half size alphanumeric characters".

Because there are 2 bytes of alphanumeric characters in Japanese characters.
e.g. ＡＢＣ，１２３