### PR TITLE
Fix moved account handling in IndexedDB feature (regression from #6826)

### DIFF
--- a/app/javascript/mastodon/actions/importer/index.js
+++ b/app/javascript/mastodon/actions/importer/index.js
@@ -39,7 +39,7 @@ export function importFetchedAccounts(accounts) {
     pushUnique(normalAccounts, normalizeAccount(account));
 
     if (account.moved) {
-      processAccount(account);
+      processAccount(account.moved);
     }
   }
 

--- a/app/javascript/mastodon/actions/importer/normalizer.js
+++ b/app/javascript/mastodon/actions/importer/normalizer.js
@@ -10,6 +10,10 @@ export function normalizeAccount(account) {
   account.display_name_html = emojify(escapeTextContentForBrowser(displayName));
   account.note_emojified = emojify(account.note);
 
+  if (account.moved) {
+    account.moved = account.moved.id;
+  }
+
   return account;
 }
 


### PR DESCRIPTION
* **Fix stack overflow on importFetchedAccounts**

  ![image](https://user-images.githubusercontent.com/705555/37889563-f303c4b8-3107-11e8-8a65-9bbe735c608e.png)

  When the account has moved property, it should process destination
  account instead of source account itself.

* **Set account id instead of account object for moved property**

  This restores "foo has moved to" indication on account view, and
  fixes `reblog` index on `accounts` object store.