### PR TITLE
Avoid modifying emoji data inline

### DIFF
--- a/app/javascript/mastodon/features/emoji/emoji_compressed.js
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.js
@@ -64,14 +64,14 @@ Object.keys(emojiMap).forEach(key => {
 
 Object.keys(emojiIndex.emojis).forEach(key => {
   const { native } = emojiIndex.emojis[key];
-  const { short_names, search, unified } = emojiMartData.emojis[key];
+  let { short_names, search, unified } = emojiMartData.emojis[key];
   if (short_names[0] !== key) {
     throw new Error('The compresser expects the first short_code to be the ' +
       'key. It may need to be rewritten if the emoji change such that this ' +
       'is no longer the case.');
   }
 
-  short_names.splice(0, 1); // first short name can be inferred from the key
+  short_names = short_names.slice(1); // first short name can be inferred from the key
 
   const searchData = [native, short_names, search];
   if (unicodeToUnifiedName(native) !== unified) {


### PR DESCRIPTION
This `splice()` appears to cause some bugs in certain Webpack configurations (e.g. `--display-optimization-bailout`). There's really no need to modify the array in-place; it's safer to use `slice()`.

Note that this PR doesn't change anything in production; the output JS files are exactly the same size. (I checked.) This just ensures we don't shoot ourselves in the foot if Webpack decides to re-run the script a second time for debugging purposes (which appears to be what is happening here).