### PR TITLE
German translation issue on landingpage CTA

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -31,9 +31,9 @@ de:
     privacy_policy: Datenschutzerklärung
     source_code: Quellcode
     status_count_after:
-      one: Status
-      other: Status
-    status_count_before: die
+      one: Statusmeldung
+      other: Statusmeldungen
+    status_count_before: mit
     terms: Nutzungsbedingungen
     user_count_after:
       one: Benutzer


### PR DESCRIPTION
There is a German translation issue on the landingpage's CTA showing number of users and status posted on the instance.

But as it is right now a verb is missing for the number of status posted. But adding there the right verb like "Zuhause für X Benutzer die Y Status veröffentlichten" the text at the bottom of the numbers is getting a bit too big.

That's the reason I changed wording to "Zuhause für X Benutzer mit Y Statusmeldungen" which seems shorter and more in balance regarding top and bottom text on the numbers.

Before:

<img width="210" alt="bildschirmfoto 2018-10-03 um 22 10 58" src="https://user-images.githubusercontent.com/1077917/46437602-05060780-c75c-11e8-9911-c85eda420acc.png">

After:

<img width="281" alt="bildschirmfoto 2018-10-03 um 22 19 41" src="https://user-images.githubusercontent.com/1077917/46437611-0b947f00-c75c-11e8-887a-1d429c6683af.png">
