### PR TITLE
Add semi-support for Video/Image objects in ActivityPub

### DIFF
--- a/app/helpers/jsonld_helper.rb
+++ b/app/helpers/jsonld_helper.rb
@@ -9,6 +9,24 @@ module JsonLdHelper
     value.is_a?(Array) ? value.first : value
   end
 
+  # The url attribute can be a string, an array of strings, or an array of objects.
+  # The objects could include a mimeType. Not-included mimeType means it's text/html.
+  def url_to_href(value, preferred_type = nil)
+    single_value = if value.is_a?(Array) && !value.first.is_a?(String)
+                     value.find { |link| preferred_type.nil? || ((link['mimeType'].presence || 'text/html') == preferred_type) }
+                   elsif value.is_a?(Array)
+                     value.first
+                   else
+                     value
+                   end
+
+    if single_value.nil? || single_value.is_a?(String)
+      single_value
+    else
+      single_value['href']
+    end
+  end
+
   def as_array(value)
     value.is_a?(Array) ? value : [value]
   end

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ActivityPub::Activity::Create < ActivityPub::Activity
+  SUPPORTED_TYPES = %w(Article Note).freeze
+  CONVERTED_TYPES = %w(Image Video).freeze
+
   def perform
     return if delete_arrived_first?(object_uri) || unsupported_object_type?
 
@@ -165,7 +168,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def text_from_content
-    return Formatter.instance.linkify([text_from_name, object_url].join(' ')) if converted_object_type?
+    return Formatter.instance.linkify([text_from_name, object_url || @object['id']].join(' ')) if converted_object_type?
 
     if @object['content'].present?
       @object['content']
@@ -214,11 +217,11 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def supported_object_type?
-    %w(Article Note).include?(@object['type'])
+    SUPPORTED_TYPES.include?(@object['type'])
   end
 
   def converted_object_type?
-    %w(Video Image).include?(@object['type'])
+    CONVERTED_TYPES.include?(@object['type'])
   end
 
   def skip_download?

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -194,22 +194,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
   def object_url
     return if @object['url'].blank?
-
-    # The url attribute can be a string, an array of strings, or an array of objects.
-    # The objects could include a mimeType. Not-included mimeType means it's text/html.
-    # We need to prefer text/html. So if the attribute has the fullest information,
-    # we've got to select an item that either has no mimeType or text/html mimeType
-    value = if @object['url'].is_a?(Array) && !@object['url'].first.is_a?(String)
-              @object['url'].find { |url| url['mimeType'].blank? || url['mimeType'] == 'text/html' }
-            elsif @object['url'].is_a?(Array)
-              @object['url'].first
-            else
-              @object['url']
-            end
-
-    return value if value.nil? || value.is_a?(String)
-
-    value['href']
+    url_to_href(@object['url'], 'text/html')
   end
 
   def content_language_map?

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -51,12 +51,7 @@ class Formatter
 
   def simplified_format(account)
     return reformat(account.note).html_safe unless account.local? # rubocop:disable Rails/OutputSafety
-
-    html = encode_and_link_urls(account.note)
-    html = simple_format(html, {}, sanitize: false)
-    html = html.delete("\n")
-
-    html.html_safe # rubocop:disable Rails/OutputSafety
+    linkify(account.note)
   end
 
   def sanitize(html, config)
@@ -66,6 +61,14 @@ class Formatter
   def format_spoiler(status)
     html = encode(status.spoiler_text)
     html = encode_custom_emojis(html, status.emojis)
+    html.html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+  def linkify(text)
+    html = encode_and_link_urls(text)
+    html = simple_format(html, {}, sanitize: false)
+    html = html.delete("\n")
+
     html.html_safe # rubocop:disable Rails/OutputSafety
   end
 

--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -42,7 +42,7 @@ class ActivityPub::FetchRemoteStatusService < BaseService
   end
 
   def expected_type?
-    %w(Note Article).include? @json['type']
+    %w(Note Article Video Image).include? @json['type']
   end
 
   def needs_update(actor)

--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -42,7 +42,7 @@ class ActivityPub::FetchRemoteStatusService < BaseService
   end
 
   def expected_type?
-    %w(Note Article Video Image).include? @json['type']
+    (ActivityPub::Activity::Create::SUPPORTED_TYPES + ActivityPub::Activity::Create::CONVERTED_TYPES).include? @json['type']
   end
 
   def needs_update(actor)

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -107,12 +107,7 @@ class ActivityPub::ProcessAccountService < BaseService
 
   def url
     return if @json['url'].blank?
-
-    value = first_of_value(@json['url'])
-
-    return value if value.is_a?(String)
-
-    value['href']
+    url_to_href(@json['url'], 'text/html')
   end
 
   def outbox_total_items

--- a/spec/services/activitypub/fetch_remote_status_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_status_service_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ActivityPub::FetchRemoteStatusService do
+  include ActionView::Helpers::TextHelper
+
   let(:sender) { Fabricate(:account) }
   let(:recipient) { Fabricate(:account) }
   let(:valid_domain) { Rails.configuration.x.local_domain }
@@ -19,6 +21,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService do
 
   describe '#call' do
     before do
+      stub_request(:head, 'https://example.com/watch?v=12345').to_return(status: 404, body: '')
       subject.call(object[:id], prefetched_body: Oj.dump(object))
     end
 
@@ -30,6 +33,39 @@ RSpec.describe ActivityPub::FetchRemoteStatusService do
 
         expect(status).to_not be_nil
         expect(status.text).to eq 'Lorem ipsum'
+      end
+    end
+
+    context 'with Video object' do
+      let(:object) do
+        {
+          '@context': 'https://www.w3.org/ns/activitystreams',
+          id: "https://#{valid_domain}/@foo/1234",
+          type: 'Video',
+          name: 'Nyan Cat 10 hours remix',
+          attributedTo: ActivityPub::TagManager.instance.uri_for(sender),
+          url: [
+            {
+              type: 'Link',
+              mimeType: 'application/x-bittorrent',
+              href: 'https://example.com/12345.torrent',
+            },
+
+            {
+              type: 'Link',
+              mimeType: 'text/html',
+              href: 'https://example.com/watch?v=12345',
+            },
+          ],
+        }
+      end
+
+      it 'creates status' do
+        status = sender.statuses.first
+
+        expect(status).to_not be_nil
+        expect(status.url).to eq 'https://example.com/watch?v=12345'
+        expect(strip_tags(status.text)).to eq 'Nyan Cat 10 hours remix https://example.com/watch?v=12345'
       end
     end
   end


### PR DESCRIPTION
PeerTube now talks ActivityPub: Chocobozzz/PeerTube#104

Video and Image objects will create corresponding text status records with manually crafted text contents (title + URL). Furthermore, the code now supports extracting the language from `nameMap` attribute as fallback of `contentMap` (name = title, since there is no title attribute)

The implications of this is that since PeerTube implements the right OpenGraph tags (e.g. `twitter:player`) such toots will actually embed the PeerTube video player as their preview card; it also means that replies to the "toot" will still be sent to the right object upstream and show up as comments on PeerTube.

Mind that at the time of writing PeerTube actually needs to fix their language serialization because they use a non-existing `language` attribute when the established way is `nameMap`/`contentMap`, and likewise the text/html URL is missing from their `url` array.