### PR TITLE
Fix N+1 at notification

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -24,7 +24,7 @@ class Notification < ApplicationRecord
     favourite:      'Favourite',
   }.freeze
 
-  STATUS_INCLUDES = [:account, :stream_entry, :media_attachments, :tags, mentions: :account, reblog: [:stream_entry, :account, :media_attachments, :tags, mentions: :account]].freeze
+  STATUS_INCLUDES = [:account, :application, :stream_entry, :media_attachments, :tags, mentions: :account, reblog: [:stream_entry, :account, :application, :media_attachments, :tags, mentions: :account]].freeze
 
   belongs_to :account
   belongs_to :from_account, class_name: 'Account'
@@ -55,9 +55,11 @@ class Notification < ApplicationRecord
   def target_status
     case type
     when :reblog
-      activity&.reblog
-    when :favourite, :mention
-      activity&.status
+      status&.reblog
+    when :favourite
+      favourite&.status
+    when :mention
+      mention&.status
     end
   end
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -6,23 +6,18 @@ RSpec.describe Notification, type: :model do
   end
 
   describe '#target_status' do
-    before do
-      allow(notification).to receive(:type).and_return(type)
-      allow(notification).to receive(:activity).and_return(activity)
-    end
-
-    let(:notification) { Fabricate(:notification) }
-    let(:status)       { instance_double('Status') }
-    let(:favourite)    { instance_double('Favourite') }
-    let(:mention)      { instance_double('Mention') }
+    let(:notification) { Fabricate(:notification, activity_type: type, activity: activity) }
+    let(:status)       { Fabricate(:status) }
+    let(:reblog)       { Fabricate(:status, reblog: status) }
+    let(:favourite)    { Fabricate(:favourite, status: status) }
+    let(:mention)      { Fabricate(:mention, status: status) }
 
     context 'type is :reblog' do
       let(:type)     { :reblog }
-      let(:activity) { status }
+      let(:activity) { reblog }
 
-      it 'calls activity.reblog' do
-        expect(activity).to receive(:reblog)
-        notification.target_status
+      it 'returns status' do
+        expect(notification.target_status).to eq status
       end
     end
 
@@ -30,9 +25,8 @@ RSpec.describe Notification, type: :model do
       let(:type)     { :favourite }
       let(:activity) { favourite }
 
-      it 'calls activity.status' do
-        expect(activity).to receive(:status)
-        notification.target_status
+      it 'returns status' do
+        expect(notification.target_status).to eq status
       end
     end
 
@@ -40,9 +34,8 @@ RSpec.describe Notification, type: :model do
       let(:type)     { :mention }
       let(:activity) { mention }
 
-      it 'calls activity.status' do
-        expect(activity).to receive(:status)
-        notification.target_status
+      it 'returns status' do
+        expect(notification.target_status).to eq status
       end
     end
   end


### PR DESCRIPTION
The preloaded object was not used and an N + 1 problem occurred. Also, `application` was leaked from cache_associated. This PR fixes N + 1 problem that occurred in Notification.

