### PR TITLE
i18n: Update ja translation for moderator badge.

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -48,6 +48,7 @@ ja:
     reserved_username: このユーザー名は予約されています。
     roles:
       admin: Admin
+      moderator: Moderator
     unfollow: フォロー解除
   admin:
     account_moderation_notes:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -48,7 +48,7 @@ ja:
     reserved_username: このユーザー名は予約されています。
     roles:
       admin: Admin
-      moderator: Moderator
+      moderator: Mod
     unfollow: フォロー解除
   admin:
     account_moderation_notes:


### PR DESCRIPTION
Add Japanese translation for #5728 .

This is still English, but I thought this was good for the badge.