### PR TITLE
Do not hide boost notifications from followed people with hidden boosts

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -31,7 +31,7 @@ class NotifyService < BaseService
   end
 
   def blocked_reblog?
-    @recipient.muting_reblogs?(@notification.from_account)
+    false
   end
 
   def blocked_follow_request?

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -104,9 +104,9 @@ RSpec.describe NotifyService, type: :service do
       is_expected.to change(Notification, :count)
     end
 
-    it 'hides reblogs when disabled' do
-      recipient.follow!(sender, reblogs: false)
-      is_expected.to_not change(Notification, :count)
+    it 'shows reblogs when disabled' do
+      recipient.follow!(sender, reblogs: true)
+      is_expected.to change(Notification, :count)
     end
   end
 


### PR DESCRIPTION
Not displaying boosts from a followed user in the Home timeline and not
having notifications when they reblog your own content are two very
separate concerns, tying them together seem counter-intuitive and unwanted.