### PR TITLE
fix: initial state of PrivacyDropdown is should not be null

### DIFF
--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
@@ -164,7 +164,7 @@ class PrivacyDropdown extends React.PureComponent {
 
   state = {
     open: false,
-    placement: null,
+    placement: 'bottom',
   };
 
   handleToggle = ({ target }) => {


### PR DESCRIPTION
Even if it is changed by handleToggle before mount, it's better that the initial placement state of PrivacyDropdown is not null.

![image](https://user-images.githubusercontent.com/24884114/47186539-d5feb100-d36b-11e8-92d7-5486cbce77ec.png)
