### PR TITLE
Fix ReferenceError when Cache API is missing (regression from #6902)

### DIFF
--- a/app/javascript/mastodon/storage/modifier.js
+++ b/app/javascript/mastodon/storage/modifier.js
@@ -4,7 +4,10 @@ import { autoPlayGif } from '../initial_state';
 const accountAssetKeys = ['avatar', 'avatar_static', 'header', 'header_static'];
 const avatarKey = autoPlayGif ? 'avatar' : 'avatar_static';
 const limit = 1024;
-const asyncCache = caches.open('mastodon-system');
+
+// ServiceWorker and Cache API is not available on iOS 11
+// https://webkit.org/status/#specification-service-workers
+const asyncCache = window.caches ? caches.open('mastodon-system') : Promise.reject();
 
 function put(name, objects, onupdate, oncreate) {
   return asyncDB.then(db => new Promise((resolve, reject) => {


### PR DESCRIPTION
```
Reference Error: Can't find variable: caches
```

Cache API is not supported on Safari / WebKit yet.

Since those caching is optional, this patch simply ignores it.