### PR TITLE
Remove translations of default theme, except en.yml

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -517,8 +517,6 @@ de:
     pinned: Angehefteter Beitrag
     reblogged: teilte
     sensitive_content: Heikle Inhalte
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%d.%m.%Y %H:%M"

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -423,8 +423,6 @@ eo:
     sensitive_content: Tikla enhavo
   terms:
     title: "%{instance} Reguloj de servo kaj Politikaj pri privatecoj"
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -587,8 +587,6 @@ fa:
 
       <p>این نوشته اقتباسی است از <a href="https://github.com/discourse/discourse">سیاست رازداری Discourse</a>.</p>
     title: شرایط استفاده و سیاست رازداری %{instance}
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%d %b %Y, %H:%M"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -587,8 +587,6 @@ fr:
 
       <p>Originellement adapté à partir de la politique de confidentialité de <a href="https://github.com/discourse/discourse">Discourse</a>.</p>
     title: "%{instance} Conditions d’utilisations et politique de confidentialité"
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%d %b %Y, %H:%M"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -607,8 +607,6 @@ ja:
 
       <p>オリジナルの出典 <a href="https://github.com/discourse/discourse">Discourse privacy policy</a>.</p>
     title: "%{instance} 利用規約・プライバシーポリシー"
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%Y年%m月%d日 %H:%M"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -518,8 +518,6 @@ ko:
     sensitive_content: 민감한 컨텐츠
   terms:
     title: "%{instance} 이용약관과 개인정보 취급 방침"
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%Y년 %m월 %d일 %H:%M"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -587,8 +587,6 @@ nl:
 
       <p>Originally adapted from the <a href="https://github.com/discourse/discourse">Discourse privacy policy</a>.</p>
     title: "%{instance} Terms of Service and Privacy Policy"
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%d %B %Y om %H:%M"

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -678,8 +678,6 @@ oc:
 
       <p>Prima adaptacion de la <a href="https://github.com/discourse/discourse">politica de confidencialitat de Discourse</a>.</p>
     title: Condicions d’utilizacion e politica de confidencialitat de %{instance}
-  themes:
-    default: Mastodon
   time:
     formats:
       default: Lo %d %b de %Y a %Ho%M

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -611,8 +611,6 @@ pl:
 
       <p>Tekst bazuje na <a href="https://github.com/discourse/discourse">polityce prywatności Discourse</a>.</p>
     title: Zasady korzystania i polityka prywatności %{instance}
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -607,8 +607,6 @@ pt-BR:
 
       <p>Originalmente adaptado da <a href="https://github.com/discourse/discourse">política de privacidade do Discourse</a>.</p>
     title: "%{instance} Termos de Serviço e Política de Privacidade"
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -521,8 +521,6 @@ ru:
     sensitive_content: Чувствительный контент
   terms:
     title: Условия обслуживания и политика конфиденциальности %{instance}
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -587,8 +587,6 @@ sv:
 
       <p>Ursprungligen anpassad från <a href="https://github.com/discourse/discourse">Discourse integritetspolicy</a>.</p>
     title: "%{instance} Användarvillkor och Sekretesspolicy"
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -601,8 +601,6 @@ zh-CN:
 
       <p>原文出自 <a href="https://github.com/discourse/discourse">Discourse 隐私权政策</a>。</p>
     title: "%{instance} 使用条款和隐私权政策"
-  themes:
-    default: Mastodon
   time:
     formats:
       default: "%Y年%-m月%d日 %H:%M"


### PR DESCRIPTION
I think the translation of default theme "Mastodon" should fallback to en.yml. It's because, when we change default theme, we need to change names of default theme in ALL language files 😩 . "Mastodon" is the same translation in all languages.