### PR TITLE
Fix WebPushNotificationWorker failing with 500 Error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
       multi_json (~> 1.11)
       rdf (~> 2.2)
     jsonapi-renderer (0.1.3)
-    jwt (2.1.0)
+    jwt (1.5.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)


### PR DESCRIPTION
Fix regression from #5566.

jwt 2.1.0 still does not work well.
So, revert jwt version(2.1.0 -> 1.5.6)

ref. https://github.com/zaru/webpush/issues/42