### PR TITLE
Improve appearance of settings pages for foreign languages and consistency

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -106,18 +106,13 @@ code {
       font-size: 16px;
       color: $primary-text-color;
       display: block;
-      padding-top: 5px;
-      margin-bottom: 5px;
+      margin: 5px 10px 5px 0;
       flex: 1;
-      min-width: 150px;
+      min-width: 200px;
       word-wrap: break-word;
 
       &.select {
         flex: 0;
-      }
-
-      & ~ * {
-        margin-left: 10px;
       }
     }
 
@@ -346,11 +341,6 @@ code {
         background-color: darken($error-value-color, 5%);
       }
     }
-  }
-
-  select {
-    font-size: 16px;
-    max-height: 29px;
   }
 
   .input-with-append {


### PR DESCRIPTION
## Firefox desktop
Before:
![screenshot_2018-08-28 mastodon firefox desktop before](https://user-images.githubusercontent.com/2446451/44691570-8680c080-aa5f-11e8-9a37-f93e99a12b56.png)

After:
![screenshot_2018-08-28 mastodon firefox desktop after](https://user-images.githubusercontent.com/2446451/44691569-8680c080-aa5f-11e8-82cb-4729ccda16ab.png)

## Firefox desktop (mobile view)
Before:
![screenshot_2018-08-28 mastodon mobile before](https://user-images.githubusercontent.com/2446451/44691572-8680c080-aa5f-11e8-832f-b222f368286a.png)

After:
![screenshot_2018-08-28 mastodon mobile after](https://user-images.githubusercontent.com/2446451/44691571-8680c080-aa5f-11e8-9851-a8897d362f2d.png)

## Chrome desktop
Before:
![screenshot_20180828_010039](https://user-images.githubusercontent.com/2446451/44691582-8c76a180-aa5f-11e8-98f0-470e94ab43c4.png)

After:
![screenshot_20180828_010105](https://user-images.githubusercontent.com/2446451/44691583-8c76a180-aa5f-11e8-99db-83a73e769eba.png)