### PR TITLE
Refactor remote_follow_spec.rb

### DIFF
--- a/spec/models/remote_follow_spec.rb
+++ b/spec/models/remote_follow_spec.rb
@@ -3,83 +3,65 @@
 require 'rails_helper'
 
 RSpec.describe RemoteFollow do
+  before do
+    stub_request(:get, 'https://quitter.no/.well-known/webfinger?resource=acct:gargron@quitter.no').to_return(request_fixture('webfinger.txt'))
+  end
+
+  let(:attrs)         { nil }
+  let(:remote_follow) { described_class.new(attrs) }
+
   describe '.initialize' do
-    let(:remote_follow) { RemoteFollow.new(option) }
+    subject { remote_follow.acct }
 
-    context 'option with acct' do
-      let(:option) { { acct: 'hoge@example.com' } }
+    context 'attrs with acct' do
+      let(:attrs) { { acct: 'gargron@quitter.no' } }
 
-      it 'sets acct' do
-        expect(remote_follow.acct).to eq 'hoge@example.com'
+      it 'returns acct' do
+        is_expected.to eq 'gargron@quitter.no'
       end
     end
 
-    context 'option without acct' do
-      let(:option) { {} }
+    context 'attrs without acct' do
+      let(:attrs) { {} }
 
-      it 'does not set acct' do
-        expect(remote_follow.acct).to be_nil
+      it do
+        is_expected.to be_nil
       end
     end
   end
 
   describe '#valid?' do
-    let(:remote_follow) { RemoteFollow.new }
+    subject { remote_follow.valid? }
 
-    context 'super is falsy' do
-      module InvalidSuper
-        def valid?
-          nil
-        end
-      end
-
-      before do
-        class RemoteFollow
-          include InvalidSuper
-        end
-      end
-
-      it 'returns false without calling #populate_template and #errors' do
-        expect(remote_follow).not_to receive(:populate_template)
-        expect(remote_follow).not_to receive(:errors)
-        expect(remote_follow.valid?).to be false
+    context 'attrs with acct' do
+      let(:attrs) { { acct: 'gargron@quitter.no' }}
+      
+      it do
+        is_expected.to be true
       end
     end
 
-    context 'super is truthy' do
-      module ValidSuper
-        def valid?
-          true
-        end
-      end
+    context 'attrs without acct' do
+      let(:attrs) { { } }
 
-      before do
-        class RemoteFollow
-          include ValidSuper
-        end
-      end
-
-      it 'calls #populate_template and #errors.empty?' do
-        expect(remote_follow).to receive(:populate_template)
-        expect(remote_follow).to receive_message_chain(:errors, :empty?)
-        remote_follow.valid?
+      it do
+        is_expected.to be false
       end
     end
   end
 
   describe '#subscribe_address_for' do
     before do
-      allow(remote_follow).to receive(:addressable_template).and_return(addressable_template)
+      remote_follow.valid?
     end
 
-    let(:account)                   { instance_double('Account', local_username_and_domain: local_username_and_domain) }
-    let(:addressable_template)      { instance_double('Addressable::Template') }
-    let(:local_username_and_domain) { 'hoge@example.com' }
-    let(:remote_follow)             { RemoteFollow.new }
+    let(:attrs)   { { acct: 'gargron@quitter.no' } }
+    let(:account) { Fabricate(:account, username: 'alice') }
 
-    it 'calls Addressable::Template#expand.to_s' do
-      expect(addressable_template).to receive_message_chain(:expand, :to_s).with(uri: local_username_and_domain).with(no_args)
-      remote_follow.subscribe_address_for(account)
+    subject { remote_follow.subscribe_address_for(account) }
+
+    it 'returns subscribe address' do
+      is_expected.to eq 'https://quitter.no/main/ostatussub?profile=alice%40cb6e6126.ngrok.io'
     end
   end
 end


### PR DESCRIPTION
Fix randomly fail.

