### PR TITLE
 Do not show desktop notification settings if not supported

### DIFF
--- a/app/javascript/mastodon/actions/push_notifications.js
+++ b/app/javascript/mastodon/actions/push_notifications.js
@@ -1,17 +1,9 @@
 import axios from 'axios';
 import { pushNotificationsSetting } from '../settings';
 
-export const SET_BROWSER_SUPPORT = 'PUSH_NOTIFICATIONS_SET_BROWSER_SUPPORT';
 export const SET_SUBSCRIPTION = 'PUSH_NOTIFICATIONS_SET_SUBSCRIPTION';
 export const CLEAR_SUBSCRIPTION = 'PUSH_NOTIFICATIONS_CLEAR_SUBSCRIPTION';
 export const ALERTS_CHANGE = 'PUSH_NOTIFICATIONS_ALERTS_CHANGE';
-
-export function setBrowserSupport (value) {
-  return {
-    type: SET_BROWSER_SUPPORT,
-    value,
-  };
-}
 
 export function setSubscription (subscription) {
   return {

--- a/app/javascript/mastodon/agent.js
+++ b/app/javascript/mastodon/agent.js
@@ -8,6 +8,10 @@ export function isMobile(width) {
 
 const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 
+// Last one checks for payload support: https://web-push-book.gauntface.com/chapter-06/01-non-standards-browsers/#no-payload
+const pushNotifications = ('serviceWorker' in navigator && 'PushManager' in window && 'getKey' in PushSubscription.prototype);
+const notifications = 'Notification' in window;
+
 let userTouching = false;
 let listenerOptions = detectPassiveEvents.hasSupport ? { passive: true } : false;
 
@@ -25,3 +29,11 @@ export function isUserTouching() {
 export function isIOS() {
   return iOS;
 };
+
+export function supportsPushNotifications() {
+  return pushNotifications;
+}
+
+export function supportsNotifications() {
+  return notifications;
+}

--- a/app/javascript/mastodon/agent.js
+++ b/app/javascript/mastodon/agent.js
@@ -6,11 +6,25 @@ export function isMobile(width) {
   return width <= LAYOUT_BREAKPOINT;
 };
 
+const Chrome = navigator.userAgent.includes('Chrome') && !window.MSStream;
 const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
+let desktopNotifications = 'Notification' in window;
+
+if (desktopNotifications && Chrome) {
+  try {
+    /*
+       Issue 901843006: Allow the embedder to disable the Notification constructor.
+       https://codereview.chromium.org/901843006
+     */
+    new Notification('', { silent: true, vibrate: true });
+  } catch (error) {
+    desktopNotifications = error.message !== 'Failed to construct \'Notification\': Illegal constructor. Use ServiceWorkerRegistration.showNotification() instead.';
+  }
+}
 
 // Last one checks for payload support: https://web-push-book.gauntface.com/chapter-06/01-non-standards-browsers/#no-payload
 const pushNotifications = ('serviceWorker' in navigator && 'PushManager' in window && 'getKey' in PushSubscription.prototype);
-const notifications = 'Notification' in window;
 
 let userTouching = false;
 let listenerOptions = detectPassiveEvents.hasSupport ? { passive: true } : false;
@@ -30,10 +44,10 @@ export function isIOS() {
   return iOS;
 };
 
-export function supportsPushNotifications() {
-  return pushNotifications;
+export function supportsDesktopNotifications() {
+  return desktopNotifications;
 }
 
-export function supportsNotifications() {
-  return notifications;
+export function supportsPushNotifications() {
+  return pushNotifications;
 }

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { is } from 'immutable';
 import IconButton from './icon_button';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { isIOS } from '../is_mobile';
+import { isIOS } from '../agent';
 import classNames from 'classnames';
 import { autoPlayGif } from '../initial_state';
 

--- a/app/javascript/mastodon/containers/dropdown_menu_container.js
+++ b/app/javascript/mastodon/containers/dropdown_menu_container.js
@@ -1,7 +1,7 @@
 import { openModal, closeModal } from '../actions/modal';
 import { connect } from 'react-redux';
 import DropdownMenu from '../components/dropdown_menu';
-import { isUserTouching } from '../is_mobile';
+import { isUserTouching } from '../agent';
 
 const mapStateToProps = state => ({
   isModalOpen: state.get('modal').modalType === 'ACTIONS',

--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
-import { supportsNotifications } from '../agent';
+import { supportsDesktopNotifications } from '../agent';
 import configureStore from '../store/configureStore';
 import { showOnboardingOnce } from '../actions/onboarding';
 import { BrowserRouter, Route } from 'react-router-dom';
@@ -31,7 +31,7 @@ export default class Mastodon extends React.PureComponent {
 
     // Desktop notifications
     // Ask after 1 minute
-    if (supportsNotifications() && Notification.permission === 'default') {
+    if (supportsDesktopNotifications() && Notification.permission === 'default') {
       window.setTimeout(() => Notification.requestPermission(), 60 * 1000);
     }
 

--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
+import { supportsNotifications } from '../agent';
 import configureStore from '../store/configureStore';
 import { showOnboardingOnce } from '../actions/onboarding';
 import { BrowserRouter, Route } from 'react-router-dom';
@@ -30,7 +31,7 @@ export default class Mastodon extends React.PureComponent {
 
     // Desktop notifications
     // Ask after 1 minute
-    if (typeof window.Notification !== 'undefined' && Notification.permission === 'default') {
+    if (supportsNotifications() && Notification.permission === 'default') {
       window.setTimeout(() => Notification.requestPermission(), 60 * 1000);
     }
 

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -14,7 +14,7 @@ import SensitiveButtonContainer from '../containers/sensitive_button_container';
 import EmojiPickerDropdown from '../containers/emoji_picker_dropdown_container';
 import UploadFormContainer from '../containers/upload_form_container';
 import WarningContainer from '../containers/warning_container';
-import { isMobile } from '../../../is_mobile';
+import { isMobile } from '../../../agent';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { length } from 'stringz';
 import { countableText } from '../util/counter';

--- a/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import PrivacyDropdown from '../components/privacy_dropdown';
 import { changeComposeVisibility } from '../../../actions/compose';
 import { openModal, closeModal } from '../../../actions/modal';
-import { isUserTouching } from '../../../is_mobile';
+import { isUserTouching } from '../../../agent';
 
 const mapStateToProps = state => ({
   isModalOpen: state.get('modal').modalType === 'ACTIONS',

--- a/app/javascript/mastodon/features/notifications/components/column_settings.js
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.js
@@ -4,6 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { FormattedMessage } from 'react-intl';
 import ClearColumnButton from './clear_column_button';
 import SettingToggle from './setting_toggle';
+import { supportsPushNotifications } from '../../../agent';
 
 export default class ColumnSettings extends React.PureComponent {
 
@@ -26,7 +27,7 @@ export default class ColumnSettings extends React.PureComponent {
     const showStr  = <FormattedMessage id='notifications.column_settings.show' defaultMessage='Show in column' />;
     const soundStr = <FormattedMessage id='notifications.column_settings.sound' defaultMessage='Play sound' />;
 
-    const showPushSettings = pushSettings.get('browserSupport') && pushSettings.get('isSubscribed');
+    const showPushSettings = supportsPushNotifications() && pushSettings.get('isSubscribed');
     const pushStr = showPushSettings && <FormattedMessage id='notifications.column_settings.push' defaultMessage='Push notifications' />;
     const pushMeta = showPushSettings && <FormattedMessage id='notifications.column_settings.push_meta' defaultMessage='This device' />;
 

--- a/app/javascript/mastodon/features/notifications/components/column_settings.js
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.js
@@ -4,7 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { FormattedMessage } from 'react-intl';
 import ClearColumnButton from './clear_column_button';
 import SettingToggle from './setting_toggle';
-import { supportsPushNotifications } from '../../../agent';
+import { supportsDesktopNotifications, supportsPushNotifications } from '../../../agent';
 
 export default class ColumnSettings extends React.PureComponent {
 
@@ -27,6 +27,7 @@ export default class ColumnSettings extends React.PureComponent {
     const showStr  = <FormattedMessage id='notifications.column_settings.show' defaultMessage='Show in column' />;
     const soundStr = <FormattedMessage id='notifications.column_settings.sound' defaultMessage='Play sound' />;
 
+    const showDesktopSettings = supportsDesktopNotifications();
     const showPushSettings = supportsPushNotifications() && pushSettings.get('isSubscribed');
     const pushStr = showPushSettings && <FormattedMessage id='notifications.column_settings.push' defaultMessage='Push notifications' />;
     const pushMeta = showPushSettings && <FormattedMessage id='notifications.column_settings.push_meta' defaultMessage='This device' />;
@@ -41,7 +42,7 @@ export default class ColumnSettings extends React.PureComponent {
           <span id='notifications-follow' className='column-settings__section'><FormattedMessage id='notifications.column_settings.follow' defaultMessage='New followers:' /></span>
 
           <div className='column-settings__row'>
-            <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'follow']} onChange={onChange} label={alertStr} />
+            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'follow']} onChange={onChange} label={alertStr} />}
             {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'follow']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
             <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'follow']} onChange={onChange} label={showStr} />
             <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'follow']} onChange={onChange} label={soundStr} />
@@ -52,7 +53,7 @@ export default class ColumnSettings extends React.PureComponent {
           <span id='notifications-favourite' className='column-settings__section'><FormattedMessage id='notifications.column_settings.favourite' defaultMessage='Favourites:' /></span>
 
           <div className='column-settings__row'>
-            <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'favourite']} onChange={onChange} label={alertStr} />
+            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'favourite']} onChange={onChange} label={alertStr} />}
             {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'favourite']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
             <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'favourite']} onChange={onChange} label={showStr} />
             <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'favourite']} onChange={onChange} label={soundStr} />
@@ -63,7 +64,7 @@ export default class ColumnSettings extends React.PureComponent {
           <span id='notifications-mention' className='column-settings__section'><FormattedMessage id='notifications.column_settings.mention' defaultMessage='Mentions:' /></span>
 
           <div className='column-settings__row'>
-            <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'mention']} onChange={onChange} label={alertStr} />
+            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'mention']} onChange={onChange} label={alertStr} />}
             {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'mention']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
             <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'mention']} onChange={onChange} label={showStr} />
             <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'mention']} onChange={onChange} label={soundStr} />
