### PR TITLE
Instantiate service classes for each call (fixes #5540)

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -70,11 +70,11 @@ class PostStatusService < BaseService
   end
 
   def process_mentions_service
-    @process_mentions_service ||= ProcessMentionsService.new
+    ProcessMentionsService.new
   end
 
   def process_hashtags_service
-    @process_hashtags_service ||= ProcessHashtagsService.new
+    ProcessHashtagsService.new
   end
 
   def redis

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -16,7 +16,7 @@ class ProcessMentionsService < BaseService
 
       if mentioned_account.nil? && !domain.nil?
         begin
-          mentioned_account = follow_remote_account_service.call(match.first.to_s)
+          mentioned_account = resolve_remote_account_service.call(match.first.to_s)
         rescue Goldfinger::Error, HTTP::Error
           mentioned_account = nil
         end
@@ -54,7 +54,7 @@ class ProcessMentionsService < BaseService
     ).as_json).sign!(status.account))
   end
 
-  def follow_remote_account_service
-    @follow_remote_account_service ||= ResolveRemoteAccountService.new
+  def resolve_remote_account_service
+    ResolveRemoteAccountService.new
   end
 end


### PR DESCRIPTION
`ResolveRemoteAccountService` is instantiated only once for several possible calls, and any call after the first one (with different arguments) will fail. Concretely, this will cause mentions to not be resolved when a user mentions multiple remote users unknown to the their instance in a single toot.