```console
$ ./bin/rspec --seed 37528

Randomized with seed 37528

Progress: |==========================================================================

  1) RemoteFollowController#create with a valid acct when webfinger values are wrong renders new when redirect url is nil
     Failure/Error: expect(response.body).to include(I18n.t('remote_follow.missing_resource'))

       expected "<!DOCTYPE html>\n<html lang='en'>\n<head>\n<meta charset='utf-8'>\n<meta content='width=device-width...t\" class=\"btn\">Proceed to follow</button>\n</div>\n</form></div>\n</div>\n\n</body>\n</html>\n\n" to include "Could not find the required redirect URL for your account"
       Diff:
       @@ -1,2 +1,50 @@
       -Could not find the required redirect URL for your account
       +<!DOCTYPE html>
       +<html lang='en'>
       +<head>
       +<meta charset='utf-8'>
       +<meta content='width=device-width, initial-scale=1' name='viewport'>
       +<meta content='IE=edge' http-equiv='X-UA-Compatible'>
       +<link href='/favicon-dev.ico' rel='icon' type='image/x-icon'>
       +<link href='/apple-touch-icon.png' rel='apple-touch-icon' sizes='180x180'>
       +<link color='#2B90D9' href='/mask-icon.svg' rel='mask-icon'>
       +<link href='/manifest.json' rel='manifest'>
       +<meta content='/browserconfig.xml' name='msapplication-config'>
       +<meta content='#282c37' name='theme-color'>
       +<meta content='yes' name='apple-mobile-web-app-capable'>
       +<title>Mastodon (Dev)</title>
       +<link rel="stylesheet" media="all" href="/packs-test/common.css" />
       +<link rel="stylesheet" media="all" href="/packs-test/default.css" />
       +<script src="/packs-test/common.js" crossorigin="anonymous"></script>
       +<script src="/packs-test/locale_en.js" crossorigin="anonymous"></script>
       +
       +<script src="/packs-test/public.js" crossorigin="anonymous"></script>
       +
       +</head>
       +<body class=''>
       +<div class='container'><div class='form-container'>
       +<div class='follow-prompt'>
       +<h2>You are going to follow:</h2>
       +<div class='account-card'>
       +<div class='detailed-status__display-name'>
       +<div>
       +<img alt="" width="48" height="48" class="avatar" src="/avatars/original/missing.png" />
       +</div>
       +<span class='display-name'>
       +<a class="detailed-status__display-name p-author h-card" target="_blank" rel="noopener" href="https://cb6e6126.ngrok.io/@test_user"><strong class='emojify'>test_user</strong>
       +<span>@test_user</span>
       +</a></span>
       +</div>
       +</div>
       +
       +</div>
       +<form novalidate="novalidate" class="simple_form new_remote_follow" id="new_remote_follow" action="/users/test_user/remote_follow" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" />
       +<div class="input string required remote_follow_acct"><input class="string required" placeholder="Enter your username@domain you want to follow from" type="text" value="user@example.com" name="remote_follow[acct]" id="remote_follow_acct" /></div>
       +<div class='actions'>
       +<button name="button" type="submit" class="btn">Proceed to follow</button>
       +</div>
       +</form></div>
       +</div>
       +
       +</body>
       +</html>
     # ./spec/controllers/remote_follow_controller_spec.rb:42:in `block (5 levels) in <top (required)>'

Progress: |==========================================================================

  2) RemoteFollowController#create with a valid acct when webfinger values are wrong renders new when template is nil
     Failure/Error: expect(response.body).to include(I18n.t('remote_follow.missing_resource'))

       expected "<!DOCTYPE html>\n<html lang='en'>\n<head>\n<meta charset='utf-8'>\n<meta content='width=device-width...t\" class=\"btn\">Proceed to follow</button>\n</div>\n</form></div>\n</div>\n\n</body>\n</html>\n\n" to include "Could not find the required redirect URL for your account"
       Diff:
       @@ -1,2 +1,50 @@
       -Could not find the required redirect URL for your account
       +<!DOCTYPE html>
       +<html lang='en'>
       +<head>
       +<meta charset='utf-8'>
       +<meta content='width=device-width, initial-scale=1' name='viewport'>
       +<meta content='IE=edge' http-equiv='X-UA-Compatible'>
       +<link href='/favicon-dev.ico' rel='icon' type='image/x-icon'>
       +<link href='/apple-touch-icon.png' rel='apple-touch-icon' sizes='180x180'>
       +<link color='#2B90D9' href='/mask-icon.svg' rel='mask-icon'>
       +<link href='/manifest.json' rel='manifest'>
       +<meta content='/browserconfig.xml' name='msapplication-config'>
       +<meta content='#282c37' name='theme-color'>
       +<meta content='yes' name='apple-mobile-web-app-capable'>
       +<title>Mastodon (Dev)</title>
       +<link rel="stylesheet" media="all" href="/packs-test/common.css" />
       +<link rel="stylesheet" media="all" href="/packs-test/default.css" />
       +<script src="/packs-test/common.js" crossorigin="anonymous"></script>
       +<script src="/packs-test/locale_en.js" crossorigin="anonymous"></script>
       +
       +<script src="/packs-test/public.js" crossorigin="anonymous"></script>
       +
       +</head>
       +<body class=''>
       +<div class='container'><div class='form-container'>
       +<div class='follow-prompt'>
       +<h2>You are going to follow:</h2>
       +<div class='account-card'>
       +<div class='detailed-status__display-name'>
       +<div>
       +<img alt="" width="48" height="48" class="avatar" src="/avatars/original/missing.png" />
       +</div>
       +<span class='display-name'>
       +<a class="detailed-status__display-name p-author h-card" target="_blank" rel="noopener" href="https://cb6e6126.ngrok.io/@test_user"><strong class='emojify'>test_user</strong>
       +<span>@test_user</span>
       +</a></span>
       +</div>
       +</div>
       +
       +</div>
       +<form novalidate="novalidate" class="simple_form new_remote_follow" id="new_remote_follow" action="/users/test_user/remote_follow" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" />
       +<div class="input string required remote_follow_acct"><input class="string required" placeholder="Enter your username@domain you want to follow from" type="text" value="user@example.com" name="remote_follow[acct]" id="remote_follow_acct" /></div>
       +<div class='actions'>
       +<button name="button" type="submit" class="btn">Proceed to follow</button>
       +</div>
       +</form></div>
       +</div>
       +
       +</body>
       +</html>
     # ./spec/controllers/remote_follow_controller_spec.rb:52:in `block (5 levels) in <top (required)>'

