### PR TITLE
Make hot keys optional, off by default

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -40,6 +40,7 @@ class Settings::PreferencesController < ApplicationController
       :setting_delete_modal,
       :setting_auto_play_gif,
       :setting_system_font_ui,
+      :setting_use_hotkeys,
       :setting_noindex,
       :setting_theme,
       notification_emails: %i(follow follow_request reblog favourite mention digest),

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -10,7 +10,8 @@ import StatusActionBar from './status_action_bar';
 import { FormattedMessage } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { MediaGallery, Video } from '../features/ui/util/async-components';
-import { HotKeys } from 'react-hotkeys';
+import { getHotKeys } from '../features/ui/util/optional_hotkeys';
+const HotKeys = getHotKeys();
 import classNames from 'classnames';
 
 // We use the component (and not the container) since we do not want

--- a/app/javascript/mastodon/features/hotkeys/index.js
+++ b/app/javascript/mastodon/features/hotkeys/index.js
@@ -1,0 +1,3 @@
+import { HotKeys } from 'react-hotkeys';
+
+export default HotKeys;

--- a/app/javascript/mastodon/features/notifications/components/notification.js
+++ b/app/javascript/mastodon/features/notifications/components/notification.js
@@ -6,7 +6,8 @@ import AccountContainer from '../../../containers/account_container';
 import { FormattedMessage } from 'react-intl';
 import Permalink from '../../../components/permalink';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { HotKeys } from 'react-hotkeys';
+import { getHotKeys } from '../../ui/util/optional_hotkeys';
+const HotKeys = getHotKeys();
 
 export default class Notification extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -28,7 +28,8 @@ import StatusContainer from '../../containers/status_container';
 import { openModal } from '../../actions/modal';
 import { defineMessages, injectIntl } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { HotKeys } from 'react-hotkeys';
