### PR TITLE
Validation of count works even when text of status is nil

### DIFF
--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -23,6 +23,8 @@ class StatusLengthValidator < ActiveModel::Validator
   end
 
   def countable_text(status)
+    return '' if status.text.nil?
+
     status.text.dup.tap do |new_text|
       new_text.gsub!(FetchLinkCardService::URL_PATTERN, 'x' * 23)
       new_text.gsub!(Account::MENTION_RE, '@\2')


### PR DESCRIPTION
If the status text is nil, `NoMethodError` will occur when executing `new_text.gsub!`.