### PR TITLE
fix: change Identity's id column to a bigint

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -3,12 +3,12 @@
 #
 # Table name: identities
 #
-#  id         :integer          not null, primary key
 #  user_id    :integer
 #  provider   :string           default(""), not null
 #  uid        :string           default(""), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  id         :bigint(8)        not null, primary key
 #
 
 class Identity < ApplicationRecord

--- a/db/migrate/20180812002835_identity_id_to_bigint.rb
+++ b/db/migrate/20180812002835_identity_id_to_bigint.rb
@@ -1,0 +1,21 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class IdentityIdToBigint < ActiveRecord::Migration[5.2]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      change_column_type_concurrently :identities, :id, :bigint
+      cleanup_concurrent_column_type_change :identities, :id
+    end
+  end
+
+  def down
+    safety_assured do
+      change_column_type_concurrently :identities, :id, :bigint
+      cleanup_concurrent_column_type_change :identities, :id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_08_175627) do
+ActiveRecord::Schema.define(version: 2018_08_12_002835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -211,7 +211,7 @@ ActiveRecord::Schema.define(version: 2018_08_08_175627) do
     t.index ["account_id", "target_account_id"], name: "index_follows_on_account_id_and_target_account_id", unique: true
   end
 
-  create_table "identities", id: :serial, force: :cascade do |t|
+  create_table "identities", force: :cascade do |t|
     t.integer "user_id"
     t.string "provider", default: "", null: false
     t.string "uid", default: "", null: false


### PR DESCRIPTION
This appears to be the last model created using a 5.0 migration,
where column types defaulted to `integer` rather than `bigint`.

This migration changes the column type to match that of all of the
other ID columns.

Fix #8775