### PR TITLE
Flush body when POST requests

### DIFF
--- a/app/services/send_interaction_service.rb
+++ b/app/services/send_interaction_service.rb
@@ -12,7 +12,7 @@ class SendInteractionService < BaseService
 
     return if !target_account.ostatus? || block_notification?
 
-    delivery = build_request.perform
+    delivery = build_request.perform.flush
 
     raise Mastodon::UnexpectedResponseError, delivery unless delivery.code > 199 && delivery.code < 300
   end

--- a/app/services/subscribe_service.rb
+++ b/app/services/subscribe_service.rb
@@ -6,7 +6,7 @@ class SubscribeService < BaseService
 
     @account        = account
     @account.secret = SecureRandom.hex
-    @response       = build_request.perform
+    @response       = build_request.perform.flush
 
     if response_failed_permanently?
       # We're not allowed to subscribe. Fail and move on.

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -7,7 +7,7 @@ class UnsubscribeService < BaseService
     @account = account
 
     begin
-      @response = build_request.perform
+      @response = build_request.perform.flush
 
       Rails.logger.debug "PuSH unsubscribe for #{@account.acct} failed: #{@response.status}" unless @response.status.success?
     rescue HTTP::Error, OpenSSL::SSL::SSLError => e

--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -28,7 +28,7 @@ class ActivityPub::DeliveryWorker
   end
 
   def perform_request
-    @response = build_request.perform
+    @response = build_request.perform.flush
   end
 
   def response_successful?

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -37,7 +37,7 @@ class Pubsubhubbub::DeliveryWorker
   def callback_post_payload
     request = Request.new(:post, subscription.callback_url, body: payload)
     request.add_headers(headers)
-    request.perform
+    request.perform.flush
   end
 
   def blocked_domain?


### PR DESCRIPTION
When sending a POST request to another instance by DeliveryWorker etc., body is not read. So, even though the request has been completed, the connection will last for a while. This PR solves this problem by reading the body by calling the flush method.

Related: https://github.com/httprb/http/pull/125