### PR TITLE
Collapse settings navigation only if there is sufficient space

### DIFF
--- a/app/javascript/mastodon/components/navigation_footer.js
+++ b/app/javascript/mastodon/components/navigation_footer.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { FormattedMessage } from 'react-intl';
+
+export default class NavigationFooter extends ImmutablePureComponent {
+
+  render () {
+    return (
+      <div className='static-content navigation-footer'>
+        <p>
+          <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.faq' defaultMessage='FAQ' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/User-guide.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.userguide' defaultMessage='User Guide' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.appsshort' defaultMessage='Apps' /></a>
+        </p>
+        <p>
+          <FormattedMessage
+            id='getting_started.open_source_notice'
+            defaultMessage='Mastodon is open source software. You can contribute or report issues on GitHub at {github}.'
+            values={{ github: <a href='https://github.com/tootsuite/mastodon' rel='noopener' target='_blank'>tootsuite/mastodon</a> }}
+          />
+        </p>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -78,7 +78,7 @@ export default class Compose extends React.PureComponent {
           {!columns.some(column => column.get('id') === 'PUBLIC') && (
             <Link to='/timelines/public' className='drawer__tab' title={intl.formatMessage(messages.public)} aria-label={intl.formatMessage(messages.public)}><i role='img' className='fa fa-fw fa-globe' /></Link>
           )}
-          <a href='/settings/preferences' className='drawer__tab' title={intl.formatMessage(messages.preferences)} aria-label={intl.formatMessage(messages.preferences)}><i role='img' className='fa fa-fw fa-cog' /></a>
+          <a href='/settings/preferences' className='drawer__tab' title={intl.formatMessage(messages.preferences)} aria-label={intl.formatMessage(messages.preferences)}><i role='img' className='fa fa-fw fa-sliders' /></a>
           <a href='/auth/sign_out' className='drawer__tab' data-method='delete' title={intl.formatMessage(messages.logout)} aria-label={intl.formatMessage(messages.logout)}><i role='img' className='fa fa-fw fa-sign-out' /></a>
         </nav>
       );

--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -1,32 +1,19 @@
 import React from 'react';
 import Column from '../ui/components/column';
 import ColumnLink from '../ui/components/column_link';
-import ColumnSubheading from '../ui/components/column_subheading';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import MainNavigation from '../main_navigation';
+import SettingsNavigation from '../settings_navigation';
+import { defineMessages, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+import NavigationFooter from '../../components/navigation_footer';
 import { me } from '../../initial_state';
 
 const messages = defineMessages({
   heading: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
-  home_timeline: { id: 'tabs_bar.home', defaultMessage: 'Home' },
-  notifications: { id: 'tabs_bar.notifications', defaultMessage: 'Notifications' },
-  public_timeline: { id: 'navigation_bar.public_timeline', defaultMessage: 'Federated timeline' },
-  navigation_subheading: { id: 'column_subheading.navigation', defaultMessage: 'Navigation' },
-  settings_subheading: { id: 'column_subheading.settings', defaultMessage: 'Settings' },
-  community_timeline: { id: 'navigation_bar.community_timeline', defaultMessage: 'Local timeline' },
-  preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
-  follow_requests: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
-  sign_out: { id: 'navigation_bar.logout', defaultMessage: 'Logout' },
-  favourites: { id: 'navigation_bar.favourites', defaultMessage: 'Favourites' },
-  blocks: { id: 'navigation_bar.blocks', defaultMessage: 'Blocked users' },
-  mutes: { id: 'navigation_bar.mutes', defaultMessage: 'Muted users' },
-  info: { id: 'navigation_bar.info', defaultMessage: 'Extended information' },
-  pins: { id: 'navigation_bar.pins', defaultMessage: 'Pinned toots' },
-  lists: { id: 'navigation_bar.lists', defaultMessage: 'Lists' },
-  keyboard_shortcuts: { id: 'navigation_bar.keyboard_shortcuts', defaultMessage: 'Keyboard shortcuts' },
+  settings: { id: 'settings.heading', defaultMessage: 'Settings' },
 });
 
 const mapStateToProps = state => ({
@@ -45,69 +32,45 @@ export default class GettingStarted extends ImmutablePureComponent {
     multiColumn: PropTypes.bool,
   };
 
+  state = {
+    collapseSettings: true,
+  };
+
+  componentDidMount () {
+    if (this.state.collapseSettings && this.navigation.clientHeight < this.navigation.scrollHeight) {
+      this.setState({ collapseSettings: false });
+    }
+  }
+
+  componentWillReceiveProps () {
+    this.setState({ collapseSettings: true });
+  }
+
+  componentDidUpdate () {
+    if (this.state.collapseSettings && this.navigation.clientHeight < this.navigation.scrollHeight) {
+      this.setState({ collapseSettings: false });
+    }
+  }
+
+  setRef = ref => {
+    this.navigation = ref;
+  };
+
   render () {
     const { intl, myAccount, columns, multiColumn } = this.props;
 
-    const navItems = [];
-
-    if (multiColumn) {
-      if (!columns.find(item => item.get('id') === 'HOME')) {
-        navItems.push(<ColumnLink key='0' icon='home' text={intl.formatMessage(messages.home_timeline)} to='/timelines/home' />);
-      }
-
-      if (!columns.find(item => item.get('id') === 'NOTIFICATIONS')) {
-        navItems.push(<ColumnLink key='1' icon='bell' text={intl.formatMessage(messages.notifications)} to='/notifications' />);
-      }
-
-      if (!columns.find(item => item.get('id') === 'COMMUNITY')) {
-        navItems.push(<ColumnLink key='2' icon='users' text={intl.formatMessage(messages.community_timeline)} to='/timelines/public/local' />);
-      }
-
-      if (!columns.find(item => item.get('id') === 'PUBLIC')) {
-        navItems.push(<ColumnLink key='3' icon='globe' text={intl.formatMessage(messages.public_timeline)} to='/timelines/public' />);
-      }
-    }
-
-    navItems.push(
-      <ColumnLink key='4' icon='star' text={intl.formatMessage(messages.favourites)} to='/favourites' />,
-      <ColumnLink key='5' icon='bars' text={intl.formatMessage(messages.lists)} to='/lists' />
-    );
-
-    if (myAccount.get('locked')) {
-      navItems.push(<ColumnLink key='6' icon='users' text={intl.formatMessage(messages.follow_requests)} to='/follow_requests' />);
-    }
-
-    if (multiColumn) {
-      navItems.push(<ColumnLink key='7' icon='question' text={intl.formatMessage(messages.keyboard_shortcuts)} to='/keyboard-shortcuts' />);
-    }
-
-    navItems.push(<ColumnLink key='8' icon='book' text={intl.formatMessage(messages.info)} href='/about/more' />);
-
     return (
       <Column icon='asterisk' heading={intl.formatMessage(messages.heading)} hideHeadingOnMobile>
-        <div className='getting-started__wrapper'>
-          <ColumnSubheading text={intl.formatMessage(messages.navigation_subheading)} />
-          {navItems}
-          <ColumnSubheading text={intl.formatMessage(messages.settings_subheading)} />
-          <ColumnLink icon='thumb-tack' text={intl.formatMessage(messages.pins)} to='/pinned' />
-          <ColumnLink icon='volume-off' text={intl.formatMessage(messages.mutes)} to='/mutes' />
-          <ColumnLink icon='ban' text={intl.formatMessage(messages.blocks)} to='/blocks' />
-          <ColumnLink icon='cog' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />
-          <ColumnLink icon='sign-out' text={intl.formatMessage(messages.sign_out)} href='/auth/sign_out' method='delete' />
+        <div className='navigation__wrapper' ref={this.setRef}>
+          <MainNavigation followRequestsHidden={myAccount.get('locked')} hiddenColumns={columns} multiColumn={multiColumn} />
+          {
+            this.state.collapseSettings ?
+              <SettingsNavigation /> :
+              <ColumnLink key='12' icon='cog' text={intl.formatMessage(messages.settings)} to='/settings' />
+          }
         </div>
 
-        <div className='static-content getting-started'>
-          <p>
-            <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.faq' defaultMessage='FAQ' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/User-guide.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.userguide' defaultMessage='User Guide' /></a> • <a href='https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md' rel='noopener' target='_blank'><FormattedMessage id='getting_started.appsshort' defaultMessage='Apps' /></a>
-          </p>
-          <p>
-            <FormattedMessage
-              id='getting_started.open_source_notice'
-              defaultMessage='Mastodon is open source software. You can contribute or report issues on GitHub at {github}.'
-              values={{ github: <a href='https://github.com/tootsuite/mastodon' rel='noopener' target='_blank'>tootsuite/mastodon</a> }}
-            />
-          </p>
-        </div>
+        <NavigationFooter />
       </Column>
     );
   }

--- a/app/javascript/mastodon/features/main_navigation/index.js
+++ b/app/javascript/mastodon/features/main_navigation/index.js
@@ -1,0 +1,77 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { defineMessages, injectIntl } from 'react-intl';
+import ColumnLink from '../ui/components/column_link';
+import ColumnSubheading from '../ui/components/column_subheading';
+
+const messages = defineMessages({
+  home_timeline: { id: 'tabs_bar.home', defaultMessage: 'Home' },
+  notifications: { id: 'tabs_bar.notifications', defaultMessage: 'Notifications' },
+  public_timeline: { id: 'navigation_bar.public_timeline', defaultMessage: 'Federated timeline' },
+  navigation_subheading: { id: 'column_subheading.navigation', defaultMessage: 'Navigation' },
+  community_timeline: { id: 'navigation_bar.community_timeline', defaultMessage: 'Local timeline' },
+  follow_requests: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
+  favourites: { id: 'navigation_bar.favourites', defaultMessage: 'Favourites' },
+  info: { id: 'navigation_bar.info', defaultMessage: 'Extended information' },
+  lists: { id: 'navigation_bar.lists', defaultMessage: 'Lists' },
+  keyboard_shortcuts: { id: 'navigation_bar.keyboard_shortcuts', defaultMessage: 'Keyboard shortcuts' },
+});
+
+@injectIntl
+export default class Navigation extends ImmutablePureComponent {
+
+  static propTypes = {
+    intl: PropTypes.object.isRequired,
+    followRequestsHidden: PropTypes.bool,
+    hiddenColumns: ImmutablePropTypes.list,
+    multiColumn: PropTypes.bool,
+  };
+
+  render () {
+    const { intl, followRequestsHidden, hiddenColumns, multiColumn } = this.props;
+    const navItems = [];
+
+    if (multiColumn) {
+      if (!hiddenColumns.find(item => item.get('id') === 'HOME')) {
+        navItems.push(<ColumnLink key='1' icon='home' text={intl.formatMessage(messages.home_timeline)} to='/timelines/home' />);
+      }
+
+      if (!hiddenColumns.find(item => item.get('id') === 'NOTIFICATIONS')) {
+        navItems.push(<ColumnLink key='2' icon='bell' text={intl.formatMessage(messages.notifications)} to='/notifications' />);
+      }
+
+      if (!hiddenColumns.find(item => item.get('id') === 'COMMUNITY')) {
+        navItems.push(<ColumnLink key='3' icon='users' text={intl.formatMessage(messages.community_timeline)} to='/timelines/public/local' />);
+      }
+
+      if (!hiddenColumns.find(item => item.get('id') === 'PUBLIC')) {
+        navItems.push(<ColumnLink key='4' icon='globe' text={intl.formatMessage(messages.public_timeline)} to='/timelines/public' />);
+      }
+    }
+
+    navItems.push(
+      <ColumnLink key='5' icon='star' text={intl.formatMessage(messages.favourites)} to='/favourites' />,
+      <ColumnLink key='6' icon='bars' text={intl.formatMessage(messages.lists)} to='/lists' />
+    );
+
+    if (followRequestsHidden) {
+      navItems.push(<ColumnLink key='7' icon='users' text={intl.formatMessage(messages.follow_requests)} to='/follow_requests' />);
+    }
+
+    if (multiColumn) {
+      navItems.push(<ColumnLink key='8' icon='question' text={intl.formatMessage(messages.keyboard_shortcuts)} to='/keyboard-shortcuts' />);
+    }
+
+    navItems.push(<ColumnLink key='9' icon='book' text={intl.formatMessage(messages.info)} href='/about/more' />);
+
+    return (
+      <div className='navigation__wrapper'>
+        <ColumnSubheading text={intl.formatMessage(messages.navigation_subheading)} />
+        {navItems}
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/settings/index.js
+++ b/app/javascript/mastodon/features/settings/index.js
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { defineMessages, injectIntl } from 'react-intl';
+import SettingsNavigation from '../settings_navigation';
+import Column from '../ui/components/column';
+import ColumnBackButtonSlim from '../../components/column_back_button_slim';
+import NavigationFooter from '../../components/navigation_footer';
+
+const messages = defineMessages({
+  heading: { id: 'settings.heading', defaultMessage: 'Settings' },
+});
+
+@injectIntl
+export default class Settings extends ImmutablePureComponent {
+
+  static propTypes = {
+    intl: PropTypes.object.isRequired,
+  };
+
+  render () {
+    const { intl } = this.props;
+
+    return (
+      <Column icon='cog' heading={intl.formatMessage(messages.heading)} hideHeadingOnMobile>
+        <ColumnBackButtonSlim />
+        <SettingsNavigation />
+        <NavigationFooter />
+      </Column>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/settings_navigation/index.js
+++ b/app/javascript/mastodon/features/settings_navigation/index.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { defineMessages, injectIntl } from 'react-intl';
+import ColumnLink from '../ui/components/column_link';
+import ColumnSubheading from '../ui/components/column_subheading';
+
+const messages = defineMessages({
+  settings_subheading: { id: 'settings.heading', defaultMessage: 'Settings' },
+  preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
+  sign_out: { id: 'navigation_bar.logout', defaultMessage: 'Logout' },
+  blocks: { id: 'navigation_bar.blocks', defaultMessage: 'Blocked users' },
+  mutes: { id: 'navigation_bar.mutes', defaultMessage: 'Muted users' },
+  pins: { id: 'navigation_bar.pins', defaultMessage: 'Pinned toots' },
+});
+
+@injectIntl
+export default class Settings extends ImmutablePureComponent {
+
+  static propTypes = {
+    intl: PropTypes.object.isRequired,
+  };
+
+  render () {
+    const { intl } = this.props;
+
+    return (
+      <div>
+        <ColumnSubheading text={intl.formatMessage(messages.settings_subheading)} />
+        <ColumnLink icon='thumb-tack' text={intl.formatMessage(messages.pins)} to='/pinned' />
+        <ColumnLink icon='volume-off' text={intl.formatMessage(messages.mutes)} to='/mutes' />
+        <ColumnLink icon='ban' text={intl.formatMessage(messages.blocks)} to='/blocks' />
+        <ColumnLink icon='sliders' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />
+        <ColumnLink icon='sign-out' text={intl.formatMessage(messages.sign_out)} href='/auth/sign_out' method='delete' />
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -19,6 +19,7 @@ import {
   Compose,
   Status,
   GettingStarted,
+  Settings,
   KeyboardShortcuts,
   PublicTimeline,
   CommunityTimeline,
@@ -381,6 +382,7 @@ export default class UI extends React.Component {
             <WrappedSwitch>
               <Redirect from='/' to='/getting-started' exact />
               <WrappedRoute path='/getting-started' component={GettingStarted} content={children} />
+              <WrappedRoute path='/settings' component={Settings} content={children} />
               <WrappedRoute path='/keyboard-shortcuts' component={KeyboardShortcuts} content={children} />
               <WrappedRoute path='/timelines/home' component={HomeTimeline} content={children} />
               <WrappedRoute path='/timelines/public' exact component={PublicTimeline} content={children} />

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -42,6 +42,10 @@ export function GettingStarted () {
   return import(/* webpackChunkName: "features/getting_started" */'../../getting_started');
 }
 
+export function Settings () {
+  return import(/* webpackChunkName: "features/settings" */'../../settings');
+}
+
 export function KeyboardShortcuts () {
   return import(/* webpackChunkName: "features/keyboard_shortcuts" */'../../keyboard_shortcuts');
 }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2080,19 +2080,21 @@
   cursor: default;
 }
 
-.getting-started__wrapper,
-.getting_started {
+.navigation__wrapper,
+.navigation-footer {
   background: $ui-base-color;
 }
 
-.getting-started__wrapper {
+.navigation__wrapper {
   position: relative;
   overflow-y: auto;
 }
 
-.getting-started {
-  background: $ui-base-color;
+.navigation-footer {
+  display: flex;
   flex: 1 0 auto;
+  flex-direction: column;
+  justify-content: end;
 
   p {
     color: $ui-secondary-color;


### PR DESCRIPTION
If it is not collapsed, Getting Started would look like:
![screenshot-2017-12-29 mastodon dev 1](https://user-images.githubusercontent.com/17036990/34432789-e4abc282-ecbd-11e7-899f-5dd2d3b24125.png)

And Settings button would navigate to this column:
![screenshot-2017-12-29 mastodon dev 3](https://user-images.githubusercontent.com/17036990/34435954-bcb7f144-ecd4-11e7-9f3c-40cb0898456e.png)
