### PR TITLE
Append '.test' to hostname in stub data

### DIFF
--- a/spec/fixtures/requests/oembed_json.html
+++ b/spec/fixtures/requests/oembed_json.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link href='https://host/provider.json' rel='alternate' type='application/json+oembed'>
+    <link href='https://host.test/provider.json' rel='alternate' type='application/json+oembed'>
   </head>
   <body></body>
 </html>

--- a/spec/fixtures/requests/oembed_json_xml.html
+++ b/spec/fixtures/requests/oembed_json_xml.html
@@ -7,8 +7,8 @@
       > The type attribute must contain either application/json+oembed for JSON
       > responses, or text/xml+oembed for XML.
     -->
-    <link href='https://host/provider.json' rel='alternate' type='application/json+oembed'>
-    <link href='https://host/provider.xml' rel='alternate' type='text/xml+oembed'>
+    <link href='https://host.test/provider.json' rel='alternate' type='application/json+oembed'>
+    <link href='https://host.test/provider.xml' rel='alternate' type='text/xml+oembed'>
   </head>
   <body></body>
 </html>

--- a/spec/fixtures/requests/oembed_xml.html
+++ b/spec/fixtures/requests/oembed_xml.html
@@ -7,7 +7,7 @@
       > The type attribute must contain either application/json+oembed for JSON
       > responses, or text/xml+oembed for XML.
     -->
-    <link href='https://host/provider.xml' rel='alternate' type='text/xml+oembed'>
+    <link href='https://host.test/provider.xml' rel='alternate' type='text/xml+oembed'>
   </head>
   <body></body>
 </html>

--- a/spec/helpers/jsonld_helper_spec.rb
+++ b/spec/helpers/jsonld_helper_spec.rb
@@ -32,37 +32,37 @@ describe JsonLdHelper do
   describe '#fetch_resource' do
     context 'when the second argument is false' do
       it 'returns resource even if the retrieved ID and the given URI does not match' do
-        stub_request(:get, 'https://bob/').to_return body: '{"id": "https://alice/"}'
-        stub_request(:get, 'https://alice/').to_return body: '{"id": "https://alice/"}'
+        stub_request(:get, 'https://bob.test/').to_return body: '{"id": "https://alice.test/"}'
+        stub_request(:get, 'https://alice.test/').to_return body: '{"id": "https://alice.test/"}'
 
-        expect(fetch_resource('https://bob/', false)).to eq({ 'id' => 'https://alice/' })
+        expect(fetch_resource('https://bob.test/', false)).to eq({ 'id' => 'https://alice.test/' })
       end
 
       it 'returns nil if the object identified by the given URI and the object identified by the retrieved ID does not match' do
-        stub_request(:get, 'https://mallory/').to_return body: '{"id": "https://marvin/"}'
-        stub_request(:get, 'https://marvin/').to_return body: '{"id": "https://alice/"}'
+        stub_request(:get, 'https://mallory.test/').to_return body: '{"id": "https://marvin.test/"}'
+        stub_request(:get, 'https://marvin.test/').to_return body: '{"id": "https://alice.test/"}'
 
-        expect(fetch_resource('https://mallory/', false)).to eq nil
+        expect(fetch_resource('https://mallory.test/', false)).to eq nil
       end
     end
 
     context 'when the second argument is true' do
       it 'returns nil if the retrieved ID and the given URI does not match' do
-        stub_request(:get, 'https://mallory/').to_return body: '{"id": "https://alice/"}'
-        expect(fetch_resource('https://mallory/', true)).to eq nil
+        stub_request(:get, 'https://mallory.test/').to_return body: '{"id": "https://alice.test/"}'
+        expect(fetch_resource('https://mallory.test/', true)).to eq nil
       end
     end
   end
 
   describe '#fetch_resource_without_id_validation' do
     it 'returns nil if the status code is not 200' do
