### PR TITLE
Enable streaming on heroku

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,5 @@
 https://github.com/heroku/heroku-buildpack-apt
 https://github.com/Scalingo/nodejs-buildpack
 https://github.com/Scalingo/ruby-buildpack
+https://github.com/ryandotsmith/nginx-buildpack
+https://github.com/danp/heroku-buildpack-runit

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec puma -C config/puma.rb
+web: bin/runsvdir-dyno
 worker: bundle exec sidekiq

--- a/Procfile.web
+++ b/Procfile.web
@@ -1,0 +1,2 @@
+web: bin/start-nginx bundle exec puma -C config/puma.rb -p 3000
+streaming: npm run start

--- a/app.json
+++ b/app.json
@@ -18,6 +18,11 @@
       "value": "false",
       "required": true
     },
+    "STREAMING_PORT": {
+      "description": "Binding port for streaming server.",
+      "value": "4000",
+      "required": true
+    },
     "PAPERCLIP_SECRET": {
       "description": "The secret key for storing media files",
       "generator": "secret"

--- a/app.json
+++ b/app.json
@@ -102,6 +102,12 @@
     },
     {
       "url": "heroku/ruby"
+    },
+    {
+      "url": "https://github.com/ryandotsmith/nginx-buildpack"
+    },
+    {
+      "url": "https://github.com/danp/heroku-buildpack-runit"
     }
   ],
   "scripts": {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,0 +1,91 @@
+daemon off;
+# Heroku dynos have at least 4 cores.
+worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
+
+events {
+    use epoll;
+    accept_mutex on;
+    worker_connections 1024;
+
+}
+
+http {
+    gzip on;
+    gzip_comp_level 3;
+    gzip_min_length 150;
+    gzip_proxied any;
+    gzip_types text/plain text/css text/json text/javascript
+        application/javascript application/x-javascript application/json
+        application/rss+xml application/vnd.ms-fontobject application/x-font-ttf
+        application/xml font/opentype image/svg+xml text/xml;
+
+    server_tokens off;
+
+    log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
+    access_log logs/nginx/access.log l2met;
+    error_log logs/nginx/error.log;
+
+    include mime.types;
+    default_type application/octet-stream;
+    sendfile on;
+
+    # Must read the body in 5 seconds.
+    client_body_timeout 5;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+
+    }
+
+    upstream app_server {
+        server localhost:3000 fail_timeout=0;
+    }
+
+    upstream streaming_server {
+        server localhost:4000;
+    }
+
+    server {
+        listen <%= ENV["PORT"] %> default_server;
+        server_name _;
+        keepalive_timeout 5;
+
+        root /app/public; # path to your app
+
+        proxy_set_header HOST $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_buffering off;
+        proxy_redirect off;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        tcp_nodelay on;
+
+        location ~* \.(eot|oft|svg|ttf|woff2?)$ {
+            add_header Access-Control-Allow-Origin *;
+            expires max;
+            log_not_found off;
+            access_log off;
+            add_header Cache-Control public;
+        }
+
+        location / {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_pass http://app_server;
+
+        }
+
+        location /api/v1/streaming {
+            proxy_pass http://streaming_server;
+
+        }
+    }
+
+}

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -43,11 +43,11 @@ http {
     }
 
     upstream streaming_server {
-        server localhost:4000;
+        server localhost:<%= ENV['STREAMING_PORT'] || 4000 %>;
     }
 
     server {
-        listen <%= ENV["PORT"] %> default_server;
+        listen <%= ENV["PORT"] || 80 %> default_server;
         server_name _;
         keepalive_timeout 5;
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -16,4 +16,8 @@ on_worker_boot do
   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
 end
 
+on_worker_fork do
+  FileUtils.touch('/tmp/app-initialized')
+end
+
 plugin :tmp_restart

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -460,7 +460,7 @@ const startWorker = (workerId) => {
     });
   }, 30000);
 
-  server.listen(process.env.PORT || 4000, () => {
+  server.listen(process.env.STREAMING_PORT || process.env.PORT || 4000, () => {
     log.info(`Worker ${workerId} now listening on ${server.address().address}:${server.address().port}`);
   });
 


### PR DESCRIPTION
I am using dokku(Heroku like personal PaaS) but I found mastodon is not running streaming server by default on heroku(https://github.com/tootsuite/mastodon/issues/1119).

This PR will make mastodon is able to stream on heroku by default.