### PR TITLE
Fix timeline pagination

### DIFF
--- a/app/models/concerns/paginable.rb
+++ b/app/models/concerns/paginable.rb
@@ -20,7 +20,7 @@ module Paginable
       query
     }
 
-    scope :paginate_by_id, ->(limit, **options) {
+    scope :paginate_by_id, ->(limit, options = {}) {
       if options[:min_id].present?
         paginate_by_min_id(limit, options[:min_id]).reverse
       else


### PR DESCRIPTION
Ruby's ** operator does not play well with non-Hash objects, which
the params slice is

Fix #8821