### PR TITLE
Disable Code Climate maintainability checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,21 +1,36 @@
-engines:
+version: "2"
+checks:
+  argument-count:
+    enabled: false
+  complex-logic:
+    enabled: false
+  file-lines:
+    enabled: false
+  method-complexity:
+    enabled: false
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: false
+  return-statements:
+    enabled: false
+  similar-code:
+    enabled: false
+  identical-code:
+    enabled: false
+plugins:
   brakeman:
     enabled: true
   bundler-audit:
     enabled: true
-  duplication:
-    enabled: false
   eslint:
     enabled: true
   rubocop:
     enabled: true
   scss-lint:
     enabled: true
-ratings:
-  paths:
-  - "**.rb"
-  - "**.js"
-  - "**.scss"
-exclude_paths:
+exclude_patterns:
 - spec/
 - vendor/asset


### PR DESCRIPTION
- Migrate `.codeclimate.yml` to version 2 structure
- Disable Code Climate [maintainability checks][]

https://docs.codeclimate.com/docs/advanced-configuration

[maintainability checks]: http://blog.codeclimate.com/blog/2017/10/12/10-point-technical-debt-assessment

This commit upgrades the Code Climate configuration file and disables the new maintainability checks.

Once this PR is merged, you can experiment with the new checks via pull requests (the PR will report new issues) or via the [Code Climate CLI][cli], which [now also supports the new maintainability checks][cli-support].

[cli]: https://github.com/codeclimate/codeclimate
[cli-support]: https://codeclimate.com/changelog/5a0e488824cfa902a300091c