### PR TITLE
Close connection when succeeded posting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
       railties (>= 4.0.1)
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
-    hashdiff (0.3.6)
+    hashdiff (0.3.7)
     highline (1.7.8)
     hiredis (0.6.1)
     hkdf (0.3.0)
@@ -513,7 +513,7 @@ GEM
     uniform_notifier (1.10.0)
     warden (1.2.7)
       rack (>= 1.0)
-    webmock (3.0.1)
+    webmock (3.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff

--- a/app/services/send_interaction_service.rb
+++ b/app/services/send_interaction_service.rb
@@ -12,9 +12,11 @@ class SendInteractionService < BaseService
 
     return if !target_account.ostatus? || block_notification?
 
-    delivery = build_request.perform.flush
+    delivery = build_request.perform
 
     raise Mastodon::UnexpectedResponseError, delivery unless delivery.code > 199 && delivery.code < 300
+
+    delivery.connection&.close
   end
 
   private

--- a/app/services/subscribe_service.rb
+++ b/app/services/subscribe_service.rb
@@ -6,7 +6,7 @@ class SubscribeService < BaseService
 
     @account        = account
     @account.secret = SecureRandom.hex
-    @response       = build_request.perform.flush
+    @response       = build_request.perform
 
     if response_failed_permanently?
       # We're not allowed to subscribe. Fail and move on.
@@ -20,6 +20,7 @@ class SubscribeService < BaseService
       # We need to retry at a later time. Fail loudly!
       raise Mastodon::UnexpectedResponseError, @response
     end
+    @response.connection&.close
   end
 
   private

--- a/app/services/unsubscribe_service.rb
+++ b/app/services/unsubscribe_service.rb
@@ -7,9 +7,10 @@ class UnsubscribeService < BaseService
     @account = account
 
     begin
-      @response = build_request.perform.flush
+      @response = build_request.perform
 
       Rails.logger.debug "PuSH unsubscribe for #{@account.acct} failed: #{@response.status}" unless @response.status.success?
+      @response.connection&.close
     rescue HTTP::Error, OpenSSL::SSL::SSLError => e
       Rails.logger.debug "PuSH unsubscribe for #{@account.acct} failed: #{e}"
     end

--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -16,6 +16,7 @@ class ActivityPub::DeliveryWorker
 
     raise Mastodon::UnexpectedResponseError, @response unless response_successful?
 
+    @response.connection&.close
     failure_tracker.track_success!
   rescue => e
     failure_tracker.track_failure!
@@ -31,7 +32,7 @@ class ActivityPub::DeliveryWorker
   end
 
   def perform_request
-    @response = build_request.perform.flush
+    @response = build_request.perform
   end
 
   def response_successful?

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -27,6 +27,7 @@ class Pubsubhubbub::DeliveryWorker
 
     raise Mastodon::UnexpectedResponseError, payload_delivery unless response_successful?
 
+    payload_delivery.connection&.close
     subscription.touch(:last_successful_delivery_at)
   end
 
@@ -37,7 +38,7 @@ class Pubsubhubbub::DeliveryWorker
   def callback_post_payload
     request = Request.new(:post, subscription.callback_url, body: payload)
     request.add_headers(headers)
-    request.perform.flush
+    request.perform
   end
 
   def blocked_domain?


### PR DESCRIPTION
Since we do not need to read the body, close the connection without using `flush`.

Related: #5128

Also, to pass the test we need to use a webmock that is compatible with the new http.rb. (https://github.com/bblimke/webmock/pull/721)
