### PR TITLE
Do not throw away statuses obtained via websocket when API request finishes

### DIFF
--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -40,7 +40,7 @@ const normalizeTimeline = (state, timeline, statuses, next, isPartial) => {
     mMap.set('loaded', true);
     mMap.set('isLoading', false);
     if (!hadNext) mMap.set('next', next);
-    mMap.set('items', wasLoaded ? ids.concat(oldIds) : ids);
+    mMap.set('items', wasLoaded ? ids.concat(oldIds) : oldIds.concat(ids));
     mMap.set('isPartial', isPartial);
   }));
 };


### PR DESCRIPTION
On my small instance, rendering the timelines in the initial API calls can take several seconds, during which the websocket code may forward new toots. Up until the proposed change, the web UI would, on API call completion, discard any toot received via websocket in the meantime.