### PR TITLE
Fix report text color

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4176,6 +4176,10 @@ a.status-card {
     color: $highlight-text-color;
   }
 
+  .status__content p {
+    color: $inverted-text-color;
+  }
+
   @media screen and (max-width: 480px) {
     max-height: 10vh;
   }


### PR DESCRIPTION
Since #8202 , with the standard site theme it became difficult to see the TOOT text in the report screen.
I will fix this.
![2018-08-19 15 27 52](https://user-images.githubusercontent.com/766076/44306571-9566d380-a3cc-11e8-91dd-67116c3c1d6c.png)
