### PR TITLE
Suppress backtrace when failed to communicate with a remote instance

### DIFF
--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -16,7 +16,7 @@ class ActivityPub::DeliveryWorker
 
     raise Mastodon::UnexpectedResponseError, @response unless response_successful?
   rescue => e
-    raise e.class, "Delivery failed for #{inbox_url}: #{e.message}"
+    raise e.class, "Delivery failed for #{inbox_url}: #{e.message}", e.backtrace[0]
   end
 
   private

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -17,7 +17,7 @@ class Pubsubhubbub::DeliveryWorker
     @payload = payload
     process_delivery unless blocked_domain?
   rescue => e
-    raise e.class, "Delivery failed for #{subscription&.callback_url}: #{e.message}"
+    raise e.class, "Delivery failed for #{subscription&.callback_url}: #{e.message}", e.backtrace[0]
   end
 
   private

--- a/app/workers/pubsubhubbub/subscribe_worker.rb
+++ b/app/workers/pubsubhubbub/subscribe_worker.rb
@@ -29,6 +29,6 @@ class Pubsubhubbub::SubscribeWorker
     logger.debug "PuSH re-subscribing to #{account.acct}"
     ::SubscribeService.new.call(account)
   rescue => e
-    raise e.class, "Subscribe failed for #{account&.acct}: #{e.message}"
+    raise e.class, "Subscribe failed for #{account&.acct}: #{e.message}", e.backtrace[0]
   end
 end


### PR DESCRIPTION
When we're sure that the trouble is on the remote instance, backtrace like below are a little bit too much. This change removes the backtrace except for the first two lines.

```
45 TID-ovbdu282o WARN: Mastodon::UnexpectedResponseError: Delivery failed for https://example.com/inbox: https://example.com/inbox returned code 500
45 TID-ovbdu282o WARN: /app/app/workers/activitypub/delivery_worker.rb:19:in `rescue in perform'
/app/app/workers/activitypub/delivery_worker.rb:11:in `perform'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:199:in `execute_job'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:170:in `block (2 levels) in process'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:128:in `block in invoke'
/app/vendor/bundle/ruby/2.4.0/gems/scout_apm-2.1.30/lib/scout_apm/background_job_integrations/sidekiq.rb:71:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-unique-jobs-5.0.10/lib/sidekiq_unique_jobs/server/middleware.rb:17:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:133:in `invoke'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:169:in `block in process'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:141:in `block (6 levels) in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/job_retry.rb:97:in `local'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:140:in `block (5 levels) in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/rails.rb:42:in `block in call'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/execution_wrapper.rb:85:in `wrap'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/reloader.rb:68:in `block in wrap'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/execution_wrapper.rb:85:in `wrap'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/reloader.rb:67:in `wrap'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/rails.rb:41:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:136:in `block (4 levels) in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:215:in `stats'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:131:in `block (3 levels) in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/job_logger.rb:7:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:130:in `block (2 levels) in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/job_retry.rb:72:in `global'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:129:in `block in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/logging.rb:44:in `with_context'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/logging.rb:38:in `with_job_hash_context'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:128:in `dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:168:in `process'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:85:in `process_one'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:73:in `run'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/util.rb:16:in `watchdog'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/util.rb:25:in `block in safe_thread'
```