### PR TITLE
Fix JS security issue in unescapeHTML()

### DIFF
--- a/app/javascript/mastodon/utils/html.js
+++ b/app/javascript/mastodon/utils/html.js
@@ -1,5 +1,6 @@
 export const unescapeHTML = (html) => {
   const wrapper = document.createElement('div');
   wrapper.innerHTML = html.replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n').replace(/<[^>]*>/g, '');
+  wrapper.innerHTML = wrapper.textContent;
   return wrapper.textContent;
 };


### PR DESCRIPTION
As far as I understand, the purpose of the `unescapeHTML()` function is to remove any HTML tags, and replace paragraphs and break line tags with new line characters.

The current implementation can be exploited using HTML entity characters.

`unescapeHTML('<script>evil()</script>')` will return `evil()`, however `unescapeHTML('&lt;script&gt;evil()&lt;/script&gt;')` will return `<script>evil()<\script>`. This is because in the process of setting the `innerHTML` and then requesting the textContent, those HTML entities get changed back into their original representation. This leaves the gate open for a potential XSS attack, as a developer might assume the function returns a safe string.

This fix prevents that from happening, by first setting the innerHTML once more to the textContent, and then requesting the textContent, thus removing any HTML that has been encoded using HTML entities.