### PR TITLE
Fix "Show more" URL on paginated threads for remote statuses

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -4,9 +4,9 @@ class StatusesController < ApplicationController
   include SignatureAuthentication
   include Authorization
 
-  ANCESTORS_LIMIT = 20
-  DESCENDANTS_LIMIT = 20
-  DESCENDANTS_DEPTH_LIMIT = 4
+  ANCESTORS_LIMIT         = 40
+  DESCENDANTS_LIMIT       = 60
+  DESCENDANTS_DEPTH_LIMIT = 20
 
   layout 'public'
 
@@ -71,7 +71,7 @@ class StatusesController < ApplicationController
   end
 
   def set_descendants
-    @max_descendant_thread_id = params[:max_descendant_thread_id]&.to_i
+    @max_descendant_thread_id   = params[:max_descendant_thread_id]&.to_i
     @since_descendant_thread_id = params[:since_descendant_thread_id]&.to_i
 
     descendants = cache_collection(
@@ -84,11 +84,12 @@ class StatusesController < ApplicationController
       ),
       Status
     )
+
     @descendant_threads = []
 
     if descendants.present?
       statuses = [descendants.first]
-      depth = 1
+      depth    = 1
 
       descendants.drop(1).each_with_index do |descendant, index|
         if descendants[index].id == descendant.in_reply_to_id

--- a/app/controllers/stream_entries_controller.rb
+++ b/app/controllers/stream_entries_controller.rb
@@ -23,6 +23,7 @@ class StreamEntriesController < ApplicationController
           skip_session!
           expires_in 3.minutes, public: true
         end
+
         render xml: OStatus::AtomSerializer.render(OStatus::AtomSerializer.new.entry(@stream_entry, true))
       end
     end

--- a/app/views/stream_entries/_status.html.haml
+++ b/app/views/stream_entries/_status.html.haml
@@ -5,18 +5,19 @@
   is_successor    ||= false
   direct_reply_id ||= false
   parent_id       ||= false
-  is_direct_parent = direct_reply_id == status.id
-  is_direct_child  = parent_id == status.in_reply_to_id
-  centered ||= include_threads && !is_predecessor && !is_successor
-  h_class       = microformats_h_class(status, is_predecessor, is_successor, include_threads)
-  style_classes = style_classes(status, is_predecessor, is_successor, include_threads)
-  mf_classes    = microformats_classes(status, is_direct_parent, is_direct_child)
-  entry_classes = h_class + ' ' + mf_classes + ' ' + style_classes
+  is_direct_parent  = direct_reply_id == status.id
+  is_direct_child   = parent_id == status.in_reply_to_id
+  centered        ||= include_threads && !is_predecessor && !is_successor
+  h_class           = microformats_h_class(status, is_predecessor, is_successor, include_threads)
+  style_classes     = style_classes(status, is_predecessor, is_successor, include_threads)
+  mf_classes        = microformats_classes(status, is_direct_parent, is_direct_child)
+  entry_classes     = h_class + ' ' + mf_classes + ' ' + style_classes
 
 - if status.reply? && include_threads
   - if @next_ancestor
     .entry{ class: entry_classes }
-      = render 'stream_entries/more', url: short_account_status_url(@next_ancestor.account.username, @next_ancestor)
+      = render 'stream_entries/more', url: TagManager.instance.url_for(@next_ancestor)
+
   = render partial: 'stream_entries/status', collection: @ancestors, as: :status, locals: { is_predecessor: true, direct_reply_id: status.in_reply_to_id }
 
 .entry{ class: entry_classes }

--- a/app/views/stream_entries/_status.html.haml
+++ b/app/views/stream_entries/_status.html.haml
@@ -45,9 +45,10 @@
       = render 'stream_entries/more', url: short_account_status_url(status.account.username, status, max_descendant_thread_id: @since_descendant_thread_id + 1)
   - @descendant_threads.each do |thread|
     = render partial: 'stream_entries/status', collection: thread[:statuses], as: :status, locals: { is_successor: true, parent_id: status.id }
+
     - if thread[:next_status]
       .entry{ class: entry_classes }
-        = render 'stream_entries/more', url: short_account_status_url(thread[:next_status].account.username, thread[:next_status])
+        = render 'stream_entries/more', url: TagManager.instance.url_for(thread[:next_status])
   - if @next_descendant_thread
     .entry{ class: entry_classes }
       = render 'stream_entries/more', url: short_account_status_url(status.account.username, status, since_descendant_thread_id: @max_descendant_thread_id - 1)


### PR DESCRIPTION
Also, change pagination limits. Strictly speaking, thread depth is the most important value, because a conversation between two individuals is always going to be a deep nested tree rather than many items on the same depth level. We need to ensure those are not needlessly paginated. New limits:

|||
|-|-|
|Ancestors (depth up)|20->40|
|Siblings (same depth)|20->60|
|Descendants (depth down)|4->20|