### PR TITLE
Throttle media post

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -53,6 +53,10 @@ class Rack::Attack
     req.ip if req.api_request?
   end
 
+  throttle('throttle_media', limit: 30, period: 30.minutes) do |req|
+    req.authenticated_user_id if req.post? && req.path.start_with('/api/v1/media')
+  end
+
   throttle('protected_paths', limit: 25, period: 5.minutes) do |req|
     req.ip if req.post? && req.path =~ PROTECTED_PATHS_REGEX
   end


### PR DESCRIPTION
I noticed that the rate limit for the media is so low that it allows to fill 10 gigabytes in 20 minutes, effectively causing denial-of-service, so here is a fix. I appreciate opinions about the concrete numbers for the rate limit:

The previous rate limit allowed to post media so fast that it is possible
to fill up the disk space even before an administrator notices. The new
rate limit is configured so that it takes 24 hours to eat 10 gigabytes:
10 * 1024 / 8 / (24 * 60 / 30) = 27 (which is rounded to 30)

The period is set long so that it does not prevent from attaching several
media to one post, which would happen in a short period. For example,
if the period is 5 minutes, the rate limit would be:
10 * 1024 / 8 / (24 * 60 / 5) = 4

This long period allows to lift the limit up.