### PR TITLE
Prevent actions log from crashing when displaying deleted status (fixes #8133)

### DIFF
--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -34,7 +34,11 @@ module Admin::ActionLogsHelper
       link_to attributes['domain'], "https://#{attributes['domain']}"
     when 'Status'
       tmp_status = Status.new(attributes)
-      link_to tmp_status.account&.acct || "##{tmp_status.account_id}", TagManager.instance.url_for(tmp_status)
+      if tmp_status.account
+        link_to tmp_status.account&.acct || "##{tmp_status.account_id}", admin_account_path(tmp_status.account_id)
+      else
+        I18n.t('admin.action_logs.deleted_status')
+      end
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,6 +184,7 @@ en:
         unsuspend_account: "%{name} unsuspended %{target}'s account"
         update_custom_emoji: "%{name} updated emoji %{target}"
         update_status: "%{name} updated status by %{target}"
+      deleted_status: "(deleted status)"
       title: Audit log
     custom_emojis:
       by_domain: Domain


### PR DESCRIPTION
When a status is updated (not deleted or created) in the admin view, only its id and the actual modification are saved. This meant that if the status got deleted afterwards, the status was deleted afterward, the code was still trying to link to it.

EDIT: This is not perfect, and it can't be (because we haven't the required information in the database), but here is what it looks like:
![screenshot_2018-08-16 audit log - dev instance](https://user-images.githubusercontent.com/384364/44216411-280d3580-a175-11e8-9f3c-62e5d20813d1.png)
