### PR TITLE
RTL: fix margins: public-layout.header.nav-button

### DIFF
--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -294,4 +294,12 @@ body.rtl {
       }
     }
   }
+  .public-layout {
+    .header {
+      .nav-button {
+        margin-left: 8px;
+        margin-right: 0;
+      }
+    }
+  }
 }

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -294,6 +294,7 @@ body.rtl {
       }
     }
   }
+
   .public-layout {
     .header {
       .nav-button {


### PR DESCRIPTION
Before:
![selection_576](https://user-images.githubusercontent.com/3006332/46237647-2777d980-c386-11e8-8a5b-e52f16cf1667.png)

After:
![selection_578](https://user-images.githubusercontent.com/3006332/46237648-2c3c8d80-c386-11e8-80a6-0361b522beef.png)

Please test it though, since I haven't tested if rtl.css is loaded at all for public pages.

With the new public page design, text direction for individual RTL toots is also wrong (this is the old #2350, re-opened). But I can't figure out how to fix it.