### PR TITLE
Fix HTTP responses for salmon and ActivityPub inbox processing

### DIFF
--- a/app/controllers/activitypub/inboxes_controller.rb
+++ b/app/controllers/activitypub/inboxes_controller.rb
@@ -11,7 +11,7 @@ class ActivityPub::InboxesController < Api::BaseController
       process_payload
       head 202
     else
-      head 401
+      [signature_verification_failure_reason, 401]
     end
   end
 

--- a/app/controllers/activitypub/inboxes_controller.rb
+++ b/app/controllers/activitypub/inboxes_controller.rb
@@ -9,9 +9,9 @@ class ActivityPub::InboxesController < Api::BaseController
     if signed_request_account
       upgrade_account
       process_payload
-      head 201
-    else
       head 202
+    else
+      head 401
     end
   end
 

--- a/app/controllers/api/salmon_controller.rb
+++ b/app/controllers/api/salmon_controller.rb
@@ -7,9 +7,11 @@ class Api::SalmonController < Api::BaseController
   def update
     if verify_payload?
       process_salmon
-      head 201
-    else
       head 202
+    elsif payload.present?
+      head 401
+    else
+      head 400
     end
   end
 

--- a/app/controllers/api/salmon_controller.rb
+++ b/app/controllers/api/salmon_controller.rb
@@ -9,7 +9,7 @@ class Api::SalmonController < Api::BaseController
       process_salmon
       head 202
     elsif payload.present?
-      head 401
+      [signature_verification_failure_reason, 401]
     else
       head 400
     end

--- a/spec/controllers/api/salmon_controller_spec.rb
+++ b/spec/controllers/api/salmon_controller_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe Api::SalmonController, type: :controller do
         post :update, params: { id: account.id }
       end
 
-      it 'returns http success' do
-        expect(response).to have_http_status(202)
+      it 'returns http client error' do
+        expect(response).to have_http_status(400)
       end
     end
   end


### PR DESCRIPTION
Mastodon currently returns 202 Accepted when a request is not signed (and thus *not* accepted, causing a silent failure), and 201 Created otherwise (even though it's not immediately created but will be processed in a worker).

This pull request fixes that by returning 401 Unauthorized (maybe something else is better suited) and 202 Accepted respectively. It also returns some information on why the signature couldn't be verified.