### PR TITLE
Remove preview_card fabricator

### DIFF
--- a/spec/fabricators/preview_card_fabricator.rb
+++ b/spec/fabricators/preview_card_fabricator.rb
@@ -1,4 +1,0 @@
-Fabricator(:preview_card) do
-  status
-  url 'http://example.com'
-end


### PR DESCRIPTION
`preview_card` fabricator has a removed attribute, status, and is no longer functional.