### PR TITLE
Push discovered status through streaming API within a time window

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -74,7 +74,7 @@ class ActivityPub::Activity
 
     # Only continue if the status is supposed to have
     # arrived in real-time
-    return unless @options[:override_timestamps]
+    return unless @options[:override_timestamps] || status.within_realtime_window?
 
     distribute_to_followers(status)
   end

--- a/app/lib/ostatus/activity/creation.rb
+++ b/app/lib/ostatus/activity/creation.rb
@@ -61,7 +61,7 @@ class OStatus::Activity::Creation < OStatus::Activity::Base
     Rails.logger.debug "Queuing remote status #{status.id} (#{id}) for distribution"
 
     LinkCrawlWorker.perform_async(status.id) unless status.spoiler_text?
-    DistributionWorker.perform_async(status.id) if @options[:override_timestamps]
+    DistributionWorker.perform_async(status.id) if @options[:override_timestamps] || status.within_realtime_window?
 
     status
   end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -80,6 +80,8 @@ class Status < ApplicationRecord
 
   delegate :domain, to: :account, prefix: true
 
+  REAL_TIME_WINDOW = 6.hours
+
   def searchable_by(preloaded = nil)
     ids = [account_id]
 
@@ -106,6 +108,10 @@ class Status < ApplicationRecord
 
   def reblog?
     !reblog_of_id.nil?
+  end
+
+  def within_realtime_window?
+    created_at >= REAL_TIME_WINDOW.ago
   end
 
   def verb


### PR DESCRIPTION
Time window of 6 hours.

Alice and Bob are on server Alpha. Bob doesn't have any followers but Alice. Alice has followers on server Charlie. Alice boosts Bob's status. Alice's followers will see Bob's status, but nobody else on server Charlie will see it, because it won't appear on the federated timeline. So Bob has less chances of getting followers from server Charlie.

This PR fixes this behaviour as long as Bob's post is not older than 6 hours.