### PR TITLE
Use username/domain to match existing accounts in ActivityPub

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -16,7 +16,7 @@ class ActivityPub::ProcessAccountService < BaseService
 
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?
-        @account        = Account.find_by(uri: @uri)
+        @account        = Account.find_remote(@username, @domain)
         @old_public_key = @account&.public_key
         @old_protocol   = @account&.protocol
 


### PR DESCRIPTION
See also: #6837, #6667 

This makes ActivityPub processing behaviour consistent with ResolveAccountService, and username/domain ultimately authoritative over URIs. That's not *purist*, I admit, but at the same time: If the username/domain is how people address each other (and it is), why should something else differentiate accounts? So I think it's fine.

This PR does not resolve the potential presence of duplicates.