### PR TITLE
Disable AMS logging

### DIFF
--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,3 +1,5 @@
 ActiveModelSerializers.config.tap do |config|
   config.default_includes = '**'
 end
+
+ActiveSupport::Notifications.unsubscribe(ActiveModelSerializers::Logging::RENDER_EVENT)


### PR DESCRIPTION
Especially in production it's just noise and doesn't mix well with the log format