### PR TITLE
Fix #5082 - disable retweet link for followers only toot

### DIFF
--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -43,6 +43,8 @@ export default class DetailedStatus extends ImmutablePureComponent {
 
     let media           = '';
     let applicationLink = '';
+    let reblogLink = '';
+    let reblogIcon = 'retweet';
 
     if (status.get('media_attachments').size > 0) {
       if (status.get('media_attachments').some(item => item.get('type') === 'unknown')) {
@@ -80,6 +82,23 @@ export default class DetailedStatus extends ImmutablePureComponent {
       applicationLink = <span> · <a className='detailed-status__application' href={status.getIn(['application', 'website'])} target='_blank' rel='noopener'>{status.getIn(['application', 'name'])}</a></span>;
     }
 
+    if (status.get('visibility') === 'direct') {
+      reblogIcon = 'envelope';
+    } else if (status.get('visibility') === 'private') {
+      reblogIcon = 'lock';
+    }
+
+    if (status.get('visibility') === 'private') {
+      reblogLink = <i className={`fa fa-${reblogIcon}`} />;
+    } else {
+      reblogLink = (<Link to={`/statuses/${status.get('id')}/reblogs`} className='detailed-status__link'>
+        <i className={`fa fa-${reblogIcon}`} />
+        <span className='detailed-status__reblogs'>
+          <FormattedNumber value={status.get('reblogs_count')} />
+        </span>
+      </Link>);
+    }
+
     return (
       <div className='detailed-status'>
         <a href={status.getIn(['account', 'url'])} onClick={this.handleAccountClick} className='detailed-status__display-name'>
@@ -94,12 +113,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
         <div className='detailed-status__meta'>
           <a className='detailed-status__datetime' href={status.get('url')} target='_blank' rel='noopener'>
             <FormattedDate value={new Date(status.get('created_at'))} hour12={false} year='numeric' month='short' day='2-digit' hour='2-digit' minute='2-digit' />
-          </a>{applicationLink} · <Link to={`/statuses/${status.get('id')}/reblogs`} className='detailed-status__link'>
-            <i className='fa fa-retweet' />
-            <span className='detailed-status__reblogs'>
-              <FormattedNumber value={status.get('reblogs_count')} />
-            </span>
-          </Link> · <Link to={`/statuses/${status.get('id')}/favourites`} className='detailed-status__link'>
+          </a>{applicationLink} · {reblogLink} · <Link to={`/statuses/${status.get('id')}/favourites`} className='detailed-status__link'>
             <i className='fa fa-star' />
             <span className='detailed-status__favorites'>
               <FormattedNumber value={status.get('favourites_count')} />

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -42,7 +42,6 @@
     - if status.direct_visibility?
       %span<
         = fa_icon('envelope')
-        %span= status.reblogs_count
     - elsif status.private_visibility?
       %span<
         = fa_icon('lock')

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -39,9 +39,17 @@
       - else
         = link_to status.application.name, status.application.website, class: 'detailed-status__application', target: '_blank', rel: 'noopener'
       ·
-    %span<
-      = fa_icon('retweet')
-      %span= status.reblogs_count
+    - if status.direct_visibility?
+      %span<
+        = fa_icon('envelope')
+        %span= status.reblogs_count
+    - elsif status.private_visibility?
+      %span<
+        = fa_icon('lock')
+    - else
+      %span<
+        = fa_icon('retweet')
+        %span= status.reblogs_count
     ·
     %span<
       = fa_icon('star')


### PR DESCRIPTION
## What

Followers-only toots are not boostable/retweetable yet retweet icon and count is shown. This fixes that.

## Why

Make the toot a little less weird 😂 

## Screenshots

![screencapture-localhost-3000-web-statuses-98828179277168451-1508028741617](https://user-images.githubusercontent.com/12711548/31580597-47222c34-b187-11e7-8fd0-34e1c9b9215f.png)
![screencapture-localhost-3000-users-admin-updates-5-1508028713673](https://user-images.githubusercontent.com/12711548/31580599-4a25d0ac-b187-11e7-9011-263098206691.png)