-      stub_request(:get, 'https://host/').to_return status: 400, body: '{}'
-      expect(fetch_resource_without_id_validation('https://host/')).to eq nil
+      stub_request(:get, 'https://host.test/').to_return status: 400, body: '{}'
+      expect(fetch_resource_without_id_validation('https://host.test/')).to eq nil
     end
 
     it 'returns hash' do
-      stub_request(:get, 'https://host/').to_return status: 200, body: '{}'
-      expect(fetch_resource_without_id_validation('https://host/')).to eq({})
+      stub_request(:get, 'https://host.test/').to_return status: 200, body: '{}'
+      expect(fetch_resource_without_id_validation('https://host.test/')).to eq({})
     end
   end
 end

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Formatter do
   let(:local_account)  { Fabricate(:account, domain: nil, username: 'alice') }
-  let(:remote_account) { Fabricate(:account, domain: 'remote', username: 'bob', url: 'https://remote/') }
+  let(:remote_account) { Fabricate(:account, domain: 'remote.test', username: 'bob', url: 'https://remote.test/') }
 
   shared_examples 'encode and link URLs' do
     context 'matches a stand-alone medium URL' do
@@ -377,12 +377,12 @@ RSpec.describe Formatter do
       end
 
       context 'contains linkable mentions for remote accounts' do
-        let(:text) { '@bob@remote' }
+        let(:text) { '@bob@remote.test' }
 
         before { remote_account }
 
         it 'links' do
-          is_expected.to eq '<p><span class="h-card"><a href="https://remote/" class="u-url mention">@<span>bob</span></a></span></p>'
+          is_expected.to eq '<p><span class="h-card"><a href="https://remote.test/" class="u-url mention">@<span>bob</span></a></span></p>'
         end
       end
 

--- a/spec/lib/ostatus/atom_serializer_spec.rb
+++ b/spec/lib/ostatus/atom_serializer_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe OStatus::AtomSerializer do
     end
 
     it 'appends activity:object with target account' do
-      target_account = Fabricate(:account, domain: 'domain', uri: 'https://domain/id')
+      target_account = Fabricate(:account, domain: 'domain.test', uri: 'https://domain.test/id')
       follow_request = Fabricate(:follow_request, target_account: target_account)
 
       follow_request_salmon = serialize(follow_request)
 
       object = follow_request_salmon.nodes.find { |node| node.name == 'activity:object' }
-      expect(object.id.text).to eq 'https://domain/id'
+      expect(object.id.text).to eq 'https://domain.test/id'
     end
   end
 
@@ -413,20 +413,20 @@ RSpec.describe OStatus::AtomSerializer do
 
         entry = OStatus::AtomSerializer.new.entry(remote_status.stream_entry, true)
         entry.nodes.delete_if { |node| node[:type] == 'application/activity+json' } # Remove ActivityPub link to simplify test
-        xml = OStatus::AtomSerializer.render(entry).gsub('cb6e6126.ngrok.io', 'remote')
+        xml = OStatus::AtomSerializer.render(entry).gsub('cb6e6126.ngrok.io', 'remote.test')
 
         remote_status.destroy!
         remote_account.destroy!
 
         account = Account.create!(
-          domain: 'remote',
+          domain: 'remote.test',
           username: 'username',
           last_webfingered_at: Time.now.utc
         )
 
         ProcessFeedService.new.call(xml, account)
 
-        expect(Status.find_by(uri: "https://remote/users/#{remote_status.account.to_param}/statuses/#{remote_status.id}")).to be_instance_of Status
+        expect(Status.find_by(uri: "https://remote.test/users/#{remote_status.account.to_param}/statuses/#{remote_status.id}")).to be_instance_of Status
       end
     end
 
@@ -776,13 +776,13 @@ RSpec.describe OStatus::AtomSerializer do
     end
 
     it 'appends activity:object element with target account' do
-      target_account = Fabricate(:account, domain: 'domain', uri: 'https://domain/id')
+      target_account = Fabricate(:account, domain: 'domain.test', uri: 'https://domain.test/id')
       block = Fabricate(:block, target_account: target_account)
 
       block_salmon = OStatus::AtomSerializer.new.block_salmon(block)
 
       object = block_salmon.nodes.find { |node| node.name == 'activity:object' }
