### PR TITLE
Fix padding on select elements in preferences

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -420,6 +420,7 @@ code {
     border: 1px solid darken($ui-base-color, 14%);
     border-radius: 4px;
     padding: 10px;
+    padding-right: 30px;
     height: 41px;
   }
 


### PR DESCRIPTION
Add right-padding to select elements to take the up/down arrows into account.

Thanks Tixie for finding the issue!