### PR TITLE
Postgres 10.5 stable in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   db:
     restart: always
-    image: postgres:9.6-alpine
+    image: postgres:10.5-alpine
     networks:
       - internal_network
 ### Uncomment to enable DB persistence


### PR DESCRIPTION
As this is a jump in version and would require additional work for the exporting of the database at v9 and import at v10... for all existing docker installations?

Likely just close this unless we can automate/document the process.