### PR TITLE
Use #any? instead of #exists? when checking media attachments

### DIFF
--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -81,7 +81,7 @@ class BatchedRemoveStatusService < BaseService
       redis.publish('timeline:public', payload)
       redis.publish('timeline:public:local', payload) if status.local?
 
-      if status.media_attachments.exists?
+      if status.media_attachments.any?
         redis.publish('timeline:public:media', payload)
         redis.publish('timeline:public:local:media', payload) if status.local?
       end

--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -25,7 +25,7 @@ class FanOutOnWriteService < BaseService
     return if status.reply? && status.in_reply_to_account_id != status.account_id
 
     deliver_to_public(status)
-    deliver_to_media(status) if status.media_attachments.exists?
+    deliver_to_media(status) if status.media_attachments.any?
   end
 
   private

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -20,7 +20,7 @@ class RemoveStatusService < BaseService
     remove_reblogs
     remove_from_hashtags
     remove_from_public
-    remove_from_media if status.media_attachments.exists?
+    remove_from_media if status.media_attachments.any?
     remove_from_direct if status.direct_visibility?
 
     @status.destroy!


### PR DESCRIPTION
If media_attachments are not loaded, SQL query is the same, but the #exists? method performs SQL query even if preloaded