### PR TITLE
Change 2FA input to use "number" type

### DIFF
--- a/app/views/auth/sessions/two_factor.html.haml
+++ b/app/views/auth/sessions/two_factor.html.haml
@@ -2,7 +2,7 @@
   = t('auth.login')
 
 = simple_form_for(resource, as: resource_name, url: session_path(resource_name), method: :post) do |f|
-  = f.input :otp_attempt, type: :number, placeholder: t('simple_form.labels.defaults.otp_attempt'), input_html: { 'aria-label' => t('simple_form.labels.defaults.otp_attempt'), :autocomplete => 'off' }, required: true, autofocus: true, hint: t('simple_form.hints.sessions.otp')
+  = f.input :otp_attempt, type: :number, placeholder: t('simple_form.labels.defaults.otp_attempt'), input_html: { 'aria-label' => t('simple_form.labels.defaults.otp_attempt'), :autocomplete => 'off', type: 'number' }, required: true, autofocus: true, hint: t('simple_form.hints.sessions.otp')
 
   .actions
     = f.button :button, t('auth.login'), type: :submit

--- a/app/views/settings/two_factor_authentication/confirmations/new.html.haml
+++ b/app/views/settings/two_factor_authentication/confirmations/new.html.haml
@@ -11,7 +11,7 @@
       %p.hint= t('two_factor_authentication.manual_instructions')
       %samp.qr-alternative__code= current_user.otp_secret.scan(/.{4}/).join(' ')
 
-  = f.input :code, hint: t('two_factor_authentication.code_hint'), placeholder: t('simple_form.labels.defaults.otp_attempt'), input_html: { :autocomplete => 'off' }
+  = f.input :code, hint: t('two_factor_authentication.code_hint'), placeholder: t('simple_form.labels.defaults.otp_attempt'), input_html: { :autocomplete => 'off', type: 'number' }
 
   .actions
     = f.button :button, t('two_factor_authentication.enable'), type: :submit

--- a/app/views/settings/two_factor_authentications/show.html.haml
+++ b/app/views/settings/two_factor_authentications/show.html.haml
@@ -10,7 +10,7 @@
   %hr/
 
   = simple_form_for @confirmation, url: settings_two_factor_authentication_path, method: :delete do |f|
-    = f.input :code, hint: t('two_factor_authentication.code_hint'), placeholder: t('simple_form.labels.defaults.otp_attempt'), input_html: { :autocomplete => 'off' }
+    = f.input :code, hint: t('two_factor_authentication.code_hint'), placeholder: t('simple_form.labels.defaults.otp_attempt'), input_html: { :autocomplete => 'off', type: 'number' }
 
     .actions
       = f.button :button, t('two_factor_authentication.disable'), type: :submit


### PR DESCRIPTION
Fixes #5527

Here's what mobile Chrome looks like:

![chrome](https://user-images.githubusercontent.com/283842/32146584-c0c156ae-bc96-11e7-8b68-494a4fa383b2.png)

And it also works in mobile Firefox:

![firefox](https://user-images.githubusercontent.com/283842/32146663-06743008-bc98-11e7-87e3-29a3ed013e54.png)

It doesn't seem to work on iOS for some reason:

![screenshot 2017 10 29 11 14 13](https://user-images.githubusercontent.com/283842/32146823-a6d9306e-bc9a-11e7-89d9-b20cbd53fdd8.png)


On some desktop browsers (Chrome, Firefox, Safari – see below) there is now a +/- toggle to increase or decrease the number, but I don't think it's a big deal, and it's nice to have the numeric keypad on mobile. In most cases people will just be copy-pasting this anyway.

![screens](https://user-images.githubusercontent.com/283842/32146662-02559836-bc98-11e7-91cb-ce1b5af850db.png)
