### PR TITLE
Update pam documentation

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -146,7 +146,6 @@ STREAMING_CLUSTER_NUM=1
 # The pam environment variable "email" is provided by:
 # https://github.com/devkral/pam_email_extractor
 # PAM_ENABLED=true
-#
 # Fallback Suffix for email address generation (nil by default)
 # PAM_DEFAULT_SUFFIX=pam
 # Name of the pam service (pam "auth" section is evaluated)

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -141,8 +141,13 @@ STREAMING_CLUSTER_NUM=1
 # GID=1000
 
 # PAM authentication (optional)
+# PAM authentication uses for the email generation the "email" pam variable
+# and optional as fallback PAM_DEFAULT_SUFFIX
+# The pam environment variable "email" is provided by:
+# https://github.com/devkral/pam_email_extractor
 # PAM_ENABLED=true
-# Suffix for email address generation (nil by default)
+#
+# Fallback Suffix for email address generation (nil by default)
 # PAM_DEFAULT_SUFFIX=pam
 # Name of the pam service (pam "auth" section is evaluated)
 # PAM_DEFAULT_SERVICE=rpam


### PR DESCRIPTION
Document the usage of the pam environment variable "email" by the pam integration.

Link to the now finished pam_email_extractor.
 
 pam_email_extractor  extracts the email address of a user from various sources and provides it as "email" pam environment