### PR TITLE
Disable simplecov on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ aliases:
             command: ./bin/rails parallel:create parallel:load_schema parallel:prepare
         - run:
             name: Run Tests
-            command: ./bin/retry bundle exec parallel_test ./spec/ --group-by filesize --type rspec --format progress
+            command: ./bin/retry bundle exec parallel_test ./spec/ --group-by filesize --type rspec
 
 jobs:
   install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ aliases:
           RAILS_ENV: test
           PARALLEL_TEST_PROCESSORS: 4
           ALLOW_NOPAM: true
+          DISABLE_SIMPLECOV: true
     working_directory: ~/projects/mastodon/
 
   - &attach_workspace
@@ -90,7 +91,7 @@ aliases:
             command: ./bin/rails parallel:create parallel:load_schema parallel:prepare
         - run:
             name: Run Tests
-            command: ./bin/retry bundle exec parallel_test ./spec/ --group-by filesize --type rspec
+            command: ./bin/retry bundle exec parallel_test ./spec/ --group-by filesize --type rspec --format progress
 
 jobs:
   install:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
-require 'simplecov'
-
 GC.disable
 
-SimpleCov.start 'rails' do
-  add_group 'Services', 'app/services'
-  add_group 'Presenters', 'app/presenters'
-  add_group 'Validators', 'app/validators'
+if ENV['DISABLE_SIMPLECOV'] != 'true'
+  require 'simplecov'
+  SimpleCov.start 'rails' do
+    add_group 'Services', 'app/services'
+    add_group 'Presenters', 'app/presenters'
+    add_group 'Validators', 'app/validators'
+  end
 end
 
 gc_counter = -1


### PR DESCRIPTION
`parallel_test` does not correctly generate coverage using `simplecov`. Disable `simplecov` on CircleCI to avoid unnecessary processing.
