### PR TITLE
Fix account and tag searches with leading/trailing spaces

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -23,7 +23,7 @@ class Tag < ApplicationRecord
 
   class << self
     def search_for(term, limit = 5)
-      pattern = sanitize_sql_like(term) + '%'
+      pattern = sanitize_sql_like(term.strip) + '%'
       Tag.where('lower(name) like lower(?)', pattern).order(:name).limit(limit)
     end
   end

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -4,7 +4,7 @@ class AccountSearchService < BaseService
   attr_reader :query, :limit, :options, :account
 
   def call(query, limit, account = nil, options = {})
-    @query   = query
+    @query   = query.strip
     @limit   = limit
     @options = options
     @account = account


### PR DESCRIPTION
I did an account search with a trailing space and no account was found; I removed the trailing space and then the account has been found. The same happen with tags and with leading spaces.