### PR TITLE
Fix nil account issue in ProcessAccountService

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -28,7 +28,7 @@ class ActivityPub::ProcessAccountService < BaseService
 
     after_protocol_change! if protocol_changed?
     after_key_change! if key_changed?
-    check_featured_collection! if @account.featured_collection_url.present?
+    check_featured_collection! if @account&.featured_collection_url&.present?
 
     @account
   rescue Oj::ParseError


### PR DESCRIPTION
This apparently fixed a problem with federation that we had in toot.cafe (https://github.com/tootcafe/discussions/issues/32). For whatever reason, one of the accounts ended up being null inside of the SynchronizeFeaturedCollectionWorker  job, resulting in this exception being thrown.

Somehow that caused the Sidekiq queue to balloon to ~170k jobs and federation was broken because nothing could get through: no remote follows, toots didn't federate out, etc.

With this patch, our Sidekiq queue is finally dwindling down and we are federating again. I'm not sure what caused this issue, but I'd be happy to help investigate if you have suggestions for how to go about it.