### PR TITLE
delete outer join in status model

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -111,6 +111,7 @@ class Account < ApplicationRecord
   scope :expiring, ->(time) { remote.where.not(subscription_expires_at: nil).where('subscription_expires_at < ?', time) }
   scope :partitioned, -> { order('row_number() over (partition by domain)') }
   scope :silenced, -> { where(silenced: true) }
+  scope :not_silenced, -> { where(silenced: false) }
   scope :suspended, -> { where(suspended: true) }
   scope :recent, -> { reorder(id: :desc) }
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -69,10 +69,10 @@ class Status < ApplicationRecord
   scope :without_reblogs, -> { where('statuses.reblog_of_id IS NULL') }
   scope :with_public_visibility, -> { where(visibility: :public) }
   scope :tagged_with, ->(tag) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag }) }
-  scope :excluding_silenced_accounts, -> { left_outer_joins(:account).where(accounts: { silenced: false }) }
-  scope :including_silenced_accounts, -> { left_outer_joins(:account).where(accounts: { silenced: true }) }
+  scope :excluding_silenced_accounts, -> { where(account_id: Account.select(:id).not_silenced) }
+  scope :including_silenced_accounts, -> { where(account_id: Account.select(:id).silenced) }
   scope :not_excluded_by_account, ->(account) { where.not(account_id: account.excluded_from_timeline_account_ids) }
-  scope :not_domain_blocked_by_account, ->(account) { account.excluded_from_timeline_domains.blank? ? left_outer_joins(:account) : left_outer_joins(:account).where('accounts.domain IS NULL OR accounts.domain NOT IN (?)', account.excluded_from_timeline_domains) }
+  scope :not_domain_blocked_by_account, ->(account) { where.not(account_id: Account.select(:id).where(domain: account.excluded_from_timeline_domains)) if account.excluded_from_timeline_domains.present? }
 
   cache_associated :account, :application, :media_attachments, :tags, :stream_entry, mentions: :account, reblog: [:account, :application, :stream_entry, :tags, :media_attachments, mentions: :account], thread: :account
 


### PR DESCRIPTION
refactor status model

### before
`
SELECT  "statuses"."id", "statuses"."updated_at" FROM "statuses" LEFT OUTER JOIN "accounts" ON "accounts"."id" = "statuses"."account_id" WHERE "statuses"."visibility" = $1 AND (statuses.reblog_of_id IS NULL) AND (statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id) AND (1=1) AND "accounts"."silenced" = $2 ORDER BY "statuses"."id" DESC LIMIT $3
`

### after
`
 SELECT  "statuses"."id", "statuses"."updated_at" FROM "statuses" WHERE "statuses"."visibility" = $1 AND (statuses.reblog_of_id IS NULL) AND (statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id) AND (1=1) AND "statuses"."account_id" IN (SELECT "accounts"."id" FROM "accounts" WHERE "accounts"."silenced" = $2) ORDER BY "statuses"."id" DESC LIMIT $3
`