### PR TITLE
Increase max height of preview card image

### DIFF
--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -32,7 +32,7 @@ class PreviewCard < ApplicationRecord
 
   has_and_belongs_to_many :statuses
 
-  has_attached_file :image, styles: { original: '280x120>' }, convert_options: { all: '-quality 80 -strip' }
+  has_attached_file :image, styles: { original: '280x280>' }, convert_options: { all: '-quality 80 -strip' }
 
   include Attachmentable
   include Remotable


### PR DESCRIPTION
We added horizontal layout to preview card for wide image. However, max height of the thumbnail is still limited to 120px and it makes nearly square images to too small for that layout.

This PR increases max height as well as max width.