### PR TITLE
Update bot preference text

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -4,7 +4,7 @@ en:
     hints:
       defaults:
         avatar: PNG, GIF or JPG. At most 2MB. Will be downscaled to 400x400px
-        bot: Warns people that the account does not represent a person
+        bot: Indicates that this account exhibits automated behavior
         digest: Only sent after a long period of inactivity and only if you have received any personal messages in your absence
         display_name:
           one: <span class="name-counter">1</span> character left

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -4,7 +4,7 @@ en:
     hints:
       defaults:
         avatar: PNG, GIF or JPG. At most 2MB. Will be downscaled to 400x400px
-        bot: Indicates that this account exhibits automated behavior
+        bot: This account mainly performs automated actions and might not be monitored
         digest: Only sent after a long period of inactivity and only if you have received any personal messages in your absence
         display_name:
           one: <span class="name-counter">1</span> character left


### PR DESCRIPTION
1. this change makes the wording more neutral—with the recent discourse around quote unquote russian bots, there's no reason to play into that and suggest that we need to be "warned", as if bots were a bad thing to have on your network.
   -  (a compromise here may be "flags this account as performing automated actions or behavior")
2. many accounts, like meetup, event, or brand accounts, do not represent persons but should not use the "bot" badge. see also colloquial use of "russian bots", as above, fabricated personas that don't represent people but aren't automated, something we should discourage calling a 'bot'. 
3. it gets to the heart of what we're trying to signal, automated interaction or posting.

see discussion on https://github.com/tootsuite/mastodon/pull/7391