### PR TITLE
Add post-deployment migration system

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
   - 'Vagrantfile'
   - 'vendor/**/*'
   - 'lib/json_ld/*'
+  - 'lib/templates/**/*'
 
 Bundler/OrderedGems:
   Enabled: false

--- a/config/initializers/0_post_deployment_migrations.rb
+++ b/config/initializers/0_post_deployment_migrations.rb
@@ -1,0 +1,15 @@
+# Post deployment migrations are included by default. This file must be loaded
+# before other initializers as Rails may otherwise memoize a list of migrations
+# excluding the post deployment migrations.
+
+unless ENV['SKIP_POST_DEPLOYMENT_MIGRATIONS']
+  Rails.application.config.paths['db'].each do |db_path|
+    path = Rails.root.join(db_path, 'post_migrate').to_s
+
+    Rails.application.config.paths['db/migrate'] << path
+
+    # Rails memoizes migrations at certain points where it won't read the above
+    # path just yet. As such we must also update the following list of paths.
+    ActiveRecord::Migrator.migrations_paths << path
+  end
+end

--- a/lib/generators/post_deployment_migration_generator.rb
+++ b/lib/generators/post_deployment_migration_generator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails/generators'
+
+module Rails
+  class PostDeploymentMigrationGenerator < Rails::Generators::NamedBase
+    def create_migration_file
+      timestamp = Time.zone.now.strftime('%Y%m%d%H%M%S')
+
+      template 'migration.rb', "db/post_migrate/#{timestamp}_#{file_name}.rb"
+    end
+
+    def migration_class_name
+      file_name.camelize
+    end
+  end
+end

--- a/lib/templates/rails/post_deployment_migration/migration.rb
+++ b/lib/templates/rails/post_deployment_migration/migration.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class <%= migration_class_name %> < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+  end
+end


### PR DESCRIPTION
Adopted from GitLab CE. Generate new migration with:

    rails g post_deployment_migration name_of_migration_here

By default they are run together with db:migrate. To not run them,
the env variable SKIP_POST_DEPLOYMENT_MIGRATIONS must be set

Code by Yorick Peterse <yorickpeterse@gmail.com>, see also:

https://gitlab.com/gitlab-org/gitlab-ce/commit/83c8241160ed48ab066e2c5bd58d0914a745197c