### PR TITLE
Fix error (Reloading browser at status detail column causes error)

### DIFF
--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -242,8 +242,8 @@ export default class Status extends ImmutablePureComponent {
   componentDidUpdate () {
     const { ancestorsIds } = this.props;
 
-    if (ancestorsIds) {
-      const element = this.node.querySelectorAll('.focusable')[this.props.ancestorsIds.size];
+    if (ancestorsIds && ancestorsIds.size > 0) {
+      const element = this.node.querySelectorAll('.focusable')[ancestorsIds.size];
       element.scrollIntoView();
     }
   }


### PR DESCRIPTION
#5245 
When displaying status column with no ancestors, it will causes error if you reload the browser.