### PR TITLE
Limit the languages used for notification mailer test

### DIFF
--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NotificationMailer, type: :mailer do
 
   shared_examples 'localized subject' do |*args, **kwrest|
     it 'renders subject localized for the locale of the receiver' do
-      locale = I18n.available_locales.sample
+      locale = %i(de en).sample
       receiver.update!(locale: locale)
       expect(mail.subject).to eq I18n.t(*args, kwrest.merge(locale: locale))
     end


### PR DESCRIPTION
Some available languages lack translations for notification mails. Now it tests for two languages which is certain to have required translations: German and English.

German is the language the current project owner, Eugen Rochko speaks, and providing English translations for new messages is de facto mandatory.