### PR TITLE
Fix an error when video playback buffer is empty

### DIFF
--- a/app/javascript/mastodon/features/video/index.js
+++ b/app/javascript/mastodon/features/video/index.js
@@ -210,7 +210,9 @@ export default class Video extends React.PureComponent {
   }
 
   handleProgress = () => {
-    this.setState({ buffer: this.video.buffered.end(0) / this.video.duration * 100 });
+    if (this.video.buffered.length > 0) {
+      this.setState({ buffer: this.video.buffered.end(0) / this.video.duration * 100 });
+    }
   }
 
   handleOpenVideo = () => {


### PR DESCRIPTION
```
react-dom.production.min.js:36 Uncaught DOMException: Failed to execute 'end' on 'TimeRanges': The index provided (0) is greater than or equal to the maximum bound (0).
    at r.handleProgress (https://mstdn.maud.io/packs/common-eb49aa45153efdfb41af.js:1:149182)
    at Object.g (https://mstdn.maud.io/packs/common-eb49aa45153efdfb41af.js:1:554890)
    at Object.invokeGuardedCallback (https://mstdn.maud.io/packs/common-eb49aa45153efdfb41af.js:1:600941)
    at Object.invokeGuardedCallbackAndCatchFirstError (https://mstdn.maud.io/packs/common-eb49aa45153efdfb41af.js:1:601058)
    at b (https://mstdn.maud.io/packs/common-eb49aa45153efdfb41af.js:1:555156)
    at Object.executeDispatchesInOrder (https://mstdn.maud.io/packs/common-eb49aa45153efdfb41af.js:1:602124)
    at C (https://mstdn.maud.io/packs/common-eb49aa45153efdfb41af.js:1:556483)
    at j (https://mstdn.maud.io/packs/common-eb49aa45153efdfb41af.js:1:556607)
    at Array.forEach (<anonymous>)
    at S (https://mstdn.maud.io/packs/common-eb49aa45153efdfb41af.js:1:556432)
```