### PR TITLE
change defaults for redis, postgres

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,12 +1,12 @@
 # Service dependencies
 # You may set REDIS_URL instead for more advanced options
 # You may also set REDIS_NAMESPACE to share Redis between multiple Mastodon servers
-REDIS_HOST=redis
+REDIS_HOST=localhost
 REDIS_PORT=6379
 # You may set DATABASE_URL instead for more advanced options
-DB_HOST=db
+DB_HOST=localhost
 DB_USER=postgres
-DB_NAME=postgres
+DB_NAME=mastodon
 DB_PASS=
 DB_PORT=5432
 # Optional ElasticSearch configuration


### PR DESCRIPTION
* if REDIS_HOST is set to default, logins doesn't work. It isn't obvious and costed me 3 hours to figure out.
* Postgresql throws an error but it would be nicer if it just works.
* rename default database to mastodon as clashes are more unlikely (had that issue)