### PR TITLE
Fix PuSH workers

### DIFF
--- a/app/workers/pubsubhubbub/subscribe_worker.rb
+++ b/app/workers/pubsubhubbub/subscribe_worker.rb
@@ -20,7 +20,7 @@ class Pubsubhubbub::SubscribeWorker
 
   sidekiq_retries_exhausted do |msg, _e|
     account = Account.find(msg['args'].first)
-    logger.error "PuSH subscription attempts for #{account.acct} exhausted. Unsubscribing"
+    Sidekiq.logger.error "PuSH subscription attempts for #{account.acct} exhausted. Unsubscribing"
     ::UnsubscribeService.new.call(account)
   end
 


### PR DESCRIPTION
PuSH subscription/unsubscription/confirmation appears to have been buggy for a while.
This patch uses `Rails.logger` instead of the undefined name `logger` where needed.