### PR TITLE
Add symbolic link for yarnpkg (regression from #7889)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN apk -U upgrade \
  && rm yarn.tar.gz \
  && mv /tmp/src/yarn-v$YARN_VERSION /opt/yarn \
  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
+ && ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg \
  && wget -O libiconv.tar.gz "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-$LIBICONV_VERSION.tar.gz" \
  && echo "$LIBICONV_DOWNLOAD_SHA256 *libiconv.tar.gz" | sha256sum -c - \
  && tar -xzf libiconv.tar.gz -C /tmp/src \

--- a/bin/yarn
+++ b/bin/yarn
@@ -2,7 +2,7 @@
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
   begin
-    exec "yarnpkg #{ARGV.join(' ')}" unless Dir.exist?('node_modules')
+    exec "yarnpkg", *ARGV
   rescue Errno::ENOENT
     $stderr.puts "Yarn executable was not detected in the system."
     $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"


### PR DESCRIPTION
```console
$ docker run -e OTP_SECRET=x -e SECRET_KEY_BASE=x --rm -it tootsuite/mastodon:edge ./bin/rails assets:precompile
I, [2018-06-26T17:43:26.942564 #7]  INFO -- : Writing /mastodon/public/assets/doorkeeper/admin/application-50d68ad91b15067c63771e4811d971d7a56406c472a878021d1fb95d066efd8d.css
I, [2018-06-26T17:43:26.943030 #7]  INFO -- : Writing /mastodon/public/assets/doorkeeper/admin/application-50d68ad91b15067c63771e4811d971d7a56406c472a878021d1fb95d066efd8d.css.gz
I, [2018-06-26T17:43:26.949967 #7]  INFO -- : Writing /mastodon/public/assets/doorkeeper/application-29873392fba1f6a4fd5359214f854d900e24920096164f6e5343dbc0de69df0d.css
I, [2018-06-26T17:43:26.950140 #7]  INFO -- : Writing /mastodon/public/assets/doorkeeper/application-29873392fba1f6a4fd5359214f854d900e24920096164f6e5343dbc0de69df0d.css.gz
I, [2018-06-26T17:43:26.951738 #7]  INFO -- : Writing /mastodon/public/assets/pghero/favicon-db10337a56c45eb43c22ff5019546b520fa22c7281d4d385f235cbca67ed26bb.png
I, [2018-06-26T17:43:27.143863 #7]  INFO -- : Writing /mastodon/public/assets/pghero/application-b6568ba483c03c4fdcd8edd641f3b341ac0314ba01ab186645b8fc231cdff02e.js
I, [2018-06-26T17:43:27.144033 #7]  INFO -- : Writing /mastodon/public/assets/pghero/application-b6568ba483c03c4fdcd8edd641f3b341ac0314ba01ab186645b8fc231cdff02e.js.gz
I, [2018-06-26T17:43:27.155180 #7]  INFO -- : Writing /mastodon/public/assets/pghero/application-d7ee8e7dc0785de97337625e0f1030e1a892327ef4e72a48043ce09fd964874d.css
I, [2018-06-26T17:43:27.155327 #7]  INFO -- : Writing /mastodon/public/assets/pghero/application-d7ee8e7dc0785de97337625e0f1030e1a892327ef4e72a48043ce09fd964874d.css.gz
Yarn not installed. Please download and install Yarn from https://yarnpkg.com/lang/en/docs/install/
```