### PR TITLE
Do not default site_title with site_hostname in InstanceHelper

### DIFF
--- a/app/helpers/instance_helper.rb
+++ b/app/helpers/instance_helper.rb
@@ -2,7 +2,7 @@
 
 module InstanceHelper
   def site_title
-    Setting.site_title.presence || site_hostname
+    Setting.site_title
   end
 
   def site_hostname

--- a/spec/helpers/instance_helper_spec.rb
+++ b/spec/helpers/instance_helper_spec.rb
@@ -15,12 +15,6 @@ describe InstanceHelper do
 
       expect(helper.site_title).to eq 'New site title'
     end
-
-    it 'returns empty string when Setting.site_title is nil' do
-      Setting.site_title = nil
-
-      expect(helper.site_title).to eq 'cb6e6126.ngrok.io'
-    end
   end
 
   describe 'site_hostname' do


### PR DESCRIPTION
site_title is "Mastodon" by default configuration, and there is no need to
default site_title with site_hostname in InstanceHelper.