### PR TITLE
Add error message with invalid email confirmation

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -68,12 +68,14 @@ class Api::BaseController < ApplicationController
   end
 
   def require_user!
-    if current_user && !current_user.disabled? && current_user.confirmed?
-      set_user_activity
-    elsif current_user
-      render json: { error: 'Your login is currently disabled' }, status: 403
-    else
+    if !current_user
       render json: { error: 'This method requires an authenticated user' }, status: 422
+    elsif current_user.disabled?
+      render json: { error: 'Your login is currently disabled' }, status: 403
+    elsif !current_user.confirmed?
+      render json: { error: 'Email confirmation is not completed' }, status: 403
+    else
+      set_user_activity
     end
   end
 


### PR DESCRIPTION
In order to distinguish it from the case where the account is disabled, add an error message when mail confirmation is not completed.