### PR TITLE
Specify AGPLv3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mastodon",
-  "license": "AGPL-3.0",
+  "license": "AGPL-3.0+",
   "engines": {
     "node": ">=6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mastodon",
-  "license": "AGPL-3.0+",
+  "license": "AGPL-3.0-or-later",
   "engines": {
     "node": ">=6"
   },


### PR DESCRIPTION
Since the documentation doesn't specify you can use Mastodon as AGPLv3 or any later version.

> If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.