### PR TITLE
Forward deletes on the same path as reply forwarding

### DIFF
--- a/app/lib/activitypub/activity/delete.rb
+++ b/app/lib/activitypub/activity/delete.rb
@@ -17,21 +17,25 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
   end
 
   def delete_note
-    status   = Status.find_by(uri: object_uri, account: @account)
-    status ||= Status.find_by(uri: @object['atomUri'], account: @account) if @object.is_a?(Hash) && @object['atomUri'].present?
+    @status   = Status.find_by(uri: object_uri, account: @account)
+    @status ||= Status.find_by(uri: @object['atomUri'], account: @account) if @object.is_a?(Hash) && @object['atomUri'].present?
 
     delete_later!(object_uri)
 
-    return if status.nil?
+    return if @status.nil?
 
-    forward_for_reblogs(status)
-    delete_now!(status)
+    if @status.public_visibility? || @status.unlisted_visibility?
+      forward_for_reply 
+      forward_for_reblogs
+    end
+
+    delete_now!
   end
 
-  def forward_for_reblogs(status)
+  def forward_for_reblogs
     return if @json['signature'].blank?
 
-    rebloggers_ids = status.reblogs.includes(:account).references(:account).merge(Account.local).pluck(:account_id)
+    rebloggers_ids = @status.reblogs.includes(:account).references(:account).merge(Account.local).pluck(:account_id)
     inboxes        = Account.where(id: ::Follow.where(target_account_id: rebloggers_ids).select(:account_id)).inboxes - [@account.preferred_inbox_url]
 
     ActivityPub::DeliveryWorker.push_bulk(inboxes) do |inbox_url|
@@ -39,8 +43,22 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
     end
   end
 
-  def delete_now!(status)
-    RemoveStatusService.new.call(status)
+  def replied_to_status
+    return @replied_to_status if defined?(@replied_to_status)
+    @replied_to_status = @status.thread
+  end
+
+  def reply_to_local?
+    !replied_to_status.nil? && replied_to_status.account.local?
+  end
+
+  def forward_for_reply
+    return unless @json['signature'].present? && reply_to_local?
+    ActivityPub::RawDistributionWorker.perform_async(Oj.dump(@json), replied_to_status.account_id, [@account.preferred_inbox_url])
+  end
+
+  def delete_now!
+    RemoveStatusService.new.call(@status)
   end
 
   def payload

--- a/app/lib/activitypub/activity/delete.rb
+++ b/app/lib/activitypub/activity/delete.rb
@@ -25,7 +25,7 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
     return if @status.nil?
 
     if @status.public_visibility? || @status.unlisted_visibility?
-      forward_for_reply 
+      forward_for_reply
       forward_for_reblogs
     end
 


### PR DESCRIPTION
Public reply to someone is forwarded to followers of the replied-to person. Delete of that reply is sent to the replied-to person, but is not forwarded to their followers. This fixes that.