### PR TITLE
Add resend confirmation for admin

### DIFF
--- a/app/controllers/admin/confirmations_controller.rb
+++ b/app/controllers/admin/confirmations_controller.rb
@@ -3,6 +3,7 @@
 module Admin
   class ConfirmationsController < BaseController
     before_action :set_user
+    before_action :check_confirmation, only: [:resend]
 
     def create
       authorize @user, :confirm?
@@ -11,10 +12,28 @@ module Admin
       redirect_to admin_accounts_path
     end
 
+    def resend
+      authorize @user, :confirm?
+
+      @user.resend_confirmation_instructions
+
+      log_action :confirm, @user
+
+      flash[:notice] = I18n.t('admin.accounts.resend_confirmation.success')
+      redirect_to admin_accounts_path
+    end
+
     private
 
     def set_user
       @user = Account.find(params[:account_id]).user || raise(ActiveRecord::RecordNotFound)
+    end
+
+    def check_confirmation
+      if @user.confirmed?
+        flash[:error] = I18n.t('admin.accounts.resend_confirmation.already_confirmed')
+        redirect_to admin_accounts_path
+      end
     end
   end
 end

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -36,13 +36,19 @@
           %th= t('admin.accounts.email')
           %td
             = @account.user_email
-            - if @account.user_confirmed?
-              = fa_icon('check')
             = table_link_to 'edit', t('admin.accounts.change_email.label'), admin_account_change_email_path(@account.id) if can?(:change_email, @account.user)
         - if @account.user_unconfirmed_email.present?
           %th= t('admin.accounts.unconfirmed_email')
           %td
             = @account.user_unconfirmed_email
+        %tr
+          %th= t('admin.accounts.email_status')
+          %td
+            - if @account.user&.confirmed?
+              = t('admin.accounts.confirmed')
+            - else
+              = t('admin.accounts.confirming')
+              = table_link_to 'refresh', t('admin.accounts.resend_confirmation.send'), resend_admin_account_confirmation_path(@account.id), method: :post if can?(:confirm, @account.user)
         %tr
           %th= t('admin.accounts.login_status')
           %td

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -61,6 +61,7 @@ ar:
       by_domain: النطاق
       confirm: تأكيد
       confirmed: مؤكَّد
+      confirming: التأكد
       demote: إنزال الرُتبة الوظيفية
       disable: تعطيل
       disable_two_factor_authentication: تعطيل 2FA
@@ -69,6 +70,7 @@ ar:
       domain: النطاق
       edit: تعديل
       email: البريد الإلكتروني
+      email_status: حالة البريد الإلكتروني
       enable: تفعيل
       enabled: مفعَّل
       feed_url: عنوان رابط التغذية
@@ -106,6 +108,10 @@ ar:
       public: عمومي
       push_subscription_expires: انتهاء الاشتراك ”PuSH“
       redownload: تحديث الصورة الرمزية
+      resend_confirmation:
+        already_confirmed: هذا المستخدم مؤكد بالفعل
+        send: أعد إرسال رسالة البريد الالكتروني الخاصة بالتأكيد
+        success: تم إرسال رسالة التأكيد بنجاح!
       reset: إعادة التعيين
       reset_password: إعادة ضبط كلمة السر
       resubscribe: اشترك مرة أخرى

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -70,6 +70,7 @@ ca:
         title: Canviar adreça de correu de %{username}
       confirm: Confirma
       confirmed: Confirmat
+      confirming: Confirmando
       demote: Degrada
       disable: Inhabilita
       disable_two_factor_authentication: Desactiva 2FA
@@ -78,6 +79,7 @@ ca:
       domain: Domini
       edit: Edita
       email: Correu electrònic
+      email_status: Estado del correo electrónico
       enable: Habilita
       enabled: Habilitat
       feed_url: URL del canal
@@ -116,6 +118,10 @@ ca:
       push_subscription_expires: La subscripció PuSH expira
       redownload: Actualitza l'avatar
       remove_avatar: Eliminar avatar
+      resend_confirmation:
+        already_confirmed: Este usuario ya está confirmado
+        send: Reenviar el correo electrónico de confirmación
+        success: "¡Correo electrónico de confirmación enviado con éxito!"
       reset: Reinicialitza
       reset_password: Restableix la contrasenya
       resubscribe: Torna a subscriure

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -70,6 +70,7 @@ de:
         title: E-Mail-Adresse für %{username} ändern
       confirm: Bestätigen
       confirmed: Bestätigt
