### PR TITLE
Do not encode HTML entities in initial Web Push payload body

### DIFF
--- a/app/serializers/web/notification_serializer.rb
+++ b/app/serializers/web/notification_serializer.rb
@@ -33,6 +33,7 @@ class Web::NotificationSerializer < ActiveModel::Serializer
   end
 
   def body
-    truncate(strip_tags(object.target_status&.spoiler_text&.presence || object.target_status&.text || object.from_account.note), length: 140)
+    str = truncate(strip_tags(object.target_status&.spoiler_text&.presence || object.target_status&.text || object.from_account.note), length: 140)
+    HTMLEntities.new.decode(str.to_str) # Do not encode entities, since this value will not be used in HTML
   end
 end


### PR DESCRIPTION
The web UI does not expect to decode stuff like `&#39;` for `'` when creating notifications, and the body is not going to be used for rendering HTML