### PR TITLE
Do not fetch environment variables to determine default locale

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -48,7 +48,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
   end
 
   def languages
-    [ENV.fetch('DEFAULT_LOCALE', I18n.default_locale)]
+    [I18n.default_locale]
   end
 
   private

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 def render_static_page(action, dest:, **opts)
-  I18n.with_locale(ENV['DEFAULT_LOCALE'] || I18n.default_locale) do
-    html = ApplicationController.render(action, opts)
-    File.write(dest, html)
-  end
+  html = ApplicationController.render(action, opts)
+  File.write(dest, html)
 end
 
 namespace :assets do


### PR DESCRIPTION
The default locale is now set by config.

This is a follow-up of #6850. These changes were not necessary when the prior pull request, #3754 was written, but today it is.