### PR TITLE
Fix shortname problem in emojify() (regression from #5016)

### DIFF
--- a/app/javascript/mastodon/emoji.js
+++ b/app/javascript/mastodon/emoji.js
@@ -7,29 +7,34 @@ const emojify = (str, customEmojis = {}) => {
   let rtn = '';
   for (;;) {
     let match, i = 0, tag;
-    while (i < str.length && (tag = '<&:'.indexOf(str[i])) === -1 && !(match = trie.search(str.slice(i)))) {
+    while (i < str.length && (tag = '<&'.indexOf(str[i])) === -1 && str[i] !== ':' && !(match = trie.search(str.slice(i)))) {
       i += str.codePointAt(i) < 65536 ? 1 : 2;
     }
     if (i === str.length)
       break;
     else if (tag >= 0) {
-      let tagend = str.indexOf('>;:'[tag], i + 1) + 1;
+      const tagend = str.indexOf('>;'[tag], i + 1) + 1;
       if (!tagend)
         break;
-      if (str[i] === ':') {
-        const shortname = str.slice(i, tagend);
+      rtn += str.slice(0, tagend);
+      str = str.slice(tagend);
+    } else if (str[i] === ':') {
+      try {
+        // if replacing :shortname: succeed, exit this block with "continue"
+        const closeColon = str.indexOf(':', i + 1) + 1;
+        if (!closeColon) throw null; // no pair of ':'
         const lt = str.indexOf('<', i + 1);
-        if ((lt === -1 || lt >= tagend) && shortname in customEmojis) {
+        if (!(lt === -1 || lt >= closeColon)) throw null; // tag appeared before closing ':'
+        const shortname = str.slice(i, closeColon);
+        if (shortname in customEmojis) {
           rtn += str.slice(0, i) + `<img draggable="false" class="emojione" alt="${shortname}" title="${shortname}" src="${customEmojis[shortname]}" />`;
-          str = str.slice(tagend);
-        } else {
-          rtn += str.slice(0, i + 1);
-          str = str.slice(i + 1);
+          str = str.slice(closeColon);
+          continue;
         }
-      } else {
-        rtn += str.slice(0, tagend);
-        str = str.slice(tagend);
-      }
+      } catch (e) {}
+      // replacing :shortname: failed
+      rtn += str.slice(0, i + 1);
+      str = str.slice(i + 1);
     } else {
       const [filename, shortCode] = unicodeMapping[match];
       rtn += str.slice(0, i) + `<img draggable="false" class="emojione" alt="${match}" title=":${shortCode}:" src="/emoji/${filename}.svg" />`;


### PR DESCRIPTION
When colon appears end of line, skiped all character containing unicode emojis. Fixed.
https://github.com/tootsuite/mastodon/pull/5016#issuecomment-331012008