### PR TITLE
Video preload should be a string

### DIFF
--- a/app/javascript/mastodon/features/video/index.js
+++ b/app/javascript/mastodon/features/video/index.js
@@ -233,7 +233,7 @@ export default class Video extends React.PureComponent {
           ref={this.setVideoRef}
           src={src}
           poster={preview}
-          preload={startTime ? true : null}
+          preload={startTime ? 'auto' : 'none'}
           loop
           role='button'
           tabIndex='0'


### PR DESCRIPTION
According to [MDN's docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-preload) this is supposed to be a string. I assume the intention is that if `startTime` is greater than 0 we want `auto` which hints to the browser to preload, whereas `none` will not preload.

I saw a warning about this in the dev console; it seems gone now after the buffer change, but seems like we may as well follow the docs on this.