### PR TITLE
Canonical link for media attachments

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -26,7 +26,7 @@ class StatusesController < ApplicationController
         skip_session! unless @stream_entry.hidden?
 
         render_cached_json(['activitypub', 'note', @status.cache_key], content_type: 'application/activity+json', public: !@stream_entry.hidden?) do
-          ActiveModelSerializers::SerializableResource.new(@status, serializer: ActivityPub::NoteSerializer, adapter: ActivityPub::Adapter)
+          ActiveModelSerializers::SerializableResource.new(@status, serializer: ActivityPub::NoteSerializer, adapter: ActivityPub::Adapter, scope: Server.new(request.user_agent), scope_name: :current_server)
         end
       end
     end

--- a/app/lib/activitypub/activity/announce.rb
+++ b/app/lib/activitypub/activity/announce.rb
@@ -30,8 +30,10 @@ class ActivityPub::Activity::Announce < ActivityPub::Activity
       return if ActivityPub::TagManager.instance.local_uri?(object_uri)
 
       ActivityPub::FetchRemoteStatusService.new.call(object_uri, id: true)
-    elsif @object['url'].present?
-      ::FetchRemoteStatusService.new.call(@object['url'])
+    else
+      href = @object['url'].is_a?(Array) ? find_href(@object['url'], 'self', 'application/activity+json') : nil
+      href = first_href(@object['url']) if href.nil?
+      ::FetchRemoteStatusService.new.call(href) if href.present?
     end
   end
 

--- a/app/lib/server.rb
+++ b/app/lib/server.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Server
+  MAX_VERSION_REJECTS_LINK = Gem::Version.create('2.3.0')
+  private_constant :MAX_VERSION_REJECTS_LINK
+
+  def initialize(agent)
+    matched = agent.match(/Mastodon\/([\.\d]*)/)
+    @accepts_link = matched.nil? ? true : Gem::Version.create(matched[1]) > MAX_VERSION_REJECTS_LINK
+  end
+
+  def accepts_link?
+    @accepts_link
+  end
+end

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -105,7 +105,26 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
     end
 
     def url
-      object.local? ? full_asset_url(object.file.url(:original, false)) : object.remote_url
+      if object.local?
+        if current_server.accepts_link?
+          [
+            {
+              type: 'Link',
+              href: full_asset_url(object.file.url(:original, false)),
+              rel: 'self',
+            },
+            {
+              type: 'Link',
+              href: media_proxy_url(object, :original),
+              rel: 'canonical',
+            },
+          ]
+        else
+          full_asset_url(object.file.url(:original, false))
+        end
+      else
+        object.remote_url
+      end
     end
 
     def focal_point?

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -114,7 +114,8 @@ class ActivityPub::ProcessAccountService < BaseService
   def url
     return if @json['url'].blank?
 
-    url_candidate = url_to_href(@json['url'], 'text/html')
+    url_candidate = @json['url'].is_a?(Array) ? find_href(@json['url'], 'alternate', 'text/html') : nil
+    url_candidate = first_href(@json['url']) if url_candidate.nil?
 
     if unsupported_uri_scheme?(url_candidate) || mismatching_origin?(url_candidate)
       nil

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -42,6 +42,14 @@ describe StatusesController do
       end
     end
 
+    context 'JSON of status which requires server information to serialize is requested' do
+      it 'returns http success' do
+        status = Fabricate(:status, media_attachments: [Fabricate(:media_attachment)])
+        get :show, format: :json, params: { account_username: status.account.username, id: status }
+        expect(response).to have_http_status :success
+      end
+    end
+
     context 'account is not suspended and status is permitted' do
       it 'assigns @account' do
         status = Fabricate(:status)

--- a/spec/helpers/jsonld_helper_spec.rb
+++ b/spec/helpers/jsonld_helper_spec.rb
@@ -65,4 +65,72 @@ describe JsonLdHelper do
       expect(fetch_resource_without_id_validation('https://host/')).to eq({})
     end
   end
