### PR TITLE
paperclip: allow S3 server-side encryption

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -91,6 +91,7 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # S3_REGION=
 # S3_PROTOCOL=http
 # S3_HOSTNAME=192.168.1.123:9000
+# S3_SERVER_SIDE_ENCRYPTION=AES256
 
 # S3 (Minio Config (optional) Please check Minio instance for details)
 # S3_ENABLED=true

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -29,6 +29,7 @@ if ENV['S3_ENABLED'] == 'true'
       'Cache-Control' => 'max-age=315576000',
     },
     s3_permissions: ENV.fetch('S3_PERMISSION') { 'public-read' },
+    s3_server_side_encryption: ENV.fetch('S3_SERVER_SIDE_ENCRYPTION') { false },
     s3_region: s3_region,
     s3_credentials: {
       bucket: ENV['S3_BUCKET'],


### PR DESCRIPTION
S3 offers a server-side encryption feature, where they will encrypt data
at-rest and decrypt it on-the-fly before serving. This may provide an
additional layer of protection for our users' media assets.

It is disabled by default, but can be enabled by adding:

S3_SERVER_SIDE_ENCRYPTION=AES256

to .env.production.