### PR TITLE
api: show if elasticsearch is enabled or not when requesting instance properties

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -5,7 +5,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   attributes :uri, :title, :description, :email,
              :version, :urls, :stats, :thumbnail,
-             :languages
+             :languages, :elasticsearch_enabled
 
   has_one :contact_account, serializer: REST::AccountSerializer
 
@@ -49,6 +49,10 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   def languages
     [I18n.default_locale]
+  end
+
+  def elasticsearch_enabled
+    Chewy.enabled?
   end
 
   private


### PR DESCRIPTION
This allows remote instances to know if a Mastodon instance has elasticsearch enabled or not, which can be useful for not federating with those instances.