### PR TITLE
Avoid OEmbed if response does not respond to url

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -87,6 +87,7 @@ class FetchLinkCardService < BaseService
     when 'link'
       @card.image = URI.parse(response.thumbnail_url) if response.respond_to?(:thumbnail_url)
     when 'photo'
+      return false unless response.respond_to?(:url)
       @card.embed_url = response.url
       @card.width     = response.width.presence  || 0
       @card.height    = response.height.presence || 0


### PR DESCRIPTION
Avoid error when the url returns a mostly valid oembed, but has no url in it, causing a MethodError: undefined method `url' for #<OEmbed::Response::Photo:0x000056505def9620>.
This was happening with a link from Derpibooru tagged with NSFW content.