### PR TITLE
When OAuth password verification fails, return 401 instead of redirect

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -7,15 +7,14 @@ Doorkeeper.configure do
     current_user || redirect_to(new_user_session_url)
   end
 
-  resource_owner_from_credentials do |routes|
-    request.params[:user] = { email: request.params[:username], password: request.params[:password] }
-    request.env["devise.allow_params_authentication"] = true
-    request.env["warden"].authenticate!(scope: :user)
+  resource_owner_from_credentials do |_routes|
+    user = User.find_by(email: request.params[:username])
+    user if !user&.otp_required_for_login? && user&.valid_password?(request.params[:password])
   end
 
   # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
   admin_authenticator do
-    (current_user && current_user.admin?) || redirect_to(new_user_session_url)
+    current_user&.admin? || redirect_to(new_user_session_url)
   end
 
   # Authorization Code expiration time (default 10 minutes).


### PR DESCRIPTION
Call to warden.authenticate! in resource_owner_from_credentials would make the request redirect to sign-in path, which is a bad response for apps. Now bad credentials just return nil, which leads to HTTP 401 from Doorkeeper. Also, accounts with enabled 2FA cannot be logged into this way.

As far as I know this only affects `POST /oauth/token` response with grant_type=password