### PR TITLE
Use same CORS policy for /@:username and /users/:username

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -17,6 +17,10 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       headers: :any,
       methods: [:get],
       credentials: false
+    resource '/users/:username',
+      headers: :any,
+      methods: [:get],
+      credentials: false
     resource '/api/*',
       headers: :any,
       methods: [:post, :put, :delete, :get, :patch, :options],


### PR DESCRIPTION
Fixes #8189

rack-cors being called before the application router, it does not follow
the redirection, and we need a separate rule for /users/:username.