### PR TITLE
Merge `HIDDEN_SERVICE_VIA_TRANSPARENT_PROXY` into `ALLOW_ACCESS_TO_HI…

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -229,5 +229,3 @@ STREAMING_CLUSTER_NUM=1
 # http_proxy=http://gateway.local:8118
 # Access control for hidden service.
 # ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
-# If you use transparent proxy to access to hidden service, uncomment following for skipping private address check.
-# HIDDEN_SERVICE_VIA_TRANSPARENT_PROXY=true

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -154,7 +154,7 @@ class Request
       alias new open
 
       def thru_hidden_service?(host)
-        Rails.configuration.x.hidden_service_via_transparent_proxy && /\.(onion|i2p)$/.match(host)
+        Rails.configuration.x.access_to_hidden_service && /\.(onion|i2p)$/.match(host)
       end
     end
   end

--- a/config/initializers/http_client_proxy.rb
+++ b/config/initializers/http_client_proxy.rb
@@ -11,7 +11,6 @@ Rails.application.configure do
   end
 
   config.x.access_to_hidden_service = ENV['ALLOW_ACCESS_TO_HIDDEN_SERVICE'] == 'true'
-  config.x.hidden_service_via_transparent_proxy = ENV['HIDDEN_SERVICE_VIA_TRANSPARENT_PROXY'] == 'true'
 end
 
 module Goldfinger

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,6 @@ services:
 ## Uncomment to enable federation with tor instances along with adding the following ENV variables
 ## http_proxy=http://privoxy:8118
 ## ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
-## HIDDEN_SERVICE_VIA_TRANSPARENT_PROXY=true
 #  tor:
 #    build: https://github.com/usbsnowcrash/docker-tor.git
 #    networks:


### PR DESCRIPTION
…DDEN_SERVICE`

If Mastodon accesses to the hidden service via transparent proxy, it's needed to avoid checking whether it's a private address, since `.onion` is resolved to a private address.

![tor-to-tor](https://user-images.githubusercontent.com/1224508/41994712-4b1cec26-7a8a-11e8-8345-e71af835fac9.png)

I was previously using the `HIDDEN_SERVICE_VIA_TRANSPARENT_PROXY` to provide that function. However, I realized that using `HIDDEN_SERVICE_VIA_TRANSPARENT_PROXY` is redundant, since this specification is always used with `ALLOW_ACCESS_TO_HIDDEN_SERVICE`. Therefore, I decided to integrate the setting of `HIDDEN_SERVICE_VIA_TRANSPARENT_PROXY` into` ALLOW_ACCESS_TO_HIDDEN_SERVICE`.