### PR TITLE
Add POST /api/v1/notifications/:id/dismiss

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -296,6 +296,10 @@ Rails.application.routes.draw do
       resources :notifications, only: [:index, :show] do
         collection do
           post :clear
+          post :dismiss # Deprecated
+        end
+
+        member do
           post :dismiss
         end
       end


### PR DESCRIPTION
POST /api/v1/notifications/dismiss was a mistake in #2251 

We have to leave it in for backwards-compatibility...