### PR TITLE
tasks/mastodon: fix prompt for Redis password

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -109,7 +109,7 @@ namespace :mastodon do
 
         env['REDIS_PASSWORD'] = prompt.ask('Redis password:') do |q|
           q.required false
-          a.default nil
+          q.default nil
           q.modify :strip
         end
 


### PR DESCRIPTION
The change introduced in ca9192d9ba1c27689d7a14d0fb5b426c3d73c9f4 broke the setup when prompting for a Redis password due to a typo.