### PR TITLE
When posting in mobile mode, go back to previous history location

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -144,7 +144,11 @@ export function submitCompose(routerHistory) {
 
       if (response.data.visibility === 'direct' && getState().getIn(['conversations', 'mounted']) <= 0 && routerHistory) {
         routerHistory.push('/timelines/direct');
-      } else if (response.data.visibility !== 'direct') {
+      } else if (routerHistory && routerHistory.location.pathname === '/statuses/new' && window.history.state) {
+        routerHistory.goBack();
+      }
+
+      if (response.data.visibility !== 'direct') {
         insertIfOnline('home');
       }
 


### PR DESCRIPTION
Fixes #7112

I am not 100% about this one: it's a behavior change that seems to be for the better, but it's still a behavior change.

Also, maybe there are edge cases I haven't thought about regarding navigation while the toot is sending?