### PR TITLE
Allow more than the max pins if account is not local

### DIFF
--- a/app/validators/status_pin_validator.rb
+++ b/app/validators/status_pin_validator.rb
@@ -5,6 +5,6 @@ class StatusPinValidator < ActiveModel::Validator
     pin.errors.add(:base, I18n.t('statuses.pin_errors.reblog')) if pin.status.reblog?
     pin.errors.add(:base, I18n.t('statuses.pin_errors.ownership')) if pin.account_id != pin.status.account_id
     pin.errors.add(:base, I18n.t('statuses.pin_errors.private')) unless %w(public unlisted).include?(pin.status.visibility)
-    pin.errors.add(:base, I18n.t('statuses.pin_errors.limit')) if pin.account.status_pins.count > 4
+    pin.errors.add(:base, I18n.t('statuses.pin_errors.limit')) if pin.account.status_pins.count > 4 && pin.account.local?
   end
 end

--- a/spec/models/status_pin_spec.rb
+++ b/spec/models/status_pin_spec.rb
@@ -37,5 +37,36 @@ RSpec.describe StatusPin, type: :model do
 
       expect(StatusPin.new(account: account, status: status).save).to be false
     end
+
+    max_pins = 5
+    it 'does not allow pins above the max' do
+      account = Fabricate(:account)
+      status = []
+
+      (max_pins + 1).times do |i|
+        status[i] = Fabricate(:status, account: account)
+      end
+
+      max_pins.times do |i|
+        expect(StatusPin.new(account: account, status: status[i]).save).to be true
+      end
+
+      expect(StatusPin.new(account: account, status: status[max_pins]).save).to be false
+    end
+
+    it 'allows pins above the max for remote accounts' do
+      account = Fabricate(:account, domain: 'remote', username: 'bob', url: 'https://remote/')
+      status = []
+
+      (max_pins + 1).times do |i|
+        status[i] = Fabricate(:status, account: account)
+      end
+
+      max_pins.times do |i|
+        expect(StatusPin.new(account: account, status: status[i]).save).to be true
+      end
+
+      expect(StatusPin.new(account: account, status: status[max_pins]).save).to be true
+    end
   end
 end


### PR DESCRIPTION
Sidekiq sometimes throws errors for users that have more pinned items than the allowed by the local instance. It should only validate the number of pins for local accounts.

I don't know if the origin of this is users that pinned items before #4923 or if it is mod servers that allow to pin more toots, but in any case I should not have extra errors in sidekiq because of that.