### PR TITLE
Call address instead of exchange

### DIFF
--- a/app/validators/email_mx_validator.rb
+++ b/app/validators/email_mx_validator.rb
@@ -16,7 +16,7 @@ class EmailMxValidator < ActiveModel::Validator
     return true if domain.nil?
 
     records = Resolv::DNS.new.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a.map { |e| e.exchange.to_s }
-    records = Resolv::DNS.new.getresources(domain, Resolv::DNS::Resource::IN::A).to_a.map { |e| e.exchange.to_s } if records.empty?
+    records = Resolv::DNS.new.getresources(domain, Resolv::DNS::Resource::IN::A).to_a.map { |e| e.address.to_s } if records.empty?
 
     records.empty? || on_blacklist?(records)
   end


### PR DESCRIPTION
Since `Resolv::DNS::Resource::IN::A` has no exchange method, we call the address method instead.