### PR TITLE
Revise Japanese translation of `deleted_status`

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -185,7 +185,7 @@ ja:
         unsuspend_account: "%{name} さんが %{target} さんの停止を解除しました"
         update_custom_emoji: "%{name} さんがカスタム絵文字 %{target} を更新しました"
         update_status: "%{name} さんが %{target} さんの投稿を更新しました"
-      deleted_status: "(削除されました)"
+      deleted_status: "(削除済)"
       title: 操作履歴
     custom_emojis:
       by_domain: ドメイン


### PR DESCRIPTION
レポート関連の翻訳にある`deleted_status`は、ステータスが削除された残骸を示すものなので、
動作ではなく名詞として翻訳する方がより適切です。

![screenshot_20180825_091810](https://user-images.githubusercontent.com/1224508/44613061-6081d300-a849-11e8-9058-ba0e54eac6f1.png)
![screenshot_20180825_093128](https://user-images.githubusercontent.com/1224508/44613077-bd7d8900-a849-11e8-8098-324d49913a2e.png)

