### PR TITLE
Retoot count increases without reason

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -134,7 +134,7 @@ class Status < ApplicationRecord
     CustomEmoji.from_text([spoiler_text, text].join(' '), account.domain)
   end
 
-  after_create :store_uri, if: :local?
+  after_create_commit :store_uri, if: :local?
 
   before_validation :prepare_contents, if: :local?
   before_validation :set_reblog

--- a/spec/services/reblog_service_spec.rb
+++ b/spec/services/reblog_service_spec.rb
@@ -34,9 +34,13 @@ RSpec.describe ReblogService do
       allow(ActivityPub::DistributionWorker).to receive(:perform_async)
       subject.call(alice, status)
     end
-    
+
+    it 'creates a reblog' do
+      expect(status.reblogs.count).to eq 1
+    end
+
     describe 'after_create_commit :store_uri' do
-      it 'creates a reblog' do
+      it 'keeps consistent reblog count' do
         expect(status.reblogs.count).to eq 1
       end
     end

--- a/spec/services/reblog_service_spec.rb
+++ b/spec/services/reblog_service_spec.rb
@@ -34,9 +34,11 @@ RSpec.describe ReblogService do
       allow(ActivityPub::DistributionWorker).to receive(:perform_async)
       subject.call(alice, status)
     end
-
-    it 'creates a reblog' do
-      expect(status.reblogs.count).to eq 1
+    
+    describe 'after_create_commit :store_uri' do
+      it 'creates a reblog' do
+        expect(status.reblogs.count).to eq 1
+      end
     end
 
     it 'distributes to followers' do


### PR DESCRIPTION
-The store_uri method for Statuses was being called on after_create and causing reblogs to be incremented twice.
-This calls it when the transaction is finished by using after_create_commit.
-Fixes #4916.
