### PR TITLE
Use raw status code on have_http_status

### DIFF
--- a/spec/controllers/about_controller_spec.rb
+++ b/spec/controllers/about_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AboutController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe AboutController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe AboutController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe AccountsController, type: :controller do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'returns correct format' do

--- a/spec/controllers/activitypub/outboxes_controller_spec.rb
+++ b/spec/controllers/activitypub/outboxes_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ActivityPub::OutboxesController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'returns application/activity+json' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Admin::AccountsController, type: :controller do
 
     it 'returns http success' do
       get :index
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -72,7 +72,7 @@ RSpec.describe Admin::AccountsController, type: :controller do
 
     it 'returns http success' do
       get :show, params: { id: account.id }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/admin/change_email_controller_spec.rb
+++ b/spec/controllers/admin/change_email_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Admin::ChangeEmailsController, type: :controller do
 
       get :show, params: { account_id: account.id }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/admin/confirmations_controller_spec.rb
+++ b/spec/controllers/admin/confirmations_controller_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe Admin::ConfirmationsController, type: :controller do
     it 'raises an error when there is no account' do
       post :create, params: { account_id: 'fake' }
 
-      expect(response).to have_http_status(:missing)
+      expect(response).to have_http_status(404)
     end
 
     it 'raises an error when there is no user' do
       account = Fabricate(:account, user: nil)
       post :create, params: { account_id: account.id }
 
-      expect(response).to have_http_status(:missing)
+      expect(response).to have_http_status(404)
     end
   end
 end

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Admin::DomainBlocksController, type: :controller do
       assigned = assigns(:domain_blocks)
       expect(assigned.count).to eq 1
       expect(assigned.klass).to be DomainBlock
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe Admin::DomainBlocksController, type: :controller do
       get :new
 
       expect(assigns(:domain_block)).to be_instance_of(DomainBlock)
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe Admin::DomainBlocksController, type: :controller do
       domain_block = Fabricate(:domain_block)
       get :show, params: { id: domain_block.id }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/email_domain_blocks_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Admin::EmailDomainBlocksController, type: :controller do
       assigned = assigns(:email_domain_blocks)
       expect(assigned.count).to eq 1
       expect(assigned.klass).to be EmailDomainBlock
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -34,7 +34,7 @@ RSpec.describe Admin::EmailDomainBlocksController, type: :controller do
       get :new
 
       expect(assigns(:email_domain_block)).to be_instance_of(EmailDomainBlock)
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Admin::InstancesController, type: :controller do
       expect(instances.size).to eq 1
       expect(instances[0].domain).to eq 'less.popular'
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/admin/reported_statuses_controller_spec.rb
+++ b/spec/controllers/admin/reported_statuses_controller_spec.rb
@@ -84,7 +84,7 @@ describe Admin::ReportedStatusesController do
       allow(RemovalWorker).to receive(:perform_async)
 
       delete :destroy, params: { report_id: report, id: status }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(RemovalWorker).
         to have_received(:perform_async).with(status.id)
     end

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -18,7 +18,7 @@ describe Admin::ReportsController do
       reports = assigns(:reports).to_a
       expect(reports.size).to eq 1
       expect(reports[0]).to eq specified
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'returns http success with resolved filter' do
@@ -31,7 +31,7 @@ describe Admin::ReportsController do
       expect(reports.size).to eq 1
       expect(reports[0]).to eq specified
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -42,7 +42,7 @@ describe Admin::ReportsController do
       get :show, params: { id: report }
 
       expect(assigns(:report)).to eq report
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -52,7 +52,7 @@ describe Admin::ReportsController do
         report = Fabricate(:report)
         put :update, params: { id: report, outcome: 'unknown' }
 
-        expect(response).to have_http_status(:missing)
+        expect(response).to have_http_status(404)
       end
     end
 

--- a/spec/controllers/admin/settings_controller_spec.rb
+++ b/spec/controllers/admin/settings_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Admin::SettingsController, type: :controller do
       it 'returns http success' do
         get :edit
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 

--- a/spec/controllers/admin/statuses_controller_spec.rb
+++ b/spec/controllers/admin/statuses_controller_spec.rb
@@ -20,7 +20,7 @@ describe Admin::StatusesController do
 
       statuses = assigns(:statuses).to_a
       expect(statuses.size).to eq 2
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'returns http success with media' do
@@ -28,7 +28,7 @@ describe Admin::StatusesController do
 
       statuses = assigns(:statuses).to_a
       expect(statuses.size).to eq 1
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -99,7 +99,7 @@ describe Admin::StatusesController do
       allow(RemovalWorker).to receive(:perform_async)
 
       delete :destroy, params: { account_id: account.id, id: status }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(RemovalWorker).
         to have_received(:perform_async).with(status.id)
     end

