### PR TITLE
Fix context performance by partially reverting #7083

### DIFF
--- a/app/models/concerns/status_threading_concern.rb
+++ b/app/models/concerns/status_threading_concern.rb
@@ -51,12 +51,12 @@ module StatusThreadingConcern
   end
 
   def descendant_statuses(limit, max_child_id, since_child_id, depth)
-    Status.find_by_sql([<<-SQL.squish, id: id, limit: limit, max_child_id: max_child_id, since_child_id: since_child_id, depth: depth])
+    descendants_with_self = Status.find_by_sql([<<-SQL.squish, id: id, limit: limit, max_child_id: max_child_id, since_child_id: since_child_id, depth: depth])
       WITH RECURSIVE search_tree(id, path)
       AS (
         SELECT id, ARRAY[id]
         FROM statuses
-        WHERE in_reply_to_id = :id AND COALESCE(id < :max_child_id, TRUE) AND COALESCE(id > :since_child_id, TRUE)
+        WHERE id = :id AND COALESCE(id < :max_child_id, TRUE) AND COALESCE(id > :since_child_id, TRUE)
         UNION ALL
         SELECT statuses.id, path || statuses.id
         FROM search_tree
@@ -68,6 +68,8 @@ module StatusThreadingConcern
       ORDER BY path
       LIMIT :limit
     SQL
+
+    return descendants_with_self - [self]
   end
 
   def find_statuses_from_tree_path(ids, account)

--- a/app/models/concerns/status_threading_concern.rb
+++ b/app/models/concerns/status_threading_concern.rb
@@ -51,6 +51,10 @@ module StatusThreadingConcern
   end
 
   def descendant_statuses(limit, max_child_id, since_child_id, depth)
+    # use limit + 1 and depth + 1 because 'self' is included
+    depth = depth + 1 if depth.present?
+    limit = limit + 1 if limit.present?
+
     descendants_with_self = Status.find_by_sql([<<-SQL.squish, id: id, limit: limit, max_child_id: max_child_id, since_child_id: since_child_id, depth: depth])
       WITH RECURSIVE search_tree(id, path)
       AS (

--- a/app/models/concerns/status_threading_concern.rb
+++ b/app/models/concerns/status_threading_concern.rb
@@ -69,7 +69,7 @@ module StatusThreadingConcern
       LIMIT :limit
     SQL
 
-    return descendants_with_self - [self]
+    descendants_with_self - [self]
   end
 
   def find_statuses_from_tree_path(ids, account)

--- a/app/models/concerns/status_threading_concern.rb
+++ b/app/models/concerns/status_threading_concern.rb
@@ -52,8 +52,8 @@ module StatusThreadingConcern
 
   def descendant_statuses(limit, max_child_id, since_child_id, depth)
     # use limit + 1 and depth + 1 because 'self' is included
-    depth = depth + 1 if depth.present?
-    limit = limit + 1 if limit.present?
+    depth += 1 if depth.present?
+    limit += 1 if limit.present?
 
     descendants_with_self = Status.find_by_sql([<<-SQL.squish, id: id, limit: limit, max_child_id: max_child_id, since_child_id: since_child_id, depth: depth])
       WITH RECURSIVE search_tree(id, path)


### PR DESCRIPTION
This was causing a major performance lag when requesting status context on cybrespace, and led to many timeouts. it's already been reverted by pawoo.

Do we know why this wans't causing problems on mastodon.social? It feels like it would have been really obvious....