### PR TITLE
Add parallel test processors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,10 @@ aliases:
       - image: circleci/ruby:2.5.1-stretch-node
         environment: &ruby_environment
           BUNDLE_APP_CONFIG: ./.bundle/
-          RAILS_ENV: test
-          NODE_ENV: test
           DB_HOST: localhost
           DB_USER: root
-          LOCAL_DOMAIN: cb6e6126.ngrok.io
-          LOCAL_HTTPS: true
-          PARALLEL_TEST_PROCESSORS: 2
+          RAILS_ENV: test
+          PARALLEL_TEST_PROCESSORS: 4
           ALLOW_NOPAM: true
     working_directory: ~/projects/mastodon/
 

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,5 @@
+# Node.js
+NODE_ENV=test
 # Federation
 LOCAL_DOMAIN=cb6e6126.ngrok.io
 LOCAL_HTTPS=true


### PR DESCRIPTION
Circle CI has two vCPUs by default ([doc](https://circleci.com/docs/2.0/configuration-reference/#resource_class)).

Add test processors for speed up.
 