### PR TITLE
Change belongs_to_required_by_default to true

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -102,7 +102,7 @@ class Account < ApplicationRecord
   has_many :lists, through: :list_accounts
 
   # Account migrations
-  belongs_to :moved_to_account, class_name: 'Account'
+  belongs_to :moved_to_account, class_name: 'Account', optional: true
 
   scope :remote, -> { where.not(domain: nil) }
   scope :local, -> { where(domain: nil) }

--- a/app/models/account_domain_block.rb
+++ b/app/models/account_domain_block.rb
@@ -13,7 +13,7 @@
 class AccountDomainBlock < ApplicationRecord
   include Paginable
 
-  belongs_to :account, required: true
+  belongs_to :account
   validates :domain, presence: true, uniqueness: { scope: :account_id }
 
   after_create  :remove_blocking_cache

--- a/app/models/admin/action_log.rb
+++ b/app/models/admin/action_log.rb
@@ -16,8 +16,8 @@
 class Admin::ActionLog < ApplicationRecord
   serialize :recorded_changes
 
-  belongs_to :account, required: true
-  belongs_to :target, required: true, polymorphic: true
+  belongs_to :account
+  belongs_to :target, polymorphic: true
 
   default_scope -> { order('id desc') }
 

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -13,8 +13,8 @@
 class Block < ApplicationRecord
   include Paginable
 
-  belongs_to :account, required: true
-  belongs_to :target_account, class_name: 'Account', required: true
+  belongs_to :account
+  belongs_to :target_account, class_name: 'Account'
 
   validates :account_id, uniqueness: { scope: :target_account_id }
 

--- a/app/models/conversation_mute.rb
+++ b/app/models/conversation_mute.rb
@@ -9,6 +9,6 @@
 #
 
 class ConversationMute < ApplicationRecord
-  belongs_to :account, required: true
-  belongs_to :conversation, required: true
+  belongs_to :account
+  belongs_to :conversation
 end

--- a/app/models/favourite.rb
+++ b/app/models/favourite.rb
@@ -13,8 +13,8 @@
 class Favourite < ApplicationRecord
   include Paginable
 
-  belongs_to :account, inverse_of: :favourites, required: true
-  belongs_to :status,  inverse_of: :favourites, counter_cache: true, required: true
+  belongs_to :account, inverse_of: :favourites
+  belongs_to :status,  inverse_of: :favourites, counter_cache: true
 
   has_one :notification, as: :activity, dependent: :destroy
 

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -14,12 +14,11 @@
 class Follow < ApplicationRecord
   include Paginable
 
-  belongs_to :account, counter_cache: :following_count, required: true
+  belongs_to :account, counter_cache: :following_count
 
   belongs_to :target_account,
              class_name: 'Account',
-             counter_cache: :followers_count,
-             required: true
+             counter_cache: :followers_count
 
   has_one :notification, as: :activity, dependent: :destroy
 

--- a/app/models/follow_request.rb
+++ b/app/models/follow_request.rb
@@ -14,8 +14,8 @@
 class FollowRequest < ApplicationRecord
   include Paginable
 
-  belongs_to :account, required: true
-  belongs_to :target_account, class_name: 'Account', required: true
+  belongs_to :account
+  belongs_to :target_account, class_name: 'Account'
 
   has_one :notification, as: :activity, dependent: :destroy
 

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -20,7 +20,7 @@ class Import < ApplicationRecord
 
   self.inheritance_column = false
 
-  belongs_to :account, required: true
+  belongs_to :account
 
   enum type: [:following, :blocking, :muting]
 

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -14,7 +14,7 @@
 #
 
 class Invite < ApplicationRecord
-  belongs_to :user, required: true
+  belongs_to :user
   has_many :users, inverse_of: :invite
 
   scope :available, -> { where(expires_at: nil).or(where('expires_at >= ?', Time.now.utc)) }

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -15,7 +15,7 @@ class List < ApplicationRecord
 
   PER_ACCOUNT_LIMIT = 50
 
