### PR TITLE
fix : mobile style of /about/more

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -124,6 +124,7 @@
     box-sizing: border-box;
     max-width: 800px;
     margin: 0 auto;
+    word-wrap: break-word;
   }
 
   .header-wrapper {


### PR DESCRIPTION
`/about/more` : site setting (description)

![](https://raw.githubusercontent.com/mba-hack/images/master/github_pullreq_mastodon_css_mobile.png)