### PR TITLE
Remove Puma pidfile before boot if container receives SIGTERM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000 -b '0.0.0.0'"
     networks:
       - external_network
       - internal_network


### PR DESCRIPTION
Fixes an issue mentioned in https://github.com/docker/compose/issues/1393