### PR TITLE
Fix PropTypes.oneOfType() warning

### DIFF
--- a/app/javascript/mastodon/features/ui/components/column_loading.js
+++ b/app/javascript/mastodon/features/ui/components/column_loading.js
@@ -8,7 +8,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 export default class ColumnLoading extends ImmutablePureComponent {
 
   static propTypes = {
-    title: PropTypes.oneOfType(PropTypes.node, PropTypes.string),
+    title: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
     icon: PropTypes.string,
   };
 


### PR DESCRIPTION
This fixes a React warning. (It has no impact during production, but it's annoying during development.)

![screenshot 2017-09-22 07 38 31](https://user-images.githubusercontent.com/283842/30749726-22648e58-9f69-11e7-86d9-60746887ba4a.png)
