### PR TITLE
Add option to auto-delete old statuses

### DIFF
--- a/app/models/deletion_schedule.rb
+++ b/app/models/deletion_schedule.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: deletion_schedules
+#
+#  id         :bigint(8)        not null, primary key
+#  user_id    :bigint(8)
+#  delay      :integer          default(604800), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class DeletionSchedule < ApplicationRecord
+  belongs_to :user
+
+  validates :delay, presence: true, numericality: { only_integer: true, greater_than: 7.days.seconds }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,7 @@ class User < ApplicationRecord
 
   has_many :applications, class_name: 'Doorkeeper::Application', as: :owner
   has_many :backups, inverse_of: :user
+  has_one :deletion_schedule, dependent: :destroy
 
   validates :locale, inclusion: I18n.available_locales.map(&:to_s), if: :locale?
   validates_with BlacklistedEmailValidator, if: :email_changed?

--- a/app/workers/deletion_schedule_worker.rb
+++ b/app/workers/deletion_schedule_worker.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class DeletionScheduleWorker
+  include Sidekiq::Worker
+
+  sidekiq_options unique: :until_executed, retry: 0
+
+  def perform(account_id, delay)
+    RemovalWorker.push_bulk(status_ids(account_id, snowflake_at(Time.now.utc - delay.seconds)))
+  end
+
+  private
+
+  def snowflake_at(time)
+    Mastodon::Snowflake.id_at(time)
+  end
+
+  def status_ids(account_id, cut_off_id)
+    Status.where(account_id: account_id)
+          .where(Status.arel_table[:id].lt(cut_off_id))
+          .reorder(id: :asc)
+          .limit(100)
+          .pluck(:id)
+  end
+end

--- a/app/workers/scheduler/deletion_scheduler.rb
+++ b/app/workers/scheduler/deletion_scheduler.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Scheduler::DeletionScheduler
+  include Sidekiq::Worker
+
+  sidekiq_options unique: :until_executed, retry: 0
+
+  def perform
+    DeletionSchedule.includes(:user).find_in_batches do |schedules|
+      DeletionScheduleWorker.push_bulk(schedules) do |schedule|
+        [schedule.user.account_id, schedule.delay]
+      end
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -36,3 +36,6 @@
   pghero_scheduler:
     cron: '0 0 * * *'
     class: Scheduler::PgheroScheduler
+  deletion_scheduler:
+    cron: '<%= Random.rand(0..59) %> <%= Random.rand(0..23) %> * * *'
+    class: Scheduler::DeletionScheduler

--- a/db/migrate/20181127224209_create_deletion_schedules.rb
+++ b/db/migrate/20181127224209_create_deletion_schedules.rb
@@ -1,0 +1,10 @@
+class CreateDeletionSchedules < ActiveRecord::Migration[5.2]
+  def change
+    create_table :deletion_schedules do |t|
+      t.belongs_to :user, foreign_key: { on_delete: :cascade }
+      t.integer :delay, null: false, default: 7.days.seconds
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_27_130500) do
+ActiveRecord::Schema.define(version: 2018_11_27_224209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,14 @@ ActiveRecord::Schema.define(version: 2018_11_27_130500) do
     t.datetime "updated_at", null: false
     t.boolean "whole_word", default: true, null: false
     t.index ["account_id"], name: "index_custom_filters_on_account_id"
+  end
+
+  create_table "deletion_schedules", force: :cascade do |t|
+    t.bigint "user_id"
+    t.integer "delay", default: 604800, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_deletion_schedules_on_user_id"
   end
 
   create_table "domain_blocks", force: :cascade do |t|
@@ -645,6 +653,7 @@ ActiveRecord::Schema.define(version: 2018_11_27_130500) do
   add_foreign_key "conversation_mutes", "accounts", name: "fk_225b4212bb", on_delete: :cascade
   add_foreign_key "conversation_mutes", "conversations", on_delete: :cascade
   add_foreign_key "custom_filters", "accounts", on_delete: :cascade
+  add_foreign_key "deletion_schedules", "users", on_delete: :cascade
   add_foreign_key "favourites", "accounts", name: "fk_5eb6c2b873", on_delete: :cascade
   add_foreign_key "favourites", "statuses", name: "fk_b0e856845e", on_delete: :cascade
   add_foreign_key "follow_requests", "accounts", column: "target_account_id", name: "fk_9291ec025d", on_delete: :cascade

--- a/spec/fabricators/deletion_schedule_fabricator.rb
+++ b/spec/fabricators/deletion_schedule_fabricator.rb
@@ -1,0 +1,4 @@
+Fabricator(:deletion_schedule) do
+  user
+  delay 30.days.seconds
+end

--- a/spec/models/deletion_schedule_spec.rb
+++ b/spec/models/deletion_schedule_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DeletionSchedule, type: :model do
+
+end


### PR DESCRIPTION
Fix #1295 

**Concerns**: Deletes are relatively expensive, and filling the Sidekiq queue with deletes can cause other kinds of content to stall, and user experience to be impacted. This PR limits the impact by scheduling at most 100 deletes per user during a run.

> Why don't you queue a `RemovalWorker` for a later date when a status is created, like ephermal.glitch.social does?

Sidekiq queues are stored in Redis, which is a RAM-based database (it dumps to disk only for persistence reasons). Assuming that a large instance has everyone opt into the auto-delete feature with a long delay, the Sidekiq queue for future deletes will grow at the same pace as all new statuses that are created, exhausting available RAM. It is not a good idea to use the Sidekiq queue for long-term storage.

Therefore, this PR queries old statuses periodically instead.