### PR TITLE
Adds port mapping for ElasticSearch docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
 #      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 #    networks:
 #      - internal_network
+#    ports:
+#      - "9200:9200"
 #### Uncomment to enable ES persistance
 ##    volumes:
 ##      - ./elasticsearch:/usr/share/elasticsearch/data


### PR DESCRIPTION
Hello! Nice work on 2.3.0. I had some trouble getting ElasticSearch to work via Docker, and was only able to get Rails to connect to the container once adding the port mapping in this PR.