### PR TITLE
Display a warning when composing unlisted toots with something looking like a hashtag

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -5,13 +5,19 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { me } from '../../../initial_state';
 
+const APPROX_HASHTAG_RE = /(?:^|[^\/\)\w])#(\S+)/i;
+
 const mapStateToProps = state => ({
   needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),
+  hashtagWarning: state.getIn(['compose', 'privacy']) !== 'public' && APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])),
 });
 
-const WarningWrapper = ({ needsLockWarning }) => {
+const WarningWrapper = ({ needsLockWarning, hashtagWarning }) => {
   if (needsLockWarning) {
     return <Warning message={<FormattedMessage id='compose_form.lock_disclaimer' defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.' values={{ locked: <a href='/settings/profile'><FormattedMessage id='compose_form.lock_disclaimer.lock' defaultMessage='locked' /></a> }} />} />;
+  }
+  if (hashtagWarning) {
+    return <Warning message={<FormattedMessage id='compose_form.hashtag_warning' defaultMessage="This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag." />} />;
   }
 
   return null;
@@ -19,6 +25,7 @@ const WarningWrapper = ({ needsLockWarning }) => {
 
 WarningWrapper.propTypes = {
   needsLockWarning: PropTypes.bool,
+  hashtagWarning: PropTypes.bool,
 };
 
 export default connect(mapStateToProps)(WarningWrapper);


### PR DESCRIPTION
It was decided in #5463 that unlisted toots should not appear in hashtag timelines/searches.
However, this behavior may not be intuitive and is never explicitly explained to the user.
This pull request attempts to fix that by displaying a warning whenever the user writes an unlisted toot containing a hashtag.