### PR TITLE
Move dropdown transform origin to top edge

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -214,6 +214,7 @@
 
 .dropdown-menu {
   position: absolute;
+  transform-origin: 50% 0;
 }
 
 .dropdown--active .icon-button {
@@ -2943,6 +2944,7 @@ button.icon-button.active i.fa-retweet {
   border-radius: 4px;
   margin-left: 40px;
   overflow: hidden;
+  transform-origin: 50% 0;
 }
 
 .privacy-dropdown__option {


### PR DESCRIPTION
Makes the dropdowns pop out from the buttons instead of their center.

Current animation:
<img src="https://user-images.githubusercontent.com/5412095/34320140-2076ab6c-e7f3-11e7-82d7-afaa41774ad4.gif" width="298" />

Animation with `transform-origin: 50% 0`:
<img src="https://user-images.githubusercontent.com/5412095/34320141-259f4d38-e7f3-11e7-8209-c8597d706b25.gif" width="298" />