### PR TITLE
Twidere mention workaround

### DIFF
--- a/app/javascript/mastodon/features/compose/util/counter.js
+++ b/app/javascript/mastodon/features/compose/util/counter.js
@@ -5,5 +5,5 @@ const urlPlaceholder = 'xxxxxxxxxxxxxxxxxxxxxxx';
 export function countableText(inputText) {
   return inputText
     .replace(urlRegex, urlPlaceholder)
-    .replace(/(?:^|[^\/\w])@(([a-z0-9_]+)@[a-z0-9\.\-]+[a-z0-9]+)/ig, '@$2');
+    .replace(/(^|[^\/\w])@(([a-z0-9_]+)@[a-z0-9\.\-]+[a-z0-9]+)/ig, '$1@$3');
 };

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -44,7 +44,7 @@
 #
 
 class Account < ApplicationRecord
-  MENTION_RE = /(?:^|[^\/[:word:]])@(([a-z0-9_]+)(?:@[a-z0-9\.\-]+[a-z0-9]+)?)/i
+  MENTION_RE = /(?<=^|[^\/[:word:]])@(([a-z0-9_]+)(?:@[a-z0-9\.\-]+[a-z0-9]+)?)/i
 
   include AccountAvatar
   include AccountFinderConcern

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -10,17 +10,20 @@ class ProcessMentionsService < BaseService
   def call(status)
     return unless status.local?
 
-    status.text.scan(Account::MENTION_RE).each do |match|
+    status.text = status.text.gsub(Account::MENTION_RE) do |match|
       begin
-        mentioned_account = resolve_remote_account_service.call(match.first.to_s)
+        mentioned_account = resolve_remote_account_service.call($1)
       rescue Goldfinger::Error, HTTP::Error
         mentioned_account = nil
       end
 
-      next if mentioned_account.nil? || (mentioned_account.ostatus? && status.stream_entry.hidden?)
+      next match if mentioned_account.nil? || (mentioned_account.ostatus? && status.stream_entry.hidden?)
 
       mentioned_account.mentions.where(status: status).first_or_create(status: status)
+      "@#{mentioned_account.acct}"
     end
+
+    status.save!
 
     status.mentions.includes(:account).each do |mention|
       create_notification(status, mention)


### PR DESCRIPTION
This pull request works around a bug in both Twidere (https://github.com/TwidereProject/Twidere-Android/issues/1001) and Tootdon.

Tootdon and Twidere construct `@user@domain` handles from mentions in toots based
solely on the mention text and account URI's domain without performing any
webfinger call or retrieving account info from the Mastodon server.

As a result, when a remote user has `WEB_DOMAIN` ≠ `LOCAL_DOMAIN`, Twidere and
Tootdon will construct the mention as `@user@WEB_DOMAIN`. Now, this will usually
resolve to the correct account (since the recommended configuration is to have
`WEB_DOMAIN` perform webfinger redirections to `LOCAL_DOMAIN`) when processing
mentions, but won't do so when displaying them (as it does not go through the
whole account resolution at that time).

While this is essentially a workaround for a bug in other software, it's a simple workaround whereas fixing Twidere would be more involved. In addition, it also fixes some inconsistency in Mastodon: it is somewhat dubious for Mastodon to manage to resolve the account in one place (`ProcessMentionsService`) and fail in another (status serialization).

Lastly, this PR depends on #5539 but that could be changed.