### PR TITLE
Rename FetchRemoteResourceService to ResolveURLService

### DIFF
--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FetchRemoteResourceService < BaseService
+class ResolveURLService < BaseService
   include JsonLdHelper
 
   attr_reader :url

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -8,7 +8,7 @@ class SearchService < BaseService
 
     default_results.tap do |results|
       if url_query?
-        results.merge!(remote_resource_results) unless remote_resource.nil?
+        results.merge!(url_resource_results) unless url_resource.nil?
       elsif query.present?
         results[:accounts] = AccountSearchService.new.call(query, limit, account, resolve: resolve)
         results[:hashtags] = Tag.search_for(query.gsub(/\A#/, ''), limit) unless query.start_with?('@')
@@ -24,15 +24,15 @@ class SearchService < BaseService
     query =~ /\Ahttps?:\/\//
   end
 
-  def remote_resource_results
-    { remote_resource_symbol => [remote_resource] }
+  def url_resource_results
+    { url_resource_symbol => [url_resource] }
   end
 
-  def remote_resource
-    @_remote_resource ||= FetchRemoteResourceService.new.call(query)
+  def url_resource
+    @_url_resource ||= ResolveURLService.new.call(query)
   end
 
-  def remote_resource_symbol
-    remote_resource.class.name.downcase.pluralize.to_sym
+  def url_resource_symbol
+    url_resource.class.name.downcase.pluralize.to_sym
   end
 end

--- a/spec/services/resolve_url_service_spec.rb
+++ b/spec/services/resolve_url_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe FetchRemoteResourceService do
+describe ResolveURLService do
   subject { described_class.new }
 
   describe '#call' do

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -26,7 +26,7 @@ describe SearchService do
       context 'that does not find anything' do
         it 'returns the empty results' do
           service = double(call: nil)
-          allow(FetchRemoteResourceService).to receive(:new).and_return(service)
+          allow(ResolveURLService).to receive(:new).and_return(service)
           results = subject.call(@query, 10)
 
           expect(service).to have_received(:call).with(@query)
@@ -38,7 +38,7 @@ describe SearchService do
         it 'includes the account in the results' do
           account = Account.new
           service = double(call: account)
-          allow(FetchRemoteResourceService).to receive(:new).and_return(service)
+          allow(ResolveURLService).to receive(:new).and_return(service)
 
           results = subject.call(@query, 10)
           expect(service).to have_received(:call).with(@query)
@@ -50,7 +50,7 @@ describe SearchService do
         it 'includes the status in the results' do
           status = Status.new
           service = double(call: status)
-          allow(FetchRemoteResourceService).to receive(:new).and_return(service)
+          allow(ResolveURLService).to receive(:new).and_return(service)
 
           results = subject.call(@query, 10)
           expect(service).to have_received(:call).with(@query)


### PR DESCRIPTION
The service used to be named `FetchRemoteResourceService` resolves local URL as well.