### PR TITLE
Revert connect timeout from 1s to 10s

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -94,7 +94,7 @@ class Request
   end
 
   def timeout
-    { connect: 1, read: 10, write: 10 }
+    { connect: 10, read: 10, write: 10 }
   end
 
   def http_client


### PR DESCRIPTION
The failure rate in Sidekiq is too high

Perhaps there could instead be a separate way to limit DNS timeouts, because it seems like the problem is that the connect timeout covers both DNS resolution and time to first byte?