### PR TITLE
make it possible to stream public timelines without authorization

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -44,7 +44,7 @@ rules:
   - last
   consistent-return: error
   dot-notation: error
-  eqeqeq: error
+  eqeqeq: [ error, always, { null: ignore } ]
   indent:
   - warn
   - 2

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -44,7 +44,7 @@ rules:
   - last
   consistent-return: error
   dot-notation: error
-  eqeqeq: [ error, always, { null: ignore } ]
+  eqeqeq: error
   indent:
   - warn
   - 2

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -239,7 +239,7 @@ const startWorker = (workerId) => {
 
   const wsVerifyClient = (info, cb) => {
     const location = url.parse(info.req.url, true);
-    const auth_required = !PUBLIC_STREAMS.some(stream => stream === location.query.stream);
+    const authRequired = !PUBLIC_STREAMS.some(stream => stream === location.query.stream);
 
     accountFromRequest(info.req, err => {
       if (!err) {
@@ -248,7 +248,7 @@ const startWorker = (workerId) => {
         log.error(info.req.requestId, err.toString());
         cb(false, 401, 'Unauthorized');
       }
-    }, auth_required);
+    }, authRequired);
   };
 
   const PUBLIC_ENDPOINTS = [
@@ -264,8 +264,8 @@ const startWorker = (workerId) => {
       return;
     }
 
-    const auth_required = PUBLIC_ENDPOINTS.some(endpoint => endpoint === req.path);
-    accountFromRequest(req, next, auth_required);
+    const authRequired = !PUBLIC_ENDPOINTS.some(endpoint => endpoint === req.path);
+    accountFromRequest(req, next, authRequired);
   };
 
   const errorMiddleware = (err, req, res, {}) => {
@@ -337,7 +337,7 @@ const startWorker = (workerId) => {
             return;
           }
 
-          if (req.accountId != null) {
+          if (!req.accountId) {
             const queries = [
               client.query(`SELECT 1 FROM blocks WHERE (account_id = $1 AND target_account_id IN (${placeholders(targetAccountIds, 2)})) OR (account_id = $2 AND target_account_id = $1) UNION SELECT 1 FROM mutes WHERE account_id = $1 AND target_account_id IN (${placeholders(targetAccountIds, 2)})`, [req.accountId, unpackedPayload.account.id].concat(targetAccountIds)),
             ];

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -442,7 +442,7 @@ const startWorker = (workerId) => {
   };
 
   app.use(setRequestId);
-  app.use(setRemoteAddress)
+  app.use(setRemoteAddress);
   app.use(allowCrossDomain);
   app.use(authenticationMiddleware);
   app.use(errorMiddleware);

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -411,8 +411,10 @@ const startWorker = (workerId) => {
 
   // Setup stream end for WebSockets
   const streamWsEnd = (req, ws, closeHandler = false) => (id, listener) => {
+    const accountId = req.accountId || '(anonymous user)';
+
     ws.on('close', () => {
-      log.verbose(req.requestId, `Ending stream for ${req.accountId}`);
+      log.verbose(req.requestId, `Ending stream for ${accountId}`);
       unsubscribe(id, listener);
       if (closeHandler) {
         closeHandler();
@@ -420,7 +422,7 @@ const startWorker = (workerId) => {
     });
 
     ws.on('error', () => {
-      log.verbose(req.requestId, `Ending stream for ${req.accountId}`);
+      log.verbose(req.requestId, `Ending stream for ${accountId}`);
       unsubscribe(id, listener);
       if (closeHandler) {
         closeHandler();

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -227,6 +227,19 @@ const startWorker = (workerId) => {
   };
 
   const wsVerifyClient = (info, cb) => {
+    const PUBLIC_STREAMS = [
+      'public',
+      'public:local',
+      'hashtag',
+      'hashtag:local',
+    ];
+
+    const location = url.parse(info.req.url, true);
+    if (PUBLIC_STREAMS.some(stream => stream === location.query.stream)) {
+      cb(true, undefined, undefined);
+      return;
+    }
+
     accountFromRequest(info.req, err => {
       if (!err) {
         cb(true, undefined, undefined);
@@ -238,7 +251,19 @@ const startWorker = (workerId) => {
   };
 
   const authenticationMiddleware = (req, res, next) => {
+    const PUBLIC_ENDPOINTS = [
+      '/api/v1/streaming/public',
+      '/api/v1/streaming/public/local',
+      '/api/v1/streaming/hashtag',
+      '/api/v1/streaming/hashtag/local',
+    ];
+
     if (req.method === 'OPTIONS') {
+      next();
+      return;
+    }
+
+    if (PUBLIC_ENDPOINTS.some(endpoint => endpoint === req.path)) {
       next();
       return;
     }

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -238,7 +238,6 @@ const startWorker = (workerId) => {
   ];
 
   const wsVerifyClient = (info, cb) => {
-
     const location = url.parse(info.req.url, true);
     const auth_required = !PUBLIC_STREAMS.some(stream => stream === location.query.stream);
 


### PR DESCRIPTION
Public timelines can be fetched via `/api/v1/timelines/public` without authorization, but streaming them needs authorization token now. This PR make it consistent between normal fetching APIs and streaming APIs.