--- a/spec/controllers/admin/subscriptions_controller_spec.rb
+++ b/spec/controllers/admin/subscriptions_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Admin::SubscriptionsController, type: :controller do
       expect(subscriptions.count).to eq 1
       expect(subscriptions[0]).to eq specified
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -23,7 +23,7 @@ describe Api::BaseController do
     it 'does not protect from forgery' do
       ActionController::Base.allow_forgery_protection = true
       post 'success'
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/api/oembed_controller_spec.rb
+++ b/spec/controllers/api/oembed_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::OEmbedController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/push_controller_spec.rb
+++ b/spec/controllers/api/push_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::PushController, type: :controller do
           '3600',
           nil
         )
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(202)
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe Api::PushController, type: :controller do
           account,
           'https://callback.host/api',
         )
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(202)
       end
     end
 

--- a/spec/controllers/api/salmon_controller_spec.rb
+++ b/spec/controllers/api/salmon_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::SalmonController, type: :controller do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(202)
       end
 
       it 'creates remote account' do

--- a/spec/controllers/api/subscriptions_controller_spec.rb
+++ b/spec/controllers/api/subscriptions_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::SubscriptionsController, type: :controller do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'echoes back the challenge' do
@@ -27,7 +27,7 @@ RSpec.describe Api::SubscriptionsController, type: :controller do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:missing)
+        expect(response).to have_http_status(404)
       end
     end
   end
@@ -59,7 +59,7 @@ RSpec.describe Api::SubscriptionsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'creates statuses for feed' do

--- a/spec/controllers/api/v1/accounts/credentials_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/credentials_controller_spec.rb
@@ -14,7 +14,7 @@ describe Api::V1::Accounts::CredentialsController do
     describe 'GET #show' do
       it 'returns http success' do
         get :show
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 
@@ -36,7 +36,7 @@ describe Api::V1::Accounts::CredentialsController do
         end
 
         it 'returns http success' do
-          expect(response).to have_http_status(:success)
+          expect(response).to have_http_status(200)
         end
 
         it 'updates account info' do

--- a/spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::V1::Accounts::FollowerAccountsController do
     it 'returns http success' do
       get :index, params: { account_id: user.account.id, limit: 1 }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::V1::Accounts::FollowingAccountsController do
     it 'returns http success' do
       get :index, params: { account_id: user.account.id, limit: 1 }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/v1/accounts/lists_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/lists_controller_spec.rb
@@ -17,7 +17,7 @@ describe Api::V1::Accounts::ListsController do
   describe 'GET #index' do
     it 'returns http success' do
       get :index, params: { account_id: account.id }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/v1/accounts/relationships_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/relationships_controller_spec.rb
@@ -25,7 +25,7 @@ describe Api::V1::Accounts::RelationshipsController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'returns JSON with correct data' do
@@ -43,7 +43,7 @@ describe Api::V1::Accounts::RelationshipsController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'returns JSON with correct data' do

--- a/spec/controllers/api/v1/accounts/search_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/search_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Api::V1::Accounts::SearchController, type: :controller do
     it 'returns http success' do
       get :show, params: { q: 'query' }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::V1::Accounts::StatusesController do
     it 'returns http success' do
       get :index, params: { account_id: user.account.id, limit: 1 }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.headers['Link'].links.size).to eq(2)
     end
 
@@ -23,7 +23,7 @@ describe Api::V1::Accounts::StatusesController do
       it 'returns http success' do
         get :index, params: { account_id: user.account.id, only_media: true }
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 
@@ -35,7 +35,7 @@ describe Api::V1::Accounts::StatusesController do
       it 'returns http success' do
         get :index, params: { account_id: user.account.id, exclude_replies: true }
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 
@@ -47,7 +47,7 @@ describe Api::V1::Accounts::StatusesController do
       it 'returns http success' do
         get :index, params: { account_id: user.account.id, pinned: true }
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
   end

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
   describe 'GET #show' do
     it 'returns http success' do
       get :show, params: { id: user.account.id }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -28,7 +28,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
       let(:locked) { false }
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'returns JSON with following=true and requested=false' do
@@ -47,7 +47,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
       let(:locked) { true }
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'returns JSON with following=false and requested=true' do
@@ -72,7 +72,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'removes the following relation between user and target user' do
@@ -89,7 +89,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'removes the following relation between user and target user' do
@@ -110,7 +110,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'removes the blocking relation between user and target user' do
@@ -127,7 +127,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'does not remove the following relation between user and target user' do
@@ -152,7 +152,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'does not remove the following relation between user and target user' do
@@ -177,7 +177,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'removes the muting relation between user and target user' do

