### PR TITLE
one user i18n

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -36,7 +36,7 @@ de:
     status_count_before: mit
     terms: Nutzungsbedingungen
     user_count_after:
-      one: Benutzer:innen
+      one: Benutzer:in
       other: Benutzer:innen
     user_count_before: Zuhause für
     what_is_mastodon: Was ist Mastodon?


### PR DESCRIPTION
In german one female user is "Benutzerin" not "Benutzerinnen"