### PR TITLE
Redesign admin accounts index

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -95,7 +95,6 @@ module Admin
         :remote,
         :by_domain,
         :silenced,
-        :alphabetic,
         :suspended,
         :username,
         :display_name,

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -94,6 +94,7 @@ module Admin
         :local,
         :remote,
         :by_domain,
+        :active,
         :silenced,
         :suspended,
         :username,

--- a/app/helpers/admin/account_moderation_notes_helper.rb
+++ b/app/helpers/admin/account_moderation_notes_helper.rb
@@ -24,7 +24,7 @@ module Admin::AccountModerationNotesHelper
 
   def name_tag_classes(account, inline = false)
     classes = [inline ? 'inline-name-tag' : 'name-tag']
-    classes << 'suspended' if account.suspended?
+    classes << 'suspended' if account.suspended? || (account.local? && account.user.nil?)
     classes.join(' ')
   end
 end

--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Admin::FilterHelper
-  ACCOUNT_FILTERS      = %i(local remote by_domain silenced suspended alphabetic username display_name email ip staff).freeze
+  ACCOUNT_FILTERS      = %i(local remote by_domain active silenced suspended username display_name email ip staff).freeze
   REPORT_FILTERS       = %i(resolved account_id target_account_id).freeze
   INVITE_FILTER        = %i(available expired).freeze
   CUSTOM_EMOJI_FILTERS = %i(local remote by_domain shortcode).freeze

--- a/app/helpers/stream_entries_helper.rb
+++ b/app/helpers/stream_entries_helper.rb
@@ -34,12 +34,14 @@ module StreamEntriesHelper
     end
   end
 
-  def account_badge(account)
+  def account_badge(account, all: false)
     if account.bot?
       content_tag(:div, content_tag(:div, t('accounts.roles.bot'), class: 'account-role bot'), class: 'roles')
-    elsif Setting.show_staff_badge && account.user_staff?
+    elsif (Setting.show_staff_badge && account.user_staff?) || all
       content_tag(:div, class: 'roles') do
-        if account.user_admin?
+        if all && !account.user_staff?
+          content_tag(:div, t('admin.accounts.roles.user'), class: 'account-role')
+        elsif account.user_admin?
           content_tag(:div, t('accounts.roles.admin'), class: 'account-role admin')
         elsif account.user_moderator?
           content_tag(:div, t('accounts.roles.moderator'), class: 'account-role moderator')

--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -63,7 +63,7 @@ function main() {
       content.textContent = timeAgoString({
         formatMessage: ({ id, defaultMessage }, values) => (new IntlMessageFormat(messages[id] || defaultMessage, locale)).format(values),
         formatDate: (date, options) => (new Intl.DateTimeFormat(locale, options)).format(date),
-      }, datetime, now, datetime.getFullYear());
+      }, datetime, now, now.getFullYear());
     });
 
     const reactComponents = document.querySelectorAll('[data-component]');

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -123,6 +123,7 @@ class Account < ApplicationRecord
   scope :suspended, -> { where(suspended: true) }
   scope :without_suspended, -> { where(suspended: false) }
   scope :recent, -> { reorder(id: :desc) }
+  scope :bots, -> { where(actor_type: %w(Application Service)) }
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }
   scope :by_domain_accounts, -> { group(:domain).select(:domain, 'COUNT(*) AS accounts_count').order('accounts_count desc') }
   scope :matches_username, ->(value) { where(arel_table[:username].matches("#{value}%")) }

--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -5,19 +5,25 @@ class AccountFilter
 
   def initialize(params)
     @params = params
+    set_defaults!
   end
 
   def results
-    scope = Account.recent
+    scope = Account.recent.includes(:user)
 
     params.each do |key, value|
-      scope.merge!(scope_for(key, value)) if value.present?
+      scope.merge!(scope_for(key, value.to_s.strip)) if value.present?
     end
 
     scope
   end
 
   private
+
+  def set_defaults!
+    params['local']  = '1' if params['remote'].blank?
+    params['active'] = '1' if params['suspended'].blank? && params['silenced'].blank?
+  end
 
   def scope_for(key, value)
     case key.to_s
