### PR TITLE
Add --verbose and --dry-run option to tootctl media remove

### DIFF
--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -10,6 +10,8 @@ module Mastodon
   class MediaCLI < Thor
     option :days, type: :numeric, default: 7
     option :background, type: :boolean, default: false
+    option :verbose, type: :boolean, default: false
+    option :dry_run, type: :boolean, default: false
     desc 'remove', 'Remove remote media files'
     long_desc <<-DESC
       Removes locally cached copies of media attachments from other servers.
@@ -22,22 +24,27 @@ module Mastodon
       possible. In Sidekiq they will be processed with higher concurrency, but
       it may impact other operations of the Mastodon server, and it may overload
       the underlying file storage.
+
+      With the --verbose option, output deleting file ID to console (only when --background false).
+
+      With the --dry-run option, output the number of files to delete without deleting.
     DESC
     def remove
       time_ago  = options[:days].days.ago
       queued    = 0
       processed = 0
+      options[:dry_run] ? dry_run = "(DRY RUN)" : dry_run = ""
 
       if options[:background]
         MediaAttachment.where.not(remote_url: '').where.not(file_file_name: nil).where('created_at < ?', time_ago).select(:id).reorder(nil).find_in_batches do |media_attachments|
           queued += media_attachments.size
-          Maintenance::UncacheMediaWorker.push_bulk(media_attachments.map(&:id))
+          Maintenance::UncacheMediaWorker.push_bulk(media_attachments.map(&:id)) if !options[:dry_run]
         end
       else
         MediaAttachment.where.not(remote_url: '').where.not(file_file_name: nil).where('created_at < ?', time_ago).reorder(nil).find_in_batches do |media_attachments|
           media_attachments.each do |m|
-            Maintenance::UncacheMediaWorker.new.perform(m)
-            say('.', :green, false)
+            Maintenance::UncacheMediaWorker.new.perform(m) if !options[:dry_run]
+            options[:verbose] ? say(m.id) : say('.', :green, false)
             processed += 1
           end
         end
@@ -46,9 +53,9 @@ module Mastodon
       say
 
       if options[:background]
-        say("Scheduled the deletion of #{queued} media attachments", :green)
+        say("Scheduled the deletion of #{queued} media attachments #{dry_run}.", :green)
       else
-        say("Removed #{processed} media attachments", :green)
+        say("Removed #{processed} media attachments #{dry_run}.", :green)
       end
     end
   end


### PR DESCRIPTION
This feature add --verbose and --dry-run option to CLI interface for removing remote media.

This will allow us to know in advance the number of files to be deleted and to learn a bit more about the files to be deleted.