### PR TITLE
Check for empty "last_status" before sorting DM column

### DIFF
--- a/app/javascript/mastodon/reducers/conversations.js
+++ b/app/javascript/mastodon/reducers/conversations.js
@@ -56,7 +56,13 @@ const expandNormalizedConversations = (state, conversations, next) => {
 
         list = list.concat(items);
 
-        return list.sortBy(x => x.get('last_status'), (a, b) => { if(a === null || b === null) return -1; compareId(a, b) * -1});
+        return list.sortBy(x => x.get('last_status'), (a, b) => {
+          if(a === null || b === null) {
+            return -1;
+          }
+
+          return compareId(a, b) * -1;
+        });
       });
     }
 

--- a/app/javascript/mastodon/reducers/conversations.js
+++ b/app/javascript/mastodon/reducers/conversations.js
@@ -56,7 +56,7 @@ const expandNormalizedConversations = (state, conversations, next) => {
 
         list = list.concat(items);
 
-        return list.sortBy(x => x.get('last_status'), (a, b) => compareId(a, b) * -1);
+        return list.sortBy(x => x.get('last_status'), (a, b) => { if(a === null || b === null) return -1; compareId(a, b) * -1});
       });
     }
 


### PR DESCRIPTION
This is considered a quick-fix for empty DM columns and a follow-up for #9170

Fix #9199 
