### PR TITLE
Display toot in timeline if it's from a followed account and mentions us

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -163,6 +163,7 @@ class FeedManager
       should_filter   = !Follow.where(account_id: receiver_id, target_account_id: status.in_reply_to_account_id).exists?         # and I'm not following the person it's a reply to
       should_filter &&= receiver_id != status.in_reply_to_account_id                                                             # and it's not a reply to me
       should_filter &&= status.account_id != status.in_reply_to_account_id                                                       # and it's not a self-reply
+      should_filter &&= !status.mentions.where(account_id: receiver_id).exists?                                                  # and it doesn't mention me
       return should_filter
     elsif status.reblog?                                                                                                         # Filter out a reblog
       should_filter   = Follow.where(account_id: receiver_id, target_account_id: status.account_id, show_reblogs: false).exists? # if the reblogger's reblogs are suppressed


### PR DESCRIPTION
I am not sure whether that is just me, but I'm frequently confused when a public toot from someone appears in my notifications but not in my home timeline. This happens when the toot is a reply to someone not followed.

This pull request changes the behavior to always include in the home timeline toots from people we follow and mentioning us.