### PR TITLE
Control the focus when clicking the "CW" button.

### DIFF
--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -128,10 +128,22 @@ export default class ComposeForm extends ImmutablePureComponent {
     } else if(prevProps.is_submitting && !this.props.is_submitting) {
       this.autosuggestTextarea.textarea.focus();
     }
+
+    if (this.props.spoiler !== prevProps.spoiler) {
+      if (this.props.spoiler) {
+        this.spoilerText.focus();
+      } else {
+        this.autosuggestTextarea.textarea.focus();
+      }
+    }
   }
 
   setAutosuggestTextarea = (c) => {
     this.autosuggestTextarea = c;
+  }
+
+  setSpoilerText = (c) => {
+    this.spoilerText = c;
   }
 
   handleEmojiPick = (data) => {
@@ -164,7 +176,7 @@ export default class ComposeForm extends ImmutablePureComponent {
         <div className={`spoiler-input ${this.props.spoiler ? 'spoiler-input--visible' : ''}`}>
           <label>
             <span style={{ display: 'none' }}>{intl.formatMessage(messages.spoiler_placeholder)}</span>
-            <input placeholder={intl.formatMessage(messages.spoiler_placeholder)} value={this.props.spoiler_text} onChange={this.handleChangeSpoilerText} onKeyDown={this.handleKeyDown} type='text' className='spoiler-input__input'  id='cw-spoiler-input' />
+            <input placeholder={intl.formatMessage(messages.spoiler_placeholder)} value={this.props.spoiler_text} onChange={this.handleChangeSpoilerText} onKeyDown={this.handleKeyDown} type='text' className='spoiler-input__input'  id='cw-spoiler-input' ref={this.setSpoilerText} />
           </label>
         </div>
 


### PR DESCRIPTION
Now, cursor is lost when click "CW". I think that people click "CW" because they want to input the spoiler text.

This PR implements to:
* Focus to the spoiler text when CW turns on.
* Focus back to the textarea when CW turns off.

![spoiler](https://user-images.githubusercontent.com/32974885/41198751-efbbbeb6-6cbf-11e8-8ff0-86c9c26cbd1a.gif)
