### PR TITLE
Ensure replied-to is a status not a boost

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -434,6 +434,9 @@ class Status < ApplicationRecord
   end
 
   def set_conversation
+    # clients might send the ID of the boost itself instead of the boosted status
+    self.thread = thread.reblog if thread&.reblog?
+
     self.reply = !(in_reply_to_id.nil? && thread.nil?) unless reply
 
     if reply? && !thread.nil?

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -434,7 +434,6 @@ class Status < ApplicationRecord
   end
 
   def set_conversation
-    # clients might send the ID of the boost itself instead of the boosted status
     self.thread = thread.reblog if thread&.reblog?
 
     self.reply = !(in_reply_to_id.nil? && thread.nil?) unless reply

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -23,7 +23,7 @@ class PostStatusService < BaseService
     status = nil
     text   = options.delete(:spoiler_text) if text.blank? && options[:spoiler_text].present?
 
-    in_reply_to = Status.find(in_reply_to.reblog_of_id) if in_reply_to.reblog?
+    in_reply_to = Status.find(in_reply_to.reblog_of_id) if in_reply_to&.reblog?
 
     ApplicationRecord.transaction do
       status = account.statuses.create!(text: text,

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -23,8 +23,6 @@ class PostStatusService < BaseService
     status = nil
     text   = options.delete(:spoiler_text) if text.blank? && options[:spoiler_text].present?
 
-    in_reply_to = Status.find(in_reply_to.reblog_of_id) if in_reply_to&.reblog?
-
     ApplicationRecord.transaction do
       status = account.statuses.create!(text: text,
                                         media_attachments: media || [],

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -23,6 +23,8 @@ class PostStatusService < BaseService
     status = nil
     text   = options.delete(:spoiler_text) if text.blank? && options[:spoiler_text].present?
 
+    in_reply_to = Status.find(in_reply_to.reblog_of_id) if in_reply_to.reblog?
+
     ApplicationRecord.transaction do
       status = account.statuses.create!(text: text,
                                         media_attachments: media || [],

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe PostStatusService, type: :service do
     expect(status.thread).to eq in_reply_to_status
   end
 
+  it 'creates response to the original status of boost' do
+    boosted_status = Fabricate(:status)
+    in_reply_to_status = Fabricate(:status, reblog: boosted_status)
+    account = Fabricate(:account)
+    text = "test status update"
+
+    status = subject.call(account, text, in_reply_to_status)
+
+    expect(status).to be_persisted
+    expect(status.text).to eq text
+    expect(status.thread).to eq boosted_status
+  end
+
   it 'creates a sensitive status' do
     status = create_status_with_options(sensitive: true)
 


### PR DESCRIPTION
## Issue 
Fixes #8794

## Outline
If the given in-reply-to status is a boost, use the ID of the original status for replying.

## To do
- [x] tests for this specific case