Progress: |==========================================================================

  3) RemoteFollowController#create with a valid acct when webfinger values are good redirects to the remote location
     Failure/Error: expect(response).to redirect_to(address)
       Expected response to be a <3XX: redirect>, but was a <200: OK>
     # ./spec/controllers/remote_follow_controller_spec.rb:71:in `block (5 levels) in <top (required)>'

Progress: |==========================================================================

  4) RemoteFollowController#create with a valid acct when webfinger values are good saves the session
     Failure/Error: expect(session[:remote_follow]).to eq 'user@example.com'

       expected: "user@example.com"
            got: nil

       (compared using ==)
     # ./spec/controllers/remote_follow_controller_spec.rb:65:in `block (5 levels) in <top (required)>'

Progress: |==========================================================================

  5) RemoteFollowController#create with an invalid acct renders new when occur HTTP::ConnectionError
     Failure/Error: expect(response.body).to include(I18n.t('remote_follow.missing_resource'))

       expected "<!DOCTYPE html>\n<html lang='en'>\n<head>\n<meta charset='utf-8'>\n<meta content='width=device-width...t\" class=\"btn\">Proceed to follow</button>\n</div>\n</form></div>\n</div>\n\n</body>\n</html>\n\n" to include "Could not find the required redirect URL for your account"
       Diff:
       @@ -1,2 +1,50 @@
       -Could not find the required redirect URL for your account
       +<!DOCTYPE html>
       +<html lang='en'>
       +<head>
       +<meta charset='utf-8'>
       +<meta content='width=device-width, initial-scale=1' name='viewport'>
       +<meta content='IE=edge' http-equiv='X-UA-Compatible'>
       +<link href='/favicon-dev.ico' rel='icon' type='image/x-icon'>
       +<link href='/apple-touch-icon.png' rel='apple-touch-icon' sizes='180x180'>
       +<link color='#2B90D9' href='/mask-icon.svg' rel='mask-icon'>
       +<link href='/manifest.json' rel='manifest'>
       +<meta content='/browserconfig.xml' name='msapplication-config'>
       +<meta content='#282c37' name='theme-color'>
       +<meta content='yes' name='apple-mobile-web-app-capable'>
       +<title>Mastodon (Dev)</title>
       +<link rel="stylesheet" media="all" href="/packs-test/common.css" />
       +<link rel="stylesheet" media="all" href="/packs-test/default.css" />
       +<script src="/packs-test/common.js" crossorigin="anonymous"></script>
       +<script src="/packs-test/locale_en.js" crossorigin="anonymous"></script>
       +
       +<script src="/packs-test/public.js" crossorigin="anonymous"></script>
       +
       +</head>
       +<body class=''>
       +<div class='container'><div class='form-container'>
       +<div class='follow-prompt'>
       +<h2>You are going to follow:</h2>
       +<div class='account-card'>
       +<div class='detailed-status__display-name'>
       +<div>
       +<img alt="" width="48" height="48" class="avatar" src="/avatars/original/missing.png" />
       +</div>
       +<span class='display-name'>
       +<a class="detailed-status__display-name p-author h-card" target="_blank" rel="noopener" href="https://cb6e6126.ngrok.io/@test_user"><strong class='emojify'>test_user</strong>
       +<span>@test_user</span>
       +</a></span>
       +</div>
       +</div>
       +
       +</div>
       +<form novalidate="novalidate" class="simple_form new_remote_follow" id="new_remote_follow" action="/users/test_user/remote_follow" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" />
       +<div class="input string required remote_follow_acct"><input class="string required" placeholder="Enter your username@domain you want to follow from" type="text" value="user@unknown" name="remote_follow[acct]" id="remote_follow_acct" /></div>
       +<div class='actions'>
       +<button name="button" type="submit" class="btn">Proceed to follow</button>
       +</div>
       +</form></div>
       +</div>
       +
       +</body>
       +</html>
     # ./spec/controllers/remote_follow_controller_spec.rb:96:in `block (4 levels) in <top (required)>'

