### PR TITLE
Make RubyGems for development and test optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ services:
 
 install:
   - nvm install
-  - bundle install --path=vendor/bundle --with pam_authentication --without development production --retry=3 --jobs=16
+  - bundle install --path=vendor/bundle --with test --without production --retry=3 --jobs=16
   - yarn install
 
 before_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN apk -U upgrade \
 COPY Gemfile Gemfile.lock package.json yarn.lock .yarnclean /mastodon/
 
 RUN bundle config build.nokogiri --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include \
- && bundle install -j$(getconf _NPROCESSORS_ONLN) --deployment --without test development \
+ && bundle install -j$(getconf _NPROCESSORS_ONLN) --deployment \
  && yarn --pure-lockfile \
  && yarn cache clean
 

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'cld3', '~> 3.2.0'
 gem 'devise', '~> 4.4'
 gem 'devise-two-factor', '~> 3.0', git: 'https://github.com/ykzts/devise-two-factor.git', branch: 'rails-5.2'
 
-group :pam_authentication, optional: true do
+group :pam_authentication, :test, optional: true do
   gem 'devise_pam_authenticatable2', '~> 9.1'
 end
 
@@ -92,7 +92,7 @@ gem 'webpush'
 gem 'json-ld-preloaded', '~> 2.2'
 gem 'rdf-normalize', '~> 0.3'
 
-group :development, :test do
+group :development, :test, optional: true do
   gem 'fabrication', '~> 2.20'
   gem 'fuubar', '~> 2.2'
   gem 'i18n-tasks', '~> 0.9', require: false
@@ -104,7 +104,7 @@ group :production, :test do
   gem 'private_address_check', '~> 0.4.1'
 end
 
-group :test do
+group :test, optional: true do
   gem 'capybara', '~> 2.18'
   gem 'climate_control', '~> 0.2'
   gem 'faker', '~> 1.8'
@@ -116,7 +116,7 @@ group :test do
   gem 'parallel_tests', '~> 2.21'
 end
 
-group :development do
+group :development, optional: true do
   gem 'active_record_query_trace', '~> 1.5'
   gem 'annotate', '~> 2.7'
   gem 'better_errors', '~> 2.4'


### PR DESCRIPTION
Commit 8e88a18316d45a459a31d67487bccc247592d187 makes --with flag
necessary when configuring test. Traditionally, however, Mastodon required
to have --with flag for production configuration. If we have --with flag
for one situation, we can make such a flag unnecessary for the other.

This commit makes --with flag optional for production environment. While
the behavior is contrast with the traditional behavior, I decided to do
so because:
* It is easy to implement as both of group pam_authentication and test will
be optional.
* The production environment should be prioritized than the test
environment.

You can install RubyGems with the following command after applying this
commit:
* For production (removing all --without flags)
bundle install
* For development (adding two --with flags)
bundle install --with development test
* For minimal test (adding one --with flag, removing one --with and one
--without flag)
bundle install --with test --without production