### PR TITLE
Add placeholder text color to form of media attachments

### DIFF
--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -371,6 +371,11 @@
       &:focus {
         color: $white;
       }
+
+      &::placeholder {
+        opacity: 0.54;
+        color: $ui-secondary-color;
+      }
     }
 
     &.active {


### PR DESCRIPTION
ref #5123

### screenshot (on Google Chrome)

before | after
-|-
![before screenshot](https://user-images.githubusercontent.com/12539/31118594-ee1ed8ac-a868-11e7-9e88-246abd6ac792.png) | ![after screenshot](https://user-images.githubusercontent.com/12539/31118595-ee53c1fc-a868-11e7-91a7-ee7f61a6da0e.png)
