### PR TITLE
Add LDAP_TLS_NO_VERIFY option, don't require LDAP_ENABLED outside .env

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -55,6 +55,8 @@ module Devise
   @@ldap_bind_dn = nil
   mattr_accessor :ldap_password
   @@ldap_password = nil
+  mattr_accessor :ldap_tls_no_verify
+  @@ldap_tls_no_verify = false
 
   class Strategies::PamAuthenticatable
     def valid?
@@ -357,5 +359,6 @@ Devise.setup do |config|
     config.ldap_bind_dn        = ENV.fetch('LDAP_BIND_DN')
     config.ldap_password       = ENV.fetch('LDAP_PASSWORD')
     config.ldap_uid            = ENV.fetch('LDAP_UID', 'cn')
+    config.ldap_tls_no_verify  = ENV['LDAP_TLS_NO_VERIFY'] == 'true'
   end
 end

--- a/lib/devise/ldap_authenticatable.rb
+++ b/lib/devise/ldap_authenticatable.rb
@@ -1,49 +1,53 @@
 # frozen_string_literal: true
 
-if ENV['LDAP_ENABLED'] == 'true'
-  require 'net/ldap'
-  require 'devise/strategies/authenticatable'
+require 'net/ldap'
+require 'devise/strategies/authenticatable'
 
-  module Devise
-    module Strategies
-      class LdapAuthenticatable < Authenticatable
-        def authenticate!
-          if params[:user]
-            ldap = Net::LDAP.new(
-              host: Devise.ldap_host,
-              port: Devise.ldap_port,
-              base: Devise.ldap_base,
-              encryption: {
-                method: Devise.ldap_method,
-                tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS,
-              },
-              auth: {
-                method: :simple,
-                username: Devise.ldap_bind_dn,
-                password: Devise.ldap_password,
-              },
-              connect_timeout: 10
-            )
+module Devise
+  module Strategies
+    class LdapAuthenticatable < Authenticatable
+      def authenticate!
+        if params[:user]
+          ldap = Net::LDAP.new(
+            host: Devise.ldap_host,
+            port: Devise.ldap_port,
+            base: Devise.ldap_base,
+            encryption: {
+              method: Devise.ldap_method,
+              tls_options: tls_options,
+            },
+            auth: {
+              method: :simple,
+              username: Devise.ldap_bind_dn,
+              password: Devise.ldap_password,
+            },
+            connect_timeout: 10
+          )
 
-            if (user_info = ldap.bind_as(base: Devise.ldap_base, filter: "(#{Devise.ldap_uid}=#{email})", password: password))
-              user = User.ldap_get_user(user_info.first)
-              success!(user)
-            else
-              return fail(:invalid_login)
-            end
+          if (user_info = ldap.bind_as(base: Devise.ldap_base, filter: "(#{Devise.ldap_uid}=#{email})", password: password))
+            user = User.ldap_get_user(user_info.first)
+            success!(user)
+          else
+            return fail(:invalid_login)
           end
         end
+      end
 
-        def email
-          params[:user][:email]
-        end
+      def email
+        params[:user][:email]
+      end
 
-        def password
-          params[:user][:password]
+      def password
+        params[:user][:password]
+      end
+
+      def tls_options
+        OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.tap do |options|
+          options[:verify_mode] = OpenSSL::SSL::VERIFY_NONE if Devise.ldap_tls_no_verify
         end
       end
     end
   end
-
-  Warden::Strategies.add(:ldap_authenticatable, Devise::Strategies::LdapAuthenticatable)
 end
+
+Warden::Strategies.add(:ldap_authenticatable, Devise::Strategies::LdapAuthenticatable)


### PR DESCRIPTION
Fix #6816, fix #6790