### PR TITLE
[WIP] notify users after admin actions

### DIFF
--- a/app/controllers/admin/reported_statuses_controller.rb
+++ b/app/controllers/admin/reported_statuses_controller.rb
@@ -16,11 +16,11 @@ module Admin
     private
 
     def status_params
-      params.require(:status).permit(:sensitive)
+      params.require(:status).permit(:notify_users, :sensitive)
     end
 
     def form_status_batch_params
-      params.require(:form_status_batch).permit(status_ids: [])
+      params.require(:form_status_batch).permit(:notify_users, status_ids: [])
     end
 
     def action_from_button

--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -38,7 +38,9 @@ module Admin
     private
 
     def form_status_batch_params
-      params.require(:form_status_batch).permit(:action, status_ids: [])
+      params.require(:form_status_batch).permit(
+        :notify_users, :action, status_ids: []
+      )
     end
 
     def set_account

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -22,6 +22,7 @@ class Notification < ApplicationRecord
     follow:         'Follow',
     follow_request: 'FollowRequest',
     favourite:      'Favourite',
+    action_log:     'ActionLog',
   }.freeze
 
   STATUS_INCLUDES = [:account, :application, :stream_entry, :media_attachments, :tags, mentions: :account, reblog: [:stream_entry, :account, :application, :media_attachments, :tags, mentions: :account]].freeze
@@ -35,6 +36,7 @@ class Notification < ApplicationRecord
   belongs_to :follow,         foreign_type: 'Follow',        foreign_key: 'activity_id', optional: true
   belongs_to :follow_request, foreign_type: 'FollowRequest', foreign_key: 'activity_id', optional: true
   belongs_to :favourite,      foreign_type: 'Favourite',     foreign_key: 'activity_id', optional: true
+  belongs_to :action_log,      foreign_type: 'ActionLog',     foreign_key: 'activity_id', optional: true
 
   validates :account_id, uniqueness: { scope: [:activity_type, :activity_id] }
   validates :activity_type, inclusion: { in: TYPE_CLASS_MAP.values }
@@ -97,7 +99,7 @@ class Notification < ApplicationRecord
     return unless new_record?
 
     case activity_type
-    when 'Status', 'Follow', 'Favourite', 'FollowRequest'
+    when 'Status', 'Follow', 'Favourite', 'FollowRequest', 'ActionLog'
       self.from_account_id = activity&.account_id
     when 'Mention'
       self.from_account_id = activity&.status&.account_id

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -78,9 +78,10 @@ class NotifyService < BaseService
   end
 
   def blocked?
-    blocked   = @recipient.suspended?                            # Skip if the recipient account is suspended anyway
-    blocked ||= from_self?                                       # Skip for interactions with self
+    blocked = from_self?                                         # Skip for interactions with self
     blocked ||= domain_blocking?                                 # Skip for domain blocked accounts
+    return blocked if @notification.type.to_s == 'ActionLog'     # Return if object is ActionLog
+    blocked ||= @recipient.suspended?                            # Skip if the recipient account is suspended anyway
     blocked ||= @recipient.blocking?(@notification.from_account) # Skip for blocked accounts
     blocked ||= @recipient.muting_notifications?(@notification.from_account)
     blocked ||= hellbanned?                                      # Hellban

--- a/app/views/admin/statuses/index.html.haml
+++ b/app/views/admin/statuses/index.html.haml
@@ -28,6 +28,7 @@
       %label.batch-table__toolbar__select.batch-checkbox-all
         = check_box_tag :batch_checkbox_all, nil, false
       .batch-table__toolbar__actions
+        = check_box_tag :notify_users, t('admin.action_logs.notify_users'), true
         = f.button safe_join([fa_icon('eye-slash'), t('admin.statuses.batch.nsfw_on')]), name: :nsfw_on, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
         = f.button safe_join([fa_icon('eye'), t('admin.statuses.batch.nsfw_off')]), name: :nsfw_off, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
         = f.button safe_join([fa_icon('trash'), t('admin.statuses.batch.delete')]), name: :delete, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -199,6 +199,7 @@ en:
         update_status: "%{name} updated status by %{target}"
       deleted_status: "(deleted status)"
       title: Audit log
+      notify_users: "Notify Users"
     custom_emojis:
       by_domain: Domain
       copied_msg: Successfully created local copy of the emoji


### PR DESCRIPTION
Users should know if their posts were updated by an admin.
This patchset will lay the foundation by sending users messages if their posts are modified.

Maybe instance local messages from Admin can be integrated later.