### PR TITLE
Isolate each specs for cache store

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,6 +23,10 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  # The default store, file_store is shared by processses parallely executed
+  # and should not be used.
+  config.cache_store = :memory_store
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -90,9 +90,7 @@ describe InstancePresenter do
 
   describe "user_count" do
     it "returns the number of site users" do
-      cache = double
-      allow(Rails).to receive(:cache).and_return(cache)
-      allow(cache).to receive(:fetch).with("user_count").and_return(123)
+      Rails.cache.write 'user_count', 123
 
       expect(instance_presenter.user_count).to eq(123)
     end
@@ -100,9 +98,7 @@ describe InstancePresenter do
 
   describe "status_count" do
     it "returns the number of local statuses" do
-      cache = double
-      allow(Rails).to receive(:cache).and_return(cache)
-      allow(cache).to receive(:fetch).with("local_status_count").and_return(234)
+      Rails.cache.write 'local_status_count', 234
 
       expect(instance_presenter.status_count).to eq(234)
     end
@@ -110,9 +106,7 @@ describe InstancePresenter do
 
   describe "domain_count" do
     it "returns the number of known domains" do
-      cache = double
-      allow(Rails).to receive(:cache).and_return(cache)
-      allow(cache).to receive(:fetch).with("distinct_domain_count").and_return(345)
+      Rails.cache.write 'distinct_domain_count', 345
 
       expect(instance_presenter.domain_count).to eq(345)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -51,6 +51,8 @@ RSpec.configure do |config|
   end
 
   config.after :each do
+    Rails.cache.clear
+
     keys = Redis.current.keys
     Redis.current.del(keys) if keys.any?
   end


### PR DESCRIPTION
The cache store is explicitly used by some specs, but they were not isolated and therefore not reliable. This fixes the issue by clearing the cache after each specs.