### PR TITLE
Improve public status page title

### DIFF
--- a/app/views/stream_entries/show.html.haml
+++ b/app/views/stream_entries/show.html.haml
@@ -1,3 +1,6 @@
+- content_for :page_title do
+  = t('statuses.title', name: display_name(@account), quote: truncate(@stream_entry.activity.text, length: 50, omission: '…'))
+
 - content_for :header_tags do
   - if @account.user&.setting_noindex
     %meta{ name: 'robots', content: 'noindex' }/

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -599,6 +599,7 @@ en:
       private: Non-public toot cannot be pinned
       reblog: A boost cannot be pinned
     show_more: Show more
+    title: '%{name}: "%{quote}"'
     visibilities:
       private: Followers-only
       private_long: Only show to followers


### PR DESCRIPTION
Before:

> Mastodon

After:

> Display name: "Text of the toot truncated to 50 characters..." - Mastodon