### PR TITLE
Change border color of activity-stream

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -189,11 +189,18 @@
 // Change the default colors used on some parts of the profile pages
 .activity-stream-tabs {
   background: $account-background-color;
+  border-bottom-color: lighten($ui-base-color, 8%);
 }
 
 .activity-stream {
   .entry {
     background: $account-background-color;
+
+    .detailed-status.light,
+    .more.light,
+    .status.light {
+      border-bottom-color: lighten($ui-base-color, 8%);
+    }
   }
 
   .status.light {


### PR DESCRIPTION
https://github.com/tootsuite/mastodon/pull/7722#issuecomment-394219459

I set same color as in log in UI.

![image](https://user-images.githubusercontent.com/27640522/40897412-efc4956e-67f5-11e8-9ae4-920f9f7f63ad.png)
![image](https://user-images.githubusercontent.com/27640522/40897374-b2a3aaee-67f5-11e8-96d1-36f3c923ad2b.png)

Edit：

> very subtly darker than the background

This "background" means white(toots) or grey(background)? Borders should be more lighter (less contrasted)? If yes, I can change all border colors including in log-in UI. Please tell me your opinion @Gargron .