### PR TITLE
Allow admin to deactivate invite created by users

### DIFF
--- a/app/policies/invite_policy.rb
+++ b/app/policies/invite_policy.rb
@@ -10,7 +10,7 @@ class InvitePolicy < ApplicationPolicy
   end
 
   def destroy?
-    owner? || staff?
+    owner? || (Setting.min_invite_role == 'admin' ? admin? : staff?)
   end
 
   private

--- a/app/views/admin/invites/_invite.html.haml
+++ b/app/views/admin/invites/_invite.html.haml
@@ -16,4 +16,6 @@
         %time.formatted{ datetime: invite.expires_at.iso8601, title: l(invite.expires_at) }
           = l invite.expires_at
   %td= table_link_to 'link', public_invite_url(invite_code: invite.code), public_invite_url(invite_code: invite.code)
-  %td= table_link_to 'times', t('invites.delete'), invite_path(invite), method: :delete if policy(invite).destroy?
+  %td
+    - if !invite.expired? && policy(invite).destroy?
+      = table_link_to 'times', t('invites.delete'), admin_invite_path(invite), method: :delete

--- a/app/views/invites/_invite.html.haml
+++ b/app/views/invites/_invite.html.haml
@@ -12,4 +12,6 @@
         %time.formatted{ datetime: invite.expires_at.iso8601, title: l(invite.expires_at) }
           = l invite.expires_at
   %td= table_link_to 'link', public_invite_url(invite_code: invite.code), public_invite_url(invite_code: invite.code)
-  %td= table_link_to 'times', t('invites.delete'), invite_path(invite), method: :delete if policy(invite).destroy?
+  %td
+    - if invite.expired? && policy(invite).destroy?
+      = table_link_to 'times', t('invites.delete'), invite_path(invite), method: :delete


### PR DESCRIPTION
Admin (and moderators) should be able to deactivate invites created by users.

Also deletes the deactivate button for deactivated invite.
