### PR TITLE
Restore profile links in /admin/accounts

### DIFF
--- a/app/views/admin/accounts/_account.html.haml
+++ b/app/views/admin/accounts/_account.html.haml
@@ -13,3 +13,6 @@
       %time.time-ago{ datetime: account.user_current_sign_in_at.iso8601, title: l(account.user_current_sign_in_at) }= l account.user_current_sign_in_at
     - else
       \-
+  %td
+    = table_link_to 'circle', t('admin.accounts.web'), web_path("accounts/#{account.id}")
+    = table_link_to 'globe', t('admin.accounts.public'), TagManager.instance.url_for(account)

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -41,6 +41,7 @@
         %th= t('admin.accounts.role')
         %th= t('admin.accounts.most_recent_ip')
         %th= t('admin.accounts.most_recent_activity')
+        %th
     %tbody
       = render @accounts
 


### PR DESCRIPTION
Fixes #9431 

Before
--------

![screenshot_2018-12-11 accounts - dev instance](https://user-images.githubusercontent.com/384364/49803700-dc4c5080-fd50-11e8-8573-6577e95d3d05.png)


After
------

![screenshot_2018-12-11 accounts - dev instance 1](https://user-images.githubusercontent.com/384364/49803707-dfdfd780-fd50-11e8-9704-07def4163cd3.png)
