### PR TITLE
Fix tag mb_chars comparison of profile directory

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -181,8 +181,8 @@ class Account < ApplicationRecord
   end
 
   def tags_as_strings=(tag_names)
-    tag_names.map! { |name| name.mb_chars.downcase }
-    tag_names.uniq!(&:to_s)
+    tag_names.map! { |name| name.mb_chars.downcase.to_s }
+    tag_names.uniq!
 
     # Existing hashtags
     hashtags_map = Tag.where(name: tag_names).each_with_object({}) { |tag, h| h[tag.name] = tag }
@@ -190,7 +190,7 @@ class Account < ApplicationRecord
     # Initialize not yet existing hashtags
     tag_names.each do |name|
       next if hashtags_map.key?(name)
-      hashtags_map[name.downcase] = Tag.new(name: name)
+      hashtags_map[name] = Tag.new(name: name)
     end
 
     # Remove hashtags that are to be deleted


### PR DESCRIPTION
```
ActiveRecord::RecordInvalid (バリデーションに失敗しました: Nameはすでに存在します):

app/models/account.rb:211:in `block (2 levels) in tags_as_strings='
app/models/account.rb:210:in `block in tags_as_strings='
app/models/account.rb:209:in `each_value'
app/models/account.rb:209:in `tags_as_strings='
app/services/update_account_service.rb:30:in `process_hashtags'
app/services/update_account_service.rb:13:in `block in call'
app/services/update_account_service.rb:8:in `tap'
app/services/update_account_service.rb:8:in `call'
app/controllers/settings/profiles_controller.rb:20:in `update'
```

It is a comparison problem of mb_chars, which is caused by duplicate registration of Tag.
Fix this problem.