### PR TITLE
Fix AccountFinderConcern::AccountFinder#with_usernames

### DIFF
--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -44,7 +44,7 @@ module AccountFinderConcern
     end
 
     def with_usernames
-      Account.where.not(username: [nil, ''])
+      Account.where.not(username: '')
     end
 
     def matching_username


### PR DESCRIPTION
Originally `username` cannot be `nil`.
https://github.com/tootsuite/mastodon/blob/master/db/schema.rb#L37