### PR TITLE
Fix connect timeout not being enforced

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -146,7 +146,7 @@ class Request
         time_slot = 10.0 / addresses.size
 
         addresses.each do |address|
-          ::Timeout::timeout(time_slot, HTTP::TimeoutError) do
+          ::Timeout.timeout(time_slot, HTTP::TimeoutError) do
             begin
               raise Mastodon::HostValidationError if PrivateAddressCheck.private_address?(IPAddr.new(address.ip_address))
               return super(address.ip_address, *args)

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -146,13 +146,14 @@ class Request
         time_slot = 10.0 / addresses.size
 
         addresses.each do |address|
-          ::Timeout.timeout(time_slot, HTTP::TimeoutError) do
-            begin
-              raise Mastodon::HostValidationError if PrivateAddressCheck.private_address?(IPAddr.new(address.ip_address))
+          begin
+            raise Mastodon::HostValidationError if PrivateAddressCheck.private_address?(IPAddr.new(address.ip_address))
+
+            ::Timeout.timeout(time_slot, HTTP::TimeoutError) do
               return super(address.ip_address, *args)
-            rescue => e
-              outer_e = e
             end
+          rescue => e
+            outer_e = e
           end
         end
 

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -45,7 +45,7 @@ class Request
     end
 
     begin
-      yield response.extend(ClientLimit)
+      yield response.extend(ClientLimit) if block_given?
     ensure
       http_client.close
     end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -48,9 +48,11 @@ describe Request do
       end
 
       it 'executes a HTTP request when the first address is private' do
-        allow(Addrinfo).to receive(:foreach).with('example.com', nil, nil, :SOCK_STREAM)
-                                            .and_yield(Addrinfo.new(["AF_INET", 0, "example.com", "0.0.0.0"], :PF_INET, :SOCK_STREAM))
-                                            .and_yield(Addrinfo.new(["AF_INET6", 0, "example.com", "2001:4860:4860::8844"], :PF_INET6, :SOCK_STREAM))
+        resolver = double
+
+        allow(resolver).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:4860:4860::8844))
+        allow(resolver).to receive(:timeouts=).and_return(nil)
+        allow(Resolv::DNS).to receive(:open).and_yield(resolver)
 
         expect { |block| subject.perform &block }.to yield_control
         expect(a_request(:get, 'http://example.com')).to have_been_made.once
@@ -81,7 +83,12 @@ describe Request do
       end
 
       it 'raises Mastodon::ValidationError' do
-        allow(Resolv::DNS).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:db8::face))
+        resolver = double
+
+        allow(resolver).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:db8::face))
+        allow(resolver).to receive(:timeouts=).and_return(nil)
+        allow(Resolv::DNS).to receive(:open).and_yield(resolver)
+
         expect { subject.perform }.to raise_error Mastodon::ValidationError
       end
     end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -81,9 +81,9 @@ describe Request do
       end
 
       it 'raises Mastodon::ValidationError' do
-        allow(Addrinfo).to receive(:foreach).with('example.com', nil, nil, :SOCK_STREAM)
-                                            .and_yield(Addrinfo.new(["AF_INET", 0, "example.com", "0.0.0.0"], :PF_INET, :SOCK_STREAM))
-                                            .and_yield(Addrinfo.new(["AF_INET6", 0, "example.com", "2001:db8::face"], :PF_INET6, :SOCK_STREAM))
+        allow(Addrinfo).to receive(:getaddrinfo).with('example.com', nil, nil, :SOCK_STREAM)
+                                            .and_return([Addrinfo.new(["AF_INET", 0, "example.com", "0.0.0.0"], :PF_INET, :SOCK_STREAM), Addrinfo.new(["AF_INET6", 0, "example.com", "2001:db8::face"], :PF_INET6, :SOCK_STREAM)])
+
         expect { subject.perform }.to raise_error Mastodon::ValidationError
       end
     end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -81,9 +81,7 @@ describe Request do
       end
 
       it 'raises Mastodon::ValidationError' do
-        allow(Addrinfo).to receive(:getaddrinfo).with('example.com', nil, nil, :SOCK_STREAM)
-                                            .and_return([Addrinfo.new(["AF_INET", 0, "example.com", "0.0.0.0"], :PF_INET, :SOCK_STREAM), Addrinfo.new(["AF_INET6", 0, "example.com", "2001:db8::face"], :PF_INET6, :SOCK_STREAM)])
-
+        allow(Resolv::DNS).to receive(:getaddresses).with('example.com').and_return(%w(0.0.0.0 2001:db8::face))
         expect { subject.perform }.to raise_error Mastodon::ValidationError
       end
     end


### PR DESCRIPTION
The loop was catching the timeout exception that should stop execution, so the next IP would no longer be within a timed block, which led to requests taking much longer than 10 seconds.

Regression from #6813

Now, the total timeout is 1 second for DNS look-up, and 10 seconds for socket opening, wherein 2 IPs are tried one after the other within those 10 seconds. So if there is only one IP, we wait 10 seconds, if there's two IPs, we wait 5 seconds each.