### PR TITLE
Grouped web push notification should not have an icon

### DIFF
--- a/app/javascript/mastodon/service_worker/web_push_notifications.js
+++ b/app/javascript/mastodon/service_worker/web_push_notifications.js
@@ -14,7 +14,6 @@ const notify = options =>
           .sort((n1, n2) => n1.timestamp < n2.timestamp)
           .map(notification => notification.title).join('\n'),
         badge: '/badge.png',
-        icon: '/android-chrome-192x192.png',
         tag: GROUP_TAG,
         data: {
           url: (new URL('/web/notifications', self.location)).href,


### PR DESCRIPTION
I'm frankly not sure what happens when there's no icon - maybe it displays no icon next to the notification, or maybe it displays the badge (ideally), but displaying the launcher icon next to the notification definitely does not feel native.