### PR TITLE
Reduce server load caused by anonymous viewing.

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -10,6 +10,8 @@ class AccountsController < ApplicationController
   def show
     respond_to do |format|
       format.html do
+        mark_cacheable! unless user_signed_in?
+
         @body_classes      = 'with-modals'
         @pinned_statuses   = []
         @endorsed_accounts = @account.endorsed_accounts.to_a.sample(4)
@@ -30,17 +32,21 @@ class AccountsController < ApplicationController
       end
 
       format.atom do
+        mark_cacheable!
+
         @entries = @account.stream_entries.where(hidden: false).with_includes.paginate_by_max_id(PAGE_SIZE, params[:max_id], params[:since_id])
         render xml: OStatus::AtomSerializer.render(OStatus::AtomSerializer.new.feed(@account, @entries.reject { |entry| entry.status.nil? }))
       end
 
       format.rss do
+        mark_cacheable!
+
         @statuses = cache_collection(default_statuses.without_reblogs.without_replies.limit(PAGE_SIZE), Status)
         render xml: RSS::AccountSerializer.render(@account, @statuses)
       end
 
       format.json do
-        skip_session!
+        mark_cacheable!
 
         render_cached_json(['activitypub', 'actor', @account], content_type: 'application/activity+json') do
           ActiveModelSerializers::SerializableResource.new(@account, serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -151,6 +151,11 @@ class ApplicationController < ActionController::Base
     response.headers['Vary'] = 'Accept'
   end
 
+  def mark_cacheable!
+    skip_session!
+    expires_in 0, public: true
+  end
+
   def skip_session!
     request.session_options[:skip] = true
   end

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -6,6 +6,8 @@ class FollowerAccountsController < ApplicationController
   def index
     respond_to do |format|
       format.html do
+        mark_cacheable! unless user_signed_in?
+
         next if @account.user_hides_network?
 
         follows

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -27,6 +27,8 @@ class StatusesController < ApplicationController
   def show
     respond_to do |format|
       format.html do
+        mark_cacheable! unless user_signed_in?
+
         @body_classes = 'with-modals'
 
         set_ancestors
@@ -36,7 +38,7 @@ class StatusesController < ApplicationController
       end
 
       format.json do
-        skip_session! unless @stream_entry.hidden?
+        mark_cacheable! unless @stream_entry.hidden?
 
         render_cached_json(['activitypub', 'note', @status], content_type: 'application/activity+json', public: !@stream_entry.hidden?) do
           ActiveModelSerializers::SerializableResource.new(@status, serializer: ActivityPub::NoteSerializer, adapter: ActivityPub::Adapter)


### PR DESCRIPTION
Do not start a session if the current user is not logged in for public-facing pages.

Mark pages that don't care about sessions as publicly cacheable.

Keep the max age as 0 so proxies and browsers will still try to retrieve an updated version but can still fall back to the stale version if the site is down or too slow.

Fixes #9035.