### PR TITLE
Reduce motion for boost animation

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2154,7 +2154,8 @@
 
 @import 'boost';
 
-button.icon-button i.fa-retweet {
+.no-reduce-motion button.icon-button i.fa-retweet {
+
   background-position: 0 0;
   height: 19px;
   transition: background-position 0.9s steps(10);
@@ -2165,11 +2166,21 @@ button.icon-button i.fa-retweet {
   &::before {
     display: none !important;
   }
+
 }
 
-button.icon-button.active i.fa-retweet {
+.no-reduce-motion button.icon-button.active i.fa-retweet {
   transition-duration: 0.9s;
   background-position: 0 100%;
+}
+
+.reduce-motion button.icon-button i.fa-retweet {
+  color: $ui-base-lighter-color;
+  transition: color 100ms ease-in;
+}
+
+.reduce-motion button.icon-button.active i.fa-retweet {
+  color: $ui-highlight-color;
 }
 
 .status-card {

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,7 +28,7 @@
 
   - body_classes ||= @body_classes || ''
   - body_classes += ' system-font' if current_account&.user&.setting_system_font_ui
-  - body_classes += (' reduce-motion' if current_account&.user&.setting_reduce_motion) || ' no-reduce-motion'
+  - body_classes += current_account&.user&.setting_reduce_motion ? ' reduce-motion' : ' no-reduce-motion'
 
   %body{ class: add_rtl_body_class(body_classes) }
     = content_for?(:content) ? yield(:content) : yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -28,6 +28,7 @@
 
   - body_classes ||= @body_classes || ''
   - body_classes += ' system-font' if current_account&.user&.setting_system_font_ui
+  - body_classes += (' reduce-motion' if current_account&.user&.setting_reduce_motion) || ' no-reduce-motion'
 
   %body{ class: add_rtl_body_class(body_classes) }
     = content_for?(:content) ? yield(:content) : yield


### PR DESCRIPTION
Fixes #5833. Video demonstrations: [before](https://gfycat.com/ShyIdealisticBelugawhale) and [after](https://gfycat.com/SimplisticTidyBinturong).

When motion is reduced, it does a little `transition: color` animation rather than the standard rotation animation. Note that it doesn't look exactly like the non-reduced-motion version because I'm adding a color to the SVG rather than using an entirely different SVG with a frame for each frame of the animation.

I added a CSS class for `reduce-motion` because it was simpler to do this all in CSS. I also added `no-reduce-motion` because `:not()` queries tend to be bad for performance compared to a simple class lookup.
