### PR TITLE
Allow the media modal to be closed by pressing back

### DIFF
--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -16,6 +16,8 @@ const messages = defineMessages({
   next: { id: 'lightbox.next', defaultMessage: 'Next' },
 });
 
+const previewState = 'previewMediaModal';
+
 @injectIntl
 export default class MediaModal extends ImmutablePureComponent {
 
@@ -24,6 +26,10 @@ export default class MediaModal extends ImmutablePureComponent {
     index: PropTypes.number.isRequired,
     onClose: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
+  };
+
+  static contextTypes = {
+    router: PropTypes.object,
   };
 
   state = {
@@ -61,10 +67,20 @@ export default class MediaModal extends ImmutablePureComponent {
 
   componentDidMount () {
     window.addEventListener('keyup', this.handleKeyUp, false);
+    const history = this.context.router.history;
+    history.push(history.location.pathname, previewState);
+    this.unlistenHistory = history.listen(() => {
+      this.props.onClose();
+    });
   }
 
   componentWillUnmount () {
     window.removeEventListener('keyup', this.handleKeyUp);
+    this.unlistenHistory();
+
+    if (this.context.router.history.location.state === previewState) {
+      this.context.router.history.goBack();
+    }
   }
 
   getIndex () {


### PR DESCRIPTION
The purpose of this change is to be able to close the media modal using the back button (popular behaviour on Android phones).