### PR TITLE
Add strong_migrations to production dependency (regression from #5231)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem 'sidekiq-bulk', '~>0.1.1'
 gem 'simple-navigation', '~> 4.0'
 gem 'simple_form', '~> 3.4'
 gem 'sprockets-rails', '~> 3.2', require: 'sprockets/railtie'
+gem 'strong_migrations'
 gem 'twitter-text', '~> 1.14'
 gem 'tzinfo-data', '~> 1.2017'
 gem 'webpacker', '~> 3.0'
@@ -105,7 +106,6 @@ group :development do
   gem 'brakeman', '~> 4.0', require: false
   gem 'bundler-audit', '~> 0.6', require: false
   gem 'scss_lint', '~> 0.53', require: false
-  gem 'strong_migrations'
 
   gem 'capistrano', '~> 3.8'
   gem 'capistrano-rails', '~> 1.2'


### PR DESCRIPTION
Since now we use `safety_assured` from strong_migration gem in the migration, we need to install even on production environment.

This also disables dangerous rake task in a default:

https://github.com/ankane/strong_migrations/blob/v0.1.9/README.md#dangerous-tasks