@@ -27,10 +33,10 @@ class AccountFilter
       Account.remote
     when 'by_domain'
       Account.where(domain: value)
+    when 'active'
+      Account.without_suspended
     when 'silenced'
       Account.silenced
-    when 'alphabetic'
-      Account.reorder(nil).alphabetic
     when 'suspended'
       Account.suspended
     when 'username'
@@ -40,11 +46,7 @@ class AccountFilter
     when 'email'
       accounts_with_users.merge User.matches_email(value)
     when 'ip'
-      if valid_ip?(value)
-        accounts_with_users.merge User.with_recent_ip_address(value)
-      else
-        Account.default_scoped
-      end
+      valid_ip?(value) ? accounts_with_users.merge(User.with_recent_ip_address(value)) : Account.none
     when 'staff'
       accounts_with_users.merge User.staff
     else
@@ -57,8 +59,7 @@ class AccountFilter
   end
 
   def valid_ip?(value)
-    IPAddr.new(value)
-    true
+    IPAddr.new(value) && true
   rescue IPAddr::InvalidAddressError
     false
   end

--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -46,7 +46,7 @@ class AccountFilter
     when 'email'
       accounts_with_users.merge User.matches_email(value)
     when 'ip'
-      valid_ip?(value) ? accounts_with_users.merge(User.with_recent_ip_address(value)) : Account.none
+      valid_ip?(value) ? accounts_with_users.where('users.current_sign_in_ip <<= ?', value) : Account.none
     when 'staff'
       accounts_with_users.merge User.staff
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,7 +83,6 @@ class User < ApplicationRecord
   scope :inactive, -> { where(arel_table[:current_sign_in_at].lt(ACTIVE_DURATION.ago)) }
   scope :active, -> { confirmed.where(arel_table[:current_sign_in_at].gteq(ACTIVE_DURATION.ago)).joins(:account).where(accounts: { suspended: false }) }
   scope :matches_email, ->(value) { where(arel_table[:email].matches("#{value}%")) }
-  scope :with_recent_ip_address, ->(value) { where(arel_table[:current_sign_in_ip].eq(value).or(arel_table[:last_sign_in_ip].eq(value))) }
 
   before_validation :sanitize_languages
 

--- a/app/views/admin/accounts/_account.html.haml
+++ b/app/views/admin/accounts/_account.html.haml
@@ -1,18 +1,15 @@
 %tr
-  %td.username
-    = account.username
   %td
-    - unless account.local?
-      = link_to account.domain, admin_accounts_path(by_domain: account.domain)
+    = admin_account_link_to(account)
   %td
-    - if account.local?
-      - if account.user.nil?
-        = t("admin.accounts.moderation.suspended")
-      - else
-        = t("admin.accounts.roles.#{account.user.role}")
+    %div{ style: 'margin: -2px 0' }= account_badge(account, all: true)
+  %td
+    - if account.user_current_sign_in_ip
+      %samp= account.user_current_sign_in_ip
     - else
-      = account.protocol.humanize
+      \-
   %td
-    = table_link_to 'circle', t('admin.accounts.web'), web_path("accounts/#{account.id}")
-    = table_link_to 'globe', t('admin.accounts.public'), TagManager.instance.url_for(account)
-    = table_link_to 'pencil', t('admin.accounts.edit'), admin_account_path(account.id)
+    - if account.user_current_sign_in_at
+      %time.time-ago{ datetime: account.user_current_sign_in_at.iso8601, title: l(account.user_current_sign_in_at) }= l account.user_current_sign_in_at
+    - else
+      \-

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -5,41 +5,19 @@
   .filter-subset
     %strong= t('admin.accounts.location.title')
     %ul
