### PR TITLE
Fix assets loading when WEB_DOMAIN ≠ LOCAL_DOMAIN

### DIFF
--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -27,7 +27,7 @@ function formatPublicPath(host = '', path = '') {
 
 const output = {
   path: resolve('public', settings.public_output_path),
-  publicPath: formatPublicPath(env.ASSET_HOST || env.LOCAL_DOMAIN, settings.public_output_path),
+  publicPath: formatPublicPath(env.ASSET_HOST || env.WEB_DOMAIN || env.LOCAL_DOMAIN, settings.public_output_path),
 };
 
 module.exports = {


### PR DESCRIPTION
Since 872a0d5bd801c998d911f7da582a60d2f714a710, assets URL are absolute and
not relative. Unfortunately, the domain used to build such URLs is the wrong
one: LOCAL_DOMAIN, and not WEB_DOMAIN, where the assets are stored.