### PR TITLE
Uniform media and video spoiler settings and fix them of the light theme

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -87,6 +87,17 @@
   }
 }
 
+// Change the background colors of media and video spoiler
+
+.media-spoiler,
+.video-player__spoiler {
+  background: $ui-base-color;
+}
+
+.account-gallery__item a {
+  background-color: $ui-base-color;
+}
+
 // Change the colors used in the dropdown menu
 .dropdown-menu {
   background: $ui-base-color;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4555,7 +4555,7 @@ a.status-card {
     height: 100%;
     z-index: 4;
     border: 0;
-    background: $base-shadow-color;
+    background: $base-overlay-background;
     color: $darker-text-color;
     transition: none;
     pointer-events: none;


### PR DESCRIPTION
- Change video spoiler background setting to `$base-overlay-background` as same as media spoiler one.
- Adjust media and video spoiler background color of the light theme.

Default theme: exactly the same appearance.

Light theme:

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/27640522/41202541-fa06a9fe-6d04-11e8-9fb9-54859ed262b1.png)|![image](https://user-images.githubusercontent.com/27640522/41202530-d83a0c80-6d04-11e8-82a8-64e839a3223b.png)|

, and video spoiler background bug in the light theme is also fixed.