### PR TITLE
Refactor 500 file generation for the future extensions

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,18 +1,22 @@
 # frozen_string_literal: true
 
+def render_static_page(action, dest:, **opts)
+  I18n.with_locale(ENV['DEFAULT_LOCALE'] || I18n.default_locale) do
+    html = ApplicationController.render(action, opts)
+    File.write(dest, html)
+  end
+end
+
 namespace :assets do
-  desc 'Generate 500.html'
-  task :generate_500 do
-    I18n.with_locale(ENV['DEFAULT_LOCALE'] || I18n.default_locale) do
-      html = ApplicationController.render('errors/500', layout: 'error')
-      File.write(Rails.root.join('public', '500.html'), html)
-    end
+  desc 'Generate static pages'
+  task :generate_static_pages do
+    render_static_page 'errors/500', layout: 'error', dest: Rails.root.join('public', '500.html')
   end
 end
 
 if Rake::Task.task_defined?('assets:precompile')
   Rake::Task['assets:precompile'].enhance do
     Webpacker::Manifest.load
-    Rake::Task['assets:generate_500'].invoke
+    Rake::Task['assets:generate_static_pages'].invoke
   end
 end


### PR DESCRIPTION
I created a new method `render_static_page` and made it easier to add more static pages to be rendered in `assets:precompile`. This PR renames `generate_500` to `generate_static_pages` because we might need to add more static pages here in the future. Moreover, some instance owners might want to extend here to render such as maintenance page.