### PR TITLE
Fix typo in paperclip.rb

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -19,7 +19,7 @@ if ENV['S3_ENABLED'] == 'true'
 
   s3_region   = ENV.fetch('S3_REGION')   { 'us-east-1' }
   s3_protocol = ENV.fetch('S3_PROTOCOL') { 'https' }
-  s3_hostname = ENV.fetch('S3_HOSTNAME') { "s3-#{s3_region}}.amazonaws.com" }
+  s3_hostname = ENV.fetch('S3_HOSTNAME') { "s3-#{s3_region}.amazonaws.com" }
 
   Paperclip::Attachment.default_options.merge!(
     storage: :s3,


### PR DESCRIPTION
Fix incorrect `s3_hostname` string.

The incorrect `s3_hostname` would look like `s3-ap-northeast-1%7D.amazonaws.com` .