### PR TITLE
Clone response before put it to the cache (regression from #6902)

### DIFF
--- a/app/javascript/mastodon/service_worker/entry.js
+++ b/app/javascript/mastodon/service_worker/entry.js
@@ -56,10 +56,10 @@ self.addEventListener('fetch', function(event) {
         const fetched = await fetch(event.request);
 
         if (fetched.ok) {
-          await cache.put(event.request.url, fetched);
+          await cache.put(event.request.url, fetched.clone());
         }
 
-        return fetched.clone();
+        return fetched;
       }
 
       return cached;


### PR DESCRIPTION
`Response.prototype.clone()` must be called before the response used.

This fixes an error from ServiceWorker and failing to load image when the image is not cached.

![image](https://user-images.githubusercontent.com/705555/37968508-4d0d5166-3209-11e8-84a9-d702c450201d.png)
