### PR TITLE
make pam more understandable and useful

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -155,8 +155,8 @@ STREAMING_CLUSTER_NUM=1
 # The pam environment variable "email" is provided by:
 # https://github.com/devkral/pam_email_extractor
 # PAM_ENABLED=true
-# Fallback Suffix for email address generation (nil by default)
-# PAM_DEFAULT_SUFFIX=pam
+# Fallback email domain for email address generation (LOCAL_DOMAIN by default)
+# PAM_EMAIL_DOMAIN=example.com
 # Name of the pam service (pam "auth" section is evaluated)
 # PAM_DEFAULT_SERVICE=rpam
 # Name of the pam service used for checking if an user can register (pam "account" section is evaluated) (nil (disabled) by default)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -342,7 +342,7 @@ Devise.setup do |config|
     config.usernamefield          = nil
     config.emailfield             = 'email'
     config.check_at_sign          = true
-    config.pam_default_suffix     = ENV.fetch('PAM_DEFAULT_SUFFIX') { nil }
+    config.pam_default_suffix     = ENV.fetch('PAM_EMAIL_DOMAIN') { ENV['LOCAL_DOMAIN'] }
     config.pam_default_service    = ENV.fetch('PAM_DEFAULT_SERVICE') { 'rpam' }
     config.pam_controlled_service = ENV.fetch('PAM_CONTROLLED_SERVICE') { nil }
   end


### PR DESCRIPTION
* rename PAM_DEFAULT_SUFFIX to PAM_EMAIL_DOMAIN
* default to LOCAL_DOMAIN (should be more intuitive and useful than blocking logins where no email environment variable was found)