### PR TITLE
[WiP] Fix uri handling (#5167)

### DIFF
--- a/app/services/account_deduplication_service.rb
+++ b/app/services/account_deduplication_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class AccountDeduplicationService < BaseService
+  def call(reference_account)
+    Account.where.not(id: reference_account.id).where(uri: reference_account.uri).each do |account|
+      if account.protocol == reference_account.protocol && account.public_key == reference_account.public_key
+        # The accounts are functionnaly the same, merge them
+        merge_accounts(reference_account, account)
+      end
+      account.destroy
+    end
+  end
+
+  private
+
+  def merge_accounts(reference_account, account)
+    ActiveRecord.transaction do
+      # Re-attribute statuses
+      account.statuses.find_each do |status|
+        status.account = reference_account
+        status.save
+      end
+
+      # Re-attribute favourites
+      account.favourites.find_each do |fav|
+        fav.account = reference_account
+        fav.save
+      end
+
+      # Re-attribute mentions
+      account.mentions.find_each do |mention|
+        mention.account = reference_account
+        mention.save
+      end
+
+      # Re-follow reference account
+      account.followers.where(domain: nil).find_each do |follower|
+        # Schedule re-follow
+        begin
+          FollowService.new.call(follower, reference_account)
+        rescue Mastodon::NotPermittedError, ActiveRecord::RecordNotFound, Mastodon::UnexpectedResponseError, HTTP::Error, OpenSSL::SSL::SSLError
+          next
+        end
+      end
+    end
+  end
+end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -16,7 +16,8 @@ class ActivityPub::ProcessAccountService < BaseService
 
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?
-        @account        = Account.find_by(uri: @uri)
+        @account        = Account.find_by(username: @username, domain: @domain)
+        @account      ||= Account.find_by(uri: @uri)
         @old_public_key = @account&.public_key
         @old_protocol   = @account&.protocol
 
@@ -49,6 +50,8 @@ class ActivityPub::ProcessAccountService < BaseService
   def update_account
     @account.last_webfingered_at = Time.now.utc
     @account.protocol            = :activitypub
+    @account.username            = @username
+    @account.domain              = @domain
 
     set_immediate_attributes!
     set_fetchable_attributes!

--- a/app/services/concerns/author_extractor.rb
+++ b/app/services/concerns/author_extractor.rb
@@ -2,6 +2,12 @@
 
 module AuthorExtractor
   def author_from_xml(xml, update_profile = true)
+    acct = acct_uri_from_xml(xml)
+    return nil if acct.nil?
+    ResolveRemoteAccountService.new.call(acct, update_profile)
+  end
+
+  def acct_uri_from_xml(xml)
     return nil if xml.nil?
 
     # Try <email> for acct
@@ -18,6 +24,6 @@ module AuthorExtractor
       acct   = "#{username}@#{domain}"
     end
 
-    ResolveRemoteAccountService.new.call(acct, update_profile)
+    acct
   end
 end

--- a/app/services/resolve_remote_account_service.rb
+++ b/app/services/resolve_remote_account_service.rb
@@ -50,6 +50,8 @@ class ResolveRemoteAccountService < BaseService
         else
           handle_ostatus
         end
+
+        account_deduplication
       end
     end
 
@@ -60,6 +62,10 @@ class ResolveRemoteAccountService < BaseService
   end
 
   private
+
+  def account_deduplication
+    AccountDeduplicationService.new.call(@account)
+  end
 
   def links_missing?
     !(activitypub_ready? || ostatus_ready?)

--- a/app/services/resolve_remote_account_service.rb
+++ b/app/services/resolve_remote_account_service.rb
@@ -95,9 +95,9 @@ class ResolveRemoteAccountService < BaseService
   end
 
   def handle_activitypub
-    return if actor_json.nil?
-
-    @account = ActivityPub::ProcessAccountService.new.call(@username, @domain, actor_json)
+    @account = ActivityPub::FetchRemoteAccountService.new.call(actor_url,
+                                                               webfinger_username: @username,
+                                                               webfinger_domain: @domain)
   rescue Oj::ParseError
     nil
   end

--- a/spec/fixtures/requests/activitypub-webfinger-noncanonical.txt
+++ b/spec/fixtures/requests/activitypub-webfinger-noncanonical.txt
@@ -1,0 +1,7 @@
+HTTP/1.1 200 OK
+Cache-Control: max-age=0, private, must-revalidate
+Content-Type: application/jrd+json; charset=utf-8
+X-Content-Type-Options: nosniff
+Date: Sun, 17 Sep 2017 06:22:50 GMT
+
+{"subject":"acct:foo@ap2.example.com","aliases":["https://ap.example.com/@foo","https://ap.example.com/users/foo","foo@ap.example.com"],"links":[{"rel":"http://webfinger.net/rel/profile-page","type":"text/html","href":"https://ap.example.com/@foo"},{"rel":"http://schemas.google.com/g/2010#updates-from","type":"application/atom+xml","href":"https://ap.example.com/users/foo.atom"},{"rel":"self","type":"application/activity+json","href":"https://ap.example.com/users/foo"},{"rel":"salmon","href":"https://ap.example.com/api/salmon/1"},{"rel":"magic-public-key","href":"data:application/magic-public-key,RSA.u3L4vnpNLzVH31MeWI394F0wKeJFsLDAsNXGeOu0QF2x-h1zLWZw_agqD2R3JPU9_kaDJGPIV2Sn5zLyUA9S6swCCMOtn7BBR9g9sucgXJmUFB0tACH2QSgHywMAybGfmSb3LsEMNKsGJ9VsvYoh8lDET6X4Pyw-ZJU0_OLo_41q9w-OrGtlsTm_PuPIeXnxa6BLqnDaxC-4IcjG_FiPahNCTINl_1F_TgSSDZ4Taf4U9XFEIFw8wmgploELozzIzKq-t8nhQYkgAkt64euWpva3qL5KD1mTIZQEP-LZvh3s2WHrLi3fhbdRuwQ2c0KkJA2oSTFPDpqqbPGZ3QvuHQ==.AQAB"},{"rel":"http://ostatus.org/schema/1.0/subscribe","template":"https://ap.example.com/authorize_follow?acct={uri}"}]}

--- a/spec/fixtures/requests/webfinger-noncanonical.txt
+++ b/spec/fixtures/requests/webfinger-noncanonical.txt
@@ -1,0 +1,11 @@
+HTTP/1.1 200 OK
+Server: nginx/1.6.2
+Date: Sun, 20 Mar 2016 11:13:16 GMT
+Content-Type: application/jrd+json
+Transfer-Encoding: chunked
+Connection: keep-alive
+Access-Control-Allow-Origin: *
+Vary: Accept-Encoding,Cookie
+Strict-Transport-Security: max-age=31536000; includeSubdomains;
+
+{"subject":"acct:gargron@quitter.yes","aliases":["https:\/\/quitter.no\/user\/7477","https:\/\/quitter.no\/gargron","https:\/\/quitter.no\/index.php\/user\/7477","https:\/\/quitter.no\/index.php\/gargron","acct:gargron@quitter.no"],"links":[{"rel":"http:\/\/webfinger.net\/rel\/profile-page","type":"text\/html","href":"https:\/\/quitter.no\/gargron"},{"rel":"http:\/\/gmpg.org\/xfn\/11","type":"text\/html","href":"https:\/\/quitter.no\/gargron"},{"rel":"describedby","type":"application\/rdf+xml","href":"https:\/\/quitter.no\/gargron\/foaf"},{"rel":"http:\/\/apinamespace.org\/atom","type":"application\/atomsvc+xml","href":"https:\/\/quitter.no\/api\/statusnet\/app\/service\/gargron.xml"},{"rel":"http:\/\/apinamespace.org\/twitter","href":"https:\/\/quitter.no\/api\/"},{"rel":"http:\/\/specs.openid.net\/auth\/2.0\/provider","href":"https:\/\/quitter.no\/gargron"},{"rel":"http:\/\/schemas.google.com\/g\/2010#updates-from","type":"application\/atom+xml","href":"https:\/\/quitter.no\/api\/statuses\/user_timeline\/7477.atom"},{"rel":"magic-public-key","href":"data:application\/magic-public-key,RSA.1ZBkHTavLvxH3FzlKv4O6WtlILKRFfNami3_Rcu8EuogtXSYiS-bB6hElZfUCSHbC4uLemOA34PEhz__CDMozax1iI_t8dzjDnh1x0iFSup7pSfW9iXk_WU3Dm74yWWW2jildY41vWgrEstuQ1dJ8vVFfSJ9T_tO4c-T9y8vDI8=.AQAB"},{"rel":"salmon","href":"https:\/\/quitter.no\/main\/salmon\/user\/7477"},{"rel":"http:\/\/salmon-protocol.org\/ns\/salmon-replies","href":"https:\/\/quitter.no\/main\/salmon\/user\/7477"},{"rel":"http:\/\/salmon-protocol.org\/ns\/salmon-mention","href":"https:\/\/quitter.no\/main\/salmon\/user\/7477"},{"rel":"http:\/\/ostatus.org\/schema\/1.0\/subscribe","template":"https:\/\/quitter.no\/main\/ostatussub?profile={uri}"}]}


### PR DESCRIPTION
This is a work-in-progress attempt to fix #5167.
Basically, it forces every author URI to map back to an “acct:” URI by the same rules used to discover an “acct:” URI for unknown users, both in OStatus and ActivityPub, then proceed to merge/delete duplicate accounts.

What is still missing:
- Do not temporarily create URI conflicts if none exist (the current patched code will create a new account with shared URI then proceed to delete the old one)
- ~~~Re-follow on account migration~~~
- ~~~Avoid (up to two per account update) needless webfinger calls when discovering ActivityPub authors~~~
- Provide a task to deduplicate every problematic set of users in the database
- Enforce author URI uniqueness at model/database level
- Make sure there aren't any race condition
- RSpec: ~~~remote account merging and~~~ re-following
- Actually test it