### PR TITLE
 Subordinate push settings to desktop settings 

### DIFF
--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -39,6 +39,7 @@ const unescapeHTML = (html) => {
 export function updateNotifications(notification, intlMessages, intlLocale) {
   return (dispatch, getState) => {
     const showAlert = getState().getIn(['settings', 'notifications', 'alerts', notification.type], true);
+    const showPushAlert = getState().getIn(['push_notifications', 'alerts', notification.type]);
     const playSound = getState().getIn(['settings', 'notifications', 'sounds', notification.type], true);
 
     dispatch({
@@ -52,7 +53,7 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
     fetchRelatedRelationships(dispatch, [notification]);
 
     // Desktop notifications
-    if (typeof window.Notification !== 'undefined' && showAlert) {
+    if (typeof window.Notification !== 'undefined' && showAlert && !showPushAlert) {
       const title = new IntlMessageFormat(intlMessages[`notification.${notification.type}`], intlLocale).format({ name: notification.account.display_name.length > 0 ? notification.account.display_name : notification.account.username });
       const body  = (notification.status && notification.status.spoiler_text.length > 0) ? notification.status.spoiler_text : unescapeHTML(notification.status ? notification.status.content : '');
 

--- a/app/javascript/mastodon/actions/push_notifications.js
+++ b/app/javascript/mastodon/actions/push_notifications.js
@@ -1,17 +1,9 @@
 import axios from 'axios';
 import { pushNotificationsSetting } from '../settings';
 
-export const SET_BROWSER_SUPPORT = 'PUSH_NOTIFICATIONS_SET_BROWSER_SUPPORT';
 export const SET_SUBSCRIPTION = 'PUSH_NOTIFICATIONS_SET_SUBSCRIPTION';
 export const CLEAR_SUBSCRIPTION = 'PUSH_NOTIFICATIONS_CLEAR_SUBSCRIPTION';
 export const ALERTS_CHANGE = 'PUSH_NOTIFICATIONS_ALERTS_CHANGE';
-
-export function setBrowserSupport (value) {
-  return {
-    type: SET_BROWSER_SUPPORT,
-    value,
-  };
-}
 
 export function setSubscription (subscription) {
   return {

--- a/app/javascript/mastodon/agent.js
+++ b/app/javascript/mastodon/agent.js
@@ -8,6 +8,10 @@ export function isMobile(width) {
 
 const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 
+// Last one checks for payload support: https://web-push-book.gauntface.com/chapter-06/01-non-standards-browsers/#no-payload
+const pushNotifications = ('serviceWorker' in navigator && 'PushManager' in window && 'getKey' in PushSubscription.prototype);
+const notifications = 'Notification' in window;
+
 let userTouching = false;
 let listenerOptions = detectPassiveEvents.hasSupport ? { passive: true } : false;
 
@@ -25,3 +29,11 @@ export function isUserTouching() {
 export function isIOS() {
   return iOS;
 };
+
+export function supportsPushNotifications() {
+  return pushNotifications;
+}
+
+export function supportsNotifications() {
+  return notifications;
+}

--- a/app/javascript/mastodon/agent.js
+++ b/app/javascript/mastodon/agent.js
@@ -6,11 +6,25 @@ export function isMobile(width) {
   return width <= LAYOUT_BREAKPOINT;
 };
 
+const Chrome = navigator.userAgent.includes('Chrome') && !window.MSStream;
 const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
+let desktopNotifications = 'Notification' in window;
+
+if (desktopNotifications && Chrome) {
+  try {
+    /*
+       Issue 901843006: Allow the embedder to disable the Notification constructor.
+       https://codereview.chromium.org/901843006
+     */
+    new Notification('', { silent: true, vibrate: true });
+  } catch (error) {
+    desktopNotifications = error.message !== 'Failed to construct \'Notification\': Illegal constructor. Use ServiceWorkerRegistration.showNotification() instead.';
+  }
+}
 
 // Last one checks for payload support: https://web-push-book.gauntface.com/chapter-06/01-non-standards-browsers/#no-payload
 const pushNotifications = ('serviceWorker' in navigator && 'PushManager' in window && 'getKey' in PushSubscription.prototype);
-const notifications = 'Notification' in window;
 
 let userTouching = false;
 let listenerOptions = detectPassiveEvents.hasSupport ? { passive: true } : false;
@@ -30,10 +44,10 @@ export function isIOS() {
   return iOS;
 };
 
-export function supportsPushNotifications() {
-  return pushNotifications;
+export function supportsDesktopNotifications() {
+  return desktopNotifications;
 }
 
-export function supportsNotifications() {
-  return notifications;
+export function supportsPushNotifications() {
+  return pushNotifications;
 }

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { is } from 'immutable';
 import IconButton from './icon_button';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { isIOS } from '../is_mobile';
+import { isIOS } from '../agent';
 import classNames from 'classnames';
 import { autoPlayGif } from '../initial_state';
 

--- a/app/javascript/mastodon/containers/dropdown_menu_container.js
+++ b/app/javascript/mastodon/containers/dropdown_menu_container.js
@@ -1,7 +1,7 @@
 import { openModal, closeModal } from '../actions/modal';
 import { connect } from 'react-redux';
 import DropdownMenu from '../components/dropdown_menu';
-import { isUserTouching } from '../is_mobile';
+import { isUserTouching } from '../agent';
 
 const mapStateToProps = state => ({
   isModalOpen: state.get('modal').modalType === 'ACTIONS',

--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
-import { supportsNotifications } from '../agent';
+import { supportsDesktopNotifications } from '../agent';
 import configureStore from '../store/configureStore';
 import { showOnboardingOnce } from '../actions/onboarding';
 import { BrowserRouter, Route } from 'react-router-dom';
@@ -31,7 +31,7 @@ export default class Mastodon extends React.PureComponent {
 
     // Desktop notifications
     // Ask after 1 minute
-    if (supportsNotifications() && Notification.permission === 'default') {
+    if (supportsDesktopNotifications() && Notification.permission === 'default') {
       window.setTimeout(() => Notification.requestPermission(), 60 * 1000);
     }
 

--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
+import { supportsNotifications } from '../agent';
 import configureStore from '../store/configureStore';
 import { showOnboardingOnce } from '../actions/onboarding';
 import { BrowserRouter, Route } from 'react-router-dom';
@@ -30,7 +31,7 @@ export default class Mastodon extends React.PureComponent {
 
     // Desktop notifications
     // Ask after 1 minute
-    if (typeof window.Notification !== 'undefined' && Notification.permission === 'default') {
+    if (supportsNotifications() && Notification.permission === 'default') {
       window.setTimeout(() => Notification.requestPermission(), 60 * 1000);
     }
 

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -14,7 +14,7 @@ import SensitiveButtonContainer from '../containers/sensitive_button_container';
 import EmojiPickerDropdown from '../containers/emoji_picker_dropdown_container';
 import UploadFormContainer from '../containers/upload_form_container';
 import WarningContainer from '../containers/warning_container';
-import { isMobile } from '../../../is_mobile';
+import { isMobile } from '../../../agent';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { length } from 'stringz';
 import { countableText } from '../util/counter';

--- a/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import PrivacyDropdown from '../components/privacy_dropdown';
 import { changeComposeVisibility } from '../../../actions/compose';
 import { openModal, closeModal } from '../../../actions/modal';
-import { isUserTouching } from '../../../is_mobile';
+import { isUserTouching } from '../../../agent';
 
 const mapStateToProps = state => ({
   isModalOpen: state.get('modal').modalType === 'ACTIONS',

--- a/app/javascript/mastodon/features/notifications/components/column_settings.js
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.js
@@ -38,49 +38,36 @@ export default class ColumnSettings extends React.PureComponent {
           <ClearColumnButton onClick={onClear} />
         </div>
 
-        <div role='group' aria-labelledby='notifications-follow'>
-          <span id='notifications-follow' className='column-settings__section'><FormattedMessage id='notifications.column_settings.follow' defaultMessage='New followers:' /></span>
+        {[
+          {
+            key: 'follow',
+            label: <FormattedMessage id='notifications.column_settings.follow' defaultMessage='New followers:' />,
+          }, {
+            key: 'favourite',
+            label: <FormattedMessage id='notifications.column_settings.favourite' defaultMessage='Favourites:' />,
+          }, {
+            key: 'mention',
+            label: <FormattedMessage id='notifications.column_settings.mention' defaultMessage='Mentions:' />,
+          }, {
+            key: 'reblog',
+            label: <FormattedMessage id='notifications.column_settings.reblog' defaultMessage='Boosts:' />,
+          },
+        ].map(({ key, label }, index) => {
+          const labelId = `notifications-${index}`;
 
-          <div className='column-settings__row'>
-            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'follow']} onChange={onChange} label={alertStr} />}
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'follow']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'follow']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'follow']} onChange={onChange} label={soundStr} />
-          </div>
-        </div>
+          return (
+            <div key={index} role='group' aria-labelledby={labelId}>
+              <span id={labelId} className='column-settings__section'>{label}</span>
 
-        <div role='group' aria-labelledby='notifications-favourite'>
-          <span id='notifications-favourite' className='column-settings__section'><FormattedMessage id='notifications.column_settings.favourite' defaultMessage='Favourites:' /></span>
-
-          <div className='column-settings__row'>
-            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'favourite']} onChange={onChange} label={alertStr} />}
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'favourite']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'favourite']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'favourite']} onChange={onChange} label={soundStr} />
-          </div>
-        </div>
-
-        <div role='group' aria-labelledby='notifications-mention'>
-          <span id='notifications-mention' className='column-settings__section'><FormattedMessage id='notifications.column_settings.mention' defaultMessage='Mentions:' /></span>
-
-          <div className='column-settings__row'>
-            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'mention']} onChange={onChange} label={alertStr} />}
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'mention']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'mention']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'mention']} onChange={onChange} label={soundStr} />
-          </div>
-        </div>
-
-        <div role='group' aria-labelledby='notifications-reblog'>
-          <span id='notifications-reblog' className='column-settings__section'><FormattedMessage id='notifications.column_settings.reblog' defaultMessage='Boosts:' /></span>
-
-          <div className='column-settings__row'>
-            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'reblog']} onChange={onChange} label={alertStr} />}
-            {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'reblog']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
-            <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'reblog']} onChange={onChange} label={showStr} />
-            <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'reblog']} onChange={onChange} label={soundStr} />
-          </div>
-        </div>
+              <div className='column-settings__row'>
+                {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', key]} onChange={onChange} label={alertStr} />}
+                {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', key]} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
+                <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', key]} onChange={onChange} label={showStr} />
+                <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', key]} onChange={onChange} label={soundStr} />
+              </div>
+            </div>
+          );
+        })}
       </div>
     );
   }

