### PR TITLE
improved appearance of notification filter on safari

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4806,10 +4806,12 @@ a.status-card.compact:hover {
   border-bottom: 1px solid lighten($ui-base-color, 8%);
   cursor: default;
   display: flex;
+  flex-shrink: 0;
 
   button {
     background: darken($ui-base-color, 4%);
     border: 0;
+    margin: 0;
   }
 
   button,


### PR DESCRIPTION
In Safari, the display of the quick filter bar of the notification was incomplete.

fix #9562 

| before | after |
| ----- | -----|
| <img width="363" alt="2018-12-19 2 58 02" src="https://user-images.githubusercontent.com/5253290/50173514-13b39200-033b-11e9-8dca-e2362a30ad79.png"> | <img width="383" alt="2018-12-19 2 57 47" src="https://user-images.githubusercontent.com/5253290/50173533-1ca46380-033b-11e9-8b95-588ec029e8f8.png"> |

