### PR TITLE
Add a circuit breaker for ActivityPub deliveries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'devise-two-factor', '~> 3.0'
 group :pam_authentication, optional: true do
   gem 'devise_pam_authenticatable2', '~> 9.0'
 end
+
 gem 'net-ldap', '~> 0.10'
 gem 'omniauth-cas', '~> 1.1'
 gem 'omniauth-saml', '~> 1.10'
@@ -79,6 +80,7 @@ gem 'sidekiq-bulk', '~>0.1.1'
 gem 'simple-navigation', '~> 4.0'
 gem 'simple_form', '~> 3.4'
 gem 'sprockets-rails', '~> 3.2', require: 'sprockets/railtie'
+gem 'stoplight', '~> 2.1.3'
 gem 'strong_migrations'
 gem 'tty-command'
 gem 'tty-prompt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -550,6 +550,7 @@ GEM
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     statsd-ruby (1.2.1)
+    stoplight (2.1.3)
     streamio-ffmpeg (3.0.2)
       multi_json (~> 1.8)
     strong_migrations (0.1.9)
@@ -716,6 +717,7 @@ DEPENDENCIES
   simple_form (~> 3.4)
   simplecov (~> 0.14)
   sprockets-rails (~> 3.2)
+  stoplight (~> 2.1.3)
   streamio-ffmpeg (~> 3.0)
   strong_migrations
   tty-command

--- a/config/initializers/stoplight.rb
+++ b/config/initializers/stoplight.rb
@@ -1,0 +1,3 @@
+require 'stoplight'
+
+Stoplight::Light.default_data_store = Stoplight::DataStore::Redis.new(Redis.current)


### PR DESCRIPTION
>A circuit breaker is an automatically operated electrical switch designed to protect an electrical circuit from damage caused by excess current from an overload or short circuit. **Its basic function is to interrupt current flow after a fault is detected.**

The purpose of `DeliveryFailureTracker`, and how it is integrated, is to stop *enqueueing* deliveries to dead endpoints (after 7 days of continuous failures). Items that are already enqueued are not affected, and short term failures are ignored.

When a host is experiencing issues, it can respond way too slowly, maxing out the 10 second timeout and failing. More and more deliveries to the same host will be enqueued, congesting the push queue, each job taking 10 seconds... In this case, what we need is:

- Do not stop *enqueueing* items, because the host will likely come back sometime later, and will need those items
- But we need to reduce the failure time from 10 seconds to 0 seconds

Stoplight is a circuit breaker gem. It wraps our delivery code. There are three states:

- green: deliveries go through transparently
- red: after 3 failures, deliveries fail instantly (delivery not actually executed)
- yellow: after cooldown period of 60 seconds, deliveries go through transparently again, and either succeed (back to green) or fail (back to red)

The threshold (3) and cooldown (60 seconds) could be adjusted. Perhaps retry scheduling could also be adjusted to better work with those parameters, for example, the first 3 failures could follow the backoff algorithm in use right now, after that, wait at least 60 seconds before scheduling the next retry.