+      confirming: Bestätigung
       demote: Degradieren
       disable: Ausschalten
       disable_two_factor_authentication: 2FA abschalten
@@ -78,6 +79,7 @@ de:
       domain: Domain
       edit: Bearbeiten
       email: E-Mail
+      email_status: E-Mail-Status
       enable: Freischalten
       enabled: Freigegeben
       feed_url: Feed-URL
@@ -116,6 +118,10 @@ de:
       push_subscription_expires: PuSH-Abonnement läuft aus
       redownload: Avatar neu laden
       remove_avatar: Profilbild entfernen
+      resend_confirmation:
+        already_confirmed: Dieser Benutzer wurde bereits bestätigt
+        send: Bestätigungsmail erneut senden
+        success: Bestätigungs-E-Mail erfolgreich gesendet!
       reset: Zurücksetzen
       reset_password: Passwort zurücksetzen
       resubscribe: Wieder abonnieren

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
         title: Change Email for %{username}
       confirm: Confirm
       confirmed: Confirmed
+      confirming: Confirming
       demote: Demote
       disable: Disable
       disable_two_factor_authentication: Disable 2FA
@@ -78,6 +79,7 @@ en:
       domain: Domain
       edit: Edit
       email: E-mail
+      email_status: E-mail Status
       enable: Enable
       enabled: Enabled
       feed_url: Feed URL
@@ -116,6 +118,10 @@ en:
       push_subscription_expires: PuSH subscription expires
       redownload: Refresh avatar
       remove_avatar: Remove avatar
+      resend_confirmation:
+        already_confirmed: This user is already confirmed
+        send: Resend confirmation email
+        success: Confirmation email successfully sent!
       reset: Reset
       reset_password: Reset password
       resubscribe: Resubscribe

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -61,6 +61,7 @@ eo:
       by_domain: Domajno
       confirm: Konfirmi
       confirmed: Konfirmita
+      confirming: Konfirmante
       demote: Degradi
       disable: Malebligi
       disable_two_factor_authentication: Malebligi 2FA
@@ -69,6 +70,7 @@ eo:
       domain: Domajno
       edit: Redakti
       email: Retpoŝto
+      email_status: Retpoŝto Stato
       enable: Ebligi
       enabled: Ebligita
       feed_url: URL de la fluo
@@ -106,6 +108,10 @@ eo:
       public: Publika
       push_subscription_expires: Eksvalidiĝo de la abono al PuSH
       redownload: Aktualigi profilbildon
+      resend_confirmation:
+        already_confirmed: Ĉi tiu uzanto jam estas konfirmita
+        send: Esend konfirmi retpoŝton
+        success: Konfirma retpoŝto sukcese sendis
       reset: Restarigi
       reset_password: Restarigi pasvorton
       resubscribe: Reaboni

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -70,6 +70,7 @@ es:
         title: Cambiar el correo electrónico de %{username}
       confirm: Confirmar
       confirmed: Confirmado
+      confirming: Confirmando
       demote: Degradar
       disable: Deshabilitar
       disable_two_factor_authentication: Desactivar autenticación de dos factores
@@ -78,6 +79,7 @@ es:
       domain: Dominio
       edit: Editar
       email: E-mail
+      email_status: E-mail Status
       enable: Habilitar
       enabled: Habilitada
       feed_url: URL de notificaciones
@@ -116,6 +118,10 @@ es:
       push_subscription_expires: Expiración de la suscripción PuSH
       redownload: Refrescar avatar
       remove_avatar: Eliminar el avatar
+      resend_confirmation:
+        already_confirmed: Este usuario ya está confirmado
+        send: Reenviar el correo electrónico de confirmación
+        success: "¡Correo electrónico de confirmación enviado con éxito"
       reset: Reiniciar
       reset_password: Reiniciar contraseña
       resubscribe: Re-suscribir

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -61,6 +61,7 @@ fa:
       by_domain: دامین
       confirm: تأیید
       confirmed: تأیید شد
+      confirming: تأیید
       demote: تنزل‌دادن
       disable: غیرفعال
       disable_two_factor_authentication: غیرفعال‌سازی ورود دومرحله‌ای
@@ -69,6 +70,7 @@ fa:
       domain: دامین
       edit: ویرایش
       email: ایمیل
+      email_status: وضعیت ایمیل
       enable: فعال
       enabled: فعال
       feed_url: نشانی فید
