### PR TITLE
Update model annotations to use BIGINT for IDs

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -3,7 +3,7 @@
 #
 # Table name: accounts
 #
-#  id                      :integer          not null, primary key
+#  id                      :bigint           not null, primary key
 #  username                :string           default(""), not null
 #  domain                  :string
 #  secret                  :string           default(""), not null

--- a/app/models/account_domain_block.rb
+++ b/app/models/account_domain_block.rb
@@ -6,8 +6,8 @@
 #  domain     :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  account_id :integer
-#  id         :integer          not null, primary key
+#  account_id :bigint
+#  id         :bigint           not null, primary key
 #
 
 class AccountDomainBlock < ApplicationRecord

--- a/app/models/account_moderation_note.rb
+++ b/app/models/account_moderation_note.rb
@@ -3,10 +3,10 @@
 #
 # Table name: account_moderation_notes
 #
-#  id                :integer          not null, primary key
+#  id                :bigint           not null, primary key
 #  content           :text             not null
-#  account_id        :integer          not null
-#  target_account_id :integer          not null
+#  account_id        :bigint           not null
+#  target_account_id :bigint           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -5,9 +5,9 @@
 #
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  account_id        :integer          not null
-#  id                :integer          not null, primary key
-#  target_account_id :integer          not null
+#  account_id        :bigint           not null
+#  id                :bigint           not null, primary key
+#  target_account_id :bigint           not null
 #
 
 class Block < ApplicationRecord

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -3,7 +3,7 @@
 #
 # Table name: conversations
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  uri        :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/conversation_mute.rb
+++ b/app/models/conversation_mute.rb
@@ -3,9 +3,9 @@
 #
 # Table name: conversation_mutes
 #
-#  conversation_id :integer          not null
-#  account_id      :integer          not null
-#  id              :integer          not null, primary key
+#  conversation_id :bigint           not null
+#  account_id      :bigint           not null
+#  id              :bigint           not null, primary key
 #
 
 class ConversationMute < ApplicationRecord

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -3,7 +3,7 @@
 #
 # Table name: custom_emojis
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  shortcode          :string           default(""), not null
 #  domain             :string
 #  image_file_name    :string

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -8,7 +8,7 @@
 #  updated_at   :datetime         not null
 #  severity     :integer          default("silence")
 #  reject_media :boolean          default(FALSE), not null
-#  id           :integer          not null, primary key
+#  id           :bigint           not null, primary key
 #
 
 class DomainBlock < ApplicationRecord

--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -3,7 +3,7 @@
 #
 # Table name: email_domain_blocks
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  domain     :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/favourite.rb
+++ b/app/models/favourite.rb
@@ -5,9 +5,9 @@
 #
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  account_id :integer          not null
-#  id         :integer          not null, primary key
-#  status_id  :integer          not null
+#  account_id :bigint           not null
+#  id         :bigint           not null, primary key
+#  status_id  :bigint           not null
 #
 
 class Favourite < ApplicationRecord

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -5,9 +5,9 @@
 #
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  account_id        :integer          not null
-#  id                :integer          not null, primary key
-#  target_account_id :integer          not null
+#  account_id        :bigint           not null
+#  id                :bigint           not null, primary key
+#  target_account_id :bigint           not null
 #
 
 class Follow < ApplicationRecord

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -5,9 +5,9 @@
 #
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  account_id        :integer          not null
-#  id                :integer          not null, primary key
-#  target_account_id :integer          not null
+#  account_id        :bigint           not null
+#  id                :bigint           not null, primary key
+#  target_account_id :bigint           not null
 #
 
 class FollowRequest < ApplicationRecord

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -11,8 +11,8 @@
 #  data_content_type :string
 #  data_file_size    :integer
 #  data_updated_at   :datetime
-#  account_id        :integer          not null
-#  id                :integer          not null, primary key
+#  account_id        :bigint           not null
+#  id                :bigint           not null, primary key
 #
 
 class Import < ApplicationRecord

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -3,14 +3,14 @@
 #
 # Table name: media_attachments
 #
-#  id                :integer          not null, primary key
-#  status_id         :integer
+#  id                :bigint           not null, primary key
+#  status_id         :bigint
 #  file_file_name    :string
 #  file_content_type :string
 #  file_file_size    :integer
 #  file_updated_at   :datetime
 #  remote_url        :string           default(""), not null
-#  account_id        :integer
+#  account_id        :bigint
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  shortcode         :string

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -3,11 +3,11 @@
 #
 # Table name: mentions
 #
-#  status_id  :integer
+#  status_id  :bigint
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  account_id :integer
-#  id         :integer          not null, primary key
+#  account_id :bigint
+#  id         :bigint           not null, primary key
 #
 
 class Mention < ApplicationRecord

--- a/app/models/mute.rb
+++ b/app/models/mute.rb
@@ -5,9 +5,9 @@
 #
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  account_id        :integer          not null
-#  id                :integer          not null, primary key
-#  target_account_id :integer          not null
+#  account_id        :bigint           not null
+#  id                :bigint           not null, primary key
+#  target_account_id :bigint           not null
 #
 
 class Mute < ApplicationRecord

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -3,13 +3,13 @@
 #
 # Table name: notifications
 #
-#  id              :integer          not null, primary key
-#  account_id      :integer
-#  activity_id     :integer
+#  id              :bigint           not null, primary key
+#  account_id      :bigint
+#  activity_id     :bigint
 #  activity_type   :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  from_account_id :integer
+#  from_account_id :bigint
 #
 
 class Notification < ApplicationRecord

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -3,7 +3,7 @@
 #
 # Table name: preview_cards
 #
