### PR TITLE
Add account creation date to admin user details UI

### DIFF
--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -66,8 +66,10 @@
               = t('admin.accounts.enabled')
               = table_link_to 'lock', t('admin.accounts.disable'), disable_admin_account_path(@account.id), method: :post if can?(:disable, @account.user)
         %tr
-          %th= t('admin.accounts.most_recent_ip')
-          %td= @account.user_current_sign_in_ip
+          %th= t('admin.accounts.account_created')
+          %td
+            %time.formatted{ datetime: @account.created_at.iso8601, title: l(@account.created_at) }
+              = l @account.created_at
         %tr
           %th= t('admin.accounts.most_recent_activity')
           %td
@@ -76,6 +78,9 @@
                 = l @account.user_current_sign_in_at
             - else
               \-
+        %tr
+          %th= t('admin.accounts.most_recent_ip')
+          %td= @account.user_current_sign_in_ip
       - else
         %tr
           %th= t('admin.accounts.profile_url')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
       delete: Delete
       destroyed_msg: Moderation note successfully destroyed!
     accounts:
+      account_created: Account Created
       are_you_sure: Are you sure?
       avatar: Avatar
       by_domain: Domain


### PR DESCRIPTION
A helpful piece of information to have when viewing a local user is their registration date. This PR adds that to the table of admin-visible info. It also rearranges the "Most recent" info so that the most recent time comes first (to line up with the registration date info)