### PR TITLE
i18n: improve "Welcome" translation in Portuguese

### DIFF
--- a/app/javascript/mastodon/locales/pt-BR.json
+++ b/app/javascript/mastodon/locales/pt-BR.json
@@ -189,7 +189,7 @@
   "onboarding.page_one.federation": "Mastodon é uma rede de servidores independentes que se juntam para fazer uma grande rede social. Nós chamamos estes servidores de instâncias.",
   "onboarding.page_one.full_handle": "Seu nome de usuário completo",
   "onboarding.page_one.handle_hint": "Isso é o que você diz aos seus amigos para que eles possam te mandar mensagens ou te seguir a partir de outra instância.",
-  "onboarding.page_one.welcome": "Seja bem-vindo(a) ao Mastodon!",
+  "onboarding.page_one.welcome": "Boas-vindas ao Mastodon!",
   "onboarding.page_six.admin": "O administrador de sua instância é {admin}.",
   "onboarding.page_six.almost_done": "Quase acabando...",
   "onboarding.page_six.appetoot": "Bom Apetoot!",

--- a/app/javascript/mastodon/locales/pt.json
+++ b/app/javascript/mastodon/locales/pt.json
@@ -189,7 +189,7 @@
   "onboarding.page_one.federation": "Mastodon é uma rede de servidores independentes ligados entre si para fazer uma grande rede social. Nós chamamos instâncias a estes servidores.",
   "onboarding.page_one.full_handle": "O teu nome de utilizador completo",
   "onboarding.page_one.handle_hint": "Isto é o que dizes aos teus amigos para pesquisar.",
-  "onboarding.page_one.welcome": "Bem-vindo(a) ao Mastodon!",
+  "onboarding.page_one.welcome": "Boas-vindas ao Mastodon!",
   "onboarding.page_six.admin": "O administrador da tua instância é {admin}.",
   "onboarding.page_six.almost_done": "Quase pronto...",
   "onboarding.page_six.appetoot": "Bon Appetoot!",

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -709,7 +709,7 @@ pt-BR:
       tip_local_timeline: A timeline local é uma visão contínua das pessoas que estão em %{instance}. Esses são seus vizinhos próximos!
       tip_mobile_webapp: Se o seu navegador móvel oferecer a opção de adicionar Mastodon à tela inicial, você pode receber notificações push. Vai funcionar quase como um aplicativo nativo!
       tips: Dicas
-      title: Boas-vindas à bordo, %{name}!
+      title: Boas-vindas a bordo, %{name}!
   users:
     invalid_email: O endereço de e-mail é inválido
     invalid_otp_token: Código de autenticação inválido


### PR DESCRIPTION
Instead of using "bem-vindo(a)" (a masculine form of "Welcome" with a "(a)" in the end to mean "bem-vinda" for the feminine form), use "boas-vindas", which is a gender-neutral form of "Welcome").

There is already precedent for using "boas-vindas" in the Brazilian Portuguese localization, in `config/locales/pt-BR.yml`. European Portuguese dictionary Priberam also [registers it as a valid form](https://www.priberam.pt/dlpo/boas-vindas) so I applied it to both `pt` and `pt-BR`.

Also made a minor orthography fix in one of the `pt-BR` welcome messages.