### PR TITLE
Selectable federate mode

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -48,7 +48,11 @@ class AccountsController < ApplicationController
   end
 
   def default_statuses
-    @account.statuses.where(visibility: [:public, :unlisted])
+    if current_account.nil?
+      @account.statuses.where(visibility: [:public, :unlisted], federate: true)
+    else
+      @account.statuses.where(visibility: [:public, :unlisted])
+    end
   end
 
   def only_media_scope

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -45,6 +45,7 @@ class Api::V1::StatusesController < Api::BaseController
                                          media_ids: status_params[:media_ids],
                                          sensitive: status_params[:sensitive],
                                          spoiler_text: status_params[:spoiler_text],
+                                         federate: status_params[:federate],
                                          visibility: status_params[:visibility],
                                          application: doorkeeper_token.application,
                                          idempotency: request.headers['Idempotency-Key'])
@@ -72,7 +73,7 @@ class Api::V1::StatusesController < Api::BaseController
   end
 
   def status_params
-    params.permit(:status, :in_reply_to_id, :sensitive, :spoiler_text, :visibility, media_ids: [])
+    params.permit(:status, :in_reply_to_id, :sensitive, :spoiler_text, :federate, :visibility, media_ids: [])
   end
 
   def pagination_params(core_params)

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -34,6 +34,7 @@ export const COMPOSE_UNMOUNT = 'COMPOSE_UNMOUNT';
 export const COMPOSE_SENSITIVITY_CHANGE = 'COMPOSE_SENSITIVITY_CHANGE';
 export const COMPOSE_SPOILERNESS_CHANGE = 'COMPOSE_SPOILERNESS_CHANGE';
 export const COMPOSE_SPOILER_TEXT_CHANGE = 'COMPOSE_SPOILER_TEXT_CHANGE';
+export const COMPOSE_FEDERATE_CHANGE  = 'COMPOSE_FEDERATE_CHANGE';
 export const COMPOSE_VISIBILITY_CHANGE  = 'COMPOSE_VISIBILITY_CHANGE';
 export const COMPOSE_LISTABILITY_CHANGE = 'COMPOSE_LISTABILITY_CHANGE';
 export const COMPOSE_COMPOSING_CHANGE = 'COMPOSE_COMPOSING_CHANGE';
