### PR TITLE
Sanitize and sandbox toot embeds

### DIFF
--- a/app/controllers/api/web/embeds_controller.rb
+++ b/app/controllers/api/web/embeds_controller.rb
@@ -10,6 +10,7 @@ class Api::Web::EmbedsController < Api::Web::BaseController
     render json: status, serializer: OEmbedSerializer, width: 400
   rescue ActiveRecord::RecordNotFound
     oembed = FetchOEmbedService.new.call(params[:url])
+    oembed[:html] = Formatter.instance.sanitize(oembed[:html], Sanitize::Config::MASTODON_OEMBED) if oembed[:html].present?
 
     if oembed
       render json: oembed

--- a/app/javascript/mastodon/features/ui/components/embed_modal.js
+++ b/app/javascript/mastodon/features/ui/components/embed_modal.js
@@ -77,6 +77,7 @@ class EmbedModal extends ImmutablePureComponent {
             className='embed-modal__iframe'
             frameBorder='0'
             ref={this.setIframeRef}
+            sandbox='allow-same-origin'
             title='preview'
           />
         </div>


### PR DESCRIPTION
Up until now, we blindly included oEmbed replies from remote toots in the embed modal.
Thankfully, since we introduced a Content Security Policy, this is not a security issue in Mastodon itself.

It however causes Content Security Policy warnings, and we may still provide users with malicious instructions.

The proposed change sanitizes the oEmbed content before suggesting it to the user, and also sandboxes the code to prevent executing scripts in a same-origin context.

This does cause some functionality loss: the generated code for embedding remote toots will not include the JS snippet needed to adjust the iframe's height.