### PR TITLE
When must_be_following_dm is on, only notify if recipient dm'ed user

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -53,13 +53,8 @@ class NotifyService < BaseService
     @notification.type == :mention && @notification.target_status.direct_visibility?
   end
 
-  def replied_to_status_is_direct_message?
-    replied_to_status = Status.find(@notification.target_status.in_reply_to_id)
-    replied_to_status.direct_visibility?
-  end
-
   def response_to_recipient?
-    @notification.target_status.in_reply_to_account_id == @recipient.id && replied_to_status_is_direct_message?
+    @notification.target_status.in_reply_to_account_id == @recipient.id && @notification.target_status.thread&.direct_visibility?
   end
 
   def optional_non_following_and_direct?

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -53,8 +53,13 @@ class NotifyService < BaseService
     @notification.type == :mention && @notification.target_status.direct_visibility?
   end
 
+  def replied_to_status_is_direct_message?
+    replied_to_status = Status.find(@notification.target_status.in_reply_to_id)
+    replied_to_status.direct_visibility?
+  end
+
   def response_to_recipient?
-    @notification.target_status.in_reply_to_account_id == @recipient.id
+    @notification.target_status.in_reply_to_account_id == @recipient.id && replied_to_status_is_direct_message?
   end
 
   def optional_non_following_and_direct?

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -62,8 +62,17 @@ RSpec.describe NotifyService do
         is_expected.to_not change(Notification, :count)
       end
 
-      context 'if the message chain initiated by recipient' do
+      context 'if the message chain initiated by recipient, but is not direct message' do
         let(:reply_to) { Fabricate(:status, account: recipient) }
+        let(:activity) { Fabricate(:mention, account: recipient, status: Fabricate(:status, account: sender, visibility: :direct, thread: reply_to)) }
+
+        it 'does not notify' do
+          is_expected.to_not change(Notification, :count)
+        end
+      end
+
+      context 'if the message chain initiated by recipient and is direct message' do
+        let(:reply_to) { Fabricate(:status, account: recipient, visibility: :direct) }
         let(:activity) { Fabricate(:mention, account: recipient, status: Fabricate(:status, account: sender, visibility: :direct, thread: reply_to)) }
 
         it 'does notify' do


### PR DESCRIPTION
Currently, when must_be_following_dm is on, if a user sends a direct message replying to any status from the recipient, the recipient gets a notification. This should not be the case, as if the recipient posted something publicly this can be used to spam their notifications.