### PR TITLE
request: in the event of failure, try other IPs (#6761)

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -94,9 +94,16 @@ class Request
   class Socket < TCPSocket
     class << self
       def open(host, *args)
-        address = IPSocket.getaddress(host)
-        raise Mastodon::HostValidationError if PrivateAddressCheck.private_address? IPAddr.new(address)
-        super address, *args
+        outer_e = nil
+        Addrinfo::foreach(host, nil, nil, :SOCK_STREAM) do |address|
+          raise Mastodon::HostValidationError if PrivateAddressCheck.private_address? IPAddr.new(address.ip_address)
+          begin
+            return super address.ip_address, *args
+          rescue => e
+            outer_e = e
+          end
+        end
+        raise outer_e if outer_e
       end
 
       alias new open

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -96,8 +96,8 @@ class Request
       def open(host, *args)
         outer_e = nil
         Addrinfo.foreach(host, nil, nil, :SOCK_STREAM) do |address|
-          raise Mastodon::HostValidationError if PrivateAddressCheck.private_address? IPAddr.new(address.ip_address)
           begin
+            raise Mastodon::HostValidationError if PrivateAddressCheck.private_address? IPAddr.new(address.ip_address)
             return super address.ip_address, *args
           rescue => e
             outer_e = e

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -95,7 +95,7 @@ class Request
     class << self
       def open(host, *args)
         outer_e = nil
-        Addrinfo::foreach(host, nil, nil, :SOCK_STREAM) do |address|
+        Addrinfo.foreach(host, nil, nil, :SOCK_STREAM) do |address|
           raise Mastodon::HostValidationError if PrivateAddressCheck.private_address? IPAddr.new(address.ip_address)
           begin
             return super address.ip_address, *args

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -48,6 +48,13 @@ describe Request do
         expect(a_request(:get, 'http://example.com')).to have_been_made.once
       end
 
+      it 'executes a HTTP request when the first address is private' do
+        allow(Addrinfo).to receive(:foreach).with('example.com', nil, nil, :SOCK_STREAM).and_return([
+          Addrinfo.new(["AF_INET", 0, "example.com", "0.0.0.0"], :PF_INET, :SOCK_STREAM),
+          Addrinfo.new(["AF_INET6", 0, "example.com", "2001:4860:4860::8844"], :PF_INET6, :SOCK_STREAM)].each)
+        expect(a_request(:get, 'http://example.com')).to have_been_made.once
+      end
+
       it 'sets headers' do
         expect(a_request(:get, 'http://example.com').with(headers: subject.headers)).to have_been_made
       end
@@ -61,7 +68,9 @@ describe Request do
       end
 
       it 'raises Mastodon::ValidationError' do
-        allow(Addrinfo).to receive(:foreach).with('example.com', nil, nil, :SOCK_STREAM).and_return([Addrinfo.tcp('0.0.0.0', nil), Addrinfo.tcp('2001:db8::face', nil)])
+        allow(Addrinfo).to receive(:foreach).with('example.com', nil, nil, :SOCK_STREAM).and_return([
+          Addrinfo.new(["AF_INET", 0, "example.com", "0.0.0.0"], :PF_INET, :SOCK_STREAM),
+          Addrinfo.new(["AF_INET6", 0, "example.com", "2001:db8::face"], :PF_INET6, :SOCK_STREAM)].each)
         expect{ subject.perform }.to raise_error Mastodon::ValidationError
       end
     end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -61,7 +61,7 @@ describe Request do
       end
 
       it 'raises Mastodon::ValidationError' do
-        allow(IPSocket).to receive(:getaddress).with('example.com').and_return('0.0.0.0')
+        allow(Addrinfo).to receive(:foreach).with('example.com', nil, nil, :SOCK_STREAM).and_return([Addrinfo.tcp('0.0.0.0', nil), Addrinfo.tcp('2001:db8::face', nil)])
         expect{ subject.perform }.to raise_error Mastodon::ValidationError
       end
     end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -49,9 +49,9 @@ describe Request do
       end
 
       it 'executes a HTTP request when the first address is private' do
-        allow(Addrinfo).to receive(:foreach).with('example.com', nil, nil, :SOCK_STREAM).and_return([
-          Addrinfo.new(["AF_INET", 0, "example.com", "0.0.0.0"], :PF_INET, :SOCK_STREAM),
-          Addrinfo.new(["AF_INET6", 0, "example.com", "2001:4860:4860::8844"], :PF_INET6, :SOCK_STREAM)].each)
+        allow(Addrinfo).to receive(:foreach).with('example.com', nil, nil, :SOCK_STREAM)
+                                            .and_yield(Addrinfo.new(["AF_INET", 0, "example.com", "0.0.0.0"], :PF_INET, :SOCK_STREAM))
+                                            .and_yield(Addrinfo.new(["AF_INET6", 0, "example.com", "2001:4860:4860::8844"], :PF_INET6, :SOCK_STREAM))
         expect(a_request(:get, 'http://example.com')).to have_been_made.once
       end
 
@@ -68,9 +68,9 @@ describe Request do
       end
 
       it 'raises Mastodon::ValidationError' do
-        allow(Addrinfo).to receive(:foreach).with('example.com', nil, nil, :SOCK_STREAM).and_return([
-          Addrinfo.new(["AF_INET", 0, "example.com", "0.0.0.0"], :PF_INET, :SOCK_STREAM),
-          Addrinfo.new(["AF_INET6", 0, "example.com", "2001:db8::face"], :PF_INET6, :SOCK_STREAM)].each)
+        allow(Addrinfo).to receive(:foreach).with('example.com', nil, nil, :SOCK_STREAM)
+                                            .and_yield(Addrinfo.new(["AF_INET", 0, "example.com", "0.0.0.0"], :PF_INET, :SOCK_STREAM))
+                                            .and_yield(Addrinfo.new(["AF_INET6", 0, "example.com", "2001:db8::face"], :PF_INET6, :SOCK_STREAM))
         expect{ subject.perform }.to raise_error Mastodon::ValidationError
       end
     end


### PR DESCRIPTION
In the case where a name has multiple A/AAAA records, we should
try subsequent records instead of immediately failing when we have a
failure on the first IP address.

This significantly improves delivery success when there are network
connectivity problems affecting only IPv4 or IPv6.