--- a/app/javascript/mastodon/features/notifications/components/column_settings.js
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.js
@@ -4,6 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { FormattedMessage } from 'react-intl';
 import ClearColumnButton from './clear_column_button';
 import SettingToggle from './setting_toggle';
+import { supportsPushNotifications } from '../../../agent';
 
 export default class ColumnSettings extends React.PureComponent {
 
@@ -26,7 +27,7 @@ export default class ColumnSettings extends React.PureComponent {
     const showStr  = <FormattedMessage id='notifications.column_settings.show' defaultMessage='Show in column' />;
     const soundStr = <FormattedMessage id='notifications.column_settings.sound' defaultMessage='Play sound' />;
 
-    const showPushSettings = pushSettings.get('browserSupport') && pushSettings.get('isSubscribed');
+    const showPushSettings = supportsPushNotifications() && pushSettings.get('isSubscribed');
     const pushStr = showPushSettings && <FormattedMessage id='notifications.column_settings.push' defaultMessage='Push notifications' />;
     const pushMeta = showPushSettings && <FormattedMessage id='notifications.column_settings.push_meta' defaultMessage='This device' />;
 

--- a/app/javascript/mastodon/features/notifications/components/column_settings.js
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.js
@@ -4,7 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { FormattedMessage } from 'react-intl';
 import ClearColumnButton from './clear_column_button';
 import SettingToggle from './setting_toggle';
-import { supportsPushNotifications } from '../../../agent';
+import { supportsDesktopNotifications, supportsPushNotifications } from '../../../agent';
 
 export default class ColumnSettings extends React.PureComponent {
 
@@ -27,6 +27,7 @@ export default class ColumnSettings extends React.PureComponent {
     const showStr  = <FormattedMessage id='notifications.column_settings.show' defaultMessage='Show in column' />;
     const soundStr = <FormattedMessage id='notifications.column_settings.sound' defaultMessage='Play sound' />;
 
+    const showDesktopSettings = supportsDesktopNotifications();
     const showPushSettings = supportsPushNotifications() && pushSettings.get('isSubscribed');
     const pushStr = showPushSettings && <FormattedMessage id='notifications.column_settings.push' defaultMessage='Push notifications' />;
     const pushMeta = showPushSettings && <FormattedMessage id='notifications.column_settings.push_meta' defaultMessage='This device' />;
@@ -41,7 +42,7 @@ export default class ColumnSettings extends React.PureComponent {
           <span id='notifications-follow' className='column-settings__section'><FormattedMessage id='notifications.column_settings.follow' defaultMessage='New followers:' /></span>
 
           <div className='column-settings__row'>
-            <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'follow']} onChange={onChange} label={alertStr} />
+            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'follow']} onChange={onChange} label={alertStr} />}
             {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'follow']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
             <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'follow']} onChange={onChange} label={showStr} />
             <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'follow']} onChange={onChange} label={soundStr} />
