### PR TITLE
Add configuration option to filter replies in lists

### DIFF
--- a/app/controllers/api/v1/lists_controller.rb
+++ b/app/controllers/api/v1/lists_controller.rb
@@ -38,6 +38,6 @@ class Api::V1::ListsController < Api::BaseController
   end
 
   def list_params
-    params.permit(:title)
+    params.permit(:title, :replies_policy)
   end
 end

--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -150,10 +150,10 @@ export const createListFail = error => ({
   error,
 });
 
-export const updateList = (id, title, shouldReset) => (dispatch, getState) => {
+export const updateList = (id, title, shouldReset, replies_policy) => (dispatch, getState) => {
   dispatch(updateListRequest(id));
 
-  api(getState).put(`/api/v1/lists/${id}`, { title }).then(({ data }) => {
+  api(getState).put(`/api/v1/lists/${id}`, { title, replies_policy }).then(({ data }) => {
     dispatch(updateListSuccess(data));
 
     if (shouldReset) {

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -19,9 +19,9 @@ import Icon from 'mastodon/components/icon';
 const messages = defineMessages({
   deleteMessage: { id: 'confirmations.delete_list.message', defaultMessage: 'Are you sure you want to permanently delete this list?' },
   deleteConfirm: { id: 'confirmations.delete_list.confirm', defaultMessage: 'Delete' },
-  all_replies:   { id: 'lists.replies_policy.all_replies', defaultMessage: 'to any followed user' },
-  no_replies:    { id: 'lists.replies_policy.no_replies', defaultMessage: 'none' },
-  list_replies:  { id: 'lists.replies_policy.list_replies', defaultMessage: 'only to list' },
+  all_replies:   { id: 'lists.replies_policy.all_replies', defaultMessage: 'any followed user' },
+  no_replies:    { id: 'lists.replies_policy.no_replies', defaultMessage: 'no one' },
+  list_replies:  { id: 'lists.replies_policy.list_replies', defaultMessage: 'members of the list' },
 });
 
 const mapStateToProps = (state, props) => ({
@@ -134,15 +134,14 @@ class ListTimeline extends React.PureComponent {
     }));
   }
 
-  handleRepliesPolicyClick = () => {
-    const { dispatch, list } = this.props;
+  handleRepliesPolicyChange = ({ target }) => {
+    const { dispatch } = this.props;
     const { id } = this.props.params;
-    const replies_policy = { 'all_replies': 'no_replies', 'no_replies': 'list_replies', 'list_replies': 'all_replies' }[list.get('replies_policy')];
-    dispatch(updateList(id, undefined, false, replies_policy));
+    dispatch(updateList(id, undefined, false, target.value));
   }
 
   render () {
-    const { shouldUpdateScroll, hasUnread, columnId, multiColumn, list, intl } = this.props;
+    const { shouldUpdateScroll, hasUnread, columnId, multiColumn, list } = this.props;
     const { id } = this.props.params;
     const pinned = !!columnId;
     const title  = list ? list.get('title') : id;
@@ -187,9 +186,21 @@ class ListTimeline extends React.PureComponent {
             </button>
 
             { replies_policy !== undefined && (
-              <button className='text-btn column-header__setting-btn' tabIndex='0' onClick={this.handleRepliesPolicyClick}>
-                <i className='fa fa-reply' /> <FormattedMessage id='lists.replies_policy.title' defaultMessage='Show replies: {policy}' values={{ policy: intl.formatMessage(messages[replies_policy]) }} />
-              </button>
+              <div>
+                <div className='column-settings__row'>
+                  <fieldset>
+                    <legend><FormattedMessage id='lists.replies_policy.title' defaultMessage='Show replies to:' /></legend>
+                    { ['no_replies', 'list_replies', 'all_replies'].map(policy => (
+                      <div className='setting-radio'>
+                        <input className='setting-radio__input' id={['setting', 'radio', id, policy].join('-')} type='radio' value={policy} checked={replies_policy === policy} onChange={this.handleRepliesPolicyChange} />
+                        <label className='setting-radio__label' htmlFor={['setting', 'radio', id, policy].join('-')}>
+                          <FormattedMessage {...messages[policy]} />
+                        </label>
+                      </div>
+                    ))}
+                  </fieldset>
+                </div>
+              </div>
             )}
           </div>
         </ColumnHeader>

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -15,6 +15,7 @@ import { openModal } from '../../actions/modal';
 import MissingIndicator from '../../components/missing_indicator';
 import LoadingIndicator from '../../components/loading_indicator';
 import Icon from 'mastodon/components/icon';
+import RadioButton from 'mastodon/components/radio_button';
 
 const messages = defineMessages({
   deleteMessage: { id: 'confirmations.delete_list.message', defaultMessage: 'Are you sure you want to permanently delete this list?' },
@@ -141,7 +142,7 @@ class ListTimeline extends React.PureComponent {
   }
 
   render () {
-    const { shouldUpdateScroll, hasUnread, columnId, multiColumn, list } = this.props;
+    const { shouldUpdateScroll, hasUnread, columnId, multiColumn, list, intl } = this.props;
     const { id } = this.props.params;
     const pinned = !!columnId;
     const title  = list ? list.get('title') : id;
@@ -176,7 +177,7 @@ class ListTimeline extends React.PureComponent {
           pinned={pinned}
           multiColumn={multiColumn}
         >
-          <div className='column-header__links'>
+          <div className='column-settings__row column-header__links'>
             <button className='text-btn column-header__setting-btn' tabIndex='0' onClick={this.handleEditClick}>
               <Icon id='pencil' /> <FormattedMessage id='lists.edit' defaultMessage='Edit list' />
             </button>
@@ -184,25 +185,20 @@ class ListTimeline extends React.PureComponent {
             <button className='text-btn column-header__setting-btn' tabIndex='0' onClick={this.handleDeleteClick}>
               <Icon id='trash' /> <FormattedMessage id='lists.delete' defaultMessage='Delete list' />
             </button>
-
-            { replies_policy !== undefined && (
-              <div>
-                <div className='column-settings__row'>
-                  <fieldset>
-                    <legend><FormattedMessage id='lists.replies_policy.title' defaultMessage='Show replies to:' /></legend>
-                    { ['no_replies', 'list_replies', 'all_replies'].map(policy => (
-                      <div className='setting-radio'>
-                        <input className='setting-radio__input' id={['setting', 'radio', id, policy].join('-')} type='radio' value={policy} checked={replies_policy === policy} onChange={this.handleRepliesPolicyChange} />
-                        <label className='setting-radio__label' htmlFor={['setting', 'radio', id, policy].join('-')}>
-                          <FormattedMessage {...messages[policy]} />
-                        </label>
-                      </div>
-                    ))}
-                  </fieldset>
-                </div>
-              </div>
-            )}
           </div>
+
+          { replies_policy !== undefined && (
+            <div role='group' aria-labelledby={`list-${id}-replies-policy`}>
+              <span id={`list-${id}-replies-policy`} className='column-settings__section'>
+                <FormattedMessage id='lists.replies_policy.title' defaultMessage='Show replies to:' />
+              </span>
+              <div className='column-settings__row'>
+                { ['no_replies', 'list_replies', 'all_replies'].map(policy => (
+                  <RadioButton name='order' value={policy} label={intl.formatMessage(messages[policy])} checked={replies_policy === policy} onChange={this.handleRepliesPolicyChange} />
+                ))}
+              </div>
+            </div>
+          )}
         </ColumnHeader>
 
         <StatusListContainer

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -19,9 +19,9 @@ import Icon from 'mastodon/components/icon';
 const messages = defineMessages({
   deleteMessage: { id: 'confirmations.delete_list.message', defaultMessage: 'Are you sure you want to permanently delete this list?' },
   deleteConfirm: { id: 'confirmations.delete_list.confirm', defaultMessage: 'Delete' },
-  all_replies:   { id: 'lists.replies_policy.all_replies', defaultMessage: 'any followed user' },
-  no_replies:    { id: 'lists.replies_policy.no_replies', defaultMessage: 'no one' },
-  list_replies:  { id: 'lists.replies_policy.list_replies', defaultMessage: 'members of the list' },
+  all_replies:   { id: 'lists.replies_policy.all_replies', defaultMessage: 'Any followed user' },
+  no_replies:    { id: 'lists.replies_policy.no_replies', defaultMessage: 'No one' },
+  list_replies:  { id: 'lists.replies_policy.list_replies', defaultMessage: 'Members of the list' },
 });
 
 const mapStateToProps = (state, props) => ({

--- a/app/javascript/mastodon/features/list_timeline/index.js
+++ b/app/javascript/mastodon/features/list_timeline/index.js
@@ -10,7 +10,7 @@ import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { connectListStream } from '../../actions/streaming';
 import { expandListTimeline } from '../../actions/timelines';
-import { fetchList, deleteList } from '../../actions/lists';
+import { fetchList, deleteList, updateList } from '../../actions/lists';
 import { openModal } from '../../actions/modal';
 import MissingIndicator from '../../components/missing_indicator';
 import LoadingIndicator from '../../components/loading_indicator';
@@ -19,6 +19,9 @@ import Icon from 'mastodon/components/icon';
 const messages = defineMessages({
   deleteMessage: { id: 'confirmations.delete_list.message', defaultMessage: 'Are you sure you want to permanently delete this list?' },
   deleteConfirm: { id: 'confirmations.delete_list.confirm', defaultMessage: 'Delete' },
+  all_replies:   { id: 'lists.replies_policy.all_replies', defaultMessage: 'to any followed user' },
+  no_replies:    { id: 'lists.replies_policy.no_replies', defaultMessage: 'none' },
+  list_replies:  { id: 'lists.replies_policy.list_replies', defaultMessage: 'only to list' },
 });
 
 const mapStateToProps = (state, props) => ({
@@ -131,11 +134,19 @@ class ListTimeline extends React.PureComponent {
     }));
   }
 
+  handleRepliesPolicyClick = () => {
+    const { dispatch, list } = this.props;
+    const { id } = this.props.params;
+    const replies_policy = { 'all_replies': 'no_replies', 'no_replies': 'list_replies', 'list_replies': 'all_replies' }[list.get('replies_policy')];
+    dispatch(updateList(id, undefined, false, replies_policy));
+  }
+
   render () {
-    const { shouldUpdateScroll, hasUnread, columnId, multiColumn, list } = this.props;
+    const { shouldUpdateScroll, hasUnread, columnId, multiColumn, list, intl } = this.props;
     const { id } = this.props.params;
     const pinned = !!columnId;
     const title  = list ? list.get('title') : id;
+    const replies_policy = list ? list.get('replies_policy') : undefined;
 
     if (typeof list === 'undefined') {
       return (
@@ -174,6 +185,12 @@ class ListTimeline extends React.PureComponent {
             <button className='text-btn column-header__setting-btn' tabIndex='0' onClick={this.handleDeleteClick}>
               <Icon id='trash' /> <FormattedMessage id='lists.delete' defaultMessage='Delete list' />
             </button>
+
+            { replies_policy !== undefined && (
+              <button className='text-btn column-header__setting-btn' tabIndex='0' onClick={this.handleRepliesPolicyClick}>
+                <i className='fa fa-reply' /> <FormattedMessage id='lists.replies_policy.title' defaultMessage='Show replies: {policy}' values={{ policy: intl.formatMessage(messages[replies_policy]) }} />
+              </button>
+            )}
           </div>
         </ColumnHeader>
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3864,33 +3864,11 @@ a.status-card.compact:hover {
   line-height: 24px;
 }
 
-.setting-toggle__label,
-.setting-radio__label {
+.setting-toggle__label {
   color: $darker-text-color;
   display: inline-block;
   margin-bottom: 14px;
   margin-left: 8px;
-  vertical-align: middle;
-}
-
-.setting-radio {
-  display: block;
-  line-height: 18px;
-}
-
-.setting-radio__label {
-  margin-bottom: 0;
-}
-
-.column-settings__row legend {
-  color: $darker-text-color;
-  cursor: default;
-  display: block;
-  font-weight: 500;
-  margin-top: 10px;
-}
-
-.setting-radio__input {
   vertical-align: middle;
 }
 
@@ -5977,6 +5955,10 @@ a.status-card.compact:hover {
   .radio-button {
     display: block;
   }
+}
+
+.column-settings__row .radio-button {
+  display: block;
 }
 
 .radio-button {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3864,11 +3864,33 @@ a.status-card.compact:hover {
   line-height: 24px;
 }
 
-.setting-toggle__label {
+.setting-toggle__label,
+.setting-radio__label {
   color: $darker-text-color;
   display: inline-block;
   margin-bottom: 14px;
   margin-left: 8px;
+  vertical-align: middle;
+}
+
+.setting-radio {
+  display: block;
+  line-height: 18px;
+}
+
+.setting-radio__label {
+  margin-bottom: 0;
+}
+
+.column-settings__row legend {
+  color: $darker-text-color;
+  cursor: default;
+  display: block;
+  font-weight: 500;
+  margin-top: 10px;
+}
+
+.setting-radio__input {
   vertical-align: middle;
 }
 

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -49,7 +49,8 @@ class FeedManager
   def push_to_list(list, status)
     if status.reply? && status.in_reply_to_account_id != status.account_id
       should_filter = status.in_reply_to_account_id != list.account_id
-      should_filter &&= !ListAccount.where(list_id: list.id, account_id: status.in_reply_to_account_id).exists?
+      should_filter &&= !list.show_all_replies?
+      should_filter &&= !(list.show_list_replies? && ListAccount.where(list_id: list.id, account_id: status.in_reply_to_account_id).exists?)
       return false if should_filter
     end
 

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -3,17 +3,20 @@
 #
 # Table name: lists
 #
-#  id         :bigint(8)        not null, primary key
-#  account_id :bigint(8)        not null
-#  title      :string           default(""), not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id             :bigint(8)        not null, primary key
+#  account_id     :bigint(8)        not null
+#  title          :string           default(""), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  replies_policy :integer          default("list_replies"), not null
 #
 
 class List < ApplicationRecord
   include Paginable
 
   PER_ACCOUNT_LIMIT = 50
+
+  enum replies_policy: [:list_replies, :all_replies, :no_replies], _prefix: :show
 
   belongs_to :account, optional: true
 

--- a/app/serializers/rest/list_serializer.rb
+++ b/app/serializers/rest/list_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::ListSerializer < ActiveModel::Serializer
-  attributes :id, :title
+  attributes :id, :title, :replies_policy
 
   def id
     object.id.to_s

--- a/db/migrate/20181127165847_add_show_replies_to_lists.rb
+++ b/db/migrate/20181127165847_add_show_replies_to_lists.rb
@@ -1,0 +1,23 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddShowRepliesToLists < ActiveRecord::Migration[5.2]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_column_with_default(
+        :lists,
+        :replies_policy,
+        :integer,
+        allow_null: false,
+        default: 0
+      )
+    end
+  end
+
+  def down
+    remove_column :lists, :replies_policy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -468,6 +468,7 @@ ActiveRecord::Schema.define(version: 2020_06_30_190544) do
     t.string "title", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "replies_policy", default: 0, null: false
     t.index ["account_id"], name: "index_lists_on_account_id"
   end
 


### PR DESCRIPTION
There are three possible settings:
- Don't show replies (same behavior as Mastodon 2.6)
- Show all replies to followed users (same behavior as Mastodon < 2.6)
- Show only replies to users in the list (default)

Changing is done by ~~clicking on the link, which cycles between the settings (yeah, that's not great UI)~~ a set of radio buttons.

~~Note that only “show all replies” shows mentions to yourself. That could probably be changed.~~
All settings show replies to yourself.