### PR TITLE
Change the password form order

### DIFF
--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -321,7 +321,7 @@
   "status.show_less_all": "全て隠す",
   "status.show_more": "もっと見る",
   "status.show_more_all": "全て見る",
-  "status.show_thread": "続きを読む",
+  "status.show_thread": "スレッドを表示",
   "status.unmute_conversation": "会話のミュートを解除",
   "status.unpin": "プロフィールの固定表示を解除",
   "suggestions.dismiss": "隠す",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -321,7 +321,7 @@
   "status.show_less_all": "全て隠す",
   "status.show_more": "もっと見る",
   "status.show_more_all": "全て見る",
-  "status.show_thread": "スレッドを表示",
+  "status.show_thread": "続きを読む",
   "status.unmute_conversation": "会話のミュートを解除",
   "status.unpin": "プロフィールの固定表示を解除",
   "suggestions.dismiss": "隠す",

--- a/app/views/auth/registrations/edit.html.haml
+++ b/app/views/auth/registrations/edit.html.haml
@@ -9,13 +9,14 @@
       = f.input :email, wrapper: :with_label, input_html: { 'aria-label' => t('simple_form.labels.defaults.email') }, required: true, hint: false
 
     .fields-group
-      = f.input :password, wrapper: :with_label, input_html: { 'aria-label' => t('simple_form.labels.defaults.new_password'), :autocomplete => 'off' }, hint: false
+      = f.input :current_password, wrapper: :with_label, input_html: { 'aria-label' => t('simple_form.labels.defaults.current_password'), :autocomplete => 'off' }, required: true
+
+    .fields-group
+      = f.input :password, wrapper: :with_label, label: t('simple_form.labels.defaults.new_password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.new_password'), :autocomplete => 'off' }, hint: false
 
     .fields-group
       = f.input :password_confirmation, wrapper: :with_label, label: t('simple_form.labels.defaults.confirm_new_password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_new_password'), :autocomplete => 'off' }
 
-    .fields-group
-      = f.input :current_password, wrapper: :with_label, input_html: { 'aria-label' => t('simple_form.labels.defaults.current_password'), :autocomplete => 'off' }, required: true
 
     .actions
       = f.button :button, t('generic.save_changes'), type: :submit


### PR DESCRIPTION
Change the order of password change form on Preferences -> Security page.

I think that in the many password change form, the current password -> new password is in order.

With this change, I think that we can reduce the case of failing to change the password.

Also fixes the problem where translation of "New password" is not applied to label.

Before:
<img width="1171" alt="2018-11-12 21 39 33" src="https://user-images.githubusercontent.com/766076/48348476-d5381100-e6c4-11e8-8928-84b1fc55a64b.png">
After:
<img width="1171" alt="2018-11-12 20 54 38" src="https://user-images.githubusercontent.com/766076/48348506-e6811d80-e6c4-11e8-8239-1d685b1308fd.png">
