### PR TITLE
Inactive header in main profile to match column.

### DIFF
--- a/app/javascript/styles/mastodon/containers.scss
+++ b/app/javascript/styles/mastodon/containers.scss
@@ -345,6 +345,23 @@
     margin-bottom: 10px;
     box-shadow: 0 0 15px rgba($base-shadow-color, 0.2);
 
+    &.inactive {
+      opacity: 0.5;
+
+      .public-account-header__image,
+      .avatar {
+        filter: grayscale(100%);
+      }
+
+      .logo-button {
+        background-color: $secondary-text-color;
+
+        svg path:last-child {
+          fill: $secondary-text-color;
+        }
+      }
+    }
+
     &__image {
       border-radius: 4px 4px 0 0;
       overflow: hidden;
@@ -581,6 +598,10 @@
             &::after {
               border-bottom: 4px solid $highlight-text-color;
               opacity: 1;
+            }
+
+            &.inactive::after {
+              border-bottom-color: $secondary-text-color;
             }
           }
 

--- a/app/views/accounts/_header.html.haml
+++ b/app/views/accounts/_header.html.haml
@@ -1,4 +1,4 @@
-.public-account-header
+.public-account-header{:class => ("inactive" if account.moved?)}
   .public-account-header__image
     = image_tag account.header.url, class: 'parallax'
   .public-account-header__bar


### PR DESCRIPTION
This PR adds an inactive class to the main profile page, greying it out in the same way as when a moved profile is viewed in-column (see second screenshot on #8503), including the follow button. Might count as fixing #8503.

![screen shot 2018-08-29 at 19 57 42](https://user-images.githubusercontent.com/154364/44809142-d5486a80-abc5-11e8-95b2-bfb3256ea000.png)