--- a/spec/controllers/api/v1/apps/credentials_controller_spec.rb
+++ b/spec/controllers/api/v1/apps/credentials_controller_spec.rb
@@ -16,7 +16,7 @@ describe Api::V1::Apps::CredentialsController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'does not contain client credentials' do

--- a/spec/controllers/api/v1/apps_controller_spec.rb
+++ b/spec/controllers/api/v1/apps_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V1::AppsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'creates an OAuth app' do

--- a/spec/controllers/api/v1/blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/blocks_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Api::V1::BlocksController, type: :controller do
 
     it 'returns http success' do
       get :index
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/v1/custom_emojis_controller_spec.rb
+++ b/spec/controllers/api/v1/custom_emojis_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::CustomEmojisController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/v1/domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/domain_blocks_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Api::V1::DomainBlocksController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'returns blocked domains' do
@@ -31,7 +31,7 @@ RSpec.describe Api::V1::DomainBlocksController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'creates a domain block' do
@@ -45,7 +45,7 @@ RSpec.describe Api::V1::DomainBlocksController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'deletes a domain block' do

--- a/spec/controllers/api/v1/follow_requests_controller_spec.rb
+++ b/spec/controllers/api/v1/follow_requests_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Api::V1::FollowRequestsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -28,7 +28,7 @@ RSpec.describe Api::V1::FollowRequestsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'allows follower to follow' do
@@ -42,7 +42,7 @@ RSpec.describe Api::V1::FollowRequestsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'removes follow request' do

--- a/spec/controllers/api/v1/follows_controller_spec.rb
+++ b/spec/controllers/api/v1/follows_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::V1::FollowsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'creates account for remote user' do
@@ -45,7 +45,7 @@ RSpec.describe Api::V1::FollowsController, type: :controller do
 
     it 'returns http success if already following, too' do
       post :create, params: { uri: 'gargron@quitter.no' }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/v1/instances_controller_spec.rb
+++ b/spec/controllers/api/v1/instances_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::V1::InstancesController, type: :controller do
     it 'returns http success' do
       get :show
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/v1/lists/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/lists/accounts_controller_spec.rb
@@ -17,7 +17,7 @@ describe Api::V1::Lists::AccountsController do
     it 'returns http success' do
       get :show, params: { list_id: list.id }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -30,7 +30,7 @@ describe Api::V1::Lists::AccountsController do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'adds account to the list' do
@@ -44,7 +44,7 @@ describe Api::V1::Lists::AccountsController do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'removes account from the list' do

--- a/spec/controllers/api/v1/lists_controller_spec.rb
+++ b/spec/controllers/api/v1/lists_controller_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Api::V1::ListsController, type: :controller do
   describe 'GET #index' do
     it 'returns http success' do
       get :index
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
   describe 'GET #show' do
     it 'returns http success' do
       get :show, params: { id: list.id }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe Api::V1::ListsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'creates list' do
@@ -44,7 +44,7 @@ RSpec.describe Api::V1::ListsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'updates the list' do
@@ -58,7 +58,7 @@ RSpec.describe Api::V1::ListsController, type: :controller do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'deletes the list' do

--- a/spec/controllers/api/v1/media_controller_spec.rb
+++ b/spec/controllers/api/v1/media_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Api::V1::MediaController, type: :controller do
         end
 
         it 'returns http 422' do
-          expect(response).to have_http_status(:error)
+          expect(response).to have_http_status(500)
         end
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe Api::V1::MediaController, type: :controller do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'creates a media attachment' do
@@ -63,7 +63,7 @@ RSpec.describe Api::V1::MediaController, type: :controller do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'creates a media attachment' do
@@ -85,7 +85,7 @@ RSpec.describe Api::V1::MediaController, type: :controller do
       end
 
       xit 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       xit 'creates a media attachment' do

