### PR TITLE
WebSub: ATOM before RSS

### DIFF
--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -8,8 +8,8 @@
     %meta{ name: 'robots', content: 'noindex' }/
 
   %link{ rel: 'salmon', href: api_salmon_url(@account.id) }/
-  %link{ rel: 'alternate', type: 'application/rss+xml', href: account_url(@account, format: 'rss') }/
   %link{ rel: 'alternate', type: 'application/atom+xml', href: account_url(@account, format: 'atom') }/
+  %link{ rel: 'alternate', type: 'application/rss+xml', href: account_url(@account, format: 'rss') }/
   %link{ rel: 'alternate', type: 'application/activity+json', href: ActivityPub::TagManager.instance.uri_for(@account) }/
 
   - if @older_url


### PR DESCRIPTION
Hello,
The ATOM feed contains the hub declaration for WebSub, but the RSS version does not.
Currently, the RSS version is declared first, and the ATOM version second.
RSS/ATOM clients typically pick whichever version comes first, and will thus not see the WebSub feature.
I therefore suggest putting the ATOM version first, as it is more feature-rich than its RSS counterpart is.

Clients not compatible with ATOM would not pick it anyway due to the different type attribute.

A more complicated alternative would be to declare the WebSub feature in the RSS version as well, using something like the following code, and ensuring that clients subscribed to the RSS version would receive PuSH updates just like those subscribed to the ATOM version.

```xml
<rss version="2.0" xmlns:webfeeds="http://webfeeds.org/rss/1.0" xmlns:atom="http://www.w3.org/2005/Atom">
	<channel>
		<atom:link rel="self" type="application/rss+xml" href="https://diaspodon.fr/users/test.rss"/>
		<atom:link rel="hub" href="https://diaspodon.fr/api/push"/>
	</channel>
</rss>
```