### PR TITLE
Fix no avatars on mobile devices with 'smaller' screens

### DIFF
--- a/app/javascript/styles/mastodon/containers.scss
+++ b/app/javascript/styles/mastodon/containers.scss
@@ -375,10 +375,6 @@
             border: 0;
             border-radius: 4px;
           }
-
-          @media screen and (max-width: 360px) {
-            display: none;
-          }
         }
       }
 


### PR DESCRIPTION
Although these 'smaller' screens are just normal configured LG G2's. It doesn't make sense to hide an avatar at all by the way.