### PR TITLE
Fix that the copy button of verify link did not work

### DIFF
--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -184,7 +184,7 @@ function main() {
   });
 
   delegate(document, '.input-copy button', 'click', ({ target }) => {
-    const input = target.parentNode.querySelector('input');
+    const input = target.parentNode.querySelector('.input-copy__wrapper input');
 
     input.focus();
     input.select();


### PR DESCRIPTION
Fix #8930 .

ref: #8703 