### PR TITLE
Fix thinking_face emoji autocomplete

### DIFF
--- a/app/javascript/mastodon/features/emoji/emoji_utils.js
+++ b/app/javascript/mastodon/features/emoji/emoji_utils.js
@@ -125,13 +125,16 @@ function getData(emoji) {
 }
 
 function intersect(a, b) {
-  let aSet = new Set(a);
-  let bSet = new Set(b);
-  let intersection = new Set(
-    [...aSet].filter(x => bSet.has(x))
-  );
-
-  return Array.from(intersection);
+  let set;
+  let list;
+  if (a.length < b.length) {
+    set = new Set(a);
+    list = b;
+  } else {
+    set = new Set(b);
+    list = a;
+  }
+  return Array.from(new Set(list.filter(x => set.has(x))));
 }
 
 export { getData, getSanitizedData, intersect };

--- a/spec/javascript/components/emoji_index.test.js
+++ b/spec/javascript/components/emoji_index.test.js
@@ -96,4 +96,11 @@ describe('emoji_index', () => {
     expect(search('polo').map(trimEmojis)).to.deep.equal(expected);
     expect(emojiIndex.search('polo').map(trimEmojis)).to.deep.equal(expected);
   });
+
+  it('can search for thinking_face', () => {
+    let expected = [ { id: 'thinking_face', unified: '1f914', native: '🤔' } ];
+    expect(search('thinking_fac').map(trimEmojis)).to.deep.equal(expected);
+    // this is currently broken in emoji-mart
+    // expect(emojiIndex.search('thinking_fac').map(trimEmojis)).to.deep.equal(expected);
+  });
 });


### PR DESCRIPTION
As discovered by @unarist, there's a bug in `emoji-mart`'s search where no results are returned when you type `:thinking_fac`:

> `search()` function split it by `-` `_` and treat as AND query. that `intersect()` function calculates intersection of all search result, by iterating items in one Set and check existence in other Set.
to use `Array.prototype.filter()`, it converts Set to Array using spread operator, but Babel compiles `[...x]` to `[].concat(x)`, and it results array which has `x` as an item.

We can fix this by avoiding `[...x]` in the `intersect()` function, which this PR accomplishes. I'll also open a PR on emoji-mart so that it can get fixed over there too.