### PR TITLE
Cache instance info

### DIFF
--- a/app/controllers/api/v1/instances_controller.rb
+++ b/app/controllers/api/v1/instances_controller.rb
@@ -4,6 +4,8 @@ class Api::V1::InstancesController < Api::BaseController
   respond_to :json
 
   def show
-    render json: {}, serializer: REST::InstanceSerializer
+    render_cached_json('api:v1:instances', expires_in: 5.minutes) do
+      ActiveModelSerializers::SerializableResource.new({}, serializer: REST::InstanceSerializer)
+    end
   end
 end


### PR DESCRIPTION
The Web API that returns instance information is mechanically accessed from multiple external crawlers. 

Reduce the load by short-term caching
