### PR TITLE
Ignore keyevents during text composition

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -84,6 +84,12 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
       return;
     }
 
+    if (e.which === 229 || e.isComposing) {
+      // Ignore key events during text composition
+      // e.key may be a name of the physical key even in this case (e.x. Safari / Chrome on Mac)
+      return;
+    }
+
     switch(e.key) {
     case 'Escape':
       if (suggestions.size === 0 || suggestionsHidden) {


### PR DESCRIPTION
KeyboardEvent.key may be physical key name (Escape, Tab, etc.) even in text composition and it causes hotkeys or suggestion selection. So we need to check e.which or e.isComposing.

Checking e.which also allows us to avoid Esc key on compositionend in Safari.