### PR TITLE
Implement text blocks

### DIFF
--- a/app/controllers/admin/text_blocks_controller.rb
+++ b/app/controllers/admin/text_blocks_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Admin
+  class TextBlocksController < BaseController
+    before_action :set_new_text_block, only: [:index, :create]
+    before_action :find_and_set_text_block, only: [:show, :update, :destroy]
+    before_action :authorize_text_block
+
+    def index
+      page = params[:page]
+      @text_block = TextBlock.new if page.nil?
+      @text_blocks = TextBlock.recent.page(page)
+    end
+
+    def show; end
+
+    def create
+      if @text_block.save
+        log_action :create, @text_block
+        redirect_to({ action: :index }, notice: I18n.t('admin.text_blocks.created'))
+      else
+        @text_blocks = TextBlock.page(0)
+        flash.now[:alert] = @text_block.errors.full_messages.first
+        render :index
+      end
+    end
+
+    def update
+      if @text_block.update text_block_params
+        log_action :update, @text_block
+        redirect_to({ action: :index }, notice: I18n.t('admin.text_blocks.updated'))
+      else
+        flash.now[:alert] = @text_block.errors.full_messages.first
+        render :show
+      end
+    end
+
+    def destroy
+      if @text_block.destroy
+        log_action :destroy, @text_block
+        flash[:notice] = I18n.t('admin.text_blocks.destroyed')
+      else
+        flash[:alert] = @text_block.errors.full_messages.first
+      end
+
+      redirect_to action: :index
+    end
+
+    private
+
+    def authorize_text_block
+      authorize @text_block
+    end
+
+    def set_new_text_block
+      @text_block = TextBlock.new(text_block_params)
+    end
+
+    def find_and_set_text_block
+      @text_block = TextBlock.find(params.require(:id))
+    end
+
+    def text_block_params
+      params[:text_block]&.permit(:text, :severity)
+    end
+  end
+end

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::Timelines::PublicController < Api::BaseController
   private
 
   def load_statuses
-    cached_public_statuses
+    cached_public_statuses.reject { |status| TextBlock.silence? status }
   end
 
   def cached_public_statuses

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::Timelines::TagController < Api::BaseController
   end
 
   def load_statuses
-    cached_tagged_statuses
+    cached_tagged_statuses.reject { |status| TextBlock.silence? status }
   end
 
   def cached_tagged_statuses

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -72,6 +72,9 @@ class Account < ApplicationRecord
   validates :display_name, length: { maximum: 30 }, if: -> { local? && will_save_change_to_display_name? }
   validates :note, length: { maximum: 160 }, if: -> { local? && will_save_change_to_note? }
 
+  validates :display_name, text_blocks: true
+  validates :note, text_blocks: true
+
   # Timelines
   has_many :stream_entries, inverse_of: :account, dependent: :destroy
   has_many :statuses, inverse_of: :account, dependent: :destroy

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -61,6 +61,8 @@ class MediaAttachment < ApplicationRecord
   validates :account, presence: true
   validates :description, length: { maximum: 420 }, if: :local?
 
+  validates :description, text_blocks: true
+
   scope :attached,   -> { where.not(status_id: nil) }
   scope :unattached, -> { where(status_id: nil) }
   scope :local,      -> { where(remote_url: '') }

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -61,6 +61,9 @@ class Status < ApplicationRecord
   validates_with StatusLengthValidator
   validates :reblog, uniqueness: { scope: :account }, if: :reblog?
 
+  validates :text, text_blocks: true
+  validates :spoiler_text, text_blocks: true
+
   default_scope { recent }
 
   scope :recent, -> { reorder(id: :desc) }

