### PR TITLE
Update remote ActivityPub users when fetching their toots

### DIFF
--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -16,7 +16,7 @@ class ActivityPub::FetchRemoteStatusService < BaseService
     return if actor_id.nil? || !trustworthy_attribution?(@json['id'], actor_id)
 
     actor = ActivityPub::TagManager.instance.uri_to_resource(actor_id, Account)
-    actor = ActivityPub::FetchRemoteAccountService.new.call(actor_id, id: true) if actor.nil?
+    actor = ActivityPub::FetchRemoteAccountService.new.call(actor_id, id: true) if actor.nil? || needs_update(actor)
 
     return if actor.suspended?
 
@@ -43,5 +43,9 @@ class ActivityPub::FetchRemoteStatusService < BaseService
 
   def expected_type?
     %w(Note Article).include? @json['type']
+  end
+
+  def needs_update(actor)
+    actor.possibly_stale?
   end
 end


### PR DESCRIPTION
On small instances, it is really frequent for remote users toots from remote non-followed users to be fetched (because of a followed user replying or boosting them), but in that case, in the ActivityPub codepath, their profile is *not* updated, which may sometime cause confusion, e.g. when a message references their avatar/name, or suggests reading their bios.

This commit changes this behavior by refreshing profile data (respecting the common 1 refresh per day per account cap) even if the user is known.