### PR TITLE
Fix the 500.html rendering error in production environment

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -2,6 +2,7 @@
 
 if Rake::Task.task_defined?('assets:precompile')
   Rake::Task['assets:precompile'].enhance do
+    Webpacker::Manifest.load
     html = ApplicationController.render('errors/500', layout: 'error')
     File.write(Rails.root.join('public', '500.html'), html)
   end


### PR DESCRIPTION
After #5067 is merged, I got an error `ActionView::Template::Error: Can't find common.css in /Users/nullkal/devel/mastodon/public/packs/manifest.json. Is webpack still compiling?` in the production environment (edge.mstdn.jp).

It seems the reason of it is that `manifest.json` is not reloaded after the webpack's asset compilation. So, I added the code to make it be reloaded manually.