### PR TITLE
Fix overflowing emojis on some devices

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -604,7 +604,7 @@
   line-height: 20px;
   word-wrap: break-word;
   font-weight: 400;
-  overflow: hidden;
+  overflow: visible;
   white-space: pre-wrap;
 
   &:focus {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -604,8 +604,9 @@
   line-height: 20px;
   word-wrap: break-word;
   font-weight: 400;
-  overflow: visible;
+  overflow: hidden;
   white-space: pre-wrap;
+  padding-top: 2px;
 
   &:focus {
     outline: 0;
@@ -858,7 +859,7 @@
 .status__action-bar {
   align-items: center;
   display: flex;
-  margin-top: 10px;
+  margin-top: 8px;
 }
 
 .status__action-bar-button {


### PR DESCRIPTION
I find out some devices display images in paragraph a bit higher, I can't check all devices, so I set overflow as visible.