### PR TITLE
Fix offline-plugin warning in dev mode

### DIFF
--- a/app/javascript/mastodon/main.js
+++ b/app/javascript/mastodon/main.js
@@ -1,4 +1,3 @@
-import * as OfflinePluginRuntime from 'offline-plugin/runtime';
 import * as WebPushSubscription from './web_push_subscription';
 import Mastodon from 'mastodon/containers/mastodon';
 import React from 'react';
@@ -25,7 +24,7 @@ function main() {
     ReactDOM.render(<Mastodon {...props} />, mountNode);
     if (process.env.NODE_ENV === 'production') {
       // avoid offline in dev mode because it's harder to debug
-      OfflinePluginRuntime.install();
+      require('offline-plugin/runtime').install();
       WebPushSubscription.register();
     }
     perf.stop('main()');


### PR DESCRIPTION
This gets rid of an annoying warning in dev mode:

```
offline-plugin: runtime was installed without OfflinePlugin being added
to the webpack.config.js. See https://goo.gl/2Ca7NO for details.
```