### PR TITLE
Remove unneeded command and switch to images for TOR

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,14 +78,13 @@ services:
 ## http_proxy=http://privoxy:8118
 ## ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
 #  tor:
-#    build: https://github.com/usbsnowcrash/docker-tor.git
+#    image: sirboops/tor
 #    networks:
 #      - external_network
 #      - internal_network
 #
 #  privoxy:
-#    build: https://github.com/usbsnowcrash/docker-privoxy.git
-#    command: /opt/sbin/privoxy --no-daemon --user privoxy.privoxy /opt/config
+#    image: sirboops/privoxy
 #    volumes:
 #      - ./priv-config:/opt/config
 #    networks:


### PR DESCRIPTION
Switch to images when enabling tor federation, The images currently being used are out of date and no need to build what can be pulled from docker hub