### PR TITLE
Always represent numbers by strings in instance activity API

### DIFF
--- a/app/controllers/api/v1/instances/activity_controller.rb
+++ b/app/controllers/api/v1/instances/activity_controller.rb
@@ -21,9 +21,9 @@ class Api::V1::Instances::ActivityController < Api::BaseController
 
       weeks << {
         week: week.to_time.to_i.to_s,
-        statuses: Redis.current.get("activity:statuses:local:#{week_id}") || 0,
-        logins: Redis.current.pfcount("activity:logins:#{week_id}"),
-        registrations: Redis.current.get("activity:accounts:local:#{week_id}") || 0,
+        statuses: Redis.current.get("activity:statuses:local:#{week_id}") || '0',
+        logins: Redis.current.pfcount("activity:logins:#{week_id}").to_s,
+        registrations: Redis.current.get("activity:accounts:local:#{week_id}") || '0',
       }
     end
 


### PR DESCRIPTION
Fixes #6197.