### PR TITLE
Add preview image to photo preview cards

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -9,7 +9,7 @@ import StatusContent from './status_content';
 import StatusActionBar from './status_action_bar';
 import { FormattedMessage } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { MediaGallery, Video } from '../features/ui/util/async-components';
+import { StatusMediaGalleryContainer, Video } from '../features/ui/util/async-components';
 import { HotKeys } from 'react-hotkeys';
 import classNames from 'classnames';
 
@@ -190,8 +190,12 @@ export default class Status extends ImmutablePureComponent {
         );
       } else {
         media = (
-          <Bundle fetchComponent={MediaGallery} loading={this.renderLoadingMediaGallery} >
-            {Component => <Component media={status.get('media_attachments')} sensitive={status.get('sensitive')} height={110} onOpenMedia={this.props.onOpenMedia} />}
+          <Bundle fetchComponent={StatusMediaGalleryContainer} loading={this.renderLoadingMediaGallery} >
+            {Component => <Component
+              id={status.get('id')}
+              height={110}
+              onOpenMedia={this.props.onOpenMedia}
+            />}
           </Bundle>
         );
       }

--- a/app/javascript/mastodon/components/status_media_gallery.js
+++ b/app/javascript/mastodon/components/status_media_gallery.js
@@ -1,0 +1,44 @@
+import Immutable from 'immutable';
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import MediaGallery from './media_gallery';
+
+export default class StatusMediaGallery extends ImmutablePureComponent {
+
+  static propTypes = {
+    card: ImmutablePropTypes.map,
+    status: ImmutablePropTypes.map.isRequired,
+  }
+
+  render () {
+    const { card, status, ...props } = this.props;
+    let mediaProperty = status.get('media_attachments');
+
+    if (status.get('spoiler_text').length === 0 &&
+        card !== undefined && card.get('type') === 'photo') {
+      mediaProperty = mediaProperty.push(Immutable.fromJS({
+        id: 'card',
+        type: 'image',
+        url: card.get('embed_url'),
+        preview_url: card.get('image'),
+        description: card.get('title'),
+        meta: {
+          original: {
+            width: card.get('width'),
+            height: card.get('height'),
+          },
+        },
+      }));
+    }
+
+    return (
+      <MediaGallery
+        sensitive={status.get('sensitive')}
+        media={mediaProperty}
+        {...props}
+      />
+    );
+  }
+
+}

--- a/app/javascript/mastodon/containers/status_media_gallery_container.js
+++ b/app/javascript/mastodon/containers/status_media_gallery_container.js
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+import StatusMediaGallery from '../components/status_media_gallery';
+import { makeGetStatus } from '../selectors';
+
+const makeMapStateToProps = () => {
+  const getStatus = makeGetStatus();
+
+  const mapStateToProps = (state, props) => ({
+    card: state.getIn(['cards', props.id]),
+    status: getStatus(state, props.id),
+  });
+
+  return mapStateToProps;
+};
+
+export default connect(makeMapStateToProps)(StatusMediaGallery);

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -4,8 +4,8 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import Avatar from '../../../components/avatar';
 import DisplayName from '../../../components/display_name';
 import StatusContent from '../../../components/status_content';
-import MediaGallery from '../../../components/media_gallery';
 import AttachmentList from '../../../components/attachment_list';
+import StatusMediaGalleryContainer from '../../../containers/status_media_gallery_container';
 import { Link } from 'react-router-dom';
 import { FormattedDate, FormattedNumber } from 'react-intl';
 import CardContainer from '../containers/card_container';
@@ -63,10 +63,8 @@ export default class DetailedStatus extends ImmutablePureComponent {
         );
       } else {
         media = (
-          <MediaGallery
-            standalone
-            sensitive={status.get('sensitive')}
-            media={status.get('media_attachments')}
+          <StatusMediaGalleryContainer
+            id={status.get('id')}
             height={300}
             onOpenMedia={this.props.onOpenMedia}
           />

--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -42,6 +42,7 @@ const makeMapStateToProps = () => {
   const getStatus = makeGetStatus();
 
   const mapStateToProps = (state, props) => ({
+    card: state.getIn(['cards', props.params.statusId]),
     status: getStatus(state, props.params.statusId),
     ancestorsIds: state.getIn(['contexts', 'ancestors', props.params.statusId]),
     descendantsIds: state.getIn(['contexts', 'descendants', props.params.statusId]),
@@ -268,7 +269,7 @@ export default class Status extends ImmutablePureComponent {
 
   render () {
     let ancestors, descendants;
-    const { status, ancestorsIds, descendantsIds } = this.props;
+    const { card, status, ancestorsIds, descendantsIds } = this.props;
     const { fullscreen } = this.state;
 
     if (status === null) {
@@ -309,6 +310,7 @@ export default class Status extends ImmutablePureComponent {
             <HotKeys handlers={handlers}>
               <div className='focusable' tabIndex='0'>
                 <DetailedStatus
+                  card={card}
                   status={status}
                   onOpenVideo={this.handleOpenVideo}
                   onOpenMedia={this.handleOpenMedia}

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -106,8 +106,8 @@ export function ReportModal () {
   return import(/* webpackChunkName: "modals/report_modal" */'../components/report_modal');
 }
 
-export function MediaGallery () {
-  return import(/* webpackChunkName: "status/media_gallery" */'../../../components/media_gallery');
+export function StatusMediaGalleryContainer () {
+  return import(/* webpackChunkName: "status/media_gallery" */'../../../containers/status_media_gallery_container');
 }
 
 export function Video () {

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -88,6 +88,7 @@ class FetchLinkCardService < BaseService
       @card.image = URI.parse(response.thumbnail_url) if response.respond_to?(:thumbnail_url)
     when 'photo'
       @card.embed_url = response.url
+      @card.image     = URI.parse(response.url)
       @card.width     = response.width.presence  || 0
       @card.height    = response.height.presence || 0
     when 'video'


### PR DESCRIPTION
The below is a screenshot of a preview of one media attachment (left) and one embedded photo (right). Note that the preview is only shown after a card is loaded.
![screen shot 2017-12-10 at 16 11 14](https://user-images.githubusercontent.com/17036990/33802854-c2dab59e-ddc4-11e7-8270-708ef25194ec.png)
