### PR TITLE
Omit optional dependencies on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem 'puma', '~> 3.10'
 gem 'rails', '~> 5.1.4'
 gem 'uglifier', '~> 3.2'
 
-gem 'hamlit-rails', '~> 0.2'
+gem 'hamlit-rails', '~> 0.2', platforms: [:ruby, :mswin]
+gem 'haml-rails', '~> 1.0', platform: :jruby
 gem 'pg', '~> 0.20'
 gem 'pghero', '~> 1.7'
 gem 'dotenv-rails', '~> 2.2'
@@ -31,7 +32,7 @@ gem 'cld3', '~> 3.2.0'
 gem 'devise', '~> 4.2'
 gem 'devise-two-factor', '~> 3.0'
 gem 'doorkeeper', '~> 4.2'
-gem 'fast_blank', '~> 1.0'
+gem 'fast_blank', '~> 1.0', platforms: [:ruby, :mswin]
 gem 'goldfinger', '~> 2.0'
 gem 'hiredis', '~> 0.6'
 gem 'redis-namespace', '~> 1.5'
@@ -39,7 +40,7 @@ gem 'htmlentities', '~> 4.3'
 gem 'http', '~> 2.2'
 gem 'http_accept_language', '~> 2.1'
 gem 'httplog', '~> 0.99'
-gem 'idn-ruby', require: 'idn'
+gem 'idn-ruby', require: 'idn', platforms: [:ruby, :mswin]
 gem 'kaminari', '~> 1.1'
 gem 'link_header', '~> 0.0'
 gem 'mime-types', '~> 3.1'
@@ -100,7 +101,7 @@ group :development do
   gem 'active_record_query_trace', '~> 1.5'
   gem 'annotate', '~> 2.7'
   gem 'better_errors', '~> 2.4'
-  gem 'binding_of_caller', '~> 0.7'
+  gem 'binding_of_caller', '~> 0.7', platforms: [:ruby, :mswin]
   gem 'bullet', '~> 5.5'
   gem 'letter_opener', '~> 1.4'
   gem 'letter_opener_web', '~> 1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -574,6 +574,7 @@ DEPENDENCIES
   fog-openstack (~> 0.1)
   fuubar (~> 2.2)
   goldfinger (~> 2.0)
+  haml-rails (~> 1.0)
   hamlit-rails (~> 0.2)
   hiredis (~> 0.6)
   htmlentities (~> 4.3)


### PR DESCRIPTION
Probably not entirely working, but removes some things that are not needed on JRuby that don't have ports.

Reference: https://www.youtube.com/watch?v=Lja3HDcHNJA&feature=youtu.be&t=32m

cc @headius 