### PR TITLE
Add uniqueness to block email domains

### DIFF
--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -4,14 +4,33 @@
 # Table name: email_domain_blocks
 #
 #  id         :bigint           not null, primary key
-#  domain     :string           not null
+#  domain     :string           default(""), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
 
 class EmailDomainBlock < ApplicationRecord
+  before_validation :normalize_domain
+
+  validates :domain, presence: true, uniqueness: true
+
   def self.block?(email)
-    domain = email.gsub(/.+@([^.]+)/, '\1')
+    _, domain = email.split('@', 2)
+
+    return true if domain.nil?
+
+    begin
+      domain = TagManager.instance.normalize_domain(domain)
+    rescue Addressable::URI::InvalidURIError
+      return true
+    end
+
     where(domain: domain).exists?
+  end
+
+  private
+
+  def normalize_domain
+    self.domain = TagManager.instance.normalize_domain(domain)
   end
 end

--- a/db/migrate/20171114080328_add_index_domain_to_email_domain_blocks.rb
+++ b/db/migrate/20171114080328_add_index_domain_to_email_domain_blocks.rb
@@ -1,0 +1,8 @@
+class AddIndexDomainToEmailDomainBlocks < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :email_domain_blocks, :domain, algorithm: :concurrently, unique: true
+    change_column_default :email_domain_blocks, :domain, from: nil, to: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171109012327) do
+ActiveRecord::Schema.define(version: 20171114080328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,9 +126,10 @@ ActiveRecord::Schema.define(version: 20171109012327) do
   end
 
   create_table "email_domain_blocks", force: :cascade do |t|
-    t.string "domain", null: false
+    t.string "domain", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["domain"], name: "index_email_domain_blocks_on_domain", unique: true
   end
 
   create_table "favourites", force: :cascade do |t|

--- a/spec/models/email_domain_block_spec.rb
+++ b/spec/models/email_domain_block_spec.rb
@@ -13,9 +13,10 @@ RSpec.describe EmailDomainBlock, type: :model do
       Fabricate(:email_domain_block, domain: 'example.com')
       expect(EmailDomainBlock.block?('nyarn@example.com')).to eq true
     end
+
     it 'returns true if the domain is not registed' do
-      Fabricate(:email_domain_block, domain: 'domain')
-      expect(EmailDomainBlock.block?('example')).to eq false
+      Fabricate(:email_domain_block, domain: 'example.com')
+      expect(EmailDomainBlock.block?('nyarn@example.net')).to eq false
     end
   end
 end


### PR DESCRIPTION
Email Domain Block will allow you to enter duplicate domains and empty domains. I think this is an incorrect behavior.

![](https://user-images.githubusercontent.com/12539/32771636-b990bfc8-c966-11e7-88fb-d687e7b18a1d.png)

Normalize to the domain name so that duplication is eliminated.
