### PR TITLE
Update docker config and move some workers to different queues

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,8 +3,8 @@
 :queues:
   - default
   - push
-  - pull
   - mailers
+  - pull
 :schedule:
   subscriptions_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(4..6) %> * * *'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bundle exec sidekiq -q default -q mailers -q pull -q push
+    command: bundle exec sidekiq -q default -q push -q mailers -q pull
     depends_on:
       - db
       - redis


### PR DESCRIPTION
From reading the workers and #8342, my understanding is that the different queues are for the following purposes:
- `default`: base functionality within the instance, highest-priority
- `push`: federation (mostly outwards), high priority
- `mailers`: used for mails (notifications, digest, …), low priority
- `pull`: lowest-priority tasks, mainly federation-related

So they are a bit of a misnomer, which makes thing a bit confusing, but they are essentially `critical`, `normal`, `low`, `lowest`. I changed the docker-compose file to match that.

I also moved a few tasks:
- ~~~I moved the maintenance tasks to `mailers`, because they are non-essential and typically involve hundreds or thousands of jobs.~~~
- I moved the incoming federation-related processing tasks to `push` so they do not interfere with local functionality.

EDIT: Updated with my understanding that `mailers` is for all kinds of mails, not just the digests, so it's higher priority than `pull`.