### PR TITLE
Increase rate limit on protected paths

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -53,7 +53,7 @@ class Rack::Attack
     req.ip if req.api_request?
   end
 
-  throttle('protected_paths', limit: 5, period: 5.minutes) do |req|
+  throttle('protected_paths', limit: 25, period: 5.minutes) do |req|
     req.ip if req.post? && req.path =~ PROTECTED_PATHS_REGEX
   end
 


### PR DESCRIPTION
Previously each protected path had a separate rate limit. Now they're all in the same bucket, so people are more likely to hit one with register->login. Increasing to 25 per 5 minutes should be fine.