### PR TITLE
tootctl accounts [add|del|cull]

### DIFF
--- a/lib/mastodon/cli_helper.rb
+++ b/lib/mastodon/cli_helper.rb
@@ -4,5 +4,6 @@ dev_null = Logger.new('/dev/null')
 
 Rails.logger                 = dev_null
 ActiveRecord::Base.logger    = dev_null
+ActiveJob::Base.logger       = dev_null
 HttpLog.configuration.logger = dev_null
 Paperclip.options[:log]      = false


### PR DESCRIPTION
```
Usage:
  tootctl accounts add USERNAME --email=EMAIL

Options:
  --email=EMAIL                    
  [--confirmed], [--no-confirmed]  
  [--role=ROLE]                    
                                   # Default: user
  [--reattach], [--no-reattach]    
  [--force]                        

Description:
  Create a new user account with a given USERNAME and an e-mail address provided 
  with --email.

  With the --confirmed option, the confirmation e-mail will be skipped and the 
  account will be active straight away.

  With the --role option one of "user", "admin" or "moderator" can be supplied. 
  Defaults to "user"

  With the --reattach option, the new user will be reattached to a given 
  existing username of an old account. If the old account is still in use by 
  someone else, you can supply the --force option to delete the old record and 
  reattach the username to the new account anyway.
```

```
Usage:
  tootctl accounts del USERNAME

Description:
  Remove a user account with a given USERNAME.
```

```
Usage:
  tootctl accounts cull

Options:
  [--dry-run], [--no-dry-run]  

Description:
  Query every single remote account in the database to determine if it still 
  exists on the origin server, and if it doesn't, remove it from the database.

  Accounts that have had confirmed activity within the last week are excluded 
  from the checks.

  If 10 or more accounts from the same domain cannot be queried due to a 
  connection error (such as missing DNS records) then the domain is considered 
  dead, and all other accounts from it are deleted without further querying.

  With the --dry-run option, no deletes will actually be carried out.
```