### PR TITLE
Fix handling of temporary failures in ProcessMentionsService

### DIFF
--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -18,7 +18,7 @@ class ProcessMentionsService < BaseService
       end
 
       if mentioned_account.nil?
-        username, domain  = match.first.split('@')
+        username, domain  = $1.split('@')
         mentioned_account = Account.find_remote(username, domain)
       end
 

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -41,4 +41,25 @@ RSpec.describe ProcessMentionsService do
       expect(a_request(:post, remote_user.inbox_url)).to have_been_made.once
     end
   end
+
+  context 'Temporarily-unreachable ActivityPub user' do
+    let(:remote_user) { Fabricate(:account, username: 'remote_user', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox', last_webfingered_at: nil) }
+
+    subject { ProcessMentionsService.new }
+
+    before do
+      stub_request(:get, "https://example.com/.well-known/host-meta").to_return(status: 404)
+      stub_request(:get, "https://example.com/.well-known/webfinger?resource=acct:remote_user@example.com").to_return(status: 500)
+      stub_request(:post, remote_user.inbox_url)
+      subject.call(status)
+    end
+
+    it 'creates a mention' do
+      expect(remote_user.mentions.where(status: status).count).to eq 1
+    end
+
+    it 'sends activity to the inbox' do
+      expect(a_request(:post, remote_user.inbox_url)).to have_been_made.once
+    end
+  end
 end


### PR DESCRIPTION
My PR #5702 was apparently broken, this PR aims to fix it and add appropriate tests.