### PR TITLE
Reduce the number of synchronous resolves when posting toots

### DIFF
--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -11,18 +11,20 @@ class ProcessMentionsService < BaseService
     return unless status.local?
 
     status.text = status.text.gsub(Account::MENTION_RE) do |match|
-      begin
-        mentioned_account = resolve_remote_account_service.call($1)
-      rescue Goldfinger::Error, HTTP::Error
-        mentioned_account = nil
+      username, domain  = $1.split('@')
+      mentioned_account = Account.find_remote(username, domain)
+
+      if mention_undeliverable?(status, mentioned_account)
+        begin
+          mentioned_account = resolve_remote_account_service.call($1)
+        rescue Goldfinger::Error, HTTP::Error
+          mentioned_account = nil
+        end
       end
 
-      if mentioned_account.nil?
-        username, domain  = $1.split('@')
-        mentioned_account = Account.find_remote(username, domain)
-      end
+      mentioned_account ||= Account.find_remote(username, domain)
 
-      next match if mentioned_account.nil? || (!mentioned_account.local? && mentioned_account.ostatus? && status.stream_entry.hidden?)
+      next match if mention_undeliverable?(status, mentioned_account)
 
       mentioned_account.mentions.where(status: status).first_or_create(status: status)
       "@#{mentioned_account.acct}"
@@ -36,6 +38,10 @@ class ProcessMentionsService < BaseService
   end
 
   private
+
+  def mention_undeliverable?(status, mentioned_account)
+    mentioned_account.nil? || (!mentioned_account.local? && mentioned_account.ostatus? && status.stream_entry.hidden?)
+  end
 
   def create_notification(status, mention)
     mentioned_account = mention.account


### PR DESCRIPTION
In order to gracefully handle OStatus → ActivityPub migration, Mastodon resolves mentioned remote accounts.
This is only needed for OStatus accounts mentioned in private/direct toots, though.
This PR restricts those synchronous resolves to those cases.