### PR TITLE
Update Polish string

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -25,7 +25,7 @@ module SettingsHelper
     nl: 'Nederlands',
     no: 'Norsk',
     oc: 'Occitan',
-    pl: 'Polszczyzna',
+    pl: 'Polski',
     pt: 'Português',
     'pt-BR': 'Português do Brasil',
     ru: 'Русский',


### PR DESCRIPTION
The title 'Polszczyzna' for Polish locale was incorrect, it should read 'Polski'. This pull request fixes that.