### PR TITLE
Update _bio.html.haml to allow emoji labels

### DIFF
--- a/app/views/accounts/_bio.html.haml
+++ b/app/views/accounts/_bio.html.haml
@@ -3,7 +3,7 @@
     .account__header__fields
       - account.fields.each do |field|
         %dl
-          %dt.emojify{ title: field.name }= field.name
+          %dt.emojify{ title: field.name }= Formatter.instance.format_field(account, field.name, custom_emojify: true)
           %dd.emojify{ title: field.value }= Formatter.instance.format_field(account, field.value, custom_emojify: true)
 
   = account_badge(account)


### PR DESCRIPTION
On my local instance (https://ruby.social) we have a custom emoji for `:octocat:` (:octocat:). I would love to be able to use the emoji in the metadata for my profile.

Instead of:

| github | https://github.com/phaedryx

It could be:

| :octocat: | https://github.com/phaedryx

(using a single emoji makes it easier to read the urls in the narrow columns)