### PR TITLE
Remove timestamps on any option

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -7,6 +7,8 @@ Paperclip.interpolates :filename do |attachment, style|
   [basename(attachment, style), extension(attachment, style)].delete_if(&:blank?).join('.')
 end
 
+Paperclip::Attachment.default_options[:use_timestamp]  = false
+
 if ENV['S3_ENABLED'] == 'true'
   Aws.eager_autoload!(services: %w(S3))
 
@@ -18,7 +20,6 @@ if ENV['S3_ENABLED'] == 'true'
   Paperclip::Attachment.default_options[:s3_headers]     = { 'Cache-Control' => 'max-age=315576000' }
   Paperclip::Attachment.default_options[:s3_permissions] = ENV.fetch('S3_PERMISSION') { 'public-read' }
   Paperclip::Attachment.default_options[:s3_region]      = ENV.fetch('S3_REGION') { 'us-east-1' }
-  Paperclip::Attachment.default_options[:use_timestamp]  = false
 
   Paperclip::Attachment.default_options[:s3_credentials] = {
     bucket: ENV.fetch('S3_BUCKET'),


### PR DESCRIPTION
Timestamps were not removed on non-S3 usages.

Related to #2185 and #2123