### PR TITLE
Fix enforce HTTPS in production.

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_mastodon_session', secure: (ENV['LOCAL_HTTPS'] == 'true')
+Rails.application.config.session_store :cookie_store, key: '_mastodon_session', secure: (Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
 
   config.before :each, type: :feature do
-    https = ENV['LOCAL_HTTPS'] == 'true'
+    https = Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true'
     Capybara.app_host = "http#{https ? 's' : ''}://#{ENV.fetch('LOCAL_DOMAIN')}"
   end
 


### PR DESCRIPTION
When .env.production don't has 'LOCAL_HTTPS=true', cookies don't has secure attribute and so on ...