### PR TITLE
Document REDIS_NAMESPACE

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,5 +1,6 @@
 # Service dependencies
 # You may set REDIS_URL instead for more advanced options
+# You may also set REDIS_NAMESPACE to share Redis between multiple Mastodon servers
 REDIS_HOST=redis
 REDIS_PORT=6379
 # You may set DATABASE_URL instead for more advanced options


### PR DESCRIPTION
I noticed that this feature (https://github.com/tootsuite/mastodon/pull/2869) didn't seem to be documented anywhere. Seems `.env.production.sample` would be a good place for it?