### PR TITLE
Fix account URI when updating ActivityPub account

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -44,7 +44,6 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.protocol    = :activitypub
     @account.username    = @username
     @account.domain      = @domain
-    @account.uri         = @uri
     @account.suspended   = true if auto_suspend?
     @account.silenced    = true if auto_silence?
     @account.private_key = nil
@@ -67,6 +66,7 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.followers_url           = @json['followers'] || ''
     @account.featured_collection_url = @json['featured'] || ''
     @account.url                     = url || @uri
+    @account.uri                     = @uri
     @account.display_name            = @json['name'] || ''
     @account.note                    = @json['summary'] || ''
     @account.locked                  = @json['manuallyApprovesFollowers'] || false


### PR DESCRIPTION
Updates account `uri` field on each call to `update_account` instead of only once during `create_account` to mirror the same behavior in OStatus [`ResolveAccountService` class][0].

ActivityPub accounts are identified using `@username` and `@domain` pair instead of URI since #6842.

This fixes a bug when the account identified by `@username` and `@domain` changes its URI (#7479).

[0]:
https://github.com/tootsuite/mastodon/blob/03b69ebc450efc07246bd64204276941b7ede3fc/app/services/resolve_account_service.rb#L121