### PR TITLE
Fix gradient, regression from #7927

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -378,7 +378,7 @@ code {
         right: 0;
         bottom: 1px;
         width: 5px;
-        background-image: linear-gradient(to right, rgba($classic-base-color, 0), $classic-base-color);
+        background-image: linear-gradient(to right, rgba($ui-base-color, 0), $ui-base-color);
       }
     }
   }

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -217,7 +217,7 @@ body.rtl {
     &::after {
       right: auto;
       left: 0;
-      background-image: linear-gradient(to left, rgba($classic-base-color, 0), $classic-base-color);
+      background-image: linear-gradient(to left, rgba($ui-base-color, 0), $ui-base-color);
     }
   }
 


### PR DESCRIPTION
The background color of the registration form is not `$classic-base-color` but `$ui-base-color`.

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/27640522/42363088-1049fb0e-8131-11e8-8bdb-f41773a394b9.png)|![image](https://user-images.githubusercontent.com/27640522/42363142-546590aa-8131-11e8-8207-5b13ecdb84a6.png)|

In defaul theme, the appearance is exactly the same.

Regression from #7927 .