### PR TITLE
Use already-known remote user data if resolving temporarily fails in mentions

### DIFF
--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -17,6 +17,11 @@ class ProcessMentionsService < BaseService
         mentioned_account = nil
       end
 
+      if mentioned_account.nil?
+        username, domain  = match.first.split('@')
+        mentioned_account = Account.find_remote(username, domain)
+      end
+
       next match if mentioned_account.nil? || (!mentioned_account.local? && mentioned_account.ostatus? && status.stream_entry.hidden?)
 
       mentioned_account.mentions.where(status: status).first_or_create(status: status)


### PR DESCRIPTION
Resolving a remote account can temporarily fail (connectivity error, remote server down or overloaded).
In this case, we should re-use previously-known remote account info if possible, as the delivery worker can retry a bunch of times, overcoming such temporary issues.