### PR TITLE
Fix #5351 - Redirection with page params after copy emoji

### DIFF
--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -31,10 +31,12 @@ module Admin
       emoji = CustomEmoji.new(domain: nil, shortcode: @custom_emoji.shortcode, image: @custom_emoji.image)
 
       if emoji.save
-        redirect_to admin_custom_emojis_path, notice: I18n.t('admin.custom_emojis.copied_msg')
+        flash[:notice] = I18n.t('admin.custom_emojis.copied_msg')
       else
-        redirect_to admin_custom_emojis_path, alert: I18n.t('admin.custom_emojis.copy_failed_msg')
+        flash[:alert] = I18n.t('admin.custom_emojis.copy_failed_msg')
       end
+
+      redirect_to admin_custom_emojis_path(params[:page])
     end
 
     def enable

--- a/app/views/admin/custom_emojis/_custom_emoji.html.haml
+++ b/app/views/admin/custom_emojis/_custom_emoji.html.haml
@@ -10,7 +10,7 @@
       = custom_emoji.domain
   %td
     - unless custom_emoji.local?
-      = table_link_to 'copy', t('admin.custom_emojis.copy'), copy_admin_custom_emoji_path(custom_emoji), method: :post
+      = table_link_to 'copy', t('admin.custom_emojis.copy'), copy_admin_custom_emoji_path(custom_emoji, page: params[:page]), method: :post
   %td
     - if custom_emoji.disabled?
       = table_link_to 'power-off', t('admin.custom_emojis.enable'), enable_admin_custom_emoji_path(custom_emoji), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }


### PR DESCRIPTION
## What

As reported in #5351, on admin panel, when copy an emoji (non-local emoji) in the *Custom Emoji* section and it's on page > 1, it always redirect back to page 1 regardless of whether it's successful/fail. This change fixes that.

## Why

It's an inconvenience when trying to copy multiple emojis located on page > 1.

## Other possible issues

The same inconvenience happens on the other actions on `CustomEmojisController`, such as `#copy`, `#enable` & `#disable`