### PR TITLE
Implement emoji import feature

### DIFF
--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -4,17 +4,48 @@ module Admin
   class CustomEmojisController < BaseController
     def index
       @custom_emojis = CustomEmoji.local
+      @status = Status.new
     end
 
-    def new
+    def import_form
+      @custom_emoji = CustomEmoji.new
+      render_import_form_with_status_url import_form_params.require(:url)
+    rescue ActionController::ParameterMissing
+      redirect_to action: :index, flash: { error: I18n.t('admin.custom_emojis.status_unspecified_msg') }
+    end
+
+    def upload_form
       @custom_emoji = CustomEmoji.new
       @custom_emoji.build_custom_emoji_icon
     end
 
-    def create
+    def import
+      super_custom_emoji = CustomEmoji.find(import_params.require(:super_id))
+    rescue ActionController::ParameterMissing
+      @custom_emoji = CustomEmoji.new
+      flash.now[:error] = I18n.t('admin.custom_emojis.emoji_unspecified_msg')
+      render_import_form_with_status_id params.require(:status).require(:id)
+    rescue ActiveRecord::RecordNotFound
+      @custom_emoji = CustomEmoji.new
+      flash.now[:error] = I18n.t('admin.custom_emojis.emoji_not_found_msg')
+      render_import_form_with_status_id params.require(:status).require(:id)
+    else
       @custom_emoji = CustomEmoji.new(
-        custom_emoji_icon: CustomEmojiIcon.new(image: resource_params.dig(:custom_emoji_icon, :image)),
-        shortcode: resource_params[:shortcode]
+        custom_emoji_icon: super_custom_emoji.custom_emoji_icon,
+        shortcode: import_params[:shortcode] || super_custom_emoji.shortcode
+      )
+
+      if @custom_emoji.save
+        redirect_to admin_custom_emojis_path, notice: I18n.t('admin.custom_emojis.created_msg')
+      else
+        render_import_form_with_status_id params.require(:status).require(:id)
+      end
+    end
+
+    def upload
+      @custom_emoji = CustomEmoji.new(
+        custom_emoji_icon: CustomEmojiIcon.new(image: upload_params.dig(:custom_emoji_icon, :image)),
+        shortcode: upload_params[:shortcode]
       )
 
       saved = ApplicationRecord.transaction do
@@ -24,7 +55,7 @@ module Admin
       if saved
         redirect_to admin_custom_emojis_path, notice: I18n.t('admin.custom_emojis.created_msg')
       else
-        render :new
+        render :upload_form
       end
     end
 
@@ -42,8 +73,40 @@ module Admin
 
     private
 
-    def resource_params
-      params.require(:custom_emoji).permit([:shortcode, { custom_emoji_icon: :image }])
+    def render_import_form_with_status_url(url)
+      status = FetchRemoteResourceService.new.call(url)
+      if status&.respond_to? :emojis
+        render_import_form_with_status status
+      else
+        redirect_to action: :index, flash: { error: I18n.t('admin.custom_emojis.status_not_found_msg') }
+      end
+    end
+
+    def render_import_form_with_status_id(id)
+      render_import_form_with_status Status.find(id)
+    rescue ActiveRecord::RecordNotFound
+      redirect_to action: :index, flash: { error: I18n.t('admin.custom_emojis.status_not_found_msg') }
+    end
+
+    def render_import_form_with_status(status)
+      @status = status
+      @remote_custom_emojis = status.emojis.reject do |custom_emoji|
+        custom_emoji.custom_emoji_icon.custom_emojis.local.exists?
+      end
+
+      render :import_form
+    end
+
+    def import_form_params
+      params.require(:status).permit(:url)
+    end
+
+    def import_params
+      params.require(:custom_emoji).permit([:shortcode, :super_id])
+    end
+
+    def upload_params
+      params.require(:custom_emoji).permit([:shortcode, { custom_emoji_icon: [:image] }])
     end
   end
 end

--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -8,12 +8,20 @@ module Admin
 
     def new
       @custom_emoji = CustomEmoji.new
+      @custom_emoji.build_custom_emoji_icon
     end
 
     def create
-      @custom_emoji = CustomEmoji.new(resource_params)
+      @custom_emoji = CustomEmoji.new(
+        custom_emoji_icon: CustomEmojiIcon.new(image: resource_params.dig(:custom_emoji_icon, :image)),
+        shortcode: resource_params[:shortcode]
+      )
 
-      if @custom_emoji.save
+      saved = ApplicationRecord.transaction do
+        @custom_emoji.custom_emoji_icon.save && @custom_emoji.save
+      end
+
+      if saved
         redirect_to admin_custom_emojis_path, notice: I18n.t('admin.custom_emojis.created_msg')
       else
         render :new
@@ -21,14 +29,21 @@ module Admin
     end
 
     def destroy
-      CustomEmoji.find(params[:id]).destroy
+      custom_emoji = CustomEmoji.local.find(params[:id])
+      custom_emoji.destroy!
+
+      ApplicationRecord.transaction do
+        icon = custom_emoji.custom_emoji_icon
+        icon.destroy! if icon.local?
+      end
+
       redirect_to admin_custom_emojis_path, notice: I18n.t('admin.custom_emojis.destroyed_msg')
     end
 
     private
 
     def resource_params
-      params.require(:custom_emoji).permit(:shortcode, :image)
+      params.require(:custom_emoji).permit([:shortcode, { custom_emoji_icon: :image }])
     end
   end
 end

--- a/app/controllers/emojis_controller.rb
+++ b/app/controllers/emojis_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class EmojisController < ApplicationController
+  before_action :set_emoji
+
+  def show
+    respond_to do |format|
+      format.json do
+        render json: @emoji, serializer: ActivityPub::CustomEmojiIconSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'
+      end
+
+      format.atom do
+        render xml: OStatus::AtomSerializer.render(OStatus::AtomSerializer.new.emoji_icon(@emoji, true))
+      end
+    end
+  end
+
+  private
+
+  def set_emoji
+    @emoji = CustomEmojiIcon.local.find(params.require(:id))
+  end
+end

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -49,6 +49,10 @@ class ActivityPub::Activity
 
   protected
 
+  def emoji_from_uri(uri)
+    ActivityPub::TagManager.instance.uri_to_resource(uri, CustomEmojiIcon)
+  end
+
   def status_from_uri(uri)
     ActivityPub::TagManager.instance.uri_to_resource(uri, Status)
   end

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -28,6 +28,8 @@ class ActivityPub::TagManager
     return target.uri if target.respond_to?(:local?) && !target.local?
 
     case target.object_type
+    when :emoji
+      emoji_url(target)
     when :person
       account_url(target)
     when :note, :comment, :activity
@@ -95,6 +97,8 @@ class ActivityPub::TagManager
       case klass.name
       when 'Account'
         klass.find_local(uri_to_local_id(uri, :username))
+      when 'CustomEmojiIcon'
+        klass.find_local(uri_to_local_id(uri))
       else
         StatusFinder.new(uri).status
       end

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -92,7 +92,7 @@ class Formatter
   def encode_custom_emojis(html, emojis)
     return html if emojis.empty?
 
-    emoji_map = emojis.map { |e| [e.shortcode, full_asset_url(e.image.url)] }.to_h
+    emoji_map = emojis.map { |e| [e.shortcode, full_asset_url(e.custom_emoji_icon.image.url)] }.to_h
 
     i                     = -1
     inside_tag            = false

--- a/app/lib/ostatus/activity/creation.rb
+++ b/app/lib/ostatus/activity/creation.rb
@@ -160,10 +160,6 @@ class OStatus::Activity::Creation < OStatus::Activity::Base
   end
 
   def save_emojis(parent)
