### PR TITLE
feat(ShowMore): Add classname to show more/show less button

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -158,7 +158,7 @@ export default class StatusContent extends React.PureComponent {
           <p style={{ marginBottom: hidden && status.get('mentions').isEmpty() ? '0px' : null }}>
             <span dangerouslySetInnerHTML={spoilerContent} />
             {' '}
-            <button tabIndex='0' className='status__content__spoiler-link' onClick={this.handleSpoilerClick}>{toggleText}</button>
+            <button tabIndex='0' className={`status__content__spoiler-link ${hidden ? 'status__content__spoiler-link--show-more' : 'status__content__spoiler-link--show-less'}`} onClick={this.handleSpoilerClick}>{toggleText}</button>
           </p>
 
           {mentionsPlaceholder}


### PR DESCRIPTION
Hi - Based on this toot - https://mastodon.observer/web/statuses/99742882182857387

Some people may want to apply custom styles to the show more / show less buttons. However in the current scheme there's no simple way to differentiate between the two. This change is to add a classname to indicate which button is active to allow custom styling or future styling. Thanks.