### PR TITLE
Fix error when pinning the DM column

### DIFF
--- a/app/javascript/mastodon/features/direct_timeline/index.js
+++ b/app/javascript/mastodon/features/direct_timeline/index.js
@@ -5,7 +5,7 @@ import Column from '../../components/column';
 import ColumnHeader from '../../components/column_header';
 import { expandConversations } from '../../actions/conversations';
 import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
-import { defineMessages, injectIntl } from 'react-intl';
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { connectDirectStream } from '../../actions/streaming';
 import ConversationsListContainer from './containers/conversations_list_container';
 
@@ -84,7 +84,14 @@ class DirectTimeline extends React.PureComponent {
           multiColumn={multiColumn}
         />
 
-        <ConversationsListContainer shouldUpdateScroll={shouldUpdateScroll} />
+        <ConversationsListContainer
+          trackScroll={!pinned}
+          scrollKey={`direct_timeline-${columnId}`}
+          timelineId='direct'
+          onLoadMore={this.handleLoadMore}
+          emptyMessage={<FormattedMessage id='empty_column.direct' defaultMessage="You don't have any direct messages yet. When you send or receive one, it will show up here." />}
+          shouldUpdateScroll={shouldUpdateScroll}
+        />
       </Column>
     );
   }


### PR DESCRIPTION
After #8832 , if you tried to pin  the DM column in WebUI, the screen will not be displayed.

I wrote a PR to fix this.

However, when I look at the change in # 8832, it seems to be deleting part of the part related to pinning.
( Reference: https://github.com/tootsuite/mastodon/pull/8832/files#diff-8c49e70a7c6be1febaec5e02cc9dd4f2R87 )

I am worried about whether it is okay to fix this or if it is better to disable pinning.