### PR TITLE
Update docker-compose to cope with build-time assets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,6 @@ services:
       - redis
 #      - es
     volumes:
-      - ./public/assets:/mastodon/public/assets
-      - ./public/packs:/mastodon/public/packs
       - ./public/system:/mastodon/public/system
 
   streaming:
@@ -78,7 +76,6 @@ services:
       - external_network
       - internal_network
     volumes:
-      - ./public/packs:/mastodon/public/packs
       - ./public/system:/mastodon/public/system
 ## Uncomment to enable federation with tor instances along with adding the following ENV variables
 ## http_proxy=http://privoxy:8118


### PR DESCRIPTION
#7780 means that asset compilation happens as a build step.

Having the assets and packs volumes defined in `docker-compose.yml` breaks this. For people who run under Docker Compose, I believe this will fix their CSS (which even running the asset recompilation separately did not).