### PR TITLE
Do not hide NSFW media/CW'd text in OpenGraph tags

### DIFF
--- a/app/views/stream_entries/_og_description.html.haml
+++ b/app/views/stream_entries/_og_description.html.haml
@@ -1,4 +1,1 @@
-- if activity.is_a?(Status) && activity.spoiler_text?
-  = opengraph 'og:description', activity.spoiler_text
-- else
-  = opengraph 'og:description', activity.content
+= opengraph 'og:description', [activity.spoiler_text, activity.text].reject(&:blank?).join("\n\n")

--- a/app/views/stream_entries/_og_image.html.haml
+++ b/app/views/stream_entries/_og_image.html.haml
@@ -1,4 +1,4 @@
-- if activity.is_a?(Status) && activity.non_sensitive_with_media?
+- if activity.is_a?(Status) && activity.media_attachments.any?
   - activity.media_attachments.each do |media|
     - if media.image?
       = opengraph 'og:image', full_asset_url(media.file.url(:original))


### PR DESCRIPTION
Reasoning: HTML title tag affects everyone. But OpenGraph only affects
when somebody is deliberately sharing the content, usually in an
environment where such content is expected. Hiding the content in
OpenGraph tags results in deceitful previews which inhibit the
shareability of the post.

Example: Somebody writes a clever post about politics but kindly
puts a "uspol" content warning on it. Mastodon users are thankful,
but sharing this post on another platform results in non-Mastodon
users believing the entire contents of the post is "uspol" and not
clicking through/reading and re-sharing.