### PR TITLE
Skip deliveries to inboxes that have already been marked as unavailable

### DIFF
--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -11,6 +11,8 @@ class ActivityPub::DeliveryWorker
   HEADERS = { 'Content-Type' => 'application/activity+json' }.freeze
 
   def perform(json, source_account_id, inbox_url, options = {})
+    return if DeliveryFailureTracker.unavailable?(inbox_url)
+
     @options        = options.with_indifferent_access
     @json           = json
     @source_account = Account.find(source_account_id)


### PR DESCRIPTION
While currently *distribution* to unavailable inboxes is stopped, already queued items still keep trying to deliver, which can mean a lot of retries. This allows to skip all that.