### PR TITLE
Fix un-reblogged status being at wrong position in the home timeline

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -198,10 +198,11 @@ class FeedManager
       # 2. Remove the reblogged status from the `:reblogs` zset.
       redis.zrem(reblog_key, status.reblog_of_id)
 
-      # 3. Add the reblogged status to the feed using the reblogging
-      # status' ID as its score, and the reblogged status' ID as its
-      # value.
-      redis.zadd(timeline_key, status.id, status.reblog_of_id)
+      # 3. Add the reblogged status to the feed.
+      # Note that we can't use old score in here
+      # and it must be an ID of corresponding status
+      # because we need to filter timeline by status ID.
+      redis.zadd(timeline_key, status.reblog_of_id, status.reblog_of_id)
 
       # 4. Remove the reblogging status from the feed (as normal)
     end


### PR DESCRIPTION
We've changed un-reblogging behavior when we implement Snowflake, to insert un-reblogged status at the position reblogging status existed.

https://github.com/tootsuite/mastodon/blob/fa0be3f834b54bb276eb5233195181fa3760710f/app/lib/feed_manager.rb#L201-L204

However, our API expects home timeline is ordered by status ids, and max_id/since_id filters by zset score. Due to this, un-reblogged status appears as a last item of result set, and timeline expansion may skips many statuses.

Here is a screenshot of responses of `/api/v1/timelines/home` around reblog/un-reblog.

![image](https://user-images.githubusercontent.com/705555/31602850-2d0ae184-b299-11e7-89c4-5ecc2fcf990d.png)

So this reverts that change...reblogged status inserted at corresponding position to its id.

**Note:** Even if this fix applied, very old reblogged status will still be at the bottom of home timeline cache. So if we're going to implement load more statuses from DB, the issue would happens again unless we remove it from Redis.

cc @aschmitz @Gargron 