### PR TITLE
fix logic for pam_controlled_service

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -149,7 +149,7 @@ STREAMING_CLUSTER_NUM=1
 # PAM_DEFAULT_SUFFIX=pam
 # Name of the pam service (pam "auth" section is evaluated)
 # PAM_DEFAULT_SERVICE=rpam
-# Name of the pam service used for checking if an user can register (pam "account" section is evaluated)
+# Name of the pam service used for checking if an user can register (pam "account" section is evaluated) (nil (disabled) by default)
 # PAM_CONTROLLED_SERVICE=rpam
 
 # Global OAuth settings (optional) :

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -322,6 +322,6 @@ Devise.setup do |config|
     config.check_at_sign          = true
     config.pam_default_suffix     = ENV.fetch('PAM_DEFAULT_SUFFIX') { nil }
     config.pam_default_service    = ENV.fetch('PAM_DEFAULT_SERVICE') { 'rpam' }
-    config.pam_controlled_service = ENV.fetch('PAM_CONTROLLED_SERVICE') { 'rpam' }
+    config.pam_controlled_service = ENV.fetch('PAM_CONTROLLED_SERVICE') { nil }
   end
 end


### PR DESCRIPTION
nil is a valid option to disable pam_controlled_service.
app/validators/unreserved_username_validator.rb:

´´´ ruby
def pam_controlled?(value)
    return false unless Devise.pam_authentication && Devise.pam_controlled_service
    Rpam2.account(Devise.pam_controlled_service, value).present?
end
´´´