### PR TITLE
Update uws dependency to 10.148.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "throng": "^4.0.0",
     "tiny-queue": "^0.2.1",
     "uuid": "^3.1.0",
-    "uws": "^8.14.0",
+    "uws": "^10.148.0",
     "webpack": "^3.9.1",
     "webpack-bundle-analyzer": "^2.9.1",
     "webpack-manifest-plugin": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7526,9 +7526,9 @@ uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
-uws@^8.14.0:
-  version "8.14.1"
-  resolved "https://registry.yarnpkg.com/uws/-/uws-8.14.1.tgz#de09619f305f6174d5516a9c6942cb120904b20b"
+uws@^10.148.0:
+  version "10.148.0"
+  resolved "https://registry.yarnpkg.com/uws/-/uws-10.148.0.tgz#3fcd35f083ca515e091cd33b2d78f0f51a666215"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This release fixes issues with open events, adds Node 10 support
and drops Node 4, 5, 6 and 7. This fixes running the streaming
server on Arch and other distros that ship node 10.

Changes: https://github.com/elementengineering/uWebSockets-bindings/compare/6152fb6787704a61584f920eb27ff5441d3c8c8f...689c15c59e5065b22415266f398ed29118dbe562