### PR TITLE
fix : mixed content of custom emoji

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -101,6 +101,9 @@ class Formatter
         emoji     = emoji_map[shortcode]
 
         if emoji
+          if emoji.match(/^http:\/\/.*/) then
+            emoji.sub!('http://','//')
+          end
           replacement = "<img draggable=\"false\" class=\"emojione\" alt=\":#{shortcode}:\" title=\":#{shortcode}:\" src=\"#{emoji}\" />"
           before_html = shortname_start_index.positive? ? html[0..shortname_start_index - 1] : ''
           html        = before_html + replacement + html[i + 1..-1]


### PR DESCRIPTION
## Problem

My instance, since the URL of custom emoji is `http://`, there was a mixed content problem.

This commit is to fix it.

`img src` : `http://xxx/emoji.png` -> `//xxx/emoji.png`

I am not using AWS S3.

## Find and fix mixed content

https://developers.google.com/web/fundamentals/security/prevent-mixed-content/fixing-mixed-content

### Error message

```js
Mixed Content: The page at 'https://${host}/${user}' was loaded over HTTPS, but requested an insecure video 'http://${host}/system/custom_emojis/images/000/000/xxx/original/coolcat.png'. This content should also be served over HTTPS.
```

### Page where the problem occurred

public user page.

url : `https://${host}/@user`, example : https://mstdn.syui.cf/@syui

### Before

```html
<img draggable="false" class="emojione" alt=":coolcat:" title=":coolcat:" src="http://${host}/system/custom_emojis/images/000/000/xxx/original/coolcat.png?xxxxxxx">
```

###  After

`img src` : `http://` -> `//`

```html
<img draggable="false" class="emojione" alt=":coolcat:" title=":coolcat:" src="//${host}/system/custom_emojis/images/000/000/xxx/original/coolcat.png?xxxxxxx">
```
