### PR TITLE
Keep WebPush settings

### DIFF
--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -28,6 +28,8 @@ class Api::Web::PushSubscriptionsController < Api::BaseController
       },
     }
 
+    data.deep_merge!(params[:data]) if params[:data]
+
     web_subscription = ::Web::PushSubscription.create!(
       endpoint: params[:subscription][:endpoint],
       key_p256dh: params[:subscription][:keys][:p256dh],

--- a/app/javascript/mastodon/actions/push_notifications.js
+++ b/app/javascript/mastodon/actions/push_notifications.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { setSettingsToLocalStorage } from '../web_push_subscription';
 
 export const SET_BROWSER_SUPPORT = 'PUSH_NOTIFICATIONS_SET_BROWSER_SUPPORT';
 export const SET_SUBSCRIPTION = 'PUSH_NOTIFICATIONS_SET_SUBSCRIPTION';
@@ -42,11 +43,15 @@ export function saveSettings() {
     const state = getState().get('push_notifications');
     const subscription = state.get('subscription');
     const alerts = state.get('alerts');
+    const data = { alerts };
 
     axios.put(`/api/web/push_subscriptions/${subscription.get('id')}`, {
-      data: {
-        alerts,
-      },
+      data,
+    }).then(() => {
+      const me = getState().getIn(['meta', 'me']);
+      if (me) {
+        setSettingsToLocalStorage(me, data);
+      }
     });
   };
 }

--- a/spec/controllers/api/web/push_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/web/push_subscriptions_controller_spec.rb
@@ -48,6 +48,23 @@ describe Api::Web::PushSubscriptionsController do
       expect(push_subscription['key_p256dh']).to eq(create_payload[:subscription][:keys][:p256dh])
       expect(push_subscription['key_auth']).to eq(create_payload[:subscription][:keys][:auth])
     end
+
+    context 'with initial data' do
+      it 'saves alert settings' do
+        sign_in(user)
+
+        stub_request(:post, create_payload[:subscription][:endpoint]).to_return(status: 200)
+
+        post :create, format: :json, params: create_payload.merge(alerts_payload)
+
+        push_subscription = Web::PushSubscription.find_by(endpoint: create_payload[:subscription][:endpoint])
+
+        expect(push_subscription.data['follow']).to eq(alerts_payload[:data][:follow])
+        expect(push_subscription.data['favourite']).to eq(alerts_payload[:data][:favourite])
+        expect(push_subscription.data['reblog']).to eq(alerts_payload[:data][:reblog])
+        expect(push_subscription.data['mention']).to eq(alerts_payload[:data][:mention])
+      end
+    end
   end
 
   describe 'PUT #update' do


### PR DESCRIPTION
When logging out, the WebPush setting disappears. So, I propose a feature to save the WebPush setting to localStorage and restore it at login.