### PR TITLE
 Do not emojify short code preceeded or succeeded by [:space:]

### DIFF
--- a/app/javascript/mastodon/features/emoji/__tests__/emoji-test.js
+++ b/app/javascript/mastodon/features/emoji/__tests__/emoji-test.js
@@ -45,6 +45,30 @@ describe('emoji', () => {
       expect(emojify('<p data-foo="\uD83D\uDC69\uD83D\uDC69\uD83D\uDC66"></p>')).toEqual('<p data-foo="\uD83D\uDC69\uD83D\uDC69\uD83D\uDC66"></p>');
     });
 
+    it('does custom emoji without surrounding characters', () => {
+      expect(emojify(':emojo:', { ':emojo:': { static_url: 'emojo.png' } })).toEqual('<img draggable="false" class="emojione" alt=":emojo:" title=":emojo:" src="emojo.png" />');
+    });
+
+    it('does custom emoji with surrounding HTML tags', () => {
+      expect(emojify('<p>:emojo:</p>', { ':emojo:': { static_url: 'emojo.png' } })).toEqual('<p><img draggable="false" class="emojione" alt=":emojo:" title=":emojo:" src="emojo.png" /></p>');
+    });
+
+    it('does custom emoji with surrounding spaces', () => {
+      expect(emojify(' :emojo: ', { ':emojo:': { static_url: 'emojo.png' } })).toEqual(' <img draggable="false" class="emojione" alt=":emojo:" title=":emojo:" src="emojo.png" /> ');
+    });
+
+    it('does custom emoji with preceeding :', () => {
+      expect(emojify(': :emojo:', { ':emojo:': { static_url: 'emojo.png' } })).toEqual(': <img draggable="false" class="emojione" alt=":emojo:" title=":emojo:" src="emojo.png" />');
+    });
+
+    it('does not custom emoji with non-space character immediately before', () => {
+      expect(emojify('emojo:emojo:', { ':emojo:': { static_url: 'emojo.png' } })).toEqual('emojo:emojo:');
+    });
+
+    it('does not custom emoji with non-space character immediately after', () => {
+      expect(emojify(':emojo:emojo', { ':emojo:': { static_url: 'emojo.png' } })).toEqual(':emojo:emojo');
+    });
+
     it('does multiple emoji properly (issue 5188)', () => {
       expect(emojify('👌🌈💕')).toEqual('<img draggable="false" class="emojione" alt="👌" title=":ok_hand:" src="/emoji/1f44c.svg" /><img draggable="false" class="emojione" alt="🌈" title=":rainbow:" src="/emoji/1f308.svg" /><img draggable="false" class="emojione" alt="💕" title=":two_hearts:" src="/emoji/1f495.svg" />');
       expect(emojify('👌 🌈 💕')).toEqual('<img draggable="false" class="emojione" alt="👌" title=":ok_hand:" src="/emoji/1f44c.svg" /> <img draggable="false" class="emojione" alt="🌈" title=":rainbow:" src="/emoji/1f308.svg" /> <img draggable="false" class="emojione" alt="💕" title=":two_hearts:" src="/emoji/1f495.svg" />');

--- a/app/javascript/mastodon/features/emoji/emoji.js
+++ b/app/javascript/mastodon/features/emoji/emoji.js
@@ -9,11 +9,19 @@ const assetHost = process.env.CDN_HOST || '';
 const emojify = (str, customEmojis = {}) => {
   const tagCharsWithoutEmojis = '<&';
   const tagCharsWithEmojis = Object.keys(customEmojis).length ? '<&:' : '<&';
-  let rtn = '', tagChars = tagCharsWithEmojis;
+  let rtn = '', i, shortCodeStart, tagChars = tagCharsWithEmojis, invisible = 0;
+
+  if (str[0] === ':') {
+    i = 1;
+    shortCodeStart = 0;
+  } else {
+    i = 0;
+    shortCodeStart = null;
+  }
 
   // This loop initializes the internal state.
   for (;;) {
-    let i = 0, shortCodeStart = null, invisible = 0;
+    const allowedAroundShortCode = '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\u0009\u000a\u000b\u000c\u000d';
 
     // This loop looks for:
     // 1. the end of the string and
@@ -28,58 +36,63 @@ const emojify = (str, customEmojis = {}) => {
       }
 
       const tag = tagChars.indexOf(str[i]);
-      if (tag < 0) {
-        if (invisible <= 0) {
-          const match = trie.search(str.slice(i));
-          if (match) {
-            // An Unicode emoji was matched to.
+      if (tag === 2) {
+        const shortCodeEnd = i + 1;
 
-            const { filename, shortCode } = unicodeMapping[match];
-            const title = shortCode ? `:${shortCode}:` : '';
-            rtn += str.slice(0, i) + `<img draggable="false" class="emojione" alt="${match}" title="${title}" src="${assetHost}/emoji/${filename}.svg" />`;
-            i += match.length;
+        if (shortCodeStart !== null &&
+            (allowedAroundShortCode.includes(str[shortCodeEnd]) || shortCodeEnd >= str.length)) {
+          // Shortcode ended without any intrusive strings.
+
+          // Get replacee as ':shortCode:'
+          const shortCode = str.slice(shortCodeStart, shortCodeEnd);
+
+          if (shortCode in customEmojis) {
+            const filename = autoPlayGif ? customEmojis[shortCode].url : customEmojis[shortCode].static_url;
+            rtn += str.slice(0, shortCodeStart) + `<img draggable="false" class="emojione" alt="${shortCode}" title="${shortCode}" src="${filename}" />`;
+            i++;
             break;
           }
         }
-      } else if (tag < 2) {
+
+        if (allowedAroundShortCode.includes(str[i - 1])) {
+          // Short code started.
+
+          // Note that it is just a "candidate"; there may not be an ending
+          // colon and the end of the string, an HTML tag, or a Unicode emoji
+          // may appear. Therefore here just mark the start and continue the
+          // loop.
+          shortCodeStart = i;
+        }
+      } else if (tag >= 0) {
         // An HTML tag started. Look for its end and advance i after that if
         // found.
         const rend = str.indexOf('>;'[tag], i + 1) + 1;
         if (rend) {
-          if (invisible) {
-            if (str[i + 1] === '/') {
-              if (!--invisible) {
-                tagChars = tagCharsWithEmojis;
-              }
-            } else if (str[rend - 2] !== '/') {
-              invisible++;
+          if (!invisible) {
+            if (str.startsWith('<span class="invisible">', i)) {
+              invisible = 1;
+              tagChars = tagCharsWithoutEmojis;
             }
-          } else if (str.startsWith('<span class="invisible">', i)) {
-            invisible = 1;
-            tagChars = tagCharsWithoutEmojis;
+          } else if (str[i + 1] === '/') {
+            if (!--invisible) {
+              tagChars = tagCharsWithEmojis;
+            }
+          } else if (str[rend - 2] !== '/') {
+            invisible++;
           }
 
           i = rend;
           continue;
         }
-      } else if (shortCodeStart === null) {
-        // Short code started.
+      } else if (invisible <= 0) {
+        const match = trie.search(str.slice(i));
+        if (match) {
+          // An Unicode emoji was matched to.
 
-        // Note that it is just a "candidate"; there may not be an ending
-        // colon and the end of the string, an HTML tag, or a Unicode emoji
-        // may appear. Therefore here just mark the start and continue the
-        // loop.
-        shortCodeStart = i;
-      } else {
-        // Shortcode ended without any intrusive strings.
-
-        // Get replacee as ':shortCode:'
-        const shortCode = str.slice(shortCodeStart, i + 1);
-
-        if (shortCode in customEmojis) {
-          const filename = autoPlayGif ? customEmojis[shortCode].url : customEmojis[shortCode].static_url;
-          rtn += str.slice(0, shortCodeStart) + `<img draggable="false" class="emojione" alt="${shortCode}" title="${shortCode}" src="${filename}" />`;
-          i++;
+          const { filename, shortCode } = unicodeMapping[match];
+          const title = shortCode ? `:${shortCode}:` : '';
+          rtn += str.slice(0, i) + `<img draggable="false" class="emojione" alt="${match}" title="${title}" src="${assetHost}/emoji/${filename}.svg" />`;
+          i += match.length;
           break;
         }
       }
@@ -89,6 +102,9 @@ const emojify = (str, customEmojis = {}) => {
 
     // Slice the remainder.
     str = str.slice(i);
+
+    i = 0;
+    shortCodeStart = null;
   }
 };
 

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -21,9 +21,13 @@
 class CustomEmoji < ApplicationRecord
   SHORTCODE_RE_FRAGMENT = '[a-zA-Z0-9_]{2,}'
 
-  SCAN_RE = /(?<=[^[:alnum:]:]|\n|^)
+  HTML_SCAN_RE = /(?<=>|[[:space:]]|^)
     :(#{SHORTCODE_RE_FRAGMENT}):
-    (?=[^[:alnum:]:]|$)/x
+    (?=<|[[:space:]]|$)/x
+
+  RAW_SCAN_RE = /(?<=[[:space:]]|^)
+    :(#{SHORTCODE_RE_FRAGMENT}):
+    (?=[[:space:]]|$)/x
 
   has_one :local_counterpart, -> { where(domain: nil) }, class_name: 'CustomEmoji', primary_key: :shortcode, foreign_key: :shortcode
 
@@ -44,17 +48,5 @@ class CustomEmoji < ApplicationRecord
 
   def object_type
     :emoji
-  end
-
-  class << self
-    def from_text(text, domain)
-      return [] if text.blank?
-
-      shortcodes = text.scan(SCAN_RE).map(&:first).uniq
-
-      return [] if shortcodes.empty?
-
-      where(shortcode: shortcodes, domain: domain, disabled: false)
-    end
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -130,10 +130,6 @@ class Status < ApplicationRecord
     !sensitive? && media_attachments.any?
   end
 
-  def emojis
-    CustomEmoji.from_text([spoiler_text, text].join(' '), account.domain)
-  end
-
   after_create_commit :store_uri, if: :local?
 
   around_create Mastodon::Snowflake::Callbacks

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -23,7 +23,7 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   end
 
   def content
-    Formatter.instance.format(object)
+    formatted[0]
   end
 
   def in_reply_to
@@ -57,7 +57,13 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   end
 
   def virtual_tags
-    object.mentions + object.tags + object.emojis
+    object.mentions +
+      object.tags +
+      CustomEmoji.where(
+        shortcode: formatted[1],
+        domain: object.account.domain,
+        disabled: false
+      )
   end
 
   def atom_uri
@@ -143,5 +149,11 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   end
 
   class CustomEmojiSerializer < ActivityPub::EmojiSerializer
+  end
+
+  private
+
+  def formatted
+    @formatted ||= Formatter.instance.format(object)
   end
 end

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -40,7 +40,15 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def content
-    Formatter.instance.format(object)
+    formatted[0]
+  end
+
+  def emojis
+    CustomEmoji.where(
+      shortcode: formatted[1],
+      domain: object.account.domain,
+      disabled: false
+    )
   end
 
   def url
@@ -118,5 +126,11 @@ class REST::StatusSerializer < ActiveModel::Serializer
     def url
       tag_url(object)
     end
+  end
+
+  private
+
+  def formatted
+    @formatted ||= Formatter.instance.format(object)
   end
 end

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -17,7 +17,7 @@
       %p{ style: 'margin-bottom: 0' }<
         %span.p-summary> #{Formatter.instance.format_spoiler(status)}&nbsp;
         %a.status__content__spoiler-link{ href: '#' }= t('statuses.show_more')
-    .e-content{ lang: status.language, style: "display: #{status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl_status?(status) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status, custom_emojify: true)
+    .e-content{ lang: status.language, style: "display: #{status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl_status?(status) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status, custom_emojify: true)[0]
 
   - if !status.media_attachments.empty?
     - if status.media_attachments.first.video?

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -18,7 +18,7 @@
       %p{ style: 'margin-bottom: 0' }<
         %span.p-summary> #{Formatter.instance.format_spoiler(status)}&nbsp;
         %a.status__content__spoiler-link{ href: '#' }= t('statuses.show_more')
-    .e-content{ lang: status.language, style: "display: #{status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl_status?(status) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status, custom_emojify: true)
+    .e-content{ lang: status.language, style: "display: #{status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl_status?(status) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status, custom_emojify: true)[0]
 
   - unless status.media_attachments.empty?
     - if status.media_attachments.first.video?

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe ActivityPub::Activity::Create do
         status = sender.statuses.first
 
         expect(status).to_not be_nil
-        expect(status.emojis.map(&:shortcode)).to include('tinking')
+        expect(CustomEmoji.where(shortcode: 'tinking')).to exist
       end
     end
 

--- a/spec/lib/extractor_spec.rb
+++ b/spec/lib/extractor_spec.rb
@@ -69,11 +69,36 @@ describe Extractor do
     end
   end
 
-  describe 'extract_cashtags_with_indices' do
-    it 'returns []' do
-      text = '$cashtag'
-      extracted = Extractor.extract_cashtags_with_indices(text)
-      expect(extracted).to eq []
+  describe 'extract_shortcodes_with_indices' do
+    it 'returns shortcodes surrounded by HTML tag if it is in HTML' do
+      text = '<p>Hello :coolcat:</p>'
+      extracted = Extractor.extract_shortcodes_with_indices(text, html: true)
+      expect(extracted).to eq [
+        { shortcode: 'coolcat', indices: [ 9, 18 ] }
+      ]
+    end
+
+    it 'does not return shortcodes surrounded by HTML tag if it is not in HTML' do
+      text = '<p>Hello :coolcat:</p>'
+      extracted = Extractor.extract_shortcodes_with_indices(text, html: false)
+      expect(extracted).to be_empty
+    end
+
+    it 'returns shortcodes as an array' do
+      text = 'Hello :coolcat:'
+      extracted = Extractor.extract_shortcodes_with_indices(text)
+      expect(extracted).to eq [
+        { shortcode: 'coolcat', indices: [ 6, 15 ] }
+      ]
+    end
+
+    it 'yields shortcodes if a block is given' do
+      text = 'Hello :coolcat:'
+      Extractor.extract_mentions_or_lists_with_indices(text) do |shortcode, start_position, end_position|
+        expect(shortcode).to eq 'coolcat'
+        expect(start_position).to eq 6
+        expect(end_position).to eq 14
+      end
     end
   end
 end

--- a/spec/models/custom_emoji_spec.rb
+++ b/spec/models/custom_emoji_spec.rb
@@ -29,26 +29,4 @@ RSpec.describe CustomEmoji, type: :model do
       expect(custom_emoji.object_type).to be :emoji
     end
   end
-
-  describe '.from_text' do
-    let!(:emojo) { Fabricate(:custom_emoji) }
-
-    subject { described_class.from_text(text, nil) }
-
-    context 'with plain text' do
-      let(:text) { 'Hello :coolcat:' }
-
-      it 'returns records used via shortcodes in text' do
-        is_expected.to include(emojo)
-      end
-    end
-
-    context 'with html' do
-      let(:text) { '<p>Hello :coolcat:</p>' }
-
-      it 'returns records used via shortcodes in text' do
-        is_expected.to include(emojo)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Resolves #5528. This involves a breaking change to replace `[^[:alnum:]]` with `[[:space:]]` in the regular expression used on the server side.