### PR TITLE
Support Page type in search input

### DIFF
--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -20,7 +20,7 @@ class ResolveURLService < BaseService
   def process_url
     if equals_or_includes_any?(type, %w(Application Group Organization Person Service))
       FetchRemoteAccountService.new.call(atom_url, body, protocol)
-    elsif equals_or_includes_any?(type, %w(Note Article Image Video))
+    elsif equals_or_includes_any?(type, %w(Note Article Image Video Page))
       FetchRemoteStatusService.new.call(atom_url, body, protocol)
     end
   end


### PR DESCRIPTION
This one is related to #9121 

***

Right now, search input only resolves URLs that are one of `Note`, `Article`, `Image` or `Video` type. While Mastodon now supports a `Page` object type, it would be great to add such support to the search input as well.

ps. sorry for not including this in #9121 