### PR TITLE
Improve embeds

### DIFF
--- a/app/controllers/remote_follow_controller.rb
+++ b/app/controllers/remote_follow_controller.rb
@@ -5,6 +5,7 @@ class RemoteFollowController < ApplicationController
 
   before_action :set_account
   before_action :gone, if: :suspended_account?
+  before_action :set_body_classes
 
   def new
     @remote_follow = RemoteFollow.new(session_params)

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -46,7 +46,12 @@ class StatusesController < ApplicationController
   end
 
   def embed
+    raise ActiveRecord::RecordNotFound if @status.hidden?
+
+    skip_session!
+    expires_in 180, public: true
     response.headers['X-Frame-Options'] = 'ALLOWALL'
+
     render 'stream_entries/embed', layout: 'embedded'
   end
 

--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -64,7 +64,7 @@ function main() {
     [].forEach.call(document.querySelectorAll('.logo-button'), (content) => {
       content.addEventListener('click', (e) => {
         e.preventDefault();
-        window.open(e.target.href, 'mastodon-intent', 'width=400,height=400,resizable=no,menubar=no,status=no,scrollbars=yes');
+        window.open(e.target.href, 'mastodon-intent', 'width=445,height=600,resizable=no,menubar=no,status=no,scrollbars=yes');
       });
     });
 

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -464,6 +464,7 @@
   background: $simple-background-color;
 
   &__header {
+    background: $base-shadow-color;
     background-size: cover;
     background-position: center center;
     height: 90px;

--- a/app/javascript/styles/mastodon/stream_entries.scss
+++ b/app/javascript/styles/mastodon/stream_entries.scss
@@ -324,6 +324,9 @@
         .button.button-secondary.logo-button {
           flex: 0 auto;
           font-size: 14px;
+          background: $ui-highlight-color;
+          color: $primary-text-color;
+          border: 0;
 
           svg {
             width: 20px;
@@ -332,19 +335,21 @@
             margin-right: 5px;
 
             path:first-child {
-              fill: $ui-primary-color;
+              fill: $primary-text-color;
             }
 
             path:last-child {
-              fill: $simple-background-color;
+              fill: $ui-highlight-color;
             }
           }
 
           &:active,
           &:focus,
           &:hover {
-            svg path:first-child {
-              fill: lighten($ui-primary-color, 4%);
+            background: lighten($ui-highlight-color, 10%);
+
+            svg path:last-child {
+              fill: lighten($ui-highlight-color, 10%);
             }
           }
         }

--- a/app/views/remote_follow/new.html.haml
+++ b/app/views/remote_follow/new.html.haml
@@ -11,3 +11,5 @@
 
     .actions
       = f.button :button, t('remote_follow.proceed'), type: :submit
+
+    %p.hint.subtle-hint= t('remote_follow.no_account_html', sign_up_path: open_registrations? ? new_user_registration_path : 'https://joinmastodon.org')

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -8,7 +8,7 @@
       %span= acct(status.account)
 
   - if embedded_view?
-    = link_to "web+mastodon://follow?uri=#{status.account.local_username_and_domain}", class: 'button button-secondary logo-button', target: '_new' do
+    = link_to account_remote_follow_path(status.account), class: 'button button-secondary logo-button', target: '_new' do
       = render file: Rails.root.join('app', 'javascript', 'images', 'logo.svg')
       = t('accounts.follow')
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,6 +615,7 @@ en:
   remote_follow:
     acct: Enter your username@domain you want to follow from
     missing_resource: Could not find the required redirect URL for your account
+    no_account_html: Don't have an account? You can <a href='%{sign_up_path}' target='_blank'>sign up here</a>
     proceed: Proceed to follow
     prompt: 'You are going to follow:'
   remote_unfollow:


### PR DESCRIPTION
- Make them reverse-proxy-cacheable
- Make the follow button open remote follow dialog instead of web+mastodon:// link which may fail
- Add sign up prompt below remote follow dialog
- Make follow button blue instead of almost transparent

![screen shot 2018-06-30 at 23 48 21](https://user-images.githubusercontent.com/184731/42129260-18dcf0a2-7cc0-11e8-94c6-0599d44f436a.png)