### PR TITLE
Updated ruby/node images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:8.11.3-alpine as node
-FROM ruby:2.4.4-alpine3.6
+FROM node:8.12.0-alpine as node
+FROM ruby:2.5.1-alpine3.7
 
 LABEL maintainer="https://github.com/tootsuite/mastodon" \
       description="Your self-hosted, globally interconnected microblogging community"


### PR DESCRIPTION
run all tests I'm aware of. No regressions found.

Ruby 2.5.1 is a standard release. lots of backport bugfixes. (2018-03-28)
Node 8.12 is a LTS release (2018-09-11)
Alpine is a bonus.

- https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-5-1-released/
- https://nodejs.org/en/blog/release/v8.12.0/