-      %li= filter_link_to t('admin.accounts.location.all'), local: nil, remote: nil
-      %li
-        - if selected? local: '1', remote: nil
-          = filter_link_to t('admin.accounts.location.local'), {local: nil, remote: nil}, {local: '1', remote: nil}
-        - else
-          = filter_link_to t('admin.accounts.location.local'), local: '1', remote: nil
-      %li
-        - if selected? remote: '1', local: nil
-          = filter_link_to t('admin.accounts.location.remote'), {remote: nil, local: nil}, {remote: '1', local: nil}
-        - else
-          = filter_link_to t('admin.accounts.location.remote'), remote: '1', local: nil
+      %li= filter_link_to t('admin.accounts.location.local'), remote: nil
+      %li= filter_link_to t('admin.accounts.location.remote'), remote: '1'
   .filter-subset
     %strong= t('admin.accounts.moderation.title')
     %ul
-      %li= filter_link_to t('admin.accounts.moderation.all'), silenced: nil, suspended: nil
-      %li
-        - if selected? silenced: '1'
-          = filter_link_to t('admin.accounts.moderation.silenced'), {silenced: nil}, {silenced: '1'}
-        - else
-          = filter_link_to t('admin.accounts.moderation.silenced'), silenced: '1'
-      %li
-        - if selected? suspended: '1'
-          = filter_link_to t('admin.accounts.moderation.suspended'), {suspended: nil}, {suspended: '1'}
-        - else
-          = filter_link_to t('admin.accounts.moderation.suspended'), suspended: '1'
+      %li= filter_link_to t('admin.accounts.moderation.active'), silenced: nil, suspended: nil
+      %li= filter_link_to t('admin.accounts.moderation.silenced'), silenced: '1', suspended: nil
+      %li= filter_link_to t('admin.accounts.moderation.suspended'), suspended: '1', silenced: nil
   .filter-subset
     %strong= t('admin.accounts.role')
     %ul
       %li= filter_link_to t('admin.accounts.moderation.all'), staff: nil
       %li= filter_link_to t('admin.accounts.roles.staff'), staff: '1'
-  .filter-subset
-    %strong= t('admin.accounts.order.title')
-    %ul
-      %li= filter_link_to t('admin.accounts.order.most_recent'), alphabetic: nil
-      %li= filter_link_to t('admin.accounts.order.alphabetic'), alphabetic: '1'
 
 = form_tag admin_accounts_url, method: 'GET', class: 'simple_form' do
   .fields-group
@@ -60,9 +38,9 @@
     %thead
       %tr
         %th= t('admin.accounts.username')
-        %th= t('admin.accounts.domain')
-        %th
-        %th
+        %th= t('admin.accounts.role')
+        %th= t('admin.accounts.most_recent_ip')
+        %th= t('admin.accounts.most_recent_activity')
     %tbody
       = render @accounts
 

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -68,7 +68,7 @@
               %time.formatted{ datetime: @account.user_current_sign_in_at.iso8601, title: l(@account.user_current_sign_in_at) }
                 = l @account.user_current_sign_in_at
             - else
-              Never
+              \-
       - else
         %tr
           %th= t('admin.accounts.profile_url')

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -115,10 +115,6 @@ ar:
       most_recent_ip: أحدث عنوان إيبي
       no_limits_imposed: مِن دون حدود مشروطة
       not_subscribed: غير مشترك
-      order:
-        alphabetic: أبجديًا
-        most_recent: الأحدث
-        title: الترتيب
       outbox_url: رابط صندوق الصادر
       perform_full_suspension: تعطيل
       profile_url: رابط الملف الشخصي

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -123,10 +123,6 @@ ca:
       most_recent_ip: IP més recent
       no_limits_imposed: Sense límits imposats
       not_subscribed: No subscrit
-      order:
-        alphabetic: Alfabètic
-        most_recent: Més recent
-        title: Ordre
       outbox_url: URL de la bústia de sortida
       perform_full_suspension: Suspèn
       profile_url: URL del perfil

--- a/config/locales/co.yml
+++ b/config/locales/co.yml
@@ -123,10 +123,6 @@ co:
       most_recent_ip: IP più ricente
       no_limits_imposed: Nisuna limita imposta
       not_subscribed: Micca abbunatu
