### PR TITLE
RTL: remove blank character inside bdi

### DIFF
--- a/app/javascript/mastodon/components/display_name.js
+++ b/app/javascript/mastodon/components/display_name.js
@@ -22,7 +22,7 @@ export default class DisplayName extends React.PureComponent {
 
     return (
       <span className='display-name'>
-        <bdi><strong className='display-name__html' dangerouslySetInnerHTML={displayNameHtml} /></bdi> {suffix}
+        <bdi><strong className='display-name__html' dangerouslySetInnerHTML={displayNameHtml}/></bdi> {suffix}
       </span>
     );
   }

--- a/app/javascript/mastodon/components/display_name.js
+++ b/app/javascript/mastodon/components/display_name.js
@@ -22,7 +22,8 @@ export default class DisplayName extends React.PureComponent {
 
     return (
       <span className='display-name'>
-        <bdi><strong className='display-name__html' dangerouslySetInnerHTML={displayNameHtml}/></bdi> {suffix}
+        <bdi><strong className='display-name__html' dangerouslySetInnerHTML={displayNameHtml} /></bdi>
+        <span>{suffix}</span>
       </span>
     );
   }


### PR DESCRIPTION
When RTL layout is active, an account with LTR display-name is rendered incorrectly. I'm talking about this:
![bdi_before](https://user-images.githubusercontent.com/3006332/47266406-2164bb00-d536-11e8-8534-491aaa5fb74a.png)

Before:
![image](https://user-images.githubusercontent.com/3006332/47266412-4eb16900-d536-11e8-8c14-163b02f0beeb.png)

After:
![image](https://user-images.githubusercontent.com/3006332/47266410-43f6d400-d536-11e8-9b2a-6b6c25a4222d.png)

Or maybe I am getting it wrong, and _this_ is not the blank character I should remove?