### PR TITLE
SMTP_OPENSSL_VERIFY_MODE should not be set to 'peer' unless there is a client certificate

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -256,10 +256,11 @@ namespace :mastodon do
             q.modify :strip
           end
 
-          env['SMTP_OPENSSL_VERIFY_MODE'] = prompt.ask('SMTP OpenSSL verify mode:') do |q|
-            q.required
-            q.default 'peer'
-            q.modify :strip
+          if prompt.yes?('Do you want to use a client certificate to authenticate to the server?', default: false)
+            env['SMTP_OPENSSL_VERIFY_MODE'] = 'peer'
+            prompt.ask('Path to the client certificate:') do |q|
+              q.required
+              q.modify :strip
           end
         end
 


### PR DESCRIPTION
Otherwise, this gives the following error:

```
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)
```

PS: I don't know how to write Ruby code, please check the syntax is ok