### PR TITLE
add index on stream_entries table

### DIFF
--- a/db/migrate/20171129172043_add_index_on_stream_entries.rb
+++ b/db/migrate/20171129172043_add_index_on_stream_entries.rb
@@ -1,0 +1,7 @@
+class AddIndexOnStreamEntries < ActiveRecord::Migration[5.1]
+  def change
+    commit_db_transaction
+    add_index :stream_entries, [:account_id, :activity_type, :id], algorithm: :concurrently
+    remove_index :stream_entries, name: :index_stream_entries_on_account_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171125190735) do
+ActiveRecord::Schema.define(version: 20171129172043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -431,7 +431,7 @@ ActiveRecord::Schema.define(version: 20171125190735) do
     t.datetime "updated_at", null: false
     t.boolean "hidden", default: false, null: false
     t.bigint "account_id"
-    t.index ["account_id"], name: "index_stream_entries_on_account_id"
+    t.index ["account_id", "activity_type", "id"], name: "index_stream_entries_on_account_id_and_activity_type_and_id"
     t.index ["activity_id", "activity_type"], name: "index_stream_entries_on_activity_id_and_activity_type"
   end
 


### PR DESCRIPTION
This pull request is adding index for below statement .
`SELECT  "stream_entries".* FROM "stream_entries" WHERE "stream_entries"."activity_type" = ? AND "stream_entries"."account_id" = ? AND "stream_entries"."hidden" = ? ORDER BY "stream_entries"."id" DESC LIMIT ?`

This statement executed 67,112 times.

## before
```
                                                                               QUERY PLAN                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..754.44 rows=20 width=48) (actual time=54.970..167.629 rows=20 loops=1)
   ->  Index Scan Backward using index_stream_entries_on_id on stream_entries  (cost=0.43..450939.73 rows=11961 width=48) (actual time=54.968..167.617 rows=20 loops=1)
         Filter: ((NOT hidden) AND ((activity_type)::text = 'Status'::text) AND (account_id = 11109))
         Rows Removed by Filter: 298624
 Planning time: 0.109 ms
 Execution time: 167.658 ms
(6 rows)
```
## after
```
                                                                   QUERY PLAN                                                                   
------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..167.31 rows=20 width=48) (actual time=1.718..5.579 rows=20 loops=1)
   ->  Index Scan Backward using test3 on stream_entries  (cost=0.43..103891.09 rows=12451 width=48) (actual time=1.717..5.572 rows=20 loops=1)
         Index Cond: ((account_id = 11109) AND ((activity_type)::text = 'Status'::text))
         Filter: (NOT hidden)
 Planning time: 0.126 ms
 Execution time: 5.603 ms
(6 rows)
```
