### PR TITLE
Fully disable hotkeys when input element is focused

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -186,7 +186,7 @@ export default class UI extends React.Component {
 
   componentDidMount () {
     this.hotkeys.__mousetrap__.stopCallback = (e, element) => {
-      return !(e.altKey || e.ctrlKey || e.metaKey) && ['TEXTAREA', 'SELECT', 'INPUT'].includes(element.tagName);
+      return ['TEXTAREA', 'SELECT', 'INPUT'].includes(element.tagName);
     };
   }
 


### PR DESCRIPTION
Because alt+n is a way to enter some kinda letter on some keyboard