### PR TITLE
Better public hashtag pages

### DIFF
--- a/app/javascript/styles/about.scss
+++ b/app/javascript/styles/about.scss
@@ -704,7 +704,6 @@
     .features #mastodon-timeline {
       height: 70vh;
       width: 100%;
-      min-width: 330px;
       margin-bottom: 50px;
 
       .column {
@@ -718,84 +717,95 @@
   }
 
   &.tag-page {
-    .brand {
-      padding-top: 20px;
-      margin-bottom: 20px;
+    .features {
+      padding: 30px 0;
 
-      img {
-        height: 48px;
-        width: auto;
-      }
-    }
+      .container {
+        max-width: 820px;
 
-    .container {
-      max-width: 690px;
-    }
+        #mastodon-timeline {
+          margin-right: 0;
+          border-top-right-radius: 0;
+        }
 
-    .cta {
-      margin: 40px 0;
-      margin-bottom: 80px;
+        .about-mastodon {
+          .about-hashtag {
+            background: darken($ui-base-color, 4%);
+            padding: 0 20px 20px 30px;
+            border-radius: 0 5px 5px 0;
 
-      .button {
-        margin-right: 4px;
-      }
-    }
+            .brand {
+              padding-top: 20px;
+              margin-bottom: 20px;
 
-    .about-mastodon {
-      max-width: 330px;
+              img {
+                height: 48px;
+                width: auto;
+              }
+            }
 
-      p {
-        strong {
-          color: $ui-secondary-color;
-          font-weight: 700;
+            p {
+              strong {
+                color: $ui-secondary-color;
+                font-weight: 700;
+              }
+            }
+
+            .cta {
+              margin: 0;
+
+              .button {
+                margin-right: 4px;
+              }
+            }
+          }
+
+          .features-list {
+            margin-left: 30px;
+            margin-right: 10px;
+          }
         }
       }
     }
 
     @media screen and (max-width: 675px) {
-      .container {
-        display: flex;
-        flex-direction: column;
-      }
-
       .features {
-        padding: 20px 0;
-      }
+        padding: 10px 0;
 
-      .about-mastodon {
-        order: 1;
-        flex: 0 0 auto;
-        max-width: 100%;
-      }
+        .container {
+          display: flex;
+          flex-direction: column;
 
-      #mastodon-timeline {
-        order: 2;
-        flex: 0 0 auto;
-        height: 60vh;
-      }
+          #mastodon-timeline {
+            order: 2;
+            flex: 0 0 auto;
+            height: 60vh;
+            margin-bottom: 20px;
+            border-top-right-radius: 4px;
+          }
 
-      .cta {
-        margin: 20px 0;
-        margin-bottom: 30px;
-      }
+          .about-mastodon {
+            order: 1;
+            flex: 0 0 auto;
+            max-width: 100%;
 
-      .features-list {
-        display: none;
-      }
+            .about-hashtag {
+              background: unset;
+              padding: 0;
+              border-radius: 0;
 
-      .stripe {
-        display: none;
+              .cta {
+                margin: 20px 0;
+              }
+            }
+
+            .features-list {
+              display: none;
+            }
+          }
+        }
       }
     }
-  }
-
-  .stripe {
-    width: 100%;
-    height: 360px;
-    overflow: hidden;
-    background: darken($ui-base-color, 4%);
-    position: absolute;
-    z-index: -1;
   }
 }
 

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -7,29 +7,41 @@
   = render 'og'
 
 .landing-page.tag-page
-  .stripe
   .features
     .container
       #mastodon-timeline{ data: { props: Oj.dump(default_props.merge(hashtag: @tag.name)) } }
 
       .about-mastodon
-        .brand
-          = link_to root_url do
-            = image_tag asset_pack_path('logo_full.svg'), alt: 'Mastodon'
+        .about-hashtag
+          .brand
+            = link_to root_url do
+              = image_tag asset_pack_path('logo_full.svg'), alt: 'Mastodon'
 
-        %p= t 'about.about_hashtag_html', hashtag: @tag.name
+          %p= t 'about.about_hashtag_html', hashtag: @tag.name
 
-        .cta
-          = link_to t('auth.login'), new_user_session_path, class: 'button button-secondary'
-          = link_to t('about.learn_more'), root_url, class: 'button button-alternative'
+          .cta
+            = link_to t('auth.login'), new_user_session_path, class: 'button button-secondary'
+            = link_to t('about.learn_more'), root_url, class: 'button button-alternative'
 
         .features-list
+          .features-list__row
+            .text
+              %h6= t 'about.features.real_conversation_title'
+              = t 'about.features.real_conversation_body'
+            .visual
+              = fa_icon 'fw comments'
           .features-list__row
             .text
               %h6= t 'about.features.not_a_product_title'
               = t 'about.features.not_a_product_body'
             .visual
               = fa_icon 'fw users'
+          .features-list__row
+            .text
+              %h6= t 'about.features.within_reach_title'
+              = t 'about.features.within_reach_body'
+            .visual
+              = fa_icon 'fw mobile'
           .features-list__row
             .text
               %h6= t 'about.features.humane_approach_title'


### PR DESCRIPTION
## Change background color style of hashtag description

It's because
1. Background color setting by its height breaks with a long tag or in some languages. (it is difficult to cover all cases by wide margin between hashtag description and features)
2. In order to display all four features of mastodon.
3. The timeline on two background colors makes me feel inconsistent (the timeline on about pages is only on single background color)

<details>
<summary>The problem of 1. reason looks like</summary>
<img src="https://user-images.githubusercontent.com/27640522/31509306-0b3e5caa-afbc-11e7-82c0-74593e37f97d.png" alt="reason" />
</details>
​

This is how it looks like, how do you feel?
![ws000115](https://user-images.githubusercontent.com/27640522/31509239-c75af7aa-afbb-11e7-96b3-86911fcdf42a.png)
You can also check this on my instance https://md.cryo.jp/tags/test .
**(Mobile view is not changed at all.)**

## Fix overflowing timelines in hashtag and about pages.

Before and after images
<img src="https://user-images.githubusercontent.com/27640522/31509443-76663570-afbc-11e7-824e-1d418fe3db3c.png" alt="before" />

This is related to #5237 .