### PR TITLE
Add a missing question mark in rack_attack.rb

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -54,7 +54,7 @@ class Rack::Attack
   end
 
   throttle('throttle_media', limit: 30, period: 30.minutes) do |req|
-    req.authenticated_user_id if req.post? && req.path.start_with('/api/v1/media')
+    req.authenticated_user_id if req.post? && req.path.start_with?('/api/v1/media')
   end
 
   throttle('protected_paths', limit: 25, period: 5.minutes) do |req|


### PR DESCRIPTION
Reported at https://github.com/tootsuite/mastodon/commit/b1d4471e36830aa7dc4425ff6c48035a95c9367a#r28841392.
~~\# question: why did it work?~~ I found I haven't `./bin/rails dev:cache`. I confirmed the rate limit is now in effect.