### PR TITLE
Remove most behaviour disparities between blocks and mutes

### DIFF
--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -16,11 +16,11 @@ class StatusPolicy < ApplicationPolicy
   end
 
   def reblog?
-    !direct? && (!private? || owned?) && show? && !current_account.blocking?(author)
+    !direct? && (!private? || owned?) && show? && !current_account&.blocking?(author)
   end
 
   def favourite?
-    show? && !current_account.blocking?(author)
+    show? && !current_account&.blocking?(author)
   end
 
   def destroy?

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -16,7 +16,7 @@ class StatusPolicy < ApplicationPolicy
   end
 
   def reblog?
-    !direct? && (!private? || owned?) && show?
+    !direct? && (!private? || owned?) && show? && !current_account.blocking?(author)
   end
 
   def destroy?

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -19,6 +19,10 @@ class StatusPolicy < ApplicationPolicy
     !direct? && (!private? || owned?) && show? && !current_account.blocking?(author)
   end
 
+  def favourite?
+    show? && !current_account.blocking?(author)
+  end
+
   def destroy?
     staff? || owned?
   end

--- a/app/services/favourite_service.rb
+++ b/app/services/favourite_service.rb
@@ -8,7 +8,7 @@ class FavouriteService < BaseService
   # @param [Status] status
   # @return [Favourite]
   def call(account, status)
-    authorize_with account, status, :show?
+    authorize_with account, status, :favourite?
 
     favourite = Favourite.find_by(account: account, status: status)
 


### PR DESCRIPTION
The only differences between block and mute should be:

- Mutes can optionally NOT affect notifications
- Mutes should not be visible to the muted

Fix #7230
Fix #5713