### PR TITLE
Fix handling of ActivityPub activities lacking some attributes

### DIFF
--- a/app/lib/activitypub/activity/accept.rb
+++ b/app/lib/activitypub/activity/accept.rb
@@ -26,7 +26,7 @@ class ActivityPub::Activity::Accept < ActivityPub::Activity
   end
 
   def relay
-    @relay ||= Relay.find_by(follow_activity_id: object_uri)
+    @relay ||= Relay.find_by(follow_activity_id: object_uri) unless object_uri.nil?
   end
 
   def relay_follow?

--- a/app/lib/activitypub/activity/delete.rb
+++ b/app/lib/activitypub/activity/delete.rb
@@ -17,6 +17,8 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
   end
 
   def delete_note
+    return if object_uri.nil?
+
     @status   = Status.find_by(uri: object_uri, account: @account)
     @status ||= Status.find_by(uri: @object['atomUri'], account: @account) if @object.is_a?(Hash) && @object['atomUri'].present?
 

--- a/app/lib/activitypub/activity/reject.rb
+++ b/app/lib/activitypub/activity/reject.rb
@@ -28,7 +28,7 @@ class ActivityPub::Activity::Reject < ActivityPub::Activity
   end
 
   def relay
-    @relay ||= Relay.find_by(follow_activity_id: object_uri)
+    @relay ||= Relay.find_by(follow_activity_id: object_uri) unless object_uri.nil?
   end
 
   def relay_follow?

--- a/app/lib/activitypub/activity/undo.rb
+++ b/app/lib/activitypub/activity/undo.rb
@@ -19,6 +19,8 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
   private
 
   def undo_announce
+    return if object_uri.nil?
+
     status   = Status.find_by(uri: object_uri, account: @account)
     status ||= Status.find_by(uri: @object['atomUri'], account: @account) if @object.is_a?(Hash) && @object['atomUri'].present?
 


### PR DESCRIPTION
In particular, this caused `Accept` from Misskey to be handled as an `Accept` for a relay, if any *disabled* relay is defined.