### PR TITLE
Rename ResolveRemoteAccountService to ResolveAccountService

### DIFF
--- a/app/controllers/activitypub/inboxes_controller.rb
+++ b/app/controllers/activitypub/inboxes_controller.rb
@@ -28,7 +28,7 @@ class ActivityPub::InboxesController < Api::BaseController
   def upgrade_account
     if signed_request_account.ostatus?
       signed_request_account.update(last_webfingered_at: nil)
-      ResolveRemoteAccountWorker.perform_async(signed_request_account.acct)
+      ResolveAccountWorker.perform_async(signed_request_account.acct)
     end
 
     Pubsubhubbub::UnsubscribeWorker.perform_async(signed_request_account.id) if signed_request_account.subscribed?

--- a/app/controllers/authorize_follows_controller.rb
+++ b/app/controllers/authorize_follows_controller.rb
@@ -41,7 +41,7 @@ class AuthorizeFollowsController < ApplicationController
   end
 
   def account_from_remote_follow
-    ResolveRemoteAccountService.new.call(acct_without_prefix)
+    ResolveAccountService.new.call(acct_without_prefix)
   end
 
   def acct_param_is_url?

--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -114,7 +114,7 @@ module SignatureVerification
 
   def account_from_key_id(key_id)
     if key_id.start_with?('acct:')
-      ResolveRemoteAccountService.new.call(key_id.gsub(/\Aacct:/, ''))
+      ResolveAccountService.new.call(key_id.gsub(/\Aacct:/, ''))
     elsif !ActivityPub::TagManager.instance.local_uri?(key_id)
       account   = ActivityPub::TagManager.instance.uri_to_resource(key_id, Account)
       account ||= ActivityPub::FetchRemoteKeyService.new.call(key_id, id: false)

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -163,7 +163,7 @@ class Account < ApplicationRecord
 
   def refresh!
     return if local?
-    ResolveRemoteAccountService.new.call(acct)
+    ResolveAccountService.new.call(acct)
   end
 
   def unsuspend!

--- a/app/models/form/migration.rb
+++ b/app/models/form/migration.rb
@@ -20,6 +20,6 @@ class Form::Migration
   private
 
   def set_account
-    self.account = (ResolveRemoteAccountService.new.call(acct) if account.nil? && acct.present?)
+    self.account = (ResolveAccountService.new.call(acct) if account.nil? && acct.present?)
   end
 end

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -18,7 +18,7 @@ class AccountSearchService < BaseService
     return [] if query_blank_or_hashtag? || limit < 1
 
     if resolving_non_matching_remote_account?
-      [ResolveRemoteAccountService.new.call("#{query_username}@#{query_domain}")].compact
+      [ResolveAccountService.new.call("#{query_username}@#{query_domain}")].compact
     else
       search_results_and_exact_match.compact.uniq.slice(0, limit)
     end

--- a/app/services/concerns/author_extractor.rb
+++ b/app/services/concerns/author_extractor.rb
@@ -18,6 +18,6 @@ module AuthorExtractor
       acct   = "#{username}@#{domain}"
     end
 
-    ResolveRemoteAccountService.new.call(acct, update_profile)
+    ResolveAccountService.new.call(acct, update_profile)
   end
 end

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -9,7 +9,7 @@ class FollowService < BaseService
   # @param [true, false, nil] reblogs Whether or not to show reblogs, defaults to true
   def call(source_account, uri, reblogs: nil)
     reblogs = true if reblogs.nil?
-    target_account = uri.is_a?(Account) ? uri : ResolveRemoteAccountService.new.call(uri)
+    target_account = uri.is_a?(Account) ? uri : ResolveAccountService.new.call(uri)
 
     raise ActiveRecord::RecordNotFound if target_account.nil? || target_account.id == source_account.id || target_account.suspended?
     raise Mastodon::NotPermittedError  if target_account.blocking?(source_account) || source_account.blocking?(target_account)

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -16,7 +16,7 @@ class ProcessMentionsService < BaseService
 
       if mention_undeliverable?(status, mentioned_account)
         begin
-          mentioned_account = resolve_remote_account_service.call($1)
+          mentioned_account = resolve_account_service.call($1)
         rescue Goldfinger::Error, HTTP::Error
           mentioned_account = nil
         end
@@ -63,7 +63,7 @@ class ProcessMentionsService < BaseService
     ).as_json).sign!(status.account))
   end
 
-  def resolve_remote_account_service
-    ResolveRemoteAccountService.new
+  def resolve_account_service
+    ResolveAccountService.new
   end
 end

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ResolveRemoteAccountService < BaseService
+class ResolveAccountService < BaseService
   include OStatus2::MagicKey
   include JsonLdHelper
 

