### PR TITLE
Fix VerifyAccountLinksWorker not being queued

### DIFF
--- a/app/services/update_account_service.rb
+++ b/app/services/update_account_service.rb
@@ -9,16 +9,19 @@ class UpdateAccountService < BaseService
       next unless ret
 
       authorize_all_follow_requests(account) if was_locked && !account.locked
-      VerifyAccountLinksWorker.perform_async(@account.id) if account.fields_changed?
+      check_links(account)
     end
   end
 
   private
 
   def authorize_all_follow_requests(account)
-    follow_requests = FollowRequest.where(target_account: account)
-    AuthorizeFollowWorker.push_bulk(follow_requests) do |req|
+    AuthorizeFollowWorker.push_bulk(FollowRequest.where(target_account: account).select(:account_id, :target_account_id)) do |req|
       [req.account_id, req.target_account_id]
     end
+  end
+
+  def check_links(account)
+    VerifyAccountLinksWorker.perform_async(account.id)
   end
 end


### PR DESCRIPTION
UX-wise, people expect that saving the profile will re-check links even without changing fields content. Bug-wise, `@account` was undefined.

Regression from #8703