### PR TITLE
Moderation: Allow moderators to disable the ability for an account to post media

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -2,9 +2,13 @@
 
 module Admin
   class AccountsController < BaseController
-    before_action :set_account, only: [:show, :subscribe, :unsubscribe, :redownload, :remove_avatar, :enable, :disable, :memorialize]
+    before_action :set_account, only: [
+      :show, :subscribe, :unsubscribe, :redownload, :remove_avatar,
+      :enable, :disable, :enable_media_uploads, :disable_media_uploads,
+      :memorialize
+    ]
     before_action :require_remote_account!, only: [:subscribe, :unsubscribe, :redownload]
-    before_action :require_local_account!, only: [:enable, :disable, :memorialize]
+    before_action :require_local_account!, only: [:enable, :disable, :enable_media_uploads, :disable_media_uploads, :memorialize]
 
     def index
       authorize :account, :index?
@@ -47,6 +51,20 @@ module Admin
       authorize @account.user, :disable?
       @account.user.disable!
       log_action :disable, @account.user
+      redirect_to admin_account_path(@account.id)
+    end
+
+    def disable_media_uploads
+      authorize @account, :disable_media_uploads?
+      @account.disable_media_uploads!
+      log_action :disable_media_uploads, @account.user
+      redirect_to admin_account_path(@account.id)
+    end
+
+    def enable_media_uploads
+      authorize @account, :enable_media_uploads?
+      @account.enable_media_uploads!
+      log_action :enable_media_uploads, @account.user
       redirect_to admin_account_path(@account.id)
     end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -45,6 +45,7 @@
 #  moved_to_account_id     :integer
 #  featured_collection_url :string
 #  fields                  :jsonb
+#  media_uploads_disabled  :boolean          default(FALSE), not null
 #
 
 class Account < ApplicationRecord
@@ -184,6 +185,14 @@ class Account < ApplicationRecord
       user&.disable! if local?
       update!(memorial: true)
     end
+  end
+
+  def disable_media_uploads!
+    update!(media_uploads_disabled: true)
+  end
+
+  def enable_media_uploads!
+    update!(media_uploads_disabled: false)
   end
 
   def keypair

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -25,6 +25,14 @@ class AccountPolicy < ApplicationPolicy
     staff?
   end
 
+  def enable_media_uploads?
+    staff?
+  end
+
+  def disable_media_uploads?
+    staff? && !record.user&.staff?
+  end
+
   def redownload?
     admin?
   end

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -19,7 +19,7 @@ class PostStatusService < BaseService
       return Status.find(existing_id) if existing_id
     end
 
-    media  = validate_media!(options[:media_ids])
+    media  = validate_media!(options[:media_ids], account)
     status = nil
     text   = options.delete(:spoiler_text) if text.blank? && options[:spoiler_text].present?
     text   = '.' if text.blank? && !media.empty?
@@ -53,8 +53,10 @@ class PostStatusService < BaseService
 
   private
 
-  def validate_media!(media_ids)
+  def validate_media!(media_ids, account)
     return if media_ids.blank? || !media_ids.is_a?(Enumerable)
+
+    raise Mastodon::ValidationError, I18n.t('media_attachments.validations.media_uploads_disabled') if account.media_uploads_disabled?
 
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.too_many') if media_ids.size > 4
 

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -44,6 +44,15 @@
           %td
             = @account.user_unconfirmed_email
         %tr
+          %th= t('admin.accounts.media_uploads')
+          %td
+            - if @account.media_uploads_disabled?
+              = t('admin.accounts.disabled')
+              = table_link_to 'unlock', t('admin.accounts.enable'), enable_media_uploads_admin_account_path(@account.id), method: :post if can?(:enable_media_uploads, @account)
+            - else
+              = t('admin.accounts.enabled')
+              = table_link_to 'lock', t('admin.accounts.disable'), disable_media_uploads_admin_account_path(@account.id), method: :post if can?(:disable_media_uploads, @account)
+        %tr
           %th= t('admin.accounts.login_status')
           %td
             - if @account.user&.disabled?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,7 @@ en:
         title: Location
       login_status: Login status
       media_attachments: Media attachments
+      media_uploads: Media Uploads
       memorialize: Turn into memoriam
       moderation:
         all: All
@@ -532,6 +533,7 @@ en:
   media_attachments:
     validations:
       images_and_video: Cannot attach a video to a status that already contains images
+      media_uploads_disabled: You are prohibited from posting images and videos
       too_many: Cannot attach more than 4 files
   migrations:
     acct: username@domain of the new account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,8 @@ Rails.application.routes.draw do
         post :unsubscribe
         post :enable
         post :disable
+        post :enable_media_uploads
+        post :disable_media_uploads
         post :redownload
         post :remove_avatar
         post :memorialize

--- a/db/migrate/20180415004402_add_media_uploads_enabled_to_accounts.rb
+++ b/db/migrate/20180415004402_add_media_uploads_enabled_to_accounts.rb
@@ -1,0 +1,15 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddMediaUploadsEnabledToAccounts < ActiveRecord::Migration[5.2]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    safety_assured { add_column_with_default :accounts, :media_uploads_disabled, :bool, default: false }
+  end
+
+  def down
+    remove_column :accounts, :media_uploads_disabled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_04_10_204633) do
+ActiveRecord::Schema.define(version: 2018_04_15_004402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2018_04_10_204633) do
     t.bigint "moved_to_account_id"
     t.string "featured_collection_url"
     t.jsonb "fields"
+    t.boolean "media_uploads_disabled", default: false, null: false
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), lower((domain)::text)", name: "index_accounts_on_username_and_domain_lower"
     t.index ["uri"], name: "index_accounts_on_uri"


### PR DESCRIPTION
The account is still allowed to upload media, however, the creation of the status will not be allowed. Disabling media at upload seems to have a less clear meaning to a user (i.e., it seems like something went wrong).

Unfortunately, this is a breaking change, as not all clients respect the error message sent back (ahem, amaroq)