### PR TITLE
Fix e-mail changed notification (fixes #6778)

### DIFF
--- a/app/views/user_mailer/email_changed.html.haml
+++ b/app/views/user_mailer/email_changed.html.haml
@@ -38,7 +38,7 @@
                           %table.input{ align: 'center', cellspacing: 0, cellpadding: 0 }
                             %tbody
                               %tr
-                                %td= @resource.unconfirmed_email
+                                %td= @resource.try(:unconfirmed_email) ? @resource.unconfirmed_email : @resource.email
 
 %table.email-table{ cellspacing: 0, cellpadding: 0 }
   %tbody

--- a/app/views/user_mailer/email_changed.text.erb
+++ b/app/views/user_mailer/email_changed.text.erb
@@ -4,6 +4,6 @@
 
 <%= t 'devise.mailer.email_changed.explanation' %>
 
-<%= @resource.unconfirmed_email %>
+<%= @resource.try(:unconfirmed_email) ? @resource.unconfirmed_email : @resource.email %>
 
 <%= t 'devise.mailer.email_changed.extra' %>


### PR DESCRIPTION
In Devise::Mailer#email_changed, the new email might be in the email attr.
See: https://github.com/plataformatec/devise/blob/master/app/views/devise/mailer/email_changed.html.erb