### PR TITLE
status: preserve visibility attribute when reblogging (infoleak fix)

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -278,6 +278,7 @@ class Status < ApplicationRecord
 
   def set_visibility
     self.visibility = (account.locked? ? :private : :public) if visibility.nil?
+    self.visibility = reblog.visibility if reblog?
     self.sensitive  = false if sensitive.nil?
   end
 


### PR DESCRIPTION
While investigating an infoleak problem specific to mastodon-hardened, I observed that mastodon always sets post visibility to public for reblogs.

There are no logical cases where a reblog should not match the visibility of it's parent.

This should fix *all* remaining visibility-related Mastodon OStatus infoleaks.