### PR TITLE
Remove prop types from external libraries

### DIFF
--- a/config/webpack/loaders/babel.js
+++ b/config/webpack/loaders/babel.js
@@ -4,11 +4,7 @@ const env = process.env.NODE_ENV || 'development';
 
 module.exports = {
   test: /\.js$/,
-  // include react-intl because transform-react-remove-prop-types needs to apply to it
-  exclude: {
-    test: /node_modules/,
-    exclude: /react-intl[\/\\](?!locale-data)/,
-  },
+  exclude: /node_modules/,
   loader: 'babel-loader',
   options: {
     forceEnv: env,

--- a/config/webpack/loaders/babel_external.js
+++ b/config/webpack/loaders/babel_external.js
@@ -1,0 +1,21 @@
+const { resolve } = require('path');
+
+const env = process.env.NODE_ENV || 'development';
+
+if (env === 'development') {
+  module.exports = {};
+} else {
+  // babel options to apply only to external libraries, e.g. remove-prop-types
+  module.exports = {
+    test: /\.js$/,
+    include: /node_modules/,
+    loader: 'babel-loader',
+    options: {
+      babelrc: false,
+      plugins: [
+        'transform-react-remove-prop-types',
+      ],
+      cacheDirectory: env === 'development' ? false : resolve(__dirname, '..', '..', '..', 'tmp', 'cache', 'babel-loader-external'),
+    },
+  };
+}


### PR DESCRIPTION
This adds a second `babel-loader` which only applies `transform-react-remove-prop-types`. It removes 1.21 kB from `common.js` and 114 bytes from `application.js` (every little bit counts!).

You might recall that in https://github.com/tootsuite/mastodon/pull/3937 we ran into a regression because of Babel being applied to third-party libraries (`node_modules`). This PR ensures that when Babel runs on `node_modules`, it only runs the one transform.

This is live on https://malfunctioning.technology ; I tested and didn't see any errors due to removing the prop-types.