### PR TITLE
Improve language filter

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -173,7 +173,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def language_from_content
-    return nil unless language_map?
+    return LanguageDetector.instance.detect(text_from_content, @account) unless language_map?
     @object['contentMap'].keys.first
   end
 

--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -38,12 +38,31 @@ class LanguageDetector
   end
 
   def simplify_text(text)
-    text.dup.tap do |new_text|
+    new_text = remove_html(text)
+    new_text.tap do |new_text|
       new_text.gsub!(FetchLinkCardService::URL_PATTERN, '')
       new_text.gsub!(Account::MENTION_RE, '')
       new_text.gsub!(Tag::HASHTAG_RE, '')
       new_text.gsub!(/\s+/, ' ')
     end
+  end
+
+  def new_scrubber
+    scrubber= Rails::Html::PermitScrubber.new
+    scrubber.tags = ['br', 'p']
+    scrubber
+  end
+
+  def scrubber
+    @scrubber ||= new_scrubber
+  end
+
+  def remove_html(text)
+    text = Loofah.fragment(text).scrub!(scrubber).to_s
+    text.gsub!('<br>', "\n")
+    text.gsub!('</p><p>', "\n\n")
+    text.gsub!(/(^<p>|<\/p>$)/, '')
+    text
   end
 
   def default_locale(account)

--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -42,7 +42,9 @@ class LanguageDetector
     new_text.gsub!(FetchLinkCardService::URL_PATTERN, '')
     new_text.gsub!(Account::MENTION_RE, '')
     new_text.gsub!(Tag::HASHTAG_RE, '')
+    new_text.gsub!(/:#{CustomEmoji::SHORTCODE_RE_FRAGMENT}:/, '')
     new_text.gsub!(/\s+/, ' ')
+    new_text
   end
 
   def new_scrubber

--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -39,17 +39,15 @@ class LanguageDetector
 
   def simplify_text(text)
     new_text = remove_html(text)
-    new_text.tap do |new_text|
-      new_text.gsub!(FetchLinkCardService::URL_PATTERN, '')
-      new_text.gsub!(Account::MENTION_RE, '')
-      new_text.gsub!(Tag::HASHTAG_RE, '')
-      new_text.gsub!(/\s+/, ' ')
-    end
+    new_text.gsub!(FetchLinkCardService::URL_PATTERN, '')
+    new_text.gsub!(Account::MENTION_RE, '')
+    new_text.gsub!(Tag::HASHTAG_RE, '')
+    new_text.gsub!(/\s+/, ' ')
   end
 
   def new_scrubber
-    scrubber= Rails::Html::PermitScrubber.new
-    scrubber.tags = ['br', 'p']
+    scrubber = Rails::Html::PermitScrubber.new
+    scrubber.tags = %w(br p)
     scrubber
   end
 


### PR DESCRIPTION
After investigating #5035 I've made some tests at masto.donte.com.br to find out what could improve the language filter and this are the results of my investigation.

I'm removing html tags as the first stage of simplify text, so that the final text sent to CLD3 only the original text or as close to that as possible.

Also, when receiving a text in ActivityPub, if the language doesn't come, I'm trying to detect it from the text that was received.