### PR TITLE
Fix follow/unfollow buttons on public profile (fixes #7036)

### DIFF
--- a/app/controllers/concerns/remote_account_controller_concern.rb
+++ b/app/controllers/concerns/remote_account_controller_concern.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RemoteAccountControllerConcern
+  extend ActiveSupport::Concern
+
+  included do
+    layout 'public'
+    before_action :set_account
+    before_action :check_account_suspension
+  end
+
+  private
+
+  def set_account
+    @account = Account.find_remote!(params[:acct])
+  end
+
+  def check_account_suspension
+    gone if @account.suspended?
+  end
+end

--- a/app/controllers/remote_unfollows.rb
+++ b/app/controllers/remote_unfollows.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class RemoteUnfollowsController < ApplicationController
+  layout 'modal'
+
+  before_action :authenticate_user!
+  before_action :set_body_classes
+
+  def create
+    @account = unfollow_attempt.try(:target_account)
+
+    if @account.nil?
+      render :error
+    else
+      render :success
+    end
+  rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
+    render :error
+  end
+
+  private
+
+  def unfollow_attempt
+    username, domain = acct_without_prefix.split('@')
+    UnfollowService.new.call(current_account, Account.find_remote!(username, domain))
+  end
+
+  def acct_without_prefix
+    acct_params.gsub(/\Aacct:/, '')
+  end
+
+  def acct_params
+    params.fetch(:acct, '')
+  end
+
+  def set_body_classes
+    @body_classes = 'modal-layout'
+  end
+end

--- a/app/views/accounts/_follow_button.html.haml
+++ b/app/views/accounts/_follow_button.html.haml
@@ -8,16 +8,16 @@
   - if user_signed_in? && current_account.id != account.id && !requested
     .controls
       - if following
-        = link_to account_unfollow_path(account), data: { method: :post }, class: 'icon-button' do
+        = link_to (account.local? ? account_unfollow_path(account) : remote_unfollow_path(acct: account.acct)), data: { method: :post }, class: 'icon-button' do
           = fa_icon 'user-times'
           = t('accounts.unfollow')
       - else
-        = link_to account_follow_path(account), data: { method: :post }, class: 'icon-button' do
+        = link_to (account.local? ? account_follow_path(account) : authorize_follow_path(acct: account.acct)), data: { method: :post }, class: 'icon-button' do
           = fa_icon 'user-plus'
           = t('accounts.follow')
   - elsif !user_signed_in?
     .controls
       .remote-follow
-        = link_to account_remote_follow_path(account), class: 'icon-button' do
+        = link_to (account.local? ? account_remote_follow_path(account) : "web+mastodon://follow?uri=#{account.uri}"), class: 'icon-button' do
           = fa_icon 'user-plus'
           = t('accounts.remote_follow')

--- a/app/views/accounts/_follow_grid.html.haml
+++ b/app/views/accounts/_follow_grid.html.haml
@@ -2,6 +2,6 @@
   - if accounts.empty?
     = render partial: 'accounts/nothing_here'
   - else
-    = render partial: 'accounts/grid_card', collection: accounts, as: :account, cached: true
+    = render partial: 'accounts/grid_card', collection: accounts, as: :account, cached: !user_signed_in?
 
 = paginate follows

--- a/app/views/remote_unfollows/_card.html.haml
+++ b/app/views/remote_unfollows/_card.html.haml
@@ -1,0 +1,13 @@
+.account-card
+  .detailed-status__display-name
+    %div
+      = image_tag account.avatar.url(:original), alt: '', width: 48, height: 48, class: 'avatar'
+
+    %span.display-name
+      - account_url = local_assigns[:admin] ? admin_account_path(account.id) : TagManager.instance.url_for(account)
+      = link_to account_url, class: 'detailed-status__display-name p-author h-card', target: '_blank', rel: 'noopener' do
+        %strong.emojify= display_name(account)
+        %span @#{account.acct}
+
+  - if account.note?
+    .account__header__content.emojify= Formatter.instance.simplified_format(account)

--- a/app/views/remote_unfollows/_post_follow_actions.html.haml
+++ b/app/views/remote_unfollows/_post_follow_actions.html.haml
@@ -1,0 +1,4 @@
+.post-follow-actions
+  %div= link_to t('authorize_follow.post_follow.web'), web_url("accounts/#{@account.id}"), class: 'button button--block'
+  %div= link_to t('authorize_follow.post_follow.return'), TagManager.instance.url_for(@account), class: 'button button--block'
+  %div= t('authorize_follow.post_follow.close')

--- a/app/views/remote_unfollows/error.html.haml
+++ b/app/views/remote_unfollows/error.html.haml
@@ -1,0 +1,3 @@
+.form-container
+  .flash-message#error_explanation
+    = t('remote_unfollow.error')

--- a/app/views/remote_unfollows/success.html.haml
+++ b/app/views/remote_unfollows/success.html.haml
@@ -1,0 +1,10 @@
+- content_for :page_title do
+  = t('remote_unfollow.title', acct: @account.acct)
+
+.form-container
+  .follow-prompt
+    %h2= t('remote_unfollow.unfollowed')
+
+    = render 'card', account: @account
+
+  = render 'post_follow_actions'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Rails.application.routes.draw do
   get '/media_proxy/:id/(*any)', to: 'media_proxy#show', as: :media_proxy
 
   # Remote follow
+  resource :remote_unfollow, only: [:create]
   resource :authorize_follow, only: [:show, :create]
   resource :share, only: [:show, :create]
 


### PR DESCRIPTION
- Present non-logged users with web+mastodon:// URLs for remote accounts.
  We cannot know the “remote follow” page URL, if any, so use “web+mastodon://” instead, we cannot do much better without further specs.
- Hijack `authorize_follows` for the follow link for remote accounts, add similar `remote_unfollows` to unfollow remote accounts
- Do not cache rendered statuses for logged in users (as the follow/unfollow button is user-dependent)