### PR TITLE
Fix that Rails.cache information could not be sent via StatsD

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -9,7 +9,7 @@ if ENV['STATSD_ADDR'].present?
   ::NSA.inform_statsd(statsd) do |informant|
     informant.collect(:action_controller, :web)
     informant.collect(:active_record, :db)
-    informant.collect(:cache, :cache)
+    informant.collect(:active_support_cache, :cache)
     informant.collect(:sidekiq, :sidekiq)
   end
 end


### PR DESCRIPTION
```console
$ ./bin/rails c
Chewy console strategy is `urgent`
Loading development environment (Rails 5.2.1)
[1] pry(main)> NSA::Statsd::Informant::COLLECTOR_TYPES[:cache]
=> NSA::Collectors::Null
[2] pry(main)> NSA::Statsd::Informant::COLLECTOR_TYPES[:active_support_cache]
=> NSA::Collectors::ActiveSupportCache
[3] pry(main)>
```