### PR TITLE
Add devise_pam_authenticatable2 to testgroup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ aliases:
 
         - run: ruby -e 'puts RUBY_VERSION' | tee /tmp/.ruby-version
         - *restore_ruby_dependencies
-        - run: bundle install --clean --jobs 16 --path ./vendor/bundle/ --retry 3 --with pam_authentication --without development production
+        - run: bundle install --clean --jobs 16 --path ./vendor/bundle/ --retry 3 --without development production
         - save_cache:
             key: v2-ruby-dependencies-{{ checksum "/tmp/.ruby-version" }}-{{ checksum "Gemfile.lock" }}
             paths:

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'devise', '~> 4.4'
 gem 'devise-two-factor', '~> 3.0'
 
 group :pam_authentication, optional: true do
-  gem 'devise_pam_authenticatable2', '~> 9.1'
+  gem 'devise_pam_authenticatable2', '~> 9.1', group: :test
 end
 
 gem 'net-ldap', '~> 0.10'


### PR DESCRIPTION
Since `devise_pam_authenticatable2` is used in test, it changed to belong to the test group. It is installed when `--without test` is not specified or when `--with pam_authentication` is specified. That is, `devise_pam_authenticatable2` will be installed if both are specified.

related: #7147