### PR TITLE
Fix Esc hotkey behavior

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -86,7 +86,9 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
 
     switch(e.key) {
     case 'Escape':
-      if (!suggestionsHidden) {
+      if (suggestions.size === 0 || suggestionsHidden) {
+        document.querySelector('.ui').parentElement.focus();
+      } else {
         e.preventDefault();
         this.setState({ suggestionsHidden: true });
       }
@@ -123,16 +125,6 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
     }
 
     this.props.onKeyDown(e);
-  }
-
-  onKeyUp = e => {
-    if (e.key === 'Escape' && this.state.suggestionsHidden) {
-      document.querySelector('.ui').parentElement.focus();
-    }
-
-    if (this.props.onKeyUp) {
-      this.props.onKeyUp(e);
-    }
   }
 
   onBlur = () => {
@@ -186,7 +178,7 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
   }
 
   render () {
-    const { value, suggestions, disabled, placeholder, autoFocus } = this.props;
+    const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus } = this.props;
     const { suggestionsHidden } = this.state;
     const style = { direction: 'ltr' };
 
@@ -208,7 +200,7 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
             value={value}
             onChange={this.onChange}
             onKeyDown={this.onKeyDown}
-            onKeyUp={this.onKeyUp}
+            onKeyUp={onKeyUp}
             onBlur={this.onBlur}
             onPaste={this.onPaste}
             style={style}


### PR DESCRIPTION
This fixes following cases which causes hotkey action accidentally:

* hitting Esc key to cancel text composition (mostly in CJK) #5574

  Although events on cancelling composition are still heavily browser / input method dependent, but this implementation would covers current UI Events spec and some exceptions.

* hitting Esc key to close autocomplete suggestions

  ![before](https://user-images.githubusercontent.com/705555/39049048-abf099fc-44da-11e8-892e-821d2f8a02f0.gif)

  As you can see, hitting Esc key removes focus from textarea not only closing suggestions.

This PR changes to use keydown event instead of keyup event as well as other hotkeys. I've also wrote fix with keyup events, but this solution is much simpler and seems enough.