### PR TITLE
optimize direct message 2: add mentions.direct column and some partial index

### DIFF
--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -8,6 +8,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  account_id :bigint(8)
+#  direct     :boolean          default(FALSE), not null
 #
 
 class Mention < ApplicationRecord
@@ -24,4 +25,11 @@ class Mention < ApplicationRecord
     to: :account,
     prefix: true
   )
+
+  before_save :prepare_save
+
+  def prepare_save
+    self.direct = status.direct_visibility?
+    self
+  end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -204,6 +204,7 @@ class Status < ApplicationRecord
       query_to_me = Status
                     .joins(:mentions)
                     .merge(Mention.where(account_id: account.id))
+                    .where(Mention.arel_table[:direct].eq(true))
                     .where(Status.arel_table[:visibility].eq(3))
                     .limit(limit)
                     .order('mentions.status_id DESC')

--- a/db/migrate/20180526013701_add_index_statuses_dm_account.rb
+++ b/db/migrate/20180526013701_add_index_statuses_dm_account.rb
@@ -1,0 +1,7 @@
+class AddIndexStatusesDmAccount < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :statuses, [:account_id, :id, :updated_at], where: 'visibility = 3', algorithm: :concurrently, name: 'index_statuses_dm_account'
+  end
+end

--- a/db/migrate/20180526013703_add_column_mentions_direct.rb
+++ b/db/migrate/20180526013703_add_column_mentions_direct.rb
@@ -1,0 +1,26 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddColumnMentionsDirect < ActiveRecord::Migration[5.0]
+
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+
+    safety_assured do
+      add_column_with_default :mentions, :direct, :boolean, default: false, allow_null: false
+    end
+
+    Status.unscoped.select('id').where(Status.arel_table[:visibility].eq(3)).find_in_batches do |batch|
+      Mention.where(status_id: batch.map(&:id)).update_all('direct=TRUE')
+    end
+
+    add_index :mentions, [:account_id, :status_id], where: 'direct', algorithm: :concurrently, name: 'index_mentions_direct'
+  end
+
+  def down
+    remove_index :mentions, name: 'index_mentions_direct'
+    remove_column :mentions, :direct, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_14_140000) do
+ActiveRecord::Schema.define(version: 2018_05_26_013703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -265,6 +265,8 @@ ActiveRecord::Schema.define(version: 2018_05_14_140000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "account_id"
+    t.boolean "direct", default: false, null: false
+    t.index ["account_id", "status_id"], name: "index_mentions_direct", where: "direct"
     t.index ["account_id", "status_id"], name: "index_mentions_on_account_id_and_status_id", unique: true
     t.index ["status_id"], name: "index_mentions_on_status_id"
   end
@@ -447,6 +449,7 @@ ActiveRecord::Schema.define(version: 2018_05_14_140000) do
     t.bigint "account_id", null: false
     t.bigint "application_id"
     t.bigint "in_reply_to_account_id"
+    t.index ["account_id", "id", "updated_at"], name: "index_statuses_dm_account", where: "(visibility = 3)"
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20180106", order: { id: :desc }
     t.index ["conversation_id"], name: "index_statuses_on_conversation_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"


### PR DESCRIPTION
This is the separated part from https://github.com/tootsuite/mastodon/pull/7614 .

Please try this if you feel slowly when showing direct message timeline, 

- add partial index for statuses: ["account_id", "id", "updated_at"], name: "index_statuses_dm_account", where: "(visibility = 3)"
- add column mentions.direct  (boolean not null), true if related status is direct message
- add partial index for mentions: ["account_id", "status_id"], name: "index_mentions_direct", where: "direct"
- add where expression to direct timeline query that references mentions.direct column. 

The size of the partial index depends on the ratio of DM in statuses or mentions. The same thing can be said for index update overhead. The update overhead will not increase for status and mentions other than DM.

For additional columns, disk usage will be increased a few bytes per every rows in the mentions table.
Migration takes time depends on size of mentions because this repository does not allows nullable boolean column and then we have to update all rows in mentions table.