### PR TITLE
Redirect to account status page for page of status stream entry

### DIFF
--- a/app/controllers/stream_entries_controller.rb
+++ b/app/controllers/stream_entries_controller.rb
@@ -15,8 +15,7 @@ class StreamEntriesController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        @ancestors   = @stream_entry.activity.reply? ? cache_collection(@stream_entry.activity.ancestors(current_account), Status) : []
-        @descendants = cache_collection(@stream_entry.activity.descendants(current_account), Status)
+        redirect_to short_account_status_url(params[:account_username], @stream_entry.activity) if @type == 'status'
       end
 
       format.atom do

--- a/spec/controllers/stream_entries_controller_spec.rb
+++ b/spec/controllers/stream_entries_controller_spec.rb
@@ -66,16 +66,12 @@ RSpec.describe StreamEntriesController, type: :controller do
   describe 'GET #show' do
     include_examples 'before_action', :show
 
-    it 'renders with HTML' do
-      ancestor = Fabricate(:status)
-      status = Fabricate(:status, in_reply_to_id: ancestor.id)
-      descendant = Fabricate(:status, in_reply_to_id: status.id)
+    it 'redirects to status page' do
+      status = Fabricate(:status)
 
       get :show, params: { account_username: status.account.username, id: status.stream_entry.id }
 
-      expect(assigns(:ancestors)).to eq [ancestor]
-      expect(assigns(:descendants)).to eq [descendant]
-      expect(response).to have_http_status(:success)
+      expect(response).to redirect_to(short_account_status_url(status.account, status))
     end
 
     it 'returns http success with Atom' do


### PR DESCRIPTION
Commit 519119f657cf97ec187008a28dba00c1125a9292 missed a change for
stream entry page. Instead of duplicating the change, redirect to account
status page. It would also help crawlers (of search engines, for example)
to understand a stream entry URL and its corresponding status URL points
to the same page.