### PR TITLE
Use workspace instead of caching for built assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,12 +81,6 @@ aliases:
         - run: ruby -e 'puts RUBY_VERSION' | tee /tmp/.ruby-version
         - *restore_ruby_dependencies
 
-        - restore_cache:
-            keys:
-              - precompiled-assets-{{ .Branch }}-{{ .Revision }}
-              - precompiled-assets-{{ .Branch }}-
-              - precompiled-assets-
-
         - run:
             name: Prepare Tests
             command: ./bin/rails parallel:create parallel:load_schema parallel:prepare
@@ -125,11 +119,11 @@ jobs:
       - run: ruby -e 'puts RUBY_VERSION' | tee /tmp/.ruby-version
       - *restore_ruby_dependencies
       - run: ./bin/rails assets:precompile
-      - save_cache:
-          key: precompiled-assets-{{ .Branch }}-{{ .Revision }}
+      - persist_to_workspace:
+          root: ~/projects/
           paths:
-            - ./public/assets
-            - ./public/packs-test/
+              - ./mastodon/public/assets
+              - ./mastodon/public/packs-test/
 
   test-ruby2.5:
     <<: *defaults


### PR DESCRIPTION
Tests cannot run without built assets, and we want
exactly the matching assets. This is not a cache.