### PR TITLE
Add RSS feeds for end-users

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TagsController < ApplicationController
+  PAGE_SIZE = 20
+
   before_action :set_body_classes
   before_action :set_instance_presenter
 
@@ -13,8 +15,15 @@ class TagsController < ApplicationController
         @initial_state_json   = serializable_resource.to_json
       end
 
+      format.rss do
+        @statuses = Status.as_tag_timeline(@tag).limit(PAGE_SIZE)
+        @statuses = cache_collection(@statuses, Status)
+
+        render xml: RSS::TagSerializer.render(@tag, @statuses)
+      end
+
       format.json do
-        @statuses = Status.as_tag_timeline(@tag, current_account, params[:local]).paginate_by_max_id(20, params[:max_id])
+        @statuses = Status.as_tag_timeline(@tag, current_account, params[:local]).paginate_by_max_id(PAGE_SIZE, params[:max_id])
         @statuses = cache_collection(@statuses, Status)
 
         render json: collection_presenter,

--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -12,17 +12,17 @@ module StreamEntriesHelper
     prepend_str = [
       [
         number_to_human(account.statuses_count, strip_insignificant_zeros: true),
-        t('accounts.posts'),
+        I18n.t('accounts.posts'),
       ].join(' '),
 
       [
         number_to_human(account.following_count, strip_insignificant_zeros: true),
-        t('accounts.following'),
+        I18n.t('accounts.following'),
       ].join(' '),
 
       [
         number_to_human(account.followers_count, strip_insignificant_zeros: true),
-        t('accounts.followers'),
+        I18n.t('accounts.followers'),
       ].join(' '),
     ].join(', ')
 
@@ -40,16 +40,16 @@ module StreamEntriesHelper
       end
     end
 
-    text = attachments.to_a.reject { |_, value| value.zero? }.map { |key, value| t("statuses.attached.#{key}", count: value) }.join(' · ')
+    text = attachments.to_a.reject { |_, value| value.zero? }.map { |key, value| I18n.t("statuses.attached.#{key}", count: value) }.join(' · ')
 
     return if text.blank?
 
-    t('statuses.attached.description', attached: text)
+    I18n.t('statuses.attached.description', attached: text)
   end
 
   def status_text_summary(status)
     return if status.spoiler_text.blank?
-    t('statuses.content_warning', warning: status.spoiler_text)
+    I18n.t('statuses.content_warning', warning: status.spoiler_text)
   end
 
   def status_description(status)

--- a/app/lib/rss_builder.rb
+++ b/app/lib/rss_builder.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+class RSSBuilder
+  class ItemBuilder
+    def initialize
+      @item = Ox::Element.new('item')
+    end
+
+    def title(str)
+      @item << (Ox::Element.new('title') << str)
+
+      self
+    end
+
+    def link(str)
+      @item << Ox::Element.new('guid').tap do |guid|
+        guid['isPermalink'] = 'true'
+        guid << str
+      end
+
+      @item << (Ox::Element.new('link') << str)
+
+      self
+    end
+
+    def pub_date(date)
+      @item << (Ox::Element.new('pubDate') << date.to_formatted_s(:rfc822))
+
+      self
+    end
+
+    def description(str)
+      @item << (Ox::Element.new('description') << str)
+
+      self
+    end
+
+    def enclosure(url, type, size)
+      @item << Ox::Element.new('enclosure').tap do |enclosure|
+        enclosure['url']    = url
+        enclosure['length'] = size
+        enclosure['type']   = type
+      end
+
+      self
+    end
+
+    def to_element
+      @item
+    end
+  end
+
+  def initialize
+    @document = Ox::Document.new(version: '1.0')
+    @channel  = Ox::Element.new('channel')
+
+    @document << (rss << @channel)
+  end
+
+  def title(str)
+    @channel << (Ox::Element.new('title') << str)
+
+    self
+  end
+
+  def link(str)
+    @channel << (Ox::Element.new('link') << str)
+
+    self
+  end
+
+  def image(str)
+    @channel << Ox::Element.new('image').tap do |image|
+      image << (Ox::Element.new('url') << str)
+      image << (Ox::Element.new('title') << '')
+      image << (Ox::Element.new('link') << '')
+    end
+
+    @channel << (Ox::Element.new('webfeeds:icon') << str)
+
+    self
+  end
+
+  def cover(str)
+    @channel << Ox::Element.new('webfeeds:cover').tap do |cover|
+      cover['image'] = str
+    end
+
+    self
+  end
+
+  def logo(str)
+    @channel << (Ox::Element.new('webfeeds:logo') << str)
+
+    self
+  end
+
+  def accent_color(str)
+    @channel << (Ox::Element.new('webfeeds:accentColor') << str)
+
+    self
+  end
+
+  def description(str)
+    @channel << (Ox::Element.new('description') << str)
+
+    self
+  end
+
+  def item
+    @channel << ItemBuilder.new.tap do |item|
+      yield item
+    end.to_element
+
+    self
+  end
+
+  def to_xml
+    ('<?xml version="1.0" encoding="UTF-8"?>' + Ox.dump(@document, effort: :tolerant)).force_encoding('UTF-8')
+  end
+
+  private
+
+  def rss
+    Ox::Element.new('rss').tap do |rss|
+      rss['version']        = '2.0'
+      rss['xmlns:webfeeds'] = 'http://webfeeds.org/rss/1.0'
+    end
+  end
+end

