### PR TITLE
Add :few keys for sk lang plurals

### DIFF
--- a/config/locales/devise.sk.yml
+++ b/config/locales/devise.sk.yml
@@ -78,6 +78,6 @@ sk:
       not_found: nenájdený
       not_locked: nebol uzamknutý
       not_saved:
-        one: "%{resource} nebol uložený kôli chybe:"
         few: "%{resource} nebol uložený kôli %{count} chybám:"
+        one: "%{resource} nebol uložený kôli chybe:"
         other: "%{resource} nebol uložený kôli %{count} chybám:"

--- a/config/locales/devise.sk.yml
+++ b/config/locales/devise.sk.yml
@@ -79,4 +79,5 @@ sk:
       not_locked: nebol uzamknutý
       not_saved:
         one: "%{resource} nebol uložený kôli chybe:"
+        few: "%{resource} nebol uložený kôli %{count} chybám:"
         other: "%{resource} nebol uložený kôli %{count} chybám:"

--- a/config/locales/simple_form.sk.yml
+++ b/config/locales/simple_form.sk.yml
@@ -8,12 +8,14 @@ sk:
         digest: Odoslané iba v prípade dlhodobej neprítomnosti, a len ak ste obdŕžali nejaké osobné správy kým ste boli preč
         display_name:
           one: Ostáva ti <span class="name-counter">1</span> znak
+          few: Ostávajú ti <span class="name-counter">%{count}</span> znaky
           other: Ostáva ti <span class="name-counter">%{count}</span> znakov
         fields: Môžeš mať 4 položky na svojom profile zobrazené vo forme tabuľky
         header: PNG, GIF alebo JPG. Maximálne 2MB. Bude zmenšený na 700x335px
         locked: Musíte manuálne schváliť sledujúcich
         note:
           one: Ostáva vám <span class="note-counter">1</span> znak
+          few: Ostávajú ti <span class="note-counter">%{count}</span> znaky
           other: Ostáva ti <span class="note-counter">%{count}</span> znakov
         setting_noindex: Ovplyvňuje verejný profil a statusy
         setting_theme: Toto ovplyvňuje ako Mastodon vyzerá pri prihlásení z hociakého zariadenia.

--- a/config/locales/simple_form.sk.yml
+++ b/config/locales/simple_form.sk.yml
@@ -7,15 +7,15 @@ sk:
         bot: Varuje užívateľov, že daný účet nerepreyentuje ozajstného človeka
         digest: Odoslané iba v prípade dlhodobej neprítomnosti, a len ak ste obdŕžali nejaké osobné správy kým ste boli preč
         display_name:
-          one: Ostáva ti <span class="name-counter">1</span> znak
           few: Ostávajú ti <span class="name-counter">%{count}</span> znaky
+          one: Ostáva ti <span class="name-counter">1</span> znak
           other: Ostáva ti <span class="name-counter">%{count}</span> znakov
         fields: Môžeš mať 4 položky na svojom profile zobrazené vo forme tabuľky
         header: PNG, GIF alebo JPG. Maximálne 2MB. Bude zmenšený na 700x335px
         locked: Musíte manuálne schváliť sledujúcich
         note:
-          one: Ostáva vám <span class="note-counter">1</span> znak
           few: Ostávajú ti <span class="note-counter">%{count}</span> znaky
+          one: Ostáva vám <span class="note-counter">1</span> znak
           other: Ostáva ti <span class="note-counter">%{count}</span> znakov
         setting_noindex: Ovplyvňuje verejný profil a statusy
         setting_theme: Toto ovplyvňuje ako Mastodon vyzerá pri prihlásení z hociakého zariadenia.

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -228,6 +228,7 @@ sk:
       show:
         affected_accounts:
           one: Jeden účet v databáze ovplyvnený
+          few: "%{count} účty v databáze ovplyvnených"
           other: "%{count} účtov v databáze ovplyvnených"
         retroactive:
           silence: Zrušiť stíšenie všetkých existujúcich účtov z tejto domény
