### PR TITLE
Retry ActivityPub delivery a few more times

### DIFF
--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::DeliveryWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push', retry: 5, dead: false
+  sidekiq_options queue: 'push', retry: 8, dead: false
 
   HEADERS = { 'Content-Type' => 'application/activity+json' }.freeze
 


### PR DESCRIPTION
Increase the number of attempts to deliver toots through ActivityPub.

If I understand correctly how sidekiq works (https://github.com/mperham/sidekiq/blob/bd93f8430b2d1a7e320b7185aee114ef2bdabae5/lib/sidekiq/job_retry.rb#L203), Mastodon's current number of retries (up to 5 times) means delivery will be attempted for about a cumulative 10 minutes (7~14min), which is a pretty small amount of time (for perspective, on my small server, upgrading my instance may take up to one hour).

The proposed change would bring that cumulative time to around 1h20~1h40.

The downside is that this increases the chance of toots being displayed out-of-order, as they are saved to the timeline in the order of processing.