### PR TITLE
Integrating `:one` and `:other` in ar.yml (regression from #8535)

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -30,22 +30,16 @@ ar:
     other_instances: خوادم أخرى
     privacy_policy: سياسة الخصوصية
     source_code: الشفرة المصدرية
-    status_count_after:
-      one: منشور
-      other: منشورات
+    status_count_after: منشورات
     status_count_before: نشروا
     terms: شروط الخدمة
-    user_count_after:
-      one: مستخدِم
-      other: مستخدِمين
+    user_count_after: مستخدِمين
     user_count_before: يستضيف
     what_is_mastodon: ما هو ماستدون ؟
   accounts:
     choices_html: 'توصيات %{name} :'
     follow: إتبع
-    followers:
-      one: متابِع
-      other: متابِعون
+    followers: متابِعون
     following: يتابعون
     joined: انضم·ت في %{date}
     media: الوسائط
@@ -56,9 +50,7 @@ ar:
     people_who_follow: الأشخاص الذين يتبعون %{name}
     pin_errors:
       following: يجب أن تكون مِن متابعي حساب الشخص الذي تريد إبرازه
-    posts:
-      one: تبويق
-      other: تبويقات
+    posts: تبويقات
     posts_tab_heading: تبويقات
     posts_with_replies: التبويقات و الردود
     reserved_username: إسم المستخدم محجوز
@@ -264,9 +256,7 @@ ar:
         suspend: تعليق
       severity: الشدة
       show:
-        affected_accounts:
-          one: هناك حساب واحد متأثر في قاعدة البيانات
-          other: هناك %{count} حسابات في قاعدة البيانات متأثرة بذلك
+        affected_accounts: هناك %{count} حسابات في قاعدة البيانات متأثرة بذلك
         retroactive:
           silence: إلغاء الكتم عن كافة الحسابات المتواجدة على هذا النطاق
           suspend: إلغاء التعليق المفروض على كافة حسابات هذا النطاق
@@ -550,9 +540,7 @@ ar:
     followers_count: عدد المتابِعين
     lock_link: قم بتجميد حسابك
     purge: تنحية من بين متابعيك
-    success:
-      one: جارية عملية حظر المتابِعين بسلاسة من نطاق آخر ...
-      other: جارية عملية حظر المتابِعين بسلاسة من %{count} نطاقات أخرى ...
+    success: جارية عملية حظر المتابِعين بسلاسة من %{count} نطاقات أخرى ...
     true_privacy_html: تذكر دائمًا أنّ <strong>الخصوصية التامة لا يمكن بلوغها إلّا بالتعمية و التشفير من طرف إلى آخَر</strong>.
     unlocked_warning_html: يمكن لأي كان متابعة حسابك و الإطلاع مباشرة على تبويقاتك. إستخدِم %{lock_link} لمُعاينة أو رفض طلبات المتابِعين الجُدُد.
     unlocked_warning_title: إنّ حسابك غير مقفل
@@ -563,9 +551,7 @@ ar:
   generic:
     changes_saved_msg: تم حفظ التعديلات بنجاح !
     save_changes: حفظ التغييرات
-    validation_errors:
-      one: لا يزال هناك خلل ما إلى حد الآن. يُرجى إعادة النظر في الخطأ أسفله
-      other: هناك شيء ليس على ما يرام ! رجاءًا تحقق من الأخطاء الـ %{count} أسفله
+    validation_errors: هناك شيء ليس على ما يرام ! رجاءًا تحقق من الأخطاء الـ %{count} أسفله
   imports:
     preface: You can import certain data like all the people you are following or blocking into your account on this instance, from files created by an export on another instance.
     success: تم تحميل بياناتك بنجاح وسيتم معالجتها في الوقت المناسب
@@ -588,9 +574,7 @@ ar:
     expires_in_prompt: أبدا
     generate: توليد
     invited_by: 'تمت دعوتك من طرف :'
-    max_uses:
-      one: إستعمال واحد
-      other: "%{count} استخدامات"
+    max_uses: "%{count} استخدامات"
     max_uses_prompt: بلا حدود
     prompt: توليد و مشاركة روابط للسماح للآخَرين بالنفاذ إلى مثيل الخادوم هذا
     table:
@@ -616,12 +600,8 @@ ar:
       action: معاينة كافة الإشعارات
       body: هذا هو مُلَخَّص الرسائل التي فاتتك وذلك منذ آخر زيارة لك في  %{since}
       mention: "%{name} أشار إليك في :"
-      new_followers_summary:
-        one: و لقد حصلت على متابع جديد أثناء فترة غيابك ! مرحى !
-        other: و لقد تحصلت على %{count} متتبعين جدد أثناء فترة غيابك ! رائع !
-      subject:
-        one: "إشعار واحد منذ زيارتك الأخيرة \U0001F418"
-        other: "%{count} إشعارات جديدة منذ زيارتك الأخيرة \U0001F418"
+      new_followers_summary: و لقد تحصلت على %{count} متتبعين جدد أثناء فترة غيابك ! رائع !
+      subject: "%{count} إشعارات جديدة منذ زيارتك الأخيرة \U0001F418"
       title: أثناء فترة غيابك …
     favourite:
       body: 'أُعجب %{name} بمنشورك :'
@@ -739,17 +719,11 @@ ar:
   statuses:
     attached:
       description: 'مُرفَق : %{attached}'
-      image:
-        one: "%{count} صورة"
-        other: "%{count} صور"
-      video:
-        one: "%{count} فيديو"
-        other: "%{count} فيديوهات"
+      image: "%{count} صور"
+      video: "%{count} فيديوهات"
     boosted_from_html: تم إعادة ترقيته مِن %{acct_link}
     content_warning: 'تحذير عن المحتوى : %{warning}'
-    disallowed_hashtags:
-      one: 'يحتوي على وسم ممنوع : %{tags}'
-      other: 'يحتوي على وسوم ممنوعة : %{tags}'
+    disallowed_hashtags: 'يحتوي على وسوم ممنوعة : %{tags}'
     language_detection: اكتشاف اللغة تلقائيا
     open_in_web: إفتح في الويب
     over_character_limit: تم تجاوز حد الـ %{max} حرف المسموح بها


### PR DESCRIPTION
Resolve #8554

![image](https://user-images.githubusercontent.com/12539/44948362-46528100-ae57-11e8-882b-9dd881b73b3a.png)

In Arabic, `zero:`, `one:`, `two:`, `few:`, `many:` and,`other:` are required when handling numerical values. In `one:` and `other:` alone, Rails returns an error.

In this pull request, we changed to use only `other:` as fallback. Since it is just before v2.5.0 is released, it only keeps ad hoc fixes.