### PR TITLE
Set 9999 to z-index of dropdown

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1669,6 +1669,7 @@ a.account__display-name {
   padding: 4px 0;
   border-radius: 4px;
   box-shadow: 2px 4px 15px rgba($base-shadow-color, 0.4);
+  z-index: 9999;
 
   ul {
     list-style: none;


### PR DESCRIPTION
Fix order of overlapping.

Before:
![account_before](https://user-images.githubusercontent.com/32974885/47612419-5ab0a400-dabd-11e8-8335-2a29ea93ac9e.png)

After:
![account_after](https://user-images.githubusercontent.com/32974885/47612422-656b3900-dabd-11e8-940b-54125233776c.png)


Because I think that dropdown should be at the forefront just like any other modal, I set 9999.