### PR TITLE
Fix an error when ancestors get loaded before the status itself

### DIFF
--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -240,9 +240,9 @@ export default class Status extends ImmutablePureComponent {
   }
 
   componentDidUpdate () {
-    const { ancestorsIds } = this.props;
+    const { status, ancestorsIds } = this.props;
 
-    if (ancestorsIds && ancestorsIds.size > 0) {
+    if (status && ancestorsIds && ancestorsIds.size > 0) {
       const element = this.node.querySelectorAll('.focusable')[ancestorsIds.size];
       element.scrollIntoView();
     }


### PR DESCRIPTION
When ancestors get loaded, we scroll to the target status (i.e. skip ancestors). However, ancestors may get loaded before the status itself, then it causes TypeError because `this.node` is undefined yet.

```
react-dom.production.min.js:187 TypeError: Cannot read property 'querySelectorAll' of undefined
    at t.componentDidUpdate (index.js:246)
    at commitLifeCycles (react-dom.production.min.js:169)
    at n (react-dom.production.min.js:180)
    at c (react-dom.production.min.js:183)
    at l (react-dom.production.min.js:184)
    at m (react-dom.production.min.js:188)
    at h (react-dom.production.min.js:187)
    at Object.enqueueSetState (react-dom.production.min.js:140)
    at l.o.setState (react.production.min.js:12)
    at l.onStateChange (connectAdvanced.js:205)
```

Since we don't show anything until the status gets loaded, we don't need to scroll to the target status in this time. If we get the status itself later, it causes `componentDidUpdate` and scrolling correctly.