### PR TITLE
Make character limit configurable

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -136,4 +136,4 @@ STREAMING_CLUSTER_NUM=1
 # GID=1000
 
 # Maximum allowed character count
-# MAX_CHARS=500
+# MAX_TOOT_CHARS=500

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -134,3 +134,6 @@ STREAMING_CLUSTER_NUM=1
 # If you use Docker, you may want to assign UID/GID manually.
 # UID=1000
 # GID=1000
+
+# Maximum allowed character count
+# MAX_CHARS=500

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -20,7 +20,7 @@ import { length } from 'stringz';
 import { countableText } from '../util/counter';
 import initialState from '../../../initial_state';
 
-const maxChars = initialState.max_chars;
+const maxChars = initialState.max_toot_chars;
 
 const messages = defineMessages({
   placeholder: { id: 'compose_form.placeholder', defaultMessage: 'What is on your mind?' },

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -19,6 +19,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import { length } from 'stringz';
 import { countableText } from '../util/counter';
 import initialState from '../../../initial_state';
+
 const maxChars = initialState.max_chars;
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -18,6 +18,8 @@ import { isMobile } from '../../../is_mobile';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { length } from 'stringz';
 import { countableText } from '../util/counter';
+import initialState from '../../../initial_state';
+const maxChars = initialState.max_chars;
 
 const messages = defineMessages({
   placeholder: { id: 'compose_form.placeholder', defaultMessage: 'What is on your mind?' },
@@ -201,8 +203,8 @@ export default class ComposeForm extends ImmutablePureComponent {
           </div>
 
           <div className='compose-form__publish'>
-            <div className='character-counter__wrapper'><CharacterCounter max={500} text={text} /></div>
-            <div className='compose-form__publish-button-wrapper'><Button text={publishText} onClick={this.handleSubmit} disabled={disabled || this.props.is_uploading || length(text) > 500 || (text.length !== 0 && text.trim().length === 0)} block /></div>
+            <div className='character-counter__wrapper'><CharacterCounter max={maxChars} text={text} /></div>
+            <div className='compose-form__publish-button-wrapper'><Button text={publishText} onClick={this.handleSubmit} disabled={disabled || this.props.is_uploading || length(text) > maxChars || (text.length !== 0 && text.trim().length === 0)} block /></div>
           </div>
         </div>
       </div>

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -2,9 +2,14 @@
 
 class InitialStateSerializer < ActiveModel::Serializer
   attributes :meta, :compose, :accounts,
-             :media_attachments, :settings, :push_subscription
+             :media_attachments, :settings, :push_subscription,
+             :max_chars
 
   has_many :custom_emojis, serializer: REST::CustomEmojiSerializer
+
+  def max_chars
+    StatusLengthValidator::MAX_CHARS
+  end
 
   def custom_emojis
     CustomEmoji.local.where(disabled: false)

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -3,11 +3,11 @@
 class InitialStateSerializer < ActiveModel::Serializer
   attributes :meta, :compose, :accounts,
              :media_attachments, :settings, :push_subscription,
-             :max_chars
+             :max_toot_chars
 
   has_many :custom_emojis, serializer: REST::CustomEmojiSerializer
 
-  def max_chars
+  def max_toot_chars
     StatusLengthValidator::MAX_CHARS
   end
 

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -4,7 +4,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
   include RoutingHelper
 
   attributes :uri, :title, :description, :email,
-             :version, :urls, :stats, :thumbnail, :max_chars
+             :version, :urls, :stats, :thumbnail, :max_toot_chars
 
   def uri
     Rails.configuration.x.local_domain
@@ -30,7 +30,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
     full_asset_url(instance_presenter.thumbnail.file.url) if instance_presenter.thumbnail
   end
 
-  def max_chars
+  def max_toot_chars
     StatusLengthValidator::MAX_CHARS
   end
 

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -4,7 +4,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
   include RoutingHelper
 
   attributes :uri, :title, :description, :email,
-             :version, :urls, :stats, :thumbnail
+             :version, :urls, :stats, :thumbnail, :max_chars
 
   def uri
     Rails.configuration.x.local_domain
@@ -28,6 +28,10 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   def thumbnail
     full_asset_url(instance_presenter.thumbnail.file.url) if instance_presenter.thumbnail
+  end
+
+  def max_chars
+    StatusLengthValidator::MAX_CHARS
   end
 
   def stats

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StatusLengthValidator < ActiveModel::Validator
-  MAX_CHARS = (ENV['MAX_CHARS'] || 500).to_i
+  MAX_CHARS = (ENV['MAX_TOOT_CHARS'] || 500).to_i
 
   def validate(status)
     return unless status.local? && !status.reblog?

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StatusLengthValidator < ActiveModel::Validator
-  MAX_CHARS = 500
+  MAX_CHARS = (ENV["MAX_CHARS"] || 500).to_i
 
   def validate(status)
     return unless status.local? && !status.reblog?

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StatusLengthValidator < ActiveModel::Validator
-  MAX_CHARS = (ENV["MAX_CHARS"] || 500).to_i
+  MAX_CHARS = (ENV['MAX_CHARS'] || 500).to_i
 
   def validate(status)
     return unless status.local? && !status.reblog?


### PR DESCRIPTION
This adds a character limit configurable by setting and environment variable. It also adds the character limit to the initial state and instance endpoint, so clients can use it to set the correct limit.

Default is still 500 characters if no other value is set.

This relates to #5693 and #4915.