### PR TITLE
Revert "Default puma to running on localhost only."

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,8 +4,7 @@ threads threads_count, threads_count
 if ENV['SOCKET'] then
   bind 'unix://' + ENV['SOCKET']
 else
-  port_num = ENV.fetch('PORT') { 3000 }
-  bind "tcp://127.0.0.1:#{port_num}"
+  port ENV.fetch('PORT') { 3000 }
 end
 
 environment ENV.fetch('RAILS_ENV') { 'development' }


### PR DESCRIPTION
Reverts tootsuite/mastodon#8429

>I just realized this is gonna break my config on a multi-machine setup. I don't mind adjusting, but this change might catch more admins by surprise. The thing is, you've gotta be using iptables or ufw anyway, and even if the 3000 or 4000 port is open to the internet, it's not like you're getting anything you wouldn't be getting through nginx.