### PR TITLE
Do not use npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ RUN apk -U upgrade \
     libidn \
     libpq \
     nodejs \
-    nodejs-npm \
     protobuf \
     su-exec \
     tini \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     image: gargron/mastodon
     restart: always
     env_file: .env.production
-    command: npm run start
+    command: yarn start
     networks:
       - external_network
       - internal_network

--- a/package.json
+++ b/package.json
@@ -10,10 +10,9 @@
     "build:production": "cross-env RAILS_ENV=production ./bin/webpack",
     "manage:translations": "node ./config/webpack/translationRunner.js",
     "start": "node ./streaming/index.js",
-    "test": "npm run test:lint && npm run test:jest",
+    "test": "yarn run test:lint && yarn run test:jest",
     "test:lint": "eslint -c .eslintrc.yml --ext=js app/javascript/ config/webpack/ streaming/",
-    "test:jest": "cross-env NODE_ENV=test jest --coverage",
-    "postinstall": "npm rebuild node-sass"
+    "test:jest": "cross-env NODE_ENV=test jest --coverage"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Both of yarn and npm are used in Mastodon, but the combined usage requires
a redundant dependency and may lead to data inconsistency.

Considering that yarn has autoclean feature which npm does not have,
this change replaces all npm usage with yarn.

This change requires documentation update. Most notably, the following
command must be executed before assets precompilation if any system
dependency of node-sass has changed:

yarn install --force --pure-lockfile