### PR TITLE
Suppress type error(not a function) on calling fastSeek

### DIFF
--- a/app/javascript/mastodon/middleware/sounds.js
+++ b/app/javascript/mastodon/middleware/sounds.js
@@ -12,7 +12,11 @@ const createAudio = sources => {
 const play = audio => {
   if (!audio.paused) {
     audio.pause();
-    audio.fastSeek(0);
+    if (typeof audio.fastSeek === 'function') {
+      audio.fastSeek(0);
+    } else {
+      audio.seek(0);
+    }
   }
 
   audio.play();


### PR DESCRIPTION
In Google Chrome v61.0.3163.100. Raises errors `TypeError: e.fastSeek is not a function`.

This PR will fix that error and use `Audio#seek` for `Audio#fastSeek` 's substitute