### PR TITLE
Change list icons, different from the getting-started icons

### DIFF
--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -95,7 +95,7 @@ export default class GettingStarted extends ImmutablePureComponent {
     navItems.push(
       <ColumnLink key={i++} icon='envelope' text={intl.formatMessage(messages.direct)} to='/timelines/direct' />,
       <ColumnLink key={i++} icon='star' text={intl.formatMessage(messages.favourites)} to='/favourites' />,
-      <ColumnLink key={i++} icon='bars' text={intl.formatMessage(messages.lists)} to='/lists' />
+      <ColumnLink key={i++} icon='list-ul' text={intl.formatMessage(messages.lists)} to='/lists' />
     );
 
     height += 48*3;

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -138,7 +138,7 @@ export default class ListTimeline extends React.PureComponent {
     return (
       <Column ref={this.setRef}>
         <ColumnHeader
-          icon='bars'
+          icon='list-ul'
           active={hasUnread}
           title={title}
           onPin={this.handlePin}

--- a/app/javascript/mastodon/features/lists/index.js
+++ b/app/javascript/mastodon/features/lists/index.js
@@ -57,7 +57,7 @@ export default class Lists extends ImmutablePureComponent {
     }
 
     return (
-      <Column icon='bars' heading={intl.formatMessage(messages.heading)}>
+      <Column icon='list-ul' heading={intl.formatMessage(messages.heading)}>
         <ColumnBackButtonSlim />
 
         <NewListForm />
@@ -66,7 +66,7 @@ export default class Lists extends ImmutablePureComponent {
           <ColumnSubheading text={intl.formatMessage(messages.subheading)} />
 
           {lists.map(list =>
-            <ColumnLink key={list.get('id')} to={`/timelines/list/${list.get('id')}`} icon='bars' text={list.get('title')} />
+            <ColumnLink key={list.get('id')} to={`/timelines/list/${list.get('id')}`} icon='list-ul' text={list.get('title')} />
           )}
         </div>
       </Column>


### PR DESCRIPTION
 Explained in #7825 .

> The getting started menu now uses the same icon as the lists and the list menu. This is confusing.

![image](https://user-images.githubusercontent.com/27640522/41538283-ef32d894-7345-11e8-8f01-014cc21416bc.png)
![image](https://user-images.githubusercontent.com/27640522/41538306-02b016c0-7346-11e8-8953-056c6beb17b7.png)
