### PR TITLE
Ignore JSON-LD profile in mime type comparison

### DIFF
--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -29,7 +29,7 @@ class FetchAtomService < BaseService
 
   def perform_request(&block)
     accept = 'text/html'
-    accept = 'application/activity+json, application/ld+json, application/atom+xml, ' + accept unless @unsupported_activity
+    accept = 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams", application/atom+xml, ' + accept unless @unsupported_activity
 
     Request.new(:get, @url).add_headers('Accept' => accept).perform(&block)
   end

--- a/app/services/fetch_atom_service.rb
+++ b/app/services/fetch_atom_service.rb
@@ -39,7 +39,7 @@ class FetchAtomService < BaseService
 
     if response.mime_type == 'application/atom+xml'
       [@url, { prefetched_body: response.body_with_limit }, :ostatus]
-    elsif ['application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'].include?(response.mime_type)
+    elsif ['application/activity+json', 'application/ld+json'].include?(response.mime_type)
       body = response.body_with_limit
       json = body_to_json(body)
       if supported_context?(json) && equals_or_includes_any?(json['type'], ActivityPub::FetchRemoteAccountService::SUPPORTED_TYPES) && json['inbox'].present?

--- a/spec/services/fetch_atom_service_spec.rb
+++ b/spec/services/fetch_atom_service_spec.rb
@@ -60,8 +60,15 @@ RSpec.describe FetchAtomService, type: :service do
         it { is_expected.to eq [url, { :prefetched_body => "" }, :ostatus] }
       end
 
-      context 'content_type is json' do
-        let(:content_type) { 'application/activity+json' }
+      context 'content_type is activity+json' do
+        let(:content_type) { 'application/activity+json; charset=utf-8' }
+        let(:body) { json }
+
+        it { is_expected.to eq [1, { prefetched_body: body, id: true }, :activitypub] }
+      end
+
+      context 'content_type is ld+json with profile' do
+        let(:content_type) { 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' }
         let(:body) { json }
 
         it { is_expected.to eq [1, { prefetched_body: body, id: true }, :activitypub] }


### PR DESCRIPTION
## Issue
Fixes #8773

## Changes
* add profile to json+ld Accept
* ignore profile on response if json+ld (response struct doesn't parse profile sadly)

## Tests
- [x] with profile
- [x] with charset