### PR TITLE
Switch to "summary" Twitter Card type (#5050)

### DIFF
--- a/app/views/stream_entries/show.html.haml
+++ b/app/views/stream_entries/show.html.haml
@@ -6,6 +6,8 @@
   %link{ rel: 'alternate', type: 'application/json+oembed', href: api_oembed_url(url: account_stream_entry_url(@account, @stream_entry), format: 'json') }/
   %link{ rel: 'alternate', type: 'application/activity+json', href: ActivityPub::TagManager.instance.uri_for(@stream_entry.activity) }/
 
+  %meta{ name: 'twitter:card', content: 'summary' }/
+
   = opengraph 'og:site_name', site_title
   = opengraph 'og:type', 'article'
   = opengraph 'og:title', "#{@account.username} on #{site_hostname}"
@@ -13,8 +15,6 @@
 
   = render 'stream_entries/og_description', activity: @stream_entry.activity
   = render 'stream_entries/og_image', activity: @stream_entry.activity, account: @account
-
-  = opengraph 'twitter:card', 'summary_large_image'
 
 - if show_landing_strip?
   = render partial: 'shared/landing_strip', locals: { account: @stream_entry.account }


### PR DESCRIPTION
Switches from "summary_large_image" to "summary" Card type for Twitter in the post meta tags. See the discussion and comparison in issue #5050.
Also replaces opengraph with meta, since Twitter asks for name instead of property.