### PR TITLE
Skip mailer job retries when a record no longer exists

### DIFF
--- a/config/initializers/delivery_job.rb
+++ b/config/initializers/delivery_job.rb
@@ -1,0 +1,3 @@
+ActionMailer::DeliveryJob.class_eval do
+  discard_on ActiveJob::DeserializationError
+end


### PR DESCRIPTION
Fix #8666