### PR TITLE
Do not process undeliverable mentions

### DIFF
--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -11,15 +11,10 @@ class ProcessMentionsService < BaseService
     return unless status.local?
 
     status.text.scan(Account::MENTION_RE).each do |match|
-      username, domain  = match.first.split('@')
-      mentioned_account = Account.find_remote(username, domain)
-
-      if mentioned_account.nil? && !domain.nil?
-        begin
-          mentioned_account = resolve_remote_account_service.call(match.first.to_s)
-        rescue Goldfinger::Error, HTTP::Error
-          mentioned_account = nil
-        end
+      begin
+        mentioned_account = resolve_remote_account_service.call(match.first.to_s)
+      rescue Goldfinger::Error, HTTP::Error
+        mentioned_account = nil
       end
 
       next if mentioned_account.nil?

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -17,7 +17,7 @@ class ProcessMentionsService < BaseService
         mentioned_account = nil
       end
 
-      next if mentioned_account.nil?
+      next if mentioned_account.nil? || (mentioned_account.ostatus? && status.stream_entry.hidden?)
 
       mentioned_account.mentions.where(status: status).first_or_create(status: status)
     end


### PR DESCRIPTION
This is a hotfix for #5535. It skips processing/rendering mentions for remote OStatus users so that at a user knows that something wrong is going on, which is much better than the statu quo (silently dropping messages).

This is still pretty bad design and should be in the long-term replaced by something more informative and more general, such as delivery ack/nack (with some info if possible).

The first commit in this PR is actually #5539, which I hope will be merged soonish :)