### PR TITLE
Use CircleCI workflows for ruby dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,11 @@ aliases:
             paths:
               - ./.bundle/
               - ./vendor/bundle/
+        - persist_to_workspace:
+            root: ~/projects/
+            paths:
+                - ./mastodon/.bundle/
+                - ./mastodon/vendor/bundle/
 
   - &test_steps
       steps:
@@ -77,9 +82,6 @@ aliases:
 
         - *install_system_dependencies
         - run: sudo apt-get install -y ffmpeg
-
-        - run: ruby -e 'puts RUBY_VERSION' | tee /tmp/.ruby-version
-        - *restore_ruby_dependencies
 
         - run:
             name: Prepare Tests
@@ -116,8 +118,6 @@ jobs:
     steps:
       - *attach_workspace
       - *install_system_dependencies
-      - run: ruby -e 'puts RUBY_VERSION' | tee /tmp/.ruby-version
-      - *restore_ruby_dependencies
       - run: ./bin/rails assets:precompile
       - persist_to_workspace:
           root: ~/projects/
@@ -170,8 +170,6 @@ jobs:
     <<: *defaults
     steps:
       - *attach_workspace
-      - run: ruby -e 'puts RUBY_VERSION' | tee /tmp/.ruby-version
-      - *restore_ruby_dependencies
       - run: bundle exec i18n-tasks check-normalized
       - run: bundle exec i18n-tasks unused
 
@@ -186,9 +184,11 @@ workflows:
       - install-ruby2.4:
           requires:
             - install
+            - install-ruby2.5
       - install-ruby2.3:
           requires:
             - install
+            - install-ruby2.5
       - build:
           requires:
             - install-ruby2.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ aliases:
 
         - run: ruby -e 'puts RUBY_VERSION' | tee /tmp/.ruby-version
         - *restore_ruby_dependencies
-        - run: bundle install --clean --jobs 16 --path ./vendor/bundle/ --retry 3 --with pam_authentication --without development production
+        - run: bundle install --clean --jobs 16 --path ./vendor/bundle/ --retry 3 --with pam_authentication --without development production && bundle clean
         - save_cache:
             key: v2-ruby-dependencies-{{ checksum "/tmp/.ruby-version" }}-{{ checksum "Gemfile.lock" }}
             paths:


### PR DESCRIPTION
The CircleCI config used caches both for actually caching the dependencies between runs, and to pass data to the build and test jobs.
However, those jobs require more guarantees than just a cache: they need the correct versions of the gems to be available no matter what.
This is not guaranteed by caches, and I actually saw a cache not getting saved in glitch-soc CI, causing a build failure downstream.

Unfortunately, in order to make the order of cache layers deterministic, I had to make install-ruby2.3 and install-ruby2.4 depend on install-ruby2.5.