### PR TITLE
Ensure unfilled fields are shown when errors are shown

### DIFF
--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -20,6 +20,7 @@ class Settings::ProfilesController < ApplicationController
       ActivityPub::UpdateDistributionWorker.perform_async(@account.id)
       redirect_to settings_profile_path, notice: I18n.t('generic.changes_saved_msg')
     else
+      @account.build_fields
       render :show
     end
   end


### PR DESCRIPTION
Fix #7486