### PR TITLE
Determine if oEmbed should be used by iframe presence for video/rich type

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -115,7 +115,7 @@ export default class Card extends React.PureComponent {
     }
   }
 
-  renderVideo () {
+  renderHtml () {
     const { card }  = this.props;
     const content   = { __html: card.get('html') };
     const { width } = this.state;
@@ -125,7 +125,7 @@ export default class Card extends React.PureComponent {
     return (
       <div
         ref={this.setRef}
-        className='status-card-video'
+        className='status-card-html'
         dangerouslySetInnerHTML={content}
         style={{ height }}
       />
@@ -144,9 +144,12 @@ export default class Card extends React.PureComponent {
       return this.renderLink();
     case 'photo':
       return this.renderPhoto();
-    case 'video':
-      return this.renderVideo();
     case 'rich':
+    case 'video':
+      if (card.has('html')) {
+        return this.renderHtml();
+      }
+      // fallthrough
     default:
       return null;
     }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2182,8 +2182,7 @@ button.icon-button.active i.fa-retweet {
   }
 }
 
-.status-card-video,
-.status-card-rich,
+.status-card-html,
 .status-card-photo {
   margin-top: 14px;
   overflow: hidden;
@@ -2203,7 +2202,7 @@ button.icon-button.active i.fa-retweet {
   margin: 0;
 }
 
-.status-card-video {
+.status-card-html {
   iframe {
     width: 100%;
     height: 100%;

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -98,13 +98,11 @@ class FetchLinkCardService < BaseService
       @card.image     = URI.parse(embed.url)
       @card.width     = embed.width.presence  || 0
       @card.height    = embed.height.presence || 0
-    when 'video'
+    when 'rich', 'video'
+      return false unless embed.html =~ /iframe/i
       @card.width  = embed.width.presence  || 0
       @card.height = embed.height.presence || 0
       @card.html   = Formatter.instance.sanitize(embed.html, Sanitize::Config::MASTODON_OEMBED)
-    when 'rich'
-      # Most providers rely on <script> tags, which is a no-no
-      return false
     end
 
     @card.save_with_optional_image!

--- a/spec/fixtures/files/link_to_oembed.html
+++ b/spec/fixtures/files/link_to_oembed.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link
+      type="application/json+oembed"
+      href="https://example.com/oembed?url=https%3A%2F%2Fexample.com%2Flink_to_oembed"
+    >
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
The old code said "most providers rely on `<script>` tags", but the substantial number of rich oEmbed providers listed at https://oembed.com/ have iframe instead of script. SoundCloud and CodePen are notable examples. This change would accept those providers.