### PR TITLE
Improve IntersectionObserverArticle perf

### DIFF
--- a/app/javascript/mastodon/components/intersection_observer_article.js
+++ b/app/javascript/mastodon/components/intersection_observer_article.js
@@ -58,26 +58,31 @@ export default class IntersectionObserverArticle extends React.Component {
   }
 
   handleIntersection = (entry) => {
-    const { onHeightChange, saveHeightKey, id } = this.props;
+    this.entry = entry;
 
-    if (this.node && this.node.children.length !== 0) {
-      // save the height of the fully-rendered element
-      this.height = getRectFromEntry(entry).height;
+    scheduleIdleTask(this.calculateHeight);
+    this.setState(this.updateStateAfterIntersection);
+  }
 
-      if (onHeightChange && saveHeightKey) {
-        onHeightChange(saveHeightKey, id, this.height);
-      }
+  updateStateAfterIntersection = (prevState) => {
+    if (prevState.isIntersecting && !this.entry.isIntersecting) {
+      scheduleIdleTask(this.hideIfNotIntersecting);
     }
+    return {
+      isIntersecting: this.entry.isIntersecting,
+      isHidden: false,
+    };
+  }
 
-    this.setState((prevState) => {
-      if (prevState.isIntersecting && !entry.isIntersecting) {
-        scheduleIdleTask(this.hideIfNotIntersecting);
-      }
-      return {
-        isIntersecting: entry.isIntersecting,
-        isHidden: false,
-      };
-    });
+  calculateHeight = () => {
+    const { onHeightChange, saveHeightKey, id } = this.props;
+    // save the height of the fully-rendered element (this is expensive
+    // on Chrome, where we need to fall back to getBoundingClientRect)
+    this.height = getRectFromEntry(this.entry).height;
+
+    if (onHeightChange && saveHeightKey) {
+      onHeightChange(saveHeightKey, id, this.height);
+    }
   }
 
   hideIfNotIntersecting = () => {


### PR DESCRIPTION
This should improve performance of IntersectionObserverArticle, especially in Chrome. The main idea is to avoid calling `getBoundingClientRect()` unless we are in a `requestIdleCallback`. (Recall that we have to do this for Chrome because of a bug in its IntersectionObserverEntry objects.)

We only need to call gBCR to calculate the height, which is used for unrendered, and this is a low-priority task, so it should be `rIC`-able. This should avoid the situation where we're spending a lot of time in `onIntersection` doing both React rendering and `gBCR`.

I've deployed this to malfunctioning.technology; I'd like to thoroughly test across browsers and hopefully have @sorin-davidoi take a look before merging. :smiley:

Before:

![screenshot 2017-09-29 18 39 33](https://user-images.githubusercontent.com/283842/31041152-b5665934-a545-11e7-960b-2b2b3f51eaa6.png)

(Notice all the purple rectangles with red corners… those are `gBCR` calls forcing reflows.)

After:

![screenshot 2017-09-29 18 39 36](https://user-images.githubusercontent.com/283842/31041164-c8abccd6-a545-11e7-8894-0848e8c3e8be.png)

(`gBCR` calls are deferred until later and don't block rendering during scroll.)