### PR TITLE
Implement the ability for an Administrator or Moderator to remove an account avatar

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class AccountsController < BaseController
-    before_action :set_account, only: [:show, :subscribe, :unsubscribe, :redownload, :enable, :disable, :memorialize]
+    before_action :set_account, only: [:show, :subscribe, :unsubscribe, :redownload, :remove_avatar, :enable, :disable, :memorialize]
     before_action :require_remote_account!, only: [:subscribe, :unsubscribe, :redownload]
     before_action :require_local_account!, only: [:enable, :disable, :memorialize]
 
@@ -56,6 +56,17 @@ module Admin
       @account.reset_avatar!
       @account.reset_header!
       @account.save!
+
+      redirect_to admin_account_path(@account.id)
+    end
+
+    def remove_avatar
+      authorize @account, :remove_avatar?
+
+      @account.avatar = nil
+      @account.save!
+
+      log_action :remove_avatar, @account.user
 
       redirect_to admin_account_path(@account.id)
     end

--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -86,7 +86,7 @@ module Admin::ActionLogsHelper
       opposite_verbs?(log) ? 'negative' : 'positive'
     when :update, :reset_password, :disable_2fa, :memorialize
       'neutral'
-    when :demote, :silence, :disable, :suspend
+    when :demote, :silence, :disable, :suspend, :remove_avatar
       'negative'
     when :destroy
       opposite_verbs?(log) ? 'positive' : 'negative'

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -29,6 +29,10 @@ class AccountPolicy < ApplicationPolicy
     admin?
   end
 
+  def remove_avatar?
+    staff?
+  end
+
   def subscribe?
     admin?
   end

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -14,6 +14,14 @@
         %th= t('admin.accounts.display_name')
         %td= @account.display_name
 
+      %tr
+        %th= t('admin.accounts.avatar')
+        %th
+          = link_to @account.avatar.url(:original) do
+            = image_tag @account.avatar.url(:original), alt: '', width: 40, height: 40, class: 'avatar'
+          - if @account.local? && @account.avatar?
+            = table_link_to 'trash', t('admin.accounts.remove_avatar'), remove_avatar_admin_account_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_avatar, @account)
+
       - if @account.local?
         %tr
           %th= t('admin.accounts.role')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
       destroyed_msg: Moderation note successfully destroyed!
     accounts:
       are_you_sure: Are you sure?
+      avatar: Avatar
       by_domain: Domain
       confirm: Confirm
       confirmed: Confirmed
@@ -108,6 +109,7 @@ en:
       public: Public
       push_subscription_expires: PuSH subscription expires
       redownload: Refresh avatar
+      remove_avatar: Remove avatar
       reset: Reset
       reset_password: Reset password
       resubscribe: Resubscribe
@@ -150,6 +152,7 @@ en:
         enable_user: "%{name} enabled login for user %{target}"
         memorialize_account: "%{name} turned %{target}'s account into a memoriam page"
         promote_user: "%{name} promoted user %{target}"
+        remove_avatar_user: "%{name} removed %{target}'s avatar"
         reset_password_user: "%{name} reset password of user %{target}"
         resolve_report: "%{name} dismissed report %{target}"
         silence_account: "%{name} silenced %{target}'s account"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,7 @@ Rails.application.routes.draw do
         post :enable
         post :disable
         post :redownload
+        post :remove_avatar
         post :memorialize
       end
 


### PR DESCRIPTION
We need this functionality on switter in order to quickly remove NSFW avatars from user accounts and thought it'd be good to contribute it back.