### PR TITLE
Use LoadingBar instead of blur to indicate that an image is loading (fixes #4060)

### DIFF
--- a/app/javascript/mastodon/features/ui/components/image_loader.js
+++ b/app/javascript/mastodon/features/ui/components/image_loader.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { LoadingBar } from 'react-redux-loading-bar';
 import ZoomableImage from './zoomable_image';
 
 export default class ImageLoader extends React.PureComponent {
@@ -23,6 +24,7 @@ export default class ImageLoader extends React.PureComponent {
   state = {
     loading: true,
     error: false,
+    width: null,
   }
 
   removers = [];
@@ -122,6 +124,7 @@ export default class ImageLoader extends React.PureComponent {
 
   setCanvasRef = c => {
     this.canvas = c;
+    if (c) this.setState({ width: c.offsetWidth });
   }
 
   render () {
@@ -135,6 +138,7 @@ export default class ImageLoader extends React.PureComponent {
 
     return (
       <div className={className}>
+        <LoadingBar loading={loading ? 1 : 0} className='loading-bar' style={{ width: this.state.width || width }} />
         {loading ? (
           <canvas
             className='image-loader__preview-canvas'

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1446,6 +1446,7 @@ a.account__display-name {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-direction: column;
 
   .image-loader__preview-canvas {
     max-width: $media-modal-media-max-width;
@@ -1454,8 +1455,8 @@ a.account__display-name {
     object-fit: contain;
   }
 
-  &.image-loader--loading .image-loader__preview-canvas {
-    filter: blur(2px);
+  .loading-bar {
+    position: relative;
   }
 
   &.image-loader--amorphous .image-loader__preview-canvas {


### PR DESCRIPTION
It doesn't change how images are loaded (maybe using `srcset` would be better?), but removes the blur on the preview and uses a fake loading bar instead.