### PR TITLE
RTL: fix settings button margins in column headers

### DIFF
--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -46,8 +46,8 @@ body.rtl {
   .column-header__buttons {
     left: 0;
     right: auto;
-    margin-left: -15px;
-    margin-right: 0;
+    margin-left: 0;
+    margin-right: -15px;
   }
 
   .column-inline-form .icon-button {


### PR DESCRIPTION
Mastodon, with interface language set to Persian (فارسی)

Before (current state):
![selection_570](https://user-images.githubusercontent.com/3006332/45929040-a4512080-bf4c-11e8-975d-60638c732040.png)

After (with this commit):
![selection_571](https://user-images.githubusercontent.com/3006332/45929041-aa470180-bf4c-11e8-80a5-565dddd70e85.png)
