### PR TITLE
Add Docker configuration for development

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -3,18 +3,10 @@ FROM ruby:2.5.0-alpine3.7
 LABEL maintainer="https://github.com/tootsuite/mastodon" \
       description="Your self-hosted, globally interconnected microblogging community"
 
-ARG UID=991
-ARG GID=991
-
-ENV RAILS_SERVE_STATIC_FILES=true \
-    RAILS_ENV=production NODE_ENV=production
-
 ARG YARN_VERSION=1.5.1
 ARG YARN_DOWNLOAD_SHA256=cd31657232cf48d57fdbff55f38bfa058d2fb4950450bd34af72dac796af4de1
 ARG LIBICONV_VERSION=1.15
 ARG LIBICONV_DOWNLOAD_SHA256=ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178
-
-EXPOSE 3000 4000
 
 WORKDIR /mastodon
 
@@ -62,23 +54,4 @@ RUN apk -U upgrade \
  && cd /mastodon \
  && rm -rf /tmp/* /var/cache/apk/*
 
-COPY Gemfile Gemfile.lock package.json yarn.lock .yarnclean /mastodon/
-
-RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include \
- && bundle install -j$(getconf _NPROCESSORS_ONLN) --deployment --without test development \
- && yarn --pure-lockfile \
- && yarn cache clean
-
-RUN addgroup -g ${GID} mastodon && adduser -h /mastodon -s /bin/sh -D -G mastodon -u ${UID} mastodon \
- && mkdir -p /mastodon/public/system /mastodon/public/assets /mastodon/public/packs \
- && chown -R mastodon:mastodon /mastodon/public
-
-COPY . /mastodon
-
-RUN chown -R mastodon:mastodon /mastodon
-
-VOLUME /mastodon/public/system /mastodon/public/assets /mastodon/public/packs
-
-USER mastodon
-
-ENTRYPOINT ["/sbin/tini", "--"]
+RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,25 @@
+FROM tootsuite/mastodon-base
+
+LABEL maintainer="https://github.com/tootsuite/mastodon" \
+      description="Mastodon for development"
+
+EXPOSE 3000 3035 4000
+
+ENV BUNDLE_APP_CONFIG=/mastodon/.bundle \
+    REDIS_HOST=redis \
+    REDIS_PORT=6379 \
+    DB_HOST=db \
+    DB_USER=postgres \
+    DB_NAME=postgres \
+    DB_PASS= \
+    DB_PORT=5432 \
+    WEBPACKER_DEV_SERVER_HOST=asset
+
+RUN apk add openssl \
+ && openssl req -newkey rsa:2048 -x509 -days 365 -nodes \
+                -subj /CN=*.localdomain \
+                -keyout /common.key \
+                -out /usr/local/share/ca-certificates/common.crt \
+ && update-ca-certificates
+
+VOLUME /mastodon

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,4 @@
+FROM nginx:1.13-alpine
+
+COPY --from=tootsuite/mastodon-development /common.key /usr/local/share/ca-certificates/common.crt /etc/nginx/
+COPY default.conf /etc/nginx/conf.d

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,32 @@
+FROM gargron/mastodon-base
+
+LABEL maintainer="https://github.com/tootsuite/mastodon" \
+      description="Mastodon for production"
+
+ARG UID=991
+ARG GID=991
+
+ENV RAILS_SERVE_STATIC_FILES=true \
+    RAILS_ENV=production NODE_ENV=production
+
+EXPOSE 3000 4000
+
+COPY Gemfile Gemfile.lock package.json yarn.lock .yarnclean /mastodon/
+
+RUN bundle install -j$(getconf _NPROCESSORS_ONLN) --deployment --without test development \
+ && yarn --pure-lockfile \
+ && yarn cache clean
+
+RUN addgroup -g ${GID} mastodon && adduser -h /mastodon -s /bin/sh -D -G mastodon -u ${UID} mastodon \
+ && mkdir -p /mastodon/public/system /mastodon/public/assets /mastodon/public/packs \
+ && chown -R mastodon:mastodon /mastodon/public
+
+COPY . /mastodon
+
+RUN chown -R mastodon:mastodon /mastodon
+
+VOLUME /mastodon/public/system /mastodon/public/assets /mastodon/public/packs
+
+USER mastodon
+
+ENTRYPOINT ["/sbin/tini", "--"]

--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -30,6 +30,16 @@ const output = {
   publicPath: formatPublicPath(env.CDN_HOST, settings.public_output_path),
 };
 
+if ('dev_server' in settings) {
+  if (env.WEBPACKER_DEV_SERVER_HOST) {
+    settings.dev_server.host = env.WEBPACKER_DEV_SERVER_HOST;
+  }
+
+  if (env.WEBPACKER_DEV_SERVER_PUBLIC) {
+    settings.dev_server.public = env.WEBPACKER_DEV_SERVER_PUBLIC;
+  }
+}
+
 module.exports = {
   settings,
   themes,

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -31,6 +31,7 @@ module.exports = merge(sharedConfig, {
     https: settings.dev_server.https,
     host: settings.dev_server.host,
     port: settings.dev_server.port,
+    public: settings.dev_server.public,
     contentBase: output.path,
     publicPath: output.publicPath,
     compress: true,

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,79 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+server {
+  listen 80;
+
+  location /api/v1/streaming {
+    proxy_set_header Host $host;
+
+    proxy_pass http://streaming:4000;
+    proxy_buffering off;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    tcp_nodelay on;
+  }
+
+  location /sockjs-node {
+    proxy_set_header Host $host;
+
+    proxy_pass http://asset:3035;
+    proxy_buffering off;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    tcp_nodelay on;
+  }
+
+  location / {
+    proxy_pass http://localhost:3000;
+  }
+}
+
+server {
+  listen 443 ssl http2;
+  ssl_certificate common.crt;
+  ssl_certificate_key common.key;
+
+  location /api/v1/streaming {
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto https;
+
+    proxy_pass http://streaming:4000;
+    proxy_buffering off;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    tcp_nodelay on;
+  }
+
+  location /packs {
+    proxy_pass http://asset:3035;
+  }
+
+  location /sockjs-node {
+    proxy_pass http://asset:3035;
+    proxy_buffering off;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    tcp_nodelay on;
+  }
+
+  location / {
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_pass http://localhost:3000;
+  }
+}

--- a/docker-compose.development.network.yml
+++ b/docker-compose.development.network.yml
@@ -1,0 +1,5 @@
+version: '3'
+networks:
+  federation:
+    external:
+      name: mastodon

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,107 @@
+version: '3'
+services:
+
+  db:
+    restart: always
+    image: postgres:9.6-alpine
+    networks:
+      - default
+    volumes:
+      - ./postgres:/var/lib/postgresql/data
+
+  redis:
+    restart: always
+    image: redis:4.0-alpine
+    networks:
+      - default
+    volumes:
+      - ./redis:/data
+
+  base:
+    build:
+      context: .
+      dockerfile: Dockerfile.base
+    image: tootsuite/mastodon-base
+
+  development:
+    build:
+      context: .
+      dockerfile: Dockerfile.development
+    image: tootsuite/mastodon-development
+
+  nginx:
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
+    networks:
+      - default
+    image: tootsuite/mastodon-nginx
+    restart: always
+    command: nginx -g 'daemon off;'
+    networks:
+      default:
+      federation:
+        aliases:
+          - ${LOCAL_DOMAIN:-mastodon.localdomain}
+    depends_on:
+      - asset
+      - streaming
+    ports:
+      - "${FRONTEND_DOMAIN:-127.0.0.1}:80:80"
+      - "${FRONTEND_DOMAIN:-127.0.0.1}:443:443"
+
+  web:
+    image: tootsuite/mastodon-development
+    restart: always
+    command: bundle exec rails runner docker_development_entrypoint.rb rails s -b '0.0.0.0'
+    network_mode: service:nginx
+    depends_on:
+      - db
+      - redis
+      - development
+    volumes:
+      - .:/mastodon
+
+  asset:
+    image: tootsuite/mastodon-development
+    environment:
+      - LOCAL_HTTPS=$LOCAL_HTTPS
+      - WEBPACKER_DEV_SERVER_PUBLIC=${FRONTEND_DOMAIN:-127.0.0.1}
+    restart: always
+    command: ./bin/webpack-dev-server
+    networks:
+      - default
+    depends_on:
+      - development
+    volumes:
+      - .:/mastodon
+
+  streaming:
+    image: tootsuite/mastodon-development
+    restart: always
+    command: yarn start
+    networks:
+      - default
+    depends_on:
+      - db
+      - redis
+      - development
+    volumes:
+      - .:/mastodon
+
+  sidekiq:
+    image: tootsuite/mastodon-development
+    restart: always
+    command: bundle exec rails runner docker_development_entrypoint.rb sidekiq -q default -q mailers -q pull -q push
+    network_mode: service:nginx
+    depends_on:
+      - db
+      - redis
+      - development
+    volumes:
+      - .:/mastodon
+
+networks:
+  default:
+    driver: bridge
+  federation:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,16 @@ services:
 ##    volumes:
 ##      - ./elasticsearch:/usr/share/elasticsearch/data
 
+  base:
+    build:
+      context: .
+      dockerfile: Dockerfile.base
+    image: tootsuite/mastodon-base
+
   web:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.production
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
@@ -51,7 +59,9 @@ services:
       - ./public/system:/mastodon/public/system
 
   streaming:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.production
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
@@ -66,7 +76,9 @@ services:
       - redis
 
   sidekiq:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.production
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production

--- a/docker_development_entrypoint.rb
+++ b/docker_development_entrypoint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+frontend_domain = ENV.fetch('FRONTEND_DOMAIN') { '127.0.0.1' }
+websocket_scheme = ENV['LOCAL_HTTPS'] == 'true' ? 'wss://' : 'ws://'
+
+ENV['STREAMING_API_BASE_URL'] = websocket_scheme + frontend_domain
+exec(*ARGV)


### PR DESCRIPTION
Mastodon has lots of system dependencies now. Resolving them to setup the development environment is sometimes troublesome or difficult because of conflicts.

This Docker configuration is an alternative for such situations. You can set up the development environment with the following procedure:
```sh
git clone https://github.com/tootsuite/mastodon.git
cd mastodon
sudo docker-compose -f docker_compose.development.yml build
sudo docker-compose -f docker_compose.development.yml run web bundle install --path vendor/bundle
sudo docker-compose -f docker_compose.development.yml run web yarn install --pure-lockfile
sudo docker-compose -f docker_compose.development.yml run web bundle exec rails db:setup
sudo docker-compose -f docker_compose.development.yml run web up
```