### PR TITLE
Add missing null handling in notification reducer (regression from #6886)

### DIFF
--- a/app/javascript/mastodon/reducers/notifications.js
+++ b/app/javascript/mastodon/reducers/notifications.js
@@ -82,7 +82,7 @@ const expandNormalizedNotifications = (state, notifications, next) => {
 };
 
 const filterNotifications = (state, relationship) => {
-  return state.update('items', list => list.filterNot(item => item.get('account') === relationship.id));
+  return state.update('items', list => list.filterNot(item => item !== null && item.get('account') === relationship.id));
 };
 
 const updateTop = (state, top) => {
@@ -94,7 +94,7 @@ const updateTop = (state, top) => {
 };
 
 const deleteByStatus = (state, statusId) => {
-  return state.update('items', list => list.filterNot(item => item.get('status') === statusId));
+  return state.update('items', list => list.filterNot(item => item !== null && item.get('status') === statusId));
 };
 
 export default function notifications(state = initialState, action) {


### PR DESCRIPTION
This patch adds null item (i.e. gap) handling on below functions to avoid TypeError.

* `filterNotifications` called on user mute/block
* `deleteByStatus` called on status deletion

![image](https://user-images.githubusercontent.com/705555/37963005-e9ab508e-31f7-11e8-851b-9cf62c90b482.png)