### PR TITLE
Trivial refactoring for emojify()

### DIFF
--- a/app/javascript/mastodon/emoji.js
+++ b/app/javascript/mastodon/emoji.js
@@ -9,39 +9,38 @@ const emojify = (str, customEmojis = {}) => {
   let rtn = '';
   for (;;) {
     let match, i = 0, tag;
-    while (i < str.length && (tag = '<&'.indexOf(str[i])) === -1 && str[i] !== ':' && !(match = trie.search(str.slice(i)))) {
+    while (i < str.length && (tag = '<&:'.indexOf(str[i])) === -1 && !(match = trie.search(str.slice(i)))) {
       i += str.codePointAt(i) < 65536 ? 1 : 2;
     }
-    if (i === str.length)
+    let rend, replacement = '';
+    if (i === str.length) {
       break;
-    else if (tag >= 0) {
-      const tagend = str.indexOf('>;'[tag], i + 1) + 1;
-      if (!tagend)
-        break;
-      rtn += str.slice(0, tagend);
-      str = str.slice(tagend);
     } else if (str[i] === ':') {
-      try {
-        // if replacing :shortname: succeed, exit this block with "continue"
-        const closeColon = str.indexOf(':', i + 1) + 1;
-        if (!closeColon) throw null; // no pair of ':'
+      if (!(() => {
+        rend = str.indexOf(':', i + 1) + 1;
+        if (!rend) return false; // no pair of ':'
         const lt = str.indexOf('<', i + 1);
-        if (!(lt === -1 || lt >= closeColon)) throw null; // tag appeared before closing ':'
-        const shortname = str.slice(i, closeColon);
+        if (!(lt === -1 || lt >= rend)) return false; // tag appeared before closing ':'
+        const shortname = str.slice(i, rend);
+        // now got a replacee as ':shortname:'
+        // if you want additional emoji handler, add statements below which set replacement and return true.
         if (shortname in customEmojis) {
-          rtn += str.slice(0, i) + `<img draggable="false" class="emojione" alt="${shortname}" title="${shortname}" src="${customEmojis[shortname]}" />`;
-          str = str.slice(closeColon);
-          continue;
+          replacement = `<img draggable="false" class="emojione" alt="${shortname}" title="${shortname}" src="${customEmojis[shortname]}" />`;
+          return true;
         }
-      } catch (e) {}
-      // replacing :shortname: failed
-      rtn += str.slice(0, i + 1);
-      str = str.slice(i + 1);
-    } else {
+        return false;
+      })()) rend = ++i;
+    } else if (tag >= 0) { // <, &
+      rend = str.indexOf('>;'[tag], i + 1) + 1;
+      if (!rend) break;
+      i = rend;
+    } else { // matched to unicode emoji
       const [filename, shortCode] = unicodeMapping[match];
-      rtn += str.slice(0, i) + `<img draggable="false" class="emojione" alt="${match}" title=":${shortCode}:" src="${assetHost}/emoji/${filename}.svg" />`;
-      str = str.slice(i + match.length);
+      replacement = `<img draggable="false" class="emojione" alt="${match}" title=":${shortCode}:" src="${assetHost}/emoji/${filename}.svg" />`;
+      rend = i + match.length;
     }
+    rtn += str.slice(0, i) + replacement;
+    str = str.slice(rend);
   }
   return rtn + str;
 };


### PR DESCRIPTION
This commit makes no improvement or new feature 

- Before modification, loop process (set rtn & str) existed on every conditional branch so unite them.
- Some instances still support old emojifier of shortcode or original one. I added a comment about suggestion for handling it.