### PR TITLE
Keep notification when muting_notifications is true

### DIFF
--- a/app/javascript/mastodon/reducers/notifications.js
+++ b/app/javascript/mastodon/reducers/notifications.js
@@ -105,7 +105,7 @@ export default function notifications(state = initialState, action) {
     return expandNormalizedNotifications(state, action.notifications, action.next);
   case ACCOUNT_BLOCK_SUCCESS:
   case ACCOUNT_MUTE_SUCCESS:
-    return filterNotifications(state, action.relationship);
+    return action.relationship.muting_notifications ? filterNotifications(state, action.relationship) : state;
   case NOTIFICATIONS_CLEAR:
     return state.set('items', ImmutableList()).set('hasMore', false);
   case TIMELINE_DELETE:

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -93,6 +93,7 @@ module AccountInteractions
     if mute.hide_notifications? != notifications
       mute.update!(hide_notifications: notifications)
     end
+    mute
   end
 
   def mute_conversation!(conversation)

--- a/app/services/mute_service.rb
+++ b/app/services/mute_service.rb
@@ -10,5 +10,6 @@ class MuteService < BaseService
     else
       FeedManager.instance.clear_from_timeline(account, target_account)
     end
+    mute
   end
 end

--- a/app/services/mute_service.rb
+++ b/app/services/mute_service.rb
@@ -3,9 +3,12 @@
 class MuteService < BaseService
   def call(account, target_account, notifications: nil)
     return if account.id == target_account.id
-    FeedManager.instance.clear_from_timeline(account, target_account)
+
     mute = account.mute!(target_account, notifications: notifications)
-    BlockWorker.perform_async(account.id, target_account.id)
-    mute
+    if mute.hide_notifications?
+      BlockWorker.perform_async(account.id, target_account.id)
+    else
+      FeedManager.instance.clear_from_timeline(account, target_account)
+    end
   end
 end

--- a/spec/models/concerns/account_interactions_spec.rb
+++ b/spec/models/concerns/account_interactions_spec.rb
@@ -108,13 +108,15 @@ describe AccountInteractions do
   end
 
   describe '#mute!' do
+    subject { account.mute!(target_account, notifications: arg_notifications) }
+
     context 'Mute does not exist yet' do
       context 'arg :notifications is nil' do
         let(:arg_notifications) { nil }
 
-        it 'creates Mute, and returns nil' do
+        it 'creates Mute, and returns Mute' do
           expect do
-            expect(account.mute!(target_account, notifications: arg_notifications)).to be nil
+            expect(subject).to be_kind_of Mute
           end.to change { account.mute_relationships.count }.by 1
         end
       end
@@ -122,9 +124,9 @@ describe AccountInteractions do
       context 'arg :notifications is false' do
         let(:arg_notifications) { false }
 
-        it 'creates Mute, and returns nil' do
+        it 'creates Mute, and returns Mute' do
           expect do
-            expect(account.mute!(target_account, notifications: arg_notifications)).to be nil
+            expect(subject).to be_kind_of Mute
           end.to change { account.mute_relationships.count }.by 1
         end
       end
@@ -132,9 +134,9 @@ describe AccountInteractions do
       context 'arg :notifications is true' do
         let(:arg_notifications) { true }
 
-        it 'creates Mute, and returns nil' do
+        it 'creates Mute, and returns Mute' do
           expect do
-            expect(account.mute!(target_account, notifications: arg_notifications)).to be nil
+            expect(subject).to be_kind_of Mute
           end.to change { account.mute_relationships.count }.by 1
         end
       end
@@ -158,36 +160,30 @@ describe AccountInteractions do
         context 'arg :notifications is nil' do
           let(:arg_notifications) { nil }
 
-          it 'returns nil without updating mute.hide_notifications' do
+          it 'returns Mute without updating mute.hide_notifications' do
             expect do
-              expect(account.mute!(target_account, notifications: arg_notifications)).to be nil
-              mute = account.mute_relationships.find_by(target_account: target_account)
-              expect(mute.hide_notifications?).to be true
-            end
+              expect(subject).to be_kind_of Mute
+            end.not_to change { mute.reload.hide_notifications? }.from(true)
           end
         end
 
         context 'arg :notifications is false' do
           let(:arg_notifications) { false }
 
-          it 'returns true, and updates mute.hide_notifications false' do
+          it 'returns Mute, and updates mute.hide_notifications false' do
             expect do
-              expect(account.mute!(target_account, notifications: arg_notifications)).to be true
-              mute = account.mute_relationships.find_by(target_account: target_account)
-              expect(mute.hide_notifications?).to be false
-            end
+              expect(subject).to be_kind_of Mute
+            end.to change { mute.reload.hide_notifications? }.from(true).to(false)
           end
         end
 
         context 'arg :notifications is true' do
           let(:arg_notifications) { true }
 
-          it 'returns nil without updating mute.hide_notifications' do
+          it 'returns Mute without updating mute.hide_notifications' do
             expect do
-              expect(account.mute!(target_account, notifications: arg_notifications)).to be nil
-              mute = account.mute_relationships.find_by(target_account: target_account)
-              expect(mute.hide_notifications?).to be true
-            end
+              expect(subject).to be_kind_of Mute
+            end.not_to change { mute.reload.hide_notifications? }.from(true)
           end
         end
       end
@@ -198,36 +194,30 @@ describe AccountInteractions do
         context 'arg :notifications is nil' do
           let(:arg_notifications) { nil }
 
-          it 'returns true, and updates mute.hide_notifications true' do
+          it 'returns Mute, and updates mute.hide_notifications true' do
             expect do
-              expect(account.mute!(target_account, notifications: arg_notifications)).to be true
-              mute = account.mute_relationships.find_by(target_account: target_account)
-              expect(mute.hide_notifications?).to be true
-            end
+              expect(subject).to be_kind_of Mute
+            end.to change { mute.reload.hide_notifications? }.from(false).to(true)
           end
         end
 
         context 'arg :notifications is false' do
           let(:arg_notifications) { false }
 
-          it 'returns nil without updating mute.hide_notifications' do
+          it 'returns Mute without updating mute.hide_notifications' do
             expect do
-              expect(account.mute!(target_account, notifications: arg_notifications)).to be nil
-              mute = account.mute_relationships.find_by(target_account: target_account)
-              expect(mute.hide_notifications?).to be false
-            end
+              expect(subject).to be_kind_of Mute
+            end.not_to change { mute.reload.hide_notifications? }.from(false)
           end
         end
 
         context 'arg :notifications is true' do
           let(:arg_notifications) { true }
 
-          it 'returns true, and updates mute.hide_notifications true' do
+          it 'returns Mute, and updates mute.hide_notifications true' do
             expect do
-              expect(account.mute!(target_account, notifications: arg_notifications)).to be true
-              mute = account.mute_relationships.find_by(target_account: target_account)
-              expect(mute.hide_notifications?).to be true
-            end
+              expect(subject).to be_kind_of Mute
+            end.to change { mute.reload.hide_notifications? }.from(false).to(true)
           end
         end
       end


### PR DESCRIPTION
Fixed a bug that existing notifications disappear if muting_notifications is set to true and muted.