### PR TITLE
Add index of account and reblog to statuses

### DIFF
--- a/db/migrate/20171122120436_add_index_account_and_reblog_of_id_to_statuses.rb
+++ b/db/migrate/20171122120436_add_index_account_and_reblog_of_id_to_statuses.rb
@@ -1,0 +1,6 @@
+class AddIndexAccountAndReblogOfIdToStatuses < ActiveRecord::Migration[5.1]
+  def change
+    commit_db_transaction
+    add_index :statuses, [:account_id, :reblog_of_id], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171119172437) do
+ActiveRecord::Schema.define(version: 20171122120436) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -397,6 +397,7 @@ ActiveRecord::Schema.define(version: 20171119172437) do
     t.bigint "application_id"
     t.bigint "in_reply_to_account_id"
     t.index ["account_id", "id"], name: "index_statuses_on_account_id_id"
+    t.index ["account_id", "reblog_of_id"], name: "index_statuses_on_account_id_and_reblog_of_id"
     t.index ["conversation_id"], name: "index_statuses_on_conversation_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["reblog_of_id"], name: "index_statuses_on_reblog_of_id"


### PR DESCRIPTION
The following queries are slow, Pawoo may take up to 3 seconds. In addition, this query is called frequently.

```
SELECT "statuses"."reblog_of_id" FROM "statuses" WHERE "statuses"."reblog_of_id" IN (99046179400728714, 99046176127578155, 99046170926784058, 99046170374900651, 99046153389623869, 99046160265702183, 99046097285901719, 99046080186626998, 99046074205722840, 99045984037260435, 99045983731556084, 99045338921659833, 99045983560245332, 99045335466626882, 99045983350250471, 99045331208338469, 99045908667215211, 99045879652396515, 99045878005639113, 99045861377305786, 99045856694868158, 99045788942898025, 99045781487599457, 99045778259286296) AND "statuses"."account_id" = 1 ORDER BY "statuses"."id" DESC
```

In this PR, indexes of account_id and reblog_of_id are created. The following explain is the result of my small individual instance execution. `index_statuses_on_account_id_and_reblog_of_id` is used and the speed is improving. It is considered to be more effective in large instances.

Before

```
Sort  (cost=122.28..122.29 rows=1 width=16) (actual time=0.150..0.150 rows=0 loops=1)
  Sort Key: id DESC
  Sort Method: quicksort  Memory: 25kB
  ->  Bitmap Heap Scan on statuses  (cost=118.23..122.27 rows=1 width=16) (actual time=0.134..0.134 rows=0 loops=1)
        Recheck Cond: ((account_id = 1) AND (reblog_of_id = ANY ('{99046179400728714,99046176127578155,99046170926784058,99046170374900651,99046153389623869,99046160265702183,99046097285901719,99046080186626998,99046074205722840,99045984037260435,99045983731556084,99045338921659833,99045983560245332,99045335466626882,99045983350250471,99045331208338469,99045908667215211,99045879652396515,99045878005639113,99045861377305786,99045856694868158,99045788942898025,99045781487599457,99045778259286296}'::bigint[])))
        ->  BitmapAnd  (cost=118.23..118.23 rows=1 width=0) (actual time=0.131..0.131 rows=0 loops=1)
              ->  Bitmap Index Scan on index_statuses_on_account_id_id  (cost=0.00..14.60 rows=291 width=0) (actual time=0.080..0.080 rows=290 loops=1)
                    Index Cond: (account_id = 1)
              ->  Bitmap Index Scan on index_statuses_on_reblog_of_id  (cost=0.00..103.38 rows=54 width=0) (actual time=0.039..0.039 rows=9 loops=1)
                    Index Cond: (reblog_of_id = ANY ('{99046179400728714,99046176127578155,99046170926784058,99046170374900651,99046153389623869,99046160265702183,99046097285901719,99046080186626998,99046074205722840,99045984037260435,99045983731556084,99045338921659833,99045983560245332,99045335466626882,99045983350250471,99045331208338469,99045908667215211,99045879652396515,99045878005639113,99045861377305786,99045856694868158,99045788942898025,99045781487599457,99045778259286296}'::bigint[]))
Planning time: 0.301 ms
Execution time: 0.207 ms
```

After

```
Sort  (cost=106.28..106.28 rows=1 width=16) (actual time=0.052..0.052 rows=0 loops=1)
  Sort Key: id DESC
  Sort Method: quicksort  Memory: 25kB
  ->  Index Scan using index_statuses_on_account_id_and_reblog_of_id on statuses  (cost=0.42..106.27 rows=1 width=16) (actual time=0.047..0.047 rows=0 loops=1)
        Index Cond: ((account_id = 1) AND (reblog_of_id = ANY ('{99046179400728714,99046176127578155,99046170926784058,99046170374900651,99046153389623869,99046160265702183,99046097285901719,99046080186626998,99046074205722840,99045984037260435,99045983731556084,99045338921659833,99045983560245332,99045335466626882,99045983350250471,99045331208338469,99045908667215211,99045879652396515,99045878005639113,99045861377305786,99045856694868158,99045788942898025,99045781487599457,99045778259286296}'::bigint[])))
Planning time: 0.131 ms
Execution time: 0.076 ms
```