### PR TITLE
Add UI for setting up account migration

### DIFF
--- a/app/controllers/settings/migrations_controller.rb
+++ b/app/controllers/settings/migrations_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Settings::MigrationsController < ApplicationController
+  layout 'admin'
+
+  before_action :authenticate_user!
+
+  def show
+    @migration = Form::Migration.new(account: current_account.moved_to_account)
+  end
+
+  def update
+    @migration = Form::Migration.new(resource_params)
+
+    if @migration.valid?
+      if current_account.moved_to_account_id != @migration.account&.id
+        current_account.update!(moved_to_account: @migration.account)
+        ActivityPub::UpdateDistributionWorker.perform_async(@account.id)
+      end
+
+      redirect_to settings_migration_path
+    else
+      render :show
+    end
+  end
+
+  private
+
+  def resource_params
+    params.require(:migration).permit(:acct)
+  end
+end

--- a/app/models/form/migration.rb
+++ b/app/models/form/migration.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Form::Migration
+  include ActiveModel::Validations
+
+  attr_accessor :acct, :account
+
+  validates :acct, presence: true
+
+  def initialize(attrs = {})
+    @account = attrs[:account]
+    @acct    = attrs[:account].acct unless @account.nil?
+    @acct    = attrs[:acct].gsub(/\A@/, '').strip unless attrs[:acct].nil?
+  end
+
+  def valid?
+    return false unless super
+    set_account
+    errors.empty?
+  end
+
+  private
+
+  def set_account
+    self.account = ResolveRemoteAccountService.new.call(acct) if account.nil? && acct.present?
+  end
+end

--- a/app/views/settings/migrations/show.html.haml
+++ b/app/views/settings/migrations/show.html.haml
@@ -1,0 +1,17 @@
+- content_for :page_title do
+  = t('settings.migrate')
+
+= simple_form_for @migration, as: :migration, url: settings_migration_path, html: { method: :put } do |f|
+  - if @migration.account
+    %p.hint= t('migrations.currently_redirecting')
+
+    .fields-group
+      = render partial: 'authorize_follows/card', locals: { account: @migration.account }
+
+  = render 'shared/error_messages', object: @migration
+
+  .fields-group
+    = f.input :acct, placeholder: t('migrations.acct')
+
+  .actions
+    = f.button :button, t('migrations.proceed'), type: :submit, class: 'negative'

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -21,3 +21,8 @@
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit
+
+%hr/
+
+%h6= t('auth.migrate_account')
+%p.muted-hint= t('auth.migrate_account_html', path: settings_migration_path)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,6 +342,8 @@ en:
     invalid_reset_password_token: Password reset token is invalid or expired. Please request a new one.
     login: Log in
     logout: Logout
+    migrate_account: Move to a different account
+    migrate_account_html: If you wish to redirect this account to a different one, you can <a href="%{path}">configure it here</a>.
     register: Sign up
     resend_confirmation: Resend confirmation instructions
     reset_password: Reset password
@@ -430,6 +432,10 @@ en:
     validations:
       images_and_video: Cannot attach a video to a status that already contains images
       too_many: Cannot attach more than 4 files
+  migrations:
+    acct: username@domain of the new account
+    currently_redirecting: 'Your profile is set to redirect to:'
+    proceed: Save
   moderation:
     title: Moderation
   notification_mailer:
@@ -544,6 +550,7 @@ en:
     export: Data export
     followers: Authorized followers
     import: Import
+    migrate: Account migration
     notifications: Notifications
     preferences: Preferences
     settings: Settings

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -5,7 +5,7 @@ SimpleNavigation::Configuration.run do |navigation|
     primary.item :web, safe_join([fa_icon('chevron-left fw'), t('settings.back')]), root_url
 
     primary.item :settings, safe_join([fa_icon('cog fw'), t('settings.settings')]), settings_profile_url do |settings|
-      settings.item :profile, safe_join([fa_icon('user fw'), t('settings.edit_profile')]), settings_profile_url
+      settings.item :profile, safe_join([fa_icon('user fw'), t('settings.edit_profile')]), settings_profile_url, highlights_on: %r{/settings/profile|/settings/migration}
       settings.item :preferences, safe_join([fa_icon('sliders fw'), t('settings.preferences')]), settings_preferences_url
       settings.item :notifications, safe_join([fa_icon('bell fw'), t('settings.notifications')]), settings_notifications_url
       settings.item :password, safe_join([fa_icon('lock fw'), t('auth.change_password')]), edit_user_registration_url, highlights_on: %r{/auth/edit|/settings/delete}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
     end
 
     resource :delete, only: [:show, :destroy]
+    resource :migration, only: [:show, :update]
 
     resources :sessions, only: [:destroy]
   end


### PR DESCRIPTION
See also #177 (partial)
Follow-up to #5746

Settings -> Edit Profile has a new section similar to "Delete account" section on the Security page, which links to the Account Migration page. This page allows you to enter a username@domain and save it. This updates the moved-to property of the account.

This does not include any follower-migrations, only a profile redirect note.