-      order:
-        alphabetic: Alfabeticu
-        most_recent: Più ricente
-        title: Urdine
       outbox_url: URL di l’outbox
       perform_full_suspension: Suspende
       profile_url: URL di u prufile

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -115,10 +115,6 @@ cs:
       most_recent_ip: Nejnovější IP
       no_limits_imposed: Nejsou nastavena žádná omezení
       not_subscribed: Neodebírá
-      order:
-        alphabetic: Abecedně
-        most_recent: Nejnovější
-        title: Pořadí
       outbox_url: URL odchozích zpráv
       perform_full_suspension: Suspendovat
       profile_url: URL profilu

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -115,10 +115,6 @@ cy:
       most_recent_ip: IP diweddaraf
       no_limits_imposed: Dim terfynau wedi'i gosod
       not_subscribed: Heb danysgrifio
-      order:
-        alphabetic: Allfabetig
-        most_recent: Diweddaraf
-        title: Trefnu
       outbox_url: Allflwch URL
       perform_full_suspension: Atal
       profile_url: URL proffil

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -122,10 +122,6 @@ da:
       most_recent_activity: Seneste aktivitet
       most_recent_ip: Senest IP
       not_subscribed: Ikke abonneret
-      order:
-        alphabetic: Alfabetisk
-        most_recent: Seneste
-        title: Rækkefølge
       outbox_url: Link til udgående
       perform_full_suspension: Udeluk
       profile_url: Link til profil

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -123,10 +123,6 @@ de:
       most_recent_ip: Letzte IP-Adresse
       no_limits_imposed: Keine Limits eingesetzt
       not_subscribed: Nicht abonniert
-      order:
-        alphabetic: Alphabetisch
-        most_recent: Neueste
-        title: Sortierung
       outbox_url: Postausgangs-URL
       perform_full_suspension: Sperren
       profile_url: Profil-URL

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -123,10 +123,6 @@ el:
       most_recent_ip: Πιο πρόσφατη IP
       no_limits_imposed: Χωρίς όρια
       not_subscribed: Άνευ συνδρομής
-      order:
-        alphabetic: Αλφαβητικά
-        most_recent: Πιο πρόσφατα
-        title: Ταξινόμηση
       outbox_url: URL εξερχομένων
       perform_full_suspension: Κάνε πλήρη αναστολή
       profile_url: URL προφίλ

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,10 +123,6 @@ en:
       most_recent_ip: Most recent IP
       no_limits_imposed: No limits imposed
       not_subscribed: Not subscribed
-      order:
-        alphabetic: Alphabetic
-        most_recent: Most recent
-        title: Order
       outbox_url: Outbox URL
       perform_full_suspension: Suspend
       profile_url: Profile URL

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -112,10 +112,6 @@ eo:
       most_recent_activity: Lasta ago
       most_recent_ip: Lasta IP
       not_subscribed: Ne abonita
-      order:
-        alphabetic: Laŭalfabete
-        most_recent: Plej lastatempa
-        title: Ordo
       outbox_url: Elira URL
       perform_full_suspension: Tute haltigi
       profile_url: Profila URL

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -123,10 +123,6 @@ es:
       most_recent_ip: IP más reciente
       no_limits_imposed: Sin límites impuestos
       not_subscribed: No se está suscrito
-      order:
-        alphabetic: Alfabético
-        most_recent: Más reciente
-        title: Orden
       outbox_url: URL de bandeja de salida
       perform_full_suspension: Suspender
       profile_url: URL del perfil

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -123,10 +123,6 @@ eu:
       most_recent_ip: Azken IP-a
       no_limits_imposed: Ez da mugarik ezarri
       not_subscribed: Harpidetu gabe
-      order:
-        alphabetic: Alfabetikoa
-        most_recent: Azkena
-        title: Ordena
       outbox_url: Irteera ontziaren URL-a
       perform_full_suspension: Kanporatu
       profile_url: Profilaren URL-a

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -123,10 +123,6 @@ fa:
       most_recent_ip: آخرین IP ها
       no_limits_imposed: بدون محدودیت
       not_subscribed: عضو نیست
