### PR TITLE
Add support for SVG custom emoji

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -230,3 +230,8 @@ STREAMING_CLUSTER_NUM=1
 # http_proxy=http://gateway.local:8118
 # Access control for hidden service.
 # ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
+
+# Allow unsafe uploads such as SVG files. Only do that if you are confident your
+# media server uses a sufficiently secure configuration (Content-Security-Policy
+# disallowing scripts execution, ideally using a separate domain name.
+# ALLOW_UNSAFE_UPLOADS=true

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -29,11 +29,11 @@ class CustomEmoji < ApplicationRecord
 
   has_one :local_counterpart, -> { where(domain: nil) }, class_name: 'CustomEmoji', primary_key: :shortcode, foreign_key: :shortcode
 
-  has_attached_file :image, styles: { static: { format: 'png', convert_options: '-coalesce -strip' } }
+  has_attached_file :image, styles: { static: { format: 'png', source_file_options: '-channel rgba -background "rgba(0,0,0,0)"', convert_options: '-coalesce -strip' } }
 
   before_validation :downcase_domain
 
-  validates_attachment :image, content_type: { content_type: 'image/png' }, presence: true, size: { less_than: LIMIT }
+  validates_attachment :image, content_type: { content_type: ['image/png', 'image/svg+xml', 'image/svg'] }, presence: true, size: { less_than: LIMIT }
   validates :shortcode, uniqueness: { scope: :domain }, format: { with: /\A#{SHORTCODE_RE_FRAGMENT}\z/ }, length: { minimum: 2 }
 
   scope :local,      -> { where(domain: nil) }

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -29,7 +29,14 @@ class CustomEmoji < ApplicationRecord
 
   has_one :local_counterpart, -> { where(domain: nil) }, class_name: 'CustomEmoji', primary_key: :shortcode, foreign_key: :shortcode
 
-  has_attached_file :image, styles: { static: { format: 'png', source_file_options: '-channel rgba -background "rgba(0,0,0,0)"', convert_options: '-coalesce -strip' } }
+  has_attached_file :image, styles: {
+    static: {
+      format: 'png',
+      source_file_options: '-channel rgba -background "rgba(0,0,0,0)"',
+      convert_options: '-coalesce -strip',
+      geometry: '200x200>',
+    },
+  }
 
   before_validation :downcase_domain
 

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -49,9 +49,10 @@ server {
     try_files $uri @proxy;
   }
 
-  location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
+  location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files|system/custom_emojis/images) {
     add_header Cache-Control "public, max-age=31536000, immutable";
     add_header Strict-Transport-Security "max-age=31536000";
+    add_header Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; media-src data:; img-src 'self' data:";
     try_files $uri @proxy;
   }
 

--- a/nanobox/nginx-web.conf.erb
+++ b/nanobox/nginx-web.conf.erb
@@ -47,8 +47,10 @@ http {
             try_files $uri @rails;
         }
 
-        location ~ ^/(emoji|packs|system/media_attachments/files|system/accounts/avatars) {
+        location ~ ^/(emoji|packs|system/media_attachments/files|system/accounts/avatars|system/custom_emojis/images) {
             add_header Cache-Control "public, max-age=31536000, immutable";
+            add_header Strict-Transport-Security "max-age=31536000";
+            add_header Content-Security-Policy "default-src 'none'; style-src 'unsafe-inline'; media-src data:; img-src 'self' data:";
             try_files $uri @rails;
         }
 


### PR DESCRIPTION
Add support for SVG custom emoji. SVG are always rasterized to provide an animation-less version.
In addition, unless the `ALLOW_UNSAFE_UPLOADS` environment variable is set to `true`, the “original” version is rasterized too, losing potential animations and other advantages of SVG (but accepting SVG emojis issued by other software).

In case `ALLOW_UNSAFE_UPLOADS` is set to `true` (which should only be done by and admin after they have reviewed their config to avoid potential XSS attacks), the original version of the emoji is copied as is, enjoying vector graphics and potential SVG animations.