### PR TITLE
Reduce wasted renders for intersection_observer_article.js

### DIFF
--- a/app/javascript/mastodon/components/intersection_observer_article.js
+++ b/app/javascript/mastodon/components/intersection_observer_article.js
@@ -21,6 +21,14 @@ export default class IntersectionObserverArticle extends ImmutablePureComponent 
     isHidden: false, // set to true in requestIdleCallback to trigger un-render
   }
 
+  updateOnProps = [
+    'id',
+    'index',
+    'listLength',
+    'saveHeightKey',
+    'cachedHeight',
+  ]
+
   shouldComponentUpdate (nextProps, nextState) {
     if (!nextState.isIntersecting && nextState.isHidden) {
       // It's only if we're not intersecting (i.e. offscreen) and isHidden is true


### PR DESCRIPTION
This reduces some unnecessary re-renders, as shown in this screenshot of `ReactPerf.wasted()`. (Scenario: load the local timeline in mobile mode, scroll to the bottom once.)

![out](https://user-images.githubusercontent.com/283842/30627048-c4f5415a-9d82-11e7-8aa8-9c6f1ac1ec4b.png)
