### PR TITLE
Compress emoji_data_light.js

### DIFF
--- a/app/javascript/mastodon/emoji_data_compressed.js
+++ b/app/javascript/mastodon/emoji_data_compressed.js
@@ -1,0 +1,22 @@
+// @preval
+const data = require('emoji-mart/dist/data').default;
+const pick = require('lodash/pick');
+const values = require('lodash/values');
+
+const condensedEmojis = Object.keys(data.emojis).map(key => {
+  if (!data.emojis[key].short_names[0] === key) {
+    throw new Error('The condenser expects the first short_code to be the ' +
+      'key. It may need to be rewritten if the emoji change such that this ' +
+      'is no longer the case.');
+  }
+  return values(pick(data.emojis[key], ['short_names', 'unified', 'search']));
+});
+
+// JSON.parse/stringify is to emulate what @preval is doing and avoid any
+// inconsistent behavior in dev mode
+module.exports = JSON.parse(JSON.stringify({
+  emojis: condensedEmojis,
+  skins: data.skins,
+  categories: data.categories,
+  short_names: data.short_names,
+}));

--- a/app/javascript/mastodon/emoji_data_light.js
+++ b/app/javascript/mastodon/emoji_data_light.js
@@ -1,17 +1,16 @@
-// @preval
-const data = require('emoji-mart/dist/data').default;
-const pick = require('lodash/pick');
+const data = require('./emoji_data_compressed');
 
-const condensedEmojis = {};
-Object.keys(data.emojis).forEach(key => {
-  condensedEmojis[key] = pick(data.emojis[key], ['short_names', 'unified', 'search']);
+// decompress
+const emojis = {};
+data.emojis.forEach(compressedEmoji => {
+  const [ short_names, unified, search ] = compressedEmoji;
+  emojis[short_names[0]] = {
+    short_names,
+    unified,
+    search,
+  };
 });
 
-// JSON.parse/stringify is to emulate what @preval is doing and avoid any
-// inconsistent behavior in dev mode
-module.exports = JSON.parse(JSON.stringify({
-  emojis: condensedEmojis,
-  skins: data.skins,
-  categories: data.categories,
-  short_names: data.short_names,
-}));
+data.emojis = emojis;
+
+module.exports = data;


### PR DESCRIPTION
This compresses `emoji_data_light` by converting objects to arrays, as suggested by @sorin-davidoi  (https://github.com/tootsuite/mastodon/pull/5175#discussion_r142101167). The size of `common.js` is reduced from 925 kB (925004) to 868 kB (867839), a savings of 57.2 kB.

I was worried there may be a tradeoff with the cost of decompression, so I [tested with perf marks](https://github.com/nolanlawson/mastodon/commit/ff8289150405ed886cc9f20f2ddea9f449c86fef) and measured the decompress time as 15ms on a Nexus 5 running Chrome and 4.5ms on the same device running Firefox. So the decompression costs are negligible.

Before and after:

![out](https://user-images.githubusercontent.com/283842/31139000-1742500e-a825-11e7-9e8e-f5dc165202ec.png)

It's very likely we could compress this further (e.g. by combining `emoji_data_compressed.js` and `emojione_light.js`, but this is a good step in that direction.