### PR TITLE
fix : Disable reverted index changes

### DIFF
--- a/db/migrate/20180514130000_improve_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
+++ b/db/migrate/20180514130000_improve_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
@@ -4,8 +4,9 @@ class ImproveIndexOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Mi
   disable_ddl_transaction!
 
   def change
-    add_index :statuses, [:account_id, :id, :visibility], where: 'visibility IN (0, 1, 2)', algorithm: :concurrently
-    add_index :statuses, [:account_id, :id], where: 'visibility = 3', algorithm: :concurrently
-    remove_index :statuses, column: [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106
+  #  These changes ware reverted by migration 20180514140000.
+  #  add_index :statuses, [:account_id, :id, :visibility], where: 'visibility IN (0, 1, 2)', algorithm: :concurrently
+  #  add_index :statuses, [:account_id, :id], where: 'visibility = 3', algorithm: :concurrently
+  #  remove_index :statuses, column: [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106
   end
 end

--- a/db/migrate/20180514140000_revert_index_change_on_statuses_for_api_v1_accounts_account_id_statuses.rb
+++ b/db/migrate/20180514140000_revert_index_change_on_statuses_for_api_v1_accounts_account_id_statuses.rb
@@ -5,10 +5,11 @@ class RevertIndexChangeOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecor
 
   def change
     safety_assured do
-      add_index :statuses, [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106
+      add_index :statuses, [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106 unless index_exists?(:statuses, name: "index_statuses_20180106")
     end
 
-    remove_index :statuses, column: [:account_id, :id, :visibility], where: 'visibility IN (0, 1, 2)', algorithm: :concurrently
-    remove_index :statuses, column: [:account_id, :id], where: 'visibility = 3', algorithm: :concurrently
+    # These index may not exists (see migration 20180514130000)
+    remove_index :statuses, column: [:account_id, :id, :visibility], where: 'visibility IN (0, 1, 2)', algorithm: :concurrently if index_exists?(:statuses, [:account_id, :id, :visibility], where: 'visibility IN (0, 1, 2)')
+    remove_index :statuses, column: [:account_id, :id], where: 'visibility = 3', algorithm: :concurrently if index_exists?(:statuses, ["account_id", "id"], where: "(visibility = 3)")
   end
 end


### PR DESCRIPTION
#7476 is reverted by #7484, but they were not disabled.

They are rebuilding index on statuses table, some instances will take long time.
They should disabled.

```
$ bundle ex rails db:migrate
   (0.3ms)  SELECT pg_try_advisory_lock(5881450594042647960)
   (1.3ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
Migrating to RevertIndexChangeOnStatusesForApiV1AccountsAccountIdStatuses (20180514140000)
Chewy strategies stack: [2] <- bypass @ /home/fusagiko/github/mastodon/vendor/bundle/ruby/2.5.0/gems/chewy-5.0.0/lib/chewy/railtie.rb:37
== 20180514140000 RevertIndexChangeOnStatusesForApiV1AccountsAccountIdStatuses: migrating
-- index_exists?(:statuses, {:name=>"index_statuses_20180106"})
   -> 0.0058s
-- add_index(:statuses, [:account_id, :id, :visibility, :updated_at], {:order=>{:id=>:desc}, :algorithm=>:concurrently, :name=>:index_statuses_20180106})
   (2.9ms)  CREATE  INDEX CONCURRENTLY "index_statuses_20180106" ON "statuses"  ("account_id", "id" DESC, "visibility", "updated_at")
   -> 0.0045s
-- index_exists?(:statuses, [:account_id, :id, :visibility], {:where=>"visibility IN (0, 1, 2)"})
   -> 0.0052s
-- remove_index(:statuses, {:column=>[:account_id, :id, :visibility], :where=>"visibility IN (0, 1, 2)", :algorithm=>:concurrently})
   (1.2ms)  DROP INDEX CONCURRENTLY "index_statuses_on_account_id_and_id_and_visibility"
   -> 0.0069s
-- index_exists?(:statuses, ["account_id", "id"], {:where=>"(visibility = 3)"})
   -> 0.0046s
-- remove_index(:statuses, {:column=>[:account_id, :id], :where=>"visibility = 3", :algorithm=>:concurrently})
   (1.2ms)  DROP INDEX CONCURRENTLY "index_statuses_on_account_id_and_id"
   -> 0.0060s
== 20180514140000 RevertIndexChangeOnStatusesForApiV1AccountsAccountIdStatuses: migrated (0.0342s)
```