### PR TITLE
Fix TypeError on follow notification (regression from #6826)

### DIFF
--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -43,7 +43,9 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
     const playSound = getState().getIn(['settings', 'notifications', 'sounds', notification.type], true);
 
     dispatch(importFetchedAccount(notification.account));
-    dispatch(importFetchedStatus(notification.status));
+    if (notification.status) {
+      dispatch(importFetchedStatus(notification.status));
+    }
 
     dispatch({
       type: NOTIFICATIONS_UPDATE,


### PR DESCRIPTION
`notification.status` may not be present, e.g. follow notification.

![image](https://user-images.githubusercontent.com/705555/38072827-22acfe8e-3363-11e8-9e45-bbec1a784360.png)
