### PR TITLE
Attempt fixing deadlocks by moving account stats update outside transaction

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -236,8 +236,8 @@ class Status < ApplicationRecord
     update_status_stat!(key => [public_send(key) - 1, 0].max)
   end
 
-  after_create  :increment_counter_caches
-  after_destroy :decrement_counter_caches
+  after_create_commit  :increment_counter_caches
+  after_destroy_commit :decrement_counter_caches
 
   after_create_commit :store_uri, if: :local?
   after_create_commit :update_statistics, if: :local?

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -426,7 +426,7 @@ class Status < ApplicationRecord
   end
 
   def store_uri
-    update_attribute(:uri, ActivityPub::TagManager.instance.uri_for(self)) if uri.nil?
+    update_column(:uri, ActivityPub::TagManager.instance.uri_for(self)) if uri.nil?
   end
 
   def prepare_contents


### PR DESCRIPTION
`increment_counter_caches` may cause deadlocks when multiple jobs touch the same account.

From my understanding, this is because `Status.create` is always called inside a transaction, and `increment_counter_caches` will be called within that transaction, causing both a read and a write of that particular row within the same transaction.

This PR makes the callback executes *after* the transaction.