--- a/spec/controllers/api/v1/mutes_controller_spec.rb
+++ b/spec/controllers/api/v1/mutes_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V1::MutesController, type: :controller do
     it 'returns http success' do
       get :index, params: { limit: 1 }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       notification = Fabricate(:notification, account: user.account)
       get :show, params: { id: notification.id }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       notification = Fabricate(:notification, account: user.account)
       post :dismiss, params: { id: notification.id }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect { notification.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       post :clear
 
       expect(notification.account.reload.notifications).to be_empty
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'includes reblog' do
@@ -82,7 +82,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'includes reblog' do

--- a/spec/controllers/api/v1/reports_controller_spec.rb
+++ b/spec/controllers/api/v1/reports_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::V1::ReportsController, type: :controller do
     it 'returns http success' do
       get :index
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe Api::V1::ReportsController, type: :controller do
 
     it 'creates a report' do
       expect(status.reload.account.targeted_reports).not_to be_empty
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'sends e-mails to admins' do

--- a/spec/controllers/api/v1/search_controller_spec.rb
+++ b/spec/controllers/api/v1/search_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Api::V1::SearchController, type: :controller do
     it 'returns http success' do
       get :index, params: { q: 'test' }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/api/v1/statuses/favourited_by_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/favourited_by_accounts_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::Statuses::FavouritedByAccountsController, type: :control
 
       it 'returns http success' do
         get :index, params: { status_id: status.id, limit: 1 }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
         expect(response.headers['Link'].links.size).to eq(2)
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe Api::V1::Statuses::FavouritedByAccountsController, type: :control
 
         it 'returns http unautharized' do
           get :index, params: { status_id: status.id }
-          expect(response).to have_http_status(:missing)
+          expect(response).to have_http_status(404)
         end
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe Api::V1::Statuses::FavouritedByAccountsController, type: :control
 
         it 'returns http success' do
           get :index, params: { status_id: status.id }
-          expect(response).to have_http_status(:success)
+          expect(response).to have_http_status(200)
         end
       end
     end

--- a/spec/controllers/api/v1/statuses/favourites_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/favourites_controller_spec.rb
@@ -22,7 +22,7 @@ describe Api::V1::Statuses::FavouritesController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'updates the favourites count' do
@@ -51,7 +51,7 @@ describe Api::V1::Statuses::FavouritesController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'updates the favourites count' do

--- a/spec/controllers/api/v1/statuses/mutes_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/mutes_controller_spec.rb
@@ -22,7 +22,7 @@ describe Api::V1::Statuses::MutesController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'creates a conversation mute' do
@@ -39,7 +39,7 @@ describe Api::V1::Statuses::MutesController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'destroys the conversation mute' do

--- a/spec/controllers/api/v1/statuses/pins_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/pins_controller_spec.rb
@@ -22,7 +22,7 @@ describe Api::V1::Statuses::PinsController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'updates the pinned attribute' do
@@ -46,7 +46,7 @@ describe Api::V1::Statuses::PinsController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'updates the pinned attribute' do

--- a/spec/controllers/api/v1/statuses/reblogged_by_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reblogged_by_accounts_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::Statuses::RebloggedByAccountsController, type: :controll
 
       it 'returns http success' do
         get :index, params: { status_id: status.id, limit: 1 }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
         expect(response.headers['Link'].links.size).to eq(2)
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe Api::V1::Statuses::RebloggedByAccountsController, type: :controll
 
         it 'returns http unautharized' do
           get :index, params: { status_id: status.id }
-          expect(response).to have_http_status(:missing)
+          expect(response).to have_http_status(404)
         end
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe Api::V1::Statuses::RebloggedByAccountsController, type: :controll
 
         it 'returns http success' do
           get :index, params: { status_id: status.id }
-          expect(response).to have_http_status(:success)
+          expect(response).to have_http_status(200)
         end
       end
     end

--- a/spec/controllers/api/v1/statuses/reblogs_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reblogs_controller_spec.rb
@@ -22,7 +22,7 @@ describe Api::V1::Statuses::ReblogsController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'updates the reblogs count' do
@@ -51,7 +51,7 @@ describe Api::V1::Statuses::ReblogsController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'updates the reblogs count' do

--- a/spec/controllers/api/v1/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
 
       it 'returns http success' do
         get :show, params: { id: status.id }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
 
       it 'returns http success' do
         get :context, params: { id: status.id }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 
@@ -40,7 +40,7 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'removes the status' do
@@ -72,7 +72,7 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
       describe 'GET #show' do
         it 'returns http unautharized' do
           get :show, params: { id: status.id }
-          expect(response).to have_http_status(:missing)
+          expect(response).to have_http_status(404)
         end
       end
 
@@ -83,14 +83,14 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
 
         it 'returns http unautharized' do
           get :context, params: { id: status.id }
-          expect(response).to have_http_status(:missing)
+          expect(response).to have_http_status(404)
         end
       end
 
       describe 'GET #card' do
         it 'returns http unautharized' do
           get :card, params: { id: status.id }
-          expect(response).to have_http_status(:missing)
+          expect(response).to have_http_status(404)
         end
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
       describe 'GET #show' do
         it 'returns http success' do
           get :show, params: { id: status.id }
-          expect(response).to have_http_status(:success)
+          expect(response).to have_http_status(200)
         end
       end
 
@@ -112,14 +112,14 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
 
         it 'returns http success' do
           get :context, params: { id: status.id }
-          expect(response).to have_http_status(:success)
+          expect(response).to have_http_status(200)
         end
       end
 
       describe 'GET #card' do
         it 'returns http success' do
           get :card, params: { id: status.id }
-          expect(response).to have_http_status(:success)
+          expect(response).to have_http_status(200)
         end
       end
     end

--- a/spec/controllers/api/v1/timelines/home_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/home_controller_spec.rb
@@ -23,7 +23,7 @@ describe Api::V1::Timelines::HomeController do
       it 'returns http success' do
         get :show
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
         expect(response.headers['Link'].links.size).to eq(2)
       end
     end

--- a/spec/controllers/api/v1/timelines/list_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/list_controller_spec.rb
@@ -24,7 +24,7 @@ describe Api::V1::Timelines::ListController do
 
       it 'returns http success' do
         get :show, params: { id: list.id }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
   end

--- a/spec/controllers/api/v1/timelines/public_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/public_controller_spec.rb
@@ -22,7 +22,7 @@ describe Api::V1::Timelines::PublicController do
       it 'returns http success' do
         get :show
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
         expect(response.headers['Link'].links.size).to eq(2)
       end
     end
@@ -35,7 +35,7 @@ describe Api::V1::Timelines::PublicController do
       it 'returns http success' do
         get :show, params: { local: true }
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
         expect(response.headers['Link'].links.size).to eq(2)
       end
     end
@@ -48,7 +48,7 @@ describe Api::V1::Timelines::PublicController do
       it 'returns http success' do
         get :show
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
         expect(response.headers['Link']).to be_nil
       end
     end

--- a/spec/controllers/api/v1/timelines/tag_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/tag_controller_spec.rb
@@ -21,7 +21,7 @@ describe Api::V1::Timelines::TagController do
 
       it 'returns http success' do
         get :show, params: { id: 'test' }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
         expect(response.headers['Link'].links.size).to eq(2)
       end
     end
@@ -33,7 +33,7 @@ describe Api::V1::Timelines::TagController do
     describe 'GET #show' do
       it 'returns http success' do
         get :show, params: { id: 'test' }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
         expect(response.headers['Link']).to be_nil
       end
     end

--- a/spec/controllers/api/web/settings_controller_spec.rb
+++ b/spec/controllers/api/web/settings_controller_spec.rb
@@ -13,7 +13,7 @@ describe Api::Web::SettingsController do
       patch :update, format: :json, params: { data: { 'onboarded' => true } }
 
       user.reload
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(user_web_setting.data['onboarded']).to eq('true')
     end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -51,7 +51,7 @@ describe ApplicationController, type: :controller do
     routes.draw { get 'success' => 'anonymous#success' }
     allow(Rails.env).to receive(:production?).and_return(false)
     get 'success'
-    expect(response).to have_http_status(:success)
+    expect(response).to have_http_status(200)
   end
 
   it "forces ssl if Rails.env.production? is 'true'" do
@@ -145,13 +145,13 @@ describe ApplicationController, type: :controller do
 
     it 'does nothing if not signed in' do
       get 'success'
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'does nothing if user who signed in is not suspended' do
       sign_in(Fabricate(:user, account: Fabricate(:account, suspended: false)))
       get 'success'
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     it 'returns http 403 if user who signed in is suspended' do

--- a/spec/controllers/auth/confirmations_controller_spec.rb
+++ b/spec/controllers/auth/confirmations_controller_spec.rb
@@ -7,7 +7,7 @@ describe Auth::ConfirmationsController, type: :controller do
     it 'returns http success' do
       @request.env['devise.mapping'] = Devise.mappings[:user]
       get :new
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/auth/passwords_controller_spec.rb
+++ b/spec/controllers/auth/passwords_controller_spec.rb
@@ -9,7 +9,7 @@ describe Auth::PasswordsController, type: :controller do
     it 'returns http success' do
       @request.env['devise.mapping'] = Devise.mappings[:user]
       get :new
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -24,7 +24,7 @@ describe Auth::PasswordsController, type: :controller do
     context 'with valid reset_password_token' do
       it 'returns http success' do
         get :edit, params: { reset_password_token: @token }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Auth::RegistrationsController, type: :controller do
       request.env["devise.mapping"] = Devise.mappings[:user]
       sign_in(Fabricate(:user))
       get :edit
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe Auth::RegistrationsController, type: :controller do
       request.env["devise.mapping"] = Devise.mappings[:user]
       sign_in(Fabricate(:user), scope: :user)
       post :update
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -63,7 +63,7 @@ RSpec.describe Auth::RegistrationsController, type: :controller do
       it 'returns http success' do
         Setting.open_registrations = true
         get :new
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Auth::SessionsController, type: :controller do
 
     it 'returns http success' do
       get :new
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/authorize_follows_controller_spec.rb
+++ b/spec/controllers/authorize_follows_controller_spec.rb
@@ -47,7 +47,7 @@ describe AuthorizeFollowsController do
 
         get :show, params: { acct: 'http://example.com' }
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
         expect(assigns(:account)).to eq account
       end
 
@@ -59,7 +59,7 @@ describe AuthorizeFollowsController do
 
         get :show, params: { acct: 'acct:found@hostname' }
 
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
         expect(assigns(:account)).to eq account
       end
     end

--- a/spec/controllers/concerns/account_controller_concern_spec.rb
+++ b/spec/controllers/concerns/account_controller_concern_spec.rb
@@ -39,7 +39,7 @@ describe ApplicationController, type: :controller do
     it 'returns http success' do
       account = Fabricate(:account)
       get 'success', params: { account_username: account.username }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/concerns/export_controller_concern_spec.rb
+++ b/spec/controllers/concerns/export_controller_concern_spec.rb
@@ -19,7 +19,7 @@ describe ApplicationController, type: :controller do
       sign_in user
       get :index, format: :csv
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq 'text/csv'
       expect(response.headers['Content-Disposition']).to eq 'attachment; filename="anonymous.csv"'
       expect(response.body).to eq user.account.username

--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -19,7 +19,7 @@ describe FollowerAccountsController do
       expect(assigned[0]).to eq follow1
       expect(assigned[1]).to eq follow0
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -19,7 +19,7 @@ describe FollowingAccountsController do
       expect(assigned[0]).to eq follow1
       expect(assigned[1]).to eq follow0
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/manifests_controller_spec.rb
+++ b/spec/controllers/manifests_controller_spec.rb
@@ -9,7 +9,7 @@ describe ManifestsController do
     end
 
     it 'returns http success' do
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -18,13 +18,13 @@ describe MediaController do
       media_attachment = Fabricate(:media_attachment, status: nil)
       get :show, params: { id: media_attachment.to_param }
 
-      expect(response).to have_http_status(:missing)
+      expect(response).to have_http_status(404)
     end
 
     it 'raises when shortcode cant be found' do
       get :show, params: { id: 'missing' }
 
-      expect(response).to have_http_status(:missing)
+      expect(response).to have_http_status(404)
     end
 
     it 'raises when not permitted to view' do
@@ -33,7 +33,7 @@ describe MediaController do
       allow_any_instance_of(MediaController).to receive(:authorize).and_raise(ActiveRecord::RecordNotFound)
       get :show, params: { id: media_attachment.to_param }
 
-      expect(response).to have_http_status(:missing)
+      expect(response).to have_http_status(404)
     end
   end
 end

--- a/spec/controllers/oauth/authorizations_controller_spec.rb
+++ b/spec/controllers/oauth/authorizations_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Oauth::AuthorizationsController, type: :controller do
 
       it 'returns http success' do
         subject
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'gives options to authorize and deny' do

--- a/spec/controllers/oauth/authorized_applications_controller_spec.rb
+++ b/spec/controllers/oauth/authorized_applications_controller_spec.rb
@@ -24,7 +24,7 @@ describe Oauth::AuthorizedApplicationsController do
 
       it 'returns http success' do
         subject
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       include_examples 'stores location for user'

--- a/spec/controllers/remote_follow_controller_spec.rb
+++ b/spec/controllers/remote_follow_controller_spec.rb
@@ -10,7 +10,7 @@ describe RemoteFollowController do
       account = Fabricate(:account)
       get :new, params: { account_username: account.to_param }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response).to render_template(:new)
       expect(assigns(:remote_follow).acct).to be_nil
     end
