### PR TITLE
Upgrade Vagrant box to Xenial

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,7 +79,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/xenial64"
 
   config.vm.provider :virtualbox do |vb|
     vb.name = "mastodon"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,6 +39,7 @@ sudo apt-get install \
   libidn11-dev \
   libprotobuf-dev \
   libreadline-dev \
+  libpam0g-dev \
   -y
 
 # Install rvm


### PR DESCRIPTION
Upgrading the dev vagrant box to Xenial allows support for newer Redis versions, fixing this issue: https://github.com/tootsuite/mastodon/issues/6399

This update also also adds the libpam0g-dev dependency to the Vagrant box required by the PAM gem to build native extensions: https://github.com/tootsuite/mastodon/commit/04fef7b8886bb78f3473e143894a521ca578f1db

As of this commit the Vagrant box will build correctly with `vagrant up`, this lets the site run and all tests pass.