@@ -106,6 +108,10 @@ fa:
       public: عمومی
       push_subscription_expires: عضویت از راه PuSH منقضی شد
       redownload: به‌روزرسانی تصویر نمایه
+      resend_confirmation:
+        already_confirmed: این کاربر قبلا تایید شده است
+        send: ایمیل تایید را دوباره بفرستید
+        success: ایمیل تایید با موفقیت ارسال شد
       reset: بازنشانی
       reset_password: بازنشانی رمز
       resubscribe: اشتراک دوباره

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -61,6 +61,7 @@ fi:
       by_domain: Verkko-osoite
       confirm: Vahvista
       confirmed: Vahvistettu
+      confirming: Vahvistavat
       demote: Alenna
       disable: Poista käytöstä
       disable_two_factor_authentication: Poista 2FA käytöstä
@@ -69,6 +70,7 @@ fi:
       domain: Verkko-osoite
       edit: Muokkaa
       email: Sähköposti
+      email_status: Sähköpostin tila
       enable: Ota käyttöön
       enabled: Käytössä
       feed_url: Syötteen URL
@@ -106,6 +108,10 @@ fi:
       public: Julkinen
       push_subscription_expires: PuSH-tilaus vanhenee
       redownload: Päivitä profiilikuva
+      resend_confirmation:
+        already_confirmed: Tämä käyttäjä on jo vahvistettu
+        send: Lähetä varmistusviesti uudelleen
+        success: Vahvistusviesti lähetettiin onnistuneesti
       reset: Palauta
       reset_password: Palauta salasana
       resubscribe: Tilaa uudelleen

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -70,6 +70,7 @@ fr:
         title: Modifier le courriel pour %{username}
       confirm: Confirmer
       confirmed: Confirmé
+      confirming: Confirmant
       demote: Rétrograder
       disable: Désactiver
       disable_two_factor_authentication: Désactiver l’authentification à deux facteurs
@@ -78,6 +79,7 @@ fr:
       domain: Domaine
       edit: Éditer
       email: Courriel
+      email_status: État de la messagerie
       enable: Activer
       enabled: Activé
       feed_url: URL du flux
@@ -116,6 +118,10 @@ fr:
       push_subscription_expires: Expiration de l’abonnement PuSH
       redownload: Rafraîchir les avatars
       remove_avatar: Supprimer l'avatar
+      resend_confirmation:
+        already_confirmed: Cet utilisateur est déjà confirmé
+        send: Renvoyer un courriel de confirmation
+        success: Email de confirmation envoyé avec succès !
       reset: Réinitialiser
       reset_password: Réinitialiser le mot de passe
       resubscribe: Se réabonner

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -70,6 +70,7 @@ gl:
         title: Cambiar o correo-e de %{username}
       confirm: Confirmar
       confirmed: Confirmado
+      confirming: Confirmar
       demote: Degradar
       disable: Deshabilitar
       disable_two_factor_authentication: Deshabilitar 2FA
@@ -78,6 +79,7 @@ gl:
       domain: Dominio
       edit: Editar
       email: E-mail
+      email_status: Estado del correo electrónico
       enable: Habilitar
       enabled: Habilitado
       feed_url: URL fonte
@@ -116,6 +118,10 @@ gl:
       push_subscription_expires: A suscrición PuSH caduca
       redownload: Actualizar avatar
       remove_avatar: Eliminar avatar
+      resend_confirmation:
+        already_confirmed: Este usuario ya está confirmado
+        send: Reenviar el correo electrónico de confirmación
+        success: "¡Correo electrónico de confirmación enviado con éxito!"
       reset: Restablecer
       reset_password: Restablecer contrasinal
       resubscribe: Voltar a suscribir

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -61,6 +61,7 @@ he:
       by_domain: שם מתחם
       confirm: אישור
       confirmed: אושר
+      confirming: המאשר
       demote: הורדה בדרגה
       disable: לחסום
       disable_two_factor_authentication: ביטול הזדהות דו-שלבית
@@ -69,6 +70,7 @@ he:
       domain: תחום
       edit: עריכה
       email: דוא"ל
+      email_status: סטטוס דוא"ל
       enable: לאפשר
       enabled: מאופשר
       feed_url: כתובת פיד
@@ -106,6 +108,10 @@ he:
       public: פומבי
       push_subscription_expires: הרשמה להודעות בדחיפה פגה
       redownload: לקריאה מחדש של האווטאר
