### PR TITLE
Improve e-mail digest feature

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -170,6 +170,10 @@ class User < ApplicationRecord
     settings.default_privacy || (account.locked? ? 'private' : 'public')
   end
 
+  def allows_digest_emails?
+    settings.notification_emails['digest']
+  end
+
   def token_for_app(a)
     return nil if a.nil? || a.owner != self
     Doorkeeper::AccessToken

--- a/app/workers/digest_mailer_worker.rb
+++ b/app/workers/digest_mailer_worker.rb
@@ -9,7 +9,7 @@ class DigestMailerWorker
 
   def perform(user_id)
     @user = User.find(user_id)
-    deliver_digest if user_receives_digest?
+    deliver_digest if @user.allows_digest_emails?
   end
 
   private
@@ -17,9 +17,5 @@ class DigestMailerWorker
   def deliver_digest
     NotificationMailer.digest(user.account).deliver_now!
     user.touch(:last_emailed_at)
-  end
-
-  def user_receives_digest?
-    user.settings.notification_emails['digest']
   end
 end

--- a/app/workers/scheduler/email_scheduler.rb
+++ b/app/workers/scheduler/email_scheduler.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'sidekiq-scheduler'
+
+class Scheduler::EmailScheduler
+  include Sidekiq::Worker
+
+  def perform
+    eligible_users.find_each do |user|
+      next unless user.allows_digest_emails?
+      DigestMailerWorker.perform_async(user.id)
+    end
+  end
+
+  private
+
+  def eligible_users
+    User.confirmed
+        .joins(:account)
+        .where(accounts: { silenced: false, suspended: false })
+        .where(disabled: false)
+        .where('current_sign_in_at < ?', 20.days.ago)
+        .where('last_emailed_at IS NULL OR last_emailed_at < ?', 20.days.ago)
+  end
+end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -4,7 +4,7 @@ en:
     hints:
       defaults:
         avatar: PNG, GIF or JPG. At most 2MB. Will be downscaled to 120x120px
-        digest: Sent after a long period of inactivity with a summary of mentions you've received in your absence
+        digest: Only sent after a long period of inactivity and only if you have received any personal messages in your absence
         display_name:
           one: <span class="name-counter">1</span> character left
           other: <span class="name-counter">%{count}</span> characters left

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -27,3 +27,6 @@
   ip_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
     class: Scheduler::IpCleanupScheduler
+  email_scheduler:
+    cron: '0 10 * * 2'
+    class: Scheduler::EmailScheduler

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -171,11 +171,10 @@ namespace :mastodon do
   end
 
   namespace :emails do
-    desc 'Send out digest e-mails'
+    desc 'Send out digest e-mails (deprecated)'
     task digest: :environment do
-      User.confirmed.joins(:account).where(accounts: { silenced: false, suspended: false }).where('current_sign_in_at < ?', 20.days.ago).find_each do |user|
-        DigestMailerWorker.perform_async(user.id)
-      end
+      # No-op
+      # This task is now executed via sidekiq-scheduler
     end
   end
 


### PR DESCRIPTION
- Move from rake task to sidekiq scheduler (every tuesday at 10 in the morning)
- Improve initial query to reduce amount of spawned workers
- Skip those who opted out inside the original worker to reduce amount of spawned workers
- Improve hint string for the digest preference to make clear that these are only sent after inactivity and only if you've been messaged in your absence