### PR TITLE
When unreblog arrives over streaming API, just delete in UI

### DIFF
--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -75,15 +75,9 @@ const updateTimeline = (state, timeline, status, references) => {
   }));
 };
 
-const deleteStatus = (state, id, accountId, references, reblogOf) => {
+const deleteStatus = (state, id, accountId, references) => {
   state.keySeq().forEach(timeline => {
-    state = state.updateIn([timeline, 'items'], list => {
-      if (reblogOf && !list.includes(reblogOf)) {
-        return list.map(item => item === id ? reblogOf : item);
-      } else {
-        return list.filterNot(item => item === id);
-      }
-    });
+    state = state.updateIn([timeline, 'items'], list => list.filterNot(item => item === id));
   });
 
   // Remove reblogs of deleted status


### PR DESCRIPTION
Follow-up to #5419, without this, deletes-of-reblogs will still cause the reblogged status to hang on without credit.

This does not have the complex logic of the other PR though, so it can take out even toots that are supposed to stay in some form. However, a refresh will load the correct state, so I think this is better than previous behaviour.