### PR TITLE
Fix XML oEmbed support discovery

### DIFF
--- a/app/lib/provider_discovery.rb
+++ b/app/lib/provider_discovery.rb
@@ -29,7 +29,7 @@ class ProviderDiscovery < OEmbed::ProviderDiscovery
       end
 
       if format.nil? || format == :xml
-        provider_endpoint ||= html.at_xpath('//link[@type="application/xml+oembed"]')&.attribute('href')&.value
+        provider_endpoint ||= html.at_xpath('//link[@type="text/xml+oembed"]')&.attribute('href')&.value
         format ||= :xml if provider_endpoint
       end
 

--- a/spec/fixtures/requests/oembed_json_xml.html
+++ b/spec/fixtures/requests/oembed_json_xml.html
@@ -1,8 +1,14 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <!--
+      oEmbed
+      https://oembed.com/
+      > The type attribute must contain either application/json+oembed for JSON
+      > responses, or text/xml+oembed for XML.
+    -->
     <link href='https://host/provider.json' rel='alternate' type='application/json+oembed'>
-    <link href='https://host/provider.xml' rel='alternate' type='application/xml+oembed'>
+    <link href='https://host/provider.xml' rel='alternate' type='text/xml+oembed'>
   </head>
   <body></body>
 </html>

--- a/spec/fixtures/requests/oembed_xml.html
+++ b/spec/fixtures/requests/oembed_xml.html
@@ -1,7 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link href='https://host/provider.xml' rel='alternate' type='application/xml+oembed'>
+    <!--
+      oEmbed
+      https://oembed.com/
+      > The type attribute must contain either application/json+oembed for JSON
+      > responses, or text/xml+oembed for XML.
+    -->
+    <link href='https://host/provider.xml' rel='alternate' type='text/xml+oembed'>
   </head>
   <body></body>
 </html>


### PR DESCRIPTION
This allows to use oEmbed, an open protocol, instead of Twitter's proprietary player card, when fetching preview cards of SoundCloud.
(fyi, SoundCloud also provides oEmbed in JSON format, but it incorrectly reports `text/json+oembed`. Just ignore it and use `text/xml+oembed`.)