### PR TITLE
Improve require_admin! and require_staff! filters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,11 +39,11 @@ class ApplicationController < ActionController::Base
   end
 
   def require_admin!
-    redirect_to root_path unless current_user&.admin?
+    forbidden unless current_user&.admin?
   end
 
   def require_staff!
-    redirect_to root_path unless current_user&.staff?
+    forbidden unless current_user&.staff?
   end
 
   def check_suspension

--- a/spec/controllers/admin/base_controller_spec.rb
+++ b/spec/controllers/admin/base_controller_spec.rb
@@ -9,18 +9,25 @@ describe Admin::BaseController, type: :controller do
     end
   end
 
-  it 'renders admin layout' do
+  it 'requires administrator or moderator' do
     routes.draw { get 'success' => 'admin/base#success' }
-    sign_in(Fabricate(:user, admin: true))
+    sign_in(Fabricate(:user, admin: false, moderator: false))
+    get :success
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it 'renders admin layout as a moderator' do
+    routes.draw { get 'success' => 'admin/base#success' }
+    sign_in(Fabricate(:user, moderator: true))
     get :success
     expect(response).to render_template layout: 'admin'
   end
 
-  it 'requires administrator' do
+  it 'renders admin layout as an admin' do
     routes.draw { get 'success' => 'admin/base#success' }
-    sign_in(Fabricate(:user, admin: false))
+    sign_in(Fabricate(:user, admin: true))
     get :success
-
-    expect(response).to redirect_to('/')
+    expect(response).to render_template layout: 'admin'
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -181,10 +181,48 @@ describe ApplicationController, type: :controller do
       routes.draw { get 'sucesss' => 'anonymous#sucesss' }
     end
 
-    it 'redirects to root path if current user is not admin' do
+    it 'returns a 403 if current user is not admin' do
       sign_in(Fabricate(:user, admin: false))
       get 'sucesss'
-      expect(response).to redirect_to('/')
+      expect(response).to have_http_status(403)
+    end
+
+    it 'returns a 403 if current user is only a moderator' do
+      sign_in(Fabricate(:user, moderator: true))
+      get 'sucesss'
+      expect(response).to have_http_status(403)
+    end
+
+    it 'does nothing if current user is admin' do
+      sign_in(Fabricate(:user, admin: true))
+      get 'sucesss'
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'require_staff!' do
+    controller do
+      before_action :require_staff!
+
+      def sucesss
+        head 200
+      end
+    end
+
+    before do
+      routes.draw { get 'sucesss' => 'anonymous#sucesss' }
+    end
+
+    it 'returns a 403 if current user is not admin or moderator' do
+      sign_in(Fabricate(:user, admin: false, moderator: false))
+      get 'sucesss'
+      expect(response).to have_http_status(403)
+    end
+
+    it 'does nothing if current user is moderator' do
+      sign_in(Fabricate(:user, moderator: true))
+      get 'sucesss'
+      expect(response).to have_http_status(200)
     end
 
     it 'does nothing if current user is admin' do


### PR DESCRIPTION
Previously these returns 302 redirects instead of 403s, which meant posting links to admin pages in slack caused them to unfurl, rather than stay as a link. The semantically correct response here is 403 forbidden (authentication will not help)

Additionally, require_admin! doesn't appear to be actively used, only require_staff!