### PR TITLE
Process mentions and reblogs even from resolved threads

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -69,12 +69,13 @@ class ActivityPub::Activity
   def distribute(status)
     crawl_links(status)
 
+    notify_about_reblog(status) if reblog_of_local_account?(status)
+    notify_about_mentions(status)
+
     # Only continue if the status is supposed to have
     # arrived in real-time
     return unless @options[:override_timestamps]
 
-    notify_about_reblog(status) if reblog_of_local_account?(status)
-    notify_about_mentions(status)
     distribute_to_followers(status)
   end
 


### PR DESCRIPTION
This may lead to out-of-order notifications, but this is better than not having
notifications at all.

Ideally, I'd want to not skip insertion into the various timelines, but it would require more changes to not end up out-of-order (and items popping in the middle of feeds could also be considered problematic…)