### PR TITLE
Skip pagination logic entirely for pinned toots (fixes #8302)

### DIFF
--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -55,7 +55,7 @@ export function expandTimeline(timelineId, path, params = {}, done = noOp) {
       return;
     }
 
-    if (!params.max_id && timeline.get('items', ImmutableList()).size > 0) {
+    if (!params.max_id && !params.pinned && timeline.get('items', ImmutableList()).size > 0) {
       params.since_id = timeline.getIn(['items', 0]);
     }
 


### PR DESCRIPTION
Pinned toots are not ordered by the identifier of the toot themselves, so #7540 intended to disable pagination for them, but #7522 re-introduced some pagination mechanism without exempting pinned toots from them.