### PR TITLE
Get rid of the Content Warning rainbows

### DIFF
--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -1,9 +1,3 @@
-@keyframes Swag {
-  0% { background-position: 0% 0%; }
-  50% { background-position: 100% 0%; }
-  100% { background-position: 200% 0%; }
-}
-
 .table {
   width: 100%;
   max-width: 100%;
@@ -193,22 +187,7 @@ a.table-action-link {
 
     strong {
       font-weight: 700;
-    }
-  }
-}
-
-.no-reduce-motion .batch-table {
-  .status__content {
-    padding-top: 0;
-
-    strong {
-      font-weight: 700;
-      background: linear-gradient(to right, orange , yellow, green, cyan, blue, violet,orange , yellow, green, cyan, blue, violet);
-      background-size: 200% 100%;
-      -webkit-background-clip: text;
-      background-clip: text;
-      color: transparent;
-      animation: Swag 2s linear 0s infinite;
+      color: $warning-red;
     }
   }
 }

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -193,6 +193,16 @@ a.table-action-link {
 
     strong {
       font-weight: 700;
+    }
+  }
+}
+
+.no-reduce-motion .batch-table {
+  .status__content {
+    padding-top: 0;
+
+    strong {
+      font-weight: 700;
       background: linear-gradient(to right, orange , yellow, green, cyan, blue, violet,orange , yellow, green, cyan, blue, violet);
       background-size: 200% 100%;
       -webkit-background-clip: text;

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -185,6 +185,10 @@ a.table-action-link {
   .status__content {
     padding-top: 0;
 
+    summary {
+      display: list-item;
+    }
+
     strong {
       font-weight: 700;
     }

--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -187,7 +187,6 @@ a.table-action-link {
 
     strong {
       font-weight: 700;
-      color: $warning-red;
     }
   }
 }

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -3,11 +3,13 @@
     = f.check_box :status_ids, { multiple: true, include_hidden: false }, status.id
   .batch-table__row__content
     .status__content><
-      - unless status.proper.spoiler_text.blank?
-        %p><
-          %strong> Content warning: #{Formatter.instance.format_spoiler(status.proper)}
-
-      = Formatter.instance.format(status.proper, custom_emojify: true)
+      - if status.proper.spoiler_text.blank?
+        = Formatter.instance.format(status.proper, custom_emojify: true)
+      - else
+        %details<
+          %summary><
+            %strong> Content warning: #{Formatter.instance.format_spoiler(status.proper)}
+          = Formatter.instance.format(status.proper, custom_emojify: true)
 
     - unless status.proper.media_attachments.empty?
       - if status.proper.media_attachments.first.video?


### PR DESCRIPTION
In my opinion, the “correct” fix would be to simply have a “Show more” button just like everywhere else, as initially proposed in #7452, for clarity, consistency, and for the reasons enumerated in #7752.

In the meantime, this PR fixes the most obvious accessibility issues with this joke commit I did not really expect to get merged.

~~~Kept the animated rainbows otherwise because the content warnings don't really stand out, but we could also remove it entirely.~~~