### PR TITLE
Implement Undo { Accept { Follow } } (fixes #8234)

### DIFF
--- a/app/lib/activitypub/activity/undo.rb
+++ b/app/lib/activitypub/activity/undo.rb
@@ -5,6 +5,8 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
     case @object['type']
     when 'Announce'
       undo_announce
+    when 'Accept'
+      undo_accept
     when 'Follow'
       undo_follow
     when 'Like'
@@ -25,6 +27,10 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
     else
       RemoveStatusService.new.call(status)
     end
+  end
+
+  def undo_accept
+    ::Follow.find_by(target_account: @account, uri: target_uri)&.revoke_request!
   end
 
   def undo_follow

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -32,6 +32,11 @@ class Follow < ApplicationRecord
     false # Force uri_for to use uri attribute
   end
 
+  def revoke_request!
+    FollowRequest.create!(account: account, target_account: target_account, show_reblogs: show_reblogs, uri: uri)
+    destroy!
+  end
+
   before_validation :set_uri, only: :create
   after_destroy :remove_endorsements
 

--- a/spec/lib/activitypub/activity/undo_spec.rb
+++ b/spec/lib/activitypub/activity/undo_spec.rb
@@ -52,6 +52,32 @@ RSpec.describe ActivityPub::Activity::Undo do
       end
     end
 
+    context 'with Accept' do
+      let(:recipient) { Fabricate(:account) }
+      let(:object_json) do
+        {
+          id: 'bar',
+          type: 'Accept',
+          actor: ActivityPub::TagManager.instance.uri_for(sender),
+          object: 'follow-to-revoke',
+        }
+      end
+
+      before do
+        recipient.follow!(sender, uri: 'follow-to-revoke')
+      end
+
+      it 'deletes follow from recipient to sender' do
+        subject.perform
+        expect(recipient.following?(sender)).to be false
+      end
+
+      it 'creates a follow request from recipient to sender' do
+        subject.perform
+        expect(recipient.requested?(sender)).to be true
+      end
+    end
+
     context 'with Block' do
       let(:recipient) { Fabricate(:account) }
 

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -37,4 +37,20 @@ RSpec.describe Follow, type: :model do
       expect(a[1]).to eq follow0
     end
   end
+
+  describe 'revoke_request!' do
+    let(:follow)         { Fabricate(:follow, account: account, target_account: target_account) }
+    let(:account)        { Fabricate(:account) }
+    let(:target_account) { Fabricate(:account) }
+
+    it 'revokes the follow relation' do
+      follow.revoke_request!
+      expect(account.following?(target_account)).to be false
+    end
+
+    it 'creates a follow request' do
+      follow.revoke_request!
+      expect(account.requested?(target_account)).to be true
+    end
+  end
 end


### PR DESCRIPTION
Receiving a Undo corresponding to a Follow from a local account to the sender is processed by reverting the Follow to a FollowRequest.