### PR TITLE
If HTTP signature is wrong and webfinger cache is stale, retry with resolve

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -44,6 +44,15 @@ module SignatureVerification
     if account.keypair.public_key.verify(OpenSSL::Digest::SHA256.new, signature, compare_signed_string)
       @signed_request_account = account
       @signed_request_account
+    elsif account.possibly_stale?
+      account = account.refresh!
+
+      if account.keypair.public_key.verify(OpenSSL::Digest::SHA256.new, signature, compare_signed_string)
+        @signed_request_account = account
+        @signed_request_account
+      else
+        @signed_request_account = nil
+      end
     else
       @signed_request_account = nil
     end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -137,6 +137,15 @@ class Account < ApplicationRecord
     subscription_expires_at.present?
   end
 
+  def possibly_stale?
+    last_webfingered_at.nil? || last_webfingered_at <= 1.day.ago
+  end
+
+  def refresh!
+    return if local?
+    ResolveRemoteAccountService.new.call(acct)
+  end
+
   def keypair
     @keypair ||= OpenSSL::PKey::RSA.new(private_key || public_key)
   end

--- a/app/services/resolve_remote_account_service.rb
+++ b/app/services/resolve_remote_account_service.rb
@@ -74,7 +74,7 @@ class ResolveRemoteAccountService < BaseService
   end
 
   def webfinger_update_due?
-    @account.nil? || @account.last_webfingered_at.nil? || @account.last_webfingered_at <= 1.day.ago
+    @account.nil? || @account.possibly_stale?
   end
 
   def activitypub_ready?


### PR DESCRIPTION
If the signature could not be verified and the webfinger of the account was last retrieved longer than the cache period, try re-resolving the account and then attempting to verify the signature again