### PR TITLE
Avoid unnecessary Motion components in icon_button.js

### DIFF
--- a/app/javascript/mastodon/components/icon_button.js
+++ b/app/javascript/mastodon/components/icon_button.js
@@ -72,6 +72,25 @@ export default class IconButton extends React.PureComponent {
       overlayed: overlay,
     });
 
+    if (!animate) {
+      // Perf optimization: avoid unnecessary <Motion> components unless
+      // we actually need to animate.
+      return (
+        <button
+          aria-label={title}
+          aria-pressed={pressed}
+          aria-expanded={expanded}
+          title={title}
+          className={classes}
+          onClick={this.handleClick}
+          style={style}
+          tabIndex={tabIndex}
+        >
+          <i className={`fa fa-fw fa-${icon}`} aria-hidden='true' />
+        </button>
+      );
+    }
+
     return (
       <Motion defaultStyle={{ rotate: active ? -360 : 0 }} style={{ rotate: animate ? spring(active ? -360 : 0, { stiffness: 120, damping: 7 }) : 0 }}>
         {({ rotate }) =>


### PR DESCRIPTION
This improves performance of toot rendering, by avoiding wrapping every `<IconButton>` in a `<Motion>` (regardless of whether it uses that `<Motion>`). Most icon buttons don't actually animate, but we're still wrapping every one in `<Motion>` even if it doesn't need it.

I tested by loading the `/getting-started` page in mobile size with 6x CPU throttling (Chrome), and then clicking on the home button. Taking the median of 3 runs, I found that this PR reduced the time to mount the `<ScrollContainer>` from ~730ms to ~660ms:

![out](https://user-images.githubusercontent.com/283842/32113377-021586e6-baf5-11e7-9e4b-960f07466a74.png)

This was in dev mode, so it may look slightly different in prod mode, but that's still a pretty sizeable reduction.