### PR TITLE
Fix jpeg files sometimes being returned with a .jpe extension

### DIFF
--- a/app/models/concerns/attachmentable.rb
+++ b/app/models/concerns/attachmentable.rb
@@ -42,8 +42,9 @@ module Attachmentable
     extensions_for_mime_type = mime_type.empty? ? [] : mime_type.first.extensions
     original_extension       = Paperclip::Interpolations.extension(attachment, :original)
     proper_extension         = extensions_for_mime_type.first.to_s
-    proper_extension         = 'jpeg' if proper_extension == 'jpe'
+    extension                = extensions_for_mime_type.include?(original_extension) ? original_extension : proper_extension
+    extension                = 'jpeg' if extension == 'jpe'
 
-    extensions_for_mime_type.include?(original_extension) ? original_extension : proper_extension
+    extension
   end
 end


### PR DESCRIPTION
While this isn't exactly *wrong*, files uploaded with a “.jpe” extension will
keep that extension, which will often cause them to be served with an
incorrect mimetype.

50689f0d41b1f02c2d26c353571dfd15d8a4f186 prevented jpeg uploaded without any proper extension to be changed to a `.jpe` extension. This PR prevents files uploaded *with* a .jpe extension from having a .jpe extension.