### PR TITLE
Skip CSRF token check in ActivityPub controllers

### DIFF
--- a/app/controllers/activitypub/base_controller.rb
+++ b/app/controllers/activitypub/base_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ActivityPub::BaseController < Api::BaseController
+  skip_before_action :verify_authenticity_token
+end

--- a/app/controllers/activitypub/inboxes_controller.rb
+++ b/app/controllers/activitypub/inboxes_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActivityPub::InboxesController < Api::BaseController
+class ActivityPub::InboxesController < ActivityPub::BaseController
   include SignatureVerification
 
   before_action :set_account

--- a/app/controllers/activitypub/outboxes_controller.rb
+++ b/app/controllers/activitypub/outboxes_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ActivityPub::OutboxesController < Api::BaseController
+class ActivityPub::OutboxesController < ActivityPub::BaseController
   before_action :set_account
 
   def show


### PR DESCRIPTION
Prior to #6223, the CSRF token check was skipped for all API controllers (which is what the ActivityPub controllers inherit from). #6223 changed the Api::BaseController to use `:null_session` instead, which
produces "Can't verify CSRF token authenticity." log lines whenever the CSRF token is invalid.

This introduces a separate BaseController class for ActivityPub which skips the CSRF check.

Note: I'm pretty sure there are a few other API controllers for which this is also the case (and where adding the `skip_before_action` would make sense). I'll look through the other controllers tomorrow, this should probably be a WIP for now.