### PR TITLE
Feature: Improve reports ui

### DIFF
--- a/app/controllers/admin/report_notes_controller.rb
+++ b/app/controllers/admin/report_notes_controller.rb
@@ -8,23 +8,24 @@ module Admin
       authorize ReportNote, :create?
 
       @report_note = current_account.report_notes.new(resource_params)
+      @report = @report_note.report
 
       if @report_note.save
         if params[:create_and_resolve]
-          @report_note.report.resolve!(current_account)
-          log_action :resolve, @report_note.report
+          @report.resolve!(current_account)
+          log_action :resolve, @report
 
           redirect_to admin_reports_path, notice: I18n.t('admin.reports.resolved_msg')
-        elsif params[:create_and_unresolve]
-          @report_note.report.unresolve!
-          log_action :reopen, @report_note.report
-
-          redirect_to admin_report_path(@report_note.report_id), notice: I18n.t('admin.report_notes.created_msg')
-        else
-          redirect_to admin_report_path(@report_note.report_id), notice: I18n.t('admin.report_notes.created_msg')
+          return
         end
+
+        if params[:create_and_unresolve]
+          @report.unresolve!
+          log_action :reopen, @report
+        end
+
+        redirect_to admin_report_path(@report), notice: I18n.t('admin.report_notes.created_msg')
       else
-        @report       = @report_note.report
         @report_notes = @report.notes.latest
         @report_history = @report.history
         @form = Form::StatusBatch.new

--- a/app/controllers/admin/report_notes_controller.rb
+++ b/app/controllers/admin/report_notes_controller.rb
@@ -17,7 +17,7 @@ module Admin
           redirect_to admin_reports_path, notice: I18n.t('admin.reports.resolved_msg')
         elsif params[:create_and_unresolve]
           @report_note.report.unresolve!
-          log_action :resolve, @report_note.report
+          log_action :reopen, @report_note.report
 
           redirect_to admin_report_path(@report_note.report_id), notice: I18n.t('admin.report_notes.created_msg')
         else

--- a/app/controllers/admin/report_notes_controller.rb
+++ b/app/controllers/admin/report_notes_controller.rb
@@ -11,10 +11,15 @@ module Admin
 
       if @report_note.save
         if params[:create_and_resolve]
-          @report_note.report.update!(action_taken: true, action_taken_by_account_id: current_account.id)
+          @report_note.report.resolve!(current_account)
           log_action :resolve, @report_note.report
 
           redirect_to admin_reports_path, notice: I18n.t('admin.reports.resolved_msg')
+        elsif params[:create_and_unresolve]
+          @report_note.report.unresolve!
+          log_action :resolve, @report_note.report
+
+          redirect_to admin_report_path(@report_note.report_id), notice: I18n.t('admin.report_notes.created_msg')
         else
           redirect_to admin_report_path(@report_note.report_id), notice: I18n.t('admin.report_notes.created_msg')
         end

--- a/app/controllers/admin/report_notes_controller.rb
+++ b/app/controllers/admin/report_notes_controller.rb
@@ -26,6 +26,7 @@ module Admin
       else
         @report       = @report_note.report
         @report_notes = @report.notes.latest
+        @report_history = @report.history
         @form = Form::StatusBatch.new
 
         render template: 'admin/reports/show'

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -13,6 +13,7 @@ module Admin
       authorize @report, :show?
       @report_note = @report.notes.new
       @report_notes = @report.notes.latest
+      @report_history = @report.history
       @form = Form::StatusBatch.new
     end
 

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -38,36 +38,33 @@ module Admin
         @report.update!(assigned_account_id: nil)
         log_action :unassigned, @report
       when 'reopen'
-        @report.update!(action_taken: false, action_taken_by_account_id: nil)
+        @report.unresolve!
         log_action :reopen, @report
       when 'resolve'
-        @report.update!(action_taken_by_current_attributes)
+        @report.resolve!(current_account)
         log_action :resolve, @report
       when 'suspend'
         Admin::SuspensionWorker.perform_async(@report.target_account.id)
+
         log_action :resolve, @report
         log_action :suspend, @report.target_account
+
         resolve_all_target_account_reports
-        @report.reload
       when 'silence'
         @report.target_account.update!(silenced: true)
+
         log_action :resolve, @report
         log_action :silence, @report.target_account
+
         resolve_all_target_account_reports
