### PR TITLE
Change Japanese translation for privacy.private.short

### DIFF
--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -211,7 +211,7 @@
   "privacy.direct.long": "メンションしたユーザーだけに公開",
   "privacy.direct.short": "ダイレクト",
   "privacy.private.long": "フォロワーだけに公開",
-  "privacy.private.short": "非公開",
+  "privacy.private.short": "フォロワー限定",
   "privacy.public.long": "公開TLに投稿する",
   "privacy.public.short": "公開",
   "privacy.unlisted.long": "公開TLで表示しない",


### PR DESCRIPTION
The old translation means "hidden," but it is vague in terms that it does
not specify the scope status is hidden. The new translation is a literal
translation of "Followers-only," without such ambiguity.

See also https://github.com/tootsuite/mastodon/pull/2538#issue-117991491, which questions the old translation, too. This is my longstanding question. I cannot find an issue/pull request dealing with the translation, so I appreciate if anyone point out something informative.