### PR TITLE
Fix composer not getting focus after reply confirmation dialog

### DIFF
--- a/app/javascript/mastodon/components/modal_root.js
+++ b/app/javascript/mastodon/components/modal_root.js
@@ -33,13 +33,15 @@ export default class ModalRoot extends React.PureComponent {
     } else if (!nextProps.children) {
       this.setState({ revealed: false });
     }
+    if (!nextProps.children && !!this.props.children) {
+      this.activeElement.focus();
+      this.activeElement = null;
+    }
   }
 
   componentDidUpdate (prevProps) {
     if (!this.props.children && !!prevProps.children) {
       this.getSiblings().forEach(sibling => sibling.removeAttribute('inert'));
-      this.activeElement.focus();
-      this.activeElement = null;
     }
     if (this.props.children) {
       requestAnimationFrame(() => {


### PR DESCRIPTION
The modal-handling code gives back focus to the element focused when the
modal opened. However, in the case of reply confirmation, it would do so
*after* the composer code itself requested focus.