### PR TITLE
fix invites in italian language

### DIFF
--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -535,6 +535,7 @@ it:
     generate: Genera
     invited_by: 'Sei stato invitato da:'
     max_uses:
+      one: "un uso"
       other: "%{count} utilizzi"
     max_uses_prompt: Nessun limite
     prompt: Genera e condividi dei link ad altri per garantire l'accesso a questa istanza

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -535,7 +535,7 @@ it:
     generate: Genera
     invited_by: 'Sei stato invitato da:'
     max_uses:
-      one: "un uso"
+      one: un uso
       other: "%{count} utilizzi"
     max_uses_prompt: Nessun limite
     prompt: Genera e condividi dei link ad altri per garantire l'accesso a questa istanza


### PR DESCRIPTION
We had the same problem in Italian language that has been resolved in this issue
https://github.com/tootsuite/mastodon/issues/6946

We have resolved adding the "one" properties

our problem was this one:                                                                                   │
│   [acd29f87-551c-409e-b952-afb7af1ff544] method=GET path=/invites format=html controller=InvitesController action=index status=500 error='ActionView::Template::Error: translation data {:other=>"%{count} ut   │
│   ilizzi"} can not be used with :count => 1. key 'one' is missing.' duration=20.81 view=0.00 db=3.55                                                                                                            │
│   [acd29f87-551c-409e-b952-afb7af1ff544]                                                                                                                                                                        │
│   [acd29f87-551c-409e-b952-afb7af1ff544] ActionView::Template::Error (translation data {:other=>"%{count} utilizzi"} can not be used with :count => 1. key 'one' is missing.):                                  │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     2:   = render 'shared/error_messages', object: @invite                                                                                                             │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     3:                                                                                                                                                                 │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     4:   .fields-group                                                                                                                                                 │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     5:     = f.input :max_uses, wrapper: :with_label, collection: [1, 5, 10, 25, 50, 100], label_method: lambda { |num| I18n.t('invites.max_uses', count: num) }, pr   │
│   ompt: I18n.t('invites.max_uses_prompt')                                                                                                                                                                       │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     6:     = f.input :expires_in, wrapper: :with_label, collection: [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week].map(&:to_i), label_method: lambda { |i| I   │
│   18n.t("invites.expires_in.#{i}") }, prompt: I18n.t('invites.expires_in_prompt')                                                                                                                               │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     7:                                                                                                                                                                 │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     8:   .fields-group     
│   [acd29f87-551c-409e-b952-afb7af1ff544]   Rendered invites/index.html.haml within layouts/admin (4.9ms)                                                                                                        │
│   [acd29f87-551c-409e-b952-afb7af1ff544] method=GET path=/invites format=html controller=InvitesController action=index status=500 error='ActionView::Template::Error: translation data {:other=>"%{count} ut   │
│   ilizzi"} can not be used with :count => 1. key 'one' is missing.' duration=20.81 view=0.00 db=3.55                                                                                                            │
│   [acd29f87-551c-409e-b952-afb7af1ff544]                                                                                                                                                                        │
│   [acd29f87-551c-409e-b952-afb7af1ff544] ActionView::Template::Error (translation data {:other=>"%{count} utilizzi"} can not be used with :count => 1. key 'one' is missing.):                                  │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     2:   = render 'shared/error_messages', object: @invite                                                                                                             │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     3:                                                                                                                                                                 │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     4:   .fields-group                                                                                                                                                 │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     5:     = f.input :max_uses, wrapper: :with_label, collection: [1, 5, 10, 25, 50, 100], label_method: lambda { |num| I18n.t('invites.max_uses', count: num) }, pr   │
│   ompt: I18n.t('invites.max_uses_prompt')                                                                                                                                                                       │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     6:     = f.input :expires_in, wrapper: :with_label, collection: [30.minutes, 1.hour, 6.hours, 12.hours, 1.day, 1.week].map(&:to_i), label_method: lambda { |i| I   │
│   18n.t("invites.expires_in.#{i}") }, prompt: I18n.t('invites.expires_in_prompt')                                                                                                                               │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     7:                                                                                                                                                                 │
│   [acd29f87-551c-409e-b952-afb7af1ff544]     8:   .fields-group     