### PR TITLE
Fix missing instance name in notification emails

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -18,6 +18,7 @@ class UserMailer < Devise::Mailer
   def reset_password_instructions(user, token, _opts = {})
     @resource = user
     @token    = token
+    @instance = Rails.configuration.x.local_domain
 
     I18n.with_locale(@resource.locale || I18n.default_locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.reset_password_instructions.subject')
@@ -26,6 +27,7 @@ class UserMailer < Devise::Mailer
 
   def password_change(user, _opts = {})
     @resource = user
+    @instance = Rails.configuration.x.local_domain
 
     I18n.with_locale(@resource.locale || I18n.default_locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.password_change.subject')


### PR DESCRIPTION
The instance name in password reset instructions email and password change notification email was missing, due to missing instance variable in UserMailer. This change supplies the `@instance` variable to correctly show which instance the mail came from.

-----

These are screenshots of actual emails I got from a running instance(mstdn.jp):

![_2017-10-04_20_08_30](https://user-images.githubusercontent.com/809530/31172908-606d4d76-a940-11e7-9b40-7ceb7e4c2825.png)

![_2017-10-04_20_08_20](https://user-images.githubusercontent.com/809530/31172905-5c267364-a940-11e7-850c-f6a94ae9cdd0.png)
