### PR TITLE
Improve account bar css

### DIFF
--- a/app/javascript/mastodon/features/account/components/action_bar.js
+++ b/app/javascript/mastodon/features/account/components/action_bar.js
@@ -142,17 +142,17 @@ export default class ActionBar extends React.PureComponent {
         <div className='account__action-bar'>
           <div className='account__action-bar-links'>
             <Link className='account__action-bar__tab' to={`/accounts/${account.get('id')}`}>
-              <span><FormattedMessage id='account.posts' defaultMessage='Toots' /></span>
+              <FormattedMessage id='account.posts' defaultMessage='Toots' />
               <strong>{shortNumberFormat(account.get('statuses_count'))}</strong>
             </Link>
 
             <Link className='account__action-bar__tab' to={`/accounts/${account.get('id')}/following`}>
-              <span><FormattedMessage id='account.follows' defaultMessage='Follows' /></span>
+              <FormattedMessage id='account.follows' defaultMessage='Follows' />
               <strong>{shortNumberFormat(account.get('following_count'))}</strong>
             </Link>
 
             <Link className='account__action-bar__tab' to={`/accounts/${account.get('id')}/followers`}>
-              <span><FormattedMessage id='account.followers' defaultMessage='Followers' /></span>
+              <FormattedMessage id='account.followers' defaultMessage='Followers' />
               <strong>{shortNumberFormat(account.get('followers_count'))}</strong>
             </Link>
           </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1257,7 +1257,7 @@ a .account__avatar {
   overflow: hidden;
   flex: 0 1 100%;
   border-right: 1px solid lighten($ui-base-color, 8%);
-  padding: 10px 0px;
+  padding: 10px 0;
 
   & > span {
     display: block;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1224,7 +1224,6 @@ a .account__avatar {
 }
 
 .account__action-bar-dropdown {
-  flex: 0 1 calc(50% - 140px);
   padding: 10px;
 
   .icon-button {
@@ -1256,9 +1255,9 @@ a .account__avatar {
 .account__action-bar__tab {
   text-decoration: none;
   overflow: hidden;
-  flex: 0 1 80px;
+  flex: 0 1 100%;
   border-right: 1px solid lighten($ui-base-color, 8%);
-  padding: 10px 5px;
+  padding: 10px 0px;
 
   & > span {
     display: block;


### PR DESCRIPTION
fix #8052 

Before/after, when using a them/custom CSS with flexible columns:
![screenshot_2018-07-28 mastodon dev before](https://user-images.githubusercontent.com/2446451/43359184-946258b8-929e-11e8-97cb-ba82985693fe.png)
![screenshot_2018-07-28 mastodon dev after](https://user-images.githubusercontent.com/2446451/43359182-941fca70-929e-11e8-9ed0-829e34e71bd6.png)

Before/after, text alignment when using no custom CSS:
![screenshot_2018-07-28 mastodon dev before 2](https://user-images.githubusercontent.com/2446451/43359185-948038ec-929e-11e8-8c13-93d21a0469d4.png)
![screenshot_2018-07-28 mastodon dev after 2](https://user-images.githubusercontent.com/2446451/43359183-94417daa-929e-11e8-9ced-1032ed9963af.png)