### PR TITLE
In remove_remote, exclude removed media attachments.

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -81,7 +81,7 @@ namespace :mastodon do
     task remove_remote: :environment do
       time_ago = ENV.fetch('NUM_DAYS') { 7 }.to_i.days.ago
 
-      MediaAttachment.where.not(remote_url: '').where('created_at < ?', time_ago).find_each do |media|
+      MediaAttachment.where.not(remote_url: '').where.not(file_file_name: nil).where('created_at < ?', time_ago).find_each do |media|
         media.file.destroy
         media.save
       end


### PR DESCRIPTION
Execute remove_remote, all media_attachments were destroyed now.
It takes very long times and the time may increase linear by time.
But it may contain erased one (by previous remove_remote).

`.where(file_file_name: nil)` means remote-only attachments, so no problem to exclude them from destroy.