### PR TITLE
Save media outside transaction

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -20,11 +20,13 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   private
 
   def process_status
+    media_attachments = process_attachments
+
     ApplicationRecord.transaction do
       @status = Status.create!(status_params)
 
       process_tags(@status)
-      process_attachments(@status)
+      attach_media(@status, media_attachments)
     end
 
     resolve_thread(@status)
@@ -105,22 +107,36 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     emoji.save
   end
 
-  def process_attachments(status)
+  def process_attachments
     return if @object['attachment'].nil?
+
+    media_attachments = []
 
     as_array(@object['attachment']).each do |attachment|
       next if unsupported_media_type?(attachment['mediaType']) || attachment['url'].blank?
 
       href             = Addressable::URI.parse(attachment['url']).normalize.to_s
-      media_attachment = MediaAttachment.create(status: status, account: status.account, remote_url: href, description: attachment['name'].presence)
+      media_attachment = MediaAttachment.create(account: @account, remote_url: href, description: attachment['name'].presence)
+      media_attachments << media_attachment
 
       next if skip_download?
 
       media_attachment.file_remote_url = href
       media_attachment.save
     end
+
+    media_attachments
   rescue Addressable::URI::InvalidURIError => e
     Rails.logger.debug e
+
+    media_attachments
+  end
+
+  def attach_media(status, media_attachments)
+    return if media_attachments.blank?
+
+    media = MediaAttachment.where(status_id: nil, id: media_attachments.take(4).map(&:id))
+    media.update(status_id: status.id)
   end
 
   def resolve_thread(status)


### PR DESCRIPTION
When processing statuses received from other instances, media creation and uploading were performed within the transaction. This will increase transaction time, so we will process the media outside the transaction.

If creation of statuses fails, the media will remain. However, since MediaCleanupScheduler deletes regularly I think that there is no problem.