### PR TITLE
Fix LoadMore on account media gallery (regression from #6876)

### DIFF
--- a/app/javascript/mastodon/features/account_gallery/index.js
+++ b/app/javascript/mastodon/features/account_gallery/index.js
@@ -67,7 +67,7 @@ export default class AccountGallery extends ImmutablePureComponent {
 
   handleScrollToBottom = () => {
     if (this.props.hasMore) {
-      this.handleLoadMore(this.props.medias.last().get('id'));
+      this.handleLoadMore(this.props.medias.last().getIn(['status', 'id']));
     }
   }
 


### PR DESCRIPTION
`max_id` in the fetch request should be a status id, but media attachment id was used.