### PR TITLE
Add comment, test to unescapeHTML

### DIFF
--- a/app/javascript/mastodon/utils/__tests__/html-test.js
+++ b/app/javascript/mastodon/utils/__tests__/html-test.js
@@ -1,0 +1,10 @@
+import * as html from '../html';
+
+describe('html', () => {
+  describe('unsecapeHTML', () => {
+    it('returns unescaped HTML', () => {
+      const output = html.unescapeHTML('<p>lorem</p><p>ipsum</p><br>&lt;br&gt;');
+      expect(output).toEqual('lorem\n\nipsum\n<br>');
+    });
+  });
+});

--- a/app/javascript/mastodon/utils/html.js
+++ b/app/javascript/mastodon/utils/html.js
@@ -1,3 +1,4 @@
+// NB: This function can still return unsafe HTML
 export const unescapeHTML = (html) => {
   const wrapper = document.createElement('div');
   wrapper.innerHTML = html.replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n').replace(/<[^>]*>/g, '');


### PR DESCRIPTION
This change adds a test and a comment with clarification regarding the `unescapeHTML()` function (as discussed in #7912). This is to avoid confusion whether the function is returning safe HTML or not.