### PR TITLE
Add visible dates for notifications in Notification column

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/notification.js
+++ b/app/javascript/mastodon/features/notifications/components/notification.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import StatusContainer from '../../../containers/status_container';
 import AccountContainer from '../../../containers/account_container';
+import RelativeTimestamp from '../../../components/relative_timestamp';
 import { injectIntl, FormattedMessage } from 'react-intl';
 import Permalink from '../../../components/permalink';
 import ImmutablePureComponent from 'react-immutable-pure-component';
@@ -87,9 +88,9 @@ class Notification extends ImmutablePureComponent {
             </div>
             <span title={notification.get('created_at')}>
               <FormattedMessage id='notification.follow' defaultMessage='{name} followed you' values={{ name: link }} />
+              <RelativeTimestamp timestamp={notification.get('created_at')} />
             </span>
           </div>
-
           <AccountContainer id={account.get('id')} withNote={false} hidden={this.props.hidden} />
         </div>
       </HotKeys>
@@ -120,6 +121,7 @@ class Notification extends ImmutablePureComponent {
               <i className='fa fa-fw fa-star star-icon' />
             </div>
             <FormattedMessage id='notification.favourite' defaultMessage='{name} favourited your status' values={{ name: link }} />
+            <RelativeTimestamp timestamp={notification.get('created_at')} />
           </div>
 
           <StatusContainer id={notification.get('status')} account={notification.get('account')} muted withDismiss hidden={!!this.props.hidden} />
@@ -139,6 +141,7 @@ class Notification extends ImmutablePureComponent {
               <i className='fa fa-fw fa-retweet' />
             </div>
             <FormattedMessage id='notification.reblog' defaultMessage='{name} boosted your status' values={{ name: link }} />
+            <RelativeTimestamp timestamp={notification.get('created_at')} />
           </div>
 
           <StatusContainer id={notification.get('status')} account={notification.get('account')} muted withDismiss hidden={this.props.hidden} />

--- a/app/javascript/mastodon/features/notifications/components/notification.js
+++ b/app/javascript/mastodon/features/notifications/components/notification.js
@@ -88,7 +88,9 @@ class Notification extends ImmutablePureComponent {
             </div>
             <span title={notification.get('created_at')}>
               <FormattedMessage id='notification.follow' defaultMessage='{name} followed you' values={{ name: link }} />
-              <RelativeTimestamp timestamp={notification.get('created_at')} />
+              <span className='notification__relative_time'>
+                <RelativeTimestamp timestamp={notification.get('created_at')} />
+              </span>
             </span>
           </div>
           <AccountContainer id={account.get('id')} withNote={false} hidden={this.props.hidden} />
@@ -121,7 +123,9 @@ class Notification extends ImmutablePureComponent {
               <i className='fa fa-fw fa-star star-icon' />
             </div>
             <FormattedMessage id='notification.favourite' defaultMessage='{name} favourited your status' values={{ name: link }} />
-            <RelativeTimestamp timestamp={notification.get('created_at')} />
+            <span className='notification__relative_time'>
+              <RelativeTimestamp className='notification__relative_time' timestamp={notification.get('created_at')} />
+            </span>
           </div>
 
           <StatusContainer id={notification.get('status')} account={notification.get('account')} muted withDismiss hidden={!!this.props.hidden} />
@@ -141,7 +145,9 @@ class Notification extends ImmutablePureComponent {
               <i className='fa fa-fw fa-retweet' />
             </div>
             <FormattedMessage id='notification.reblog' defaultMessage='{name} boosted your status' values={{ name: link }} />
-            <RelativeTimestamp timestamp={notification.get('created_at')} />
+            <span className='notification__relative_time'>
+              <RelativeTimestamp className='notification__relative_time' timestamp={notification.get('created_at')} />
+            </span>
           </div>
 
           <StatusContainer id={notification.get('status')} account={notification.get('account')} muted withDismiss hidden={this.props.hidden} />

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1489,6 +1489,7 @@ a.account__display-name {
   cursor: default;
   color: $darker-text-color;
   font-size: 15px;
+  line-height: 22px;
   position: relative;
 
   .fa {
@@ -1496,7 +1497,7 @@ a.account__display-name {
   }
 
   > span {
-    display: block;
+    display: inline;
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -1524,6 +1525,10 @@ a.account__display-name {
     color: $primary-text-color;
     text-decoration: underline;
   }
+}
+
+.notification__relative_time {
+  float: right;
 }
 
 .display-name {


### PR DESCRIPTION
UI. Implements #9422 .

Right now there is no way to tell when an action happened based on the information in the Notifications column. It took me a few days to realize that the date displayed now is the date of the original post (boosted / favourited), not the action itself. I imagine it is similarly confusing for other newcomers.

![notification_dates_done](https://user-images.githubusercontent.com/4021653/49442098-b959f380-f7c8-11e8-89f2-ec177f965cb8.png)

I would argue that the dates are really useful, but if you have a better idea _where_ to put them, I'm open.