-#  id                 :integer          not null, primary key
+#  id                 :bigint           not null, primary key
 #  url                :string           default(""), not null
 #  title              :string           default(""), not null
 #  description        :string           default(""), not null

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -8,10 +8,10 @@
 #  action_taken               :boolean          default(FALSE), not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  account_id                 :integer          not null
-#  action_taken_by_account_id :integer
-#  id                         :integer          not null, primary key
-#  target_account_id          :integer          not null
+#  account_id                 :bigint           not null
+#  action_taken_by_account_id :bigint
+#  id                         :bigint           not null, primary key
+#  target_account_id          :bigint           not null
 #
 
 class Report < ApplicationRecord

--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -3,25 +3,25 @@
 #
 # Table name: session_activations
 #
-#  id                       :integer          not null, primary key
-#  user_id                  :integer          not null
+#  id                       :bigint           not null, primary key
+#  user_id                  :bigint           not null
 #  session_id               :string           not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  user_agent               :string           default(""), not null
 #  ip                       :inet
-#  access_token_id          :integer
-#  web_push_subscription_id :integer
+#  access_token_id          :bigint
+#  web_push_subscription_id :bigint
 #
 
-#  id              :integer          not null, primary key
-#  user_id         :integer          not null
+#  id              :bigint           not null, primary key
+#  user_id         :bigint           not null
 #  session_id      :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  user_agent      :string           default(""), not null
 #  ip              :inet
-#  access_token_id :integer
+#  access_token_id :bigint
 #
 
 class SessionActivation < ApplicationRecord

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -8,8 +8,8 @@
 #  thing_type :string
 #  created_at :datetime
 #  updated_at :datetime
-#  id         :integer          not null, primary key
-#  thing_id   :integer
+#  id         :bigint           not null, primary key
+#  thing_id   :bigint
 #
 
 class Setting < RailsSettings::Base

--- a/app/models/site_upload.rb
+++ b/app/models/site_upload.rb
@@ -3,7 +3,7 @@
 #
 # Table name: site_uploads
 #
-#  id                :integer          not null, primary key
+#  id                :bigint           not null, primary key
 #  var               :string           default(""), not null
 #  file_file_name    :string
 #  file_content_type :string

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -3,25 +3,25 @@
 #
 # Table name: statuses
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  uri                    :string
-#  account_id             :integer          not null
+#  account_id             :bigint           not null
 #  text                   :text             default(""), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  in_reply_to_id         :integer
-#  reblog_of_id           :integer
+#  in_reply_to_id         :bigint
+#  reblog_of_id           :bigint
 #  url                    :string
 #  sensitive              :boolean          default(FALSE), not null
 #  visibility             :integer          default("public"), not null
-#  in_reply_to_account_id :integer
-#  application_id         :integer
+#  in_reply_to_account_id :bigint
+#  application_id         :bigint
 #  spoiler_text           :text             default(""), not null
 #  reply                  :boolean          default(FALSE), not null
 #  favourites_count       :integer          default(0), not null
 #  reblogs_count          :integer          default(0), not null
 #  language               :string
-#  conversation_id        :integer
+#  conversation_id        :bigint
 #  local                  :boolean
 #
 

--- a/app/models/status_pin.rb
+++ b/app/models/status_pin.rb
@@ -3,9 +3,9 @@
 #
 # Table name: status_pins
 #
-#  id         :integer          not null, primary key
-#  account_id :integer          not null
-#  status_id  :integer          not null
+#  id         :bigint           not null, primary key
+#  account_id :bigint           not null
+#  status_id  :bigint           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/app/models/stream_entry.rb
+++ b/app/models/stream_entry.rb
@@ -3,13 +3,13 @@
 #
 # Table name: stream_entries
 #
-#  activity_id   :integer
+#  activity_id   :bigint
 #  activity_type :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  hidden        :boolean          default(FALSE), not null
-#  account_id    :integer
-#  id            :integer          not null, primary key
+#  account_id    :bigint
+#  id            :bigint           not null, primary key
 #
 
 class StreamEntry < ApplicationRecord

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -11,8 +11,8 @@
 #  updated_at                  :datetime         not null
 #  last_successful_delivery_at :datetime
 #  domain                      :string
-#  account_id                  :integer          not null
-#  id                          :integer          not null, primary key
+#  account_id                  :bigint           not null
+#  id                          :bigint           not null, primary key
 #
 
 class Subscription < ApplicationRecord

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,7 +3,7 @@
 #
 # Table name: tags
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  name       :string           default(""), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 #
 # Table name: users
 #
-#  id                        :integer          not null, primary key
+#  id                        :bigint           not null, primary key
 #  email                     :string           default(""), not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
@@ -30,7 +30,7 @@
 #  last_emailed_at           :datetime
 #  otp_backup_codes          :string           is an Array
 #  filtered_languages        :string           default([]), not null, is an Array
-#  account_id                :integer          not null
+#  account_id                :bigint           not null
 #  disabled                  :boolean          default(FALSE), not null
 #  moderator                 :boolean          default(FALSE), not null
 #

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -3,7 +3,7 @@
 #
 # Table name: web_push_subscriptions
 #
-#  id         :integer          not null, primary key
+#  id         :bigint           not null, primary key
 #  endpoint   :string           not null
 #  key_p256dh :string           not null
 #  key_auth   :string           not null

--- a/app/models/web/setting.rb
+++ b/app/models/web/setting.rb
@@ -6,8 +6,8 @@
 #  data       :json
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  id         :integer          not null, primary key
-#  user_id    :integer
+#  id         :bigint           not null, primary key
+#  user_id    :bigint
 #
 
 class Web::Setting < ApplicationRecord


### PR DESCRIPTION
All the migrations have been updated to use BIGINTs for ID fields in the DB, but ActiveRecord needs to be told to treat those values as BIGINT as well. This PR does that.