### PR TITLE
Fix text colors related to separating high contrast theme

### DIFF
--- a/app/javascript/styles/contrast/variables.scss
+++ b/app/javascript/styles/contrast/variables.scss
@@ -4,6 +4,7 @@ $black: #000000;
 $classic-base-color: #282c37;
 $classic-primary-color: #9baec8;
 $classic-secondary-color: #d9e1e8;
+$classic-highlight-color: #2b90d9;
 
 $ui-base-color: $classic-base-color !default;
 $ui-primary-color: $classic-primary-color !default;
@@ -15,6 +16,7 @@ $ui-highlight-color: #2b5fd9;
 $darker-text-color: lighten($ui-primary-color, 20%) !default;
 $dark-text-color: lighten($ui-primary-color, 12%) !default;
 $secondary-text-color: lighten($ui-secondary-color, 6%) !default;
+$highlight-text-color: $classic-highlight-color !default;
 $action-button-color: #8d9ac2;
 
 $inverted-text-color: $black !default;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -701,7 +701,7 @@
   border-radius: 2px;
   background: transparent;
   border: 0;
-  color: $lighter-text-color;
+  color: $inverted-text-color;
   font-weight: 700;
   font-size: 11px;
   padding: 0 6px;
@@ -4036,6 +4036,10 @@ a.status-card {
   max-height: 40vh;
   overflow-y: auto;
   overflow-x: hidden;
+
+  .status__content a {
+    color: $highlight-text-color;
+  }
 
   @media screen and (max-width: 480px) {
     max-height: 10vh;


### PR DESCRIPTION
Fix
- $classic-highlight-color of high contrast theme 
- text colors of status__content__spoiler-link
- text colors of anchors of report-modal.

Related to #7213 .