### PR TITLE
Fix requirie bootsnap

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,7 +1,7 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup'  # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require 'bootsnap' # Speed up boot time by caching expensive operations.
 
 Bootsnap.setup(
   cache_dir:            'tmp/cache',


### PR DESCRIPTION
Since `bootsnap/setup` internally calls Bootsnap.setup, it is correct to require `bootsnap`.