### PR TITLE
Visually distinguish threads in conversation

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -19,6 +19,12 @@ class StatusesController < ApplicationController
         @ancestors   = @status.reply? ? cache_collection(@status.ancestors(current_account), Status) : []
         @descendants = cache_collection(@status.descendants(current_account), Status)
 
+        @map = UndergroundMap.new
+        @ancestors.each { |s| @map.add_stop(s.id, s.in_reply_to_id) }
+        @map.add_stop(@status.id, @status.in_reply_to_id)
+        @descendants.each { |s| @map.add_stop(s.id, s.in_reply_to_id) }
+        @map.calculate_lines!
+
         render 'stream_entries/show'
       end
 

--- a/app/javascript/styles/mastodon/stream_entries.scss
+++ b/app/javascript/styles/mastodon/stream_entries.scss
@@ -345,3 +345,35 @@
     }
   }
 }
+
+.entry {
+  position: relative;
+
+  .status,
+  .detailed-status {
+    position: relative;
+    z-index: 2;
+  }
+}
+
+.line {
+  position: absolute;
+  width: 0;
+  border-left: 4px solid red;
+  z-index: 0;
+
+  &--arriving {
+    top: 0;
+    height: 15px;
+  }
+
+  &--bypassing {
+    height: 100%;
+    top: 0;
+  }
+
+  &--departing {
+    bottom: 0;
+    height: calc(100% - 63px);
+  }
+}

--- a/app/lib/underground_map.rb
+++ b/app/lib/underground_map.rb
@@ -1,0 +1,97 @@
+class UndergroundMap
+  attr_reader :stops, :total_num_lines
+
+  PALETTE = %w(
+    64AC7A
+    A9CE69
+    CFD788
+    B95B38
+  ).freeze
+
+  class Stop
+    attr_reader :id
+
+    attr_accessor :num_departures, :arriving_line,
+                  :bypassing_lines, :departing_lines,
+                  :max_num_of_lines
+
+    def initialize(id, has_arrival = false)
+      @id               = id
+      @has_arrival      = has_arrival
+      @num_departures   = 0
+      @arriving_line    = nil
+      @bypassing_lines  = []
+      @departing_lines  = []
+      @max_num_of_lines = 0
+    end
+
+    def arrival?
+      @has_arrival
+    end
+
+    def outgoing_lines?
+      !(@bypassing_lines.empty? && @departing_lines.empty?)
+    end
+  end
+
+  def initialize
+    @stops           = []
+    @index_map       = {}
+    @total_num_lines = 0
+  end
+
+  def add_stop(id, previous_stop = nil)
+    @index_map[id] = @stops.size
+
+    if previous_stop
+      @stops << Stop.new(id, true)
+      @stops[@index_map[previous_stop]].num_departures += 1
+    else
+      @stops << Stop.new(id)
+    end
+  end
+
+  def find_stop(id)
+    @stops[@index_map[id]]
+  end
+
+  def color(line)
+    PALETTE[line % PALETTE.size]
+  end
+
+  def calculate_lines!
+    lines = []
+    next_line = 0
+
+    @stops.each do |stop|
+      if stop.arrival?
+        arrival = lines.pop
+
+        stop.arriving_line   = arrival
+        stop.bypassing_lines = lines.dup
+
+        unless stop.num_departures.zero?
+          new_next_line = next_line + stop.num_departures - 1
+          stop.departing_lines = (next_line...new_next_line).to_a.reverse
+          stop.departing_lines << arrival
+          next_line = new_next_line
+        end
+      else
+        stop.arriving_line   = nil
+        stop.bypassing_lines = lines.dup
+
+        new_next_line = next_line + stop.num_departures
+        stop.departing_lines = (next_line...new_next_line).to_a.reverse
+        next_line = new_next_line
+      end
+
+      lines.concat(stop.departing_lines)
+    end
+
+    @total_num_lines = next_line
+
+    @stops.each do |stop|
+      stop.max_num_of_lines = @total_num_lines
+    end
+  end
+end

--- a/app/views/stream_entries/_status.html.haml
+++ b/app/views/stream_entries/_status.html.haml
@@ -12,11 +12,19 @@
   style_classes = style_classes(status, is_predecessor, is_successor, include_threads)
   mf_classes    = microformats_classes(status, is_direct_parent, is_direct_child)
   entry_classes = h_class + ' ' + mf_classes + ' ' + style_classes
+  stop = defined?(@map) ? @map.find_stop(status.id) : nil
 
 - if status.reply? && include_threads
   = render partial: 'stream_entries/status', collection: @ancestors, as: :status, locals: { is_predecessor: true, direct_reply_id: status.in_reply_to_id }
 
 .entry{ class: entry_classes }
+  - if stop
+    - if stop.arrival?
+      .line.line--arriving{ style: "border-color: ##{@map.color(stop.arriving_line)}; left: #{20 + (stop.bypassing_lines.size * 6)}px" }
+    - stop.bypassing_lines.each_with_index do |line, i|
+      .line.line--bypassing{ style: "border-color: ##{@map.color(line)}; left: #{20 + (i * 6)}px" }
+    - stop.departing_lines.each_with_index do |line, i|
+      .line.line--departing{ style: "border-color: ##{@map.color(line)}; left: #{20 + (stop.bypassing_lines.size * 6) + (i * 6)}px" }
 
   - if status.reblog?
     .pre-header


### PR DESCRIPTION
Fix #279 

![image](https://user-images.githubusercontent.com/184731/36638245-0906b330-19f0-11e8-9b37-9a45a75155d2.png)

Code adopted from Objective-C written by @dagagren

Current limitations:

- No pretty turns, only vertical lines
- Temporary and small color palette
- If there is a lot of threads, the lines can fill up the entire horizontal space of the toot