### PR TITLE
Display full username in tooltip on search and autosuggest #7478

### DIFF
--- a/app/javascript/mastodon/components/account.js
+++ b/app/javascript/mastodon/components/account.js
@@ -101,7 +101,7 @@ export default class Account extends ImmutablePureComponent {
     return (
       <div className='account'>
         <div className='account__wrapper'>
-          <Permalink key={account.get('id')} className='account__display-name' href={account.get('url')} to={`/accounts/${account.get('id')}`}>
+          <Permalink key={account.get('id')} className='account__display-name' title={account.get('acct')} href={account.get('url')} to={`/accounts/${account.get('id')}`}>
             <div className='account__avatar-wrapper'><Avatar account={account} size={36} /></div>
             <DisplayName account={account} />
           </Permalink>

--- a/app/javascript/mastodon/features/compose/components/autosuggest_account.js
+++ b/app/javascript/mastodon/features/compose/components/autosuggest_account.js
@@ -14,7 +14,7 @@ export default class AutosuggestAccount extends ImmutablePureComponent {
     const { account } = this.props;
 
     return (
-      <div className='autosuggest-account'>
+      <div className='autosuggest-account' title={account.get('acct')}>
         <div className='autosuggest-account-icon'><Avatar account={account} size={18} /></div>
         <DisplayName account={account} />
       </div>


### PR DESCRIPTION
Modified so that the both the search results and the autosuggest popup have a tooltip that shows the username (and domain if they are not on the local instance).

![tooltip1](https://user-images.githubusercontent.com/4073413/42130308-cf15afa4-7cd8-11e8-9ccd-faa011555fd8.png)

![tooltip2](https://user-images.githubusercontent.com/4073413/42130312-dc0ff908-7cd8-11e8-86c5-a40eee5af882.png)
