### PR TITLE
Yarn install from Debian package repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,14 @@ addons:
   apt:
     sources:
     - trusty-media
+    - sourceline: deb https://dl.yarnpkg.com/debian/ stable main
+      key_url: https://dl.yarnpkg.com/debian/pubkey.gpg
     packages:
     - ffmpeg
+    - libicu-dev
     - libprotobuf-dev
     - protobuf-compiler
-    - libicu-dev
+    - yarn
 
 rvm:
   - 2.3.4
@@ -42,7 +45,6 @@ services:
 
 install:
   - nvm install
-  - npm install -g yarn
   - bundle install --path=vendor/bundle --without development production --retry=3 --jobs=16
   - yarn install
 


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/12539/33655789-64aa18f8-dab7-11e7-828d-5a69439ee5c8.png)

Installation from npm is deprecated.
