### PR TITLE
Delay link crawling for previews

### DIFF
--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -35,7 +35,8 @@ class Api::V1::StatusesController < Api::BaseController
   end
 
   def card
-    @card = @status.preview_cards.first
+    @card   = @status.preview_cards.first
+    @card ||= FetchLinkCardService.new.call(@status)
 
     if @card.nil?
       render_empty

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -73,8 +73,6 @@ class ActivityPub::Activity
   end
 
   def distribute(status)
-    crawl_links(status)
-
     notify_about_reblog(status) if reblog_of_local_account?(status)
     notify_about_mentions(status)
 
@@ -100,11 +98,6 @@ class ActivityPub::Activity
       next unless mention.account.local? && audience_includes?(mention.account)
       NotifyService.new.call(mention.account, mention)
     end
-  end
-
-  def crawl_links(status)
-    return if status.spoiler_text?
-    LinkCrawlWorker.perform_async(status.id)
   end
 
   def distribute_to_followers(status)

--- a/app/lib/ostatus/activity/creation.rb
+++ b/app/lib/ostatus/activity/creation.rb
@@ -64,8 +64,6 @@ class OStatus::Activity::Creation < OStatus::Activity::Base
 
     Rails.logger.debug "Queuing remote status #{status.id} (#{id}) for distribution"
 
-    LinkCrawlWorker.perform_async(status.id) unless status.spoiler_text?
-
     # Only continue if the status is supposed to have arrived in real-time.
     # Note that if @options[:override_timestamps] isn't set, the status
     # may have a lower snowflake id than other existing statuses, potentially

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -62,6 +62,7 @@ class FetchLinkCardService < BaseService
 
   def attach_card
     @status.preview_cards << @card
+    @card
   end
 
   def parse_urls


### PR DESCRIPTION
Fix #4486

TODO:

- [x] Do not crawl links when receiving remote status
- [x] Crawl links when requested by end-user