### PR TITLE
Ignore elasticsearch directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ vendor/bundle
 *~
 postgres
 redis
+elasticsearch

--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,10 @@ config/deploy/*
 .vscode/
 .idea/
 
-# Ignore postgres + redis volume optionally created by docker-compose
+# Ignore postgres + redis + elasticsearch volume optionally created by docker-compose
 postgres
 redis
+elasticsearch
 
 # Ignore Apple files
 .DS_Store


### PR DESCRIPTION
`elasticsearch` directory is optionally created by docker-compose. It should be ignored by `.gitignore` and `.dockerignore`.