### PR TITLE
Better Japanese translations

### DIFF
--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -11,7 +11,7 @@ ja:
       invalid: "%{authentication_keys}かパスワードが誤っています。"
       last_attempt: あと1回失敗するとアカウントがロックされます。
       locked: アカウントはロックされました。
-      not_found_in_database: "%{authentication_keys}かパスワードが誤っています"
+      not_found_in_database: "%{authentication_keys}かパスワードが誤っています。"
       timeout: セッションの有効期限が切れました。続行するには再度ログインしてください。
       unauthenticated: 続行するにはログインするか、アカウントを作成してください。
       unconfirmed: 続行するにはメールアドレスを確認する必要があります。

--- a/config/locales/doorkeeper.ja.yml
+++ b/config/locales/doorkeeper.ja.yml
@@ -25,14 +25,14 @@ ja:
         edit: 編集
         submit: 送信
       confirmations:
-        destroy: 本当に削除しますか?
+        destroy: 本当に削除しますか？
       edit:
         title: アプリの編集
       form:
         error: フォームにエラーが無いか確認してください。
       help:
         native_redirect_uri: ローカルテストに %{native_redirect_uri} を使用
-        redirect_uri: 一行に一つのURLを入力してください
+        redirect_uri: 一行に一つのURLを入力してください。
         scopes: アクセス権は半角スペースで区切ることができます。 空白のままにするとデフォルトを使用します。
       index:
         application: アプリ

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -50,7 +50,7 @@ ja:
     unfollow: フォロー解除
   admin:
     accounts:
-      are_you_sure: 本当に実行しますか?
+      are_you_sure: 本当に実行しますか？
       confirm: 確認
       confirmed: 確認済み
       disable_two_factor_authentication: 二段階認証を無効にする
@@ -113,11 +113,11 @@ ja:
       delete: 削除
       destroyed_msg: 絵文字の削除に成功しました
       emoji: 絵文字
-      image_hint: 50KBまでのPNG画像を利用できます
+      image_hint: 50KBまでのPNG画像を利用できます。
       new:
         title: 新規カスタム絵文字の追加
       shortcode: ショートコード
-      shortcode_hint: 2文字以上の半角英数字とアンダースコアのみ利用できます
+      shortcode_hint: 2文字以上の半角英数字とアンダーバーのみ利用できます。
       title: カスタム絵文字
       upload: アップロード
     domain_blocks:
@@ -191,7 +191,7 @@ ja:
         username: 連絡先のユーザー名
       registrations:
         closed_message:
-          desc_html: 新規登録を停止しているときにフロントページに表示されます。HTMLタグが使えます
+          desc_html: 新規登録を停止しているときにフロントページに表示されます。HTMLタグが使えます。
           title: 新規登録停止時のメッセージ
         deletion:
           desc_html: 誰でも自分のアカウントを削除できるようにします
@@ -203,10 +203,10 @@ ja:
         desc_html: フロントページへの表示と meta タグに使用される紹介文です。HTMLタグ、特に<code>&lt;a&gt;</code> と <code>&lt;em&gt;</code>が使えます。
         title: インスタンスの説明
       site_description_extended:
-        desc_html: あなたのインスタンスにおける行動規範やルール、ガイドライン、そのほかの記述をする際に最適な場所です。HTMLタグが使えます
+        desc_html: あなたのインスタンスにおける行動規範やルール、ガイドライン、そのほかの記述をする際に最適な場所です。HTMLタグが使えます。
         title: カスタム詳細説明
       site_terms:
-        desc_html: あなたは独自のプライバシーポリシーや利用規約、そのほかの法的根拠を書くことができます。HTMLタグが使えます
+        desc_html: あなたは独自のプライバシーポリシーや利用規約、そのほかの法的根拠を書くことができます。HTMLタグが使えます。
         title: カスタム利用規約
       site_title: インスタンスの名前
       thumbnail:
@@ -273,7 +273,7 @@ ja:
     error: 残念ながら、リモートアカウント情報の取得中にエラーが発生しました。
     follow: フォロー
     follow_request: 'あなたは以下のアカウントにフォローリクエストを送信しました:'
