### PR TITLE
Fix fetch of remote image with multiple Content-Type headers

### DIFF
--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -24,13 +24,14 @@ module Remotable
           Request.new(:get, url).perform do |response|
             next if response.code != 200
 
-            content_type = parse_content_type(response.headers['content-type'])
+            content_type = parse_content_type(response.headers.get('content-type').last)
             extname      = detect_extname_from_content_type(content_type)
 
             if extname.nil?
-              matches  = response.headers['content-disposition']&.match(/filename="([^"]*)"/)
-              filename = matches.nil? ? parsed_url.path.split('/').last : matches[1]
-              extname  = filename.nil? ? '' : File.extname(filename)
+              disposition = response.headers.get('content-disposition').last
+              matches     = disposition&.match(/filename="([^"]*)"/)
+              filename    = matches.nil? ? parsed_url.path.split('/').last : matches[1]
+              extname     = filename.nil? ? '' : File.extname(filename)
             end
 
             basename = SecureRandom.hex(8)


### PR DESCRIPTION
![screenshots on sidekiq log](https://user-images.githubusercontent.com/12539/41056457-350eefba-69ff-11e8-93aa-204d10a1351a.png)

```console
$ curl -sSI 'https://cdn.mqube.net/t/images/user/icon/495/724f26eb.jpeg?ds=s&dw=1000' | grep -i Content-Type
Content-Type: application/json
Content-Type: image/png
```

🤦‍♂️ 