@@ -74,7 +75,7 @@ export default class ColumnSettings extends React.PureComponent {
           <span id='notifications-reblog' className='column-settings__section'><FormattedMessage id='notifications.column_settings.reblog' defaultMessage='Boosts:' /></span>
 
           <div className='column-settings__row'>
-            <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'reblog']} onChange={onChange} label={alertStr} />
+            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'reblog']} onChange={onChange} label={alertStr} />}
             {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'reblog']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
             <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'reblog']} onChange={onChange} label={showStr} />
             <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'reblog']} onChange={onChange} label={soundStr} />

--- a/app/javascript/mastodon/features/ui/components/column.js
+++ b/app/javascript/mastodon/features/ui/components/column.js
@@ -3,7 +3,7 @@ import ColumnHeader from './column_header';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
 import { scrollTop } from '../../../scroll';
-import { isMobile } from '../../../is_mobile';
+import { isMobile } from '../../../agent';
 
 export default class Column extends React.PureComponent {
 

--- a/app/javascript/mastodon/features/ui/components/tabs_bar.js
+++ b/app/javascript/mastodon/features/ui/components/tabs_bar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { debounce } from 'lodash';
-import { isUserTouching } from '../../../is_mobile';
+import { isUserTouching } from '../../../agent';
 
 export const links = [
   <NavLink className='tabs-bar__link primary' to='/statuses/new' data-preview-title-id='tabs_bar.compose' data-preview-icon='pencil' ><i className='fa fa-fw fa-pencil' /><FormattedMessage id='tabs_bar.compose' defaultMessage='Compose' /></NavLink>,

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -6,7 +6,7 @@ import TabsBar from './components/tabs_bar';
 import ModalContainer from './containers/modal_container';
 import { connect } from 'react-redux';
 import { Redirect, withRouter } from 'react-router-dom';
-import { isMobile } from '../../is_mobile';
+import { isMobile } from '../../agent';
 import { debounce } from 'lodash';
 import { uploadCompose, resetCompose } from '../../actions/compose';
 import { refreshHomeTimeline } from '../../actions/timelines';

--- a/app/javascript/mastodon/reducers/push_notifications.js
+++ b/app/javascript/mastodon/reducers/push_notifications.js
@@ -1,5 +1,5 @@
 import { STORE_HYDRATE } from '../actions/store';
-import { SET_BROWSER_SUPPORT, SET_SUBSCRIPTION, CLEAR_SUBSCRIPTION, ALERTS_CHANGE } from '../actions/push_notifications';
+import { SET_SUBSCRIPTION, CLEAR_SUBSCRIPTION, ALERTS_CHANGE } from '../actions/push_notifications';
 import Immutable from 'immutable';
 
 const initialState = Immutable.Map({
@@ -11,7 +11,6 @@ const initialState = Immutable.Map({
     mention: false,
   }),
   isSubscribed: false,
-  browserSupport: false,
 });
 
 export default function push_subscriptions(state = initialState, action) {
@@ -39,8 +38,6 @@ export default function push_subscriptions(state = initialState, action) {
       }))
       .set('alerts', new Immutable.Map(action.subscription.alerts))
       .set('isSubscribed', true);
-  case SET_BROWSER_SUPPORT:
-    return state.set('browserSupport', action.value);
   case CLEAR_SUBSCRIPTION:
     return initialState;
   case ALERTS_CHANGE:

--- a/app/javascript/mastodon/web_push_subscription.js
+++ b/app/javascript/mastodon/web_push_subscription.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
+import { supportsPushNotifications } from './agent';
 import { store } from './containers/mastodon';
-import { setBrowserSupport, setSubscription, clearSubscription } from './actions/push_notifications';
+import { setSubscription, clearSubscription } from './actions/push_notifications';
 import { pushNotificationsSetting } from './settings';
 
 // Taken from https://www.npmjs.com/package/web-push
@@ -50,11 +51,7 @@ const sendSubscriptionToBackend = (subscription) => {
   return axios.post('/api/web/push_subscriptions', params).then(response => response.data);
 };
 
-// Last one checks for payload support: https://web-push-book.gauntface.com/chapter-06/01-non-standards-browsers/#no-payload
-const supportsPushNotifications = ('serviceWorker' in navigator && 'PushManager' in window && 'getKey' in PushSubscription.prototype);
-
 export function register () {
-  store.dispatch(setBrowserSupport(supportsPushNotifications));
   const me = store.getState().getIn(['meta', 'me']);
 
   if (me && !pushNotificationsSetting.get(me)) {
@@ -64,7 +61,7 @@ export function register () {
     }
   }
 
-  if (supportsPushNotifications) {
+  if (supportsPushNotifications()) {
     if (!getApplicationServerKey()) {
       console.error('The VAPID public key is not set. You will not be able to receive Web Push Notifications.');
       return;


### PR DESCRIPTION
This resolves #4236.

~~Note that the initial state of `push_notifications` reducer is also updated accordingly to reflect the result of the feature detection to the default values. Using the same result for the default values and the UI eliminates the potential inconsistency.~~

By the way, the state of `push_notifications` reducer should not have been used as the default preferences. The original code intended to send the notification preferences as `alerts` property of `data` object *only* if they are saved. Otherwise, the server should have done the feature detection and have set the default parameters depending on that. However, there is a bug that it *always* sends the notification preferences loaded from the `push_notifications` state. ~~I just exploited that to implement this.~~