### PR TITLE
Add the author of a status to cc if reblogged

### DIFF
--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -67,6 +67,8 @@ class ActivityPub::TagManager
   def cc(status)
     cc = []
 
+    cc << uri_for(status.reblog.account) if status.reblog?
+
     case status.visibility
     when 'public'
       cc << account_followers_url(status.account)


### PR DESCRIPTION
This makes slightly more sense, and ensures that the author of a post is always referenced in the audience (which some servers might rely on). And the announce is POSTed to the author's inbox anyways.