### PR TITLE
Add support for separate Redis for cache

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_store, ENV['REDIS_URL'], REDIS_CACHE_PARAMS
+  config.cache_store = :redis_store, ENV['CACHE_REDIS_URL'], REDIS_CACHE_PARAMS
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -4,18 +4,18 @@ def setup_redis_env_url(prefix = nil, defaults = true)
   prefix = prefix.to_s.upcase + '_' unless prefix.nil?
   prefix = '' if prefix.nil?
 
-  return unless ENV[prefix + 'REDIS_URL'].blank?
+  return if ENV[prefix + 'REDIS_URL'].present?
 
   password = ENV.fetch(prefix + 'REDIS_PASSWORD') { '' if defaults }
   host     = ENV.fetch(prefix + 'REDIS_HOST') { 'localhost' if defaults }
   port     = ENV.fetch(prefix + 'REDIS_PORT') { 6379 if defaults }
   db       = ENV.fetch(prefix + 'REDIS_DB') { 0 if defaults }
 
-  if [password, host, port, db].all?(&:nil?)
-    ENV[prefix + 'REDIS_URL'] = ENV['REDIS_URL']
-  else
-    ENV[prefix + 'REDIS_URL'] = "redis://#{password.blank? ? '' : ":#{password}@"}#{host}:#{port}/#{db}"
-  end
+  ENV[prefix + 'REDIS_URL'] = if [password, host, port, db].all?(&:nil?)
+                                ENV['REDIS_URL']
+                              else
+                                "redis://#{password.blank? ? '' : ":#{password}@"}#{host}:#{port}/#{db}"
+                              end
 end
 
 setup_redis_env_url

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -1,16 +1,29 @@
 # frozen_string_literal: true
 
-if ENV['REDIS_URL'].blank?
-  password = ENV.fetch('REDIS_PASSWORD') { '' }
-  host     = ENV.fetch('REDIS_HOST') { 'localhost' }
-  port     = ENV.fetch('REDIS_PORT') { 6379 }
-  db       = ENV.fetch('REDIS_DB') { 0 }
+def setup_redis_env_url(prefix = nil, defaults = true)
+  prefix = prefix.to_s.upcase + '_' unless prefix.nil?
+  prefix = '' if prefix.nil?
 
-  ENV['REDIS_URL'] = "redis://#{password.blank? ? '' : ":#{password}@"}#{host}:#{port}/#{db}"
+  return unless ENV[prefix + 'REDIS_URL'].blank?
+
+  password = ENV.fetch(prefix + 'REDIS_PASSWORD') { '' if defaults }
+  host     = ENV.fetch(prefix + 'REDIS_HOST') { 'localhost' if defaults }
+  port     = ENV.fetch(prefix + 'REDIS_PORT') { 6379 if defaults }
+  db       = ENV.fetch(prefix + 'REDIS_DB') { 0 if defaults }
+
+  if [password, host, port, db].all?(&:nil?)
+    ENV[prefix + 'REDIS_URL'] = ENV['REDIS_URL']
+  else
+    ENV[prefix + 'REDIS_URL'] = "redis://#{password.blank? ? '' : ":#{password}@"}#{host}:#{port}/#{db}"
+  end
 end
 
-namespace = ENV.fetch('REDIS_NAMESPACE') { nil }
+setup_redis_env_url
+setup_redis_env_url(:cache, false)
+
+namespace       = ENV.fetch('REDIS_NAMESPACE') { nil }
 cache_namespace = namespace ? namespace + '_cache' : 'cache'
+
 REDIS_CACHE_PARAMS = {
   expires_in: 10.minutes,
   namespace: cache_namespace,


### PR DESCRIPTION
CACHE_REDIS_URL to allow using a different Redis server for cache purposes, with cache-specific configuration such as key eviction