### PR TITLE
Update French translation

### DIFF
--- a/app/javascript/mastodon/locales/fr.json
+++ b/app/javascript/mastodon/locales/fr.json
@@ -69,7 +69,7 @@
   "emoji_button.custom": "Personnalisés",
   "emoji_button.flags": "Drapeaux",
   "emoji_button.food": "Boire et manger",
-  "emoji_button.label": "Insérer un emoji",
+  "emoji_button.label": "Insérer un émoji",
   "emoji_button.nature": "Nature",
   "emoji_button.not_found": "No emojos!! (╯°□°）╯︵ ┻━┻",
   "emoji_button.objects": "Objets",

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -125,7 +125,7 @@ fr:
       copy_failed_msg: Impossible de faire une copie locale de cet émoji
       created_msg: Émoji créé avec succès !
       delete: Supprimer
-      destroyed_msg: Emoji supprimé avec succès !
+      destroyed_msg: Émoji supprimé avec succès !
       disable: Désactiver
       disabled_msg: Émoji désactivé avec succès !
       emoji: Émoji


### PR DESCRIPTION
All occurrences of French "émoji" have an accent. This commit improve consistency by adding an accent on occurrences which don't have it.