### PR TITLE
Don't double-escape statuses in titles

### DIFF
--- a/app/views/stream_entries/show.html.haml
+++ b/app/views/stream_entries/show.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title do
-  = t('statuses.title', name: display_name(@account), quote: truncate(@stream_entry.activity.spoiler_text.presence || @stream_entry.activity.text, length: 50, omission: '…'))
+  = t('statuses.title', name: display_name(@account), quote: truncate(@stream_entry.activity.spoiler_text.presence || @stream_entry.activity.text, length: 50, omission: '…', escape: false))
 
 - content_for :header_tags do
   - if @account.user&.setting_noindex


### PR DESCRIPTION
Should fix #6560.
Apparently `truncate` also does HTML escaping, so the status was getting escaped twice in the page title.