+      resend_confirmation:
+        already_confirmed: משתמש זה כבר אושר
+        send: שלח מחדש דוא"ל אימות
+        success: הודעת האימייל נשלחה בהצלחה!
       reset: איפוס
       reset_password: אתחול סיסמא
       resubscribe: להרשם מחדש

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -61,6 +61,7 @@ hu:
       by_domain: Domain
       confirm: Megerősítés
       confirmed: Megerősítve
+      confirming: Megerősítve
       demote: Lefokozás
       disable: Kikapcsolás
       disable_two_factor_authentication: Kétlépcsős azonosítás kikapcsolása
@@ -69,6 +70,7 @@ hu:
       domain: Domain
       edit: Szerkesztés
       email: E-mail
+      email_status: E-mail állapot
       enable: Engedélyezés
       enabled: Engedélyezve
       feed_url: Hírcsatorna URL
@@ -106,6 +108,10 @@ hu:
       public: Nyilvános
       push_subscription_expires: A PuSH feliratkozás elévül
       redownload: Profilkép frissítése
+      resend_confirmation:
+        already_confirmed: Ezt a felhasználót már megerősítették
+        send: Küldd újra a megerősítő email-t
+        success: A megerősítő e-mail sikeresen elküldve!
       reset: Visszaállítás
       reset_password: Jelszó visszaállítása
       resubscribe: Feliratkozás ismét

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -29,10 +29,12 @@ id:
       are_you_sure: Anda yakin?
       confirm: Konfirmasi
       confirmed: Dikonfirmasi
+      confirming: Mengkonfirmasi
       display_name: Nama
       domain: Domain
       edit: Ubah
       email: E-mail
+      email_status: Status Email
       feed_url: URL Feed
       followers: Pengikut
       follows: Mengikut
@@ -58,6 +60,10 @@ id:
       profile_url: URL profil
       public: Publik
       push_subscription_expires: Langganan PuSH telah kadaluarsa
+      resend_confirmation:
+        already_confirmed: Pengguna ini sudah dikonfirmasi
+        send: Kirim ulang email konfirmasi
+        success: Email konfirmasi berhasil dikirim!
       reset_password: Reset kata sandi
       salmon_url: URL Salmon
       show:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -66,6 +66,7 @@ it:
         title: Cambia email per %{username}
       confirm: Conferma
       confirmed: Confermato
+      confirming: Confermando
       demote: Declassa
       disable: Disabilita
       disable_two_factor_authentication: Disabilita 2FA
@@ -74,6 +75,7 @@ it:
       domain: Dominio
       edit: Modifica
       email: Email
+      email_status: Stato email
       enable: Abilita
       enabled: Abilitato
       feed_url: URL Feed
@@ -111,6 +113,10 @@ it:
       public: Pubblico
       redownload: Aggiorna avatar
       remove_avatar: Rimuovi avatar
+      resend_confirmation:
+        already_confirmed: Questo utente è già confermato
+        send: Reinvia email di conferma
+        success: Email di conferma inviata con successo!
       reset: Reimposta
       reset_password: Reimposta password
       resubscribe: Riscriversi

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -70,6 +70,7 @@ ja:
         title: "%{username} さんのメールアドレスを変更"
       confirm: 確認
       confirmed: 確認済み
+      confirming: 確認中
       demote: 降格
       disable: 無効化
       disable_two_factor_authentication: 二段階認証を無効にする
@@ -78,6 +79,7 @@ ja:
       domain: ドメイン
       edit: 編集
       email: メールアドレス
+      email_status: メールアドレスの状態
       enable: 有効化
       enabled: 有効
       feed_url: フィードURL
@@ -116,6 +118,10 @@ ja:
       push_subscription_expires: PuSH購読期限
       redownload: アバターの更新
       remove_avatar: アイコンを削除
+      resend_confirmation:
+        already_confirmed: メールアドレスは確認済みです。
+        send: 確認メールを再送
+        success: 確認メールを再送信しました!
       reset: リセット
       reset_password: パスワード再設定
       resubscribe: 再講読

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -70,6 +70,7 @@ ko:
         title: "%{username}의 이메일 주소 변경"
       confirm: 확인
       confirmed: 확인됨
+      confirming: 확인 중
       demote: 모더레이터 강등
       disable: 비활성화
       disable_two_factor_authentication: 2단계 인증을 비활성화
