### PR TITLE
Put Emoji in attachment

### DIFF
--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -7,7 +7,7 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
              :atom_uri, :in_reply_to_atom_uri,
              :conversation
 
-  has_many :media_attachments, key: :attachment
+  has_many :virtual_attachments, key: :attachment
   has_many :virtual_tags, key: :tag
 
   def id
@@ -44,6 +44,10 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
     ActivityPub::TagManager.instance.url_for(object)
   end
 
+  def virtual_attachments
+    object.emojis + object.media_attachments
+  end
+
   def attributed_to
     ActivityPub::TagManager.instance.uri_for(object.account)
   end
@@ -57,7 +61,7 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   end
 
   def virtual_tags
-    object.mentions + object.tags + object.emojis
+    object.mentions + object.tags
   end
 
   def atom_uri
@@ -141,13 +145,13 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   class CustomEmojiSerializer < ActiveModel::Serializer
     include RoutingHelper
 
-    attributes :type, :href, :name
+    attributes :type, :url, :name
 
     def type
       'Emoji'
     end
 
-    def href
+    def url
       full_asset_url(object.image.url)
     end
 

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -225,10 +225,10 @@ RSpec.describe ActivityPub::Activity::Create do
           id: 'bar',
           type: 'Note',
           content: 'Lorem ipsum :tinking:',
-          tag: [
+          attachment: [
             {
               type: 'Emoji',
-              href: 'http://example.com/emoji.png',
+              url: 'http://example.com/emoji.png',
               name: 'tinking',
             },
           ],


### PR DESCRIPTION
The definition of `tag` says:
> The key difference between `attachment` and `tag` is that the former implies association by inclusion, while the latter implies associated by reference.

ActivityVocabulary, section 4
https://www.w3.org/TR/activitystreams-vocabulary/#dfn-tag

Though emoji behaves like other tags already implemented in terms that they are inlined, it is irrelevant from the definition. When strictly following the specification, `attachment` is suitable for Emoji.