### PR TITLE
Improve OpenStack v3 compatibility

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -113,6 +113,8 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # For Keystone V3, the value for SWIFT_TENANT should be the project name
 # SWIFT_TENANT=
 # SWIFT_PASSWORD=
+# Some OpenStack V3 providers require PROJECT_ID (optional)
+# SWIFT_PROJECT_ID=
 # Keystone V2 and V3 URLs are supported. Use a V3 URL if possible to avoid
 # issues with token rate-limiting during high load.
 # SWIFT_AUTH_URL=

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -60,7 +60,7 @@ elsif ENV['SWIFT_ENABLED'] == 'true'
     fog_credentials: {
       provider: 'OpenStack',
       openstack_username: ENV['SWIFT_USERNAME'],
-      openstack_project_id: ENV.has_key?('SWIFT_PROJECT_ID') ? ENV['SWIFT_PROJECT_ID'] : nil,
+      openstack_project_id: ENV['SWIFT_PROJECT_ID'],
       openstack_project_name: ENV['SWIFT_TENANT'],
       openstack_tenant: ENV['SWIFT_TENANT'], # Some OpenStack-v2 ignores project_name but needs tenant
       openstack_api_key: ENV['SWIFT_PASSWORD'],

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -60,6 +60,7 @@ elsif ENV['SWIFT_ENABLED'] == 'true'
     fog_credentials: {
       provider: 'OpenStack',
       openstack_username: ENV['SWIFT_USERNAME'],
+      openstack_project_id: ENV.has_key?('SWIFT_PROJECT_ID') ? ENV['SWIFT_PROJECT_ID'] : nil,
       openstack_project_name: ENV['SWIFT_TENANT'],
       openstack_tenant: ENV['SWIFT_TENANT'], # Some OpenStack-v2 ignores project_name but needs tenant
       openstack_api_key: ENV['SWIFT_PASSWORD'],


### PR DESCRIPTION
For OpenStack V3 to work with some providers it is required to provide Project ID. 