### PR TITLE
Add Japanese translations for multiple themes, custom emoji

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -109,7 +109,7 @@ ja:
       username: ユーザー名
       web: Web
     custom_emojis:
-      created_msg: 絵文字の作成に成功しました
+      created_msg: 絵文字の追加に成功しました
       delete: 削除
       destroyed_msg: 絵文字の削除に成功しました
       emoji: 絵文字

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -460,6 +460,8 @@ ja:
     settings: 設定
     two_factor_authentication: 二段階認証
     your_apps: アプリ
+  themes:
+    default: Mastodon
   statuses:
     open_in_web: Webで開く
     over_character_limit: 上限は %{max}文字までです

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -9,6 +9,7 @@ ja:
         locked: フォロワーを手動で承認する必要があります。
         note: あと<span class="note-counter">%{count}</span>文字入力できます。
         setting_noindex: 公開プロフィールおよび各投稿ページに影響します
+        setting_theme: 任意のデバイスからログインしている時の外観に影響します。
       imports:
         data: 他の Mastodon インスタンスからエクスポートしたCSVファイルを選択して下さい
       sessions:
@@ -40,6 +41,7 @@ ja:
         setting_noindex: 検索エンジンによるインデックスを拒否する
         setting_system_font_ui: システムのデフォルトフォントを使う
         setting_unfollow_modal: フォロー解除する前に確認ダイアログを表示する
+        setting_theme: サイトテーマ
         severity: 重大性
         type: インポートする項目
         username: ユーザー名


### PR DESCRIPTION
Add Japanese translations for multiple themes.

I changed translation for custom emoji.
Changed translation for created_msg to title's one.

I'm sorry sent it separately from the previous PullRequest.