### PR TITLE
Send streaming API delete to people mentioned in status

### DIFF
--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -84,6 +84,8 @@ class BatchedRemoveStatusService < BaseService
   end
 
   def unpush_from_public_timelines(status)
+    return unless status.public_visibility?
+
     payload = @json_payloads[status.id]
 
     redis.pipelined do


### PR DESCRIPTION
- Previously they wouldn't receive it unless they were author's followers
- Skip unpush from public/hashtag timelines if status wasn't public in the first place