### PR TITLE
Upgrade Paperclip > 5.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
     httplog (0.99.7)
       colorize
       rack
-    i18n (0.9.1)
+    i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.19)
       activesupport (>= 4.0.2)
@@ -284,7 +284,7 @@ GEM
     mimemagic (0.3.2)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
-    minitest (5.10.3)
+    minitest (5.11.3)
     msgpack (1.1.0)
     multi_json (1.12.2)
     net-scp (1.2.1)
@@ -307,7 +307,7 @@ GEM
       http (~> 3.0)
       nokogiri (~> 1.8)
     ox (2.8.2)
-    paperclip (5.1.0)
+    paperclip (5.2.1)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
       cocaine (~> 0.5.5)


### PR DESCRIPTION
Mitigation for [CVE-2017-0889](https://www.cvedetails.com/cve/CVE-2017-0889/).

More info: https://medium.com/in-the-weeds/all-about-paperclips-cve-2017-0889-server-side-request-forgery-ssrf-vulnerability-8cb2b1c96fe8

As far as I can see, there is only [one reference](https://github.com/rfwatson/mastodon/blob/e1c069e21f5a7a2ad8166fb66b0c106a20e0442d/app/workers/import_worker.rb#L25) to Paperclip's `io_adapter`s in the codebase. It's not clear to me what Paperclip's purpose is here - how can I generate some importable data to test this? If anybody has any thoughts they'd be much appreciated.