### PR TITLE
Increase contrast of Admin badges

### DIFF
--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -542,8 +542,8 @@
   }
 
   &.admin {
-    color: $error-red;
-    background-color: rgba($error-red, 0.1);
-    border-color: rgba($error-red, 0.5);
+    color: lighten($error-red, 12%);
+    background-color: rgba(lighten($error-red, 12%), 0.1);
+    border-color: rgba(lighten($error-red, 12%), 0.5);
   }
 }


### PR DESCRIPTION
This is to comply [WCAG 2.0 guidelines on contrast ratio](https://www.w3.org/TR/WCAG20/#visual-audio-contrast) . The minimum contrast ratio has established as 4.5.

Present contrast ratio of admin badges is 3.62.
With this commit, the ratio increases to 4.98.

|Before|After|
|-------|-----|
|![ws000158](https://user-images.githubusercontent.com/27640522/32960406-1bd6f49c-cc08-11e7-86c2-75c8a04b3de5.png)|![After](https://user-images.githubusercontent.com/27640522/32959855-48e2a2f8-cc06-11e7-91af-e829721a598f.png)|
