### PR TITLE
Profile fields fixes

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -310,10 +310,11 @@ class Account < ApplicationRecord
     attributes :name, :value, :verified_at, :account, :errors
 
     def initialize(account, attributes)
+      char_limit = account.local? ? 255 : 8092
       @account     = account
       @attributes  = attributes
-      @name        = attributes['name'].strip[0, 255]
-      @value       = attributes['value'].strip[0, 255]
+      @name        = attributes['name'].strip[0, char_limit]
+      @value       = attributes['value'].strip[0, char_limit]
       @verified_at = attributes['verified_at']&.to_datetime
       @errors      = {}
     end

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -13,9 +13,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
   class FieldSerializer < ActiveModel::Serializer
     attributes :name, :value
 
-    attribute :verified_at, if: :verifiable?
-
-    delegate :verifiable?, to: :object
+    attribute :verified_at
 
     def value
       Formatter.instance.format_field(object.account, object.value)


### PR DESCRIPTION
The first commit raises the name and value limit from 255 to 8092 for remote statuses to take into account HTML formatting.
The second commit avoids calling `verifiable?` in serializers in preparation for verifying remote account fields links.