### PR TITLE
Fix style of email domain block table

### DIFF
--- a/app/views/admin/email_domain_blocks/index.html.haml
+++ b/app/views/admin/email_domain_blocks/index.html.haml
@@ -1,13 +1,14 @@
 - content_for :page_title do
   = t('admin.email_domain_blocks.title')
 
-%table.table
-  %thead
-    %tr
-      %th= t('admin.email_domain_blocks.domain')
-      %th
-  %tbody
-    = render @email_domain_blocks
+.table-wrapper
+  %table.table
+    %thead
+      %tr
+        %th= t('admin.email_domain_blocks.domain')
+        %th
+    %tbody
+      = render @email_domain_blocks
 
 = paginate @email_domain_blocks
 = link_to t('admin.email_domain_blocks.add_new'), new_admin_email_domain_block_path, class: 'button'


### PR DESCRIPTION
Fix style problem related to #5109 .

Tables in settings pages should be wrapped in table-wrapper container which has bottom margin.

Before
![ws000085](https://user-images.githubusercontent.com/27640522/31185684-959db2ca-a967-11e7-8042-35c216cfe8c7.png)
After
![ws000086](https://user-images.githubusercontent.com/27640522/31185697-9949dd18-a967-11e7-929e-8ac14be8653e.png)
