### PR TITLE
Allow cross-origin requests to /.well-known/* URLs.

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -9,6 +9,10 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins '*'
 
+    resource '/.well-known/*',
+      headers: :any,
+      methods: [:get],
+      credentials: false
     resource '/@:username',
       headers: :any,
       methods: [:get],


### PR DESCRIPTION
Right now, this includes three endpoints: host-meta, webfinger, and change-password.

host-meta and webfinger are publicly available and do not use any authentication. Nothing bad can be done by accessing them in a user's browser.

change-password being CORS-enabled will only reveal the URL it redirects to (which is /auth/edit) but not anything about the actual /auth/edit page, because it does not have CORS enabled.

The documentation for hosting an instance on a different domain should also be updated to point out that Access-Control-Allow-Origin: * should be set at a minimum for the /.well-known/host-meta redirect to allow browser-based non-proxied instance discovery.