### PR TITLE
Fix regression in FetchRemoteResourceService

### DIFF
--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -45,7 +45,7 @@ class FetchAtomService < BaseService
     elsif ['application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'].include?(@response.mime_type)
       json = body_to_json(@response.to_s)
       if supported_context?(json) && json['type'] == 'Person' && json['inbox'].present?
-        [json['id'], { id: true }, :activitypub]
+        [json['id'], { prefetched_body: @response.to_s, id: true }, :activitypub]
       else
         @unsupported_activity = true
         nil

--- a/app/services/fetch_remote_resource_service.rb
+++ b/app/services/fetch_remote_resource_service.rb
@@ -33,7 +33,7 @@ class FetchRemoteResourceService < BaseService
   end
 
   def body
-    fetched_atom_feed.second
+    fetched_atom_feed.second[:prefetched_body]
   end
 
   def protocol

--- a/spec/services/fetch_remote_resource_service_spec.rb
+++ b/spec/services/fetch_remote_resource_service_spec.rb
@@ -22,7 +22,7 @@ describe FetchRemoteResourceService do
       allow(FetchAtomService).to receive(:new).and_return service
       feed_url = 'http://feed-url'
       feed_content = '<feed>contents</feed>'
-      allow(service).to receive(:call).with(url).and_return([feed_url, feed_content])
+      allow(service).to receive(:call).with(url).and_return([feed_url, { prefetched_body: feed_content }])
 
       account_service = double
       allow(FetchRemoteAccountService).to receive(:new).and_return(account_service)
@@ -39,7 +39,7 @@ describe FetchRemoteResourceService do
       allow(FetchAtomService).to receive(:new).and_return service
       feed_url = 'http://feed-url'
       feed_content = '<entry>contents</entry>'
-      allow(service).to receive(:call).with(url).and_return([feed_url, feed_content])
+      allow(service).to receive(:call).with(url).and_return([feed_url, { prefetched_body: feed_content }])
 
       account_service = double
       allow(FetchRemoteStatusService).to receive(:new).and_return(account_service)


### PR DESCRIPTION
`FetchAtomService`'s interface changed in #5114 but `FetchRemoteResourceService` has not been updated for this change.

I only went through #5114 quickly so it is possible that this fix breaks what was intended by #5114.