### PR TITLE
Improve performance of feed_manager_spec

### DIFF
--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -1,7 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe FeedManager do
-  it 'tracks at least as many statuses as reblogs' do
+  before do |example|
+    unless example.metadata[:skip_stub]
+      stub_const 'FeedManager::MAX_ITEMS', 10
+      stub_const 'FeedManager::REBLOG_FALLOFF', 4
+    end
+  end
+
+  it 'tracks at least as many statuses as reblogs', skip_stub: true do
     expect(FeedManager::REBLOG_FALLOFF).to be <= FeedManager::MAX_ITEMS
   end
 


### PR DESCRIPTION
In order to avoid creating many records, I changed the value of the constant to stub in the test.

before:
```
bundle exec rspec spec/lib/feed_manager_spec.rb

Randomized with seed 22807
 32/32 |============================================================== 100 ==============================================================>| Time: 00:00:46

Finished in 46.71 seconds (files took 4.32 seconds to load)
32 examples, 0 failures
```

after:
```
bundle exec rspec spec/lib/feed_manager_spec.rb

Randomized with seed 27571
 32/32 |============================================================== 100 ==============================================================>| Time: 00:00:08

Finished in 8.3 seconds (files took 4.31 seconds to load)
32 examples, 0 failures
```