-      order:
-        alphabetic: الفبایی
-        most_recent: تازه‌ترین‌ها
-        title: ترتیب
       outbox_url: نشانی صندوق خروجی
       perform_full_suspension: تعلیق
       profile_url: نشانی نمایه

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -102,10 +102,6 @@ fi:
       most_recent_activity: Viimeisin toiminta
       most_recent_ip: Viimeisin IP
       not_subscribed: Ei tilaaja
-      order:
-        alphabetic: Aakkosjärjestys
-        most_recent: Uusin
-        title: Järjestys
       outbox_url: Lähtevän postilaatikon osoite
       perform_full_suspension: Siirrä kokonaan jäähylle
       profile_url: Profiilin osoite

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -123,10 +123,6 @@ fr:
       most_recent_ip: Adresse IP la plus récente
       no_limits_imposed: Aucune limite imposée
       not_subscribed: Non abonné
-      order:
-        alphabetic: Alphabétique
-        most_recent: Plus récent
-        title: Tri
       outbox_url: URL de sortie
       perform_full_suspension: Suspendre
       profile_url: URL du profil

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -123,10 +123,6 @@ gl:
       most_recent_ip: IP máis recente
       no_limits_imposed: Sen límites impostos
       not_subscribed: Non suscrita
-      order:
-        alphabetic: Alfabética
-        most_recent: Máis recente
-        title: Orde
       outbox_url: URL caixa de saída
       perform_full_suspension: Suspender
       profile_url: URL do perfil

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -95,10 +95,6 @@ he:
       most_recent_activity: פעילות עדכנית
       most_recent_ip: כתובות אחרונות
       not_subscribed: לא רשום
-      order:
-        alphabetic: אלפביתי
-        most_recent: עדכני
-        title: סידור
       outbox_url: כתובת תיבת דואר יוצא
       perform_full_suspension: ביצוע השעייה מלאה
       profile_url: כתובת פרופיל

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -92,10 +92,6 @@ hu:
       most_recent_activity: Legutóbbi tevékenységek
       most_recent_ip: Legutóbbi IP-cím
       not_subscribed: Nincs feliratkozás
-      order:
-        alphabetic: Alfabetikus
-        most_recent: Legutóbbi
-        title: Rendezés
       outbox_url: Kimenő üzenetek URL
       perform_full_suspension: Teljes felfüggesztés
       profile_url: Profil URL

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -50,10 +50,6 @@ id:
       most_recent_activity: Aktivitas terbaru
       most_recent_ip: IP terbaru
       not_subscribed: Tidak berlangganan
-      order:
-        alphabetic: Alfabetik
-        most_recent: Terbaru
-        title: Urutan
       perform_full_suspension: Lakukan suspen penuh
       profile_url: URL profil
       public: Publik

--- a/config/locales/io.yml
+++ b/config/locales/io.yml
@@ -44,10 +44,6 @@ io:
       most_recent_activity: Most recent activity
       most_recent_ip: Most recent IP
       not_subscribed: Not subscribed
-      order:
-        alphabetic: Alphabetic
-        most_recent: Most recent
-        title: Order
       perform_full_suspension: Perform full suspension
       profile_url: Profile URL
       public: Public

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -123,10 +123,6 @@ it:
       most_recent_ip: IP più recenti
       no_limits_imposed: Nessun limite imposto
       not_subscribed: Non sottoscritto
-      order:
-        alphabetic: Alfabetico
-        most_recent: Più recente
-        title: Ordine
       outbox_url: URL outbox
       perform_full_suspension: Sospendi
       profile_url: URL profilo

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -123,10 +123,6 @@ ja:
       most_recent_ip: 直近のIP
       no_limits_imposed: 制限なし
       not_subscribed: 購読していない
