### PR TITLE
Fix empty query sent to postgres for custom emojis

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -33,7 +33,11 @@ class CustomEmoji < ApplicationRecord
   class << self
     def from_text(text, domain)
       return [] if text.blank?
-      shortcodes = text.scan(SCAN_RE).map(&:first)
+
+      shortcodes = text.scan(SCAN_RE).map(&:first).uniq
+
+      return [] if shortcodes.empty?
+
       where(shortcode: shortcodes, domain: domain)
     end
   end


### PR DESCRIPTION
When shortcodes array was empty it sent a WHERE 1=0 query to the db.