### PR TITLE
New variable OAUTH_REDIRECT_AT_SIGN_IN + Ref #6538

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -149,6 +149,10 @@ STREAMING_CLUSTER_NUM=1
 # Name of the pam service used for checking if an user can register (pam "account" section is evaluated)
 # PAM_CONTROLLED_SERVICE=rpam
 
+# Global OAuth settings (optional) :
+# If you have only one strategy, you may want to enable this
+# OAUTH_REDIRECT_AT_SIGN_IN=true
+
 # Optional CAS authentication (cf. omniauth-cas) :
 # CAS_ENABLED=true
 # CAS_URL=https://sso.myserver.com/

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -10,6 +10,15 @@ class Auth::SessionsController < Devise::SessionsController
   prepend_before_action :authenticate_with_two_factor, if: :two_factor_enabled?, only: [:create]
   before_action :set_instance_presenter, only: [:new]
 
+  def new
+    Devise.omniauth_configs.each do |provider, config|
+      if config.strategy.redirect_at_sign_in
+        return redirect_to(omniauth_authorize_path(resource_name, provider))
+      end
+    end
+    super
+  end
+
   def create
     super do |resource|
       remember_me(resource)

--- a/app/models/concerns/omniauthable.rb
+++ b/app/models/concerns/omniauthable.rb
@@ -53,8 +53,11 @@ module Omniauthable
     private
 
     def user_params_from_auth(auth)
-      email_is_verified = auth.info.email && (auth.info.verified || auth.info.verified_email)
-      email             = auth.info.email if email_is_verified && !User.exists?(email: auth.info.email)
+      strategy          = Devise.omniauth_configs[auth.provider.to_sym].strategy
+      assume_verified   = strategy.try(:security).try(:assume_email_is_verified)
+      email_is_verified = auth.info.verified || auth.info.verified_email || assume_verified
+      email             = auth.info.verified_email || auth.info.email
+      email             = email_is_verified && !User.exists?(email: auth.info.email) && email
 
       {
         email: email ? email : "#{TEMP_EMAIL_PREFIX}-#{auth.uid}-#{auth.provider}.com",

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,10 +4,12 @@ end
 
 Devise.setup do |config|
   # Devise omniauth strategies
+  options = {}
+  options[:redirect_at_sign_in] = ENV['OAUTH_REDIRECT_AT_SIGN_IN'] == 'true'
 
   # CAS strategy
   if ENV['CAS_ENABLED'] == 'true'
-    cas_options = {}
+    cas_options = options
     cas_options[:url] = ENV['CAS_URL'] if ENV['CAS_URL']
     cas_options[:host] = ENV['CAS_HOST'] if ENV['CAS_HOST']
     cas_options[:port] = ENV['CAS_PORT'] if ENV['CAS_PORT']
@@ -18,7 +20,7 @@ Devise.setup do |config|
     cas_options[:login_url] = ENV['CAS_LOGIN_URL'] if ENV['CAS_LOGIN_URL']
     cas_options[:uid_field] = ENV['CAS_UID_FIELD'] || 'user' if ENV['CAS_UID_FIELD']
     cas_options[:ca_path] = ENV['CAS_CA_PATH'] if ENV['CAS_CA_PATH']
-    cas_options[:disable_ssl_verification] = ENV['CAS_DISABLE_SSL_VERIFICATION'] == 'true' if ENV['CAS_DISABLE_SSL_VERIFICATION']
+    cas_options[:disable_ssl_verification] = ENV['CAS_DISABLE_SSL_VERIFICATION'] == 'true'
     cas_options[:uid_key] = ENV['CAS_UID_KEY'] || 'user'
     cas_options[:name_key] = ENV['CAS_NAME_KEY'] || 'name'
     cas_options[:email_key] = ENV['CAS_EMAIL_KEY'] || 'email'
@@ -33,7 +35,7 @@ Devise.setup do |config|
 
   # SAML strategy
   if ENV['SAML_ENABLED'] == 'true'
-    saml_options = {}
+    saml_options = options
     saml_options[:assertion_consumer_service_url] = ENV['SAML_ACS_URL'] if ENV['SAML_ACS_URL']
     saml_options[:issuer] = ENV['SAML_ISSUER'] if ENV['SAML_ISSUER']
     saml_options[:idp_sso_target_url] = ENV['SAML_IDP_SSO_TARGET_URL']  if ENV['SAML_IDP_SSO_TARGET_URL']


### PR DESCRIPTION
I think that 99% of SSO users would rather be redirected to their IDP at login than having to click on an ugly button "SAML" or "CAS".

(+ fixed previous PR #6538 with more generic approach )