@@ -20,7 +20,7 @@ describe RemoteFollowController do
       account = Fabricate(:account)
       get :new, params: { account_username: account.to_param }
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response).to render_template(:new)
       expect(assigns(:remote_follow).acct).to eq 'user@example.com'
     end

--- a/spec/controllers/settings/applications_controller_spec.rb
+++ b/spec/controllers/settings/applications_controller_spec.rb
@@ -15,7 +15,7 @@ describe Settings::ApplicationsController do
 
     it 'shows apps' do
       get :index
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(assigns(:applications)).to include(app)
       expect(assigns(:applications)).to_not include(other_app)
     end
@@ -25,7 +25,7 @@ describe Settings::ApplicationsController do
   describe 'GET #show' do
     it 'returns http success' do
       get :show, params: { id: app.id }
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(assigns[:application]).to eql(app)
     end
 
@@ -40,7 +40,7 @@ describe Settings::ApplicationsController do
   describe 'GET #new' do
     it 'works' do
       get :new
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 
@@ -102,7 +102,7 @@ describe Settings::ApplicationsController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'renders form again' do
@@ -151,7 +151,7 @@ describe Settings::ApplicationsController do
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'renders form again' do

--- a/spec/controllers/settings/deletes_controller_spec.rb
+++ b/spec/controllers/settings/deletes_controller_spec.rb
@@ -13,7 +13,7 @@ describe Settings::DeletesController do
 
       it 'renders confirmation page' do
         get :show
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 

