### PR TITLE
Revert "Fix dark background error on user-mention autosuggest (#7937)"

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -52,7 +52,7 @@
   }
 
   .autosuggest-textarea__suggestions {
-    background: lighten($ui-base-color, 4%);
+    background: darken($ui-base-color, 6%);
   }
 
   .autosuggest-textarea__suggestions__item {


### PR DESCRIPTION
This reverts commit 7da74e3157f3b793a1b462ca143d87d6221716eb.

Bug: `.autosuggest-textarea__suggestions`'s background color and hovered `.autosuggest-textarea__suggestions__item`s color became the same by #7937 .