### PR TITLE
Don't resize avatars/headers if their dimensions are already right

### DIFF
--- a/app/models/concerns/account_avatar.rb
+++ b/app/models/concerns/account_avatar.rb
@@ -7,9 +7,15 @@ module AccountAvatar
 
   class_methods do
     def avatar_styles(file)
-      styles = { original: '120x120#' }
-      styles[:static] = { format: 'png', convert_options: '-coalesce' } if file.content_type == 'image/gif'
+      styles   = {}
+      geometry = Paperclip::Geometry.from_file(file)
+
+      styles[:original] = '120x120#' if geometry.width != geometry.height || geometry.width > 120 || geometry.height > 120
+      styles[:static]   = { format: 'png', convert_options: '-coalesce' } if file.content_type == 'image/gif'
+
       styles
+    rescue Paperclip::Errors::NotIdentifiedByImageMagickError
+      {}
     end
 
     private :avatar_styles
@@ -17,7 +23,7 @@ module AccountAvatar
 
   included do
     # Avatar upload
-    has_attached_file :avatar, styles: ->(f) { avatar_styles(f) }, convert_options: { all: '-quality 80 -strip' }
+    has_attached_file :avatar, styles: ->(f) { avatar_styles(f) }, convert_options: { all: '-strip' }
     validates_attachment_content_type :avatar, content_type: IMAGE_MIME_TYPES
     validates_attachment_size :avatar, less_than: 2.megabytes
   end

--- a/app/models/concerns/account_header.rb
+++ b/app/models/concerns/account_header.rb
@@ -7,9 +7,15 @@ module AccountHeader
 
   class_methods do
     def header_styles(file)
-      styles = { original: '700x335#' }
-      styles[:static] = { format: 'png', convert_options: '-coalesce' } if file.content_type == 'image/gif'
+      styles   = {}
+      geometry = Paperclip::Geometry.from_file(file)
+
+      styles[:original] = '700x335#' unless geometry.width == 700 && geometry.height == 335
+      styles[:static]   = { format: 'png', convert_options: '-coalesce' } if file.content_type == 'image/gif'
+
       styles
+    rescue Paperclip::Errors::NotIdentifiedByImageMagickError
+      {}
     end
 
     private :header_styles
@@ -17,7 +23,7 @@ module AccountHeader
 
   included do
     # Header upload
-    has_attached_file :header, styles: ->(f) { header_styles(f) }, convert_options: { all: '-quality 80 -strip' }
+    has_attached_file :header, styles: ->(f) { header_styles(f) }, convert_options: { all: '-strip' }
     validates_attachment_content_type :header, content_type: IMAGE_MIME_TYPES
     validates_attachment_size :header, less_than: 2.megabytes
   end


### PR DESCRIPTION
Avoids corruption of GIF avatars as long as they are already the right size, which is usually the case with Mastodon, and saves some CPU cycles.

Also don't apply "-quality 80" option which is probably the reason for slight color differences between original and remote image (because it would apply it twice, once on original instance, and again on the receiving instance)