### PR TITLE
Use atomUri in Undo activity of Announce

### DIFF
--- a/app/lib/activitypub/activity/undo.rb
+++ b/app/lib/activitypub/activity/undo.rb
@@ -17,7 +17,8 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
   private
 
   def undo_announce
-    status = Status.find_by(uri: object_uri, account: @account)
+    status   = Status.find_by(uri: object_uri, account: @account)
+    status ||= Status.find_by(uri: @object['atomUri'], account: @account) if @object.is_a?(Hash) && @object['atomUri'].present?
 
     if status.nil?
       delete_later!(object_uri)

--- a/app/serializers/activitypub/activity_serializer.rb
+++ b/app/serializers/activitypub/activity_serializer.rb
@@ -5,6 +5,7 @@ class ActivityPub::ActivitySerializer < ActiveModel::Serializer
 
   has_one :proper, key: :object, serializer: ActivityPub::NoteSerializer, unless: :announce?
   attribute :proper_uri, key: :object, if: :announce?
+  attribute :atom_uri, if: :announce?
 
   def id
     ActivityPub::TagManager.instance.activity_uri_for(object)
@@ -32,6 +33,10 @@ class ActivityPub::ActivitySerializer < ActiveModel::Serializer
 
   def proper_uri
     ActivityPub::TagManager.instance.uri_for(object.proper)
+  end
+
+  def atom_uri
+    OStatus::TagManager.instance.uri_for(object)
   end
 
   def announce?

--- a/spec/lib/activitypub/activity/undo_spec.rb
+++ b/spec/lib/activitypub/activity/undo_spec.rb
@@ -25,16 +25,30 @@ RSpec.describe ActivityPub::Activity::Undo do
           type: 'Announce',
           actor: ActivityPub::TagManager.instance.uri_for(sender),
           object: ActivityPub::TagManager.instance.uri_for(status),
+          atomUri: 'barbar',
         }
       end
 
-      before do
-        Fabricate(:status, reblog: status, account: sender, uri: 'bar')
+      context do
+        before do
+          Fabricate(:status, reblog: status, account: sender, uri: 'bar')
+        end
+
+        it 'deletes the reblog' do
+          subject.perform
+          expect(sender.reblogged?(status)).to be false
+        end
       end
 
-      it 'deletes the reblog' do
-        subject.perform
-        expect(sender.reblogged?(status)).to be false
+      context 'with atomUri' do
+        before do
+          Fabricate(:status, reblog: status, account: sender, uri: 'barbar')
+        end
+
+        it 'deletes the reblog by atomUri' do
+          subject.perform
+          expect(sender.reblogged?(status)).to be false
+        end
       end
     end
 


### PR DESCRIPTION
This allows deletion of reblogs which delivered before with OStatus URI.