### PR TITLE
Do not move CWs to toot body when toot body is empty

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -21,7 +21,7 @@ class PostStatusService < BaseService
 
     media  = validate_media!(options[:media_ids])
     status = nil
-    text   = options.delete(:spoiler_text) if text.blank? && options[:spoiler_text].present?
+    text   = '.' if text.blank? && options[:spoiler_text].present?
 
     ApplicationRecord.transaction do
       status = account.statuses.create!(text: text,

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -21,7 +21,10 @@ class PostStatusService < BaseService
 
     media  = validate_media!(options[:media_ids])
     status = nil
-    text   = '.' if text.blank? && options[:spoiler_text].present?
+    if text.blank? && options[:spoiler_text].present?
+      text = '.'
+      text = media.find(&:video?) ? '📹' : '🖼' unless media.empty?
+    end
 
     ApplicationRecord.transaction do
       status = account.statuses.create!(text: text,


### PR DESCRIPTION
Instead of leaving the toot body blank, it replaces it with a placeholder text such as 📹 or 🖼 according to the type of attached media.

This is a port of https://github.com/glitch-soc/mastodon/pull/788 and a way to fix #6825