### PR TITLE
Add local followers page to admin account UI

### DIFF
--- a/app/controllers/admin/followers_controller.rb
+++ b/app/controllers/admin/followers_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Admin
+  class FollowersController < BaseController
+    before_action :set_account
+
+    PER_PAGE = 40
+
+    def index
+      authorize :account, :index?
+      @followers = followers.recent.page(params[:page]).per(PER_PAGE)
+    end
+
+    def set_account
+      @account = Account.find(params[:account_id])
+    end
+
+    def followers
+      Follow.includes(:account).where(target_account: @account)
+    end
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -138,6 +138,10 @@ class Account < ApplicationRecord
     "#{username}@#{Rails.configuration.x.local_domain}"
   end
 
+  def local_followers_count
+    Follow.where(target_account_id: id).count
+  end
+
   def to_webfinger_s
     "acct:#{local_username_and_domain}"
   end

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -89,7 +89,9 @@
         %td= number_to_human @account.following_count
       %tr
         %th= t('admin.accounts.followers')
-        %td= number_to_human @account.followers_count
+        %td
+          = number_to_human @account.followers_count
+          = link_to t('admin.accounts.followers_local', local: number_to_human(@account.local_followers_count)), admin_account_followers_path(@account.id)
       %tr
         %th= t('admin.accounts.statuses')
         %td= link_to number_to_human(@account.statuses_count), admin_account_statuses_path(@account.id)

--- a/app/views/admin/followers/index.html.haml
+++ b/app/views/admin/followers/index.html.haml
@@ -1,0 +1,29 @@
+- content_for :header_tags do
+  = javascript_pack_tag 'admin', integrity: true, async: true, crossorigin: 'anonymous'
+
+- content_for :page_title do
+  = t('admin.followers.title', acct: @account.acct)
+
+.filters
+  .filter-subset
+    %strong= t('admin.accounts.location.title')
+    %ul
+      %li= link_to t('admin.accounts.location.local'), admin_account_followers_path(@account.id), class: 'selected'
+  .back-link{ style: 'flex: 1 1 auto; text-align: right' }
+    = link_to admin_account_path(@account.id) do
+      %i.fa.fa-chevron-left.fa-fw
+      = t('admin.followers.back_to_account')
+
+.table-wrapper
+  %table.table
+    %thead
+      %tr
+        %th= t('admin.accounts.username')
+        %th= t('admin.accounts.role')
+        %th= t('admin.accounts.most_recent_ip')
+        %th= t('admin.accounts.most_recent_activity')
+        %th
+    %tbody
+      = render partial: 'admin/accounts/account', collection: @followers.map{|a| a.account}
+
+= paginate @followers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,7 @@ en:
       feed_url: Feed URL
       followers: Followers
       followers_url: Followers URL
+      followers_local: "(%{local} local)"
       follows: Follows
       header: Header
       inbox_url: Inbox URL
@@ -296,6 +297,9 @@ en:
         create: Add domain
         title: New e-mail blacklist entry
       title: E-mail blacklist
+    followers:
+      title: "%{acct}'s Followers"
+      back_to_account: Back To Account
     instances:
       account_count: Known accounts
       domain_name: Domain

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,8 +105,8 @@ en:
       enabled: Enabled
       feed_url: Feed URL
       followers: Followers
-      followers_url: Followers URL
       followers_local: "(%{local} local)"
+      followers_url: Followers URL
       follows: Follows
       header: Header
       inbox_url: Inbox URL
@@ -298,8 +298,8 @@ en:
         title: New e-mail blacklist entry
       title: E-mail blacklist
     followers:
-      title: "%{acct}'s Followers"
       back_to_account: Back To Account
+      title: "%{acct}'s Followers"
     instances:
       account_count: Known accounts
       domain_name: Domain

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,7 @@ Rails.application.routes.draw do
       resource :reset, only: [:create]
       resource :action, only: [:new, :create], controller: 'account_actions'
       resources :statuses, only: [:index, :create, :update, :destroy]
+      resources :followers, only: [:index]
 
       resource :confirmation, only: [:create] do
         collection do


### PR DESCRIPTION
For moderation, I often find myself wondering who, locally, is following a remote user. Currently, to see this, I have to go back to the web UI, paste in their full handle, click their profile, and go to the "Followers" tab (plus, this information is incidental, and if mastodon ever decides to resolve all of the follower information, there will be no place local followers are shown).

This PR adds a new page which is accessible via the "following" count on the admin's account view page, which shows the local followers. (It has a filter parameter for account location to indicate that only local followers are shown, and leave room for expansion if mastodon ever decides to store the entire remote follow list).