### PR TITLE
Specify middleware versions in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,14 @@ services:
 
   db:
     restart: always
-    image: postgres:alpine
+    image: postgres:9.6-alpine
 ### Uncomment to enable DB persistance
 #    volumes:
 #      - ./postgres:/var/lib/postgresql/data
 
   redis:
     restart: always
-    image: redis:alpine
+    image: redis:4.0-alpine
 ### Uncomment to enable REDIS persistance
 #    volumes:
 #      - ./redis:/data


### PR DESCRIPTION
PostgreSQL10 has been released, but upgrading from older versions needs dump/restore. If you pull new version without those handling, db service will fail to launch.

To prevent accidentally upgrading, and as a recommended version, this patch specifies PostgreSQL and Redis version.