### PR TITLE
Create special case to prefer "jpeg" over "jpe" file extension

### DIFF
--- a/app/models/concerns/attachmentable.rb
+++ b/app/models/concerns/attachmentable.rb
@@ -41,7 +41,9 @@ module Attachmentable
 
     extensions_for_mime_type = mime_type.empty? ? [] : mime_type.first.extensions
     original_extension       = Paperclip::Interpolations.extension(attachment, :original)
+    proper_extension         = extensions_for_mime_type.first.to_s
+    proper_extension         = 'jpeg' if proper_extension == 'jpe'
 
-    extensions_for_mime_type.include?(original_extension) ? original_extension : extensions_for_mime_type.first
+    extensions_for_mime_type.include?(original_extension) ? original_extension : proper_extension
   end
 end


### PR DESCRIPTION
Fix #7787
Fix #2403

Blame the ruby mime types library for returning "jpe" as the first item