### PR TITLE
Directly use <Motion/> if not reducing motion

### DIFF
--- a/app/javascript/mastodon/features/ui/util/optional_motion.js
+++ b/app/javascript/mastodon/features/ui/util/optional_motion.js
@@ -1,49 +1,5 @@
-// Like react-motion's Motion, but checks to see if the user prefers
-// reduced motion and uses a cross-fade in those cases.
-
-import React from 'react';
-import Motion from 'react-motion/lib/Motion';
-import PropTypes from 'prop-types';
 import { reduceMotion } from '../../../initial_state';
+import ReducedMotion from './reduced_motion';
+import Motion from 'react-motion/lib/Motion';
 
-const stylesToKeep = ['opacity', 'backgroundOpacity'];
-
-const extractValue = (value) => {
-  // This is either an object with a "val" property or it's a number
-  return (typeof value === 'object' && value && 'val' in value) ? value.val : value;
-};
-
-class OptionalMotion extends React.Component {
-
-  static propTypes = {
-    defaultStyle: PropTypes.object,
-    style: PropTypes.object,
-    children: PropTypes.func,
-  }
-
-  render() {
-
-    const { style, defaultStyle, children } = this.props;
-
-    if (reduceMotion) {
-      Object.keys(style).forEach(key => {
-        if (stylesToKeep.includes(key)) {
-          return;
-        }
-        // If it's setting an x or height or scale or some other value, we need
-        // to preserve the end-state value without actually animating it
-        style[key] = defaultStyle[key] = extractValue(style[key]);
-      });
-    }
-
-    return (
-      <Motion style={style} defaultStyle={defaultStyle}>
-        {children}
-      </Motion>
-    );
-  }
-
-}
-
-
-export default OptionalMotion;
+export default reduceMotion ? ReducedMotion : Motion;

--- a/app/javascript/mastodon/features/ui/util/reduced_motion.js
+++ b/app/javascript/mastodon/features/ui/util/reduced_motion.js
@@ -1,0 +1,44 @@
+// Like react-motion's Motion, but reduces all animations to cross-fades
+// for the benefit of users with motion sickness.
+import React from 'react';
+import Motion from 'react-motion/lib/Motion';
+import PropTypes from 'prop-types';
+
+const stylesToKeep = ['opacity', 'backgroundOpacity'];
+
+const extractValue = (value) => {
+  // This is either an object with a "val" property or it's a number
+  return (typeof value === 'object' && value && 'val' in value) ? value.val : value;
+};
+
+class ReducedMotion extends React.Component {
+
+  static propTypes = {
+    defaultStyle: PropTypes.object,
+    style: PropTypes.object,
+    children: PropTypes.func,
+  }
+
+  render() {
+
+    const { style, defaultStyle, children } = this.props;
+
+    Object.keys(style).forEach(key => {
+      if (stylesToKeep.includes(key)) {
+        return;
+      }
+      // If it's setting an x or height or scale or some other value, we need
+      // to preserve the end-state value without actually animating it
+      style[key] = defaultStyle[key] = extractValue(style[key]);
+    });
+
+    return (
+      <Motion style={style} defaultStyle={defaultStyle}>
+        {children}
+      </Motion>
+    );
+  }
+
+}
+
+export default ReducedMotion;


### PR DESCRIPTION
This is a minor refactoring and perf improvement (possibly). Since we know statically if the user wants to reduce motion, `optional_motion.js` can directly export `Motion` instead of wrapping it in an extra component.

GitHub is not good at this diff, but most of the logic from `optional_motion.js` was moved into `reduced_motion.js`.