### PR TITLE
Change the disclaimer under the sign up form

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -333,7 +333,7 @@ en:
     warning: Be very careful with this data. Never share it with anyone!
     your_token: Your access token
   auth:
-    agreement_html: By signing up you agree to <a href="%{rules_path}">our terms of service</a> and <a href="%{terms_path}">privacy policy</a>.
+    agreement_html: By signing up you confirm to have read <a href="%{rules_path}">our extended informations page</a> and agree to <a href="%{terms_path}">our terms of service</a>.
     change_password: Security
     delete_account: Delete account
     delete_account_html: If you wish to delete your account, you can <a href="%{path}">proceed here</a>. You will be asked for confirmation.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -333,7 +333,7 @@ en:
     warning: Be very careful with this data. Never share it with anyone!
     your_token: Your access token
   auth:
-    agreement_html: By signing up you confirm to have read <a href="%{rules_path}">our extended informations page</a> and agree to <a href="%{terms_path}">our terms of service</a>.
+    agreement_html: By signing up you agree to follow <a href="%{rules_path}">the rules of the instance</a> and <a href="%{terms_path}">our terms of service</a>.
     change_password: Security
     delete_account: Delete account
     delete_account_html: If you wish to delete your account, you can <a href="%{path}">proceed here</a>. You will be asked for confirmation.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -283,7 +283,7 @@ fr:
     warning: Soyez prudent⋅e avec ces données. Ne les partagez pas !
     your_token: Votre jeton d’accès
   auth:
-    agreement_html: En vous inscrivant, vous souscrivez à <a href="%{rules_path}">nos conditions d’utilisation</a> ainsi qu’à <a href="%{terms_path}">notre politique de confidentialité</a>.
+    agreement_html: En vous inscrivant, vous déclarez avoir pris connaissance de <a href="%{rules_path}">notre page d’information étendue</a> et souscrivez à <a href="%{terms_path}">nos conditions d’utilisation</a>.
     change_password: Sécurité
     delete_account: Supprimer le compte
     delete_account_html: Si vous désirez supprimer votre compte, vous pouvez <a href="%{path}">cliquer ici</a>. Il vous sera demandé de confirmer cette action.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -283,7 +283,7 @@ fr:
     warning: Soyez prudent⋅e avec ces données. Ne les partagez pas !
     your_token: Votre jeton d’accès
   auth:
-    agreement_html: En vous inscrivant, vous déclarez avoir pris connaissance de <a href="%{rules_path}">notre page d’information étendue</a> et souscrivez à <a href="%{terms_path}">nos conditions d’utilisation</a>.
+    agreement_html: En vous inscrivant, vous souscrivez <a href="%{rules_path}">aux règles de l’instance</a> et à <a href="%{terms_path}">nos conditions d’utilisation</a>.
     change_password: Sécurité
     delete_account: Supprimer le compte
     delete_account_html: Si vous désirez supprimer votre compte, vous pouvez <a href="%{path}">cliquer ici</a>. Il vous sera demandé de confirmer cette action.


### PR DESCRIPTION
- Change the disclaimer under the sign up form. This change should make the message more clear and coherent. See [this discussion on Mastodon](https://dev.glitch.social/@Sylvhem/99062862188384217).
- Update the French translation accordingly.