### PR TITLE
Better admin view of statuses

### DIFF
--- a/app/javascript/styles/mastodon/stream_entries.scss
+++ b/app/javascript/styles/mastodon/stream_entries.scss
@@ -85,6 +85,13 @@
 
         .status__relative-time {
           color: $lighter-text-color;
+          float: left;
+        }
+
+        .status__visibility {
+          color: $lighter-text-color;
+          float: right;
+          padding-left: 4px;
         }
       }
     }

--- a/app/views/admin/statuses/index.html.haml
+++ b/app/views/admin/statuses/index.html.haml
@@ -36,7 +36,7 @@
         .batch-checkbox
           = f.check_box :status_ids, { multiple: true, include_hidden: false }, status.id
         .activity-stream.activity-stream-headless
-          .entry= render 'stream_entries/simple_status', status: status
+          .entry= render 'stream_entries/status', status: status
         .account-status__actions
           - unless status.media_attachments.empty?
             = link_to admin_account_status_path(@account.id, status, current_params.merge(status: { sensitive: !status.sensitive })), method: :patch, class: 'icon-button nsfw-button', title: t("admin.reports.nsfw.#{!status.sensitive}") do

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -39,20 +39,24 @@
       - else
         = link_to status.application.name, status.application.website, class: 'detailed-status__application', target: '_blank', rel: 'noopener'
       ·
-    - if status.direct_visibility?
-      %span<
-        = fa_icon('envelope')
-    - elsif status.private_visibility?
-      %span<
-        = fa_icon('lock')
-    - else
+    - if status.public_visibility? || status.unlisted_visibility?
       %span<
         = fa_icon('retweet')
         %span= status.reblogs_count
-    ·
+      ·
     %span<
       = fa_icon('star')
       %span= status.favourites_count
+    ·
+    %span<
+      - if status.public_visibility?
+        = fa_icon('globe')
+      - elsif status.unlisted_visibility?
+        = fa_icon('unlock-alt')
+      - elsif status.direct_visibility?
+        = fa_icon('envelope')
+      - elsif status.private_visibility?
+        = fa_icon('lock')
 
     - if user_signed_in?
       ·

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -4,6 +4,15 @@
       = link_to TagManager.instance.url_for(status), class: 'status__relative-time u-url u-uid', target: stream_link_target, rel: 'noopener' do
         %time.time-ago{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
       %data.dt-published{ value: status.created_at.to_time.iso8601 }
+      %span.status__visibility<
+        - if status.public_visibility?
+          = fa_icon('globe')
+        - elsif status.unlisted_visibility?
+          = fa_icon('unlock-alt')
+        - elsif status.direct_visibility?
+          = fa_icon('envelope')
+        - elsif status.private_visibility?
+          = fa_icon('lock')
 
     = link_to TagManager.instance.url_for(status.account), class: 'status__display-name p-author h-card', target: stream_link_target, rel: 'noopener' do
       .status__avatar


### PR DESCRIPTION
Some fixes in the admin view:
- Clearly display whether a toot is a boost or not (previously, boosts were misrepresented as original content from the booster, without the media attachments)
- Display toot's privacy

![screenshot-2018-3-30 etat du compte - mastodon instance perso de thibg](https://user-images.githubusercontent.com/384364/38143926-ff9bbfbc-3442-11e8-84d9-2ebe9592e48a.png)

This also changes how toots are displayed on the public/simple page.

![screenshot-2018-3-30 t h i b g thib sitedethib com](https://user-images.githubusercontent.com/384364/38143987-3ef9d432-3443-11e8-9a91-061485820f15.png)