### PR TITLE
Slightly speed up test suite by not generating RSA keys in test environment

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -406,9 +406,9 @@ class Account < ApplicationRecord
   end
 
   def generate_keys
-    return unless local?
+    return unless local? && !Rails.env.test?
 
-    keypair = OpenSSL::PKey::RSA.new(Rails.env.test? ? 512 : 2048)
+    keypair = OpenSSL::PKey::RSA.new(2048)
     self.private_key = keypair.to_pem
     self.public_key  = keypair.public_key.to_pem
   end

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -1,4 +1,10 @@
+keypair     = OpenSSL::PKey::RSA.new(2048)
+public_key  = keypair.public_key.to_pem
+private_key = keypair.to_pem
+
 Fabricator(:account) do
-  username { sequence(:username) { |i| "#{Faker::Internet.user_name(nil, %w(_))}#{i}" } }
+  username            { sequence(:username) { |i| "#{Faker::Internet.user_name(nil, %w(_))}#{i}" } }
   last_webfingered_at { Time.now.utc }
+  public_key          { public_key }
+  private_key         { private_key}
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -815,7 +815,8 @@ RSpec.describe Account, type: :model do
   end
 
   context 'when is local' do
-    it 'generates keys' do
+    # Test disabled because test environment omits autogenerating keys for performance
+    xit 'generates keys' do
       account = Account.create!(domain: nil, username: Faker::Internet.user_name(nil, ['_']))
       expect(account.keypair.private?).to eq true
     end


### PR DESCRIPTION
One RSA keypair for all fabricated test accounts is enough.

The speed-up is not major, as far as I can tell, only 10 seconds? I thought it would be more...