### PR TITLE
Show target status on audit log page

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -419,6 +419,10 @@
     font-size: 12px;
     word-wrap: break-word;
     min-height: 20px;
+
+    .activity-stream {
+      margin-bottom: 10px;
+    }
   }
 
   &__icon {

--- a/app/models/admin/action_log.rb
+++ b/app/models/admin/action_log.rb
@@ -25,6 +25,13 @@ class Admin::ActionLog < ApplicationRecord
     super.to_sym
   end
 
+  def recorded_target
+    case target_type
+    when 'Status'
+      Status.new(recorded_changes)
+    end
+  end
+
   before_validation :set_changes
 
   private

--- a/app/views/admin/action_logs/_action_log.html.haml
+++ b/app/views/admin/action_logs/_action_log.html.haml
@@ -12,4 +12,8 @@
       = fa_icon icon_for_log(action_log)
       .log-entry__icon__overlay{ class: class_for_log_icon(action_log) }
   .log-entry__extras
+    - target = action_log.target || action_log.recorded_target
+    - if target.is_a? Status
+      .activity-stream.activity-stream-headless
+        .entry= render 'stream_entries/simple_status', status: target
     = log_extra_attributes relevant_log_changes(action_log)


### PR DESCRIPTION
Changed to show the target status on the audit log page.

![image](https://user-images.githubusercontent.com/4199439/36477705-7f750dd0-1745-11e8-823c-59ccb7418ca2.png)
