### PR TITLE
Replace bypass option with bypass_sign_in

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -10,7 +10,7 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
     return unless request.patch? && params[:user]
     if @user.update(user_params)
       @user.skip_reconfirmation!
-      sign_in(@user, bypass: true)
+      bypass_sign_in(@user)
       redirect_to root_path, notice: I18n.t('devise.confirmations.send_instructions')
     else
       @show_errors = true


### PR DESCRIPTION
While working on https://github.com/tootsuite/mastodon/pull/7866, I noticed a warning below.

```
DEPRECATION WARNING: [Devise] bypass option is deprecated and it will be removed in future version of Devise.
Please use bypass_sign_in method instead.
```

So, as instructed, replaced it with bypass_sign_in! 👍 

