### PR TITLE
Revert "Separate chown command in Dockerfile. Use tootsuite/mastodon …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.5.0-alpine3.7
 
 LABEL maintainer="https://github.com/tootsuite/mastodon" \
-      description="Your self-hosted, globally interconnected microblogging community"
+      description="A GNU Social-compatible microblogging server"
 
 ARG UID=991
 ARG GID=991
@@ -73,9 +73,7 @@ RUN addgroup -g ${GID} mastodon && adduser -h /mastodon -s /bin/sh -D -G mastodo
  && mkdir -p /mastodon/public/system /mastodon/public/assets /mastodon/public/packs \
  && chown -R mastodon:mastodon /mastodon/public
 
-COPY . /mastodon
-
-RUN chown -R mastodon:mastodon /mastodon
+COPY --chown=mastodon:mastodon . /mastodon
 
 VOLUME /mastodon/public/system /mastodon/public/assets /mastodon/public/packs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 
   web:
     build: .
-    image: tootsuite/mastodon
+    image: gargron/mastodon
     restart: always
     env_file: .env.production
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
@@ -52,7 +52,7 @@ services:
 
   streaming:
     build: .
-    image: tootsuite/mastodon
+    image: gargron/mastodon
     restart: always
     env_file: .env.production
     command: yarn start
@@ -67,7 +67,7 @@ services:
 
   sidekiq:
     build: .
-    image: tootsuite/mastodon
+    image: gargron/mastodon
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq -q default -q mailers -q pull -q push


### PR DESCRIPTION
…image (#6662)"

This reverts commit d7573fe584ea622e22f5a68f2bf120b7682c49f7.

The problem the commit addressed is occurred on an out-dated Docker configuration.

The report of the problem was made in #6605. The reporter has shown his Docker installation:
```
marcus@zeus:~/u4u.org/mastodon$ apt-cache policy docker-engine
docker-engine:
  Installiert:           17.05.0~ce-0~ubuntu-xenial
  Installationskandidat: 17.05.0~ce-0~ubuntu-xenial
  Versionstabelle:
 *** 17.05.0~ce-0~ubuntu-xenial 500
        500 https://apt.dockerproject.org/repo ubuntu-xenial/main amd64 Packages
        100 /var/lib/dpkg/status
``` 

The used edition is the Community Edition. The edition has two release channels, stable and edge. The latest stable version is 17.12.1, and 17.05.0- is an out date Community Edition version. Moreover, as suggested in https://github.com/tootsuite/mastodon/issues/6605#issuecomment-370557897, the repository configuration is also old.

Updating the repository configuration and then Docker will solve the problem. I have already confirmed the up-to-date configuration works. (See https://github.com/tootsuite/mastodon/issues/6495#issuecomment-370328359. Ubuntu 16.04, which the reporter of #6605 also used.)

We also do not have to worry about the version provided for Ubuntu 16.04 by its distributor, Canonical. The version is too old even to use Mastodon's compose file written in version 3 format.

Considering all the above, there is no need to support the old version. An administrator using an old version should be advised to update Docker.