### PR TITLE
Touch account on successful response, change char shown when culled

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -242,8 +242,9 @@ module Mastodon
           end
 
           culled += 1
-          say('.', :green, false)
+          say('+', :green, false)
         else
+          account.touch # Touch account even during dry run to avoid getting the account into the window again
           say('.', nil, false)
         end
       end


### PR DESCRIPTION
Just the color is not enough change since not everyone uses colored
terminals.
Touching the account makes it so that the account is not in the
threshold window in case of running again