### PR TITLE
Isolate internal services from external networks in Docker configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   db:
     restart: always
     image: postgres:9.6-alpine
+    networks:
+      - internal_network
 ### Uncomment to enable DB persistance
 #    volumes:
 #      - ./postgres:/var/lib/postgresql/data
@@ -11,6 +13,8 @@ services:
   redis:
     restart: always
     image: redis:4.0-alpine
+    networks:
+      - internal_network
 ### Uncomment to enable REDIS persistance
 #    volumes:
 #      - ./redis:/data
@@ -21,6 +25,9 @@ services:
     restart: always
     env_file: .env.production
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    networks:
+      - external_network
+      - internal_network
     ports:
       - "3000:3000"
     depends_on:
@@ -37,6 +44,9 @@ services:
     restart: always
     env_file: .env.production
     command: npm run start
+    networks:
+      - external_network
+      - internal_network
     ports:
       - "4000:4000"
     depends_on:
@@ -52,5 +62,13 @@ services:
     depends_on:
       - db
       - redis
+    networks:
+      - external_network
+      - internal_network
     volumes:
       - ./public/system:/mastodon/public/system
+
+networks:
+  external_network:
+  internal_network:
+    internal: true


### PR DESCRIPTION
The database and Redis do not need external connections, so isolate them and prevent unauthorized access.