### PR TITLE
Break out nested relationship API keys

### DIFF
--- a/app/javascript/mastodon/components/account.js
+++ b/app/javascript/mastodon/components/account.js
@@ -81,7 +81,7 @@ export default class Account extends ImmutablePureComponent {
         buttons = <IconButton active icon='unlock-alt' title={intl.formatMessage(messages.unblock, { name: account.get('username') })} onClick={this.handleBlock} />;
       } else if (muting) {
         let hidingNotificationsButton;
-        if (muting.get('notifications')) {
+        if (account.getIn(['relationship', 'muting_notifications'])) {
           hidingNotificationsButton = <IconButton active icon='bell' title={intl.formatMessage(messages.unmute_notifications, { name: account.get('username') })} onClick={this.handleUnmuteNotifications} />;
         } else {
           hidingNotificationsButton = <IconButton active icon='bell-slash' title={intl.formatMessage(messages.mute_notifications, { name: account.get('username')  })} onClick={this.handleMuteNotifications} />;
@@ -93,7 +93,7 @@ export default class Account extends ImmutablePureComponent {
           </div>
         );
       } else {
-        buttons = <IconButton icon={following ? 'user-times' : 'user-plus'} title={intl.formatMessage(following ? messages.unfollow : messages.follow)} onClick={this.handleFollow} active={following ? true : false} />;
+        buttons = <IconButton icon={following ? 'user-times' : 'user-plus'} title={intl.formatMessage(following ? messages.unfollow : messages.follow)} onClick={this.handleFollow} active={following} />;
       }
     }
 

--- a/app/javascript/mastodon/features/account/components/action_bar.js
+++ b/app/javascript/mastodon/features/account/components/action_bar.js
@@ -63,9 +63,8 @@ export default class ActionBar extends React.PureComponent {
     if (account.get('id') === me) {
       menu.push({ text: intl.formatMessage(messages.edit_profile), href: '/settings/profile' });
     } else {
-      const following = account.getIn(['relationship', 'following']);
-      if (following) {
-        if (following.get('reblogs')) {
+      if (account.getIn(['relationship', 'following'])) {
+        if (account.getIn(['relationship', 'showing_reblogs'])) {
           menu.push({ text: intl.formatMessage(messages.hideReblogs, { name: account.get('username') }), action: this.props.onReblogToggle });
         } else {
           menu.push({ text: intl.formatMessage(messages.showReblogs, { name: account.get('username') }), action: this.props.onReblogToggle });

--- a/app/javascript/mastodon/features/account_timeline/containers/header_container.js
+++ b/app/javascript/mastodon/features/account_timeline/containers/header_container.js
@@ -68,7 +68,7 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
   },
 
   onReblogToggle (account) {
-    if (account.getIn(['relationship', 'following', 'reblogs'])) {
+    if (account.getIn(['relationship', 'show_reblogs'])) {
       dispatch(followAccount(account.get('id'), false));
     } else {
       dispatch(followAccount(account.get('id'), true));

--- a/app/serializers/rest/relationship_serializer.rb
+++ b/app/serializers/rest/relationship_serializer.rb
@@ -13,8 +13,8 @@ class REST::RelationshipSerializer < ActiveModel::Serializer
   end
 
   def showing_reblogs
-    instance_options[:relationships].following[object.id].try(:reblogs) ||
-      instance_options[:relationships].requested[object.id].try(:reblogs) ||
+    (instance_options[:relationships].following[object.id] || {})[:reblogs] ||
+      (instance_options[:relationships].requested[object.id] || {})[:reblogs] ||
       false
   end
 
@@ -31,7 +31,7 @@ class REST::RelationshipSerializer < ActiveModel::Serializer
   end
 
   def muting_notifications
-    instance_options[:relationships].muting[object.id].try(:notifications) || false
+    (instance_options[:relationships].muting[object.id] || {})[:notifications] || false
   end
 
   def requested

--- a/app/serializers/rest/relationship_serializer.rb
+++ b/app/serializers/rest/relationship_serializer.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 
 class REST::RelationshipSerializer < ActiveModel::Serializer
-  attributes :id, :following, :followed_by, :blocking,
-             :muting, :requested, :domain_blocking
+  attributes :id, :following, :showing_reblogs, :followed_by, :blocking,
+             :muting, :muting_notifications, :requested, :domain_blocking
 
   def id
     object.id.to_s
   end
 
   def following
-    instance_options[:relationships].following[object.id] || false
+    instance_options[:relationships].following[object.id] ? true : false
+  end
+
+  def showing_reblogs
+    instance_options[:relationships].following.dig(object.id, :reblogs) ||
+    instance_options[:relationships].requested.dig(object.id, :reblogs) || false
   end
 
   def followed_by
@@ -21,11 +26,15 @@ class REST::RelationshipSerializer < ActiveModel::Serializer
   end
 
   def muting
-    instance_options[:relationships].muting[object.id] || false
+    instance_options[:relationships].muting[object.id] ? true : false
+  end
+
+  def muting_notifications
+    instance_options[:relationships].muting.dig(object.id, :notifications) || false
   end
 
   def requested
-    instance_options[:relationships].requested[object.id] || false
+    instance_options[:relationships].requested[object.id] ? true : false
   end
 
   def domain_blocking

--- a/app/serializers/rest/relationship_serializer.rb
+++ b/app/serializers/rest/relationship_serializer.rb
@@ -14,7 +14,8 @@ class REST::RelationshipSerializer < ActiveModel::Serializer
 
   def showing_reblogs
     instance_options[:relationships].following.dig(object.id, :reblogs) ||
-    instance_options[:relationships].requested.dig(object.id, :reblogs) || false
+      instance_options[:relationships].requested.dig(object.id, :reblogs) ||
+      false
   end
 
   def followed_by

--- a/app/serializers/rest/relationship_serializer.rb
+++ b/app/serializers/rest/relationship_serializer.rb
@@ -13,8 +13,8 @@ class REST::RelationshipSerializer < ActiveModel::Serializer
   end
 
   def showing_reblogs
-    instance_options[:relationships].following.dig(object.id, :reblogs) ||
-      instance_options[:relationships].requested.dig(object.id, :reblogs) ||
+    instance_options[:relationships].following[object.id].try(:reblogs) ||
+      instance_options[:relationships].requested[object.id].try(:reblogs) ||
       false
   end
 
@@ -31,7 +31,7 @@ class REST::RelationshipSerializer < ActiveModel::Serializer
   end
 
   def muting_notifications
-    instance_options[:relationships].muting.dig(object.id, :notifications) || false
+    instance_options[:relationships].muting[object.id].try(:notifications) || false
   end
 
   def requested

--- a/spec/controllers/api/v1/accounts/relationships_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/relationships_controller_spec.rb
@@ -32,7 +32,7 @@ describe Api::V1::Accounts::RelationshipsController do
         json = body_as_json
 
         expect(json).to be_a Enumerable
-        expect(json.first[:following]).to be_truthy
+        expect(json.first[:following]).to be true
         expect(json.first[:followed_by]).to be false
       end
     end
@@ -51,7 +51,8 @@ describe Api::V1::Accounts::RelationshipsController do
 
         expect(json).to be_a Enumerable
         expect(json.first[:id]).to eq simon.id.to_s
-        expect(json.first[:following]).to be_truthy
+        expect(json.first[:following]).to be true
+        expect(json.first[:showing_reblogs]).to be true
         expect(json.first[:followed_by]).to be false
         expect(json.first[:muting]).to be false
         expect(json.first[:requested]).to be false
@@ -59,6 +60,7 @@ describe Api::V1::Accounts::RelationshipsController do
 
         expect(json.second[:id]).to eq lewis.id.to_s
         expect(json.second[:following]).to be false
+        expect(json.second[:showing_reblogs]).to be false
         expect(json.second[:followed_by]).to be true
         expect(json.second[:muting]).to be false
         expect(json.second[:requested]).to be false

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
         expect(response).to have_http_status(:success)
       end
 
-      it 'returns JSON with following=truthy and requested=false' do
+      it 'returns JSON with following=true and requested=false' do
         json = body_as_json
 
-        expect(json[:following]).to be_truthy
+        expect(json[:following]).to be true
         expect(json[:requested]).to be false
       end
 
@@ -50,11 +50,11 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
         expect(response).to have_http_status(:success)
       end
 
-      it 'returns JSON with following=false and requested=truthy' do
+      it 'returns JSON with following=false and requested=true' do
         json = body_as_json
 
         expect(json[:following]).to be false
-        expect(json[:requested]).to be_truthy
+        expect(json[:requested]).to be true
       end
 
       it 'creates a follow request relation between user and target user' do


### PR DESCRIPTION
This closes #5856 by restoring the existing behavior of the `muting` and `following` keys (returning booleans rather than truthy or false). It adds `showing_reblogs` and `muting_notifications` keys:

* `showing_reblogs` returns true if:
  1. You've requested to follow the user, with reblogs shown, or
  2. You are following the user, with reblogs shown.
* `muting_notifications` returns true if you have muted the user and their notifications as well.