-      order:
-        alphabetic: アルファベット順
-        most_recent: 直近の活動順
-        title: 順序
       outbox_url: Outbox URL
       perform_full_suspension: 完全に活動停止させる
       profile_url: プロフィールURL

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -112,10 +112,6 @@ ka:
       most_recent_activity: უახლესი აქტივობა
       most_recent_ip: უახლესი აი-პი
       not_subscribed: გამოუწერელი
-      order:
-        alphabetic: ანბანური
-        most_recent: უახლესი
-        title: წესრიგი
       outbox_url: აუთბოქსის ურლ
       perform_full_suspension: მოახდინეთ სრული შეჩერება
       profile_url: პროფილის ურლ

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -123,10 +123,6 @@ ko:
       most_recent_ip: 최근 IP
       no_limits_imposed: 제한 없음
       not_subscribed: 구독하지 않음
-      order:
-        alphabetic: 알파벳 순
-        most_recent: 최근 순
-        title: 순서
       outbox_url: 발신함 URL
       perform_full_suspension: 정지시키기
       profile_url: 프로필 URL

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -123,10 +123,6 @@ nl:
       most_recent_ip: Laatst gebruikt IP-adres
       no_limits_imposed: Geen limieten ingesteld
       not_subscribed: Niet geabonneerd
-      order:
-        alphabetic: Alfabetisch
-        most_recent: Meest recent
-        title: Sorteren
       outbox_url: Outbox-URL
       perform_full_suspension: Opschorten
       profile_url: Profiel-URL

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -92,10 +92,6 @@
       most_recent_activity: Nyligste aktivitet
       most_recent_ip: Nyligste IP
       not_subscribed: Ikke abonnért
-      order:
-        alphabetic: Alfabetisk
-        most_recent: Nyligst
-        title: Rekkefølge
       outbox_url: Utboks URL
       perform_full_suspension: Utfør full utvisning
       profile_url: Profil-URL

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -123,10 +123,6 @@ oc:
       most_recent_ip: IP mai recenta
       no_limits_imposed: Cap de limit impausat
       not_subscribed: Pas seguidor
-      order:
-        alphabetic: Alfabetic
-        most_recent: Mai recent
-        title: Ordre
       outbox_url: URL Outbox
       perform_full_suspension: Suspendre
       profile_url: URL del perfil

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -131,10 +131,6 @@ pl:
       most_recent_ip: Ostatnie IP
       no_limits_imposed: Nie nałożono ograniczeń
       not_subscribed: Nie zasubskrybowano
-      order:
-        alphabetic: Alfabetycznie
-        most_recent: Najnowsze
-        title: Kolejność
       outbox_url: Adres skrzynki nadawczej
       perform_full_suspension: Zawieś
       profile_url: Adres profilu

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -123,10 +123,6 @@ pt-BR:
       most_recent_ip: IP mais recente
       no_limits_imposed: Nenhum limite imposto
       not_subscribed: Não está inscrito
-      order:
-        alphabetic: Alfabética
-        most_recent: Mais recente
-        title: Ordem
       outbox_url: URL da caixa de saída
       perform_full_suspension: Suspender
       profile_url: URL do perfil

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -92,10 +92,6 @@ pt:
       most_recent_activity: Actividade mais recente
       most_recent_ip: IP mais recente
       not_subscribed: Não inscrito
-      order:
-        alphabetic: Alfabética
-        most_recent: Mais recente
-        title: Ordem
       outbox_url: URL da caixa de saída
       perform_full_suspension: Fazer suspensão completa
       profile_url: URL do perfil

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -128,10 +128,6 @@ ru:
       most_recent_activity: Последняя активность
       most_recent_ip: Последний IP
       not_subscribed: Не подписаны
-      order:
-        alphabetic: По алфавиту
-        most_recent: По дате
-        title: Порядок
       outbox_url: URL исходящих
       perform_full_suspension: Полная блокировка
       profile_url: URL профиля

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -113,10 +113,6 @@ sk:
       most_recent_activity: Posledná aktivita
       most_recent_ip: Posledná IP
       not_subscribed: Nezaregistrované
