### PR TITLE
Dockerfile: Nodejs 8.12 -> 8.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.12.0-alpine as node
+FROM node:8.14.0-alpine as node
 FROM ruby:2.4.5-alpine3.8
 
 LABEL maintainer="https://github.com/tootsuite/mastodon" \


### PR DESCRIPTION
Quick one-liner.

This is a security release: https://nodejs.org/en/blog/release/v8.14.0/