### PR TITLE
Fix FetchAtomService  content type handling

### DIFF
--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -29,7 +29,7 @@ class FetchAtomService < BaseService
 
   def perform_request(&block)
     accept = 'text/html'
-    accept = 'application/activity+json, application/ld+json, application/atom+xml, ' + accept unless @unsupported_activity
+    accept = 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/atom+xml, ' + accept unless @unsupported_activity
 
     Request.new(:get, @url).add_headers('Accept' => accept).perform(&block)
   end

--- a/spec/services/fetch_atom_service_spec.rb
+++ b/spec/services/fetch_atom_service_spec.rb
@@ -60,8 +60,15 @@ RSpec.describe FetchAtomService, type: :service do
         it { is_expected.to eq [url, { :prefetched_body => "" }, :ostatus] }
       end
 
-      context 'content_type is json' do
+      context 'content_type is activity+json' do
         let(:content_type) { 'application/activity+json' }
+        let(:body) { json }
+
+        it { is_expected.to eq [1, { prefetched_body: body, id: true }, :activitypub] }
+      end
+
+      context 'content_type is ld+json with profile' do
+        let(:content_type) { 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' }
         let(:body) { json }
 
         it { is_expected.to eq [1, { prefetched_body: body, id: true }, :activitypub] }


### PR DESCRIPTION
## Issue
Fixes #8773 

## Changes
* add profile to json+ld in the Accept header as required by the spec
* use `headers['Content-type']` instead of `mime_type`
  The latter strips out the `profile` part of the content type header, so compliant ActivityPub services don't get handled properly. `headers['Content-type']` has the "raw" content type with the profile, so use that for checking.