### PR TITLE
feat(cookies): Use the same-site attribute to lax

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -10,6 +10,7 @@ Warden::Manager.after_set_user except: :fetch do |user, warden|
     expires: 1.year.from_now,
     httponly: true,
     secure: (Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true'),
+    same_site: :lax,
   }
 end
 
@@ -20,6 +21,7 @@ Warden::Manager.after_fetch do |user, warden|
       expires: 1.year.from_now,
       httponly: true,
       secure: (Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true'),
+      same_site: :lax,
     }
   else
     warden.logout

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_mastodon_session', secure: (Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true')
+Rails.application.config.session_store :cookie_store, key: '_mastodon_session', secure: (Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true'), same_site: :lax

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,7 @@ Devise::Test::ControllerHelpers.module_eval do
       value: resource.activate_session(warden.request),
       expires: 1.year.from_now,
       httponly: true,
+      same_site: :lax,
     }
   end
 end


### PR DESCRIPTION
CSFR-prevention is already implemented but adding this doesn't hurt.

A brief introduction to Same-Site cookies (and the difference between strict and
lax) can be found at https://blog.mozilla.org/security/2018/04/24/same-site-cookies-in-firefox-60/

TLDR: We use lax since we want the cookies to be sent when the user navigates
safely from an external site.