### PR TITLE
Dockerfile: Nodejs 8.11.2->8.12.0, Ruby Alpine3.6->Alpine3.7 (the latter for Docker build + memory reasons)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:8.11.3-alpine as node
-FROM ruby:2.4.4-alpine3.6
+FROM node:8.12.0-alpine as node
+FROM ruby:2.4.4-alpine3.7
 
 LABEL maintainer="https://github.com/tootsuite/mastodon" \
       description="Your self-hosted, globally interconnected microblogging community"


### PR DESCRIPTION
Alpine 3.7 shouldn't have a problem running on Docker (as my instance has been running for months on 2.4.4-alpine3.7) and should help with the Docker Hub build system failures.