### PR TITLE
Refresh manifest before generate 500.html (regression from #5067)

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 
-if Rake::Task.task_defined?('assets:precompile')
-  Rake::Task['assets:precompile'].enhance do
+namespace :assets do
+  desc 'Generate 500.html'
+  task :generate_500 do
     html = ApplicationController.render('errors/500', layout: 'error')
     File.write(Rails.root.join('public', '500.html'), html)
+  end
+end
+
+if Rake::Task.task_defined?('assets:precompile')
+  Rake::Task['assets:precompile'].enhance do
+    Webpacker::Manifest.load
+
+    Rake::Task['assets:generate_500'].invoke
   end
 end


### PR DESCRIPTION
`Webpacker::Manifest` caches values when not in the development environment.

https://github.com/rails/webpacker/blob/v2.0.0/lib/webpacker/manifest.rb#L17

It needs to be refreshed before generating 500.html.
