### PR TITLE
Fix URLs incorrectly having trailing hyphen removed

### DIFF
--- a/config/initializers/twitter_regex.rb
+++ b/config/initializers/twitter_regex.rb
@@ -2,7 +2,7 @@ module Twitter
   class Regex
 
     REGEXEN[:valid_general_url_path_chars] = /[^\p{White_Space}\(\)\?]/iou
-    REGEXEN[:valid_url_path_ending_chars] = /[^\p{White_Space}\(\)\?!\*';:=\,\.\$%\[\]\p{Pd}~&\|@]|(?:#{REGEXEN[:valid_url_balanced_parens]})/iou
+    REGEXEN[:valid_url_path_ending_chars] = /[^\p{White_Space}\(\)\?!\*';:=\,\.\$%\[\]~&\|@]|(?:#{REGEXEN[:valid_url_balanced_parens]})/iou
     REGEXEN[:valid_url_balanced_parens] = /
       \(
         (?:

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe FetchLinkCardService do
     stub_request(:head, 'http://example.com/日本語').to_return(status: 200, headers: { 'Content-Type' => 'text/html' })
     stub_request(:get, 'http://example.com/日本語').to_return(request_fixture('sjis.txt'))
     stub_request(:head, 'https://github.com/qbi/WannaCry').to_return(status: 404)
+    stub_request(:head, 'http://example.com/test-').to_return(status: 200, headers: { 'Content-Type' => 'text/html' })
+    stub_request(:get, 'http://example.com/test-').to_return(request_fixture('idn.txt'))
 
     subject.call(status)
   end
@@ -61,6 +63,14 @@ RSpec.describe FetchLinkCardService do
       it 'works with Japanese path string' do
         expect(a_request(:get, 'http://example.com/日本語')).to have_been_made.at_least_once
         expect(status.preview_cards.first.title).to eq("SJISのページ")
+      end
+    end
+
+    context do
+      let(:status) { Fabricate(:status, text: 'test http://example.com/test-') }
+
+      it 'works with a URL ending with a hyphen' do
+        expect(a_request(:get, 'http://example.com/test-')).to have_been_made.at_least_once
       end
     end
   end


### PR DESCRIPTION
In cases where a URL has a trailing hyphen the FetchLinkCardService incorrectly removes the hyphen when it is parsed

The hyphen is not a reserved character in the URI spec https://tools.ietf.org/html/rfc3986#section-2.2

This fixes issue #6430