### PR TITLE
fix overlooked LOCAL_HTTPS references

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
   private
 
   def https_enabled?
-    Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true'
+    Rails.env.production?
   end
 
   def store_current_location

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
   private
 
   def https_enabled?
-    Rails.env.production? && ENV['LOCAL_HTTPS'] == 'true'
+    Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true'
   end
 
   def store_current_location

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_mastodon_session', secure: (ENV['LOCAL_HTTPS'] == 'true')
+Rails.application.config.session_store :cookie_store,
+  key: '_mastodon_session',
+  secure: (Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
 
   config.before :each, type: :feature do
-    https = ENV['LOCAL_HTTPS'] == 'true'
+    https = Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true'
     Capybara.app_host = "http#{https ? 's' : ''}://#{ENV.fetch('LOCAL_DOMAIN')}"
   end
 


### PR DESCRIPTION
This PR fixes two overlooked references to LOCAL_HTTPS. In order, this fixes:

 - the last-resort fallback to forcing HTTPS if the web server (using a non-default configuration) manages to forward a HTTP request to the 

   note that this may break users (such as apache users) with misconfigured servers that don't forward x-forwarded-proto. This needs a mention in the release notes otherwise it will cause an infinite loop.

 - mastodon session cookies will now be marked 'https only' again, to prevent against MITM downgrade attacks.