### PR TITLE
Add DM-only non-follow muting & accept notifications by follow request

### DIFF
--- a/app/controllers/settings/notifications_controller.rb
+++ b/app/controllers/settings/notifications_controller.rb
@@ -26,7 +26,7 @@ class Settings::NotificationsController < ApplicationController
   def user_settings_params
     params.require(:user).permit(
       notification_emails: %i(follow follow_request reblog favourite mention digest),
-      interactions: %i(must_be_follower must_be_following)
+      interactions: %i(must_be_follower must_be_following must_be_following_dm)
     )
   end
 end

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -44,7 +44,7 @@ class Settings::PreferencesController < ApplicationController
       :setting_noindex,
       :setting_theme,
       notification_emails: %i(follow follow_request reblog favourite mention digest),
-      interactions: %i(must_be_follower must_be_following)
+      interactions: %i(must_be_follower must_be_following must_be_following_dm)
     )
   end
 end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -5,6 +5,7 @@ class NotifyService < BaseService
     @recipient    = recipient
     @activity     = activity
     @notification = Notification.new(account: @recipient, activity: @activity)
+    @visibility   = nil
 
     return if recipient.user.nil? || blocked?
 
@@ -15,6 +16,14 @@ class NotifyService < BaseService
   end
 
   private
+
+  def visibility
+    unless @visibility.nil? && (@activity.is_a?(Follow) || @activity.is_a?(FollowRequest))
+      status = @activity.is_a?(Status) ? @activity : @activity.status
+      @visibility = status.visibility
+    end
+    @visibility
+  end
 
   def blocked_mention?
     FeedManager.instance.filter?(:mentions, @notification.mention.status, @recipient.id)
@@ -37,16 +46,17 @@ class NotifyService < BaseService
   end
 
   def blocked?
-    blocked   = @recipient.suspended?                                                                                                # Skip if the recipient account is suspended anyway
-    blocked ||= @recipient.id == @notification.from_account.id                                                                       # Skip for interactions with self
-    blocked ||= @recipient.domain_blocking?(@notification.from_account.domain) && !@recipient.following?(@notification.from_account) # Skip for domain blocked accounts
-    blocked ||= @recipient.blocking?(@notification.from_account)                                                                     # Skip for blocked accounts
-    blocked ||= @recipient.muting?(@notification.from_account)                                                                       # Skip for muted accounts
-    blocked ||= (@notification.from_account.silenced? && !@recipient.following?(@notification.from_account))                         # Hellban
-    blocked ||= (@recipient.user.settings.interactions['must_be_follower']  && !@notification.from_account.following?(@recipient))   # Options
-    blocked ||= (@recipient.user.settings.interactions['must_be_following'] && !@recipient.following?(@notification.from_account))   # Options
+    blocked   = @recipient.suspended?                                                                                                                             # Skip if the recipient account is suspended anyway
+    blocked ||= @recipient.id == @notification.from_account.id                                                                                                    # Skip for interactions with self
+    blocked ||= @recipient.domain_blocking?(@notification.from_account.domain) && !@recipient.following?(@notification.from_account)                              # Skip for domain blocked accounts
+    blocked ||= @recipient.blocking?(@notification.from_account)                                                                                                  # Skip for blocked accounts
+    blocked ||= @recipient.muting?(@notification.from_account)                                                                                                    # Skip for muted accounts
+    blocked ||= (@notification.from_account.silenced? && !@recipient.following?(@notification.from_account))                                                      # Hellban
+    blocked ||= (@recipient.user.settings.interactions['must_be_follower']     && !@notification.from_account.following?(@recipient))                             # Options
+    blocked ||= (@recipient.user.settings.interactions['must_be_following']    && !@recipient.following?(@notification.from_account))                             # Options
+    blocked ||= (@recipient.user.settings.interactions['must_be_following_dm'] && !@recipient.following?(@notification.from_account) && visibility == 'direct')   # Options
     blocked ||= conversation_muted?
-    blocked ||= send("blocked_#{@notification.type}?")                                                                               # Type-dependent filters
+    blocked ||= send("blocked_#{@notification.type}?")                                                                                                            # Type-dependent filters
     blocked
   end
 

--- a/app/views/settings/notifications/show.html.haml
+++ b/app/views/settings/notifications/show.html.haml
@@ -20,6 +20,7 @@
     = f.simple_fields_for :interactions, hash_to_object(current_user.settings.interactions) do |ff|
       = ff.input :must_be_follower, as: :boolean, wrapper: :with_label
       = ff.input :must_be_following, as: :boolean, wrapper: :with_label
+      = ff.input :must_be_following_dm, as: :boolean, wrapper: :with_label
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -54,6 +54,7 @@ en:
       interactions:
         must_be_follower: Block notifications from non-followers
         must_be_following: Block notifications from people you don't follow
+        must_be_following_dm: Block only Direct Messages from people you don't follow
       notification_emails:
         digest: Send digest e-mails
         favourite: Send e-mail when someone favourites your status

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,6 +36,7 @@ defaults: &defaults
   interactions:
     must_be_follower: false
     must_be_following: false
+    must_be_following_dm: false
   reserved_usernames:
     - admin
     - support

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -96,5 +96,10 @@ RSpec.describe NotifyService do
       user.settings.interactions = interactions.merge('must_be_following_dm' => true)
       is_expected.to_not change(Notification, :count)
     end
+    
+    it 'does notify when direct messages are sent to the recipient with a follow request' do
+      FollowRequest.create(account: recipient, target_account: asshole)
+      is_expected.to change(Notification, :count)
+    end
   end
 end

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -86,4 +86,15 @@ RSpec.describe NotifyService do
       end
     end
   end
+
+  context do
+    let(:asshole)  { Fabricate(:account, username: 'asshole') }
+    let(:activity) { Fabricate(:mention, account: recipient, status: Fabricate(:status, account: sender, visibility: :direct)) }
+
+    it 'does not notify when direct messages from non-followed user are muted' do
+      interactions = user.settings.interactions
+      user.settings.interactions = interactions.merge('must_be_following_dm' => true)
+      is_expected.to_not change(Notification, :count)
+    end
+  end
 end


### PR DESCRIPTION
This is a continuation of #5503.

It fixes all the Ruby style issues and introduces two new tests, which both test the DM muting feature against no follows as well as tests it against follow requests.

Since a follow request from a recipient indicates an intent to follow, it doesn't make sense to eliminate notifications from that person a recipient is trying to follow.