--- a/app/serializers/rss/account_serializer.rb
+++ b/app/serializers/rss/account_serializer.rb
@@ -1,0 +1,37 @@
+class RSS::AccountSerializer
+  include ActionView::Helpers::NumberHelper
+  include StreamEntriesHelper
+  include RoutingHelper
+
+  def render(account, statuses)
+    builder = RSSBuilder.new
+
+    builder.title("#{display_name(account)} (@#{account.local_username_and_domain})")
+           .description(account_description(account))
+           .link(TagManager.instance.url_for(account))
+           .logo(full_asset_url(asset_pack_path('logo.svg')))
+           .accent_color('2b90d9')
+
+    builder.image(full_asset_url(account.avatar.url(:original))) if account.avatar?
+    builder.cover(full_asset_url(account.header.url(:original))) if account.header?
+
+    statuses.each do |status|
+      builder.item do |item|
+        item.title(status.title)
+            .link(TagManager.instance.url_for(status))
+            .pub_date(status.created_at)
+            .description(status.spoiler_text.presence || Formatter.instance.format(status).to_str)
+
+        status.media_attachments.each do |media|
+          item.enclosure(full_asset_url(media.file.url(:original, false)), media.file.content_type, length: media.file.size)
+        end
+      end
+    end
+
+    builder.to_xml
+  end
+
+  def self.render(account, statuses)
+    self.new.render(account, statuses)
+  end
+end

--- a/app/serializers/rss/account_serializer.rb
+++ b/app/serializers/rss/account_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RSS::AccountSerializer
   include ActionView::Helpers::NumberHelper
   include StreamEntriesHelper
@@ -32,6 +34,6 @@ class RSS::AccountSerializer
   end
 
   def self.render(account, statuses)
-    self.new.render(account, statuses)
+    new.render(account, statuses)
   end
 end

--- a/app/serializers/rss/tag_serializer.rb
+++ b/app/serializers/rss/tag_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RSS::TagSerializer
   include ActionView::Helpers::NumberHelper
   include ActionView::Helpers::SanitizeHelper
@@ -30,6 +32,6 @@ class RSS::TagSerializer
   end
 
   def self.render(tag, statuses)
-    self.new.render(tag, statuses)
+    new.render(tag, statuses)
   end
 end

--- a/app/serializers/rss/tag_serializer.rb
+++ b/app/serializers/rss/tag_serializer.rb
@@ -1,0 +1,35 @@
+class RSS::TagSerializer
+  include ActionView::Helpers::NumberHelper
+  include ActionView::Helpers::SanitizeHelper
+  include StreamEntriesHelper
+  include RoutingHelper
+
+  def render(tag, statuses)
+    builder = RSSBuilder.new
+
+    builder.title("##{tag.name}")
+           .description(strip_tags(I18n.t('about.about_hashtag_html', hashtag: tag.name)))
+           .link(tag_url(tag))
+           .logo(full_asset_url(asset_pack_path('logo.svg')))
+           .accent_color('2b90d9')
+
+    statuses.each do |status|
+      builder.item do |item|
+        item.title(status.title)
+            .link(TagManager.instance.url_for(status))
+            .pub_date(status.created_at)
+            .description(status.spoiler_text.presence || Formatter.instance.format(status).to_str)
+
+        status.media_attachments.each do |media|
+          item.enclosure(full_asset_url(media.file.url(:original, false)), media.file.content_type, length: media.file.size)
+        end
+      end
+    end
+
+    builder.to_xml
+  end
+
+  def self.render(tag, statuses)
+    self.new.render(tag, statuses)
+  end
+end


### PR DESCRIPTION
Got a lot of complaints about Atom feeds confusing IFTTT and whatever else, because the Atom feeds contain a lot of extra information for OStatus federation. RSS is meant for end-users instead.

Fix #6178