### PR TITLE
Fix nil host in remotable

### DIFF
--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -18,7 +18,7 @@ module Remotable
           return
         end
 
-        return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.empty? || self[attribute_name] == url
+        return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.blank? || self[attribute_name] == url
 
         begin
           Request.new(:get, url).perform do |response|

--- a/spec/models/concerns/remotable_spec.rb
+++ b/spec/models/concerns/remotable_spec.rb
@@ -88,7 +88,18 @@ RSpec.describe Remotable do
 
       context 'parsed_url.host is empty' do
         it 'makes no request' do
-          parsed_url = double(scheme: 'https', host: double(empty?: true))
+          parsed_url = double(scheme: 'https', host: double(blank?: true))
+          allow(Addressable::URI).to receive_message_chain(:parse, :normalize)
+            .with(url).with(no_args).and_return(parsed_url)
+
+          foo.hoge_remote_url = url
+          expect(request).not_to have_been_requested
+        end
+      end
+
+      context 'parsed_url.host is nil' do
+        it 'makes no request' do
+          parsed_url = Addressable::URI.parse('https:https://example.com/path/file.png')
           allow(Addressable::URI).to receive_message_chain(:parse, :normalize)
             .with(url).with(no_args).and_return(parsed_url)
 


### PR DESCRIPTION
Host can be nil in urls like 'https:https://example.com/path/file.png'