### PR TITLE
Minor scrollable list fixes

### DIFF
--- a/app/javascript/mastodon/features/account_gallery/index.js
+++ b/app/javascript/mastodon/features/account_gallery/index.js
@@ -103,7 +103,7 @@ class AccountGallery extends ImmutablePureComponent {
       );
     }
 
-    if (hasMore) {
+    if (hasMore && !(isLoading && medias.size === 0)) {
       loadOlder = <LoadMore visible={!isLoading} onClick={this.handleLoadOlder} />;
     }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2107,6 +2107,7 @@ a.account__display-name {
   &__append {
     flex: 1 1 auto;
     position: relative;
+    min-height: 120px;
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2901,7 +2901,6 @@ a.status-card.compact:hover {
     transform: translateX(-50%);
     margin: 82px 0 0 50%;
     white-space: nowrap;
-    animation: loader-label 1.15s infinite cubic-bezier(0.215, 0.610, 0.355, 1.000);
   }
 }
 
@@ -2910,11 +2909,20 @@ a.status-card.compact:hover {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 0;
-  height: 0;
+  width: 42px;
+  height: 42px;
   box-sizing: border-box;
+  background-color: transparent;
   border: 0 solid lighten($ui-base-color, 26%);
+  border-width: 6px;
   border-radius: 50%;
+}
+
+.no-reduce-motion .loading-indicator span {
+  animation: loader-label 1.15s infinite cubic-bezier(0.215, 0.610, 0.355, 1.000);
+}
+
+.no-reduce-motion .loading-indicator__figure {
   animation: loader-figure 1.15s infinite cubic-bezier(0.215, 0.610, 0.355, 1.000);
 }
 


### PR DESCRIPTION
## Make sure the loading indicator has enough vertical space

This fixes broken display on accounts with lengthy bios.

### Before

![screenshot_2018-12-17 dev instance 2](https://user-images.githubusercontent.com/384364/50098493-57fc4080-021c-11e9-8ef4-6825b7150335.png)

### After

![screenshot_2018-12-17 dev instance 1](https://user-images.githubusercontent.com/384364/50098507-5df22180-021c-11e9-8296-5d199ee689db.png)

## Respect the `reduce_motion` setting

Do not animate the loader indicator when `reduce_motion` is set.

![screenshot_2018-12-17 dev instance](https://user-images.githubusercontent.com/384364/50098644-9e519f80-021c-11e9-920a-e07d81ae0aef.png)
