### PR TITLE
fix RuboCop error

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,6 +30,7 @@ plugins:
     channel: eslint-4
   rubocop:
     enabled: true
+    channel: rubocop-0-54
   scss-lint:
     enabled: true
 exclude_patterns:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,5 +107,8 @@ Style/RegexpLiteral:
 Style/SymbolArray:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: 'comma'
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: 'comma'


### PR DESCRIPTION
RuboCop doesn't work by following error.

```
$ rubocop
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in .rubocop.yml, please update it)
```

it comes from RuboCop 0.53.0 [\[Fix #3394\] Separate Array & Hash Literal Comma configuration by garettarrowood · Pull Request #5307 · bbatsov/rubocop](https://github.com/bbatsov/rubocop/pull/5307)