### PR TITLE
Use nullDB during asset compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 
 before_script:
   - bundle exec rake parallel:create parallel:load_schema parallel:prepare
-  - bundle exec rails assets:precompile
+  - bundle exec rails assets:precompile DB_ADAPTER=nulldb
   - ln -s /usr/bin/x86_64-linux-gnu-g++-6 "$HOME/g++"
 
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'paperclip', '~> 5.1'
 gem 'paperclip-av-transcoder', '~> 0.6'
 
 gem 'active_model_serializers', '~> 0.10'
+gem 'activerecord-nulldb-adapter'
 gem 'addressable', '~> 2.5'
 gem 'bootsnap'
 gem 'browser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       activemodel (= 5.1.4)
       activesupport (= 5.1.4)
       arel (~> 8.0)
+    activerecord-nulldb-adapter (0.3.7)
+      activerecord (>= 2.0.0)
     activesupport (5.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -536,6 +538,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10)
   active_record_query_trace (~> 1.5)
+  activerecord-nulldb-adapter
   addressable (~> 2.5)
   annotate (~> 2.7)
   aws-sdk (~> 2.9)

--- a/boxfile.yml
+++ b/boxfile.yml
@@ -44,7 +44,7 @@ run.config:
 
 deploy.config:
   extra_steps:
-    - NODE_ENV=production bundle exec rake assets:precompile
+    - NODE_ENV=production DB_ADAPTER=nulldb bundle exec rake assets:precompile
   transform:
     - "sed 's/LOCAL_HTTPS=.*/LOCAL_HTTPS=true/i' /app/.env.nanobox | envsubst > /app/.env.production"
     - |-

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,5 @@
 default: &default
-  adapter: postgresql
+  adapter: <%= ENV['DB_ADAPTER'] || 'postgresql' %>
   pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>
   timeout: 5000
   encoding: unicode


### PR DESCRIPTION
This change allows Nanobox users to continue deploying Mastodon instances, and also speeds up the asset compilation phase for other users who might want it. It adds the ActiveRecord nullDB driver, and lets users switch to it by setting an environment variable (`DB_ADAPTER=nulldriver`), which can be done as part of the `rake assets:precompile` command. For Nanobox users, it relieves the need for an actual database connection during the `compile` step (part of the deploy process which prepares the code for upload to the server). For all users, it speeds up asset compilation by converting all DB calls to no-ops, which is considerably faster than talking to an actual Postgres DB during a phase which doesn't actually need DB access to begin with (even though Rails loads itself entirely for the process anyway).

Blocks tootsuite/documentation#403