-    do_not_download = DomainBlock.find_by(domain: parent.account.domain)&.reject_media?
-
-    return if do_not_download
-
     @xml.xpath('./xmlns:link[@rel="emoji"]', xmlns: OStatus::TagManager::XMLNS).each do |link|
       next unless link['href'] && link['name']
 
@@ -172,8 +168,29 @@ class OStatus::Activity::Creation < OStatus::Activity::Base
 
       next unless emoji.nil?
 
-      emoji = CustomEmoji.new(shortcode: shortcode, domain: parent.account.domain)
-      emoji.image_remote_url = link['href']
+      icon = ActivityPub::TagManager.instance.uri_to_resource(link['href'], CustomEmojiIcon)
+      if icon.nil?
+        begin
+          parsed_href = Addressable::URI.parse(link['href'])
+        rescue Addressable::URI::InvalidURIError => e
+          Rails.logger.debug e
+          next
+        end
+
+        do_not_download = DomainBlock.find_by(domain: parsed_href.normalized_host)&.reject_media?
+
+        next if do_not_download
+
+        icon = FetchRemoteCustomEmojiIconService.new.call(link['href'])
+      end
+
+      next if icon.nil?
+
+      emoji = CustomEmoji.new(
+        custom_emoji_icon: icon,
+        shortcode: shortcode,
+        domain: parent.account.domain
+      )
       emoji.save
     end
   end

--- a/app/lib/ostatus/atom_serializer.rb
+++ b/app/lib/ostatus/atom_serializer.rb
@@ -34,6 +34,22 @@ class OStatus::AtomSerializer
     author
   end
 
+  def emoji_icon(icon, root = false)
+    image = Ox::Element.new('entry')
+
+    add_namespaces(image) if root
+    append_element(image, 'id', OStatus::TagManager.instance.uri_for(icon))
+    append_element(
+      image,
+      'link',
+      nil,
+      rel: :enclosure,
+      href: icon.image_remote_url || full_asset_url(icon.image.url(:original, false))
+    )
+
+    image
+  end
+
   def feed(account, stream_entries)
     feed = Ox::Element.new('feed')
 
@@ -370,7 +386,7 @@ class OStatus::AtomSerializer
     append_element(entry, 'mastodon:scope', status.visibility)
 
     status.emojis.each do |emoji|
-      append_element(entry, 'link', nil, rel: :emoji, href: full_asset_url(emoji.image.url), name: emoji.shortcode)
+      append_element(entry, 'link', nil, rel: :emoji, href: OStatus::TagManager.instance.uri_for(emoji.custom_emoji_icon), name: emoji.shortcode)
     end
   end
 end

--- a/app/lib/ostatus/tag_manager.rb
+++ b/app/lib/ostatus/tag_manager.rb
@@ -64,6 +64,8 @@ class OStatus::TagManager
     return target.uri if target.respond_to?(:local?) && !target.local?
 
     case target.object_type
+    when :emoji
+      emoji_url(target)
     when :person
       account_url(target)
     when :note, :comment, :activity

--- a/app/lib/tag_manager.rb
+++ b/app/lib/tag_manager.rb
@@ -29,7 +29,8 @@ class TagManager
   end
 
   def local_url?(url)
-    uri    = Addressable::URI.parse(url).normalize
+    uri = Addressable::URI.parse(url).normalize
+    return false if uri.host.nil?
     domain = uri.host + (uri.port ? ":#{uri.port}" : '')
     TagManager.instance.web_domain?(domain)
   end

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -3,15 +3,12 @@
 #
 # Table name: custom_emojis
 #
-#  id                 :integer          not null, primary key
-#  shortcode          :string           default(""), not null
-#  domain             :string
-#  image_file_name    :string
-#  image_content_type :string
-#  image_file_size    :integer
-#  image_updated_at   :datetime
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id                   :integer          not null, primary key
+#  shortcode            :string           default(""), not null
+#  domain               :string
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  custom_emoji_icon_id :integer          not null
 #
 
 class CustomEmoji < ApplicationRecord