@@ -78,6 +79,7 @@ ko:
       domain: 도메인
       edit: 편집
       email: E-mail
+      email_status: 이메일 상태
       enable: 활성화
       enabled: 활성화된
       feed_url: 피드 URL
@@ -116,6 +118,10 @@ ko:
       push_subscription_expires: PuSH 구독 기간 만료
       redownload: 아바타 업데이트
       remove_avatar: 아바타 지우기
+      resend_confirmation:
+        already_confirmed: 이 사용자는 이미 확인되었습니다.
+        send: 다시 확인 이메일
+        success: 확인 이메일이 전송되었습니다.
       reset: 초기화
       reset_password: 비밀번호 초기화
       resubscribe: 다시 구독

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -70,6 +70,7 @@ nl:
         title: E-mailadres veranderen voor %{username}
       confirm: Bevestigen
       confirmed: Bevestigd
+      confirming: Bevestiging
       demote: Degraderen
       disable: Uitschakelen
       disable_two_factor_authentication: 2FA uitschakelen
@@ -78,6 +79,7 @@ nl:
       domain: Domein
       edit: Bewerken
       email: E-mail
+      email_status: E-mail Status
       enable: Inschakelen
       enabled: Ingeschakeld
       feed_url: Feed-URL
@@ -116,6 +118,10 @@ nl:
       push_subscription_expires: PuSH-abonnement verloopt op
       redownload: Avatar vernieuwen
       remove_avatar: Avatar verwijderen
+      resend_confirmation:
+        already_confirmed: Deze gebruiker is al bevestigd
+        send: Verzend bevestigingsmail opnieuw
+        success: Bevestigingsmail succesvol verzonden!
       reset: Opnieuw
       reset_password: Wachtwoord opnieuw instellen
       resubscribe: Opnieuw abonneren

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -61,6 +61,7 @@
       by_domain: Domene
       confirm: Bekreft
       confirmed: Bekreftet
+      confirming: Bekrefte
       demote: Degrader
       disable: Deaktiver
       disable_two_factor_authentication: Skru av 2FA
@@ -69,6 +70,7 @@
       domain: Domene
       edit: Redigér
       email: E-post
+      email_status: E-poststatus
       enable: Aktiver
       enabled: Aktivert
       feed_url: Feed-URL
@@ -106,6 +108,10 @@
       public: Offentlig
       push_subscription_expires: PuSH-abonnent utløper
       redownload: Oppdater avatar
+      resend_confirmation:
+        already_confirmed: Denne brukeren er allerede bekreftet
+        send: Send bekreftelses-epost på nytt
+        success: Bekreftelses e-post er vellykket sendt!
       reset: Tilbakestill
       reset_password: Nullstill passord
       resubscribe: Abonner på nytt

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -70,6 +70,7 @@ oc:
         title: Cambiar l’adreça a %{username}
       confirm: Confirmar
       confirmed: Confirmat
+      confirming: Confirmando
       demote: Retrogradar
       disable: Desactivar
       disable_two_factor_authentication: Desactivar 2FA
@@ -78,6 +79,7 @@ oc:
       domain: Domeni
       edit: Modificar
       email: Corrièl
+      email_status: Estado del correo electrónico
       enable: Activar
       enabled: Activat
       feed_url: Flux URL
@@ -116,6 +118,10 @@ oc:
       push_subscription_expires: Fin de l’abonament PuSH
       redownload: Actualizar los avatars
       remove_avatar: Supriir l’avatar
+      resend_confirmation:
+        already_confirmed: Este usuario ya está confirmado
+        send: Reenviar el correo electrónico de confirmación
+        success: "¡Correo electrónico de confirmación enviado con éxito!"
       reset: Reïnicializar
       reset_password: Reïnicializar lo senhal
       resubscribe: Se tornar abonar

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -70,6 +70,7 @@ pl:
         title: Zmień adres e-mail dla %{username}
       confirm: Potwierdź
       confirmed: Potwierdzono
+      confirming: Potwierdzam
       demote: Degraduj
       disable: Dezaktywuj
       disable_two_factor_authentication: Wyłącz uwierzytelnianie dwuetapowe
@@ -78,6 +79,7 @@ pl:
       domain: Domena
       edit: Edytuj
       email: Adres e-mail
+      email_status: Status e-maila
       enable: Aktywuj
       enabled: Aktywowano
       feed_url: Adres kanału
