### PR TITLE
[WIP]Fix unpermitted parameters

### DIFF
--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -63,6 +63,6 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:account_id, :limit, :max_id, :since_id).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -63,6 +63,6 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:account_id, :limit, :max_id, :since_id).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -69,7 +69,7 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit, :only_media, :exclude_replies).merge(core_params)
+    params.permit(:account_id, :limit, :max_id, :since_id, :only_media, :exclude_replies, :pinned).merge(core_params)
   end
 
   def insert_pagination_headers

--- a/app/controllers/api/v1/blocks_controller.rb
+++ b/app/controllers/api/v1/blocks_controller.rb
@@ -57,6 +57,6 @@ class Api::V1::BlocksController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:limit, :max_id, :since_id).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/domain_blocks_controller.rb
@@ -67,7 +67,7 @@ class Api::V1::DomainBlocksController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:limit, :max_id, :since_id).merge(core_params)
   end
 
   def domain_block_params

--- a/app/controllers/api/v1/favourites_controller.rb
+++ b/app/controllers/api/v1/favourites_controller.rb
@@ -66,6 +66,6 @@ class Api::V1::FavouritesController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:status_id, :limit, :max_id, :since_id).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/follow_requests_controller.rb
+++ b/app/controllers/api/v1/follow_requests_controller.rb
@@ -71,6 +71,6 @@ class Api::V1::FollowRequestsController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:limit, :max_id, :since_id).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/lists/accounts_controller.rb
+++ b/app/controllers/api/v1/lists/accounts_controller.rb
@@ -88,7 +88,7 @@ class Api::V1::Lists::AccountsController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:limit, :max_id, :since_id).merge(core_params)
   end
 
   def unlimited?

--- a/app/controllers/api/v1/mutes_controller.rb
+++ b/app/controllers/api/v1/mutes_controller.rb
@@ -59,6 +59,6 @@ class Api::V1::MutesController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:limit, :max_id, :since_id).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -76,12 +76,12 @@ class Api::V1::NotificationsController < Api::BaseController
   end
 
   def exclude_types
-    val = params.permit(exclude_types: [])[:exclude_types] || []
+    val = params.permit(:limit, :max_id, :since_id, exclude_types: [])[:exclude_types] || []
     val = [val] unless val.is_a?(Enumerable)
     val
   end
 
   def pagination_params(core_params)
-    params.permit(:limit, exclude_types: []).merge(core_params)
+    params.permit(:limit, :max_id, :since_id, exclude_types: []).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
@@ -77,6 +77,6 @@ class Api::V1::Statuses::FavouritedByAccountsController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:limit, :max_id, :since_id).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
@@ -74,6 +74,6 @@ class Api::V1::Statuses::RebloggedByAccountsController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:limit, :max_id, :since_id).merge(core_params)
   end
 end

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -43,7 +43,7 @@ class Api::V1::Timelines::HomeController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:local, :limit).merge(core_params)
+    params.permit(:local, :limit, :max_id, :since_id).merge(core_params)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/list_controller.rb
+++ b/app/controllers/api/v1/timelines/list_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::Timelines::ListController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:limit).merge(core_params)
+    params.permit(:limit, :max_id, :since_id).merge(core_params)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::Timelines::PublicController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:local, :limit, :only_media).merge(core_params)
+    params.permit(:local, :limit, :max_id, :since_id, :only_media).merge(core_params)
   end
 
   def next_path

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -54,7 +54,7 @@ class Api::V1::Timelines::TagController < Api::BaseController
   end
 
   def pagination_params(core_params)
-    params.permit(:local, :limit, :only_media).merge(core_params)
+    params.permit(:id, :local, :limit, :max_id, :since_id, :only_media).merge(core_params)
   end
 
   def next_path

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,6 +12,9 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  # Raise exception when requested with unpermitted parameters in development
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp/caching-dev.txt').exist?
     config.action_controller.perform_caching = true


### PR DESCRIPTION
Note:  This change will not affect the production.

I found these message in development, but rails didn't raise.
```
04:53:59 web.1     | [active_model_serializers] Rendered ActiveModel::Serializer::CollectionSerializer with ActiveModelSerializers::Adapter::Attributes (613.46ms)
04:53:59 web.1     | Unpermitted parameter: :account_id
04:53:59 web.1     | Unpermitted parameter: :account_id
04:53:59 web.1     | Completed 200 OK in 2127ms (Views: 611.0ms | ActiveRecord: 407.7ms)
```

It was because `config.action_controller.action_on_unpermitted_parameters`' s default is `:log`.
It's just only logging.

However, parameters should be explicitly allowed at least in development.
I changed this config in `config/environments/development.rb`, and fix some unpermitted parameters.

Example, when requested with unpermitted parameters, rails raise exception and output these messages in developmnet.
```
06:08:51 web.1     | 
06:08:51 web.1     | ActionController::UnpermittedParameters - found unpermitted parameters: :max_id, :limit:
06:08:51 web.1     |   app/controllers/api/v1/notifications_controller.rb:79:in `exclude_types'
06:08:51 web.1     |   app/controllers/api/v1/notifications_controller.rb:47:in `browserable_account_notifications'
06:08:51 web.1     |   app/controllers/api/v1/notifications_controller.rb:39:in `paginated_notifications'
06:08:51 web.1     |   app/controllers/api/v1/notifications_controller.rb:35:in `load_notifications'
06:08:51 web.1     |   app/controllers/api/v1/notifications_controller.rb:13:in `index'
06:08:51 web.1     | 
```
![image](https://user-images.githubusercontent.com/24884114/37800358-e1f1967c-2e65-11e8-9d73-786f98d47a20.png)

I fixed only what I clearly reproduce.
There may be other unacceptable parameters.