### PR TITLE
Improve keyboard shortcuts descriptions

### DIFF
--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.js
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.js
@@ -41,6 +41,10 @@ export default class KeyboardShortcuts extends ImmutablePureComponent {
                 <td><FormattedMessage id='keyboard_shortcuts.mention' defaultMessage='to mention author' /></td>
               </tr>
               <tr>
+                <td><kbd>p</kbd></td>
+                <td><FormattedMessage id='keyboard_shortcuts.profile' defaultMessage="to open author's profile" /></td>
+              </tr>
+              <tr>
                 <td><kbd>f</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.favourite' defaultMessage='to favourite' /></td>
               </tr>

--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.js
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.js
@@ -49,7 +49,7 @@ export default class KeyboardShortcuts extends ImmutablePureComponent {
                 <td><FormattedMessage id='keyboard_shortcuts.boost' defaultMessage='to boost' /></td>
               </tr>
               <tr>
-                <td><kbd>enter</kbd></td>
+                <td><kbd>enter</kbd>, <kbd>o</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.enter' defaultMessage='to open status' /></td>
               </tr>
               <tr>
@@ -57,11 +57,11 @@ export default class KeyboardShortcuts extends ImmutablePureComponent {
                 <td><FormattedMessage id='keyboard_shortcuts.toggle_hidden' defaultMessage='to show/hide text behind CW' /></td>
               </tr>
               <tr>
-                <td><kbd>up</kbd></td>
+                <td><kbd>up</kbd>, <kbd>k</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.up' defaultMessage='to move up in the list' /></td>
               </tr>
               <tr>
-                <td><kbd>down</kbd></td>
+                <td><kbd>down</kbd>, <kbd>j</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.down' defaultMessage='to move down in the list' /></td>
               </tr>
               <tr>

--- a/app/javascript/mastodon/locales/ar.json
+++ b/app/javascript/mastodon/locales/ar.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "مفتاح الإختصار",
   "keyboard_shortcuts.legend": "لعرض هذا المفتاح",
   "keyboard_shortcuts.mention": "لذِكر الناشر",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "للردّ",
   "keyboard_shortcuts.search": "للتركيز على البحث",
   "keyboard_shortcuts.toggle_hidden": "لعرض أو إخفاء النص مِن وراء التحذير",

--- a/app/javascript/mastodon/locales/ast.json
+++ b/app/javascript/mastodon/locales/ast.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hotkey",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "to focus search",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/bg.json
+++ b/app/javascript/mastodon/locales/bg.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hotkey",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "to focus search",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/ca.json
+++ b/app/javascript/mastodon/locales/ca.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Tecla d'accés directe",
   "keyboard_shortcuts.legend": "per a mostrar aquesta llegenda",
   "keyboard_shortcuts.mention": "per esmentar l'autor",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "respondre",
   "keyboard_shortcuts.search": "per centrar la cerca",
   "keyboard_shortcuts.toggle_hidden": "per a mostrar/amagar text sota CW",

--- a/app/javascript/mastodon/locales/co.json
+++ b/app/javascript/mastodon/locales/co.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Accorta",
   "keyboard_shortcuts.legend": "vede a legenda",
   "keyboard_shortcuts.mention": "mintuvà l'autore",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "risponde",
   "keyboard_shortcuts.search": "fucalizà nant'à l'area di circata",
   "keyboard_shortcuts.toggle_hidden": "vede/piattà u testu daretu à l'avertimentu CW",

--- a/app/javascript/mastodon/locales/cs.json
+++ b/app/javascript/mastodon/locales/cs.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hotkey",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "to focus search",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/da.json
+++ b/app/javascript/mastodon/locales/da.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hurtigtast",
   "keyboard_shortcuts.legend": "for at vise denne legende",
   "keyboard_shortcuts.mention": "for at nævne forfatteren",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "for at svare",
   "keyboard_shortcuts.search": "for at fokusere søgningen",
   "keyboard_shortcuts.toggle_hidden": "for at vise/skjule tekst bag CW",

--- a/app/javascript/mastodon/locales/de.json
+++ b/app/javascript/mastodon/locales/de.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Tastenkürzel",
   "keyboard_shortcuts.legend": "um diese Übersicht anzuzeigen",
   "keyboard_shortcuts.mention": "um Autor_in zu erwähnen",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "um zu antworten",
   "keyboard_shortcuts.search": "um die Suche zu fokussieren",
   "keyboard_shortcuts.toggle_hidden": "um den Text hinter einer Inhaltswarnung zu verstecken oder ihn anzuzeigen",

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -1255,6 +1255,10 @@
         "id": "keyboard_shortcuts.mention"
       },
       {
+        "defaultMessage": "to open author's profile",
+        "id": "keyboard_shortcuts.profile"
+      },
+      {
         "defaultMessage": "to favourite",
         "id": "keyboard_shortcuts.favourite"
       },

--- a/app/javascript/mastodon/locales/el.json
+++ b/app/javascript/mastodon/locales/el.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Συντόμευση",
   "keyboard_shortcuts.legend": "για να εμφανίσεις αυτόν τον οδηγό",
   "keyboard_shortcuts.mention": "για να αναφέρεις το συγγραφέα",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "για απάντηση",
   "keyboard_shortcuts.search": "για εστίαση αναζήτησης",
   "keyboard_shortcuts.toggle_hidden": "για εμφάνιση/απόκρυψη κειμένου πίσω από την προειδοποίηση",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hotkey",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "to focus search",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/eo.json
+++ b/app/javascript/mastodon/locales/eo.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Rapidklavo",
   "keyboard_shortcuts.legend": "por montri ĉi tiun noton",
   "keyboard_shortcuts.mention": "por mencii la aŭtoron",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "por respondi",
   "keyboard_shortcuts.search": "por fokusigi la serĉilon",
   "keyboard_shortcuts.toggle_hidden": "por montri/kaŝi tekston malantaŭ enhava averto",

--- a/app/javascript/mastodon/locales/es.json
+++ b/app/javascript/mastodon/locales/es.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Tecla caliente",
   "keyboard_shortcuts.legend": "para mostrar esta leyenda",
   "keyboard_shortcuts.mention": "para mencionar al autor",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "para responder",
   "keyboard_shortcuts.search": "para poner el foco en la búsqueda",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/eu.json
+++ b/app/javascript/mastodon/locales/eu.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Laster-tekla",
   "keyboard_shortcuts.legend": "legenda hau bistaratzea",
   "keyboard_shortcuts.mention": "egilea aipatzea",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "erantzutea",
   "keyboard_shortcuts.search": "bilaketan fokua jartzea",
   "keyboard_shortcuts.toggle_hidden": "testua erakustea/ezkutatzea abisu baten atzean",

--- a/app/javascript/mastodon/locales/fa.json
+++ b/app/javascript/mastodon/locales/fa.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "میان‌بر",
   "keyboard_shortcuts.legend": "برای نمایش این راهنما",
   "keyboard_shortcuts.mention": "برای نام‌بردن از نویسنده",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "برای پاسخ‌دادن",
   "keyboard_shortcuts.search": "برای فعال‌کردن جستجو",
   "keyboard_shortcuts.toggle_hidden": "برای نمایش/نهفتن نوشتهٔ پشت هشدار محتوا",

--- a/app/javascript/mastodon/locales/fi.json
+++ b/app/javascript/mastodon/locales/fi.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Pikanäppäin",
   "keyboard_shortcuts.legend": "näytä tämä selite",
   "keyboard_shortcuts.mention": "mainitse julkaisija",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "vastaa",
   "keyboard_shortcuts.search": "siirry hakukenttään",
   "keyboard_shortcuts.toggle_hidden": "näytä/piilota sisältövaroituksella merkitty teksti",

--- a/app/javascript/mastodon/locales/fr.json
+++ b/app/javascript/mastodon/locales/fr.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Raccourci",
   "keyboard_shortcuts.legend": "pour afficher cette légende",
   "keyboard_shortcuts.mention": "pour mentionner l'auteur",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "pour répondre",
   "keyboard_shortcuts.search": "pour cibler la recherche",
   "keyboard_shortcuts.toggle_hidden": "pour afficher/cacher un texte derrière CW",

--- a/app/javascript/mastodon/locales/gl.json
+++ b/app/javascript/mastodon/locales/gl.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Tecla de acceso directo",
   "keyboard_shortcuts.legend": "para mostrar esta lenda",
   "keyboard_shortcuts.mention": "para mencionar o autor",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "para responder",
   "keyboard_shortcuts.search": "para centrar a busca",
   "keyboard_shortcuts.toggle_hidden": "mostrar/agochar un texto detrás do AC",

--- a/app/javascript/mastodon/locales/he.json
+++ b/app/javascript/mastodon/locales/he.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "מקש קיצור",
   "keyboard_shortcuts.legend": "להציג את הפירוש",
   "keyboard_shortcuts.mention": "לאזכר את המחבר(ת)",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "לענות",
   "keyboard_shortcuts.search": "להתמקד בחלון החיפוש",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/hr.json
+++ b/app/javascript/mastodon/locales/hr.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hotkey",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "to focus search",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/hu.json
+++ b/app/javascript/mastodon/locales/hu.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Gyorsbillentyű",
   "keyboard_shortcuts.legend": "jelmagyarázat megjelenítése",
   "keyboard_shortcuts.mention": "szerző megjelenítése",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "válaszolás",
   "keyboard_shortcuts.search": "kereső kiemelése",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/hy.json
+++ b/app/javascript/mastodon/locales/hy.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Հատուկ ստեղն",
   "keyboard_shortcuts.legend": "այս ձեռնարկը ցուցադրելու համար",
   "keyboard_shortcuts.mention": "հեղինակին նշելու համար",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "պատասխանելու համար",
   "keyboard_shortcuts.search": "որոնման դաշտին սեւեռվելու համար",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/id.json
+++ b/app/javascript/mastodon/locales/id.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hotkey",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "untuk fokus mencari",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/io.json
+++ b/app/javascript/mastodon/locales/io.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hotkey",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "to focus search",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/it.json
+++ b/app/javascript/mastodon/locales/it.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Tasto di scelta rapida",
   "keyboard_shortcuts.legend": "per mostrare questa spiegazione",
   "keyboard_shortcuts.mention": "per menzionare l'autore",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "per rispondere",
   "keyboard_shortcuts.search": "per spostare il focus sulla ricerca",
   "keyboard_shortcuts.toggle_hidden": "per mostrare/nascondere il testo dei CW",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "ホットキー",
   "keyboard_shortcuts.legend": "この一覧を表示",
   "keyboard_shortcuts.mention": "メンション",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "返信",
   "keyboard_shortcuts.search": "検索欄に移動",
   "keyboard_shortcuts.toggle_hidden": "CWで隠れた文を見る/隠す",

--- a/app/javascript/mastodon/locales/ko.json
+++ b/app/javascript/mastodon/locales/ko.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "핫키",
   "keyboard_shortcuts.legend": "이 도움말 표시",
   "keyboard_shortcuts.mention": "멘션",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "답장",
   "keyboard_shortcuts.search": "검색창에 포커스",
   "keyboard_shortcuts.toggle_hidden": "CW로 가려진 텍스트를 표시/비표시",

--- a/app/javascript/mastodon/locales/nl.json
+++ b/app/javascript/mastodon/locales/nl.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Sneltoets",
   "keyboard_shortcuts.legend": "om deze legenda te tonen",
   "keyboard_shortcuts.mention": "om de auteur te vermelden",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "om te reageren",
   "keyboard_shortcuts.search": "om het zoekvak te focussen",
   "keyboard_shortcuts.toggle_hidden": "om tekst achter een waarschuwing (CW) te tonen/verbergen",

--- a/app/javascript/mastodon/locales/no.json
+++ b/app/javascript/mastodon/locales/no.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Lyntast",
   "keyboard_shortcuts.legend": "å vise denne forklaringen",
   "keyboard_shortcuts.mention": "å nevne forfatter",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "for å svare",
   "keyboard_shortcuts.search": "å fokusere søk",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/oc.json
+++ b/app/javascript/mastodon/locales/oc.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Acorchis",
   "keyboard_shortcuts.legend": "mostrar aquesta legenda",
   "keyboard_shortcuts.mention": "mencionar l’autor",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "respondre",
   "keyboard_shortcuts.search": "anar a la recèrca",
   "keyboard_shortcuts.toggle_hidden": "mostrar/amagar lo tèxte dels avertiments",

--- a/app/javascript/mastodon/locales/pl.json
+++ b/app/javascript/mastodon/locales/pl.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Klawisz",
   "keyboard_shortcuts.legend": "aby wyświetlić tą legendę",
   "keyboard_shortcuts.mention": "aby wspomnieć o autorze",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "aby odpowiedzieć",
   "keyboard_shortcuts.search": "aby przejść do pola wyszukiwania",
   "keyboard_shortcuts.toggle_hidden": "aby wyświetlić lub ukryć wpis spod CW",

--- a/app/javascript/mastodon/locales/pt-BR.json
+++ b/app/javascript/mastodon/locales/pt-BR.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Atalho",
   "keyboard_shortcuts.legend": "para mostrar essa legenda",
   "keyboard_shortcuts.mention": "para mencionar o autor",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "para responder",
   "keyboard_shortcuts.search": "para focar a pesquisa",
   "keyboard_shortcuts.toggle_hidden": "mostrar/esconder o texto com aviso de conteúdo",

--- a/app/javascript/mastodon/locales/pt.json
+++ b/app/javascript/mastodon/locales/pt.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Atalho",
   "keyboard_shortcuts.legend": "para mostrar esta legenda",
   "keyboard_shortcuts.mention": "para mencionar o autor",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "para responder",
   "keyboard_shortcuts.search": "para focar na pesquisa",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/ru.json
+++ b/app/javascript/mastodon/locales/ru.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Гор. клавиша",
   "keyboard_shortcuts.legend": "показать это окно",
   "keyboard_shortcuts.mention": "упомянуть автора поста",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "ответить",
   "keyboard_shortcuts.search": "перейти к поиску",
   "keyboard_shortcuts.toggle_hidden": "показать/скрыть текст за предупреждением",

--- a/app/javascript/mastodon/locales/sk.json
+++ b/app/javascript/mastodon/locales/sk.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Klávesa",
   "keyboard_shortcuts.legend": "zobraziť túto legendu",
   "keyboard_shortcuts.mention": "spomenúť autora",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "odpovedať",
   "keyboard_shortcuts.search": "zamerať sa na vyhľadávanie",
   "keyboard_shortcuts.toggle_hidden": "ukáž/skry text za CW",

--- a/app/javascript/mastodon/locales/sl.json
+++ b/app/javascript/mastodon/locales/sl.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hitra tipka",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "to focus search",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/sr-Latn.json
+++ b/app/javascript/mastodon/locales/sr-Latn.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Prečica",
   "keyboard_shortcuts.legend": "da prikažete ovaj podsetnik",
   "keyboard_shortcuts.mention": "da pomenete autora",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "da odgovorite",
   "keyboard_shortcuts.search": "da se prebacite na pretragu",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/sr.json
+++ b/app/javascript/mastodon/locales/sr.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Пречица",
   "keyboard_shortcuts.legend": "да прикажете овај подсетник",
   "keyboard_shortcuts.mention": "да поменете аутора",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "да одговорите",
   "keyboard_shortcuts.search": "да се пребаците на претрагу",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/sv.json
+++ b/app/javascript/mastodon/locales/sv.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Snabbvalstangent",
   "keyboard_shortcuts.legend": "att visa denna översikt",
   "keyboard_shortcuts.mention": "att nämna författaren",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "att svara",
   "keyboard_shortcuts.search": "att fokusera sökfältet",
   "keyboard_shortcuts.toggle_hidden": "att visa/gömma text bakom CW",

--- a/app/javascript/mastodon/locales/te.json
+++ b/app/javascript/mastodon/locales/te.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "హాట్ కీ",
   "keyboard_shortcuts.legend": "ఈ లెజెండ్ ప్రదర్శించడానికి",
   "keyboard_shortcuts.mention": "రచయితను ప్రస్తావించడానికి",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "ప్రత్యుత్తరం ఇవ్వడానికి",
   "keyboard_shortcuts.search": "శోధనపై దృష్టి పెట్టండి",
   "keyboard_shortcuts.toggle_hidden": "CW వెనుక ఉన్న పాఠ్యాన్ని చూపడానికి / దాచడానికి",

--- a/app/javascript/mastodon/locales/th.json
+++ b/app/javascript/mastodon/locales/th.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hotkey",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "to focus search",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/tr.json
+++ b/app/javascript/mastodon/locales/tr.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hotkey",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "to focus search",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/uk.json
+++ b/app/javascript/mastodon/locales/uk.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "Hotkey",
   "keyboard_shortcuts.legend": "to display this legend",
   "keyboard_shortcuts.mention": "to mention author",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "to reply",
   "keyboard_shortcuts.search": "to focus search",
   "keyboard_shortcuts.toggle_hidden": "to show/hide text behind CW",

--- a/app/javascript/mastodon/locales/zh-CN.json
+++ b/app/javascript/mastodon/locales/zh-CN.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "快捷键",
   "keyboard_shortcuts.legend": "显示此列表",
   "keyboard_shortcuts.mention": "提及嘟文作者",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "回复嘟文",
   "keyboard_shortcuts.search": "选择搜索框",
   "keyboard_shortcuts.toggle_hidden": "显示或隐藏被折叠的正文",

--- a/app/javascript/mastodon/locales/zh-HK.json
+++ b/app/javascript/mastodon/locales/zh-HK.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "快速鍵",
   "keyboard_shortcuts.legend": "顯示這個說明",
   "keyboard_shortcuts.mention": "提及作者",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "回覆",
   "keyboard_shortcuts.search": "把標示移動到搜索",
   "keyboard_shortcuts.toggle_hidden": "顯示或隱藏被標為敏感的文字",

--- a/app/javascript/mastodon/locales/zh-TW.json
+++ b/app/javascript/mastodon/locales/zh-TW.json
@@ -137,6 +137,7 @@
   "keyboard_shortcuts.hotkey": "快速鍵",
   "keyboard_shortcuts.legend": "顯示這個說明",
   "keyboard_shortcuts.mention": "到提到的作者",
+  "keyboard_shortcuts.profile": "to open author's profile",
   "keyboard_shortcuts.reply": "到回應",
   "keyboard_shortcuts.search": "把滑鼠移動到搜尋",
   "keyboard_shortcuts.toggle_hidden": "顯示或隱藏被標為敏感的嘟文",


### PR DESCRIPTION
- Add missing documentation for “p”
- Document key variants when needed

There are more documented hotkeys (g + {h, n, l, t, d, s, f, p, u, b, m}) but I'm not too sure how to represent them concisely.

Before:
![screenshot_2018-07-24 mastodon instance perso de thibg](https://user-images.githubusercontent.com/384364/43160922-d097e9a8-8f86-11e8-9300-8056788c2457.png)

After:
![screenshot_2018-07-24 mastodon instance perso de thibg 1](https://user-images.githubusercontent.com/384364/43162138-62c6f2c6-8f8a-11e8-8972-64d9516c68a5.png)
