### PR TITLE
Always install LDAP, CAS and SAML gems, because they don't require deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,9 +33,9 @@ gem 'devise', '~> 4.4'
 gem 'devise-two-factor', '~> 3.0'
 
 gem 'devise_pam_authenticatable2', '~> 8.0', install_if: -> { ENV['PAM_ENABLED'] == 'true' }
-gem 'net-ldap', '~> 0.10', install_if: -> { ENV['LDAP_ENABLED'] == 'true' }
-gem 'omniauth-cas', '~> 1.1', install_if: -> { ENV['CAS_ENABLED'] == 'true' }
-gem 'omniauth-saml', '~> 1.10', install_if: -> { ENV['SAML_ENABLED'] == 'true' }
+gem 'net-ldap', '~> 0.10'
+gem 'omniauth-cas', '~> 1.1'
+gem 'omniauth-saml', '~> 1.10'
 gem 'omniauth', '~> 1.2'
 
 gem 'doorkeeper', '~> 4.2'


### PR DESCRIPTION
Fix #6534

PAM requires a system dependency so...