### PR TITLE
Fix #5306: Stop hotkeys in input fields even when shift is pressed

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -186,7 +186,7 @@ export default class UI extends React.Component {
 
   componentDidMount () {
     this.hotkeys.__mousetrap__.stopCallback = (e, element) => {
-      return !(e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) && ['TEXTAREA', 'SELECT', 'INPUT'].includes(element.tagName);
+      return !(e.altKey || e.ctrlKey || e.metaKey) && ['TEXTAREA', 'SELECT', 'INPUT'].includes(element.tagName);
     };
   }
 


### PR DESCRIPTION
AZERTY layouts require pressing shift to press a number at all, so
it triggers a column switch even when simply typing numbers in
textarea