Before:
```
16:32:07 web.1     | Started GET "/api/v1/notifications" for 127.0.0.1 at 2017-11-19 16:32:07 +0900
16:32:07 web.1     | Processing by Api::V1::NotificationsController#index as HTML
16:32:07 web.1     |   Doorkeeper::AccessToken Load (1.1ms)  SELECT  "oauth_access_tokens".* FROM "oauth_access_tokens" WHERE "oauth_access_tokens"."token" = $1 LIMIT $2  [["token", "6cd8f6061e584e0e994d3a1317adb09efeeccdb9839f1167e664c4a8d8e6ad04"], ["LIMIT", 1]]
16:32:07 web.1     |   User Load (0.8ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:07 web.1     |   Account Load (1.1ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:07 web.1     | Creating scope :cache_ids. Overwriting existing method Notification.cache_ids.
16:32:07 web.1     |   Notification Load (1.2ms)  SELECT  "notifications"."id", "notifications"."updated_at", "notifications"."activity_type", "notifications"."activity_id" FROM "notifications" WHERE "notifications"."account_id" = $1 AND "notifications"."activity_type" IN ('Mention', 'Status', 'Follow', 'Favourite') ORDER BY "notifications"."id" DESC LIMIT $2  [["account_id", 1], ["LIMIT", 15]]
16:32:07 web.1     |   Notification Load (1.3ms)  SELECT "notifications".* FROM "notifications" WHERE "notifications"."id" IN (16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2)
16:32:07 web.1     |   Account Load (1.3ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 2
16:32:07 web.1     |   Status Load (4.1ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."id" IN (1, 2, 3, 4, 99029868538377793, 99029868594034190, 99029868651032286, 99029868711432130, 5, 99029869638805452, 6, 99029870603460578) ORDER BY "statuses"."id" DESC
16:32:07 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 2
16:32:07 web.1     |   StreamEntry Load (1.2ms)  SELECT "stream_entries".* FROM "stream_entries" WHERE "stream_entries"."activity_type" = $1 AND "stream_entries"."activity_id" IN (99029870603460578, 99029869638805452, 99029868711432130, 99029868651032286, 99029868594034190, 99029868538377793)  [["activity_type", "Status"]]
16:32:07 web.1     |   MediaAttachment Load (1.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN (99029870603460578, 99029869638805452, 99029868711432130, 99029868651032286, 99029868594034190, 99029868538377793) ORDER BY "media_attachments"."id" ASC
16:32:07 web.1     |   HABTM_Tags Load (1.6ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN (99029870603460578, 99029869638805452, 99029868711432130, 99029868651032286, 99029868594034190, 99029868538377793)
16:32:07 web.1     |   Mention Load (1.4ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" IN (99029870603460578, 99029869638805452, 99029868711432130, 99029868651032286, 99029868594034190, 99029868538377793)
16:32:07 web.1     |   Status Load (5.1ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."id" IN (99029870422921597, 99029869122027412, 99029867015843608, 99029867148034114, 99029867272742183, 99029867411964730) ORDER BY "statuses"."id" DESC
16:32:07 web.1     |   StreamEntry Load (1.5ms)  SELECT "stream_entries".* FROM "stream_entries" WHERE "stream_entries"."activity_type" = $1 AND "stream_entries"."activity_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)  [["activity_type", "Status"]]
16:32:07 web.1     |   Account Load (5.2ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 1
16:32:07 web.1     |   MediaAttachment Load (1.1ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608) ORDER BY "media_attachments"."id" ASC
16:32:07 web.1     |   HABTM_Tags Load (1.3ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)
16:32:07 web.1     |   Mention Load (4.4ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)
16:32:07 web.1     |   Mention Load (2.4ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."id" IN (1, 2, 3, 4, 99029868538377793, 99029868594034190, 99029868651032286, 99029868711432130, 5, 99029869638805452, 6, 99029870603460578)
16:32:07 web.1     |   Status Load (1.3ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."id" IN (99029869385243825, 99029869871076346, 99029870111530942) ORDER BY "statuses"."id" DESC
16:32:07 web.1     |   CACHE Account Load (0.1ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 2
16:32:07 web.1     |   StreamEntry Load (1.2ms)  SELECT "stream_entries".* FROM "stream_entries" WHERE "stream_entries"."activity_type" = $1 AND "stream_entries"."activity_id" IN (99029870111530942, 99029869871076346, 99029869385243825)  [["activity_type", "Status"]]
16:32:07 web.1     |   MediaAttachment Load (1.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN (99029870111530942, 99029869871076346, 99029869385243825) ORDER BY "media_attachments"."id" ASC
16:32:07 web.1     |   HABTM_Tags Load (0.9ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN (99029870111530942, 99029869871076346, 99029869385243825)
16:32:07 web.1     |   Mention Load (1.6ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" IN (99029870111530942, 99029869871076346, 99029869385243825)
16:32:07 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 1
16:32:07 web.1     |   Favourite Load (0.9ms)  SELECT "favourites".* FROM "favourites" WHERE "favourites"."id" IN (1, 2, 3, 4, 99029868538377793, 99029868594034190, 99029868651032286, 99029868711432130, 5, 99029869638805452, 6, 99029870603460578)
16:32:07 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 2
16:32:07 web.1     |   Status Load (2.9ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."id" IN (99029867015843608, 99029867148034114, 99029867272742183, 99029867411964730, 99029869122027412, 99029870422921597) ORDER BY "statuses"."id" DESC
16:32:07 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 1
16:32:07 web.1     |   CACHE StreamEntry Load (0.0ms)  SELECT "stream_entries".* FROM "stream_entries" WHERE "stream_entries"."activity_type" = $1 AND "stream_entries"."activity_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)  [["activity_type", "Status"]]
16:32:07 web.1     |   CACHE MediaAttachment Load (0.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608) ORDER BY "media_attachments"."id" ASC
16:32:07 web.1     |   CACHE HABTM_Tags Load (0.0ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)
16:32:07 web.1     |   CACHE Mention Load (0.0ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)
16:32:07 web.1     |   Follow Load (0.9ms)  SELECT "follows".* FROM "follows" WHERE "follows"."id" IN (1, 2, 3, 4, 99029868538377793, 99029868594034190, 99029868651032286, 99029868711432130, 5, 99029869638805452, 6, 99029870603460578)
16:32:07 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 2
16:32:07 web.1     |   Status Load (1.2ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029870603460578], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (1.6ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029870422921597], ["LIMIT", 1]]
16:32:07 web.1     |   Favourite Load (2.9ms)  SELECT  "favourites".* FROM "favourites" WHERE "favourites"."id" = $1 LIMIT $2  [["id", 6], ["LIMIT", 1]]
16:32:07 web.1     |   CACHE Status Load (0.0ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029870422921597], ["LIMIT", 1]]
16:32:07 web.1     |   Mention Load (1.0ms)  SELECT  "mentions".* FROM "mentions" WHERE "mentions"."id" = $1 LIMIT $2  [["id", 3], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (5.0ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029870111530942], ["LIMIT", 1]]
16:32:07 web.1     |   Mention Load (0.8ms)  SELECT  "mentions".* FROM "mentions" WHERE "mentions"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (2.4ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029869871076346], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (1.1ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029869638805452], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (1.0ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029869122027412], ["LIMIT", 1]]
16:32:07 web.1     |   Favourite Load (0.9ms)  SELECT  "favourites".* FROM "favourites" WHERE "favourites"."id" = $1 LIMIT $2  [["id", 5], ["LIMIT", 1]]
16:32:07 web.1     |   CACHE Status Load (0.0ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029869122027412], ["LIMIT", 1]]
16:32:07 web.1     |   Mention Load (1.0ms)  SELECT  "mentions".* FROM "mentions" WHERE "mentions"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (1.3ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029869385243825], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (1.0ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029868711432130], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (1.3ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029867015843608], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (1.2ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029868651032286], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (2.3ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029867148034114], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (1.1ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029868594034190], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (0.9ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029867272742183], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (3.6ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029868538377793], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (1.1ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029867411964730], ["LIMIT", 1]]
16:32:07 web.1     |   Favourite Load (0.8ms)  SELECT  "favourites".* FROM "favourites" WHERE "favourites"."id" = $1 LIMIT $2  [["id", 4], ["LIMIT", 1]]
16:32:07 web.1     |   CACHE Status Load (0.0ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029867411964730], ["LIMIT", 1]]
16:32:07 web.1     |   Favourite Load (0.8ms)  SELECT  "favourites".* FROM "favourites" WHERE "favourites"."id" = $1 LIMIT $2  [["id", 3], ["LIMIT", 1]]
16:32:07 web.1     |   CACHE Status Load (0.0ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029867272742183], ["LIMIT", 1]]
16:32:07 web.1     |   Favourite Load (0.9ms)  SELECT  "favourites".* FROM "favourites" WHERE "favourites"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
16:32:07 web.1     |   CACHE Status Load (0.0ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029867148034114], ["LIMIT", 1]]
16:32:07 web.1     |   Favourite Load (1.0ms)  SELECT  "favourites".* FROM "favourites" WHERE "favourites"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:07 web.1     |   CACHE Status Load (0.0ms)  SELECT  "statuses".* FROM "statuses" WHERE "statuses"."id" = $1 ORDER BY "statuses"."id" DESC LIMIT $2  [["id", 99029867015843608], ["LIMIT", 1]]
16:32:07 web.1     |   Status Load (1.0ms)  SELECT "statuses"."reblog_of_id" FROM "statuses" WHERE "statuses"."reblog_of_id" IN (99029870422921597, 99029870111530942, 99029869871076346, 99029869122027412, 99029869385243825, 99029867015843608, 99029867148034114, 99029867272742183, 99029867411964730) AND "statuses"."account_id" = $1 ORDER BY "statuses"."id" DESC  [["account_id", 1]]
16:32:07 web.1     |   Favourite Load (0.9ms)  SELECT "favourites"."status_id" FROM "favourites" WHERE "favourites"."status_id" IN (99029870422921597, 99029870111530942, 99029869871076346, 99029869122027412, 99029869385243825, 99029867015843608, 99029867148034114, 99029867272742183, 99029867411964730) AND "favourites"."account_id" = $1  [["account_id", 1]]
16:32:07 web.1     |   ConversationMute Load (0.9ms)  SELECT "conversation_mutes"."conversation_id" FROM "conversation_mutes" WHERE "conversation_mutes"."conversation_id" IN (11, 9, 3, 1, 2, 4) AND "conversation_mutes"."account_id" = $1  [["account_id", 1]]
16:32:08 web.1     |   StatusPin Load (1.0ms)  SELECT "status_pins"."status_id" FROM "status_pins" WHERE "status_pins"."status_id" IN (99029870422921597, 99029870422921597, 99029869122027412, 99029869122027412, 99029867015843608, 99029867148034114, 99029867272742183, 99029867411964730, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608) AND "status_pins"."account_id" = $1  [["account_id", 1]]
16:32:08 web.1     | [active_model_serializers]   Mention Load (1.2ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029870422921597]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   Doorkeeper::Application Load (2.9ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   MediaAttachment Load (3.8ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029870422921597]]
16:32:08 web.1     | [active_model_serializers]   Tag Load (1.0ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029870422921597]]
16:32:08 web.1     | [active_model_serializers]   CACHE Mention Load (0.0ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029870422921597]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE MediaAttachment Load (0.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029870422921597]]
16:32:08 web.1     | [active_model_serializers]   CACHE Tag Load (0.0ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029870422921597]]
16:32:08 web.1     | [active_model_serializers]   Mention Load (1.5ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029870111530942]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   Account Load (1.2ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   MediaAttachment Load (1.1ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029870111530942]]
16:32:08 web.1     | [active_model_serializers]   Tag Load (1.1ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029870111530942]]
16:32:08 web.1     | [active_model_serializers]   Mention Load (0.9ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029869871076346]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   MediaAttachment Load (1.1ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029869871076346]]
16:32:08 web.1     | [active_model_serializers]   Tag Load (0.9ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029869871076346]]
16:32:08 web.1     | [active_model_serializers]   Mention Load (0.9ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029869122027412]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   MediaAttachment Load (1.1ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029869122027412]]
16:32:08 web.1     | [active_model_serializers]   Tag Load (1.3ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029869122027412]]
16:32:08 web.1     | [active_model_serializers]   CACHE Mention Load (0.0ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029869122027412]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE MediaAttachment Load (0.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029869122027412]]
16:32:08 web.1     | [active_model_serializers]   CACHE Tag Load (0.0ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029869122027412]]
16:32:08 web.1     | [active_model_serializers]   Mention Load (1.0ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029869385243825]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   MediaAttachment Load (1.1ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029869385243825]]
16:32:08 web.1     | [active_model_serializers]   Tag Load (0.9ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029869385243825]]
16:32:08 web.1     | [active_model_serializers]   Mention Load (0.8ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029867015843608]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   MediaAttachment Load (1.9ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029867015843608]]
16:32:08 web.1     | [active_model_serializers]   Tag Load (2.0ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029867015843608]]
16:32:08 web.1     | [active_model_serializers]   Mention Load (1.1ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029867148034114]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   MediaAttachment Load (1.1ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029867148034114]]
16:32:08 web.1     | [active_model_serializers]   Tag Load (0.8ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029867148034114]]
16:32:08 web.1     | [active_model_serializers]   Mention Load (0.9ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029867272742183]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   MediaAttachment Load (1.6ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029867272742183]]
16:32:08 web.1     | [active_model_serializers]   Tag Load (0.8ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029867272742183]]
16:32:08 web.1     | [active_model_serializers]   Mention Load (1.0ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029867411964730]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.1ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   MediaAttachment Load (1.2ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029867411964730]]
16:32:08 web.1     | [active_model_serializers]   Tag Load (0.9ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029867411964730]]
16:32:08 web.1     | [active_model_serializers]   CACHE Mention Load (0.0ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029867411964730]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE MediaAttachment Load (0.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029867411964730]]
16:32:08 web.1     | [active_model_serializers]   CACHE Tag Load (0.0ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029867411964730]]
16:32:08 web.1     | [active_model_serializers]   CACHE Mention Load (0.0ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029867272742183]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE MediaAttachment Load (0.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029867272742183]]
16:32:08 web.1     | [active_model_serializers]   CACHE Tag Load (0.0ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029867272742183]]
16:32:08 web.1     | [active_model_serializers]   CACHE Mention Load (0.0ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029867148034114]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.0ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE MediaAttachment Load (0.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029867148034114]]
16:32:08 web.1     | [active_model_serializers]   CACHE Tag Load (0.0ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029867148034114]]
16:32:08 web.1     | [active_model_serializers]   CACHE Mention Load (0.0ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" = $1  [["status_id", 99029867015843608]]
16:32:08 web.1     | [active_model_serializers]   CACHE Account Load (0.0ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE Doorkeeper::Application Load (0.1ms)  SELECT  "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:32:08 web.1     | [active_model_serializers]   CACHE MediaAttachment Load (0.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 99029867015843608]]
16:32:08 web.1     | [active_model_serializers]   CACHE Tag Load (0.0ms)  SELECT "tags".* FROM "tags" INNER JOIN "statuses_tags" ON "tags"."id" = "statuses_tags"."tag_id" WHERE "statuses_tags"."status_id" = $1  [["status_id", 99029867015843608]]
16:32:08 web.1     | [active_model_serializers] Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::Attributes (530.35ms)
16:32:08 web.1     | Completed 200 OK in 1225ms (Views: 482.1ms | ActiveRecord: 212.5ms)
```

