### PR TITLE
reorder simple form ul to list vertically (fixes #8236)

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -154,9 +154,10 @@ code {
       margin-bottom: 15px;
     }
 
-    li {
-      float: left;
-      width: 50%;
+    ul {
+      columns: 2;
+      -webkit-columns: 2;
+      -moz-columns: 2;
     }
   }
 

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -156,8 +156,6 @@ code {
 
     ul {
       columns: 2;
-      -webkit-columns: 2;
-      -moz-columns: 2;
     }
   }
 


### PR DESCRIPTION
Modified the filter languages list so that they are listed alphabetically vertically rather than horizontally.

![screenshot from 2018-08-20 20-31-45](https://user-images.githubusercontent.com/4073413/44362239-439b7780-a4b8-11e8-8b82-789219f3e932.png)
