### PR TITLE
Suppress backtrace from Request#perform

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -32,7 +32,7 @@ class Request
   def perform
     http_client.headers(headers).public_send(@verb, @url.to_s, @options)
   rescue => e
-    raise e.class, "#{e.message} on #{@url}"
+    raise e.class, "#{e.message} on #{@url}", e.backtrace[0]
   end
 
   def headers


### PR DESCRIPTION
One more place to suppress backtrace in addition to #5076.

This change third and further lines from backtraces like this:

```
46 TID-otqtc69w8 WARN: HTTP::TimeoutError: Read timed out after 10 seconds on https://example.com/users/account#main-key
46 TID-otqtc69w8 WARN: /app/app/lib/request.rb:35:in `rescue in perform'
/app/app/lib/request.rb:33:in `perform'
/app/app/helpers/jsonld_helper.rb:26:in `fetch_resource'
/app/app/services/activitypub/fetch_remote_key_service.rb:8:in `call'
/app/app/lib/activitypub/linked_data_signature.rb:22:in `verify_account!'
/app/app/services/activitypub/process_collection_service.rb:46:in `verify_account!'
/app/app/services/activitypub/process_collection_service.rb:11:in `call'
/app/app/workers/activitypub/processing_worker.rb:9:in `perform'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:199:in `execute_job'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:170:in `block (2 levels) in process'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:128:in `block in invoke'
/app/vendor/bundle/ruby/2.4.0/gems/scout_apm-2.1.30/lib/scout_apm/background_job_integrations/sidekiq.rb:71:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-unique-jobs-5.0.10/lib/sidekiq_unique_jobs/server/middleware.rb:17:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:130:in `block in invoke'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/middleware/chain.rb:133:in `invoke'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:169:in `block in process'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:141:in `block (6 levels) in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/job_retry.rb:97:in `local'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:140:in `block (5 levels) in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/rails.rb:42:in `block in call'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/execution_wrapper.rb:85:in `wrap'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/reloader.rb:68:in `block in wrap'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/execution_wrapper.rb:85:in `wrap'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.4/lib/active_support/reloader.rb:67:in `wrap'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/rails.rb:41:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:136:in `block (4 levels) in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:215:in `stats'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:131:in `block (3 levels) in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/job_logger.rb:7:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:130:in `block (2 levels) in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/job_retry.rb:72:in `global'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:129:in `block in dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/logging.rb:44:in `with_context'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/logging.rb:38:in `with_job_hash_context'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:128:in `dispatch'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:168:in `process'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:85:in `process_one'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/processor.rb:73:in `run'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/util.rb:16:in `watchdog'
/app/vendor/bundle/ruby/2.4.0/gems/sidekiq-5.0.4/lib/sidekiq/util.rb:25:in `block in safe_thread'
```