@@ -116,6 +118,10 @@ pl:
       push_subscription_expires: Subskrypcja PuSH wygasa
       redownload: Odśwież awatar
       remove_avatar: Usun awatar
+      resend_confirmation:
+        already_confirmed: Ten użytkownik jest już potwierdzony
+        send: Wyślij ponownie email potwierdzający
+        success: E-mail z potwierdzeniem został wysłany!
       reset: Resetuj
       reset_password: Resetuj hasło
       resubscribe: Ponów subskrypcję

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -70,6 +70,7 @@ pt-BR:
         title: Mudar e-mail para %{username}
       confirm: Confirmar
       confirmed: Confirmado
+      confirming: Confirmando
       demote: Rebaixar
       disable: Desativar
       disable_two_factor_authentication: Desativar 2FA
@@ -78,6 +79,7 @@ pt-BR:
       domain: Domínio
       edit: Editar
       email: E-mail
+      email_status: Estado del correo electrónico
       enable: Ativar
       enabled: Ativado
       feed_url: URL do feed
@@ -116,6 +118,10 @@ pt-BR:
       push_subscription_expires: Inscrição PuSH expira
       redownload: Atualizar avatar
       remove_avatar: Remover avatar
+      resend_confirmation:
+        already_confirmed: Este usuario ya está confirmado
+        send: Reenviar el correo electrónico de confirmación
+        success: "¡Correo electrónico de confirmación enviado con éxito!"
       reset: Anular
       reset_password: Modificar senha
       resubscribe: Reinscrever-se

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -61,6 +61,7 @@ pt:
       by_domain: Domínio
       confirm: Confirme
       confirmed: Confirmado
+      confirming: Confirmer
       demote: Rebaixar
       disable: Desativar
       disable_two_factor_authentication: Desativar 2FA
@@ -69,6 +70,7 @@ pt:
       domain: Domínio
       edit: Editar
       email: E-mail
+      email_status: État de la messagerie
       enable: Ativar
       enabled: Ativado
       feed_url: URL do Feed
@@ -106,6 +108,10 @@ pt:
       public: Público
       push_subscription_expires: A Inscrição PuSH expira
       redownload: Atualizar avatar
+      resend_confirmation:
+        already_confirmed: Cet utilisateur est déjà confirmé
+        send: Renvoyer un courriel de confirmation
+        success: Email de confirmation envoyé avec succès!
       reset: Restaurar
       reset_password: Reset palavra-passe
       resubscribe: Reinscrever

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -61,6 +61,7 @@ ru:
       by_domain: Домен
       confirm: Подтвердить
       confirmed: Подтверждено
+      confirming: подтверждающий
       demote: Разжаловать
       disable: Отключить
       disable_two_factor_authentication: Отключить 2FA
@@ -69,6 +70,7 @@ ru:
       domain: Домен
       edit: Изменить
       email: E-mail
+      email_status: Статус электронной почты
       enable: Включить
       enabled: Включен
       feed_url: URL фида
@@ -106,6 +108,10 @@ ru:
       public: Публичный
       push_subscription_expires: Подписка PuSH истекает
       redownload: Обновить аватар
+      resend_confirmation:
+        already_confirmed: Этот пользователь уже подтвержден
+        send: Повторно отправить подтверждение по электронной почте
+        success: Письмо с подтверждением успешно отправлено!
       reset: Сбросить
       reset_password: Сбросить пароль
       resubscribe: Переподписаться

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -70,6 +70,7 @@ sk:
         title: Zmeň email pre %{username}
       confirm: Potvrdiť
       confirmed: Potvrdený
+      confirming: Potvrdzujúci
       demote: Degradovať
       disable: Zablokovať
       disable_two_factor_authentication: Zakázať 2FA
@@ -78,6 +79,7 @@ sk:
       domain: Doména
       edit: Upraviť
       email: Email
+      email_status: Stav Email
       enable: Povoliť
       enabled: Povolený
       feed_url: URL časovej osi
@@ -116,6 +118,10 @@ sk:
       push_subscription_expires: PuSH odoberanie expiruje
       redownload: Obnoviť avatar
       remove_avatar: Odstrániť avatár
+      resend_confirmation:
+        already_confirmed: Tento používateľ už bol potvrdený
+        send: Znova odoslať potvrdzovací e-mail
+        success: Potvrdený e-mail bol úspešne odoslaný!
       reset: Reset
       reset_password: Obnoviť heslo
       resubscribe: Znovu odoberať

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -61,6 +61,7 @@ sr-Latn:
       by_domain: Domen
       confirm: Potvrdi
       confirmed: Potvrđeno
