### PR TITLE
Use only two sidekiq queues

### DIFF
--- a/app/workers/activitypub/post_upgrade_worker.rb
+++ b/app/workers/activitypub/post_upgrade_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::PostUpgradeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'default'
 
   def perform(domain)
     Account.where(domain: domain)

--- a/app/workers/activitypub/reply_distribution_worker.rb
+++ b/app/workers/activitypub/reply_distribution_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::ReplyDistributionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push'
+  sidekiq_options queue: 'default'
 
   def perform(status_id)
     @status  = Status.find(status_id)

--- a/app/workers/activitypub/synchronize_featured_collection_worker.rb
+++ b/app/workers/activitypub/synchronize_featured_collection_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::SynchronizeFeaturedCollectionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', unique: :until_executed
+  sidekiq_options queue: 'default', unique: :until_executed
 
   def perform(account_id)
     ActivityPub::FetchFeaturedCollectionService.new.call(Account.find(account_id))

--- a/app/workers/activitypub/update_distribution_worker.rb
+++ b/app/workers/activitypub/update_distribution_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::UpdateDistributionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push'
+  sidekiq_options queue: 'default'
 
   def perform(account_id)
     @account = Account.find(account_id)

--- a/app/workers/admin/suspension_worker.rb
+++ b/app/workers/admin/suspension_worker.rb
@@ -3,7 +3,7 @@
 class Admin::SuspensionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'default'
 
   def perform(account_id, remove_user = false)
     SuspendAccountService.new.call(Account.find(account_id), remove_user: remove_user)

--- a/app/workers/after_remote_follow_request_worker.rb
+++ b/app/workers/after_remote_follow_request_worker.rb
@@ -3,7 +3,7 @@
 class AfterRemoteFollowRequestWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: 5
+  sidekiq_options queue: 'default', retry: 5
 
   attr_reader :follow_request
 

--- a/app/workers/backup_worker.rb
+++ b/app/workers/backup_worker.rb
@@ -3,7 +3,7 @@
 class BackupWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', backtrace: true, retry: 5, dead: false
+  sidekiq_options queue: 'mailers', backtrace: true, retry: 5, dead: false
 
   sidekiq_retries_exhausted do |msg|
     backup_id = msg['args'].first

--- a/app/workers/import/relationship_worker.rb
+++ b/app/workers/import/relationship_worker.rb
@@ -3,7 +3,7 @@
 class Import::RelationshipWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: 8, dead: false
+  sidekiq_options queue: 'default', retry: 8, dead: false
 
   def perform(account_id, target_account_uri, relationship)
     from_account   = Account.find(account_id)

--- a/app/workers/import_worker.rb
+++ b/app/workers/import_worker.rb
@@ -5,7 +5,7 @@ require 'csv'
 class ImportWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: false
+  sidekiq_options queue: 'default', retry: false
 
   attr_reader :import
 

--- a/app/workers/link_crawl_worker.rb
+++ b/app/workers/link_crawl_worker.rb
@@ -3,7 +3,7 @@
 class LinkCrawlWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: 0
+  sidekiq_options queue: 'mailers', retry: 0
 
   def perform(status_id)
     FetchLinkCardService.new.call(Status.find(status_id))

--- a/app/workers/maintenance/destroy_media_worker.rb
+++ b/app/workers/maintenance/destroy_media_worker.rb
@@ -3,7 +3,7 @@
 class Maintenance::DestroyMediaWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'mailers'
 
   def perform(media_attachment_id)
     media = MediaAttachment.find(media_attachment_id)

--- a/app/workers/maintenance/redownload_account_media_worker.rb
+++ b/app/workers/maintenance/redownload_account_media_worker.rb
@@ -3,7 +3,7 @@
 class Maintenance::RedownloadAccountMediaWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: false
+  sidekiq_options queue: 'mailers', retry: false
 
   def perform(account_id)
     account = Account.find(account_id)

--- a/app/workers/maintenance/uncache_media_worker.rb
+++ b/app/workers/maintenance/uncache_media_worker.rb
@@ -3,7 +3,7 @@
 class Maintenance::UncacheMediaWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'mailers'
 
   def perform(media_attachment_id)
     media = MediaAttachment.find(media_attachment_id)

--- a/app/workers/notification_worker.rb
+++ b/app/workers/notification_worker.rb
@@ -3,7 +3,7 @@
 class NotificationWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push', retry: 5
+  sidekiq_options queue: 'default', retry: 5
 
   def perform(xml, source_account_id, target_account_id)
     SendInteractionService.new.call(xml, Account.find(source_account_id), Account.find(target_account_id))

