### PR TITLE
Do not re-query mentions from serializers

### DIFF
--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -57,7 +57,7 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   end
 
   def virtual_tags
-    object.mentions.order(:id) + object.tags + object.emojis
+    object.mentions.to_a.sort_by(&:id) + object.tags + object.emojis
   end
 
   def atom_uri

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -87,7 +87,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def ordered_mentions
-    object.mentions.order(:id)
+    object.mentions.to_a.sort_by(&:id)
   end
 
   class ApplicationSerializer < ActiveModel::Serializer


### PR DESCRIPTION
Mentions were pre-fetched. There's no need to query n+1 times again just to sort them.

Fix performance regression from #6836