### PR TITLE
Optimize Status#permitted_for 500x (account timeline)

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -216,9 +216,7 @@ class Status < ApplicationRecord
         # non-followers can see everything that isn't private/direct, but can see stuff they are mentioned in.
         visibility.push(:private) if account.following?(target_account)
 
-        joins("LEFT OUTER JOIN mentions ON statuses.id = mentions.status_id AND mentions.account_id = #{account.id}")
-          .where(arel_table[:visibility].in(visibility).or(Mention.arel_table[:id].not_eq(nil)))
-          .order(visibility: :desc)
+        where(visibility: visibility).or(where(id: account.mentions.select(:status_id)))
       end
     end
 


### PR DESCRIPTION
The main change of this PR is removing `order by visibility` hack.

This was introduced to force using of `index_statuses_on_account_id` instead of PK index (#3069), but it seems no longer needed probably due to `index_statuses_on_account_id_id` (#3895). Removing this avoids reading lot of rows, so really improves first fetching of the user who has lot of statuses.

I have also changed JOIN to IN + subquery, which slightly faster in most cases.

**Before:**

```
EXPLAIN (ANALYZE, BUFFERS) SELECT "statuses"."id", "statuses"."updated_at" FROM "statuses" LEFT OUTER JOIN mentions ON statuses.id = mentions.status_id AND mentions.account_id = 1 WHERE "statuses"."account_id" = 2 AND ("statuses"."visibility" IN (0, 1, 2) OR "mentions"."id" IS NOT NULL) ORDER BY "statuses"."id" DESC, "statuses"."visibility" DESC LIMIT 40;
                                                                                  QUERY PLAN                            
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=24024.73..24024.83 rows=40 width=20) (actual time=127.508..127.513 rows=40 loops=1)
   Buffers: shared hit=8608
   ->  Sort  (cost=24024.73..24583.48 rows=223500 width=20) (actual time=127.507..127.510 rows=40 loops=1)
         Sort Key: statuses.id DESC, statuses.visibility DESC
         Sort Method: top-N heapsort  Memory: 28kB
         Buffers: shared hit=8608
         ->  Hash Left Join  (cost=48.83..16959.97 rows=223500 width=20) (actual time=0.128..105.229 rows=112427 loops=1)
               Hash Cond: (statuses.id = mentions.status_id)
               Filter: ((statuses.visibility = ANY ('{0,1,2}'::integer[])) OR (mentions.id IS NOT NULL))
               Rows Removed by Filter: 112426
               Buffers: shared hit=8608
               ->  Seq Scan on statuses  (cost=0.00..16072.00 rows=223500 width=20) (actual time=0.011..63.113 rows=224853 loops=1)
                     Filter: (account_id = 2)
                     Rows Removed by Filter: 375147
                     Buffers: shared hit=8572
               ->  Hash  (cost=46.33..46.33 rows=200 width=16) (actual time=0.108..0.108 rows=200 loops=1)
                     Buckets: 1024  Batches: 1  Memory Usage: 18kB
                     Buffers: shared hit=36
                     ->  Bitmap Heap Scan on mentions  (cost=9.83..46.33 rows=200 width=16) (actual time=0.027..0.084 rows=200 loops=1)
                           Recheck Cond: (account_id = 1)
                           Heap Blocks: exact=34
                           Buffers: shared hit=36
                           ->  Bitmap Index Scan on index_mentions_on_account_id_and_status_id  (cost=0.00..9.78 rows=200 width=0) (actual time=0.019..0.019 rows=200 loops=1)
                                 Index Cond: (account_id = 1)
                                 Buffers: shared hit=2
 Planning time: 0.327 ms
 Execution time: 127.598 ms
```

**After:**

```
EXPLAIN (ANALYZE, BUFFERS) SELECT "statuses"."id", "statuses"."updated_at" FROM "statuses" WHERE ("statuses"."account_id" = 2 AND "statuses"."visibility" IN (0, 1, 2) OR "statuses"."account_id" = 2 AND "statuses"."id" IN (SELECT "mentions"."status_id" FROM "mentions" WHERE "mentions"."account_id" = 1)) ORDER BY "statuses"."id" DESC LIMIT 40;
                                                                             QUERY PLAN                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=47.25..53.35 rows=40 width=16) (actual time=0.022..0.189 rows=40 loops=1)
   Buffers: shared hit=41
   ->  Index Scan Backward using index_statuses_on_account_id_id on statuses  (cost=47.25..25602.69 rows=167718 width=16) (actual time=0.020..0.186 rows=40 loops=1)
         Index Cond: (account_id = 2)
         Filter: ((visibility = ANY ('{0,1,2}'::integer[])) OR (hashed SubPlan 1))
         Rows Removed by Filter: 39
         Buffers: shared hit=41
         SubPlan 1
           ->  Bitmap Heap Scan on mentions  (cost=9.83..46.33 rows=200 width=8) (actual time=0.025..0.102 rows=200 loops=1)
                 Recheck Cond: (account_id = 1)
                 Heap Blocks: exact=34
                 Buffers: shared hit=36
                 ->  Bitmap Index Scan on index_mentions_on_account_id_and_status_id  (cost=0.00..9.78 rows=200 width=0) (actual time=0.017..0.017 rows=200 loops=1)
                       Index Cond: (account_id = 1)
                       Buffers: shared hit=2
 Planning time: 0.192 ms
 Execution time: 0.227 ms
```

@akihikodaki This would work better on most cases, but I haven't tested on large instance and I'm not sure about previous hack is completely no longer needed or not. Let me know if you have any concerns.

Special thanks to @tateisu for providing great example (which took 3000 msec for execution)