### PR TITLE
Introduce redux-persist

### DIFF
--- a/app/javascript/mastodon/actions/accounts.js
+++ b/app/javascript/mastodon/actions/accounts.js
@@ -68,7 +68,7 @@ export function fetchAccount(id) {
   return (dispatch, getState) => {
     dispatch(fetchRelationships([id]));
 
-    if (getState().getIn(['accounts', id], null) !== null) {
+    if (getState().accounts.get(id, null) !== null) {
       return;
     }
 
@@ -107,7 +107,7 @@ export function fetchAccountFail(id, error) {
 
 export function followAccount(id, reblogs = true) {
   return (dispatch, getState) => {
-    const alreadyFollowing = getState().getIn(['relationships', id, 'following']);
+    const alreadyFollowing = getState().relationships.getIn([id, 'following']);
     dispatch(followAccountRequest(id));
 
     api(getState).post(`/api/v1/accounts/${id}/follow`, { reblogs }).then(response => {
@@ -123,7 +123,7 @@ export function unfollowAccount(id) {
     dispatch(unfollowAccountRequest(id));
 
     api(getState).post(`/api/v1/accounts/${id}/unfollow`).then(response => {
-      dispatch(unfollowAccountSuccess(response.data, getState().get('statuses')));
+      dispatch(unfollowAccountSuccess(response.data, getState().statuses));
     }).catch(error => {
       dispatch(unfollowAccountFail(error));
     });
@@ -180,7 +180,7 @@ export function blockAccount(id) {
 
     api(getState).post(`/api/v1/accounts/${id}/block`).then(response => {
       // Pass in entire statuses map so we can use it to filter stuff in different parts of the reducers
-      dispatch(blockAccountSuccess(response.data, getState().get('statuses')));
+      dispatch(blockAccountSuccess(response.data, getState().statuses));
     }).catch(error => {
       dispatch(blockAccountFail(id, error));
     });
@@ -249,7 +249,7 @@ export function muteAccount(id, notifications) {
 
     api(getState).post(`/api/v1/accounts/${id}/mute`, { notifications }).then(response => {
       // Pass in entire statuses map so we can use it to filter stuff in different parts of the reducers
-      dispatch(muteAccountSuccess(response.data, getState().get('statuses')));
+      dispatch(muteAccountSuccess(response.data, getState().statuses));
     }).catch(error => {
       dispatch(muteAccountFail(id, error));
     });
@@ -353,7 +353,7 @@ export function fetchFollowersFail(id, error) {
 
 export function expandFollowers(id) {
   return (dispatch, getState) => {
-    const url = getState().getIn(['user_lists', 'followers', id, 'next']);
+    const url = getState().user_lists.getIn(['followers', id, 'next']);
 
     if (url === null) {
       return;
@@ -437,7 +437,7 @@ export function fetchFollowingFail(id, error) {
 
 export function expandFollowing(id) {
   return (dispatch, getState) => {
-    const url = getState().getIn(['user_lists', 'following', id, 'next']);
+    const url = getState().user_lists.getIn(['following', id, 'next']);
 
     if (url === null) {
       return;
@@ -482,7 +482,7 @@ export function expandFollowingFail(id, error) {
 
 export function fetchRelationships(accountIds) {
   return (dispatch, getState) => {
-    const loadedRelationships = getState().get('relationships');
+    const loadedRelationships = getState().relationships;
     const newAccountIds = accountIds.filter(id => loadedRelationships.get(id, null) === null);
 
     if (newAccountIds.length === 0) {
@@ -557,7 +557,7 @@ export function fetchFollowRequestsFail(error) {
 
 export function expandFollowRequests() {
   return (dispatch, getState) => {
-    const url = getState().getIn(['user_lists', 'follow_requests', 'next']);
+    const url = getState().user_lists.getIn(['follow_requests', 'next']);
 
     if (url === null) {
       return;

--- a/app/javascript/mastodon/actions/blocks.js
+++ b/app/javascript/mastodon/actions/blocks.js
@@ -44,7 +44,7 @@ export function fetchBlocksFail(error) {
 
 export function expandBlocks() {
   return (dispatch, getState) => {
-    const url = getState().getIn(['user_lists', 'blocks', 'next']);
+    const url = getState().user_lists.getIn(['blocks', 'next']);
 
     if (url === null) {
       return;

--- a/app/javascript/mastodon/actions/cards.js
+++ b/app/javascript/mastodon/actions/cards.js
@@ -6,7 +6,7 @@ export const STATUS_CARD_FETCH_FAIL    = 'STATUS_CARD_FETCH_FAIL';
 
 export function fetchStatusCard(id) {
   return (dispatch, getState) => {
-    if (getState().getIn(['cards', id], null) !== null) {
+    if (getState().cards.get(id, null) !== null) {
       return;
     }
 

--- a/app/javascript/mastodon/actions/favourites.js
+++ b/app/javascript/mastodon/actions/favourites.js
@@ -10,7 +10,7 @@ export const FAVOURITED_STATUSES_EXPAND_FAIL    = 'FAVOURITED_STATUSES_EXPAND_FA
 
 export function fetchFavouritedStatuses() {
   return (dispatch, getState) => {
-    if (getState().getIn(['status_lists', 'favourites', 'isLoading'])) {
+    if (getState().status_lists.getIn(['favourites', 'isLoading'])) {
       return;
     }
 
@@ -48,9 +48,9 @@ export function fetchFavouritedStatusesFail(error) {
 
 export function expandFavouritedStatuses() {
   return (dispatch, getState) => {
-    const url = getState().getIn(['status_lists', 'favourites', 'next'], null);
+    const url = getState().status_lists.getIn(['favourites', 'next'], null);
 
-    if (url === null || getState().getIn(['status_lists', 'favourites', 'isLoading'])) {
+    if (url === null || getState().status_lists.getIn(['favourites', 'isLoading'])) {
       return;
     }
 

--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -41,7 +41,7 @@ export const LIST_EDITOR_REMOVE_SUCCESS = 'LIST_EDITOR_REMOVE_SUCCESS';
 export const LIST_EDITOR_REMOVE_FAIL    = 'LIST_EDITOR_REMOVE_FAIL';
 
 export const fetchList = id => (dispatch, getState) => {
-  if (getState().getIn(['lists', id])) {
+  if (getState().lists.get(id)) {
     return;
   }
 
@@ -91,8 +91,8 @@ export const fetchListsFail = error => ({
 });
 
 export const submitListEditor = shouldReset => (dispatch, getState) => {
-  const listId = getState().getIn(['listEditor', 'listId']);
-  const title  = getState().getIn(['listEditor', 'title']);
+  const listId = getState().listEditor.get('listId');
+  const title  = getState().listEditor.get('title');
 
   if (listId === null) {
     dispatch(createList(title, shouldReset));
@@ -104,7 +104,7 @@ export const submitListEditor = shouldReset => (dispatch, getState) => {
 export const setupListEditor = listId => (dispatch, getState) => {
   dispatch({
     type: LIST_EDITOR_SETUP,
-    list: getState().getIn(['lists', listId]),
+    list: getState().lists.get(listId),
   });
 
   dispatch(fetchListAccounts(listId));
@@ -251,7 +251,7 @@ export const changeListSuggestions = value => ({
 });
 
 export const addToListEditor = accountId => (dispatch, getState) => {
-  dispatch(addToList(getState().getIn(['listEditor', 'listId']), accountId));
+  dispatch(addToList(getState().listEditor.get('listId'), accountId));
 };
 
 export const addToList = (listId, accountId) => (dispatch, getState) => {
@@ -282,7 +282,7 @@ export const addToListFail = (listId, accountId, error) => ({
 });
 
 export const removeFromListEditor = accountId => (dispatch, getState) => {
-  dispatch(removeFromList(getState().getIn(['listEditor', 'listId']), accountId));
+  dispatch(removeFromList(getState().listEditor.get('listId'), accountId));
 };
 
 export const removeFromList = (listId, accountId) => (dispatch, getState) => {

--- a/app/javascript/mastodon/actions/mutes.js
+++ b/app/javascript/mastodon/actions/mutes.js
@@ -48,7 +48,7 @@ export function fetchMutesFail(error) {
 
 export function expandMutes() {
   return (dispatch, getState) => {
-    const url = getState().getIn(['user_lists', 'mutes', 'next']);
+    const url = getState().user_lists.getIn(['mutes', 'next']);
 
     if (url === null) {
       return;

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -38,8 +38,8 @@ const unescapeHTML = (html) => {
 
 export function updateNotifications(notification, intlMessages, intlLocale) {
   return (dispatch, getState) => {
-    const showAlert = getState().getIn(['settings', 'notifications', 'alerts', notification.type], true);
-    const playSound = getState().getIn(['settings', 'notifications', 'sounds', notification.type], true);
+    const showAlert = getState().settings.getIn(['notifications', 'alerts', notification.type], true);
+    const playSound = getState().settings.getIn(['notifications', 'sounds', notification.type], true);
 
     dispatch({
       type: NOTIFICATIONS_UPDATE,
@@ -65,12 +65,12 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
   };
 };
 
-const excludeTypesFromSettings = state => state.getIn(['settings', 'notifications', 'shows']).filter(enabled => !enabled).keySeq().toJS();
+const excludeTypesFromSettings = state => state.settings.getIn(['notifications', 'shows']).filter(enabled => !enabled).keySeq().toJS();
 
 export function refreshNotifications() {
   return (dispatch, getState) => {
     const params = {};
-    const ids    = getState().getIn(['notifications', 'items']);
+    const ids    = getState().notifications.get('items');
 
     let skipLoading = false;
 
@@ -78,7 +78,7 @@ export function refreshNotifications() {
       params.since_id = ids.first().get('id');
     }
 
-    if (getState().getIn(['notifications', 'loaded'])) {
+    if (getState().notifications.get('loaded')) {
       skipLoading = true;
     }
 
@@ -125,9 +125,9 @@ export function refreshNotificationsFail(error, skipLoading) {
 
 export function expandNotifications() {
   return (dispatch, getState) => {
-    const items  = getState().getIn(['notifications', 'items'], ImmutableList());
+    const items  = getState().notifications.get('items', ImmutableList());
 
-    if (getState().getIn(['notifications', 'isLoading']) || items.size === 0) {
+    if (getState().notifications.get('isLoading') || items.size === 0) {
       return;
     }
 

--- a/app/javascript/mastodon/actions/onboarding.js
+++ b/app/javascript/mastodon/actions/onboarding.js
@@ -3,7 +3,7 @@ import { changeSetting, saveSettings } from './settings';
 
 export function showOnboardingOnce() {
   return (dispatch, getState) => {
-    const alreadySeen = getState().getIn(['settings', 'onboarded']);
+    const alreadySeen = getState().settings.get('onboarded');
 
     if (!alreadySeen) {
       dispatch(openModal('ONBOARDING'));

--- a/app/javascript/mastodon/actions/push_notifications/registerer.js
+++ b/app/javascript/mastodon/actions/push_notifications/registerer.js
@@ -57,7 +57,7 @@ export function register () {
     dispatch(setBrowserSupport(supportsPushNotifications));
 
     if (me && !pushNotificationsSetting.get(me)) {
-      const alerts = getState().getIn(['push_notifications', 'alerts']);
+      const alerts = getState().push_notifications.get('alerts');
       if (alerts) {
         pushNotificationsSetting.set(me, { alerts: alerts });
       }
@@ -76,7 +76,7 @@ export function register () {
             // We have a subscription, check if it is still valid
             const currentServerKey = (new Uint8Array(subscription.options.applicationServerKey)).toString();
             const subscriptionServerKey = urlBase64ToUint8Array(getApplicationServerKey()).toString();
-            const serverEndpoint = getState().getIn(['push_notifications', 'subscription', 'endpoint']);
+            const serverEndpoint = getState().push_notifications.get(['subscription', 'endpoint']);
 
             // If the VAPID public key did not change and the endpoint corresponds
             // to the endpoint saved in the backend, the subscription is valid
@@ -132,7 +132,7 @@ export function register () {
 
 export function saveSettings() {
   return (_, getState) => {
-    const state = getState().get('push_notifications');
+    const state = getState().push_notifications;
     const subscription = state.get('subscription');
     const alerts = state.get('alerts');
     const data = { alerts };

--- a/app/javascript/mastodon/actions/reports.js
+++ b/app/javascript/mastodon/actions/reports.js
@@ -43,10 +43,10 @@ export function submitReport() {
     dispatch(submitReportRequest());
 
     api(getState).post('/api/v1/reports', {
-      account_id: getState().getIn(['reports', 'new', 'account_id']),
-      status_ids: getState().getIn(['reports', 'new', 'status_ids']),
-      comment: getState().getIn(['reports', 'new', 'comment']),
-      forward: getState().getIn(['reports', 'new', 'forward']),
+      account_id: getState().reports.getIn(['new', 'account_id']),
+      status_ids: getState().reports.getIn(['new', 'status_ids']),
+      comment: getState().reports.getIn(['new', 'comment']),
+      forward: getState().reports.getIn(['new', 'forward']),
     }).then(response => {
       dispatch(closeModal());
       dispatch(submitReportSuccess(response.data));

--- a/app/javascript/mastodon/actions/search.js
+++ b/app/javascript/mastodon/actions/search.js
@@ -24,7 +24,7 @@ export function clearSearch() {
 
 export function submitSearch() {
   return (dispatch, getState) => {
-    const value = getState().getIn(['search', 'value']);
+    const value = getState().search.get('value');
 
     if (value.length === 0) {
       return;

--- a/app/javascript/mastodon/actions/settings.js
+++ b/app/javascript/mastodon/actions/settings.js
@@ -17,11 +17,11 @@ export function changeSetting(path, value) {
 };
 
 const debouncedSave = debounce((dispatch, getState) => {
-  if (getState().getIn(['settings', 'saved'])) {
+  if (getState().settings.get('saved')) {
     return;
   }
 
-  const data = getState().get('settings').filter((_, path) => path !== 'saved').toJS();
+  const data = getState().settings.filter((_, path) => path !== 'saved').toJS();
 
   api(getState).put('/api/web/settings', { data }).then(() => dispatch({ type: SETTING_SAVE }));
 }, 5000, { trailing: true });

--- a/app/javascript/mastodon/actions/statuses.js
+++ b/app/javascript/mastodon/actions/statuses.js
@@ -36,7 +36,7 @@ export function fetchStatusRequest(id, skipLoading) {
 
 export function fetchStatus(id) {
   return (dispatch, getState) => {
-    const skipLoading = getState().getIn(['statuses', id], null) !== null;
+    const skipLoading = getState().statuses.get(id, null) !== null;
 
     dispatch(fetchContext(id));
     dispatch(fetchStatusCard(id));

--- a/app/javascript/mastodon/actions/streaming.js
+++ b/app/javascript/mastodon/actions/streaming.js
@@ -14,7 +14,7 @@ const { messages } = getLocale();
 export function connectTimelineStream (timelineId, path, pollingRefresh = null) {
 
   return connectStream (path, pollingRefresh, (dispatch, getState) => {
-    const locale = getState().getIn(['meta', 'locale']);
+    const locale = getState().meta.get('locale');
     return {
       onConnect() {
         dispatch(connectTimeline(timelineId));

--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -32,15 +32,15 @@ export function refreshTimelineSuccess(timeline, statuses, skipLoading, next, pa
 
 export function updateTimeline(timeline, status) {
   return (dispatch, getState) => {
-    const references = status.reblog ? getState().get('statuses').filter((item, itemId) => (itemId === status.reblog.id || item.get('reblog') === status.reblog.id)).map((_, itemId) => itemId) : [];
+    const references = status.reblog ? getState().statuses.filter((item, itemId) => (itemId === status.reblog.id || item.get('reblog') === status.reblog.id)).map((_, itemId) => itemId) : [];
     const parents = [];
 
     if (status.in_reply_to_id) {
-      let parent = getState().getIn(['statuses', status.in_reply_to_id]);
+      let parent = getState().statuses.get(status.in_reply_to_id);
 
       while (parent && parent.get('in_reply_to_id')) {
         parents.push(parent.get('id'));
-        parent = getState().getIn(['statuses', parent.get('in_reply_to_id')]);
+        parent = getState().statuses.get(parent.get('in_reply_to_id'));
       }
     }
 
@@ -63,9 +63,9 @@ export function updateTimeline(timeline, status) {
 
 export function deleteFromTimelines(id) {
   return (dispatch, getState) => {
-    const accountId  = getState().getIn(['statuses', id, 'account']);
-    const references = getState().get('statuses').filter(status => status.get('reblog') === id).map(status => [status.get('id'), status.get('account')]);
-    const reblogOf   = getState().getIn(['statuses', id, 'reblog'], null);
+    const accountId  = getState().statuses.getIn([id, 'account']);
+    const references = getState().statuses.filter(status => status.get('reblog') === id).map(status => [status.get('id'), status.get('account')]);
+    const reblogOf   = getState().statuses.getIn([id, 'reblog'], null);
 
     dispatch({
       type: TIMELINE_DELETE,
@@ -87,7 +87,7 @@ export function refreshTimelineRequest(timeline, skipLoading) {
 
 export function refreshTimeline(timelineId, path, params = {}) {
   return function (dispatch, getState) {
-    const timeline = getState().getIn(['timelines', timelineId], ImmutableMap());
+    const timeline = getState().timelines.get(timelineId, ImmutableMap());
 
     if (timeline.get('isLoading') || (timeline.get('online') && !timeline.get('isPartial'))) {
       return;
@@ -138,7 +138,7 @@ export function refreshTimelineFail(timeline, error, skipLoading) {
 
 export function expandTimeline(timelineId, path, params = {}) {
   return (dispatch, getState) => {
-    const timeline = getState().getIn(['timelines', timelineId], ImmutableMap());
+    const timeline = getState().timelines.get(timelineId, ImmutableMap());
     const ids      = timeline.get('items', ImmutableList());
 
     if (timeline.get('isLoading') || ids.size === 0) {

--- a/app/javascript/mastodon/api.js
+++ b/app/javascript/mastodon/api.js
@@ -21,7 +21,7 @@ ready(setCSRFHeader);
 
 export default getState => axios.create({
   headers: Object.assign(csrfHeader, getState ? {
-    'Authorization': `Bearer ${getState().getIn(['meta', 'access_token'], '')}`,
+    'Authorization': `Bearer ${getState().meta.get('access_token', '')}`,
   } : {}),
 
   transformResponse: [function (data) {

--- a/app/javascript/mastodon/containers/dropdown_menu_container.js
+++ b/app/javascript/mastodon/containers/dropdown_menu_container.js
@@ -5,9 +5,9 @@ import DropdownMenu from '../components/dropdown_menu';
 import { isUserTouching } from '../is_mobile';
 
 const mapStateToProps = state => ({
-  isModalOpen: state.get('modal').modalType === 'ACTIONS',
-  dropdownPlacement: state.getIn(['dropdown_menu', 'placement']),
-  openDropdownId: state.getIn(['dropdown_menu', 'openId']),
+  isModalOpen: state.modal.modalType === 'ACTIONS',
+  dropdownPlacement: state.dropdown_menu.get('placement'),
+  openDropdownId: state.dropdown_menu.get('openId'),
 });
 
 const mapDispatchToProps = (dispatch, { status, items }) => ({

--- a/app/javascript/mastodon/containers/intersection_observer_article_container.js
+++ b/app/javascript/mastodon/containers/intersection_observer_article_container.js
@@ -3,7 +3,7 @@ import IntersectionObserverArticle from '../components/intersection_observer_art
 import { setHeight } from '../actions/height_cache';
 
 const makeMapStateToProps = (state, props) => ({
-  cachedHeight: state.getIn(['height_cache', props.saveHeightKey, props.id]),
+  cachedHeight: state.height_cache.getIn([props.saveHeightKey, props.id]),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { persistStore } from 'redux-persist';
+import { PersistGate } from 'redux-persist/integration/react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
 import configureStore from '../store/configureStore';
@@ -18,6 +20,8 @@ addLocaleData(localeData);
 export const store = configureStore();
 const hydrateAction = hydrateStore(initialState);
 store.dispatch(hydrateAction);
+
+const persistor = persistStore(store);
 
 export default class Mastodon extends React.PureComponent {
 
@@ -57,11 +61,13 @@ export default class Mastodon extends React.PureComponent {
     return (
       <IntlProvider locale={locale} messages={messages}>
         <Provider store={store}>
-          <BrowserRouter basename='/web'>
-            <ScrollContext>
-              <Route path='/' component={UI} />
-            </ScrollContext>
-          </BrowserRouter>
+          <PersistGate persistor={persistor}>
+            <BrowserRouter basename='/web'>
+              <ScrollContext>
+                <Route path='/' component={UI} />
+              </ScrollContext>
+            </BrowserRouter>
+          </PersistGate>
         </Provider>
       </IntlProvider>
     );

--- a/app/javascript/mastodon/features/account_gallery/index.js
+++ b/app/javascript/mastodon/features/account_gallery/index.js
@@ -16,8 +16,8 @@ import LoadMore from '../../components/load_more';
 
 const mapStateToProps = (state, props) => ({
   medias: getAccountGallery(state, props.params.accountId),
-  isLoading: state.getIn(['timelines', `account:${props.params.accountId}:media`, 'isLoading']),
-  hasMore: !!state.getIn(['timelines', `account:${props.params.accountId}:media`, 'next']),
+  isLoading: state.timelines.getIn([`account:${props.params.accountId}:media`, 'isLoading']),
+  hasMore: !!state.timelines.getIn([`account:${props.params.accountId}:media`, 'next']),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/account_timeline/index.js
+++ b/app/javascript/mastodon/features/account_timeline/index.js
@@ -16,10 +16,10 @@ const mapStateToProps = (state, { params: { accountId }, withReplies = false }) 
   const path = withReplies ? `${accountId}:with_replies` : accountId;
 
   return {
-    statusIds: state.getIn(['timelines', `account:${path}`, 'items'], ImmutableList()),
-    featuredStatusIds: withReplies ? ImmutableList() : state.getIn(['timelines', `account:${accountId}:pinned`, 'items'], ImmutableList()),
-    isLoading: state.getIn(['timelines', `account:${path}`, 'isLoading']),
-    hasMore: !!state.getIn(['timelines', `account:${path}`, 'next']),
+    statusIds: state.timelines.getIn([`account:${path}`, 'items'], ImmutableList()),
+    featuredStatusIds: withReplies ? ImmutableList() : state.timelines.getIn([`account:${accountId}:pinned`, 'items'], ImmutableList()),
+    isLoading: state.timelines.getIn([`account:${path}`, 'isLoading']),
+    hasMore: !!state.timelines.getIn([`account:${path}`, 'next']),
   };
 };
 

--- a/app/javascript/mastodon/features/blocks/index.js
+++ b/app/javascript/mastodon/features/blocks/index.js
@@ -16,7 +16,7 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  accountIds: state.getIn(['user_lists', 'blocks', 'items']),
+  accountIds: state.user_lists.getIn(['blocks', 'items']),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/community_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/community_timeline/containers/column_settings_container.js
@@ -3,7 +3,7 @@ import ColumnSettings from '../components/column_settings';
 import { changeSetting } from '../../../actions/settings';
 
 const mapStateToProps = state => ({
-  settings: state.getIn(['settings', 'community']),
+  settings: state.settings.get('community'),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/community_timeline/index.js
+++ b/app/javascript/mastodon/features/community_timeline/index.js
@@ -18,7 +18,7 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  hasUnread: state.getIn(['timelines', 'community', 'unread']) > 0,
+  hasUnread: state.timelines.getIn(['community', 'unread']) > 0,
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/compose/components/upload_button.js
+++ b/app/javascript/mastodon/features/compose/components/upload_button.js
@@ -12,7 +12,7 @@ const messages = defineMessages({
 
 const makeMapStateToProps = () => {
   const mapStateToProps = state => ({
-    acceptContentTypes: state.getIn(['media_attachments', 'accept_content_types']),
+    acceptContentTypes: state.media_attachments.get('accept_content_types'),
   });
 
   return mapStateToProps;

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -12,18 +12,18 @@ import {
 } from '../../../actions/compose';
 
 const mapStateToProps = state => ({
-  text: state.getIn(['compose', 'text']),
-  suggestion_token: state.getIn(['compose', 'suggestion_token']),
-  suggestions: state.getIn(['compose', 'suggestions']),
-  spoiler: state.getIn(['compose', 'spoiler']),
-  spoiler_text: state.getIn(['compose', 'spoiler_text']),
-  privacy: state.getIn(['compose', 'privacy']),
-  focusDate: state.getIn(['compose', 'focusDate']),
-  preselectDate: state.getIn(['compose', 'preselectDate']),
-  is_submitting: state.getIn(['compose', 'is_submitting']),
-  is_uploading: state.getIn(['compose', 'is_uploading']),
-  showSearch: state.getIn(['search', 'submitted']) && !state.getIn(['search', 'hidden']),
-  anyMedia: state.getIn(['compose', 'media_attachments']).size > 0,
+  text: state.compose.get('text'),
+  suggestion_token: state.compose.get('suggestion_token'),
+  suggestions: state.compose.get('suggestions'),
+  spoiler: state.compose.get('spoiler'),
+  spoiler_text: state.compose.get('spoiler_text'),
+  privacy: state.compose.get('privacy'),
+  focusDate: state.compose.get('focusDate'),
+  preselectDate: state.compose.get('preselectDate'),
+  is_submitting: state.compose.get('is_submitting'),
+  is_uploading: state.compose.get('is_uploading'),
+  showSearch: state.search.get('submitted') && !state.search.get('hidden'),
+  anyMedia: state.compose.get('media_attachments').size > 0,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/javascript/mastodon/features/compose/containers/emoji_picker_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/emoji_picker_dropdown_container.js
@@ -28,7 +28,7 @@ const DEFAULTS = [
 ];
 
 const getFrequentlyUsedEmojis = createSelector([
-  state => state.getIn(['settings', 'frequentlyUsedEmojis'], ImmutableMap()),
+  state => state.settings.get('frequentlyUsedEmojis', ImmutableMap()),
 ], emojiCounters => {
   let emojis = emojiCounters
     .keySeq()
@@ -45,7 +45,7 @@ const getFrequentlyUsedEmojis = createSelector([
 });
 
 const getCustomEmojis = createSelector([
-  state => state.get('custom_emojis'),
+  state => state.custom_emojis,
 ], emojis => emojis.filter(e => e.get('visible_in_picker')).sort((a, b) => {
   const aShort = a.get('shortcode').toLowerCase();
   const bShort = b.get('shortcode').toLowerCase();
@@ -61,7 +61,7 @@ const getCustomEmojis = createSelector([
 
 const mapStateToProps = state => ({
   custom_emojis: getCustomEmojis(state),
-  skinTone: state.getIn(['settings', 'skinTone']),
+  skinTone: state.settings.get('skinTone'),
   frequentlyUsedEmojis: getFrequentlyUsedEmojis(state),
 });
 

--- a/app/javascript/mastodon/features/compose/containers/navigation_container.js
+++ b/app/javascript/mastodon/features/compose/containers/navigation_container.js
@@ -4,7 +4,7 @@ import { me } from '../../../initial_state';
 
 const mapStateToProps = state => {
   return {
-    account: state.getIn(['accounts', me]),
+    account: state.accounts.get(me),
   };
 };
 

--- a/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
@@ -5,8 +5,8 @@ import { openModal, closeModal } from '../../../actions/modal';
 import { isUserTouching } from '../../../is_mobile';
 
 const mapStateToProps = state => ({
-  isModalOpen: state.get('modal').modalType === 'ACTIONS',
-  value: state.getIn(['compose', 'privacy']),
+  isModalOpen: state.modal.modalType === 'ACTIONS',
+  value: state.compose.get('privacy'),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/compose/containers/reply_indicator_container.js
+++ b/app/javascript/mastodon/features/compose/containers/reply_indicator_container.js
@@ -7,7 +7,7 @@ const makeMapStateToProps = () => {
   const getStatus = makeGetStatus();
 
   const mapStateToProps = state => ({
-    status: getStatus(state, state.getIn(['compose', 'in_reply_to'])),
+    status: getStatus(state, state.compose.get('in_reply_to')),
   });
 
   return mapStateToProps;

--- a/app/javascript/mastodon/features/compose/containers/search_container.js
+++ b/app/javascript/mastodon/features/compose/containers/search_container.js
@@ -8,8 +8,8 @@ import {
 import Search from '../components/search';
 
 const mapStateToProps = state => ({
-  value: state.getIn(['search', 'value']),
-  submitted: state.getIn(['search', 'submitted']),
+  value: state.search.get('value'),
+  submitted: state.search.get('submitted'),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/compose/containers/search_results_container.js
+++ b/app/javascript/mastodon/features/compose/containers/search_results_container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import SearchResults from '../components/search_results';
 
 const mapStateToProps = state => ({
-  results: state.getIn(['search', 'results']),
+  results: state.search.get('results'),
 });
 
 export default connect(mapStateToProps)(SearchResults);

--- a/app/javascript/mastodon/features/compose/containers/sensitive_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/sensitive_button_container.js
@@ -14,9 +14,9 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  visible: state.getIn(['compose', 'media_attachments']).size > 0,
-  active: state.getIn(['compose', 'sensitive']),
-  disabled: state.getIn(['compose', 'spoiler']),
+  visible: state.compose.get('media_attachments').size > 0,
+  active: state.compose.get('sensitive'),
+  disabled: state.compose.get('spoiler'),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
@@ -10,8 +10,8 @@ const messages = defineMessages({
 
 const mapStateToProps = (state, { intl }) => ({
   label: 'CW',
-  title: intl.formatMessage(state.getIn(['compose', 'spoiler']) ? messages.marked : messages.unmarked),
-  active: state.getIn(['compose', 'spoiler']),
+  title: intl.formatMessage(state.compose.get('spoiler') ? messages.marked : messages.unmarked),
+  active: state.compose.get('spoiler'),
   ariaControls: 'cw-spoiler-input',
 });
 

--- a/app/javascript/mastodon/features/compose/containers/upload_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_button_container.js
@@ -3,8 +3,8 @@ import UploadButton from '../components/upload_button';
 import { uploadCompose } from '../../../actions/compose';
 
 const mapStateToProps = state => ({
-  disabled: state.getIn(['compose', 'is_uploading']) || (state.getIn(['compose', 'media_attachments']).size > 3 || state.getIn(['compose', 'media_attachments']).some(m => m.get('type') === 'video')),
-  resetFileKey: state.getIn(['compose', 'resetFileKey']),
+  disabled: state.compose.get('is_uploading') || (state.compose.get('media_attachments').size > 3 || state.compose.get('media_attachments').some(m => m.get('type') === 'video')),
+  resetFileKey: state.compose.get('resetFileKey'),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/compose/containers/upload_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_container.js
@@ -4,7 +4,7 @@ import { undoUploadCompose, changeUploadCompose } from '../../../actions/compose
 import { openModal } from '../../../actions/modal';
 
 const mapStateToProps = (state, { id }) => ({
-  media: state.getIn(['compose', 'media_attachments']).find(item => item.get('id') === id),
+  media: state.compose.getIn('media_attachments').find(item => item.get('id') === id),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/compose/containers/upload_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_form_container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import UploadForm from '../components/upload_form';
 
 const mapStateToProps = state => ({
-  mediaIds: state.getIn(['compose', 'media_attachments']).map(item => item.get('id')),
+  mediaIds: state.compose.get('media_attachments').map(item => item.get('id')),
 });
 
 export default connect(mapStateToProps)(UploadForm);

--- a/app/javascript/mastodon/features/compose/containers/upload_progress_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_progress_container.js
@@ -2,8 +2,8 @@ import { connect } from 'react-redux';
 import UploadProgress from '../components/upload_progress';
 
 const mapStateToProps = state => ({
-  active: state.getIn(['compose', 'is_uploading']),
-  progress: state.getIn(['compose', 'progress']),
+  active: state.compose.get('is_uploading'),
+  progress: state.compose.get('progress'),
 });
 
 export default connect(mapStateToProps)(UploadProgress);

--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -8,8 +8,8 @@ import { me } from '../../../initial_state';
 const APPROX_HASHTAG_RE = /(?:^|[^\/\)\w])#(\w*[a-zA-Z·]\w*)/i;
 
 const mapStateToProps = state => ({
-  needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),
-  hashtagWarning: state.getIn(['compose', 'privacy']) !== 'public' && APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])),
+  needsLockWarning: state.compose.get('privacy') === 'private' && !state.accounts.getIn([me, 'locked']),
+  hashtagWarning: state.compose.get('privacy') !== 'public' && APPROX_HASHTAG_RE.test(state.compose.get('text')),
 });
 
 const WarningWrapper = ({ needsLockWarning, hashtagWarning }) => {

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -25,8 +25,8 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  columns: state.getIn(['settings', 'columns']),
-  showSearch: state.getIn(['search', 'submitted']) && !state.getIn(['search', 'hidden']),
+  columns: state.settings.get('columns'),
+  showSearch: state.search.get('submitted') && !state.search.get('hidden'),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/favourited_statuses/index.js
+++ b/app/javascript/mastodon/features/favourited_statuses/index.js
@@ -16,9 +16,9 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  statusIds: state.getIn(['status_lists', 'favourites', 'items']),
-  isLoading: state.getIn(['status_lists', 'favourites', 'isLoading'], true),
-  hasMore: !!state.getIn(['status_lists', 'favourites', 'next']),
+  statusIds: state.status_lists.getIn(['favourites', 'items']),
+  isLoading: state.status_lists.getIn(['favourites', 'isLoading'], true),
+  hasMore: !!state.status_lists.getIn(['favourites', 'next']),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/favourites/index.js
+++ b/app/javascript/mastodon/features/favourites/index.js
@@ -11,7 +11,7 @@ import ColumnBackButton from '../../components/column_back_button';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 const mapStateToProps = (state, props) => ({
-  accountIds: state.getIn(['user_lists', 'favourited_by', props.params.statusId]),
+  accountIds: state.user_lists.getIn(['favourited_by', props.params.statusId]),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/follow_requests/index.js
+++ b/app/javascript/mastodon/features/follow_requests/index.js
@@ -16,7 +16,7 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  accountIds: state.getIn(['user_lists', 'follow_requests', 'items']),
+  accountIds: state.user_lists.getIn(['follow_requests', 'items']),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/followers/index.js
+++ b/app/javascript/mastodon/features/followers/index.js
@@ -17,8 +17,8 @@ import ColumnBackButton from '../../components/column_back_button';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 const mapStateToProps = (state, props) => ({
-  accountIds: state.getIn(['user_lists', 'followers', props.params.accountId, 'items']),
-  hasMore: !!state.getIn(['user_lists', 'followers', props.params.accountId, 'next']),
+  accountIds: state.user_lists.getIn(['followers', props.params.accountId, 'items']),
+  hasMore: !!state.user_lists.getIn(['followers', props.params.accountId, 'next']),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/following/index.js
+++ b/app/javascript/mastodon/features/following/index.js
@@ -17,8 +17,8 @@ import ColumnBackButton from '../../components/column_back_button';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 const mapStateToProps = (state, props) => ({
-  accountIds: state.getIn(['user_lists', 'following', props.params.accountId, 'items']),
-  hasMore: !!state.getIn(['user_lists', 'following', props.params.accountId, 'next']),
+  accountIds: state.user_lists.getIn(['following', props.params.accountId, 'items']),
+  hasMore: !!state.user_lists.getIn(['following', props.params.accountId, 'next']),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -32,10 +32,10 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  myAccount: state.getIn(['accounts', me]),
-  columns: state.getIn(['settings', 'columns']),
-  unreadFollowRequests: state.getIn(['user_lists', 'follow_requests', 'items'], ImmutableList()).size,
-  unreadNotifications: state.getIn(['notifications', 'unread']),
+  myAccount: state.accounts.get(me),
+  columns: state.settings.get('columns'),
+  unreadFollowRequests: state.user_lists.getIn(['follow_requests', 'items'], ImmutableList()).size,
+  unreadNotifications: state.notifications.get('unread'),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/hashtag_timeline/index.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.js
@@ -13,7 +13,7 @@ import { FormattedMessage } from 'react-intl';
 import { connectHashtagStream } from '../../actions/streaming';
 
 const mapStateToProps = (state, props) => ({
-  hasUnread: state.getIn(['timelines', `hashtag:${props.params.id}`, 'unread']) > 0,
+  hasUnread: state.timelines.getIn([`hashtag:${props.params.id}`, 'unread']) > 0,
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/home_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/home_timeline/containers/column_settings_container.js
@@ -3,7 +3,7 @@ import ColumnSettings from '../components/column_settings';
 import { changeSetting, saveSettings } from '../../../actions/settings';
 
 const mapStateToProps = state => ({
-  settings: state.getIn(['settings', 'home']),
+  settings: state.settings.get('home'),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/home_timeline/index.js
+++ b/app/javascript/mastodon/features/home_timeline/index.js
@@ -15,8 +15,8 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  hasUnread: state.getIn(['timelines', 'home', 'unread']) > 0,
-  isPartial: state.getIn(['timelines', 'home', 'isPartial'], false),
+  hasUnread: state.timelines.getIn(['home', 'unread']) > 0,
+  isPartial: state.timelines.getIn(['home', 'isPartial'], false),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/list_editor/components/account.js
+++ b/app/javascript/mastodon/features/list_editor/components/account.js
@@ -20,7 +20,7 @@ const makeMapStateToProps = () => {
 
   const mapStateToProps = (state, { accountId, added }) => ({
     account: getAccount(state, accountId),
-    added: typeof added === 'undefined' ? state.getIn(['listEditor', 'accounts', 'items']).includes(accountId) : added,
+    added: typeof added === 'undefined' ? state.listEditor.getIn(['accounts', 'items']).includes(accountId) : added,
   });
 
   return mapStateToProps;

--- a/app/javascript/mastodon/features/list_editor/components/search.js
+++ b/app/javascript/mastodon/features/list_editor/components/search.js
@@ -10,7 +10,7 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  value: state.getIn(['listEditor', 'suggestions', 'value']),
+  value: state.listEditor.getIn(['suggestions', 'value']),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/list_editor/index.js
+++ b/app/javascript/mastodon/features/list_editor/index.js
@@ -11,9 +11,9 @@ import Motion from '../ui/util/optional_motion';
 import spring from 'react-motion/lib/spring';
 
 const mapStateToProps = state => ({
-  title: state.getIn(['listEditor', 'title']),
-  accountIds: state.getIn(['listEditor', 'accounts', 'items']),
-  searchAccountIds: state.getIn(['listEditor', 'suggestions', 'items']),
+  title: state.listEditor.get('title'),
+  accountIds: state.listEditor.getIn(['accounts', 'items']),
+  searchAccountIds: state.listEditor.getIn(['suggestions', 'items']),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -20,8 +20,8 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = (state, props) => ({
-  list: state.getIn(['lists', props.params.id]),
-  hasUnread: state.getIn(['timelines', `list:${props.params.id}`, 'unread']) > 0,
+  list: state.lists.get(props.params.id),
+  hasUnread: state.timelines.getIn([`list:${props.params.id}`, 'unread']) > 0,
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/lists/components/new_list_form.js
+++ b/app/javascript/mastodon/features/lists/components/new_list_form.js
@@ -11,8 +11,8 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  value: state.getIn(['listEditor', 'title']),
-  disabled: state.getIn(['listEditor', 'isSubmitting']),
+  value: state.listEditor.get('title'),
+  disabled: state.listEditor.get('isSubmitting'),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/lists/index.js
+++ b/app/javascript/mastodon/features/lists/index.js
@@ -18,7 +18,7 @@ const messages = defineMessages({
   subheading: { id: 'lists.subheading', defaultMessage: 'Your lists' },
 });
 
-const getOrderedLists = createSelector([state => state.get('lists')], lists => {
+const getOrderedLists = createSelector([state => state.lists], lists => {
   if (!lists) {
     return lists;
   }

--- a/app/javascript/mastodon/features/mutes/index.js
+++ b/app/javascript/mastodon/features/mutes/index.js
@@ -16,7 +16,7 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  accountIds: state.getIn(['user_lists', 'mutes', 'items']),
+  accountIds: state.user_lists.getIn(['mutes', 'items']),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/notifications/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/column_settings_container.js
@@ -12,8 +12,8 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  settings: state.getIn(['settings', 'notifications']),
-  pushSettings: state.get('push_notifications'),
+  settings: state.settings.get('notifications'),
+  pushSettings: state.push_notifications,
 });
 
 const mapDispatchToProps = (dispatch, { intl }) => ({

--- a/app/javascript/mastodon/features/notifications/index.js
+++ b/app/javascript/mastodon/features/notifications/index.js
@@ -19,15 +19,15 @@ const messages = defineMessages({
 });
 
 const getNotifications = createSelector([
-  state => ImmutableList(state.getIn(['settings', 'notifications', 'shows']).filter(item => !item).keys()),
-  state => state.getIn(['notifications', 'items']),
+  state => ImmutableList(state.settings.getIn(['notifications', 'shows']).filter(item => !item).keys()),
+  state => state.notifications.get('items'),
 ], (excludedTypes, notifications) => notifications.filterNot(item => excludedTypes.includes(item.get('type'))));
 
 const mapStateToProps = state => ({
   notifications: getNotifications(state),
-  isLoading: state.getIn(['notifications', 'isLoading'], true),
-  isUnread: state.getIn(['notifications', 'unread']) > 0,
-  hasMore: !!state.getIn(['notifications', 'next']),
+  isLoading: state.notifications.get('isLoading', true),
+  isUnread: state.notifications.get('unread') > 0,
+  hasMore: !!state.notifications.get('next'),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/pinned_statuses/index.js
+++ b/app/javascript/mastodon/features/pinned_statuses/index.js
@@ -14,8 +14,8 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  statusIds: state.getIn(['status_lists', 'pins', 'items']),
-  hasMore: !!state.getIn(['status_lists', 'pins', 'next']),
+  statusIds: state.status_lists.getIn(['pins', 'items']),
+  hasMore: !!state.status_lists.getIn(['pins', 'next']),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/public_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/public_timeline/containers/column_settings_container.js
@@ -3,7 +3,7 @@ import ColumnSettings from '../../community_timeline/components/column_settings'
 import { changeSetting } from '../../../actions/settings';
 
 const mapStateToProps = state => ({
-  settings: state.getIn(['settings', 'public']),
+  settings: state.settings.get('public'),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/public_timeline/index.js
+++ b/app/javascript/mastodon/features/public_timeline/index.js
@@ -18,7 +18,7 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  hasUnread: state.getIn(['timelines', 'public', 'unread']) > 0,
+  hasUnread: state.timelines.getIn(['public', 'unread']) > 0,
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/reblogs/index.js
+++ b/app/javascript/mastodon/features/reblogs/index.js
@@ -11,7 +11,7 @@ import ColumnBackButton from '../../components/column_back_button';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
 const mapStateToProps = (state, props) => ({
-  accountIds: state.getIn(['user_lists', 'reblogged_by', props.params.statusId]),
+  accountIds: state.user_lists.getIn(['reblogged_by', props.params.statusId]),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/report/components/status_check_box.js
+++ b/app/javascript/mastodon/features/report/components/status_check_box.js
@@ -27,8 +27,8 @@ export default class StatusCheckBox extends React.PureComponent {
     if (status.get('media_attachments').size > 0) {
       if (status.get('media_attachments').some(item => item.get('type') === 'unknown')) {
 
-      } else if (status.getIn(['media_attachments', 0, 'type']) === 'video') {
-        const video = status.getIn(['media_attachments', 0]);
+      } else if (status.media_attachments.getIn([0, 'type']) === 'video') {
+        const video = status.media_attachments.get(0);
 
         media = (
           <Bundle fetchComponent={Video} loading={this.renderLoadingVideoPlayer} >

--- a/app/javascript/mastodon/features/report/containers/status_check_box_container.js
+++ b/app/javascript/mastodon/features/report/containers/status_check_box_container.js
@@ -4,8 +4,8 @@ import { toggleStatusReport } from '../../../actions/reports';
 import { Set as ImmutableSet } from 'immutable';
 
 const mapStateToProps = (state, { id }) => ({
-  status: state.getIn(['statuses', id]),
-  checked: state.getIn(['reports', 'new', 'status_ids'], ImmutableSet()).includes(id),
+  status: state.statuses.get(id),
+  checked: state.reports.getIn(['new', 'status_ids'], ImmutableSet()).includes(id),
 });
 
 const mapDispatchToProps = (dispatch, { id }) => ({

--- a/app/javascript/mastodon/features/status/containers/card_container.js
+++ b/app/javascript/mastodon/features/status/containers/card_container.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import Card from '../components/card';
 
 const mapStateToProps = (state, { statusId }) => ({
-  card: state.getIn(['cards', statusId], null),
+  card: state.cards.get(statusId, null),
 });
 
 export default connect(mapStateToProps)(Card);

--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -55,8 +55,8 @@ const makeMapStateToProps = () => {
 
   const mapStateToProps = (state, props) => ({
     status: getStatus(state, props.params.statusId),
-    ancestorsIds: state.getIn(['contexts', 'ancestors', props.params.statusId]),
-    descendantsIds: state.getIn(['contexts', 'descendants', props.params.statusId]),
+    ancestorsIds: state.contexts.getIn(['ancestors', props.params.statusId]),
+    descendantsIds: state.contexts.getIn(['descendants', props.params.statusId]),
   });
 
   return mapStateToProps;

--- a/app/javascript/mastodon/features/ui/components/focal_point_modal.js
+++ b/app/javascript/mastodon/features/ui/components/focal_point_modal.js
@@ -8,7 +8,7 @@ import { changeUploadCompose } from '../../../actions/compose';
 import { getPointerPosition } from '../../video';
 
 const mapStateToProps = (state, { id }) => ({
-  media: state.getIn(['compose', 'media_attachments']).find(item => item.get('id') === id),
+  media: state.compose.get('media_attachments').find(item => item.get('id') === id),
 });
 
 const mapDispatchToProps = (dispatch, { id }) => ({

--- a/app/javascript/mastodon/features/ui/components/mute_modal.js
+++ b/app/javascript/mastodon/features/ui/components/mute_modal.js
@@ -11,9 +11,9 @@ import { toggleHideNotifications } from '../../../actions/mutes';
 
 const mapStateToProps = state => {
   return {
-    isSubmitting: state.getIn(['reports', 'new', 'isSubmitting']),
-    account: state.getIn(['mutes', 'new', 'account']),
-    notifications: state.getIn(['mutes', 'new', 'notifications']),
+    isSubmitting: state.reports.getIn(['new', 'isSubmitting']),
+    account: state.mutes.getIn(['new', 'account']),
+    notifications: state.mutes.getIn(['new', 'notifications']),
   };
 };
 

--- a/app/javascript/mastodon/features/ui/components/onboarding_modal.js
+++ b/app/javascript/mastodon/features/ui/components/onboarding_modal.js
@@ -172,9 +172,9 @@ PageSix.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  myAccount: state.getIn(['accounts', me]),
-  admin: state.getIn(['accounts', state.getIn(['meta', 'admin'])]),
-  domain: state.getIn(['meta', 'domain']),
+  myAccount: state.accounts.get(me),
+  admin: state.accounts.get(state.meta.get('admin')),
+  domain: state.meta.get('domain'),
 });
 
 @connect(mapStateToProps)

--- a/app/javascript/mastodon/features/ui/components/report_modal.js
+++ b/app/javascript/mastodon/features/ui/components/report_modal.js
@@ -23,14 +23,14 @@ const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();
 
   const mapStateToProps = state => {
-    const accountId = state.getIn(['reports', 'new', 'account_id']);
+    const accountId = state.reports.getIn(['new', 'account_id']);
 
     return {
-      isSubmitting: state.getIn(['reports', 'new', 'isSubmitting']),
+      isSubmitting: state.reports.getIn(['new', 'isSubmitting']),
       account: getAccount(state, accountId),
-      comment: state.getIn(['reports', 'new', 'comment']),
-      forward: state.getIn(['reports', 'new', 'forward']),
-      statusIds: OrderedSet(state.getIn(['timelines', `account:${accountId}`, 'items'])).union(state.getIn(['reports', 'new', 'status_ids'])),
+      comment: state.reports.getIn(['new', 'comment']),
+      forward: state.reports.getIn(['new', 'forward']),
+      statusIds: OrderedSet(state.timelines.getIn([`account:${accountId}`, 'items'])).union(state.reports.getIn(['new', 'status_ids'])),
     };
   };
 

--- a/app/javascript/mastodon/features/ui/containers/columns_area_container.js
+++ b/app/javascript/mastodon/features/ui/containers/columns_area_container.js
@@ -2,8 +2,8 @@ import { connect } from 'react-redux';
 import ColumnsArea from '../components/columns_area';
 
 const mapStateToProps = state => ({
-  columns: state.getIn(['settings', 'columns']),
-  isModalOpen: !!state.get('modal').modalType,
+  columns: state.settings.get('columns'),
+  isModalOpen: !!state.modal.modalType,
 });
 
 export default connect(mapStateToProps, null, null, { withRef: true })(ColumnsArea);

--- a/app/javascript/mastodon/features/ui/containers/loading_bar_container.js
+++ b/app/javascript/mastodon/features/ui/containers/loading_bar_container.js
@@ -2,7 +2,7 @@ import { connect }    from 'react-redux';
 import LoadingBar from 'react-redux-loading-bar';
 
 const mapStateToProps = (state) => ({
-  loading: state.get('loadingBar'),
+  loading: state.loadingBar,
 });
 
 export default connect(mapStateToProps)(LoadingBar.WrappedComponent);

--- a/app/javascript/mastodon/features/ui/containers/modal_container.js
+++ b/app/javascript/mastodon/features/ui/containers/modal_container.js
@@ -3,8 +3,8 @@ import { closeModal } from '../../../actions/modal';
 import ModalRoot from '../components/modal_root';
 
 const mapStateToProps = state => ({
-  type: state.get('modal').modalType,
-  props: state.get('modal').modalProps,
+  type: state.modal.modalType,
+  props: state.modal.modalProps,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/mastodon/features/ui/containers/status_list_container.js
+++ b/app/javascript/mastodon/features/ui/containers/status_list_container.js
@@ -7,9 +7,9 @@ import { debounce } from 'lodash';
 import { me } from '../../../initial_state';
 
 const makeGetStatusIds = () => createSelector([
-  (state, { type }) => state.getIn(['settings', type], ImmutableMap()),
-  (state, { type }) => state.getIn(['timelines', type, 'items'], ImmutableList()),
-  (state)           => state.get('statuses'),
+  (state, { type }) => state.settings.get(type, ImmutableMap()),
+  (state, { type }) => state.timelines.get([type, 'items'], ImmutableList()),
+  (state)           => state.statuses,
 ], (columnSettings, statusIds, statuses) => {
   const rawRegex = columnSettings.getIn(['regex', 'body'], '').trim();
   let regex      = null;
@@ -46,9 +46,9 @@ const makeMapStateToProps = () => {
 
   const mapStateToProps = (state, { timelineId }) => ({
     statusIds: getStatusIds(state, { type: timelineId }),
-    isLoading: state.getIn(['timelines', timelineId, 'isLoading'], true),
-    isPartial: state.getIn(['timelines', timelineId, 'isPartial'], false),
-    hasMore: !!state.getIn(['timelines', timelineId, 'next']),
+    isLoading: state.timelines.getIn([timelineId, 'isLoading'], true),
+    isPartial: state.timelines.getIn([timelineId, 'isPartial'], false),
+    hasMore: !!state.timelines.getIn([timelineId, 'next']),
   });
 
   return mapStateToProps;

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -54,9 +54,9 @@ const messages = defineMessages({
 });
 
 const mapStateToProps = state => ({
-  isComposing: state.getIn(['compose', 'is_composing']),
-  hasComposingText: state.getIn(['compose', 'text']) !== '',
-  dropdownMenuIsOpen: state.getIn(['dropdown_menu', 'openId']) !== null,
+  isComposing: state.compose.get('is_composing'),
+  hasComposingText: state.compose.get('text') !== '',
+  dropdownMenuIsOpen: state.dropdown_menu.get('openId') !== null,
 });
 
 const keyMap = {

--- a/app/javascript/mastodon/reducers/index.js
+++ b/app/javascript/mastodon/reducers/index.js
@@ -1,4 +1,4 @@
-import { combineReducers } from 'redux-immutable';
+import { combineReducers } from 'redux';
 import dropdown_menu from './dropdown_menu';
 import timelines from './timelines';
 import meta from './meta';

--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -1,10 +1,10 @@
 import { createSelector } from 'reselect';
 import { List as ImmutableList } from 'immutable';
 
-const getAccountBase         = (state, id) => state.getIn(['accounts', id], null);
-const getAccountCounters     = (state, id) => state.getIn(['accounts_counters', id], null);
-const getAccountRelationship = (state, id) => state.getIn(['relationships', id], null);
-const getAccountMoved        = (state, id) => state.getIn(['accounts', state.getIn(['accounts', id, 'moved'])]);
+const getAccountBase         = (state, id) => state.accounts.get(id, null);
+const getAccountCounters     = (state, id) => state.accounts_counters.get(id, null);
+const getAccountRelationship = (state, id) => state.relationships.get(id, null);
+const getAccountMoved        = (state, id) => state.accounts.get(state.accounts.getIn([id, 'moved']));
 
 export const makeGetAccount = () => {
   return createSelector([getAccountBase, getAccountCounters, getAccountRelationship, getAccountMoved], (base, counters, relationship, moved) => {
@@ -22,10 +22,10 @@ export const makeGetAccount = () => {
 export const makeGetStatus = () => {
   return createSelector(
     [
-      (state, id) => state.getIn(['statuses', id]),
-      (state, id) => state.getIn(['statuses', state.getIn(['statuses', id, 'reblog'])]),
-      (state, id) => state.getIn(['accounts', state.getIn(['statuses', id, 'account'])]),
-      (state, id) => state.getIn(['accounts', state.getIn(['statuses', state.getIn(['statuses', id, 'reblog']), 'account'])]),
+      (state, id) => state.statuses.get(id),
+      (state, id) => state.statuses.get(state.statuses.getIn([id, 'reblog'])),
+      (state, id) => state.accounts.get(state.statuses.getIn([id, 'account'])),
+      (state, id) => state.accounts.get(state.statuses.getIn([state.statuses.getIn([id, 'reblog']), 'account'])),
     ],
 
     (statusBase, statusReblog, accountBase, accountReblog) => {
@@ -47,7 +47,7 @@ export const makeGetStatus = () => {
   );
 };
 
-const getAlertsBase = state => state.get('alerts');
+const getAlertsBase = state => state.alerts;
 
 export const getAlerts = createSelector([getAlertsBase], (base) => {
   let arr = [];
@@ -70,15 +70,15 @@ export const getAlerts = createSelector([getAlertsBase], (base) => {
 export const makeGetNotification = () => {
   return createSelector([
     (_, base)             => base,
-    (state, _, accountId) => state.getIn(['accounts', accountId]),
+    (state, _, accountId) => state.accounts.get(accountId),
   ], (base, account) => {
     return base.set('account', account);
   });
 };
 
 export const getAccountGallery = createSelector([
-  (state, id) => state.getIn(['timelines', `account:${id}:media`, 'items'], ImmutableList()),
-  state       => state.get('statuses'),
+  (state, id) => state.timelines.getIn([`account:${id}:media`, 'items'], ImmutableList()),
+  state       => state.statuses,
 ], (statusIds, statuses) => {
   let medias = ImmutableList();
 

--- a/app/javascript/mastodon/store/configureStore.js
+++ b/app/javascript/mastodon/store/configureStore.js
@@ -1,12 +1,36 @@
+import { fromJS } from 'immutable';
 import { createStore, applyMiddleware, compose } from 'redux';
+import { createTransform, persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 import thunk from 'redux-thunk';
+import initialState from '../initial_state';
 import appReducer from '../reducers';
 import loadingBarMiddleware from '../middleware/loading_bar';
 import errorsMiddleware from '../middleware/errors';
 import soundsMiddleware from '../middleware/sounds';
 
+function immutableTransform(config) {
+  return createTransform(
+    object => object.toJSON ? object.toJSON() : JSON.stringify(object),
+    string => fromJS(JSON.parse(string)),
+    config
+  );
+}
+
+const persistConfig = {
+  key: 'mastodon:' + initialState.meta.me,
+  storage,
+  transforms: [immutableTransform()],
+  whitelist: [
+    'accounts', 'accounts_counters', 'cards', 'contexts',
+    'lists', 'media_attachments', 'mutes', 'notifications',
+    'relationships', 'settings', 'status_lists', 'statuses',
+    'timelines', 'user_lists',
+  ],
+};
+
 export default function configureStore() {
-  return createStore(appReducer, compose(applyMiddleware(
+  return createStore(persistReducer(persistConfig, appReducer), compose(applyMiddleware(
     thunk,
     loadingBarMiddleware({ promiseTypeSuffixes: ['REQUEST', 'SUCCESS', 'FAIL'] }),
     errorsMiddleware(),

--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -2,8 +2,8 @@ import WebSocketClient from 'websocket.js';
 
 export function connectStream(path, pollingRefresh = null, callbacks = () => ({ onConnect() {}, onDisconnect() {}, onReceive() {} })) {
   return (dispatch, getState) => {
-    const streamingAPIBaseURL = getState().getIn(['meta', 'streaming_api_base_url']);
-    const accessToken = getState().getIn(['meta', 'access_token']);
+    const streamingAPIBaseURL = getState().meta.get('streaming_api_base_url');
+    const accessToken = getState().meta.get('access_token');
     const { onConnect, onDisconnect, onReceive } = callbacks(dispatch, getState);
     let polling = null;
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "react-toggle": "^4.0.1",
     "redis": "^2.7.1",
     "redux": "^3.7.1",
+    "redux-persist": "^5.9.1",
     "redux-thunk": "^2.2.0",
     "requestidlecallback": "^0.3.0",
     "reselect": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "react-toggle": "^4.0.1",
     "redis": "^2.7.1",
     "redux": "^3.7.1",
-    "redux-immutable": "^4.0.0",
     "redux-thunk": "^2.2.0",
     "requestidlecallback": "^0.3.0",
     "reselect": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6280,10 +6280,6 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
-redux-immutable@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/redux-immutable/-/redux-immutable-4.0.0.tgz#3a1a32df66366462b63691f0e1dc35e472bbc9f3"
-
 redux-thunk@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6280,6 +6280,10 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-persist@^5.9.1:
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.9.1.tgz#83bd4abd526ef768f63fceee338fa9d8ed6552d6"
+
 redux-thunk@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"


### PR DESCRIPTION
This makes some Redux state persistent and let it work offline.

Some caveats:
* redux-immutable was removed because it is incompatible with redux-persist. It was still possible to remove the dependency because Mastodon does not use features of Immutable like `set` functions for the global state.
* Persistent immutable objects are serialized with `toJS` and deserialized with `fromJS`. Therefore persistent objects are limited to particular types. As far as I see, the objects to be persistent match the condition. [redux-persist-transform-immutable](https://github.com/rt2zz/redux-persist-transform-immutable) is a more sophisticated alternative, but I decided not to use it because of https://github.com/rt2zz/redux-persist-transform-immutable/issues/33 and the simple serialization works for this case.
* We must change the version of persistent store when we change the structure of it after applying this change.