### PR TITLE
Fix styles of error pages

### DIFF
--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -29,8 +29,7 @@ body {
     font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", mastodon-font-sans-serif, sans-serif;
   }
 
-  &.app-body,
-  &.error {
+  &.app-body {
     position: fixed;
     width: 100%;
     height: 100%;
@@ -70,25 +69,34 @@ body {
   }
 
   &.error {
+    position: absolute;
     text-align: center;
     color: $ui-primary-color;
-    padding: 20px;
+    background: $ui-base-color;
+    width: 100%;
+    height: 100%;
+    padding: 0;
     display: flex;
     justify-content: center;
     align-items: center;
 
-    .dialog img {
-      display: block;
-      max-width: 470px;
-      width: 100%;
-      height: auto;
-      margin-top: -120px;
-    }
+    .dialog {
+      vertical-align: middle;
+      margin: 20px;
 
-    .dialog h1 {
-      font-size: 20px;
-      line-height: 28px;
-      font-weight: 400;
+      img {
+        display: block;
+        max-width: 470px;
+        width: 100%;
+        height: auto;
+        margin-top: -120px;
+      }
+
+      h1 {
+        font-size: 20px;
+        line-height: 28px;
+        font-weight: 400;
+      }
     }
   }
 }


### PR DESCRIPTION
Fix overflowing error pages,
and rearrange some sass codes.

Before and after images below.
![ws000109](https://user-images.githubusercontent.com/27640522/31460153-63d7ad7e-af00-11e7-864a-c33c8293cdd6.png) ![ws000108](https://user-images.githubusercontent.com/27640522/31460160-6719e9ac-af00-11e7-8f96-e2cd1485def6.png)
