### PR TITLE
Allow ActivityPub Note's tag and attachment to be single objects

### DIFF
--- a/app/helpers/jsonld_helper.rb
+++ b/app/helpers/jsonld_helper.rb
@@ -9,6 +9,10 @@ module JsonLdHelper
     value.is_a?(Array) ? value.first : value
   end
 
+  def as_array(value)
+    value.is_a?(Array) ? value : [value]
+  end
+
   def value_or_id(value)
     value.is_a?(String) || value.nil? ? value : value['id']
   end

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -53,9 +53,9 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def process_tags(status)
-    return unless @object['tag'].is_a?(Array)
+    return if @object['tag'].nil?
 
-    @object['tag'].each do |tag|
+    as_array(@object['tag']).each do |tag|
       case tag['type']
       when 'Hashtag'
         process_hashtag tag, status
@@ -103,9 +103,9 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def process_attachments(status)
-    return unless @object['attachment'].is_a?(Array)
+    return if @object['attachment'].nil?
 
-    @object['attachment'].each do |attachment|
+    as_array(@object['attachment']).each do |attachment|
       next if unsupported_media_type?(attachment['mediaType']) || attachment['url'].blank?
 
       href             = Addressable::URI.parse(attachment['url']).normalize.to_s


### PR DESCRIPTION
In JSON-LD, `[{"type": "Mention"}]` and `{"type": "Mention"}` are equal. So, allow this when parsing tags and attachments. By default, [Kroeg](https://github.com/puckipedia/Kroeg) defaults to not using JSON arrays if it isn't needed, thus causing an incompatibility with Mastodon.