### PR TITLE
Escape HTML in profile name preview in profile settings

### DIFF
--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -135,7 +135,7 @@ function main() {
     const name = document.querySelector('.card .display-name strong');
 
     if (name) {
-      name.innerHTML = emojify(target.value);
+      name.textContent = emojify(target.value);
     }
   });
 

--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -1,3 +1,4 @@
+import escapeTextContentForBrowser from 'escape-html';
 import loadPolyfills from '../mastodon/load_polyfills';
 import ready from '../mastodon/ready';
 import { start } from '../mastodon/common';
@@ -135,7 +136,7 @@ function main() {
     const name = document.querySelector('.card .display-name strong');
     if (name) {
       if (target.value) {
-        name.textContent = emojify(target.value);
+        name.innerHTML = emojify(escapeTextContentForBrowser(target.value));
       } else {
         name.textContent = document.querySelector('#default_account_display_name').textContent;
       }

--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -133,9 +133,12 @@ function main() {
 
   delegate(document, '#account_display_name', 'input', ({ target }) => {
     const name = document.querySelector('.card .display-name strong');
-
     if (name) {
-      name.textContent = emojify(target.value);
+      if (target.value) {
+        name.textContent = emojify(target.value);
+      } else {
+        name.textContent = document.querySelector('#default_account_display_name').textContent;
+      }
     }
   });
 

--- a/app/views/application/_card.html.haml
+++ b/app/views/application/_card.html.haml
@@ -9,7 +9,7 @@
         = image_tag account.avatar.url, alt: '', width: 48, height: 48, class: 'u-photo'
 
       .display-name
-        %span{:id=>"default_account_display_name", :style=>"display:none;"}= display_name(account, custom_emojify: true)
+        %span{id: "default_account_display_name", style: "display:none;"}= display_name(account, custom_emojify: true)
         %bdi
           %strong.emojify.p-name= display_name(account, custom_emojify: true)
         %span

--- a/app/views/application/_card.html.haml
+++ b/app/views/application/_card.html.haml
@@ -9,7 +9,7 @@
         = image_tag account.avatar.url, alt: '', width: 48, height: 48, class: 'u-photo'
 
       .display-name
-        %span{id: "default_account_display_name", style: "display:none;"}= display_name(account, custom_emojify: true)
+        %span{id: "default_account_display_name", style: "display:none;"}= account.username
         %bdi
           %strong.emojify.p-name= display_name(account, custom_emojify: true)
         %span

--- a/app/views/application/_card.html.haml
+++ b/app/views/application/_card.html.haml
@@ -9,6 +9,7 @@
         = image_tag account.avatar.url, alt: '', width: 48, height: 48, class: 'u-photo'
 
       .display-name
+        %span{:id=>"default_account_display_name", :style=>"display:none;"}= display_name(account, custom_emojify: true)
         %bdi
           %strong.emojify.p-name= display_name(account, custom_emojify: true)
         %span


### PR DESCRIPTION
Addresses #9343 . Additionally falls back to the default profile name if user deletes their custom one.

Right now the data about the default name is set in a `display: none` span, but it can be provided to JavaScript in some other way.

Personally I'd rewrite this view to React some day, but we should be good for now.