### PR TITLE
Fix prev/next links on public profile page

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -18,7 +18,8 @@ class AccountsController < ApplicationController
         @pinned_statuses = cache_collection(@account.pinned_statuses, Status) if show_pinned_statuses?
         @statuses        = filtered_statuses.paginate_by_max_id(20, params[:max_id], params[:since_id])
         @statuses        = cache_collection(@statuses, Status)
-        @next_url        = next_url unless @statuses.empty?
+        @next_url        = next_url if @statuses.last.id > filtered_statuses.last.id
+        @prev_url        = prev_url if @statuses.first.id < filtered_statuses.first.id
       end
 
       format.atom do
@@ -70,12 +71,20 @@ class AccountsController < ApplicationController
   end
 
   def next_url
+    pagination_url(max_id: @statuses.last.id)
+  end
+
+  def prev_url
+    pagination_url(since_id: @statuses.first.id)
+  end
+
+  def pagination_url(max_id: nil, since_id: nil)
     if media_requested?
-      short_account_media_url(@account, max_id: @statuses.last.id)
+      short_account_media_url(@account, max_id: max_id, since_id: since_id)
     elsif replies_requested?
-      short_account_with_replies_url(@account, max_id: @statuses.last.id)
+      short_account_with_replies_url(@account, max_id: max_id, since_id: since_id)
     else
-      short_account_url(@account, max_id: @statuses.last.id)
+      short_account_url(@account, max_id: max_id, since_id: since_id)
     end
   end
 

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AccountsController < ApplicationController
+  PAGE_SIZE = 20
+
   include AccountControllerConcern
 
   before_action :set_cache_headers
@@ -16,16 +18,16 @@ class AccountsController < ApplicationController
         end
 
         @pinned_statuses = cache_collection(@account.pinned_statuses, Status) if show_pinned_statuses?
-        @statuses        = filtered_statuses.paginate_by_max_id(20, params[:max_id], params[:since_id])
+        @statuses        = filtered_status_page(params)
         @statuses        = cache_collection(@statuses, Status)
         unless @statuses.empty?
-          @next_url        = next_url if @statuses.last.id > filtered_statuses.last.id
-          @prev_url        = prev_url if @statuses.first.id < filtered_statuses.first.id
+          @older_url        = older_url if @statuses.last.id > filtered_statuses.last.id
+          @newer_url        = newer_url if @statuses.first.id < filtered_statuses.first.id
         end
       end
 
       format.atom do
-        @entries = @account.stream_entries.where(hidden: false).with_includes.paginate_by_max_id(20, params[:max_id], params[:since_id])
+        @entries = @account.stream_entries.where(hidden: false).with_includes.paginate_by_max_id(PAGE_SIZE, params[:since_id])
         render xml: OStatus::AtomSerializer.render(OStatus::AtomSerializer.new.feed(@account, @entries.reject { |entry| entry.status.nil? }))
       end
 
@@ -72,21 +74,22 @@ class AccountsController < ApplicationController
     @account = Account.find_local!(params[:username])
   end
 
-  def next_url
+  def older_url
+    ::Rails.logger.info("older: max_id #{@statuses.last.id}, url #{pagination_url(max_id: @statuses.last.id)}")
     pagination_url(max_id: @statuses.last.id)
   end
 
-  def prev_url
-    pagination_url(since_id: @statuses.first.id)
+  def newer_url
+    pagination_url(min_id: @statuses.first.id)
   end
 
-  def pagination_url(max_id: nil, since_id: nil)
+  def pagination_url(max_id: nil, min_id: nil)
     if media_requested?
-      short_account_media_url(@account, max_id: max_id, since_id: since_id)
+      short_account_media_url(@account, max_id: max_id, min_id: min_id)
     elsif replies_requested?
-      short_account_with_replies_url(@account, max_id: max_id, since_id: since_id)
+      short_account_with_replies_url(@account, max_id: max_id, min_id: min_id)
     else
-      short_account_url(@account, max_id: max_id, since_id: since_id)
+      short_account_url(@account, max_id: max_id, min_id: min_id)
     end
   end
 
@@ -96,5 +99,13 @@ class AccountsController < ApplicationController
 
   def replies_requested?
     request.path.ends_with?('/with_replies')
+  end
+
+  def filtered_status_page(params)
+    if params[:min_id].present?
+      filtered_statuses.paginate_by_min_id(PAGE_SIZE, params[:min_id]).reverse
+    else
+      filtered_statuses.paginate_by_max_id(PAGE_SIZE, params[:max_id], params[:since_id]).to_a
+    end
   end
 end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -18,8 +18,10 @@ class AccountsController < ApplicationController
         @pinned_statuses = cache_collection(@account.pinned_statuses, Status) if show_pinned_statuses?
         @statuses        = filtered_statuses.paginate_by_max_id(20, params[:max_id], params[:since_id])
         @statuses        = cache_collection(@statuses, Status)
-        @next_url        = next_url if @statuses.last.id > filtered_statuses.last.id
-        @prev_url        = prev_url if @statuses.first.id < filtered_statuses.first.id
+        unless @statuses.empty
+          @next_url        = next_url if @statuses.last.id > filtered_statuses.last.id
+          @prev_url        = prev_url if @statuses.first.id < filtered_statuses.first.id
+        end
       end
 
       format.atom do

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -27,7 +27,7 @@ class AccountsController < ApplicationController
       end
 
       format.atom do
