### PR TITLE
Fix background color of emoji-mart-bar in light theme

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -47,6 +47,14 @@
   background: darken($ui-base-color, 6%);
 }
 
+.emoji-mart-bar {
+  border-color: lighten($ui-base-color, 8%);
+
+  &:first-child {
+    background: $ui-base-color;
+  }
+}
+
 .focusable:focus {
   background: $ui-base-color;
 }

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -55,6 +55,11 @@
   }
 }
 
+.emoji-mart-search input {
+  background: rgba($ui-base-color, 0.3);
+  border-color: $ui-base-color;
+}
+
 .focusable:focus {
   background: $ui-base-color;
 }


### PR DESCRIPTION
|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/27640522/41192047-5e2dfd88-6c33-11e8-91ca-2a67616e277f.png)|![image](https://user-images.githubusercontent.com/27640522/41192035-453a2a86-6c33-11e8-9366-96207bd1be29.png)|

I cant find out why unselected emoji-mart-anchor-bar appears only in mastodon-light theme...