### PR TITLE
Reduce padding of profile metadata boxes to allow more text

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5367,7 +5367,7 @@ noscript {
   dt,
   dd {
     box-sizing: border-box;
-    padding: 14px 20px;
+    padding: 14px 5px;
     text-align: center;
     max-height: 48px;
     overflow: hidden;


### PR DESCRIPTION
Before:

![screenshot_2018-08-28 eldritch cafe](https://user-images.githubusercontent.com/2446451/44689515-191d6180-aa58-11e8-9049-082ca379055e.png)

After:
![screenshot_2018-08-28 eldritch cafe 3](https://user-images.githubusercontent.com/2446451/44689517-191d6180-aa58-11e8-9cb6-30f680fc64a2.png)
![screenshot_2018-08-28 eldritch cafe 1](https://user-images.githubusercontent.com/2446451/44689516-191d6180-aa58-11e8-8341-ef8062d5a2a3.png)