### PR TITLE
“Two-factor code” → “Two-factor authentication code”

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -18,7 +18,7 @@ en:
       imports:
         data: CSV file exported from another Mastodon instance
       sessions:
-        otp: Enter the Two-factor code from your phone or use one of your recovery codes.
+        otp: Enter the Two-factor authentication code from your phone or use one of your recovery codes.
       user:
         filtered_languages: Checked languages will be filtered from public timelines for you
     labels:
@@ -38,7 +38,7 @@ en:
         max_uses: Max number of uses
         new_password: New password
         note: Bio
-        otp_attempt: Two-factor code
+        otp_attempt: Two-factor authentication code
         password: Password
         setting_auto_play_gif: Auto-play animated GIFs
         setting_boost_modal: Show confirmation dialog before boosting


### PR DESCRIPTION
It has more sense for me…