### PR TITLE
Add healthcheck commands to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     image: postgres:9.6-alpine
     networks:
       - internal_network
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
     volumes:
       - ./postgres:/var/lib/postgresql/data
 
@@ -14,6 +16,8 @@ services:
     image: redis:4.0-alpine
     networks:
       - internal_network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
     volumes:
       - ./redis:/data
 
@@ -24,6 +28,8 @@ services:
 #      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 #    networks:
 #      - internal_network
+#    healthcheck:
+#      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
 #    volumes:
 #      - ./elasticsearch:/usr/share/elasticsearch/data
 
@@ -36,6 +42,8 @@ services:
     networks:
       - external_network
       - internal_network
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider --header 'x-forwarded-proto: https' --proxy off localhost:3000/api/v1/instance || exit 1"]
     ports:
       - "127.0.0.1:3000:3000"
     depends_on:
@@ -54,6 +62,8 @@ services:
     networks:
       - external_network
       - internal_network
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider --header 'x-forwarded-proto: https' --proxy off localhost:4000/api/v1/streaming/health || exit 1"]
     ports:
       - "127.0.0.1:4000:4000"
     depends_on:


### PR DESCRIPTION
This will allow Docker to be automatically check the health of services.

Docker won't do anything other than showing the state in the output of `docker-compose ps` by default, but some management tools may watch for container health events.

Here's what my local instance looks like right now:

```
          Name                        Command                  State                     Ports
-------------------------------------------------------------------------------------------------------------
mastodon_db_1              docker-entrypoint.sh postgres    Up (healthy)
mastodon_es_1              /usr/local/bin/docker-entr ...   Up (healthy)
mastodon_redis_1           docker-entrypoint.sh redis ...   Up (healthy)
mastodon_redis_cache_1     docker-entrypoint.sh redis ...   Up (healthy)
mastodon_sidekiq_1         /sbin/tini -- bundle exec  ...   Up             3000/tcp, 4000/tcp
mastodon_streaming_1       /sbin/tini -- yarn start         Up (healthy)   3000/tcp, 127.0.0.1:4000->4000/tcp
mastodon_web_1             /sbin/tini -- bash -c rm - ...   Up (healthy)   127.0.0.1:3000->3000/tcp, 4000/tcp
```