### PR TITLE
Changed "Toots with replies" to read "Toots and replies"

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
     people_followed_by: People whom %{name} follows
     people_who_follow: People who follow %{name}
     posts: Toots
-    posts_with_replies: Toots with replies
+    posts_with_replies: Toots and replies
     remote_follow: Remote follow
     reserved_username: The username is reserved
     roles:


### PR DESCRIPTION
Changed "Toots with replies" to read "Toots and replies"
This only affects the English translation, but modifying the others wouldn't be much work.
I could do the Japanese one as well

The relevant issue: https://github.com/tootsuite/mastodon/issues/5093