### PR TITLE
Typo in signature verification failure logging

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -58,11 +58,11 @@ module SignatureVerification
         @signed_request_account = account
         @signed_request_account
       else
-        @signed_verification_failure_reason = "Verification failed for #{account.username}@#{account.domain} #{account.uri}"
+        @signature_verification_failure_reason = "Verification failed for #{account.username}@#{account.domain} #{account.uri}"
         @signed_request_account = nil
       end
     else
-      @signed_verification_failure_reason = "Verification failed for #{account.username}@#{account.domain} #{account.uri}"
+      @signature_verification_failure_reason = "Verification failed for #{account.username}@#{account.domain} #{account.uri}"
       @signed_request_account = nil
     end
   end


### PR DESCRIPTION
`@signature_verification_failure_reason` is used in most places but`@signed_verification_failure_reason` appears in two places.

Likely those errors are not returned.