### PR TITLE
Remove placeholder text for media-only toots

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -22,7 +22,6 @@ class PostStatusService < BaseService
     media  = validate_media!(options[:media_ids])
     status = nil
     text   = options.delete(:spoiler_text) if text.blank? && options[:spoiler_text].present?
-    text   = '.' if text.blank? && media.present?
 
     ApplicationRecord.transaction do
       status = account.statuses.create!(text: text,


### PR DESCRIPTION
Ref: cfa9b6e13ab3c434f3901df6f614d0aa94a3d1ed

This breaks compatibility with pre-2.3.0 Mastodon and older
software, but at the time of writing the network is >80% above
that version.

Compatibility broken only for toots with no text.