### PR TITLE
Make backend code counts endline as 1 char instead of 2, like front-end

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -112,11 +112,6 @@ class Account < ApplicationRecord
 
   delegate :chosen_languages, to: :user, prefix: false, allow_nil: true
 
-  # Convert newlines so validation doesn't count them as two characters
-  def note=(val)
-    self['note'] = val.gsub("\r\n", "\n")
-  end
-
   def local?
     domain.nil?
   end
@@ -462,11 +457,17 @@ class Account < ApplicationRecord
   end
 
   before_create :generate_keys
+  before_validation :normalize_note
   before_validation :normalize_domain
   before_validation :prepare_contents, if: :local?
   before_destroy :clean_feed_manager
 
   private
+
+  # Convert newlines so validation doesn't count them as two characters
+  def normalize_note
+    self.note = note.gsub("\r\n", "\n")
+  end
 
   def prepare_contents
     display_name&.strip!

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -112,6 +112,11 @@ class Account < ApplicationRecord
 
   delegate :chosen_languages, to: :user, prefix: false, allow_nil: true
 
+  # Convert newlines so validation doesn't count them as two characters
+  def note=(val)
+    self['note'] = val.gsub("\r\n", "\n")
+  end
+
   def local?
     domain.nil?
   end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -604,6 +604,7 @@ RSpec.describe Account, type: :model do
 
       it 'is valid if the note has 160 characters when endlines are counted as one character' do
         account = Fabricate.build(:account, note: Faker::Lorem.characters(159).insert(1, "\r\n"))
+        account.save
         account.valid?
         expect(account).to be_valid
       end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -601,6 +601,12 @@ RSpec.describe Account, type: :model do
         account.valid?
         expect(account).to model_have_error_on_field(:note)
       end
+
+      it 'is valid if the note has 160 characters when endlines are counted as one character' do
+        account = Fabricate.build(:account, note: Faker::Lorem.characters(159).insert(1, "\r\n"))
+        account.valid?
+        expect(account).to be_valid
+      end
     end
 
     context 'when is remote' do


### PR DESCRIPTION
Fix #4419 