### PR TITLE
Allow use of plurals on about page stats.

### DIFF
--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -18,11 +18,11 @@
           .information-board__section
             %span= t 'about.user_count_before'
             %strong= number_with_delimiter @instance_presenter.user_count
-            %span= t 'about.user_count_after'
+            %span= t 'about.user_count_after', count: @instance_presenter.user_count
           .information-board__section
             %span= t 'about.status_count_before'
             %strong= number_with_delimiter @instance_presenter.status_count
-            %span= t 'about.status_count_after'
+            %span= t 'about.status_count_after', count: @instance_presenter.status_count
         .row__mascot
           .landing-page__mascot
             = image_tag asset_pack_path('elephant_ui_plane.svg')

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -56,11 +56,11 @@
                 .information-board__section
                   %span= t 'about.user_count_before'
                   %strong= number_with_delimiter @instance_presenter.user_count
-                  %span= t 'about.user_count_after'
+                  %span= t 'about.user_count_after', count: @instance_presenter.user_count
                 .information-board__section
                   %span= t 'about.status_count_before'
                   %strong= number_with_delimiter @instance_presenter.status_count
-                  %span= t 'about.status_count_after'
+                  %span= t 'about.status_count_after', count: @instance_presenter.status_count
               .row__mascot
                 .landing-page__mascot
                   = image_tag asset_pack_path('elephant_ui_plane.svg')
@@ -88,11 +88,11 @@
                 .information-board__section
                   %span= t 'about.user_count_before'
                   %strong= number_with_delimiter @instance_presenter.user_count
-                  %span= t 'about.user_count_after'
+                  %span= t 'about.user_count_after', count: @instance_presenter.user_count
                 .information-board__section
                   %span= t 'about.status_count_before'
                   %strong= number_with_delimiter @instance_presenter.status_count
-                  %span= t 'about.status_count_after'
+                  %span= t 'about.status_count_after', count: @instance_presenter.status_count
               .row__mascot
                 .landing-page__mascot
                   = image_tag asset_pack_path('elephant_ui_plane.svg')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,10 +30,14 @@ en:
     other_instances: Instance list
     privacy_policy: Privacy policy
     source_code: Source code
-    status_count_after: statuses
+    status_count_after:
+      one: status
+      other: statuses
     status_count_before: Who authored
     terms: Terms of service
-    user_count_after: users
+    user_count_after:
+      one: user
+      other: users
     user_count_before: Home to
     what_is_mastodon: What is Mastodon?
   accounts:


### PR DESCRIPTION
This allows an instance to say "Home to 1 user" instead of "Home to 1 users", and similarly if they've only made one status.

Before: <img align="middle" src="https://user-images.githubusercontent.com/154364/44457743-faecd700-a5fb-11e8-8042-d7a7858bf12d.png" alt="Home to 1 users"> and after: <img src="https://user-images.githubusercontent.com/154364/44457742-faecd700-a5fb-11e8-9dea-7a8b4bef7506.png"  align="middle" alt="Home to 1 user">
(ignore colour change, screenshots from different installs).