### PR TITLE
Unify links container implementation in about pages

### DIFF
--- a/app/views/about/_links.html.haml
+++ b/app/views/about/_links.html.haml
@@ -1,0 +1,16 @@
+.container.links
+  .brand
+    = link_to root_url do
+      = image_tag asset_pack_path('logo_full.svg'), alt: 'Mastodon'
+
+  %ul.nav
+    %li
+      - if user_signed_in?
+        = link_to t('settings.back'), root_url, class: 'webapp-btn'
+      - else
+        = link_to t('auth.login'), new_user_session_path, class: 'webapp-btn'
+    %li= link_to t('about.about_this'), about_more_path
+    %li
+      = link_to 'https://joinmastodon.org/' do
+        = "#{t('about.other_instances')}"
+        %i.fa.fa-external-link{ style: 'padding-left: 5px;' }

--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -8,22 +8,7 @@
 .landing-page
   .header-wrapper.compact
     .header
-      .container.links
-        .brand
-          = link_to root_url do
-            = image_tag asset_pack_path('logo_full.svg'), alt: 'Mastodon'
-
-        %ul.nav
-          %li
-            - if user_signed_in?
-              = link_to t('settings.back'), root_url, class: 'webapp-btn'
-            - else
-              = link_to t('auth.login'), new_user_session_path, class: 'webapp-btn'
-          %li= link_to t('about.about_this'), about_more_path
-          %li
-            = link_to 'https://joinmastodon.org/' do
-              = "#{t('about.other_instances')}"
-              %i.fa.fa-external-link{ style: 'padding-left: 5px;' }
+      = render 'links'
 
       .container.hero
         .heading

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -12,22 +12,7 @@
       = image_tag asset_pack_path('elephant-fren.png'), alt: '', role: 'presentation', class: 'mascot'
 
     .header
-      .container.links
-        .brand
-          = link_to root_url do
-            = image_tag asset_pack_path('logo_full.svg'), alt: 'Mastodon'
-
-        %ul.nav
-          %li
-            - if user_signed_in?
-              = link_to t('settings.back'), root_url, class: 'webapp-btn'
-            - else
-              = link_to t('auth.login'), new_user_session_path, class: 'webapp-btn'
-          %li= link_to t('about.about_this'), about_more_path
-          %li
-            = link_to 'https://joinmastodon.org/' do
-              = "#{t('about.other_instances')}"
-              %i.fa.fa-external-link{ style: 'padding-left: 5px;' }
+      = render 'links'
 
       .container.hero
         .floats

--- a/app/views/about/terms.html.haml
+++ b/app/views/about/terms.html.haml
@@ -4,19 +4,7 @@
 .landing-page
   .header-wrapper.compact
     .header
-      .container.links
-        .brand
-          = link_to root_url do
-            = image_tag asset_pack_path('logo_full.svg'), alt: 'Mastodon'
-
-        %ul.nav
-          %li
-            - if user_signed_in?
-              = link_to t('settings.back'), root_url, class: 'webapp-btn'
-            - else
-              = link_to t('auth.login'), new_user_session_path, class: 'webapp-btn'
-          %li= link_to t('about.about_this'), about_more_path
-          %li= link_to t('about.other_instances'), 'https://joinmastodon.org/'
+      = render 'links'
 
   .extended-description
     .container


### PR DESCRIPTION
They were redundant, and also had a inconsistency; the button for "other instances" had an icon for the external link in "more" page, but it didn't in the other pages.

This unifies the implementation, and the external link icon is now shown in all the about pages.