### PR TITLE
RTL: fix toot alignments in public pages, fixes #2350

### DIFF
--- a/app/javascript/styles/mastodon/stream_entries.scss
+++ b/app/javascript/styles/mastodon/stream_entries.scss
@@ -3,7 +3,6 @@
   border-radius: 4px;
   overflow: hidden;
   margin-bottom: 10px;
-  text-align: left;
 
   @media screen and (max-width: $no-gap-breakpoint) {
     margin-bottom: 0;


### PR DESCRIPTION
Since 2.5.0, RTL toots in public pages are broken. They are "direction; rtl", but "text-align: left".
I have tested this commit on RTL profiles (solves the issue indeed) and on LTR profiles (as far as I can see, no visible side effects whatsoever). 

Please also check that I'm not breaking something inadvertently (it seems to me that I'm not).

An [RTL profile](https://mastodon.social/@mansoor) before (left-justified :unamused:):
![selection_595](https://user-images.githubusercontent.com/3006332/46915400-ab97a700-cfab-11e8-97bb-cd9d8b10ded2.png)
and after (correct text alignment):
![selection_594](https://user-images.githubusercontent.com/3006332/46915412-be11e080-cfab-11e8-9cd6-d8ed27715e87.png)

An [LTR profile](https://social.tchncs.de/@milan) before:
![milan_before](https://user-images.githubusercontent.com/3006332/46915422-df72cc80-cfab-11e8-81df-15cfd8afee1e.png)
and after (no difference):
![milan_after](https://user-images.githubusercontent.com/3006332/46915426-e568ad80-cfab-11e8-90cc-3ce32ec882a8.png)