### PR TITLE
feat(auth/session_controller): Send Clear-Site-Data when logging out

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -10,6 +10,7 @@ class Auth::SessionsController < Devise::SessionsController
   prepend_before_action :authenticate_with_two_factor, if: :two_factor_enabled?, only: [:create]
   before_action :set_instance_presenter, only: [:new]
   before_action :set_body_classes
+  after_action :clear_site_data, only: [:destroy]
 
   def new
     Devise.omniauth_configs.each do |provider, config|
@@ -120,5 +121,11 @@ class Auth::SessionsController < Devise::SessionsController
       paths << short_account_path(username: resource.account)
     end
     paths
+  end
+
+  def clear_site_data
+    # Should be '"*"' but that doen't work in Chrome (neither does '"executionContexts"')
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data
+    response.headers['Clear-Site-Data'] = '"cache", "cookies", "storage"'
   end
 end


### PR DESCRIPTION
Will clear the browser's cache, cookies and storage.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data
https://w3c.github.io/webappsec-clear-site-data/