### PR TITLE
Update Yarn to version 1.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ENV UID=991 GID=991 \
     RAILS_SERVE_STATIC_FILES=true \
     RAILS_ENV=production NODE_ENV=production
 
+ARG YARN_VERSION=1.1.0
+ARG YARN_DOWNLOAD_SHA256=171c1f9ee93c488c0d774ac6e9c72649047c3f896277d88d0f805266519430f3
 ARG LIBICONV_VERSION=1.15
 ARG LIBICONV_DOWNLOAD_SHA256=ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178
 
@@ -19,6 +21,7 @@ RUN apk -U upgrade \
     build-base \
     icu-dev \
     libidn-dev \
+    libressl \
     libtool \
     postgresql-dev \
     protobuf-dev \
@@ -32,16 +35,21 @@ RUN apk -U upgrade \
     imagemagick \
     libidn \
     libpq \
-    nodejs-npm \
     nodejs \
+    nodejs-npm \
     protobuf \
     su-exec \
     tini \
-    yarn \
  && update-ca-certificates \
+ && mkdir -p /tmp/src /opt \
+ && wget -O yarn.tar.gz "https://github.com/yarnpkg/yarn/releases/download/v1.1.0/yarn-v$YARN_VERSION.tar.gz" \
+ && echo "$YARN_DOWNLOAD_SHA256 *yarn.tar.gz" | sha256sum -c - \
+ && tar -xzf yarn.tar.gz -C /tmp/src \
+ && rm yarn.tar.gz \
+ && mv /tmp/src/yarn-v$YARN_VERSION /opt/yarn \
+ && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
  && wget -O libiconv.tar.gz "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-$LIBICONV_VERSION.tar.gz" \
  && echo "$LIBICONV_DOWNLOAD_SHA256 *libiconv.tar.gz" | sha256sum -c - \
- && mkdir -p /tmp/src \
  && tar -xzf libiconv.tar.gz -C /tmp/src \
  && rm libiconv.tar.gz \
  && cd /tmp/src/libiconv-$LIBICONV_VERSION \
@@ -56,7 +64,7 @@ COPY Gemfile Gemfile.lock package.json yarn.lock /mastodon/
 
 RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include \
  && bundle install -j$(getconf _NPROCESSORS_ONLN) --deployment --without test development \
- && yarn --ignore-optional --pure-lockfile
+ && yarn --pure-lockfile
 
 COPY . /mastodon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apk -U upgrade \
     tini \
  && update-ca-certificates \
  && mkdir -p /tmp/src /opt \
- && wget -O yarn.tar.gz "https://github.com/yarnpkg/yarn/releases/download/v1.1.0/yarn-v$YARN_VERSION.tar.gz" \
+ && wget -O yarn.tar.gz "https://github.com/yarnpkg/yarn/releases/download/v$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
  && echo "$YARN_DOWNLOAD_SHA256 *yarn.tar.gz" | sha256sum -c - \
  && tar -xzf yarn.tar.gz -C /tmp/src \
  && rm yarn.tar.gz \


### PR DESCRIPTION
Resolve #5124

Webpacker is required newer Yarn (rails/webpacker#727).

However, old Yarn is used in Docker. We must make use of new Yarn.