### PR TITLE
Show confirmation dialog on leaving WebUI while composing

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -46,7 +46,7 @@ import { defineMessages, injectIntl } from 'react-intl';
 import '../../components/status';
 
 const messages = defineMessages({
-  beforeUnload: { id: 'ui.beforeunload', defaultMessage: 'Your composing text will be lost by leaving from Mastodon.' },
+  beforeUnload: { id: 'ui.beforeunload', defaultMessage: 'Your draft will be lost if you leave Mastodon.' },
 });
 
 const mapStateToProps = state => ({
@@ -107,8 +107,9 @@ export default class UI extends React.Component {
     const { intl, isComposing, hasComposingText } = this.props;
 
     if (isComposing && hasComposingText) {
-      // Now this text won't be displayed to users (except Edge)
-      // but still used as a flag to show a confirmation dialog.
+      // Setting returnValue to any string causes confirmation dialog.
+      // Many browsers no longer display this text to users,
+      // but we set user-friendly message for other browsers, e.g. Edge.
       e.returnValue = intl.formatMessage(messages.beforeUnload);
     }
   }


### PR DESCRIPTION
Currently, Back button and Back hotkey can cause leaving from WebUI, as well as browser's back button. Users may hit those buttons accidentally, and their composing text will be lost.

So this prevents it by showing confirmation dialog from `onbeforeunload` event.

Thoughts:

* Custom message on `returnValue` is only used on Edge. So maybe we can put simple text or blank string.
* `onbeforeunload` can also mitigate #946 #3515, but I don't think it's good because 1) this may not work on mobile and some cases 2) I think it should back to Getting Started or simply ignore instead of unwanted dialog.
* Even this case, we may want to save and load composing text silently without dialog.