### PR TITLE
Do not re-position scroll when loading more (inserting items from below)

### DIFF
--- a/app/javascript/mastodon/components/scrollable_list.js
+++ b/app/javascript/mastodon/components/scrollable_list.js
@@ -72,7 +72,7 @@ export default class ScrollableList extends PureComponent {
     const someItemInserted = React.Children.count(prevProps.children) > 0 &&
       React.Children.count(prevProps.children) < React.Children.count(this.props.children) &&
       this.getFirstChildKey(prevProps) !== this.getFirstChildKey(this.props);
-    if (someItemInserted && this.node.scrollTop > 0 || this.state.mouseOver) {
+    if (someItemInserted && this.node.scrollTop > 0 || (this.state.mouseOver && !prevProps.isLoading)) {
       return this.node.scrollHeight - this.node.scrollTop;
     } else {
       return null;


### PR DESCRIPTION
When a scrollable list is loading, let it scroll to top. Otherwise, having the cursor hover the list while it's initially loading will result in it scrolling to the bottom (and triggering another load event).