### PR TITLE
Show "read more" link on overly long in-stream statuses

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -285,7 +285,7 @@ export default class Status extends ImmutablePureComponent {
               </a>
             </div>
 
-            <StatusContent status={status} onClick={this.handleClick} expanded={!status.get('hidden')} onExpandedToggle={this.handleExpandedToggle} />
+            <StatusContent status={status} onClick={this.handleClick} expanded={!status.get('hidden')} onExpandedToggle={this.handleExpandedToggle} collapsable />
 
             {media}
 

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -57,7 +57,12 @@ export default class StatusContent extends React.PureComponent {
       link.setAttribute('rel', 'noopener');
     }
 
-    if (this.props.collapsable && this.state.collapsed === null && node.clientHeight > 200) this.setState({ collapsed: true });
+    if (
+      this.props.collapsable
+      && this.state.collapsed === null
+      && node.clientHeight > 200
+      && this.props.status.get('spoiler_text').length === 0
+    ) this.setState({ collapsed: true });
   }
 
   componentDidMount () {

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -190,13 +190,13 @@ export default class StatusContent extends React.PureComponent {
         >
           <div dangerouslySetInnerHTML={content} />
           {this.state.collapsed !== null ?
-            <a
-              className="status__content__collapse-button"
+            <button
+              className='status__content__collapse-button'
               onClick={this.handleCollapsedClick}
             >
               <i className='fa fa-fw fa-angle-double-down' />
-            </a>
-          : null}
+            </button>
+            : null}
         </div>
       );
     } else {

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -17,11 +17,14 @@ export default class StatusContent extends React.PureComponent {
     expanded: PropTypes.bool,
     onExpandedToggle: PropTypes.func,
     onClick: PropTypes.func,
+    collapsable: PropTypes.bool,
   };
 
   state = {
     hidden: true,
+    collapsed: null,
   };
+  //  `collapsed: null` indicates that an element doesn't need collapsing, while `true` or `false` indicates that it does (and is/isn't).
 
   _updateStatusLinks () {
     const node = this.node;
@@ -53,6 +56,8 @@ export default class StatusContent extends React.PureComponent {
       link.setAttribute('target', '_blank');
       link.setAttribute('rel', 'noopener');
     }
+
+    if (this.props.collapsable && this.state.collapsed === null && node.clientHeight > 200) this.setState({ collapsed: true });
   }
 
   componentDidMount () {
@@ -113,6 +118,11 @@ export default class StatusContent extends React.PureComponent {
     }
   }
 
+  handleCollapsedClick = (e) => {
+    e.preventDefault();
+    this.setState({ collapsed: !this.state.collapsed });
+  }
+
   setRef = (c) => {
     this.node = c;
   }
@@ -132,6 +142,8 @@ export default class StatusContent extends React.PureComponent {
     const classNames = classnames('status__content', {
       'status__content--with-action': this.props.onClick && this.context.router,
       'status__content--with-spoiler': status.get('spoiler_text').length > 0,
+      'status__content--collapsed': this.state.collapsed === true,
+      'status__content--expanded': this.state.collapsed === false,
     });
 
     if (isRtl(status.get('search_index'))) {
@@ -175,8 +187,17 @@ export default class StatusContent extends React.PureComponent {
           style={directionStyle}
           onMouseDown={this.handleMouseDown}
           onMouseUp={this.handleMouseUp}
-          dangerouslySetInnerHTML={content}
-        />
+        >
+          <div dangerouslySetInnerHTML={content} />
+          {this.state.collapsed !== null ?
+            <a
+              className="status__content__collapse-button"
+              onClick={this.handleCollapsedClick}
+            >
+              <i className='fa fa-fw fa-angle-double-down' />
+            </a>
+          : null}
+        </div>
       );
     } else {
       return (

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -755,6 +755,8 @@
   text-align: center;
   background: $action-button-color;
   transition: background .2s ease-in-out, color .2s ease-in-out;
+  border: 0;
+  border-radius: 2px;
 
   &:hover {
     background: lighten($action-button-color, 7%);
@@ -762,7 +764,9 @@
 
   i {
     transition: transform .2s ease-in-out;
-    &, &:hover {
+
+    &,
+    &:hover {
       color: $inverted-text-color !important;
     }
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -724,51 +724,22 @@
 }
 
 .status__content.status__content--collapsed {
-  padding-bottom: 25px;
-  max-height: 200px;
-
-  i {
-    transform: rotateX(0);
-  }
+  max-height: 20px * 15; // 15 lines is roughly above 500 characters
 }
 
-.status__content.status__content--expanded, {
-  padding-bottom: 25px;
-  height: auto;
-
-  i {
-    transform: rotateX(180deg);
-  }
-}
-
-.status__content__collapse-button {
+.status__content__read-more-button {
   display: block;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
-  height: 25px;
-  font-size: 18px;
-  line-height: 25px;
-  color: $inverted-text-color;
-  text-align: center;
-  background: $action-button-color;
-  transition: background .2s ease-in-out, color .2s ease-in-out;
+  font-size: 15px;
+  line-height: 20px;
+  color: lighten($ui-highlight-color, 8%);
   border: 0;
-  border-radius: 2px;
+  background: transparent;
+  padding: 0;
+  padding-top: 8px;
 
-  &:hover {
-    background: lighten($action-button-color, 7%);
-  }
-
-  i {
-    transition: transform .2s ease-in-out;
-
-    &,
-    &:hover {
-      color: $inverted-text-color !important;
-    }
+  &:hover,
+  &:active {
+    text-decoration: underline;
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -725,7 +725,7 @@
 
 .status__content.status__content--collapsed {
   padding-bottom: 25px;
-  height: 200px;
+  max-height: 200px;
 
   i {
     transform: rotateX(0);

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -631,11 +631,13 @@
 
 .status__content,
 .reply-indicator__content {
+  position: relative;
   font-size: 15px;
   line-height: 20px;
   word-wrap: break-word;
   font-weight: 400;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: pre-wrap;
   padding-top: 2px;
   color: $primary-text-color;
@@ -718,6 +720,48 @@
     &.status__content__text--visible {
       display: block;
     }
+  }
+}
+
+.status__content.status__content--collapsed {
+  padding-bottom: 25px;
+  height: 200px;
+
+  i {
+    transform: rotateX(0);
+  }
+}
+
+.status__content.status__content--expanded, {
+  padding-bottom: 25px;
+  height: auto;
+
+  i {
+    transform: rotateX(180deg);
+  }
+}
+
+.status__content__collapse-button {
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 25px;
+  font-size: 18px;
+  line-height: 25px;
+  color: $ui-secondary-color;
+  text-align: center;
+  background: linear-gradient(to top, transparent, rgba(lighten($ui-primary-color, 13%), .3)), $ui-primary-color;
+  transition: background .2s ease-in-out, color .2s ease-in-out;
+
+  &:hover {
+    background-color: lighten($ui-primary-color, 8%);
+  }
+
+  i {
+    transition: transform .2s ease-in-out;
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -751,17 +751,20 @@
   height: 25px;
   font-size: 18px;
   line-height: 25px;
-  color: $ui-secondary-color;
+  color: $inverted-text-color;
   text-align: center;
-  background: linear-gradient(to top, transparent, rgba(lighten($ui-primary-color, 13%), .3)), $ui-primary-color;
+  background: $action-button-color;
   transition: background .2s ease-in-out, color .2s ease-in-out;
 
   &:hover {
-    background-color: lighten($ui-primary-color, 8%);
+    background: lighten($action-button-color, 7%);
   }
 
   i {
     transition: transform .2s ease-in-out;
+    &, &:hover {
+      color: $inverted-text-color !important;
+    }
   }
 }
 


### PR DESCRIPTION
Collapsed:

![image](https://user-images.githubusercontent.com/3816428/44120093-8208aa34-a01b-11e8-9f95-d55f16a6b971.png)

Extended:

![image](https://user-images.githubusercontent.com/3816428/44120107-8e352652-a01b-11e8-9401-7dcbbacc48e5.png)


Note: originally done for mastofe of pleroma, on this MR: https://git.pleroma.social/pleroma/mastofe/merge_requests/12

And I won’t fix issues on this PR, this is basically sending the patch to upstream.