### PR TITLE
Enforce username format for remote users, too

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -68,6 +68,7 @@ class Account < ApplicationRecord
 
   # Remote user validations
   validates :username, uniqueness: { scope: :domain, case_sensitive: true }, if: -> { !local? && will_save_change_to_username? }
+  validates :username, format: { with: /\A#{USERNAME_RE}\z/i }, if: -> { !local? && will_save_change_to_username? }
 
   # Local user validations
   validates :username, format: { with: /\A[a-z0-9_]+\z/i }, length: { maximum: 30 }, if: -> { local? && will_save_change_to_username? }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -618,10 +618,10 @@ RSpec.describe Account, type: :model do
         expect(account).not_to model_have_error_on_field(:username)
       end
 
-      it 'is valid even if the username doesn\'t only contains letters, numbers and underscores' do
+      it 'is invalid if the username doesn\'t only contains letters, numbers and underscores' do
         account = Fabricate.build(:account, domain: 'domain', username: 'the-doctor')
         account.valid?
-        expect(account).not_to model_have_error_on_field(:username)
+        expect(account).to model_have_error_on_field(:username)
       end
 
       it 'is valid even if the username is longer then 30 characters' do


### PR DESCRIPTION
Initially I thought there might be valid reasons for remote users to
have a different, unpredicted username format. However, I now realize
such a difference would be unusable and unexpected within Mastodon.

Fix #8058