### PR TITLE
Add database statement timeout of 60s

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,8 @@ default: &default
   pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>
   timeout: 5000
   encoding: unicode
+  variables:
+    statement_timeout: 60000
 
 development:
   <<: *default


### PR DESCRIPTION
I have not observed any queries with average duration of over 60 seconds. Having a statement timeout should ensure that database deadlocks, if they occur, will not remain forever until manual restart. However, **this has absolutely no effect when using pgBouncer**.

When using pgBouncer, the only way to enforce a statement timeout is setting it on the database directly:

    ALTER DATABASE mastodon_production SET statement_timeout = '60s';