### PR TITLE
Append confirmation link as plain text

### DIFF
--- a/app/views/user_mailer/confirmation_instructions.en.html.erb
+++ b/app/views/user_mailer/confirmation_instructions.en.html.erb
@@ -5,6 +5,9 @@
 <p>To confirm your inscription, please click on the following link : <br>
 <%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %>
 
+<p>If above link not worked, Copy and paste this URL</p>
+<span><%= confirmation_url(@resource, confirmation_token: @token) %></span>
+
 <p>Please also check out our <%= link_to 'terms and conditions', terms_url %>.</p>
 
 <p>Sincerely,<p>

--- a/app/views/user_mailer/confirmation_instructions.en.html.erb
+++ b/app/views/user_mailer/confirmation_instructions.en.html.erb
@@ -2,8 +2,8 @@
 
 <p>You just created an account on <%= @instance %>.</p>
 
-<p>To confirm your inscription, please click on the following link : <br>
-<%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %>
+<p>If the above link did not work, copy and paste this URL into your address bar: <br>
+<%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
 
 <p>If above link not worked, Copy and paste this URL</p>
 <span><%= confirmation_url(@resource, confirmation_token: @token) %></span>


### PR DESCRIPTION
Some mail application is malfunctioning with links.
link as plaintext is useful when this situation:
![screenshot from 2017-09-29 20-05-41](https://user-images.githubusercontent.com/5047683/31013607-bf674054-a551-11e7-83d3-8d9639bc14ac.png)
(I was not able to click that link, So I used "view original" feature to complete email confirmation)