### PR TITLE
Fix Procfile on OS X

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: PORT=3000 bundle exec puma -C config/puma.rb
-sidekiq: PORT=3000 bundle exec sidekiq
-stream: PORT=4000 yarn run start
+web: env PORT=3000 bundle exec puma -C config/puma.rb
+sidekiq: env PORT=3000 bundle exec sidekiq
+stream: env PORT=4000 yarn run start
 webpack: ./bin/webpack-dev-server --listen-host 0.0.0.0


### PR DESCRIPTION
On OS X, "foreman s" complains for some reason about bare enviroment variables, probably due to cross-platform differences in how programs get started. Adding an env call fixes this.