### PR TITLE
Do not drop follow relationships on user-specific domain blocks

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -126,6 +126,7 @@ class Account < ApplicationRecord
   scope :matches_username, ->(value) { where(arel_table[:username].matches("#{value}%")) }
   scope :matches_display_name, ->(value) { where(arel_table[:display_name].matches("#{value}%")) }
   scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
+  scope :not_domain_blocked_by_account, ->(account) { where('domain IS NULL OR domain NOT IN (?)', account.excluded_from_timeline_domains) if account.excluded_from_timeline_domains.present? }
 
   delegate :email,
            :unconfirmed_email,

--- a/app/services/block_domain_from_account_service.rb
+++ b/app/services/block_domain_from_account_service.rb
@@ -3,6 +3,5 @@
 class BlockDomainFromAccountService < BaseService
   def call(account, domain)
     account.block_domain!(domain)
-    account.passive_relationships.where(account: Account.where(domain: domain)).delete_all
   end
 end

--- a/app/workers/activitypub/distribution_worker.rb
+++ b/app/workers/activitypub/distribution_worker.rb
@@ -25,7 +25,7 @@ class ActivityPub::DistributionWorker
   end
 
   def inboxes
-    @inboxes ||= @account.followers.inboxes
+    @inboxes ||= @account.followers.not_domain_blocked_by_account(@account).inboxes
   end
 
   def signed_payload

--- a/spec/services/block_domain_from_account_service_spec.rb
+++ b/spec/services/block_domain_from_account_service_spec.rb
@@ -10,10 +10,4 @@ RSpec.describe BlockDomainFromAccountService, type: :service do
     subject.call(alice, 'evil.org')
     expect(alice.domain_blocking?('evil.org')).to be true
   end
-
-  it 'purge followers from blocked domain' do
-    wolf.follow!(alice)
-    subject.call(alice, 'evil.org')
-    expect(wolf.following?(alice)).to be false
-  end
 end


### PR DESCRIPTION
This behavior is extremely confusing, especially since the wording (hiding)
does not hint at this and that follow relations from the user to blocked accounts
are preserved.