### PR TITLE
Fix regeneration marker not expiring

### DIFF
--- a/app/controllers/concerns/user_tracking_concern.rb
+++ b/app/controllers/concerns/user_tracking_concern.rb
@@ -32,7 +32,7 @@ module UserTrackingConcern
   end
 
   def regenerate_feed!
-    Redis.current.setnx("account:#{current_user.account_id}:regeneration", true) == 1 && Redis.current.expire("account:#{current_user.account_id}:regeneration", 3_600 * 24)
+    Redis.current.setnx("account:#{current_user.account_id}:regeneration", true) && Redis.current.expire("account:#{current_user.account_id}:regeneration", 1.day.seconds)
     RegenerationWorker.perform_async(current_user.account_id)
   end
 end

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -341,6 +341,15 @@ namespace :mastodon do
       LinkCrawlWorker.push_bulk status_ids
     end
 
+    desc 'Remove all home feed regeneration markers'
+    task remove_regeneration_markers: :environment do
+      keys = Redis.current.keys('account:*:regeneration')
+
+      Redis.current.pipelined do
+        keys.each { |key| Redis.current.del(key) }
+      end
+    end
+
     desc 'Check every known remote account and delete those that no longer exist in origin'
     task purge_removed_accounts: :environment do
       prepare_for_options!

--- a/spec/controllers/concerns/user_tracking_concern_spec.rb
+++ b/spec/controllers/concerns/user_tracking_concern_spec.rb
@@ -69,6 +69,12 @@ describe ApplicationController, type: :controller do
         expect(RegenerationWorker).to have_received(:perform_async)
       end
 
+      it 'sets the regeneration marker to expire' do
+        allow(RegenerationWorker).to receive(:perform_async)
+        get :show
+        expect(Redis.current.ttl("account:#{user.account_id}:regeneration")).to be >= 0
+      end
+
       it 'regenerates feed when sign in is older than two weeks' do
         get :show
 


### PR DESCRIPTION
- Fix the safeguard that sets the regeneration marker to expire just in case RegenerationWorker never gets to run (and delete the marker)
- Add rake task to remove all regeneration markers that might have been left behind by old versions (`rake mastodon:maintenance::remove_regeneration_markers`)