### PR TITLE
Do not render first page of following and followers collections unless explicitly asked to

### DIFF
--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -4,11 +4,10 @@ class FollowingAccountsController < ApplicationController
   include AccountControllerConcern
 
   def index
-    @follows = Follow.where(account: @account).recent.page(params[:page]).per(FOLLOW_PER_PAGE).preload(:target_account)
-
     respond_to do |format|
       format.html do
-        @relationships = AccountRelationshipsPresenter.new(@follows.map(&:target_account_id), current_user.account_id) if user_signed_in?
+        follows
+        @relationships = AccountRelationshipsPresenter.new(follows.map(&:target_account_id), current_user.account_id) if user_signed_in?
       end
 
       format.json do
@@ -22,28 +21,31 @@ class FollowingAccountsController < ApplicationController
 
   private
 
+  def follows
+    @follows ||= Follow.where(account: @account).recent.page(params[:page]).per(FOLLOW_PER_PAGE).preload(:target_account)
+  end
+
   def page_url(page)
     account_following_index_url(@account, page: page) unless page.nil?
   end
 
   def collection_presenter
-    page = ActivityPub::CollectionPresenter.new(
-      id: account_following_index_url(@account, page: params.fetch(:page, 1)),
-      type: :ordered,
-      size: @account.following_count,
-      items: @follows.map { |f| ActivityPub::TagManager.instance.uri_for(f.target_account) },
-      part_of: account_following_index_url(@account),
-      next: page_url(@follows.next_page),
-      prev: page_url(@follows.prev_page)
-    )
     if params[:page].present?
-      page
+      ActivityPub::CollectionPresenter.new(
+        id: account_following_index_url(@account, page: params.fetch(:page, 1)),
+        type: :ordered,
+        size: @account.following_count,
+        items: follows.map { |f| ActivityPub::TagManager.instance.uri_for(f.target_account) },
+        part_of: account_following_index_url(@account),
+        next: page_url(follows.next_page),
+        prev: page_url(follows.prev_page)
+      )
     else
       ActivityPub::CollectionPresenter.new(
         id: account_following_index_url(@account),
         type: :ordered,
         size: @account.following_count,
-        first: page
+        first: page_url(1)
       )
     end
   end


### PR DESCRIPTION
Partial fix to #7204 making following and followers collections cheaper to render.

I haven't changed the outbox controller yet as it's using a different logic and an intermediate cache.