-      order:
-        alphabetic: Abecedne
-        most_recent: Podľa času
-        title: Zoradiť
       outbox_url: URL poslaných
       perform_full_suspension: Suspendovať
       profile_url: URL profilu

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -102,10 +102,6 @@ sl:
       moderation_notes: Opombe moderiranja
       most_recent_activity: Zadnja aktivnost
       most_recent_ip: Zadnji IP
-      order:
-        alphabetic: Po abecedi
-        most_recent: Najnovejše
-        title: Red
       promote: Spodbujanje
   remote_interaction:
     prompt: 'Želite interakcijo s tem trobom:'

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -92,10 +92,6 @@ sr-Latn:
       most_recent_activity: Najskorija aktivnost
       most_recent_ip: Najskorija IP adresa
       not_subscribed: Nije pretplaćen
-      order:
-        alphabetic: Abecedni
-        most_recent: Najskoriji
-        title: Redosled
       outbox_url: Odlazno sanduče
       perform_full_suspension: Izvrši kompletno isključenje
       profile_url: Adresa profila

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -113,10 +113,6 @@ sr:
       most_recent_activity: Најскорија активност
       most_recent_ip: Најскорија IP адреса
       not_subscribed: Није претплаћен
-      order:
-        alphabetic: Абецедни
-        most_recent: Најскорији
-        title: Редослед
       outbox_url: Одлазно сандуче
       perform_full_suspension: Изврши комплетно искључење
       profile_url: Адреса профила

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -103,10 +103,6 @@ sv:
       most_recent_activity: Senaste aktivitet
       most_recent_ip: Senaste IP
       not_subscribed: Inte prenumererat
-      order:
-        alphabetic: Alfabetiskt
-        most_recent: Senaste
-        title: Ordning
       outbox_url: Utkorg URL
       perform_full_suspension: Utför full avstängning
       profile_url: Profil URL

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -49,10 +49,6 @@ th:
       most_recent_activity: กิจกรรมล่าสุด
       most_recent_ip: IP ล่าสุด
       not_subscribed: Not subscribed
-      order:
-        alphabetic: ตามตัวอักษร
-        most_recent: ล่าสุด
-        title: จัดเรียง
       perform_full_suspension: Perform full suspension
       profile_url: Profile URL
       public: สาธารณะ

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -48,10 +48,6 @@ tr:
       most_recent_activity: Son aktivite
       most_recent_ip: Son IP
       not_subscribed: Abone edilmedi
-      order:
-        alphabetic: Alfabetik
-        most_recent: En son
-        title: Sıralama
       perform_full_suspension: Tamamen uzaklaştır
       profile_url: Profil linki
       public: Herkese açık

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -108,10 +108,6 @@ uk:
       most_recent_activity: Остання активність
       most_recent_ip: Останній IP
       not_subscribed: Не підписані
-      order:
-        alphabetic: За алфавітом
-        most_recent: За датою
-        title: Порядок
       outbox_url: Вихідний URL
       perform_full_suspension: Повне блокування
       profile_url: URL профілю

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -114,10 +114,6 @@ zh-CN:
       most_recent_activity: 最后一次活跃的时间
       most_recent_ip: 最后一次活跃的 IP 地址
       not_subscribed: 未订阅
-      order:
-        alphabetic: 按字母
-        most_recent: 按时间
-        title: 排序
       outbox_url: 发件箱（Outbox）URL
       perform_full_suspension: 永久封禁
       profile_url: 个人资料页面 URL

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -103,10 +103,6 @@ zh-HK:
       most_recent_activity: 最新活動
       most_recent_ip: 最新 IP 位域
       not_subscribed: 未訂閱
-      order:
-        alphabetic: 按字母
-        most_recent: 按時間
-        title: 排序
       outbox_url: 寄件箱（Outbox）URL
       perform_full_suspension: 完全停權
       profile_url: 個人檔案 URL

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -108,10 +108,6 @@ zh-TW:
       most_recent_activity: 最近活動
       most_recent_ip: 最近 IP 位址
       not_subscribed: 未訂閱
