### PR TITLE
Fix theme translations alphabetically

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -461,8 +461,6 @@ en:
     settings: Settings
     two_factor_authentication: Two-factor Authentication
     your_apps: Your applications
-  themes:
-    default: Mastodon
   statuses:
     open_in_web: Open in web
     over_character_limit: character limit of %{max} exceeded
@@ -554,6 +552,8 @@ en:
 
       <p>Originally adapted from the <a href="https://github.com/discourse/discourse">Discourse privacy policy</a>.</p>
     title: "%{instance} Terms of Service and Privacy Policy"
+  themes:
+    default: Mastodon
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -460,8 +460,6 @@ ja:
     settings: 設定
     two_factor_authentication: 二段階認証
     your_apps: アプリ
-  themes:
-    default: Mastodon
   statuses:
     open_in_web: Webで開く
     over_character_limit: 上限は %{max}文字までです
@@ -553,6 +551,8 @@ ja:
 
       <p>オリジナルの出典 <a href="https://github.com/discourse/discourse">Discourse privacy policy</a>.</p>
     title: "%{instance} 利用規約・プライバシーポリシー"
+  themes:
+    default: Mastodon
   time:
     formats:
       default: "%Y年%m月%d日 %H:%M"

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -539,8 +539,6 @@ oc:
     settings: Paramètres
     two_factor_authentication: Autentificacion en dos temps
     your_apps: Vòstras aplicacions
-  themes:
-    default: Mastodon
   statuses:
     open_in_web: Dobrir sul web
     over_character_limit: limit de %{max} caractèrs passat
@@ -632,6 +630,8 @@ oc:
 
       <p>Prima adaptacion de la <a href="https://github.com/discourse/discourse">politica de confidencialitat de Discourse</a>.</p>
     title: Condicions d’utilizacion e politica de confidencialitat de %{instance}
+  themes:
+    default: Mastodon
   time:
     formats:
       default: Lo %d %b de %Y a %Ho%M

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -462,8 +462,6 @@ pl:
     settings: Ustawienia
     two_factor_authentication: Uwierzytelnianie dwuetapowe
     your_apps: Twoje aplikacje
-  themes:
-    default: Mastodon
   statuses:
     open_in_web: Otwórz w przeglądarce
     over_character_limit: limit %{max} znaków przekroczony
@@ -555,6 +553,8 @@ pl:
 
       <p>Tekst bazuje na <a href="https://github.com/discourse/discourse">polityce prywatności Discourse</a>.</p>
     title: Zasady korzystania i polityka prywatności %{instance}
+  themes:
+    default: Mastodon
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -44,8 +44,8 @@ en:
         setting_delete_modal: Show confirmation dialog before deleting a toot
         setting_noindex: Opt-out of search engine indexing
         setting_system_font_ui: Use system's default font
-        setting_unfollow_modal: Show confirmation dialog before unfollowing someone
         setting_theme: Site theme 
+        setting_unfollow_modal: Show confirmation dialog before unfollowing someone
         severity: Severity
         type: Import type
         username: Username

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -40,8 +40,8 @@ ja:
         setting_delete_modal: トゥートを削除する前に確認ダイアログを表示する
         setting_noindex: 検索エンジンによるインデックスを拒否する
         setting_system_font_ui: システムのデフォルトフォントを使う
-        setting_unfollow_modal: フォロー解除する前に確認ダイアログを表示する
         setting_theme: サイトテーマ
+        setting_unfollow_modal: フォロー解除する前に確認ダイアログを表示する
         severity: 重大性
         type: インポートする項目
         username: ユーザー名

--- a/config/locales/simple_form.oc.yml
+++ b/config/locales/simple_form.oc.yml
@@ -44,8 +44,8 @@ oc:
         setting_delete_modal: Afichar una fenèstra de confirmacion abans de suprimir un estatut
         setting_noindex: Èsser pas indexat pels motors de recèrca
         setting_system_font_ui: Utilizar la policia Font del sisèma
-        setting_unfollow_modal: Afichar una confirmacion abans de quitar de sègre qualqu’un
         setting_theme: Tèma del site
+        setting_unfollow_modal: Afichar una confirmacion abans de quitar de sègre qualqu’un
         severity: Severitat
         type: Tip d’impòrt
         username: Nom d’utilizaire


### PR DESCRIPTION
Hashes in YAML translations files should be ordered alphabetically.

Polish translation of setting_theme is correctly ordered 👍 