### PR TITLE
Use iframe as sandbox to embed remote card

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2202,16 +2202,11 @@
   }
 }
 
-.status-card-video,
+.status-card-html,
 .status-card-rich,
 .status-card-photo {
   margin-top: 14px;
   overflow: hidden;
-
-  iframe {
-    width: 100%;
-    height: auto;
-  }
 }
 
 .status-card-photo {
@@ -2223,11 +2218,8 @@
   margin: 0;
 }
 
-.status-card-video {
-  iframe {
-    width: 100%;
-    height: 100%;
-  }
+.status-card-html {
+  width: 100%;
 }
 
 .status-card__title {

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -42,27 +42,5 @@ class Sanitize
         CLASS_WHITELIST_TRANSFORMER,
       ]
     )
-
-    MASTODON_OEMBED ||= freeze_config merge(
-      RELAXED,
-      elements: RELAXED[:elements] + %w(audio embed iframe source video),
-
-      attributes: merge(
-        RELAXED[:attributes],
-        'audio'  => %w(controls),
-        'embed'  => %w(height src type width),
-        'iframe' => %w(allowfullscreen frameborder height scrolling src width),
-        'source' => %w(src type),
-        'video'  => %w(controls height loop width),
-        'div'    => [:data]
-      ),
-
-      protocols: merge(
-        RELAXED[:protocols],
-        'embed'  => { 'src' => HTTP_PROTOCOLS },
-        'iframe' => { 'src' => HTTP_PROTOCOLS },
-        'source' => { 'src' => HTTP_PROTOCOLS }
-      )
-    )
   end
 end

--- a/app/serializers/rest/preview_card_serializer.rb
+++ b/app/serializers/rest/preview_card_serializer.rb
@@ -5,8 +5,9 @@ class REST::PreviewCardSerializer < ActiveModel::Serializer
 
   attributes :url, :title, :description, :type,
              :author_name, :author_url, :provider_name,
-             :provider_url, :html, :width, :height,
+             :provider_url, :width, :height,
              :image, :embed_url
+  attribute :html, key: :unsafe_html
 
   def image
     object.image? ? full_asset_url(object.image.url(:original)) : nil

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -98,13 +98,10 @@ class FetchLinkCardService < BaseService
       @card.image     = URI.parse(embed.url)
       @card.width     = embed.width.presence  || 0
       @card.height    = embed.height.presence || 0
-    when 'video'
+    when 'video', 'rich'
       @card.width  = embed.width.presence  || 0
       @card.height = embed.height.presence || 0
-      @card.html   = Formatter.instance.sanitize(embed.html, Sanitize::Config::MASTODON_OEMBED)
-    when 'rich'
-      # Most providers rely on <script> tags, which is a no-no
-      return false
+      @card.html   = embed.html
     end
 
     @card.save_with_optional_image!


### PR DESCRIPTION
_breaking_: this renames `html` to `unsafe_html` because it should not be assumed safe.
![screenshot-2018-1-30 mastodon dev 1](https://user-images.githubusercontent.com/17036990/35554012-8ae14e6e-05dd-11e8-808d-333506a0383e.png)
