### PR TITLE
fix: Execute PAM authentication tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ aliases:
           ALLOW_NOPAM: true
           CONTINUOUS_INTEGRATION: true
           DISABLE_SIMPLECOV: true
+          PAM_ENABLED: true	
+          PAM_DEFAULT_SERVICE: pam_test	
+          PAM_CONTROLLED_SERVICE: pam_test_controlled
     working_directory: ~/projects/mastodon/
 
   - &attach_workspace

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -55,55 +55,53 @@ RSpec.describe Auth::SessionsController, type: :controller do
       request.env['devise.mapping'] = Devise.mappings[:user]
     end
 
-    if ENV['PAM_ENABLED'] == 'true'
-      context 'using PAM authentication' do
-        context 'using a valid password' do
-          before do
-            post :create, params: { user: { email: "pam_user1", password: '123456' } }
-          end
-
-          it 'redirects to home' do
-            expect(response).to redirect_to(root_path)
-          end
-
-          it 'logs the user in' do
-            expect(controller.current_user).to be_instance_of(User)
-          end
+    context 'using PAM authentication', if: ENV['PAM_ENABLED'] == 'true' do
+      context 'using a valid password' do
+        before do
+          post :create, params: { user: { email: "pam_user1", password: '123456' } }
         end
 
-        context 'using an invalid password' do
-          before do
-            post :create, params: { user: { email: "pam_user1", password: 'WRONGPW' } }
-          end
-
-          it 'shows a login error' do
-            expect(flash[:alert]).to match I18n.t('devise.failure.invalid', authentication_keys: 'Email')
-          end
-
-          it "doesn't log the user in" do
-            expect(controller.current_user).to be_nil
-          end
+        it 'redirects to home' do
+          expect(response).to redirect_to(root_path)
         end
 
-        context 'using a valid email and existing user' do
-          let(:user) do
-            account = Fabricate.build(:account, username: 'pam_user1')
-            account.save!(validate: false)
-            user = Fabricate(:user, email: 'pam@example.com', password: nil, account: account)
-            user
-          end
+        it 'logs the user in' do
+          expect(controller.current_user).to be_instance_of(User)
+        end
+      end
 
-          before do
-            post :create, params: { user: { email: user.email, password: '123456' } }
-          end
+      context 'using an invalid password' do
+        before do
+          post :create, params: { user: { email: "pam_user1", password: 'WRONGPW' } }
+        end
 
-          it 'redirects to home' do
-            expect(response).to redirect_to(root_path)
-          end
+        it 'shows a login error' do
+          expect(flash[:alert]).to match I18n.t('devise.failure.invalid', authentication_keys: 'Email')
+        end
 
-          it 'logs the user in' do
-            expect(controller.current_user).to eq user
-          end
+        it "doesn't log the user in" do
+          expect(controller.current_user).to be_nil
+        end
+      end
+
+      context 'using a valid email and existing user' do
+        let(:user) do
+          account = Fabricate.build(:account, username: 'pam_user1')
+          account.save!(validate: false)
+          user = Fabricate(:user, email: 'pam@example.com', password: nil, account: account)
+          user
+        end
+
+        before do
+          post :create, params: { user: { email: user.email, password: '123456' } }
+        end
+
+        it 'redirects to home' do
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'logs the user in' do
+          expect(controller.current_user).to eq user
         end
       end
     end


### PR DESCRIPTION
and use 'if' option of context block

Current master(fd5285658f477c5b6a9c7af0935b5c889729b2e0): https://circleci.com/gh/takayamaki/mastodon/674
`2314 examples, 0 failures, 21 pendings`

This PR(ead4f791b4f89b68728cb4e0d19a86be87862681): https://circleci.com/gh/takayamaki/mastodon/692
`2320 examples, 0 failures, 21 pendings`

ref: #9027