### PR TITLE
match hashtag regex in js client with server

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { me } from '../../../initial_state';
 
-const APPROX_HASHTAG_RE = /(?:^|[^\/\)\w])#(\S+)/i;
+const APPROX_HASHTAG_RE = /(?:^|[^\/\)\w])#(\w*[a-zA-Z]\w*)/i;
 
 const mapStateToProps = state => ({
   needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),


### PR DESCRIPTION
This fixes #6414

the slight mismatch in hashtag regex between js and ruby was causing
hashtag warning to be displayed for unlisted tweets when an invalid
hashtag was entered

exact version of ruby regex not possible in JS as POSIX bracket
expressions are not supported, this version approximates and doesn't
give same unicode support

Ruby:
[[:word:]_]*[[:alpha:]_][[:word:]_]*

JS:
\w*[a-zA-Z]\w*