### PR TITLE
Add aria-autocomplete='list' in Textarea

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -209,6 +209,7 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
             onBlur={this.onBlur}
             onPaste={this.onPaste}
             style={style}
+            aria-autocomplete='list'
           />
         </label>
 


### PR DESCRIPTION
This suggestion feature would be good for accessibility if specify `aria-autocomplete='list'`

ref: https://www.w3.org/TR/wai-aria-1.1/#aria-autocomplete