### PR TITLE
Fix nil error in migration

### DIFF
--- a/db/migrate/20180528141303_fix_accounts_unique_index.rb
+++ b/db/migrate/20180528141303_fix_accounts_unique_index.rb
@@ -49,7 +49,7 @@ class FixAccountsUniqueIndex < ActiveRecord::Migration[5.2]
         # are always either going to be local or not local, so only
         # one check is needed. Since we cannot support two users with
         # the same username locally, one has to go. 😢
-        other_account.user.destroy
+        other_account.user&.destroy
       end
 
       other_account.destroy


### PR DESCRIPTION
Under rare circumstances the user record could have already been deleted before...