### PR TITLE
Add a button to compose on another instance for intents

### DIFF
--- a/app/controllers/intents_controller.rb
+++ b/app/controllers/intents_controller.rb
@@ -9,7 +9,7 @@ class IntentsController < ApplicationController
       when 'follow'
         return redirect_to authorize_follow_path(acct: uri.query_values['uri'].gsub(/\Aacct:/, ''))
       when 'share'
-        return redirect_to share_path(text: uri.query_values['text'])
+        return redirect_to share_path(text: uri.query_values['text'], web: true)
       end
     end
 

--- a/app/controllers/shares_controller.rb
+++ b/app/controllers/shares_controller.rb
@@ -21,7 +21,7 @@ class SharesController < ApplicationController
       current_account: current_account,
       token: current_session.token,
       admin: Account.find_local(Setting.site_contact_username),
-      text: text,
+      compose: { share: params[:web].nil?, text: text },
     }
   end
 

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import CharacterCounter from './character_counter';
 import Button from '../../../components/button';
 import ImmutablePropTypes from 'react-immutable-proptypes';
@@ -50,6 +51,7 @@ export default class ComposeForm extends ImmutablePureComponent {
     onPaste: PropTypes.func.isRequired,
     onPickEmoji: PropTypes.func.isRequired,
     showSearch: PropTypes.bool,
+    showShare: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -142,7 +144,7 @@ export default class ComposeForm extends ImmutablePureComponent {
   }
 
   render () {
-    const { intl, onPaste, showSearch } = this.props;
+    const { intl, onPaste, showSearch, showShare } = this.props;
     const disabled = this.props.is_submitting;
     const text     = [this.props.spoiler_text, countableText(this.props.text)].join('');
 
@@ -203,7 +205,22 @@ export default class ComposeForm extends ImmutablePureComponent {
         </div>
 
         <div className='compose-form__publish'>
-          <div className='compose-form__publish-button-wrapper'><Button text={publishText} onClick={this.handleSubmit} disabled={disabled || this.props.is_uploading || length(text) > 500 || (text.length !== 0 && text.trim().length === 0)} block /></div>
+          {showShare && (
+            <div className='compose-form__share-button-wrapper'>
+              <a
+                className='button button--block'
+                href={`web+mastodon://share?text=${encodeURIComponent(this.props.text)}`}
+              >
+                <FormattedMessage
+                  id='compose_form.share'
+                  defaultMessage='Compose on another instance'
+                />
+              </a>
+            </div>
+          )}
+          <div className='compose-form__publish-button-wrapper'>
+            <Button text={publishText} onClick={this.handleSubmit} disabled={disabled || this.props.is_uploading || length(text) > 500 || (text.length !== 0 && text.trim().length === 0)} block />
+          </div>
         </div>
       </div>
     );

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -12,6 +12,7 @@ import {
 } from '../../../actions/compose';
 
 const mapStateToProps = state => ({
+  showShare: state.getIn(['compose', 'share']),
   text: state.getIn(['compose', 'text']),
   suggestion_token: state.getIn(['compose', 'suggestion_token']),
   suggestions: state.getIn(['compose', 'suggestions']),

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -57,6 +57,7 @@
   "compose_form.publish": "Toot",
   "compose_form.publish_loud": "{publish}!",
   "compose_form.sensitive": "Mark media as sensitive",
+  "compose_form.share": "Compose on another instance",
   "compose_form.spoiler": "Hide text behind warning",
   "compose_form.spoiler_placeholder": "Write your warning here",
   "confirmation_modal.cancel": "Cancel",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -57,6 +57,7 @@
   "compose_form.publish": "トゥート",
   "compose_form.publish_loud": "{publish}！",
   "compose_form.sensitive": "メディアを閲覧注意としてマークする",
+  "compose_form.share": "他のインスタンスで編集する",
   "compose_form.spoiler": "テキストを隠す",
   "compose_form.spoiler_placeholder": "ここに警告を書いてください",
   "confirmation_modal.cancel": "キャンセル",

--- a/app/javascript/mastodon/locales/pl.json
+++ b/app/javascript/mastodon/locales/pl.json
@@ -57,6 +57,7 @@
   "compose_form.publish": "Wyślij",
   "compose_form.publish_loud": "{publish}!",
   "compose_form.sensitive": "Oznacz treści jako wrażliwe",
+  "compose_form.share": "Wyślij z innej instancji",
   "compose_form.spoiler": "Ukryj tekst za ostrzeżeniem",
   "compose_form.spoiler_placeholder": "Wprowadź swoje ostrzeżenie o zawartości",
   "confirmation_modal.cancel": "Anuluj",

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -54,6 +54,7 @@ const initialState = ImmutableMap({
   default_sensitive: false,
   resetFileKey: Math.floor((Math.random() * 0x10000)),
   idempotencyKey: null,
+  share: false,
 });
 
 function statusToTextMentions(state, status) {
@@ -147,9 +148,11 @@ const privacyPreference = (a, b) => {
 const hydrate = (state, hydratedState) => {
   state = clearAll(state.merge(hydratedState));
 
-  if (hydratedState.has('text')) {
-    state = state.set('text', hydratedState.get('text'));
-  }
+  ['share', 'text'].forEach(key => {
+    if (hydratedState.has(key)) {
+      state = state.set(key, hydratedState.get(key));
+    }
+  });
 
   return state;
 };

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -538,12 +538,30 @@
 
   .compose-form__publish {
     display: flex;
+    flex-wrap: wrap;
     justify-content: flex-end;
     min-width: 0;
 
-    .compose-form__publish-button-wrapper {
+    .compose-form__publish-button-wrapper,
+    .compose-form__share-button-wrapper {
       overflow: hidden;
-      padding-top: 10px;
+      padding: 10px 10px 0 0;
+      position: relative;
+      right: -10px;
+    }
+
+    .compose-form__share-button-wrapper {
+      > a {
+        background: $ui-secondary-color;
+        color: $ui-base-color;
+
+        &:focus,
+        &:hover,
+        &:active {
+          background: $ui-highlight-color;
+          color: $ui-secondary-color;
+        }
+      }
     }
   }
 }

--- a/app/presenters/initial_state_presenter.rb
+++ b/app/presenters/initial_state_presenter.rb
@@ -2,5 +2,5 @@
 
 class InitialStatePresenter < ActiveModelSerializers::Model
   attributes :settings, :push_subscription, :token,
-             :current_account, :admin, :text
+             :current_account, :admin, :compose
 end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -41,7 +41,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:default_sensitive] = object.current_account.user.setting_default_sensitive
     end
 
-    store[:text] = object.text if object.text
+    store.merge!(object.compose) if object.compose
 
     store
   end


### PR DESCRIPTION
Though we have neat `web+mastodon` protocol for sharing, some Web sites use a link for intents on particular instances. That would work better for those who use such instances because it does not require registering the protocol handler, but that would not work at all for others.
This commit adds a button to "compose on another instance button" to fix the behavior which is an obstacle for federation.
![screenshot-2018-1-1 mastodon dev](https://user-images.githubusercontent.com/17036990/34466947-9f0beb3c-ef27-11e7-884c-2b15865adf22.png)
