### PR TITLE
Remove translateZ(0) on modal overlay

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3067,7 +3067,6 @@ button.icon-button.active i.fa-retweet {
   right: 0;
   bottom: 0;
   background: rgba($base-overlay-background, 0.7);
-  transform: translateZ(0);
 }
 
 .modal-root__container {


### PR DESCRIPTION
This appears to have been added in https://github.com/tootsuite/mastodon/commit/cca41ea544fe7de3e7afdc250992a1c6e48d2a31 and AFAICT it is not needed. I deployed this fix to malfunctioning.technology and tested opening a modal gallery and swiping left and right in both mobile Firefox and mobile Chrome on a Nexus 5, and didn't observe any performance degradation compared to master.

In principle, usages of `translateZ(0)` are very suspect because they force the browser to create a GPU layer. It's almost always better to use `will-change` as documented [here](https://dev.opera.com/articles/css-will-change-property/).

Also, the overlay element that we animate now is `.modal-root`, not `.modal-root__overlay`, and `.modal-root` already has `will-change: opacity` applied to it.