Progress: |==========================================================================

  6) RemoteFollowController#create with an invalid acct renders new with error when goldfinger fails
     Failure/Error: expect(response.body).to include(I18n.t('remote_follow.missing_resource'))

       expected "<!DOCTYPE html>\n<html lang='en'>\n<head>\n<meta charset='utf-8'>\n<meta content='width=device-width...t\" class=\"btn\">Proceed to follow</button>\n</div>\n</form></div>\n</div>\n\n</body>\n</html>\n\n" to include "Could not find the required redirect URL for your account"
       Diff:
       @@ -1,2 +1,50 @@
       -Could not find the required redirect URL for your account
       +<!DOCTYPE html>
       +<html lang='en'>
       +<head>
       +<meta charset='utf-8'>
       +<meta content='width=device-width, initial-scale=1' name='viewport'>
       +<meta content='IE=edge' http-equiv='X-UA-Compatible'>
       +<link href='/favicon-dev.ico' rel='icon' type='image/x-icon'>
       +<link href='/apple-touch-icon.png' rel='apple-touch-icon' sizes='180x180'>
       +<link color='#2B90D9' href='/mask-icon.svg' rel='mask-icon'>
       +<link href='/manifest.json' rel='manifest'>
       +<meta content='/browserconfig.xml' name='msapplication-config'>
       +<meta content='#282c37' name='theme-color'>
       +<meta content='yes' name='apple-mobile-web-app-capable'>
       +<title>Mastodon (Dev)</title>
       +<link rel="stylesheet" media="all" href="/packs-test/common.css" />
       +<link rel="stylesheet" media="all" href="/packs-test/default.css" />
       +<script src="/packs-test/common.js" crossorigin="anonymous"></script>
       +<script src="/packs-test/locale_en.js" crossorigin="anonymous"></script>
       +
       +<script src="/packs-test/public.js" crossorigin="anonymous"></script>
       +
       +</head>
       +<body class=''>
       +<div class='container'><div class='form-container'>
       +<div class='follow-prompt'>
       +<h2>You are going to follow:</h2>
       +<div class='account-card'>
       +<div class='detailed-status__display-name'>
       +<div>
       +<img alt="" width="48" height="48" class="avatar" src="/avatars/original/missing.png" />
       +</div>
       +<span class='display-name'>
       +<a class="detailed-status__display-name p-author h-card" target="_blank" rel="noopener" href="https://cb6e6126.ngrok.io/@test_user"><strong class='emojify'>test_user</strong>
       +<span>@test_user</span>
       +</a></span>
       +</div>
       +</div>
       +
       +</div>
       +<form novalidate="novalidate" class="simple_form new_remote_follow" id="new_remote_follow" action="/users/test_user/remote_follow" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" />
       +<div class="input string required remote_follow_acct"><input class="string required" placeholder="Enter your username@domain you want to follow from" type="text" value="user@example.com" name="remote_follow[acct]" id="remote_follow_acct" /></div>
       +<div class='actions'>
       +<button name="button" type="submit" class="btn">Proceed to follow</button>
       +</div>
       +</form></div>
       +</div>
       +
       +</body>
       +</html>
     # ./spec/controllers/remote_follow_controller_spec.rb:88:in `block (4 levels) in <top (required)>'

