### PR TITLE
Fix scrolling of dropdown when offscreen

### DIFF
--- a/app/javascript/styles/basics.scss
+++ b/app/javascript/styles/basics.scss
@@ -30,7 +30,7 @@ body {
   }
 
   &.app-body {
-    position: fixed;
+    position: absolute;
     width: 100%;
     height: 100%;
     padding: 0;


### PR DESCRIPTION
This is a very small fix, but it appears to allow the body to scroll for both the status dropdown and the emoji dropdown when they extend offscreen:

![screenshot 2017-10-17 08 03 00](https://user-images.githubusercontent.com/283842/31674080-ba580a04-b315-11e7-8496-73d3f98145cf.png)

![screenshot 2017-10-17 08 27 50](https://user-images.githubusercontent.com/283842/31674082-c128369c-b315-11e7-92b4-76e25f1d0dd4.png)

Here's [a video](https://gfycat.com/FortunateSlightCub) showing what it looks like in Firefox on macOS.

I tested this in Firefox, Edge, Chrome, and Safari, I tested modals and fullscreen videos, I tested mobile viewport sizes, and everything seems good to me. But I may have missed something, so I would appreciate a thorough review from someone else, since this changes a style on the entire `body` element and so may have some other effect I'm not aware of.