### PR TITLE
Allow more than 4 attachments per status in the backend

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -67,7 +67,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         visibility: visibility_from_audience,
         thread: replied_to_status,
         conversation: conversation_from_uri(@object['conversation']),
-        media_attachment_ids: process_attachments.take(4).map(&:id),
+        media_attachment_ids: process_attachments.map(&:id),
       }
     end
   end


### PR DESCRIPTION
This commit allows more than 4 attachments per status in the backend. Such attachments were already processed, but not attached to any status.

Marked as WiP because changes to the WebUI would be needed to make more sense:
- [ ] Add a “and more” or something in the inline media gallery when there are more than 4 pics (the modal would allow seeing them all)
- [ ] Add a way to access all media when there are more than one and the first is a video