### PR TITLE
Add not assigned background colors.

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -462,7 +462,7 @@
 
   .features {
     padding: 50px 0;
-    backgroud: $ui-base-color;
+    background: $ui-base-color;
 
     .container {
       display: flex;

--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -462,6 +462,7 @@
 
   .features {
     padding: 50px 0;
+    backgroud: $ui-base-color;
 
     .container {
       display: flex;
@@ -577,6 +578,7 @@
     font-size: 16px;
     line-height: 30px;
     color: $ui-primary-color;
+    background: $ui-base-color;
 
     a {
       color: $ui-highlight-color;


### PR DESCRIPTION
`.features` and `.extended-description` inherit `background` property from `body`. This lets css `filter()` function work incorrectly.
For example, an extension for colour blind people doesn't work on it.