### PR TITLE
Revert index change on statuses for api/v1/accounts account_id statuses

### DIFF
--- a/db/migrate/20180514140000_revert_index_change_on_statuses_for_api_v1_accounts_account_id_statuses.rb
+++ b/db/migrate/20180514140000_revert_index_change_on_statuses_for_api_v1_accounts_account_id_statuses.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RevertIndexChangeOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      add_index :statuses, [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106
+    end
+
+    remove_index :statuses, column: [:account_id, :id, :visibility], where: 'visibility IN (0, 1, 2)', algorithm: :concurrently
+    remove_index :statuses, column: [:account_id, :id], where: 'visibility = 3', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_14_130000) do
+ActiveRecord::Schema.define(version: 2018_05_14_140000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -447,8 +447,7 @@ ActiveRecord::Schema.define(version: 2018_05_14_130000) do
     t.bigint "account_id", null: false
     t.bigint "application_id"
     t.bigint "in_reply_to_account_id"
-    t.index ["account_id", "id", "visibility"], name: "index_statuses_on_account_id_and_id_and_visibility", where: "(visibility = ANY (ARRAY[0, 1, 2]))"
-    t.index ["account_id", "id"], name: "index_statuses_on_account_id_and_id", where: "(visibility = 3)"
+    t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20180106", order: { id: :desc }
     t.index ["conversation_id"], name: "index_statuses_on_conversation_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["reblog_of_id", "account_id"], name: "index_statuses_on_reblog_of_id_and_account_id"


### PR DESCRIPTION
The altered index does not cover the following query:
```SQL
SELECT "statuses"."id", "statuses"."updated_at" FROM "statuses" WHERE "statuses"."account_id" = ? ORDER BY "statuses"."id" DESC LIMIT 20;
```

Reverting the change will solve the problem.