@@ -21,14 +18,10 @@ class CustomEmoji < ApplicationRecord
     :(#{SHORTCODE_RE_FRAGMENT}):
     (?=[^[:alnum:]:]|$)/x
 
-  has_attached_file :image
-
-  validates_attachment :image, content_type: { content_type: 'image/png' }, presence: true, size: { in: 0..50.kilobytes }
+  belongs_to :custom_emoji_icon, inverse_of: :custom_emojis
   validates :shortcode, uniqueness: { scope: :domain }, format: { with: /\A#{SHORTCODE_RE_FRAGMENT}\z/ }, length: { minimum: 2 }
 
   scope :local, -> { where(domain: nil) }
-
-  include Remotable
 
   class << self
     def from_text(text, domain)

--- a/app/models/custom_emoji_icon.rb
+++ b/app/models/custom_emoji_icon.rb
@@ -19,6 +19,7 @@ class CustomEmojiIcon < ApplicationRecord
   validates_attachment :image, content_type: { content_type: 'image/png' }, presence: true, size: { in: 0..50.kilobytes }
 
   scope :local, -> { where(uri: nil) }
+  scope :remote, -> { where.not(uri: nil) }
 
   include Remotable
 

--- a/app/models/custom_emoji_icon.rb
+++ b/app/models/custom_emoji_icon.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: custom_emoji_icons
+#
+#  id                 :integer          not null, primary key
+#  uri                :string
+#  image_remote_url   :string
+#  image_file_name    :string
+#  image_content_type :string
+#  image_file_size    :integer
+#  image_updated_at   :datetime
+#
+
+class CustomEmojiIcon < ApplicationRecord
+  has_many :custom_emojis, inverse_of: :custom_emoji_icon
+
+  has_attached_file :image
+  validates_attachment :image, content_type: { content_type: 'image/png' }, presence: true, size: { in: 0..50.kilobytes }
+
+  scope :local, -> { where(uri: nil) }
+
+  include Remotable
+
+  def self.find_local(id)
+    local.find(id)
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+
+  def local?
+    uri.nil?
+  end
+
+  def object_type
+    :emoji
+  end
+end

--- a/app/serializers/activitypub/custom_emoji_icon_serializer.rb
+++ b/app/serializers/activitypub/custom_emoji_icon_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ActivityPub::CustomEmojiIconSerializer < ActiveModel::Serializer
+  include RoutingHelper
+
+  attributes :id, :type, :url
+
+  def id
+    ActivityPub::TagManager.instance.uri_for(object)
+  end
+
+  def type
+    'Image'
+  end
+
+  def url
+    object.image_remote_url || full_asset_url(object.image.url)
+  end
+end

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -145,14 +145,14 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   class CustomEmojiSerializer < ActiveModel::Serializer
     include RoutingHelper
 
-    attributes :type, :href, :name
+    attributes :type, :name
 
     def type
       'Emoji'
     end
 
-    def href
-      full_asset_url(object.image.url)
+    def icon
+      ActivityPub::TagManager.instance.uri_for(object.custom_emoji_icon)
     end
 
     def name

--- a/app/serializers/rest/custom_emoji_serializer.rb
+++ b/app/serializers/rest/custom_emoji_serializer.rb
@@ -6,6 +6,6 @@ class REST::CustomEmojiSerializer < ActiveModel::Serializer
   attributes :shortcode, :url
 
   def url
-    full_asset_url(object.image.url)
+    full_asset_url(object.custom_emoji_icon.image.url)
   end
 end

--- a/app/services/activitypub/fetch_remote_custom_emoji_icon_service.rb
+++ b/app/services/activitypub/fetch_remote_custom_emoji_icon_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ActivityPub::FetchRemoteCustomEmojiIconService < BaseService
+  include JsonLdHelper
+
+  def call(uri, prefetched_json = nil)
+    @json = body_to_json(prefetched_json) || fetch_resource(uri)
+
+    return unless supported_context?(@json) && expected_type?
+
+    icon = CustomEmojiIcon.new(uri: @json['id'])
+    icon.image_remote_url = @json['url']
+    icon.save ? icon : nil
+  rescue Addressable::InvalidURIError => e
+    Rails.logger.debug e
+    nil
+  end
+
+  private
+
+  def expected_type?
+    @json['type'] == 'Image'
+  end
+end

--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -15,8 +15,8 @@ class FetchAtomService < BaseService
   rescue OpenSSL::SSL::SSLError => e
     Rails.logger.debug "SSL error: #{e}"
     nil
-  rescue HTTP::ConnectionError => e
-    Rails.logger.debug "HTTP ConnectionError: #{e}"
+  rescue HTTP::Error => e
+    Rails.logger.debug "HTTP error: #{e}"
     nil
   end
 

--- a/app/services/fetch_remote_custom_emoji_icon_service.rb
+++ b/app/services/fetch_remote_custom_emoji_icon_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class FetchRemoteCustomEmojiIconService < BaseService
+  def call(url, prefetched_body = nil, protocol = :ostatus)
+    if prefetched_body.nil?
+      resource_url, body, protocol = FetchAtomService.new.call(url)
+    else
+      resource_url = url
+      body         = prefetched_body
+    end
+
+    case protocol
+    when :ostatus
+      process_atom(resource_url, body)
+    when :activitypub
+      ActivityPub::FetchRemoteCustomEmojiIconService.new.call(resource_url, body)
+    end
+  end
+
+  private
+
+  def process_atom(url, body)
+    xml = Nokogiri::XML(body)
+    xml.encoding = 'utf-8'
+
+    entry = xml.at_xpath('/xmlns:entry', xmlns: OStatus::TagManager::XMLNS)
+    uri = entry.at_xpath('./xmlns:id', xmlns: OStatus::TagManager::XMLNS).content
+    href = entry.at_xpath('./xmlns:link[@rel="enclosure"]', xmlns: OStatus::TagManager::XMLNS)['href']
+
+    icon = CustomEmojiIcon.new(uri: uri)
+    icon.image_remote_url = href
+    icon.save ? icon : nil
+  rescue TypeError
+    Rails.logger.debug "Unparseable URL given: #{url}"
+    nil
+  rescue Nokogiri::XML::XPath::SyntaxError
+    Rails.logger.debug 'Invalid XML or missing namespace'
+    nil
+  end
+end

--- a/app/views/admin/custom_emojis/_custom_emoji.html.haml
+++ b/app/views/admin/custom_emojis/_custom_emoji.html.haml
@@ -1,6 +1,6 @@
 %tr
   %td
-    = image_tag custom_emoji.image.url, class: 'emojione', alt: ":#{custom_emoji.shortcode}:"
+    = image_tag custom_emoji.custom_emoji_icon.image.url, class: 'emojione', alt: ":#{custom_emoji.shortcode}:"
   %td
     %samp= ":#{custom_emoji.shortcode}:"
   %td

--- a/app/views/admin/custom_emojis/import_form.html.haml
+++ b/app/views/admin/custom_emojis/import_form.html.haml
@@ -1,0 +1,16 @@
+- content_for :page_title do
+  = t('.title')
+
+= simple_form_for @custom_emoji, url: import_admin_custom_emojis_path do |f|
+  %input{ name: 'status[id]', value: @status.id, type: 'hidden' }
+
+  .fields-group
+    = f.input :shortcode, placeholder: t('admin.custom_emojis.overriding_shortcode'), hint: t('admin.custom_emojis.shortcode_hint')
+    - @remote_custom_emojis.each do |remote_custom_emoji|
+      %label
+        %input{ name: 'custom_emoji[super_id]', type: 'radio', value: remote_custom_emoji.id }
+        %img.emojione{ alt: remote_custom_emoji.shortcode, src: full_asset_url(remote_custom_emoji.custom_emoji_icon.image.url) }
+        %code :#{remote_custom_emoji.shortcode}:
+
+  .actions
+    = f.button :button, t('admin.custom_emojis.import.shorthand'), type: :submit

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -11,4 +11,19 @@
     %tbody
       = render @custom_emojis
 
-= link_to t('admin.custom_emojis.upload'), new_admin_custom_emoji_path, class: 'button'
+%hr
+
+%section
+  %h3
+    = t('admin.custom_emojis.upload.link')
+  = link_to t('admin.custom_emojis.upload.shorthand'), upload_form_admin_custom_emojis_path, class: 'button'
+
+%hr
+
+%section
+  %h3
+    = t('admin.custom_emojis.import.link')
+  = simple_form_for @status, class: 'custom-emojis-import-status-form', method: 'get', url: import_form_admin_custom_emojis_path do |f|
+    = render 'shared/error_messages', object: @status
+    = f.input :url, placeholder: 'URL'
+    = f.button :button, t('admin.custom_emojis.import.shorthand'), type: :submit

--- a/app/views/admin/custom_emojis/new.html.haml
+++ b/app/views/admin/custom_emojis/new.html.haml
@@ -5,8 +5,9 @@
   = render 'shared/error_messages', object: @custom_emoji
 
   .fields-group
-    = f.input :shortcode, placeholder: t('admin.custom_emojis.shortcode'), hint: t('admin.custom_emojis.shortcode_hint')
-    = f.input :image, input_html: { accept: 'image/png' }, hint: t('admin.custom_emojis.image_hint')
+    = f.input :shortcode, required: true, placeholder: t('admin.custom_emojis.shortcode'), hint: t('admin.custom_emojis.shortcode_hint')
+    = f.simple_fields_for :custom_emoji_icon do |g|
+      = g.input :image, as: :file, required: true, input_html: { accept: 'image/png' }, hint: t('admin.custom_emojis.icon_hint')
 
   .actions
     = f.button :button, t('admin.custom_emojis.upload'), type: :submit

--- a/app/views/admin/custom_emojis/upload_form.html.haml
+++ b/app/views/admin/custom_emojis/upload_form.html.haml
@@ -10,4 +10,4 @@
       = g.input :image, as: :file, required: true, input_html: { accept: 'image/png' }, hint: t('admin.custom_emojis.icon_hint')
 
   .actions
-    = f.button :button, t('admin.custom_emojis.upload'), type: :submit
+    = f.button :button, t('admin.custom_emojis.upload.shorthand'), type: :submit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,7 +113,7 @@ en:
       delete: Delete
       destroyed_msg: Emojo successfully destroyed!
       emoji: Emoji
-      image_hint: PNG up to 50KB
+      icon_hint: PNG up to 50KB
       new:
         title: Add new custom emoji
       shortcode: Shortcode

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,13 +113,25 @@ en:
       delete: Delete
       destroyed_msg: Emojo successfully destroyed!
       emoji: Emoji
+      emoji_not_found_msg: The specified emoji was not found
+      emoji_unspecified_msg: The emoji to import is not specified
       icon_hint: PNG up to 50KB
-      new:
-        title: Add new custom emoji
+      import:
+        link: Import from toot
+        shorthand: Import
+      import_form:
+        title: Import new custom emoji
+      overriding_shortcode: Overriding shortcode (optional)
+      upload:
+        link: Upload image
+        shorthand: Upload
+      upload_form:
+        title: Upload new custom emoji
       shortcode: Shortcode
       shortcode_hint: At least 2 characters, only alphanumeric characters and underscores
+      status_not_found_msg: The specified toot was not found
+      status_unspecified_msg: The toot to search for emojis is not specified
       title: Custom emojis
-      upload: Upload
     domain_blocks:
       add_new: Add new
       created_msg: Domain block is now being processed

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -113,13 +113,24 @@ ja:
       delete: 削除
       destroyed_msg: 絵文字の削除に成功しました
       emoji: 絵文字
+      emoji_not_found_msg: 指定された絵文字が見つかりませんでした
+      emoji_unspecified_msg: インポートする絵文字が指定されていません
       icon_hint: 50KBまでのPNG画像を利用できます。
-      new:
-        title: 新規カスタム絵文字の追加
+      import:
+        link: トゥートからインポート
+        shorthand: インポート
+      import_form:
+        title: 新規カスタム絵文字のインポート
+      upload:
+        link: 画像をアップロード
+        shorthand: アップロード
+      upload_form:
+        title: 新規カスタム絵文字のアップロード
       shortcode: ショートコード
       shortcode_hint: 2文字以上の半角英数字とアンダーバーのみ利用できます。
+      status_not_found_msg: 指定されたトゥートが見つかりませんでした
+      status_unspecified_msg: 絵文字を探すトゥートが指定されていません
       title: カスタム絵文字
-      upload: アップロード
     domain_blocks:
       add_new: 新規追加
       created_msg: ドメインブロック処理を完了しました

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -113,7 +113,7 @@ ja:
       delete: 削除
       destroyed_msg: 絵文字の削除に成功しました
       emoji: 絵文字
-      image_hint: 50KBまでのPNG画像を利用できます。
+      icon_hint: 50KBまでのPNG画像を利用できます。
       new:
         title: 新規カスタム絵文字の追加
       shortcode: ショートコード

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -112,13 +112,14 @@ ko:
       delete: 삭제
       destroyed_msg: 에모지가 성공적으로 삭제되었습니다!
       emoji: Emoji
-      image_hint: 50KB 이하의 PNG
-      new:
+      icon_hint: 50KB 이하의 PNG
+      upload:
+        shorthand: 업로드
+      upload_form:
         title: 새 커스텀 에모지 추가
       shortcode: Shortcode
       shortcode_hint: 최소 2글자, 영문자, 숫자, _만 사용 가능
       title: 커스텀 에모지
-      upload: 업로드
     domain_blocks:
       add_new: 추가하기
       created_msg: 도메인 차단 처리를 완료했습니다.

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -113,7 +113,7 @@ oc:
       delete: Suprimir
       destroyed_msg: Emojo ben suprimit !
       emoji: Emoji
-      image_hint: PNG cap a 50Ko
+      icon_hint: PNG cap a 50Ko
       new:
         title: Ajustar un nòu emoji personal
       shortcode: Acorchi

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -114,12 +114,13 @@ oc:
       destroyed_msg: Emojo ben suprimit !
       emoji: Emoji
       icon_hint: PNG cap a 50Ko
-      new:
+      upload:
+        shorthand: Enviar
+      upload_form:
         title: Ajustar un nòu emoji personal
       shortcode: Acorchi
       shortcode_hint: Almens 2 caractèrs, solament alfanumerics e jonhent bas
       title: Emojis personals
-      upload: Enviar
     domain_blocks:
       add_new: N’ajustar un nòu
       created_msg: Domeni blocat es a èsser tractat

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -112,12 +112,13 @@ pl:
       destroyed_msg: Pomyślnie usunięto emoji!
       emoji: Emoji
       icon_hint: Plik PNG ważący do 50KB
-      new:
+      upload:
+        shorthand: Wyślij
+      upload_form:
         title: Dodaj nowe niestandardowe emoji
       shortcode: Shortcode
       shortcode_hint: Co najmniej 2 znaki, tylko znaki alfanumeryczne i podkreślniki
       title: Niestandardowe emoji
-      upload: Wyślij
     domain_blocks:
       add_new: Dodaj nową
       created_msg: Blokada domen jest przetwarzana

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -111,7 +111,7 @@ pl:
       delete: Usuń
       destroyed_msg: Pomyślnie usunięto emoji!
       emoji: Emoji
-      image_hint: Plik PNG ważący do 50KB
+      icon_hint: Plik PNG ważący do 50KB
       new:
         title: Dodaj nowe niestandardowe emoji
       shortcode: Shortcode

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
     resources :sessions, only: [:destroy]
   end
 
+  resources :emojis, only: [:show]
   resources :media, only: [:show]
   resources :tags,  only: [:show]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -138,7 +138,14 @@ Rails.application.routes.draw do
       resource :two_factor_authentication, only: [:destroy]
     end
 
-    resources :custom_emojis, only: [:index, :new, :create, :destroy]
+    resources :custom_emojis, only: [:index, :destroy] do
+      collection do
+        get :import_form
+        get :upload_form
+        post :import
+        post :upload
+      end
+    end
   end
 
   get '/admin', to: redirect('/admin/settings/edit', status: 302)

--- a/db/migrate/20170929000000_create_custom_emoji_icons.rb
+++ b/db/migrate/20170929000000_create_custom_emoji_icons.rb
@@ -1,0 +1,21 @@
+class CreateCustomEmojiIcons < ActiveRecord::Migration[5.1]
+  def change
+    reversible do |dir|
+      dir.up { safety_assured { execute 'TRUNCATE custom_emojis' } }
+    end
+
+    create_table :custom_emoji_icons do |t|
+      t.column :uri, :string
+      t.column :image_remote_url, :string
+      t.attachment :image
+      t.index :uri, unique: true
+    end
+
+    remove_attachment :custom_emojis, :image
+    add_belongs_to :custom_emojis, :custom_emoji_icon, foreign_key: { on_delete: :cascade, on_update: :cascade }, null: false
+
+    reversible do |dir|
+      dir.down { safety_assured { execute 'TRUNCATE custom_emojis' } }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170927215609) do
+ActiveRecord::Schema.define(version: 20170929000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,15 +89,23 @@ ActiveRecord::Schema.define(version: 20170927215609) do
     t.index ["uri"], name: "index_conversations_on_uri", unique: true
   end
 
-  create_table "custom_emojis", force: :cascade do |t|
-    t.string "shortcode", default: "", null: false
-    t.string "domain"
+  create_table "custom_emoji_icons", force: :cascade do |t|
+    t.string "uri"
+    t.string "image_remote_url"
     t.string "image_file_name"
     t.string "image_content_type"
     t.integer "image_file_size"
     t.datetime "image_updated_at"
+    t.index ["uri"], name: "index_custom_emoji_icons_on_uri", unique: true
+  end
+
+  create_table "custom_emojis", force: :cascade do |t|
+    t.string "shortcode", default: "", null: false
+    t.string "domain"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "custom_emoji_icon_id", null: false
+    t.index ["custom_emoji_icon_id"], name: "index_custom_emojis_on_custom_emoji_icon_id"
     t.index ["shortcode", "domain"], name: "index_custom_emojis_on_shortcode_and_domain", unique: true
   end
 
@@ -444,6 +452,7 @@ ActiveRecord::Schema.define(version: 20170927215609) do
   add_foreign_key "blocks", "accounts", name: "fk_4269e03e65", on_delete: :cascade
   add_foreign_key "conversation_mutes", "accounts", name: "fk_225b4212bb", on_delete: :cascade
   add_foreign_key "conversation_mutes", "conversations", on_delete: :cascade
+  add_foreign_key "custom_emojis", "custom_emoji_icons", on_update: :cascade, on_delete: :cascade
   add_foreign_key "favourites", "accounts", name: "fk_5eb6c2b873", on_delete: :cascade
   add_foreign_key "favourites", "statuses", name: "fk_b0e856845e", on_delete: :cascade
   add_foreign_key "follow_requests", "accounts", column: "target_account_id", name: "fk_9291ec025d", on_delete: :cascade

--- a/spec/controllers/admin/custom_emojis_controller_spec.rb
+++ b/spec/controllers/admin/custom_emojis_controller_spec.rb
@@ -36,29 +36,150 @@ describe Admin::CustomEmojisController, type: :controller do
     end
   end
 
-  describe 'GET #new' do
+  describe 'GET #import_form' do
+    context 'when the URL of the status is not specified' do
+      it 'redirects to index with error message' do
+        get :import_form
+        expect(response).to redirect_to admin_custom_emojis_url(flash: { error: I18n.t('admin.custom_emojis.status_unspecified_msg') })
+      end
+    end
+
+    context 'when no status was found at the specified URL' do
+      it 'redirects to index with error message' do
+        get :import_form, params: { status: { url: 'invalid URL' } }
+        expect(response).to redirect_to admin_custom_emojis_url(flash: { error: I18n.t('admin.custom_emojis.status_not_found_msg') })
+      end
+    end
+
+    context 'when the specified URL points something else status' do
+      it 'redirects to index with error message' do
+        Fabricate(:account, domain: nil, username: 'username')
+        get :import_form, params: { status: { url: 'http://cb6e6126.ngrok.io/@username' } }
+        expect(response).to redirect_to admin_custom_emojis_url(flash: { error: I18n.t('admin.custom_emojis.status_not_found_msg') })
+      end
+    end
+
+    context 'when valid status URL is specified' do
+      let(:account) { Fabricate(:account, domain: 'remote.account.domain') }
+      let(:status) { Fabricate(:status, account: account, text: ':emojo:') }
+      let(:url) { "http://cb6e6126.ngrok.io#{short_account_status_path(status.account.username, status)}" }
+
+      context 'with emojis' do
+        let(:custom_emoji_icon) do
+          stub_request(:get, 'https://remote/custom/emojo/icon/image').to_return body: attachment_fixture('emojo.png')
+
+          Fabricate(
+            :custom_emoji_icon,
+            uri: 'https://remote/custom/emojo/icon',
+            image_remote_url: 'https://remote/custom/emojo/icon/image'
+          )
+        end
+
+        let!(:custom_emoji) do
+          Fabricate(
+            :custom_emoji,
+            custom_emoji_icon: custom_emoji_icon,
+            domain: 'remote.account.domain',
+            shortcode: 'emojo'
+          )
+        end
+
+        it 'does not render emojis already imported' do
+          Fabricate(:custom_emoji, custom_emoji_icon: custom_emoji_icon, domain: nil)
+          get :import_form, params: { status: { url: url } }
+          expect(response.body).not_to include ':emojo:'
+        end
+
+        it 'renders emojis' do
+          get :import_form, params: { status: { url: url } }
+          expect(response.body).to include ':emojo:'
+        end
+      end
+
+      it 'renders status id' do
+        get :import_form, params: { status: { url: url } }
+        expect(response.body).to include status.id.to_s
+      end
+
+      it 'returns http success' do
+        get :import_form, params: { status: { url: url } }
+        expect(response).to have_http_status :success
+      end
+    end
+  end
+
+  describe 'GET #upload_form' do
     it 'returns http success' do
-      get :new
+      get :upload_form
       expect(response).to have_http_status :success
     end
   end
 
-  describe 'POST #create' do
+  describe 'POST #import' do
+    context 'when custom emoji is not specified' do
+      it 'renders import form with error message' do
+        post :import, params: { status: { id: Fabricate(:status) } }
+        expect(flash[:error]).to eq I18n.t('admin.custom_emojis.emoji_unspecified_msg')
+      end
+    end
+
+    context 'when specified custom emoji does not exist' do
+      it 'renders import form with error message' do
+        post :import, params: { custom_emoji: { super_id: 42 }, status: { id: Fabricate(:status) } }
+        expect(flash[:error]).to eq I18n.t('admin.custom_emojis.emoji_not_found_msg')
+      end
+    end
+
+    context 'when specified custom emoji exists' do
+      let(:super_custom_emoji) { Fabricate(:custom_emoji, domain: Faker::Internet.domain_name, shortcode: 'shortcode') }
+
+      it 'creates custom emoji' do
+        post :import, params: { custom_emoji: { super_id: super_custom_emoji } }
+        expect(CustomEmoji.joins(:custom_emoji_icon).where(custom_emoji_icon: super_custom_emoji.custom_emoji_icon, domain: nil, shortcode: 'shortcode')).to exist
+      end
+
+      it 'overrides shortcode if provided' do
+        post :import, params: { custom_emoji: { shortcode: 'overriden', super_id: super_custom_emoji } }
+        expect(CustomEmoji.joins(:custom_emoji_icon).where(custom_emoji_icon: super_custom_emoji.custom_emoji_icon, domain: nil, shortcode: 'overriden')).to exist
+      end
+
+      it 'redirects to index with notice' do
+        post :import, params: { custom_emoji: { super_id: super_custom_emoji } }
+
+        expect(flash[:notice]).to eq I18n.t('admin.custom_emojis.created_msg')
+        expect(response).to redirect_to admin_custom_emojis_path
+      end
+
+      it 'returns http success even if validation failed' do
+        Fabricate(:custom_emoji, domain: nil, shortcode: 'shortcode')
+
+        post :import, params: { custom_emoji: { super_id: super_custom_emoji }, status: { id: Fabricate(:status) } }
+        expect(response).to have_http_status :success
+      end
+    end
+
+    it 'redirects to index with error message if there is an error and the status is not found' do
+      post :import, params: { status: { id: 42 } }
+      expect(response).to redirect_to admin_custom_emojis_url(flash: { error: I18n.t('admin.custom_emojis.status_not_found_msg') })
+    end
+  end
+
+  describe 'POST #upload' do
     it 'creates custom emoji' do
-      post :create, params: { custom_emoji: { shortcode: 'shortcode', custom_emoji_icon: { image: fixture_file_upload('files/emojo.png') } } }
+      post :upload, params: { custom_emoji: { shortcode: 'shortcode', custom_emoji_icon: { image: fixture_file_upload('files/emojo.png') } } }
 
       expect(CustomEmoji.joins(:custom_emoji_icon).where(domain: nil, shortcode: 'shortcode', custom_emoji_icons: { uri: nil })).to exist
     end
 
     it 'redirects to index with notice' do
-      post :create, params: { custom_emoji: { shortcode: 'shortcode', custom_emoji_icon: { image: fixture_file_upload('files/emojo.png') } } }
+      post :upload, params: { custom_emoji: { shortcode: 'shortcode', custom_emoji_icon: { image: fixture_file_upload('files/emojo.png') } } }
 
       expect(flash[:notice]).to eq I18n.t('admin.custom_emojis.created_msg')
       expect(response).to redirect_to admin_custom_emojis_path
     end
 
     it 'returns http success even if validation failed' do
-      post :create, params: { custom_emoji: { shortcode: 'a', custom_emoji_icon: { image: fixture_file_upload('files/emojo.png') } } }
+      post :upload, params: { custom_emoji: { shortcode: 'a', custom_emoji_icon: { image: fixture_file_upload('files/emojo.png') } } }
       expect(response).to have_http_status :success
     end
   end

--- a/spec/controllers/admin/custom_emojis_controller_spec.rb
+++ b/spec/controllers/admin/custom_emojis_controller_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::CustomEmojisController, type: :controller do
+  render_views
+
+  before { sign_in Fabricate(:user, admin: true) }
+
+  describe 'GET #index' do
+    it 'renders shortcode and associated deletion path' do
+      emojo = Fabricate(:custom_emoji, domain: nil, shortcode: 'emojo')
+
+      get :index
+
+      expect(response.body).to include ':emojo:'
+      expect(response.body).to include admin_custom_emoji_path(emojo)
+    end
+
+    it 'does not render shortcode and associated deletion path of remote emojis' do
+      emojo = Fabricate(
+        :custom_emoji,
+        domain: Faker::Internet.domain_name,
+        shortcode: 'emojo'
+      )
+
+      get :index
+
+      expect(response.body).not_to include ':emojo:'
+      expect(response.body).not_to include admin_custom_emoji_path(emojo)
+    end
+
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status :success
+    end
+  end
+
+  describe 'GET #new' do
+    it 'returns http success' do
+      get :new
+      expect(response).to have_http_status :success
+    end
+  end
+
+  describe 'POST #create' do
+    it 'creates custom emoji' do
+      post :create, params: { custom_emoji: { shortcode: 'shortcode', custom_emoji_icon: { image: fixture_file_upload('files/emojo.png') } } }
+
+      expect(CustomEmoji.joins(:custom_emoji_icon).where(domain: nil, shortcode: 'shortcode', custom_emoji_icons: { uri: nil })).to exist
+    end
+
+    it 'redirects to index with notice' do
+      post :create, params: { custom_emoji: { shortcode: 'shortcode', custom_emoji_icon: { image: fixture_file_upload('files/emojo.png') } } }
+
+      expect(flash[:notice]).to eq I18n.t('admin.custom_emojis.created_msg')
+      expect(response).to redirect_to admin_custom_emojis_path
+    end
+
+    it 'returns http success even if validation failed' do
+      post :create, params: { custom_emoji: { shortcode: 'a', custom_emoji_icon: { image: fixture_file_upload('files/emojo.png') } } }
+      expect(response).to have_http_status :success
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys custom emoji' do
+      custom_emoji = Fabricate(:custom_emoji, domain: nil)
+      delete :destroy, params: { id: custom_emoji }
+      expect { custom_emoji.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it 'destroys custom emoji icon as well if it is local' do
+      custom_emoji_icon = Fabricate(:custom_emoji_icon, uri: nil)
+      custom_emoji = Fabricate(:custom_emoji, custom_emoji_icon: custom_emoji_icon)
+
+      delete :destroy, params: { id: custom_emoji }
+
+      expect { custom_emoji_icon.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+
+    it 'redirects to index with notice' do
+      custom_emoji = Fabricate(:custom_emoji, domain: nil)
+
+      delete :destroy, params: { id: custom_emoji }
+
+      expect(flash[:notice]).to eq I18n.t('admin.custom_emojis.destroyed_msg')
+      expect(response).to redirect_to admin_custom_emojis_path
+    end
+  end
+end

--- a/spec/controllers/emojis_controller_spec.rb
+++ b/spec/controllers/emojis_controller_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EmojisController, type: :controller do
+  describe 'GET #show' do
+    let(:emoji) { Fabricate(:custom_emoji_icon, uri: nil) }
+
+    it 'renders Atom' do
+      get :show, format: 'atom', params: { id: emoji }
+      expect(response).to have_http_status :success
+    end
+
+    it 'renders JSON' do
+      get :show, format: 'json', params: { id: emoji }
+      expect(response).to have_http_status :success
+    end
+  end
+end

--- a/spec/fabricators/custom_emoji_fabricator.rb
+++ b/spec/fabricators/custom_emoji_fabricator.rb
@@ -1,5 +1,4 @@
 Fabricator(:custom_emoji) do
   shortcode 'coolcat'
-  domain    nil
-  image     { File.open(Rails.root.join('spec', 'fixtures', 'files', 'emojo.png')) }
+  custom_emoji_icon
 end

--- a/spec/fabricators/custom_emoji_icon_fabricator.rb
+++ b/spec/fabricators/custom_emoji_icon_fabricator.rb
@@ -1,0 +1,3 @@
+Fabricator(:custom_emoji_icon) do
+  image { File.open(Rails.root.join('spec', 'fixtures', 'files', 'emojo.png')) }
+end

--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -101,6 +101,16 @@ RSpec.describe ActivityPub::TagManager do
       expect(subject.uri_to_resource('https://example.com/123#456', Account)).to eq account
     end
 
+    it 'returns the local emoji' do
+      emoji = Fabricate(:custom_emoji_icon, uri: nil)
+      expect(subject.uri_to_resource(subject.uri_for(emoji), CustomEmojiIcon)).to eq emoji
+    end
+
+    it 'returns the remote emoji by matching URI without fragment part' do
+      emoji = Fabricate(:custom_emoji_icon, uri: 'https://example.com/123')
+      expect(subject.uri_to_resource('https://example.com/123#456', CustomEmojiIcon)).to eq emoji
+    end
+
     it 'returns the local status for ActivityPub URI' do
       status = Fabricate(:status)
       expect(subject.uri_to_resource(subject.uri_for(status), Status)).to eq status

--- a/spec/lib/ostatus/activity/creation_spec.rb
+++ b/spec/lib/ostatus/activity/creation_spec.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe OStatus::Activity::Creation do
+  subject do
+    class C < OStatus::Activity::Creation
+      def reblog
+        nil
+      end
+    end
+
+    C
+  end
+
+  describe '#perform' do
+    def stub_emoji_request_success
+      stub_request(:get, 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png').to_return body: attachment_fixture('emojo.png')
+      stub_request(:get, 'https://kickass.zone/emojis/1').to_return headers: { 'Content-Type': 'application/activity+json' }, body: <<~JSON
+        {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          "id": "https://kickass.zone/emojis/1",
+          "type": "Image",
+          "url": "https://kickass.zone/system/custom_emoji_icons/images/emojo.png"
+        }
+      JSON
+    end
+
+    def stub_emoji_request_error
+      stub_request(:get, 'https://kickass.zone/emojis/1').to_return status: 400
+    end
+
+    it 'does not perform if account is suspended'
+    it 'performs via ActivityPub if it contains ActivityPub URI and the visibility is public'
+    it 'returns an existing status with the same ID if any'
+    it 'saves status'
+    it 'saves mentions'
+    it 'saves hashtags'
+    it 'saves media'
+
+    it 'does not raise even if href of emoji is missing' do
+      account = Fabricate(:account, suspended: false)
+
+      xml = Nokogiri::XML(<<~XML)
+        <?xml version="1.0"?>
+        <entry xmlns="http://www.w3.org/2005/Atom" xmlns:activity="http://activitystrea.ms/spec/1.0/">
+          <id>tag:kickass.zone,2016-10-10:objectId=17:objectType=Status</id>
+          <published>2016-10-10T00:41:31Z</published>
+          <content type="html">&lt;p&gt;Social media needs MOAR cats! :manekineko:</content>
+          <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
+          <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
+          <link name="manekineko" rel="emoji"/>
+        </entry>
+      XML
+
+      subject.new(xml.at_xpath('//xmlns:entry', xmlns: OStatus::TagManager::XMLNS), account).perform
+    end
+
+    it 'does not raise even if name of emoji is missing' do
+      stub_emoji_request_success
+      account = Fabricate(:account, suspended: false)
+
+      xml = Nokogiri::XML(<<~XML)
+        <?xml version="1.0"?>
+        <entry xmlns="http://www.w3.org/2005/Atom" xmlns:activity="http://activitystrea.ms/spec/1.0/">
+          <id>tag:kickass.zone,2016-10-10:objectId=17:objectType=Status</id>
+          <published>2016-10-10T00:41:31Z</published>
+          <content type="html">&lt;p&gt;Social media needs MOAR cats! :manekineko:</content>
+          <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
+          <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
+          <link href="https://kickass.zone/emojis/1" rel="emoji"/>
+        </entry>
+      XML
+
+      subject.new(xml.at_xpath('//xmlns:entry', xmlns: OStatus::TagManager::XMLNS), account).perform
+    end
+
+    it 'does not raise even if custom emoji already exists' do
+      stub_emoji_request_success
+      Fabricate(:custom_emoji, domain: 'kickass.zone', shortcode: 'manekineko')
+      account = Fabricate(:account, suspended: false)
+
+      xml = Nokogiri::XML(<<~XML)
+        <?xml version="1.0"?>
+        <entry xmlns="http://www.w3.org/2005/Atom" xmlns:activity="http://activitystrea.ms/spec/1.0/">
+          <id>tag:kickass.zone,2016-10-10:objectId=17:objectType=Status</id>
+          <published>2016-10-10T00:41:31Z</published>
+          <content type="html">&lt;p&gt;Social media needs MOAR cats! :manekineko:</content>
+          <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
+          <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
+          <link href="https://kickass.zone/emojis/1" name="manekineko" rel="emoji"/>
+        </entry>
+      XML
+
+      subject.new(xml.at_xpath('//xmlns:entry', xmlns: OStatus::TagManager::XMLNS), account).perform
+    end
+
+    context 'when custom emoji icon already exists' do
+      it 'does not raise' do
+        stub_emoji_request_success
+        Fabricate(:custom_emoji_icon, uri: 'https://kickass.zone/emojis/1')
+        account = Fabricate(:account, suspended: false)
+
+        xml = Nokogiri::XML(<<~XML)
+          <?xml version="1.0"?>
+          <entry xmlns="http://www.w3.org/2005/Atom" xmlns:activity="http://activitystrea.ms/spec/1.0/">
+            <id>tag:kickass.zone,2016-10-10:objectId=17:objectType=Status</id>
+            <published>2016-10-10T00:41:31Z</published>
+            <content type="html">&lt;p&gt;Social media needs MOAR cats! :manekineko:</content>
+            <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
+            <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
+            <link href="https://kickass.zone/emojis/1" name="manekineko" rel="emoji"/>
+          </entry>
+        XML
+
+        subject.new(xml.at_xpath('//xmlns:entry', xmlns: OStatus::TagManager::XMLNS), account).perform
+      end
+    end
+
+    context 'when custom emoji icon does not exist' do
+      it 'does not fetch custom emoji icon if domain is blocked' do
+        stub_emoji_request_success
+        Fabricate(:domain_block, domain: 'kickass.zone', reject_media: true)
+        account = Fabricate(:account, suspended: false)
+
+        xml = Nokogiri::XML(<<~XML)
+          <?xml version="1.0"?>
+          <entry xmlns="http://www.w3.org/2005/Atom" xmlns:activity="http://activitystrea.ms/spec/1.0/">
+            <id>tag:kickass.zone,2016-10-10:objectId=17:objectType=Status</id>
+            <published>2016-10-10T00:41:31Z</published>
+            <content type="html">&lt;p&gt;Social media needs MOAR cats! :manekineko:</content>
+            <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
+            <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
+            <link href="https://kickass.zone/emojis/1" name="manekineko" rel="emoji"/>
+          </entry>
+        XML
+
+        subject.new(xml.at_xpath('//xmlns:entry', xmlns: OStatus::TagManager::XMLNS), account).perform
+
+        expect(CustomEmojiIcon.where(uri: 'https://kickass.zone/emojis/1')).not_to exist
+      end
+
+      it 'fetches custom emoji icon' do
+        stub_emoji_request_success
+        account = Fabricate(:account, suspended: false)
+
+        xml = Nokogiri::XML(<<~XML)
+          <?xml version="1.0"?>
+          <entry xmlns="http://www.w3.org/2005/Atom" xmlns:activity="http://activitystrea.ms/spec/1.0/">
+            <id>tag:kickass.zone,2016-10-10:objectId=17:objectType=Status</id>
+            <published>2016-10-10T00:41:31Z</published>
+            <content type="html">&lt;p&gt;Social media needs MOAR cats! :manekineko:</content>
+            <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
+            <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
+            <link href="https://kickass.zone/emojis/1" name="manekineko" rel="emoji"/>
+          </entry>
+        XML
+
+        subject.new(xml.at_xpath('//xmlns:entry', xmlns: OStatus::TagManager::XMLNS), account).perform
+
+        expect(CustomEmojiIcon.where(uri: 'https://kickass.zone/emojis/1', image_remote_url: 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png')).to exist
+      end
+
+      it 'does not raise even if custom emoji icon cannot be fetched' do
+        stub_emoji_request_error
+        account = Fabricate(:account, suspended: false)
+
+        xml = Nokogiri::XML(<<~XML)
+          <?xml version="1.0"?>
+          <entry xmlns="http://www.w3.org/2005/Atom" xmlns:activity="http://activitystrea.ms/spec/1.0/">
+            <id>tag:kickass.zone,2016-10-10:objectId=17:objectType=Status</id>
+            <published>2016-10-10T00:41:31Z</published>
+            <content type="html">&lt;p&gt;Social media needs MOAR cats! :manekineko:</content>
+            <activity:verb>http://activitystrea.ms/schema/1.0/post</activity:verb>
+            <activity:object-type>http://activitystrea.ms/schema/1.0/note</activity:object-type>
+            <link href="https://kickass.zone/emojis/1" name="manekineko" rel="emoji"/>
+          </entry>
+        XML
+
+        expect { subject.new(xml.at_xpath('//xmlns:entry', xmlns: OStatus::TagManager::XMLNS), account).perform }.not_to raise_error
+      end
+    end
+
+    it 'saves emojis'
+  end
+end

--- a/spec/lib/tag_manager_spec.rb
+++ b/spec/lib/tag_manager_spec.rb
@@ -78,6 +78,10 @@ RSpec.describe TagManager do
       expect(TagManager.instance.local_url?('https://DoMaIn/')).to eq true
     end
 
+    it 'returns false for URL without host' do
+      expect(TagManager.instance.local_url?('')).to eq false
+    end
+
     it 'returns false for string with irrelevant characters' do
       Rails.configuration.x.web_domain = 'domain'
       expect(TagManager.instance.local_url?('https://domainn/')).to eq false

--- a/spec/models/custom_emoji_icon_spec.rb
+++ b/spec/models/custom_emoji_icon_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CustomEmojiIcon, type: :model do
+  describe 'local scope' do
+    it 'returns local custom emoji icons' do
+      local = Fabricate(:custom_emoji_icon, uri: nil)
+      expect(CustomEmojiIcon.local).to include local
+    end
+
+    it 'does not return remote custom emoji icons' do
+      remote = Fabricate(:custom_emoji_icon, uri: 'remote')
+      expect(CustomEmojiIcon.local).not_to include remote
+    end
+  end
+
+  describe '#local?' do
+    it 'returns true if custom emoji icon is local' do
+      local = Fabricate(:custom_emoji_icon, uri: nil)
+      expect(local.local?).to eq true
+    end
+
+    it 'returns false if custom emoji icon is not local' do
+      local = Fabricate(:custom_emoji_icon, uri: 'https://remote/')
+      expect(local.local?).to eq false
+    end
+  end
+
+  describe '#object_type' do
+    it 'returns :emoji' do
+      expect(Fabricate(:custom_emoji_icon).object_type).to eq :emoji
+    end
+  end
+end

--- a/spec/models/custom_emoji_icon_spec.rb
+++ b/spec/models/custom_emoji_icon_spec.rb
@@ -15,6 +15,18 @@ describe CustomEmojiIcon, type: :model do
     end
   end
 
+  describe 'remote scope' do
+    it 'does not return local custom emoji icons' do
+      local = Fabricate(:custom_emoji_icon, uri: nil)
+      expect(CustomEmojiIcon.remote).not_to include local
+    end
+
+    it 'returns remote custom emoji icons' do
+      remote = Fabricate(:custom_emoji_icon, uri: 'remote')
+      expect(CustomEmojiIcon.remote).to include remote
+    end
+  end
+
   describe '#local?' do
     it 'returns true if custom emoji icon is local' do
       local = Fabricate(:custom_emoji_icon, uri: nil)

--- a/spec/services/activitypub/fetch_remote_custom_emoji_icon_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_custom_emoji_icon_service_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ActivityPub::FetchRemoteCustomEmojiIconService, type: :service do
+  it 'uses prefetched_json if provided' do
+    json = <<~JSON
+      {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "id": "https://kickass.zone/emojis/1",
+        "type": "Image",
+        "url": "https://kickass.zone/system/custom_emoji_icons/images/emojo.png"
+      }
+    JSON
+
+    stub_request(:get, 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png').to_return body: attachment_fixture('emojo.png')
+
+    result = ActivityPub::FetchRemoteCustomEmojiIconService.new.call(nil, json)
+
+    expect(result.uri).to eq 'https://kickass.zone/emojis/1'
+  end
+
+  it 'fetches from remote if prefetched_json is not provided' do
+    json = <<~JSON
+      {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "id": "https://kickass.zone/emojis/1",
+        "type": "Image",
+        "url": "https://kickass.zone/system/custom_emoji_icons/images/emojo.png"
+      }
+    JSON
+
+    stub_request(:get, 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png').to_return body: attachment_fixture('emojo.png')
+    stub_request(:get, 'https://kickass.zone/emojis/1').to_return headers: { 'Content-Type': 'application/activity+json' }, body: json
+
+    result = ActivityPub::FetchRemoteCustomEmojiIconService.new.call('https://kickass.zone/emojis/1')
+
+    expect(result.uri).to eq 'https://kickass.zone/emojis/1'
+  end
+
+  it 'returns nil unless the context is supported' do
+    json = <<~JSON
+      {
+        "id": "https://kickass.zone/emojis/1",
+        "type": "Image",
+        "url": "https://kickass.zone/system/custom_emoji_icons/images/emojo.png"
+      }
+    JSON
+
+    stub_request(:get, 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png').to_return body: attachment_fixture('emojo.png')
+
+    result = ActivityPub::FetchRemoteCustomEmojiIconService.new.call(nil, json)
+
+    expect(result).to eq nil
+  end
+
+  it 'returns nil unless the type is Image' do
+    json = <<~JSON
+      {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "id": "https://kickass.zone/emojis/1",
+        "url": "https://kickass.zone/system/custom_emoji_icons/images/emojo.png"
+      }
+    JSON
+
+    stub_request(:get, 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png').to_return body: attachment_fixture('emojo.png')
+
+    result = ActivityPub::FetchRemoteCustomEmojiIconService.new.call(nil, json)
+
+    expect(result).to eq nil
+  end
+
+  it 'returns nil if it failed to save' do
+    json = <<~JSON
+      {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "id": "https://kickass.zone/emojis/1",
+        "type": "Image",
+        "url": "https://kickass.zone/system/custom_emoji_icons/images/emojo.png"
+      }
+    JSON
+
+    stub_request(:get, 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png').to_return status: 400
+    result = ActivityPub::FetchRemoteCustomEmojiIconService.new.call(nil, json)
+
+    expect(result).to eq nil
+  end
+end

--- a/spec/services/fetch_atom_service_spec.rb
+++ b/spec/services/fetch_atom_service_spec.rb
@@ -1,4 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe FetchAtomService do
+  it 'returns nil if URL is blank'
+  it 'processes URL'
+  it 'retries without ActivityPub'
+  it 'rescues SSL error'
+
+  it 'rescues HTTP error' do
+    expect(FetchAtomService.new.call('invalid')).to eq nil
+  end
 end

--- a/spec/services/fetch_remote_custom_emoji_icon_service_spec.rb
+++ b/spec/services/fetch_remote_custom_emoji_icon_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe FetchRemoteCustomEmojiIconService, type: :service do
+  context 'when protocol is ostatus' do
+    it 'creates an icon' do
+      stub_request(:get, 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png').to_return body: attachment_fixture('emojo.png')
+
+      result = FetchRemoteCustomEmojiIconService.new.call(nil, <<~XML)
+        <?xml version="1.0"?>
+        <entry xmlns="http://www.w3.org/2005/Atom">
+          <id>https://kickass.zone/emojis/1</id>
+          <link href="https://kickass.zone/system/custom_emoji_icons/images/emojo.png" rel="enclosure"/>
+        </entry>
+      XML
+
+      expect(result.uri).to eq 'https://kickass.zone/emojis/1'
+    end
+
+    it 'returns nil if it failed to save' do
+      stub_request(:get, 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png').to_return status: 400
+
+      result = FetchRemoteCustomEmojiIconService.new.call(nil, <<~XML)
+        <?xml version="1.0"?>
+        <entry xmlns="http://www.w3.org/2005/Atom">
+          <id>https://kickass.zone/emojis/1</id>
+          <link href="https://kickass.zone/system/custom_emoji_icons/images/emojo.png" rel="enclosure"/>
+        </entry>
+      XML
+
+      expect(result).to eq nil
+    end
+  end
+
+  it 'uses prefetched_body if provided' do
+    stub_request(:get, 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png').to_return body: attachment_fixture('emojo.png')
+    result = FetchRemoteCustomEmojiIconService.new.call(nil, <<~XML)
+      <?xml version="1.0"?>
+      <entry xmlns="http://www.w3.org/2005/Atom">
+        <id>https://kickass.zone/emojis/1</id>
+        <link href="https://kickass.zone/system/custom_emoji_icons/images/emojo.png" rel="enclosure"/>
+      </entry>
+    XML
+
+    expect(result.uri).to eq 'https://kickass.zone/emojis/1'
+    expect(result.image_remote_url).to eq 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png'
+  end
+
+  it 'fetches from remote if prefetched_body is not provided' do
+    stub_request(:get, 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png').to_return body: attachment_fixture('emojo.png')
+    stub_request(:get, 'https://kickass.zone/emojis/1').to_return headers: { 'Content-Type': 'application/activity+json' }, body: <<-JSON
+      {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "id": "https://kickass.zone/emojis/1",
+        "type": "Image",
+        "url": "https://kickass.zone/system/custom_emoji_icons/images/emojo.png"
+      }
+    JSON
+
+    result = FetchRemoteCustomEmojiIconService.new.call('https://kickass.zone/emojis/1')
+
+    expect(result.uri).to eq 'https://kickass.zone/emojis/1'
+    expect(result.image_remote_url).to eq 'https://kickass.zone/system/custom_emoji_icons/images/emojo.png'
+  end
+end


### PR DESCRIPTION
shortcode as identifier of custom emojis is a barrier when implementing emojis shared by multiple instances because it is not global identifier.
This is a part of a change suggested at #5107. ~~It is not tested well yet.~~