### PR TITLE
Detailed SMTP setup

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -291,6 +291,7 @@ namespace :mastodon do
 
           mail = ActionMailer::Base.new.mail to: send_to, subject: 'Test', body: 'Mastodon SMTP configuration works!'
           mail.deliver
+          break
         rescue StandardError => e
           prompt.error 'E-mail could not be sent with this configuration, try again.'
           prompt.error e.message

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -244,6 +244,18 @@ namespace :mastodon do
           q.echo false
         end
 
+        env['SMTP_AUTH_METHOD'] = prompt.ask('SMTP authentication:') do |q|
+          q.required
+          q.default 'plain'
+          q.modify :strip
+        end
+
+        env['SMTP_OPENSSL_VERIFY_MODE'] = prompt.ask('SMTP OpenSSL verify mode:') do |q|
+          q.required
+          q.default 'peer'
+          q.modify :strip
+        end
+
         env['SMTP_FROM_ADDRESS'] = prompt.ask('E-mail address to send e-mails "from":') do |q|
           q.required true
           q.default "Mastodon <notifications@#{env['LOCAL_DOMAIN']}>"
@@ -261,7 +273,8 @@ namespace :mastodon do
             :user_name            => env['SMTP_LOGIN'].presence,
             :password             => env['SMTP_PASSWORD'].presence,
             :domain               => env['LOCAL_DOMAIN'],
-            :authentication       => :plain,
+            :authentication       => env['SMTP_AUTH_METHOD'] == 'none' ? nil : env['SMTP_AUTH_METHOD'] || :plain,
+            :openssl_verify_mode  => env['SMTP_OPENSSL_VERIFY_MODE'],
             :enable_starttls_auto => true,
           }
 

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -224,36 +224,43 @@ namespace :mastodon do
       prompt.say "\n"
 
       loop do
-        env['SMTP_SERVER'] = prompt.ask('SMTP server:') do |q|
-          q.required true
-          q.default 'smtp.mailgun.org'
-          q.modify :strip
-        end
+        if prompt.yes?('Do you want to send e-mails from localhost?', default: false)
+          env['SMTP_SERVER'] = 'localhost'
+          env['SMTP_PORT'] = 25
+          env['SMTP_AUTH_METHOD'] = 'none'
+          env['SMTP_OPENSSL_VERIFY_MODE'] = 'none'
+        else
+          env['SMTP_SERVER'] = prompt.ask('SMTP server:') do |q|
+            q.required true
+            q.default 'smtp.mailgun.org'
+            q.modify :strip
+          end
 
-        env['SMTP_PORT'] = prompt.ask('SMTP port:') do |q|
-          q.required true
-          q.default 587
-          q.convert :int
-        end
+          env['SMTP_PORT'] = prompt.ask('SMTP port:') do |q|
+            q.required true
+            q.default 587
+            q.convert :int
+          end
 
-        env['SMTP_LOGIN'] = prompt.ask('SMTP username:') do |q|
-          q.modify :strip
-        end
+          env['SMTP_LOGIN'] = prompt.ask('SMTP username:') do |q|
+            q.modify :strip
+          end
 
-        env['SMTP_PASSWORD'] = prompt.ask('SMTP password:') do |q|
-          q.echo false
-        end
+          env['SMTP_PASSWORD'] = prompt.ask('SMTP password:') do |q|
+            q.echo false
+          end
 
-        env['SMTP_AUTH_METHOD'] = prompt.ask('SMTP authentication:') do |q|
-          q.required
-          q.default 'plain'
-          q.modify :strip
-        end
+          env['SMTP_AUTH_METHOD'] = prompt.ask('SMTP authentication:') do |q|
+            q.required
+            q.default 'plain'
+            q.modify :strip
+          end
 
-        env['SMTP_OPENSSL_VERIFY_MODE'] = prompt.ask('SMTP OpenSSL verify mode:') do |q|
-          q.required
-          q.default 'peer'
-          q.modify :strip
+          env['SMTP_OPENSSL_VERIFY_MODE'] = prompt.ask('SMTP OpenSSL verify mode:') do |q|
+            q.required
+            q.default 'peer'
+            q.modify :strip
+          end
         end
 
         env['SMTP_FROM_ADDRESS'] = prompt.ask('E-mail address to send e-mails "from":') do |q|


### PR DESCRIPTION
`mastodon:setup` has some bugs about its SMTP settings setup.

1. It doesn't allow to set `SMTP_AUTH_METHOD` and `SMTP_OPENSSL_VERIFY_MODE`.
1. There's no hint to set localhost as the SMTP server.
1. The loop of SMTP settings won't exit if the test mail is successfully delivered.

This PR fixes these problems.