### PR TITLE
Make some migration script more robust (fixes #8007)

### DIFF
--- a/db/migrate/20180528141303_fix_accounts_unique_index.rb
+++ b/db/migrate/20180528141303_fix_accounts_unique_index.rb
@@ -1,4 +1,13 @@
 class FixAccountsUniqueIndex < ActiveRecord::Migration[5.2]
+  class Account < ApplicationRecord
+    # Dummy class, to make migration possible across version changes
+    has_one :user, inverse_of: :account
+
+    def local?
+      domain.nil?
+    end
+  end
+
   disable_ddl_transaction!
 
   def up


### PR DESCRIPTION
Include a dummy Account class in the migration script containing only the
attributes relevant to the migration in order to not rely as much on the
codebase being in sync with the database schema.