### PR TITLE
more sane phrasing in 🇸🇪 translation

### DIFF
--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -9,7 +9,7 @@ sv:
     contact_missing: Inte inställd
     contact_unavailable: N/A
     description_headline: Vad är %{domain}?
-    domain_count_after: annan instans
+    domain_count_after: andra instanser
     domain_count_before: Uppkopplad mot
     extended_description_html: |
       <h3>En bra plats för regler</h3>

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -29,7 +29,7 @@ sv:
     other_instances: Instanslista
     source_code: Källkod
     status_count_after: statusar
-    status_count_before: Vem författade
+    status_count_before: Som skapat
     user_count_after: användare
     user_count_before: Hem till
     what_is_mastodon: Vad är Mastodon?


### PR DESCRIPTION
Noticed this phrase "Vem författade" when I first saw the default front page of mastodon and I don't think it's right.

Proper phrase I think would be "Som författat" but I also felt that the word "författa" when compared to "skapat" (created) felt rigid, old fashioned and so formal that it might be off putting. I felt that "Som skapat" fits better. It translates to "Who have created" or "Who have made".