### PR TITLE
Rescue when there's no extension in the remotable

### DIFF
--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -29,7 +29,7 @@ module Remotable
           filename = matches.nil? ? parsed_url.path.split('/').last : matches[1]
           basename = SecureRandom.hex(8)
           begin
-            extname  = File.extname(filename)
+            extname = File.extname(filename)
           rescue TypeError
             return
           end

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -28,10 +28,10 @@ module Remotable
           matches  = response.headers['content-disposition']&.match(/filename="([^"]*)"/)
           filename = matches.nil? ? parsed_url.path.split('/').last : matches[1]
           basename = SecureRandom.hex(8)
-          extname = unless filename.nil?
-                      File.extname(filename)
-                    else
+          extname = if filename.nil?
                       ''
+                    else
+                      File.extname(filename)
                     end
 
           send("#{attachment_name}=", StringIO.new(response.to_s))

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -28,7 +28,11 @@ module Remotable
           matches  = response.headers['content-disposition']&.match(/filename="([^"]*)"/)
           filename = matches.nil? ? parsed_url.path.split('/').last : matches[1]
           basename = SecureRandom.hex(8)
-          extname = File.extname(filename) unless filename.nil?
+          extname = unless filename.nil?
+                      File.extname(filename)
+                    else
+                      ''
+                    end
 
           send("#{attachment_name}=", StringIO.new(response.to_s))
           send("#{attachment_name}_file_name=", basename + extname)

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -28,7 +28,11 @@ module Remotable
           matches  = response.headers['content-disposition']&.match(/filename="([^"]*)"/)
           filename = matches.nil? ? parsed_url.path.split('/').last : matches[1]
           basename = SecureRandom.hex(8)
-          extname  = File.extname(filename)
+          begin
+            extname  = File.extname(filename)
+          rescue TypeError
+            return
+          end
 
           send("#{attachment_name}=", StringIO.new(response.to_s))
           send("#{attachment_name}_file_name=", basename + extname)

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -28,11 +28,7 @@ module Remotable
           matches  = response.headers['content-disposition']&.match(/filename="([^"]*)"/)
           filename = matches.nil? ? parsed_url.path.split('/').last : matches[1]
           basename = SecureRandom.hex(8)
-          begin
-            extname = File.extname(filename)
-          rescue TypeError
-            return
-          end
+          extname = File.extname(filename) unless filename.nil?
 
           send("#{attachment_name}=", StringIO.new(response.to_s))
           send("#{attachment_name}_file_name=", basename + extname)


### PR DESCRIPTION
Sometimes the remotable is pointing to a directory with no file extension. Maybe it should not be expecting to identify based on extensions to begin with, but since it's the case, it should be ready for it.

This caused errors on my sidekiq of the type:
```
WARN: TypeError: no implicit conversion of nil into String
WARN: /home/mastodon/live/app/models/concerns/remotable.rb:31:in `extname'
```