### PR TITLE
Add back button to keyboard shortcuts legend column

### DIFF
--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.js
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Column from '../ui/components/column';
+import ColumnBackButtonSlim from '../../components/column_back_button_slim';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import ImmutablePureComponent from 'react-immutable-pure-component';
@@ -20,7 +21,8 @@ export default class KeyboardShortcuts extends ImmutablePureComponent {
     const { intl } = this.props;
 
     return (
-      <Column icon='question' heading={intl.formatMessage(messages.heading)} hideHeadingOnMobile>
+      <Column icon='question' heading={intl.formatMessage(messages.heading)}>
+        <ColumnBackButtonSlim />
         <div className='keyboard-shortcuts scrollable optionally-scrollable'>
           <table>
             <thead>


### PR DESCRIPTION
There is no way to back from key shortcuts legend except to input `?`. It is bad for the person who accidentally displayed it.

Heading bar and back button are needed on mobile view for direct access by using last used tab functions.