### PR TITLE
Soft-delete statuses, really delete after 30 days

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -277,6 +277,13 @@
   display: flex;
   margin-bottom: 10px;
 
+  &.deleted {
+    .entry,
+    .batch-checkbox {
+      opacity: 0.6;
+    }
+  }
+
   .activity-stream {
     flex: 2 0 0;
     margin-right: 20px;

--- a/app/models/concerns/paranoid.rb
+++ b/app/models/concerns/paranoid.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Paranoid
+  extend ActiveSupport::Concern
+
+  included do
+    scope :without_deleted, -> { where('deleted_at IS NULL') }
+    scope :with_deleted,    -> { unscoped.recent }
+    scope :only_deleted,    -> { with_deleted.where('deleted_at IS NOT NULL') }
+  end
+
+  def soft_destroy
+    touch(:deleted_at)
+  end
+
+  alias soft_destroy! soft_destroy
+
+  def destroyed?
+    deleted_at.present? || super
+  end
+end

--- a/app/models/concerns/status_threading_concern.rb
+++ b/app/models/concerns/status_threading_concern.rb
@@ -34,7 +34,7 @@ module StatusThreadingConcern
         SELECT statuses.id, statuses.in_reply_to_id, path || statuses.id
         FROM search_tree
         JOIN statuses ON statuses.id = search_tree.in_reply_to_id
-        WHERE NOT statuses.id = ANY(path)
+        WHERE NOT statuses.id = ANY(path) AND statuses.deleted_at IS NULL
       )
       SELECT id
       FROM search_tree
@@ -61,7 +61,7 @@ module StatusThreadingConcern
         SELECT statuses.id, path || statuses.id
         FROM search_tree
         JOIN statuses ON statuses.in_reply_to_id = search_tree.id
-        WHERE NOT statuses.id = ANY(path)
+        WHERE NOT statuses.id = ANY(path) AND statuses.deleted_at IS NULL
       )
       SELECT id
       FROM search_tree

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -25,7 +25,7 @@ class Report < ApplicationRecord
   validates :comment, length: { maximum: 1000 }
 
   def statuses
-    Status.where(id: status_ids).includes(:account, :media_attachments, :mentions)
+    Status.with_deleted.where(id: status_ids).includes(:account, :media_attachments, :mentions)
   end
 
   def media_attachments

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -23,6 +23,7 @@
 #  account_id             :integer          not null
 #  application_id         :integer
 #  in_reply_to_account_id :integer
+#  deleted_at             :datetime
 #
 
 class Status < ApplicationRecord
@@ -30,6 +31,7 @@ class Status < ApplicationRecord
   include Streamable
   include Cacheable
   include StatusThreadingConcern
+  include Paranoid
 
   enum visibility: [:public, :unlisted, :private, :direct], _suffix: :visibility
 
@@ -59,7 +61,7 @@ class Status < ApplicationRecord
   validates_with StatusLengthValidator
   validates :reblog, uniqueness: { scope: :account }, if: :reblog?
 
-  default_scope { recent }
+  default_scope { without_deleted.recent }
 
   scope :recent, -> { reorder(id: :desc) }
   scope :remote, -> { where(local: false).or(where.not(uri: nil)) }

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -23,7 +23,7 @@ class BatchedRemoveStatusService < BaseService
     @activity_xml          = {}
 
     # Ensure that rendered XML reflects destroyed state
-    statuses.each(&:destroy)
+    statuses.each(&:soft_destroy)
 
     # Batch by source account
     statuses.group_by(&:account_id).each_value do |account_statuses|

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -20,7 +20,7 @@ class RemoveStatusService < BaseService
     remove_from_hashtags
     remove_from_public
 
-    @status.destroy!
+    @status.soft_destroy!
 
     return unless @account.local?
 

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -8,7 +8,6 @@ class SuspendAccountService < BaseService
     purge_user!
     purge_profile!
     purge_content!
-    unsubscribe_push_subscribers!
   end
 
   private
@@ -25,17 +24,6 @@ class SuspendAccountService < BaseService
     @account.statuses.reorder(nil).find_in_batches do |statuses|
       BatchedRemoveStatusService.new.call(statuses)
     end
