### PR TITLE
Fix #6395 - overlapping profile name and domain

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -352,7 +352,7 @@ code {
     position: relative;
 
     .input input {
-      padding-right: 127px;
+      padding-right: 142px;
     }
 
     .append {
@@ -366,6 +366,20 @@ code {
       font-family: inherit;
       pointer-events: none;
       cursor: default;
+      max-width: 140px;
+      white-space: nowrap;
+      overflow: hidden;
+
+      &::after {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 1px;
+        width: 5px;
+        background-image: linear-gradient(to right, rgba($classic-base-color, 0), $classic-base-color);
+      }
     }
   }
 }

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -206,13 +206,19 @@ body.rtl {
   }
 
   .simple_form .input-with-append .input input {
-    padding-left: 127px;
+    padding-left: 142px;
     padding-right: 0;
   }
 
   .simple_form .input-with-append .append {
     right: auto;
     left: 0;
+
+    &::after {
+      right: auto;
+      left: 0;
+      background-image: linear-gradient(to left, rgba($classic-base-color, 0), $classic-base-color);
+    }
   }
 
   .table th,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1668712/42171211-9fe0717c-7e10-11e8-8b26-ea0fd5e154ef.png)

After:
![image](https://user-images.githubusercontent.com/1668712/42171165-7e1362fc-7e10-11e8-8880-ea0cf7f6dfed.png)

This change crops the "append" element and adds a little fade out at the end so that it doesn't look too jarring. We should probably eventually find a solution to display that phrase in full, but for now I think this is an improvement.