### PR TITLE
Do not override timestamps for incoming toots

### DIFF
--- a/app/workers/activitypub/processing_worker.rb
+++ b/app/workers/activitypub/processing_worker.rb
@@ -6,6 +6,6 @@ class ActivityPub::ProcessingWorker
   sidekiq_options backtrace: true
 
   def perform(account_id, body)
-    ActivityPub::ProcessCollectionService.new.call(body, Account.find(account_id), override_timestamps: true)
+    ActivityPub::ProcessCollectionService.new.call(body, Account.find(account_id))
   end
 end

--- a/app/workers/processing_worker.rb
+++ b/app/workers/processing_worker.rb
@@ -6,6 +6,6 @@ class ProcessingWorker
   sidekiq_options backtrace: true
 
   def perform(account_id, body)
-    ProcessFeedService.new.call(body, Account.find(account_id), override_timestamps: true)
+    ProcessFeedService.new.call(body, Account.find(account_id))
   end
 end


### PR DESCRIPTION
I feel like this has already been discussed, but I could not remember nor find the rationale behind overriding timestamps on incoming toots.
I think this causes more harm than good. Indeed, it is an unnecessary distinction between fetched and received toots. Furthermore, it occurs from time to time that a temporary failure or large sidekiq queue would cause messages to be delayed for some extended amount of time. In this situation, having a large difference between the displayed time and the actual time the toot was sent can be quite confusing.