### PR TITLE
Fix password recovery

### DIFF
--- a/app/views/auth/passwords/edit.html.haml
+++ b/app/views/auth/passwords/edit.html.haml
@@ -1,18 +1,18 @@
 - content_for :page_title do
   = t('auth.set_new_password')
 
-  = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-    = render 'shared/error_messages', object: resource
+= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = render 'shared/error_messages', object: resource
 
-    - if use_pam? || current_user.encrypted_password.present?
-      = f.input :reset_password_token, as: :hidden
+  - if !use_pam? || current_user.encrypted_password.present?
+    = f.input :reset_password_token, as: :hidden
 
-      = f.input :password, autofocus: true, placeholder: t('simple_form.labels.defaults.new_password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.new_password'), :autocomplete => 'off' }
-      = f.input :password_confirmation, placeholder: t('simple_form.labels.defaults.confirm_new_password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_new_password'), :autocomplete => 'off' }
+    = f.input :password, autofocus: true, placeholder: t('simple_form.labels.defaults.new_password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.new_password'), :autocomplete => 'off' }
+    = f.input :password_confirmation, placeholder: t('simple_form.labels.defaults.confirm_new_password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_new_password'), :autocomplete => 'off' }
 
-      .actions
-        = f.button :button, t('auth.set_new_password'), type: :submit
-    - else
-      = t('simple_form.labels.defaults.pam_account')
+    .actions
+      = f.button :button, t('auth.set_new_password'), type: :submit
+  - else
+    = t('simple_form.labels.defaults.pam_account')
 
 .form-footer= render 'auth/shared/links'

--- a/app/views/auth/passwords/edit.html.haml
+++ b/app/views/auth/passwords/edit.html.haml
@@ -4,7 +4,7 @@
 = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
   = render 'shared/error_messages', object: resource
 
-  - if !use_pam? || current_user.encrypted_password.present?
+  - if !use_pam? || resource.encrypted_password.present?
     = f.input :reset_password_token, as: :hidden
 
     = f.input :password, autofocus: true, placeholder: t('simple_form.labels.defaults.new_password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.new_password'), :autocomplete => 'off' }

--- a/app/views/auth/registrations/edit.html.haml
+++ b/app/views/auth/registrations/edit.html.haml
@@ -4,7 +4,7 @@
 = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'auth_edit' }) do |f|
   = render 'shared/error_messages', object: resource
 
-  - if !use_pam? || current_user.encrypted_password.present?
+  - if !use_pam? || resource.encrypted_password.present?
     = f.input :email, placeholder: t('simple_form.labels.defaults.email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.email') }
     = f.input :password, placeholder: t('simple_form.labels.defaults.new_password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.new_password'), :autocomplete => 'off' }
     = f.input :password_confirmation, placeholder: t('simple_form.labels.defaults.confirm_new_password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_new_password'), :autocomplete => 'off' }


### PR DESCRIPTION
Password recovery has been broken since 04fef7b8886bb78f3473e143894a521ca578f1db.
There are three causes for that:
1. Incorrect indentation
2. `use_pam?` instead of `!use_pam?` (the logic in registrations/edit.html.haml confirms this)
3. `current_user` is null, at least in my case

I fixed the first two issues, but not the third. So password recovery might still fail if `use_pam?` returns true I guess.