### PR TITLE
Dockerfile: run asset precompilation as a build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,6 @@ VOLUME /mastodon/public/system
 
 USER mastodon
 
-RUN OTP_SECRET=$(bundle exec rails secret) SECRET_KEY_BASE=$(bundle exec rails secret) bundle exec rails assets:precompile
+RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder bundle exec rails assets:precompile
 
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,10 @@ COPY . /mastodon
 
 RUN chown -R mastodon:mastodon /mastodon
 
-VOLUME /mastodon/public/system /mastodon/public/assets /mastodon/public/packs
+VOLUME /mastodon/public/system
 
 USER mastodon
+
+RUN OTP_SECRET=$(bundle exec rails secret) SECRET_KEY_BASE=$(bundle exec rails secret) bundle exec rails assets:precompile
 
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
This saves Docker users from having to run `rails assets:precompile` manually upon upgrade, by embedding compiled assets and packs in the image.

See glitch-soc/mastodon#536 for some prior discussion.

/assets and /packs should no longer be volumes, since they are embedded in the image now. This might require documentation updates as well.

The build step uses randomly-generated, placeholder `OTP_SECRET` and `SECRET_KEY_BASE` to run the compilation process. (Let me know if there's anything wrong with this approach; I'm not sure if these values are used for anything during compiling.)