### PR TITLE
Styled scrollbars in Firefox Nightly

### DIFF
--- a/app/javascript/styles/mastodon/reset.scss
+++ b/app/javascript/styles/mastodon/reset.scss
@@ -53,6 +53,11 @@ table {
   border-spacing: 0;
 }
 
+html {
+  scrollbar-face-color: lighten($ui-base-color, 4%);
+  scrollbar-track-color: rgba($base-overlay-background, 0.1);
+}
+
 ::-webkit-scrollbar {
   width: 12px;
   height: 12px;


### PR DESCRIPTION
You currently need to enable `layout.css.scrollbar-colors.enabled` in `about:config` in Firefox
Nightly.

![image](https://user-images.githubusercontent.com/2109702/45259216-c16fe600-b3c7-11e8-8b68-c7d7742ba4ab.png)