+
+  describe '#find_href' do
+    it 'returns href of Link with given rel' do
+      expect(find_href([{ 'type' => 'Link', 'href' => 'https://example.com/', 'rel' => 'self' }], 'self')).to eq 'https://example.com/'
+    end
+
+    it 'returns href of Link with rel array including given rel' do
+      expect(find_href([{ 'type' => 'Link', 'href' => 'https://example.com/', 'rel' => ['self'] }], 'self')).to eq 'https://example.com/'
+    end
+
+    it 'returns href of Link without rel' do
+      expect(find_href([{ 'type' => 'Link', 'href' => 'https://example.com/' }], 'self')).to eq 'https://example.com/'
+    end
+
+    it 'returns nil if Link with given rel is not found' do
+      expect(find_href([{ 'type' => 'Link', 'href' => 'https://example.com/', 'rel' => '' }], 'self')).to eq nil
+    end
+
+    it 'returns nil if only Link with rel whose type is invalid is given' do
+      expect(find_href([{ 'type' => 'Link', 'href' => 'https://example.com/', 'rel' => {} }], 'self')).to eq nil
+    end
+
+    it 'returns href of Link with given mime type' do
+      expect(find_href([{ 'type' => 'Link', 'href' => 'https://example.com/', 'mimeType' => 'text/html' }], nil, 'text/html')).to eq 'https://example.com/'
+    end
+
+    it 'returns href of Link with mime type array including given mime type' do
+      expect(find_href([{ 'type' => 'Link', 'href' => 'https://example.com/', 'mimeType' => ['text/html'] }], nil, 'text/html')).to eq 'https://example.com/'
+    end
+
+    it 'returns href of Link without mime type' do
+      expect(find_href([{ 'type' => 'Link', 'href' => 'https://example.com/' }], nil, 'text/html')).to eq 'https://example.com/'
+    end
+
+    it 'returns nil if Link with given mime type is not found' do
+      expect(find_href([{ 'type' => 'Link', 'href' => 'https://example.com/', 'mimeType' => '' }], nil, 'text/html')).to eq nil
+    end
+
+    it 'returns nil if only Link with mime type whose type is invalid is given' do
+      expect(find_href([{ 'type' => 'Link', 'href' => 'https://example.com/', 'mimeType' => {} }], nil, 'text/html')).to eq nil
+    end
+
+    it 'returns string element' do
+      expect(find_href(['https://example.com/'], 'self', 'text/html')).to eq 'https://example.com/'
+    end
+
+    it 'returns nil if only invalid object is given' do
+      expect(find_href([{}])).to eq nil
+    end
+  end
+
+  describe '#first_href' do
+    it 'returns href given array' do
+      expect(first_href(['https://example.com/'])).to eq 'https://example.com/'
+    end
+
+    it 'returns href given string' do
+      expect(first_href('https://example.com/')).to eq 'https://example.com/'
+    end
+
+    it 'returns href given Link object' do
+      expect(first_href({ 'type' => 'Link', 'href' => 'https://example.com/' })).to eq 'https://example.com/'
+    end
+
+    it 'returns nil given Link object with invalid href' do
+      expect(first_href({ 'type' => 'Link', 'href' => {} })).to eq nil
+    end
+  end
 end

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -263,6 +263,33 @@ RSpec.describe ActivityPub::Activity::Create do
       end
     end
 
+    context 'with media attachments with canonical urls' do
+      let(:object_json) do
+        {
+          id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+          type: 'Note',
+          content: 'Lorem ipsum',
+          attachment: [
+            {
+              type: 'Document',
+              mediaType: 'image/png',
+              url: [
+                { type: 'Link', href: 'http://example.com/attachment.png', rel: 'self' },
+                { type: 'Link', href: 'http://example.com/canonical.png', rel: 'canonical' },
+              ],
+            },
+          ],
+        }
+      end
+
+      it 'creates status' do
+        status = sender.statuses.first
+
+        expect(status).to_not be_nil
+        expect(status.media_attachments.map(&:remote_url)).to include('http://example.com/canonical.png')
+      end
+    end
+
     context 'with hashtags' do
       let(:object_json) do
         {

--- a/spec/lib/server_spec.rb
+++ b/spec/lib/server_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Server do
+  describe 'accepts_link?' do
+    subject { Server.new(agent).accepts_link? }
+
+    context 'if the user agent is Mastodon older than or equal to 2.3.0' do
+      let(:agent) { 'http.rb/3.0.0 (Mastodon/2.3.0; +https://example.com/)' }
+      it { is_expected.to eq false }
+    end
+
+    context 'if the user agent is Mastodon newer than 2.3.0' do
+      let(:agent) { 'http.rb/3.0.0 (Mastodon/2.3.1; +https://example.com/)' }
+      it { is_expected.to eq true }
+    end
+
+    context 'if the user agent is unknown' do
+      let(:agent) { 'http.rb/3.0.0 (NCSA_Mosaic/2.3.0; +https://example.com/)' }
+      it { is_expected.to eq true }
+    end
+  end
+end


### PR DESCRIPTION
#6672 removed media link from the status text, but a user may still want to use the link. This utilizes ActivityStreams representation to include the canonical link.