### PR TITLE
Retry delivering toots over ActivityPub for about 2 days

### DIFF
--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::DeliveryWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push', retry: 8, dead: false
+  sidekiq_options queue: 'push', retry: 16, dead: false
 
   HEADERS = { 'Content-Type' => 'application/activity+json' }.freeze
 


### PR DESCRIPTION
Currently, Mastodon will retry delivering toots for a bit over 1 hour.
This is a very short timespan when considering private and direct toots, which
cannot be seen by the recipient at all after the delivery attempts have failed.

Ideally, private and direct toots should have a different number of retries,
but I do not know how to do that.