### PR TITLE
fix ruby 2.5 rvm install in vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,7 +48,7 @@ curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-instal
 source /home/vagrant/.rvm/scripts/rvm
 
 # Install Ruby
-rvm install ruby-$RUBY_VERSION
+rvm reinstall ruby-$RUBY_VERSION --disable-binary
 
 # Configure database
 sudo -u postgres createuser -U postgres vagrant -s


### PR DESCRIPTION
Fix for #6391

RVM has a known issue with installing Ruby 2.5 on the version of Ubuntu
the Vagrant box is using: https://github.com/rvm/rvm/issues/4291

This bug was preventing any gem installs in the vagrant box.