### PR TITLE
Support fetching Pleroma statuses from the search bar

### DIFF
--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -62,7 +62,8 @@ class FetchAtomService < BaseService
   end
 
   def expected_type?(json)
-    equals_or_includes_any?(json['type'], ActivityPub::Activity::Create::SUPPORTED_TYPES + ActivityPub::Activity::Create::CONVERTED_TYPES)
+    type = json['type'] == 'Create' && json['object'] ? json['object']['type'] : json['type']
+    equals_or_includes_any?(type, ActivityPub::Activity::Create::SUPPORTED_TYPES + ActivityPub::Activity::Create::CONVERTED_TYPES)
   end
 
   def process_html(response)

--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -18,10 +18,20 @@ class ResolveURLService < BaseService
   private
 
   def process_url
-    if equals_or_includes_any?(type, %w(Application Group Organization Person Service))
-      FetchRemoteAccountService.new.call(atom_url, body, protocol)
-    elsif equals_or_includes_any?(type, %w(Note Article Image Video))
-      FetchRemoteStatusService.new.call(atom_url, body, protocol)
+    object_url = atom_url
+    object_body = body
+    object_type = type
+
+    if protocol == :activitypub && type == 'Create'
+      object_url = json_data['object']['id']
+      object_type = json_data['object']['type']
+      object_body = nil
+    end
+
+    if equals_or_includes_any?(object_type, %w(Application Group Organization Person Service))
+      FetchRemoteAccountService.new.call(object_url, object_body, protocol)
+    elsif equals_or_includes_any?(object_type, %w(Note Article Image Video))
+      FetchRemoteStatusService.new.call(object_url, object_body, protocol)
     end
   end
 


### PR DESCRIPTION
In pleroma, public HTML notes URL correspond to the Create activity and not
the Note activity itself. This changes accepts Create activities for objects
handled by Mastodon.