### PR TITLE
Use Redis-based counter cache for Account#statuses_count

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ gem 'webpush'
 
 gem 'json-ld', '~> 2.2'
 gem 'rdf-normalize', '~> 0.3'
+gem 'counter_cache-rails', '~> 0.4'
 
 group :development, :test do
   gem 'fabrication', '~> 2.20'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,8 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    counter_cache-rails (0.4.0)
+      rails (>= 5.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -652,6 +654,7 @@ DEPENDENCIES
   chewy (~> 5.0)
   cld3 (~> 3.2.0)
   climate_control (~> 0.2)
+  counter_cache-rails (~> 0.4)
   derailed_benchmarks
   devise (~> 4.4)
   devise-two-factor (~> 3.0)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -37,7 +37,7 @@ class Status < ApplicationRecord
 
   belongs_to :application, class_name: 'Doorkeeper::Application', optional: true
 
-  belongs_to :account, inverse_of: :statuses, counter_cache: true
+  belongs_to :account, inverse_of: :statuses
   belongs_to :in_reply_to_account, foreign_key: 'in_reply_to_account_id', class_name: 'Account', optional: true
   belongs_to :conversation, optional: true
 

--- a/config/initializers/counter_cache.rb
+++ b/config/initializers/counter_cache.rb
@@ -1,0 +1,3 @@
+CounterCacheRails.configure do |config|
+  config.expires_in = 1.day
+end


### PR DESCRIPTION
UPDATEs on the accounts table are quite slow. Creating a status increments the count, but the real problem is deleting statuses in batches. UPDATEs for every deleted status bring everything
to a halt. This way, the increments/decrements happen in Redis, and then eventually are written back into the database when the count cache expires and is re-fetched from the database.

Cleaner re-implementation of #6281

Fix #828