### PR TITLE
i18n: Add ja translations

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -120,6 +120,7 @@ ja:
       moderation_notes: モデレーションメモ
       most_recent_activity: 直近の活動
       most_recent_ip: 直近のIP
+      no_limits_imposed: 制限なし
       not_subscribed: 購読していない
       order:
         alphabetic: アルファベット順
@@ -155,8 +156,10 @@ ja:
         report: レポート
         targeted_reports: このアカウントについてのレポート
       silence: サイレンス
+      silenced: サイレンス済み
       statuses: トゥート数
       subscribe: 購読する
+      suspended: 停止済み
       title: アカウント
       unconfirmed_email: 確認待ちのメールアドレス
       undo_silenced: サイレンスから戻す
@@ -300,8 +303,13 @@ ja:
       title: 招待
     relays:
       add_new: リレーを追加
+      delete: 削除
       description_html: "<strong>連合リレー</strong>とは、登録しているサーバー間の公開トゥートを仲介するサーバーです。<strong>中小規模のサーバーが連合のコンテンツを見つけるのを助けます。</strong>これを使用しない場合、ローカルユーザーがリモートユーザーを手動でフォローする必要があります。"
+      disable: 無効化
+      disabled: 無効
+      enable: 有効化
       enable_hint: 有効にすると、リレーから全ての公開トゥートを受信するようになり、またこのサーバーの全ての公開トゥートをリレーに送信するようになります。
+      enabled: 有効
       inbox_url: リレーURL
       pending: リレーサーバーの承認待ちです
       save_and_enable: 保存して有効にする


### PR DESCRIPTION
Add Japanese translations for the group reports and more.

I usually do this with the Weblate, but it currently fails to rebase and it can not be applied.

When we will get further problems with the Weblate by merging this PR, please do not merge. (eg: reset)
In that case I'm waiting for the Weblate problem to be solved.