-
-    [
-      @account.media_attachments,
-      @account.stream_entries,
-      @account.notifications,
-      @account.favourites,
-      @account.active_relationships,
-      @account.passive_relationships,
-    ].each do |association|
-      destroy_all(association)
-    end
   end
 
   def purge_profile!
@@ -45,13 +33,5 @@ class SuspendAccountService < BaseService
     @account.avatar.destroy
     @account.header.destroy
     @account.save!
-  end
-
-  def unsubscribe_push_subscribers!
-    destroy_all(@account.subscriptions)
-  end
-
-  def destroy_all(association)
-    association.in_batches.destroy_all
   end
 end

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -32,17 +32,20 @@
         .media-spoiler-show-button.button= t('admin.statuses.media.show')
         .media-spoiler-hide-button.button= t('admin.statuses.media.hide')
     - @report.statuses.each do |status|
-      .report-status{ data: { id: status.id } }
+      .report-status{ class: status.destroyed? ? 'deleted' : '', data: { id: status.id } }
         .batch-checkbox
-          = f.check_box :status_ids, { multiple: true, include_hidden: false }, status.id
+          = f.check_box :status_ids, { multiple: true, include_hidden: false, disabled: status.destroyed? }, status.id
         .activity-stream.activity-stream-headless
           .entry= render 'stream_entries/simple_status', status: status
         .report-status__actions
-          - unless status.media_attachments.empty?
-            = link_to admin_report_reported_status_path(@report, status, status: { sensitive: !status.sensitive }), method: :put, class: 'icon-button nsfw-button', title: t("admin.reports.nsfw.#{!status.sensitive}") do
-              = fa_icon status.sensitive? ? 'eye' : 'eye-slash'
-          = link_to admin_report_reported_status_path(@report, status), method: :delete, class: 'icon-button trash-button', title: t('admin.reports.delete'), data: { confirm: t('admin.reports.are_you_sure') }, remote: true do
-            = fa_icon 'trash'
+          - if status.destroyed?
+            .icon-button.trash-button.disabled= fa_icon 'trash'
+          - else
+            - unless status.media_attachments.empty?
+              = link_to admin_report_reported_status_path(@report, status, status: { sensitive: !status.sensitive }), method: :put, class: 'icon-button nsfw-button', title: t("admin.reports.nsfw.#{!status.sensitive}") do
+                = fa_icon status.sensitive? ? 'eye' : 'eye-slash'
+            = link_to admin_report_reported_status_path(@report, status), method: :delete, class: 'icon-button trash-button', title: t('admin.reports.delete'), data: { confirm: t('admin.reports.are_you_sure') }, remote: true do
+              = fa_icon 'trash'
 
 %hr/
 

--- a/app/workers/scheduler/dead_records_cleanup_scheduler.rb
+++ b/app/workers/scheduler/dead_records_cleanup_scheduler.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'sidekiq-scheduler'
+
+class Scheduler::DeadRecordsCleanupScheduler
+  include Sidekiq::Worker
+
+  DATA_RETENTION = 30.days
+
+  def perform
+    Status.only_deleted.where('deleted_at < ?', DATA_RETENTION.ago).reorder(nil).in_batches.destroy_all
+  end
+end

