### PR TITLE
Ignore HEAD method if does not support

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -38,7 +38,7 @@ class FetchLinkCardService < BaseService
     @card ||= PreviewCard.new(url: @url)
     res     = Request.new(:head, @url).perform
 
-    return if res.code != 200 || res.mime_type != 'text/html'
+    return if res.code != 405 && (res.code != 200 || res.mime_type != 'text/html')
 
     attempt_oembed || attempt_opengraph
   end


### PR DESCRIPTION
Some web pages (e.g. `www.amazon.com`) do not support the HEAD method. Web pages that do not supported to the HEAD method returns "405 Method Not Allowed".

If you do not supported to the HEAD method, want to invalidate the Content-Type check.

### screenshot

![screenshot](https://user-images.githubusercontent.com/12539/33796907-4521394e-dd41-11e7-87fd-1e13086f113c.png)
