### PR TITLE
Add health endpoint to streaming API

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -452,6 +452,12 @@ const startWorker = (workerId) => {
   app.use(setRequestId);
   app.use(setRemoteAddress);
   app.use(allowCrossDomain);
+
+  app.get('/api/v1/streaming/health', (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('OK');
+  });
+
   app.use(authenticationMiddleware);
   app.use(errorMiddleware);
 


### PR DESCRIPTION
    GET /api/v1/streaming/health

Answers with OK. Fix #8337