### PR TITLE
In REST API, when URL can be missing, cast it to nil

### DIFF
--- a/app/serializers/rest/application_serializer.rb
+++ b/app/serializers/rest/application_serializer.rb
@@ -15,4 +15,8 @@ class REST::ApplicationSerializer < ActiveModel::Serializer
   def client_secret
     object.secret
   end
+
+  def website
+    object.website.presence
+  end
 end

--- a/app/serializers/rest/media_attachment_serializer.rb
+++ b/app/serializers/rest/media_attachment_serializer.rb
@@ -19,6 +19,10 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
     end
   end
 
+  def remote_url
+    object.remote_url.presence
+  end
+
   def preview_url
     if object.needs_redownload?
       media_proxy_url(object.id, :small)


### PR DESCRIPTION
Reference: <https://mastodon.social/@WAHa_06x36/20836861>