### PR TITLE
Fix width of single media on media-gallery in users pages

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -161,10 +161,8 @@ class Item extends React.PureComponent {
       );
     }
 
-    const style = standalone ? {} : { left, top, right, bottom, width: `${width}%`, height: `${height}%` };
-
     return (
-      <div className={classNames('media-gallery__item', { standalone })} key={attachment.get('id')} style={style}>
+      <div className={classNames('media-gallery__item', { standalone })} key={attachment.get('id')} style={{ left: left, top: top, right: right, bottom: bottom, width: `${width}%`, height: `${height}%` }}>
         {thumbnail}
       </div>
     );


### PR DESCRIPTION
Fix bug related to #5054 .

`width: 100%;` setting is needed for single media on media-gallery in users pages.
Of course, uncropping single image and media spoiler sizing for detail status view works properly.

Before and after images below.
![ba22](https://user-images.githubusercontent.com/27640522/30821139-41ff0e52-a25f-11e7-9bb2-db2889a7f95e.png)
