### PR TITLE
Resolve remote accounts when mentioned even if they are already known

### DIFF
--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -11,15 +11,10 @@ class ProcessMentionsService < BaseService
     return unless status.local?
 
     status.text.scan(Account::MENTION_RE).each do |match|
-      username, domain  = match.first.split('@')
-      mentioned_account = Account.find_remote(username, domain)
-
-      if mentioned_account.nil? && !domain.nil?
-        begin
-          mentioned_account = resolve_remote_account_service.call(match.first.to_s)
-        rescue Goldfinger::Error, HTTP::Error
-          mentioned_account = nil
-        end
+      begin
+        mentioned_account = resolve_remote_account_service.call(match.first.to_s)
+      rescue Goldfinger::Error, HTTP::Error
+        mentioned_account = nil
       end
 
       next if mentioned_account.nil?


### PR DESCRIPTION
If there is one place where the remote account information *needs* to be up-to-date (at least for the public key and protocol information), it's when delivering toots (especially direct messages).

Without this change, Mastodon mentioning an user never triggers account resolving (unless the remote user is not known at all), which is particularly annoying when dealing with OStatus → ActivityPub migration, as Direct Messages are disabled for OStatus.

This change triggers resolving (still capped to one resolving per account per day in `ResolveRemoteAccountService`) when mentioning remote users, which may increase traffic a bit.