### PR TITLE
Add rake task to check and purge accounts that are missing in origin

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'optparse'
+require 'colorize'
+
 namespace :mastodon do
   desc 'Execute daily tasks (deprecated)'
   task :daily do
@@ -341,10 +344,34 @@ namespace :mastodon do
 
     desc 'Check every known remote account and delete those that no longer exist in origin'
     task purge_removed_accounts: :environment do
+      prepare_for_options!
+
+      options = {}
+
+      OptionParser.new do |opts|
+        opts.banner = 'Usage: rails mastodon:maintenance:purge_removed_accounts [options]'
+
+        opts.on('-f', '--force', 'Remove all encountered accounts without asking for confirmation') do
+          options[:force] = true
+        end
+
+        opts.on('-h', '--help', 'Display this message') do
+          puts opts
+          exit
+        end
+      end.parse!
+
+      disable_log_stdout!
+
+      total        = Account.remote.where(protocol: :activitypub).count
+      progress_bar = ProgressBar.create(total: total, format: '%c/%C |%w>%i| %e')
+
       Account.remote.where(protocol: :activitypub).partitioned.find_each do |account|
+        progress_bar.increment
+
         begin
           res = Request.new(:head, account.uri).perform
-        rescue
+        rescue StandardError
           # This could happen due to network timeout, DNS timeout, wrong SSL cert, etc,
           # which should probably not lead to perceiving the account as deleted, so
           # just skip till next time
@@ -352,16 +379,37 @@ namespace :mastodon do
         end
 
         if [404, 410].include?(res.code)
-          puts "It seems like #{account.acct} no longer exists. Purge the account from the database? [Y/n]: "
-          confirm = STDIN.gets.chomp
-
-          if confirm.casecmp('n').zero?
-            next
-          else
+          if options[:force]
             account.destroy
+          else
+            progress_bar.pause
+            progress_bar.clear
+            print "\nIt seems like #{account.acct} no longer exists. Purge the account from the database? [Y/n]: ".colorize(:yellow)
+            confirm = STDIN.gets.chomp
+            puts ''
+            progress_bar.resume
+
+            if confirm.casecmp('n').zero?
+              next
+            else
+              account.destroy
+            end
           end
         end
       end
     end
   end
+end
+
+def disable_log_stdout!
+  dev_null = Logger.new('/dev/null')
+
+  Rails.logger                 = dev_null
+  ActiveRecord::Base.logger    = dev_null
+  HttpLog.configuration.logger = dev_null
+  Paperclip.options[:log]      = false
+end
+
+def prepare_for_options!
+  2.times { ARGV.shift }
 end


### PR DESCRIPTION
Maybe this is useful? :thinking: 

![image](https://user-images.githubusercontent.com/184731/34324058-2c292528-e863-11e7-8513-3bf1ee9dcc42.png)

![image](https://user-images.githubusercontent.com/184731/34324063-3be7fb6a-e863-11e7-985c-cb1d80b387ac.png)

The task checks every remote ActivityPub account by performing a HEAD request at the account's URI. We only check ActivityPub because OStatus account's can be a bit more finicky I imagine. The number of accounts that will be checked is pre-counted and displayed in the progress bar. The accounts are iterated in a "partitioned" way, i.e. the domains are rotated in such a way that no subsequent requests are made to the same domain and they are spread out as much as possible, to prevent overloading any particular domain.

Unfortunately the progress bar appears anew under every prompt. Maybe we should get rid of the prompts?