### PR TITLE
Fix compatibility with PeerTube

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -79,6 +79,8 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     hashtag = Tag.where(name: hashtag).first_or_initialize(name: hashtag)
 
     status.tags << hashtag
+  rescue ActiveRecord::RecordInvalid
+    nil
   end
 
   def process_mention(tag, status)

--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -44,7 +44,7 @@ class FetchAtomService < BaseService
       json = body_to_json(body)
       if supported_context?(json) && json['type'] == 'Person' && json['inbox'].present?
         [json['id'], { prefetched_body: body, id: true }, :activitypub]
-      elsif supported_context?(json) && json['type'] == 'Note'
+      elsif supported_context?(json) && expected_type?(json)
         [json['id'], { prefetched_body: body, id: true }, :activitypub]
       else
         @unsupported_activity = true
@@ -59,6 +59,10 @@ class FetchAtomService < BaseService
         process_html(response)
       end
     end
+  end
+
+  def expected_type?(json)
+    (ActivityPub::Activity::Create::SUPPORTED_TYPES + ActivityPub::Activity::Create::CONVERTED_TYPES).include? json['type']
   end
 
   def process_html(response)

--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -19,7 +19,7 @@ class ResolveURLService < BaseService
     case type
     when 'Person'
       FetchRemoteAccountService.new.call(atom_url, body, protocol)
-    when 'Note'
+    when 'Note', 'Article', 'Image', 'Video'
       FetchRemoteStatusService.new.call(atom_url, body, protocol)
     end
   end


### PR DESCRIPTION
Fixes:
- Fetching `Video` objects by URL
- Ignore hashtags that do not conform to Mastodon's limitations instead of erroring out