### PR TITLE
Fix hashtags not being federated on mentions (fixes #6900)

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -35,8 +35,8 @@ class PostStatusService < BaseService
                                         application: options[:application])
     end
 
-    process_mentions_service.call(status)
     process_hashtags_service.call(status)
+    process_mentions_service.call(status)
 
     LinkCrawlWorker.perform_async(status.id) unless status.spoiler_text?
     DistributionWorker.perform_async(status.id)


### PR DESCRIPTION
Statuses are serialized and sent to mentioned users in `process_mentions`, but hashtags aren't processed yet at that point…