### PR TITLE
update devise_pam_authenticatable2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       devise (~> 4.0)
       railties (< 5.3)
       rotp (~> 2.0)
-    devise_pam_authenticatable2 (9.1.0)
+    devise_pam_authenticatable2 (9.1.1)
       devise (>= 4.0.0)
       rpam2 (~> 4.0)
     diff-lcs (1.3)


### PR DESCRIPTION
Update to 9.1.1
Fixes pam authentication for hosts with "n"s in their names.
