### PR TITLE
In thread view, only scroll first update, scroll to replied-to post

### DIFF
--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -78,6 +78,7 @@ export default class Status extends ImmutablePureComponent {
 
   componentWillReceiveProps (nextProps) {
     if (nextProps.params.statusId !== this.props.params.statusId && nextProps.params.statusId) {
+      this._scrolledIntoView = false;
       this.props.dispatch(fetchStatus(nextProps.params.statusId));
     }
   }
@@ -240,11 +241,17 @@ export default class Status extends ImmutablePureComponent {
   }
 
   componentDidUpdate () {
+    if (this._scrolledIntoView) {
+      return;
+    }
+
     const { status, ancestorsIds } = this.props;
 
     if (status && ancestorsIds && ancestorsIds.size > 0) {
-      const element = this.node.querySelectorAll('.focusable')[ancestorsIds.size];
-      element.scrollIntoView();
+      const element = this.node.querySelectorAll('.focusable')[ancestorsIds.size - 1];
+
+      element.scrollIntoView(true);
+      this._scrolledIntoView = true;
     }
   }
 


### PR DESCRIPTION
- Only perform the "scroll into view" on first update, not when e.g. additional replies are appended
- Instead of scrolling to the focused status, scroll to the replied-to status, but align that scroll to top