### PR TITLE
Add admin ability to remove an user's header image

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class AccountsController < BaseController
-    before_action :set_account, only: [:show, :subscribe, :unsubscribe, :redownload, :remove_avatar, :enable, :disable, :memorialize]
+    before_action :set_account, only: [:show, :subscribe, :unsubscribe, :redownload, :remove_avatar, :remove_header, :enable, :disable, :memorialize]
     before_action :require_remote_account!, only: [:subscribe, :unsubscribe, :redownload]
     before_action :require_local_account!, only: [:enable, :disable, :memorialize]
 
@@ -67,6 +67,17 @@ module Admin
       @account.save!
 
       log_action :remove_avatar, @account.user
+
+      redirect_to admin_account_path(@account.id)
+    end
+
+    def remove_header
+      authorize @account, :remove_header?
+
+      @account.header = nil
+      @account.save!
+
+      log_action :remove_header, @account.user
 
       redirect_to admin_account_path(@account.id)
     end

--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -92,7 +92,7 @@ module Admin::ActionLogsHelper
       opposite_verbs?(log) ? 'negative' : 'positive'
     when :update, :reset_password, :disable_2fa, :memorialize, :change_email
       'neutral'
-    when :demote, :silence, :disable, :suspend, :remove_avatar, :reopen
+    when :demote, :silence, :disable, :suspend, :remove_avatar, :remove_header, :reopen
       'negative'
     when :destroy
       opposite_verbs?(log) ? 'positive' : 'negative'

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -33,6 +33,10 @@ class AccountPolicy < ApplicationPolicy
     staff?
   end
 
+  def remove_header?
+    staff?
+  end
+
   def subscribe?
     admin?
   end

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -16,7 +16,7 @@
 
       %tr
         %th= t('admin.accounts.avatar')
-        %th
+        %td
           = link_to @account.avatar.url(:original) do
             = image_tag @account.avatar.url(:original), alt: '', width: 40, height: 40, class: 'avatar'
           - if @account.local? && @account.avatar?

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -21,6 +21,13 @@
             = image_tag @account.avatar.url(:original), alt: '', width: 40, height: 40, class: 'avatar'
           - if @account.local? && @account.avatar?
             = table_link_to 'trash', t('admin.accounts.remove_avatar'), remove_avatar_admin_account_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_avatar, @account)
+      %tr
+        %th= t('admin.accounts.header')
+        %td
+          = link_to @account.header.url(:original) do
+            = image_tag @account.header.url(:original), alt: '', width: 128, height: 40, class: 'header'
+          - if @account.local? && @account.header?
+            = table_link_to 'trash', t('admin.accounts.remove_header'), remove_header_admin_account_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_header, @account)
 
       - if @account.local?
         %tr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -176,6 +176,7 @@ Rails.application.routes.draw do
         post :disable
         post :redownload
         post :remove_avatar
+        post :remove_header
         post :memorialize
       end
 


### PR DESCRIPTION
Also fixed up a `th` being used instead of `td`  in the page markup.

Before
--------

![screenshot_2018-12-11 thib - dev instance](https://user-images.githubusercontent.com/384364/49804720-a0ff5100-fd53-11e8-9a39-c92d0bcbce24.png)


After
------

![screenshot_2018-12-11 thib - dev instance 1](https://user-images.githubusercontent.com/384364/49804727-a492d800-fd53-11e8-9b3e-714f714eda86.png)
