### PR TITLE
Upgrade Node.js to v8.x on Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+FROM node:8.11.3-alpine as node
 FROM ruby:2.4.4-alpine3.6
 
 LABEL maintainer="https://github.com/tootsuite/mastodon" \
@@ -11,14 +12,17 @@ ENV PATH=/mastodon/bin:$PATH \
     RAILS_ENV=production \
     NODE_ENV=production
 
-ARG YARN_VERSION=1.3.2
-ARG YARN_DOWNLOAD_SHA256=6cfe82e530ef0837212f13e45c1565ba53f5199eec2527b85ecbcd88bf26821d
 ARG LIBICONV_VERSION=1.15
 ARG LIBICONV_DOWNLOAD_SHA256=ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178
 
 EXPOSE 3000 4000
 
 WORKDIR /mastodon
+
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node /opt/yarn-* /opt/yarn
 
 RUN apk -U upgrade \
  && apk add -t build-dependencies \
@@ -39,20 +43,13 @@ RUN apk -U upgrade \
     imagemagick \
     libidn \
     libpq \
-    nodejs \
-    nodejs-npm \
     protobuf \
     tini \
     tzdata \
  && update-ca-certificates \
- && mkdir -p /tmp/src /opt \
- && wget -O yarn.tar.gz "https://github.com/yarnpkg/yarn/releases/download/v$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
- && echo "$YARN_DOWNLOAD_SHA256 *yarn.tar.gz" | sha256sum -c - \
- && tar -xzf yarn.tar.gz -C /tmp/src \
- && rm yarn.tar.gz \
- && mv /tmp/src/yarn-v$YARN_VERSION /opt/yarn \
  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
  && ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg \
+ && mkdir -p /tmp/src /opt \
  && wget -O libiconv.tar.gz "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-$LIBICONV_VERSION.tar.gz" \
  && echo "$LIBICONV_DOWNLOAD_SHA256 *libiconv.tar.gz" | sha256sum -c - \
  && tar -xzf libiconv.tar.gz -C /tmp/src \

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "tiny-queue": "^0.2.1",
     "uglifyjs-webpack-plugin": "^1.2.7",
     "uuid": "^3.1.0",
-    "uws": "^10.148.1",
+    "uws": "10.148.0",
     "webpack": "^4.16.0",
     "webpack-bundle-analyzer": "^2.13.1",
     "webpack-cli": "^3.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8385,9 +8385,9 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
-uws@^10.148.1:
-  version "10.148.1"
-  resolved "https://registry.yarnpkg.com/uws/-/uws-10.148.1.tgz#fd1a79cf6118a388e0a1bed8a1397030d2c4fd2c"
+uws@10.148.0:
+  version "10.148.0"
+  resolved "https://registry.yarnpkg.com/uws/-/uws-10.148.0.tgz#3fcd35f083ca515e091cd33b2d78f0f51a666215"
 
 v8-compile-cache@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Node.js v6 is no longer supported in #7448. Therefore, streaming does not run in Docker.
