### PR TITLE
Remove su-exec from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ RUN apk -U upgrade \
     libpq \
     nodejs \
     protobuf \
-    su-exec \
     tini \
     tzdata \
  && update-ca-certificates \


### PR DESCRIPTION
It is no longer necessary since commit
be9bab171dc2b1fe43bc742decb71f64541ca347.