### PR TITLE
Make the Polish locale description sound natural

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -23,7 +23,7 @@ module SettingsHelper
     nl: 'Nederlands',
     no: 'Norsk',
     oc: 'Occitan',
-    pl: 'Polszczyzna',
+    pl: 'Polski',
     pt: 'Português',
     'pt-BR': 'Português do Brasil',
     ru: 'Русский',


### PR DESCRIPTION
_Polszczyzna_ does not sound natural in this context.