### PR TITLE
Do not check for file existence when serializing ActivityPub actor

### DIFF
--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -93,11 +93,11 @@ class ActivityPub::ActorSerializer < ActiveModel::Serializer
   end
 
   def avatar_exists?
-    object.avatar.exists?
+    object.avatar?
   end
 
   def header_exists?
-    object.header.exists?
+    object.header?
   end
 
   def manually_approves_followers


### PR DESCRIPTION
When serializing an ActivityPub actor, Mastodon checks for the existence
of the avatar/header files. This is not necessary, only check if avatar/header
is set.

https://github.com/thoughtbot/paperclip/blob/fd8bf49d3895de2904b43f95d11af0736fbd0f5b/README.md#checking-a-file-exists