### PR TITLE
Check if router is injected in media modal

### DIFF
--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -67,19 +67,23 @@ export default class MediaModal extends ImmutablePureComponent {
 
   componentDidMount () {
     window.addEventListener('keyup', this.handleKeyUp, false);
-    const history = this.context.router.history;
-    history.push(history.location.pathname, previewState);
-    this.unlistenHistory = history.listen(() => {
-      this.props.onClose();
-    });
+    if (this.context.router) {
+      const history = this.context.router.history;
+      history.push(history.location.pathname, previewState);
+      this.unlistenHistory = history.listen(() => {
+        this.props.onClose();
+      });
+    }
   }
 
   componentWillUnmount () {
     window.removeEventListener('keyup', this.handleKeyUp);
-    this.unlistenHistory();
+    if (this.context.router) {
+      this.unlistenHistory();
 
-    if (this.context.router.history.location.state === previewState) {
-      this.context.router.history.goBack();
+      if (this.context.router.history.location.state === previewState) {
+        this.context.router.history.goBack();
+      }
     }
   }
 


### PR DESCRIPTION
In certain scenarios the router does not exist (public view). Issue mentioned in #7934. This change adds a check to avoid issues.

A TODO could be falling back to native History API.