### PR TITLE
Allow retrieval of private statuses (single or in outbox) using HTTP signatures

### DIFF
--- a/app/controllers/activitypub/outboxes_controller.rb
+++ b/app/controllers/activitypub/outboxes_controller.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class ActivityPub::OutboxesController < Api::BaseController
+  include SignatureVerification
+
   before_action :set_account
 
   def show
-    @statuses = @account.statuses.permitted_for(@account, current_account).paginate_by_max_id(20, params[:max_id], params[:since_id])
+    @statuses = @account.statuses.permitted_for(@account, signed_request_account).paginate_by_max_id(20, params[:max_id], params[:since_id])
     @statuses = cache_collection(@statuses, Status)
 
     render json: outbox_presenter, serializer: ActivityPub::CollectionSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'

--- a/app/controllers/concerns/signature_authentication.rb
+++ b/app/controllers/concerns/signature_authentication.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SignatureAuthentication
+  extend ActiveSupport::Concern
+
+  include SignatureVerification
+
+  def current_account
+    super || signed_request_account
+  end
+end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class StatusesController < ApplicationController
+  include SignatureAuthentication
   include Authorization
 
   layout 'public'


### PR DESCRIPTION
This defines a new concern that allows a controller to use either the normal cookie auth, or fall back to HTTP signatures. The outbox controller and statuses controller then use this concern to allow remote servers to get private statuses, by authenticating as a specific user. 
This is the server-to-server communication required for #5818, effectively