### PR TITLE
Add .bundle to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.bundle
 .env
 .env.*
 public/system


### PR DESCRIPTION
```console
$ bundle install --path vendor/bundle
$ #
$ # (snip)
$ #
$ docker build -t ykzts/mastodon:edge --no-cache .
$ docker run --rm ykzts/mastodon:edge cat .bundle/config
---
BUNDLE_PATH: "vendor/bundle/"
$ docker run --rm ykzts/mastodon:edge ./bin/rails -v
/usr/local/lib/ruby/site_ruby/2.4.0/bundler/spec_set.rb:88:in `block in materialize': Could not find rpam2-4.0.2 in any of the sources (Bundler::GemNotFound)
        from /usr/local/lib/ruby/site_ruby/2.4.0/bundler/spec_set.rb:82:in `map!'
        from /usr/local/lib/ruby/site_ruby/2.4.0/bundler/spec_set.rb:82:in `materialize'
        from /usr/local/lib/ruby/site_ruby/2.4.0/bundler/definition.rb:170:in `specs'
        from /usr/local/lib/ruby/site_ruby/2.4.0/bundler/definition.rb:237:in `specs_for'
        from /usr/local/lib/ruby/site_ruby/2.4.0/bundler/definition.rb:226:in `requested_specs'
        from /usr/local/lib/ruby/site_ruby/2.4.0/bundler/runtime.rb:108:in `block in definition_method'
        from /usr/local/lib/ruby/site_ruby/2.4.0/bundler/runtime.rb:20:in `setup'
        from /usr/local/lib/ruby/site_ruby/2.4.0/bundler.rb:107:in `setup'
        from /usr/local/lib/ruby/site_ruby/2.4.0/bundler/setup.rb:20:in `<top (required)>'
        from /usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:59:in `require'
        from /usr/local/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:59:in `require'
        from /mastodon/config/boot.rb:3:in `<top (required)>'
        from ./bin/rails:3:in `require_relative'
        from ./bin/rails:3:in `<main>'
```
