### PR TITLE
Allow attributedTo in a status to be an embedded object

### DIFF
--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -30,7 +30,7 @@ class ActivityPub::FetchRemoteStatusService < BaseService
   end
 
   def actor_id
-    first_of_value(@json['attributedTo'])
+    value_or_id(first_of_value(@json['attributedTo']))
   end
 
   def trustworthy_attribution?(uri, attributed_to)


### PR DESCRIPTION
```
{
    "type": "Note",
    "attributedTo": {"id": "https://puckipedia.com/", "name": "HACKER TEEN PUCKIPEDIA" [...]},
    "content": "[...] I'm at it again"
}
```

This is currently causing a stuck task on a ton of Mastodon instances, I think. Worked around it in Kroeg for now.