### PR TITLE
Disables autocorrect/autocapitalize on remote username field.

### DIFF
--- a/app/views/remote_follow/new.html.haml
+++ b/app/views/remote_follow/new.html.haml
@@ -7,7 +7,7 @@
   = simple_form_for @remote_follow, as: :remote_follow, url: account_remote_follow_path(@account) do |f|
     = render 'shared/error_messages', object: @remote_follow
 
-    = f.input :acct, placeholder: t('remote_follow.acct')
+    = f.input :acct, placeholder: t('remote_follow.acct'), input_html: { autocapitalize: 'none', autocorrect: 'off' }
 
     .actions
       = f.button :button, t('remote_follow.proceed'), type: :submit


### PR DESCRIPTION
Hello! So this is a super-minor nitpick but it's been bugging me for ages so I thought I'd send a PR. Basically when remote following in Safari on iOS, the keyboard capitalizes the first word of the username and also enables autocorrect. 

<details><summary>You can see the enabled shift key in this screenshot.</summary>

![simulator screen shot - iphone x - 2018-05-19 at 13 21 19](https://user-images.githubusercontent.com/498212/40271192-ecc46f5a-5b67-11e8-8fec-3f79041331e0.png)

</details>

After applying this PR, both autocorrect and autocapitalize are disabled for that field, which will make remote following accounts a little easier for iOS users.

<details><summary>Shift key now disabled 🎉 </summary>

![simulator screen shot - iphone x - 2018-05-19 at 13 21 09](https://user-images.githubusercontent.com/498212/40271213-2d3f4424-5b68-11e8-820f-3321d3fa99be.png)

</details>

Apple's docs for this are [here](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize). If there's a better way to implement this, just let me know 👍