### PR TITLE
Add ffmpeg buildpack for scalingo

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,4 @@
 https://github.com/heroku/heroku-buildpack-apt
+https://github.com/Scalingo/ffmpeg-buildpack
 https://github.com/Scalingo/nodejs-buildpack
 https://github.com/Scalingo/ruby-buildpack

--- a/scalingo.json
+++ b/scalingo.json
@@ -91,6 +91,11 @@
       "description": "Internal scalingo configuration",
       "required": true,
       "value": "https://github.com/Scalingo/multi-buildpack.git"
+    },
+    "WITH_FFPROBE": {
+      "description": "Internal scalingo configuration to install ffprobe",
+      "required": true,
+      "value": "true"
     }
   },
   "scripts": {


### PR DESCRIPTION
sidekiq in the scalingo setup was constantly experiencing the following error:
```
Av::UnableToDetect: Unable to detect any supported library
```

During the deployment, ffmpeg is not installed with the following error.   
Since scalingo provides the ffmpeg buildpack, I've modified it to use it.

```
-----> Fetching .debs for ffmpeg
       Reading package lists...
       Building dependency tree...
       Package ffmpeg is not available, but is referred to by another package.
       This may mean that the package is missing, has been obsoleted, or
       is only available from another source
       
E: Package 'ffmpeg' has no installation candidate
```

Note: For existing applications, admins needs to add 'WITH_FFPROBE=true' to environment variable.