### PR TITLE
Fix home regeneration not being triggered when logging in

### DIFF
--- a/app/controllers/concerns/user_tracking_concern.rb
+++ b/app/controllers/concerns/user_tracking_concern.rb
@@ -3,7 +3,6 @@
 module UserTrackingConcern
   extend ActiveSupport::Concern
 
-  REGENERATE_FEED_DAYS = 14
   UPDATE_SIGN_IN_HOURS = 24
 
   included do
@@ -14,25 +13,10 @@ module UserTrackingConcern
 
   def set_user_activity
     return unless user_needs_sign_in_update?
-
-    # Mark as signed-in today
     current_user.update_tracked_fields!(request)
-    ActivityTracker.record('activity:logins', current_user.id)
-
-    # Regenerate feed if needed
-    regenerate_feed! if user_needs_feed_update?
   end
 
   def user_needs_sign_in_update?
     user_signed_in? && (current_user.current_sign_in_at.nil? || current_user.current_sign_in_at < UPDATE_SIGN_IN_HOURS.hours.ago)
-  end
-
-  def user_needs_feed_update?
-    current_user.last_sign_in_at < REGENERATE_FEED_DAYS.days.ago
-  end
-
-  def regenerate_feed!
-    Redis.current.setnx("account:#{current_user.account_id}:regeneration", true) && Redis.current.expire("account:#{current_user.account_id}:regeneration", 1.day.seconds)
-    RegenerationWorker.perform_async(current_user.account_id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,7 +129,7 @@ class User < ApplicationRecord
     new_user = !confirmed?
 
     super
-    update_statistics! if new_user
+    prepare_new_user! if new_user
   end
 
   def confirm!
@@ -137,7 +137,12 @@ class User < ApplicationRecord
 
     skip_confirmation!
     save!
-    update_statistics! if new_user
+    prepare_new_user! if new_user
+  end
+
+  def update_tracked_fields!(request)
+    super
+    prepare_returning_user!
   end
 
   def promote!
@@ -220,9 +225,23 @@ class User < ApplicationRecord
     filtered_languages.reject!(&:blank?)
   end
 
-  def update_statistics!
+  def prepare_new_user!
     BootstrapTimelineWorker.perform_async(account_id)
     ActivityTracker.increment('activity:accounts:local')
     UserMailer.welcome(self).deliver_later
+  end
+
+  def prepare_returning_user!
+    ActivityTracker.record('activity:logins', id)
+    regenerate_feed! if needs_feed_update?
+  end
+
+  def regenerate_feed!
+    Redis.current.setnx("account:#{account_id}:regeneration", true) && Redis.current.expire("account:#{account_id}:regeneration", 1.day.seconds)
+    RegenerationWorker.perform_async(account_id)
+  end
+
+  def needs_feed_update?
+    last_sign_in_at < ACTIVE_DURATION.ago
   end
 end


### PR DESCRIPTION
Fix #6331

UserTrackingConcern is circumvented by SessionsController#create because it calls warden, which calls the User#update_tracked_fields! method directly. Move returning user logic to that method.

I.e. the home regeneration logic would work perfectly if you still have a valid cookie. If you have to go through the login form, the login form would update the current_sign_in_at values without triggering home regeneration, and subsequent page visits would not pick up the slack because they think the job is done.