### PR TITLE
Compact status_ids in StatusRelationshipsPresenter

### DIFF
--- a/app/presenters/status_relationships_presenter.rb
+++ b/app/presenters/status_relationships_presenter.rb
@@ -11,7 +11,7 @@ class StatusRelationshipsPresenter
       @pins_map       = {}
     else
       statuses            = statuses.compact
-      status_ids          = statuses.flat_map { |s| [s.id, s.reblog_of_id] }.uniq
+      status_ids          = statuses.flat_map { |s| [s.id, s.reblog_of_id] }.uniq.compact
       conversation_ids    = statuses.map(&:conversation_id).compact.uniq
       pinnable_status_ids = statuses.map(&:proper).select { |s| s.account_id == current_account_id && %w(public unlisted).include?(s.visibility) }.map(&:id)
 


### PR DESCRIPTION
Remove `null` status IDs from the list to queries more efficient. On my [single user instance](mastodon.zunda.ninja), this could suppress response time spikes seen as 95-percentile (top panel; after the release `c7cd56241`) for a comparable traffic (bottom panel):

![screen shot 2017-09-21 at 7 59 51 am](https://user-images.githubusercontent.com/30968/30779888-a0926e04-a099-11e7-89dc-1cd4e0fc9f1d.png)

Before applying this change some of SQL queries ran slow.

For a request against `Api::V1::NotificationsController#index`, query from `/app/models/status.rb:177` was like below and ran for about 100 seconds.

```
SELECT "statuses"."reblog_of_id" FROM "statuses" WHERE ("statuses"."reblog_of_id" = ? OR "statuses"."reblog_of_id" IS NULL) AND "statuses"."account_id" = ? ORDER BY "statuses"."id" DESC
```

For a request against `Timelines::PublicController#show`, query from `app/controllers/application_controller.rb:89` was like below and ran fo about 120 seconds.

```
SELECT "statuses"."id", "statuses"."updated_at" FROM "statuses" LEFT OUTER JOIN "accounts" ON "accounts"."id" = "statuses"."account_id" WHERE ("statuses"."local" = ? OR "statuses"."uri" IS NULL) AND "statuses"."visibility" = ? AND (statuses.reblog_of_id IS NULL) AND (statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id) AND "accounts"."silenced" = ? ORDER BY "statuses"."id" DESC LIMIT ?
```

@unarist found that the phrase `OR "statuses"."reblog_of_id" IS NULL` is not necessary and is eliminated with this patch.


