### PR TITLE
Show column scrollbars only when necessary

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2038,7 +2038,7 @@ a.account__display-name {
 }
 
 .scrollable {
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   flex: 1 1 auto;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Instead of showing scrollbars all the time by setting overflow-y:scroll let the browser decide when to show and not show by setting overflow behaviour to auto.

Fixes #8521