### PR TITLE
Fix list editor modal on narrow devices

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4489,8 +4489,12 @@ noscript {
   flex-direction: column;
   border-radius: 8px;
   box-shadow: 2px 4px 15px rgba($base-shadow-color, 0.4);
-  width: 40vh;
+  width: 380px;
   overflow: hidden;
+
+  @media screen and (max-width: 420px) {
+    width: 90%;
+  }
 
   h4 {
     padding: 15px 0;


### PR DESCRIPTION
Set list editor modal width as 90% on narrow devices(max-width: 420px).

Screenshots of iPhone SE

Before | After
--|--
![before image](https://user-images.githubusercontent.com/27640522/33675477-07e89402-daf6-11e7-89b1-07bdcfcbde91.png) | ![after image](https://user-images.githubusercontent.com/27640522/33675453-f2277070-daf5-11e7-9de3-448993bf6cf2.png)

Set list editor modal width as from 40vh to 380px.
It's for horizontal mobile phones and single timelines view on vertical PC display.

Related to #5811 