### PR TITLE
Revert "Updated ruby/node images"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:8.12.0-alpine as node
-FROM ruby:2.5.1-alpine3.7
+FROM node:8.11.3-alpine as node
+FROM ruby:2.4.4-alpine3.6
 
 LABEL maintainer="https://github.com/tootsuite/mastodon" \
       description="Your self-hosted, globally interconnected microblogging community"


### PR DESCRIPTION
Reverts tootsuite/mastodon#8700
It crashed sidekick after 4~ days, but it crashed.

As per discussion, this could be caused by alpine3.7 (sadly 2.5.1-alpine3.6 does not exist).

>mastodon@ip-10-0-0-140:~$ docker container logs dd6cc8b27859 > crash
/mastodon/vendor/bundle/ruby/2.5.0/gems/rdf-3.0.2/lib/rdf/model/statement.rb:332: [BUG] Segmentation fault at 0x00007efcb3517bc0
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux-musl]

>/mastodon/vendor/bundle/ruby/2.5.0/gems/nokogiri-1.8.4/lib/nokogiri/html/document.rb:150: [BUG] Segmentation fault at 0x00007f8200e79bc0
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux-musl]

