### PR TITLE
Change streaming API URL when remote development

### DIFF
--- a/config/initializers/ostatus.rb
+++ b/config/initializers/ostatus.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   config.x.alternate_domains = alternate_domains.split(/\s*,\s*/)
 
   config.action_mailer.default_url_options = { host: web_host, protocol: https ? 'https://' : 'http://', trailing_slash: false }
-  config.x.streaming_api_base_url          = 'ws://localhost:4000'
+  config.x.streaming_api_base_url          = "ws://#{ENV['REMOTE_DEV'] == 'true' ? host.split(':').first : 'localhost'}:4000"
 
   if Rails.env.production?
     config.x.streaming_api_base_url = ENV.fetch('STREAMING_API_BASE_URL') { "ws#{https ? 's' : ''}://#{web_host}" }

--- a/config/initializers/ostatus.rb
+++ b/config/initializers/ostatus.rb
@@ -17,9 +17,12 @@ Rails.application.configure do
   config.x.alternate_domains = alternate_domains.split(/\s*,\s*/)
 
   config.action_mailer.default_url_options = { host: web_host, protocol: https ? 'https://' : 'http://', trailing_slash: false }
-  config.x.streaming_api_base_url          = "ws://#{ENV['REMOTE_DEV'] == 'true' ? host.split(':').first : 'localhost'}:4000"
 
-  if Rails.env.production?
-    config.x.streaming_api_base_url = ENV.fetch('STREAMING_API_BASE_URL') { "ws#{https ? 's' : ''}://#{web_host}" }
+  config.x.streaming_api_base_url = ENV.fetch('STREAMING_API_BASE_URL') do
+    if Rails.env.production?
+      "ws#{https ? 's' : ''}://#{web_host}"
+    else
+      "ws://#{ENV['REMOTE_DEV'] == 'true' ? host.split(':').first : 'localhost'}:4000"
+    end
   end
 end


### PR DESCRIPTION
currently always `ws://localhost:4000`.