### PR TITLE
Fix non-local statuses are html_encoded in public_page.

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -22,7 +22,7 @@ class Formatter
     unless status.local?
       html = reformat(raw_content)
       html = encode_custom_emojis(html, status.emojis) if options[:custom_emojify]
-      return html
+      return html.html_safe # rubocop:disable Rails/OutputSafety
     end
 
     linkable_accounts = status.mentions.map(&:account)
@@ -39,7 +39,7 @@ class Formatter
   end
 
   def reformat(html)
-    sanitize(html, Sanitize::Config::MASTODON_STRICT).html_safe # rubocop:disable Rails/OutputSafety
+    sanitize(html, Sanitize::Config::MASTODON_STRICT)
   end
 
   def plaintext(status)


### PR DESCRIPTION
Now encode_custom_emojis run after reformat.
So "html" is treated unsafe string.
( In public_page, statuses string are http encoded. Ex. https://mstdn.maud.io/@Ayano )