### PR TITLE
Fix CLI interface for removing remote media

### DIFF
--- a/app/workers/maintenance/uncache_media_worker.rb
+++ b/app/workers/maintenance/uncache_media_worker.rb
@@ -6,7 +6,7 @@ class Maintenance::UncacheMediaWorker
   sidekiq_options queue: 'pull'
 
   def perform(media_attachment_id)
-    media = MediaAttachment.find(media_attachment_id)
+    media = media_attachment_id.is_a?(MediaAttachment) ? media_attachment_id : MediaAttachment.find(media_attachment_id)
 
     return if media.file.blank?
 

--- a/app/workers/maintenance/uncache_media_worker.rb
+++ b/app/workers/maintenance/uncache_media_worker.rb
@@ -6,7 +6,7 @@ class Maintenance::UncacheMediaWorker
   sidekiq_options queue: 'pull'
 
   def perform(media_attachment_id)
-    media = media_attachment_id.is_a?(MediaAttachment) ? media_attachment_id : MediaAttachment.find(media_attachment_id)
+    media = MediaAttachment.find(media_attachment_id)
 
     return if media.file.blank?
 

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -34,7 +34,7 @@ module Mastodon
           Maintenance::UncacheMediaWorker.push_bulk(media_attachments.map(&:id))
         else
           media_attachments.each do |m|
-            Maintenance::UncacheMediaWorker.new.perform(m.id)
+            Maintenance::UncacheMediaWorker.new.perform(m)
             say('.', :green, false)
             processed += 1
           end

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -34,7 +34,7 @@ module Mastodon
           Maintenance::UncacheMediaWorker.push_bulk(media_attachments.map(&:id))
         else
           media_attachments.each do |m|
-            Maintenance::UncacheMediaWorker.new.perform(m)
+            Maintenance::UncacheMediaWorker.new.perform(m.id)
             say('.', :green, false)
             processed += 1
           end


### PR DESCRIPTION
I like #8411 's CLI interface very much.
Thank you!

But I think that it can't delete media files without "--background" option.
Because media_cli.rb's "m" is "MediaAttachment" which extracted "id" only at the time of extraction, I think that it does not include other values.

I think that this change will fix this.