### PR TITLE
DataTransfer.types may Array-like object

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -230,7 +230,7 @@ export default class UI extends React.PureComponent {
       this.dragTargets.push(e.target);
     }
 
-    if (e.dataTransfer && e.dataTransfer.types.includes('Files')) {
+    if (e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files')) {
       this.setState({ draggingOver: true });
     }
   }


### PR DESCRIPTION
[DataTransfer.types](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/types) is Array of string on Chrome, but it is 
`DomStringList` on MS-Edge. so it throws an Error.

![image](https://user-images.githubusercontent.com/5253290/41509533-4f7b09e4-7290-11e8-81e7-da955b9f3347.png)
