### PR TITLE
Fix 2fa description in Japanese

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -795,7 +795,7 @@ ja:
       default: "%Y年%m月%d日 %H:%M"
   two_factor_authentication:
     code_hint: 確認するには認証アプリで表示されたコードを入力してください
-    description_html: "<strong>二段階認証</strong>を有効にするとログイン時、電話でコードを受け取る必要があります。"
+    description_html: "<strong>二段階認証</strong>を有効にするとログイン時、認証アプリからコードを入力する必要があります。"
     disable: 無効
     enable: 有効
     enabled: 二段階認証は有効になっています


### PR DESCRIPTION
The 2FA description in Japanese is not clear enough.
It sounds like you need to get 2FA code from SMS, but the reality is you use app and not SMS.