### PR TITLE
Exclude replies from list timelines

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -40,6 +40,7 @@ class FeedManager
   end
 
   def push_to_list(list, status)
+    return false if status.reply?
     return false unless add_to_feed(:list, list.id, status)
     trim(:list, list.id)
     PushUpdateWorker.perform_async(list.account_id, status.id, "timeline:list:#{list.id}") if push_update_required?("timeline:list:#{list.id}")

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -40,7 +40,7 @@ class FeedManager
   end
 
   def push_to_list(list, status)
-    return false if status.reply?
+    return false if status.reply? && status.in_reply_to_account_id != status.account_id
     return false unless add_to_feed(:list, list.id, status)
     trim(:list, list.id)
     PushUpdateWorker.perform_async(list.account_id, status.id, "timeline:list:#{list.id}") if push_update_required?("timeline:list:#{list.id}")


### PR DESCRIPTION
A small tweak in list behaviour: Now all posts that are replies are filtered out, so that now only "genuine" posts are displayed in the list.

Of course this is a bit sub-optimal in that it would be better to have a certain subset of these replies - namely those on posts whose authors are also list members. But filtering that requires a bit more complex logic.

One would have to find the post to which the reply relates. Then seek the author of this post and then a comparison, if they are a list member.

The best way would be to provide the user with a setting which gives them an option to choose whether the want the "old" or "new" behavior.

This is a first approach to solve issue #5916