### PR TITLE
mastodon:maintenance:purge_removed_accounts task should suspend account before delete it

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -752,6 +752,7 @@ namespace :mastodon do
 
         if [404, 410].include?(res.code)
           if options[:force]
+            SuspendAccountService.new.call(account)
             account.destroy
           else
             progress_bar.pause
@@ -764,6 +765,7 @@ namespace :mastodon do
             if confirm.casecmp('n').zero?
               next
             else
+              SuspendAccountService.new.call(account)
               account.destroy
             end
           end


### PR DESCRIPTION
Now, it seem deleting account in single transaction.
Deleting account in single transaction is too long.

I had executed this, some user couldn't post new statuses in that time.
After I aborted the task, they could post new statuses.
I guessed that it caused by getting statuses_count column lock.

The task should suspend account by SuspendAccountService and BatchedRemoveStatusService before deleteing it.