### PR TITLE
Fix different counts for display name and bio

### DIFF
--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -1,6 +1,7 @@
 import loadPolyfills from '../mastodon/load_polyfills';
 import ready from '../mastodon/ready';
 import { start } from '../mastodon/common';
+import punycode from 'punycode';
 
 start();
 
@@ -134,7 +135,7 @@ function main() {
     const name        = document.querySelector('.card .display-name strong');
 
     if (nameCounter) {
-      nameCounter.textContent = 30 - length(target.value);
+      nameCounter.textContent = 30 - punycode.ucs2.decode(target.value).length;
     }
 
     if (name) {
@@ -146,7 +147,7 @@ function main() {
     const noteCounter = document.querySelector('.note-counter');
 
     if (noteCounter) {
-      noteCounter.textContent = 160 - length(target.value);
+      noteCounter.textContent = 160 - punycode.ucs2.decode(target.value).length;
     }
   });
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -408,6 +408,8 @@ class Account < ApplicationRecord
   def prepare_contents
     display_name&.strip!
     note&.strip!
+    display_name.gsub!("\r\n", "\n")
+    note.gsub!("\r\n", "\n")
   end
 
   def generate_keys

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -596,10 +596,22 @@ RSpec.describe Account, type: :model do
         expect(account).to model_have_error_on_field(:display_name)
       end
 
+      it 'display name with newline and carriage returns gets modified to have only newline' do
+        account = Fabricate.build(:account, display_name: "My display name is\r\ncool")
+        account.valid?
+        expect(account.display_name).to eq "My display name is\ncool"
+      end
+
       it 'is invalid if the note is longer than 160 characters' do
         account = Fabricate.build(:account, note: Faker::Lorem.characters(161))
         account.valid?
         expect(account).to model_have_error_on_field(:note)
+      end
+
+      it 'Note with newline and carriage return returns correct size' do
+        account = Fabricate.build(:account, note: "My note came from a weird browser\r\nBut I like it!")
+        account.valid?
+        expect(account.note).to eq "My note came from a weird browser\nBut I like it!"
       end
     end
 


### PR DESCRIPTION
This follows the fix suggested by https://tech.mybuilder.com/managing-newlines-and-unicode-within-javascript-and-php/

Fixes #4419

Is there a way to test public.js? I know that there's some tests inside `app/javascript/mastodon/`, but could I also create one for this file?

It seems before this code was using stringz length, which considers `'🏳️‍🌈'.length` == 1. The problem is that the backend considers `"🏳️‍🌈".length` == 4, even if we use rails mb_chars thingy: `"🏳️‍🌈".mb_chars.length` == 4.