### PR TITLE
Disable status content outline

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -519,6 +519,10 @@
   overflow: hidden;
   white-space: pre-wrap;
 
+  &:focus {
+    outline: 0;
+  }
+
   &.status__content--with-spoiler {
     white-space: normal;
 


### PR DESCRIPTION
Unify styles with WebKit (Blink) and Firefox.

### screenshot

before | after
-|-
![before screenshot](https://user-images.githubusercontent.com/12539/33742240-b77b0eaa-dbea-11e7-9fc6-d01bc31b5244.png) | ![after screenshot](https://user-images.githubusercontent.com/12539/33742246-c1076b80-dbea-11e7-966c-dbe7d94431ac.png)

