### PR TITLE
Add instance-wide setting to disable profile directory

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -28,6 +28,7 @@ module Admin
       @pam_enabled           = ENV['PAM_ENABLED'] == 'true'
       @hidden_service        = ENV['ALLOW_ACCESS_TO_HIDDEN_SERVICE'] == 'true'
       @trending_hashtags     = TrendingTags.get(7)
+      @profile_directory     = Setting.profile_directory
     end
 
     private

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -26,6 +26,7 @@ module Admin
       show_known_fediverse_at_about_page
       preview_sensitive_media
       custom_css
+      profile_directory
     ).freeze
 
     BOOLEAN_SETTINGS = %w(
@@ -37,6 +38,7 @@ module Admin
       peers_api_enabled
       show_known_fediverse_at_about_page
       preview_sensitive_media
+      profile_directory
     ).freeze
 
     UPLOAD_SETTINGS = %w(

--- a/app/controllers/directories_controller.rb
+++ b/app/controllers/directories_controller.rb
@@ -3,22 +3,25 @@
 class DirectoriesController < ApplicationController
   layout 'public'
 
+  before_action :check_enabled
   before_action :set_instance_presenter
   before_action :set_tag, only: :show
   before_action :set_tags
   before_action :set_accounts
 
   def index
-    return not_found unless Setting.profile_directory
     render :index
   end
 
   def show
-    return not_found unless Setting.profile_directory
     render :index
   end
 
   private
+
+  def check_enabled
+    return not_found unless Setting.profile_directory
+  end
 
   def set_tag
     @tag = Tag.discoverable.find_by!(name: params[:id].downcase)

--- a/app/controllers/directories_controller.rb
+++ b/app/controllers/directories_controller.rb
@@ -9,10 +9,12 @@ class DirectoriesController < ApplicationController
   before_action :set_accounts
 
   def index
+    return not_found unless Setting.profile_directory
     render :index
   end
 
   def show
+    return not_found unless Setting.profile_directory
     render :index
   end
 

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -44,6 +44,8 @@ class Form::AdminSettings
     :preview_sensitive_media=,
     :custom_css,
     :custom_css=,
+    :profile_directory,
+    :profile_directory=,
     to: Setting
   )
 end

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -58,6 +58,12 @@
           - else
             %span.pull-right.negative-hint= fa_icon 'times fw'
         %li
+          = link_to t('admin.dashboard.feature_profile_directory'), edit_admin_settings_path
+          - if @profile_directory
+            %span.pull-right.positive-hint= fa_icon 'check fw'
+          - else
+            %span.pull-right.negative-hint= fa_icon 'times fw'
+        %li
           = link_to t('admin.dashboard.feature_relay'), admin_relays_path
           - if @relay_enabled
             %span.pull-right.positive-hint= fa_icon 'check fw'

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -62,6 +62,9 @@
   .fields-group
     = f.input :preview_sensitive_media, as: :boolean, wrapper: :with_label, label: t('admin.settings.preview_sensitive_media.title'), hint: t('admin.settings.preview_sensitive_media.desc_html')
 
+  .fields-group
+    = f.input :profile_directory, as: :boolean, wrapper: :with_label, label: t('admin.settings.profile_directory.title'), hint: t('admin.settings.profile_directory.desc_html')
+
   %hr.spacer/
 
   .fields-group

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -9,7 +9,8 @@
           = link_to root_url, class: 'brand' do
             = image_tag asset_pack_path('logo_full.svg'), alt: 'Mastodon'
 
-          = link_to t('directories.directory'), explore_path, class: 'nav-link'
+          - if Setting.profile_directory
+            = link_to t('directories.directory'), explore_path, class: 'nav-link'
           = link_to t('about.about_this'), about_more_path, class: 'nav-link'
           = link_to t('about.apps'), 'https://joinmastodon.org/apps', class: 'nav-link'
         .nav-center

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -26,8 +26,9 @@
   .fields-group
     = f.input :bot, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.bot')
 
-  .fields-group
-    = f.input :discoverable, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.discoverable_html', min_followers: Account::MIN_FOLLOWERS_DISCOVERY, path: explore_path)
+  - if Setting.profile_directory
+    .fields-group
+      = f.input :discoverable, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.discoverable_html', min_followers: Account::MIN_FOLLOWERS_DISCOVERY, path: explore_path)
 
   %hr.spacer/
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -229,6 +229,7 @@ en:
       config: Configuration
       feature_deletions: Account deletions
       feature_invites: Invite links
+      feature_profile_directory: Profile directory
       feature_registrations: Registrations
       feature_relay: Federation relay
       features: Features
@@ -376,6 +377,9 @@ en:
       preview_sensitive_media:
         desc_html: Link previews on other websites will display a thumbnail even if the media is marked as sensitive
         title: Show sensitive media in OpenGraph previews
+      profile_directory:
+        desc_html: Allow users to be discoverable
+        title: Enable profile directory
       registrations:
         closed_message:
           desc_html: Displayed on frontpage when registrations are closed. You can use HTML tags

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,7 @@ defaults: &defaults
   site_contact_username: ''
   site_contact_email: ''
   open_registrations: true
+  profile_directory: true
   closed_registrations_message: ''
   open_deletion: true
   min_invite_role: 'admin'


### PR DESCRIPTION
Fixes #9496

When the profile directory is disabled:
- The “discoverable” setting is hidden from users
- The “profile directory” link is not shown on public pages
- /explore returns 404