### PR TITLE
Use randomized setTimeout when fallback-polling and re-add since_id

### DIFF
--- a/app/javascript/mastodon/actions/streaming.js
+++ b/app/javascript/mastodon/actions/streaming.js
@@ -36,10 +36,9 @@ export function connectTimelineStream (timelineId, path, pollingRefresh = null) 
   });
 }
 
-function refreshHomeTimelineAndNotification (dispatch) {
-  dispatch(expandHomeTimeline());
-  dispatch(expandNotifications());
-}
+const refreshHomeTimelineAndNotification = (dispatch, done) => {
+  dispatch(expandHomeTimeline({}, () => dispatch(expandNotifications({}, done))));
+};
 
 export const connectUserStream = () => connectTimelineStream('home', 'user', refreshHomeTimelineAndNotification);
 export const connectCommunityStream = () => connectTimelineStream('community', 'public:local');


### PR DESCRIPTION
Fix #7489 

I am not sure why but somehow we stopped using since_id to minimize response load. I have re-added it to notifications and timelines.

Instead of setInterval, polling will now use setTimeout and wait until the previous requests finish before making new ones. Furthermore, a randomized interval between polls will ensure that when streaming API goes down when a lot of people are active, it does not overload the REST API with simultaneous requests from everyone.