### PR TITLE
Fix account migration feature

### DIFF
--- a/app/controllers/settings/migrations_controller.rb
+++ b/app/controllers/settings/migrations_controller.rb
@@ -12,13 +12,10 @@ class Settings::MigrationsController < ApplicationController
   def update
     @migration = Form::Migration.new(resource_params)
 
-    if @migration.valid?
-      if current_account.moved_to_account_id != @migration.account&.id
-        current_account.update!(moved_to_account: @migration.account)
-        ActivityPub::UpdateDistributionWorker.perform_async(current_account.id)
-      end
-
-      redirect_to settings_migration_path
+    if @migration.valid? && migration_account_changed?
+      current_account.update!(moved_to_account: @migration.account)
+      ActivityPub::UpdateDistributionWorker.perform_async(current_account.id)
+      redirect_to settings_migration_path, notice: I18n.t('migrations.updated_msg')
     else
       render :show
     end
@@ -28,5 +25,9 @@ class Settings::MigrationsController < ApplicationController
 
   def resource_params
     params.require(:migration).permit(:acct)
+  end
+
+  def migration_account_changed?
+    current_account.moved_to_account_id != @migration.account&.id
   end
 end

--- a/app/controllers/settings/migrations_controller.rb
+++ b/app/controllers/settings/migrations_controller.rb
@@ -15,7 +15,7 @@ class Settings::MigrationsController < ApplicationController
     if @migration.valid?
       if current_account.moved_to_account_id != @migration.account&.id
         current_account.update!(moved_to_account: @migration.account)
-        ActivityPub::UpdateDistributionWorker.perform_async(@account.id)
+        ActivityPub::UpdateDistributionWorker.perform_async(current_account.id)
       end
 
       redirect_to settings_migration_path

--- a/app/models/form/migration.rb
+++ b/app/models/form/migration.rb
@@ -5,8 +5,6 @@ class Form::Migration
 
   attr_accessor :acct, :account
 
-  validates :acct, presence: true
-
   def initialize(attrs = {})
     @account = attrs[:account]
     @acct    = attrs[:account].acct unless @account.nil?
@@ -22,6 +20,6 @@ class Form::Migration
   private
 
   def set_account
-    self.account = ResolveRemoteAccountService.new.call(acct) if account.nil? && acct.present?
+    self.account = (ResolveRemoteAccountService.new.call(acct) if account.nil? && acct.present?)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -460,6 +460,7 @@ en:
     acct: username@domain of the new account
     currently_redirecting: 'Your profile is set to redirect to:'
     proceed: Save
+    updated_msg: Your account migration setting successfully updated!
   moderation:
     title: Moderation
   notification_mailer:


### PR DESCRIPTION
This PR fixes these issues in account migration feature:
* User can't remove account migrate information once added.
* An error occurs updating account migrate information
* No flash is displayed after updating of account migrate information