### PR TITLE
Use summary_large_image only with media attachments

### DIFF
--- a/app/views/stream_entries/_og_image.html.haml
+++ b/app/views/stream_entries/_og_image.html.haml
@@ -17,7 +17,9 @@
       - unless media.file.meta.nil?
         = opengraph 'og:video:width', media.file.meta['small']['width']
         = opengraph 'og:video:height', media.file.meta['small']['height']
+  = opengraph 'twitter:card', 'summary_large_image'
 - else
   = opengraph 'og:image', full_asset_url(account.avatar.url(:original))
   = opengraph 'og:image:width', '120'
   = opengraph 'og:image:height','120'
+  = opengraph 'twitter:card', 'summary'

--- a/app/views/stream_entries/show.html.haml
+++ b/app/views/stream_entries/show.html.haml
@@ -14,8 +14,6 @@
   = render 'stream_entries/og_description', activity: @stream_entry.activity
   = render 'stream_entries/og_image', activity: @stream_entry.activity, account: @account
 
-  = opengraph 'twitter:card', 'summary_large_image'
-
 - if show_landing_strip?
   = render partial: 'shared/landing_strip', locals: { account: @stream_entry.account }
 


### PR DESCRIPTION
- Fix #5050
- Resolves #5197