### PR TITLE
Handle submit event of new list form

### DIFF
--- a/app/javascript/mastodon/features/lists/components/new_list_form.js
+++ b/app/javascript/mastodon/features/lists/components/new_list_form.js
@@ -36,10 +36,9 @@ export default class NewListForm extends React.PureComponent {
     this.props.onChange(e.target.value);
   }
 
-  handleKeyUp = e => {
-    if (e.keyCode === 13) {
-      this.props.onSubmit();
-    }
+  handleSubmit = e => {
+    e.preventDefault();
+    this.props.onSubmit();
   }
 
   handleClick = () => {
@@ -53,7 +52,7 @@ export default class NewListForm extends React.PureComponent {
     const title = intl.formatMessage(messages.title);
 
     return (
-      <div className='column-inline-form'>
+      <form className='column-inline-form' onSubmit={this.handleSubmit}>
         <label>
           <span style={{ display: 'none' }}>{label}</span>
 
@@ -62,7 +61,6 @@ export default class NewListForm extends React.PureComponent {
             value={value}
             disabled={disabled}
             onChange={this.handleChange}
-            onKeyUp={this.handleKeyUp}
             placeholder={label}
           />
         </label>
@@ -73,7 +71,7 @@ export default class NewListForm extends React.PureComponent {
           title={title}
           onClick={this.handleClick}
         />
-      </div>
+      </form>
     );
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4467,6 +4467,10 @@ noscript {
     input {
       width: 100%;
       margin-bottom: 6px;
+
+      &:focus {
+        outline: 0;
+      }
     }
   }
 


### PR DESCRIPTION
Multiple results are returned from the input string in the Input Method (e.g. Japanese IM) targeting some languages. You need to press "Enter" key to confirm input.

But Mastodon monitors entry of the Enter key when creating the list. Therefore, I can not make the list correctly in Japanese.

Handling the submit event of the form element will result in the movement as assumed in Japanese IM.