### PR TITLE
Measures to time out when waiting for startup of an instance running on Passenger.

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -81,7 +81,7 @@ class Request
   end
 
   def timeout
-    { write: 10, connect: 10, read: 10 }
+    { write: 10, connect: 60, read: 10 }
   end
 
   def http_client


### PR DESCRIPTION
Our instance is running on Nginx-Passenger. Nginx-Passenger stops unused instances and starts when needed. The instance normally starts in about 5 seconds. However, we have a lot of instances running on one server, so it takes more than 10 seconds to start up when the server is busy. At that time, if the external server sends Toote, a timeout error will occur.
HTTP :: TimeoutError: Delivery failed for https: //***.m.to/inbox: Read timed out after 10 seconds on https: //***.m.to/inbox
Please approve this amendment to avoid this error.