### PR TITLE
update devise_pam_authenticatable2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'devise', '~> 4.4'
 gem 'devise-two-factor', '~> 3.0'
 
 group :pam_authentication, optional: true do
-  gem 'devise_pam_authenticatable2', '~> 9.1'
+  gem 'devise_pam_authenticatable2', '~> 9.2'
 end
 
 gem 'net-ldap', '~> 0.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       devise (~> 4.0)
       railties (< 5.3)
       rotp (~> 2.0)
-    devise_pam_authenticatable2 (9.1.1)
+    devise_pam_authenticatable2 (9.2.0)
       devise (>= 4.0.0)
       rpam2 (~> 4.0)
     diff-lcs (1.3)
@@ -669,7 +669,7 @@ DEPENDENCIES
   derailed_benchmarks
   devise (~> 4.4)
   devise-two-factor (~> 3.0)
-  devise_pam_authenticatable2 (~> 9.1)
+  devise_pam_authenticatable2 (~> 9.2)
   doorkeeper (~> 5.0)
   dotenv-rails (~> 2.2, < 2.3)
   fabrication (~> 2.20)


### PR DESCRIPTION
new feature: pam gets ip address of client (via remote_ip).

Useful for fail2ban like applications.