### PR TITLE
Improve index on statuses for api/v1/accounts account_id statuses

### DIFF
--- a/db/migrate/20180514130000_improve_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
+++ b/db/migrate/20180514130000_improve_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ImproveIndexOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :statuses, [:account_id, :id, :visibility], where: 'visibility IN (0, 1, 2)', algorithm: :concurrently
+    add_index :statuses, [:account_id, :id], where: 'visibility = 3', algorithm: :concurrently
+    remove_index :statuses, column: [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_10_230049) do
+ActiveRecord::Schema.define(version: 2018_05_14_130000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -447,7 +447,8 @@ ActiveRecord::Schema.define(version: 2018_05_10_230049) do
     t.bigint "account_id", null: false
     t.bigint "application_id"
     t.bigint "in_reply_to_account_id"
-    t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20180106", order: { id: :desc }
+    t.index ["account_id", "id", "visibility"], name: "index_statuses_on_account_id_and_id_and_visibility", where: "(visibility = ANY (ARRAY[0, 1, 2]))"
+    t.index ["account_id", "id"], name: "index_statuses_on_account_id_and_id", where: "(visibility = 3)"
     t.index ["conversation_id"], name: "index_statuses_on_conversation_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["reblog_of_id", "account_id"], name: "index_statuses_on_reblog_of_id_and_account_id"


### PR DESCRIPTION
Queries with the combination of account_id, id, and visibility can be
categorized in three types:
1. Querying for public and unlisted to enumerate statuses visible to
anyone.
2. Querying for public, unlisted, and private to enumerate statuses
visible to follower.
3. Querying for direct to enumerate own direct statuses.

1 and 2 is covered by the index with condition 'visibility IN (0, 1, 2)'.
It would bring better performance in case that there are many direct
statuses.

The index with condition 'visibility = 3' is just for 3. It would be much
faster to query direct statuses thanks to this query.

The total size of those two indexes are expected to be smaller than the
deleted one because they are partial and does not have to cover all the
table.

In case of Pawoo, index with condition 'visibility IN (0, 1, 2)' costed 2.8 GB while the removed index costed 3.5GB. The index with condition 'visibility = 3' is not created as it has no benefit without direct column.