### PR TITLE
Skip VS15 (Emoji textual presentation).

### DIFF
--- a/app/javascript/mastodon/features/emoji/__tests__/emoji-test.js
+++ b/app/javascript/mastodon/features/emoji/__tests__/emoji-test.js
@@ -73,5 +73,10 @@ describe('emoji', () => {
       expect(emojify('<span class="invisible">😄<br/>😴</span>😇'))
         .toEqual('<span class="invisible">😄<br/>😴</span><img draggable="false" class="emojione" alt="😇" title=":innocent:" src="/emoji/1f607.svg" />');
     });
+
+    it('skips the textual presentation VS15 character', () => {
+      expect(emojify('✴︎')) // This is U+2734 EIGHT POINTED BLACK STAR then U+FE0E VARIATION SELECTOR-15
+        .toEqual('<img draggable="false" class="emojione" alt="✴" title=":eight_pointed_black_star:" src="/emoji/2734.svg" />');
+    });
   });
 });

--- a/app/javascript/mastodon/features/emoji/emoji.js
+++ b/app/javascript/mastodon/features/emoji/emoji.js
@@ -62,6 +62,10 @@ const emojify = (str, customEmojis = {}) => {
       const title = shortCode ? `:${shortCode}:` : '';
       replacement = `<img draggable="false" class="emojione" alt="${match}" title="${title}" src="${assetHost}/emoji/${filename}.svg" />`;
       rend = i + match.length;
+      // If the matched character was followed by VS15 (for selecting text presentation), skip it.
+      if (str.codePointAt(rend) === 65038) {
+        rend += 1;
+      }
     }
     rtn += str.slice(0, i) + replacement;
     str = str.slice(rend);


### PR DESCRIPTION
Mastodon converts all Emoji to images, whether they have a VS15 after
them or not, but leaves the VS15 in the string, which is displayed as
a black box in Safari. Fixes #2431.