### PR TITLE
Ensure push subscription is immediately removed when application is revoked

### DIFF
--- a/app/controllers/oauth/authorized_applications_controller.rb
+++ b/app/controllers/oauth/authorized_applications_controller.rb
@@ -8,6 +8,11 @@ class Oauth::AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicatio
 
   include Localized
 
+  def destroy
+    Web::PushSubscription.unsubscribe_for(params[:id], current_resource_owner)
+    super
+  end
+
   private
 
   def store_current_location

--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Oauth::TokensController < Doorkeeper::TokensController
+  def revoke
+    unsubscribe_for_token if authorized? && token.accessible?
+    super
+  end
+
+  private
+
+  def unsubscribe_for_token
+    Web::PushSubscription.where(access_token_id: token.id).delete_all
+  end
+end

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -50,6 +50,15 @@ class Web::PushSubscription < ApplicationRecord
                                end
   end
 
+  class << self
+    def unsubscribe_for(application_id, resource_owner)
+      access_token_ids = Doorkeeper::AccessToken.where(application_id: application_id, resource_owner_id: resource_owner.id, revoked_at: nil)
+                                                .pluck(:id)
+
+      where(access_token_id: access_token_ids).delete_all
+    end
+  end
+
   private
 
   def push_payload(message, ttl = 5.minutes.seconds)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ Rails.application.routes.draw do
   end
 
   use_doorkeeper do
-    controllers authorizations: 'oauth/authorizations', authorized_applications: 'oauth/authorized_applications'
+    controllers authorizations: 'oauth/authorizations',
+                authorized_applications: 'oauth/authorized_applications',
+                tokens: 'oauth/tokens'
   end
 
   get '.well-known/host-meta', to: 'well_known/host_meta#show', as: :host_meta, defaults: { format: 'xml' }

--- a/spec/controllers/oauth/authorized_applications_controller_spec.rb
+++ b/spec/controllers/oauth/authorized_applications_controller_spec.rb
@@ -39,4 +39,24 @@ describe Oauth::AuthorizedApplicationsController do
       include_examples 'stores location for user'
     end
   end
+
+  describe 'DELETE #destroy' do
+    let!(:user) { Fabricate(:user) }
+    let!(:application) { Fabricate(:application) }
+    let!(:access_token) { Fabricate(:accessible_access_token, application: application, resource_owner_id: user.id) }
+    let!(:web_push_subscription) { Fabricate(:web_push_subscription, user: user, access_token: access_token) }
+
+    before do
+      sign_in user, scope: :user
+      post :destroy, params: { id: application.id }
+    end
+
+    it 'revokes access tokens for the application' do
+      expect(Doorkeeper::AccessToken.where(application: application).first.revoked_at).to_not be_nil
+    end
+
+    it 'removes subscriptions for the application\'s access tokens' do
+      expect(Web::PushSubscription.where(user: user).count).to eq 0
+    end
+  end
 end

--- a/spec/controllers/oauth/tokens_controller_spec.rb
+++ b/spec/controllers/oauth/tokens_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Oauth::TokensController, type: :controller do
+  describe 'POST #revoke' do
+    let!(:user) { Fabricate(:user) }
+    let!(:access_token) { Fabricate(:accessible_access_token, resource_owner_id: user.id) }
+    let!(:web_push_subscription) { Fabricate(:web_push_subscription, user: user, access_token: access_token) }
+
+    before do
+      post :revoke, params: { token: access_token.token }
+    end
+
+    it 'revokes the token' do
+      expect(access_token.reload.revoked_at).to_not be_nil
+    end
+
+    it 'removes web push subscription for token' do
+      expect(Web::PushSubscription.where(access_token: access_token).count).to eq 0
+    end
+  end
+end

--- a/spec/fabricators/web_push_subscription_fabricator.rb
+++ b/spec/fabricators/web_push_subscription_fabricator.rb
@@ -1,4 +1,4 @@
-Fabricator(:web_push_subscription) do
+Fabricator(:web_push_subscription, from: Web::PushSubscription) do
   endpoint   Faker::Internet.url
   key_p256dh Faker::Internet.password
   key_auth   Faker::Internet.password

--- a/spec/fabricators/web_setting_fabricator.rb
+++ b/spec/fabricators/web_setting_fabricator.rb
@@ -1,3 +1,2 @@
-Fabricator('Web::Setting') do
-
+Fabricator(:web_setting, from: Web::Setting) do
 end


### PR DESCRIPTION
Before:

- There is a foreign key with cascading deletion that ensures a subscription will not exist after its access token is deleted
- There is a weekly worker that deletes access tokens that have been revoked
- Session activation has a callback that removes subscriptions when the session activation is destroyed

This PR also adds immediate deletion of subscriptions when the application is revoked from "Authorized applications" screen or through the OAuth token revocation API.