--- a/spec/controllers/settings/exports_controller_spec.rb
+++ b/spec/controllers/settings/exports_controller_spec.rb
@@ -17,7 +17,7 @@ describe Settings::ExportsController do
         export = assigns(:export)
         expect(export).to be_instance_of Export
         expect(export.account).to eq user.account
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
     end
 

--- a/spec/controllers/settings/follower_domains_controller_spec.rb
+++ b/spec/controllers/settings/follower_domains_controller_spec.rb
@@ -36,7 +36,7 @@ describe Settings::FollowerDomainsController do
     it 'returns http success' do
       sign_in user, scope: :user
       subject
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
 
     include_examples 'authenticate user'

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Settings::ImportsController, type: :controller do
   describe "GET #show" do
     it "returns http success" do
       get :show
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/settings/notifications_controller_spec.rb
+++ b/spec/controllers/settings/notifications_controller_spec.rb
@@ -12,7 +12,7 @@ describe Settings::NotificationsController do
   describe 'GET #show' do
     it 'returns http success' do
       get :show
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/settings/preferences_controller_spec.rb
+++ b/spec/controllers/settings/preferences_controller_spec.rb
@@ -12,7 +12,7 @@ describe Settings::PreferencesController do
   describe 'GET #show' do
     it 'returns http success' do
       get :show
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/settings/profiles_controller_spec.rb
+++ b/spec/controllers/settings/profiles_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Settings::ProfilesController, type: :controller do
   describe "GET #show" do
     it "returns http success" do
       get :show
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb
@@ -15,7 +15,7 @@ describe Settings::TwoFactorAuthentication::ConfirmationsController do
       expect(assigns(:confirmation)).to be_instance_of Form::TwoFactorConfirmation
       expect(assigns(:provision_url)).to eq 'otpauth://totp/local-part@domain?secret=thisisasecretforthespecofnewview&issuer=cb6e6126.ngrok.io'
       expect(assigns(:qrcode)).to be_instance_of RQRCode::QRCode
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response).to render_template(:new)
     end
   end