After:
```
16:39:51 web.1     | Started GET "/api/v1/notifications" for 127.0.0.1 at 2017-11-19 16:39:51 +0900
16:39:52 web.1     | Processing by Api::V1::NotificationsController#index as HTML
16:39:52 web.1     |   Doorkeeper::AccessToken Load (1.0ms)  SELECT  "oauth_access_tokens".* FROM "oauth_access_tokens" WHERE "oauth_access_tokens"."token" = $1 LIMIT $2  [["token", "6cd8f6061e584e0e994d3a1317adb09efeeccdb9839f1167e664c4a8d8e6ad04"], ["LIMIT", 1]]
16:39:52 web.1     |   User Load (0.9ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:39:52 web.1     |   Account Load (1.7ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
16:39:52 web.1     | Creating scope :cache_ids. Overwriting existing method Notification.cache_ids.
16:39:52 web.1     |   Notification Load (1.4ms)  SELECT  "notifications"."id", "notifications"."updated_at", "notifications"."activity_type", "notifications"."activity_id" FROM "notifications" WHERE "notifications"."account_id" = $1 AND "notifications"."activity_type" IN ('Mention', 'Status', 'Follow', 'Favourite') ORDER BY "notifications"."id" DESC LIMIT $2  [["account_id", 1], ["LIMIT", 15]]
16:39:52 web.1     |   Notification Load (1.2ms)  SELECT "notifications".* FROM "notifications" WHERE "notifications"."id" IN (16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2)
16:39:52 web.1     |   Account Load (1.1ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 2
16:39:52 web.1     |   Status Load (1.3ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."id" IN (1, 2, 3, 4, 99029868538377793, 99029868594034190, 99029868651032286, 99029868711432130, 5, 99029869638805452, 6, 99029870603460578) ORDER BY "statuses"."id" DESC
16:39:52 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 2
16:39:52 web.1     |   StreamEntry Load (0.9ms)  SELECT "stream_entries".* FROM "stream_entries" WHERE "stream_entries"."activity_type" = $1 AND "stream_entries"."activity_id" IN (99029870603460578, 99029869638805452, 99029868711432130, 99029868651032286, 99029868594034190, 99029868538377793)  [["activity_type", "Status"]]
16:39:52 web.1     |   MediaAttachment Load (0.9ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN (99029870603460578, 99029869638805452, 99029868711432130, 99029868651032286, 99029868594034190, 99029868538377793) ORDER BY "media_attachments"."id" ASC
16:39:52 web.1     |   HABTM_Tags Load (1.0ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN (99029870603460578, 99029869638805452, 99029868711432130, 99029868651032286, 99029868594034190, 99029868538377793)
16:39:52 web.1     |   Mention Load (1.1ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" IN (99029870603460578, 99029869638805452, 99029868711432130, 99029868651032286, 99029868594034190, 99029868538377793)
16:39:52 web.1     |   Status Load (1.1ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."id" IN (99029870422921597, 99029869122027412, 99029867015843608, 99029867148034114, 99029867272742183, 99029867411964730) ORDER BY "statuses"."id" DESC
16:39:52 web.1     |   StreamEntry Load (1.5ms)  SELECT "stream_entries".* FROM "stream_entries" WHERE "stream_entries"."activity_type" = $1 AND "stream_entries"."activity_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)  [["activity_type", "Status"]]
16:39:52 web.1     |   Account Load (1.3ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 1
16:39:52 web.1     |   Doorkeeper::Application Load (1.2ms)  SELECT "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = 1
16:39:52 web.1     |   MediaAttachment Load (1.1ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608) ORDER BY "media_attachments"."id" ASC
16:39:52 web.1     |   HABTM_Tags Load (0.9ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)
16:39:52 web.1     |   Mention Load (1.1ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)
16:39:52 web.1     |   Mention Load (1.6ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."id" IN (1, 2, 3, 4, 99029868538377793, 99029868594034190, 99029868651032286, 99029868711432130, 5, 99029869638805452, 6, 99029870603460578)
16:39:52 web.1     |   Status Load (1.4ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."id" IN (99029869385243825, 99029869871076346, 99029870111530942) ORDER BY "statuses"."id" DESC
16:39:52 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 2
16:39:52 web.1     |   CACHE Doorkeeper::Application Load (0.2ms)  SELECT "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = 1
16:39:52 web.1     |   StreamEntry Load (1.5ms)  SELECT "stream_entries".* FROM "stream_entries" WHERE "stream_entries"."activity_type" = $1 AND "stream_entries"."activity_id" IN (99029870111530942, 99029869871076346, 99029869385243825)  [["activity_type", "Status"]]
16:39:52 web.1     |   MediaAttachment Load (1.3ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN (99029870111530942, 99029869871076346, 99029869385243825) ORDER BY "media_attachments"."id" ASC
16:39:52 web.1     |   HABTM_Tags Load (1.1ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN (99029870111530942, 99029869871076346, 99029869385243825)
16:39:52 web.1     |   Mention Load (1.1ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" IN (99029870111530942, 99029869871076346, 99029869385243825)
16:39:52 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 1
16:39:52 web.1     |   Favourite Load (1.0ms)  SELECT "favourites".* FROM "favourites" WHERE "favourites"."id" IN (1, 2, 3, 4, 99029868538377793, 99029868594034190, 99029868651032286, 99029868711432130, 5, 99029869638805452, 6, 99029870603460578)
16:39:52 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 2
16:39:52 web.1     |   Status Load (1.7ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."id" IN (99029867015843608, 99029867148034114, 99029867272742183, 99029867411964730, 99029869122027412, 99029870422921597) ORDER BY "statuses"."id" DESC
16:39:52 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 1
16:39:52 web.1     |   CACHE Doorkeeper::Application Load (0.0ms)  SELECT "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = 1
16:39:52 web.1     |   CACHE StreamEntry Load (0.0ms)  SELECT "stream_entries".* FROM "stream_entries" WHERE "stream_entries"."activity_type" = $1 AND "stream_entries"."activity_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)  [["activity_type", "Status"]]
16:39:52 web.1     |   CACHE MediaAttachment Load (0.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608) ORDER BY "media_attachments"."id" ASC
16:39:52 web.1     |   CACHE HABTM_Tags Load (0.0ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)
16:39:52 web.1     |   CACHE Mention Load (0.1ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."status_id" IN (99029870422921597, 99029869122027412, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608)
16:39:52 web.1     |   Follow Load (0.8ms)  SELECT "follows".* FROM "follows" WHERE "follows"."id" IN (1, 2, 3, 4, 99029868538377793, 99029868594034190, 99029868651032286, 99029868711432130, 5, 99029869638805452, 6, 99029870603460578)
16:39:52 web.1     |   CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = 2
16:39:52 web.1     |   Status Load (1.3ms)  SELECT "statuses"."reblog_of_id" FROM "statuses" WHERE "statuses"."reblog_of_id" IN (99029870422921597, 99029870111530942, 99029869871076346, 99029869122027412, 99029869385243825, 99029867015843608, 99029867148034114, 99029867272742183, 99029867411964730) AND "statuses"."account_id" = $1 ORDER BY "statuses"."id" DESC  [["account_id", 1]]
16:39:52 web.1     |   Favourite Load (1.5ms)  SELECT "favourites"."status_id" FROM "favourites" WHERE "favourites"."status_id" IN (99029870422921597, 99029870111530942, 99029869871076346, 99029869122027412, 99029869385243825, 99029867015843608, 99029867148034114, 99029867272742183, 99029867411964730) AND "favourites"."account_id" = $1  [["account_id", 1]]
16:39:52 web.1     |   ConversationMute Load (0.8ms)  SELECT "conversation_mutes"."conversation_id" FROM "conversation_mutes" WHERE "conversation_mutes"."conversation_id" IN (11, 9, 3, 1, 2, 4) AND "conversation_mutes"."account_id" = $1  [["account_id", 1]]
16:39:52 web.1     |   StatusPin Load (0.9ms)  SELECT "status_pins"."status_id" FROM "status_pins" WHERE "status_pins"."status_id" IN (99029870422921597, 99029870422921597, 99029869122027412, 99029869122027412, 99029867015843608, 99029867148034114, 99029867272742183, 99029867411964730, 99029867411964730, 99029867272742183, 99029867148034114, 99029867015843608) AND "status_pins"."account_id" = $1  [["account_id", 1]]
16:39:53 web.1     | [active_model_serializers] Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::Attributes (336.2ms)
16:39:53 web.1     | Completed 200 OK in 990ms (Views: 332.6ms | ActiveRecord: 100.1ms)
```