### PR TITLE
Optionally expose public toots over API without auth

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -22,6 +22,7 @@ module Admin
       min_invite_role
       activity_api_enabled
       peers_api_enabled
+      public_toots_api
       show_known_fediverse_at_about_page
       preview_sensitive_media
       custom_css
@@ -34,6 +35,7 @@ module Admin
       show_staff_badge
       activity_api_enabled
       peers_api_enabled
+      public_toots_api
       show_known_fediverse_at_about_page
       preview_sensitive_media
     ).freeze

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Accounts::StatusesController < Api::BaseController
-  before_action -> { doorkeeper_authorize! :read, :'read:statuses' }
+  before_action -> { doorkeeper_authorize! :read, :'read:statuses' }, unless: :public_toots_api?
   before_action :set_account
   after_action :insert_pagination_headers
 
@@ -13,6 +13,10 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   end
 
   private
+
+  def public_toots_api?
+    Setting.public_toots_api
+  end
 
   def set_account
     @account = Account.find(params[:account_id])

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -42,6 +42,8 @@ class Form::AdminSettings
     :show_known_fediverse_at_about_page=,
     :preview_sensitive_media,
     :preview_sensitive_media=,
+    :public_toots_api,
+    :public_toots_api=,
     :custom_css,
     :custom_css=,
     to: Setting

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -64,6 +64,9 @@
     = f.input :peers_api_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.peers_api_enabled.title'), hint: t('admin.settings.peers_api_enabled.desc_html')
 
   .fields-group
+    = f.input :public_toots_api, as: :boolean, wrapper: :with_label, label: t('admin.settings.public_toots_api.title'), hint: t('admin.settings.public_toots_api.desc_html')
+
+  .fields-group
     = f.input :preview_sensitive_media, as: :boolean, wrapper: :with_label, label: t('admin.settings.preview_sensitive_media.title'), hint: t('admin.settings.preview_sensitive_media.desc_html')
 
   .actions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -359,6 +359,9 @@ en:
       preview_sensitive_media:
         desc_html: Link previews on other websites will display a thumbnail even if the media is marked as sensitive
         title: Show sensitive media in OpenGraph previews
+      public_toots_api:
+        desc_html: Public toots will be accessible over the API without authenticating
+        title: Publish public toots in API
       registrations:
         closed_message:
           desc_html: Displayed on frontpage when registrations are closed. You can use HTML tags

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,6 +54,7 @@ defaults: &defaults
   bootstrap_timeline_accounts: ''
   activity_api_enabled: true
   peers_api_enabled: true
+  public_toots_api: false
   show_known_fediverse_at_about_page: true
 development:
   <<: *defaults


### PR DESCRIPTION
Fixes #7087. Admins would have to opt-in.