### PR TITLE
Monkey-patch Paperclip to use GraphicsMagick instead of ImageMagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apk -U upgrade \
     file \
     git \
     icu-libs \
-    imagemagick \
+    graphicsmagick \
     libidn \
     libpq \
     nodejs \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ sudo apt-get install \
   libpq-dev \
   libxml2-dev \
   libxslt1-dev \
-  imagemagick \
+  graphicsmagick \
   nodejs \
   redis-server \
   redis-tools \

--- a/boxfile.yml
+++ b/boxfile.yml
@@ -9,7 +9,7 @@ run.config:
     - nodejs
 
     # for images:
-    - ImageMagick
+    - GraphicsMagick
 
     # for videos:
     - ffmpeg3

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,5 +1,28 @@
 # frozen_string_literal: true
 
+# Monkey-patch Paperclip to use GraphicsMagick instead of ImageMagick
+# Inspired by https://github.com/thoughtbot/paperclip/issues/662#issuecomment-154091686
+module PaperclipGraphicsMagick
+  module Paperclip
+    module Helpers
+      Magick_commands = ['animate', 'compare', 'composite', 'conjure',
+                         'convert', 'display', 'identify', 'import', 'mogrify',
+                         'montage']
+
+      def run(cmd, arguments = "", interpolation_values = {}, local_options = {})
+        if Magick_commands.include?(cmd.to_s)
+          arguments.prepend(cmd + ' ')
+          cmd = 'gm'
+        end
+
+        super
+      end
+    end
+  end
+end
+
+Paperclip.extend PaperclipGraphicsMagick::Paperclip::Helpers
+
 Paperclip.options[:read_timeout] = 60
 
 Paperclip.interpolates :filename do |attachment, style|

--- a/spec/controllers/api/v1/media_controller_spec.rb
+++ b/spec/controllers/api/v1/media_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::MediaController, type: :controller do
 
   describe 'POST #create' do
     describe 'with paperclip errors' do
-      context 'when imagemagick cant identify the file type' do
+      context 'when graphicsmagick cant identify the file type' do
         before do
           expect_any_instance_of(Account).to receive_message_chain(:media_attachments, :create!).and_raise(Paperclip::Errors::NotIdentifiedByImageMagickError)
           post :create, params: { file: fixture_file_upload('files/attachment.jpg', 'image/jpeg') }


### PR DESCRIPTION
GraphicsMagick is generally considered more secure and more efficient than ImageMagick, although I am not sure how much of that is true.
Unfortunately, Paperclip uses ImageMagick, and not GraphicsMagick.
Unless I am mistaken, there is no other way than monkey-patching Paperclip to use GraphicsMagick.

Marking it as work in progress as I am not too sure about the benefits, and I'm not too sure GraphicsMagick is an exact drop-in replacement to ImageMagick for our purposes. I will be running this patch and see if any issue arises.