### PR TITLE
Revert #6479, hide sensitive text/images from OpenGraph previews

### DIFF
--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -29,6 +29,35 @@ module StreamEntriesHelper
     [prepend_str, account.note].join(' · ')
   end
 
+  def media_summary(status)
+    attachments = { image: 0, video: 0 }
+
+    status.media_attachments.each do |media|
+      if media.video?
+        attachments[:video] += 1
+      else
+        attachments[:image] += 1
+      end
+    end
+
+    text = attachments.to_a.reject { |_, value| value.zero? }.map { |key, value| t("statuses.attached.#{key}", count: value) }.join(' · ')
+
+    return if text.blank?
+
+    t('statuses.attached.description', attached: text)
+  end
+
+  def status_text_summary(status)
+    return if status.spoiler_text.blank?
+    t('statuses.content_warning', warning: status.spoiler_text)
+  end
+
+  def status_description(status)
+    components = [[media_summary(status), status_text_summary(status)].reject(&:blank?).join(' · ')]
+    components << status.text if status.spoiler_text.blank?
+    components.reject(&:blank?).join("\n\n")
+  end
+
   def stream_link_target
     embedded_view? ? '_blank' : nil
   end

--- a/app/views/accounts/_og.html.haml
+++ b/app/views/accounts/_og.html.haml
@@ -1,6 +1,6 @@
 = opengraph 'og:url', url
 = opengraph 'og:site_name', site_title
-= opengraph 'og:title', [yield(:page_title).strip.presence, site_title].compact.join(' - ')
+= opengraph 'og:title', yield(:page_title).strip
 = opengraph 'og:description', account_description(account)
 = opengraph 'og:image', full_asset_url(account.avatar.url(:original))
 = opengraph 'og:image:width', '120'

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title do
-  = "#{display_name(@account)} (@#{@account.username})"
+  = "#{display_name(@account)} (@#{@account.local_username_and_domain})"
 
 - content_for :header_tags do
   %meta{ name: 'description', content: account_description(@account) }/

--- a/app/views/stream_entries/_og_description.html.haml
+++ b/app/views/stream_entries/_og_description.html.haml
@@ -1,1 +1,1 @@
-= opengraph 'og:description', [activity.spoiler_text, activity.text].reject(&:blank?).join("\n\n")
+= opengraph 'og:description', status_description(activity)

--- a/app/views/stream_entries/_og_image.html.haml
+++ b/app/views/stream_entries/_og_image.html.haml
@@ -1,4 +1,4 @@
-- if activity.is_a?(Status) && activity.media_attachments.any?
+- if activity.is_a?(Status) && activity.non_sensitive_with_media?
   - player_card = false
   - activity.media_attachments.each do |media|
     - if media.image?

--- a/app/views/stream_entries/show.html.haml
+++ b/app/views/stream_entries/show.html.haml
@@ -11,8 +11,8 @@
 
   = opengraph 'og:site_name', site_title
   = opengraph 'og:type', 'article'
-  = opengraph 'og:title', "#{@account.display_name.presence || @account.username} on #{site_hostname}"
-  = opengraph 'og:url', account_stream_entry_url(@account, @stream_entry)
+  = opengraph 'og:title', "#{display_name(@account)} (@#{@account.local_username_and_domain})"
+  = opengraph 'og:url', short_account_status_url(@account, @stream_entry)
 
   = render 'stream_entries/og_description', activity: @stream_entry.activity
   = render 'stream_entries/og_image', activity: @stream_entry.activity, account: @account

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -62,3 +62,4 @@ ignore_unused:
   - 'errors.429'
   - 'admin.accounts.roles.*'
   - 'admin.action_logs.actions.*'
+  - 'statuses.attached.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -634,6 +634,15 @@ en:
     two_factor_authentication: Two-factor Auth
     your_apps: Your applications
   statuses:
+    attached:
+      description: 'Attached: %{attached}'
+      image:
+        one: "%{count} image"
+        other: "%{count} images"
+      video:
+        one: "%{count} video"
+        other: "%{count} videos"
+    content_warning: 'Content warning: %{warning}'
     open_in_web: Open in web
     over_character_limit: character limit of %{max} exceeded
     pin_errors:


### PR DESCRIPTION
See: #6479

Display summary of attachments in description, and mark up content warning if present, e.g.:

    Attached: 3 images · Content warning: Dota 2

When text is not supposed to be hidden, it looks more like:

    Attached: 3 images

    Here is the text of the toot

With #6817, multilinguagility should be assured...

Other changes:

Instead of "Alice on Mastodon", use "Alice (@alice@example.com)" in OpenGraph titles, since "Mastodon" would be value of the OpenGraph `site_name`