### PR TITLE
docker-compose: Only bind ports 3000 and 4000 on localhost.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - external_network
       - internal_network
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     depends_on:
       - db
       - redis
@@ -60,7 +60,7 @@ services:
       - external_network
       - internal_network
     ports:
-      - "4000:4000"
+      - "127.0.0.1:4000:4000"
     depends_on:
       - db
       - redis


### PR DESCRIPTION
This is a duplicate of #999, but #999 does not seem to be applied to master despite being merged.