### PR TITLE
Refix extraspace for emojis

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -803,7 +803,7 @@
     .emojione {
       width: 24px;
       height: 24px;
-      margin: -3px 0 0;
+      margin: -1px 0 0;
     }
   }
 


### PR DESCRIPTION
Follow-up fix of #5902 
Top lacked emoji and misalignment are left... This fix them.

Before | After
--|--
![ws000141](https://user-images.githubusercontent.com/27640522/33806602-22550436-de0e-11e7-97ee-9ee879230f02.png) | ![ws000142](https://user-images.githubusercontent.com/27640522/33806604-27fb7db6-de0e-11e7-8dc3-b505e73a1c30.png)
