### PR TITLE
don't display any descendants of .invisible

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -246,11 +246,9 @@
   position: absolute;
 
   img, svg {
-    display: inline-block !important;
     margin: 0 !important;
     border: 0 !important;
     padding: 0 !important;
-    font-size: 0 !important;
     width: 0 !important;
     height: 0 !important;
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -245,7 +245,8 @@
   height: 0;
   position: absolute;
 
-  img, svg {
+  img,
+  svg {
     margin: 0 !important;
     border: 0 !important;
     padding: 0 !important;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -244,6 +244,16 @@
   width: 0;
   height: 0;
   position: absolute;
+
+  * {
+    display: inline-block !important;
+    margin: 0 !important;
+    border: 0 !important;
+    padding: 0 !important;
+    font-size: 0 !important;
+    width: 0 !important;
+    height: 0 !important;
+  }
 }
 
 .ellipsis {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -245,7 +245,7 @@
   height: 0;
   position: absolute;
 
-  * {
+  img, svg {
     display: inline-block !important;
     margin: 0 !important;
     border: 0 !important;


### PR DESCRIPTION
This is an alternative to #5558 for resolving #5553, #5554.
#5558 will break when `span` is nested. Also, if images is inserted into the `.invisible` by another bug, It will be displayed.
Using `!important` rule is generally considered a bad practice. However, it's rare to apply other styles to hidden elements, so this is OK, probably...