### PR TITLE
Display deleted users' role as “Suspended”

### DIFF
--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -18,7 +18,10 @@
         %tr
           %th= t('admin.accounts.role')
           %td
-            = t("admin.accounts.roles.#{@account.user&.role}")
+            - if @account.user.nil?
+              = t("admin.accounts.moderation.suspended")
+            - else
+              = t("admin.accounts.roles.#{@account.user&.role}")
             = table_link_to 'angle-double-up', t('admin.accounts.promote'), promote_admin_account_role_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:promote, @account.user)
             = table_link_to 'angle-double-down', t('admin.accounts.demote'), demote_admin_account_role_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:demote, @account.user)
         %tr


### PR DESCRIPTION
Follow-up to 6eb60260b1b771e8cd42d3b58b82b2781a067991 which missed a spot where
the same error occurs.