### PR TITLE
Move push notifications settings (regression from #5879)

### DIFF
--- a/app/javascript/mastodon/actions/push_notifications.js
+++ b/app/javascript/mastodon/actions/push_notifications.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { setSettingsToLocalStorage } from '../web_push_subscription';
+import { pushNotificationsSetting } from '../settings';
 
 export const SET_BROWSER_SUPPORT = 'PUSH_NOTIFICATIONS_SET_BROWSER_SUPPORT';
 export const SET_SUBSCRIPTION = 'PUSH_NOTIFICATIONS_SET_SUBSCRIPTION';
@@ -50,7 +50,7 @@ export function saveSettings() {
     }).then(() => {
       const me = getState().getIn(['meta', 'me']);
       if (me) {
-        setSettingsToLocalStorage(me, data);
+        pushNotificationsSetting.set(me, data);
       }
     });
   };

--- a/app/javascript/mastodon/settings.js
+++ b/app/javascript/mastodon/settings.js
@@ -1,0 +1,46 @@
+export default class Settings {
+
+  constructor(keyBase = null) {
+    this.keyBase = keyBase;
+  }
+
+  generateKey(id) {
+    return this.keyBase ? [this.keyBase, `id${id}`].join('.') : id;
+  }
+
+  set(id, data) {
+    const key = this.generateKey(id);
+    try {
+      const encodedData = JSON.stringify(data);
+      localStorage.setItem(key, encodedData);
+      return data;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  get(id) {
+    const key = this.generateKey(id);
+    try {
+      const rawData = localStorage.getItem(key);
+      return JSON.parse(rawData);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  remove(id) {
+    const data = this.get(id);
+    if (data) {
+      const key = this.generateKey(id);
+      try {
+        localStorage.removeItem(key);
+      } catch (e) {
+      }
+    }
+    return data;
+  }
+
+}
+
+export const pushNotificationsSetting = new Settings('mastodon_push_notification_data');

--- a/app/javascript/mastodon/web_push_subscription.js
+++ b/app/javascript/mastodon/web_push_subscription.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { store } from './containers/mastodon';
 import { setBrowserSupport, setSubscription, clearSubscription } from './actions/push_notifications';
+import { pushNotificationsSetting } from './settings';
 
 // Taken from https://www.npmjs.com/package/web-push
 const urlBase64ToUint8Array = (base64String) => {
@@ -40,7 +41,7 @@ const sendSubscriptionToBackend = (subscription) => {
 
   const me = store.getState().getIn(['meta', 'me']);
   if (me) {
-    const data = getSettingsFromLocalStorage(me);
+    const data = pushNotificationsSetting.get(me);
     if (data) {
       params.data = data;
     }
@@ -52,16 +53,14 @@ const sendSubscriptionToBackend = (subscription) => {
 // Last one checks for payload support: https://web-push-book.gauntface.com/chapter-06/01-non-standards-browsers/#no-payload
 const supportsPushNotifications = ('serviceWorker' in navigator && 'PushManager' in window && 'getKey' in PushSubscription.prototype);
 
-const SUBSCRIPTION_DATA_STORAGE_KEY = 'mastodon_push_notification_data';
-
 export function register () {
   store.dispatch(setBrowserSupport(supportsPushNotifications));
   const me = store.getState().getIn(['meta', 'me']);
 
-  if (me && !getSettingsFromLocalStorage(me)) {
+  if (me && !pushNotificationsSetting.get(me)) {
     const alerts = store.getState().getIn(['push_notifications', 'alerts']);
     if (alerts) {
-      setSettingsToLocalStorage(me, { alerts: alerts });
+      pushNotificationsSetting.set(me, { alerts: alerts });
     }
   }
 
@@ -99,7 +98,7 @@ export function register () {
         if (!(subscription instanceof PushSubscription)) {
           store.dispatch(setSubscription(subscription));
           if (me) {
-            setSettingsToLocalStorage(me, { alerts: subscription.alerts });
+            pushNotificationsSetting.setf(me, { alerts: subscription.alerts });
           }
         }
       })
@@ -113,7 +112,7 @@ export function register () {
         // Clear alerts and hide UI settings
         store.dispatch(clearSubscription());
         if (me) {
-          removeSettingsFromLocalStorage(me);
+          pushNotificationsSetting.remove(me);
         }
 
         try {
@@ -127,22 +126,4 @@ export function register () {
   } else {
     console.warn('Your browser does not support Web Push Notifications.');
   }
-}
-
-export function setSettingsToLocalStorage(id, data) {
-  try {
-    localStorage.setItem(`${SUBSCRIPTION_DATA_STORAGE_KEY}_${id}`, JSON.stringify(data));
-  } catch (e) {}
-}
-
-export function getSettingsFromLocalStorage(id) {
-  try {
-    return JSON.parse(localStorage.getItem(`${SUBSCRIPTION_DATA_STORAGE_KEY}_${id}`));
-  } catch (e) {}
-
-  return null;
-}
-
-export function removeSettingsFromLocalStorage(id) {
-  localStorage.removeItem(`${SUBSCRIPTION_DATA_STORAGE_KEY}_${id}`);
 }

--- a/app/javascript/mastodon/web_push_subscription.js
+++ b/app/javascript/mastodon/web_push_subscription.js
@@ -98,7 +98,7 @@ export function register () {
         if (!(subscription instanceof PushSubscription)) {
           store.dispatch(setSubscription(subscription));
           if (me) {
-            pushNotificationsSetting.setf(me, { alerts: subscription.alerts });
+            pushNotificationsSetting.set(me, { alerts: subscription.alerts });
           }
         }
       })


### PR DESCRIPTION
Some non-Web UI pages (e.g. `/about`, `/share?text=...`, `/tag/...`, etc...) are broken from #5879.

![stacktrace](https://user-images.githubusercontent.com/12539/33794158-5ca06316-dd09-11e7-9c9d-4414ab9d97e5.png)

Because `import` of [`web_push_subscription.js` has been added to `actions/push_notifications.js`](https://github.com/tootsuite/mastodon/commit/99242b92bcc1965b2a72c01216bce7c232322f15#diff-909284b73f02fe2ba5ef1d0f7a92f4ccR2), `store/configureStore.js` is circularly referenced.

Reported by https://theboss.tech/@the_boss/99143135685541289