Progress: |=========================================================================================================|

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Account MENTION_RE does not match URL querystring
     # Temporarily skipped with xit
     # ./spec/models/account_spec.rb:583

  2) AccountModerationNote add some examples to (or delete) /Users/ykzts/works/ykzts/mastodon/spec/models/account_moderation_note_spec.rb
     # Not yet implemented
     # ./spec/models/account_moderation_note_spec.rb:4

  3) ActivityPub::InboxesController POST #create 
     # Not yet implemented
     # ./spec/controllers/activitypub/inboxes_controller_spec.rb:5

  4) Notification#from_account 
     # Not yet implemented
     # ./spec/models/notification_spec.rb:5

  5) Api::V1::MediaController POST #create video/webm returns http success
     # Temporarily skipped with xit
     # ./spec/controllers/api/v1/media_controller_spec.rb:87

  6) Api::V1::MediaController POST #create video/webm uploads a file
     # Temporarily skipped with xit
     # ./spec/controllers/api/v1/media_controller_spec.rb:95

  7) Api::V1::MediaController POST #create video/webm returns media ID in JSON
     # Temporarily skipped with xit
     # ./spec/controllers/api/v1/media_controller_spec.rb:99

  8) Api::V1::MediaController POST #create video/webm creates a media attachment
     # Temporarily skipped with xit
     # ./spec/controllers/api/v1/media_controller_spec.rb:91

  9) ActivityPub::ProcessAccountService 
     # Not yet implemented
     # ./spec/services/activitypub/process_account_service_spec.rb:4

  10) Admin::AccountModerationNotesHelper add some examples to (or delete) /Users/ykzts/works/ykzts/mastodon/spec/helpers/admin/account_moderation_notes_helper_spec.rb
     # Not yet implemented
     # ./spec/helpers/admin/account_moderation_notes_helper_spec.rb:14

  11) FanOutOnWriteService delivers status to local followers
      # some sort of problem in test environment causes this to sometimes fail
      Failure/Error: expect(Feed.new(:home, follower).get(10).map(&:id)).to include status.id
        expected [] to include 99001463991695067
      # ./spec/services/fan_out_on_write_service_spec.rb:27:in `block (2 levels) in <top (required)>'

  12) JsonLdHelper#first_of_value 
     # Not yet implemented
     # ./spec/helpers/jsonld_helper_spec.rb:25

  13) JsonLdHelper#supported_context? 
     # Not yet implemented
     # ./spec/helpers/jsonld_helper_spec.rb:29

  14) SendInteractionService sends an XML envelope to the Salmon end point of remote user
     # Not yet implemented
     # ./spec/services/send_interaction_service_spec.rb:6

  15) User behaves like Settings-extended settings behaves like ScopedSettings does not mutate defaults via the cache
     # Temporarily skipped with xit
     # ./spec/support/examples/lib/settings/scoped_settings.rb:66

  16) ResolveRemoteAccountService with an ActivityPub account 
     # Not yet implemented
     # ./spec/services/resolve_remote_account_service_spec.rb:108

  17) StatusLengthValidator#validate does not add errors onto local reblogs
     # Not yet implemented
     # ./spec/validators/status_length_validator_spec.rb:8

  18) StatusLengthValidator#validate does not add errors onto remote statuses
     # Not yet implemented
     # ./spec/validators/status_length_validator_spec.rb:7

Finished in 4 minutes 15.4 seconds (files took 5.57 seconds to load)
1889 examples, 6 failures, 18 pending

Failed examples:

rspec ./spec/controllers/remote_follow_controller_spec.rb:36 # RemoteFollowController#create with a valid acct when webfinger values are wrong renders new when redirect url is nil
rspec ./spec/controllers/remote_follow_controller_spec.rb:45 # RemoteFollowController#create with a valid acct when webfinger values are wrong renders new when template is nil
rspec ./spec/controllers/remote_follow_controller_spec.rb:68 # RemoteFollowController#create with a valid acct when webfinger values are good redirects to the remote location
rspec ./spec/controllers/remote_follow_controller_spec.rb:64 # RemoteFollowController#create with a valid acct when webfinger values are good saves the session
rspec ./spec/controllers/remote_follow_controller_spec.rb:91 # RemoteFollowController#create with an invalid acct renders new when occur HTTP::ConnectionError
rspec ./spec/controllers/remote_follow_controller_spec.rb:83 # RemoteFollowController#create with an invalid acct renders new with error when goldfinger fails

Randomized with seed 37528

Coverage report generated for RSpec to /Users/ykzts/works/ykzts/mastodon/coverage. 7647 / 9270 LOC (82.49%) covered.
```