### PR TITLE
Don't capture scheme-less URLs in the status (regression from #4941)

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -3,7 +3,7 @@
 class FetchLinkCardService < BaseService
   URL_PATTERN = %r{
     (                                                                                                 #   $1 URL
-      (https?:\/\/)?                                                                                  #   $2 Protocol (optional)
+      (https?:\/\/)                                                                                   #   $2 Protocol (required)
       (#{Twitter::Regex[:valid_domain]})                                                              #   $3 Domain(s)
       (?::(#{Twitter::Regex[:valid_port_number]}))?                                                   #   $4 Port number (optional)
       (/#{Twitter::Regex[:valid_url_path]}*)?                                                         #   $5 URL Path and anchor


### PR DESCRIPTION
Specifically, this fixes status length calculation to be same as JS side. (fixes #5433)

BTW, since this pattern used in not only preview card fetching, we should extract it (with twitter-regex?) and write tests I think.