### PR TITLE
Fix reduced motion breaking public galleries

### DIFF
--- a/app/javascript/mastodon/features/ui/util/optional_motion.js
+++ b/app/javascript/mastodon/features/ui/util/optional_motion.js
@@ -1,34 +1,56 @@
 // Like react-motion's Motion, but checks to see if the user prefers
 // reduced motion and uses a cross-fade in those cases.
 
+import React from 'react';
 import Motion from 'react-motion/lib/Motion';
-import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 const stylesToKeep = ['opacity', 'backgroundOpacity'];
+
+let reduceMotion;
 
 const extractValue = (value) => {
   // This is either an object with a "val" property or it's a number
   return (typeof value === 'object' && value && 'val' in value) ? value.val : value;
 };
 
-const mapStateToProps = (state, ownProps) => {
-  const reduceMotion = state.getIn(['meta', 'reduce_motion']);
+class OptionalMotion extends React.Component {
 
-  if (reduceMotion) {
-    const { style, defaultStyle } = ownProps;
-
-    Object.keys(style).forEach(key => {
-      if (stylesToKeep.includes(key)) {
-        return;
-      }
-      // If it's setting an x or height or scale or some other value, we need
-      // to preserve the end-state value without actually animating it
-      style[key] = defaultStyle[key] = extractValue(style[key]);
-    });
-
-    return { style, defaultStyle };
+  static propTypes = {
+    defaultStyle: PropTypes.object,
+    style: PropTypes.object,
+    children: PropTypes.func,
   }
-  return {};
-};
 
-export default connect(mapStateToProps)(Motion);
+  render() {
+
+    const { style, defaultStyle, children } = this.props;
+
+    if (typeof reduceMotion !== 'boolean') {
+      // This never changes without a page reload, so we can just grab it
+      // once from the body classes as opposed to using Redux's connect(),
+      // which would unnecessarily update every state change
+      reduceMotion = document.body.classList.contains('reduce-motion');
+    }
+    if (reduceMotion) {
+      Object.keys(style).forEach(key => {
+        if (stylesToKeep.includes(key)) {
+          return;
+        }
+        // If it's setting an x or height or scale or some other value, we need
+        // to preserve the end-state value without actually animating it
+        style[key] = defaultStyle[key] = extractValue(style[key]);
+      });
+    }
+
+    return (
+      <Motion style={style} defaultStyle={defaultStyle}>
+        {children}
+      </Motion>
+    );
+  }
+
+}
+
+
+export default OptionalMotion;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,6 +27,7 @@
     = yield :header_tags
 
   - body_classes ||= @body_classes || ''
+  - body_classes += ' reduce-motion' if current_account&.user&.setting_reduce_motion
   - body_classes += ' system-font' if current_account&.user&.setting_system_font_ui
 
   %body{ class: add_rtl_body_class(body_classes) }


### PR DESCRIPTION
I'm not sure if this is a very React-y/Redux-y way of solving this problem, but this fixes the issue of galleries being broken on public statuses.

Instead of using Redux's `connect()`, it adds a body class called `reduce-motion` (similar to `system-font`), which we can check once inside a custom Higher Order Component to decide whether to override the `Motion` styles or not.

Benefits:

* works on pages without Redux
* don't have to worry if the component will update whenever anything in the Redux store changes (i.e. no potential perf problems)
* opens possibility to add CSS styles for `reduce-motion` since it's a body class now

Downsides:

* Not very React-y/Redux-y
* We need our HoC to support everything `Motion` supports, although for now that appears to be just `style` and `defaultStyle` so we're okay