### PR TITLE
make account avatar and header image clearable

### DIFF
--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -28,7 +28,10 @@ class Settings::ProfilesController < ApplicationController
   private
 
   def account_params
-    params.require(:account).permit(:display_name, :note, :avatar, :header, :locked, :bot, fields_attributes: [:name, :value])
+    params.require(:account).permit(
+      :display_name, :note, :avatar, :header, :locked, :bot, :subaction,
+      fields_attributes: [:name, :value]
+    )
   end
 
   def set_account

--- a/app/services/update_account_service.rb
+++ b/app/services/update_account_service.rb
@@ -4,6 +4,17 @@ class UpdateAccountService < BaseService
   def call(account, params, raise_error: false)
     was_locked = account.locked
     update_method = raise_error ? :update! : :update
+    if params[:subaction] == 'clear_avatar'
+      params = {
+        avatar: nil,
+        avatar_remote_url: ''
+      }
+    elsif params[:subaction] == 'clear_header'
+      params = {
+        header: nil,
+        header_remote_url: ''
+      }
+    end
     account.send(update_method, params).tap do |ret|
       next unless ret
       authorize_all_follow_requests(account) if was_locked && !account.locked

--- a/app/services/update_account_service.rb
+++ b/app/services/update_account_service.rb
@@ -7,12 +7,12 @@ class UpdateAccountService < BaseService
     if params[:subaction] == 'clear_avatar'
       params = {
         avatar: nil,
-        avatar_remote_url: ''
+        avatar_remote_url: '',
       }
     elsif params[:subaction] == 'clear_header'
       params = {
         header: nil,
-        header_remote_url: ''
+        header_remote_url: '',
       }
     end
     account.send(update_method, params).tap do |ret|

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -12,8 +12,13 @@
 
   .fields-group
     = f.input :avatar, wrapper: :with_label, input_html: { accept: AccountAvatar::IMAGE_MIME_TYPES.join(',') }, hint: t('simple_form.hints.defaults.avatar', dimensions: '400x400', size: number_to_human_size(AccountAvatar::LIMIT))
+    .actions
+      = f.button :button, t('generic.clear'), name: 'account[subaction]', type: :submit, value: 'clear_avatar'
 
     = f.input :header, wrapper: :with_label, input_html: { accept: AccountHeader::IMAGE_MIME_TYPES.join(',') }, hint: t('simple_form.hints.defaults.header', dimensions: '1500x500', size: number_to_human_size(AccountHeader::LIMIT))
+    .actions
+      = f.button :button, t('generic.clear'), name: 'account[subaction]', type: :submit, value: 'clear_header'
+
 
   .fields-group
     = f.input :locked, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.locked')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,6 +570,7 @@ en:
     more: More…
     resources: Resources
   generic:
+    clear: Clear
     changes_saved_msg: Changes successfully saved!
     save_changes: Save changes
     validation_errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,8 +570,8 @@ en:
     more: More…
     resources: Resources
   generic:
-    clear: Clear
     changes_saved_msg: Changes successfully saved!
+    clear: Clear
     save_changes: Save changes
     validation_errors:
       one: Something isn't quite right yet! Please review the error below


### PR DESCRIPTION
This PR allows the removal of avatar and header images.
Before the way to go, was to replace the image.
 