### PR TITLE
Adjust emoji-mart-anchor-bar for environments that use display scaling

### DIFF
--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -62,16 +62,16 @@
   }
 
   .emoji-mart-anchor-bar {
-    bottom: 0;
+    bottom: -1px;
   }
 }
 
 .emoji-mart-anchor-bar {
   position: absolute;
-  bottom: -3px;
+  bottom: -5px;
   left: 0;
   width: 100%;
-  height: 3px;
+  height: 4px;
   background-color: $highlight-text-color;
 }
 


### PR DESCRIPTION
Unselected emoji-mart-anchor-bar appears due to display scaling in Windows.

||Before|After|
|--|--|--|
|With display scaling|![image](https://user-images.githubusercontent.com/27640522/41195487-13b7be52-6c69-11e8-87da-0bffa439f7db.png)|![image](https://user-images.githubusercontent.com/27640522/41195482-09557ec2-6c69-11e8-8219-ca4015589de3.png)|
|Without display scaling (exactly the same)|![image](https://user-images.githubusercontent.com/27640522/41195533-ed8e4be6-6c69-11e8-8871-a6fdb8a1dcb0.png)|![image](https://user-images.githubusercontent.com/27640522/41195536-f4f468c0-6c69-11e8-9dbf-8c42de9cdbca.png)|

