### PR TITLE
Make clicks on the status action bar expand toots

### DIFF
--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -248,7 +248,7 @@ class StatusActionBar extends ImmutablePureComponent {
     );
 
     return (
-      <div className='status__action-bar'>
+      <div className='status__action-bar' role='presentation' onClick={this.handleOpen}>
         <div className='status__action-bar__counter'><IconButton className='status__action-bar-button' title={replyTitle} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} /><span className='status__action-bar__counter__label' >{obfuscatedCount(status.get('replies_count'))}</span></div>
         <IconButton className='status__action-bar-button' disabled={!publicStatus} active={status.get('reblogged')} pressed={status.get('reblogged')} title={!publicStatus ? intl.formatMessage(messages.cannot_reblog) : intl.formatMessage(messages.reblog)} icon={reblogIcon} onClick={this.handleReblogClick} />
         <IconButton className='status__action-bar-button star-icon' animate active={status.get('favourited')} pressed={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} />


### PR DESCRIPTION
Possible fix for #8529, this makes clicks on the status action bar (the area underneath toots where the various buttons are) expand the current toot. Leaves the larger area under the profile picture alone, to keep previous behavior that lets users focus the toot without expanding it. Any suggestions are welcome to cover other use-cases.

The image has the new clickable zones on the status action bar.
![clickable_zones_changed](https://user-images.githubusercontent.com/1120797/49778881-517a4000-fcd5-11e8-90f3-5c42a50cf765.png)