### PR TITLE
Add margin to account for Edge disappearing scrollbar

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -620,6 +620,12 @@
   border-bottom: 1px solid lighten($ui-base-color, 8%);
   cursor: default;
 
+  @supports (-ms-overflow-style: -ms-autohiding-scrollbar) {
+    // Add margin to avoid Edge auto-hiding scrollbar appearing over content.
+    // On Edge 16 this is 16px and Edge <=15 it's 12px, so aim for 16px.
+    padding-right: 26px; // 10px + 16px
+  }
+
   @keyframes fade {
     0% { opacity: 0; }
     100% { opacity: 1; }
@@ -1735,13 +1741,6 @@
 .scrollable.fullscreen {
   @supports(display: grid) { // hack to fix Chrome <57
     contain: none;
-  }
-}
-
-.item-list {
-  @supports (-ms-overflow-style: -ms-autohiding-scrollbar) {
-    // auto-hiding scrollbar in Edge, add margin to avoid scrollbar appearing over content
-    padding-right: 16px;
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1738,6 +1738,13 @@
   }
 }
 
+.item-list {
+  @supports (-ms-overflow-style: -ms-autohiding-scrollbar) {
+    // auto-hiding scrollbar in Edge, add margin to avoid scrollbar appearing over content
+    padding-right: 16px;
+  }
+}
+
 .column-back-button {
   background: lighten($ui-base-color, 4%);
   color: $ui-highlight-color;


### PR DESCRIPTION
Because we use auto-hiding scrollbars in Edge (https://github.com/tootsuite/mastodon/pull/975), it's unfortunately a little difficult to click on the dates in a toot, because the scrollbar might obscure them:

![before](https://user-images.githubusercontent.com/283842/31980395-1304be0e-b901-11e7-9a78-fa4c0eb31ee5.png)

(Scrollbars invisible on the left, scrollbars visible on the right.)

I propose adding a padding to account for the space taken up by the scrollbar. So afterwards it looks like this:

![after](https://user-images.githubusercontent.com/283842/31980509-cf0e95b6-b901-11e7-8dae-69949f318e07.png)

In Edge 16 (the latest release, Fall Creators Update) the scrollbars are 16px. On older versions  of Edge they're 12px. So on Edge <16 the padding will be slightly too high, but hopefully folks will just upgrade quickly to Edge 16.

This PR won't affect non-Edge browsers because of the `@supports` rule.