### PR TITLE
Clear timer when unmounting RelativeTimestamp components

### DIFF
--- a/app/javascript/mastodon/components/relative_timestamp.js
+++ b/app/javascript/mastodon/components/relative_timestamp.js
@@ -94,6 +94,10 @@ export default class RelativeTimestamp extends React.Component {
     this._scheduleNextUpdate(nextProps, nextState);
   }
 
+  componentWillUnmount () {
+    clearTimeout(this._timer);
+  }
+
   _scheduleNextUpdate (props, state) {
     clearTimeout(this._timer);
 


### PR DESCRIPTION
Possibly the cause of #5379, #5377