### PR TITLE
Update bcrypt to 3.1.12 fix issue with Fedora

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.2)
-    bcrypt (3.1.11)
+    bcrypt (3.1.12)
     benchmark-ips (2.7.2)
     better_errors (2.4.0)
       coderay (>= 1.0.0)


### PR DESCRIPTION
Ref: codahale/bcrypt-ruby#170