### PR TITLE
Don't normalize URLs in toots

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -171,10 +171,10 @@ class Formatter
   end
 
   def link_to_url(entity)
-    normalized_url = Addressable::URI.parse(entity[:url]).normalize
-    html_attrs     = { target: '_blank', rel: 'nofollow noopener' }
+    url        = Addressable::URI.parse(entity[:url])
+    html_attrs = { target: '_blank', rel: 'nofollow noopener' }
 
-    Twitter::Autolink.send(:link_to_text, entity, link_html(entity[:url]), normalized_url, html_attrs)
+    Twitter::Autolink.send(:link_to_text, entity, link_html(entity[:url]), url, html_attrs)
   rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
     encode(entity[:url])
   end

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Formatter do
       let(:text) { 'http://google.com' }
 
       it 'has valid URL' do
-        is_expected.to include 'href="http://google.com/"'
+        is_expected.to include 'href="http://google.com"'
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe Formatter do
       let(:text) { 'https://nic.みんな/' }
 
       it 'has valid URL' do
-        is_expected.to include 'href="https://nic.xn--q9jyb4c/"'
+        is_expected.to include 'href="https://nic.みんな/"'
       end
 
       it 'has display URL' do
@@ -53,7 +53,7 @@ RSpec.describe Formatter do
       let(:text) { 'http://www.google.com!' }
 
       it 'has valid URL' do
-        is_expected.to include 'href="http://www.google.com/"'
+        is_expected.to include 'href="http://www.google.com"'
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Formatter do
       let(:text) { "http://www.google.com'" }
 
       it 'has valid URL' do
-        is_expected.to include 'href="http://www.google.com/"'
+        is_expected.to include 'href="http://www.google.com"'
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe Formatter do
       let(:text) { 'http://www.google.com>' }
 
       it 'has valid URL' do
-        is_expected.to include 'href="http://www.google.com/"'
+        is_expected.to include 'href="http://www.google.com"'
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe Formatter do
       let(:text) { 'https://ja.wikipedia.org/wiki/日本' }
 
       it 'has valid URL' do
-        is_expected.to include 'href="https://ja.wikipedia.org/wiki/%E6%97%A5%E6%9C%AC"'
+        is_expected.to include 'href="https://ja.wikipedia.org/wiki/日本"'
       end
     end
 
@@ -101,7 +101,7 @@ RSpec.describe Formatter do
       let(:text) { 'https://ko.wikipedia.org/wiki/대한민국' }
 
       it 'has valid URL' do
-        is_expected.to include 'href="https://ko.wikipedia.org/wiki/%EB%8C%80%ED%95%9C%EB%AF%BC%EA%B5%AD"'
+        is_expected.to include 'href="https://ko.wikipedia.org/wiki/대한민국"'
       end
     end
 
@@ -109,7 +109,7 @@ RSpec.describe Formatter do
       let(:text) { 'https://baike.baidu.com/item/中华人民共和国' }
 
       it 'has valid URL' do
-        is_expected.to include 'href="https://baike.baidu.com/item/%E4%B8%AD%E5%8D%8E%E4%BA%BA%E6%B0%91%E5%85%B1%E5%92%8C%E5%9B%BD"'
+        is_expected.to include 'href="https://baike.baidu.com/item/中华人民共和国"'
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe Formatter do
       let(:text) { 'https://zh.wikipedia.org/wiki/臺灣' }
 
       it 'has valid URL' do
-        is_expected.to include 'href="https://zh.wikipedia.org/wiki/%E8%87%BA%E7%81%A3"'
+        is_expected.to include 'href="https://zh.wikipedia.org/wiki/臺灣"'
       end
     end
 


### PR DESCRIPTION
URL normalization is ill-defined and may cause certain links to break.

As normalization serves no purpose in rendering links in toots, this pull request avoids normalizing them.

Some more background is available in this thread: https://mastodon.gougere.fr/@bortzmeyer/99264235735779201