### PR TITLE
Configure webpack to poll for changes in development

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -4,6 +4,17 @@ const merge = require('webpack-merge');
 const sharedConfig = require('./shared.js');
 const { settings, output } = require('./configuration.js');
 
+const watchOptions = {
+  ignored: /node_modules/,
+};
+
+if (process.env.VAGRANT) {
+  // If we are in Vagrant, we can't rely on inotify to update us with changed
+  // files, so we must poll instead. Here, we poll every second to see if
+  // anything has changed.
+  watchOptions.poll = 1000;
+}
+
 module.exports = merge(sharedConfig, {
   devtool: 'cheap-module-eval-source-map',
 
@@ -26,9 +37,6 @@ module.exports = merge(sharedConfig, {
     headers: { 'Access-Control-Allow-Origin': '*' },
     historyApiFallback: true,
     disableHostCheck: true,
-    watchOptions: {
-      ignored: /node_modules/,
-      poll: 1000,
-    },
+    watchOptions: watchOptions,
   },
 });

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -28,6 +28,7 @@ module.exports = merge(sharedConfig, {
     disableHostCheck: true,
     watchOptions: {
       ignored: /node_modules/,
+      poll: 1000,
     },
   },
 });


### PR DESCRIPTION
Vagrant on Linux/macOS hosts shared files via NFS, which doesn't support inotify-based watching of files. This tweak makes webpack check for changes every second, and rebuild if necessary. This removes the need to restart Foreman every time a frontend file changes. Note that rebuilding is still a relatively lengthy process.

The polling frequency can be changed to taste.