### PR TITLE
Display content warning in mail notification emails (fixes #6824)

### DIFF
--- a/app/views/notification_mailer/_status.html.haml
+++ b/app/views/notification_mailer/_status.html.haml
@@ -24,6 +24,11 @@
                                       %bdi= display_name(status.account)
                                       = "@#{status.account.acct}"
 
+                              - if status.spoiler_text?
+                                %div{ dir: rtl_status?(status) ? 'rtl' : 'ltr' }
+                                  %p
+                                    = Formatter.instance.format_spoiler(status)
+
                               %div{ dir: rtl_status?(status) ? 'rtl' : 'ltr' }
                                 = Formatter.instance.format(status)
 

--- a/app/views/notification_mailer/_status.text.erb
+++ b/app/views/notification_mailer/_status.text.erb
@@ -1,3 +1,8 @@
+<% if status.spoiler_text? %>
+<%= raw status.spoiler_text %>
+----
+
+<% end %>
 <%= raw Formatter.instance.plaintext(status) %>
 
 <%= raw t('application_mailer.view')%> <%= web_url("statuses/#{status.id}") %>


### PR DESCRIPTION
This adds the content warning to mail notifications.

Text version has the status prependend by the CW, “----” and a blank line.

I am not completely convinced by the HTML version, but I'm not sure how to make it better.

Here is an example (with “test” as a CW):
![screenshot_20180319-174728](https://user-images.githubusercontent.com/384364/37609689-0ec4b03c-2b9e-11e8-8022-9a63059caa74.png)