### PR TITLE
Redis 5.0.0 is out.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 
   redis:
     restart: always
-    image: redis:4.0-alpine
+    image: redis:5.0-alpine
     networks:
       - internal_network
     volumes:


### PR DESCRIPTION
I'm going to test the straight up replacement.. might be worth waiting for 5.0.1, but the Mastodon usecase isn't using any of the more complex caching procedures.

Should be able to be swapped out easy enough.