### PR TITLE
Fixes #8987 broken alignment at "Remote interaction dialog"

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -562,12 +562,12 @@ code {
 .oauth-prompt,
 .follow-prompt {
   margin-bottom: 30px;
-  text-align: center;
   color: $darker-text-color;
 
   h2 {
     font-size: 16px;
     margin-bottom: 30px;
+    text-align: center;
   }
 
   strong {


### PR DESCRIPTION
Before (regression from PR https://github.com/tootsuite/mastodon/pull/8979)
![selection_597](https://user-images.githubusercontent.com/3006332/46948751-647ae600-d07f-11e8-9449-17034605ab73.png)

After:
![selection_596](https://user-images.githubusercontent.com/3006332/46948792-82484b00-d07f-11e8-8e08-c189dfc922f5.png)
