### PR TITLE
Fixes/mentions reply order

### DIFF
--- a/app/lib/ostatus/atom_serializer.rb
+++ b/app/lib/ostatus/atom_serializer.rb
@@ -351,7 +351,7 @@ class OStatus::AtomSerializer
     append_element(entry, 'summary', status.spoiler_text, 'xml:lang': status.language) if status.spoiler_text?
     append_element(entry, 'content', Formatter.instance.format(status).to_str, type: 'html', 'xml:lang': status.language)
 
-    status.mentions.each do |mentioned|
+    status.mentions.order(:id).each do |mentioned|
       append_element(entry, 'link', nil, rel: :mentioned, 'ostatus:object-type': OStatus::TagManager::TYPES[:person], href: OStatus::TagManager.instance.uri_for(mentioned.account))
     end
 

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -57,7 +57,7 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   end
 
   def virtual_tags
-    object.mentions + object.tags + object.emojis
+    object.mentions.order(:id) + object.tags + object.emojis
   end
 
   def atom_uri

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -15,7 +15,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   belongs_to :account, serializer: REST::AccountSerializer
 
   has_many :media_attachments, serializer: REST::MediaAttachmentSerializer
-  has_many :mentions
+  has_many :ordered_mentions, key: :mentions
   has_many :tags
   has_many :emojis, serializer: REST::CustomEmojiSerializer
 
@@ -84,6 +84,10 @@ class REST::StatusSerializer < ActiveModel::Serializer
       current_user.account_id == object.account_id &&
       !object.reblog? &&
       %w(public unlisted).include?(object.visibility)
+  end
+
+  def ordered_mentions
+    object.mentions.order(:id)
   end
 
   class ApplicationSerializer < ActiveModel::Serializer


### PR DESCRIPTION
When replying to a toot from the WebUI, the compose box is pre-filled with mentions pulled from the original toot. Unfortunately, they are sometimes reversed (see #6737).

This is because the WebUI relies on the order of the `mentions` fields of the status. This order is not enforced on the server side and will be in fact reversed.

This does not occur when replying to a toot from another Mastodon instance, since the mention list will be serialized twice (ActivityPub/OStatus, then the REST API), reversed each time.

This Pull Request fixes this by enforcing the serialized order to match the order the `Mention` records were inserted into the database.

Unfortunately, this means the behavior will be broken for toots from other instances that haven't been updated to this patch.