### PR TITLE
Fix some failure cases on FetchLinkCardService

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -72,6 +72,8 @@ class FetchLinkCardService < BaseService
   def attempt_oembed
     response = OEmbed::Providers.get(@url)
 
+    return false unless response.respond_to?(:type)
+
     @card.type          = response.type
     @card.title         = response.respond_to?(:title)         ? response.title         : ''
     @card.author_name   = response.respond_to?(:author_name)   ? response.author_name   : ''
@@ -113,7 +115,7 @@ class FetchLinkCardService < BaseService
     detector.strip_tags = true
 
     guess = detector.detect(html, response.charset)
-    page  = Nokogiri::HTML(html, nil, guess&.fetch(:encoding))
+    page  = Nokogiri::HTML(html, nil, guess&.fetch(:encoding, nil))
 
     if meta_property(page, 'twitter:player')
       @card.type   = :video


### PR DESCRIPTION
* If OEmbed response doesn't have a required property `type`, ignore it.
  e.g. `NoMethodError: undefined method 'type' for ...`
* If we failed to detect encoding, fallback to default behavior of Nokogiri.
  e.g. `KeyError: key not found: :encoding`