### PR TITLE
Improve direct message warning again

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -17,11 +17,19 @@ const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning
   if (needsLockWarning) {
     return <Warning message={<FormattedMessage id='compose_form.lock_disclaimer' defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.' values={{ locked: <a href='/settings/profile'><FormattedMessage id='compose_form.lock_disclaimer.lock' defaultMessage='locked' /></a> }} />} />;
   }
+
   if (hashtagWarning) {
     return <Warning message={<FormattedMessage id='compose_form.hashtag_warning' defaultMessage="This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag." />} />;
   }
+
   if (directMessageWarning) {
-    return <Warning message={<FormattedMessage id='compose_form.direct_message_warning' defaultMessage='This toot will only be sent to all the mentioned users. However, the operators of your instance and any receiving instances may see this message.' />} />;
+    const message = (
+      <span>
+        <FormattedMessage id='compose_form.direct_message_warning' defaultMessage='This toot will only be sent to all the mentioned users.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a>
+      </span>
+    );
+
+    return <Warning message={message} />;
   }
 
   return null;

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -60,7 +60,7 @@
   "column_header.unpin": "Unpin",
   "column_subheading.navigation": "Navigation",
   "column_subheading.settings": "Settings",
-  "compose_form.direct_message_warning": "This toot will only be sent to the mentioned users. However, the operators of yours and any of the receiving instances may inspect this message.",
+  "compose_form.direct_message_warning": "This toot will only be sent to the mentioned users.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",


### PR DESCRIPTION
Ref: https://github.com/tootsuite/mastodon/pull/7420#pullrequestreview-120703069

![image](https://user-images.githubusercontent.com/184731/40270043-097faf96-5b87-11e8-8369-d9e49e381055.png)

"Learn more" link opens privacy policy in new tab. Relevant bit is at the top of the policy:

![image](https://user-images.githubusercontent.com/184731/40270048-23aa47b4-5b87-11e8-81a9-5d6d143c433d.png)
