### PR TITLE
Improvements to toots display in admin view

### DIFF
--- a/app/helpers/admin/account_moderation_notes_helper.rb
+++ b/app/helpers/admin/account_moderation_notes_helper.rb
@@ -10,10 +10,16 @@ module Admin::AccountModerationNotesHelper
     end
   end
 
+  def admin_account_inline_link_to(account)
+    link_to admin_account_path(account.id), class: name_tag_classes(account, true) do
+      content_tag(:span, account.acct, class: 'username')
+    end
+  end
+
   private
 
-  def name_tag_classes(account)
-    classes = ['name-tag']
+  def name_tag_classes(account, inline = false)
+    classes = [inline ? 'inline-name-tag' : 'name-tag']
     classes << 'suspended' if account.suspended?
     classes.join(' ')
   end

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -484,18 +484,11 @@
 }
 
 a.name-tag,
-.name-tag {
-  display: flex;
-  align-items: center;
+.name-tag,
+a.inline-name-tag,
+.inline-name-tag {
   text-decoration: none;
   color: $secondary-text-color;
-
-  .avatar {
-    display: block;
-    margin: 0;
-    margin-right: 5px;
-    border-radius: 50%;
-  }
 
   .username {
     font-weight: 500;
@@ -507,6 +500,26 @@ a.name-tag,
       color: lighten($error-red, 12%);
     }
 
+    .avatar {
+      filter: grayscale(100%);
+      opacity: 0.8;
+    }
+  }
+}
+
+a.name-tag,
+.name-tag {
+  display: flex;
+  align-items: center;
+
+  .avatar {
+    display: block;
+    margin: 0;
+    margin-right: 5px;
+    border-radius: 50%;
+  }
+
+  &.suspended {
     .avatar {
       filter: grayscale(100%);
       opacity: 0.8;

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -1,3 +1,9 @@
+@keyframes Swag {
+  0% { background-position: 0% 0%; }
+  50% { background-position: 100% 0%; }
+  100% { background-position: 200% 0%; }
+}
+
 .table {
   width: 100%;
   max-width: 100%;
@@ -187,6 +193,11 @@ a.table-action-link {
 
     strong {
       font-weight: 700;
+      background: linear-gradient(to right, orange , yellow, green, cyan, blue, violet,orange , yellow, green, cyan, blue, violet);
+      background-size: 200% 100%;
+      background-clip: text;
+      color: transparent;
+      animation: Swag 2s linear 0s infinite;
     }
   }
 }

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -3,26 +3,30 @@
     = f.check_box :status_ids, { multiple: true, include_hidden: false }, status.id
   .batch-table__row__content
     .status__content><
-      - unless status.spoiler_text.blank?
+      - unless status.proper.spoiler_text.blank?
         %p><
-          %strong= Formatter.instance.format_spoiler(status)
+          %strong= Formatter.instance.format_spoiler(status.proper)
 
-      = Formatter.instance.format(status, custom_emojify: true)
+      = Formatter.instance.format(status.proper, custom_emojify: true)
 
-    - unless status.media_attachments.empty?
-      - if status.media_attachments.first.video?
-        - video = status.media_attachments.first
-        = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: status.sensitive? && !current_account&.user&.setting_display_sensitive_media, width: 610, height: 343, inline: true
+    - unless status.proper.media_attachments.empty?
+      - if status.proper.media_attachments.first.video?
+        - video = status.proper.media_attachments.first
+        = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: status.proper.sensitive? && !current_account&.user&.setting_display_sensitive_media, width: 610, height: 343, inline: true
       - else
-        = react_component :media_gallery, height: 343, sensitive: status.sensitive? && !current_account&.user&.setting_display_sensitive_media, 'autoPlayGif': current_account&.user&.setting_auto_play_gif, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json }
+        = react_component :media_gallery, height: 343, sensitive: status.proper.sensitive? && !current_account&.user&.setting_display_sensitive_media, 'autoPlayGif': current_account&.user&.setting_auto_play_gif, media: status.proper.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json }
 
     .detailed-status__meta
       = link_to TagManager.instance.url_for(status), class: 'detailed-status__datetime', target: stream_link_target, rel: 'noopener' do
         %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
       ·
-      = fa_visibility_icon(status)
-      = t("statuses.visibilities.#{status.visibility}")
-      - if status.sensitive?
+      - if status.reblog?
+        = fa_icon('retweet fw')
+        = t('statuses.boosted_from_html', acct_link: admin_account_inline_link_to(status.proper.account))
+      - else
+        = fa_visibility_icon(status)
+        = t("statuses.visibilities.#{status.visibility}")
+      - if status.proper.sensitive?
         ·
         = fa_icon('eye-slash fw')
         = t('stream_entries.sensitive_content')

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -5,10 +5,9 @@
     .status__content><
       - unless status.proper.spoiler_text.blank?
         %p><
-          %strong> #{Formatter.instance.format_spoiler(status.proper)}&nbsp;
-          %a.status__content__spoiler-link{ href: '#' }= t('statuses.show_more')
+          %strong> Content warning: #{Formatter.instance.format_spoiler(status.proper)}
 
-      .e-content{ lang: status.language, style: "display: block; direction: #{rtl_status?(status) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status.proper, custom_emojify: true)
+      = Formatter.instance.format(status.proper, custom_emojify: true)
 
     - unless status.proper.media_attachments.empty?
       - if status.proper.media_attachments.first.video?

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -5,9 +5,10 @@
     .status__content><
       - unless status.proper.spoiler_text.blank?
         %p><
-          %strong= Formatter.instance.format_spoiler(status.proper)
+          %strong> #{Formatter.instance.format_spoiler(status.proper)}&nbsp;
+          %a.status__content__spoiler-link{ href: '#' }= t('statuses.show_more')
 
-      = Formatter.instance.format(status.proper, custom_emojify: true)
+      .e-content{ lang: status.language, style: "display: block; direction: #{rtl_status?(status) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status.proper, custom_emojify: true)
 
     - unless status.proper.media_attachments.empty?
       - if status.proper.media_attachments.first.video?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -682,6 +682,7 @@ en:
       video:
         one: "%{count} video"
         other: "%{count} videos"
+    boosted_from_html: Boosted from %{acct_link}
     content_warning: 'Content warning: %{warning}'
     disallowed_hashtags:
       one: 'contained a disallowed hashtag: %{tags}'


### PR DESCRIPTION
* Shows “Boosted from [link to admin view of original account]” for boosted toots and show proper media/CW/sensitive status

![screenshot-2018-5-11 etat du compte - thib - mastodon instance perso de thibg](https://user-images.githubusercontent.com/384364/39940627-30762f86-555a-11e8-9fdc-ad1aff25cf44.png)

* Restore “show more” button from public views to make CW usage clearer (though content is initially unfolded)

![screenshot-2018-5-11 etat du compte - thib - mastodon instance perso de thibg 1](https://user-images.githubusercontent.com/384364/39940672-5e3641ae-555a-11e8-8a9e-fc5e65cc0838.png)