### PR TITLE
Remove rack-timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,6 @@ gem 'pundit', '~> 1.1'
 gem 'premailer-rails'
 gem 'rack-attack', '~> 5.2'
 gem 'rack-cors', '~> 1.0', require: 'rack/cors'
-gem 'rack-timeout', '~> 0.4'
 gem 'rails-i18n', '~> 5.1'
 gem 'rails-settings-cached', '~> 0.6'
 gem 'redis', '~> 4.0', require: ['redis', 'redis/connection/hiredis']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,7 +425,6 @@ GEM
       rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
-    rack-timeout (0.4.2)
     rails (5.2.0)
       actioncable (= 5.2.0)
       actionmailer (= 5.2.0)
@@ -726,7 +725,6 @@ DEPENDENCIES
   pundit (~> 1.1)
   rack-attack (~> 5.2)
   rack-cors (~> 1.0)
-  rack-timeout (~> 0.4)
   rails (~> 5.2.0)
   rails-controller-testing (~> 1.0)
   rails-i18n (~> 5.1)

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,6 +1,0 @@
-Rack::Timeout::Logger.disable
-Rack::Timeout.service_timeout = false
-
-if Rails.env.production?
-  Rack::Timeout.service_timeout = 90
-end


### PR DESCRIPTION
Timeout considered harmful due to leaving the app in a broken
state, including unreaped database connections