### PR TITLE
Fix last_status parameter for notifications and conversations

### DIFF
--- a/app/javascript/mastodon/actions/conversations.js
+++ b/app/javascript/mastodon/actions/conversations.js
@@ -38,7 +38,7 @@ export const expandConversations = ({ maxId } = {}) => (dispatch, getState) => {
   const params = { max_id: maxId };
 
   if (!maxId) {
-    params.since_id = getState().getIn(['conversations', 0, 'last_status']);
+    params.since_id = getState().getIn(['conversations', 'items', 0, 'last_status']);
   }
 
   api(getState).get('/api/v1/conversations', { params })

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -106,7 +106,7 @@ export function expandNotifications({ maxId } = {}, done = noOp) {
     };
 
     if (!maxId && notifications.get('items').size > 0) {
-      params.since_id = notifications.getIn(['items', 0]);
+      params.since_id = notifications.getIn(['items', 0, 'id']);
     }
 
     dispatch(expandNotificationsRequest(isLoadingMore));


### PR DESCRIPTION
In notification's cases, the items are full notifications, they don't hold only the id.
In case of conversations, the path was wrong.