### PR TITLE
Do not require onClose property in NavigationBar

### DIFF
--- a/app/javascript/mastodon/features/compose/components/navigation_bar.js
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.js
@@ -11,7 +11,7 @@ export default class NavigationBar extends ImmutablePureComponent {
 
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
-    onClose: PropTypes.func.isRequired,
+    onClose: PropTypes.func,
   };
 
   render () {


### PR DESCRIPTION
`NavigationBar` can be used as mock as it is in `OnboardingModal`. In such a case, `onClose` property is not required.