### PR TITLE
Store preview image for embedded photo in preview cards

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -88,6 +88,7 @@ class FetchLinkCardService < BaseService
       @card.image = URI.parse(response.thumbnail_url) if response.respond_to?(:thumbnail_url)
     when 'photo'
       @card.embed_url = response.url
+      @card.image     = URI.parse(response.url)
       @card.width     = response.width.presence  || 0
       @card.height    = response.height.presence || 0
     when 'video'


### PR DESCRIPTION
The preview image would be useful to embed in timeline.

See #5957.