### PR TITLE
Add profile options on compose form

### DIFF
--- a/app/javascript/mastodon/features/compose/components/action_bar.js
+++ b/app/javascript/mastodon/features/compose/components/action_bar.js
@@ -44,7 +44,7 @@ export default class ActionBar extends React.PureComponent {
     return (
       <div className='compose__action-bar'>
         <div className='compose__action-bar-dropdown'>
-          <DropdownMenuContainer items={menu} icon='bars' size={24} direction='right' />
+          <DropdownMenuContainer items={menu} icon='ellipsis-v' size={24} direction='right' />
         </div>
       </div>
     );

--- a/app/javascript/mastodon/features/compose/components/action_bar.js
+++ b/app/javascript/mastodon/features/compose/components/action_bar.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import PropTypes from 'prop-types';
+import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
+import { Link } from 'react-router-dom';
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import { me } from '../../../initial_state';
+
+const messages = defineMessages({
+  edit_profile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },
+  pins: { id: 'navigation_bar.pins', defaultMessage: 'Pinned toots' },
+  preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
+  follow_requests: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
+  favourites: { id: 'navigation_bar.favourites', defaultMessage: 'Favourites' },
+  lists: { id: 'navigation_bar.lists', defaultMessage: 'Lists' },
+  blocks: { id: 'navigation_bar.blocks', defaultMessage: 'Blocked users' },
+  domain_blocks: { id: 'navigation_bar.domain_blocks', defaultMessage: 'Hidden domains' },
+  mutes: { id: 'navigation_bar.mutes', defaultMessage: 'Muted users' },
+});
+
+@injectIntl
+export default class ActionBar extends React.PureComponent {
+
+  static propTypes = {
+    account: ImmutablePropTypes.map.isRequired,
+    intl: PropTypes.object.isRequired,
+  };
+
+  render () {
+    const { account, intl } = this.props;
+
+    let menu = [];
+    let extraInfo = '';
+
+    menu.push({ text: intl.formatMessage(messages.edit_profile), href: '/settings/profile' });
+    menu.push({ text: intl.formatMessage(messages.preferences), href: '/settings/preferences' });
+    menu.push({ text: intl.formatMessage(messages.pins), to: '/pinned' });
+    menu.push(null);
+    menu.push({ text: intl.formatMessage(messages.follow_requests), to: '/follow_requests' });
+    menu.push({ text: intl.formatMessage(messages.favourites), to: '/favourites' });
+    menu.push({ text: intl.formatMessage(messages.lists), to: '/lists' });
+    menu.push(null);
+    menu.push({ text: intl.formatMessage(messages.mutes), to: '/mutes' });
+    menu.push({ text: intl.formatMessage(messages.blocks), to: '/blocks' });
+    menu.push({ text: intl.formatMessage(messages.domain_blocks), to: '/domain_blocks' });
+
+    return (
+      <div className='compose__action-bar'>
+        <div className='compose__action-bar-dropdown'>
+          <DropdownMenuContainer items={menu} icon='bars' size={24} direction='right' />
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/compose/components/action_bar.js
+++ b/app/javascript/mastodon/features/compose/components/action_bar.js
@@ -2,9 +2,7 @@ import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
 import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
-import { Link } from 'react-router-dom';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { me } from '../../../initial_state';
+import { defineMessages, injectIntl } from 'react-intl';
 
 const messages = defineMessages({
   edit_profile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },
@@ -27,10 +25,9 @@ export default class ActionBar extends React.PureComponent {
   };
 
   render () {
-    const { account, intl } = this.props;
+    const { intl } = this.props;
 
     let menu = [];
-    let extraInfo = '';
 
     menu.push({ text: intl.formatMessage(messages.edit_profile), href: '/settings/profile' });
     menu.push({ text: intl.formatMessage(messages.preferences), href: '/settings/preferences' });

--- a/app/javascript/mastodon/features/compose/components/navigation_bar.js
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ActionBar from './action_bar';
 import Avatar from '../../../components/avatar';
 import Permalink from '../../../components/permalink';
+import IconButton from '../../../components/icon_button';
 import { FormattedMessage } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
@@ -10,6 +12,7 @@ export default class NavigationBar extends ImmutablePureComponent {
 
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
+    onClose: PropTypes.func,
   };
 
   render () {
@@ -28,7 +31,10 @@ export default class NavigationBar extends ImmutablePureComponent {
           <a href='/settings/profile' className='navigation-bar__profile-edit'><FormattedMessage id='navigation_bar.edit_profile' defaultMessage='Edit profile' /></a>
         </div>
 
-        <ActionBar account={this.props.account} />
+        <div class='navigation-bar__actions'>
+          <IconButton className="close" title='' icon='close' onClick={this.props.onClose} />
+          <ActionBar account={this.props.account} />
+        </div>
       </div>
     );
   }

--- a/app/javascript/mastodon/features/compose/components/navigation_bar.js
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.js
@@ -32,7 +32,7 @@ export default class NavigationBar extends ImmutablePureComponent {
         </div>
 
         <div class='navigation-bar__actions'>
-          <IconButton className="close" title='' icon='close' onClick={this.props.onClose} />
+          <IconButton className='close' title='' icon='close' onClick={this.props.onClose} />
           <ActionBar account={this.props.account} />
         </div>
       </div>

--- a/app/javascript/mastodon/features/compose/components/navigation_bar.js
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ActionBar from './action_bar';
 import Avatar from '../../../components/avatar';
 import IconButton from '../../../components/icon_button';
 import Permalink from '../../../components/permalink';
@@ -11,7 +12,6 @@ export default class NavigationBar extends ImmutablePureComponent {
 
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
-    onClose: PropTypes.func,
   };
 
   render () {
@@ -30,7 +30,7 @@ export default class NavigationBar extends ImmutablePureComponent {
           <a href='/settings/profile' className='navigation-bar__profile-edit'><FormattedMessage id='navigation_bar.edit_profile' defaultMessage='Edit profile' /></a>
         </div>
 
-        <IconButton title='' icon='close' onClick={this.props.onClose} />
+        <ActionBar account={this.props.account} />
       </div>
     );
   }

--- a/app/javascript/mastodon/features/compose/components/navigation_bar.js
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ActionBar from './action_bar';
 import Avatar from '../../../components/avatar';
-import IconButton from '../../../components/icon_button';
 import Permalink from '../../../components/permalink';
 import { FormattedMessage } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1509,6 +1509,23 @@ a.account__display-name {
   .permalink {
     text-decoration: none;
   }
+
+  .navigation-bar__actions {
+    position:relative;
+
+    .icon-button.close {
+      position:absolute;
+      pointer-events: none;
+      transform: scale(0.0, 1.0) translate(-100%, 0);
+      opacity: 0;
+    }
+
+    .compose__action-bar .icon-button {
+      pointer-events: auto;
+      transform: scale(1.0, 1.0) translate(0, 0);
+      opacity: 1;
+    }
+  }
 }
 
 .navigation-bar__profile {
@@ -4927,9 +4944,18 @@ noscript {
       transition: margin-top $duration $delay;
     }
 
-    & > .icon-button {
-      will-change: opacity;
-      transition: opacity $duration $delay;
+    .navigation-bar__actions {
+      & > .icon-button.close {
+        will-change: opacity transform;
+        transition: opacity $duration*0.5 $delay,
+                    transform $duration $delay;
+      }
+
+      & > .compose__action-bar .icon-button {
+        will-change: opacity transform;
+        transition: opacity $duration*0.5 $delay+$duration*0.5,
+                    transform $duration $delay;
+      }
     }
   }
 
@@ -4956,9 +4982,18 @@ noscript {
         margin-top: -50px;
       }
 
-      .icon-button {
-        pointer-events: auto;
-        opacity: 1;
+      .navigation-bar__actions {
+        .icon-button.close {
+          pointer-events: auto;
+          opacity: 1;
+          transform: scale(1.0, 1.0) translate(0, 0);
+        }
+
+        .compose__action-bar .icon-button {
+          pointer-events: none;
+          opacity: 0;
+          transform: scale(0.0, 1.0) translate(100%, 0);
+        }
       }
     }
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1511,10 +1511,10 @@ a.account__display-name {
   }
 
   .navigation-bar__actions {
-    position:relative;
+    position: relative;
 
     .icon-button.close {
-      position:absolute;
+      position: absolute;
       pointer-events: none;
       transform: scale(0.0, 1.0) translate(-100%, 0);
       opacity: 0;
@@ -4947,13 +4947,13 @@ noscript {
     .navigation-bar__actions {
       & > .icon-button.close {
         will-change: opacity transform;
-        transition: opacity $duration*0.5 $delay,
+        transition: opacity $duration * 0.5 $delay,
                     transform $duration $delay;
       }
 
       & > .compose__action-bar .icon-button {
         will-change: opacity transform;
-        transition: opacity $duration*0.5 $delay+$duration*0.5,
+        transition: opacity $duration * 0.5 $delay + $duration * 0.5,
                     transform $duration $delay;
       }
     }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1509,11 +1509,6 @@ a.account__display-name {
   .permalink {
     text-decoration: none;
   }
-
-  .icon-button {
-    pointer-events: none;
-    opacity: 0;
-  }
 }
 
 .navigation-bar__profile {


### PR DESCRIPTION
As of 2.4.1 the only way to access mutes, blocks, and domain block options is from a submenu when viewing your own profile

This PR adds an action button to the compose form to expose the same options in a more convenient and discoverable way. It provides essentially the same menu options without reintroducing clutter to the getting started menu and using an intuitive connection (your profile information is already shown in the compose form, so options related to it, such as your mutes and domain blocks, make sense to access from this button).

May need some UI work, the button is a little low contrast right now. Also should be considered whether the "edit profile" link under your username is now redundant considering the same option is available in the new menu.

![image](https://user-images.githubusercontent.com/1606822/41283997-efa2c806-6dec-11e8-8f52-d7828b48b9ca.png)
![image](https://user-images.githubusercontent.com/1606822/41283960-d5b143a0-6dec-11e8-957e-95686414623c.png)
