### PR TITLE
Respect noindex rule in remote follow view (fix #7869)

### DIFF
--- a/app/views/remote_follow/new.html.haml
+++ b/app/views/remote_follow/new.html.haml
@@ -1,3 +1,7 @@
+- content_for :header_tags do
+  - if @account.user&.setting_noindex
+    %meta{ name: 'robots', content: 'noindex' }/
+
 .form-container
   .follow-prompt
     %h2= t('remote_follow.prompt')


### PR DESCRIPTION
This change adds a noindex meta tag to the remote follow view if the user has opted out of search engine indexing.