+import { getHotKeys } from '../ui/util/optional_hotkeys';
+const HotKeys = getHotKeys();
 
 const messages = defineMessages({
   deleteConfirm: { id: 'confirmations.delete.confirm', defaultMessage: 'Delete' },

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -37,7 +37,8 @@ import {
   Mutes,
   PinnedStatuses,
 } from './util/async-components';
-import { HotKeys } from 'react-hotkeys';
+import { getHotKeys } from '../ui/util/optional_hotkeys';
+const HotKeys = getHotKeys();
 
 // Dummy import, to make sure that <Status /> ends up in the application bundle.
 // Without this it ends up in ~8 very commonly used bundles.
@@ -185,9 +186,11 @@ export default class UI extends React.Component {
   }
 
   componentDidMount () {
-    this.hotkeys.__mousetrap__.stopCallback = (e, element) => {
-      return ['TEXTAREA', 'SELECT', 'INPUT'].includes(element.tagName);
-    };
+    if (this.hotkeys.__mousetrap__) { // false if user has disabled hotkeys
+      this.hotkeys.__mousetrap__.stopCallback = (e, element) => {
+        return ['TEXTAREA', 'SELECT', 'INPUT'].includes(element.tagName);
+      };
+    }
   }
 
   shouldComponentUpdate (nextProps) {

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -1,3 +1,7 @@
+export function HotKeys () {
+  return import(/* webpackChunkName: "hotkeys" */'../../hotkeys/index.js');
+}
+
 export function EmojiPicker () {
   return import(/* webpackChunkName: "emoji_picker" */'../../emoji/emoji_picker');
 }

--- a/app/javascript/mastodon/features/ui/util/optional_hotkeys.js
+++ b/app/javascript/mastodon/features/ui/util/optional_hotkeys.js
@@ -1,0 +1,40 @@
+// Hot keys are an optional feature, so only load them if the
+// body class "use-hotkeys" exists. We use the body class rather than
+// the Redux store because the value never changes without a page reload,
+// so we can just check once and load HotKeys once.
+
+import { HotKeys as HotKeysAsync } from './async-components';
+import ready from '../../../ready';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+let HotKeys;
+
+class NoHotKeys extends React.Component {
+
+  static propTypes = {
+    children: PropTypes.node,
+  }
+
+  render() {
+    return (<div>{this.props.children}</div>);
+  }
+
+}
+
+export function loadHotKeys() {
+  return new Promise(resolve => ready(resolve)).then(() => {
+    if (document.body.classList.contains('use-hotkeys')) {
+      return HotKeysAsync().then(TheHotKeys => {
+        HotKeys = TheHotKeys.default;
+      });
+    } else {
+      HotKeys = NoHotKeys;
+      return Promise.resolve();
+    }
+  });
+}
+
+export function getHotKeys() {
+  return HotKeys;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,6 +1,7 @@
 import loadPolyfills from '../mastodon/load_polyfills';
+import { loadHotKeys } from '../mastodon/features/ui/util/optional_hotkeys';
 
-loadPolyfills().then(() => {
+Promise.all([loadPolyfills(), loadHotKeys()]).then(() => {
   require('../mastodon/main').default();
 }).catch(e => {
   console.error(e);

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -24,6 +24,7 @@ class UserSettingsDecorator
     user.settings['delete_modal']        = delete_modal_preference if change?('setting_delete_modal')
     user.settings['auto_play_gif']       = auto_play_gif_preference if change?('setting_auto_play_gif')
     user.settings['system_font_ui']      = system_font_ui_preference if change?('setting_system_font_ui')
+    user.settings['use_hotkeys']         = use_hotkeys_preference if change?('setting_use_hotkeys')
     user.settings['noindex']             = noindex_preference if change?('setting_noindex')
     user.settings['theme']               = theme_preference if change?('setting_theme')
   end
@@ -58,6 +59,10 @@ class UserSettingsDecorator
 
   def system_font_ui_preference
     boolean_cast_setting 'setting_system_font_ui'
+  end
+
+  def use_hotkeys_preference
+    boolean_cast_setting 'setting_use_hotkeys'
   end
 
   def auto_play_gif_preference

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,6 +106,10 @@ class User < ApplicationRecord
     settings.system_font_ui
   end
 
+  def setting_use_hotkeys
+    settings.use_hotkeys
+  end
+
   def setting_noindex
     settings.noindex
   end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,6 +27,7 @@
     = yield :header_tags
 
   - body_classes ||= @body_classes || ''
+  - body_classes += ' use-hotkeys' if current_account&.user&.setting_use_hotkeys
   - body_classes += ' system-font' if current_account&.user&.setting_system_font_ui
 
   %body{ class: add_rtl_body_class(body_classes) }

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -36,6 +36,7 @@
   .fields-group
     = f.input :setting_auto_play_gif, as: :boolean, wrapper: :with_label
     = f.input :setting_system_font_ui, as: :boolean, wrapper: :with_label
+    = f.input :setting_use_hotkeys, as: :boolean, wrapper: :with_label
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -45,6 +45,7 @@ en:
         setting_delete_modal: Show confirmation dialog before deleting a toot
         setting_noindex: Opt-out of search engine indexing
         setting_system_font_ui: Use system's default font
+        setting_use_hotkeys: Enable keyboard shortcuts
         setting_theme: Site theme
         setting_unfollow_modal: Show confirmation dialog before unfollowing someone
         severity: Severity

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,6 +23,7 @@ defaults: &defaults
   delete_modal: true
   auto_play_gif: false
   system_font_ui: false
+  use_hotkeys: false
   noindex: false
   theme: 'default'
   notification_emails:


### PR DESCRIPTION
Hotkeys are an awesome feature, but given that:

1. It's a power user feature; most people won't ever use it
2. It carries some perf overhead in terms of bundle size and extra components
3. It's not useful on mobile devices
4. It might confuse users who accidentally hit a key and don't understand why the UI changed

...I would argue that it should be an optional feature, off by default.

This PR adds a new option to the preferences:

![screenshot 2017-10-15 12 11 34](https://user-images.githubusercontent.com/283842/31588117-12833e80-b1a2-11e7-98c0-06dd4e3b3fd9.png)

This adds a body class called `use-hotkeys` that is used at the same time we load polyfills to conditionally load a chunk called `hotkeys.js`. (Hence it will delay the first load if you have the feature enabled, but after that the JS file should be cached.)

The perf impact is that `common.js` is reduced from 792 kb (791539) to 757 kB (757267) – 34.3 kB smaller. Also there is less work to create the hotkey/mousetrap components, but I'm not sure what the exact perf impact is there.

![out](https://user-images.githubusercontent.com/283842/31588239-12fc839c-b1a4-11e7-92a1-f6234bc54176.png)


This is a functional change, so I'm happy to discuss whether or not this should be on by default (with a preload to avoid delaying first load), but I've laid out the case for why it should be off by default.