@@ -52,7 +53,7 @@ export default class ColumnSettings extends React.PureComponent {
           <span id='notifications-favourite' className='column-settings__section'><FormattedMessage id='notifications.column_settings.favourite' defaultMessage='Favourites:' /></span>
 
           <div className='column-settings__row'>
-            <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'favourite']} onChange={onChange} label={alertStr} />
+            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'favourite']} onChange={onChange} label={alertStr} />}
             {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'favourite']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
             <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'favourite']} onChange={onChange} label={showStr} />
             <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'favourite']} onChange={onChange} label={soundStr} />
@@ -63,7 +64,7 @@ export default class ColumnSettings extends React.PureComponent {
           <span id='notifications-mention' className='column-settings__section'><FormattedMessage id='notifications.column_settings.mention' defaultMessage='Mentions:' /></span>
 
           <div className='column-settings__row'>
-            <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'mention']} onChange={onChange} label={alertStr} />
+            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'mention']} onChange={onChange} label={alertStr} />}
             {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'mention']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
             <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'mention']} onChange={onChange} label={showStr} />
             <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'mention']} onChange={onChange} label={soundStr} />
@@ -74,7 +75,7 @@ export default class ColumnSettings extends React.PureComponent {
           <span id='notifications-reblog' className='column-settings__section'><FormattedMessage id='notifications.column_settings.reblog' defaultMessage='Boosts:' /></span>
 
           <div className='column-settings__row'>
-            <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'reblog']} onChange={onChange} label={alertStr} />
+            {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', 'reblog']} onChange={onChange} label={alertStr} />}
             {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', 'reblog']} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
             <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', 'reblog']} onChange={onChange} label={showStr} />
             <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', 'reblog']} onChange={onChange} label={soundStr} />

--- a/app/javascript/mastodon/features/notifications/components/column_settings.js
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.js
@@ -54,16 +54,20 @@ export default class ColumnSettings extends React.PureComponent {
           },
         ].map(({ key, label }, index) => {
           const labelId = `notifications-${index}`;
+          const desktopSettingKey = ['alerts', key];
+          const pushSettingKey = ['alerts', key];
+          const showSettingKey = ['shows', key];
+          const soundSettingkey = ['sounds', key];
 
           return (
             <div key={index} role='group' aria-labelledby={labelId}>
               <span id={labelId} className='column-settings__section'>{label}</span>
 
               <div className='column-settings__row'>
-                {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={['alerts', key]} onChange={onChange} label={alertStr} />}
-                {showPushSettings && <SettingToggle prefix='notifications_push' settings={pushSettings} settingKey={['alerts', key]} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
-                <SettingToggle prefix='notifications' settings={settings} settingKey={['shows', key]} onChange={onChange} label={showStr} />
-                <SettingToggle prefix='notifications' settings={settings} settingKey={['sounds', key]} onChange={onChange} label={soundStr} />
+                {showDesktopSettings && <SettingToggle prefix='notifications_desktop' settings={settings} settingKey={desktopSettingKey} onChange={onChange} label={alertStr} />}
+                {showPushSettings && <SettingToggle disabled={showDesktopSettings && !settings.getIn(desktopSettingKey)} sub={showDesktopSettings} prefix='notifications_push' settings={pushSettings} settingKey={pushSettingKey} meta={pushMeta} onChange={this.onPushChange} label={pushStr} />}
+                <SettingToggle prefix='notifications' settings={settings} settingKey={showSettingKey} onChange={onChange} label={showStr} />
+                <SettingToggle prefix='notifications' settings={settings} settingKey={soundSettingkey} onChange={onChange} label={soundStr} />
               </div>
             </div>
           );

--- a/app/javascript/mastodon/features/notifications/components/setting_toggle.js
+++ b/app/javascript/mastodon/features/notifications/components/setting_toggle.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
@@ -7,6 +8,8 @@ export default class SettingToggle extends React.PureComponent {
 
   static propTypes = {
     prefix: PropTypes.string,
+    disabled: PropTypes.bool,
+    sub: PropTypes.bool,
     settings: ImmutablePropTypes.map.isRequired,
     settingKey: PropTypes.array.isRequired,
     label: PropTypes.node.isRequired,
@@ -19,12 +22,12 @@ export default class SettingToggle extends React.PureComponent {
   }
 
   render () {
-    const { prefix, settings, settingKey, label, meta } = this.props;
+    const { prefix, disabled, sub, settings, settingKey, label, meta } = this.props;
     const id = ['setting-toggle', prefix, ...settingKey].filter(Boolean).join('-');
 
     return (
-      <div className='setting-toggle'>
-        <Toggle id={id} checked={settings.getIn(settingKey)} onChange={this.onChange} onKeyDown={this.onKeyDown} />
+      <div className={classNames('setting-toggle', { 'setting-toggle_sub': sub })}>
+        <Toggle id={id} checked={settings.getIn(settingKey)} disabled={disabled} onChange={this.onChange} onKeyDown={this.onKeyDown} />
         <label htmlFor={id} className='setting-toggle__label'>{label}</label>
         {meta && <span className='setting-meta__label'>{meta}</span>}
       </div>

--- a/app/javascript/mastodon/features/ui/components/column.js
+++ b/app/javascript/mastodon/features/ui/components/column.js
@@ -3,7 +3,7 @@ import ColumnHeader from './column_header';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
 import { scrollTop } from '../../../scroll';
-import { isMobile } from '../../../is_mobile';
+import { isMobile } from '../../../agent';
 
 export default class Column extends React.PureComponent {
 

--- a/app/javascript/mastodon/features/ui/components/tabs_bar.js
+++ b/app/javascript/mastodon/features/ui/components/tabs_bar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { debounce } from 'lodash';
-import { isUserTouching } from '../../../is_mobile';
+import { isUserTouching } from '../../../agent';
 
 export const links = [
   <NavLink className='tabs-bar__link primary' to='/statuses/new' data-preview-title-id='tabs_bar.compose' data-preview-icon='pencil' ><i className='fa fa-fw fa-pencil' /><FormattedMessage id='tabs_bar.compose' defaultMessage='Compose' /></NavLink>,

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -6,7 +6,7 @@ import TabsBar from './components/tabs_bar';
 import ModalContainer from './containers/modal_container';
 import { connect } from 'react-redux';
 import { Redirect, withRouter } from 'react-router-dom';
-import { isMobile } from '../../is_mobile';
+import { isMobile } from '../../agent';
 import { debounce } from 'lodash';
 import { uploadCompose, resetCompose } from '../../actions/compose';
 import { refreshHomeTimeline } from '../../actions/timelines';

--- a/app/javascript/mastodon/reducers/push_notifications.js
+++ b/app/javascript/mastodon/reducers/push_notifications.js
@@ -1,5 +1,5 @@
 import { STORE_HYDRATE } from '../actions/store';
-import { SET_BROWSER_SUPPORT, SET_SUBSCRIPTION, CLEAR_SUBSCRIPTION, ALERTS_CHANGE } from '../actions/push_notifications';
+import { SET_SUBSCRIPTION, CLEAR_SUBSCRIPTION, ALERTS_CHANGE } from '../actions/push_notifications';
 import Immutable from 'immutable';
 
 const initialState = Immutable.Map({
@@ -11,7 +11,6 @@ const initialState = Immutable.Map({
     mention: false,
   }),
   isSubscribed: false,
-  browserSupport: false,
 });
 
 export default function push_subscriptions(state = initialState, action) {
@@ -39,8 +38,6 @@ export default function push_subscriptions(state = initialState, action) {
       }))
       .set('alerts', new Immutable.Map(action.subscription.alerts))
       .set('isSubscribed', true);
-  case SET_BROWSER_SUPPORT:
-    return state.set('browserSupport', action.value);
   case CLEAR_SUBSCRIPTION:
     return initialState;
   case ALERTS_CHANGE:

--- a/app/javascript/mastodon/web_push_subscription.js
+++ b/app/javascript/mastodon/web_push_subscription.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
+import { supportsPushNotifications } from './agent';
 import { store } from './containers/mastodon';
-import { setBrowserSupport, setSubscription, clearSubscription } from './actions/push_notifications';
+import { setSubscription, clearSubscription } from './actions/push_notifications';
 import { pushNotificationsSetting } from './settings';
 
 // Taken from https://www.npmjs.com/package/web-push
@@ -50,11 +51,7 @@ const sendSubscriptionToBackend = (subscription) => {
   return axios.post('/api/web/push_subscriptions', params).then(response => response.data);
 };
 
-// Last one checks for payload support: https://web-push-book.gauntface.com/chapter-06/01-non-standards-browsers/#no-payload
-const supportsPushNotifications = ('serviceWorker' in navigator && 'PushManager' in window && 'getKey' in PushSubscription.prototype);
-
 export function register () {
-  store.dispatch(setBrowserSupport(supportsPushNotifications));
   const me = store.getState().getIn(['meta', 'me']);
 
   if (me && !pushNotificationsSetting.get(me)) {
@@ -64,7 +61,7 @@ export function register () {
     }
   }
 
-  if (supportsPushNotifications) {
+  if (supportsPushNotifications()) {
     if (!getApplicationServerKey()) {
       console.error('The VAPID public key is not set. You will not be able to receive Web Push Notifications.');
       return;

--- a/app/javascript/mastodon/web_push_subscription.js
+++ b/app/javascript/mastodon/web_push_subscription.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { supportsPushNotifications } from './agent';
+import { supportsDesktopNotifications, supportsPushNotifications } from './agent';
 import { store } from './containers/mastodon';
 import { setSubscription, clearSubscription } from './actions/push_notifications';
 import { pushNotificationsSetting } from './settings';
@@ -38,7 +38,10 @@ const unsubscribe = ({ registration, subscription }) =>
   subscription ? subscription.unsubscribe().then(() => registration) : registration;
 
 const sendSubscriptionToBackend = (subscription) => {
-  const params = { subscription };
+  const params = {
+    desktop_enabled: supportsDesktopNotifications(),
+    subscription,
+  };
 
   const me = store.getState().getIn(['meta', 'me']);
   if (me) {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2669,6 +2669,10 @@ button.icon-button.active i.fa-retweet {
   line-height: 24px;
 }
 
+.setting-toggle_sub {
+  margin-left: 16px;
+}
+
 .setting-toggle__label,
 .setting-meta__label {
   color: $ui-primary-color;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,7 @@ class User < ApplicationRecord
   belongs_to :invite, counter_cache: :uses
   accepts_nested_attributes_for :account
 
+  has_one :web_setting, class_name: 'Web::Setting', dependent: :delete, inverse_of: :user
   has_many :applications, class_name: 'Doorkeeper::Application', as: :owner
 
   validates :locale, inclusion: I18n.available_locales.map(&:to_s), if: :locale?

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -3,13 +3,14 @@
 #
 # Table name: web_push_subscriptions
 #
-#  id         :integer          not null, primary key
-#  endpoint   :string           not null
-#  key_p256dh :string           not null
-#  key_auth   :string           not null
-#  data       :json
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id              :integer          not null, primary key
+#  endpoint        :string           not null
+#  key_p256dh      :string           not null
+#  key_auth        :string           not null
+#  data            :json
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  desktop_enabled :boolean          default(TRUE), not null
 #
 
 require 'webpush'

--- a/db/migrate/20171216000000_add_desktop_enabled_to_web_push_subscriptions.rb
+++ b/db/migrate/20171216000000_add_desktop_enabled_to_web_push_subscriptions.rb
@@ -1,0 +1,13 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddDesktopEnabledToWebPushSubscriptions < ActiveRecord::Migration[5.1]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      add_column_with_default :web_push_subscriptions, :desktop_enabled, :boolean, default: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171212195226) do
+ActiveRecord::Schema.define(version: 20171216000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -500,6 +500,7 @@ ActiveRecord::Schema.define(version: 20171212195226) do
     t.json "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "desktop_enabled", default: true, null: false
   end
 
   create_table "web_settings", force: :cascade do |t|

--- a/spec/fabricators/web_push_subscription_fabricator.rb
+++ b/spec/fabricators/web_push_subscription_fabricator.rb
@@ -1,4 +1,4 @@
-Fabricator(:web_push_subscription) do
+Fabricator(:web_push_subscription, from: 'Web::PushSubscription') do
   endpoint   Faker::Internet.url
   key_p256dh Faker::Internet.password
   key_auth   Faker::Internet.password


### PR DESCRIPTION
This pull request is a follow-up of #6036.
This resolves #6034.

Push notifications are now options for desktop notifications. For users, it should look like an option to make desktop notifications persistent.
![screen shot 2017-12-16 at 15 23 32](https://user-images.githubusercontent.com/17036990/34067890-20266982-e275-11e7-86a3-e7ba2c06130c.png)
