### PR TITLE
Fetch remote status on behalf of the user pasting URL (fixes #8193)

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -46,6 +46,7 @@ class Settings::PreferencesController < ApplicationController
       :setting_noindex,
       :setting_theme,
       :setting_hide_network,
+      :setting_fetch_anonymously,
       notification_emails: %i(follow follow_request reblog favourite mention digest report),
       interactions: %i(must_be_follower must_be_following)
     )

--- a/app/javascript/mastodon/features/compose/components/search_results.js
+++ b/app/javascript/mastodon/features/compose/components/search_results.js
@@ -1,19 +1,22 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { FormattedMessage } from 'react-intl';
 import AccountContainer from '../../../containers/account_container';
 import StatusContainer from '../../../containers/status_container';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import Hashtag from '../../../components/hashtag';
+import { fetchAnonymously } from '../../../initial_state';
 
 export default class SearchResults extends ImmutablePureComponent {
 
   static propTypes = {
     results: ImmutablePropTypes.map.isRequired,
+    query: PropTypes.string.isRequired,
   };
 
   render () {
-    const { results } = this.props;
+    const { results, query } = this.props;
 
     let accounts, statuses, hashtags;
     let count = 0;
@@ -36,6 +39,17 @@ export default class SearchResults extends ImmutablePureComponent {
           <h5><i className='fa fa-fw fa-quote-right' /><FormattedMessage id='search_results.statuses' defaultMessage='Toots' /></h5>
 
           {results.get('statuses').map(statusId => <StatusContainer key={statusId} id={statusId} />)}
+        </div>
+      );
+    } else if (count === 0 && query.trim().startsWith('https://') && fetchAnonymously) {
+      statuses = (
+        <div className='search-results__section'>
+          <h5><i className='fa fa-fw fa-quote-right' /><FormattedMessage id='search_results.statuses' defaultMessage='Toots' /></h5>
+
+          <div className='search-results__warning'>
+            <FormattedMessage id='search_results.fetch_anonymously_warning' defaultMessage='Nothing was found at the requested URL. It may require authentication, but your account is configured to not authentify to remote instances. You can {change_setting}.' values={{ change_setting: <a href='/settings/preferences#user_setting_fetch_anonymously'><FormattedMessage id='search_results.change_setting' defaultMessage='change this setting' /></a> }} />
+
+          </div>
         </div>
       );
     }

--- a/app/javascript/mastodon/features/compose/components/search_results.js
+++ b/app/javascript/mastodon/features/compose/components/search_results.js
@@ -47,7 +47,7 @@ export default class SearchResults extends ImmutablePureComponent {
           <h5><i className='fa fa-fw fa-quote-right' /><FormattedMessage id='search_results.statuses' defaultMessage='Toots' /></h5>
 
           <div className='search-results__warning'>
-            <FormattedMessage id='search_results.fetch_anonymously_warning' defaultMessage='Nothing was found at the requested URL. It may require authentication, but your account is configured to not authentify to remote instances. You can {change_setting}.' values={{ change_setting: <a href='/settings/preferences#user_setting_fetch_anonymously'><FormattedMessage id='search_results.change_setting' defaultMessage='change this setting' /></a> }} />
+            <FormattedMessage id='search_results.fetch_anonymously_warning' defaultMessage='Nothing was found at the requested URL. It may require authentication, but your account is configured to not authenticate to remote instances. You can {change_setting}.' values={{ change_setting: <a href='/settings/preferences#user_setting_fetch_anonymously'><FormattedMessage id='search_results.change_setting' defaultMessage='change this setting' /></a> }} />
 
           </div>
         </div>

--- a/app/javascript/mastodon/features/compose/containers/search_results_container.js
+++ b/app/javascript/mastodon/features/compose/containers/search_results_container.js
@@ -3,6 +3,7 @@ import SearchResults from '../components/search_results';
 
 const mapStateToProps = state => ({
   results: state.getIn(['search', 'results']),
+  query: state.getIn(['search', 'value']),
 });
 
 export default connect(mapStateToProps)(SearchResults);

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -13,5 +13,6 @@ export const me = getMeta('me');
 export const searchEnabled = getMeta('search_enabled');
 export const invitesEnabled = getMeta('invites_enabled');
 export const version = getMeta('version');
+export const fetchAnonymously = getMeta('fetch_anonymously');
 
 export default initialState;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3555,6 +3555,38 @@ a.status-card {
   }
 }
 
+.search-results__warning {
+  color: $inverted-text-color;
+  background: $ui-primary-color;
+  padding: 10px;
+  font-size: 13px;
+  font-weight: 400;
+
+  strong {
+    color: $inverted-text-color;
+    font-weight: 500;
+
+    @each $lang in $cjk-langs {
+      &:lang(#{$lang}) {
+        font-weight: 700;
+      }
+    }
+  }
+
+  a {
+    color: $lighter-text-color;
+    font-weight: 500;
+    text-decoration: underline;
+
+    &:hover,
+    &:active,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+}
+
+
 .modal-root {
   position: relative;
   transition: opacity 0.3s linear;

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -30,6 +30,7 @@ class UserSettingsDecorator
     user.settings['noindex']                 = noindex_preference if change?('setting_noindex')
     user.settings['theme']                   = theme_preference if change?('setting_theme')
     user.settings['hide_network']            = hide_network_preference if change?('setting_hide_network')
+    user.settings['fetch_anonymously']       = fetch_anonymously_preference if change?('setting_fetch_anonymously')
   end
 
   def merged_notification_emails
@@ -82,6 +83,10 @@ class UserSettingsDecorator
 
   def hide_network_preference
     boolean_cast_setting 'setting_hide_network'
+  end
+
+  def fetch_anonymously_preference
+    boolean_cast_setting 'setting_fetch_anonymously'
   end
 
   def theme_preference

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,7 @@ class User < ApplicationRecord
 
   delegate :auto_play_gif, :default_sensitive, :unfollow_modal, :boost_modal, :delete_modal,
            :reduce_motion, :system_font_ui, :noindex, :theme, :display_sensitive_media, :hide_network,
-           :default_language, to: :settings, prefix: :setting, allow_nil: false
+           :default_language, :fetch_anonymously, to: :settings, prefix: :setting, allow_nil: false
 
   attr_reader :invite_code
 

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -26,6 +26,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:auto_play_gif]           = object.current_account.user.setting_auto_play_gif
       store[:display_sensitive_media] = object.current_account.user.setting_display_sensitive_media
       store[:reduce_motion]           = object.current_account.user.setting_reduce_motion
+      store[:fetch_anonymously]       = object.current_account.user.setting_fetch_anonymously
     end
 
     store

--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -6,7 +6,7 @@ class FetchAtomService < BaseService
   def call(url, on_behalf_of: nil)
     return if url.blank?
 
-    @on_behalf_of = on_behalf_of
+    @on_behalf_of = on_behalf_of unless on_behalf_of&.user&.setting_fetch_anonymously
 
     result = process(url)
 
@@ -33,7 +33,7 @@ class FetchAtomService < BaseService
     accept = 'text/html'
     accept = 'application/activity+json, application/ld+json, application/atom+xml, ' + accept unless @unsupported_activity
 
-    let request = Request.new(:get, @url).add_headers('Accept' => accept)
+    request = Request.new(:get, @url).add_headers('Accept' => accept)
     request.on_behalf_of(@on_behalf_of) if @on_behalf_of
     request.perform(&block)
   end

--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -3,8 +3,10 @@
 class FetchAtomService < BaseService
   include JsonLdHelper
 
-  def call(url)
+  def call(url, on_behalf_of: nil)
     return if url.blank?
+
+    @on_behalf_of = on_behalf_of
 
     result = process(url)
 
@@ -31,7 +33,9 @@ class FetchAtomService < BaseService
     accept = 'text/html'
     accept = 'application/activity+json, application/ld+json, application/atom+xml, ' + accept unless @unsupported_activity
 
-    Request.new(:get, @url).add_headers('Accept' => accept).perform(&block)
+    let request = Request.new(:get, @url).add_headers('Accept' => accept)
+    request.on_behalf_of(@on_behalf_of) if @on_behalf_of
+    request.perform(&block)
   end
 
   def process_response(response, terminal = false)

--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -26,7 +26,7 @@ class ResolveURLService < BaseService
   end
 
   def fetched_atom_feed
-    @_fetched_atom_feed ||= FetchAtomService.new.call(url)
+    @_fetched_atom_feed ||= FetchAtomService.new.call(url, on_behalf_of: @on_behalf_of)
   end
 
   def atom_url

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -34,6 +34,9 @@
   .fields-group
     = f.input :setting_hide_network, as: :boolean, wrapper: :with_label
 
+  .fields-group
+    = f.input :setting_fetch_anonymously, as: :boolean, wrapper: :with_label
+
   %hr#settings_web/
 
   - if Themes.instance.names.size > 1

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -25,7 +25,7 @@ en:
         phrase: Will be matched regardless of casing in text or content warning of a toot
         scopes: Which APIs the application will be allowed to access. If you select a top-level scope, you don't need to select individual ones.
         setting_default_language: The language of your toots can be detected automatically, but it's not always accurate
-        setting_fetch_anonymously: Fetching remote private toots from their URL requires authenticating your account name to the remote instance. For this reason, unless this option is enabled, pasting URLs in the search box may disclose your account name to remote instances.
+        setting_fetch_anonymously: Fetching remote private toots from their URL requires authenticating your account to the remote instance. For this reason, unless this option is enabled, pasting URLs in the search box may disclose your account name to remote instances.
         setting_hide_network: Who you follow and who follows you will not be shown on your profile
         setting_noindex: Affects your public profile and status pages
         setting_theme: Affects how Mastodon looks when you're logged in from any device.
@@ -74,7 +74,7 @@ en:
         setting_default_sensitive: Always mark media as sensitive
         setting_delete_modal: Show confirmation dialog before deleting a toot
         setting_display_sensitive_media: Always show media marked as sensitive
-        setting_fetch_anonymously: Never authentify to remote instances when pasting a URL in the search box
+        setting_fetch_anonymously: Never authenticate to remote instances when pasting a URL in the search box
         setting_hide_network: Hide your network
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -25,6 +25,7 @@ en:
         phrase: Will be matched regardless of casing in text or content warning of a toot
         scopes: Which APIs the application will be allowed to access. If you select a top-level scope, you don't need to select individual ones.
         setting_default_language: The language of your toots can be detected automatically, but it's not always accurate
+        setting_fetch_anonymously: Fetching remote private toots from their URL requires authenticating your account name to the remote instance. For this reason, unless this option is enabled, pasting URLs in the search box may disclose your account name to remote instances.
         setting_hide_network: Who you follow and who follows you will not be shown on your profile
         setting_noindex: Affects your public profile and status pages
         setting_theme: Affects how Mastodon looks when you're logged in from any device.
@@ -73,6 +74,7 @@ en:
         setting_default_sensitive: Always mark media as sensitive
         setting_delete_modal: Show confirmation dialog before deleting a toot
         setting_display_sensitive_media: Always show media marked as sensitive
+        setting_fetch_anonymously: Never authentify to remote instances when pasting a URL in the search box
         setting_hide_network: Hide your network
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,6 +22,7 @@ defaults: &defaults
   show_staff_badge: true
   default_sensitive: false
   hide_network: false
+  fetch_anonymously: true
   unfollow_modal: false
   boost_modal: false
   delete_modal: true

--- a/spec/services/resolve_url_service_spec.rb
+++ b/spec/services/resolve_url_service_spec.rb
@@ -10,7 +10,7 @@ describe ResolveURLService, type: :service do
       url = 'http://example.com/missing-atom'
       service = double
       allow(FetchAtomService).to receive(:new).and_return service
-      allow(service).to receive(:call).with(url).and_return(nil)
+      allow(service).to receive(:call).with(url, on_behalf_of: nil).and_return(nil)
 
       result = subject.call(url)
       expect(result).to be_nil
@@ -22,7 +22,7 @@ describe ResolveURLService, type: :service do
       allow(FetchAtomService).to receive(:new).and_return service
       feed_url = 'http://feed-url'
       feed_content = '<feed>contents</feed>'
-      allow(service).to receive(:call).with(url).and_return([feed_url, { prefetched_body: feed_content }])
+      allow(service).to receive(:call).with(url, on_behalf_of: nil).and_return([feed_url, { prefetched_body: feed_content }])
 
       account_service = double
       allow(FetchRemoteAccountService).to receive(:new).and_return(account_service)
@@ -39,7 +39,7 @@ describe ResolveURLService, type: :service do
       allow(FetchAtomService).to receive(:new).and_return service
       feed_url = 'http://feed-url'
       feed_content = '<entry>contents</entry>'
-      allow(service).to receive(:call).with(url).and_return([feed_url, { prefetched_body: feed_content }])
+      allow(service).to receive(:call).with(url, on_behalf_of: nil).and_return([feed_url, { prefetched_body: feed_content }])
 
       account_service = double
       allow(FetchRemoteStatusService).to receive(:new).and_return(account_service)


### PR DESCRIPTION
Since it can disclose to the remote instance that the local user is trying to fetch a toot, that is opt-in:
![screenshot_2018-08-19 preferences - dev instance 3](https://user-images.githubusercontent.com/384364/44312662-040f5580-a3fc-11e8-8ba6-c3c28abc7241.png)

EDIT: Edited to reflect that it is now opt-in.

If the feature hasn't been opted in and an URL-based search fails to return a result, the following warning is displayed, linking to the above setting:
![screenshot_2018-08-19 dev instance 5](https://user-images.githubusercontent.com/384364/44312665-083b7300-a3fc-11e8-81c5-35a43006f7bf.png)

