### PR TITLE
Reduce discrepancies between server and client-side character count

### DIFF
--- a/app/javascript/mastodon/features/compose/util/counter.js
+++ b/app/javascript/mastodon/features/compose/util/counter.js
@@ -5,5 +5,5 @@ const urlPlaceholder = 'xxxxxxxxxxxxxxxxxxxxxxx';
 export function countableText(inputText) {
   return inputText
     .replace(urlRegex, urlPlaceholder)
-    .replace(/(?:^|[^\/\w])@(([a-z0-9_]+)@[a-z0-9\.\-]+)/ig, '@$2');
+    .replace(/(?:^|[^\/\w])@(([a-z0-9_]+)@[a-z0-9\.\-]+[a-z0-9]+)/ig, '@$2');
 };


### PR DESCRIPTION
There are various occasions where client-side and server-side toot character count disagree, potentially leading to rejected toots even though the web UI displays a non-negative number of available characters.

While I am pretty sure there are still discrepancies in the URL parsing code, this PR fixes a small mismatch in the regular expressions used for mentions.