--- a/app/models/text_block.rb
+++ b/app/models/text_block.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: text_blocks
+#
+#  id         :integer          not null, primary key
+#  text       :string           not null
+#  severity   :integer          not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class TextBlock < ApplicationRecord
+  after_commit :uncache
+
+  enum severity: [:silence, :reject]
+
+  scope :recent, -> { reorder(id: :desc) }
+
+  def self.silence?(object)
+    (object.is_a?(Status) && (silence?(object.account) || object.media_attachments.any? { |attachment| silence? attachment })) ||
+      [:description, :display_name, :name, :note, :spoiler_text, :text].any? do |key|
+        object.respond_to?(key) && silenced_texts.any? do |text|
+          object.public_send(key)&.include? text
+        end
+      end
+  end
+
+  def self.rejected_texts
+    Rails.cache.fetch :rejected_texts do
+      where(severity: :reject).pluck(:text)
+    end
+  end
+
+  def self.silenced_texts
+    Rails.cache.fetch :silenced_texts do
+      where(severity: :silence).pluck(:text)
+    end
+  end
+
+  private
+
+  def uncache
+    Rails.cache.delete :rejected_texts
+    Rails.cache.delete :silenced_texts
+  end
+end

--- a/app/policies/text_block_policy.rb
+++ b/app/policies/text_block_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class TextBlockPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    admin?
+  end
+
+  def update?
+    admin?
+  end
+
+  def destroy?
+    admin?
+  end
+end

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -9,7 +9,7 @@ class AccountSearchService < BaseService
     @options = options
     @account = account
 
-    search_service_results
+    search_service_results.reject { |result| TextBlock.silence? result }
   end
 
   private

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -17,7 +17,7 @@ class FanOutOnWriteService < BaseService
       deliver_to_lists(status)
     end
 
-    return if status.account.silenced? || !status.public_visibility? || status.reblog?
+    return if status.account.silenced? || !status.public_visibility? || status.reblog? || TextBlock.silence?(status)
 
     render_anonymous_payload(status)
     deliver_to_hashtags(status)

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -31,11 +31,13 @@ class SearchService < BaseService
                             .query(multi_match: { type: 'most_fields', query: query, operator: 'and', fields: %w(text text.stemmed) })
                             .limit(limit).objects
 
-    statuses.reject { |status| StatusFilter.new(status, account).filtered? }
+    statuses.reject do |status|
+      StatusFilter.new(status, account).filtered? || TextBlock.silence?(tag)
+    end
   end
 
   def perform_hashtags_search!
