### PR TITLE
Adjust account__action-bar contents

### DIFF
--- a/app/javascript/mastodon/features/account/components/action_bar.js
+++ b/app/javascript/mastodon/features/account/components/action_bar.js
@@ -140,10 +140,6 @@ export default class ActionBar extends React.PureComponent {
         {extraInfo}
 
         <div className='account__action-bar'>
-          <div className='account__action-bar-dropdown'>
-            <DropdownMenuContainer items={menu} icon='bars' size={24} direction='right' />
-          </div>
-
           <div className='account__action-bar-links'>
             <Link className='account__action-bar__tab' to={`/accounts/${account.get('id')}`}>
               <span><FormattedMessage id='account.posts' defaultMessage='Toots' /></span>
@@ -159,6 +155,10 @@ export default class ActionBar extends React.PureComponent {
               <span><FormattedMessage id='account.followers' defaultMessage='Followers' /></span>
               <strong>{shortNumberFormat(account.get('followers_count'))}</strong>
             </Link>
+          </div>
+
+          <div className='account__action-bar-dropdown'>
+            <DropdownMenuContainer items={menu} icon='ellipsis-v' size={24} direction='right' />
           </div>
         </div>
       </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1211,6 +1211,10 @@ a .account__avatar {
   flex: 0 1 calc(50% - 140px);
   padding: 10px;
 
+  .icon-button {
+    vertical-align: middle;
+  }
+
   .dropdown--active {
     .dropdown__content.dropdown__right {
       left: 6px;
@@ -1230,13 +1234,14 @@ a .account__avatar {
   display: flex;
   flex: 1 1 auto;
   line-height: 18px;
+  text-align: center;
 }
 
 .account__action-bar__tab {
   text-decoration: none;
   overflow: hidden;
   flex: 0 1 80px;
-  border-left: 1px solid lighten($ui-base-color, 8%);
+  border-right: 1px solid lighten($ui-base-color, 8%);
   padding: 10px 5px;
 
   & > span {


### PR DESCRIPTION
https://github.com/tootsuite/mastodon/pull/7789#issuecomment-396822683

> Also now uses the ellipsis-v icon instead of hamburger button. I do want to point out that this is inconsistent with the icon used on profiles, so maybe it should be changed both places?

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/27640522/41496680-a9446ecc-7180-11e8-9109-65ed93f6ad8b.png)|![image](https://user-images.githubusercontent.com/27640522/41496676-9ab6fd20-7180-11e8-9fef-56ff96e16bfd.png)|

And I set vertical align of the icon as middle, the deflection is fixed.

cc: @chr-1x 