### PR TITLE
Better pagination for ActivityPub outbox

### DIFF
--- a/app/controllers/activitypub/collections_controller.rb
+++ b/app/controllers/activitypub/collections_controller.rb
@@ -22,7 +22,7 @@ class ActivityPub::CollectionsController < Api::BaseController
   end
 
   def set_statuses
-    @statuses = scope_for_collection.paginate_by_max_id(20, params[:max_id], params[:since_id])
+    @statuses = scope_for_collection
     @statuses = cache_collection(@statuses, Status)
   end
 

--- a/app/controllers/activitypub/outboxes_controller.rb
+++ b/app/controllers/activitypub/outboxes_controller.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class ActivityPub::OutboxesController < Api::BaseController
+  LIMIT = 20
+
   include SignatureVerification
 
   before_action :set_account
+  before_action :set_statuses
 
   def show
-    @statuses = @account.statuses.permitted_for(@account, signed_request_account).paginate_by_max_id(20, params[:max_id], params[:since_id])
-    @statuses = cache_collection(@statuses, Status)
-
     render json: outbox_presenter, serializer: ActivityPub::OutboxSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'
   end
 
@@ -19,11 +19,47 @@ class ActivityPub::OutboxesController < Api::BaseController
   end
 
   def outbox_presenter
-    ActivityPub::CollectionPresenter.new(
-      id: account_outbox_url(@account),
-      type: :ordered,
-      size: @account.statuses_count,
-      items: @statuses
-    )
+    if page_requested?
+      ActivityPub::CollectionPresenter.new(
+        id: account_outbox_url(@account, page_params),
+        type: :ordered,
+        part_of: account_outbox_url(@account),
+        prev: prev_page,
+        next: next_page,
+        items: @statuses
+      )
+    else
+      ActivityPub::CollectionPresenter.new(
+        id: account_outbox_url(@account),
+        type: :ordered,
+        size: @account.statuses_count,
+        first: account_outbox_url(@account, page: true),
+        last: account_outbox_url(@account, page: true, min_id: 0)
+      )
+    end
+  end
+
+  def next_page
+    account_outbox_url(@account, page: true, max_id: @statuses.last.id) if @statuses.size == LIMIT
+  end
+
+  def prev_page
+    account_outbox_url(@account, page: true, min_id: @statuses.first.id) unless @statuses.empty?
+  end
+
+  def set_statuses
+    return unless page_requested?
+
+    @statuses = @account.statuses.permitted_for(@account, signed_request_account)
+    @statuses = params[:min_id].present? ? @statuses.paginate_by_min_id(LIMIT, params[:min_id]).reverse : @statuses.paginate_by_max_id(LIMIT, params[:max_id])
+    @statuses = cache_collection(@statuses, Status)
+  end
+
+  def page_requested?
+    params[:page] == 'true'
+  end
+
+  def page_params
+    { page: true, max_id: params[:max_id], min_id: params[:min_id] }.compact
   end
 end

--- a/app/presenters/activitypub/collection_presenter.rb
+++ b/app/presenters/activitypub/collection_presenter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ActivityPub::CollectionPresenter < ActiveModelSerializers::Model
-  attributes :id, :type, :size, :items, :part_of, :first, :next, :prev
+  attributes :id, :type, :size, :items, :part_of, :first, :last, :next, :prev
 end

--- a/app/serializers/activitypub/collection_serializer.rb
+++ b/app/serializers/activitypub/collection_serializer.rb
@@ -7,12 +7,14 @@ class ActivityPub::CollectionSerializer < ActiveModel::Serializer
     super
   end
 
-  attributes :id, :type, :total_items
+  attributes :id, :type
+  attribute :total_items, if: -> { object.size.present? }
   attribute :next, if: -> { object.next.present? }
   attribute :prev, if: -> { object.prev.present? }
   attribute :part_of, if: -> { object.part_of.present? }
 
   has_one :first, if: -> { object.first.present? }
+  has_one :last, if: -> { object.last.present? }
   has_many :items, key: :items, if: -> { (!object.items.nil? || page?) && !ordered? }
   has_many :items, key: :ordered_items, if: -> { (!object.items.nil? || page?) && ordered? }
 


### PR DESCRIPTION
Mastodon fetches these collections only to read `totalItems` number. We can improve performance by not including `items` directly in the collection, but instead using `first` to link to a CollectionPage. Also, this adds proper, discoverable pagination.

Fix #7204 

This improves outbox (and removes unused pagination code from collections). See #7357 for following/followers.