### PR TITLE
HTTP Signatures: relaxed Date verification

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -95,7 +95,8 @@ module SignatureVerification
 
   def matches_time_window?
     begin
-      time_sent = Time.httpdate(request.headers['Date'])
+      date_header = request.headers['Date']
+      time_sent = Time.httpdate(date_header) rescue Time.parse(date_header)
     rescue ArgumentError
       return false
     end


### PR DESCRIPTION
`Thu, 1 Nov 2018 09:02:46 GMT` is not accepted by `Time.httpdate` as `not RFC 2616 compliant date`, possible because it require leading zeros in day part. While RFC2616 compliance is questionable, `Time.parse` get correct results from it.