### PR TITLE
Set background to the navigation of Getting Started column

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2072,6 +2072,11 @@
   cursor: default;
 }
 
+.getting-started__wrapper,
+.getting_started {
+  background: $ui-base-color;
+}
+
 .getting-started__wrapper {
   position: relative;
   overflow-y: auto;


### PR DESCRIPTION
The background of the navigation matters because its scrollbar is transparent.
Resolves #6154.