### PR TITLE
Add atom renderer to hashtags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -13,6 +13,12 @@ class TagsController < ApplicationController
         @initial_state_json   = serializable_resource.to_json
       end
 
+      format.atom do
+        @statuses = Status.as_tag_timeline(@tag, current_account, params[:local]).paginate_by_max_id(20, params[:max_id])
+        @statuses = cache_collection(@statuses, Status)
+        render xml: OStatus::AtomSerializer.render(OStatus::AtomSerializer.new.tag_feed(@tag, @statuses))
+      end
+
       format.json do
         @statuses = Status.as_tag_timeline(@tag, current_account, params[:local]).paginate_by_max_id(20, params[:max_id])
         @statuses = cache_collection(@statuses, Status)

--- a/app/lib/ostatus/atom_serializer.rb
+++ b/app/lib/ostatus/atom_serializer.rb
@@ -40,7 +40,8 @@ class OStatus::AtomSerializer
     add_namespaces(feed)
 
     append_element(feed, 'id', tag_url(tag, format: 'atom'))
-    # append_element(feed, 'title', tag.name.downcase)
+    append_element(feed, 'title', "\##{tag.name.downcase}")
+    append_element(feed, 'updated', statuses.first.updated_at.iso8601)
 
     append_element(feed, 'link', nil, rel: :alternate, type: 'text/html', href: tag_url(tag, format: 'html'))
     append_element(feed, 'link', nil, rel: :self, type: 'application/atom+xml', href: tag_url(tag, format: 'atom'))


### PR DESCRIPTION
Render hashtags as an atom feed when accessing `https://WEB_DOMAIN/tags/hashtag.atom`, thus allowing people to subscribe to given hashtags.

I'm not too happy with the code duplication, but statuses do not necessarily have a `StreamingEntry` associated.