### PR TITLE
Skip processing when HEAD method returns 501

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -40,7 +40,7 @@ class FetchLinkCardService < BaseService
     @card ||= PreviewCard.new(url: @url)
 
     failed = Request.new(:head, @url).perform do |res|
-      res.code != 405 && (res.code != 200 || res.mime_type != 'text/html')
+      res.code != 405 && res.code != 501 && (res.code != 200 || res.mime_type != 'text/html')
     end
 
     return if failed


### PR DESCRIPTION
> The HyperText Transfer Protocol (HTTP) `501 Not Implemented` server error response code indicates that the request method is not supported by the server and cannot be handled. The only methods that servers are required to support (and therefore that must not return this code) are GET and HEAD.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501

similar Pull Request #5949