### PR TITLE
Unlink socket file when exists.

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -617,6 +617,9 @@ const startWorker = (workerId) => {
   }, 30000);
 
   if (process.env.SOCKET || process.env.PORT && isNaN(+process.env.PORT)) {
+    if (process.env.SOCKET && fs.existsSync(process.env.SOCKET)) {
+      fs.unlinkSync(process.env.SOCKET);
+    }
     server.listen(process.env.SOCKET || process.env.PORT, () => {
       fs.chmodSync(server.address(), 0o666);
       log.info(`Worker ${workerId} now listening on ${server.address()}`);


### PR DESCRIPTION
When exists socket file which created in previous process, streaming raise error looping and use 100% cpu time.

This avoid above problem by unlink existing files which given socket path.