### PR TITLE
Do not check outbox/featured if account has local followers

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -164,6 +164,10 @@ class Account < ApplicationRecord
     subscription_expires_at.present?
   end
 
+  def locally_followed?
+    passive_relationships.any?
+  end
+
   def possibly_stale?
     last_webfingered_at.nil? || last_webfingered_at <= 1.day.ago
   end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -30,7 +30,7 @@ class ActivityPub::ProcessAccountService < BaseService
 
     after_protocol_change! if protocol_changed?
     after_key_change! if key_changed?
-    check_featured_collection! if @account.featured_collection_url.present?
+    check_featured_collection! if check_featured_collection?
 
     @account
   rescue Oj::ParseError
@@ -77,7 +77,7 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.avatar_remote_url = image_url('icon')  unless skip_download?
     @account.header_remote_url = image_url('image') unless skip_download?
     @account.public_key        = public_key || ''
-    @account.statuses_count    = outbox_total_items    if outbox_total_items.present?
+    @account.statuses_count    = outbox_total_items    if check_outbox?
     @account.following_count   = following_total_items if following_total_items.present?
     @account.followers_count   = followers_total_items if followers_total_items.present?
     @account.moved_to_account  = @json['movedTo'].present? ? moved_account : nil
@@ -89,6 +89,10 @@ class ActivityPub::ProcessAccountService < BaseService
 
   def after_key_change!
     RefollowWorker.perform_async(@account.id)
+  end
+
+  def check_featured_collection?
+    @account.featured_collection_url.present? && !@account.locally_followed?
   end
 
   def check_featured_collection!
@@ -137,6 +141,10 @@ class ActivityPub::ProcessAccountService < BaseService
     haystack = Addressable::URI.parse(@uri).host
 
     !haystack.casecmp(needle).zero?
+  end
+
+  def check_outbox?
+    !@account.locally_followed? && outbox_total_items.present?
   end
 
   def outbox_total_items


### PR DESCRIPTION
See #7204: If account has local followers, we will receive Create/Delete and Add/Remove and update those things correctly.

I'm not sure about this PR though. Are there edge cases where someone might have followers before the correct data is fetched? Network issues could also lead to desync which would no longer get corrected...