@@ -105,6 +106,7 @@ export function submitCompose() {
       media_ids: getState().getIn(['compose', 'media_attachments']).map(item => item.get('id')),
       sensitive: getState().getIn(['compose', 'sensitive']),
       spoiler_text: getState().getIn(['compose', 'spoiler_text'], ''),
+      federate: getState().getIn(['compose', 'federate']),
       visibility: getState().getIn(['compose', 'privacy']),
     }, {
       headers: {
@@ -350,6 +352,12 @@ export function changeComposeSpoilerText(text) {
   return {
     type: COMPOSE_SPOILER_TEXT_CHANGE,
     text,
+  };
+};
+
+export function changeComposeFederate() {
+  return {
+    type: COMPOSE_FEDERATE_CHANGE,
   };
 };
 

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { injectIntl, defineMessages } from 'react-intl';
 import IconButton from '../../../components/icon_button';
+import PrivacySettingsToggleContainer from '../containers/privacy_settings_toggle_container';
 import Overlay from 'react-overlays/lib/Overlay';
 import Motion from '../../ui/util/optional_motion';
 import spring from 'react-motion/lib/spring';
@@ -28,6 +30,7 @@ class PrivacyDropdownMenu extends React.PureComponent {
     style: PropTypes.object,
     items: PropTypes.array.isRequired,
     value: PropTypes.string.isRequired,
+    settings: ImmutablePropTypes.map.isRequired,
     onClose: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
   };
@@ -72,6 +75,7 @@ class PrivacyDropdownMenu extends React.PureComponent {
       <Motion defaultStyle={{ opacity: 0, scaleX: 0.85, scaleY: 0.75 }} style={{ opacity: spring(1, { damping: 35, stiffness: 400 }), scaleX: spring(1, { damping: 35, stiffness: 400 }), scaleY: spring(1, { damping: 35, stiffness: 400 }) }}>
         {({ opacity, scaleX, scaleY }) => (
           <div className='privacy-dropdown__dropdown' style={{ ...style, opacity: opacity, transform: `scale(${scaleX}, ${scaleY})` }} ref={this.setRef}>
+            <PrivacySettingsToggleContainer />
             {items.map(item =>
               <div role='button' tabIndex='0' key={item.value} data-index={item.value} onKeyDown={this.handleClick} onClick={this.handleClick} className={classNames('privacy-dropdown__option', { active: item.value === value })}>
                 <div className='privacy-dropdown__option__icon'>
@@ -100,6 +104,7 @@ export default class PrivacyDropdown extends React.PureComponent {
     isModalOpen: PropTypes.bool.isRequired,
     onModalOpen: PropTypes.func,
     onModalClose: PropTypes.func,
+    settings: ImmutablePropTypes.map.isRequired,
     value: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
@@ -117,6 +122,7 @@ export default class PrivacyDropdown extends React.PureComponent {
         this.props.onModalOpen({
           actions: this.options.map(option => ({ ...option, active: option.value === this.props.value })),
           onClick: this.handleModalActionClick,
+          object: <PrivacySettingsToggleContainer />,
         });
       }
     } else {
@@ -164,7 +170,7 @@ export default class PrivacyDropdown extends React.PureComponent {
   }
 
   render () {
-    const { value, intl } = this.props;
+    const { value, intl, settings } = this.props;
     const { open } = this.state;
 
     const valueOption = this.options.find(item => item.value === value);
@@ -189,6 +195,7 @@ export default class PrivacyDropdown extends React.PureComponent {
           <PrivacyDropdownMenu
             items={this.options}
             value={value}
+            settings={settings}
             onClose={this.handleClose}
             onChange={this.handleChange}
           />

--- a/app/javascript/mastodon/features/compose/components/privacy_settings_toggle.js
+++ b/app/javascript/mastodon/features/compose/components/privacy_settings_toggle.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { FormattedMessage } from 'react-intl';
+import SettingToggle from '../../notifications/components/setting_toggle';
+
+export default class PrivacySettingsToggle extends React.PureComponent {
+
+  static propTypes = {
+    settings: ImmutablePropTypes.map.isRequired,
+    onChange: PropTypes.func.isRequired,
+  };
+
+  render () {
+    const { settings, onChange } = this.props;
+
+    const federateStr = <FormattedMessage id='privacy.federate' defaultMessage='Deliver to other instances' />;
+
+    return (
+      <div className='privacy-dropdown__federate'>
+        <SettingToggle settings={settings} settingKey={['federate']} onChange={onChange} label={federateStr} />
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -17,6 +17,7 @@ const mapStateToProps = state => ({
   suggestions: state.getIn(['compose', 'suggestions']),
   spoiler: state.getIn(['compose', 'spoiler']),
   spoiler_text: state.getIn(['compose', 'spoiler_text']),
+  federate: state.getIn(['compose', 'federate']),
   privacy: state.getIn(['compose', 'privacy']),
   focusDate: state.getIn(['compose', 'focusDate']),
   preselectDate: state.getIn(['compose', 'preselectDate']),

--- a/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
@@ -7,6 +7,7 @@ import { isUserTouching } from '../../../is_mobile';
 const mapStateToProps = state => ({
   isModalOpen: state.get('modal').modalType === 'ACTIONS',
   value: state.getIn(['compose', 'privacy']),
+  settings: state,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/compose/containers/privacy_settings_toggle_container.js
+++ b/app/javascript/mastodon/features/compose/containers/privacy_settings_toggle_container.js
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux';
+import PrivacySettingsToggle from '../components/privacy_settings_toggle';
+import { changeComposeFederate } from '../../../actions/compose';
+
+const mapStateToProps = state => ({
+  settings: state.getIn(['compose']),
+});
+
+const mapDispatchToProps = dispatch => ({
+
+  onChange () {
+    dispatch(changeComposeFederate());
+  },
+
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(PrivacySettingsToggle);

--- a/app/javascript/mastodon/features/ui/components/actions_modal.js
+++ b/app/javascript/mastodon/features/ui/components/actions_modal.js
@@ -15,6 +15,7 @@ export default class ActionsModal extends ImmutablePureComponent {
     status: ImmutablePropTypes.map,
     actions: PropTypes.array,
     onClick: PropTypes.func,
+    object: PropTypes.object,
   };
 
   renderAction = (action, i) => {
@@ -59,10 +60,12 @@ export default class ActionsModal extends ImmutablePureComponent {
         <StatusContent status={this.props.status} />
       </div>
     );
+    const object = this.props.object;
 
     return (
       <div className='modal-root__modal actions-modal'>
         {status}
+        {object}
 
         <ul>
           {this.props.actions.map(this.renderAction)}

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -151,6 +151,7 @@
   "onboarding.page_two.compose": "Write posts from the compose column. You can upload images, change privacy settings, and add content warnings with the icons below.",
   "onboarding.skip": "Skip",
   "privacy.change": "Adjust status privacy",
+  "privacy.federate": "Deliver to other instances",
   "privacy.direct.long": "Post to mentioned users only",
   "privacy.direct.short": "Direct",
   "privacy.private.long": "Post to followers only",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -151,6 +151,7 @@
   "onboarding.page_two.compose": "フォームから投稿できます。イメージや、公開範囲の設定や、表示時の警告の設定は下部のアイコンから行なえます。",
   "onboarding.skip": "スキップ",
   "privacy.change": "投稿のプライバシーを変更",
+  "privacy.federate": "他のインスタンスにも配送する",
   "privacy.direct.long": "メンションしたユーザーだけに公開",
   "privacy.direct.short": "ダイレクト",
   "privacy.private.long": "フォロワーだけに公開",

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -19,6 +19,7 @@ import {
   COMPOSE_SENSITIVITY_CHANGE,
   COMPOSE_SPOILERNESS_CHANGE,
   COMPOSE_SPOILER_TEXT_CHANGE,
+  COMPOSE_FEDERATE_CHANGE,
   COMPOSE_VISIBILITY_CHANGE,
   COMPOSE_COMPOSING_CHANGE,
   COMPOSE_EMOJI_INSERT,
@@ -38,6 +39,7 @@ const initialState = ImmutableMap({
   sensitive: false,
   spoiler: false,
   spoiler_text: '',
+  federate: null,
   privacy: null,
   text: '',
   focusDate: null,
@@ -50,6 +52,7 @@ const initialState = ImmutableMap({
   media_attachments: ImmutableList(),
   suggestion_token: null,
   suggestions: ImmutableList(),
+  default_federate: true,
   default_privacy: 'public',
   default_sensitive: false,
   resetFileKey: Math.floor((Math.random() * 0x10000)),
@@ -73,6 +76,7 @@ function clearAll(state) {
     map.set('spoiler_text', '');
     map.set('is_submitting', false);
     map.set('in_reply_to', null);
+    map.set('federate', state.get('default_federate'));
     map.set('privacy', state.get('default_privacy'));
     map.set('sensitive', false);
     map.update('media_attachments', list => list.clear());
@@ -186,6 +190,10 @@ export default function compose(state = initialState, action) {
     return state
       .set('spoiler_text', action.text)
       .set('idempotencyKey', uuid());
+  case COMPOSE_FEDERATE_CHANGE:
+    return state
+      .set('federate', !state.get('federate'))
+      .set('idempotencyKey', uuid());
   case COMPOSE_VISIBILITY_CHANGE:
     return state
       .set('privacy', action.value)
@@ -200,6 +208,7 @@ export default function compose(state = initialState, action) {
     return state.withMutations(map => {
       map.set('in_reply_to', action.status.get('id'));
       map.set('text', statusToTextMentions(state, action.status));
+      map.set('federate', action.status.get('federate') && state.get('default_federate'));
       map.set('privacy', privacyPreference(action.status.get('visibility'), state.get('default_privacy')));
       map.set('focusDate', new Date());
       map.set('preselectDate', new Date());
@@ -220,6 +229,7 @@ export default function compose(state = initialState, action) {
       map.set('text', '');
       map.set('spoiler', false);
       map.set('spoiler_text', '');
+      map.set('federate', state.get('default_federate'));
       map.set('privacy', state.get('default_privacy'));
       map.set('idempotencyKey', uuid());
     });

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2905,6 +2905,11 @@ button.icon-button.active i.fa-retweet {
   overflow: hidden;
 }
 
+.privacy-dropdown__federate {
+  padding: 10px;
+  cursor: pointer;
+}
+
 .privacy-dropdown__option {
   color: $ui-base-color;
   padding: 10px;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -94,6 +94,10 @@ class User < ApplicationRecord
     super && !disabled?
   end
 
+  def setting_default_federate
+    settings.default_federate
+  end
+
   def setting_default_privacy
     settings.default_privacy || (account.locked? ? 'private' : 'public')
   end

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -13,8 +13,10 @@ class StatusPolicy
       owned? || status.mentions.where(account: account).exists?
     elsif private?
       owned? || account&.following?(status.account) || status.mentions.where(account: account).exists?
+    elsif !federate?
+      !account.nil? && !blocked?
     else
-      account.nil? || !status.account.blocking?(account)
+      account.nil? || !blocked?
     end
   end
 
@@ -44,5 +46,13 @@ class StatusPolicy
 
   def private?
     status.private_visibility?
+  end
+
+  def federate?
+    status.federate?
+  end
+
+  def blocked?
+    status.account.blocking?(account)
   end
 end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -36,6 +36,7 @@ class InitialStateSerializer < ActiveModel::Serializer
 
     if object.current_account
       store[:me]                = object.current_account.id.to_s
+      store[:default_federate]   = object.current_account.user.setting_default_federate
       store[:default_privacy]   = object.current_account.user.setting_default_privacy
       store[:default_sensitive] = object.current_account.user.setting_default_sensitive
     end

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -2,7 +2,7 @@
 
 class REST::StatusSerializer < ActiveModel::Serializer
   attributes :id, :created_at, :in_reply_to_id, :in_reply_to_account_id,
-             :sensitive, :spoiler_text, :visibility, :language,
+             :sensitive, :spoiler_text, :federate, :visibility, :language,
              :uri, :content, :url, :reblogs_count, :favourites_count
 
   attribute :favourited, if: :current_user?

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -27,6 +27,7 @@ class PostStatusService < BaseService
                                         thread: in_reply_to,
                                         sensitive: options[:sensitive],
                                         spoiler_text: options[:spoiler_text] || '',
+                                        federate: options[:federate].nil? ? Setting.default_federate : options[:federate],
                                         visibility: options[:visibility] || account.user&.setting_default_privacy,
                                         language: LanguageDetector.instance.detect(text, account),
                                         application: options[:application])

--- a/app/workers/activitypub/distribution_worker.rb
+++ b/app/workers/activitypub/distribution_worker.rb
@@ -21,7 +21,7 @@ class ActivityPub::DistributionWorker
   private
 
   def skip_distribution?
-    @status.direct_visibility?
+    @status.direct_visibility? || !@status.federate?
   end
 
   def inboxes

--- a/app/workers/activitypub/reply_distribution_worker.rb
+++ b/app/workers/activitypub/reply_distribution_worker.rb
@@ -21,7 +21,7 @@ class ActivityPub::ReplyDistributionWorker
   private
 
   def skip_distribution?
-    @status.private_visibility? || @status.direct_visibility?
+    @status.private_visibility? || @status.direct_visibility? || !@status.federate?
   end
 
   def inboxes

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,7 @@ defaults: &defaults
   closed_registrations_message: ''
   open_deletion: true
   timeline_preview: true
+  default_federate: true 
   default_sensitive: false
   unfollow_modal: false
   boost_modal: false

--- a/db/migrate/20171015090310_add_federate_flag.rb
+++ b/db/migrate/20171015090310_add_federate_flag.rb
@@ -1,0 +1,5 @@
+class AddFederateFlag < ActiveRecord::Migration[5.1]
+  def change
+    add_column :statuses, :federate, :boolean, null: true
+  end
+end

--- a/db/migrate/20171106192950_change_status_federate_flag_non_null.rb
+++ b/db/migrate/20171106192950_change_status_federate_flag_non_null.rb
@@ -1,0 +1,12 @@
+class ChangeStatusFederateFlagNonNull < ActiveRecord::Migration[5.1]
+  def up
+    Status.find_in_batches do |statuses|
+      Status.where(federate: nil).update_all federate: true
+    end
+    safety_assured { change_column_null :statuses, :federate, false }
+    safety_assured { change_column_default :statuses, :federate, true }
+  end
+  def down
+    change_column_null :statuses, :federate, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -362,6 +362,7 @@ ActiveRecord::Schema.define(version: 20171107143624) do
     t.bigint "account_id", null: false
     t.bigint "application_id"
     t.bigint "in_reply_to_account_id"
+    t.boolean "federate", default: true, null: false
     t.index ["account_id", "id"], name: "index_statuses_on_account_id_id"
     t.index ["conversation_id"], name: "index_statuses_on_conversation_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe AccountsController, type: :controller do
   render_views
 
   let(:alice)  { Fabricate(:account, username: 'alice') }
+  let(:bob)  { Fabricate(:user) }
+  let(:eve)  { Fabricate(:user) }
 
   describe 'GET #show' do
     let!(:status1) { Status.create!(account: alice, text: 'Hello world') }
@@ -13,99 +15,150 @@ RSpec.describe AccountsController, type: :controller do
     let!(:status5) { Status.create!(account: alice, text: 'Kitsune') }
     let!(:status6) { Status.create!(account: alice, text: 'Neko') }
     let!(:status7) { Status.create!(account: alice, text: 'Tanuki') }
+    let!(:status8) { Status.create!(account: alice, text: 'Local only', federate: false) }
 
     let!(:status_pin1) { StatusPin.create!(account: alice, status: status5, created_at: 5.days.ago) }
     let!(:status_pin2) { StatusPin.create!(account: alice, status: status6, created_at: 2.years.ago) }
     let!(:status_pin3) { StatusPin.create!(account: alice, status: status7, created_at: 10.minutes.ago) }
 
     before do
+      alice.block!(eve.account)
       status3.media_attachments.create!(account: alice, file: fixture_file_upload('files/attachment.jpg', 'image/jpeg'))
     end
 
-    context 'atom' do
+    shared_examples 'responses' do
       before do
-        get :show, params: { username: alice.username, max_id: status4.stream_entry.id, since_id: status1.stream_entry.id }, format: 'atom'
+        sign_in(current_user) if defined? current_user
+        get :show, params: {
+          username: alice.username,
+          max_id: (max_id if defined? max_id),
+          since_id: (since_id if defined? since_id),
+          current_user: (current_user if defined? current_user),
+        }, format: format
       end
 
       it 'assigns @account' do
         expect(assigns(:account)).to eq alice
       end
 
-      it 'assigns @entries' do
-        entries = assigns(:entries).to_a
-        expect(entries.size).to eq 2
-        expect(entries[0].status).to eq status3
-        expect(entries[1].status).to eq status2
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
       end
 
-      it 'returns http success with Atom' do
-        expect(response).to have_http_status(:success)
+      it 'returns correct format' do
+        expect(response.content_type).to eq content_type
+      end
+    end
+
+    context 'atom' do
+      let(:format) { 'atom' }
+      let(:content_type) { 'application/atom+xml' }
+
+      shared_examples 'responsed streams' do
+        it 'assigns @entries' do
+          entries = assigns(:entries).to_a
+          expect(entries.size).to eq expected_statuses.size
+          entries.each.zip(expected_statuses.each) do |entry, expected_status|
+            expect(entry.status).to eq expected_status
+          end
+        end
+      end
+
+      include_examples 'responses'
+
+      context 'without max_id nor since_id' do
+        let(:expected_statuses) { [status7, status6, status5, status4, status3, status2, status1] }
+
+        include_examples 'responsed streams'
+      end
+
+      context 'with anonymous visitor' do
+        context 'with max_id and since_id' do
+          let(:max_id) { status4.stream_entry.id }
+          let(:since_id) { status1.stream_entry.id }
+          let(:expected_statuses) { [status3, status2] }
+
+          include_examples 'responsed streams'
+        end
+
+        context 'without since_id nor max_id' do
+          let(:expected_statuses) { [status7, status6, status5, status4, status3, status2, status1] }
+          let(:expected_pinned_statuses) { [status7, status5, status6] }
+
+          include_examples 'responsed streams'
+        end
       end
     end
 
     context 'activitystreams2' do
-      before do
-        get :show, params: { username: alice.username }, format: 'json'
-      end
+      let(:format) { 'json' }
+      let(:content_type) { 'application/activity+json' }
 
-      it 'assigns @account' do
-        expect(assigns(:account)).to eq alice
-      end
-
-      it 'returns http success with Activity Streams 2.0' do
-        expect(response).to have_http_status(:success)
-      end
-
-      it 'returns application/activity+json' do
-        expect(response.content_type).to eq 'application/activity+json'
-      end
+      include_examples 'responses'
     end
 
-    context 'html without since_id nor max_id' do
-      before do
-        get :show, params: { username: alice.username }
+    context 'html' do
+      let(:format) { nil }
+      let(:content_type) { 'text/html' }
+
+      shared_examples 'responsed statuses' do
+        it 'assigns @pinned_statuses' do
+          pinned_statuses = assigns(:pinned_statuses).to_a
+          expect(pinned_statuses.size).to eq expected_pinned_statuses.size
+          pinned_statuses.each.zip(expected_pinned_statuses.each) do |pinned_status, expected_pinned_status|
+            expect(pinned_status).to eq expected_pinned_status
+          end
+        end
+
+        it 'assigns @statuses' do
+          statuses = assigns(:statuses).to_a
+          expect(statuses.size).to eq expected_statuses.size
+          statuses.each.zip(expected_statuses.each) do |status, expected_status|
+            expect(status).to eq expected_status
+          end
+        end
       end
 
-      it 'assigns @account' do
-        expect(assigns(:account)).to eq alice
+      include_examples 'responses'
+
+      context 'with anonymous visitor' do
+        context 'without since_id nor max_id' do
+          let(:expected_statuses) { [status7, status6, status5, status4, status3, status2, status1] }
+          let(:expected_pinned_statuses) { [status7, status5, status6] }
+
+          include_examples 'responsed statuses'
+        end
+
+        context 'with since_id nor max_id' do
+          let(:max_id) { status4.id }
+          let(:since_id) { status1.id }
+          let(:expected_statuses) { [status3, status2] }
+          let(:expected_pinned_statuses) { [] }
+
+          include_examples 'responsed statuses'
+        end
       end
 
-      it 'assigns @pinned_statuses' do
-        pinned_statuses = assigns(:pinned_statuses).to_a
-        expect(pinned_statuses.size).to eq 3
-        expect(pinned_statuses[0]).to eq status7
-        expect(pinned_statuses[1]).to eq status5
-        expect(pinned_statuses[2]).to eq status6
+      context 'with local visitor' do
+        let(:current_user) { bob }
+
+        context 'without since_id nor max_id' do
+          let(:expected_statuses) { [status8, status7, status6, status5, status4, status3, status2, status1] }
+          let(:expected_pinned_statuses) { [status7, status5, status6] }
+
+          include_examples 'responsed statuses'
+        end
       end
 
-      it 'returns http success' do
-        expect(response).to have_http_status(:success)
-      end
-    end
+      context 'with blocked visitor' do
+        let(:current_user) { eve }
 
-    context 'html with since_id and max_id' do
-      before do
-        get :show, params: { username: alice.username, max_id: status4.id, since_id: status1.id }
-      end
+        context 'without since_id nor max_id' do
+          let(:expected_statuses) { [] }
+          let(:expected_pinned_statuses) { [] }
 
-      it 'assigns @account' do
-        expect(assigns(:account)).to eq alice
-      end
-
-      it 'assigns @statuses' do
-        statuses = assigns(:statuses).to_a
-        expect(statuses.size).to eq 2
-        expect(statuses[0]).to eq status3
-        expect(statuses[1]).to eq status2
-      end
-
-      it 'assigns an empty array to @pinned_statuses' do
-        pinned_statuses = assigns(:pinned_statuses).to_a
-        expect(pinned_statuses.size).to eq 0
-      end
-
-      it 'returns http success' do
-        expect(response).to have_http_status(:success)
+          include_examples 'responsed statuses'
+        end
       end
     end
   end

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe StatusPolicy, type: :model do
       expect(subject).to permit(nil, status)
     end
 
+    it 'denies access for not federated when no viewer' do
+      status.federate = false
+
+      expect(subject).not_to permit(nil, status)
+    end
+
     it 'denies access when viewer is blocked' do
       block = Fabricate(:block)
       status.visibility = :private

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe PostStatusService do
     expect(status.visibility).to eq "private"
   end
 
+  it 'creates a status with the given federate flag' do
+    status = create_status_with_options(federate: false)
+
+    expect(status).to be_persisted
+    expect(status.federate).to eq false
+  end
+
   it 'creates a status for the given application' do
     application = Fabricate(:application)
 

--- a/spec/workers/activitypub/distribution_worker_spec.rb
+++ b/spec/workers/activitypub/distribution_worker_spec.rb
@@ -44,5 +44,16 @@ describe ActivityPub::DistributionWorker do
         expect(ActivityPub::DeliveryWorker).to_not have_received(:push_bulk)
       end
     end
+
+    context 'with unfederate flag' do
+      before do
+        status.update(federate: false)
+      end
+
+      it 'does nothing' do
+        subject.perform(status.id)
+        expect(ActivityPub::DeliveryWorker).to_not have_received(:push_bulk)
+      end
+    end
   end
 end

--- a/spec/workers/pubsubhubbub/distribution_worker_spec.rb
+++ b/spec/workers/pubsubhubbub/distribution_worker_spec.rb
@@ -42,5 +42,15 @@ describe Pubsubhubbub::DistributionWorker do
         expect(Pubsubhubbub::DeliveryWorker).to_not have_received(:push_bulk)
       end
     end
+
+    describe 'with unfederate flag' do
+      let(:status) { Fabricate(:status, account: alice, text: 'Hello', federate: false) }
+
+      it 'does not deliver payload' do
+        allow(Pubsubhubbub::DeliveryWorker).to receive(:push_bulk)
+        subject.perform(status.stream_entry.id)
+        expect(Pubsubhubbub::DeliveryWorker).to_not have_received(:push_bulk)
+      end
+    end
   end
 end


### PR DESCRIPTION
Related Issue: #861 

As argued in above issue, local instance only post is desirable feature for smaller or closed community. This PR enables below:

- select whether to deliver or show the the post to user on other instances, like this pic.

<img src = 'https://mstdn.nanamachi.net/system/media_attachments/files/000/036/671/original/f88ad163618b3795.png' width = '300px' >

- when federate flag is false:

  - neither PuSH nor ActivityPub work for non-reply toot
  - ActivityPub distributes mentions only for mentioned user (like direct message)
  - visitor who do not log in the instance cannot see the toots via any methods below: web, atom or api
  - reblogs will be also unfederated

- federate flag is true in default and modifiable with config/settings.yml
- individual user CANNOT save default settings --- this does NOT mean they cannot choose, but only cannot save.