### PR TITLE
If DEFAULT_LOCALE is set, enforce it instead of HTTP request locale

### DIFF
--- a/app/controllers/concerns/localized.rb
+++ b/app/controllers/concerns/localized.rb
@@ -17,7 +17,11 @@ module Localized
   end
 
   def default_locale
-    request_locale || I18n.default_locale
+    if ENV['DEFAULT_LOCALE'].present?
+      I18n.default_locale
+    else
+      request_locale || I18n.default_locale
+    end
   end
 
   def request_locale


### PR DESCRIPTION
Fix #6784 

Allows instances to be more obvious about being regional.