### PR TITLE
Add nginx and systemd templates

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,10 +1,10 @@
 ---
 :concurrency: 5
 :queues:
-  - default
-  - push
-  - mailers
-  - pull
+  - [default, 6]
+  - [push, 4]
+  - [mailers, 2]
+  - [pull]
 :schedule:
   subscriptions_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(4..6) %> * * *'

--- a/dist/mastodon-sidekiq.service
+++ b/dist/mastodon-sidekiq.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=mastodon-sidekiq
+After=network.target
+
+[Service]
+Type=simple
+User=mastodon
+WorkingDirectory=/home/mastodon/live
+Environment="RAILS_ENV=production"
+Environment="DB_POOL=25"
+Environment="MALLOC_ARENA_MAX=2"
+ExecStart=/home/mastodon/.rbenv/shims/bundle exec sidekiq -c 25
+TimeoutSec=15
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/mastodon-streaming.service
+++ b/dist/mastodon-streaming.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=mastodon-streaming
+After=network.target
+
+[Service]
+Type=simple
+User=mastodon
+WorkingDirectory=/home/mastodon/live
+Environment="NODE_ENV=production"
+Environment="PORT=4000"
+Environment="STREAMING_CLUSTER_NUM=1"
+ExecStart=/usr/bin/npm run start
+TimeoutSec=15
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/mastodon-web.service
+++ b/dist/mastodon-web.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=mastodon-web
+After=network.target
+
+[Service]
+Type=simple
+User=mastodon
+WorkingDirectory=/home/mastodon/live
+Environment="RAILS_ENV=production"
+Environment="PORT=3000"
+ExecStart=/home/mastodon/.rbenv/shims/bundle exec puma -C config/puma.rb
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+TimeoutSec=15
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -1,0 +1,106 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  ''      close;
+}
+
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=CACHE:10m inactive=7d max_size=1g;
+
+server {
+  listen 80;
+  listen [::]:80;
+  server_name example.com;
+  root /home/mastodon/live/public;
+  location /.well-known/acme-challenge/ { allow all; }
+  location / { return 301 https://$host$request_uri; }
+}
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  server_name example.com;
+
+  ssl_protocols TLSv1.2;
+  ssl_ciphers HIGH:!MEDIUM:!LOW:!aNULL:!NULL:!SHA;
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
+
+  # Uncomment these lines once you acquire a certificate:
+  # ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+  # ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+
+  keepalive_timeout    70;
+  sendfile             on;
+  client_max_body_size 80m;
+
+  root /home/mastodon/live/public;
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_vary on;
+  gzip_proxied any;
+  gzip_comp_level 6;
+  gzip_buffers 16 8k;
+  gzip_http_version 1.1;
+  gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+  add_header Strict-Transport-Security "max-age=31536000";
+
+  location / {
+    try_files $uri @proxy;
+  }
+
+  location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Strict-Transport-Security "max-age=31536000";
+    try_files $uri @proxy;
+  }
+
+  location /sw.js {
+    add_header Cache-Control "public, max-age=0";
+    add_header Strict-Transport-Security "max-age=31536000";
+    try_files $uri @proxy;
+  }
+
+  location @proxy {
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Proxy "";
+    proxy_pass_header Server;
+
+    proxy_pass http://127.0.0.1:3000;
+    proxy_buffering on;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    proxy_cache CACHE;
+    proxy_cache_valid 200 7d;
+    proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+    add_header X-Cached $upstream_cache_status;
+    add_header Strict-Transport-Security "max-age=31536000";
+
+    tcp_nodelay on;
+  }
+
+  location /api/v1/streaming {
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Proxy "";
+
+    proxy_pass http://127.0.0.1:4000;
+    proxy_buffering off;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    tcp_nodelay on;
+  }
+
+  error_page 500 501 502 503 504 /500.html;
+}

--- a/docs/Contributing-to-Mastodon/Sponsors.md
+++ b/docs/Contributing-to-Mastodon/Sponsors.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Contributing-to-Mastodon/Sponsors.md)

--- a/docs/Contributing-to-Mastodon/Translating.md
+++ b/docs/Contributing-to-Mastodon/Translating.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Contributing-to-Mastodon/Translating.md)

--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Extensions.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/README.md)

--- a/docs/Running-Mastodon/Administration-guide.md
+++ b/docs/Running-Mastodon/Administration-guide.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Administration-guide.md)

--- a/docs/Running-Mastodon/Development-guide.md
+++ b/docs/Running-Mastodon/Development-guide.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Development-guide.md)

--- a/docs/Running-Mastodon/Heroku-guide.md
+++ b/docs/Running-Mastodon/Heroku-guide.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Heroku-guide.md)

--- a/docs/Running-Mastodon/Production-guide.md
+++ b/docs/Running-Mastodon/Production-guide.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Production-guide.md)

--- a/docs/Running-Mastodon/Scalingo-guide.md
+++ b/docs/Running-Mastodon/Scalingo-guide.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Scalingo-guide.md)

--- a/docs/Running-Mastodon/Tuning.md
+++ b/docs/Running-Mastodon/Tuning.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Tuning.md)

--- a/docs/Running-Mastodon/Vagrant-guide.md
+++ b/docs/Running-Mastodon/Vagrant-guide.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Vagrant-guide.md)

--- a/docs/Specs-and-RFCs-used.md
+++ b/docs/Specs-and-RFCs-used.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Specs-and-RFCs-used.md)

--- a/docs/Using-Mastodon/2FA.md
+++ b/docs/Using-Mastodon/2FA.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/2FA.md)

--- a/docs/Using-Mastodon/Apps.md
+++ b/docs/Using-Mastodon/Apps.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/Apps.md)

--- a/docs/Using-Mastodon/FAQ.md
+++ b/docs/Using-Mastodon/FAQ.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/FAQ.md)

--- a/docs/Using-Mastodon/List-of-Mastodon-instances.md
+++ b/docs/Using-Mastodon/List-of-Mastodon-instances.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/List-of-Mastodon-instances.md)

--- a/docs/Using-Mastodon/User-guide.md
+++ b/docs/Using-Mastodon/User-guide.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/User-guide.md)

--- a/docs/Using-the-API/API.md
+++ b/docs/Using-the-API/API.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md)

--- a/docs/Using-the-API/OAuth-details.md
+++ b/docs/Using-the-API/OAuth-details.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-the-API/OAuth-details.md)

--- a/docs/Using-the-API/Push-notifications.md
+++ b/docs/Using-the-API/Push-notifications.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-the-API/Push-notifications.md)

--- a/docs/Using-the-API/Streaming-API.md
+++ b/docs/Using-the-API/Streaming-API.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-the-API/Streaming-API.md)

--- a/docs/Using-the-API/Testing-with-cURL.md
+++ b/docs/Using-the-API/Testing-with-cURL.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-the-API/Testing-with-cURL.md)

--- a/docs/Using-the-API/Tips-for-app-developers.md
+++ b/docs/Using-the-API/Tips-for-app-developers.md
@@ -1,1 +1,0 @@
-[The documentation has moved to its own repository](https://github.com/tootsuite/documentation/blob/master/Using-the-API/Tips-for-app-developers.md)


### PR DESCRIPTION
So they can be copied during installation instead of looking them up in the documentation

Make default sidekiq configuration use weighted queues, and make the systemd sidekiq template use the default configuration from the file.

Remove deprecated docs directory