### PR TITLE
Fix .column-back-button line-height

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2011,6 +2011,7 @@ a.account__display-name {
   cursor: pointer;
   flex: 0 0 auto;
   font-size: 16px;
+  line-height: inherit;
   border: 0;
   text-align: unset;
   padding: 15px;


### PR DESCRIPTION
Since `line-height` is not specified for `.column-back-button`, there is a difference in size from `.column-header` depending on font.

In this PR, add `line-height` to `.column-back-button`.

Before:  
![2018-07-26_05-30-42_chrome](https://user-images.githubusercontent.com/3516343/43225981-86ee0174-9095-11e8-9c34-3c1dd68f44aa.png)

✨ After:  
![2018-07-26_05-30-59_chrome](https://user-images.githubusercontent.com/3516343/43225984-8a3ac77c-9095-11e8-92b6-d191cf684902.png)
