### PR TITLE
Fix building assets in test environment

### DIFF
--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -7,7 +7,7 @@ const { readFileSync } = require('fs');
 
 const configPath = resolve('config', 'webpacker.yml');
 const loadersDir = join(__dirname, 'loaders');
-const settings = safeLoad(readFileSync(configPath), 'utf8')[env.NODE_ENV];
+const settings = safeLoad(readFileSync(configPath), 'utf8')[env.RAILS_ENV || env.NODE_ENV];
 
 const themePath = resolve('config', 'themes.yml');
 const themes = safeLoad(readFileSync(themePath), 'utf8');

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -40,6 +40,10 @@ test:
   # Compile test packs to a separate directory
   public_output_path: packs-test
 
+  # CircleCI precompiles packs prior to running the tests.
+  # Also avoids race conditions in parallel_tests.
+  compile: false
+
 production:
   <<: *default
 


### PR DESCRIPTION
Webpacker (Ruby wrapper to webpack) uses RAILS_ENV-based environments while
the javascript configuration for webpack re-reads this configuration file using
the NODE_ENV environment variable. This means that when RAILS_ENV=test, running
“assets:precompile” compiled the production packs in “public/packs” while
webpacker expects them in “public/packs-test”. This causes Ruby to recompile
them on-the-fly, possibly leading to race conditions in parallel_tests.

This changes:
- Disables on-the-fly compilation in test environment
- Changes the javascript part to read the correct environment