@@ -479,6 +480,7 @@ sk:
     purge: Odstrániť následovateľa
     success:
       one: Počas utišovania sledovateľov z jednej domény...
+      few: Počas utišovania sledovateľov z %{count} domén...
       other: Počas utišovania sledovateľov z %{count} domén...
     true_privacy_html: Prosím majte na vedomí, <strong> 1 že ozajstné súkromie sa dá dosiahnúť iba za pomoci end-to-end enkrypcie</strong> 2.
     unlocked_warning_html: Hocikto ťa môže následovať aby mohol/a ihneď vidieť tvoje súkromné príspevky. %{lock_link} aby si mohla skontrolovať a odmietať sledovateľov.
@@ -489,7 +491,8 @@ sk:
     save_changes: Uložiť zmeny
     validation_errors:
       one: Niečo nieje úplne v poriadku! Prosím skontroluj chybu
-      other: Niečo ešte stále nieje v poriadku! Prosím skontroluj všetky %{count} chyby
+      few: Niečo ešte stále nieje v poriadku! Prosím skontroluj všetky %{count} chyby
+      other: Niečo ešte stále nieje v poriadku! Prosím skontroluj všetkých %{count} chýb
   imports:
     preface: Môžeš importovať dáta ktoré si exportoval/a z iného Mastodon serveru, ako sú napríklad zoznamy ľudí ktorých sleduješ, alebo blokuješ.
     success: Tvoje dáta boli nahraté úspešne, a budú teraz spracované v danom čase
@@ -513,6 +516,7 @@ sk:
     generate: Vygeneruj
     max_uses:
       one: jedno použitie
+      few: "%{count} použitia"
       other: "%{count} použití"
     max_uses_prompt: Bez limitov
     prompt: Vygeneruj a zdieľaj linky s ostatnými aby mali umožnený prístup k tomuto serveru
@@ -543,10 +547,12 @@ sk:
       mention: "%{name} ťa spomenul/a v:"
       new_followers_summary:
         one: Taktiež, získal/a si jedného nového následovníka zatiaľ čo si bol/a preč. Yay!
+        few: Taktiež, získal/a si %{count} nových následovníkov za tú dobu čo si bol/a preč. Yay!
         other: Taktiež, získal/a si %{count} nových následovníkov za tú dobu čo si bol/a preč. Yay!
       subject:
         one: "1 nová notifikácia od tvojej poslednej návštevy \U0001F418"
-        other: "%{count} nové notifikácie od tvojej poslednej návštevy \U0001F418"
+        few: "%{count} nové notifikácie od tvojej poslednej návštevy \U0001F418"
+        other: "%{count} nových notifikácií od tvojej poslednej návštevy \U0001F418"
       title: Zatiaľ čo si bol/a preč…
     favourite:
       body: 'Tvoj príspevok bol uložený medi obľúbené užívateľa %{name}:'
@@ -641,9 +647,11 @@ sk:
       description: 'Priložené: %{attached}'
       image:
         one: "%{count} obrázok"
+        few: "%{count} obrázky"
         other: "%{count} obrázkov"
       video:
         one: "%{count} video"
+        few: "%{count} videá"
         other: "%{count} videí"
     content_warning: 'Varovanie o obsahu: %{warning}'
     open_in_web: Otvor v okne prehliadača

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -227,8 +227,8 @@ sk:
       severity: Závažnosť
       show:
         affected_accounts:
-          one: Jeden účet v databáze ovplyvnený
           few: "%{count} účty v databáze ovplyvnených"
+          one: Jeden účet v databáze ovplyvnený
           other: "%{count} účtov v databáze ovplyvnených"
         retroactive:
           silence: Zrušiť stíšenie všetkých existujúcich účtov z tejto domény
@@ -479,8 +479,8 @@ sk:
     lock_link: Zamknite svoj účet
     purge: Odstrániť následovateľa
     success:
