### PR TITLE
Support Page object type

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -2,7 +2,7 @@
 
 class ActivityPub::Activity::Create < ActivityPub::Activity
   SUPPORTED_TYPES = %w(Note).freeze
-  CONVERTED_TYPES = %w(Image Video Article).freeze
+  CONVERTED_TYPES = %w(Image Video Article Page).freeze
 
   def perform
     return if delete_arrived_first?(object_uri) || unsupported_object_type? || invalid_origin?(@object['id'])


### PR DESCRIPTION
It would be great if Mastodon could support a `Page` object type (https://www.w3.org/TR/activitystreams-vocabulary/#dfn-page) as a convertable object type.

That would make it possible to let [Prismo](https://gitlab.com/mbajur/prismo) (or any other link aggregation AP-based service) and Mastodon talk together using a proper object types (Prismo is currently forced to use `Note` and `Article` for links posted which is not really valid)