### PR TITLE
Make scroll bars wider

### DIFF
--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -125,3 +125,8 @@ button {
     outline: 0 !important;
   }
 }
+
+::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -125,8 +125,3 @@ button {
     outline: 0 !important;
   }
 }
-
-::-webkit-scrollbar {
-  width: 12px;
-  height: 12px;
-}

--- a/app/javascript/styles/mastodon/reset.scss
+++ b/app/javascript/styles/mastodon/reset.scss
@@ -53,11 +53,6 @@ table {
   border-spacing: 0;
 }
 
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
 ::-webkit-scrollbar-thumb {
   background: lighten($ui-base-color, 4%);
   border: 0px none $base-border-color;


### PR DESCRIPTION
I think the scroll bars on Mastodon's front-end could be a bit wider than 8px. I probably didn't execute this exactly right, but I _tried_ to bump it up to 12px in `basics.scss` (I admittedly did not spend a lot of time trying to figure out which scss file). 

Also, I couldn't figure out how to test this cuz I couldn't figure out how to install Ruby 2.5.1 on my machine :(

So in general this is not a great PR haha. But my request still stands -- wider scroll bars would be nice. 