### PR TITLE
Set touchstart listener to 'passive', remove 'once'

### DIFF
--- a/app/javascript/mastodon/is_mobile.js
+++ b/app/javascript/mastodon/is_mobile.js
@@ -1,3 +1,5 @@
+import detectPassiveEvents from 'detect-passive-events';
+
 const LAYOUT_BREAKPOINT = 1024;
 
 export function isMobile(width) {
@@ -5,11 +7,16 @@ export function isMobile(width) {
 };
 
 const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
-let userTouching = false;
 
-window.addEventListener('touchstart', () => {
+let userTouching = false;
+let listenerOptions = detectPassiveEvents.hasSupport ? { passive: true } : false;
+
+function touchListener() {
   userTouching = true;
-}, { once: true });
+  window.removeEventListener('touchstart', touchListener, listenerOptions);
+}
+
+window.addEventListener('touchstart', touchListener, listenerOptions);
 
 export function isUserTouching() {
   return userTouching;


### PR DESCRIPTION
This is a minor perf improvement as well as a compat improvement. Since this event doesn't call `preventDefault()`, we can mark it as `passive`. This allows [browsers that support it](http://caniuse.com/#search=passive) to avoid deoptimizing scrolling.

I also removed `once` because [its browser support is not very complete yet](http://caniuse.com/#search=once), so we can just manually remove the event instead.