-      one: Počas utišovania sledovateľov z jednej domény...
       few: Počas utišovania sledovateľov z %{count} domén...
+      one: Počas utišovania sledovateľov z jednej domény...
       other: Počas utišovania sledovateľov z %{count} domén...
     true_privacy_html: Prosím majte na vedomí, <strong> 1 že ozajstné súkromie sa dá dosiahnúť iba za pomoci end-to-end enkrypcie</strong> 2.
     unlocked_warning_html: Hocikto ťa môže následovať aby mohol/a ihneď vidieť tvoje súkromné príspevky. %{lock_link} aby si mohla skontrolovať a odmietať sledovateľov.
@@ -490,8 +490,8 @@ sk:
     powered_by: poháňané vďaka %{link}
     save_changes: Uložiť zmeny
     validation_errors:
-      one: Niečo nieje úplne v poriadku! Prosím skontroluj chybu
       few: Niečo ešte stále nieje v poriadku! Prosím skontroluj všetky %{count} chyby
+      one: Niečo nieje úplne v poriadku! Prosím skontroluj chybu
       other: Niečo ešte stále nieje v poriadku! Prosím skontroluj všetkých %{count} chýb
   imports:
     preface: Môžeš importovať dáta ktoré si exportoval/a z iného Mastodon serveru, ako sú napríklad zoznamy ľudí ktorých sleduješ, alebo blokuješ.
@@ -515,8 +515,8 @@ sk:
     expires_in_prompt: Nikdy
     generate: Vygeneruj
     max_uses:
-      one: jedno použitie
       few: "%{count} použitia"
+      one: jedno použitie
       other: "%{count} použití"
     max_uses_prompt: Bez limitov
     prompt: Vygeneruj a zdieľaj linky s ostatnými aby mali umožnený prístup k tomuto serveru
@@ -546,12 +546,12 @@ sk:
       body: Tu nájdete krátky súhrn správ ktoré ste zmeškali od svojej poslednj návštevi od %{since}
       mention: "%{name} ťa spomenul/a v:"
       new_followers_summary:
-        one: Taktiež, získal/a si jedného nového následovníka zatiaľ čo si bol/a preč. Yay!
         few: Taktiež, získal/a si %{count} nových následovníkov za tú dobu čo si bol/a preč. Yay!
+        one: Taktiež, získal/a si jedného nového následovníka zatiaľ čo si bol/a preč. Yay!
         other: Taktiež, získal/a si %{count} nových následovníkov za tú dobu čo si bol/a preč. Yay!
       subject:
-        one: "1 nová notifikácia od tvojej poslednej návštevy \U0001F418"
         few: "%{count} nové notifikácie od tvojej poslednej návštevy \U0001F418"
+        one: "1 nová notifikácia od tvojej poslednej návštevy \U0001F418"
         other: "%{count} nových notifikácií od tvojej poslednej návštevy \U0001F418"
       title: Zatiaľ čo si bol/a preč…
     favourite:
@@ -646,12 +646,12 @@ sk:
     attached:
       description: 'Priložené: %{attached}'
       image:
-        one: "%{count} obrázok"
         few: "%{count} obrázky"
+        one: "%{count} obrázok"
         other: "%{count} obrázkov"
       video:
-        one: "%{count} video"
         few: "%{count} videá"
+        one: "%{count} video"
         other: "%{count} videí"
     content_warning: 'Varovanie o obsahu: %{warning}'
     open_in_web: Otvor v okne prehliadača


### PR DESCRIPTION
While en has rule only for :one and :other, sk and other langs can have also :few.

   :sk => { :i18n => { :plural => { :keys => [:one, :few, :other], :rule => lambda { |n| n == 1 ? :one : [2, 3, 4].include?(n) ? :few : :other } } } },
   :en => { :i18n => { :plural => { :keys => [:one, :other], :rule => lambda { |n| n == 1 ? :one : :other } } } },

This is commit adds :few keys for sk lang where needed.