### PR TITLE
Ensure SynchronizeFeaturedCollectionWorker is unique and clean up

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -23,10 +23,10 @@ class ActivityPub::ProcessAccountService < BaseService
         create_account if @account.nil?
         update_account
         process_tags
-      else
-        return
       end
     end
+
+    return if @account.nil?
 
     after_protocol_change! if protocol_changed?
     after_key_change! if key_changed?

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -22,13 +22,15 @@ class ActivityPub::ProcessAccountService < BaseService
 
         create_account if @account.nil?
         update_account
-        process_tags(@account)
+        process_tags
+      else
+        return
       end
     end
 
     after_protocol_change! if protocol_changed?
     after_key_change! if key_changed?
-    check_featured_collection! if @account&.featured_collection_url&.present?
+    check_featured_collection! if @account.featured_collection_url.present?
 
     @account
   rescue Oj::ParseError
@@ -189,17 +191,18 @@ class ActivityPub::ProcessAccountService < BaseService
     { redis: Redis.current, key: "process_account:#{@uri}" }
   end
 
-  def process_tags(account)
+  def process_tags
     return if @json['tag'].blank?
+
     as_array(@json['tag']).each do |tag|
       case tag['type']
       when 'Emoji'
-        process_emoji tag, account
+        process_emoji tag
       end
     end
   end
 
-  def process_emoji(tag, _account)
+  def process_emoji(tag)
     return if skip_download?
     return if tag['name'].blank? || tag['icon'].blank? || tag['icon']['url'].blank?
 

--- a/app/workers/activitypub/synchronize_featured_collection_worker.rb
+++ b/app/workers/activitypub/synchronize_featured_collection_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::SynchronizeFeaturedCollectionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'pull', unique: :until_executed
 
   def perform(account_id)
     ActivityPub::FetchFeaturedCollectionService.new.call(Account.find(account_id))


### PR DESCRIPTION
Fix #7041 

I have changed @nolanlawson's fix for the underlying issue, because I believe that the only condition under which `@account` could be nil in that line is if the lock was not acquired. So returning early in the case should be a better fix. Since this is a rare and strange issue in the first place, I don't know if I'm right.

The sidekiq job thing should ensure multiple jobs with the same argument should not be allowed. Although it will not clear out already enqueued jobs.