### PR TITLE
Do not ignore unknown media attachments, only skip them

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -113,13 +113,13 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     media_attachments = []
 
     as_array(@object['attachment']).each do |attachment|
-      next if unsupported_media_type?(attachment['mediaType']) || attachment['url'].blank?
+      next if attachment['url'].blank?
 
       href             = Addressable::URI.parse(attachment['url']).normalize.to_s
       media_attachment = MediaAttachment.create(account: @account, remote_url: href, description: attachment['name'].presence, focus: attachment['focalPoint'])
       media_attachments << media_attachment
 
-      next if skip_download?
+      next if unsupported_media_type?(attachment['mediaType']) || skip_download?
 
       media_attachment.file_remote_url = href
       media_attachment.save


### PR DESCRIPTION
That way, they are displayed in a list below the corresponding toot.