### PR TITLE
Fix issues with sending direct messages from user profile

### DIFF
--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -265,7 +265,7 @@ export default function compose(state = initialState, action) {
       .set('idempotencyKey', uuid());
   case COMPOSE_DIRECT:
     return state
-      .update('text', text => `${text}@${action.account.get('acct')} `)
+      .update('text', text => `@${action.account.get('acct')} `)
       .set('privacy', 'direct')
       .set('focusDate', new Date())
       .set('idempotencyKey', uuid());

--- a/app/javascript/mastodon/reducers/search.js
+++ b/app/javascript/mastodon/reducers/search.js
@@ -4,7 +4,11 @@ import {
   SEARCH_FETCH_SUCCESS,
   SEARCH_SHOW,
 } from '../actions/search';
-import { COMPOSE_MENTION, COMPOSE_REPLY } from '../actions/compose';
+import {
+  COMPOSE_MENTION,
+  COMPOSE_REPLY,
+  COMPOSE_DIRECT,
+} from '../actions/compose';
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
 
 const initialState = ImmutableMap({
@@ -29,6 +33,7 @@ export default function search(state = initialState, action) {
     return state.set('hidden', false);
   case COMPOSE_REPLY:
   case COMPOSE_MENTION:
+  case COMPOSE_DIRECT:
     return state.set('hidden', true);
   case SEARCH_FETCH_SUCCESS:
     return state.set('results', ImmutableMap({


### PR DESCRIPTION
This follows on from #6956, essentially I didn't realise the search overlay didn't auto-close when starting to compose a message. Also fixed an issue around the compose text remaining when starting a direct message. I'm fairly certain the user intent would be to have the text area clear when they go to a profile and click "direct message"

Unfortunately react-intl doesn't support formatting lists (i.e., "john, fred, and sally" vs "john and fred"), so I wasn't able to change the warning message to include the users.