### PR TITLE
Fix React warning about tabIndex on status with CW

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -153,7 +153,7 @@ export default class StatusContent extends React.PureComponent {
 
           {mentionsPlaceholder}
 
-          <div tabIndex={!hidden && 0} className={`status__content__text ${!hidden ? 'status__content__text--visible' : ''}`} style={directionStyle} dangerouslySetInnerHTML={content} />
+          <div tabIndex={!hidden ? 0 : null} className={`status__content__text ${!hidden ? 'status__content__text--visible' : ''}`} style={directionStyle} dangerouslySetInnerHTML={content} />
         </div>
       );
     } else if (this.props.onClick) {


### PR DESCRIPTION
```
Warning: Received `false` for non-boolean attribute `tabIndex`. If this is expected, cast the value to a string.
    in div (at status_content.js:156)
    in div (at status_content.js:147)
    in StatusContent (at status.js:241)
...
```