### PR TITLE
Return collect response when fail put cache to storage

### DIFF
--- a/app/javascript/mastodon/service_worker/entry.js
+++ b/app/javascript/mastodon/service_worker/entry.js
@@ -32,8 +32,11 @@ self.addEventListener('fetch', function(event) {
     const asyncCache = openWebCache();
 
     event.respondWith(asyncResponse.then(
-      response => asyncCache.then(cache => cache.put('/', response.clone()))
-        .then(() => response),
+      response => {
+        const clonedResponse = response.clone();
+        asyncCache.then(cache => cache.put('/', clonedResponse)).catch();
+        return response;
+      },
       () => asyncCache.then(cache => cache.match('/'))));
   } else if (url.pathname === '/auth/sign_out') {
     const asyncResponse = fetch(event.request);
@@ -58,14 +61,9 @@ self.addEventListener('fetch', function(event) {
 
           return asyncResponse.then(response => {
             if (response.ok) {
-              const put = cache.put(event.request.url, response.clone());
-
-              put.catch(() => freeStorage());
-
-              return put.then(() => {
-                freeStorage();
-                return response;
-              });
+              cache
+                .put(event.request.url, response.clone())
+                .catch(err=>console.error(err)).then(freeStorage()).catch();
             }
 
             return response;

--- a/app/javascript/mastodon/service_worker/entry.js
+++ b/app/javascript/mastodon/service_worker/entry.js
@@ -63,7 +63,7 @@ self.addEventListener('fetch', function(event) {
             if (response.ok) {
               cache
                 .put(event.request.url, response.clone())
-                .catch(err=>console.error(err)).then(freeStorage()).catch();
+                .catch(()=>{}).then(freeStorage()).catch();
             }
 
             return response;


### PR DESCRIPTION
When failing ServiceWorker Cache putting (ex: `Quota exceeded`), the response will not return to front process. So images or page cannot show.

Errors should be ignored.


(There is a possibility to solve #7833 )

Example problem:
<img src="https://user-images.githubusercontent.com/5253290/41667961-39fb61d0-74e9-11e8-967f-796eefd48c26.png" width="50%">
![image](https://user-images.githubusercontent.com/5253290/41668005-4f9fecfe-74e9-11e8-9765-c45ed99373f6.png)
