### PR TITLE
Remove unnecessary css property

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -2932,8 +2932,6 @@ button.icon-button.active i.fa-retweet {
 }
 
 .search__input {
-  padding-right: 30px;
-  color: $ui-secondary-color;
   outline: 0;
   box-sizing: border-box;
   display: block;


### PR DESCRIPTION
The padding-right property and the color property were duplicatedly declared.

The value set for each color property was different.
I keeped the latter value which is currently in effect.