### PR TITLE
Fix migration failure due to StrongMigrations on production env (regression from #5234)

### DIFF
--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-StrongMigrations.start_after = 20170924022025 if Rails.env.development?
+StrongMigrations.start_after = 20170924022025


### PR DESCRIPTION
To enable StrongMigration on production (#5234), also we need to set `StrongMigrations.start_after`.

Migration from 1.6.1 fails on production due to this bug.