### PR TITLE
RTL: fix admin account avatar margin in about page

### DIFF
--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -341,14 +341,15 @@ body.rtl {
       margin-right: 20px;
     }
   }
-}
 
-.landing-page__information {
-  .account__display-name {
-    margin-right: 0;
-  }
-
-  .account__avatar-wrapper {
-    margin-left: 0;
+  .landing-page__information {
+    .account__display-name {
+      margin-right: 0;
+      margin-left: 5px;
+    }
+    .account__avatar-wrapper {
+      margin-left: 12px;
+      margin-right: 0;
+    }
   }
 }

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -347,6 +347,7 @@ body.rtl {
       margin-right: 0;
       margin-left: 5px;
     }
+
     .account__avatar-wrapper {
       margin-left: 12px;
       margin-right: 0;


### PR DESCRIPTION
This is PR https://github.com/tootsuite/mastodon/pull/9005 again, done right.

Previously, I mistakenly added the styles _outside_ of the top-level `body.rtl { }` domain, therefore it caused problems for everyone, and it was reverted in PR https://github.com/tootsuite/mastodon/pull/9020.

Now I hope this fixes the original problem without affecting non-RTL layouts.