### PR TITLE
foreign_key, non-nullable, dependent: destroy in account_moderation_notes

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -91,8 +91,8 @@ class Account < ApplicationRecord
   has_many :targeted_reports, class_name: 'Report', foreign_key: :target_account_id
 
   # Moderation notes
-  has_many :account_moderation_notes
-  has_many :targeted_moderation_notes, class_name: 'AccountModerationNote', foreign_key: :target_account_id
+  has_many :account_moderation_notes, dependent: :destroy
+  has_many :targeted_moderation_notes, class_name: 'AccountModerationNote', foreign_key: :target_account_id, dependent: :destroy
 
   scope :remote, -> { where.not(domain: nil) }
   scope :local, -> { where(domain: nil) }

--- a/app/models/account_moderation_note.rb
+++ b/app/models/account_moderation_note.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: account_moderation_notes
 #
 #  id                :integer          not null, primary key
 #  content           :text             not null
-#  account_id        :integer
-#  target_account_id :integer
+#  account_id        :integer          not null
+#  target_account_id :integer          not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/db/migrate/20171010023049_add_foreign_key_to_account_moderation_notes.rb
+++ b/db/migrate/20171010023049_add_foreign_key_to_account_moderation_notes.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToAccountModerationNotes < ActiveRecord::Migration[5.1]
+  def change
+    add_foreign_key :account_moderation_notes, :accounts
+  end
+end

--- a/db/migrate/20171010025614_change_accounts_nonnullable_in_account_moderation_notes.rb
+++ b/db/migrate/20171010025614_change_accounts_nonnullable_in_account_moderation_notes.rb
@@ -1,0 +1,6 @@
+class ChangeAccountsNonnullableInAccountModerationNotes < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :account_moderation_notes, :account_id, false
+    change_column_null :account_moderation_notes, :target_account_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171010023049) do
+ActiveRecord::Schema.define(version: 20171010025614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,8 +25,8 @@ ActiveRecord::Schema.define(version: 20171010023049) do
 
   create_table "account_moderation_notes", force: :cascade do |t|
     t.text "content", null: false
-    t.bigint "account_id"
-    t.bigint "target_account_id"
+    t.bigint "account_id", null: false
+    t.bigint "target_account_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_account_moderation_notes_on_account_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171006142024) do
+ActiveRecord::Schema.define(version: 20171010023049) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -459,6 +459,7 @@ ActiveRecord::Schema.define(version: 20171006142024) do
   end
 
   add_foreign_key "account_domain_blocks", "accounts", name: "fk_206c6029bd", on_delete: :cascade
+  add_foreign_key "account_moderation_notes", "accounts"
   add_foreign_key "account_moderation_notes", "accounts", column: "target_account_id"
   add_foreign_key "blocks", "accounts", column: "target_account_id", name: "fk_9571bfabc1", on_delete: :cascade
   add_foreign_key "blocks", "accounts", name: "fk_4269e03e65", on_delete: :cascade


### PR DESCRIPTION
Sorry. I forgot to specify `foreign_key: true` to `accounts` in #5240. 

EDIT1: I added foreign key constraint for `target_account`, but I forgot to do for `account` in #5240.
EDIT2: Sorry, I also forgot to specify `null: false` and `dependent: :destroy`, too.