### PR TITLE
Fix ActivityPub::Activity::Create

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -90,7 +90,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
     # If the payload was delivered to a specific inbox, the inbox owner must have
     # access to it, unless they already have access to it anyway
-    return if @options[:delivered_to_account_id].nil? || @mentions.any? { mention.account_id == @options[:delivered_to_account_id] }
+    return if @options[:delivered_to_account_id].nil? || @mentions.any? { |mention| mention.account_id == @options[:delivered_to_account_id] }
 
     @mentions << Mention.new(account_id: @options[:delivered_to_account_id], silent: true)
 

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -94,7 +94,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
     @mentions << Mention.new(account_id: @options[:delivered_to_account_id], silent: true)
 
-    return unless @param[:visibility] == :direct
+    return unless @params[:visibility] == :direct
 
     @params[:visibility] = :limited
   end


### PR DESCRIPTION
Fix regression from #9093 .

Fixed an issue that cannot be delivered from the misskey.