### PR TITLE
Fix OpenGraph meta tag's translation error

### DIFF
--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -40,16 +40,16 @@ module StreamEntriesHelper
       end
     end
 
-    text = attachments.to_a.reject { |_, value| value.zero? }.map { |key, value| t("statuses.attached.#{key}", count: value) }.join(' · ')
+    text = attachments.to_a.reject { |_, value| value.zero? }.map { |key, value| t("statuses.attached.#{key}", count: value, default: t("statuses.attached.#{key}", locale: :en)) }.join(' · ')
 
     return if text.blank?
 
-    t('statuses.attached.description', attached: text)
+    t('statuses.attached.description', attached: text, default: t('statuses.attached.description', locale: :en))
   end
 
   def status_text_summary(status)
     return if status.spoiler_text.blank?
-    t('statuses.content_warning', warning: status.spoiler_text)
+    t('statuses.content_warning', warning: status.spoiler_text, default: t('statuses.content_warning', locale: :en))
   end
 
   def status_description(status)

--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -40,16 +40,16 @@ module StreamEntriesHelper
       end
     end
 
-    text = attachments.to_a.reject { |_, value| value.zero? }.map { |key, value| t("statuses.attached.#{key}", count: value, default: t("statuses.attached.#{key}", locale: :en)) }.join(' · ')
+    text = attachments.to_a.reject { |_, value| value.zero? }.map { |key, value| t("statuses.attached.#{key}", count: value, default: t("statuses.attached.#{key}", count: value, locale: :en)) }.join(' · ')
 
     return if text.blank?
 
-    t('statuses.attached.description', attached: text, default: t('statuses.attached.description', locale: :en))
+    t('statuses.attached.description', attached: text, default: t('statuses.attached.description', attached: text, locale: :en))
   end
 
   def status_text_summary(status)
     return if status.spoiler_text.blank?
-    t('statuses.content_warning', warning: status.spoiler_text, default: t('statuses.content_warning', locale: :en))
+    t('statuses.content_warning', warning: status.spoiler_text, default: t('statuses.content_warning', warning: status.spoiler_text, locale: :en))
   end
 
   def status_description(status)


### PR DESCRIPTION
After #6818 , "translation missing" is displayed in og: description of OGP meta tag on toot direct link  in untranslated language.
This PR will fix it.

before:
![2](https://user-images.githubusercontent.com/766076/37646699-b076251c-2c6d-11e8-8f70-443d85fc4f92.jpg)


after:
![3](https://user-images.githubusercontent.com/766076/37646723-ba0db572-2c6d-11e8-96c6-cea6f6bebf83.jpg)
