### PR TITLE
Fix error at emoji_compressed in Firefox in development environment

### DIFF
--- a/app/javascript/mastodon/features/emoji/emoji_compressed.js
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.js
@@ -54,7 +54,9 @@ Object.keys(emojiMap).forEach(key => {
   if (typeof shortcode === 'undefined') {
     emojisWithoutShortCodes.push(filenameData);
   } else {
-    shortCodesToEmojiData[shortcode] = shortCodesToEmojiData[shortcode] || [[]];
+    if (!Array.isArray(shortCodesToEmojiData[shortcode])) {
+      shortCodesToEmojiData[shortcode] = [[]];
+    }
     shortCodesToEmojiData[shortcode][0].push(filenameData);
   }
 });


### PR DESCRIPTION
When `shortcode` is "watch", error occurs in Firefox 52 ESR.
cc @nolanlawson 

P.S.
The error is `TypeError: shortCodesToEmojiData[shortcode][0] is undefined`. Sorry for lack of explanation...