-    Tag.search_for(query.gsub(/\A#/, ''), limit)
+    Tag.search_for(query.gsub(/\A#/, ''), limit).reject { |tag| TextBlock.silence? tag }
   end
 
   def default_results

--- a/app/validators/text_blocks_validator.rb
+++ b/app/validators/text_blocks_validator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class TextBlocksValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.nil?
+
+    rejected = TextBlock.rejected_texts.find { |text| value.include? text }
+    record.errors.add attribute, I18n.t('rejected_text', text: rejected) if rejected.present?
+  end
+end

--- a/app/views/admin/text_blocks/_text_block.html.haml
+++ b/app/views/admin/text_blocks/_text_block.html.haml
@@ -1,0 +1,11 @@
+= simple_form_for text_block, url: text_block.persisted? ? admin_text_block_path(text_block) : admin_text_blocks_path do |f|
+  = render 'shared/error_messages', object: text_block
+
+  = f.input :text, placeholder: t('admin.text_blocks.text'), disabled: text_block.persisted?, readonly: text_block.persisted?, required: true
+
+  = f.input :severity, collection: TextBlock.severities.keys, wrapper: :with_label, include_blank: false, label_method: ->(type) { t(".severities.#{type}") }
+
+  %p.hint= t('admin.text_blocks.severity.desc_html')
+
+  .actions
+    = f.button :button, text_block.persisted? ? t('admin.text_blocks.save') : t('admin.text_blocks.create')

--- a/app/views/admin/text_blocks/index.html.haml
+++ b/app/views/admin/text_blocks/index.html.haml
@@ -1,0 +1,27 @@
+- content_for :page_title do
+  = t('admin.text_blocks.title')
+
+.table-wrapper
+  %table.table
+    %thead
+      %tr
+        %th= t('admin.text_blocks.text')
+        %th= t('admin.text_blocks.severity.title')
+        %th
+        %th
+    %tbody
+      - @text_blocks.each do |text_block|
+        %tr
+          %td= link_to text_block.text, admin_text_block_path(text_block)
+          %td= t("admin.text_blocks.severities.#{text_block.severity}")
+          %td
+            = table_link_to 'trash', t('admin.text_blocks.destroy'), admin_text_block_path(text_block), method: :delete
+
+= paginate @text_blocks
+
+- if @text_block.present?
+  %hr
+
+  %h3= t('admin.text_blocks.new')
+
+  = render @text_block

--- a/app/views/admin/text_blocks/show.haml
+++ b/app/views/admin/text_blocks/show.haml
@@ -1,0 +1,11 @@
+- content_for :page_title do
+  = t('.title')
+
+= render @text_block
+
+%hr
+
+%h3= t('admin.text_blocks.deletion')
+
+.simple_form
+  = link_to t('admin.text_blocks.destroy'), admin_text_block_path(@text_block), class: 'block-button', method: :delete

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,6 +335,25 @@ en:
       last_delivery: Last delivery
       title: WebSub
       topic: Topic
+    text_blocks:
+      create: Block text
+      created: Text successfully blocked
+      deletion: Unblock text
+      destroy: Unblock
+      destroyed: Text successfully unblocked
+      new: New text block
+      save: Save
+      severities:
+        reject: Reject
+        silence: Silence
+      severity:
+        desc_html: "<strong>Silence</strong> will make the objects including the text invisible on public timeline and search window. <strong>Reject</strong> will reject all of the objects including the text."
+        title: Severity
+      show:
+        title: Text block details
+      text: Text
+      title: Text blocks
+      updated: Text block entry successfully updated
     title: Administration
   admin_mailer:
     new_report:
@@ -558,6 +577,7 @@ en:
       title: "%{name} mentioned you"
     reblog:
       title: "%{name} boosted your status"
+  rejected_text: 'Prohibited text: %{text}'
   remote_follow:
     acct: Enter your username@domain you want to follow from
     missing_resource: Could not find the required redirect URL for your account

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -332,6 +332,25 @@ ja:
       last_delivery: 最終配送
       title: WebSub
       topic: トピック
+    text_blocks:
+      create: 文字列をブロックする
+      created: 文字列のブロックに成功しました
+      deletion: 文字列ブロックの解除
+      destroy: ブロックを解除
+      destroyed: 文字列ブロックの解除に成功しました
+      new: 新しい文字列ブロック
+      save: 保存
+      severities:
+        reject: 拒否
+        silence: サイレンス
+      severity:
+        desc_html: "<strong>サイレンス</strong>は文字列を含むオブジェクトを公開タイムラインと検索画面で非表示にします。<strong>拒否</strong>は文字列を含む全てのオブジェクトを拒否します。"
+        title: 深刻度
+      show:
+        title: 文字列ブロックの詳細
+      text: 文字列
+      title: 文字列ブロック
+      updated: 文字列ブロックの更新に成功しました
     title: 管理
   admin_mailer:
     new_report:

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -30,6 +30,7 @@ SimpleNavigation::Configuration.run do |navigation|
       admin.item :instances, safe_join([fa_icon('cloud fw'), t('admin.instances.title')]), admin_instances_url, highlights_on: %r{/admin/instances}, if: -> { current_user.admin? }
       admin.item :domain_blocks, safe_join([fa_icon('lock fw'), t('admin.domain_blocks.title')]), admin_domain_blocks_url, highlights_on: %r{/admin/domain_blocks}, if: -> { current_user.admin? }
       admin.item :email_domain_blocks, safe_join([fa_icon('envelope fw'), t('admin.email_domain_blocks.title')]), admin_email_domain_blocks_url, highlights_on: %r{/admin/email_domain_blocks}, if: -> { current_user.admin? }
+      admin.item :text_blocks, safe_join([fa_icon('language fw'), t('admin.text_blocks.title')]), admin_text_blocks_url, highlights_on: %r{/admin/text_blocks}, if: -> { current_user.admin? }
     end
 
     primary.item :admin, safe_join([fa_icon('cogs fw'), t('admin.title')]), proc { current_user.admin? ? edit_admin_settings_url : admin_custom_emojis_url }, if: proc { current_user.staff? } do |admin|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,6 +121,7 @@ Rails.application.routes.draw do
     resources :subscriptions, only: [:index]
     resources :domain_blocks, only: [:index, :new, :create, :show, :destroy]
     resources :email_domain_blocks, only: [:index, :new, :create, :destroy]
+    resources :text_blocks, only: [:index, :show, :create, :update, :destroy]
     resources :action_logs, only: [:index]
     resource :settings, only: [:edit, :update]
     resources :invites, only: [:index, :create, :destroy]

--- a/db/migrate/20180210000000_create_text_blocks.rb
+++ b/db/migrate/20180210000000_create_text_blocks.rb
@@ -1,0 +1,9 @@
+class CreateTextBlocks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :text_blocks do |t|
+      t.string :text, index: { unique: true }, null: false
+      t.integer :severity, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180206000000) do
+ActiveRecord::Schema.define(version: 20180210000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -462,6 +462,14 @@ ActiveRecord::Schema.define(version: 20180206000000) do
     t.datetime "updated_at", null: false
     t.index "lower((name)::text) text_pattern_ops", name: "hashtag_search_index"
     t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
+  create_table "text_blocks", id: :serial, force: :cascade do |t|
+    t.string "text", null: false
+    t.integer "severity", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["text"], name: "index_text_blocks_on_text", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/controllers/admin/text_blocks_controller_spec.rb
+++ b/spec/controllers/admin/text_blocks_controller_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::TextBlocksController, type: :controller do
+  describe 'POST #create' do
+    subject { post :create, params: { text_block: { text: 'text', severity: 'silence' } } }
+
+    context 'when authorized' do
+      before { sign_in Fabricate(:user, admin: true) }
+
+      context 'when text block creation fails' do
+        before do
+          allow_any_instance_of(TextBlock).to receive(:save).and_return(false)
+        end
+
+        it { is_expected.to render_template :index }
+      end
+
+      it 'creates text block' do
+        subject
+
+        expect(Admin::ActionLog.where(
+          action: 'create',
+          target: TextBlock.find_by!(text: 'text', severity: 'silence')
+        )).to exist
+      end
+
+      it 'notes successful creation' do
+        subject
+        expect(flash[:notice]).to eq I18n.t('admin.text_blocks.created')
+      end
+
+      it { is_expected.to redirect_to action: :index }
+    end
+
+    context 'when unauthorized' do
+      before { sign_in Fabricate(:user, moderator: true) }
+      it { is_expected.to have_http_status :forbidden }
+    end
+  end
+
+  describe 'POST #update' do
+    let(:text_block) { Fabricate(:text_block) }
+    subject { patch :update, params: { id: text_block, text_block: { text: 'text', severity: 'silence' } } }
+
+    context 'when authorized' do
+      before { sign_in Fabricate(:user, admin: true) }
+
+      context 'when text block update fails' do
+        before do
+          allow_any_instance_of(TextBlock).to receive(:update).and_return(false)
+        end
+
+        it { is_expected.to render_template :show }
+      end
+
+      it 'updates text block' do
+        subject
+
+        text_block.reload
+        expect(text_block.text).to eq 'text'
+        expect(text_block.severity).to eq 'silence'
+        expect(Admin::ActionLog.where(action: 'update', target: text_block)).to exist
+      end
+
+      it 'notes successful creation' do
+        subject
+        expect(flash[:notice]).to eq I18n.t('admin.text_blocks.updated')
+      end
+
+      it { is_expected.to redirect_to action: :index }
+    end
+
+    context 'when unauthorized' do
+      before { sign_in Fabricate(:user, moderator: true) }
+      it { is_expected.to have_http_status :forbidden }
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let(:text_block) { Fabricate(:text_block) }
+    subject { delete :destroy, params: { id: text_block } }
+
+    context 'when authorized' do
+      before { sign_in Fabricate(:user, admin: true) }
+
+      context 'when text block deletion fails' do
+        before do
+          allow_any_instance_of(TextBlock).to receive(:destroy) do |text_block|
+            text_block.errors.add :base
+            false
+          end
+        end
+
+        it 'alerts deletion failure' do
+          subject
+          expect(flash[:alert]).to eq 'is invalid'
+        end
+      end
+
+      it 'destroys text block' do
+        subject
+        expect{ text_block.reload }.to raise_error ActiveRecord::RecordNotFound
+        expect(Admin::ActionLog.where(action: 'destroy', target: text_block)).to exist
+      end
+
+      it 'notes successful deletion' do
+        subject
+        expect(flash[:notice]).to eq I18n.t('admin.text_blocks.destroyed')
+      end
+
+      it { is_expected.to redirect_to action: :index }
+    end
+
+    context 'when unauthorized' do
+      before { sign_in Fabricate(:user, moderator: true) }
+      it { is_expected.to have_http_status :forbidden }
+    end
+  end
+end

--- a/spec/controllers/api/v1/timelines/public_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/public_controller_spec.rb
@@ -19,6 +19,12 @@ describe Api::V1::Timelines::PublicController do
         PostStatusService.new.call(user.account, 'New status from user for federated public timeline.')
       end
 
+      it 'does not show statuses with silenced texts' do
+        Fabricate(:text_block, text: 'line', severity: :silence)
+        get :show
+        expect(body_as_json).to be_empty
+      end
+
       it 'returns http success' do
         get :show
 

--- a/spec/controllers/api/v1/timelines/tag_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/tag_controller_spec.rb
@@ -19,6 +19,12 @@ describe Api::V1::Timelines::TagController do
         PostStatusService.new.call(user.account, 'It is a #test')
       end
 
+      it 'does not show statuses with silenced texts' do
+        Fabricate(:text_block, text: 'It', severity: :silence)
+        get :show, params: { id: 'test' }
+        expect(body_as_json).to be_empty
+      end
+
       it 'returns http success' do
         get :show, params: { id: 'test' }
         expect(response).to have_http_status(:success)

--- a/spec/fabricators/text_block_fabricator.rb
+++ b/spec/fabricators/text_block_fabricator.rb
@@ -1,0 +1,4 @@
+Fabricator(:text_block) do
+  text ''
+  severity TextBlock.severities.values.sample
+end

--- a/spec/models/text_block_spec.rb
+++ b/spec/models/text_block_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TextBlock, type: :model do
+  describe '.silence?' do
+    before { Fabricate(:text_block, text: 'silenced', severity: :silence) }
+
+    it 'returns false if the given object does not include silenced texts' do
+      attachment = Fabricate(:media_attachment, description: 'fine')
+      expect(TextBlock.silence?(attachment)).to eq false
+    end
+
+    it 'returns true if description includes silenced texts' do
+      attachment = Fabricate(:media_attachment, description: 'silenced')
+      expect(TextBlock.silence?(attachment)).to eq true
+    end
+
+    it 'returns true if display name includes silenced texts' do
+      account = Fabricate(:account, display_name: 'silenced')
+      expect(TextBlock.silence?(account)).to eq true
+    end
+
+    it 'returns true if name includes silenced texts' do
+      tag = Fabricate(:tag, name: 'silenced')
+      expect(TextBlock.silence?(tag)).to eq true
+    end
+
+    it 'returns true if note includes silenced texts' do
+      account = Fabricate(:account, note: 'silenced')
+      expect(TextBlock.silence?(account)).to eq true
+    end
+
+    it 'returns true if spoiler text includes silenced texts' do
+      status = Fabricate(:status, spoiler_text: 'silenced')
+      expect(TextBlock.silence?(status)).to eq true
+    end
+
+    it 'returns true if text includes silenced texts' do
+      status = Fabricate(:status, text: 'silenced')
+      expect(TextBlock.silence?(status)).to eq true
+    end
+  end
+
+  describe '.rejected_texts' do
+    it 'includes rejected texts' do
+      Fabricate(:text_block, text: 'rejected', severity: :reject)
+      expect(TextBlock.rejected_texts).to include 'rejected'
+    end
+
+    it 'does not include silenced texts' do
+      Fabricate(:text_block, text: 'silenced', severity: :silence)
+      expect(TextBlock.rejected_texts).not_to include 'silenced'
+    end
+
+    it 'caches' do
+      TextBlock.rejected_texts
+
+      expect do |callback|
+        ActiveSupport::Notifications.subscribed callback, 'sql.active_record' do
+          TextBlock.rejected_texts
+        end
+      end.not_to yield_control
+    end
+  end
+
+  describe '.silenced_texts' do
+    it 'does not include rejected texts' do
+      Fabricate(:text_block, text: 'rejected', severity: :reject)
+      expect(TextBlock.silenced_texts).not_to include 'rejected'
+    end
+
+    it 'includes silenced texts' do
+      Fabricate(:text_block, text: 'silenced', severity: :silence)
+      expect(TextBlock.silenced_texts).to include 'silenced'
+    end
+
+    it 'caches' do
+      TextBlock.silenced_texts
+
+      expect do |callback|
+        ActiveSupport::Notifications.subscribed callback, 'sql.active_record' do
+          TextBlock.silenced_texts
+        end
+      end.not_to yield_control
+    end
+  end
+
+  it 'uncaches rejected texts after commit' do
+    TextBlock.rejected_texts
+
+    Fabricate(:text_block)
+
+    expect do |callback|
+      ActiveSupport::Notifications.subscribed callback, 'sql.active_record' do
+        TextBlock.rejected_texts
+      end
+    end.to yield_control
+  end
+
+  it 'uncaches silenced texts after commit' do
+    TextBlock.silenced_texts
+
+    Fabricate(:text_block)
+
+    expect do |callback|
+      ActiveSupport::Notifications.subscribed callback, 'sql.active_record' do
+        TextBlock.silenced_texts
+      end
+    end.to yield_control
+  end
+end

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -137,5 +137,13 @@ describe AccountSearchService do
         expect(service).not_to have_received(:call)
       end
     end
+
+    it 'does not return account with silenced texts' do
+      Fabricate(:text_block, text: 'silenced', severity: :silence)
+      match = Fabricate(:account, username: 'matchingusername', display_name: 'silenced')
+
+      results = subject.call('match', 5)
+      expect(results).not_to eq [match]
+    end
   end
 end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -91,6 +91,16 @@ describe SearchService do
           expect(Tag).not_to have_received(:search_for)
           expect(results).to eq empty_results
         end
+
+        it 'does not include tag if its name is silenced' do
+          Fabricate(:text_block, text: 'silenced', severity: :silence)
+          query = '#tag'
+          tag = Tag.new(name: 'tagsilenced')
+          allow(Tag).to receive(:search_for).with('tag', 10).and_return([tag])
+
+          results = subject.call(query, 10)
+          expect(results).not_to eq empty_results.merge(hashtags: [tag])
+        end
       end
     end
   end

--- a/spec/validators/text_blocks_validator_spec.rb
+++ b/spec/validators/text_blocks_validator_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe TextBlocksValidator do
+  class Model
+    include ActiveModel::Validations
+    validates :text, text_blocks: true
+  end
+
+  it 'says valid if given value is nil' do
+    class Model
+      def text
+        nil
+      end
+    end
+
+    expect(Model.new).to be_valid
+  end
+
+  it 'says valid if given value does not have rejected texts' do
+    class Model
+      def text
+        'valid'
+      end
+    end
+
+    Fabricate(:text_block, text: 'rejected', severity: :reject)
+
+    expect(Model.new).to be_valid
+  end
+
+  it 'says invalid if given value has rejected texts' do
+    class Model
+      def text
+        'rejected'
+      end
+    end
+
+    Fabricate(:text_block, text: 'rejected', severity: :reject)
+
+    model = Model.new
+    expect(model).to be_invalid
+    expect(model.errors[:text]).to eq [I18n.t('rejected_text', text: 'rejected')]
+  end
+end


### PR DESCRIPTION
This is a response to:
Un carattere indiano fa crashare iPhone, Mac e iPad | MobileWorld
http://www.mobileworld.it/2018/02/14/carattere-indiano-crash-iphone-mac-ipad-144881/

Because such a problem is expected to occur also in the future, this kind of feature would be necessary.

~~This implementation is primitive and has rooms of improvements, but works.~~

UPDATE:

* Implemented various improvements. Now it supports logging and severity "silence", and is usable not only for security purpose, but also for moderation purpose. The silence feature is expected to be used to exclude aggressive words from the public timeline without interfering users' activity.

* The "reject" severity reports what word is prohibited in its error message. It is like HTTP 451 and to prevent arbitrary censorship on the fediverse.

* ~~Spec and edit feature is pending.~~

UPDATE:

* All features has been implemented.