### PR TITLE
fix CSP / X-Frame-Options for media embeds

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -6,12 +6,17 @@ class MediaController < ApplicationController
   before_action :set_media_attachment
   before_action :verify_permitted_status!
 
+  content_security_policy only: :player do |p|
+    p.frame_ancestors(false)
+  end
+
   def show
     redirect_to @media_attachment.file.url(:original)
   end
 
   def player
     @body_classes = 'player'
+    response.headers['X-Frame-Options'] = 'ALLOWALL'
     raise ActiveRecord::RecordNotFound unless @media_attachment.video? || @media_attachment.gifv?
   end
 


### PR DESCRIPTION
Currently media is prevented from being embedded on external sites ([example](https://twitter.com/0xjomo/status/1073725102649499648)). This seems to be an oversight from #8957.

https://github.com/tootsuite/mastodon/blob/cb2435aaf5679a48c9e3867e0565dcca87cd6f2b/app/controllers/statuses_controller.rb#L22-L24

The code is basically borrowed from `statuses_controller.rb` and now being added to `media_controller.rb`.