### PR TITLE
Default puma to running on localhost only.

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,8 @@ threads threads_count, threads_count
 if ENV['SOCKET'] then
   bind 'unix://' + ENV['SOCKET']
 else
-  port ENV.fetch('PORT') { 3000 }
+  port_num = ENV.fetch('PORT') { 3000 }
+  bind "tcp://127.0.0.1:#{port_num}"
 end
 
 environment ENV.fetch('RAILS_ENV') { 'development' }


### PR DESCRIPTION
I see https://github.com/tootsuite/mastodon/issues/1283 was closed but web and streaming, when installed using the production guide, both default to listening on 0.0.0.0 though the production guide sets them up to only be needed internally.

I also see https://github.com/tootsuite/mastodon/pull/1747/files which did similar but closed due to inactivity.

This fixes the web service, the streaming can be fixed in the production guide so I'll submit a PR there too.

You can still choose to listen on 0.0.0.0 by running puma with the `--bind` option.