### PR TITLE
Fix "tootctl media remove" can't count the file size

### DIFF
--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -50,10 +50,10 @@ module Mastodon
       else
         MediaAttachment.where.not(remote_url: '').where.not(file_file_name: nil).where('created_at < ?', time_ago).reorder(nil).find_in_batches do |media_attachments|
           media_attachments.each do |m|
+            size      += m.file_file_size || 0
             Maintenance::UncacheMediaWorker.new.perform(m) unless options[:dry_run]
             options[:verbose] ? say(m.id) : say('.', :green, false)
             processed += 1
-            size      += m.file_file_size || 0
           end
         end
       end

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -50,7 +50,7 @@ module Mastodon
       else
         MediaAttachment.where.not(remote_url: '').where.not(file_file_name: nil).where('created_at < ?', time_ago).reorder(nil).find_in_batches do |media_attachments|
           media_attachments.each do |m|
-            size      += m.file_file_size || 0
+            size += m.file_file_size || 0
             Maintenance::UncacheMediaWorker.new.perform(m) unless options[:dry_run]
             options[:verbose] ? say(m.id) : say('.', :green, false)
             processed += 1


### PR DESCRIPTION
Fixed an issue where "tootctl media remove" can not count the file size.