-    following: '成功! あなたは現在以下のアカウントをフォローしています:'
+    following: '成功！ あなたは現在以下のアカウントをフォローしています:'
     post_follow:
       close: またはこのウィンドウを閉じます
       return: ユーザーのプロフィールに戻る
@@ -302,7 +302,7 @@ ja:
     warning_html: 削除が保証されるのはこのインスタンス上のコンテンツのみです。他のインスタンス等、外部に広く共有されたコンテンツについては痕跡が残ることがあります。また、現在接続できないサーバーや、あなたの更新を受け取らなくなったサーバーに対しては、削除は反映されません。
     warning_title: 共有されたコンテンツについて
   errors:
-    '403': このページを表示する権限がありません
+    '403': このページを表示する権限がありません。
     '404': お探しのページは見つかりませんでした。
     '410': お探しのページはもう存在しません。
     '422':
@@ -333,11 +333,11 @@ ja:
     powered_by: powered by %{link}
     save_changes: 変更を保存
     validation_errors:
-      one: エラーが発生しました。以下のエラーを確認してください
-      other: エラーが発生しました。以下の%{count}個のエラーを確認してください
+      one: エラーが発生しました。以下のエラーを確認してください。
+      other: エラーが発生しました。以下の%{count}個のエラーを確認してください。
   imports:
     preface: 他のインスタンスでエクスポートされたファイルから、フォロー/ブロックした情報をこのインスタンス上のアカウントにインポートできます。
-    success: ファイルは正常にアップロードされ、現在処理中です。しばらくしてから確認してください
+    success: ファイルは正常にアップロードされ、現在処理中です。しばらくしてから確認してください。
     types:
       blocking: ブロックしたアカウントリスト
       following: フォロー中のアカウントリスト
@@ -366,7 +366,7 @@ ja:
       body: "%{name} さんにフォローされています"
       subject: "%{name} さんにフォローされています"
     follow_request:
-      body: "%{name} さんがあなたにフォローをリクエストしました。"
+      body: "%{name} さんがあなたにフォローをリクエストしました"
       subject: "%{name} さんからのフォローリクエスト"
     mention:
       body: "%{name} さんから返信がありました:"
@@ -557,7 +557,7 @@ ja:
     formats:
       default: "%Y年%m月%d日 %H:%M"
   two_factor_authentication:
-    code_hint: 確認するには認証アプリで表示されたコードを入力してください
+    code_hint: 確認するには認証アプリで表示されたコードを入力してください。
     description_html: "<strong>二段階認証</strong>を有効にするとログイン時、電話でコードを受け取る必要があります。"
     disable: 無効
     enable: 有効

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -6,12 +6,12 @@ ja:
         avatar: 2MBまでのPNGやGIF、JPGが利用可能です。120x120pxまで縮小されます。
         display_name: あと<span class="name-counter">%{count}</span>文字入力できます。
         header: 2MBまでのPNGやGIF、JPGが利用可能です。 700x335pxまで縮小されます。
-        locked: フォロワーを手動で承認する必要があります。
+        locked: フォロワーを手動で承認する必要があります
         note: あと<span class="note-counter">%{count}</span>文字入力できます。
         setting_noindex: 公開プロフィールおよび各投稿ページに影響します
-        setting_theme: 任意のデバイスからログインしている時の外観に影響します。
+        setting_theme: ログインしている全てのデバイスで適用されるデザインです。
       imports:
-        data: 他の Mastodon インスタンスからエクスポートしたCSVファイルを選択して下さい
+        data: 他の Mastodon インスタンスからエクスポートしたCSVファイルを選択して下さい。
       sessions:
         otp: 携帯電話に表示された2段階認証コードを入力するか、生成したリカバリーコードを使用してください。
       user:


### PR DESCRIPTION
- Update setting_theme translation.
「任意」 should not be used for general users UI.

- Unify translations of "underscores"
「アンダーバー」 is used from the previous, and commonly used in Japan.

- Unify 「！」 and 「？」 into 全角

- Unify presence of 句点