### PR TITLE
replace newlines in desktop notifs with spaces instead of just removing them

### DIFF
--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -31,6 +31,7 @@ const fetchRelatedRelationships = (dispatch, notifications) => {
 
 const unescapeHTML = (html) => {
   const wrapper = document.createElement('div');
+  html = html.replace(/<br \/>|<br>|\n/, ' ');
   wrapper.innerHTML = html;
   return wrapper.textContent;
 };


### PR DESCRIPTION
fix desktop notifications removing spaces without any replacement, causing words to be joined
this bug was there for several months now, i finally got enough of it lol
![screenshot_20171012_202118](https://user-images.githubusercontent.com/2041118/31517498-61fa32e6-af9c-11e7-8d29-fe805ce468e9.png)

added all possible newline types, seems to have no negative effects and better to have it more general just in case imo