### PR TITLE
Use disable_ddl_transaction! to prevent warnings on migration

### DIFF
--- a/db/migrate/20171129172043_add_index_on_stream_entries.rb
+++ b/db/migrate/20171129172043_add_index_on_stream_entries.rb
@@ -1,6 +1,7 @@
 class AddIndexOnStreamEntries < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
   def change
-    commit_db_transaction
     add_index :stream_entries, [:account_id, :activity_type, :id], algorithm: :concurrently
     remove_index :stream_entries, name: :index_stream_entries_on_account_id
   end

--- a/db/migrate/20171226094803_more_faster_index_on_notifications.rb
+++ b/db/migrate/20171226094803_more_faster_index_on_notifications.rb
@@ -1,6 +1,7 @@
 class MoreFasterIndexOnNotifications < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
   def change
-    commit_db_transaction
     add_index :notifications, [:account_id, :id], order: { id: :desc }, algorithm: :concurrently
     remove_index :notifications, name: :index_notifications_on_id_and_account_id_and_activity_type
   end


### PR DESCRIPTION
Migration is wrapped by transaction, so manual `commit_db_transaction` without transaction restarting causes "there is no transaction in progress" warnings. We should use `disable_ddl_transaction!` instead, if we can omit transaction completely.

cc @takayamaki 