### PR TITLE
Reports: Merge contents and comment columns

### DIFF
--- a/app/views/admin/reports/_report.html.haml
+++ b/app/views/admin/reports/_report.html.haml
@@ -5,18 +5,18 @@
     = link_to report.target_account.acct, admin_account_path(report.target_account.id)
   %td.reporter
     = link_to report.account.acct, admin_account_path(report.account.id)
-  %td.comment
-    %span{ title: report.comment }
+  %td
+    %div{ title: report.comment }
       = truncate(report.comment, length: 30, separator: ' ')
-  %td.stats
-    - unless report.statuses.empty?
-      %span{ title: t('admin.accounts.statuses') }
-        = fa_icon('comment')
-        = report.statuses.count
-    - unless report.media_attachments.empty?
-      %span{ title: t('admin.accounts.media_attachments') }
-        = fa_icon('camera')
-        = report.media_attachments.count
+    %div
+      - unless report.statuses.empty?
+        %span{ title: t('admin.accounts.statuses') }
+          = fa_icon('comment')
+          = report.statuses.count
+      - unless report.media_attachments.empty?
+        %span{ title: t('admin.accounts.media_attachments') }
+          = fa_icon('camera')
+          = report.media_attachments.count
   %td
     - if report.assigned_account.nil?
       \-

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -18,7 +18,6 @@
           %th= t('admin.reports.id')
           %th= t('admin.reports.target')
           %th= t('admin.reports.reported_by')
-          %th= t('admin.reports.comment.label')
           %th= t('admin.reports.report_contents')
           %th= t('admin.reports.assigned')
           %th


### PR DESCRIPTION
Currently using an entire column for the content is kind of wasteful on space, so merging that with the comment column makes sense.