### PR TITLE
Add preference for report notification e-mails, skip for duplicates

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -46,7 +46,7 @@ class Settings::PreferencesController < ApplicationController
       :setting_noindex,
       :setting_theme,
       :setting_hide_network,
-      notification_emails: %i(follow follow_request reblog favourite mention digest),
+      notification_emails: %i(follow follow_request reblog favourite mention digest report),
       interactions: %i(must_be_follower must_be_following)
     )
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -60,6 +60,10 @@ class Report < ApplicationRecord
     !action_taken?
   end
 
+  def unresolved_siblings?
+    Report.where.not(id: id).where(target_account_id: target_account_id).unresolved.exists?
+  end
+
   def history
     time_range = created_at..updated_at
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -224,6 +224,10 @@ class User < ApplicationRecord
     settings.notification_emails['digest']
   end
 
+  def allows_report_emails?
+    settings.notification_emails['report']
+  end
+
   def hides_network?
     @hides_network ||= settings.hide_network
   end

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -26,7 +26,10 @@ class ReportService < BaseService
   end
 
   def notify_staff!
+    return if @report.unresolved_siblings?
+
     User.staff.includes(:account).each do |u|
+      next unless u.allows_report_emails?
       AdminMailer.new_report(u.account, @report).deliver_later
     end
   end

--- a/app/views/settings/notifications/show.html.haml
+++ b/app/views/settings/notifications/show.html.haml
@@ -12,6 +12,9 @@
       = ff.input :favourite, as: :boolean, wrapper: :with_label
       = ff.input :mention, as: :boolean, wrapper: :with_label
 
+      - if current_user.staff?
+        = ff.input :report, as: :boolean, wrapper: :with_label
+
   .fields-group
     = f.simple_fields_for :notification_emails, hash_to_object(current_user.settings.notification_emails) do |ff|
       = ff.input :digest, as: :boolean, wrapper: :with_label

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -92,6 +92,7 @@ en:
         follow_request: Send e-mail when someone requests to follow you
         mention: Send e-mail when someone mentions you
         reblog: Send e-mail when someone boosts your status
+        report: Send e-mail when a new report is submitted
     'no': 'No'
     required:
       mark: "*"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -39,6 +39,7 @@ defaults: &defaults
     mention: false
     follow_request: true
     digest: true
+    report: true
   interactions:
     must_be_follower: false
     must_be_following: false

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ReportService, type: :service do
   subject { described_class.new }
 
-  let(:source_account) { Fabricate(:account) }
+  let(:source_account) { Fabricate(:user).account }
 
   context 'for a remote account' do
     let(:remote_account) { Fabricate(:account, domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
@@ -20,6 +20,24 @@ RSpec.describe ReportService, type: :service do
     it 'does not send anything when forward is false' do
       subject.call(source_account, remote_account, forward: false)
       expect(a_request(:post, 'http://example.com/inbox')).to_not have_been_made
+    end
+  end
+
+  context 'when other reports already exist for the same target' do
+    let!(:target_account) { Fabricate(:account) }
+    let!(:other_report)   { Fabricate(:report, target_account: target_account) }
+
+    subject do
+      -> {  described_class.new.call(source_account, target_account) }
+    end
+
+    before do
+      ActionMailer::Base.deliveries.clear
+      source_account.user.settings.notification_emails['report'] = true
+    end
+
+    it 'does not send an e-mail' do
+      is_expected.to_not change(ActionMailer::Base.deliveries, :count).from(0)
     end
   end
 end


### PR DESCRIPTION
If an unresolved report for the same target account already exists, no new notification is generated