### PR TITLE
Show exact number of followers/statuses on export page/in tooltip

### DIFF
--- a/app/javascript/mastodon/features/account/components/action_bar.js
+++ b/app/javascript/mastodon/features/account/components/action_bar.js
@@ -147,17 +147,17 @@ export default class ActionBar extends React.PureComponent {
 
         <div className='account__action-bar'>
           <div className='account__action-bar-links'>
-            <Link className='account__action-bar__tab' to={`/accounts/${account.get('id')}`}>
+            <Link className='account__action-bar__tab' to={`/accounts/${account.get('id')}`} title={intl.formatNumber(account.get('statuses_count'))}>
               <FormattedMessage id='account.posts' defaultMessage='Toots' />
               <strong>{shortNumberFormat(account.get('statuses_count'))}</strong>
             </Link>
 
-            <Link className='account__action-bar__tab' to={`/accounts/${account.get('id')}/following`}>
+            <Link className='account__action-bar__tab' to={`/accounts/${account.get('id')}/following`} title={intl.formatNumber(account.get('following_count'))}>
               <FormattedMessage id='account.follows' defaultMessage='Follows' />
               <strong>{shortNumberFormat(account.get('following_count'))}</strong>
             </Link>
 
-            <Link className='account__action-bar__tab' to={`/accounts/${account.get('id')}/followers`}>
+            <Link className='account__action-bar__tab' to={`/accounts/${account.get('id')}/followers`} title={intl.formatNumber(account.get('followers_count'))}>
               <FormattedMessage id='account.followers' defaultMessage='Followers' />
               <strong>{shortNumberFormat(account.get('followers_count'))}</strong>
             </Link>

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -24,8 +24,16 @@ class Export
     account.media_attachments.sum(:file_file_size)
   end
 
+  def total_statuses
+    account.statuses_count
+  end
+
   def total_follows
-    account.following.count
+    account.following_count
+  end
+
+  def total_followers
+    account.followers_count
   end
 
   def total_blocks

--- a/app/views/accounts/_header.html.haml
+++ b/app/views/accounts/_header.html.haml
@@ -14,17 +14,17 @@
       .public-account-header__tabs__tabs
         .details-counters
           .counter{ class: active_nav_class(short_account_url(account)) }
-            = link_to short_account_url(account), class: 'u-url u-uid' do
+            = link_to short_account_url(account), class: 'u-url u-uid', title: number_with_delimiter(account.statuses_count) do
               %span.counter-number= number_to_human account.statuses_count, strip_insignificant_zeros: true
               %span.counter-label= t('accounts.posts')
 
           .counter{ class: active_nav_class(account_following_index_url(account)) }
-            = link_to account_following_index_url(account) do
+            = link_to account_following_index_url(account), title: number_with_delimiter(account.following_count) do
               %span.counter-number= number_to_human account.following_count, strip_insignificant_zeros: true
               %span.counter-label= t('accounts.following')
 
           .counter{ class: active_nav_class(account_followers_url(account)) }
-            = link_to account_followers_url(account) do
+            = link_to account_followers_url(account), title: number_with_delimiter(account.followers_count) do
               %span.counter-number= number_to_human account.followers_count, strip_insignificant_zeros: true
               %span.counter-label= t('accounts.followers')
         .spacer

--- a/app/views/settings/exports/show.html.haml
+++ b/app/views/settings/exports/show.html.haml
@@ -9,16 +9,24 @@
         %td= number_to_human_size @export.total_storage
         %td
       %tr
+        %th= t('accounts.statuses')
+        %td= number_with_delimiter @export.total_statuses
+        %td
+      %tr
         %th= t('exports.follows')
-        %td= number_to_human @export.total_follows
+        %td= number_with_delimiter @export.total_follows
         %td= table_link_to 'download', t('exports.csv'), settings_exports_follows_path(format: :csv)
       %tr
+        %th= t('accounts.followers')
+        %td= number_with_delimiter @export.total_followers
+        %td
+      %tr
         %th= t('exports.blocks')
-        %td= number_to_human @export.total_blocks
+        %td= number_with_delimiter @export.total_blocks
         %td= table_link_to 'download', t('exports.csv'), settings_exports_blocks_path(format: :csv)
       %tr
         %th= t('exports.mutes')
-        %td= number_to_human @export.total_mutes
+        %td= number_with_delimiter @export.total_mutes
         %td= table_link_to 'download', t('exports.csv'), settings_exports_mutes_path(format: :csv)
 
 %p.muted-hint= t('exports.archive_takeout.hint_html')

--- a/app/views/settings/imports/show.html.haml
+++ b/app/views/settings/imports/show.html.haml
@@ -1,11 +1,14 @@
 - content_for :page_title do
   = t('settings.import')
 
-%p.hint= t('imports.preface')
-
 = simple_form_for @import, url: settings_import_path do |f|
-  = f.input :type, collection: Import.types.keys, wrapper: :with_label, include_blank: false, label_method: lambda { |type| I18n.t("imports.types.#{type}") }, as: :radio_buttons, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
-  = f.input :data, wrapper: :with_label, hint: t('simple_form.hints.imports.data')
+  %p.hint= t('imports.preface')
+
+  .field-group
+    = f.input :type, collection: Import.types.keys, wrapper: :with_label, include_blank: false, label_method: lambda { |type| I18n.t("imports.types.#{type}") }, as: :radio_buttons, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
+
+  .field-group
+    = f.input :data, wrapper: :with_block_label, hint: t('simple_form.hints.imports.data')
 
   .actions
     = f.button :button, t('imports.upload'), type: :submit

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -48,17 +48,17 @@ describe Export do
   describe 'total_follows' do
     it 'returns the total number of the followed accounts' do
       target_accounts.each(&account.method(:follow!))
-      expect(Export.new(account).total_follows).to eq 2
+      expect(Export.new(account.reload).total_follows).to eq 2
     end
 
     it 'returns the total number of the blocked accounts' do
       target_accounts.each(&account.method(:block!))
-      expect(Export.new(account).total_blocks).to eq 2
+      expect(Export.new(account.reload).total_blocks).to eq 2
     end
 
     it 'returns the total number of the muted accounts' do
       target_accounts.each(&account.method(:mute!))
-      expect(Export.new(account).total_mutes).to eq 2
+      expect(Export.new(account.reload).total_mutes).to eq 2
     end
   end
 end


### PR DESCRIPTION
I received a complaint that with the "1.4K" number formatting it's no longer possible to know how many followers you have exactly *anywhere* except the API directly. So I am putting the exact number on the data export page. Also, number of statuses there too.

Additionally, I have added a title attribute (tooltip) on the profile counters with the exact number.