### PR TITLE
Do not require sudo on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   - public/packs-test
   - tmp/cache/babel-loader
 dist: trusty
-sudo: required
+sudo: false
 branches:
   only:
   - master


### PR DESCRIPTION
The issue which the workaround for is now addressed:
https://github.com/travis-ci/travis-ci/issues/7941#issuecomment-310667894
> We've pushed out new stable trusty images to production with a patch.

Eliminating yet another workaround. Hope it works.