### PR TITLE
Add embed columns to preview cards

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -101,7 +101,7 @@ export default class Card extends React.PureComponent {
         onClick={this.handlePhotoClick}
         role='button'
         tabIndex='0'
-        src={card.get('url')}
+        src={card.get('embed_url')}
         alt={card.get('title')}
         width={card.get('width')}
         height={card.get('height')}

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -21,6 +21,7 @@
 #  height             :integer          default(0), not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  embed_url          :string           default(""), not null
 #
 
 class PreviewCard < ApplicationRecord

--- a/app/serializers/rest/preview_card_serializer.rb
+++ b/app/serializers/rest/preview_card_serializer.rb
@@ -6,7 +6,7 @@ class REST::PreviewCardSerializer < ActiveModel::Serializer
   attributes :url, :title, :description, :type,
              :author_name, :author_url, :provider_name,
              :provider_url, :html, :width, :height,
-             :image
+             :image, :embed_url
 
   def image
     object.image? ? full_asset_url(object.image.url(:original)) : nil

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -74,9 +74,6 @@ class FetchLinkCardService < BaseService
 
     return false unless response.respond_to?(:type)
 
-    # The photo will change the URL. So, to avoid duplication of URLs, PreviewCard needs to be checked again.
-    @card = PreviewCard.find_by(url: response.url) || @card if response.type == 'photo'
-
     @card.type          = response.type
     @card.title         = response.respond_to?(:title)         ? response.title         : ''
     @card.author_name   = response.respond_to?(:author_name)   ? response.author_name   : ''
@@ -90,9 +87,9 @@ class FetchLinkCardService < BaseService
     when 'link'
       @card.image = URI.parse(response.thumbnail_url) if response.respond_to?(:thumbnail_url)
     when 'photo'
-      @card.url    = response.url
-      @card.width  = response.width.presence  || 0
-      @card.height = response.height.presence || 0
+      @card.embed_url = response.url
+      @card.width     = response.width.presence  || 0
+      @card.height    = response.height.presence || 0
     when 'video'
       @card.width  = response.width.presence  || 0
       @card.height = response.height.presence || 0

--- a/db/migrate/20171130000000_add_embed_url_to_preview_cards.rb
+++ b/db/migrate/20171130000000_add_embed_url_to_preview_cards.rb
@@ -1,0 +1,18 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddEmbedUrlToPreviewCards < ActiveRecord::Migration[5.1]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_column_with_default :preview_cards, :embed_url, :string, default: '', allow_null: false
+    end
+  end
+
+  def down
+    execute "UPDATE preview_cards SET url=embed_url WHERE embed_url!=''"
+    remove_column :preview_cards, :embed_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171129172043) do
+ActiveRecord::Schema.define(version: 20171130000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -325,6 +325,7 @@ ActiveRecord::Schema.define(version: 20171129172043) do
     t.integer "height", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "embed_url", default: "", null: false
     t.index ["url"], name: "index_preview_cards_on_url", unique: true
   end
 

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -326,5 +326,17 @@ namespace :mastodon do
         end
       end
     end
+
+    desc 'Migrate photo preview cards made before 2.1'
+    task migrate_photo_preview_cards: :environment do
+      status_ids = Status.joins(:preview_cards)
+                         .where(preview_cards: { embed_url: '', type: :photo })
+                         .reorder(nil)
+                         .group(:id)
+                         .pluck(:id)
+
+      PreviewCard.where(embed_url: '', type: :photo).delete_all
+      LinkCrawlWorker.push_bulk status_ids
+    end
   end
 end


### PR DESCRIPTION
This resolves the problem described with https://github.com/tootsuite/mastodon/pull/5763#issuecomment-345930146.

Note that the migration included in this change rebuilds the entire `preview_cards` table and takes long.
I'm not sure it is tolerated, but it is unlikely. If not, I will introduce additional changes.