### PR TITLE
Improve styling of closed registrations message, rename button

### DIFF
--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -195,21 +195,24 @@ $small-breakpoint: 960px;
   }
 
   .closed-registrations-message {
-    font-family: 'mastodon-font-sans-serif', sans-serif;
-    font-size: 16px;
-    font-weight: 400;
-    font-size: 16px;
-    line-height: 30px;
-    color: $ui-primary-color;
-    margin-bottom: 40px;
+    margin-top: 20px;
+
+    &,
+    p {
+      text-align: center;
+      font-size: 12px;
+      line-height: 18px;
+      color: $ui-primary-color;
+      margin-bottom: 0;
+
+      a {
+        color: $ui-highlight-color;
+        text-decoration: underline;
+      }
+    }
 
     p:last-child {
       margin-bottom: 0;
-    }
-
-    a {
-      color: $ui-highlight-color;
-      text-decoration: underline;
     }
   }
 

--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -194,6 +194,25 @@ $small-breakpoint: 960px;
     }
   }
 
+  .closed-registrations-message {
+    font-family: 'mastodon-font-sans-serif', sans-serif;
+    font-size: 16px;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 30px;
+    color: $ui-primary-color;
+    margin-bottom: 40px;
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+
+    a {
+      color: $ui-highlight-color;
+      text-decoration: underline;
+    }
+  }
+
   em {
     display: inline;
     margin: 0;

--- a/app/views/about/_forms.html.haml
+++ b/app/views/about/_forms.html.haml
@@ -1,13 +1,13 @@
 - if @instance_presenter.open_registrations
   = render 'registration'
 - else
+  = link_to t('auth.register_elsewhere'), 'https://joinmastodon.org', class: 'button button-primary'
+
   .closed-registrations-message
     - if @instance_presenter.closed_registrations_message.blank?
       %p= t('about.closed_registrations')
     - else
       = @instance_presenter.closed_registrations_message.html_safe
-
-  = link_to t('auth.register_elsewhere'), 'https://joinmastodon.org', class: 'button button-primary'
 
 .separator-or
   %span= t('auth.or')

--- a/app/views/about/_forms.html.haml
+++ b/app/views/about/_forms.html.haml
@@ -1,12 +1,13 @@
 - if @instance_presenter.open_registrations
   = render 'registration'
 - else
-  - if @instance_presenter.closed_registrations_message.blank?
-    %p= t('about.closed_registrations')
-  - else
-    = @instance_presenter.closed_registrations_message.html_safe
+  .closed-registrations-message
+    - if @instance_presenter.closed_registrations_message.blank?
+      %p= t('about.closed_registrations')
+    - else
+      = @instance_presenter.closed_registrations_message.html_safe
 
-  = link_to t('auth.register'), 'https://joinmastodon.org', class: 'button button-primary'
+  = link_to t('auth.register_elsewhere'), 'https://joinmastodon.org', class: 'button button-primary'
 
 .separator-or
   %span= t('auth.or')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -376,6 +376,7 @@ en:
       cas: CAS
       saml: SAML
     register: Sign up
+    register_elsewhere: Sign up on another server
     resend_confirmation: Resend confirmation instructions
     reset_password: Reset password
     security: Security


### PR DESCRIPTION
"Sign up on another server"

Fix #6683 

![image](https://user-images.githubusercontent.com/184731/37140593-92307748-22b2-11e8-8276-06eaf8879e22.png)
