### PR TITLE
Add white outline to black emojis (fix #5083)

### DIFF
--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -22,3 +22,4 @@
 @import 'mastodon/tables';
 @import 'mastodon/admin';
 @import 'mastodon/rtl';
+@import 'mastodon/accessibility';

--- a/app/javascript/styles/mastodon/accessibility.scss
+++ b/app/javascript/styles/mastodon/accessibility.scss
@@ -1,0 +1,14 @@
+$black-emojis: '8ball' 'ant' 'back' 'black_circle' 'black_large_square' 'black_medium_small_square' 'black_medium_square' 'black_nib' 'black_small_square' 'bomb' 'bust_in_silhouette' 'camera' 'camera_with_flash' 'clubs' 'copyright' 'curly_loop' 'currency_exchange' 'end' 'heavy_check_mark' 'heavy_division_sign' 'heavy_dollar_sign' 'heavy_minus_sign' 'heavy_multiplication_x' 'heavy_plus_sign' 'lower_left_fountain_pen' 'on' 'registered' 'soon' 'spades' 'spider' 'tm' 'top' 'waving_black_flag' 'wavy_dash' 'video_game';
+
+%white-emoji-outline {
+  filter: drop-shadow(1px 1px 0 $white) drop-shadow(-1px 1px 0 $white) drop-shadow(1px -1px 0 $white) drop-shadow(-1px -1px 0 $white);
+  transform: scale(.71);
+}
+
+.emojione {
+  @each $emoji in $black-emojis {
+    &[title=':#{$emoji}:'] {
+      @extend %white-emoji-outline;
+    }
+  }
+}


### PR DESCRIPTION
This change adds a white outline to black emojis so they are visible while using the default theme. It also reduces their size slightly so that the outline does not leak out outside the container.

The list of black emojis can be easily updated by appending a string to a SASS variable.

![image](https://user-images.githubusercontent.com/1668712/42222114-1c55820e-7ecc-11e8-9590-3b352ccee6fd.png)
