### PR TITLE
Fix spec for sr-Latn

### DIFF
--- a/app/controllers/concerns/localized.rb
+++ b/app/controllers/concerns/localized.rb
@@ -29,10 +29,14 @@ module Localized
   end
 
   def preferred_locale
-    http_accept_language.preferred_language_from(I18n.available_locales)
+    http_accept_language.preferred_language_from(available_locales)
   end
 
   def compatible_locale
-    http_accept_language.compatible_language_from(I18n.available_locales)
+    http_accept_language.compatible_language_from(available_locales)
+  end
+
+  def available_locales
+    I18n.available_locales.reverse
   end
 end


### PR DESCRIPTION
randomly fail...

```plain
  1) Auth::RegistrationsController POST #create  creates user
     Failure/Error: expect(user.locale).to eq(accept_language)
     
       expected: "sr-Latn"
            got: "sr"
     
       (compared using ==)
     # ./spec/controllers/auth/registrations_controller_spec.rb:100:in `block (4 levels) in <top (required)>'
     # ./spec/controllers/auth/registrations_controller_spec.rb:81:in `block (4 levels) in <top (required)>'
     # ./spec/controllers/auth/registrations_controller_spec.rb:9:in `block (3 levels) in <top (required)>'
```