### PR TITLE
Keep references to all reblogs of a status on home feed

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -161,13 +161,19 @@ class FeedManager
   # either action is appropriate.
   def add_to_feed(timeline_type, account, status)
     timeline_key = key(timeline_type, account.id)
-    reblog_key = key(timeline_type, account.id, 'reblogs')
+    reblog_key   = key(timeline_type, account.id, 'reblogs')
 
     if status.reblog?
+      reblog_set_key = key(timeline_type, account.id, "reblogs:#{status.reblog_of_id}")
+
       # If the original status or a reblog of it is within
       # REBLOG_FALLOFF statuses from the top, do not re-insert it into
       # the feed
       rank = redis.zrevrank(timeline_key, status.reblog_of_id)
+
+      redis.sadd(reblog_set_key, status.reblog_of_id) unless rank.nil?
+      redis.sadd(reblog_set_key, status.id)
+
       return false if !rank.nil? && rank < FeedManager::REBLOG_FALLOFF
 
       reblog_rank = redis.zrevrank(reblog_key, status.reblog_of_id)
@@ -188,7 +194,7 @@ class FeedManager
   # do so if appropriate.
   def remove_from_feed(timeline_type, account, status)
     timeline_key = key(timeline_type, account.id)
-    reblog_key = key(timeline_type, account.id, 'reblogs')
+    reblog_key   = key(timeline_type, account.id, 'reblogs')
 
     if status.reblog?
       # 1. If the reblogging status is not in the feed, stop.
@@ -198,11 +204,15 @@ class FeedManager
       # 2. Remove the reblogged status from the `:reblogs` zset.
       redis.zrem(reblog_key, status.reblog_of_id)
 
-      # 3. Add the reblogged status to the feed.
-      # Note that we can't use old score in here
-      # and it must be an ID of corresponding status
-      # because we need to filter timeline by status ID.
-      redis.zadd(timeline_key, status.reblog_of_id, status.reblog_of_id)
+      # 3. Remove reblog from set of this status's reblogs, and
+      # re-insert another reblog or original into the feed if
+      # one remains in the set
+      reblog_set_key = key(timeline_type, account.id, "reblogs:#{status.reblog_of_id}")
+
+      redis.srem(reblog_set_key, status.id)
+      other_reblog = redis.srandmember(reblog_set_key)
+
+      redis.zadd(timeline_key, other_reblog, other_reblog) if other_reblog
 
       # 4. Remove the reblogging status from the feed (as normal)
     end

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -215,6 +215,10 @@ class FeedManager
       redis.zadd(timeline_key, other_reblog, other_reblog) if other_reblog
 
       # 4. Remove the reblogging status from the feed (as normal)
+      # (outside conditional)
+    else
+      # If the original is getting deleted, no use for reblog references
+      redis.del(key(timeline_type, account.id, "reblogs:#{status.id}"))
     end
 
     redis.zrem(timeline_key, status.id)

--- a/app/workers/scheduler/feed_cleanup_scheduler.rb
+++ b/app/workers/scheduler/feed_cleanup_scheduler.rb
@@ -6,8 +6,9 @@ class Scheduler::FeedCleanupScheduler
 
   def perform
     redis.pipelined do
-      inactive_users.pluck(:account_id).each do |account_id|
+      inactive_users.each do |account_id|
         redis.del(FeedManager.instance.key(:home, account_id))
+        redis.del(FeedManager.instance.key(:home, account_id, 'reblogs'))
       end
     end
   end
@@ -15,7 +16,7 @@ class Scheduler::FeedCleanupScheduler
   private
 
   def inactive_users
-    User.confirmed.inactive
+    @inactive_users ||= User.confirmed.inactive.pluck(:account_id)
   end
 
   def redis


### PR DESCRIPTION
When inserting reblog: Add to set of reblogs of this status on
the feed, if original status was present in the feed, add it to
that set as well.

When removing a reblog: Remove it from that set. Take random
remaining item from the set. If one exists, re-insert it into feed,
otherwise do not re-insert anything.

Fix #4210