### PR TITLE
Added Travis configuration for building Docker images on for the Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,64 @@
 language: ruby
+sudo: required
+services:
+  - docker
 cache:
   bundler: true
   yarn: true
   directories:
-    - node_modules
-    - public/assets
-    - public/packs-test
-    - tmp/cache/babel-loader
+  - node_modules
+  - public/assets
+  - public/packs-test
+  - tmp/cache/babel-loader
 dist: trusty
 sudo: false
 branches:
   only:
-    - master
-
+  - master
+  - /^v\d+\.\d+(\.\d+)?(\S*)?(-\S*)?$/
 notifications:
   email: false
-
 env:
   global:
-    - LOCAL_DOMAIN=cb6e6126.ngrok.io
-    - LOCAL_HTTPS=true
-    - RAILS_ENV=test
-    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-    - PARALLEL_TEST_PROCESSORS=2
-
+  - LOCAL_DOMAIN=cb6e6126.ngrok.io
+  - LOCAL_HTTPS=true
+  - RAILS_ENV=test
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  - PARALLEL_TEST_PROCESSORS=2
+  - DOCKER_HUB_USERNAME=gargron
+before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y install docker-ce
 addons:
   postgresql: 9.4
   apt:
     sources:
-      - trusty-media
-      - sourceline: deb https://dl.yarnpkg.com/debian/ stable main
-        key_url: https://dl.yarnpkg.com/debian/pubkey.gpg
+    - trusty-media
+    - sourceline: deb https://dl.yarnpkg.com/debian/ stable main
+      key_url: https://dl.yarnpkg.com/debian/pubkey.gpg
     packages:
-      - ffmpeg
-      - libicu-dev
-      - libprotobuf-dev
-      - protobuf-compiler
-      - yarn
-
+    - ffmpeg
+    - libicu-dev
+    - libprotobuf-dev
+    - protobuf-compiler
+    - yarn
 rvm:
-  - 2.4.2
-  - 2.5.0
-
+- 2.4.2
+- 2.5.0
 services:
-  - redis-server
-
+- redis-server
 install:
-  - nvm install
-  - bundle install --path=vendor/bundle --without development production --retry=3 --jobs=16
-  - yarn install
-
+- nvm install
+- bundle install --path=vendor/bundle --without development production --retry=3 --jobs=16
+- yarn install
 before_script:
-  - ./bin/rails parallel:create parallel:load_schema parallel:prepare assets:precompile
-
+- "./bin/rails parallel:create parallel:load_schema parallel:prepare assets:precompile"
 script:
-  - travis_retry bundle exec parallel_test spec/ --group-by filesize --type rspec
-  - yarn test
-  - bundle exec i18n-tasks check-normalized && bundle exec i18n-tasks unused
+- travis_retry bundle exec parallel_test spec/ --group-by filesize --type rspec
+- yarn test
+- bundle exec i18n-tasks check-normalized && bundle exec i18n-tasks unused
+deploy:
+  provider: script
+  script: bash deploy_hub.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
   - public/packs-test
   - tmp/cache/babel-loader
 dist: trusty
-sudo: false
 branches:
   only:
   - master

--- a/deploy_hub.sh
+++ b/deploy_hub.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+TAG="${TRAVIS_TAG:-latest}"
+
+_logout() {
+  docker logout
+}
+
+trap _logout EXIT TERM
+
+docker login -u "${DOCKER_HUB_USERNAME}" -p "${DOCKER_HUB_PASSWORD}"
+docker build -t "${DOCKER_HUB_USERNAME}/mastodon:${TAG}" .
+docker tag "${DOCKER_HUB_USERNAME}/mastodon:${TAG}" "${DOCKER_HUB_USERNAME}/mastodon:latest"
+docker push "${DOCKER_HUB_USERNAME}/mastodon:${TAG}"
+docker push "${DOCKER_HUB_USERNAME}/mastodon:latest"


### PR DESCRIPTION
This PR implements building Docker images for either `master` or release tags on TravisCI to work around the issue of the Docker Hub using an outdated version of Docker.

Before merging this PR @Gargron needs to run the following command inside project directory:

```sh
$ travis encrypt DOCKER_HUB_PASSWORD=<their-docker-hub-password> --add
```
and check-in the resulting `.travis.yml` for this PR, otherwise the pushes to the Hub will fail (since they require a valid login).
