### PR TITLE
Add locality check to ActivityPub::FetchRemoteAccountService

### DIFF
--- a/app/services/activitypub/fetch_remote_account_service.rb
+++ b/app/services/activitypub/fetch_remote_account_service.rb
@@ -5,9 +5,10 @@ class ActivityPub::FetchRemoteAccountService < BaseService
 
   SUPPORTED_TYPES = %w(Application Group Organization Person Service).freeze
 
-  # Should be called when uri has already been checked for locality
   # Does a WebFinger roundtrip on each call
   def call(uri, id: true, prefetched_body: nil, break_on_redirect: false)
+    return ActivityPub::TagManager.instance.uri_to_resource(uri, Account) if ActivityPub::TagManager.instance.local_uri?(uri)
+
     @json = if prefetched_body.nil?
               fetch_resource(uri, id)
             else

--- a/db/migrate/20181026034033_remove_faux_remote_account_duplicates.rb
+++ b/db/migrate/20181026034033_remove_faux_remote_account_duplicates.rb
@@ -1,0 +1,16 @@
+class RemoveFauxRemoteAccountDuplicates < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    local_domain = Rails.configuration.x.local_domain
+
+    # Just a safety measure to ensure that under no circumstance
+    # we will query `domain IS NULL` because that would return
+    # actually local accounts, the originals
+    return if local_domain.nil?
+
+    Account.where(domain: local_domain).in_batches.destroy_all
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_24_224956) do
+ActiveRecord::Schema.define(version: 2018_10_26_034033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Fix #8643

Because there are a few places where it is called, it is difficult to confirm if they all previously checked it for locality. It's better to make sure within the service.