### PR TITLE
Fix Paperclip::Fog always responds Not Found in some OpenStack-v2

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -48,6 +48,7 @@ elsif ENV['SWIFT_ENABLED'] == 'true'
       provider: 'OpenStack',
       openstack_username: ENV.fetch('SWIFT_USERNAME'),
       openstack_project_name: ENV.fetch('SWIFT_TENANT'),
+      openstack_tenant: ENV.fetch('SWIFT_TENANT'), # Some OpenStack-v2 ignores project_name but needs tenant
       openstack_api_key: ENV.fetch('SWIFT_PASSWORD'),
       openstack_auth_url: ENV.fetch('SWIFT_AUTH_URL'),
       openstack_domain_name: ENV['SWIFT_DOMAIN_NAME'] || 'default',
@@ -55,7 +56,7 @@ elsif ENV['SWIFT_ENABLED'] == 'true'
       openstack_cache_ttl: ENV['SWIFT_CACHE_TTL'] || 60,
     },
     fog_directory: ENV.fetch('SWIFT_CONTAINER'),
-    fog_host: ENV.fetch('SWIFT_OBJECT_URL'),
+    fog_host: ENV['SWIFT_OBJECT_URL'],
     fog_public: true
   )
 else


### PR DESCRIPTION
#2322 was made for OpenStack-v2 (c.f. [ConoHa](https://www.conoha.jp/)) but #4889 removed 'openstack_tenant' for v3.
That causes the problem as the title of this PR.

**In detail of this issue:**
1. User tries to upload an image.
1. POST api/v1/media
1. Paperclip::Fog tries to create the object of the image.
1. Some Openstack-v2 responds 404 Not Found if no 'openstack_tenant'

In addition, this PR replaces to 'fetch' because 'fog_host' is not required parameter according to [Paperclip comment](https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/storage/fog.rb#L32-L35).

I don't know that Mastodon supports any OpenStack-v2, so if no intention to do that, then feel free to close this.