### PR TITLE
Make custom emoji domains case insensitive #9351

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -77,6 +77,6 @@ class CustomEmoji < ApplicationRecord
   end
 
   def downcase_domain
-    self.domain = domain.downcase if !domain.nil?
+    self.domain = domain.downcase unless domain.nil?
   end
 end

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -31,6 +31,8 @@ class CustomEmoji < ApplicationRecord
 
   has_attached_file :image, styles: { static: { format: 'png', convert_options: '-coalesce -strip' } }
 
+  before_validation :downcase_domain
+
   validates_attachment :image, content_type: { content_type: 'image/png' }, presence: true, size: { less_than: LIMIT }
   validates :shortcode, uniqueness: { scope: :domain }, format: { with: /\A#{SHORTCODE_RE_FRAGMENT}\z/ }, length: { minimum: 2 }
 
@@ -72,5 +74,9 @@ class CustomEmoji < ApplicationRecord
 
   def remove_entity_cache
     Rails.cache.delete(EntityCache.instance.to_key(:emoji, shortcode, domain))
+  end
+
+  def downcase_domain
+    self.domain = domain.downcase if self.domain != nil
   end
 end

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -77,6 +77,6 @@ class CustomEmoji < ApplicationRecord
   end
 
   def downcase_domain
-    self.domain = domain.downcase if self.domain != nil
+    self.domain = domain.downcase if !domain.nil?
   end
 end

--- a/app/models/custom_emoji_filter.rb
+++ b/app/models/custom_emoji_filter.rb
@@ -26,7 +26,7 @@ class CustomEmojiFilter
     when 'remote'
       CustomEmoji.remote
     when 'by_domain'
-      CustomEmoji.where(domain: value)
+      CustomEmoji.where(domain: value.downcase)
     when 'shortcode'
       CustomEmoji.search(value)
     else

--- a/db/migrate/20181207011115_downcase_custom_emoji_domains.rb
+++ b/db/migrate/20181207011115_downcase_custom_emoji_domains.rb
@@ -1,5 +1,7 @@
 class DowncaseCustomEmojiDomains < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
   def change
-    CustomEmoji.update_all('domain = lower(domain)')
+    CustomEmoji.in_batches.update_all('domain = lower(domain)')
   end
 end

--- a/db/migrate/20181207011115_downcase_custom_emoji_domains.rb
+++ b/db/migrate/20181207011115_downcase_custom_emoji_domains.rb
@@ -1,0 +1,5 @@
+class DowncaseCustomEmojiDomains < ActiveRecord::Migration[5.2]
+  def change
+    CustomEmoji.update_all('domain = lower(domain)')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_04_215309) do
+ActiveRecord::Schema.define(version: 2018_12_07_011115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -336,9 +336,9 @@ ActiveRecord::Schema.define(version: 2018_12_04_215309) do
   create_table "mutes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "hide_notifications", default: true, null: false
     t.bigint "account_id", null: false
     t.bigint "target_account_id", null: false
-    t.boolean "hide_notifications", default: true, null: false
     t.index ["account_id", "target_account_id"], name: "index_mutes_on_account_id_and_target_account_id", unique: true
     t.index ["target_account_id"], name: "index_mutes_on_target_account_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -336,9 +336,9 @@ ActiveRecord::Schema.define(version: 2018_12_07_011115) do
   create_table "mutes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "hide_notifications", default: true, null: false
     t.bigint "account_id", null: false
     t.bigint "target_account_id", null: false
+    t.boolean "hide_notifications", default: true, null: false
     t.index ["account_id", "target_account_id"], name: "index_mutes_on_account_id_and_target_account_id", unique: true
     t.index ["target_account_id"], name: "index_mutes_on_target_account_id"
   end

--- a/spec/models/custom_emoji_spec.rb
+++ b/spec/models/custom_emoji_spec.rb
@@ -75,4 +75,13 @@ RSpec.describe CustomEmoji, type: :model do
       end
     end
   end
+
+  describe 'pre_validation' do
+    let(:custom_emoji) { Fabricate(:custom_emoji, domain: 'wWw.MaStOdOn.CoM') }
+
+    it 'should downcase' do
+      custom_emoji.valid?
+      expect(custom_emoji.domain).to eq('www.mastodon.com')
+    end
+  end
 end


### PR DESCRIPTION
Make custom emoji domains case insensitive to fix #9531

Postgres supports CITEXT, but migrating the database from TEXT to CITEXT could require a whole table lock or an interim migration with dual writes.

Instead, it should be fine to migrate existing rows to lowercase one-by-one, input only lowercase input in future, and do comparisons against lowercase input.

This is my first pull request for mastodon and I haven't worked in Ruby in a long time - please let me know if I'm missing something!