### PR TITLE
Fix MENTION_RE to not match nil usernames

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -48,7 +48,7 @@
 
 class Account < ApplicationRecord
   USERNAME_RE = /[a-z0-9_]+([a-z0-9_\.]+[a-z0-9_]+)?/i
-  MENTION_RE  = /(?<=^|[^\/[:word:]])@((#{USERNAME_RE}?)(?:@[a-z0-9\.\-]+[a-z0-9]+)?)/i
+  MENTION_RE  = /(?<=^|[^\/[:word:]])@((#{USERNAME_RE})(?:@[a-z0-9\.\-]+[a-z0-9]+)?)/i
 
   include AccountAvatar
   include AccountFinderConcern


### PR DESCRIPTION
Fix broken regexp that matched nil mentions (just a single `@` sign)