-      expect(object.id.text).to eq 'https://domain/id'
+      expect(object.id.text).to eq 'https://domain.test/id'
     end
 
     it 'returns element whose rendered view triggers block when processed' do
@@ -863,13 +863,13 @@ RSpec.describe OStatus::AtomSerializer do
     end
 
     it 'appends activity:object element with target account' do
-      target_account = Fabricate(:account, domain: 'domain', uri: 'https://domain/id')
+      target_account = Fabricate(:account, domain: 'domain.test', uri: 'https://domain.test/id')
       block = Fabricate(:block, target_account: target_account)
 
       unblock_salmon = OStatus::AtomSerializer.new.unblock_salmon(block)
 
       object = unblock_salmon.nodes.find { |node| node.name == 'activity:object' }
-      expect(object.id.text).to eq 'https://domain/id'
+      expect(object.id.text).to eq 'https://domain.test/id'
     end
 
     it 'returns element whose rendered view triggers block when processed' do
@@ -1124,13 +1124,13 @@ RSpec.describe OStatus::AtomSerializer do
     end
 
     it 'appends activity:object element with target account' do
-      target_account = Fabricate(:account, domain: 'domain', uri: 'https://domain/id')
+      target_account = Fabricate(:account, domain: 'domain.test', uri: 'https://domain.test/id')
       follow = Fabricate(:follow, target_account: target_account)
 
       follow_salmon = OStatus::AtomSerializer.new.follow_salmon(follow)
 
       object = follow_salmon.nodes.find { |node| node.name == 'activity:object' }
-      expect(object.id.text).to eq 'https://domain/id'
+      expect(object.id.text).to eq 'https://domain.test/id'
     end
 
     it 'includes description' do
@@ -1242,14 +1242,14 @@ RSpec.describe OStatus::AtomSerializer do
     end
 
     it 'appends activity:object element with target account' do
-      target_account = Fabricate(:account, domain: 'domain', uri: 'https://domain/id')
+      target_account = Fabricate(:account, domain: 'domain.test', uri: 'https://domain.test/id')
       follow = Fabricate(:follow, target_account: target_account)
       follow.destroy!
 
       unfollow_salmon = OStatus::AtomSerializer.new.unfollow_salmon(follow)
 
       object = unfollow_salmon.nodes.find { |node| node.name == 'activity:object' }
-      expect(object.id.text).to eq 'https://domain/id'
+      expect(object.id.text).to eq 'https://domain.test/id'
     end
 
     it 'returns element whose rendered view triggers unfollow when processed' do

--- a/spec/lib/provider_discovery_spec.rb
+++ b/spec/lib/provider_discovery_spec.rb
@@ -7,7 +7,7 @@ describe ProviderDiscovery do
     context 'when status code is 200 and MIME type is text/html' do
       context 'Both of JSON and XML provider are discoverable' do
         before do
