### PR TITLE
check_boxes label should use display: inline-block

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -266,7 +266,7 @@ code {
         font-family: inherit;
         font-size: 14px;
         color: $primary-text-color;
-        display: block;
+        display: inline-block;
         width: auto;
         position: relative;
         padding-top: 5px;


### PR DESCRIPTION
Check boxes labels of chosen language in `/settings/preferences` are too wide.
It cause accidentally click.
Users said to me about this, "Public timeline does not work."

![2018-11-25 23-23-21](https://user-images.githubusercontent.com/24884114/48980215-9913a000-f109-11e8-9fb4-b3a5312eba4c.gif)

|before|after|
|:-:|:-:|
|![2018-11-25-232203_1920x983_scrot](https://user-images.githubusercontent.com/24884114/48980212-90bb6500-f109-11e8-9820-e28a75c17809.png)|![2018-11-25-232133_1920x983_scrot](https://user-images.githubusercontent.com/24884114/48980209-89945700-f109-11e8-9171-b138eafd90a6.png)|
