### PR TITLE
Prevent suspended accounts from appearing in AccountSearchService

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -117,6 +117,7 @@ class Account < ApplicationRecord
   scope :partitioned, -> { order(Arel.sql('row_number() over (partition by domain)')) }
   scope :silenced, -> { where(silenced: true) }
   scope :suspended, -> { where(suspended: true) }
+  scope :without_suspended, -> { where(suspended: false) }
   scope :recent, -> { reorder(id: :desc) }
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }
   scope :by_domain_accounts, -> { group(:domain).select(:domain, 'COUNT(*) AS accounts_count').order('accounts_count desc') }

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -65,9 +65,9 @@ class AccountSearchService < BaseService
   def exact_match
     @_exact_match ||= begin
       if domain_is_local?
-        search_from.find_local(query_username)
+        search_from.without_suspended.find_local(query_username)
       else
-        search_from.find_remote(query_username, query_domain)
+        search_from.without_suspended.find_remote(query_username, query_domain)
       end
     end
   end

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -137,5 +137,24 @@ describe AccountSearchService do
         expect(service).not_to have_received(:call)
       end
     end
+
+    describe 'should not include suspended accounts' do
+      it 'returns the fuzzy match first, and does not return suspended exacts' do
+        partial = Fabricate(:account, username: 'exactness')
+        exact = Fabricate(:account, username: 'exact', suspended: true)
+
+        results = subject.call('exact', 10)
+        expect(results.size).to eq 1
+        expect(results).to eq [partial]
+      end
+
+      it "does not return suspended remote accounts" do
+        remote = Fabricate(:account, username: 'a', domain: 'remote', display_name: 'e', suspended: true)
+
+        results = subject.call('a@example.com', 2)
+        expect(results.size).to eq 0
+        expect(results).to eq []
+      end
+    end
   end
 end


### PR DESCRIPTION
Partial fix for #7243 — this prevents you from being able to search/find suspended accounts, but doesn't do anything if you directly go to that account in the web UI (e.g., open in web or from a toot that's cached in a timeline).

There should probably be a change to relationships/statuses to make those calls fail for suspended accounts.