### PR TITLE
Merge indexes for reblog on statuses table

### DIFF
--- a/db/migrate/20171122120436_add_index_account_and_reblog_of_id_to_statuses.rb
+++ b/db/migrate/20171122120436_add_index_account_and_reblog_of_id_to_statuses.rb
@@ -1,6 +1,12 @@
 class AddIndexAccountAndReblogOfIdToStatuses < ActiveRecord::Migration[5.1]
-  def change
-    commit_db_transaction
-    add_index :statuses, [:account_id, :reblog_of_id], algorithm: :concurrently
+  disable_ddl_transaction!
+
+  def up
+    # This index has been superseded by migration 20171125185353
+    # add_index :statuses, [:account_id, :reblog_of_id], algorithm: :concurrently
+  end
+
+  def down
+    remove_index :statuses, [:account_id, :reblog_of_id] if index_exists?(:statuses, [:account_id, :reblog_of_id])
   end
 end

--- a/db/migrate/20171125185353_add_index_reblog_of_id_and_account_to_statuses.rb
+++ b/db/migrate/20171125185353_add_index_reblog_of_id_and_account_to_statuses.rb
@@ -1,0 +1,7 @@
+class AddIndexReblogOfIdAndAccountToStatuses < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :statuses, [:reblog_of_id, :account_id], algorithm: :concurrently
+  end
+end

--- a/db/migrate/20171125190735_remove_old_reblog_index_on_statuses.rb
+++ b/db/migrate/20171125190735_remove_old_reblog_index_on_statuses.rb
@@ -1,0 +1,14 @@
+class RemoveOldReblogIndexOnStatuses < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    # This index may not exists (see migration 20171122120436)
+    remove_index :statuses, [:account_id, :reblog_of_id] if index_exists?(:statuses, [:account_id, :reblog_of_id])
+
+    remove_index :statuses, :reblog_of_id
+  end
+
+  def down
+    add_index :statuses, :reblog_of_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171125031751) do
+ActiveRecord::Schema.define(version: 20171125190735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -409,10 +409,9 @@ ActiveRecord::Schema.define(version: 20171125031751) do
     t.bigint "application_id"
     t.bigint "in_reply_to_account_id"
     t.index ["account_id", "id"], name: "index_statuses_on_account_id_id"
-    t.index ["account_id", "reblog_of_id"], name: "index_statuses_on_account_id_and_reblog_of_id"
     t.index ["conversation_id"], name: "index_statuses_on_conversation_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
-    t.index ["reblog_of_id"], name: "index_statuses_on_reblog_of_id"
+    t.index ["reblog_of_id", "account_id"], name: "index_statuses_on_reblog_of_id_and_account_id"
     t.index ["uri"], name: "index_statuses_on_uri", unique: true
   end
 


### PR DESCRIPTION
We recently added an index for `[account_id, reblog_of_id]` at #5785, but we already have a similar index for `reblog_of_id`. Those index will be bigger according to statuses count. For example, `reblog_of_id` index uses 800MB for 10GB statuses table.

So this patch swaps indexed columns like `[reblog_of_id, account_id]`, then it will covers both usage with single index.

Since those index creation may take a while, I've also disabled previous index creation.

cc @abcang 