### PR TITLE
replace sabotaged uws with ws

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "tiny-queue": "^0.2.1",
     "uglifyjs-webpack-plugin": "^1.2.7",
     "uuid": "^3.1.0",
-    "uws": "10.148.0",
+    "ws": "6.0.0",
     "webpack": "^4.16.0",
     "webpack-bundle-analyzer": "^2.13.1",
     "webpack-cli": "^3.0.8",

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -7,7 +7,7 @@ const redis = require('redis');
 const pg = require('pg');
 const log = require('npmlog');
 const url = require('url');
-const WebSocket = require('uws');
+const WebSocket = require('ws');
 const uuid = require('uuid');
 
 const env = process.env.NODE_ENV || 'development';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8379,10 +8379,6 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
-uws@10.148.0:
-  version "10.148.0"
-  resolved "https://registry.yarnpkg.com/uws/-/uws-10.148.0.tgz#3fcd35f083ca515e091cd33b2d78f0f51a666215"
-
 v8-compile-cache@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.0.tgz#526492e35fc616864284700b7043e01baee09f0a"
@@ -8709,6 +8705,12 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
+
+ws@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.0.0.tgz#eaa494aded00ac4289d455bac8d84c7c651cef35"
+  dependencies:
+    async-limiter "~1.0.0"
 
 ws@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
Recently the uws package was sabotaged by its maintainer and causes now sometimes runtime errors.
see:
https://www.npmjs.com/package/uws
and
https://www.reddit.com/r/node/comments/91kgte/uws_has_been_deprecated/

Sorry for replacing a technical better solution by an inferior.