### PR TITLE
Fix regression #5467: fixes emoji copy

### DIFF
--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -45,9 +45,10 @@ module Admin
     def copy
       authorize @custom_emoji, :copy?
 
-      emoji = CustomEmoji.find_or_create_by(domain: nil, shortcode: @custom_emoji.shortcode)
+      emoji = CustomEmoji.find_or_initialize_by(domain: nil, shortcode: @custom_emoji.shortcode)
+      emoji.image = @custom_emoji.image
 
-      if emoji.update(image: @custom_emoji.image)
+      if emoji.save
         flash[:notice] = I18n.t('admin.custom_emojis.copied_msg')
       else
         flash[:alert] = I18n.t('admin.custom_emojis.copy_failed_msg')


### PR DESCRIPTION
After #5467, /static/ version of Emoji image is not created when perform non-overwrite Emoji copy. (when overwrite, /static/ version is created correctly.)
This PR fixes that.

Here is methods I tried on rails console.
1. Emoji copy by current method
```
irb(main):001:0> orig = CustomEmoji.find(320)
=> #<CustomEmoji id: 320, shortcode: "sabakan", domain: "biwakodon.com", image_file_name: "52ac62f1bd2ed0c5.png", image_content_type: "image/png", image_file_size: 25338, image_updated_at: "2017-10-09 12:18:01", created_at: "2017-09-26 12:32:22", updated_at: "2017-10-09 12:18:01", disabled: false, uri: nil, image_remote_url: nil, visible_in_picker: true>
irb(main):002:0> emoji = CustomEmoji.find_or_create_by(domain: nil, shortcode: orig.shortcode)
=> #<CustomEmoji id: nil, shortcode: "sabakan", domain: nil, image_file_name: nil, image_content_type: nil, image_file_size: nil, image_updated_at: nil, created_at: nil, updated_at: nil, disabled: false, uri: nil, image_remote_url: nil, visible_in_picker: true>
irb(main):003:0> emoji.update(image: orig.image)
[paperclip] copying custom_emojis/images/000/000/320/original/52ac62f1bd2ed0c5.png to local file /tmp/e3fd4c08776daba8287f1545b79cccdc20171117-31666-13zxm0l.png
Command :: file -b --mime '/tmp/e3fd4c08776daba8287f1545b79cccdc20171117-31666-vrjdpz.png'
Command :: file -b --mime '/tmp/e3fd4c08776daba8287f1545b79cccdc20171117-31666-ch7e0n.png'
[paperclip] saving custom_emojis/images/000/001/634/original/52ac62f1bd2ed0c5.png
=> true
※ /static/ version of Emoji not created...
```
2. Emoji copy not using .update()
```
irb(main):005:0* orig = CustomEmoji.find(370)
=> #<CustomEmoji id: 370, shortcode: "unarist", domain: "glitch.social", image_file_name: "1d3e31c6c760e47e.png", image_content_type: "image/png", image_file_size: 2446, image_updated_at: "2017-10-12 14:27:38", created_at: "2017-10-12 14:27:38", updated_at: "2017-10-12 14:27:38", disabled: false, uri: "https://glitch.social/emojis/439", image_remote_url: "https://static.glitch.social/custom_emojis/images/...", visible_in_picker: true>
irb(main):006:0> emoji = CustomEmoji.find_or_create_by(domain: nil, shortcode: orig.shortcode)
=> #<CustomEmoji id: nil, shortcode: "unarist", domain: nil, image_file_name: nil, image_content_type: nil, image_file_size: nil, image_updated_at: nil, created_at: nil, updated_at: nil, disabled: false, uri: nil, image_remote_url: nil, visible_in_picker: true>
irb(main):007:0> emoji.image = orig.image
[paperclip] copying custom_emojis/images/000/000/370/original/1d3e31c6c760e47e.png to local file /tmp/12c673a281637dd47f4005c9137ff40f20171117-31666-15zjv4f.png
Command :: file -b --mime '/tmp/12c673a281637dd47f4005c9137ff40f20171117-31666-1w834z.png'
=> #<Paperclip::Attachment:0x0000557e0afface8 @name=:image, @name_string="image", @instance=#<CustomEmoji id: 370, shortcode: "unarist", domain: "glitch.social", image_file_name: "1d3e31c6c760e47e.png", image_content_type: "image/png", image_file_size: 2446, image_updated_at: "2017-10-12 14:27:38", created_at: "2017-10-12 14:27:38", updated_at: "2017-10-12 14:27:38", disabled: false, uri: "https://glitch.social/emojis/439", image_remote_url: "https://static.glitch.social/custom_emojis/images/...", visible_in_picker: true>, @options={:convert_options=>{}, :default_style=>:original, :default_url=>"/:attachment/:style/missing.png", :escape_url=>true, :restricted_characters=>/[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/, :filename_cleaner=>nil, :hash_data=>":class/:attachment/:id/:style/:updated_at", :hash_digest=>"SHA1", :interpolator=>Paperclip::Interpolations, :only_process=>[], :path=>":class/:attachment/:id_partition/:style/:filename", :preserve_files=>false, :processors=>[:thumbnail], :source_file_options=>{}, :storage=>:fog, :styles=>{:static=>{:format=>"png", :convert_options=>"-coalesce -strip"}}, :url=>":fog_public_url", :url_generator=>Paperclip::UrlGenerator, :use_default_time_zone=>true, :use_timestamp=>false, :whiny=>true, :validate_media_type=>true, :check_validity_before_processing=>true, :fog_credentials=>{:provider=>"Local", :local_root=>#<Pathname:/home/mastodon/livex/public/system>}, :fog_directory=>"", :fog_host=>"/system"}, @post_processing=true, @queued_for_delete=[], @queued_for_write={}, @errors={}, @dirty=false, @interpolator=Paperclip::Interpolations, @url_generator=#<Paperclip::UrlGenerator:0x0000557e0affab58 @attachment=#<Paperclip::Attachment:0x0000557e0afface8 ...>>, @source_file_options={}, @whiny=true, @fog_credentials={:provider=>"Local", :local_root=>#<Pathname:/home/mastodon/livex/public/system>}, @connection=#<Fog::Storage::Local::Real:46999919581580 @local_root="/home/mastodon/livex/public/system" @endpoint=nil>, @directory=  <Fog::Storage::Local::Directory
    key=""
  >>
irb(main):008:0> emoji.save
Command :: file -b --mime '/tmp/12c673a281637dd47f4005c9137ff40f20171117-31666-stuazl.png'
[paperclip] saving custom_emojis/images/000/001/637/original/1d3e31c6c760e47e.png
=> true
※ /static/ version of Emoji not created...
```
3. Emoji copy by before #5467 method
```
irb(main):010:0> orig = CustomEmoji.find(809)
=> #<CustomEmoji id: 809, shortcode: "blobowo", domain: "kirishima.cloud", image_file_name: "6465d289bb353522.png", image_content_type: "image/png", image_file_size: 10745, image_updated_at: "2017-10-25 15:32:32", created_at: "2017-10-25 15:32:32", updated_at: "2017-10-25 15:32:32", disabled: false, uri: "https://kirishima.cloud/emojis/953", image_remote_url: "https://kirishima.cloud/springsong.media/custom_em...", visible_in_picker: true>
irb(main):011:0> emoji = CustomEmoji.new(domain: nil, shortcode: orig.shortcode, image: orig.image)
[paperclip] copying custom_emojis/images/000/000/809/original/6465d289bb353522.png to local file /tmp/bf5f98dcff7beed8d02cd8af4ab888cc20171117-31666-139l6wz.png
Command :: file -b --mime '/tmp/bf5f98dcff7beed8d02cd8af4ab888cc20171117-31666-bivtsy.png'
Command :: identify -format '%wx%h,%[exif:orientation]' '/tmp/bf5f98dcff7beed8d02cd8af4ab888cc20171117-31666-139l6wz.png[0]' 2>/dev/null
Command :: convert '/tmp/bf5f98dcff7beed8d02cd8af4ab888cc20171117-31666-139l6wz.png[0]' -auto-orient -coalesce -strip '/tmp/2cebcbfb83b89dc750b2045e933f20ab20171117-31666-1kjtf1c.png'
=> #<CustomEmoji id: nil, shortcode: "blobowo", domain: nil, image_file_name: "6465d289bb353522.png", image_content_type: "image/png", image_file_size: 10745, image_updated_at: "2017-11-17 14:36:22", created_at: nil, updated_at: nil, disabled: false, uri: nil, image_remote_url: nil, visible_in_picker: true>
irb(main):012:0> emoji.save
Command :: file -b --mime '/tmp/bf5f98dcff7beed8d02cd8af4ab888cc20171117-31666-1xbe2j5.png'
[paperclip] saving custom_emojis/images/000/001/638/original/6465d289bb353522.png
[paperclip] saving custom_emojis/images/000/001/638/static/6465d289bb353522.png
=> true
※ /static/ version is created correctly, but this method can't overwrite Emoji.
```
4. Use find_or_initialize_by instead of find_or_create_by
```
irb(main):013:0> orig = CustomEmoji.find(1194)
=> #<CustomEmoji id: 1194, shortcode: "nyancat_rainbow", domain: "kirishima.cloud", image_file_name: "c78ccbca594351e6.png", image_content_type: "image/png", image_file_size: 1080, image_updated_at: "2017-10-29 18:56:28", created_at: "2017-10-29 18:56:28", updated_at: "2017-10-29 18:56:28", disabled: false, uri: "https://kirishima.cloud/emojis/1731", image_remote_url: "https://kirishima.cloud/springsong.media/custom_em...", visible_in_picker: true>
irb(main):014:0> emoji = CustomEmoji.find_or_initialize_by(domain: nil, shortcode: orig.shortcode)
=> #<CustomEmoji id: nil, shortcode: "nyancat_rainbow", domain: nil, image_file_name: nil, image_content_type: nil, image_file_size: nil, image_updated_at: nil, created_at: nil, updated_at: nil, disabled: false, uri: nil, image_remote_url: nil, visible_in_picker: true>
irb(main):015:0> emoji.image = orig.image
[paperclip] copying custom_emojis/images/000/001/194/original/c78ccbca594351e6.png to local file /tmp/af86d36ee850e926965fcb1399325e0020171117-31666-12w0qnw.png
Command :: file -b --mime '/tmp/af86d36ee850e926965fcb1399325e0020171117-31666-1g6sjn6.png'
Command :: identify -format '%wx%h,%[exif:orientation]' '/tmp/af86d36ee850e926965fcb1399325e0020171117-31666-12w0qnw.png[0]' 2>/dev/null
Command :: convert '/tmp/af86d36ee850e926965fcb1399325e0020171117-31666-12w0qnw.png[0]' -auto-orient -coalesce -strip '/tmp/2ffa3e8d691fa77b9945b1509f83d1e320171117-31666-1wijpjk.png'
=> #<Paperclip::Attachment:0x0000557e0b508398 @name=:image, @name_string="image", @instance=#<CustomEmoji id: 1194, shortcode: "nyancat_rainbow", domain: "kirishima.cloud", image_file_name: "c78ccbca594351e6.png", image_content_type: "image/png", image_file_size: 1080, image_updated_at: "2017-10-29 18:56:28", created_at: "2017-10-29 18:56:28", updated_at: "2017-10-29 18:56:28", disabled: false, uri: "https://kirishima.cloud/emojis/1731", image_remote_url: "https://kirishima.cloud/springsong.media/custom_em...", visible_in_picker: true>, @options={:convert_options=>{}, :default_style=>:original, :default_url=>"/:attachment/:style/missing.png", :escape_url=>true, :restricted_characters=>/[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/, :filename_cleaner=>nil, :hash_data=>":class/:attachment/:id/:style/:updated_at", :hash_digest=>"SHA1", :interpolator=>Paperclip::Interpolations, :only_process=>[], :path=>":class/:attachment/:id_partition/:style/:filename", :preserve_files=>false, :processors=>[:thumbnail], :source_file_options=>{}, :storage=>:fog, :styles=>{:static=>{:format=>"png", :convert_options=>"-coalesce -strip"}}, :url=>":fog_public_url", :url_generator=>Paperclip::UrlGenerator, :use_default_time_zone=>true, :use_timestamp=>false, :whiny=>true, :validate_media_type=>true, :check_validity_before_processing=>true, :fog_credentials=>{:provider=>"Local", :local_root=>#<Pathname:/home/mastodon/livex/public/system>}, :fog_directory=>"", :fog_host=>"/system"}, @post_processing=true, @queued_for_delete=[], @queued_for_write={}, @errors={}, @dirty=false, @interpolator=Paperclip::Interpolations, @url_generator=#<Paperclip::UrlGenerator:0x0000557e0b508258 @attachment=#<Paperclip::Attachment:0x0000557e0b508398 ...>>, @source_file_options={}, @whiny=true, @fog_credentials={:provider=>"Local", :local_root=>#<Pathname:/home/mastodon/livex/public/system>}, @connection=#<Fog::Storage::Local::Real:46999922016700 @local_root="/home/mastodon/livex/public/system" @endpoint=nil>, @directory=  <Fog::Storage::Local::Directory
    key=""
  >>
irb(main):016:0> emoji.save
Command :: file -b --mime '/tmp/af86d36ee850e926965fcb1399325e0020171117-31666-1037vpt.png'
[paperclip] saving custom_emojis/images/000/001/639/original/c78ccbca594351e6.png
[paperclip] saving custom_emojis/images/000/001/639/static/c78ccbca594351e6.png
=> true
※ /static/ version is created correctly.
```
4a. Emoji overwrite by method 4
```
irb(main):017:0> orig = CustomEmoji.find(1194)
=> #<CustomEmoji id: 1194, shortcode: "nyancat_rainbow", domain: "kirishima.cloud", image_file_name: "c78ccbca594351e6.png", image_content_type: "image/png", image_file_size: 1080, image_updated_at: "2017-10-29 18:56:28", created_at: "2017-10-29 18:56:28", updated_at: "2017-10-29 18:56:28", disabled: false, uri: "https://kirishima.cloud/emojis/1731", image_remote_url: "https://kirishima.cloud/springsong.media/custom_em...", visible_in_picker: true>
irb(main):018:0> emoji = CustomEmoji.find_or_initialize_by(domain: nil, shortcode: orig.shortcode)
=> #<CustomEmoji id: 1639, shortcode: "nyancat_rainbow", domain: nil, image_file_name: "c78ccbca594351e6.png", image_content_type: "image/png", image_file_size: 1080, image_updated_at: "2017-11-17 14:48:36", created_at: "2017-11-17 14:48:42", updated_at: "2017-11-17 14:48:42", disabled: false, uri: nil, image_remote_url: nil, visible_in_picker: true>
irb(main):019:0> emoji.image = orig.image
[paperclip] copying custom_emojis/images/000/001/194/original/c78ccbca594351e6.png to local file /tmp/af86d36ee850e926965fcb1399325e0020171117-31666-v8ayno.png
Command :: file -b --mime '/tmp/af86d36ee850e926965fcb1399325e0020171117-31666-3d9qnw.png'
Command :: identify -format '%wx%h,%[exif:orientation]' '/tmp/af86d36ee850e926965fcb1399325e0020171117-31666-v8ayno.png[0]' 2>/dev/null
Command :: convert '/tmp/af86d36ee850e926965fcb1399325e0020171117-31666-v8ayno.png[0]' -auto-orient -coalesce -strip '/tmp/d046e6db7fc8f820a7478098d197c67120171117-31666-1uz407r.png'
=> #<Paperclip::Attachment:0x0000557e0b76cc38 @name=:image, @name_string="image", @instance=#<CustomEmoji id: 1194, shortcode: "nyancat_rainbow", domain: "kirishima.cloud", image_file_name: "c78ccbca594351e6.png", image_content_type: "image/png", image_file_size: 1080, image_updated_at: "2017-10-29 18:56:28", created_at: "2017-10-29 18:56:28", updated_at: "2017-10-29 18:56:28", disabled: false, uri: "https://kirishima.cloud/emojis/1731", image_remote_url: "https://kirishima.cloud/springsong.media/custom_em...", visible_in_picker: true>, @options={:convert_options=>{}, :default_style=>:original, :default_url=>"/:attachment/:style/missing.png", :escape_url=>true, :restricted_characters=>/[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/, :filename_cleaner=>nil, :hash_data=>":class/:attachment/:id/:style/:updated_at", :hash_digest=>"SHA1", :interpolator=>Paperclip::Interpolations, :only_process=>[], :path=>":class/:attachment/:id_partition/:style/:filename", :preserve_files=>false, :processors=>[:thumbnail], :source_file_options=>{}, :storage=>:fog, :styles=>{:static=>{:format=>"png", :convert_options=>"-coalesce -strip"}}, :url=>":fog_public_url", :url_generator=>Paperclip::UrlGenerator, :use_default_time_zone=>true, :use_timestamp=>false, :whiny=>true, :validate_media_type=>true, :check_validity_before_processing=>true, :fog_credentials=>{:provider=>"Local", :local_root=>#<Pathname:/home/mastodon/livex/public/system>}, :fog_directory=>"", :fog_host=>"/system"}, @post_processing=true, @queued_for_delete=[], @queued_for_write={}, @errors={}, @dirty=false, @interpolator=Paperclip::Interpolations, @url_generator=#<Paperclip::UrlGenerator:0x0000557e0b76caa8 @attachment=#<Paperclip::Attachment:0x0000557e0b76cc38 ...>>, @source_file_options={}, @whiny=true, @fog_credentials={:provider=>"Local", :local_root=>#<Pathname:/home/mastodon/livex/public/system>}, @connection=#<Fog::Storage::Local::Real:46999923270700 @local_root="/home/mastodon/livex/public/system" @endpoint=nil>, @directory=  <Fog::Storage::Local::Directory
    key=""
  >>
irb(main):020:0> emoji.save
Command :: file -b --mime '/tmp/af86d36ee850e926965fcb1399325e0020171117-31666-13zv6ze.png'
[paperclip] deleting custom_emojis/images/000/001/639/original/c78ccbca594351e6.png
[paperclip] deleting custom_emojis/images/000/001/639/static/c78ccbca594351e6.png
[paperclip] saving custom_emojis/images/000/001/639/original/c78ccbca594351e6.png
[paperclip] saving custom_emojis/images/000/001/639/static/c78ccbca594351e6.png
=> true
※ It seems this method works.
```

I tested this on my staging instance and it seems to work correctly (copy & overwrite).