### PR TITLE
Prevent multiple handlers for Delete of Actor from running at the same time

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -129,4 +129,10 @@ class ActivityPub::Activity
       ::FetchRemoteStatusService.new.call(@object['url'])
     end
   end
+
+  def lock_or_return(key, expire_after = 7.days.seconds)
+    yield if redis.set(key, true, nx: true, ex: expire_after)
+  ensure
+    redis.del(key)
+  end
 end

--- a/app/lib/activitypub/activity/delete.rb
+++ b/app/lib/activitypub/activity/delete.rb
@@ -12,8 +12,10 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
   private
 
   def delete_person
-    SuspendAccountService.new.call(@account)
-    @account.destroy!
+    lock_or_return("delete_in_progress:#{@account.id}") do
+      SuspendAccountService.new.call(@account)
+      @account.destroy!
+    end
   end
 
   def delete_note


### PR DESCRIPTION
Two `SuspendAccountService` should not run at the same time for the same account