### PR TITLE
Move Article from supported to converted types

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ActivityPub::Activity::Create < ActivityPub::Activity
-  SUPPORTED_TYPES = %w(Article Note).freeze
-  CONVERTED_TYPES = %w(Image Video).freeze
+  SUPPORTED_TYPES = %w(Note).freeze
+  CONVERTED_TYPES = %w(Image Video Article).freeze
 
   def perform
     return if delete_arrived_first?(object_uri) || unsupported_object_type?


### PR DESCRIPTION
So this may sound like a weird PR, but:

- Nothing currently uses `Article` (I want to, though)
- `Article` is defined as a "any kind of multi-paragraph written work", and thus, doesn't fit well within the limits of Mastodon toots

So, why not, like Image/Video now does, just show the name of the post plus a link to it? This allows people on Mastodon to reply to Articles without getting them squashed into a tiny column.
