### PR TITLE
WIP: Set backdated timestamp IDs on new old Statuses

### DIFF
--- a/app/lib/activitypub/activity/announce.rb
+++ b/app/lib/activitypub/activity/announce.rb
@@ -15,7 +15,7 @@ class ActivityPub::Activity::Announce < ActivityPub::Activity
       account: @account,
       reblog: original_status,
       uri: @json['id'],
-      created_at: @json['published'] || Time.now.utc
+      created_at: @json['published']
     )
     distribute(status)
     status

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -43,7 +43,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       text: text_from_content || '',
       language: language_from_content,
       spoiler_text: @object['summary'] || '',
-      created_at: @object['published'] || Time.now.utc,
+      created_at: @object['published'],
       reply: @object['inReplyTo'].present?,
       sensitive: @object['sensitive'] || false,
       visibility: visibility_from_audience,

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -135,6 +135,7 @@ class Status < ApplicationRecord
   end
 
   after_create :store_uri, if: :local?
+  around_create Mastodon::TimestampIds::Callbacks
 
   before_validation :prepare_contents, if: :local?
   before_validation :set_reblog

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ require_relative '../lib/mastodon/version'
 Dotenv::Railtie.load
 
 require_relative '../lib/mastodon/redis_config'
+require_relative '../lib/mastodon/timestamp_ids'
 
 module Mastodon
   class Application < Rails::Application


### PR DESCRIPTION
For any "old" status (where the creation time is before the update time, as both are already set by Rails by the time we get to around_save), we now generate an ID for the "old" (or potentially, future-dated) status, and attempt to use that to insert.

In the vast majority of cases, this should succeed. If it doesn't, we retry up to a thousand times, each time incrementing the ID by a random number between 0 and 99, to avoid too many collisions.

Note that this also necessitates setting `created_at` to nil (or leaving it unset), not Time.utc.now, when creating new statuses. (Although the only downside to setting a time is a small amount of extra work, nothing catastrophic.)