### PR TITLE
Revert "Add check for visibility.nil? even though it can't ever be, t…

### DIFF
--- a/app/lib/exceptions.rb
+++ b/app/lib/exceptions.rb
@@ -4,7 +4,6 @@ module Mastodon
   class Error < StandardError; end
   class NotPermittedError < Error; end
   class ValidationError < Error; end
-  class RaceConditionError < Error; end
 
   class UnexpectedResponseError < Error
     def initialize(response = nil)

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -6,8 +6,6 @@ class FanOutOnWriteService < BaseService
   # Push a status into home and mentions feeds
   # @param [Status] status
   def call(status)
-    raise Mastodon::RaceConditionError if status.visibility.nil?
-
     deliver_to_self(status) if status.account.local?
 
     if status.direct_visibility?


### PR DESCRIPTION
…o check for race conditions"

This reverts commit 8232f76c482d3046055bd7bf224ef7835d0fa399.

The error is unexpected and have not been observed for a long time.

Pawoo and Pawoo Music saw this error only on May 24, 2017. The exception hardly makes sense.