### PR TITLE
Suppress CSRF token warnings

### DIFF
--- a/app/controllers/api/web/push_subscriptions_controller.rb
+++ b/app/controllers/api/web/push_subscriptions_controller.rb
@@ -4,6 +4,7 @@ class Api::Web::PushSubscriptionsController < Api::BaseController
   respond_to :json
 
   before_action :require_user!
+  protect_from_forgery with: :exception
 
   def create
     params.require(:subscription).require(:endpoint)

--- a/config/initializers/suppress_csrf_warnings.rb
+++ b/config/initializers/suppress_csrf_warnings.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+ActionController::Base.log_warning_on_csrf_failure = false


### PR DESCRIPTION
CSRF token checking was enabled for API controllers in #6223, producing "Can't verify CSRF token authenticity" log spam. This disables logging of failed CSRF checks.

This also changes the protection strategy for `PushSubscriptionsController` to use exceptions, making it consistent with other controllers that use sessions.