### PR TITLE
config/boot is required first

### DIFF
--- a/bin/tootctl
+++ b/bin/tootctl
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 APP_PATH = File.expand_path('../config/application', __dir__)
+require_relative '../config/boot'
 require_relative '../lib/cli'
 Mastodon::CLI.start(ARGV)


### PR DESCRIPTION
If tootctl is executed without going through `bundle exec`, loading `thor` will fail. By loading `config/boot` first, tootctl can be executed without going through `bundle exec`.