### PR TITLE
Add label for sensitive pictures

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -183,6 +183,7 @@ export default class MediaGallery extends React.PureComponent {
 
   static propTypes = {
     sensitive: PropTypes.bool,
+    reveal: PropTypes.bool,
     standalone: PropTypes.bool,
     media: ImmutablePropTypes.list.isRequired,
     size: PropTypes.object,
@@ -196,7 +197,7 @@ export default class MediaGallery extends React.PureComponent {
   };
 
   state = {
-    visible: !this.props.sensitive || displaySensitiveMedia,
+    visible: !this.props.sensitive || this.props.reveal || displaySensitiveMedia,
   };
 
   componentWillReceiveProps (nextProps) {

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -10,6 +10,7 @@ import { autoPlayGif, displaySensitiveMedia } from '../initial_state';
 
 const messages = defineMessages({
   toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: 'Toggle visibility' },
+  sensitive: { defaultMessage: 'Sensitive', id: 'media_gallery.sensitive' },
 });
 
 class Item extends React.PureComponent {
@@ -271,9 +272,21 @@ export default class MediaGallery extends React.PureComponent {
 
     return (
       <div className='media-gallery' style={style} ref={this.handleRef}>
-        <div className={classNames('spoiler-button', { 'spoiler-button--visible': visible })}>
-          <IconButton title={intl.formatMessage(messages.toggle_visible)} icon={visible ? 'eye' : 'eye-slash'} overlay onClick={this.handleOpen} />
-        </div>
+        {visible ? (
+          <div className='sensitive-info'>
+            <IconButton
+              icon='eye'
+              onClick={this.handleOpen}
+              overlay
+              title={intl.formatMessage(messages.toggle_visible)}
+            />
+            {sensitive ? (
+              <span className='sensitive-marker'>
+                <FormattedMessage {...messages.sensitive} />
+              </span>
+            ) : null}
+          </div>
+        ) : null}
 
         {children}
       </div>

--- a/app/javascript/mastodon/features/video/index.js
+++ b/app/javascript/mastodon/features/video/index.js
@@ -93,6 +93,7 @@ export default class Video extends React.PureComponent {
     width: PropTypes.number,
     height: PropTypes.number,
     sensitive: PropTypes.bool,
+    reveal: PropTypes.bool,
     startTime: PropTypes.number,
     onOpenVideo: PropTypes.func,
     onCloseVideo: PropTypes.func,
@@ -110,7 +111,7 @@ export default class Video extends React.PureComponent {
     fullscreen: false,
     hovered: false,
     muted: false,
-    revealed: !this.props.sensitive || displaySensitiveMedia,
+    revealed: !this.props.sensitive || this.props.reveal || displaySensitiveMedia,
   };
 
   setPlayerRef = c => {

--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -35,7 +35,7 @@ delegate(document, '.media-spoiler-show-button', 'click', () => {
 });
 
 delegate(document, '.media-spoiler-hide-button', 'click', () => {
-  [].forEach.call(document.querySelectorAll('.spoiler-button.spoiler-button--visible button'), (element) => {
+  [].forEach.call(document.querySelectorAll('.sensitive-info button'), (element) => {
     element.click();
   });
 });

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2763,16 +2763,30 @@ a.status-card {
   font-weight: 700;
 }
 
-.spoiler-button {
-  display: none;
-  left: 4px;
+.sensitive-info {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   position: absolute;
-  text-shadow: 0 1px 1px $base-shadow-color, 1px 0 1px $base-shadow-color;
   top: 4px;
+  left: 4px;
   z-index: 100;
+}
 
-  &.spoiler-button--visible {
-    display: block;
+.sensitive-marker {
+  margin: 0 3px;
+  border-radius: 2px;
+  padding: 2px 6px;
+  color: $primary-text-color;
+  background: rgba($base-overlay-background, 0.5);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  opacity: .9;
+  transition: opacity .1s ease;
+
+  .media-gallery:hover & {
+    opacity: 1;
   }
 }
 

--- a/app/views/stream_entries/_content_spoiler.html.haml
+++ b/app/views/stream_entries/_content_spoiler.html.haml
@@ -1,7 +1,0 @@
-.media-spoiler-wrapper{ class: sensitive == false && 'media-spoiler-wrapper__visible' }
-  .spoiler-button
-    .icon-button.overlayed
-      %i.fa.fa-fw.fa-eye
-  .media-spoiler
-    %span= t('stream_entries.sensitive_content')
-    %span= t('stream_entries.click_to_show')

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -22,9 +22,9 @@
   - if !status.media_attachments.empty?
     - if status.media_attachments.first.video?
       - video = status.media_attachments.first
-      = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: status.sensitive? && !current_account&.user&.setting_display_sensitive_media, width: 670, height: 380, detailed: true, inline: true
+      = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: status.sensitive?, reveal: !current_account&.user&.setting_display_sensitive_media, width: 670, height: 380, detailed: true, inline: true
     - else
-      = react_component :media_gallery, height: 380, sensitive: status.sensitive? && !current_account&.user&.setting_display_sensitive_media, standalone: true, 'autoPlayGif': current_account&.user&.setting_auto_play_gif, 'reduceMotion': current_account&.user&.setting_reduce_motion, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json }
+      = react_component :media_gallery, height: 380, sensitive: status.sensitive?, reveal: !current_account&.user&.setting_display_sensitive_media, standalone: true, 'autoPlayGif': current_account&.user&.setting_auto_play_gif, 'reduceMotion': current_account&.user&.setting_reduce_motion, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json }
   - elsif status.preview_cards.first
     = react_component :card, 'maxDescription': 160, card: ActiveModelSerializers::SerializableResource.new(status.preview_cards.first, serializer: REST::PreviewCardSerializer).as_json
 

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -23,6 +23,6 @@
   - unless status.media_attachments.empty?
     - if status.media_attachments.first.video?
       - video = status.media_attachments.first
-      = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: status.sensitive? && !current_account&.user&.setting_display_sensitive_media, width: 610, height: 343, inline: true
+      = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: status.sensitive?, reveal: !current_account&.user&.setting_display_sensitive_media, width: 610, height: 343, inline: true
     - else
-      = react_component :media_gallery, height: 343, sensitive: status.sensitive? && !current_account&.user&.setting_display_sensitive_media, 'autoPlayGif': current_account&.user&.setting_auto_play_gif, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json }
+      = react_component :media_gallery, height: 343, sensitive: status.sensitive?, reveal: !current_account&.user&.setting_display_sensitive_media, 'autoPlayGif': current_account&.user&.setting_auto_play_gif, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json }

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -678,10 +678,8 @@ ar:
       unlisted: غير مُدرَج
       unlisted_long: يُمكن لأيٍ كان رُؤيتَه و لكن لن يُعرَض على الخيوط العامة
   stream_entries:
-    click_to_show: إضغط للعرض
     pinned: تبويق مثبّت
     reblogged: رقى
-    sensitive_content: محتوى حساس
   terms:
     title: شروط الخدمة وسياسة الخصوصية على %{instance}
   themes:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -144,9 +144,7 @@ bg:
       public: Публично
       unlisted: Публично, но не показвай в публичния канал
   stream_entries:
-    click_to_show: Покажи
     reblogged: споделено
-    sensitive_content: Деликатно съдържание
   time:
     formats:
       default: "%d %b, %Y, %H:%M"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -703,10 +703,8 @@ ca:
       unlisted: No llistat
       unlisted_long: Tothom ho pot veure, però no es mostra en la història federada
   stream_entries:
-    click_to_show: Clic per mostrar
     pinned: Toot fixat
     reblogged: ha impulsat
-    sensitive_content: Contingut sensible
   terms:
     body_html: |
       <h2>Privacy Policy</h2>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -703,10 +703,8 @@ de:
       unlisted: Nicht gelistet
       unlisted_long: Für alle sichtbar, aber nicht in öffentlichen Zeitleisten aufgelistet
   stream_entries:
-    click_to_show: Klicken, um zu zeigen
     pinned: Angehefteter Beitrag
     reblogged: teilte
-    sensitive_content: Heikle Inhalte
   terms:
     title: "%{instance} Nutzungsbedingungen und Datenschutzerklärung"
   themes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -703,10 +703,8 @@ en:
       unlisted: Unlisted
       unlisted_long: Everyone can see, but not listed on public timelines
   stream_entries:
-    click_to_show: Click to show
     pinned: Pinned toot
     reblogged: boosted
-    sensitive_content: Sensitive content
   terms:
     body_html: |
       <h2>Privacy Policy</h2>

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -705,10 +705,8 @@ eo:
       unlisted: Nelistigita
       unlisted_long: Ĉiuj povas vidi, sed nelistigita en publikaj tempolinioj
   stream_entries:
-    click_to_show: Alklaki por montri
     pinned: Alpinglita
     reblogged: diskonigita
-    sensitive_content: Tikla enhavo
   terms:
     title: Uzkondiĉoj kaj privateca politiko de %{instance}
   themes:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -702,10 +702,8 @@ es:
       unlisted: Público, pero no mostrar en la historia federada
       unlisted_long: Todos pueden ver, pero no está listado en las líneas de tiempo públicas
   stream_entries:
-    click_to_show: Click para mostrar
     pinned: Toot fijado
     reblogged: retooteado
-    sensitive_content: Contenido sensible
   terms:
     title: Términos del Servicio y Políticas de Privacidad de %{instance}
   themes:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -702,10 +702,8 @@ fa:
       unlisted: فهرست‌نشده
       unlisted_long: عمومی، ولی در فهرست نوشته‌ها نمایش نمی‌یابد
   stream_entries:
-    click_to_show: برای نمایش کلیک کنید
     pinned: نوشته‌های ثابت
     reblogged: بازبوقید
-    sensitive_content: محتوای حساس
   terms:
     title: شرایط استفاده و سیاست رازداری %{instance}
   themes:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -697,10 +697,8 @@ fi:
       unlisted: Listaamaton julkinen
       unlisted_long: Kaikki voivat nähdä, mutta ei näytetä julkisilla aikajanoilla
   stream_entries:
-    click_to_show: Katso napsauttamalla
     pinned: Kiinnitetty tuuttaus
     reblogged: buustasi
-    sensitive_content: Arkaluontoista sisältöä
   terms:
     title: "%{instance}, käyttöehdot ja tietosuojakäytäntö"
   themes:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -703,10 +703,8 @@ fr:
       unlisted: Public sans être affiché sur le fil public
       unlisted_long: Tout le monde peut voir vos statuts mais ils ne seront pas sur listés sur les fils publics
   stream_entries:
-    click_to_show: Cliquer pour afficher
     pinned: Pouet épinglé
     reblogged: a partagé
-    sensitive_content: Contenu sensible
   terms:
     title: "%{instance} Conditions d’utilisations et politique de confidentialité"
   themes:

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -703,10 +703,8 @@ gl:
       unlisted: Non listado
       unlisted_long: Visible para calquera, pero non listado en liñas de tempo públicas
   stream_entries:
-    click_to_show: Pulse para mostrar
     pinned: Mensaxe fixada
     reblogged: promovida
-    sensitive_content: Contido sensible
   terms:
     body_html: |
       <h2>Intimidade</h2>

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -372,9 +372,7 @@ he:
       unlisted: מוסתר
       unlisted_long: פומבי, אבל לא להצגה בפיד הציבורי
   stream_entries:
-    click_to_show: ללחוץ להצגה
     reblogged: הודהד
-    sensitive_content: תוכן רגיש
   time:
     formats:
       default: "%d %b %Y, %H:%M"

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -141,9 +141,7 @@ hr:
       public: Javno
       unlisted: Javno, no nemoj prikazati na javnom timelineu
   stream_entries:
-    click_to_show: Klikni da bi prikazao
     reblogged: potaknut
-    sensitive_content: Osjetljivi sadržaj
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -624,10 +624,8 @@ hu:
       unlisted: Listázatlan
       unlisted_long: Mindenki látja, de a nyilvános időfolyamokban nem jelenik meg
   stream_entries:
-    click_to_show: Megtekintéshez kattints
     pinned: Kitűzött tülk
     reblogged: reblogolt
-    sensitive_content: Szenzitív tartalom
   terms:
     title: "%{instance} Felhasználási feltételek és Adatkezelési nyilatkozat"
   themes:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -298,9 +298,7 @@ id:
       public_long: Bisa dilihat semua orang
       unlisted: Bisa dilihat semua orang, tapi tidak ditampilkan di linimasa publik
   stream_entries:
-    click_to_show: Klik untuk menampilkan
     reblogged: di-boost-kan
-    sensitive_content: Konten sensitif
   time:
     formats:
       default: "%d %b %Y, %H:%M"

--- a/config/locales/io.yml
+++ b/config/locales/io.yml
@@ -274,9 +274,7 @@ io:
       public: Publika
       unlisted: Publika, ma ne aperos en publika tempolinei
   stream_entries:
-    click_to_show: Kliktar por montrar
     reblogged: diskonocigita
-    sensitive_content: Titiliva kontenajo
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -566,10 +566,8 @@ it:
       unlisted: Pubblico, ma non visibile sulla timeline pubblica
       unlisted_long: Tutti lo possono vedere, ma non compare nelle timeline pubbliche
   stream_entries:
-    click_to_show: Clicca per mostrare
     pinned: Toot fissato in cima
     reblogged: condiviso
-    sensitive_content: Materiale sensibile
   themes:
     contrast: Contrasto elevato
   time:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -702,10 +702,8 @@ ja:
       unlisted: 未収載
       unlisted_long: 誰でも見ることができますが、公開タイムラインには表示されません
   stream_entries:
-    click_to_show: クリックして表示
     pinned: 固定されたトゥート
     reblogged: さんがブースト
-    sensitive_content: 閲覧注意
   terms:
     body_html: |
       <h2>プライバシーポリシー</h2>

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -704,10 +704,8 @@ ko:
       unlisted: 공개 타임라인 비공개
       unlisted_long: 누구나 볼 수 있지만, 공개 타임라인에는 표시되지 않습니다
   stream_entries:
-    click_to_show: 클릭해서 표시
     pinned: 고정된 툿
     reblogged: 님이 부스트 했습니다
-    sensitive_content: 민감한 컨텐츠
   terms:
     title: "%{instance} 이용약관과 개인정보 취급 방침"
   themes:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -703,10 +703,8 @@ nl:
       unlisted: Minder openbaar
       unlisted_long: Aan iedereen tonen, maar niet op openbare tijdlijnen
   stream_entries:
-    click_to_show: Klik om te tonen
     pinned: Vastgemaakte toot
     reblogged: boostte
-    sensitive_content: Gevoelige inhoud
   terms:
     body_html: |
       <h2>Privacy Policy</h2>

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -624,10 +624,8 @@
       unlisted: Uoppført
       unlisted_long: Synlig for alle, men ikke på offentlige tidslinjer
   stream_entries:
-    click_to_show: Klikk for å vise
     pinned: Festet tut
     reblogged: fremhevde
-    sensitive_content: Følsomt innhold
   terms:
     title: "%{instance} Personvern og villkår for bruk av nettstedet"
   themes:

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -776,10 +776,8 @@ oc:
       unlisted: Pas listat
       unlisted_long: Tot lo mond pòt veire mai serà pas visible sul flux public
   stream_entries:
-    click_to_show: Clicatz per veire
     pinned: Tut penjat
     reblogged: a partejat
-    sensitive_content: Contengut sensible
   terms:
     title: Condicions d’utilizacion e politica de confidencialitat de %{instance}
   themes:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -715,10 +715,8 @@ pl:
       unlisted: Niewypisane
       unlisted_long: Widoczne dla wszystkich, ale nie wyświetlane na publicznych osiach czasu
   stream_entries:
-    click_to_show: Naciśnij aby wyświetlić
     pinned: Przypięty wpis
     reblogged: podbił
-    sensitive_content: Wrażliwa zawartość
   terms:
     body_html: |
       <h2>Polityka prywatności</h2>

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -701,10 +701,8 @@ pt-BR:
       unlisted: Não listado
       unlisted_long: Todos podem ver, porém não será postado nas timelines públicas
   stream_entries:
-    click_to_show: Clique para mostrar
     pinned: Toot fixado
     reblogged: compartilhou
-    sensitive_content: Conteúdo sensível
   terms:
     body_html: |
       <h2>Política de privacidade</h2>

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -626,10 +626,8 @@ pt:
       unlisted: Público, mas não mostre no timeline público
       unlisted_long: Todos podem ver, porém não será postado nas timelines públicas
   stream_entries:
-    click_to_show: Clique pra mostrar
     pinned: Toot fixado
     reblogged: boosted
-    sensitive_content: Conteúdo sensível
   terms:
     title: "%{instance} Termos de Serviço e Política de Privacidade"
   themes:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -670,10 +670,8 @@ ru:
       unlisted: Скрывать из лент
       unlisted_long: Показывать всем, но не отображать в публичных лентах
   stream_entries:
-    click_to_show: Показать
     pinned: Закреплённое сообщение
     reblogged: продвинул(а)
-    sensitive_content: Чувствительный контент
   terms:
     title: Условия обслуживания и политика конфиденциальности %{instance}
   themes:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -676,10 +676,8 @@ sk:
       unlisted: Nezaradené
       unlisted_long: Všetci môžu vidieť, ale nieje zaradené do verejnej osi
   stream_entries:
-    click_to_show: Klikni pre zobrazenie
     pinned: Pripnutý toot
     reblogged: vyzdvihnutý
-    sensitive_content: Senzitívny obsah
   terms:
     title: Podmienky užívania, a pravidlá o súkromí pre %{instance}
   themes:

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -616,10 +616,8 @@ sr-Latn:
       unlisted: Neizlistano
       unlisted_long: Svako može da vidi, ali nije izlistano na javnim lajnama
   stream_entries:
-    click_to_show: Klikni da vidiš
     pinned: Prikačeni tut
     reblogged: podržano
-    sensitive_content: Osetljiv sadržaj
   terms:
     title: Uslovi korišćenja i politika privatnosti instance %{instance}
   themes:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -616,10 +616,8 @@ sr:
       unlisted: Неизлистано
       unlisted_long: Свако може да види, али није излистано на јавним лајнама
   stream_entries:
-    click_to_show: Кликни да видиш
     pinned: Прикачени тут
     reblogged: подржано
-    sensitive_content: Осетљив садржај
   terms:
     title: Услови коришћења и политика приватности инстанце %{instance}
   themes:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -701,10 +701,8 @@ sv:
       unlisted: Olistade
       unlisted_long: Alla kan se, men listas inte på offentliga tidslinjer
   stream_entries:
-    click_to_show: Klicka för att visa
     pinned: Fäst toot
     reblogged: boostad
-    sensitive_content: Känsligt innehåll
   terms:
     title: "%{instance} Användarvillkor och Sekretesspolicy"
   themes:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -302,9 +302,7 @@ th:
       unlisted: Unlisted
       unlisted_long: Everyone can see, but not listed on public timelines
   stream_entries:
-    click_to_show: คลิกเพื่อแสดง
     reblogged: boosted
-    sensitive_content: Sensitive content
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -300,9 +300,7 @@ tr:
       unlisted: Listelenmemiş
       unlisted_long: Herkes görebilir fakat herkese açık zaman tünellerinde listelenmez.
   stream_entries:
-    click_to_show: Görüntülemek için tıklayınız
     reblogged: boost edildi
-    sensitive_content: Hassas içerik
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -289,9 +289,7 @@ uk:
       unlisted: Приховувати зі стріок
       unlisted_long: Показувати всім, але не відображати в публічних стрічках
   stream_entries:
-    click_to_show: Показати
     reblogged: передмухнув(-ла)
-    sensitive_content: Непристойний контент
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -614,10 +614,8 @@ zh-CN:
       unlisted: 不公开
       unlisted_long: 所有人可见，但不会出现在公共时间轴上
   stream_entries:
-    click_to_show: 点击显示
     pinned: 置顶嘟文
     reblogged: 转嘟
-    sensitive_content: 敏感内容
   terms:
     title: "%{instance} 使用条款和隐私权政策"
   time:

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -699,10 +699,8 @@ zh-HK:
       unlisted: 公開，但不在公共時間軸顯示
       unlisted_long: 所有人都能看到，但不在公共時間軸（本站時間軸、跨站時間軸）顯示
   stream_entries:
-    click_to_show: 點擊顯示
     pinned: 置頂文章
     reblogged: 轉推
-    sensitive_content: 敏感內容
   terms:
     title: "%{instance} 使用條款和隱私權政策"
   themes:

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -269,9 +269,7 @@ zh-TW:
       public: 公開
       unlisted: 公開，但不在公共時間軸顯示
   stream_entries:
-    click_to_show: 點選顯示
     reblogged: 轉推
-    sensitive_content: 敏感內容
   time:
     formats:
       default: "%Y年%-m月%d日 %H:%M"


### PR DESCRIPTION
Add a “sensitive” label besides the eye icon to make sensitive media more obvious, refactor a bit to match glitch-soc's implementation.