### PR TITLE
Restore support to ruby 2.3, add ruby 2.3 to circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,13 @@ jobs:
         environment: *ruby_environment
     <<: *install_ruby_dependencies
 
+  install-ruby2.3:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.3.7-stretch-node
+        environment: *ruby_environment
+    <<: *install_ruby_dependencies
+
   build:
     <<: *defaults
     steps:
@@ -146,6 +153,17 @@ jobs:
       - image: circleci/redis:4.0.9-alpine
     <<: *test_steps
 
+  test-ruby2.3:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.3.7-stretch-node
+        environment: *ruby_environment
+      - image: circleci/postgres:10.3-alpine
+        environment:
+          POSTGRES_USER: root
+      - image: circleci/redis:4.0.9-alpine
+    <<: *test_steps
+
   test-webui:
     <<: *defaults
     docker:
@@ -174,6 +192,9 @@ workflows:
       - install-ruby2.4:
           requires:
             - install
+      - install-ruby2.3:
+          requires:
+            - install
       - build:
           requires:
             - install-ruby2.5
@@ -184,6 +205,10 @@ workflows:
       - test-ruby2.4:
           requires:
             - install-ruby2.4
+            - build
+      - test-ruby2.3:
+          requires:
+            - install-ruby2.3
             - build
       - test-webui:
           requires:

--- a/app/models/concerns/attachmentable.rb
+++ b/app/models/concerns/attachmentable.rb
@@ -28,7 +28,7 @@ module Attachmentable
     self.class.attachment_definitions.each_key do |attachment_name|
       attachment = send(attachment_name)
 
-      next if attachment.blank? || !attachment.content_type.match?(/image.*/) || attachment.queued_for_write[:original].blank?
+      next if attachment.blank? || !/image.*/.match?(attachment.content_type) || attachment.queued_for_write[:original].blank?
 
       width, height = FastImage.size(attachment.queued_for_write[:original].path)
 


### PR DESCRIPTION
This replace calls of String#match? with rails Regex#match?
This follows the same idea used to keep Rails 5.2 compatible with Ruby 2.2.2 in https://github.com/rails/rails/pull/32973

Solves #7642