### PR TITLE
Fix column header button

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2422,6 +2422,7 @@
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+    flex: 1;
   }
 
   &.active {
@@ -2442,7 +2443,6 @@
 .column-header__buttons {
   height: 48px;
   display: flex;
-  margin-left: auto;
 }
 
 .column-header__links .text-btn {


### PR DESCRIPTION
After the change by #6406, I noticed that the click area of the column header is only the character part. This PR has fixed this problem.

Before:
![image](https://user-images.githubusercontent.com/4199439/35732966-d8befb08-085e-11e8-980b-d61254ef1812.png)

After:
![image](https://user-images.githubusercontent.com/4199439/35732985-e5427fd0-085e-11e8-9faf-43a0d3a01159.png)
