### PR TITLE
Move "Permissions" row into main table in /admin/accounts/:id

### DIFF
--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -16,6 +16,12 @@
 
       - if @account.local?
         %tr
+          %th= t('admin.accounts.role')
+          %td
+            = t("admin.accounts.roles.#{@account.user&.role}")
+            = table_link_to 'angle-double-up', t('admin.accounts.promote'), promote_admin_account_role_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:promote, @account.user)
+            = table_link_to 'angle-double-down', t('admin.accounts.demote'), demote_admin_account_role_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:demote, @account.user)
+        %tr
           %th= t('admin.accounts.email')
           %td
             = @account.user_email
@@ -144,20 +150,6 @@
         %tr
           %th= t('admin.accounts.followers_url')
           %td= link_to @account.followers_url, @account.followers_url
-
-- else
-  %hr
-
-  .table-wrapper
-    %table.table
-      %tbody
-        %tr
-          %th= t('admin.accounts.role')
-          %td
-            = t("admin.accounts.roles.#{@account.user&.role}")
-          %td<
-            = table_link_to 'angle-double-up', t('admin.accounts.promote'), promote_admin_account_role_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:promote, @account.user)
-            = table_link_to 'angle-double-down', t('admin.accounts.demote'), demote_admin_account_role_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:demote, @account.user)
 
 %hr
 %h3= t('admin.accounts.moderation_notes')


### PR DESCRIPTION
| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/705555/32928448-50149a84-cb95-11e7-831a-5ab9f34d4922.png) | ![image](https://user-images.githubusercontent.com/705555/32928317-b9e1bf6a-cb94-11e7-9200-c29e640afd7b.png) |

I think "Permissions" is a part of basic information of the account as well as login information, so separate table seems not needed.

Also I felt current table only have a header row at first...