### PR TITLE
Finalize location on scrollable notifications when unmounting

### DIFF
--- a/app/javascript/mastodon/features/notifications/index.js
+++ b/app/javascript/mastodon/features/notifications/index.js
@@ -50,6 +50,13 @@ export default class Notifications extends React.PureComponent {
     trackScroll: true,
   };
 
+  componentWillUnmount () {
+    this.handleScrollToBottom.cancel();
+    this.handleScrollToTop.cancel();
+    this.handleScroll.cancel();
+    this.props.dispatch(scrollTopNotifications(false));
+  }
+
   handleScrollToBottom = debounce(() => {
     this.props.dispatch(scrollTopNotifications(false));
     this.props.dispatch(expandNotifications());


### PR DESCRIPTION
The top of the scrollable notifications will be invisible after unmounting.
The Redux state should be updated accordingly in such a case so that the unread notification counter will be updated later.