### PR TITLE
Fix CW issues in static view on Safari (Fixes #8354)

### DIFF
--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -78,10 +78,10 @@ function main() {
         })
         .catch(error => console.error(error));
     }
-        
-    const parallaxComponents = document.querySelectorAll('.parallax')
+    
+    const parallaxComponents = document.querySelectorAll('.parallax');
     if (parallaxComponents.length > 0 ) {
-        new Rellax('.parallax', { speed: -1 });
+      new Rellax('.parallax', { speed: -1 });
     }
 
     const history = createHistory();

--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -78,8 +78,11 @@ function main() {
         })
         .catch(error => console.error(error));
     }
-
-    new Rellax('.parallax', { speed: -1 });
+        
+    const parallaxComponents = document.querySelectorAll('.parallax')
+    if (parallaxComponents.length > 0 ) {
+        new Rellax('.parallax', { speed: -1 });
+    }
 
     const history = createHistory();
     const detailedStatuses = document.querySelectorAll('.public-layout .detailed-status');

--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -78,7 +78,7 @@ function main() {
         })
         .catch(error => console.error(error));
     }
-    
+
     const parallaxComponents = document.querySelectorAll('.parallax');
     if (parallaxComponents.length > 0 ) {
       new Rellax('.parallax', { speed: -1 });


### PR DESCRIPTION
Fixes issue #8354 

The Rellax function throws an error when there are no parallax objects on the page (such as static view for a post). Chrome and Firefox don't seem to mind but Safari appears to stop script execution at the point of the error, preventing public.js from delegating "show more" behavior. Checking to ensure parallax components exist prior on the page to calling Rellax fixes the issue.