### PR TITLE
Change max redirects followed to 2

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -85,6 +85,6 @@ class Request
   end
 
   def http_client
-    HTTP.timeout(:per_operation, timeout).follow
+    HTTP.timeout(:per_operation, timeout).follow(max_hops: 2)
   end
 end


### PR DESCRIPTION
I see no reason to allow more than that. Usually a redirect is HTTP->HTTPS, then maybe URL structure changed, but more than that is highly unlikely to be a legitimate use case.