### PR TITLE
Speed up production build

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -50,11 +50,11 @@ module.exports = merge(sharedConfig, {
     minimize: true,
     minimizer: [
       new UglifyJsPlugin({
+        cache: true,
+        parallel: true,
         sourceMap: true,
 
         uglifyOptions: {
-          mangle: true,
-
           compress: {
             warnings: false,
           },


### PR DESCRIPTION
The source map is unnecessary for production build.
It slows down the build.

Benchmark:

| Before | After |
| :-----: | :----: |
| 1m5.159s | 0m54.477s |

`Built on a VPS with 4 virtual cores and 8GB memory.`

And parallelization makes it a lot faster.

Benchmark:

| Before | After |
| :-----: | :----: |
| 1m5.159s | 0m43.487s |

`Built on a VPS with 4 virtual cores and 8GB memory.`