### PR TITLE
Do not manually update system RubyGems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ services:
   - redis-server
 
 install:
-  - gem update --system
   - nvm install
   - bundle install --path=vendor/bundle --without development production --retry=3 --jobs=16
   - yarn install


### PR DESCRIPTION
Travis CI ships compatible system RubyGems now:
https://github.com/travis-ci/travis-ci/issues/8969#issuecomment-360288970
> I have repackaged the 2.5.0 archive for Linux to include RubyGems 2.7.4, which should have the fix for this issue. Please restart the affected jobs, and let us know how they go for you.

Let's see if it works now…