### PR TITLE
Delegate #version_number and #source_url to Mastodon::Version

### DIFF
--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -12,6 +12,12 @@ class InstancePresenter
     to: Setting
   )
 
+  delegate(
+    :version_number,
+    :source_url,
+    to: 'Mastodon::Version'
+  )
+
   def contact_account
     Account.find_local(Setting.site_contact_username)
   end
@@ -26,14 +32,6 @@ class InstancePresenter
 
   def domain_count
     Rails.cache.fetch('distinct_domain_count') { Account.distinct.count(:domain) }
-  end
-
-  def version_number
-    Mastodon::Version
-  end
-
-  def source_url
-    Mastodon::Version.source_url
   end
 
   def thumbnail

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -32,6 +32,9 @@ module Mastodon
       [to_a.join('.'), flags].join
     end
 
+    alias version_number to_s
+    module_function :version_number
+
     def source_base_url
       'https://github.com/tootsuite/mastodon'
     end

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -117,4 +117,13 @@ describe InstancePresenter do
       expect(instance_presenter.domain_count).to eq(345)
     end
   end
+
+  describe '#thumbnail' do
+    it 'returns a thumbnail' do
+      thumbnail = Fabricate(:site_upload, var: 'thumbnail')
+      expect(instance_presenter.thumbnail).to eq thumbnail
+
+      Rails.cache.clear
+    end
+  end
 end


### PR DESCRIPTION
- Create an alias `Mastodon::Version.version_number` for `Mastodon::Version.to_s`
- Delegate `InstancePresenter#version_number` and `InstancePresenter#source_url` to `Mastodon::Version`

Even though `Mastodon::Version != Mastodon::Version.to_s`, I believe it's OK because It is always used like this so far:

```ruby
"#{Mastodon::Version}"   # => implicitly calling .to_s
```
https://github.com/tootsuite/mastodon/blob/master/app/views/about/show.html.haml#L71