### PR TITLE
Fix permissions for volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,9 @@ RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-in
  && yarn --pure-lockfile \
  && yarn cache clean
 
-RUN addgroup -g ${GID} mastodon && adduser -h /mastodon -s /bin/sh -D -G mastodon -u ${UID} mastodon
+RUN addgroup -g ${GID} mastodon && adduser -h /mastodon -s /bin/sh -D -G mastodon -u ${UID} mastodon \
+ && mkdir -p /mastodon/public/system /mastodon/public/assets /mastodon/public/packs \
+ && chown -R mastodon:mastodon /mastodon/public
 
 COPY --chown=mastodon:mastodon . /mastodon
 


### PR DESCRIPTION
When volumes are declared, but the corresponding directories don't exist, permissions for those directories will be root:root instead of mastodon:mastodon..

This changes makes sure the permissions of the volume directories are as expected.