### PR TITLE
ReFix font-weight of <strong> element for CJK fonts

### DIFF
--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -19,7 +19,7 @@
     display: inline;
     margin: 0;
     padding: 0;
-    font-weight: 500;
+    font-weight: 700;
     background: transparent;
     font-family: inherit;
     font-size: inherit;
@@ -381,12 +381,6 @@
         font-weight: 500;
         font-size: 32px;
         line-height: 48px;
-
-        @each $lang in $cjk-langs {
-          &:lang(#{$lang}) {
-            font-weight: 700;
-          }
-        }
       }
     }
 

--- a/app/javascript/styles/mastodon/variables.scss
+++ b/app/javascript/styles/mastodon/variables.scss
@@ -29,4 +29,4 @@ $ui-secondary-color: $classic-secondary-color !default;        // Lightest
 $ui-highlight-color: $classic-highlight-color !default;        // Vibrant
 
 // Language codes that uses CJK fonts
-$cjk-langs: zh-CN, zh-HK, zh-TW;
+$cjk-langs: ja, ko, zh-CN, zh-HK, zh-TW;


### PR DESCRIPTION
- Also apply #5914 to **Japanese** and **Korean**.
- Remove settings for `information-board-sections` , this section displays only numeric characters.
- Fix font-weight in landing pages.