### PR TITLE
Consistent blocking behavior

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::SearchController < Api::BaseController
+  include Authorization
+
   RESULTS_LIMIT = 5
 
   before_action -> { doorkeeper_authorize! :read }
@@ -9,11 +11,23 @@ class Api::V1::SearchController < Api::BaseController
   respond_to :json
 
   def index
-    @search = Search.new(search_results)
+    @search = Search.new(search)
     render json: @search, serializer: REST::SearchSerializer
   end
 
   private
+
+  def search
+    search_results.tap do |search|
+      search[:statuses].keep_if do |status|
+        begin
+          authorize status, :show?
+        rescue Mastodon::NotPermittedError
+          false
+        end
+      end
+    end
+  end
 
   def search_results
     SearchService.new.call(


### PR DESCRIPTION
There are a few inconsistencies in blocking behavior: indeed, if user Blocker blocks user Blockee, the expected behavior is that Blockee won't see messages from Blocker, and vice-versa. However, there are places where Blockee can see messages from Blocker:
1. By putting the URL of one of Blocker's public/unlisted toots in the search box
  This is a very minor issue, as Blockee could just use the URL to access the toot outside of the Web UI, but it's still inconsistent.
2. Being mentioned in one of Blocker's toots:
  In this case, the toot will pop up in the notifications, and *disappear* from the Web UI (until it is reloaded) as soon as Blockee clicks on it, which is highly confusing.
  I decided to changes the rules to keep the notifications (so talking about them behind their back would not be possible), but also make toots mentioning Blookee accessible to them.

First commit addresses the first point, and the second the second issue.