### PR TITLE
Fix #6931: Prevent submission using same logic as submit button disabling.

### DIFF
--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -74,6 +74,14 @@ export default class ComposeForm extends ImmutablePureComponent {
       this.props.onChange(this.autosuggestTextarea.textarea.value);
     }
 
+    // Submit disabled:
+    const { is_submitting, is_uploading, anyMedia } = this.props;
+    const fulltext = [this.props.spoiler_text, countableText(this.props.text)].join('');
+
+    if (is_submitting || is_uploading || length(fulltext) > 500 || (fulltext.length !== 0 && fulltext.trim().length === 0 && !anyMedia)) {
+      return;
+    }
+
     this.props.onSubmit();
   }
 


### PR DESCRIPTION
This prevents submission through ctrl/cmd+enter when the submit button is disabled.

https://github.com/tootsuite/mastodon/issues/6931