### PR TITLE
Add dependency in Dockerfile about pam.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apk -U upgrade \
     libidn-dev \
     libressl \
     libtool \
+    linux-pam-dev \
     postgresql-dev \
     protobuf-dev \
     python \


### PR DESCRIPTION
Required by the PAM gem to build native extensions: 04fef7b .