### PR TITLE
Make host_meta/webfinger replies cacheable (fixes #6100)

### DIFF
--- a/app/controllers/well_known/host_meta_controller.rb
+++ b/app/controllers/well_known/host_meta_controller.rb
@@ -4,6 +4,8 @@ module WellKnown
   class HostMetaController < ActionController::Base
     include RoutingHelper
 
+    before_action { response.headers['Vary'] = 'Accept' }
+
     def show
       @webfinger_template = "#{webfinger_url}?resource={uri}"
 

--- a/app/controllers/well_known/host_meta_controller.rb
+++ b/app/controllers/well_known/host_meta_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WellKnown
-  class HostMetaController < ApplicationController
+  class HostMetaController < ActionController::Base
     include RoutingHelper
 
     def show
@@ -10,6 +10,8 @@ module WellKnown
       respond_to do |format|
         format.xml { render content_type: 'application/xrd+xml' }
       end
+
+      expires_in(3.days, public: true)
     end
   end
 end

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module WellKnown
-  class WebfingerController < ApplicationController
+  class WebfingerController < ActionController::Base
     include RoutingHelper
 
     def show
@@ -16,6 +16,8 @@ module WellKnown
           render content_type: 'application/xrd+xml'
         end
       end
+
+      expires_in(3.days, public: true)
     rescue ActiveRecord::RecordNotFound
       head 404
     end

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -4,6 +4,8 @@ module WellKnown
   class WebfingerController < ActionController::Base
     include RoutingHelper
 
+    before_action { response.headers['Vary'] = 'Accept' }
+
     def show
       @account = Account.find_local!(username_from_resource)
 


### PR DESCRIPTION
Drop common code for handling users and sessions as webfinger queries
are very basic, public APIs.

Also explicitly mark results as cacheable with “expires_in”.