### PR TITLE
Reduce wasted renders for column_loading.js

### DIFF
--- a/app/javascript/mastodon/features/ui/components/column_loading.js
+++ b/app/javascript/mastodon/features/ui/components/column_loading.js
@@ -3,17 +3,25 @@ import PropTypes from 'prop-types';
 
 import Column from '../../../components/column';
 import ColumnHeader from '../../../components/column_header';
+import ImmutablePureComponent from 'react-immutable-pure-component';
 
-const ColumnLoading = ({ title = '', icon = ' ' }) => (
-  <Column>
-    <ColumnHeader icon={icon} title={title} multiColumn={false} focusable={false} />
-    <div className='scrollable' />
-  </Column>
-);
+export default class ColumnLoading extends ImmutablePureComponent {
 
-ColumnLoading.propTypes = {
-  title: PropTypes.node,
-  icon: PropTypes.string,
-};
+  static propTypes = {
+    title: PropTypes.node,
+    icon: PropTypes.string,
+  }
 
-export default ColumnLoading;
+  render() {
+    let { title, icon } = this.props;
+    title = title || '';
+    icon = icon || '';
+    return (
+      <Column>
+        <ColumnHeader icon={icon} title={title} multiColumn={false} focusable={false} />
+        <div className='scrollable' />
+      </Column>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/ui/components/column_loading.js
+++ b/app/javascript/mastodon/features/ui/components/column_loading.js
@@ -8,14 +8,17 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 export default class ColumnLoading extends ImmutablePureComponent {
 
   static propTypes = {
-    title: PropTypes.node,
+    title: PropTypes.oneOfType(PropTypes.node, PropTypes.string),
     icon: PropTypes.string,
-  }
+  };
+
+  static defaultProps = {
+    title: '',
+    icon: '',
+  };
 
   render() {
     let { title, icon } = this.props;
-    title = title || '';
-    icon = icon || '';
     return (
       <Column>
         <ColumnHeader icon={icon} title={title} multiColumn={false} focusable={false} />


### PR DESCRIPTION
This reduces some wasted time for this component, as shown in this `ReactPerf.printWasted()` before and after:

![out2](https://user-images.githubusercontent.com/283842/30627543-b186596c-9d85-11e7-95a5-9db76c22d02d.png)

(Scenario: load the local timeline in mobile view.)