### PR TITLE
Fix a variable for a Finnish translation

### DIFF
--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -725,7 +725,7 @@ fi:
       tip_local_timeline: Paikallinen aikajana näyttää instanssin %{instance} käyttäjien julkaisut. He ovat naapureitasi!
       tip_mobile_webapp: Jos voit lisätä Mastodonin mobiiliselaimen kautta aloitusnäytöllesi, voit vastaanottaa push-ilmoituksia. Toiminta vastaa monin tavoin tavanomaista sovellusta!
       tips: Vinkkejä
-      title: Tervetuloa mukaan, %name}!
+      title: Tervetuloa mukaan, %{name}!
   users:
     invalid_email: Virheellinen sähköpostiosoite
     invalid_otp_token: Virheellinen kaksivaiheisen todentamisen koodi


### PR DESCRIPTION
Fixes a variable in Finnish translation.

<img width="536" alt="mastodon_welcome_email" src="https://user-images.githubusercontent.com/11232111/44311088-bb4ea100-a3e9-11e8-8979-86761d5f5882.PNG">