-        @report.reload
       else
         raise ActiveRecord::RecordNotFound
       end
-    end
-
-    def action_taken_by_current_attributes
-      { action_taken: true, action_taken_by_account_id: current_account.id }
+      @report.reload
     end
 
     def resolve_all_target_account_reports
-      unresolved_reports_for_target_account.update_all(
-        action_taken_by_current_attributes
-      )
+      unresolved_reports_for_target_account.update_all(action_taken: true, action_taken_by_account_id: current_account.id)
     end
 
     def unresolved_reports_for_target_account

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -147,7 +147,7 @@
       border-bottom: 1px solid $ui-base-color;
 
       &.section-break {
-        margin: 30px 0 30px;
+        margin: 30px 0;
         border-bottom: 2px solid $ui-base-lighter-color;
       }
     }

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -145,6 +145,11 @@
       border: 0;
       background: transparent;
       border-bottom: 1px solid $ui-base-color;
+
+      &.section-break {
+        margin: 30px 0 30px;
+        border-bottom: 2px solid $ui-base-lighter-color;
+      }
     }
 
     .muted-hint {
@@ -327,6 +332,36 @@
     width: 24px;
     text-align: center;
     margin-bottom: 10px;
+  }
+}
+
+.report-note__comment {
+  margin-bottom: 20px;
+}
+
+.report-note__form {
+  margin-bottom: 20px;
+
+  .report-note__textarea {
+    box-sizing: border-box;
+    border: 0;
+    padding: 7px 4px;
+    margin-bottom: 10px;
+    font-size: 16px;
+    color: $ui-base-color;
+    display: block;
+    width: 100%;
+    outline: 0;
+    font-family: inherit;
+    resize: vertical;
+  }
+
+  .report-note__buttons {
+    text-align: right;
+  }
+
+  .report-note__button {
+    margin: 0 0 5px 5px;
   }
 }
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -61,27 +61,28 @@ class Report < ApplicationRecord
   end
 
   def history
-    report_log = Admin::ActionLog.where(
-      target_type: 'Report',
-      target_id: id,
-      created_at: created_at..updated_at
-    ).unscope(:order)
+    time_range = created_at..updated_at
 
-    target_account_log = Admin::ActionLog.where(
-      target_type: 'Account',
-      target_id: target_account_id,
-      created_at: created_at..updated_at
-    ).unscope(:order)
+    sql = [
+      Admin::ActionLog.where(
+        target_type: 'Report',
+        target_id: id,
+        created_at: time_range
+      ).unscope(:order),
 
-    statuses_log = Admin::ActionLog.where(
-      target_type: 'Status',
-      target_id: status_ids,
-      created_at: created_at..updated_at
-    ).unscope(:order)
+      Admin::ActionLog.where(
+        target_type: 'Account',
+        target_id: target_account_id,
+        created_at: time_range
+      ).unscope(:order),
 
-    query = "((#{report_log.to_sql}) UNION ALL (#{target_account_log.to_sql}) UNION ALL (#{statuses_log.to_sql})) as admin_action_logs"
-    sql = Admin::ActionLog.connection.unprepared_statement(query)
+      Admin::ActionLog.where(
+        target_type: 'Status',
+        target_id: status_ids,
+        created_at: time_range
+      ).unscope(:order),
+    ].map { |query| "(#{query.to_sql})" }.join(' UNION ALL ')
 
-    Admin::ActionLog.from(sql)
+    Admin::ActionLog.from("(#{sql}) AS admin_action_logs")
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -22,6 +22,7 @@ class Report < ApplicationRecord
   belongs_to :assigned_account, class_name: 'Account', optional: true
 
   has_many :notes, class_name: 'ReportNote', foreign_key: :report_id, inverse_of: :report, dependent: :destroy
+  has_many :history, as: :target, class_name: 'Admin::ActionLog', foreign_key: :target_id, foreign_type: :target_type, dependent: :destroy
 
   scope :unresolved, -> { where(action_taken: false) }
   scope :resolved,   -> { where(action_taken: true) }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -61,9 +61,9 @@ class Report < ApplicationRecord
   end
 
   def history
