### PR TITLE
Sort Elasticsearch result in descending order of created_at

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -30,6 +30,7 @@ class SearchService < BaseService
     statuses = StatusesIndex.filter(term: { searchable_by: account.id })
                             .query(multi_match: { type: 'most_fields', query: query, operator: 'and', fields: %w(text text.stemmed) })
                             .limit(limit)
+                            .order({created_at: {order: :desc}})
                             .objects
                             .compact
 

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -30,7 +30,7 @@ class SearchService < BaseService
     statuses = StatusesIndex.filter(term: { searchable_by: account.id })
                             .query(multi_match: { type: 'most_fields', query: query, operator: 'and', fields: %w(text text.stemmed) })
                             .limit(limit)
-                            .order({ created_at: { order: :desc }})
+                            .order(created_at: { order: :desc })
                             .objects
                             .compact
 

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -30,7 +30,7 @@ class SearchService < BaseService
     statuses = StatusesIndex.filter(term: { searchable_by: account.id })
                             .query(multi_match: { type: 'most_fields', query: query, operator: 'and', fields: %w(text text.stemmed) })
                             .limit(limit)
-                            .order({created_at: {order: :desc}})
+                            .order({created_at: { order: :desc }})
                             .objects
                             .compact
 

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -30,7 +30,7 @@ class SearchService < BaseService
     statuses = StatusesIndex.filter(term: { searchable_by: account.id })
                             .query(multi_match: { type: 'most_fields', query: query, operator: 'and', fields: %w(text text.stemmed) })
                             .limit(limit)
-                            .order({created_at: { order: :desc }})
+                            .order({ created_at: { order: :desc }})
                             .objects
                             .compact
 


### PR DESCRIPTION
Present code shows the result of Elasticsearch in random order, but sorting the result toots by their creation time helps us find toot we want more easily.