### PR TITLE
Use grapheme length regex serverside

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -408,6 +408,8 @@ class Account < ApplicationRecord
   def prepare_contents
     display_name&.strip!
     note&.strip!
+    display_name.gsub!("\r\n", "\n")
+    note.gsub!("\r\n", "\n")
   end
 
   def generate_keys

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -15,7 +15,7 @@ class StatusLengthValidator < ActiveModel::Validator
   end
 
   def countable_length(status)
-    total_text(status).mb_chars.grapheme_length
+    total_text(status).scan(Account::GRAPHEME_RE).length
   end
 
   def total_text(status)

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -5,8 +5,8 @@
   = render 'shared/error_messages', object: @account
 
   .fields-group
-    = f.input :display_name, placeholder: t('simple_form.labels.defaults.display_name'), hint: t('simple_form.hints.defaults.display_name', count: 30 - @account.display_name.size).html_safe
-    = f.input :note, placeholder: t('simple_form.labels.defaults.note'), hint: t('simple_form.hints.defaults.note', count: 160 - @account.note.size).html_safe
+    = f.input :display_name, placeholder: t('simple_form.labels.defaults.display_name'), hint: t('simple_form.hints.defaults.display_name', count: 30 - @account.display_name.scan(Account::GRAPHEME_RE).size).html_safe
+    = f.input :note, placeholder: t('simple_form.labels.defaults.note'), hint: t('simple_form.hints.defaults.note', count: 160 - @account.note.scan(Account::GRAPHEME_RE).size).html_safe
 
   = render 'application/card', account: @account
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -596,10 +596,22 @@ RSpec.describe Account, type: :model do
         expect(account).to model_have_error_on_field(:display_name)
       end
 
+      it 'display name with newline and carriage returns gets modified to have only newline' do
+        account = Fabricate.build(:account, display_name: "My display name is\r\ncool")
+        account.valid?
+        expect(account.display_name).to eq "My display name is\ncool"
+      end
+
       it 'is invalid if the note is longer than 160 characters' do
         account = Fabricate.build(:account, note: Faker::Lorem.characters(161))
         account.valid?
         expect(account).to model_have_error_on_field(:note)
+      end
+
+      it 'note with newline and carriage return gets modified to have only newline' do
+        account = Fabricate.build(:account, note: "My note came from a weird browser\r\nBut I like it!")
+        account.valid?
+        expect(account.note).to eq "My note came from a weird browser\nBut I like it!"
       end
     end
 

--- a/spec/validators/status_length_validator_spec.rb
+++ b/spec/validators/status_length_validator_spec.rb
@@ -25,6 +25,13 @@ describe StatusLengthValidator do
       expect(status.errors).to have_received(:add)
     end
 
+    rainbow_flag = '🏳️‍🌈'
+    it 'counts #{rainbow_flag} as one character' do
+      status = double(spoiler_text: '', text: rainbow_flag * 300, errors: double(add: nil), local?: true, reblog?: false)
+      subject.validate(status)
+      expect(status.errors).to_not have_received(:add)
+    end
+
     it 'counts URLs as 23 characters flat' do
       text   = ('a' * 476) + " http://#{'b' * 30}.com/example"
       status = double(spoiler_text: '', text: text, errors: double(add: nil), local?: true, reblog?: false)


### PR DESCRIPTION
<img align="right" src="https://user-images.githubusercontent.com/154364/44884085-d1921200-acb1-11e8-966c-edcc189018fd.png"> This uses the regex that `stringz` uses client-side on the server so that the character counting is the same in both places. This should let you post 500 🏳️‍🌈 as a status (previously 250), and up to the appropriate limits for display name and bio (previously e.g. 40 🏳️‍🌈 for bio rather than 160). Fixes the initial display on the edit profile page also.

This includes the newline fix from #8526.

(The regex in `stringz` comes from lodash: https://github.com/lodash/lodash/blob/48511837573d99138fc43b7e9f04eea7b01839fe/.internal/unicodeSize.js for a more nicely broken-down version)

The regex is pretty good but does not cover the full Unicode UAX29 grapheme cluster algorithm, for that you'd need something like https://github.com/orling/grapheme-splitter (and a Ruby equivalent).