@@ -71,7 +71,7 @@ describe Settings::TwoFactorAuthentication::ConfirmationsController do
 
           expect(assigns(:recovery_codes)).to eq otp_backup_codes
           expect(flash[:notice]).to eq 'Two-factor authentication successfully enabled'
-          expect(response).to have_http_status(:success)
+          expect(response).to have_http_status(200)
           expect(response).to render_template('settings/two_factor_authentication/recovery_codes/index')
         end
       end

--- a/spec/controllers/settings/two_factor_authentication/recovery_codes_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/recovery_codes_controller_spec.rb
@@ -19,7 +19,7 @@ describe Settings::TwoFactorAuthentication::RecoveryCodesController do
 
       expect(assigns(:recovery_codes)).to eq otp_backup_codes
       expect(flash[:notice]).to eq 'Recovery codes successfully regenerated'
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response).to render_template(:index)
     end
 

--- a/spec/controllers/settings/two_factor_authentications_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentications_controller_spec.rb
@@ -18,7 +18,7 @@ describe Settings::TwoFactorAuthenticationsController do
           user.update(otp_required_for_login: true)
           get :show
 
-          expect(response).to have_http_status(:success)
+          expect(response).to have_http_status(200)
         end
       end
 
@@ -27,7 +27,7 @@ describe Settings::TwoFactorAuthenticationsController do
           user.update(otp_required_for_login: false)
           get :show
 
-          expect(response).to have_http_status(:success)
+          expect(response).to have_http_status(200)
         end
       end
     end

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -85,7 +85,7 @@ describe StatusesController do
       it 'returns a success' do
         status = Fabricate(:status)
         get :show, params: { account_username: status.account.username, id: status.id }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'renders stream_entries/show' do

