### PR TITLE
Use contenthash for ExtractTextWebpackPlugin

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -55,7 +55,7 @@ module.exports = {
         resource.request = resource.request.replace(/^history/, 'history/es');
       }
     ),
-    new ExtractTextPlugin(env.NODE_ENV === 'production' ? '[name]-[hash].css' : '[name].css'),
+    new ExtractTextPlugin(env.NODE_ENV === 'production' ? '[name]-[contenthash].css' : '[name].css'),
     new ManifestPlugin({
       publicPath: output.publicPath,
       writeToFileEmit: true,


### PR DESCRIPTION
`[hash]` is not documented.

This bug was found by @abcang .