### PR TITLE
Thread toot notification mails by conversation

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -8,7 +8,7 @@ class NotificationMailer < ApplicationMailer
     @status = notification.target_status
 
     locale_for_account(@me) do
-      set_conversation_id @status.conversation
+      thread_by_conversation(@status.conversation)
       mail to: @me.user.email, subject: I18n.t('notification_mailer.mention.subject', name: @status.account.acct)
     end
   end
@@ -28,7 +28,7 @@ class NotificationMailer < ApplicationMailer
     @status  = notification.target_status
 
     locale_for_account(@me) do
-      set_conversation_id @status.conversation
+      thread_by_conversation(@status.conversation)
       mail to: @me.user.email, subject: I18n.t('notification_mailer.favourite.subject', name: @account.acct)
     end
   end
@@ -39,7 +39,7 @@ class NotificationMailer < ApplicationMailer
     @status  = notification.target_status
 
     locale_for_account(@me) do
-      set_conversation_id @status.conversation
+      thread_by_conversation(@status.conversation)
       mail to: @me.user.email, subject: I18n.t('notification_mailer.reblog.subject', name: @account.acct)
     end
   end
@@ -73,9 +73,9 @@ class NotificationMailer < ApplicationMailer
 
   private
 
-  def set_conversation_id(conversation)
+  def thread_by_conversation(conversation)
     return if conversation.nil?
-    msg_id = "<conversation-#{conversation.id}@#{Rails.configuration.x.local_domain}>"
+    msg_id = "<conversation-#{conversation.id}.#{conversation.created_at.strftime('%Y-%m-%d')}@#{Rails.configuration.x.local_domain}>"
     headers['In-Reply-To'] = msg_id
     headers['References'] = msg_id
   end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -8,6 +8,7 @@ class NotificationMailer < ApplicationMailer
     @status = notification.target_status
 
     locale_for_account(@me) do
+      set_conversation_id @status.conversation
       mail to: @me.user.email, subject: I18n.t('notification_mailer.mention.subject', name: @status.account.acct)
     end
   end
@@ -27,6 +28,7 @@ class NotificationMailer < ApplicationMailer
     @status  = notification.target_status
 
     locale_for_account(@me) do
+      set_conversation_id @status.conversation
       mail to: @me.user.email, subject: I18n.t('notification_mailer.favourite.subject', name: @account.acct)
     end
   end
@@ -37,6 +39,7 @@ class NotificationMailer < ApplicationMailer
     @status  = notification.target_status
 
     locale_for_account(@me) do
+      set_conversation_id @status.conversation
       mail to: @me.user.email, subject: I18n.t('notification_mailer.reblog.subject', name: @account.acct)
     end
   end
@@ -66,5 +69,14 @@ class NotificationMailer < ApplicationMailer
              count: @notifications.size
            )
     end
+  end
+
+  private
+
+  def set_conversation_id(conversation)
+    return if conversation.nil?
+    msg_id = "<conversation-#{conversation.id}@#{Rails.configuration.x.local_domain}>"
+    headers['In-Reply-To'] = msg_id
+    headers['References'] = msg_id
   end
 end


### PR DESCRIPTION
This change threads e-mail notifications by conversation when possible.

I initially wanted to use the (single-quoted) Mastodon-generated conversation identifiers as the local-part of the message identifier, but I decided to just take the index of the conversation in the database: indeed, we have no control over external conversations URI and thus I don't know how we could derive unique and valid e-mail addresses from those.