### PR TITLE
Nuke redirected accounts from database

### DIFF
--- a/app/services/resolve_remote_account_service.rb
+++ b/app/services/resolve_remote_account_service.rb
@@ -31,7 +31,9 @@ class ResolveRemoteAccountService < BaseService
       @username = confirmed_username
       @domain   = confirmed_domain
     elsif redirected.nil?
-      return call("#{confirmed_username}@#{confirmed_domain}", update_profile, true)
+      redirected_account = call("#{confirmed_username}@#{confirmed_domain}", update_profile, true)
+      @account.destroy unless @account.nil? || redirected_account.nil?
+      return redirected_account
     else
       Rails.logger.debug 'Requested and returned acct URIs do not match'
       return


### PR DESCRIPTION
I sometimes have issue federating to other servers.
This is very likely caused by those servers having two accounts in their database matching a same URI: indeed, I had at some point `@thib@social.sitedethib.com` handled with the same URI as my current account (`@thib@sitedethib.com`). This means when resolving my account, those remote servers may find either of those two accounts, one of which has stale data (including public key), and one has not.

One very likely failure caused by this is processing incoming activities from my account: the remote server may resolve the old account, and fail to verify signature since only my new account has up-to-date info.

The proposed change, which is slightly… brutal, is to entirely delete a redirected account. As said, it's quite brutal, and will only fit certain scenarios. This is highly related to #2032 which is still exist with ActivityPub.