### PR TITLE
Fix domain label position and color

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -427,7 +427,7 @@ code {
 
     &__append {
       position: absolute;
-      right: 1px;
+      right: 3px;
       top: 1px;
       padding: 10px;
       padding-bottom: 9px;

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -246,12 +246,12 @@ body.rtl {
 
   .simple_form .label_input__append {
     right: auto;
-    left: 0;
+    left: 3px;
 
     &::after {
       right: auto;
       left: 0;
-      background-image: linear-gradient(to left, rgba($ui-base-color, 0), $ui-base-color);
+      background-image: linear-gradient(to left, rgba(darken($ui-base-color, 10%), 0), darken($ui-base-color, 10%));
     }
   }
 


### PR DESCRIPTION
Fix domain label position which is hiding the border of the input form.

before:
![ltr-before](https://user-images.githubusercontent.com/32974885/47263338-b4075900-d53a-11e8-9f40-90e811d79760.png)

after:
![ltr-after](https://user-images.githubusercontent.com/32974885/47263340-b79ae000-d53a-11e8-8790-38eb92e21847.png)

In the RTL, fix position and color mismatch of domain label.

before:
![rtl-before](https://user-images.githubusercontent.com/32974885/47263369-33952800-d53b-11e8-835c-971c8822b13f.png)

after:
![rtl-after](https://user-images.githubusercontent.com/32974885/47263371-3859dc00-d53b-11e8-99b9-a61ff9016b98.png)