-    report_log = Admin::ActionLog.where(target_type: 'Report', target_id: id).unscope(:order)
-    target_account_log = Admin::ActionLog.where(target_type: 'Account', target_id: target_account_id).unscope(:order)
-    statuses_log = Admin::ActionLog.where(target_type: 'Status', target_id: status_ids).unscope(:order)
+    report_log = Admin::ActionLog.where(target_type: 'Report', target_id: id).where(:created_at => created_at..updated_at).unscope(:order)
+    target_account_log = Admin::ActionLog.where(target_type: 'Account', target_id: target_account_id).where(:created_at => created_at..updated_at).unscope(:order)
+    statuses_log = Admin::ActionLog.where(target_type: 'Status', target_id: status_ids).where(:created_at => created_at..updated_at).unscope(:order)
 
     sql = Admin::ActionLog.connection.unprepared_statement {
       "((#{report_log.to_sql}) UNION ALL (#{target_account_log.to_sql}) UNION ALL (#{statuses_log.to_sql})) as admin_action_logs"

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -39,4 +39,24 @@ class Report < ApplicationRecord
   def media_attachments
     MediaAttachment.where(status_id: status_ids)
   end
+
+  def assign_to_self!(current_account)
+    update!(assigned_account_id: current_account.id)
+  end
+
+  def unassign!
+    update!(assigned_account_id: nil)
+  end
+
+  def resolve!(acting_account)
+    update!(action_taken: true, action_taken_by_account_id: acting_account.id)
+  end
+
+  def unresolve!
+    update!(action_taken: false, action_taken_by_account_id: nil)
+  end
+
+  def unresolved?
+    !action_taken?
+  end
 end

--- a/app/models/report_note.rb
+++ b/app/models/report_note.rb
@@ -13,7 +13,7 @@
 
 class ReportNote < ApplicationRecord
   belongs_to :account
-  belongs_to :report, inverse_of: :notes
+  belongs_to :report, inverse_of: :notes, touch: true
 
   scope :latest, -> { reorder('created_at ASC') }
 

--- a/app/views/admin/report_notes/_report_note.html.haml
+++ b/app/views/admin/report_notes/_report_note.html.haml
@@ -1,11 +1,9 @@
-%tr
-  %td
-    %p
-      %strong= report_note.account.acct
-      on
+%li
+  %h4
+    = report_note.account.acct
+    %div{ style: 'float: right' }
       %time.formatted{ datetime: report_note.created_at.iso8601, title: l(report_note.created_at) }
         = l report_note.created_at
       = table_link_to 'trash', t('admin.reports.notes.delete'), admin_report_note_path(report_note), method: :delete if can?(:destroy, report_note)
-      %br/
-      %br/
+  %div{ class: 'report-note__comment' }
     = simple_format(h(report_note.content))

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -5,7 +5,7 @@
   = t('admin.reports.report', id: @report.id)
 
 %div{ style: 'overflow: hidden; margin-bottom: 20px' }
-  - if !@report.action_taken?
+  - if @report.unresolved?
     %div{ style: 'float: right' }
       = link_to t('admin.reports.silence_account'), admin_report_path(@report, outcome: 'silence'), method: :put, class: 'button'
       = link_to t('admin.reports.suspend_account'), admin_report_path(@report, outcome: 'suspend'), method: :put, class: 'button'
@@ -18,21 +18,28 @@
   %table.table.inline-table
     %tbody
       %tr
+        %th= t('admin.reports.created_at')
+        %td{colspan: 2}
+          %time.formatted{ datetime: @report.created_at.iso8601 }
+      %tr
         %th= t('admin.reports.updated_at')
         %td{colspan: 2}
           %time.formatted{ datetime: @report.updated_at.iso8601 }
       %tr
         %th= t('admin.reports.status')
-        %td{colspan: 2}
+        %td
           - if @report.action_taken?
             = t('admin.reports.resolved')
-            = table_link_to 'envelope-open', t('admin.reports.reopen'), admin_report_path(@report, outcome: 'reopen'), method: :put
           - else
             = t('admin.reports.unresolved')
+        %td{style: "text-align: right; overflow: hidden;"}
+          - if @report.action_taken?
+            = table_link_to 'envelope-open', t('admin.reports.reopen'), admin_report_path(@report, outcome: 'reopen'), method: :put
       - if !@report.action_taken_by_account.nil?
         %tr
           %th= t('admin.reports.action_taken_by')
-          %td= @report.action_taken_by_account.acct
+          %td{colspan: 2}
+            = @report.action_taken_by_account.acct
       - else
         %tr
           %th= t('admin.reports.assigned')
@@ -46,6 +53,8 @@
               = table_link_to 'user', t('admin.reports.assign_to_self'), admin_report_path(@report, outcome: 'assign_to_self'), method: :put
             - if !@report.assigned_account.nil?
               = table_link_to 'trash', t('admin.reports.unassign'), admin_report_path(@report, outcome: 'unassign'), method: :put
+
+%hr{ class: "section-break"}/
 
 .report-accounts
   .report-accounts__item
@@ -88,22 +97,22 @@
           = link_to admin_report_reported_status_path(@report, status), method: :delete, class: 'icon-button trash-button', title: t('admin.reports.delete'), data: { confirm: t('admin.reports.are_you_sure') }, remote: true do
             = fa_icon 'trash'
 
-%hr/
+%hr{ class: "section-break"}/
 
 %h3= t('admin.reports.notes.label')
 
 - if @report_notes.length > 0
-  .table-wrapper
-    %table.table
-      %thead
-        %tr
-          %th
-      %tbody
-        = render @report_notes
+  %ul
+    = render @report_notes
 
-= simple_form_for @report_note, url: admin_report_notes_path do |f|
+%h4= t('admin.reports.notes.new_label')
+= form_for @report_note, url: admin_report_notes_path, html: { class: 'report-note__form' } do |f|
   = render 'shared/error_messages', object: @report_note
-  = f.input :content
+  = f.text_area :content, placeholder: t('admin.reports.notes.placeholder'), rows: 6, class: 'report-note__textarea'
   = f.hidden_field :report_id
-  = f.button :button, t('admin.reports.notes.create'), type: :submit
-  = f.button :button, t('admin.reports.notes.create_and_resolve'), type: :submit, name: :create_and_resolve
+  %div{ class: 'report-note__buttons' }
+    - if @report.unresolved?
+      = f.submit t('admin.reports.notes.create_and_resolve'), name: :create_and_resolve, class: 'button report-note__button'
+    - else
+      = f.submit t('admin.reports.notes.create_and_unresolve'), name: :create_and_unresolve, class: 'button report-note__button'
+    = f.submit t('admin.reports.notes.create'), class: 'button report-note__button'

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -116,3 +116,9 @@
     - else
       = f.submit t('admin.reports.notes.create_and_unresolve'), name: :create_and_unresolve, class: 'button report-note__button'
     = f.submit t('admin.reports.notes.create'), class: 'button report-note__button'
+
+- if @report_history.length > 0
+  %h3= t('admin.reports.history')
+
+  %ul
+    = render @report_history

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,8 +247,8 @@ en:
         title: Filter
       title: Invites
     report_notes:
-      created_msg: Moderation note successfully created!
-      destroyed_msg: Moderation note successfully destroyed!
+      created_msg: Report note successfully created!
+      destroyed_msg: Report note successfully deleted!
     reports:
       action_taken_by: Action taken by
       are_you_sure: Are you sure?
@@ -257,6 +257,7 @@ en:
       comment:
         label: Report Comment
         none: None
+      created_at: Reported
       delete: Delete
       id: ID
       mark_as_resolved: Mark as resolved
@@ -264,8 +265,11 @@ en:
       notes:
         create: Add Note
         create_and_resolve: Resolve with Note
+        create_and_unresolve: Reopen with Note
         delete: Delete
-        label: Notes
+        label: Moderator Notes
+        new_label: Add Moderator Note
+        placeholder: Describe what actions have been taken, or any other updates to this report…
       nsfw:
         'false': Unhide media attachments
         'true': Hide media attachments

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -259,6 +259,7 @@ en:
         none: None
       created_at: Reported
       delete: Delete
+      history: Moderation History
       id: ID
       mark_as_resolved: Mark as resolved
       mark_as_unresolved: Mark as unresolved


### PR DESCRIPTION
After playing with the improved reports UI from #7000, I still wasn't happy with it. I've since redesigned the form for adding report notes, and added the "ActionLog" history (in a rough form) so we can see all the actions taken in relation to a specific report.

Note: I wasn't sure on the right way to implement fetching the ActionLog, so went with a relation, but now I think a Finder method would be better, as it needs to pull from the Report, the statuses of the report and the reported user; Though I'm not sure on the best way to implement this.

Here's what the page now looks like:

![localhost_3000_admin_reports_2 2](https://user-images.githubusercontent.com/30827/38280458-a9b6f7a4-37a5-11e8-82d6-d1ccc0b21576.png)
