### PR TITLE
Clean up admin UI for accounts

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -89,7 +89,8 @@ module Admin
         :username,
         :display_name,
         :email,
-        :ip
+        :ip,
+        :staff
       )
     end
   end

--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Admin::FilterHelper
-  ACCOUNT_FILTERS = %i(local remote by_domain silenced suspended recent username display_name email ip).freeze
+  ACCOUNT_FILTERS = %i(local remote by_domain silenced suspended recent username display_name email ip staff).freeze
   REPORT_FILTERS = %i(resolved account_id target_account_id).freeze
   INVITE_FILTER = %i(available expired).freeze
 

--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -45,6 +45,8 @@ class AccountFilter
       else
         Account.default_scoped
       end
+    when 'staff'
+      accounts_with_users.merge User.staff
     else
       raise "Unknown filter: #{key}"
     end

--- a/app/views/admin/accounts/_account.html.haml
+++ b/app/views/admin/accounts/_account.html.haml
@@ -4,22 +4,11 @@
   %td.domain
     - unless account.local?
       = link_to account.domain, admin_accounts_path(by_domain: account.domain)
-  %td.protocol
-    - unless account.local?
-      = account.protocol.humanize
-  %td.confirmed
+  %td
     - if account.local?
-      - if account.user_confirmed?
-        %i.fa.fa-check
-      - else
-        %i.fa.fa-times
-  %td.subscribed
-    - if account.local?
-      = t('admin.accounts.location.local')
-    - elsif account.subscribed?
-      %i.fa.fa-check
+      = t("admin.accounts.roles.#{account.user&.role}")
     - else
-      %i.fa.fa-times
+      = account.protocol.humanize
   %td
     = table_link_to 'circle', t('admin.accounts.web'), web_path("accounts/#{account.id}")
     = table_link_to 'globe', t('admin.accounts.public'), TagManager.instance.url_for(account)

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -31,6 +31,11 @@
         - else
           = filter_link_to t('admin.accounts.moderation.suspended'), suspended: '1'
   .filter-subset
+    %strong= t('admin.accounts.role')
+    %ul
+      %li= filter_link_to t('admin.accounts.moderation.all'), staff: nil
+      %li= filter_link_to t('admin.accounts.roles.staff'), staff: '1'
+  .filter-subset
     %strong= t('admin.accounts.order.title')
     %ul
       %li= filter_link_to t('admin.accounts.order.alphabetic'), recent: nil
@@ -56,9 +61,7 @@
       %tr
         %th= t('admin.accounts.username')
         %th= t('admin.accounts.domain')
-        %th= t('admin.accounts.protocol')
-        %th= t('admin.accounts.confirmed')
-        %th= fa_icon 'paper-plane-o'
+        %th
         %th
     %tbody
       = render @accounts

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -104,7 +104,7 @@
     - else
       = link_to t('admin.accounts.perform_full_suspension'), admin_account_suspension_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button' if can?(:suspend, @account)
 
-- unless @account.local?
+- if !@account.local? && @account.hub_url.present?
   %hr
   %h3 OStatus
 
@@ -132,6 +132,7 @@
       - if @account.subscribed?
         = link_to t('admin.accounts.unsubscribe'), unsubscribe_admin_account_path(@account.id), method: :post, class: 'button negative' if can?(:unsubscribe, @account)
 
+- if !@account.local? && @account.inbox_url.present?
   %hr
   %h3 ActivityPub
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,7 @@ en:
       roles:
         admin: Administrator
         moderator: Moderator
+        staff: Staff
         user: User
       salmon_url: Salmon URL
       search: Search


### PR DESCRIPTION
- Add filter by "all" vs "staff" permissions
- Remove OStatus/PuSH subscription status column
- Remove confirmed/unconfirmed checkmark column (good info but not needed in overview imo)
- Protocol column now displays protocol for remote users and user role for local users
- In detailed view, OStatus section is hidden when hub URL is missing (purely ActivityPub account)
- In detailed view, ActivityPub section is hidden when inbox URL is missing (purely OStatus account)