### PR TITLE
For now, put a "." into no-text statuses with media for backcompat

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -22,6 +22,7 @@ class PostStatusService < BaseService
     media  = validate_media!(options[:media_ids])
     status = nil
     text   = options.delete(:spoiler_text) if text.blank? && options[:spoiler_text].present?
+    text   = '.' if text.blank? && !media.empty?
 
     ApplicationRecord.transaction do
       status = account.statuses.create!(text: text,


### PR DESCRIPTION
Until 2.3 is widespread enough.