-  belongs_to :account
+  belongs_to :account, optional: true
 
   has_many :list_accounts, inverse_of: :list, dependent: :destroy
   has_many :accounts, through: :list_accounts

--- a/app/models/list_account.rb
+++ b/app/models/list_account.rb
@@ -10,9 +10,9 @@
 #
 
 class ListAccount < ApplicationRecord
-  belongs_to :list, required: true
-  belongs_to :account, required: true
-  belongs_to :follow, required: true
+  belongs_to :list
+  belongs_to :account
+  belongs_to :follow
 
   validates :account_id, uniqueness: { scope: :list_id }
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -45,8 +45,8 @@ class MediaAttachment < ApplicationRecord
     },
   }.freeze
 
-  belongs_to :account, inverse_of: :media_attachments
-  belongs_to :status,  inverse_of: :media_attachments
+  belongs_to :account, inverse_of: :media_attachments, optional: true
+  belongs_to :status,  inverse_of: :media_attachments, optional: true
 
   has_attached_file :file,
                     styles: ->(f) { file_styles f },

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -11,8 +11,8 @@
 #
 
 class Mention < ApplicationRecord
-  belongs_to :account, inverse_of: :mentions, required: true
-  belongs_to :status, required: true
+  belongs_to :account, inverse_of: :mentions
+  belongs_to :status
 
   has_one :notification, as: :activity, dependent: :destroy
 

--- a/app/models/mute.rb
+++ b/app/models/mute.rb
@@ -14,8 +14,8 @@
 class Mute < ApplicationRecord
   include Paginable
 
-  belongs_to :account, required: true
-  belongs_to :target_account, class_name: 'Account', required: true
+  belongs_to :account
+  belongs_to :target_account, class_name: 'Account'
 
   validates :account_id, uniqueness: { scope: :target_account_id }
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -26,15 +26,15 @@ class Notification < ApplicationRecord
 
   STATUS_INCLUDES = [:account, :application, :stream_entry, :media_attachments, :tags, mentions: :account, reblog: [:stream_entry, :account, :application, :media_attachments, :tags, mentions: :account]].freeze
 
-  belongs_to :account
-  belongs_to :from_account, class_name: 'Account'
-  belongs_to :activity, polymorphic: true
+  belongs_to :account, optional: true
+  belongs_to :from_account, class_name: 'Account', optional: true
+  belongs_to :activity, polymorphic: true, optional: true
 
-  belongs_to :mention,        foreign_type: 'Mention',       foreign_key: 'activity_id'
-  belongs_to :status,         foreign_type: 'Status',        foreign_key: 'activity_id'
-  belongs_to :follow,         foreign_type: 'Follow',        foreign_key: 'activity_id'
-  belongs_to :follow_request, foreign_type: 'FollowRequest', foreign_key: 'activity_id'
-  belongs_to :favourite,      foreign_type: 'Favourite',     foreign_key: 'activity_id'
+  belongs_to :mention,        foreign_type: 'Mention',       foreign_key: 'activity_id', optional: true
+  belongs_to :status,         foreign_type: 'Status',        foreign_key: 'activity_id', optional: true
+  belongs_to :follow,         foreign_type: 'Follow',        foreign_key: 'activity_id', optional: true
+  belongs_to :follow_request, foreign_type: 'FollowRequest', foreign_key: 'activity_id', optional: true
+  belongs_to :favourite,      foreign_type: 'Favourite',     foreign_key: 'activity_id', optional: true
 
   validates :account_id, uniqueness: { scope: [:activity_type, :activity_id] }
   validates :activity_type, inclusion: { in: TYPE_CLASS_MAP.values }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -17,7 +17,7 @@
 class Report < ApplicationRecord
   belongs_to :account
   belongs_to :target_account, class_name: 'Account'
-  belongs_to :action_taken_by_account, class_name: 'Account'
+  belongs_to :action_taken_by_account, class_name: 'Account', optional: true
 
   scope :unresolved, -> { where(action_taken: false) }
   scope :resolved,   -> { where(action_taken: true) }

