### PR TITLE
Exclude nil from relationships array

### DIFF
--- a/app/controllers/api/v1/accounts/relationships_controller.rb
+++ b/app/controllers/api/v1/accounts/relationships_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::Accounts::RelationshipsController < Api::BaseController
     accounts = Account.where(id: account_ids).select('id')
     # .where doesn't guarantee that our results are in the same order
     # we requested them, so return the "right" order to the requestor.
-    @accounts = accounts.index_by(&:id).values_at(*account_ids)
+    @accounts = accounts.index_by(&:id).values_at(*account_ids).compact
     render json: @accounts, each_serializer: REST::RelationshipSerializer, relationships: relationships
   end
 


### PR DESCRIPTION
When an id of an account that does not exist is specified, nil is included in the array and an error occurs in `REST::RelationshipSerializer`.

```rb
account_ids = [1, 2, 100]
accounts = Account.where(id: account_ids).select('id') # => [#<Account:0x00007f95f778f020 id: 2>, #<Account:0x00007f95f778ee40 id: 1>]
@accounts = accounts.index_by(&:id).values_at(*account_ids) # => [#<Account:0x00007f95f778ee40 id: 1>, #<Account:0x00007f95f778f020 id: 2>, nil]
```

Execute `compact` and remove nil from the array before passing it to `REST::RelationshipSerializer`.