### PR TITLE
Fix tootctl cull on dead servers

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -239,7 +239,7 @@ module Mastodon
           end
         end
 
-        if [404, 410].include?(code) || dead_servers.include?(account.domain)
+        if [404, 410].include?(code)
           unless options[:dry_run]
             SuspendAccountService.new.call(account)
             account.destroy
@@ -252,10 +252,10 @@ module Mastodon
         end
       end
 
-      # Cleanup first 9 accounts on each dead servers
+      # Remove dead servers
       unless dead_servers.empty? || options[:dry_run]
         dead_servers.each do |domain|
-          Account.where(domain: domain).each do |account|
+          Account.where(domain: domain).find_each do |account|
             SuspendAccountService.new.call(account)
             account.destroy
             culled += 1

--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -252,6 +252,18 @@ module Mastodon
         end
       end
 
+      # Cleanup first 9 accounts on each dead servers
+      unless dead_servers.empty? || options[:dry_run]
+        dead_servers.each do |domain|
+          Account.where(domain: domain).each do |account|
+            SuspendAccountService.new.call(account)
+            account.destroy
+            culled += 1
+            say('.', :green, false)
+          end
+        end
+      end
+
       say
       say("Removed #{culled} accounts (#{dead_servers.size} dead servers)#{dry_run}", :green)
 


### PR DESCRIPTION
First 9 accounts of dead servers were not deleted.
This PR will delete that accounts.