### PR TITLE
Improve error handling in streaming/index.js

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -520,12 +520,14 @@ const startWorker = (workerId) => {
 
   const onError = (err) => {
     log.error(err);
+    server.close();
+    process.exit(0);
   };
 
   process.on('SIGINT', onExit);
   process.on('SIGTERM', onExit);
   process.on('exit', onExit);
-  process.on('error', onError);
+  process.on('uncaughtException', onError);
 };
 
 throng({


### PR DESCRIPTION
On an unhandled worker exception, we should log the exception
and gracefully exit with nonzero status, instead of letting workers
silently fail and restart in an endless loop.

Note: we previously tried to handle the `'error'` signal.
That's not a signal Node fires; my patch traps `'uncaughtException'`,
which is what the code was _trying_ to do.