### PR TITLE
Delay queuing to sidekiq when deleting account

### DIFF
--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -44,7 +44,7 @@ class BatchedRemoveStatusService < BaseService
       batch_salmon_slaps(status) if status.local?
     end
 
-    at = (statuses.size * batch_index).seconds.after.to_i
+    at = ((@stream_entry_batches.size + @salmon_batches.size + @activity_json_batches.size) * batch_index).seconds.after.to_i
     Sidekiq::Client.push_bulk('class' => Pubsubhubbub::RawDistributionWorker, 'args' => @stream_entry_batches, 'at' => at)
     Sidekiq::Client.push_bulk('class' => NotificationWorker, 'args' => @salmon_batches, 'at' => at)
     Sidekiq::Client.push_bulk('class' => ActivityPub::DeliveryWorker, 'args' => @activity_json_batches, 'at' => at)

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -9,7 +9,8 @@ class BatchedRemoveStatusService < BaseService
   # Remove statuses from home feeds
   # Push delete events to streaming API for home feeds and public feeds
   # @param [Status] statuses A preferably batched array of statuses
-  def call(statuses)
+  # @param [Integer] batch_index
+  def call(statuses, batch_index = 1)
     statuses = Status.where(id: statuses.map(&:id)).includes(:account, :stream_entry).flat_map { |status| [status] + status.reblogs.includes(:account, :stream_entry).to_a }
 
     @mentions = statuses.map { |s| [s.id, s.mentions.includes(:account).to_a] }.to_h
@@ -43,9 +44,10 @@ class BatchedRemoveStatusService < BaseService
       batch_salmon_slaps(status) if status.local?
     end
 
-    Pubsubhubbub::RawDistributionWorker.push_bulk(@stream_entry_batches) { |batch| batch }
-    NotificationWorker.push_bulk(@salmon_batches) { |batch| batch }
-    ActivityPub::DeliveryWorker.push_bulk(@activity_json_batches) { |batch| batch }
+    at = (statuses.size * batch_index).seconds.after.to_i
+    Sidekiq::Client.push_bulk('class' => Pubsubhubbub::RawDistributionWorker, 'args' => @stream_entry_batches, 'at' => at)
+    Sidekiq::Client.push_bulk('class' => NotificationWorker, 'args' => @salmon_batches, 'at' => at)
+    Sidekiq::Client.push_bulk('class' => ActivityPub::DeliveryWorker, 'args' => @activity_json_batches, 'at' => at)
   end
 
   private

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -17,8 +17,8 @@ class SuspendAccountService < BaseService
   end
 
   def purge_content
-    @account.statuses.reorder(nil).find_in_batches do |statuses|
-      BatchedRemoveStatusService.new.call(statuses)
+    @account.statuses.reorder(nil).find_in_batches(batch_size: 100).with_index(1) do |statuses, batch_index|
+      BatchedRemoveStatusService.new.call(statuses, batch_index)
     end
 
     [


### PR DESCRIPTION
When deleting an account, a lot of jobs are added to the queue of sidekiq all at once, so I changed it to add it to the queue little by little. Sidekiq::Client.push_bulk is used directly because sidekiq-bulk does not support time specification.
