### PR TITLE
exclude-other-silenced-accounts

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -296,7 +296,8 @@ class Status < ApplicationRecord
 
     def account_silencing_filter(account)
       if account.silenced?
-        including_silenced_accounts
+        including_myself = left_outer_joins(:account).where(account_id: account.id).references(:accounts)
+        excluding_silenced_accounts.or(including_myself)
       else
         excluding_silenced_accounts
       end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -537,17 +537,6 @@ RSpec.describe Status, type: :model do
           expect(results).to include(es_status)
         end
       end
-
-      context 'where that account is silenced' do
-        it 'includes statuses from other accounts that are silenced' do
-          @account.update(silenced: true)
-          other_silenced_account = Fabricate(:account, silenced: true)
-          other_status = Fabricate(:status, account: other_silenced_account)
-
-          results = Status.as_public_timeline(@account)
-          expect(results).to include(other_status)
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Now, silenced users can show other silenced user's statuses, why is it necessary?