### PR TITLE
Fix overflowing tabs in account__action-bar

### DIFF
--- a/app/javascript/styles/compact_header.scss
+++ b/app/javascript/styles/compact_header.scss
@@ -6,7 +6,7 @@
     font-weight: 500;
     margin-bottom: 20px;
     padding: 0 10px;
-    overflow-wrap: break-word;
+    word-wrap: break-word;
 
     @media screen and (max-width: 740px) {
       text-align: center;

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -920,7 +920,7 @@
 }
 
 .account__action-bar-dropdown {
-  flex: 1 1 auto;
+  flex: 0 1 calc(50% - 140px);
   padding: 10px;
 
   .dropdown--active {
@@ -947,7 +947,7 @@
 .account__action-bar__tab {
   text-decoration: none;
   overflow: hidden;
-  width: 80px;
+  flex: 0 1 80px;
   border-left: 1px solid lighten($ui-base-color, 8%);
   padding: 10px 5px;
 


### PR DESCRIPTION
Stop using fixed width, and distribute spaces equally for numbers tabs.
Since unfixed width brakes current centering method, I change it to explicit one.

Before and after images below.
![ba21](https://user-images.githubusercontent.com/27640522/30775904-c7c13c74-a0d7-11e7-9d7f-a4ef748605d9.png)

----

One more minor fix.
Fix my mistake in #4534 . `overflow-wrap` is not supported on Edge.....