### PR TITLE
RTL: fix user stats in about page

### DIFF
--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -245,6 +245,10 @@ body.rtl {
     left: auto;
   }
 
+  .landing-page__call-to-action .row__information-board {
+    direction: rtl;
+  }
+
   .landing-page .header .hero .floats .float-1 {
     left: -120px;
     right: auto;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3006332/47203440-b2923100-d380-11e8-9c56-91864aaadff2.png)

After:
![image](https://user-images.githubusercontent.com/3006332/47203419-a1492480-d380-11e8-85d9-88f0dcea7ca1.png)


