### PR TITLE
[Suggestion/Discussion] Account container overhaul

### DIFF
--- a/app/javascript/mastodon/components/account.js
+++ b/app/javascript/mastodon/components/account.js
@@ -1,59 +1,29 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
 import Avatar from './avatar';
 import DisplayName from './display_name';
 import Permalink from './permalink';
-import IconButton from './icon_button';
-import { defineMessages, injectIntl } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { me } from '../initial_state';
+import OldCascadingControls from './old_cascading_controls';
 
-const messages = defineMessages({
-  follow: { id: 'account.follow', defaultMessage: 'Follow' },
-  unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
-  requested: { id: 'account.requested', defaultMessage: 'Awaiting approval' },
-  unblock: { id: 'account.unblock', defaultMessage: 'Unblock @{name}' },
-  unmute: { id: 'account.unmute', defaultMessage: 'Unmute @{name}' },
-  mute_notifications: { id: 'account.mute_notifications', defaultMessage: 'Mute notifications from @{name}' },
-  unmute_notifications: { id: 'account.unmute_notifications', defaultMessage: 'Unmute notifications from @{name}' },
-});
 
-@injectIntl
 export default class Account extends ImmutablePureComponent {
 
   static propTypes = {
     account: ImmutablePropTypes.map.isRequired,
-    onFollow: PropTypes.func.isRequired,
-    onBlock: PropTypes.func.isRequired,
-    onMute: PropTypes.func.isRequired,
-    onMuteNotifications: PropTypes.func.isRequired,
-    intl: PropTypes.object.isRequired,
     hidden: PropTypes.bool,
+    children: PropTypes.node,
   };
 
-  handleFollow = () => {
-    this.props.onFollow(this.props.account);
-  }
-
-  handleBlock = () => {
-    this.props.onBlock(this.props.account);
-  }
-
-  handleMute = () => {
-    this.props.onMute(this.props.account);
-  }
-
-  handleMuteNotifications = () => {
-    this.props.onMuteNotifications(this.props.account, true);
-  }
-
-  handleUnmuteNotifications = () => {
-    this.props.onMuteNotifications(this.props.account, false);
+  injectAccountIntoChild = (child) => {
+    return React.cloneElement(child, {
+      account: this.props.account,
+    });
   }
 
   render () {
-    const { account, intl, hidden } = this.props;
+    const { account, hidden, children } = this.props;
 
     if (!account) {
       return <div />;
@@ -68,35 +38,7 @@ export default class Account extends ImmutablePureComponent {
       );
     }
 
-    let buttons;
-
-    if (account.get('id') !== me && account.get('relationship', null) !== null) {
-      const following = account.getIn(['relationship', 'following']);
-      const requested = account.getIn(['relationship', 'requested']);
-      const blocking  = account.getIn(['relationship', 'blocking']);
-      const muting  = account.getIn(['relationship', 'muting']);
-
-      if (requested) {
-        buttons = <IconButton disabled icon='hourglass' title={intl.formatMessage(messages.requested)} />;
-      } else if (blocking) {
-        buttons = <IconButton active icon='unlock-alt' title={intl.formatMessage(messages.unblock, { name: account.get('username') })} onClick={this.handleBlock} />;
-      } else if (muting) {
-        let hidingNotificationsButton;
-        if (account.getIn(['relationship', 'muting_notifications'])) {
-          hidingNotificationsButton = <IconButton active icon='bell' title={intl.formatMessage(messages.unmute_notifications, { name: account.get('username') })} onClick={this.handleUnmuteNotifications} />;
-        } else {
-          hidingNotificationsButton = <IconButton active icon='bell-slash' title={intl.formatMessage(messages.mute_notifications, { name: account.get('username')  })} onClick={this.handleMuteNotifications} />;
-        }
-        buttons = (
-          <Fragment>
-            <IconButton active icon='volume-up' title={intl.formatMessage(messages.unmute, { name: account.get('username') })} onClick={this.handleMute} />
-            {hidingNotificationsButton}
-          </Fragment>
-        );
-      } else if (!account.get('moved') || following) {
-        buttons = <IconButton icon={following ? 'user-times' : 'user-plus'} title={intl.formatMessage(following ? messages.unfollow : messages.follow)} onClick={this.handleFollow} active={following} />;
-      }
-    }
+    const contents = children || <OldCascadingControls />;
 
     return (
       <div className='account'>
@@ -107,7 +49,7 @@ export default class Account extends ImmutablePureComponent {
           </Permalink>
 
           <div className='account__relationship'>
-            {buttons}
+            {React.Children.map(contents, this.injectAccountIntoChild)}
           </div>
         </div>
       </div>

--- a/app/javascript/mastodon/components/blocking_controls.js
+++ b/app/javascript/mastodon/components/blocking_controls.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { injectIntl, defineMessages } from 'react-intl';
+import { blockAccount, unblockAccount } from '../actions/accounts';
+import IconButton from './icon_button';
+
+const messages = defineMessages({
+  block: { id: 'account.block', defaultMessage: 'Block @{name}' },
+  unblock: { id: 'account.unblock', defaultMessage: 'Unblock @{name}' },
+});
+
+@connect()
+@injectIntl
+export default class BlockingControls extends ImmutablePureComponent {
+
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+    account: ImmutablePropTypes.map.isRequired,
+  };
+
+  handleBlocking = () => {
+    const { dispatch, account } = this.props;
+
+    if (account.getIn(['relationship', 'blocking'])) {
+      dispatch(unblockAccount(account.get('id')));
+    } else {
+      dispatch(blockAccount(account.get('id')));
+    }
+  }
+
+  render () {
+    const { intl, account } = this.props;
+    const blocking = account.getIn(['relationship', 'blocking']);
+
+    return (
+      <IconButton
+        active
+        icon={blocking ? 'unlock-alt' : 'lock'}
+        title={intl.formatMessage(blocking ? messages.unblock : messages.block, { name: account.get('username') })}
+        onClick={this.handleBlocking}
+      />
+    );
+  }
+
+}

--- a/app/javascript/mastodon/components/following_controls.js
+++ b/app/javascript/mastodon/components/following_controls.js
@@ -50,7 +50,7 @@ export default class FollowingControls extends ImmutablePureComponent {
     return (
       <IconButton
         active={following}
-        icon={following ? 'user-times' : 'user-plus'} 
+        icon={following ? 'user-times' : 'user-plus'}
         title={intl.formatMessage(following ? messages.unfollow : messages.follow)}
         onClick={this.handleFollowing}
       />

--- a/app/javascript/mastodon/components/following_controls.js
+++ b/app/javascript/mastodon/components/following_controls.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
+import { followAccount, unfollowAccount } from '../actions/accounts';
+import { openModal } from '../actions/modal';
+import { unfollowModal } from '../initial_state';
+import IconButton from './icon_button';
+
+const messages = defineMessages({
+  follow: { id: 'account.follow', defaultMessage: 'Follow' },
+  unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
+  requested: { id: 'account.requested', defaultMessage: 'Awaiting approval' },
+});
+
+@connect()
+@injectIntl
+export default class FollowingControls extends ImmutablePureComponent {
+
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+    account: ImmutablePropTypes.map.isRequired,
+  };
+
+  handleFollowing = () => {
+    const { dispatch, intl, account } = this.props;
+
+    if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
+      if (unfollowModal) {
+        dispatch(openModal('CONFIRM', {
+          message: <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
+          confirm: intl.formatMessage(messages.unfollowConfirm),
+          onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
+        }));
+      } else {
+        dispatch(unfollowAccount(account.get('id')));
+      }
+    } else {
+      dispatch(followAccount(account.get('id')));
+    }
+  }
+
+  render () {
+    const { intl, account } = this.props;
+    const following = account.getIn(['relationship', 'following']);
+
+    return (
+      <IconButton
+        active={following}
+        icon={following ? 'user-times' : 'user-plus'} 
+        title={intl.formatMessage(following ? messages.unfollow : messages.follow)}
+        onClick={this.handleFollowing}
+      />
+    );
+  }
+
+}

--- a/app/javascript/mastodon/components/muting_controls.js
+++ b/app/javascript/mastodon/components/muting_controls.js
@@ -1,0 +1,84 @@
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { injectIntl, defineMessages } from 'react-intl';
+import { muteAccount, unmuteAccount } from '../actions/accounts';
+import { initMuteModal } from '../actions/mutes';
+import IconButton from './icon_button';
+
+const messages = defineMessages({
+  mute: { id: 'account.mute', defaultMessage: 'Mute @{name}' },
+  unmute: { id: 'account.unmute', defaultMessage: 'Unmute @{name}' },
+  mute_notifications: { id: 'account.mute_notifications', defaultMessage: 'Mute notifications from @{name}' },
+  unmute_notifications: { id: 'account.unmute_notifications', defaultMessage: 'Unmute notifications from @{name}' },
+});
+
+@connect()
+@injectIntl
+export default class MutingControls extends ImmutablePureComponent {
+
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+    account: ImmutablePropTypes.map.isRequired,
+  };
+
+  handleMuting = () => {
+    const { dispatch, account } = this.props;
+
+    if (account.getIn(['relationship', 'muting'])) {
+      dispatch(unmuteAccount(account.get('id')));
+    } else {
+      dispatch(initMuteModal(account));
+    }
+  }
+
+  handleMuteNotifications = () => {
+    this.props.dispatch(muteAccount(this.props.account.get('id'), true));
+  }
+
+  handleUnmuteNotifications = () => {
+    this.props.dispatch(muteAccount(this.props.account.get('id'), false));
+  }
+
+  render () {
+    const { intl, account } = this.props;
+
+    const muting = account.getIn(['relationship', 'muting']);
+    const notifications = muting && account.getIn(['relationship', 'muting_notifications']);
+
+    const mutingProps = {
+      icon: muting ? 'volume-up' : 'volume-off',
+      title: intl.formatMessage(muting ? messages.unmute : messages.mute, { name: account.get('username') }),
+      onClick: this.handleMuting,
+    };
+
+    const notificationProps = muting && {
+      icon: notifications ? 'bell' : 'bell-slash',
+      title: intl.formatMessage(notifications ? messages.unmute_notifications : messages.mute_notifications, { name: account.get('username') }),
+      onClick: notifications? this.handleUnmuteNotifications : this.handleMuteNotifications,
+    };
+
+    return (
+      <Fragment>
+        <IconButton
+          active
+          icon={mutingProps.icon}
+          title={mutingProps.title}
+          onClick={mutingProps.onClick}
+        />
+        {muting && (
+          <IconButton
+            active
+            icon={notificationProps.icon}
+            title={notificationProps.title}
+            onClick={notificationProps.onClick}
+          />
+        )}
+      </Fragment>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/components/old_cascading_controls.js
+++ b/app/javascript/mastodon/components/old_cascading_controls.js
@@ -1,0 +1,126 @@
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
+
+import IconButton from './icon_button';
+
+import {
+  blockAccount,
+  unblockAccount,
+  muteAccount,
+  unmuteAccount,
+  followAccount,
+  unfollowAccount,
+} from '../actions/accounts';
+import { openModal } from '../actions/modal';
+import { initMuteModal } from '../actions/mutes';
+import { unfollowModal } from '../initial_state';
+
+import { me } from '../initial_state';
+
+const messages = defineMessages({
+  follow: { id: 'account.follow', defaultMessage: 'Follow' },
+  unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
+  requested: { id: 'account.requested', defaultMessage: 'Awaiting approval' },
+  unblock: { id: 'account.unblock', defaultMessage: 'Unblock @{name}' },
+  unmute: { id: 'account.unmute', defaultMessage: 'Unmute @{name}' },
+  mute_notifications: { id: 'account.mute_notifications', defaultMessage: 'Mute notifications from @{name}' },
+  unmute_notifications: { id: 'account.unmute_notifications', defaultMessage: 'Unmute notifications from @{name}' },
+  unfollowConfirm: { id: 'confirmations.unfollow.confirm', defaultMessage: 'Unfollow' },
+});
+
+@connect()
+@injectIntl
+export default class OldCascadingControls extends ImmutablePureComponent {
+
+  static propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+    account: ImmutablePropTypes.map.isRequired,
+  };
+
+  handleBlocking = () => {
+    const { dispatch, account } = this.props;
+
+    if (account.getIn(['relationship', 'blocking'])) {
+      dispatch(unblockAccount(account.get('id')));
+    } else {
+      dispatch(blockAccount(account.get('id')));
+    }
+  }
+
+  handleFollowing = () => {
+    const { dispatch, intl, account } = this.props;
+
+    if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
+      if (unfollowModal) {
+        dispatch(openModal('CONFIRM', {
+          message: <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
+          confirm: intl.formatMessage(messages.unfollowConfirm),
+          onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
+        }));
+      } else {
+        dispatch(unfollowAccount(account.get('id')));
+      }
+    } else {
+      dispatch(followAccount(account.get('id')));
+    }
+  }
+
+  handleMuting = () => {
+    const { dispatch, account } = this.props;
+
+    if (account.getIn(['relationship', 'muting'])) {
+      dispatch(unmuteAccount(account.get('id')));
+    } else {
+      dispatch(initMuteModal(account));
+    }
+  }
+
+  handleMuteNotifications = () => {
+    this.props.dispatch(muteAccount(this.props.account.get('id'), true));
+  }
+
+  handleUnmuteNotifications = () => {
+    this.props.dispatch(muteAccount(this.props.account.get('id'), false));
+  }
+
+  render () {
+    const { intl, account } = this.props;
+
+    if (account.get('id') === me || account.get('relationship', null) === null)
+      return null;
+
+    const following = account.getIn(['relationship', 'following']);
+    const requested = account.getIn(['relationship', 'requested']);
+    const blocking  = account.getIn(['relationship', 'blocking']);
+    const muting  = account.getIn(['relationship', 'muting']);
+
+    if (requested) {
+      return <IconButton disabled icon='hourglass' title={intl.formatMessage(messages.requested)} />;
+    } else if (blocking) {
+      return <IconButton active icon='unlock-alt' title={intl.formatMessage(messages.unblock, { name: account.get('username') })} onClick={this.handleBlocking} />;
+    } else if (muting) {
+      let hidingNotificationsButton;
+      if (account.getIn(['relationship', 'muting_notifications'])) {
+        hidingNotificationsButton = <IconButton active icon='bell' title={intl.formatMessage(messages.unmute_notifications, { name: account.get('username') })} onClick={this.handleUnmuteNotifications} />;
+      } else {
+        hidingNotificationsButton = <IconButton active icon='bell-slash' title={intl.formatMessage(messages.mute_notifications, { name: account.get('username')  })} onClick={this.handleMuteNotifications} />;
+      }
+      return (
+        <Fragment>
+          <IconButton active icon='volume-up' title={intl.formatMessage(messages.unmute, { name: account.get('username') })} onClick={this.handleMuting} />
+          {hidingNotificationsButton}
+        </Fragment>
+      );
+    } else if (!account.get('moved') || following) {
+      return <IconButton icon={following ? 'user-times' : 'user-plus'} title={intl.formatMessage(following ? messages.unfollow : messages.follow)} onClick={this.handleFollowing} active={following} />;
+    }
+
+    return null;
+  }
+
+}

--- a/app/javascript/mastodon/containers/account_container.js
+++ b/app/javascript/mastodon/containers/account_container.js
@@ -1,23 +1,7 @@
-import React from 'react';
 import { connect } from 'react-redux';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import { injectIntl } from 'react-intl';
 import { makeGetAccount } from '../selectors';
 import Account from '../components/account';
-import {
-  followAccount,
-  unfollowAccount,
-  blockAccount,
-  unblockAccount,
-  muteAccount,
-  unmuteAccount,
-} from '../actions/accounts';
-import { openModal } from '../actions/modal';
-import { initMuteModal } from '../actions/mutes';
-import { unfollowModal } from '../initial_state';
-
-const messages = defineMessages({
-  unfollowConfirm: { id: 'confirmations.unfollow.confirm', defaultMessage: 'Unfollow' },
-});
 
 const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();
@@ -29,44 +13,4 @@ const makeMapStateToProps = () => {
   return mapStateToProps;
 };
 
-const mapDispatchToProps = (dispatch, { intl }) => ({
-
-  onFollow (account) {
-    if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
-      if (unfollowModal) {
-        dispatch(openModal('CONFIRM', {
-          message: <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
-          confirm: intl.formatMessage(messages.unfollowConfirm),
-          onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
-        }));
-      } else {
-        dispatch(unfollowAccount(account.get('id')));
-      }
-    } else {
-      dispatch(followAccount(account.get('id')));
-    }
-  },
-
-  onBlock (account) {
-    if (account.getIn(['relationship', 'blocking'])) {
-      dispatch(unblockAccount(account.get('id')));
-    } else {
-      dispatch(blockAccount(account.get('id')));
-    }
-  },
-
-  onMute (account) {
-    if (account.getIn(['relationship', 'muting'])) {
-      dispatch(unmuteAccount(account.get('id')));
-    } else {
-      dispatch(initMuteModal(account));
-    }
-  },
-
-
-  onMuteNotifications (account, notifications) {
-    dispatch(muteAccount(account.get('id'), notifications));
-  },
-});
-
-export default injectIntl(connect(makeMapStateToProps, mapDispatchToProps)(Account));
+export default injectIntl(connect(makeMapStateToProps)(Account));

--- a/app/javascript/mastodon/features/blocks/index.js
+++ b/app/javascript/mastodon/features/blocks/index.js
@@ -12,6 +12,8 @@ import AccountContainer from '../../containers/account_container';
 import { fetchBlocks, expandBlocks } from '../../actions/blocks';
 import ScrollableList from '../../components/scrollable_list';
 
+import BlockingControls from '../../components/blocking_controls';
+
 const messages = defineMessages({
   heading: { id: 'column.blocks', defaultMessage: 'Blocked users' },
 });
@@ -62,9 +64,11 @@ export default class Blocks extends ImmutablePureComponent {
           shouldUpdateScroll={shouldUpdateScroll}
           emptyMessage={emptyMessage}
         >
-          {accountIds.map(id =>
-            <AccountContainer key={id} id={id} />
-          )}
+          {accountIds.map(id => (
+            <AccountContainer key={id} id={id}>
+              <BlockingControls />
+            </AccountContainer>
+          ))}
         </ScrollableList>
       </Column>
     );

--- a/app/javascript/mastodon/features/mutes/index.js
+++ b/app/javascript/mastodon/features/mutes/index.js
@@ -12,6 +12,8 @@ import AccountContainer from '../../containers/account_container';
 import { fetchMutes, expandMutes } from '../../actions/mutes';
 import ScrollableList from '../../components/scrollable_list';
 
+import MutingControls from '../../components/muting_controls';
+
 const messages = defineMessages({
   heading: { id: 'column.mutes', defaultMessage: 'Muted users' },
 });
@@ -62,9 +64,11 @@ export default class Mutes extends ImmutablePureComponent {
           shouldUpdateScroll={shouldUpdateScroll}
           emptyMessage={emptyMessage}
         >
-          {accountIds.map(id =>
-            <AccountContainer key={id} id={id} />
-          )}
+          {accountIds.map(id => (
+            <AccountContainer key={id} id={id}>
+              <MutingControls />
+            </AccountContainer>
+          ))}
         </ScrollableList>
       </Column>
     );

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -61,6 +61,19 @@
   {
     "descriptors": [
       {
+        "defaultMessage": "Block @{name}",
+        "id": "account.block"
+      },
+      {
+        "defaultMessage": "Unblock @{name}",
+        "id": "account.unblock"
+      }
+    ],
+    "path": "app/javascript/mastodon/components/blocking_controls.json"
+  },
+  {
+    "descriptors": [
+      {
         "defaultMessage": "Back",
         "id": "column_back_button.label"
       }
@@ -187,6 +200,68 @@
       }
     ],
     "path": "app/javascript/mastodon/components/missing_indicator.json"
+  },
+  {
+    "descriptors": [
+      {
+        "defaultMessage": "Mute @{name}",
+        "id": "account.mute"
+      },
+      {
+        "defaultMessage": "Unmute @{name}",
+        "id": "account.unmute"
+      },
+      {
+        "defaultMessage": "Mute notifications from @{name}",
+        "id": "account.mute_notifications"
+      },
+      {
+        "defaultMessage": "Unmute notifications from @{name}",
+        "id": "account.unmute_notifications"
+      }
+    ],
+    "path": "app/javascript/mastodon/components/muting_controls.json"
+  },
+  {
+    "descriptors": [
+      {
+        "defaultMessage": "Follow",
+        "id": "account.follow"
+      },
+      {
+        "defaultMessage": "Unfollow",
+        "id": "account.unfollow"
+      },
+      {
+        "defaultMessage": "Awaiting approval",
+        "id": "account.requested"
+      },
+      {
+        "defaultMessage": "Unblock @{name}",
+        "id": "account.unblock"
+      },
+      {
+        "defaultMessage": "Unmute @{name}",
+        "id": "account.unmute"
+      },
+      {
+        "defaultMessage": "Mute notifications from @{name}",
+        "id": "account.mute_notifications"
+      },
+      {
+        "defaultMessage": "Unmute notifications from @{name}",
+        "id": "account.unmute_notifications"
+      },
+      {
+        "defaultMessage": "Unfollow",
+        "id": "confirmations.unfollow.confirm"
+      },
+      {
+        "defaultMessage": "Are you sure you want to unfollow {name}?",
+        "id": "confirmations.unfollow.message"
+      }
+    ],
+    "path": "app/javascript/mastodon/components/old_cascading_controls.json"
   },
   {
     "descriptors": [


### PR DESCRIPTION
What started as an idea to fix #601 developed into overhaul of the whole compontent (or two, to be exact).

This PR pulls interactions (following, blocking, muting) from `Account(Container)` classes and makes them modular with support for any type of actions thus removing behaviour discussed in #601 (as described by @mjankowski joyeusenoelle):

> 1. Adam opens their list of blocked users.
> 2. Adam clicks the "unblock" button on Eve.
> 3. Once Eve is unblocked, the UI does not remove Eve from the list of blocked users. Instead, it changes the "unblock" button at the right-hand side of Eve's listing in the list of blocked users to a "follow" button.
> 4. If Adam clicks twice, not only is Eve unblocked, but Adam follows Eve.

Moreover, to stay compatible with old behaviour in less dangerous cases, `OldCascadingControls` is used.

I will gladly listen to any suggestions, ideas and comments.

**PS.**
I believe that, thanks to this change, [`list_editor/components/account.js`](https://github.com/tootsuite/mastodon/blob/5b2b493a908cbea55096f7f028c306f6270e3b00/app/javascript/mastodon/features/list_editor/components/account.js) and [`follow_requests/components/account_authorize.js`](https://github.com/tootsuite/mastodon/blob/5b2b493a908cbea55096f7f028c306f6270e3b00/app/javascript/mastodon/features/follow_requests/components/account_authorize.js) could be merged into `Account(Container)` by creating appropriate controls (which I could make if this PR gets accepted :wink:).