### PR TITLE
Add preference to filter registered bots from timelines

### DIFF
--- a/app/controllers/api/v1/accounts/credentials_controller.rb
+++ b/app/controllers/api/v1/accounts/credentials_controller.rb
@@ -33,6 +33,7 @@ class Api::V1::Accounts::CredentialsController < Api::BaseController
       'setting_default_privacy' => source_params.fetch(:privacy, @account.user.setting_default_privacy),
       'setting_default_sensitive' => source_params.fetch(:sensitive, @account.user.setting_default_sensitive),
       'setting_default_language' => source_params.fetch(:language, @account.user.setting_default_language),
+      'setting_filter_bots' => source_params.fetch(:filter_bots, @account.user.setting_filter_bots),
     }
   end
 end

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -44,7 +44,12 @@ class Api::V1::NotificationsController < Api::BaseController
   end
 
   def browserable_account_notifications
-    current_account.notifications.browserable(exclude_types)
+    notifications = current_account.notifications.browserable(exclude_types)
+    if current_account.filters_bots?
+      notifications.excluding_bot_accounts
+    else
+      notifications
+    end
   end
 
   def target_statuses_from_notifications

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -47,6 +47,7 @@ class Settings::PreferencesController < ApplicationController
       :setting_noindex,
       :setting_theme,
       :setting_hide_network,
+      :setting_filter_bots,
       notification_emails: %i(follow follow_request reblog favourite mention digest report),
       interactions: %i(must_be_follower must_be_following)
     )

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -31,6 +31,7 @@ class UserSettingsDecorator
     user.settings['noindex']             = noindex_preference if change?('setting_noindex')
     user.settings['theme']               = theme_preference if change?('setting_theme')
     user.settings['hide_network']        = hide_network_preference if change?('setting_hide_network')
+    user.settings['filter_bots']         = filter_bots_preference if change?('setting_filter_bots')
   end
 
   def merged_notification_emails
@@ -87,6 +88,10 @@ class UserSettingsDecorator
 
   def hide_network_preference
     boolean_cast_setting 'setting_hide_network'
+  end
+
+  def filter_bots_preference
+    boolean_cast_setting 'setting_filter_bots'
   end
 
   def theme_preference

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -148,7 +148,7 @@ class Account < ApplicationRecord
            prefix: true,
            allow_nil: true
 
-  delegate :chosen_languages, to: :user, prefix: false, allow_nil: true
+  delegate :chosen_languages, :filters_bots?, to: :user, prefix: false, allow_nil: true
 
   def local?
     domain.nil?

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -43,6 +43,7 @@ class Notification < ApplicationRecord
     types = TYPE_CLASS_MAP.values - activity_types_from_types(exclude_types + [:follow_request])
     where(activity_type: types)
   }
+  scope :excluding_bot_accounts, -> { left_outer_joins(:from_account).where("accounts.actor_type IS NULL OR accounts.actor_type NOT IN ('Application', 'Service')") }
 
   cache_associated :from_account, status: STATUS_INCLUDES, mention: [status: STATUS_INCLUDES], favourite: [:account, status: STATUS_INCLUDES], follow: :account
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,7 @@ class User < ApplicationRecord
 
   delegate :auto_play_gif, :default_sensitive, :unfollow_modal, :boost_modal, :delete_modal,
            :reduce_motion, :system_font_ui, :noindex, :theme, :display_media, :hide_network,
-           :expand_spoilers, :default_language, to: :settings, prefix: :setting, allow_nil: false
+           :expand_spoilers, :default_language, :filter_bots, to: :settings, prefix: :setting, allow_nil: false
 
   attr_reader :invite_code
 
@@ -230,6 +230,14 @@ class User < ApplicationRecord
 
   def hides_network?
     @hides_network ||= settings.hide_network
+  end
+
+  def filters_bots?
+    @filters_bots ||= settings.filter_bots
+  end
+
+  def filter_bots=(filter)
+    settings.filter_bots = @filters_bots = filter
   end
 
   def token_for_app(a)

--- a/app/serializers/rest/credential_account_serializer.rb
+++ b/app/serializers/rest/credential_account_serializer.rb
@@ -10,6 +10,7 @@ class REST::CredentialAccountSerializer < REST::AccountSerializer
       privacy: user.setting_default_privacy,
       sensitive: user.setting_default_sensitive,
       language: user.setting_default_language,
+      filter_bots: user.setting_filter_bots,
       note: object.note,
       fields: object.fields.map(&:to_h),
     }

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -34,6 +34,9 @@
   .fields-group
     = f.input :setting_hide_network, as: :boolean, wrapper: :with_label
 
+  .fields-group
+    = f.input :setting_filter_bots, as: :boolean, wrapper: :with_label
+  
   %hr#settings_web/
 
   - if Themes.instance.names.size > 1

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -28,6 +28,7 @@ en:
         setting_display_media_default: Hide media marked as sensitive
         setting_display_media_hide_all: Always hide all media
         setting_display_media_show_all: Always show media marked as sensitive
+        setting_filter_bots: Messages from bot accounts will not be shown in your timelines
         setting_hide_network: Who you follow and who follows you will not be shown on your profile
         setting_noindex: Affects your public profile and status pages
         setting_theme: Affects how Mastodon looks when you're logged in from any device.
@@ -80,6 +81,7 @@ en:
         setting_display_media_hide_all: Hide all
         setting_display_media_show_all: Show all
         setting_expand_spoilers: Always expand toots marked with content warnings
+        setting_filter_bots: Filter bots
         setting_hide_network: Hide your network
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,6 +22,7 @@ defaults: &defaults
   show_staff_badge: true
   default_sensitive: false
   hide_network: false
+  filter_bots: false
   unfollow_modal: false
   boost_modal: false
   delete_modal: true

--- a/spec/controllers/api/v1/accounts/credentials_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/credentials_controller_spec.rb
@@ -34,6 +34,7 @@ describe Api::V1::Accounts::CredentialsController do
             header: fixture_file_upload('files/attachment.jpg', 'image/jpeg'),
             source: {
               privacy: 'unlisted',
+              filter_bots: true,
               sensitive: true,
             }
           }
@@ -52,6 +53,7 @@ describe Api::V1::Accounts::CredentialsController do
           expect(user.account.header).to exist
           expect(user.setting_default_privacy).to eq('unlisted')
           expect(user.setting_default_sensitive).to eq(true)
+          expect(user.setting_filter_bots).to eq(true)
         end
 
         it 'queues up an account update distribution' do


### PR DESCRIPTION
Adds a user preference for filtering statuses bots from timelines and notifications, based on account `actor_type`

This affects
- local timeline
- federated timeline
- DM timeline
- tag timelines
- notifications

I explicitly didn't touch the home timeline, since if you're following a bot, or somebody you're following boosts a bot's status, that's probably "not bot" enough.