### PR TITLE
Allow unauthenticated REST API access to GET /api/v1/accounts/:id/statuses

### DIFF
--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Accounts::StatusesController < Api::BaseController
-  before_action -> { doorkeeper_authorize! :read, :'read:statuses' }
+  before_action -> { authorize_if_got_token! :read, :'read:statuses' }
   before_action :set_account
   after_action :insert_pagination_headers
 


### PR DESCRIPTION
Fix #7087

The same data is available over the ActivityPub outbox, RSS, and Atom, so
there is little benefit to keeping it limited in this method.