### PR TITLE
Fix FetchAtomService not finding alternatives if there's a Link header

### DIFF
--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -50,7 +50,7 @@ class FetchAtomService < BaseService
         @unsupported_activity = true
         nil
       end
-    elsif @response['Link'] && !terminal
+    elsif @response['Link'] && !terminal && link_header.find_link(%w(rel alternate))
       process_headers
     elsif @response.mime_type == 'text/html' && !terminal
       process_html
@@ -70,8 +70,6 @@ class FetchAtomService < BaseService
   end
 
   def process_headers
-    link_header = LinkHeader.parse(@response['Link'].is_a?(Array) ? @response['Link'].first : @response['Link'])
-
     json_link = link_header.find_link(%w(rel alternate), %w(type application/activity+json)) || link_header.find_link(%w(rel alternate), ['type', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'])
     atom_link = link_header.find_link(%w(rel alternate), %w(type application/atom+xml))
 
@@ -79,5 +77,9 @@ class FetchAtomService < BaseService
     result ||= process(atom_link.href, terminal: true) unless atom_link.nil?
 
     result
+  end
+
+  def link_header
+    @link_header ||= LinkHeader.parse(@response['Link'].is_a?(Array) ? @response['Link'].first : @response['Link'])
   end
 end


### PR DESCRIPTION
without them, such as is the case with GNU social

Fixes the ability to find GNU social accounts via URL in search and
when using remote follow function