+      confirming: Potvrđujući
       demote: Ražaluj
       disable: Isključi
       disable_two_factor_authentication: Isključi 2FA
@@ -69,6 +70,7 @@ sr-Latn:
       domain: Domen
       edit: Izmeni
       email: E-pošta
+      email_status: Status e-pošte
       enable: Uključi
       enabled: Uključeno
       feed_url: Adresa dovoda
@@ -106,6 +108,10 @@ sr-Latn:
       public: Javno
       push_subscription_expires: PuSH subscription expires
       redownload: Osveži avatar
+      resend_confirmation:
+        already_confirmed: Ovaj korisnik je već potvrđen
+        send: Ponovo pošaljite e-poruku za potvrdu
+        success: E-mail potvrde je uspešno poslat!
       reset: Resetuj
       reset_password: Resetuj lozinku
       resubscribe: Ponovo se pretplati

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -61,6 +61,7 @@ sr:
       by_domain: Домен
       confirm: Потврди
       confirmed: Потврђено
+      confirming: Потврдување
       demote: Ражалуј
       disable: Искључи
       disable_two_factor_authentication: Искључи 2FA
@@ -69,6 +70,7 @@ sr:
       domain: Домен
       edit: Измени
       email: Е-пошта
+      email_status: Е-пошта статус
       enable: Укључи
       enabled: Укључено
       feed_url: Адреса довода
@@ -106,6 +108,10 @@ sr:
       public: Јавно
       push_subscription_expires: PuSH subscription expires
       redownload: Освежи аватар
+      resend_confirmation:
+        already_confirmed: Овој корисник е веќе потврден
+        send: Препрати го е-мајлот за потврда
+        success: Е-пошта за потврда успешно испратена!
       reset: Ресетуј
       reset_password: Ресетуј лозинку
       resubscribe: Поново се претплати

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -70,6 +70,7 @@ sv:
         title: Byt E-postadress för %{username}
       confirm: Bekräfta
       confirmed: Bekräftad
+      confirming: Bekräftande
       demote: Degradera
       disable: inaktivera
       disable_two_factor_authentication: Inaktivera 2FA
@@ -78,6 +79,7 @@ sv:
       domain: Domän
       edit: Redigera
       email: E-post
+      email_status: E-poststatus
       enable: Aktivera
       enabled: Aktiverad
       feed_url: Flödes URL
@@ -116,6 +118,10 @@ sv:
       push_subscription_expires: PuSH-prenumerationen löper ut
       redownload: Uppdatera avatar
       remove_avatar: Ta bort avatar
+      resend_confirmation:
+        already_confirmed: Den här användaren är redan bekräftad
+        send: Skicka om e-postbekräftelse
+        success: Bekräftelsemeddelande skickas framgångsrikt!
       reset: Återställ
       reset_password: Återställ lösenord
       resubscribe: Starta en ny prenumeration

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -29,11 +29,13 @@ th:
       are_you_sure: แน่ใจนะ?
       confirm: ยืนยัน
       confirmed: ยึนยันแล้ว
+      confirming: ยืนยัน
       disable_two_factor_authentication: Disable 2FA
       display_name: ชื่อสำหรับดีสเพล
       domain: โดแมน
       edit: แก้ไข
       email: อีเมล์
+      email_status: สถานะอีเมล
       feed_url: Feed URL
       followers: ผู้ติดตาม
       follows: ติดตาม
@@ -59,6 +61,10 @@ th:
       profile_url: Profile URL
       public: สาธารณะ
       push_subscription_expires: PuSH subscription expires
+      resend_confirmation:
+        already_confirmed: ผู้ใช้รายนี้ได้รับการยืนยันแล้ว
+        send: ส่งอีเมลยืนยันอีกครั้ง
+        success: ยืนยันอีเมลเรียบร้อยแล้ว!
       reset_password: รีเซ็ตรหัสผ่าน
       salmon_url: Salmon URL
       show:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -29,10 +29,12 @@ tr:
       are_you_sure: Emin misiniz?
       confirm: Onayla
       confirmed: Onaylandı
+      confirming: Onaylama
       display_name: Görünen adınız
       domain: Sunucu
       edit: Düzenle
       email: E-posta
+      email_status: Email Durumu
       feed_url: Besleme linki
       followers: Takipçiler
       follows: Takip edilen
