### PR TITLE
Allow HTTP caching of json view of public statuses

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -28,7 +28,10 @@ class StatusesController < ApplicationController
                content_type: 'application/activity+json'
 
         # Allow HTTP caching for 3 minutes if the status is public
-        expires_in(3.minutes, public: true) unless @stream_entry.hidden?
+        unless @stream_entry.hidden?
+          request.session_options[:skip] = true
+          expires_in(3.minutes, public: true)
+        end
       end
     end
   end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -10,6 +10,7 @@ class StatusesController < ApplicationController
   before_action :set_link_headers
   before_action :check_account_suspension
   before_action :redirect_to_original, only: [:show]
+  before_action { response.headers['Vary'] = 'Accept' }
 
   def show
     respond_to do |format|
@@ -25,6 +26,9 @@ class StatusesController < ApplicationController
                serializer: ActivityPub::NoteSerializer,
                adapter: ActivityPub::Adapter,
                content_type: 'application/activity+json'
+
+        # Allow HTTP caching for 3 minutes if the status is public
+        expires_in(3.minutes, public: true) unless @stream_entry.hidden?
       end
     end
   end


### PR DESCRIPTION
Whenever a user replies or boosts a toot, it tends to cause multiple instances to access it roughly at the same time. This may lead to hundreds of requests that have to be handled by puma.

By allowing the front-end web server to cache public toots for a few minutes, the number of requests handled by puma can be greatly reduced.

This commit is a first step toward that goal, changing “Cache-control” headers as needed for json rendering of public toots (the HTML renderings are excluded as they may also contain private ancestors/replies).

Unfortunately, “Set-Cookie” is still set to maintain user sessions. I don't think this is needed for json rendering of public toots (since that's only going to be used for federation, anyway), but I'm not sure how to properly change it.