### PR TITLE
[WIP] Fix #7116: allow to specify docker user on run time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - ./public/assets:/mastodon/public/assets
       - ./public/packs:/mastodon/public/packs
       - ./public/system:/mastodon/public/system
+      - ./tmp:/mastodon/tmp
 
   streaming:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     restart: always
     env_file: .env.production
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    user: "${UID:-991}:${GID:-991}"
     networks:
       - external_network
       - internal_network


### PR DESCRIPTION
* added `user` key to `web` service of `docker-compose.yml` that reference the `UID` and `GID` in `.env.production` file (as shown in `.env.production.sample`). Allow site administrator to specify the UID and GID to own the public upload folders instead of using the hard-coded `mastodon` (991:991) user.