### PR TITLE
Implement finding accounts based on hashtags in their "note"

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -341,6 +341,10 @@ class Account < ApplicationRecord
       end
     end
 
+    def search_by_hashtags(hashtags)
+      where("note <> '' AND (array_remove(xpath('//a[contains(@class, \"hashtag\")]//text()', note::xml)::text[], '#')) @> ARRAY[?]", hashtags)
+    end
+
     private
 
     def generate_query_for_search(terms)

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -15,7 +15,11 @@ class AccountSearchService < BaseService
   private
 
   def search_service_results
-    return [] if query_blank_or_hashtag? || limit < 1
+    return [] if query_blank? || limit < 1
+
+    if query_hashtag?
+      return Account.search_by_hashtags(query_hashtags).limit(limit)
+    end
 
     if resolving_non_matching_remote_account?
       [ResolveAccountService.new.call("#{query_username}@#{query_domain}")].compact
@@ -34,8 +38,16 @@ class AccountSearchService < BaseService
     exact + search_results.to_a
   end
 
-  def query_blank_or_hashtag?
-    query.blank? || query.start_with?('#')
+  def query_blank?
+    query.blank?
+  end
+
+  def query_hashtag?
+    query.start_with?('#')
+  end
+
+  def query_hashtags
+    query.scan(/#(\w+)/).flatten
   end
 
   def split_query_string


### PR DESCRIPTION
I'm not saying this is perfect, but it'd greatly increase the ability to discover accounts you may be interested in following. Still shows the hashtags beneath.

From my reading xpath in postgresql is actually safe, although, it does require the postgresql server to be compiled with `configure --with-libxml` (on my mac this seems to be default) — we could avoid this if we had a note_raw column which stripped the html from the note, then it'd be a simple text search.

<img width="302" alt="screen shot 2018-04-09 at 7 26 56 pm" src="https://user-images.githubusercontent.com/30827/38512970-1d7e21d6-3c2d-11e8-9d50-9ca06e538755.png">

(That account is using the bio I have on Switter.at)

Additionally, this works with multiple hashtags, and they're AND'ed. Other non-hashtag text is ignored.