### PR TITLE
fix weblate for ja

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -448,7 +448,7 @@ ja:
     expires_in_prompt: 無期限
     generate: 作成
     max_uses:
-      one: 1
+      one: '1'
       other: "%{count}"
     max_uses_prompt: 無制限
     prompt: リンクを生成・共有してこのインスタンスへの新規登録を受け付けることができます。


### PR DESCRIPTION
Currently, yaml2po crashes on values that are just integers. See here for more info: https://github.com/translate/translate/issues/3619

this is a workaround until the relevant bug is closed.