### PR TITLE
Fix issues with updated emoji mart

### DIFF
--- a/app/javascript/mastodon/features/emoji/__tests__/emoji_index-test.js
+++ b/app/javascript/mastodon/features/emoji/__tests__/emoji_index-test.js
@@ -44,6 +44,11 @@ describe('emoji_index', () => {
     expect(emojiIndex.search('apple').map(trimEmojis)).toEqual(expected);
   });
 
+  it('can include/exclude categories', () => {
+    expect(search('flag', { include: ['people'] })).toEqual([]);
+    expect(emojiIndex.search('flag', { include: ['people'] })).toEqual([]);
+  });
+
   it('(different behavior from emoji-mart) do not erases custom emoji if not passed again', () => {
     const custom = [
       {
@@ -121,11 +126,6 @@ describe('emoji_index', () => {
       .not.toContain('pineapple');
     expect(emojiIndex.search('apple', { emojisToShowFilter }).map((obj) => obj.id))
       .not.toContain('pineapple');
-  });
-
-  it('can include/exclude categories', () => {
-    expect(search('flag', { include: ['people'] })).toEqual([]);
-    expect(emojiIndex.search('flag', { include: ['people'] })).toEqual([]);
   });
 
   it('does an emoji whose unified name is irregular', () => {

--- a/app/javascript/mastodon/features/emoji/__tests__/emoji_index-test.js
+++ b/app/javascript/mastodon/features/emoji/__tests__/emoji_index-test.js
@@ -44,7 +44,7 @@ describe('emoji_index', () => {
     expect(emojiIndex.search('apple').map(trimEmojis)).toEqual(expected);
   });
 
-  it('erases custom emoji if not passed again', () => {
+  it('(different behavior from emoji-mart) do not erases custom emoji if not passed again', () => {
     const custom = [
       {
         id: 'mastodon',
@@ -60,7 +60,33 @@ describe('emoji_index', () => {
     search('', { custom });
     emojiIndex.search('', { custom });
     const expected = [];
-    expect(search('masto').map(trimEmojis)).toEqual(expected);
+    const lightExpected = [
+      {
+        id: 'mastodon',
+        custom: true,
+      },
+    ];
+    expect(search('masto').map(trimEmojis)).toEqual(lightExpected);
+    expect(emojiIndex.search('masto').map(trimEmojis)).toEqual(expected);
+  });
+
+  it('(different behavior from emoji-mart) erases custom emoji if another is passed', () => {
+    const custom = [
+      {
+        id: 'mastodon',
+        name: 'mastodon',
+        short_names: ['mastodon'],
+        text: '',
+        emoticons: [],
+        keywords: ['mastodon'],
+        imageUrl: 'http://example.com',
+        custom: true,
+      },
+    ];
+    search('', { custom });
+    emojiIndex.search('', { custom });
+    const expected = [];
+    expect(search('masto', {custom: []}).map(trimEmojis)).toEqual(expected);
     expect(emojiIndex.search('masto').map(trimEmojis)).toEqual(expected);
   });
 

--- a/app/javascript/mastodon/features/emoji/__tests__/emoji_index-test.js
+++ b/app/javascript/mastodon/features/emoji/__tests__/emoji_index-test.js
@@ -91,7 +91,7 @@ describe('emoji_index', () => {
     search('', { custom });
     emojiIndex.search('', { custom });
     const expected = [];
-    expect(search('masto', {custom: []}).map(trimEmojis)).toEqual(expected);
+    expect(search('masto', { custom: [] }).map(trimEmojis)).toEqual(expected);
     expect(emojiIndex.search('masto').map(trimEmojis)).toEqual(expected);
   });
 

--- a/app/javascript/mastodon/features/emoji/emoji_mart_search_light.js
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_search_light.js
@@ -54,9 +54,13 @@ function addCustomToPool(custom, pool) {
   index = {};
 }
 
-function search(value, { emojisToShowFilter, maxResults, include, exclude, custom = [] } = {}) {
-  if (customEmojisList !== custom)
-    addCustomToPool(custom, originalPool);
+function search(value, { emojisToShowFilter, maxResults, include, exclude, custom } = {}) {
+  if (custom !== undefined) {
+    if (customEmojisList !== custom)
+      addCustomToPool(custom, originalPool);
+  } else {
+    custom = [];
+  }
 
   maxResults = maxResults || 75;
   include = include || [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,7 +2305,7 @@ elliptic@^6.0.0:
 
 emoji-mart@Gargron/emoji-mart#build:
   version "2.6.1"
-  resolved "https://codeload.github.com/Gargron/emoji-mart/tar.gz/227c56c8a1cd89a475d4cf8d9605096555e12484"
+  resolved "https://codeload.github.com/Gargron/emoji-mart/tar.gz/829d042f1c059b15050e5acb3c77adf1a851c666"
 
 emoji-regex@^6.1.0:
   version "6.5.1"


### PR DESCRIPTION
*  Changes behavior from search light to keep custom search
The new version of emoji-mart needs the search function to constantly
receive the custom emoji array. This changes the behavior back to the
previous one in the search light method to keep the emoji autocomplete
as before

* Update emoji mart to version without issue in picker