### PR TITLE
Remove duplicate indexes in lists

### DIFF
--- a/db/migrate/20171212195226_remove_duplicate_indexes_in_lists.rb
+++ b/db/migrate/20171212195226_remove_duplicate_indexes_in_lists.rb
@@ -1,0 +1,6 @@
+class RemoveDuplicateIndexesInLists < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :list_accounts, name: "index_list_accounts_on_account_id"
+    remove_index :list_accounts, name: "index_list_accounts_on_list_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171201000000) do
+ActiveRecord::Schema.define(version: 20171212195226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -202,10 +202,8 @@ ActiveRecord::Schema.define(version: 20171201000000) do
     t.bigint "account_id", null: false
     t.bigint "follow_id", null: false
     t.index ["account_id", "list_id"], name: "index_list_accounts_on_account_id_and_list_id", unique: true
-    t.index ["account_id"], name: "index_list_accounts_on_account_id"
     t.index ["follow_id"], name: "index_list_accounts_on_follow_id"
     t.index ["list_id", "account_id"], name: "index_list_accounts_on_list_id_and_account_id"
-    t.index ["list_id"], name: "index_list_accounts_on_list_id"
   end
 
   create_table "lists", force: :cascade do |t|


### PR DESCRIPTION
These indexes exist, but aren’t needed. `index_list_accounts_on_account_id` is covered by `index_list_accounts_on_account_id_and_list_id` and `index_list_accounts_on_list_id` is covered by `index_list_accounts_on_list_id_and_account_id`.