### PR TITLE
Message content overflow

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -644,6 +644,7 @@
   overflow: hidden;
   white-space: pre-wrap;
   padding-top: 2px;
+  overflow-y: auto;
 
   &:focus {
     outline: 0;
@@ -714,6 +715,14 @@
       display: block;
     }
   }
+}
+
+.reply-indicator__content {
+  max-height: 9ex;
+}
+
+.status__content {
+  max-height: 17ex;
 }
 
 .status__content__spoiler-link {


### PR DESCRIPTION
``20ch`` and ``30ch`` are arbitrary values.
I have a media-query version as a user-style lying somewhere that I could adapt.

This request was originally done for the Mastodon-FE fork of pleroma: https://git.pleroma.social/tyge/mastofe/merge_requests/1