### PR TITLE
Change PrecomputeFeedService method to brute force

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :test do
   gem 'simplecov', '~> 0.14', require: false
   gem 'webmock', '~> 3.0'
   gem 'parallel_tests', '~> 2.17'
+  gem 'timecop', '~> 0.9'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -512,6 +512,7 @@ GEM
     thread (0.2.2)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     twitter-text (1.14.7)
       unf (~> 0.1.0)
     tzinfo (1.2.4)
@@ -641,6 +642,7 @@ DEPENDENCIES
   simplecov (~> 0.14)
   sprockets-rails (~> 3.2)
   strong_migrations
+  timecop (~> 0.9)
   twitter-text (~> 1.14)
   tzinfo-data (~> 1.2017)
   uglifier (~> 3.2)

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -113,28 +113,6 @@ class FeedManager
     end
   end
 
-  def populate_feed(account)
-    added  = 0
-    limit  = FeedManager::MAX_ITEMS / 2
-    max_id = nil
-
-    loop do
-      statuses = Status.as_home_timeline(account)
-                       .paginate_by_max_id(limit, max_id)
-
-      break if statuses.empty?
-
-      statuses.each do |status|
-        next if filter_from_home?(status, account)
-        added += 1 if add_to_feed(:home, account.id, status)
-      end
-
-      break unless added.zero?
-
-      max_id = statuses.last.id
-    end
-  end
-
   private
 
   def redis

--- a/app/services/precompute_feed_service.rb
+++ b/app/services/precompute_feed_service.rb
@@ -1,8 +1,27 @@
 # frozen_string_literal: true
 
 class PrecomputeFeedService < BaseService
-  def call(account)
-    FeedManager.instance.populate_feed(account)
-    Redis.current.del("account:#{account.id}:regeneration")
+  attr_reader :into_account
+
+  def call(into_account)
+    @into_account = into_account
+
+    merge_own_timeline!
+    merge_following_timelines!
+    mark_finished!
+  end
+
+  private
+
+  def merge_following_timelines!
+    into_account.following.find_each { |from_account| FeedManager.instance.merge_into_timeline(from_account, into_account) }
+  end
+
+  def merge_own_timeline!
+    FeedManager.instance.merge_into_timeline(into_account, into_account)
+  end
+
+  def mark_finished!
+    Redis.current.del("account:#{into_account.id}:regeneration")
   end
 end

--- a/spec/controllers/concerns/user_tracking_concern_spec.rb
+++ b/spec/controllers/concerns/user_tracking_concern_spec.rb
@@ -18,29 +18,38 @@ describe ApplicationController, type: :controller do
   describe 'when signed in' do
     let(:user) { Fabricate(:user) }
 
+    before do
+      Timecop.freeze
+      sign_in user, scope: :user
+    end
+
+    after do
+      Timecop.return
+    end
+
     it 'does not track when there is a recent sign in' do
       user.update(current_sign_in_at: 60.minutes.ago)
-      prior = user.current_sign_in_at
-      sign_in user, scope: :user
-      get :show
-
-      expect(user.reload.current_sign_in_at).to be_within(1.0).of(prior)
+      expect { get :show }.to_not change { user.reload.current_sign_in_at }
     end
 
     it 'tracks when sign in is nil' do
-      user.update(current_sign_in_at: nil)
-      sign_in user, scope: :user
-      get :show
+      user.update(current_sign_in_at: nil, last_sign_in_at: nil)
 
-      expect_updated_sign_in_at(user)
+      get :show
+      user.reload
+
+      expect(user.current_sign_in_at).to be_within(1.0).of(Time.now)
+      expect(user.last_sign_in_at).to be_within(1.0).of(Time.now)
     end
 
     it 'tracks when sign in is older than one day' do
-      user.update(current_sign_in_at: 2.days.ago)
-      sign_in user, scope: :user
-      get :show
+      user.update(current_sign_in_at: 2.days.ago, last_sign_in_at: 4.days.ago)
 
-      expect_updated_sign_in_at(user)
+      get :show
+      user.reload
+
+      expect(user.current_sign_in_at).to be_within(1.0).of(Time.now)
+      expect(user.last_sign_in_at).to be_within(1.0).of(2.days.ago)
     end
 
     describe 'feed regeneration' do
@@ -55,16 +64,23 @@ describe ApplicationController, type: :controller do
         Fabricate(:status, account: bob, text: 'yes hello')
         Fabricate(:status, account: user.account, text: 'test')
 
-        user.update(last_sign_in_at: 'Tue, 04 Jul 2017 14:45:56 UTC +00:00', current_sign_in_at: 'Wed, 05 Jul 2017 22:10:52 UTC +00:00')
+        user.update(current_sign_in_at: 'Wed, 05 Jul 2017 22:10:52 UTC +00:00', last_sign_in_at: 'Tue, 04 Jul 2017 14:45:56 UTC +00:00')
+      end
 
-        sign_in user, scope: :user
+      it 'updates last sign in date such that a regeneration is triggered' do
+        allow(RegenerationWorker).to receive(:perform_async)
+
+        get :show
+        user.reload
+
+        expect(user.current_sign_in_at).to be_within(1.0).of(Time.now)
+        expect(user.last_sign_in_at).to be < 2.weeks.ago
       end
 
       it 'sets a regeneration marker while regenerating' do
         allow(RegenerationWorker).to receive(:perform_async)
         get :show
 
-        expect_updated_sign_in_at(user)
         expect(Redis.current.get("account:#{user.account_id}:regeneration")).to eq 'true'
         expect(RegenerationWorker).to have_received(:perform_async)
       end
@@ -72,20 +88,16 @@ describe ApplicationController, type: :controller do
       it 'sets the regeneration marker to expire' do
         allow(RegenerationWorker).to receive(:perform_async)
         get :show
+
         expect(Redis.current.ttl("account:#{user.account_id}:regeneration")).to be >= 0
       end
 
       it 'regenerates feed when sign in is older than two weeks' do
         get :show
 
-        expect_updated_sign_in_at(user)
         expect(Redis.current.zcard(FeedManager.instance.key(:home, user.account_id))).to eq 3
         expect(Redis.current.get("account:#{user.account_id}:regeneration")).to be_nil
       end
-    end
-
-    def expect_updated_sign_in_at(user)
-      expect(user.reload.current_sign_in_at).to be_within(1.0).of(Time.now.utc)
     end
   end
 end


### PR DESCRIPTION
See also: #6331. Yet another guess attempt by me.

On one hand I added the timecop gem and rewrote UserTrackingConcern tests to be more readable (in my opinion) and also made sure to check last_sign_in_at values as well, since it's *that* value that's checked for regeneration preconditions.

However, I did not find anything broken or odd.

In a second step I decided to try an alternative approach to home timeline regeneration. Instead of using a SQL query from `Status.as_home_timeline` together with big limits and pagination, I decided to "brute force" the process by simulating the user re-following every person, i.e. executing MergeWorker things synchronously. Synchronously because we need to know when it's "done" to unset the regeneration marker.