### PR TITLE
Do not crash in getStatusIds when there is a gap in the timeline (fixes #7400)

### DIFF
--- a/app/javascript/mastodon/features/ui/containers/status_list_container.js
+++ b/app/javascript/mastodon/features/ui/containers/status_list_container.js
@@ -21,6 +21,8 @@ const makeGetStatusIds = () => createSelector([
   }
 
   return statusIds.filter(id => {
+    if (id === null) return true;
+
     const statusForId = statuses.get(id);
     let showStatus    = true;
 


### PR DESCRIPTION
Fixes a crash occurring when the “gap” disconnection indicator is to be
displayed in a filtered timeline.