### PR TITLE
Fix copying emojos: redirect to the page you were on

### DIFF
--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -36,7 +36,7 @@ module Admin
         flash[:alert] = I18n.t('admin.custom_emojis.copy_failed_msg')
       end
 
-      redirect_to admin_custom_emojis_path(params[:page])
+      redirect_to admin_custom_emojis_path(page: params[:page])
     end
 
     def enable


### PR DESCRIPTION
Copying emojos in the admin panel used to bump you back to the first page of emojos; this (very small!) change fixes that, so you don't lose your place if you have lots of emojos!