### PR TITLE
Better singulars of account toots/following/followers

### DIFF
--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -62,17 +62,17 @@ module StreamEntriesHelper
     prepend_str = [
       [
         number_to_human(account.statuses_count, strip_insignificant_zeros: true),
-        I18n.t('accounts.posts'),
+        I18n.t('accounts.posts', count: account.statuses_count),
       ].join(' '),
 
       [
         number_to_human(account.following_count, strip_insignificant_zeros: true),
-        I18n.t('accounts.following'),
+        I18n.t('accounts.following', count: account.following_count),
       ].join(' '),
 
       [
         number_to_human(account.followers_count, strip_insignificant_zeros: true),
-        I18n.t('accounts.followers'),
+        I18n.t('accounts.followers', count: account.followers_count),
       ].join(' '),
     ].join(', ')
 

--- a/app/views/accounts/_header.html.haml
+++ b/app/views/accounts/_header.html.haml
@@ -16,17 +16,17 @@
           .counter{ class: active_nav_class(short_account_url(account)) }
             = link_to short_account_url(account), class: 'u-url u-uid', title: number_with_delimiter(account.statuses_count) do
               %span.counter-number= number_to_human account.statuses_count, strip_insignificant_zeros: true
-              %span.counter-label= t('accounts.posts')
+              %span.counter-label= t('accounts.posts', count: account.statuses_count)
 
           .counter{ class: active_nav_class(account_following_index_url(account)) }
             = link_to account_following_index_url(account), title: number_with_delimiter(account.following_count) do
               %span.counter-number= number_to_human account.following_count, strip_insignificant_zeros: true
-              %span.counter-label= t('accounts.following')
+              %span.counter-label= t('accounts.following', count: account.following_count)
 
           .counter{ class: active_nav_class(account_followers_url(account)) }
             = link_to account_followers_url(account), title: number_with_delimiter(account.followers_count) do
               %span.counter-number= number_to_human account.followers_count, strip_insignificant_zeros: true
-              %span.counter-label= t('accounts.followers')
+              %span.counter-label= t('accounts.followers', count: account.followers_count)
         .spacer
         .public-account-header__tabs__tabs__buttons
           = account_action_button(account)
@@ -37,7 +37,7 @@
       .public-account-header__extra__links
         = link_to account_following_index_url(account) do
           %strong= number_to_human account.following_count, strip_insignificant_zeros: true
-          = t('accounts.following')
+          = t('accounts.following', count: account.following_count)
         = link_to account_followers_url(account) do
           %strong= number_to_human account.followers_count, strip_insignificant_zeros: true
-          = t('accounts.followers')
+          = t('accounts.followers', count: account.followers_count)

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -29,7 +29,7 @@
       %data.p-name{ value: "#{@account.username} on #{site_hostname}" }/
 
       .account__section-headline
-        = active_link_to t('accounts.posts'), short_account_url(@account)
+        = active_link_to t('accounts.posts_tab_heading'), short_account_url(@account)
         = active_link_to t('accounts.posts_with_replies'), short_account_with_replies_url(@account)
         = active_link_to t('accounts.media'), short_account_media_url(@account)
 

--- a/app/views/admin/suspensions/new.html.haml
+++ b/app/views/admin/suspensions/new.html.haml
@@ -8,13 +8,13 @@
     %ul
       %li.negative-hint
         = number_to_human @account.statuses_count, strip_insignificant_zeros: true
-        = t('accounts.posts')
+        = t('accounts.posts', count: @account.statuses_count)
       %li.negative-hint
         = number_to_human @account.following_count, strip_insignificant_zeros: true
-        = t('accounts.following')
+        = t('accounts.following', count: @account.following_count)
       %li.negative-hint
         = number_to_human @account.followers_count, strip_insignificant_zeros: true
-        = t('accounts.followers')
+        = t('accounts.followers', count: @account.followers_count)
 
   %p.hint= t('admin.suspensions.hint_html', value: content_tag(:code, @account.acct))
 

--- a/app/views/settings/exports/show.html.haml
+++ b/app/views/settings/exports/show.html.haml
@@ -9,7 +9,7 @@
         %td= number_to_human_size @export.total_storage
         %td
       %tr
-        %th= t('accounts.statuses')
+        %th= t('accounts.statuses', count: @export.total_statuses)
         %td= number_with_delimiter @export.total_statuses
         %td
       %tr
@@ -17,7 +17,7 @@
         %td= number_with_delimiter @export.total_follows
         %td= table_link_to 'download', t('exports.csv'), settings_exports_follows_path(format: :csv)
       %tr
-        %th= t('accounts.followers')
+        %th= t('accounts.followers', count: @export.total_followers)
         %td= number_with_delimiter @export.total_followers
         %td
       %tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,9 @@ en:
   accounts:
     choices_html: "%{name}'s choices:"
     follow: Follow
-    followers: Followers
+    followers:
+      one: Follower
+      other: Followers
     following: Following
     joined: Joined %{date}
     media: Media
@@ -54,7 +56,10 @@ en:
     people_who_follow: People who follow %{name}
     pin_errors:
       following: You must be already following the person you want to endorse
-    posts: Toots
+    posts:
+      one: Toot
+      other: Toots
+    posts_tab_heading: Toots
     posts_with_replies: Toots and replies
     reserved_username: The username is reserved
     roles:


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/154364/44631972-8a331b00-a96b-11e8-862b-a0176004ce54.png" alt="Plurals for 1 toots and 1 followers" align="middle"> to <img src="https://user-images.githubusercontent.com/154364/44631980-a931ad00-a96b-11e8-94ab-31e71fd38587.png" alt="1 toot and 1 follower" align="middle">

I also passed count for the third number, following, in case that needed treatment in a non-English language. And added `accounts.posts_tab_heading` for the heading, as you don't want to assume non-English will use the same word for the heading as it would for a plural (e.g. in Welsh you always use singular nouns after numbers; so the plural of car is ceir but ten cars is deg car).