### PR TITLE
Send one Delete of Actor in ActivityPub when account is suspended

### DIFF
--- a/app/serializers/activitypub/delete_actor_serializer.rb
+++ b/app/serializers/activitypub/delete_actor_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ActivityPub::DeleteActorSerializer < ActiveModel::Serializer
+  attributes :id, :type, :actor
+  attribute :virtual_object, key: :object
+
+  def id
+    [ActivityPub::TagManager.instance.uri_for(object), '#delete'].join
+  end
+
+  def type
+    'Delete'
+  end
+
+  def actor
+    ActivityPub::TagManager.instance.uri_for(object)
+  end
+
+  def virtual_object
+    actor
+  end
+end

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -22,6 +22,8 @@ class SuspendAccountService < BaseService
   end
 
   def purge_content!
+    ActivityPub::RawDistributionWorker.perform_async(delete_actor_json, @account.id) if @account.local?
+
     @account.statuses.reorder(nil).find_in_batches do |statuses|
       BatchedRemoveStatusService.new.call(statuses)
     end
@@ -53,5 +55,15 @@ class SuspendAccountService < BaseService
 
   def destroy_all(association)
     association.in_batches.destroy_all
+  end
+
+  def delete_actor_json
+    payload = ActiveModelSerializers::SerializableResource.new(
+      @account,
+      serializer: ActivityPub::DeleteActorSerializer,
+      adapter: ActivityPub::Adapter
+    ).as_json
+
+    Oj.dump(ActivityPub::LinkedDataSignature.new(payload).sign!(@account))
   end
 end


### PR DESCRIPTION
Fix #5420

The handler for this type of payload was introduced in e482595a5dfd69efacffeddbd48f48c5b92deaea which is >=1.6.0

Please review carefully, if I've made any implementation mistakes then self-deleted/suspended accounts will leave all their content intact on remote servers.
  