### PR TITLE
Adjust Vagrant Configuration

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -1,2 +1,2 @@
 VAGRANT=true
-LOCAL_DOMAIN=mastodon.dev
+LOCAL_DOMAIN=mastodon.local

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,6 +85,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |vb|
     vb.name = "mastodon"
     vb.customize ["modifyvm", :id, "--memory", "2048"]
+    # Increase the number of CPUs. Uncomment and adjust to
+    # increase performance
+    # vb.customize ["modifyvm", :id, "--cpus", "3"]
 
     # Disable VirtualBox DNS proxy to skip long-delay IPv6 resolutions.
     # https://github.com/mitchellh/vagrant/issues/1172
@@ -97,19 +100,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   end
 
-  config.vm.hostname = "mastodon.dev"
-
   # This uses the vagrant-hostsupdater plugin, and lets you
-  # access the development site at http://mastodon.dev.
+  # access the development site at http://mastodon.local.
+  # If you change it, also change it in .env.vagrant before provisioning
+  # the vagrant server to update the development build.
+  #
   # To install:
   #   $ vagrant plugin install vagrant-hostsupdater
+  config.vm.hostname = "mastodon.local"
+
   if defined?(VagrantPlugins::HostsUpdater)
     config.vm.network :private_network, ip: "192.168.42.42", nictype: "virtio"
     config.hostsupdater.remove_on_suspend = false
   end
 
   if config.vm.networks.any? { |type, options| type == :private_network }
-    config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp']
+    config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'actimeo=1']
   else
     config.vm.synced_folder ".", "/vagrant"
   end


### PR DESCRIPTION
## Heyo

This pull request adjusts the vagrant configuration slightly to improve the developer experience.

The following changes are made:

1) Change the default dev domain name to mastodon.dev to mastodon.local
Why : .dev domain names have begun to fail without additional configuration overhead in Chrome/Firefox. .local works fine out of the box. Also added helpful comments.
*See:*
https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/
https://stackoverflow.com/questions/47809632/i-can-no-longer-access-my-local-development-dev-websites-in-chrome-http-is
https://www.theregister.co.uk/2017/11/29/google_dev_network/
https://medium.engineering/use-a-dev-domain-not-anymore-95219778e6fd

2) Add additional (commented out) CPU config options to increase Vagrant performance as needed

3) Add `actimeo=1` to `config.vm.synced_folder` in order to make hot-reloading work without having to sync clocks between host and vagrant guest.

Have a great week!