### PR TITLE
fix filter search index being too strict when looking for line breaks

### DIFF
--- a/app/javascript/mastodon/reducers/statuses.js
+++ b/app/javascript/mastodon/reducers/statuses.js
@@ -54,7 +54,7 @@ const normalizeStatus = (state, status) => {
     normalStatus.reblog = status.reblog.id;
   }
 
-  const searchContent = [status.spoiler_text, status.content].join('\n\n').replace(/<br \/>/g, '\n').replace(/<\/p><p>/g, '\n\n');
+  const searchContent = [status.spoiler_text, status.content].join('\n\n').replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n');
 
   const emojiMap = normalStatus.emojis.reduce((obj, emoji) => {
     obj[`:${emoji.shortcode}:`] = emoji;


### PR DESCRIPTION
while local toots do have the XHTML-formatted `<br />`, remote toots seem to have the modern HTML `<br>`

this fixes #6316