--- a/app/workers/import/relationship_worker.rb
+++ b/app/workers/import/relationship_worker.rb
@@ -7,7 +7,7 @@ class Import::RelationshipWorker
 
   def perform(account_id, target_account_uri, relationship)
     from_account   = Account.find(account_id)
-    target_account = ResolveRemoteAccountService.new.call(target_account_uri)
+    target_account = ResolveAccountService.new.call(target_account_uri)
 
     return if target_account.nil?
 

--- a/app/workers/resolve_account_worker.rb
+++ b/app/workers/resolve_account_worker.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class ResolveRemoteAccountWorker
+class ResolveAccountWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: 'pull', unique: :until_executed
 
   def perform(uri)
-    ResolveRemoteAccountService.new.call(uri)
+    ResolveAccountService.new.call(uri)
   end
 end

--- a/spec/controllers/authorize_follows_controller_spec.rb
+++ b/spec/controllers/authorize_follows_controller_spec.rb
@@ -30,7 +30,7 @@ describe AuthorizeFollowsController do
 
       it 'renders error when account cant be found' do
         service = double
-        allow(ResolveRemoteAccountService).to receive(:new).and_return(service)
+        allow(ResolveAccountService).to receive(:new).and_return(service)
         allow(service).to receive(:call).with('missing@hostname').and_return(nil)
 
         get :show, params: { acct: 'acct:missing@hostname' }
@@ -54,7 +54,7 @@ describe AuthorizeFollowsController do
       it 'sets account from acct uri' do
         account = Account.new
         service = double
-        allow(ResolveRemoteAccountService).to receive(:new).and_return(service)
+        allow(ResolveAccountService).to receive(:new).and_return(service)
         allow(service).to receive(:call).with('found@hostname').and_return(account)
 
         get :show, params: { acct: 'acct:found@hostname' }

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Settings::ImportsController, type: :controller do
   describe 'POST #create' do
     it 'redirects to settings path with successful following import' do
       service = double(call: nil)
-      allow(ResolveRemoteAccountService).to receive(:new).and_return(service)
+      allow(ResolveAccountService).to receive(:new).and_return(service)
       post :create, params: {
         import: {
           type: 'following',
@@ -30,7 +30,7 @@ RSpec.describe Settings::ImportsController, type: :controller do
 
     it 'redirects to settings path with successful blocking import' do
       service = double(call: nil)
-      allow(ResolveRemoteAccountService).to receive(:new).and_return(service)
+      allow(ResolveAccountService).to receive(:new).and_return(service)
       post :create, params: {
         import: {
           type: 'blocking',

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -185,8 +185,8 @@ RSpec.describe Account, type: :model do
         expect(account.refresh!).to be_nil
       end
 
-      it 'calls not ResolveRemoteAccountService#call' do
-        expect_any_instance_of(ResolveRemoteAccountService).not_to receive(:call).with(acct)
+      it 'calls not ResolveAccountService#call' do
+        expect_any_instance_of(ResolveAccountService).not_to receive(:call).with(acct)
         account.refresh!
       end
     end
@@ -194,8 +194,8 @@ RSpec.describe Account, type: :model do
     context 'domain is present' do
       let(:domain) { 'example.com' }
 
-      it 'calls ResolveRemoteAccountService#call' do
-        expect_any_instance_of(ResolveRemoteAccountService).to receive(:call).with(acct).once
+      it 'calls ResolveAccountService#call' do
+        expect_any_instance_of(ResolveAccountService).to receive(:call).with(acct).once
         account.refresh!
       end
     end

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -123,7 +123,7 @@ describe AccountSearchService do
     describe 'when there is a domain but no exact match' do
       it 'follows the remote account when resolve is true' do
         service = double(call: nil)
-        allow(ResolveRemoteAccountService).to receive(:new).and_return(service)
+        allow(ResolveAccountService).to receive(:new).and_return(service)
 
         results = subject.call('newuser@remote.com', 10, nil, resolve: true)
         expect(service).to have_received(:call).with('newuser@remote.com')
@@ -131,7 +131,7 @@ describe AccountSearchService do
 
       it 'does not follow the remote account when resolve is false' do
         service = double(call: nil)
-        allow(ResolveRemoteAccountService).to receive(:new).and_return(service)
+        allow(ResolveAccountService).to receive(:new).and_return(service)
 
         results = subject.call('newuser@remote.com', 10, nil, resolve: false)
         expect(service).not_to have_received(:call)

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ResolveRemoteAccountService do
+RSpec.describe ResolveAccountService do
   subject { described_class.new }
 
   before do


### PR DESCRIPTION
The service used to be named `ResolveRemoteAccountService` resolves local accounts as well.