### PR TITLE
Home from db after limit

### DIFF
--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -8,11 +8,11 @@ class HomeFeed < Feed
   end
 
   def get(limit, max_id = nil, since_id = nil)
-    if redis.exists("account:#{@account.id}:regeneration")
-      from_database(limit, max_id, since_id)
-    else
-      super
+    unless redis.exists("account:#{@account.id}:regeneration")
+      statuses = super
+      return statuses unless statuses.empty?
     end
+    from_database(limit, max_id, since_id)
   end
 
   private

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -18,8 +18,13 @@ class HomeFeed < Feed
   private
 
   def from_database(limit, max_id, since_id)
-    Status.as_home_timeline(@account)
-          .paginate_by_max_id(limit, max_id, since_id)
-          .reject { |status| FeedManager.instance.filter?(:home, status, @account.id) }
+    loop do
+      statuses = Status.as_home_timeline(@account)
+                       .paginate_by_max_id(limit, max_id, since_id)
+      return statuses if statuses.empty?
+      max_id = statuses.last.id
+      statuses = statuses.reject { |status| FeedManager.instance.filter?(:home, status, @account.id) }
+      return statuses unless statuses.empty?
+    end
   end
 end

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe FanOutOnWriteService do
   end
 
   it 'delivers status to local followers' do
-    pending 'some sort of problem in test environment causes this to sometimes fail'
     expect(HomeFeed.new(follower).get(10).map(&:id)).to include status.id
   end
 


### PR DESCRIPTION
This change allows to scroll back past the 400 toots limit of the Redis cache for the Home Timeline.
Indeed, some users like to read all the toots from their timeline, but may be away long enough for it to exceed the 400 toots limit.

This PR is tagged as work in progress as it may be greatly inefficient---although that only affects people actually scrolling past those 400 toots or waiting for the cache to be repopulated.

I guess it would be ideal to move the various filters to the SQL query in `Status#as_home_timeline`.