### PR TITLE
When fetching an ActivityPub-enabled status, do not re-request it as text/html

### DIFF
--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -46,6 +46,8 @@ class FetchAtomService < BaseService
       json = body_to_json(@response.to_s)
       if supported_context?(json) && json['type'] == 'Person' && json['inbox'].present?
         [json['id'], { prefetched_body: @response.to_s, id: true }, :activitypub]
+      elsif supported_context?(json) && json['type'] == 'Note'
+        [json['id'], { prefetched_body: @response.to_s, id: true }, :activitypub]
       else
         @unsupported_activity = true
         nil


### PR DESCRIPTION
When fetching remote toots (from the search bar or in workers such as `ThreadResolveworker`), the toot is currently fetched with `FetchAtomService`, which requests an ActivityPub json object if possible, but only accepts `Person` ActivityPub objects. This means any requested toot will be re-fetched as text/html.

This patch accepts ActivityPub Note objects (which can be cached by an HTTP cache) and avoid doing an additional round-trip.