### PR TITLE
Fix broken single column getting-started menu (Fix #7854)

### DIFF
--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -109,10 +109,9 @@ export default class GettingStarted extends ImmutablePureComponent {
       navItems.push(
         <ColumnSubheading key={i++} text={intl.formatMessage(messages.settings_subheading)} />,
         <ColumnLink key={i++} icon='gears' text={intl.formatMessage(messages.preferences)} href='/settings/preferences' />,
-        <ColumnLink key={i++} icon='lock' text={intl.formatMessage(messages.security)} href='/auth/edit' />
       );
 
-      height += 34 + 48*2;
+      height += 34 + 48;
     }
 
     return (

--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -79,7 +79,7 @@ export default class GettingStarted extends ImmutablePureComponent {
 
     const navItems = [];
     let i = 1;
-    let height = 0;
+    let height = (multiColumn) ? 0 : 60;
 
     if (multiColumn) {
       navItems.push(


### PR DESCRIPTION
This PR implements to:

* Fix lack of height of the .getting-started__wrapper
Because height of the .getting-started__wrapper does not includes height of the .navigation-bar.

* Remove item "Security" on the getting-started menu
Because current design to assumes that menu item "Security" does not exist, I think that is better to remove it. The "Security" link already exists on the footer.
