### PR TITLE
Leave unknown language as nil if account is remote

### DIFF
--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -12,7 +12,6 @@ class LanguageDetector
   def detect(text, account)
     input_text = prepare_text(text)
     return if input_text.blank?
-    return detect_language_code(input_text, true) unless account.local?
 
     detect_language_code(input_text) || default_locale(account)
   end
@@ -33,8 +32,8 @@ class LanguageDetector
     text.size < CHARACTER_THRESHOLD
   end
 
-  def detect_language_code(text, force = false)
-    return if !force && unreliable_input?(text)
+  def detect_language_code(text)
+    return if unreliable_input?(text)
 
     result = @identifier.find_language(text)
     iso6391(result.language.to_s).to_sym if result.reliable?

--- a/app/lib/language_detector.rb
+++ b/app/lib/language_detector.rb
@@ -12,6 +12,8 @@ class LanguageDetector
   def detect(text, account)
     input_text = prepare_text(text)
     return if input_text.blank?
+    return detect_language_code(input_text, true) unless account.local?
+
     detect_language_code(input_text) || default_locale(account)
   end
 
@@ -31,8 +33,9 @@ class LanguageDetector
     text.size < CHARACTER_THRESHOLD
   end
 
-  def detect_language_code(text)
-    return if unreliable_input?(text)
+  def detect_language_code(text, force = false)
+    return if !force && unreliable_input?(text)
+
     result = @identifier.find_language(text)
     iso6391(result.language.to_s).to_sym if result.reliable?
   end
@@ -75,6 +78,6 @@ class LanguageDetector
   end
 
   def default_locale(account)
-    account.user_locale&.to_sym || I18n.default_locale
+    return account.user_locale&.to_sym || I18n.default_locale if account.local?
   end
 end

--- a/spec/lib/language_detector_spec.rb
+++ b/spec/lib/language_detector_spec.rb
@@ -42,6 +42,7 @@ describe LanguageDetector do
 
   describe 'detect' do
     let(:account_without_user_locale) { Fabricate(:user, locale: nil).account }
+    let(:account_remote) { Fabricate(:account, domain: 'joinmastodon.org') }
 
     it 'detects english language for basic strings' do
       strings = [
@@ -101,6 +102,15 @@ describe LanguageDetector do
           result = described_class.instance.detect('', account_without_user_locale)
 
           expect(result).to eq nil
+        end
+      end
+
+      describe 'remote user' do
+        it 'force use detector' do
+          string = '안녕하세요'
+          result = described_class.instance.detect(string, account_remote)
+
+          expect(result).to eq :ko
         end
       end
 

--- a/spec/lib/language_detector_spec.rb
+++ b/spec/lib/language_detector_spec.rb
@@ -106,11 +106,11 @@ describe LanguageDetector do
       end
 
       describe 'remote user' do
-        it 'force use detector' do
+        it 'nil for foreign user when language is not present' do
           string = '안녕하세요'
           result = described_class.instance.detect(string, account_remote)
 
-          expect(result).to eq :ko
+          expect(result).to eq nil
         end
       end
 


### PR DESCRIPTION
It is not reasonable to use Local instance's language setting for foreign user's toot.