### PR TITLE
Fix hide and show media button on admin page

### DIFF
--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -28,13 +28,13 @@ delegate(document, batchCheckboxClassName, 'change', () => {
 });
 
 delegate(document, '.media-spoiler-show-button', 'click', () => {
-  [].forEach.call(document.querySelectorAll('.activity-stream .media-spoiler-wrapper'), (content) => {
-    content.classList.add('media-spoiler-wrapper__visible');
+  [].forEach.call(document.querySelectorAll('button.media-spoiler'), (element) => {
+    element.click();
   });
 });
 
 delegate(document, '.media-spoiler-hide-button', 'click', () => {
-  [].forEach.call(document.querySelectorAll('.activity-stream .media-spoiler-wrapper'), (content) => {
-    content.classList.remove('media-spoiler-wrapper__visible');
+  [].forEach.call(document.querySelectorAll('.spoiler-button.spoiler-button--visible button'), (element) => {
+    element.click();
   });
 });


### PR DESCRIPTION
The "Show media" button and "Hide media" button on the admin page has stopped working because the image display method has changed. I fixed this.