### PR TITLE
Add ldap search filter

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -162,6 +162,7 @@ STREAMING_CLUSTER_NUM=1
 # LDAP_BIND_DN=
 # LDAP_PASSWORD=
 # LDAP_UID=cn
+# LDAP_SEARCH_FILTER="%{uid}=%{email}"
 
 # PAM authentication (optional)
 # PAM authentication uses for the email generation the "email" pam variable

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -59,6 +59,8 @@ module Devise
   @@ldap_password = nil
   mattr_accessor :ldap_tls_no_verify
   @@ldap_tls_no_verify = false
+  mattr_accessor :ldap_search_filter
+  @@ldap_search_filter = nil
 
   class Strategies::PamAuthenticatable
     def valid?
@@ -362,5 +364,6 @@ Devise.setup do |config|
     config.ldap_password       = ENV.fetch('LDAP_PASSWORD')
     config.ldap_uid            = ENV.fetch('LDAP_UID', 'cn')
     config.ldap_tls_no_verify  = ENV['LDAP_TLS_NO_VERIFY'] == 'true'
+    config.ldap_search_filter  = ENV.fetch('LDAP_SEARCH_FILTER', '%{uid}=%{email}')
   end
 end

--- a/lib/devise/ldap_authenticatable.rb
+++ b/lib/devise/ldap_authenticatable.rb
@@ -24,7 +24,8 @@ module Devise
             connect_timeout: 10
           )
 
-          if (user_info = ldap.bind_as(base: Devise.ldap_base, filter: "(#{Devise.ldap_uid}=#{email})", password: password))
+          filter = format(Devise.ldap_search_filter, uid: Devise.ldap_uid, email: email)
+          if (user_info = ldap.bind_as(base: Devise.ldap_base, filter: filter, password: password))
             user = User.ldap_get_user(user_info.first)
             success!(user)
           else


### PR DESCRIPTION
This adds a search filter for ldap accounts, which permits to fine-tune the authorized users (member of a group for instance)