### PR TITLE
Add loglevel to ffmpeg in gif upload

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -59,6 +59,7 @@ class MediaAttachment < ApplicationRecord
     format: 'mp4',
     convert_options: {
       output: {
+        'loglevel' => 'fatal',
         'movflags' => 'faststart',
         'pix_fmt'  => 'yuv420p',
         'vf'       => 'scale=\'trunc(iw/2)*2:trunc(ih/2)*2\'',


### PR DESCRIPTION
This is a fix for https://github.com/tootsuite/mastodon/issues/9362

Until Cocaine/Terrapin fixes the stderr problem, adding loglevel to ffmpeg will help reduce deadlock on ffmpeg gif upload.

Although AFAIK this is only an issue that I have experienced, due to my specific setup, I think it would be a good idea to lower the default loglevel of ffmpeg as it will consume resources.

I set it to 'fatal' where only errors after which the process absolutely cannot continue are logged.

There are more verbose options but I think it those would only bring value in development and less verbose but those would completely fail to provide information on a fatal error.