### PR TITLE
Do not use permitted_for scope when querying pinned statuses

### DIFF
--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -27,19 +27,17 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   end
 
   def account_statuses
-    default_statuses.tap do |statuses|
-      statuses.merge!(only_media_scope) if truthy_param?(:only_media)
-      statuses.merge!(pinned_scope) if truthy_param?(:pinned)
-      statuses.merge!(no_replies_scope) if truthy_param?(:exclude_replies)
-    end
-  end
-
-  def default_statuses
-    permitted_account_statuses.paginate_by_max_id(
+    statuses = truthy_param?(:pinned) ? pinned_scope : permitted_account_statuses
+    statuses = statuses.paginate_by_max_id(
       limit_param(DEFAULT_STATUSES_LIMIT),
       params[:max_id],
       params[:since_id]
     )
+
+    statuses.merge!(only_media_scope) if truthy_param?(:only_media)
+    statuses.merge!(no_replies_scope) if truthy_param?(:exclude_replies)
+
+    statuses
   end
 
   def permitted_account_statuses


### PR DESCRIPTION
permitted_for scope is slow when combined with pinned status scope.
Fortunately permitted_for scope can safely be removed because a pinned
status is always public.

Here is an example of such a slow query. Note that it is as fast as 160ms because it is cached, but it took 15 seconds in the first query.

```SQL
SELECT  "statuses"."id", "statuses"."updated_at" FROM "statuses" INNER JOIN "status_pins" ON "statuses"."id" = "status_pins"."status_id" WHERE ("statuses"."account_id" = $1 AND "statuses"."visibility" IN (0, 1, 2) OR "statuses"."account_id" = $1 AND "statuses"."id" IN (SELECT "mentions"."status_id" FROM "mentions" WHERE "mentions"."account_id" = $2)) AND (statuses.created_at <= '2018-05-15 11:16:53.081209') AND "status_pins"."account_id" = $1 ORDER BY status_pins.created_at DESC LIMIT 20
```
```
Limit  (cost=44196.30..44196.30 rows=1 width=24) (actual time=160.166..160.167 rows=1 loops=1)
  ->  Sort  (cost=44196.30..44196.30 rows=1 width=24) (actual time=160.165..160.166 rows=1 loops=1)
        Sort Key: status_pins.created_at DESC
        Sort Method: quicksort  Memory: 25kB
        ->  Merge Join  (cost=28004.66..44196.29 rows=1 width=24) (actual time=160.150..160.157 rows=1 loops=1)
              Merge Cond: (statuses.id = status_pins.status_id)
              ->  Index Scan Backward using index_statuses_20180106 on statuses  (cost=27995.81..44173.97 rows=5378 width=16) (actual time=0.042..152.757 rows=30301 loops=1)
                    Index Cond: (account_id = $1)
                    Filter: ((created_at <= '2018-05-15 11:16:53.081209'::timestamp without time zone) AND ((visibility = ANY ('{0,1,2}'::integer[])) OR (hashed SubPlan 1)))
                    Rows Removed by Filter: 1060
                    SubPlan 1
                      ->  Index Only Scan using index_mentions_on_account_id_and_status_id on mentions  (cost=0.56..27962.94 rows=12918 width=8) (actual time=0.052..51.913 rows=16942 loops=1)
                            Index Cond: (account_id = $2)
                            Heap Fetches: 16639
              ->  Sort  (cost=8.85..8.85 rows=2 width=16) (actual time=0.026..0.027 rows=1 loops=1)
                    Sort Key: status_pins.status_id
                    Sort Method: quicksort  Memory: 25kB
                    ->  Bitmap Heap Scan on status_pins  (cost=3.30..8.84 rows=2 width=16) (actual time=0.014..0.021 rows=1 loops=1)
                          Recheck Cond: (account_id = $1)
                          Heap Blocks: exact=2
                          ->  Bitmap Index Scan on index_status_pins_on_account_id_and_status_id  (cost=0.00..3.30 rows=2 width=0) (actual time=0.009..0.009 rows=2 loops=1)
                                Index Cond: (account_id = $1)
Planning time: 0.441 ms
Execution time: 160.360 ms
```