### PR TITLE
Add dependencies for uWebSockets

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -5,6 +5,8 @@ libidn11
 libidn11-dev
 libpq-dev
 libprotobuf-dev
+libssl-dev
 libxdamage1
 libxfixes3
 protobuf-compiler
+zlib1g-dev


### PR DESCRIPTION
UWS needs openssl and zlib. FYI: https://github.com/uNetworking/uWebSockets/wiki/Misc.-details#dependencies