### PR TITLE
Allow to retrieve thumbnails from media shortcodes

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -6,7 +6,11 @@ class MediaController < ApplicationController
   before_action :verify_permitted_status
 
   def show
-    redirect_to media_attachment.file.url(:original)
+    if params[:thumb].present?
+      redirect_to media_attachment.file.url(:small)
+    else
+      redirect_to media_attachment.file.url(:original)
+    end
   end
 
   private


### PR DESCRIPTION
If the 'thumb' parameter is present, then we redirect to the thumbnail
url of the media.

Like in `https://functional.cafe/media/EZ52XzdwWk_fosPB0cE/?thumb`