--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -15,9 +15,9 @@
 #
 
 class SessionActivation < ApplicationRecord
-  belongs_to :user, inverse_of: :session_activations, required: true
-  belongs_to :access_token, class_name: 'Doorkeeper::AccessToken', dependent: :destroy
-  belongs_to :web_push_subscription, class_name: 'Web::PushSubscription', dependent: :destroy
+  belongs_to :user, inverse_of: :session_activations
+  belongs_to :access_token, class_name: 'Doorkeeper::AccessToken', dependent: :destroy, optional: true
+  belongs_to :web_push_subscription, class_name: 'Web::PushSubscription', dependent: :destroy, optional: true
 
   delegate :token,
            to: :access_token,

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -33,14 +33,14 @@ class Status < ApplicationRecord
 
   enum visibility: [:public, :unlisted, :private, :direct], _suffix: :visibility
 
-  belongs_to :application, class_name: 'Doorkeeper::Application'
+  belongs_to :application, class_name: 'Doorkeeper::Application', optional: true
 
-  belongs_to :account, inverse_of: :statuses, counter_cache: true, required: true
-  belongs_to :in_reply_to_account, foreign_key: 'in_reply_to_account_id', class_name: 'Account'
-  belongs_to :conversation
+  belongs_to :account, inverse_of: :statuses, counter_cache: true
+  belongs_to :in_reply_to_account, foreign_key: 'in_reply_to_account_id', class_name: 'Account', optional: true
+  belongs_to :conversation, optional: true
 
-  belongs_to :thread, foreign_key: 'in_reply_to_id', class_name: 'Status', inverse_of: :replies
-  belongs_to :reblog, foreign_key: 'reblog_of_id', class_name: 'Status', inverse_of: :reblogs, counter_cache: :reblogs_count
+  belongs_to :thread, foreign_key: 'in_reply_to_id', class_name: 'Status', inverse_of: :replies, optional: true
+  belongs_to :reblog, foreign_key: 'reblog_of_id', class_name: 'Status', inverse_of: :reblogs, counter_cache: :reblogs_count, optional: true
 
   has_many :favourites, inverse_of: :status, dependent: :destroy
   has_many :reblogs, foreign_key: 'reblog_of_id', class_name: 'Status', inverse_of: :reblog, dependent: :destroy

--- a/app/models/status_pin.rb
+++ b/app/models/status_pin.rb
@@ -11,8 +11,8 @@
 #
 
 class StatusPin < ApplicationRecord
-  belongs_to :account, required: true
-  belongs_to :status, required: true
+  belongs_to :account
+  belongs_to :status
 
   validates_with StatusPinValidator
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -19,7 +19,7 @@ class Subscription < ApplicationRecord
   MIN_EXPIRATION = 1.day.to_i
   MAX_EXPIRATION = 30.days.to_i
 
-  belongs_to :account, required: true
+  belongs_to :account
 
   validates :callback_url, presence: true
   validates :callback_url, uniqueness: { scope: :account_id }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,8 +50,8 @@ class User < ApplicationRecord
   devise :registerable, :recoverable, :rememberable, :trackable, :validatable,
          :confirmable
 
-  belongs_to :account, inverse_of: :user, required: true
-  belongs_to :invite, counter_cache: :uses
+  belongs_to :account, inverse_of: :user
+  belongs_to :invite, counter_cache: :uses, optional: true
   accepts_nested_attributes_for :account
 
   has_many :applications, class_name: 'Doorkeeper::Application', as: :owner

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,9 @@ require_relative '../lib/mastodon/redis_config'
 
 module Mastodon
   class Application < Rails::Application
+    # Initialize configuration defaults for originally generated Rails version.
+    config.load_defaults 5.1
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
In Rails v5.x, belongs_to defaulted to `required: true`. But in Mastodon `ActiveRecord::Base. Belongs_to_required_by_default` is `nil`. This is caused by one of the gems (https://github.com/rails/rails/issues/23589)

Resolved with the solution at https://github.com/rails/rails/issues/23589#issuecomment-305557647.
