### PR TITLE
When processing custom emoji, ensure a non-animated version exists

### DIFF
--- a/app/javascript/mastodon/emoji.js
+++ b/app/javascript/mastodon/emoji.js
@@ -52,7 +52,7 @@ export const buildCustomEmojis = customEmojis => {
 
   customEmojis.forEach(emoji => {
     const shortcode = emoji.get('shortcode');
-    const url       = emoji.get('url');
+    const url       = emoji.get('static_url');
     const name      = shortcode.replace(':', '');
 
     emojis.push({

--- a/app/javascript/mastodon/reducers/statuses.js
+++ b/app/javascript/mastodon/reducers/statuses.js
@@ -60,7 +60,7 @@ const normalizeStatus = (state, status) => {
 
   const searchContent = [status.spoiler_text, status.content].join(' ').replace(/<br \/>/g, '\n').replace(/<\/p><p>/g, '\n\n');
   const emojiMap = normalStatus.emojis.reduce((obj, emoji) => {
-    obj[`:${emoji.shortcode}:`] = emoji.url;
+    obj[`:${emoji.shortcode}:`] = emoji.static_url;
     return obj;
   }, {});
 

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -92,7 +92,7 @@ class Formatter
   def encode_custom_emojis(html, emojis)
     return html if emojis.empty?
 
-    emoji_map = emojis.map { |e| [e.shortcode, full_asset_url(e.image.url)] }.to_h
+    emoji_map = emojis.map { |e| [e.shortcode, full_asset_url(e.image.url(:static))] }.to_h
 
     i                     = -1
     inside_tag            = false

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -21,7 +21,7 @@ class CustomEmoji < ApplicationRecord
     :(#{SHORTCODE_RE_FRAGMENT}):
     (?=[^[:alnum:]:]|$)/x
 
-  has_attached_file :image
+  has_attached_file :image, styles: { static: { format: 'png', convert_options: '-coalesce -strip' } }
 
   validates_attachment :image, content_type: { content_type: 'image/png' }, presence: true, size: { in: 0..50.kilobytes }
   validates :shortcode, uniqueness: { scope: :domain }, format: { with: /\A#{SHORTCODE_RE_FRAGMENT}\z/ }, length: { minimum: 2 }

--- a/app/serializers/rest/custom_emoji_serializer.rb
+++ b/app/serializers/rest/custom_emoji_serializer.rb
@@ -3,9 +3,13 @@
 class REST::CustomEmojiSerializer < ActiveModel::Serializer
   include RoutingHelper
 
-  attributes :shortcode, :url
+  attributes :shortcode, :url, :static_url
 
   def url
     full_asset_url(object.image.url)
+  end
+
+  def static_url
+    full_asset_url(object.image.url(:static))
   end
 end


### PR DESCRIPTION
Use the non-animated version in web UI, but return both in API

When I picked the PNG format for custom emojis, my intention was to not allow animations, otherwise I would've allowed GIF. We respect people who want to disable GIF autoplay and use hover-to-play instead, but this is not possible in this case.