-      order:
-        alphabetic: 按字母
-        most_recent: 按時間
-        title: 排序
       outbox_url: 寄件箱 (Outbox) URL
       perform_full_suspension: 進行停權
       profile_url: 個人檔案 URL

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Admin::AccountsController, type: :controller do
         expect(h[:local]).to eq '1'
         expect(h[:remote]).to eq '1'
         expect(h[:by_domain]).to eq 'domain'
+        expect(h[:active]).to eq '1'
         expect(h[:silenced]).to eq '1'
-        expect(h[:alphabetic]).to eq '1'
         expect(h[:suspended]).to eq '1'
         expect(h[:username]).to eq 'username'
         expect(h[:display_name]).to eq 'display name'
@@ -39,8 +39,8 @@ RSpec.describe Admin::AccountsController, type: :controller do
         local: '1',
         remote: '1',
         by_domain: 'domain',
+        active: '1',
         silenced: '1',
-        alphabetic: '1',
         suspended: '1',
         username: 'username',
         display_name: 'display name',

--- a/spec/models/account_filter_spec.rb
+++ b/spec/models/account_filter_spec.rb
@@ -17,23 +17,6 @@ describe AccountFilter do
     end
   end
 
-  describe 'when an IP address is provided' do
-    it 'filters with IP when valid' do
-      filter = described_class.new(ip: '127.0.0.1')
-      allow(User).to receive(:with_recent_ip_address).and_return(User.none)
-
-      filter.results
-      expect(User).to have_received(:with_recent_ip_address).with('127.0.0.1')
-    end
-
-    it 'skips IP when invalid' do
-      filter = described_class.new(ip: '345.678.901.234')
-      expect(User).not_to receive(:with_recent_ip_address)
-
-      filter.results
-    end
-  end
-
   describe 'with valid params' do
     it 'combines filters on Account' do
       filter = described_class.new(

--- a/spec/models/account_filter_spec.rb
+++ b/spec/models/account_filter_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 describe AccountFilter do
   describe 'with empty params' do
-    it 'defaults to recent account list' do
+    it 'defaults to recent local not-suspended account list' do
       filter = described_class.new({})
 
-      expect(filter.results).to eq Account.recent
+      expect(filter.results).to eq Account.local.recent.without_suspended
     end
   end
 
@@ -60,13 +60,13 @@ describe AccountFilter do
     end
 
     describe 'that call account methods' do
-      %i(local remote silenced alphabetic suspended).each do |option|
+      %i(local remote silenced suspended).each do |option|
         it "delegates the #{option} option" do
           allow(Account).to receive(option).and_return(Account.none)
           filter = described_class.new({ option => true })
           filter.results
 
-          expect(Account).to have_received(option)
+          expect(Account).to have_received(option).at_least(1)
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,18 +89,6 @@ RSpec.describe User, type: :model do
         expect(User.matches_email('specified')).to match_array([specified])
       end
     end
-
-    describe 'with_recent_ip_address' do
-      it 'returns a relation of users who is, or was at last time, online with the given IP address' do
-        specifieds = [
-          Fabricate(:user, current_sign_in_ip: '0.0.0.42', last_sign_in_ip: '0.0.0.0'),
-          Fabricate(:user, current_sign_in_ip: nil, last_sign_in_ip: '0.0.0.42')
-        ]
-        Fabricate(:user, current_sign_in_ip: '0.0.0.0', last_sign_in_ip: '0.0.0.0')
-
-        expect(User.with_recent_ip_address('0.0.0.42')).to match_array(specifieds)
-      end
-    end
   end
 
   let(:account) { Fabricate(:account, username: 'alice') }


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/184731/48974064-f77b4880-f04d-11e8-83b0-792b531d05a0.png)

- Make clear which accounts are deleted/suspended
- Make clear which accounts are bots/staff (via badges)
- Show when local account was last active and which IP it used
- Strip whitespace before filtering
- Default to not showing remote accounts
- Default to not showing suspended accounts
- Remove alphabetic ordering

___

- Fix #9246
- Fix #8190
- See also #8122
