### PR TITLE
Add option to show only local toots in timeline preview

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -31,7 +31,7 @@ class AboutController < ApplicationController
 
   def initial_state_params
     {
-      settings: {known_fediverse: Setting.show_known_fediverse_at_about_page},
+      settings: { known_fediverse: Setting.show_known_fediverse_at_about_page },
       token: current_session&.token,
     }
   end

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -31,7 +31,7 @@ class AboutController < ApplicationController
 
   def initial_state_params
     {
-      settings: {},
+      settings: {known_fediverse: Setting.show_known_fediverse_at_about_page},
       token: current_session&.token,
     }
   end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -19,6 +19,7 @@ module Admin
       min_invite_role
       activity_api_enabled
       peers_api_enabled
+      show_known_fediverse_at_about_page
     ).freeze
 
     BOOLEAN_SETTINGS = %w(
@@ -28,6 +29,7 @@ module Admin
       show_staff_badge
       activity_api_enabled
       peers_api_enabled
+      show_known_fediverse_at_about_page
     ).freeze
 
     UPLOAD_SETTINGS = %w(

--- a/app/javascript/mastodon/containers/timeline_container.js
+++ b/app/javascript/mastodon/containers/timeline_container.js
@@ -6,6 +6,7 @@ import { hydrateStore } from '../actions/store';
 import { IntlProvider, addLocaleData } from 'react-intl';
 import { getLocale } from '../locales';
 import PublicTimeline from '../features/standalone/public_timeline';
+import CommunityTimeline from '../features/standalone/community_timeline';
 import HashtagTimeline from '../features/standalone/hashtag_timeline';
 import initialState from '../initial_state';
 
@@ -23,17 +24,24 @@ export default class TimelineContainer extends React.PureComponent {
   static propTypes = {
     locale: PropTypes.string.isRequired,
     hashtag: PropTypes.string,
+    showPublicTimeline: PropTypes.bool.isRequired
+  };
+
+  static defaultProps = {
+    showPublicTimeline: initialState.settings['known_fediverse']
   };
 
   render () {
-    const { locale, hashtag } = this.props;
+    const { locale, hashtag, showPublicTimeline } = this.props;
 
     let timeline;
 
     if (hashtag) {
       timeline = <HashtagTimeline hashtag={hashtag} />;
-    } else {
+    } else if (showPublicTimeline) {
       timeline = <PublicTimeline />;
+    } else {
+      timeline = <CommunityTimeline />;
     }
 
     return (

--- a/app/javascript/mastodon/containers/timeline_container.js
+++ b/app/javascript/mastodon/containers/timeline_container.js
@@ -24,11 +24,11 @@ export default class TimelineContainer extends React.PureComponent {
   static propTypes = {
     locale: PropTypes.string.isRequired,
     hashtag: PropTypes.string,
-    showPublicTimeline: PropTypes.bool.isRequired
+    showPublicTimeline: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {
-    showPublicTimeline: initialState.settings['known_fediverse']
+    showPublicTimeline: initialState.settings.known_fediverse,
   };
 
   render () {

--- a/app/javascript/mastodon/features/standalone/community_timeline/index.js
+++ b/app/javascript/mastodon/features/standalone/community_timeline/index.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import StatusListContainer from '../../ui/containers/status_list_container';
+import {
+  refreshCommunityTimeline,
+  expandCommunityTimeline,
+} from '../../../actions/timelines';
+import Column from '../../../components/column';
+import ColumnHeader from '../../../components/column_header';
+import { defineMessages, injectIntl } from 'react-intl';
+
+const messages = defineMessages({
+  title: { id: 'standalone.public_title', defaultMessage: 'A look inside...' },
+});
+
+@connect()
+@injectIntl
+export default class CommunityTimeline extends React.PureComponent {
+
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+  };
+
+  handleHeaderClick = () => {
+    this.column.scrollTop();
+  }
+
+  setRef = c => {
+    this.column = c;
+  }
+
+  componentDidMount () {
+    const { dispatch } = this.props;
+
+    dispatch(refreshCommunityTimeline());
+    this.disconnect = dispatch(connectPublicStream());
+  }
+
+  componentWillUnmount () {
+    if (this.disconnect) {
+      this.disconnect();
+      this.disconnect = null;
+    }
+  }
+
+  handleLoadMore = () => {
+    this.props.dispatch(expandCommunityTimeline());
+  }
+
+  render () {
+    const { intl } = this.props;
+
+    return (
+      <Column ref={this.setRef}>
+        <ColumnHeader
+          icon='users'
+          title={intl.formatMessage(messages.title)}
+          onClick={this.handleHeaderClick}
+        />
+
+        <StatusListContainer
+          timelineId='community'
+          loadMore={this.handleLoadMore}
+          scrollKey='standalone_public_timeline'
+          trackScroll={false}
+        />
+      </Column>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/standalone/community_timeline/index.js
+++ b/app/javascript/mastodon/features/standalone/community_timeline/index.js
@@ -9,6 +9,7 @@ import {
 import Column from '../../../components/column';
 import ColumnHeader from '../../../components/column_header';
 import { defineMessages, injectIntl } from 'react-intl';
+import { connectCommunityStream } from '../../../actions/streaming';
 
 const messages = defineMessages({
   title: { id: 'standalone.public_title', defaultMessage: 'A look inside...' },
@@ -35,7 +36,7 @@ export default class CommunityTimeline extends React.PureComponent {
     const { dispatch } = this.props;
 
     dispatch(refreshCommunityTimeline());
-    this.disconnect = dispatch(connectPublicStream());
+    this.disconnect = dispatch(connectCommunityStream());
   }
 
   componentWillUnmount () {

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -1220,6 +1220,15 @@
         "id": "standalone.public_title"
       }
     ],
+    "path": "app/javascript/mastodon/features/standalone/community_timeline/index.json"
+  },
+  {
+    "descriptors": [
+      {
+        "defaultMessage": "A look inside...",
+        "id": "standalone.public_title"
+      }
+    ],
     "path": "app/javascript/mastodon/features/standalone/public_timeline/index.json"
   },
   {

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -34,6 +34,8 @@ class Form::AdminSettings
     :activity_api_enabled=,
     :peers_api_enabled,
     :peers_api_enabled=,
+    :show_known_fediverse_at_about_page,
+    :show_known_fediverse_at_about_page=,
     to: Setting
   )
 end

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -19,6 +19,9 @@
     = f.input :timeline_preview, as: :boolean, wrapper: :with_label, label: t('admin.settings.timeline_preview.title'), hint: t('admin.settings.timeline_preview.desc_html')
 
   .fields-group
+    = f.input :show_known_fediverse_at_about_page, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_known_fediverse_at_about_page.title'), hint: t('admin.settings.show_known_fediverse_at_about_page.desc_html')
+
+  .fields-group
     = f.input :show_staff_badge, as: :boolean, wrapper: :with_label, label: t('admin.settings.show_staff_badge.title'), hint: t('admin.settings.show_staff_badge.desc_html')
 
   .fields-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,6 +309,9 @@ en:
       timeline_preview:
         desc_html: Display public timeline on landing page
         title: Timeline preview
+      show_known_fediverse_at_about_page:
+        desc_html: When toggled, it will show toots from all the known fediverse on preview. Otherwise it will only show local toots.
+        title: Show known fediverse on timeline preview
       title: Site settings
     statuses:
       back_to_account: Back to account page

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,6 +290,9 @@ en:
         open:
           desc_html: Allow anyone to create an account
           title: Open registration
+      show_known_fediverse_at_about_page:
+        desc_html: When toggled, it will show toots from all the known fediverse on preview. Otherwise it will only show local toots.
+        title: Show known fediverse on timeline preview
       show_staff_badge:
         desc_html: Show a staff badge on a user page
         title: Show staff badge
@@ -309,9 +312,6 @@ en:
       timeline_preview:
         desc_html: Display public timeline on landing page
         title: Timeline preview
-      show_known_fediverse_at_about_page:
-        desc_html: When toggled, it will show toots from all the known fediverse on preview. Otherwise it will only show local toots.
-        title: Show known fediverse on timeline preview
       title: Site settings
     statuses:
       back_to_account: Back to account page

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -291,6 +291,9 @@ pl:
         open:
           desc_html: Pozwól każdemu na założenie konta
           title: Otwarta rejestracja
+      show_known_fediverse_at_about_page:
+        desc_html: Jeśli włączone, podgląd instancji będzie wyświetlał wpisy z całego Fediwersum. W innym przypadku, będą wyświetlane tylko lokalne wpisy.
+        title: Pokazuj wszystkie znane wpisy na podglądzie instancji
       show_staff_badge:
         desc_html: Pokazuj odznakę uprawnień na stronie profilu użytkownika
         title: Pokazuj odznakę administracji

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -290,6 +290,9 @@ pt-BR:
         open:
           desc_html: Permitir que qualquer um crie uma conta
           title: Cadastro aberto
+      show_known_fediverse_at_about_page:
+        desc_html: Quando ligado, vai mostrar toots de todo o fediverso conhecido na prévia da timeline. Senão, mostra somente toots locais.
+        title: Mostrar fediverso conhecido na prévia da timeline
       show_staff_badge:
         desc_html: Mostrar uma insígnia de Equipe na página de usuário
         title: Mostrar insígnia de equipe
@@ -309,9 +312,6 @@ pt-BR:
       timeline_preview:
         desc_html: Exibir a timeline pública na página inicial
         title: Prévia da timeline
-      show_known_fediverse_at_about_page:
-        desc_html: Quando ligado, vai mostrar toots de todo o fediverso conhecido na prévia da timeline. Senão, mostra somente toots locais.
-        title: Mostrar fediverso conhecido na prévia da timeline
       title: Configurações do site
     statuses:
       back_to_account: Voltar para página da conta

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -309,6 +309,9 @@ pt-BR:
       timeline_preview:
         desc_html: Exibir a timeline pública na página inicial
         title: Prévia da timeline
+      show_known_fediverse_at_about_page:
+        desc_html: Quando ligado, vai mostrar toots de todo o fediverso conhecido na prévia da timeline. Senão, mostra somente toots locais.
+        title: Mostrar fediverso conhecido na prévia da timeline
       title: Configurações do site
     statuses:
       back_to_account: Voltar para página da conta

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,6 +49,7 @@ defaults: &defaults
   bootstrap_timeline_accounts: ''
   activity_api_enabled: true
   peers_api_enabled: true
+  show_known_fediverse_at_about_page: true
 development:
   <<: *defaults
 


### PR DESCRIPTION
Right know, toots from all the known fediverse are shown in the main
page of an instance. That however doesn't reflect the instance itself.
With this option the admin may choose to display only local toots so
that users checking the instance get a better idea of internal
conversations.

My Javascript is not very good, but since I have this on masto.donte, I figured someone else might want it and tried to make it an option. I'm not sure if it's the best way to get the settings or if the settings name is the best. Also, do we have tests for js? I couldn't find them.