### PR TITLE
Fix loading indicator inconsistency

### DIFF
--- a/app/javascript/mastodon/actions/custom_emojis.js
+++ b/app/javascript/mastodon/actions/custom_emojis.js
@@ -19,6 +19,7 @@ export function fetchCustomEmojis() {
 export function fetchCustomEmojisRequest() {
   return {
     type: CUSTOM_EMOJIS_FETCH_REQUEST,
+    skipLoading: true,
   };
 };
 
@@ -26,6 +27,7 @@ export function fetchCustomEmojisSuccess(custom_emojis) {
   return {
     type: CUSTOM_EMOJIS_FETCH_SUCCESS,
     custom_emojis,
+    skipLoading: true,
   };
 };
 
@@ -33,5 +35,6 @@ export function fetchCustomEmojisFail(error) {
   return {
     type: CUSTOM_EMOJIS_FETCH_FAIL,
     error,
+    skipLoading: true,
   };
 };

--- a/app/javascript/mastodon/actions/favourites.js
+++ b/app/javascript/mastodon/actions/favourites.js
@@ -30,6 +30,7 @@ export function fetchFavouritedStatuses() {
 export function fetchFavouritedStatusesRequest() {
   return {
     type: FAVOURITED_STATUSES_FETCH_REQUEST,
+    skipLoading: true,
   };
 };
 
@@ -38,6 +39,7 @@ export function fetchFavouritedStatusesSuccess(statuses, next) {
     type: FAVOURITED_STATUSES_FETCH_SUCCESS,
     statuses,
     next,
+    skipLoading: true,
   };
 };
 
@@ -45,6 +47,7 @@ export function fetchFavouritedStatusesFail(error) {
   return {
     type: FAVOURITED_STATUSES_FETCH_FAIL,
     error,
+    skipLoading: true,
   };
 };
 

--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -63,6 +63,7 @@ const parseTags = (tags = {}, mode) => {
 export function expandTimeline(timelineId, path, params = {}, done = noOp) {
   return (dispatch, getState) => {
     const timeline = getState().getIn(['timelines', timelineId], ImmutableMap());
+    const isLoadingMore = !!params.max_id;
 
     if (timeline.get('isLoading')) {
       done();
@@ -73,15 +74,15 @@ export function expandTimeline(timelineId, path, params = {}, done = noOp) {
       params.since_id = timeline.getIn(['items', 0]);
     }
 
-    dispatch(expandTimelineRequest(timelineId));
+    dispatch(expandTimelineRequest(timelineId, isLoadingMore));
 
     api(getState).get(path, { params }).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
       dispatch(importFetchedStatuses(response.data));
-      dispatch(expandTimelineSuccess(timelineId, response.data, next ? next.uri : null, response.code === 206));
+      dispatch(expandTimelineSuccess(timelineId, response.data, next ? next.uri : null, response.code === 206, isLoadingMore));
       done();
     }).catch(error => {
-      dispatch(expandTimelineFail(timelineId, error));
+      dispatch(expandTimelineFail(timelineId, error, isLoadingMore));
       done();
     });
   };
@@ -103,31 +104,31 @@ export const expandHashtagTimeline         = (hashtag, { maxId, tags } = {}, don
   }, done);
 };
 
-export function expandTimelineRequest(timeline) {
+export function expandTimelineRequest(timeline, isLoadingMore) {
   return {
     type: TIMELINE_EXPAND_REQUEST,
     timeline,
-    skipLoading: true,
+    skipLoading: !isLoadingMore,
   };
 };
 
-export function expandTimelineSuccess(timeline, statuses, next, partial) {
+export function expandTimelineSuccess(timeline, statuses, next, partial, isLoadingMore) {
   return {
     type: TIMELINE_EXPAND_SUCCESS,
     timeline,
     statuses,
     next,
     partial,
-    skipLoading: true,
+    skipLoading: !isLoadingMore,
   };
 };
 
-export function expandTimelineFail(timeline, error) {
+export function expandTimelineFail(timeline, error, isLoadingMore) {
   return {
     type: TIMELINE_EXPAND_FAIL,
     timeline,
     error,
-    skipLoading: true,
+    skipLoading: !isLoadingMore,
   };
 };
 

--- a/app/javascript/mastodon/features/notifications/index.js
+++ b/app/javascript/mastodon/features/notifications/index.js
@@ -153,6 +153,7 @@ class Notifications extends React.PureComponent {
         scrollKey={`notifications-${columnId}`}
         trackScroll={!pinned}
         isLoading={isLoading}
+        showLoading={isLoading && notifications.size === 0}
         hasMore={hasMore}
         emptyMessage={emptyMessage}
         onLoadMore={this.handleLoadOlder}


### PR DESCRIPTION
Follow-up to #9224

- When fetching more items through infinite scroll, use global indicator again
- Remove loading indicator for the custom emojis fetch request
- Use local loading indicator for notifications

This eliminates the global loading indicator from the initial page load completely!