### PR TITLE
Validate that e-mail resolves with MX and it's not blacklisted

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,6 +65,7 @@ class User < ApplicationRecord
 
   validates :locale, inclusion: I18n.available_locales.map(&:to_s), if: :locale?
   validates_with BlacklistedEmailValidator, if: :email_changed?
+  validates_with EmailMxValidator, if: :email_changed?
 
   scope :recent, -> { order(id: :desc) }
   scope :admins, -> { where(admin: true) }

--- a/app/validators/email_mx_validator.rb
+++ b/app/validators/email_mx_validator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'resolv'
+
+class EmailMxValidator < ActiveModel::Validator
+  def validate(user)
+    return if Rails.env.test?
+    user.errors.add(:email, I18n.t('users.invalid_email')) if invalid_mx?(user.email)
+  end
+
+  private
+
+  def invalid_mx?(value)
+    _, domain = value.split('@', 2)
+
+    return true if domain.nil?
+
+    records = Resolv::DNS.new.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a.map { |e| e.exchange.to_s }
+    records.empty? || on_blacklist?(records)
+  end
+
+  def on_blacklist?(values)
+    EmailDomainBlock.where(domain: values).any?
+  end
+end


### PR DESCRIPTION
Original patch by @j-a4

- Reduce e-mail bounces to invalid domains (save sending credits)
- Allow blocking an e-mail domain even when it has many aliases