### PR TITLE
enforce LOCAL_HTTPS=true in production

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -11,10 +11,11 @@ DB_PASS=
 DB_PORT=5432
 
 # Federation
-# Note: Changing LOCAL_DOMAIN or LOCAL_HTTPS at a later time will cause unwanted side effects.
+# Note: Changing LOCAL_DOMAIN at a later time will cause unwanted side effect, including breaking all existing federation.
 # LOCAL_DOMAIN should *NOT* contain the protocol part of the domain e.g https://example.com.
 LOCAL_DOMAIN=example.com 
-LOCAL_HTTPS=true
+
+# Changing LOCAL_HTTPS in production is no longer supported. (Mastodon will always serve https:// links)
 
 # Use this only if you need to run mastodon on a different domain than the one used for federation.
 # You can read more about this option on https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Serving_a_different_domain.md

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -11,7 +11,7 @@ DB_PASS=
 DB_PORT=5432
 
 # Federation
-# Note: Changing LOCAL_DOMAIN at a later time will cause unwanted side effect, including breaking all existing federation.
+# Note: Changing LOCAL_DOMAIN at a later time will cause unwanted side effects, including breaking all existing federation.
 # LOCAL_DOMAIN should *NOT* contain the protocol part of the domain e.g https://example.com.
 LOCAL_DOMAIN=example.com 
 

--- a/config/initializers/ostatus.rb
+++ b/config/initializers/ostatus.rb
@@ -3,11 +3,12 @@
 port     = ENV.fetch('PORT') { 3000 }
 host     = ENV.fetch('LOCAL_DOMAIN') { "localhost:#{port}" }
 web_host = ENV.fetch('WEB_DOMAIN') { host }
-https    = ENV['LOCAL_HTTPS'] == 'true'
 
 alternate_domains = ENV.fetch('ALTERNATE_DOMAINS') { '' }
 
 Rails.application.configure do
+  https    = Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true'
+
   config.x.local_domain = host
   config.x.web_domain   = web_host
   config.x.use_https    = https


### PR DESCRIPTION
This is one of the largest cases of instance mis-configuration, due to unclear variable naming and confusing documentation.