### PR TITLE
Add API method to remove a suggestion

### DIFF
--- a/app/controllers/api/v1/suggestions_controller.rb
+++ b/app/controllers/api/v1/suggestions_controller.rb
@@ -13,6 +13,11 @@ class Api::V1::SuggestionsController < Api::BaseController
     render json: @accounts, each_serializer: REST::AccountSerializer
   end
 
+  def destroy
+    PotentialFriendshipTracker.remove(current_account.id, params[:id])
+    render_empty
+  end
+
   private
 
   def set_accounts

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -203,7 +203,8 @@ module AccountInteractions
 
   private
 
-  def remove_potential_friendship(other_account)
+  def remove_potential_friendship(other_account, mutual = false)
     PotentialFriendshipTracker.remove(id, other_account.id)
+    PotentialFriendshipTracker.remove(other_account.id, id) if mutual
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -246,7 +246,7 @@ Rails.application.routes.draw do
 
       resources :streaming, only: [:index]
       resources :custom_emojis, only: [:index]
-      resources :suggestions, only: [:index]
+      resources :suggestions, only: [:index, :destroy]
 
       get '/search', to: 'search#index', as: :search
 


### PR DESCRIPTION
    DELETE /api/v1/suggestions/:account_id

When blocking, remove suggestion from both sides. Muting not affected,
since muting is supposed to be invisible to the target.