### PR TITLE
Migrate all old direct messages to new conversations schema

### DIFF
--- a/app/models/account_conversation.rb
+++ b/app/models/account_conversation.rb
@@ -58,6 +58,9 @@ class AccountConversation < ApplicationRecord
 
     def add_status(recipient, status)
       conversation = find_or_initialize_by(account: recipient, conversation_id: status.conversation_id, participant_account_ids: participants_from_status(recipient, status))
+
+      return conversation if conversation.status_ids.include?(status.id)
+
       conversation.status_ids << status.id
       conversation.unread = status.account_id != recipient.id
       conversation.save

--- a/db/migrate/20181024224956_migrate_account_conversations.rb
+++ b/db/migrate/20181024224956_migrate_account_conversations.rb
@@ -1,0 +1,43 @@
+class MigrateAccountConversations < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    say ''
+    say 'WARNING: This migration may take a *long* time for large instances'
+    say 'It will *not* lock tables for any significant time, but it may run'
+    say 'for a very long time. We will pause for 10 seconds to allow you to'
+    say 'interrupt this migration if you are not ready.'
+    say ''
+
+    10.downto(1) do |i|
+      say "Continuing in #{i} second#{i == 1 ? '' : 's'}...", true
+      sleep 1
+    end
+
+    local_direct_statuses.find_each do |status|
+      AccountConversation.add_status(status.account, status)
+    end
+
+    notifications_about_direct_statuses.find_each do |notification|
+      AccountConversation.add_status(notification.account, notification.target_status)
+    end
+  end
+
+  def down
+  end
+
+  private
+
+  def local_direct_statuses
+    Status.unscoped
+          .local
+          .where(visibility: :direct)
+          .includes(:account, mentions: :account)
+  end
+
+  def notifications_about_direct_statuses
+    Notification.joins(mention: :status)
+                .where(activity_type: 'Mention', statuses: { visibility: :direct })
+                .includes(:account, mention: { status: [:account, mentions: :account] })
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_18_205649) do
+ActiveRecord::Schema.define(version: 2018_10_24_224956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
First it creates a conversation record for every local DM's author (so everyone can keep track of DMs they sent). Then it iterates over notifications about DMs to create corresponding conversation records. This allows us to not mess with NotifyService filters on the fly, because if a notification exists, it can be shown.