### PR TITLE
Adjust public profile pages 2

### DIFF
--- a/app/javascript/styles/accounts.scss
+++ b/app/javascript/styles/accounts.scss
@@ -69,12 +69,16 @@
     position: relative;
     z-index: 2;
     margin-bottom: 30px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     small {
       display: block;
       font-size: 14px;
       color: $ui-highlight-color;
       font-weight: 400;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 
@@ -284,21 +288,15 @@
     color: lighten($ui-base-color, 10%);
   }
 
-  @media screen and (max-width: 360px) {
+  @media screen and (max-width: 700px) {
     padding: 30px 20px;
 
-    a,
-    .current,
-    .next,
-    .prev,
-    .gap {
+    .page {
       display: none;
     }
 
     .next,
-    .prev,
-    .next a,
-    .prev a {
+    .prev {
       display: inline-block;
     }
   }
@@ -375,6 +373,7 @@
         height: 80px;
         border-radius: 80px;
         border: 2px solid $simple-background-color;
+        background: $simple-background-color;
       }
     }
 

--- a/app/javascript/styles/forms.scss
+++ b/app/javascript/styles/forms.scss
@@ -515,6 +515,7 @@ code {
 
 .action-pagination {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
 
   .actions,

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -3,6 +3,5 @@
 Kaminari.configure do |config|
   config.default_per_page = 40
   config.window = 1
-  config.left = 3
-  config.right = 1
+  config.outer_window = 1
 end


### PR DESCRIPTION
### Set background color for transparent avatars

Before and after images
![ba23](https://user-images.githubusercontent.com/27640522/31192828-43d423fa-a97d-11e7-92d3-6dbb91cf9f15.png)


### Fix overflowing username

It is needed to re-set text-overflow and overflow in `display: block;` .

Before and after images
![ba24](https://user-images.githubusercontent.com/27640522/31192847-5164729a-a97d-11e7-8b64-653961493e80.png)

### Adjust pagination

- Fix overflowing pagination
  - Reduce first three pages buttons to only 1 button (This is same as before we started using kaminari gem)
  - Change mobile threshold.
- Fix deviation height of prev next buttons in mobile view.
`display: none;` should apply for spans not for anchors.

This fixes below
![ws000087](https://user-images.githubusercontent.com/27640522/31193399-f2edf806-a97e-11e7-99ba-d8ce9f8a1637.png)
![ws000088](https://user-images.githubusercontent.com/27640522/31193398-f2ea2640-a97e-11e7-9ed8-7a7ec134574b.png)

