### PR TITLE
Remove pointer to light theme until it is more polished

### DIFF
--- a/config/themes.yml
+++ b/config/themes.yml
@@ -1,3 +1,2 @@
 default: styles/application.scss
 contrast: styles/contrast.scss
-mastodon-light: styles/mastodon-light.scss


### PR DESCRIPTION
Sorry @Sylvhem, there are some contrast issues with the light theme. 2.4 is already at least a week behind schedule so I need to hurry up, and rather than release an unfinished theme we'll just remove the reference here and put it back in in 2.4.1 later down the line.