@@ -58,6 +60,10 @@ tr:
       profile_url: Profil linki
       public: Herkese açık
       push_subscription_expires: PuSH aboneliği dolumu
+      resend_confirmation:
+        already_confirmed: Bu kullanıcı zaten onaylandı
+        send: Doğrulama epostasını yeniden gönder
+        success: Onay e-postası başarıyla gönderildi!
       reset_password: Parolayı değiştir
       salmon_url: Salmon Linki
       show:

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -61,6 +61,7 @@ zh-CN:
       by_domain: 域名
       confirm: 确认
       confirmed: 已确认
+      confirming: 确认
       demote: 降任
       disable: 停用
       disable_two_factor_authentication: 停用双重认证
@@ -69,6 +70,7 @@ zh-CN:
       domain: 域名
       edit: 编辑
       email: 电子邮件地址
+      email_status: 电子邮件状态
       enable: 启用
       enabled: 已启用
       feed_url: 订阅 URL
@@ -106,6 +108,10 @@ zh-CN:
       public: 公开页面
       push_subscription_expires: PuSH 订阅过期时间
       redownload: 刷新头像
+      resend_confirmation:
+        already_confirmed: 该用户已被确认
+        send: 重发确认邮件
+        success: 确认电子邮件成功发送！
       reset: 重置
       reset_password: 重置密码
       resubscribe: 重新订阅

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -70,6 +70,7 @@ zh-HK:
         title: 改變 %{username} 的電郵
       confirm: 確定
       confirmed: 已確定
+      confirming: 確定
       demote: 降任
       disable: 停用
       disable_two_factor_authentication: 停用雙重認證
@@ -78,6 +79,7 @@ zh-HK:
       domain: 域名
       edit: 編輯
       email: 電郵地址
+      email_status: 电子邮件状态
       enable: 啟用
       enabled: 已啟用
       feed_url: Feed URL
@@ -116,6 +118,10 @@ zh-HK:
       push_subscription_expires: PuSH 訂閱過期
       redownload: 更新頭像
       remove_avatar: 取消頭像
+      resend_confirmation:
+        already_confirmed: 该用户已被确认
+        send: 重发确认邮件
+        success: 确认电子邮件成功发送！
       reset: 重設
       reset_password: 重設密碼
       resubscribe: 重新訂閱

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,8 +155,13 @@ Rails.application.routes.draw do
       resource :reset, only: [:create]
       resource :silence, only: [:create, :destroy]
       resource :suspension, only: [:create, :destroy]
-      resource :confirmation, only: [:create]
-      resources :statuses, only: [:index, :create]
+      resources :statuses, only: [:index, :create, :update, :destroy]
+
+      resource :confirmation, only: [:create] do
+        collection do
+          post :resend
+        end
+      end
 
       resource :role do
         member do

--- a/spec/controllers/admin/confirmations_controller_spec.rb
+++ b/spec/controllers/admin/confirmations_controller_spec.rb
@@ -30,4 +30,35 @@ RSpec.describe Admin::ConfirmationsController, type: :controller do
       expect(response).to have_http_status(404)
     end
   end
+
+  describe 'POST #resernd' do
+    subject { post :resend, params: { account_id: account.id } }
+
+    let(:account) { Fabricate(:account) }
+    let!(:user) { Fabricate(:user, confirmed_at: confirmed_at, account: account) }
+
+    before do
+      allow(UserMailer).to receive(:confirmation_instructions) { double(:email, deliver_later: nil) }
+    end
+
+    context 'when email is not confirmed' do
+      let(:confirmed_at) { nil }
+
+      it 'resends confirmation mail' do
+        expect(subject).to redirect_to admin_accounts_path
+        expect(flash[:notice]).to eq I18n.t('admin.accounts.resend_confirmation.success')
+        expect(UserMailer).to have_received(:confirmation_instructions).once
+      end
+    end
+
+    context 'when email is confirmed' do
+      let(:confirmed_at) { Time.zone.now }
+
+      it 'does not resend confirmation mail' do
+        expect(subject).to redirect_to admin_accounts_path
+        expect(flash[:error]).to eq I18n.t('admin.accounts.resend_confirmation.already_confirmed')
+        expect(UserMailer).not_to have_received(:confirmation_instructions)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Addressed this issue: https://github.com/tootsuite/mastodon/issues/7333

I added resending confirmation feature for admin user.
Thanks! 👍 