### PR TITLE
Display deleted users' role as “Suspended”

### DIFF
--- a/app/views/admin/accounts/_account.html.haml
+++ b/app/views/admin/accounts/_account.html.haml
@@ -6,7 +6,10 @@
       = link_to account.domain, admin_accounts_path(by_domain: account.domain)
   %td
     - if account.local?
-      = t("admin.accounts.roles.#{account.user&.role}")
+      - if account.user.nil?
+        = t("admin.accounts.moderation.suspended")
+      - else
+        = t("admin.accounts.roles.#{account.user.role}")
     - else
       = account.protocol.humanize
   %td


### PR DESCRIPTION
Deleted users are technically suspended, but the code displaying their status
in the admin interface was broken and displayed a javascript object holding
translations of the possible user roles instead.