### PR TITLE
Fix tootctl accounts rotate not updating public keys

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -309,8 +309,8 @@ module Mastodon
       end
 
       old_key = account.private_key
-      new_key = OpenSSL::PKey::RSA.new(2048).to_pem
-      account.update(private_key: new_key)
+      new_key = OpenSSL::PKey::RSA.new(2048)
+      account.update(private_key: new_key.to_pem, public_key: new_key.public_key.to_pem)
       ActivityPub::UpdateDistributionWorker.perform_in(delay, account.id, sign_with: old_key)
     end
   end


### PR DESCRIPTION
This allowed you to brick your system when running that command, because the accounts would continue to advertise the old public key, but sign things with the new one