-        @entries = @account.stream_entries.where(hidden: false).with_includes.paginate_by_max_id(PAGE_SIZE, params[:since_id])
+        @entries = @account.stream_entries.where(hidden: false).with_includes.paginate_by_max_id(PAGE_SIZE, params[:max_id], params[:since_id])
         render xml: OStatus::AtomSerializer.render(OStatus::AtomSerializer.new.feed(@account, @entries.reject { |entry| entry.status.nil? }))
       end
 

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -18,7 +18,7 @@ class AccountsController < ApplicationController
         @pinned_statuses = cache_collection(@account.pinned_statuses, Status) if show_pinned_statuses?
         @statuses        = filtered_statuses.paginate_by_max_id(20, params[:max_id], params[:since_id])
         @statuses        = cache_collection(@statuses, Status)
-        unless @statuses.empty
+        unless @statuses.empty?
           @next_url        = next_url if @statuses.last.id > filtered_statuses.last.id
           @prev_url        = prev_url if @statuses.first.id < filtered_statuses.first.id
         end

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -233,8 +233,8 @@
 
   a,
   .current,
-  .next,
-  .prev,
+  .newer,
+  .older,
   .page,
   .gap {
     font-size: 14px;
@@ -257,13 +257,13 @@
     cursor: default;
   }
 
-  .prev,
-  .next {
+  .older,
+  .newer {
     text-transform: uppercase;
     color: $ui-secondary-color;
   }
 
-  .prev {
+  .older {
     float: left;
     padding-left: 0;
 
@@ -273,7 +273,7 @@
     }
   }
 
-  .next {
+  .newer {
     float: right;
     padding-right: 0;
 
@@ -295,8 +295,8 @@
       display: none;
     }
 
-    .next,
-    .prev {
+    .newer,
+    .older {
       display: inline-block;
     }
   }

--- a/app/models/concerns/paginable.rb
+++ b/app/models/concerns/paginable.rb
@@ -10,5 +10,14 @@ module Paginable
       query = query.where(arel_table[:id].gt(since_id)) if since_id.present?
       query
     }
+
+    # Differs from :paginate_by_max_id in that it gives the results immediately following min_id,
+    # whereas since_id gives the items with largest id, but with since_id as a cutoff.
+    # Results will be in ascending order by id.
+    scope :paginate_by_min_id, ->(limit, min_id = nil) {
+      query = reorder(arel_table[:id]).limit(limit)
+      query = query.where(arel_table[:id].gt(min_id)) if min_id.present?
+      query
+    }
   end
 end

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -39,6 +39,9 @@
 
       = render partial: 'stream_entries/status', collection: @statuses, as: :status
 
-  - if @statuses.size == 20
+  - if @next_url || @prev_url
     .pagination
-      = link_to safe_join([t('pagination.next'), fa_icon('chevron-right')], ' '), @next_url, class: 'next', rel: 'next'
+      - if @prev_url
+        = link_to safe_join([t('pagination.prev'), fa_icon('chevron-left')], ' '), @prev_url, class: 'prev', rel: 'previous'
+      - if @next_url
+        = link_to safe_join([t('pagination.next'), fa_icon('chevron-right')], ' '), @next_url, class: 'next', rel: 'next'

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -42,6 +42,6 @@
   - if @next_url || @prev_url
     .pagination
       - if @prev_url
-        = link_to safe_join([t('pagination.prev'), fa_icon('chevron-left')], ' '), @prev_url, class: 'prev', rel: 'previous'
+        = link_to safe_join([fa_icon('chevron-left'), t('pagination.prev')], ' '), @prev_url, class: 'prev', rel: 'previous'
       - if @next_url
         = link_to safe_join([t('pagination.next'), fa_icon('chevron-right')], ' '), @next_url, class: 'next', rel: 'next'

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -39,9 +39,9 @@
 
       = render partial: 'stream_entries/status', collection: @statuses, as: :status
 
-  - if @next_url || @prev_url
+  - if @newer_url || @older_url
     .pagination
-      - if @prev_url
-        = link_to safe_join([fa_icon('chevron-left'), t('pagination.prev')], ' '), @prev_url, class: 'prev', rel: 'previous'
-      - if @next_url
-        = link_to safe_join([t('pagination.next'), fa_icon('chevron-right')], ' '), @next_url, class: 'next', rel: 'next'
+      - if @older_url
+        = link_to safe_join([fa_icon('chevron-left'), t('pagination.older')], ' '), @older_url, class: 'older', rel: 'older'
+      - if @newer_url
+        = link_to safe_join([t('pagination.newer'), fa_icon('chevron-right')], ' '), @newer_url, class: 'newer', rel: 'newer'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -536,10 +536,10 @@ en:
           trillion: T
           unit: ''
   pagination:
-    next: Next
-    prev: Prev
-    older: Older
     newer: Newer
+    next: Next
+    older: Older
+    prev: Prev
     truncate: "&hellip;"
   preferences:
     languages: Languages

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -538,6 +538,8 @@ en:
   pagination:
     next: Next
     prev: Prev
+    older: Older
+    newer: Newer
     truncate: "&hellip;"
   preferences:
     languages: Languages


### PR DESCRIPTION
This fixes #4950 by adding a "prev" link on the public profile page after the "next" link is clicked.

I changed the logic a bit as well. Previously the "next" link would show up whenever there were any statuses on the current page, leading to a "There's nothing here" page if there were no further-back statuses to retrieve. Now it doesn't show up once you've hit the end. Both new behaviors are demonstrated in this screenshot:
![pagination_fix](https://user-images.githubusercontent.com/343665/36348974-d96b281e-1430-11e8-817e-b0c0078fe9a5.jpg)

This is my first PR! 🎉  I'm happy to scale back my fix if the changes beyond what was strictly necessary to fix #4950 are deemed inappropriate here, and please let me know if this is a case that would benefit from a test! I like writing tests when possible but in my experience they're not usually that helpful for UI stuff like this.