### PR TITLE
change the spoiler input to a textarea

### DIFF
--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -171,10 +171,18 @@ export default class ComposeForm extends ImmutablePureComponent {
 
         <ReplyIndicatorContainer />
 
-        <div className={`spoiler-input ${this.props.spoiler ? 'spoiler-input--visible' : ''}`}>
+        <div className={`spoiler-textarea ${this.props.spoiler ? 'spoiler-textarea--visible' : ''}`}>
           <label>
             <span style={{ display: 'none' }}>{intl.formatMessage(messages.spoiler_placeholder)}</span>
-            <input placeholder={intl.formatMessage(messages.spoiler_placeholder)} value={this.props.spoiler_text} onChange={this.handleChangeSpoilerText} onKeyDown={this.handleKeyDown} type='text' className='spoiler-input__input'  id='cw-spoiler-input' ref={this.setSpoilerText} />
+            <textArea 
+              placeholder={intl.formatMessage(messages.spoiler_placeholder)} 
+              value={this.props.spoiler_text} 
+              onChange={this.handleChangeSpoilerText} 
+              onKeyDown={this.handleKeyDown} 
+              className='spoiler-textarea__textarea'  
+              id='cw-spoiler-textarea' 
+              ref={this.setSpoilerText} 
+            />
           </label>
         </div>
 

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -174,14 +174,14 @@ export default class ComposeForm extends ImmutablePureComponent {
         <div className={`spoiler-textarea ${this.props.spoiler ? 'spoiler-textarea--visible' : ''}`}>
           <label>
             <span style={{ display: 'none' }}>{intl.formatMessage(messages.spoiler_placeholder)}</span>
-            <textArea 
-              placeholder={intl.formatMessage(messages.spoiler_placeholder)} 
-              value={this.props.spoiler_text} 
-              onChange={this.handleChangeSpoilerText} 
-              onKeyDown={this.handleKeyDown} 
-              className='spoiler-textarea__textarea'  
-              id='cw-spoiler-textarea' 
-              ref={this.setSpoilerText} 
+            <textArea
+              placeholder={intl.formatMessage(messages.spoiler_placeholder)}
+              value={this.props.spoiler_text}
+              onChange={this.handleChangeSpoilerText}
+              onKeyDown={this.handleKeyDown}
+              className='spoiler-textarea__textarea'
+              id='cw-spoiler-textarea'
+              ref={this.setSpoilerText}
             />
           </label>
         </div>

--- a/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state, { intl }) => ({
   label: 'CW',
   title: intl.formatMessage(state.getIn(['compose', 'spoiler']) ? messages.marked : messages.unmarked),
   active: state.getIn(['compose', 'spoiler']),
-  ariaControls: 'cw-spoiler-input',
+  ariaControls: 'cw-spoiler-textarea',
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -304,23 +304,23 @@
   }
 
   .autosuggest-textarea,
-  .spoiler-input {
+  .spoiler-textarea {
     position: relative;
   }
 
-  .spoiler-input {
+  .spoiler-textarea {
     height: 0;
     transform-origin: bottom;
     opacity: 0.0;
 
-    &.spoiler-input--visible {
-      height: 47px;
+    &.spoiler-textarea--visible {
+      height: 60px;
       opacity: 1.0;
     }
   }
 
   .autosuggest-textarea__textarea,
-  .spoiler-input__input {
+  .spoiler-textarea__textarea {
     display: block;
     box-sizing: border-box;
     width: 100%;
@@ -330,7 +330,7 @@
     padding: 10px;
     font-family: inherit;
     font-size: 14px;
-    resize: vertical;
+    resize: none;
     border: 0;
     outline: 0;
 
@@ -343,7 +343,7 @@
     }
   }
 
-  .spoiler-input__input {
+  .spoiler-textarea__textarea {
     border-radius: 4px;
   }
 
@@ -576,7 +576,7 @@
   }
 }
 
-.no-reduce-motion .spoiler-input {
+.no-reduce-motion .spoiler-textarea {
   transition: height 0.4s ease, opacity 0.4s ease;
 }
 


### PR DESCRIPTION
Refs #8177 

This PR lets the user see two lines (with word wrapping) while editing their spoiler message.

![1e7daa41-9af0-4362-bb36-ef825db4bf52](https://user-images.githubusercontent.com/11466782/44320911-7ab34f80-a40a-11e8-95d0-c98ea37e5e81.png)

This is my first contribution to Mastodon and I'm fairly new to React so feedback is appreciated.