### PR TITLE
[!] Sanitize incoming classlist properly

### DIFF
--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -6,7 +6,7 @@ class Sanitize
 
     CLASS_WHITELIST_TRANSFORMER = lambda do |env|
       node = env[:node]
-      class_list = node['class']&.split(' ')
+      class_list = node['class']&.split(/[\t\n\f\r ]/)
 
       return unless class_list
 

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -11,9 +11,9 @@ class Sanitize
       return unless class_list
 
       class_list.keep_if do |e|
-        return true if e =~ /^(h|p|u|dt|e)-/ # microformats classes
-        return true if e =~ /^(mention|hashtag)$/ # semantic classes
-        return true if e =~ /^(ellipsis|invisible)$/ # link formatting classes
+        next true if e =~ /^(h|p|u|dt|e)-/ # microformats classes
+        next true if e =~ /^(mention|hashtag)$/ # semantic classes
+        next true if e =~ /^(ellipsis|invisible)$/ # link formatting classes
       end
 
       node['class'] = class_list.join(' ')

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe Formatter do
     end
 
     context 'contains malicious classes' do
-      let(:text) { '<span class="status__content__spoiler-link">Show more</span>' }
+      let(:text) { '<span class="mention	status__content__spoiler-link">Show more</span>' }
 
       it 'strips malicious classes' do
         is_expected.to_not include 'status__content__spoiler-link'


### PR DESCRIPTION
Previously (when the spinny text issue was fixed) the classlist was done by splitting by spaces. This is not enough. Any HTML whitespace (space, tab, newline, carriage return, and formfeed) are valid class separators. Together with some new features like custom emoji, you can definitely make some really impressive fake objects. Or just spinny text again. \*shrug\*

Alternatively, while testing out my code, I figured that the `return true` inside of the block actually returns from the function that sanitizes the class, effectively not sanitizing any class after the first one. Well done.

cc @nightpool 