### PR TITLE
Hide "A look inside" in mobile layout on frontpage

### DIFF
--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -923,7 +923,7 @@ $small-breakpoint: 960px;
     }
 
     @media screen and (max-width: $column-breakpoint) {
-      height: 90vh;
+      display: none;
     }
   }
 


### PR DESCRIPTION
It'd distracting and not very useful, also toots were pushing the width of the page out, ruining the responsive design.