-          stub_request(:get, 'https://host/oembed.html').to_return(
+          stub_request(:get, 'https://host.test/oembed.html').to_return(
             status: 200,
             headers: { 'Content-Type': 'text/html' },
             body: request_fixture('oembed_json_xml.html')
@@ -15,21 +15,21 @@ describe ProviderDiscovery do
         end
 
         it 'returns new OEmbed::Provider for JSON provider if :format option is set to :json' do
-          provider = ProviderDiscovery.discover_provider('https://host/oembed.html', format: :json)
-          expect(provider.endpoint).to eq 'https://host/provider.json'
+          provider = ProviderDiscovery.discover_provider('https://host.test/oembed.html', format: :json)
+          expect(provider.endpoint).to eq 'https://host.test/provider.json'
           expect(provider.format).to eq :json
         end
 
         it 'returns new OEmbed::Provider for XML provider if :format option is set to :xml' do
-          provider = ProviderDiscovery.discover_provider('https://host/oembed.html', format: :xml)
-          expect(provider.endpoint).to eq 'https://host/provider.xml'
+          provider = ProviderDiscovery.discover_provider('https://host.test/oembed.html', format: :xml)
+          expect(provider.endpoint).to eq 'https://host.test/provider.xml'
           expect(provider.format).to eq :xml
         end
       end
 
       context 'JSON provider is discoverable while XML provider is not' do
         before do
-          stub_request(:get, 'https://host/oembed.html').to_return(
+          stub_request(:get, 'https://host.test/oembed.html').to_return(
             status: 200,
             headers: { 'Content-Type': 'text/html' },
             body: request_fixture('oembed_json.html')
@@ -37,15 +37,15 @@ describe ProviderDiscovery do
         end
 
         it 'returns new OEmbed::Provider for JSON provider' do
-          provider = ProviderDiscovery.discover_provider('https://host/oembed.html')
-          expect(provider.endpoint).to eq 'https://host/provider.json'
+          provider = ProviderDiscovery.discover_provider('https://host.test/oembed.html')
+          expect(provider.endpoint).to eq 'https://host.test/provider.json'
           expect(provider.format).to eq :json
         end
       end
 
       context 'XML provider is discoverable while JSON provider is not' do
         before do
-          stub_request(:get, 'https://host/oembed.html').to_return(
+          stub_request(:get, 'https://host.test/oembed.html').to_return(
             status: 200,
             headers: { 'Content-Type': 'text/html' },
             body: request_fixture('oembed_xml.html')
@@ -53,15 +53,15 @@ describe ProviderDiscovery do
         end
 
         it 'returns new OEmbed::Provider for XML provider' do
-          provider = ProviderDiscovery.discover_provider('https://host/oembed.html')
-          expect(provider.endpoint).to eq 'https://host/provider.xml'
+          provider = ProviderDiscovery.discover_provider('https://host.test/oembed.html')
+          expect(provider.endpoint).to eq 'https://host.test/provider.xml'
           expect(provider.format).to eq :xml
         end
       end
 
       context 'Invalid XML provider is discoverable while JSON provider is not' do
         before do
-          stub_request(:get, 'https://host/oembed.html').to_return(
+          stub_request(:get, 'https://host.test/oembed.html').to_return(
             status: 200,
             headers: { 'Content-Type': 'text/html' },
             body: request_fixture('oembed_invalid_xml.html')
@@ -69,13 +69,13 @@ describe ProviderDiscovery do
         end
 
         it 'raises OEmbed::NotFound' do
-          expect { ProviderDiscovery.discover_provider('https://host/oembed.html') }.to raise_error OEmbed::NotFound
+          expect { ProviderDiscovery.discover_provider('https://host.test/oembed.html') }.to raise_error OEmbed::NotFound
         end
       end
 
       context 'Neither of JSON and XML provider is discoverable' do
         before do
-          stub_request(:get, 'https://host/oembed.html').to_return(
+          stub_request(:get, 'https://host.test/oembed.html').to_return(
             status: 200,
             headers: { 'Content-Type': 'text/html' },
             body: request_fixture('oembed_undiscoverable.html')
@@ -83,14 +83,14 @@ describe ProviderDiscovery do
         end
 
         it 'raises OEmbed::NotFound' do
-          expect { ProviderDiscovery.discover_provider('https://host/oembed.html') }.to raise_error OEmbed::NotFound
+          expect { ProviderDiscovery.discover_provider('https://host.test/oembed.html') }.to raise_error OEmbed::NotFound
         end
       end
     end
 
     context 'when status code is not 200' do
       before do
-        stub_request(:get, 'https://host/oembed.html').to_return(
+        stub_request(:get, 'https://host.test/oembed.html').to_return(
           status: 400,
           headers: { 'Content-Type': 'text/html' },
           body: request_fixture('oembed_xml.html')
@@ -98,20 +98,20 @@ describe ProviderDiscovery do
       end
 
       it 'raises OEmbed::NotFound' do
-        expect { ProviderDiscovery.discover_provider('https://host/oembed.html') }.to raise_error OEmbed::NotFound
+        expect { ProviderDiscovery.discover_provider('https://host.test/oembed.html') }.to raise_error OEmbed::NotFound
       end
     end
 
     context 'when MIME type is not text/html' do
       before do
-        stub_request(:get, 'https://host/oembed.html').to_return(
+        stub_request(:get, 'https://host.test/oembed.html').to_return(
           status: 200,
           body: request_fixture('oembed_xml.html')
         )
       end
 
       it 'raises OEmbed::NotFound' do
-        expect { ProviderDiscovery.discover_provider('https://host/oembed.html') }.to raise_error OEmbed::NotFound
+        expect { ProviderDiscovery.discover_provider('https://host.test/oembed.html') }.to raise_error OEmbed::NotFound
       end
     end
   end

--- a/spec/lib/tag_manager_spec.rb
+++ b/spec/lib/tag_manager_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TagManager do
 
     around do |example|
       original_local_domain = Rails.configuration.x.local_domain
-      Rails.configuration.x.local_domain = 'domain'
+      Rails.configuration.x.local_domain = 'domain.test'
 
       example.run
 
@@ -18,11 +18,11 @@ RSpec.describe TagManager do
     end
 
     it 'returns true if the slash-stripped string equals to local domain' do
-      expect(TagManager.instance.local_domain?('DoMaIn/')).to eq true
+      expect(TagManager.instance.local_domain?('DoMaIn.Test/')).to eq true
     end
 
     it 'returns false for irrelevant string' do
-      expect(TagManager.instance.local_domain?('DoMaIn!')).to eq false
+      expect(TagManager.instance.local_domain?('DoMaIn.Test!')).to eq false
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe TagManager do
 
     around do |example|
       original_web_domain = Rails.configuration.x.web_domain
-      Rails.configuration.x.web_domain = 'domain'
+      Rails.configuration.x.web_domain = 'domain.test'
 
       example.run
 
@@ -43,11 +43,11 @@ RSpec.describe TagManager do
     end
 
     it 'returns true if the slash-stripped string equals to web domain' do
-      expect(TagManager.instance.web_domain?('DoMaIn/')).to eq true
+      expect(TagManager.instance.web_domain?('DoMaIn.Test/')).to eq true
     end
 
     it 'returns false for string with irrelevant characters' do
-      expect(TagManager.instance.web_domain?('DoMaIn!')).to eq false
+      expect(TagManager.instance.web_domain?('DoMaIn.Test!')).to eq false
     end
   end
 
@@ -57,7 +57,7 @@ RSpec.describe TagManager do
     end
 
     it 'returns normalized domain' do
-      expect(TagManager.instance.normalize_domain('DoMaIn/')).to eq 'domain'
+      expect(TagManager.instance.normalize_domain('DoMaIn.Test/')).to eq 'domain.test'
     end
   end
 
@@ -69,18 +69,18 @@ RSpec.describe TagManager do
     end
 
     it 'returns true if the normalized string with port is local URL' do
-      Rails.configuration.x.web_domain = 'domain:42'
-      expect(TagManager.instance.local_url?('https://DoMaIn:42/')).to eq true
+      Rails.configuration.x.web_domain = 'domain.test:42'
+      expect(TagManager.instance.local_url?('https://DoMaIn.Test:42/')).to eq true
     end
 
     it 'returns true if the normalized string without port is local URL' do
-      Rails.configuration.x.web_domain = 'domain'
-      expect(TagManager.instance.local_url?('https://DoMaIn/')).to eq true
+      Rails.configuration.x.web_domain = 'domain.test'
+      expect(TagManager.instance.local_url?('https://DoMaIn.Test/')).to eq true
     end
 
     it 'returns false for string with irrelevant characters' do
-      Rails.configuration.x.web_domain = 'domain'
-      expect(TagManager.instance.local_url?('https://domainn/')).to eq false
+      Rails.configuration.x.web_domain = 'domain.test'
+      expect(TagManager.instance.local_url?('https://domainn.test/')).to eq false
     end
   end
 
@@ -88,19 +88,19 @@ RSpec.describe TagManager do
     # The following comparisons MUST be case-insensitive.
 
     it 'returns true if the needle has a correct username and domain for remote user' do
-      expect(TagManager.instance.same_acct?('username@domain', 'UsErNaMe@DoMaIn')).to eq true
+      expect(TagManager.instance.same_acct?('username@domain.test', 'UsErNaMe@DoMaIn.Test')).to eq true
     end
 
     it 'returns false if the needle is missing a domain for remote user' do
-      expect(TagManager.instance.same_acct?('username@domain', 'UsErNaMe')).to eq false
+      expect(TagManager.instance.same_acct?('username@domain.test', 'UsErNaMe')).to eq false
     end
 
     it 'returns false if the needle has an incorrect domain for remote user' do
-      expect(TagManager.instance.same_acct?('username@domain', 'UsErNaMe@incorrect')).to eq false
+      expect(TagManager.instance.same_acct?('username@domain.test', 'UsErNaMe@incorrect.test')).to eq false
     end
 
     it 'returns false if the needle has an incorrect username for remote user' do
-      expect(TagManager.instance.same_acct?('username@domain', 'incorrect@DoMaIn')).to eq false
+      expect(TagManager.instance.same_acct?('username@domain.test', 'incorrect@DoMaIn.test')).to eq false
     end
 
     it 'returns true if the needle has a correct username and domain for local user' do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -94,14 +94,14 @@ RSpec.describe Account, type: :model do
 
   describe '#save_with_optional_media!' do
     before do
-      stub_request(:get, 'https://remote/valid_avatar').to_return(request_fixture('avatar.txt'))
-      stub_request(:get, 'https://remote/invalid_avatar').to_return(request_fixture('feed.txt'))
+      stub_request(:get, 'https://remote.test/valid_avatar').to_return(request_fixture('avatar.txt'))
+      stub_request(:get, 'https://remote.test/invalid_avatar').to_return(request_fixture('feed.txt'))
     end
 
     let(:account) do
       Fabricate(:account,
-                avatar_remote_url: 'https://remote/valid_avatar',
-                header_remote_url: 'https://remote/valid_avatar')
+                avatar_remote_url: 'https://remote.test/valid_avatar',
+                header_remote_url: 'https://remote.test/valid_avatar')
     end
 
     let!(:expectation) { account.dup }
@@ -121,7 +121,7 @@ RSpec.describe Account, type: :model do
 
     context 'with invalid properties' do
       before do
-        account.avatar_remote_url = 'https://remote/invalid_avatar'
+        account.avatar_remote_url = 'https://remote.test/invalid_avatar'
         account.save_with_optional_media!
       end
 

--- a/spec/models/status_pin_spec.rb
+++ b/spec/models/status_pin_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe StatusPin, type: :model do
     end
 
     it 'allows pins above the max for remote accounts' do
-      account = Fabricate(:account, domain: 'remote', username: 'bob', url: 'https://remote/')
+      account = Fabricate(:account, domain: 'remote.test', username: 'bob', url: 'https://remote.test/')
       status = []
 
       (max_pins + 1).times do |i|

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe ActivityPub::ProcessAccountService do
   context 'property values' do
     let(:payload) do
       {
-        id: 'https://foo',
+        id: 'https://foo.test',
         type: 'Actor',
-        inbox: 'https://foo/inbox',
+        inbox: 'https://foo.test/inbox',
         attachment: [
           { type: 'PropertyValue', name: 'Pronouns', value: 'They/them' },
           { type: 'PropertyValue', name: 'Occupation', value: 'Unit test' },


### PR DESCRIPTION
If `Addressable::URI#tld` is used in the future, it's possible to cause test fail due to rising `PublicSuffix::DomainNotAllowed`
To avoid this situation, it might be suitable for using `.example`, `.test` and `.invalid` for stub data. (Only `.test` is used in this commit.)