### PR TITLE
Test if navigator.storage.estimate exists before using it

### DIFF
--- a/app/javascript/mastodon/storage/modifier.js
+++ b/app/javascript/mastodon/storage/modifier.js
@@ -184,7 +184,8 @@ export function putStatuses(records) {
 export function freeStorage() {
   // navigator.storage is not present on:
   // Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.100 Safari/537.36 Edge/16.16299
-  return 'storage' in navigator && navigator.storage.estimate().then(({ quota, usage }) => {
+  // estimate method is not present on Chrome 57.0.2987.98 on Linux.
+  return 'storage' in navigator && 'estimate' in navigator.storage && navigator.storage.estimate().then(({ quota, usage }) => {
     if (usage + storageMargin < quota) {
       return null;
     }


### PR DESCRIPTION
Not tested as I do not have the affected browser. See:
https://github.com/tootsuite/mastodon/issues/7430#issuecomment-389213223