### PR TITLE
Ignore AbortError when cancelled sharing

### DIFF
--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -67,6 +67,8 @@ export default class StatusActionBar extends ImmutablePureComponent {
     navigator.share({
       text: this.props.status.get('search_index'),
       url: this.props.status.get('url'),
+    }).catch((e) => {
+      if (e.name !== 'AbortError') console.error(e);
     });
   }
 


### PR DESCRIPTION
`navigator.share()` rejects Promise [if user cancelled sharing](https://wicg.github.io/web-share/#x2-1-1-share-method), and it may print it as an error on JavaScript console.

Example (Chrome 65 on Windows):

![image](https://user-images.githubusercontent.com/705555/38162086-0dabd1b8-3516-11e8-89b3-b046f6829fe6.png)

This patch ignores it and prints other errors on the console.