### PR TITLE
Allow users to restrict incoming DMs to follows only

### DIFF
--- a/app/controllers/settings/notifications_controller.rb
+++ b/app/controllers/settings/notifications_controller.rb
@@ -26,7 +26,7 @@ class Settings::NotificationsController < ApplicationController
   def user_settings_params
     params.require(:user).permit(
       notification_emails: %i(follow follow_request reblog favourite mention digest),
-      interactions: %i(must_be_follower must_be_following)
+      interactions: %i(must_be_follower must_be_following must_be_following_dm)
     )
   end
 end

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -44,7 +44,7 @@ class Settings::PreferencesController < ApplicationController
       :setting_noindex,
       :setting_theme,
       notification_emails: %i(follow follow_request reblog favourite mention digest),
-      interactions: %i(must_be_follower must_be_following)
+      interactions: %i(must_be_follower must_be_following must_be_following_dm)
     )
   end
 end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -5,6 +5,7 @@ class NotifyService < BaseService
     @recipient    = recipient
     @activity     = activity
     @notification = Notification.new(account: @recipient, activity: @activity)
+    @visibility   = nil
 
     return if recipient.user.nil? || blocked?
 
@@ -15,6 +16,14 @@ class NotifyService < BaseService
   end
 
   private
+  
+  def visibility
+    unless @visibility.nil? && (@activity.is_a?(Follow) || @activity.is_a?(FollowRequest))
+      status = @activity.is_a?(Status) ? @activity : @activity.status
+      @visibility = status.visibility
+    end
+    @visibility
+  end
 
   def blocked_mention?
     FeedManager.instance.filter?(:mentions, @notification.mention.status, @recipient.id)
@@ -43,8 +52,9 @@ class NotifyService < BaseService
     blocked ||= @recipient.blocking?(@notification.from_account)                                                                     # Skip for blocked accounts
     blocked ||= @recipient.muting?(@notification.from_account)                                                                       # Skip for muted accounts
     blocked ||= (@notification.from_account.silenced? && !@recipient.following?(@notification.from_account))                         # Hellban
-    blocked ||= (@recipient.user.settings.interactions['must_be_follower']  && !@notification.from_account.following?(@recipient))   # Options
-    blocked ||= (@recipient.user.settings.interactions['must_be_following'] && !@recipient.following?(@notification.from_account))   # Options
+    blocked ||= (@recipient.user.settings.interactions['must_be_follower']     && !@notification.from_account.following?(@recipient))   # Options
+    blocked ||= (@recipient.user.settings.interactions['must_be_following']    && !@recipient.following?(@notification.from_account))   # Options
+    blocked ||= (@recipient.user.settings.interactions['must_be_following_dm'] && !@recipient.following?(@notification.from_account) && visibility == 'direct')   # Options
     blocked ||= conversation_muted?
     blocked ||= send("blocked_#{@notification.type}?")                                                                               # Type-dependent filters
     blocked

--- a/app/views/settings/notifications/show.html.haml
+++ b/app/views/settings/notifications/show.html.haml
@@ -20,6 +20,7 @@
     = f.simple_fields_for :interactions, hash_to_object(current_user.settings.interactions) do |ff|
       = ff.input :must_be_follower, as: :boolean, wrapper: :with_label
       = ff.input :must_be_following, as: :boolean, wrapper: :with_label
+      = ff.input :must_be_following_dm, as: :boolean, wrapper: :with_label
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -54,6 +54,7 @@ en:
       interactions:
         must_be_follower: Block notifications from non-followers
         must_be_following: Block notifications from people you don't follow
+        must_be_following_dm: Block only Direct Messages from people you don't follow
       notification_emails:
         digest: Send digest e-mails
         favourite: Send e-mail when someone favourites your status

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,6 +36,7 @@ defaults: &defaults
   interactions:
     must_be_follower: false
     must_be_following: false
+    must_be_following_dm: false
   reserved_usernames:
     - admin
     - support


### PR DESCRIPTION
Paul & I put together a changeset that introduces users the ability to prevent DMs from reaching them.

It works similarly to how other notification blocking mechanisms works.