--- a/app/workers/pubsubhubbub/confirmation_worker.rb
+++ b/app/workers/pubsubhubbub/confirmation_worker.rb
@@ -4,7 +4,7 @@ class Pubsubhubbub::ConfirmationWorker
   include Sidekiq::Worker
   include RoutingHelper
 
-  sidekiq_options queue: 'push', retry: false
+  sidekiq_options queue: 'default', retry: false
 
   attr_reader :subscription, :mode, :secret, :lease_seconds
 

--- a/app/workers/pubsubhubbub/delivery_worker.rb
+++ b/app/workers/pubsubhubbub/delivery_worker.rb
@@ -4,7 +4,7 @@ class Pubsubhubbub::DeliveryWorker
   include Sidekiq::Worker
   include RoutingHelper
 
-  sidekiq_options queue: 'push', retry: 3, dead: false
+  sidekiq_options queue: 'default', retry: 3, dead: false
 
   sidekiq_retry_in do |count|
     5 * (count + 1)

--- a/app/workers/pubsubhubbub/distribution_worker.rb
+++ b/app/workers/pubsubhubbub/distribution_worker.rb
@@ -3,7 +3,7 @@
 class Pubsubhubbub::DistributionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push'
+  sidekiq_options queue: 'default'
 
   def perform(stream_entry_ids)
     stream_entries = StreamEntry.where(id: stream_entry_ids).includes(:status).reject { |e| e.status.nil? || e.status.hidden? }

--- a/app/workers/pubsubhubbub/raw_distribution_worker.rb
+++ b/app/workers/pubsubhubbub/raw_distribution_worker.rb
@@ -3,7 +3,7 @@
 class Pubsubhubbub::RawDistributionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push'
+  sidekiq_options queue: 'default'
 
   def perform(xml, source_account_id)
     @account       = Account.find(source_account_id)

--- a/app/workers/pubsubhubbub/subscribe_worker.rb
+++ b/app/workers/pubsubhubbub/subscribe_worker.rb
@@ -3,7 +3,7 @@
 class Pubsubhubbub::SubscribeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push', retry: 10, unique: :until_executed, dead: false
+  sidekiq_options queue: 'default', retry: 10, unique: :until_executed, dead: false
 
   sidekiq_retry_in do |count|
     case count

--- a/app/workers/pubsubhubbub/unsubscribe_worker.rb
+++ b/app/workers/pubsubhubbub/unsubscribe_worker.rb
@@ -3,7 +3,7 @@
 class Pubsubhubbub::UnsubscribeWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'push', retry: false, unique: :until_executed, dead: false
+  sidekiq_options queue: 'default', retry: false, unique: :until_executed, dead: false
 
   def perform(account_id)
     account = Account.find(account_id)

--- a/app/workers/refollow_worker.rb
+++ b/app/workers/refollow_worker.rb
@@ -3,7 +3,7 @@
 class RefollowWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: false
+  sidekiq_options queue: 'default', retry: false
 
   def perform(target_account_id)
     target_account = Account.find(target_account_id)

--- a/app/workers/remote_profile_update_worker.rb
+++ b/app/workers/remote_profile_update_worker.rb
@@ -3,7 +3,7 @@
 class RemoteProfileUpdateWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'default'
 
   def perform(account_id, body, resubscribe)
     UpdateRemoteProfileService.new.call(body, Account.find(account_id), resubscribe)

--- a/app/workers/resolve_account_worker.rb
+++ b/app/workers/resolve_account_worker.rb
@@ -3,7 +3,7 @@
 class ResolveAccountWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', unique: :until_executed
+  sidekiq_options queue: 'default', unique: :until_executed
 
   def perform(uri)
     ResolveAccountService.new.call(uri)

--- a/app/workers/thread_resolve_worker.rb
+++ b/app/workers/thread_resolve_worker.rb
@@ -3,7 +3,7 @@
 class ThreadResolveWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: 3
+  sidekiq_options queue: 'default', retry: 3
 
   sidekiq_retry_in do |count|
     15 + 10 * (count**4) + rand(10 * (count**4))


### PR DESCRIPTION
Use only two sidekiq queues, as they implicitly define priority.
Every worker now use the `default` (high-priority) queue except for
the following workers using the `mailers` (low-priority) one:
- DigestMailerWorker (because it already was)
- BackupWorker (because it's a relatively low-priority resource-intensive task)
- LinkCrawlWorker (because it's only used for preview cards, which are not super useful)
- Maintenance::DestroyMediaWorker (because those are a lot of tasks that could disrupt normal operations)
- Maintenance::RedownloadAccountMediaWorker (same as above)
- Maintenance::UncacheMediaWorker (same as above)

It's the suggested first step in solving #8342