--- a/db/migrate/20171120001007_add_deleted_at_to_statuses.rb
+++ b/db/migrate/20171120001007_add_deleted_at_to_statuses.rb
@@ -1,0 +1,9 @@
+class AddDeletedAtToStatuses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :statuses, :deleted_at, :datetime, null: true, default: nil
+
+    commit_db_transaction
+
+    add_index :statuses, :deleted_at, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20171120001450_adjust_soft_delete_indices.rb
+++ b/db/migrate/20171120001450_adjust_soft_delete_indices.rb
@@ -1,0 +1,15 @@
+class AdjustSoftDeleteIndices < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :statuses, [:account_id, :id]
+    remove_index :statuses, :conversation_id
+    remove_index :statuses, :in_reply_to_id
+    remove_index :statuses, :reblog_of_id
+
+    commit_db_transaction
+
+    add_index :statuses, [:account_id, :id], algorithm: :concurrently, where: 'deleted_at IS NULL'
+    add_index :statuses, :conversation_id, algorithm: :concurrently, where: 'deleted_at IS NULL'
+    add_index :statuses, :in_reply_to_id, algorithm: :concurrently, where: 'deleted_at IS NULL'
+    add_index :statuses, :reblog_of_id, algorithm: :concurrently, where: 'deleted_at IS NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171118012443) do
+ActiveRecord::Schema.define(version: 20171120001450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -384,10 +384,12 @@ ActiveRecord::Schema.define(version: 20171118012443) do
     t.bigint "account_id", null: false
     t.bigint "application_id"
     t.bigint "in_reply_to_account_id"
-    t.index ["account_id", "id"], name: "index_statuses_on_account_id_id"
-    t.index ["conversation_id"], name: "index_statuses_on_conversation_id"
-    t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
-    t.index ["reblog_of_id"], name: "index_statuses_on_reblog_of_id"
+    t.datetime "deleted_at"
+    t.index ["account_id", "id"], name: "index_statuses_on_account_id_and_id", where: "(deleted_at IS NULL)"
+    t.index ["conversation_id"], name: "index_statuses_on_conversation_id", where: "(deleted_at IS NULL)"
+    t.index ["deleted_at"], name: "index_statuses_on_deleted_at"
+    t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id", where: "(deleted_at IS NULL)"
+    t.index ["reblog_of_id"], name: "index_statuses_on_reblog_of_id", where: "(deleted_at IS NULL)"
     t.index ["uri"], name: "index_statuses_on_uri", unique: true
   end
 

--- a/spec/services/block_domain_service_spec.rb
+++ b/spec/services/block_domain_service_spec.rb
@@ -28,10 +28,9 @@ RSpec.describe BlockDomainService do
       expect(Account.find_remote('badguy666', 'evil.org').suspended?).to be true
     end
 
-    it 'removes the remote accounts\'s statuses and media attachments' do
-      expect { bad_status1.reload }.to raise_exception ActiveRecord::RecordNotFound
-      expect { bad_status2.reload }.to raise_exception ActiveRecord::RecordNotFound
-      expect { bad_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound
+    it 'removes the remote accounts\'s statuses' do
+      expect { Status.find(bad_status1.id) }.to raise_exception ActiveRecord::RecordNotFound
+      expect { Status.find(bad_status2.id) }.to raise_exception ActiveRecord::RecordNotFound
     end
   end
 

--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -15,19 +15,8 @@ RSpec.describe SuspendAccountService do
     let!(:passive_relationship) { Fabricate(:follow, target_account: account) }
     let!(:subscription) { Fabricate(:subscription, account: account) }
 
-    it 'deletes associated records' do
-      is_expected.to change {
-        [
-          account.statuses,
-          account.media_attachments,
-          account.stream_entries,
-          account.notifications,
-          account.favourites,
-          account.active_relationships,
-          account.passive_relationships,
-          account.subscriptions
-        ].map(&:count)
-      }.from([1, 1, 1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0, 0, 0])
+    it 'soft-deletes associated statuses' do
+      is_expected.to change { account.statuses.count }.from(1).to(0)
     end
   end
 end


### PR DESCRIPTION
Reasons:

1. Accountability:
  - if a report ends in a suspension, and statuses are gone instantly, it's very hard to tell what was reported and whether the suspend was justified
  - if an abuser sends abuse but then deletes the evidence we can't know what it was
2. Restoration:
  - if an account was suspended in error, it should be possible to restore it
  - if a user has second thoughts about their account deletion, they should be able to login again within 30 days to restore their account, as is common practice

---

- [x] Soft-deleted statuses don't show up anywhere
- [x] Sidekiq scheduler properly deletes soft-deleted statuses after 30 days
- [x] Suspending/deleting an account no longer immediately removes statuses, uploads, followers, follows, notifications, blocks, etc, instead it only soft-deletes statuses and marks account as suspended
- [x] Display deleted statuses in admin reports
- [ ] Add a way to differentiate account *deletions* from account *suspensions*
- [ ] Properly clean up followers, follows, notifications, blocks etc of a deleted/suspended account after a data retention period
- [ ] Unsuspending should restore the account **but without statuses that were deleted manually**