### PR TITLE
Do not try to rescue ActiveRecord error in Mastodon::Snowflake::Callbacks

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -136,7 +136,7 @@ class Status < ApplicationRecord
 
   after_create_commit :store_uri, if: :local?
 
-  around_create Mastodon::Snowflake::Callbacks
+  before_create Mastodon::Snowflake::Callbacks
 
   before_validation :prepare_contents, if: :local?
   before_validation :set_reblog

--- a/db/migrate/20171210000000_status_ids_to_new_timestamp_ids.rb
+++ b/db/migrate/20171210000000_status_ids_to_new_timestamp_ids.rb
@@ -1,0 +1,27 @@
+class StatusIdsToNewTimestampIds < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    # Define the temporary function used in this migration.
+    Mastodon::Snowflake::define_timestamp_id 'temporary_timestamp_id'
+
+    # Set up the statuses.id column to use the temporary function.
+    ActiveRecord::Base.connection.execute(<<~SQL)
+      ALTER TABLE statuses
+      ALTER COLUMN id
+      SET DEFAULT temporary_timestamp_id('statuses', now())
+    SQL
+
+    # Replace the function we will use to generate IDs.
+    Rake::Task['db:define_timestamp_id'].execute
+
+    # Set up the statuses.id column to use our new timestamp-based IDs.
+    ActiveRecord::Base.connection.execute(<<~SQL)
+      ALTER TABLE statuses
+      ALTER COLUMN id
+      SET DEFAULT timestamp_id('statuses', now())
+    SQL
+
+    ActiveRecord::Base.connection.execute 'DROP FUNCTION temporary_timestamp_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171201000000) do
+ActiveRecord::Schema.define(version: 20171210000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -391,7 +391,7 @@ ActiveRecord::Schema.define(version: 20171201000000) do
     t.index ["account_id", "status_id"], name: "index_status_pins_on_account_id_and_status_id", unique: true
   end
 
-  create_table "statuses", id: :bigint, default: -> { "timestamp_id('statuses'::text)" }, force: :cascade do |t|
+  create_table "statuses", id: :bigint, default: -> { "timestamp_id('statuses'::text, now())" }, force: :cascade do |t|
     t.string "uri"
     t.text "text", default: "", null: false
     t.datetime "created_at", null: false

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -63,7 +63,7 @@ namespace :db do
 
   task :define_timestamp_id do
     each_schema_load_environment do
-      Mastodon::Snowflake.define_timestamp_id
+      Mastodon::Snowflake.define_timestamp_id 'timestamp_id'
     end
   end
 


### PR DESCRIPTION
Callbacks in `Mastodon::Snowflake::Callbacks` may run in a transaction, and it cannot continue the execution if it caused an error in such a condition.

Resolves #5960.