### PR TITLE
custom_format and format_code

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -34,12 +34,31 @@ class Formatter
     html = "RT @#{prepend_reblog} #{html}" if prepend_reblog
     html = encode_and_link_urls(html, linkable_accounts)
     html = encode_custom_emojis(html, status.emojis) if options[:custom_emojify]
+    html = custom_formats(html)
     html = simple_format(html, {}, sanitize: false)
     html = html.delete("\n")
 
     html.html_safe # rubocop:disable Rails/OutputSafety
   end
 
+  def custom_formats(html)
+    html = format_code(html)
+    return html
+  end
+  
+  def format_code(html)
+    chunks = html.split("```")
+    cur_c = 1
+    while cur_c < chunks.length
+      h = chunks[cur_c]
+      h.gsub(/ /) { |match| "&nbsp;" }
+      h = "<span style=\"font-family: monospace; font-size: 0.9em;\">" + h + "</span>"
+      chunks[cur_c] = h
+      cur_c += 2
+    end
+    return chunks.join('')
+  end
+  
   def reformat(html)
     sanitize(html, Sanitize::Config::MASTODON_STRICT)
   end


### PR DESCRIPTION
This PR adds a hook in Formatter.format() for custom formatting through the custom_format() method.

As an example, it adds a code_format() method that converts text surrounded by three backticks (```) into monospace text with manual spacing preserved.

This allows instance owners to customize the display of toots on their instances - for example, role-playing instances could change the way certain lines look - and provides the basic framework (i.e. separating out custom formatting into a separate method which can call multiple other methods) to potentially allow these custom formats to be exposed on the Administration page, allowing instance owners to modify their instance's toots without modifying the codebase.

Because this is done in formatter.rb, any modifications to the *text* of the toot will be federated. Any custom CSS styling will not be.