### PR TITLE
Check Webfinger-returned author URI even when not redirected

### DIFF
--- a/app/services/activitypub/fetch_remote_account_service.rb
+++ b/app/services/activitypub/fetch_remote_account_service.rb
@@ -31,7 +31,7 @@ class ActivityPub::FetchRemoteAccountService < BaseService
     webfinger                            = Goldfinger.finger("acct:#{@username}@#{@domain}")
     confirmed_username, confirmed_domain = split_acct(webfinger.subject)
 
-    return true if @username.casecmp(confirmed_username).zero? && @domain.casecmp(confirmed_domain).zero?
+    return webfinger.link('self')&.href == @uri if @username.casecmp(confirmed_username).zero? && @domain.casecmp(confirmed_domain).zero?
 
     webfinger                            = Goldfinger.finger("acct:#{confirmed_username}@#{confirmed_domain}")
     @username, @domain                   = split_acct(webfinger.subject)


### PR DESCRIPTION
The whole point of verified_webfinger? is to check the WebFinger-discoverable
URI maps back to the known author URI. This was not actually verified if the
first Webfinger request was not a redirection.

I can't think of a scenario where that could be abused by an attacker, but it's worth fixing nonetheless.