### PR TITLE
Change owner of public directiories in Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,16 +60,8 @@ RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-in
  && yarn --pure-lockfile \
  && yarn cache clean
 
-RUN addgroup -g ${GID} mastodon && adduser -h /mastodon -s /bin/sh -D -G mastodon -u ${UID} mastodon \
- && mkdir -p /mastodon/public/system /mastodon/public/assets /mastodon/public/packs \
- && chown -R mastodon:mastodon /mastodon/public
+RUN addgroup -g ${GID} mastodon && adduser -h /mastodon -s /bin/sh -D -G mastodon -u ${UID} mastodon
 
 COPY . /mastodon
 
-RUN chown -R mastodon:mastodon /mastodon
-
 VOLUME /mastodon/public/system /mastodon/public/assets /mastodon/public/packs
-
-USER mastodon
-
-ENTRYPOINT ["/sbin/tini", "--"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    command: /mastodon/docker_entrypoint.sh bundle exec rails s -p 3000 -b '0.0.0.0'
     networks:
       - external_network
       - internal_network
@@ -55,7 +55,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: yarn start
+    command: /mastodon/docker_entrypoint.sh yarn start
     networks:
       - external_network
       - internal_network
@@ -70,7 +70,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bundle exec sidekiq -q default -q mailers -q pull -q push
+    command: /mastodon/docker_entrypoint.sh bundle exec sidekiq -q default -q mailers -q pull -q push
     depends_on:
       - db
       - redis

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+chown mastodon:mastodon /mastodon/public/system
+exec su mastodon -c "exec /sbin/tini -- $*"


### PR DESCRIPTION
Docker sets the owner of public directories to root if those directories
are missing, which prevents fresh installation.

This commit resolves the problem by:
* executing commands by administrator as root
* changing the onwer of /mastodon/public/system in the entry point

The chown operation in the entry point quickly finishes because it is
applied only to a directory.

Another difference from the old `docker_entrypoint.sh` is that it does not use `su-exec`, which removed by #6722. Instead, it simply `su` and `exec`. I confirmed it works as expected.