### PR TITLE
Force no cache on web UI page, to force full reload in pinned tabs

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,7 @@
 class HomeController < ApplicationController
   before_action :authenticate_user!
   before_action :set_initial_state_json
+  before_action :set_cache_control
 
   def index
     @body_classes = 'app-body'
@@ -60,5 +61,9 @@ class HomeController < ApplicationController
     else
       about_path
     end
+  end
+
+  def set_cache_control
+    request.headers['Cache-Control'] = 'max-age=0'
   end
 end


### PR DESCRIPTION
e.g. when Firefox is opened and Mastodon is in a pinned tab,
previously the page would be loaded with stale state that didn't
include some updates the user had already seen, and without any
triggers to force the timelines to refresh. Now the page just
gets reloaded to start with

This might fix the same issue in Chrome for Android as well