### PR TITLE
fixes Microformats markup on spoiler posts

### DIFF
--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -12,10 +12,10 @@
       = render file: Rails.root.join('app', 'javascript', 'images', 'logo.svg')
       = t('accounts.follow')
 
-  .status__content.p-name.emojify<
+  .status__content.emojify<
     - if status.spoiler_text?
       %p{ style: 'margin-bottom: 0' }<
-        %span.p-summary> #{Formatter.instance.format_spoiler(status)}&nbsp;
+        %span.p-name.p-summary> #{Formatter.instance.format_spoiler(status)}&nbsp;
         %a.status__content__spoiler-link{ href: '#' }= t('statuses.show_more')
     .e-content{ lang: status.language, style: "display: #{status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl_status?(status) ? 'rtl' : 'ltr'}" }= Formatter.instance.format(status, custom_emojify: true)
 


### PR DESCRIPTION
Currently, the `p-name` element encompasses both the preview text as well as the spoiler text. This causes problems with rendering from the Microformats data since the post appears to be an "article" where the name of the article is the full preview and spoiler text.

This change moves the `p-name` class onto the same element as `p-summary` which should provide the desired behavior to consumers even if they don't understand the `p-summary`. This will make the post appear to be an "article" where the preview text is the name of the article.