### PR TITLE
fix: test group of Gemfile should have devise_pam_authenticatable2 gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,10 @@ group :test do
   gem 'simplecov', '~> 0.16', require: false
   gem 'webmock', '~> 3.4'
   gem 'parallel_tests', '~> 2.23'
+
+  # devise_pam_authenticatable2 is enabled when test.
+  # Without it, rspec will always fail.
+  gem 'devise_pam_authenticatable2', '~> 9.2'
 end
 
 group :development do


### PR DESCRIPTION
Now, [development guide](https://github.com/tootsuite/documentation/blob/master/Running-Mastodon/Development-guide.md) says only below.
```
The command to install Ruby project dependencies is the following:

bundle install
```

However, developer that did `bundle install` without pam_authentication group will fail rspec.
Because devise_pam_authenticatable2 is enabled when test.
https://github.com/tootsuite/mastodon/blob/master/.env.test#L7
The developer will feel so strange.