### PR TITLE
Special treatment for statuses that begin with a mention

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -159,7 +159,7 @@ class FeedManager
 
     return true if Block.where(account_id: receiver_id, target_account_id: check_for_blocks).any?
 
-    if status.reply? && !status.in_reply_to_account_id.nil?                                                                      # Filter out if it's a reply
+    if !status.in_reply_to_account_id.nil?                                                                                       # Filter out if it's a reply
       should_filter   = !Follow.where(account_id: receiver_id, target_account_id: status.in_reply_to_account_id).exists?         # and I'm not following the person it's a reply to
       should_filter &&= receiver_id != status.in_reply_to_account_id                                                             # and it's not a reply to me
       should_filter &&= status.account_id != status.in_reply_to_account_id                                                       # and it's not a self-reply

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -68,7 +68,7 @@ class Status < ApplicationRecord
   scope :remote, -> { where(local: false).or(where.not(uri: nil)) }
   scope :local,  -> { where(local: true).or(where(uri: nil)) }
 
-  scope :without_replies, -> { where('statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id') }
+  scope :without_replies, -> { where('statuses.in_reply_to_account_id IS NULL').or(where('statuses.in_reply_to_account_id = statuses.account_id')) }
   scope :without_reblogs, -> { where('statuses.reblog_of_id IS NULL') }
   scope :with_public_visibility, -> { where(visibility: :public) }
   scope :tagged_with, ->(tag) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag }) }

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -349,10 +349,10 @@ class Status < ApplicationRecord
   end
 
   def set_reply_from_mention
-    return if !new_record? || reblog? || reply?
+    return if !new_record? || reblog? || (reply? && in_reply_to_account_id != account_id)
 
     if local? && text =~ /\A#{Account::MENTION_RE}/
-      username, domain         = $1.split('@')
+      username, domain         = Regexp.last_match(1).split('@')
       domain                   = nil if TagManager.instance.local_domain?(domain)
       self.in_reply_to_account = Account.find_remote(username, domain)
     end

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -24,7 +24,7 @@ class FanOutOnWriteService < BaseService
 
     deliver_to_hashtags(status)
 
-    return if status.reply? && status.in_reply_to_account_id != status.account_id
+    return if (status.reply? && status.in_reply_to_account_id != status.account_id) || status.in_reply_to_account_id.present?
 
     deliver_to_public(status)
   end

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -11,12 +11,12 @@ class ProcessMentionsService < BaseService
     return unless status.local?
 
     status.text = status.text.gsub(Account::MENTION_RE) do |match|
-      username, domain  = $1.split('@')
+      username, domain  = Regexp.last_match(1).split('@')
       mentioned_account = Account.find_remote(username, domain)
 
       if mention_undeliverable?(status, mentioned_account)
         begin
-          mentioned_account = resolve_account_service.call($1)
+          mentioned_account = resolve_account_service.call(Regexp.last_match(1))
         rescue Goldfinger::Error, HTTP::Error, OpenSSL::SSL::SSLError, Mastodon::UnexpectedResponseError
           mentioned_account = nil
         end


### PR DESCRIPTION
**TL;DR**: This introduces the behaviour that requires you to prepend your status with a "." when you *do* want to avoid it.

Detect when a status begins with a mention, locally (regex) or via ActivityPub (HTML parsing). Set "in reply to account" information which is used in the feed manager filter (home), and adjust public timelines query to exclude such statuses.

- [ ] Unsolved case: When the first-mention thing happens in a self-reply chain.