### PR TITLE
ActivityPub: Store the follow request ID in the follow request

### DIFF
--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -6,13 +6,13 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
 
     return if target_account.nil? || !target_account.local? || delete_arrived_first?(@json['id']) || @account.requested?(target_account)
 
+    follow_request = FollowRequest.create!(account: @account, target_account: target_account, remote_id: @json['id'])
+
     # Fast-forward repeat follow requests
     if @account.following?(target_account)
-      AuthorizeFollowService.new.call(@account, target_account, skip_follow_request: true)
+      AuthorizeFollowService.new.call(@account, target_account)
       return
     end
-
-    follow_request = FollowRequest.create!(account: @account, target_account: target_account)
 
     if target_account.locked?
       NotifyService.new.call(target_account, follow_request)

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -8,6 +8,7 @@
 #  account_id        :bigint           not null
 #  id                :bigint           not null, primary key
 #  target_account_id :bigint           not null
+#  remote_id         :string
 #
 
 class FollowRequest < ApplicationRecord

--- a/app/serializers/activitypub/accept_follow_serializer.rb
+++ b/app/serializers/activitypub/accept_follow_serializer.rb
@@ -3,7 +3,8 @@
 class ActivityPub::AcceptFollowSerializer < ActiveModel::Serializer
   attributes :id, :type, :actor
 
-  has_one :object, serializer: ActivityPub::FollowSerializer
+  attribute :remote_id, key: :object
+  delegate :remote_id, to: :object
 
   def id
     [ActivityPub::TagManager.instance.uri_for(object.target_account), '#accepts/follows/', object.id].join

--- a/app/serializers/activitypub/reject_follow_serializer.rb
+++ b/app/serializers/activitypub/reject_follow_serializer.rb
@@ -3,7 +3,8 @@
 class ActivityPub::RejectFollowSerializer < ActiveModel::Serializer
   attributes :id, :type, :actor
 
-  has_one :object, serializer: ActivityPub::FollowSerializer
+  attribute :remote_id, key: :object
+  delegate :remote_id, to: :object
 
   def id
     [ActivityPub::TagManager.instance.uri_for(object.target_account), '#rejects/follows/', object.id].join

--- a/app/services/authorize_follow_service.rb
+++ b/app/services/authorize_follow_service.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
 class AuthorizeFollowService < BaseService
-  def call(source_account, target_account, options = {})
-    if options[:skip_follow_request]
-      follow_request = FollowRequest.new(account: source_account, target_account: target_account)
-    else
-      follow_request = FollowRequest.find_by!(account: source_account, target_account: target_account)
-      follow_request.authorize!
-    end
+  def call(source_account, target_account)
+    follow_request = FollowRequest.find_by!(account: source_account, target_account: target_account)
+    follow_request.authorize!
 
     create_notification(follow_request) unless source_account.local?
     follow_request

--- a/db/migrate/20171112192911_add_remote_id_to_follow_request.rb
+++ b/db/migrate/20171112192911_add_remote_id_to_follow_request.rb
@@ -1,0 +1,5 @@
+class AddRemoteIdToFollowRequest < ActiveRecord::Migration[5.1]
+  def change
+    add_column :follow_requests, :remote_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171109012327) do
+ActiveRecord::Schema.define(version: 20171112192911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -146,6 +146,7 @@ ActiveRecord::Schema.define(version: 20171109012327) do
     t.datetime "updated_at", null: false
     t.bigint "account_id", null: false
     t.bigint "target_account_id", null: false
+    t.string "remote_id"
     t.index ["account_id", "target_account_id"], name: "index_follow_requests_on_account_id_and_target_account_id", unique: true
   end
 


### PR DESCRIPTION
This should fix the issue of outgoing follow accepts having wrong `object` id, by just not serializing the `object` and storing the incoming `id` for the `Follow`:

    {
        "type": "Follow",
        "object": "https://mastodon.example.com/users/puckipedia",
        "actor": "https://kroeg.example.com/users/puckipedia",
        "id": "https://kroeg.example.com/users/puckipedia/status/abcdef"
    }

results in:

    {
        "type": "Accept",
        "actor": "https://mastodon.example.com/users/puckipedia",
        "object": "https://kroeg.example.com/users/puckipedia/status/abcdef",
        "id": "https://mastodon.example.com/users/puckipedia#accepts/follows/123"
    }

Tested by following a Mastodon user from a Kroeg user. Response seemed to be fine.

oh, and sorry @Wxcafe for pointing this at your instance before remembering this was an issue