### PR TITLE
Fix bootsnap cache directory being declared relatively

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -4,7 +4,7 @@ require 'bundler/setup' # Set up gems listed in the Gemfile.
 require 'bootsnap' # Speed up boot time by caching expensive operations.
 
 Bootsnap.setup(
-  cache_dir:            'tmp/cache',
+  cache_dir:            File.expand_path('../tmp/cache', __dir__),
   development_mode:     ENV.fetch('RAILS_ENV', 'development') == 'development',
   load_path_cache:      true,
   autoload_paths_cache: true,


### PR DESCRIPTION
Resolve #9490