### PR TITLE
Store the first supported Actor type in actor_type

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -71,7 +71,7 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.note                    = @json['summary'] || ''
     @account.locked                  = @json['manuallyApprovesFollowers'] || false
     @account.fields                  = property_values || {}
-    @account.actor_type              = @json['type']
+    @account.actor_type              = actor_type
   end
 
   def set_fetchable_attributes!
@@ -94,6 +94,14 @@ class ActivityPub::ProcessAccountService < BaseService
 
   def check_featured_collection!
     ActivityPub::SynchronizeFeaturedCollectionWorker.perform_async(@account.id)
+  end
+
+  def actor_type
+    if @json['type'].is_a?(Array)
+      @json['type'].find { |type| ActivityPub::FetchRemoteAccountService::SUPPORTED_TYPES.include?(type) }
+    else
+      @json['type']
+    end
   end
 
   def image_url(key)

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe ResolveAccountService, type: :service do
         expect(account.activitypub?).to eq true
         expect(account.domain).to eq 'ap.example.com'
         expect(account.inbox_url).to eq 'https://ap.example.com/users/foo/inbox'
+        expect(account.actor_type).to eq 'Person'
       end
     end
 


### PR DESCRIPTION
This changes ProcessAccountService to set the actor_type to the first recognized Actor type in the JSON-LD document.

When an Actor has multiple types, this avoids storing it as the stringification of an Array and allows Actors with multiple types to be recognized as bots if they have Service or Application as the first standard ActivityStreams Actor type in the type property.

I've also updated the example in the specs for resolving accounts with multiple accounts to check that for an Actor with `["Person","vcard:individual"]` as its type, the `actor_type` attribute on the Account gets set to "Person".