--- a/spec/controllers/stream_entries_controller_spec.rb
+++ b/spec/controllers/stream_entries_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe StreamEntriesController, type: :controller do
     it 'returns http success with Atom' do
       status = Fabricate(:status)
       get :show, params: { account_username: status.account.username, id: status.stream_entry.id }, format: 'atom'
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
     end
   end
 

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TagsController, type: :controller do
     context 'when tag exists' do
       it 'returns http success' do
         get :show, params: { id: 'test', max_id: late.id }
-        expect(response).to have_http_status(:success)
+        expect(response).to have_http_status(200)
       end
 
       it 'renders application layout' do
@@ -25,7 +25,7 @@ RSpec.describe TagsController, type: :controller do
       it 'returns http missing for non-existent tag' do
         get :show, params: { id: 'none' }
 
-        expect(response).to have_http_status(:missing)
+        expect(response).to have_http_status(404)
       end
     end
   end

--- a/spec/controllers/well_known/host_meta_controller_spec.rb
+++ b/spec/controllers/well_known/host_meta_controller_spec.rb
@@ -7,7 +7,7 @@ describe WellKnown::HostMetaController, type: :controller do
     it 'returns http success' do
       get :show, format: :xml
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq 'application/xrd+xml'
       expect(response.body).to eq <<XML
 <?xml version="1.0"?>

--- a/spec/controllers/well_known/webfinger_controller_spec.rb
+++ b/spec/controllers/well_known/webfinger_controller_spec.rb
@@ -50,7 +50,7 @@ PEM
 
       json = body_as_json
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq 'application/jrd+json'
       expect(json[:subject]).to eq 'acct:alice@cb6e6126.ngrok.io'
       expect(json[:aliases]).to include('https://cb6e6126.ngrok.io/@alice', 'https://cb6e6126.ngrok.io/users/alice')
@@ -61,7 +61,7 @@ PEM
 
       xml = Nokogiri::XML(response.body)
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq 'application/xrd+xml'
       expect(xml.at_xpath('//xmlns:Subject').content).to eq 'acct:alice@cb6e6126.ngrok.io'
       expect(xml.xpath('//xmlns:Alias').map(&:content)).to include('https://cb6e6126.ngrok.io/@alice', 'https://cb6e6126.ngrok.io/users/alice')
@@ -81,7 +81,7 @@ PEM
 
       json = body_as_json
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq 'application/jrd+json'
       expect(json[:subject]).to eq 'acct:alice@cb6e6126.ngrok.io'
       expect(json[:aliases]).to include('https://cb6e6126.ngrok.io/@alice', 'https://cb6e6126.ngrok.io/users/alice')

--- a/spec/requests/host_meta_request_spec.rb
+++ b/spec/requests/host_meta_request_spec.rb
@@ -5,7 +5,7 @@ describe "The host_meta route" do
     it "returns an xml response" do
       get host_meta_url
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq "application/xrd+xml"
     end
   end

--- a/spec/requests/webfinger_request_spec.rb
+++ b/spec/requests/webfinger_request_spec.rb
@@ -7,7 +7,7 @@ describe 'The webfinger route' do
     it 'returns a json response' do
       get webfinger_url(resource: alice.to_webfinger_s)
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq 'application/jrd+json'
     end
   end
@@ -16,7 +16,7 @@ describe 'The webfinger route' do
     it 'returns an xml response for xml format' do
       get webfinger_url(resource: alice.to_webfinger_s, format: :xml)
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq 'application/xrd+xml'
     end
 
@@ -24,7 +24,7 @@ describe 'The webfinger route' do
       headers = { 'HTTP_ACCEPT' => 'application/xrd+xml' }
       get webfinger_url(resource: alice.to_webfinger_s), headers: headers
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq 'application/xrd+xml'
     end
   end
@@ -33,7 +33,7 @@ describe 'The webfinger route' do
     it 'returns a json response for json format' do
       get webfinger_url(resource: alice.to_webfinger_s, format: :json)
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq 'application/jrd+json'
     end
 
@@ -41,7 +41,7 @@ describe 'The webfinger route' do
       headers = { 'HTTP_ACCEPT' => 'application/jrd+json' }
       get webfinger_url(resource: alice.to_webfinger_s), headers: headers
 
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(200)
       expect(response.content_type).to eq 'application/jrd+json'
     end
   end


### PR DESCRIPTION
```plain
DEPRECATION WARNING: The success? predicate is deprecated and will be removed in Rails 6.0. Please use successful? as provided by Rack::Response::Helpers. (called from block (4 levels) in <top (required)> at /home/circleci/projects/mastodon/spec/controllers/api/push_controller_spec.rb:46)
```

https://github.com/rspec/rspec-rails/pull/1951 has not been released yet.