### PR TITLE
Improve admin UI for account view

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -62,9 +62,8 @@ module Admin
     def redownload
       authorize @account, :redownload?
 
-      @account.reset_avatar!
-      @account.reset_header!
-      @account.save!
+      @account.update!(last_webfingered_at: nil)
+      ResolveAccountService.new.call(@account)
 
       redirect_to admin_account_path(@account.id)
     end

--- a/app/javascript/styles/mastodon/dashboard.scss
+++ b/app/javascript/styles/mastodon/dashboard.scss
@@ -30,13 +30,19 @@
     }
   }
 
-  &__num {
+  &__num,
+  &__text {
     text-align: center;
     font-weight: 500;
     font-size: 24px;
+    line-height: 21px;
     color: $primary-text-color;
     font-family: $font-display, sans-serif;
     margin-bottom: 20px;
+  }
+
+  &__text {
+    font-size: 18px;
   }
 
   &__label {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -139,6 +139,10 @@ class User < ApplicationRecord
     confirmed_at.present?
   end
 
+  def invited?
+    invite_id.present?
+  end
+
   def staff?
     admin? || moderator?
   end

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -19,6 +19,7 @@ class ResolveAccountService < BaseService
       @account  = uri
       @username = @account.username
       @domain   = @account.domain
+      uri       = "#{@username}@#{@domain}"
 
       return @account if @account.local? || !webfinger_update_due?
     else

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -1,202 +1,185 @@
 - content_for :page_title do
   = @account.acct
 
-.table-wrapper
-  %table.table.inline-table
-    %tbody
-      %tr
-        %th= t('admin.accounts.username')
-        %td= @account.username
-      %tr
-        %th= t('admin.accounts.domain')
-        %td= @account.domain
-      %tr
-        %th= t('admin.accounts.display_name')
-        %td= @account.display_name
+= render 'application/card', account: @account
 
-      %tr
-        %th= t('admin.accounts.avatar')
-        %td
-          = link_to @account.avatar.url(:original) do
-            = image_tag @account.avatar.url(:original), alt: '', width: 40, height: 40, class: 'avatar'
-          - if @account.local? && @account.avatar?
-            = table_link_to 'trash', t('admin.accounts.remove_avatar'), remove_avatar_admin_account_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_avatar, @account)
-      %tr
-        %th= t('admin.accounts.header')
-        %td
-          = link_to @account.header.url(:original) do
-            = image_tag @account.header.url(:original), alt: '', width: 128, height: 40, class: 'header'
-          - if @account.local? && @account.header?
-            = table_link_to 'trash', t('admin.accounts.remove_header'), remove_header_admin_account_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_header, @account)
+.dashboard__counters{ style: 'margin-top: 10px' }
+  %div
+    = link_to admin_account_statuses_path(@account.id) do
+      .dashboard__counters__num= number_with_delimiter @account.statuses_count
+      .dashboard__counters__label= t 'admin.accounts.statuses'
+  %div
+    = link_to admin_account_statuses_path(@account.id, { media: true }) do
+      .dashboard__counters__num= number_to_human_size @account.media_attachments.sum('file_file_size')
+      .dashboard__counters__label= t 'admin.accounts.media_attachments'
+  %div
+    = link_to admin_account_followers_path(@account.id) do
+      .dashboard__counters__num= number_with_delimiter @account.local_followers_count
+      .dashboard__counters__label= t 'admin.accounts.followers'
+  %div
+    = link_to admin_reports_path(account_id: @account.id) do
+      .dashboard__counters__num= number_with_delimiter @account.reports.count
+      .dashboard__counters__label= t '.created_reports'
+  %div
+    = link_to admin_reports_path(target_account_id: @account.id) do
+      .dashboard__counters__num= number_with_delimiter @account.targeted_reports.count
+      .dashboard__counters__label= t '.targeted_reports'
+  %div
+    %div
+      .dashboard__counters__text
+        - if @account.local? && @account.user.nil?
+          %span.neutral= t('admin.accounts.deleted')
+        - elsif @account.suspended?
+          %span.red= t('admin.accounts.suspended')
+        - elsif @account.silenced?
+          %span.red= t('admin.accounts.silenced')
+        - elsif @account.local? && @account.user&.disabled?
+          %span.red= t('admin.accounts.disabled')
+        - elsif @account.local? && !@account.user&.confirmed?
+          %span.neutral= t('admin.accounts.confirming')
+        - else
+          %span.neutral= t('admin.accounts.no_limits_imposed')
+      .dashboard__counters__label= t 'admin.accounts.login_status'
 
-      - if @account.local?
-        %tr
-          %th= t('admin.accounts.role')
-          %td
-            - if @account.user.nil?
-              = t("admin.accounts.moderation.suspended")
-            - else
-              = t("admin.accounts.roles.#{@account.user&.role}")
-            = table_link_to 'angle-double-up', t('admin.accounts.promote'), promote_admin_account_role_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:promote, @account.user)
-            = table_link_to 'angle-double-down', t('admin.accounts.demote'), demote_admin_account_role_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:demote, @account.user)
-        %tr
-          %th= t('admin.accounts.email')
-          %td
-            = @account.user_email
-            = table_link_to 'edit', t('admin.accounts.change_email.label'), admin_account_change_email_path(@account.id) if can?(:change_email, @account.user)
-        - if @account.user_unconfirmed_email.present?
-          %th= t('admin.accounts.unconfirmed_email')
-          %td
-            = @account.user_unconfirmed_email
-        %tr
-          %th= t('admin.accounts.email_status')
-          %td
-            - if @account.user&.confirmed?
-              = t('admin.accounts.confirmed')
-            - else
-              = t('admin.accounts.confirming')
-              = table_link_to 'refresh', t('admin.accounts.resend_confirmation.send'), resend_admin_account_confirmation_path(@account.id), method: :post if can?(:confirm, @account.user)
-        %tr
-          %th= t('admin.accounts.login_status')
-          %td
-            - if @account.user&.disabled?
-              = t('admin.accounts.disabled')
-              = table_link_to 'unlock', t('admin.accounts.enable'), enable_admin_account_path(@account.id), method: :post if can?(:enable, @account.user)
-            - else
-              = t('admin.accounts.enabled')
-              = table_link_to 'lock', t('admin.accounts.disable'), new_admin_account_action_path(@account.id, type: 'disable') if can?(:disable, @account.user)
-        %tr
-          %th= t('admin.accounts.most_recent_ip')
-          %td= @account.user_current_sign_in_ip
-        %tr
-          %th= t('admin.accounts.most_recent_activity')
-          %td
-            - if @account.user_current_sign_in_at
-              %time.formatted{ datetime: @account.user_current_sign_in_at.iso8601, title: l(@account.user_current_sign_in_at) }
-                = l @account.user_current_sign_in_at
-            - else
-              \-
-      - else
-        %tr
-          %th= t('admin.accounts.profile_url')
-          %td= link_to @account.url, @account.url
-        %tr
-          %th= t('admin.accounts.protocol')
-          %td= @account.protocol.humanize
-
-      %tr
-        %th= t('admin.accounts.follows')
-        %td= number_to_human @account.following_count
-      %tr
-        %th= t('admin.accounts.followers')
-        %td
-          = number_to_human @account.followers_count
-          = link_to t('admin.accounts.followers_local', local: number_to_human(@account.local_followers_count)), admin_account_followers_path(@account.id)
-      %tr
-        %th= t('admin.accounts.statuses')
-        %td= link_to number_to_human(@account.statuses_count), admin_account_statuses_path(@account.id)
-      %tr
-        %th= t('admin.accounts.media_attachments')
-        %td
-          = link_to number_to_human(@account.media_attachments.count), admin_account_statuses_path(@account.id, { media: true })
-          = surround '(', ')' do
-            = number_to_human_size @account.media_attachments.sum('file_file_size')
-      %tr
-        %th= t('.created_reports')
-        %td= link_to pluralize(@account.reports.count, t('.report')), admin_reports_path(account_id: @account.id)
-      %tr
-        %th= t('.targeted_reports')
-        %td= link_to pluralize(@account.targeted_reports.count, t('.report')), admin_reports_path(target_account_id: @account.id)
-
-%div{ style: 'overflow: hidden' }
-  %div{ style: 'float: right' }
-    - if @account.local?
-      = link_to t('admin.accounts.reset_password'), admin_account_reset_path(@account.id), method: :create, class: 'button' if can?(:reset_password, @account.user)
-      - if @account.user&.otp_required_for_login?
-        = link_to t('admin.accounts.disable_two_factor_authentication'), admin_user_two_factor_authentication_path(@account.user.id), method: :delete, class: 'button' if can?(:disable_2fa, @account.user)
-      - unless @account.memorial?
-        = link_to t('admin.accounts.memorialize'), memorialize_admin_account_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive' if can?(:memorialize, @account)
-    - else
-      = link_to t('admin.accounts.redownload'), redownload_admin_account_path(@account.id), method: :post, class: 'button' if can?(:redownload, @account)
-
-  %div{ style: 'float: left' }
-    - if @account.silenced?
-      = link_to t('admin.accounts.undo_silenced'), unsilence_admin_account_path(@account.id), method: :post, class: 'button' if can?(:unsilence, @account)
-    - else
-      = link_to t('admin.accounts.silence'), new_admin_account_action_path(@account.id, type: 'silence'), class: 'button button--destructive' if can?(:silence, @account)
-
-    - if @account.local?
-      - unless @account.user_confirmed?
-        = link_to t('admin.accounts.confirm'), admin_account_confirmation_path(@account.id), method: :post, class: 'button' if can?(:confirm, @account.user)
-
-    - if @account.suspended?
-      = link_to t('admin.accounts.undo_suspension'), unsuspend_admin_account_path(@account.id), method: :post, class: 'button' if can?(:unsuspend, @account)
-    - else
-      = link_to t('admin.accounts.perform_full_suspension'), new_admin_account_action_path(@account.id, type: 'suspend'), class: 'button button--destructive' if can?(:suspend, @account)
-
-- if !@account.local? && @account.hub_url.present?
-  %hr.spacer/
-
-  %h3 OStatus
-
+- unless @account.local? && @account.user.nil?
   .table-wrapper
     %table.table.inline-table
       %tbody
-        %tr
-          %th= t('admin.accounts.feed_url')
-          %td= link_to @account.remote_url, @account.remote_url
-        %tr
-          %th= t('admin.accounts.push_subscription_expires')
-          %td
-            - if @account.subscribed?
-              %time.formatted{ datetime: @account.subscription_expires_at.iso8601, title: l(@account.subscription_expires_at) }
-                = l @account.subscription_expires_at
-            - else
-              = t('admin.accounts.not_subscribed')
-        %tr
-          %th= t('admin.accounts.salmon_url')
-          %td= link_to @account.salmon_url, @account.salmon_url
+        - if @account.local?
+          - if @account.avatar?
+            %tr
+              %th= t('admin.accounts.avatar')
+              %td= table_link_to 'trash', t('admin.accounts.remove_avatar'), remove_avatar_admin_account_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_avatar, @account)
+              %td
+
+          - if @account.header?
+            %tr
+              %th= t('admin.accounts.header')
+              %td= table_link_to 'trash', t('admin.accounts.remove_header'), remove_header_admin_account_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:remove_header, @account)
+              %td
+
+          %tr
+            %th= t('admin.accounts.role')
+            %td= t("admin.accounts.roles.#{@account.user&.role}")
+            %td
+              = table_link_to 'angle-double-up', t('admin.accounts.promote'), promote_admin_account_role_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:promote, @account.user)
+              = table_link_to 'angle-double-down', t('admin.accounts.demote'), demote_admin_account_role_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') } if can?(:demote, @account.user)
+
+          %tr
+            %th= t('admin.accounts.email')
+            %td= @account.user_email
+            %td= table_link_to 'edit', t('admin.accounts.change_email.label'), admin_account_change_email_path(@account.id) if can?(:change_email, @account.user)
+
+          - if @account.user_unconfirmed_email.present?
+            %tr
+              %th= t('admin.accounts.unconfirmed_email')
+              %td= @account.user_unconfirmed_email
+              %td
+
+          %tr
+            %th= t('admin.accounts.email_status')
+            %td
+              - if @account.user&.confirmed?
+                = t('admin.accounts.confirmed')
+              - else
+                = t('admin.accounts.confirming')
+            %td= table_link_to 'refresh', t('admin.accounts.resend_confirmation.send'), resend_admin_account_confirmation_path(@account.id), method: :post if can?(:confirm, @account.user)
+
+          %tr
+            %th= t('admin.accounts.login_status')
+            %td
+              - if @account.user&.disabled?
+                = t('admin.accounts.disabled')
+              - else
+                = t('admin.accounts.enabled')
+            %td
+              - if @account.user&.disabled?
+                = table_link_to 'unlock', t('admin.accounts.enable'), enable_admin_account_path(@account.id), method: :post if can?(:enable, @account.user)
+              - else
+                = table_link_to 'lock', t('admin.accounts.disable'), new_admin_account_action_path(@account.id, type: 'disable') if can?(:disable, @account.user)
+
+          %tr
+            %th= t('simple_form.labels.defaults.locale')
+            %td= @account.user_locale
+            %td
+
+          %tr
+            %th= t('admin.accounts.joined')
+            %td
+              %time.formatted{ datetime: @account.created_at.iso8601, title: l(@account.created_at) }= l @account.created_at
+            %td
+
+          %tr
+            %th= t('admin.accounts.most_recent_ip')
+            %td= @account.user_current_sign_in_ip
+            %td
+
+          %tr
+            %th= t('admin.accounts.most_recent_activity')
+            %td
+              - if @account.user_current_sign_in_at
+                %time.formatted{ datetime: @account.user_current_sign_in_at.iso8601, title: l(@account.user_current_sign_in_at) }= l @account.user_current_sign_in_at
+
+          - if @account.user&.invited?
+            %tr
+              %th= t('admin.accounts.invited_by')
+              %td= admin_account_link_to @account.user.invite.user.account
+              %td
+
+        - else
+          %tr
+            %th= t('admin.accounts.inbox_url')
+            %td
+              = @account.inbox_url
+              = fa_icon DeliveryFailureTracker.unavailable?(@account.inbox_url) ? 'times' : 'check'
+          %tr
+            %th= t('admin.accounts.shared_inbox_url')
+            %td
+              = @account.shared_inbox_url
+              = fa_icon DeliveryFailureTracker.unavailable?(@account.shared_inbox_url) ? 'times' : 'check'
 
   %div{ style: 'overflow: hidden' }
     %div{ style: 'float: right' }
-      = link_to @account.subscribed? ? t('admin.accounts.resubscribe') : t('admin.accounts.subscribe'), subscribe_admin_account_path(@account.id), method: :post, class: 'button' if can?(:subscribe, @account)
-      - if @account.subscribed?
-        = link_to t('admin.accounts.unsubscribe'), unsubscribe_admin_account_path(@account.id), method: :post, class: 'button negative' if can?(:unsubscribe, @account)
+      - if @account.local?
+        = link_to t('admin.accounts.reset_password'), admin_account_reset_path(@account.id), method: :create, class: 'button' if can?(:reset_password, @account.user)
+        - if @account.user&.otp_required_for_login?
+          = link_to t('admin.accounts.disable_two_factor_authentication'), admin_user_two_factor_authentication_path(@account.user.id), method: :delete, class: 'button' if can?(:disable_2fa, @account.user)
+        - unless @account.memorial?
+          = link_to t('admin.accounts.memorialize'), memorialize_admin_account_path(@account.id), method: :post, data: { confirm: t('admin.accounts.are_you_sure') }, class: 'button button--destructive' if can?(:memorialize, @account)
+      - else
+        = link_to t('admin.accounts.redownload'), redownload_admin_account_path(@account.id), method: :post, class: 'button' if can?(:redownload, @account)
 
-- if !@account.local? && @account.inbox_url.present?
+    %div{ style: 'float: left' }
+      - if @account.local?
+        = link_to t('admin.accounts.warn'), new_admin_account_action_path(@account.id, type: 'none'), class: 'button' if can?(:warn, @account)
+      - if @account.silenced?
+        = link_to t('admin.accounts.undo_silenced'), unsilence_admin_account_path(@account.id), method: :post, class: 'button' if can?(:unsilence, @account)
+      - else
+        = link_to t('admin.accounts.silence'), new_admin_account_action_path(@account.id, type: 'silence'), class: 'button button--destructive' if can?(:silence, @account)
+
+      - if @account.local?
+        - unless @account.user_confirmed?
+          = link_to t('admin.accounts.confirm'), admin_account_confirmation_path(@account.id), method: :post, class: 'button' if can?(:confirm, @account.user)
+
+      - if @account.suspended?
+        = link_to t('admin.accounts.undo_suspension'), unsuspend_admin_account_path(@account.id), method: :post, class: 'button' if can?(:unsuspend, @account)
+      - else
+        = link_to t('admin.accounts.perform_full_suspension'), new_admin_account_action_path(@account.id, type: 'suspend'), class: 'button button--destructive' if can?(:suspend, @account)
+
   %hr.spacer/
 
-  %h3 ActivityPub
+  - unless @warnings.empty?
+    = render @warnings
 
-  .table-wrapper
-    %table.table.inline-table
-      %tbody
-        %tr
-          %th= t('admin.accounts.inbox_url')
-          %td= link_to @account.inbox_url, @account.inbox_url
-        %tr
-          %th= t('admin.accounts.outbox_url')
-          %td= link_to @account.outbox_url, @account.outbox_url
-        %tr
-          %th= t('admin.accounts.shared_inbox_url')
-          %td= link_to @account.shared_inbox_url, @account.shared_inbox_url
-        %tr
-          %th= t('admin.accounts.followers_url')
-          %td= link_to @account.followers_url, @account.followers_url
+    %hr.spacer/
 
-%hr.spacer/
+  = render @moderation_notes
 
-= render @warnings
+  = simple_form_for @account_moderation_note, url: admin_account_moderation_notes_path do |f|
+    = render 'shared/error_messages', object: @account_moderation_note
 
-%hr.spacer/
+    = f.input :content, placeholder: t('admin.reports.notes.placeholder'), rows: 6
+    = f.hidden_field :target_account_id
 
-= render @moderation_notes
-
-= simple_form_for @account_moderation_note, url: admin_account_moderation_notes_path do |f|
-  = render 'shared/error_messages', object: @account_moderation_note
-
-  = f.input :content, placeholder: t('admin.reports.notes.placeholder'), rows: 6
-  = f.hidden_field :target_account_id
-
-  .actions
-    = f.button :button, t('admin.account_moderation_notes.create'), type: :submit
+    .actions
+      = f.button :button, t('admin.account_moderation_notes.create'), type: :submit

--- a/app/views/admin/followers/index.html.haml
+++ b/app/views/admin/followers/index.html.haml
@@ -1,6 +1,3 @@
-- content_for :header_tags do
-  = javascript_pack_tag 'admin', integrity: true, async: true, crossorigin: 'anonymous'
-
 - content_for :page_title do
   = t('admin.followers.title', acct: @account.acct)
 
@@ -11,8 +8,10 @@
       %li= link_to t('admin.accounts.location.local'), admin_account_followers_path(@account.id), class: 'selected'
   .back-link{ style: 'flex: 1 1 auto; text-align: right' }
     = link_to admin_account_path(@account.id) do
-      %i.fa.fa-chevron-left.fa-fw
+      = fa_icon 'chevron-left fw'
       = t('admin.followers.back_to_account')
+
+%hr.spacer/
 
 .table-wrapper
   %table.table
@@ -24,6 +23,6 @@
         %th= t('admin.accounts.most_recent_activity')
         %th
     %tbody
-      = render partial: 'admin/accounts/account', collection: @followers.map{|a| a.account}
+      = render partial: 'admin/accounts/account', collection: @followers.map(&:account)
 
 = paginate @followers

--- a/app/views/admin/statuses/index.html.haml
+++ b/app/views/admin/statuses/index.html.haml
@@ -14,7 +14,7 @@
       %li= link_to t('admin.statuses.with_media'), admin_account_statuses_path(@account.id, current_params.merge(media: true)), class: params[:media] && 'selected'
   .back-link{ style: 'flex: 1 1 auto; text-align: right' }
     = link_to admin_account_path(@account.id) do
-      %i.fa.fa-chevron-left.fa-fw
+      = fa_icon 'chevron-left fw'
       = t('admin.statuses.back_to_account')
 
 %hr.spacer/

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -170,7 +170,6 @@ ar:
       shared_inbox_url: رابط الصندوق المُشترَك للبريد الوارد
       show:
         created_reports: البلاغات التي أنشأها هذا الحساب
-        report: التقرير
         targeted_reports: التقريرات التي أُنشِأت ضد هذا الحساب
       silence: سكتهم
       silenced: تم كتمه

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -152,7 +152,6 @@ ca:
       shared_inbox_url: URL de la safata d'entrada compartida
       show:
         created_reports: Informes creats per aquest compte
-        report: informe
         targeted_reports: Informes realitzats sobre aquest compte
       silence: Silenci
       silenced: Silenciat

--- a/config/locales/co.yml
+++ b/config/locales/co.yml
@@ -154,7 +154,6 @@ co:
       shared_inbox_url: URL di l’inbox spartuta
       show:
         created_reports: Signalamenti creati da stu contu
-        report: Signalamentu
         targeted_reports: Signalamenti creati contr’à stu contu
       silence: Silenzà
       silenced: Silenzatu

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -158,7 +158,6 @@ cs:
       shared_inbox_url: URL sdílené schránky
       show:
         created_reports: Nahlášení vytvořené z tohoto účtu
-        report: nahlášení
         targeted_reports: Nahlášení vytvořena o tomto účtu
       silence: Utišit
       silenced: Utišen/a

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -142,7 +142,6 @@ cy:
       shared_inbox_url: URL Mewnflwch wedi ei rannu
       show:
         created_reports: Adroddiadau a grewyd gan y cyfri hwn
-        report: adrodd
         targeted_reports: Adroddiadau am y cyfri hwn
       silence: Tawelu
       silenced: Tawelwyd

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -149,7 +149,6 @@ da:
       shared_inbox_url: Link til delt indbakke
       show:
         created_reports: Anmeldelser oprettet af denne konto
-        report: anmeld
         targeted_reports: Anmeldelser fra denne konto
       silence: Dæmp
       silenced: Dæmpet

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -154,7 +154,6 @@ de:
       shared_inbox_url: Geteilter Posteingang URL
       show:
         created_reports: Meldungen durch dieses Konto
-        report: Meldung
         targeted_reports: Meldungen über dieses Konto
       silence: Stummschalten
       silenced: Stummgeschaltet

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -154,7 +154,6 @@ el:
       shared_inbox_url: URL κοινόχρηστων εισερχομένων
       show:
         created_reports: Αναφορές από αυτόν το λογαριασμό
-        report: καταγγελία
         targeted_reports: Αναφορές για αυτόν το λογαριασμό
       silence: Αποσιώπησε
       silenced: Αποσιωπημένοι

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,14 +84,15 @@ en:
       by_domain: Domain
       change_email:
         changed_msg: Account email successfully changed!
-        current_email: Current Email
-        label: Change Email
-        new_email: New Email
-        submit: Change Email
-        title: Change Email for %{username}
+        current_email: Current email
+        label: Change email
+        new_email: New email
+        submit: Change email
+        title: Change email for %{username}
       confirm: Confirm
       confirmed: Confirmed
       confirming: Confirming
+      deleted: Deleted
       demote: Demote
       disable: Disable
       disable_two_factor_authentication: Disable 2FA
@@ -99,18 +100,19 @@ en:
       display_name: Display name
       domain: Domain
       edit: Edit
-      email: E-mail
-      email_status: E-mail Status
+      email: Email
+      email_status: Email status
       enable: Enable
       enabled: Enabled
       feed_url: Feed URL
       followers: Followers
-      followers_local: "(%{local} local)"
       followers_url: Followers URL
       follows: Follows
       header: Header
       inbox_url: Inbox URL
+      invited_by: Invited by
       ip: IP
+      joined: Joined
       location:
         all: All
         local: Local
@@ -137,7 +139,7 @@ en:
       protocol: Protocol
       public: Public
       push_subscription_expires: PuSH subscription expires
-      redownload: Refresh avatar
+      redownload: Refresh profile
       remove_avatar: Remove avatar
       remove_header: Remove header
       resend_confirmation:
@@ -155,22 +157,22 @@ en:
         user: User
       salmon_url: Salmon URL
       search: Search
-      shared_inbox_url: Shared Inbox URL
+      shared_inbox_url: Shared inbox URL
       show:
-        created_reports: Reports created by this account
-        report: report
-        targeted_reports: Reports made about this account
+        created_reports: Made reports
+        targeted_reports: Reported by others
       silence: Silence
       silenced: Silenced
       statuses: Statuses
       subscribe: Subscribe
       suspended: Suspended
       title: Accounts
-      unconfirmed_email: Unconfirmed E-mail
+      unconfirmed_email: Unconfirmed email
       undo_silenced: Undo silence
       undo_suspension: Undo suspension
       unsubscribe: Unsubscribe
       username: Username
+      warn: Warn
       web: Web
     action_logs:
       actions:

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -152,7 +152,6 @@ eo:
       shared_inbox_url: URL de kunhavigita leterkesto
       show:
         created_reports: Signaloj kreitaj de ĉi tiu konto
-        report: signalo
         targeted_reports: Signaloj kreitaj de ĉi tiu konto
       silence: Kaŝi
       silenced: Silentigita

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -150,7 +150,6 @@ es:
       shared_inbox_url: URL de bandeja compartida
       show:
         created_reports: Reportes hechos por esta cuenta
-        report: reportar
         targeted_reports: Reportes hechos sobre esta cuenta
       silence: Silenciar
       silenced: Silenciado

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -152,7 +152,6 @@ eu:
       shared_inbox_url: Partekatutako sarrera ontziaren URL-a
       show:
         created_reports: Kontu honek sortutako txostenak
-        report: salatu
         targeted_reports: Kontu honek egindako salaketak
       silence: Isilarazi
       silenced: Isilarazita

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -150,7 +150,6 @@ fa:
       shared_inbox_url: نشانی صندوق ورودی مشترک
       show:
         created_reports: گزارش‌ها از طرف این حساب
-        report: گزارش
         targeted_reports: گزارش‌ها دربارهٔ این حساب
       silence: بی‌صدا
       silenced: بی‌صداشده

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -129,7 +129,6 @@ fi:
       shared_inbox_url: Jaetun saapuvan postilaatikon osoite
       show:
         created_reports: Tämän tilin luomat raportit
-        report: raportti
         targeted_reports: Tästä tilistä tehdyt raportit
       silence: Hiljennä
       statuses: Tilat

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -154,7 +154,6 @@ fr:
       shared_inbox_url: URL de la boite de réception partagée
       show:
         created_reports: Signalements créés par ce compte
-        report: signalement
         targeted_reports: Signalements créés visant ce compte
       silence: Masquer
       silenced: Silencié

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -154,7 +154,6 @@ gl:
       shared_inbox_url: URL da caixa de entrada compartida
       show:
         created_reports: Informes creados por esta conta
-        report: informar
         targeted_reports: Informes feitos sobre esta conta
       silence: Acalar
       silenced: Acalada

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -120,7 +120,6 @@ he:
       shared_inbox_url: תיבה משותפת לדואר נכנס
       show:
         created_reports: דיווחים מאת חשבון זה
-        report: דו"ח
         targeted_reports: דיווחים נגד חשבון זה
       silence: השתקה
       statuses: הודעות

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -118,7 +118,6 @@ hu:
       shared_inbox_url: Bejövő üzenetek URL keresése
       show:
         created_reports: Ezen fiók által létrehozott jelentések
-        report: jelentés
         targeted_reports: Jelentések ezzel a fiókkal kapcsolatban
       silence: Némítás
       statuses: Tülkök

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -62,7 +62,6 @@ id:
       salmon_url: URL Salmon
       show:
         created_reports: Laporan yang dibuat oleh akun ini
-        report: laporan
         targeted_reports: Laporan yang dibuat tentang akun ini
       silence: Diam
       statuses: Status

--- a/config/locales/io.yml
+++ b/config/locales/io.yml
@@ -52,7 +52,6 @@ io:
       salmon_url: Salmon URL
       show:
         created_reports: Reports created by this account
-        report: report
         targeted_reports: Reports made about this account
       silence: Silence
       statuses: Statuses

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -150,7 +150,6 @@ it:
       shared_inbox_url: URL Inbox Condiviso
       show:
         created_reports: Rapporti creati da questo account
-        report: segnala
         targeted_reports: Rapporti che riguardano questo account
       silence: Silenzia
       silenced: Silenziato

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -154,7 +154,6 @@ ja:
       shared_inbox_url: Shared Inbox URL
       show:
         created_reports: このアカウントで作られたレポート
-        report: レポート
         targeted_reports: このアカウントについてのレポート
       silence: サイレンス
       silenced: サイレンス済み

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -139,7 +139,6 @@ ka:
       shared_inbox_url: გაზიარებული ინბოქსის ურლ
       show:
         created_reports: ამ ანგარიშის მიერ შექმნილი რეპორტები
-        report: რეპორტი
         targeted_reports: ამ ანგარიშზე მიღებული რეპორტები
       silence: სიჩუმე
       statuses: სტატუსები

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -154,7 +154,6 @@ ko:
       shared_inbox_url: 공유된 inbox URL
       show:
         created_reports: 이 계정에서 제출된 신고
-        report: 신고
         targeted_reports: 이 계정에 대한 신고
       silence: 침묵
       silenced: 침묵 됨

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -150,7 +150,6 @@ ms:
       shared_inbox_url: URL Peti Masuk Berkongsi
       show:
         created_reports: Laporan yang dicipta oleh akaun ini
-        report: laporan
         targeted_reports: Laporan yang dicipta berkaitan akaun ini
       silence: Senyap
       silenced: Disenyapkan

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -154,7 +154,6 @@ nl:
       shared_inbox_url: Gedeelde inbox-URL
       show:
         created_reports: Door dit account aangemaakte rapportages
-        report: gerapporteerd
         targeted_reports: Over dit account aangemaakte rapportages
       silence: Negeren
       silenced: Genegeerd

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -118,7 +118,6 @@
       shared_inbox_url: Delt Innboks URL
       show:
         created_reports: Rapporter laget av denne kontoen
-        report: rapport
         targeted_reports: Rapporter laget om denne kontoen
       silence: Målbind
       statuses: Statuser

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -154,7 +154,6 @@ oc:
       shared_inbox_url: URL de recepcion partejada
       show:
         created_reports: Rapòrts creat per aqueste compte
-        report: rapòrt
         targeted_reports: Rapòrts faches tocant aqueste compte
       silence: Silenci
       silenced: Rescondut

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -160,7 +160,6 @@ pl:
       shared_inbox_url: Adres udostępnianej skrzynki
       show:
         created_reports: Zgłoszenia tego użytkownika
-        report: zgłoszeń
         targeted_reports: Zgłoszenia dotyczące tego użytkownika
       silence: Wycisz
       silenced: Wyciszono

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -152,7 +152,6 @@ pt-BR:
       shared_inbox_url: URL da caixa de entrada compartilhada
       show:
         created_reports: Denúncias criadas por esta conta
-        report: relatórios
         targeted_reports: Denúncias feitas sobre esta conta
       silence: Silenciar
       silenced: Silenciado

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -118,7 +118,6 @@ pt:
       shared_inbox_url: URL da caixa de entrada compartilhada
       show:
         created_reports: Relatórios gerados por esta conta
-        report: relatórios
         targeted_reports: Relatórios feitos sobre esta conta
       silence: Silêncio
       statuses: Status

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -155,7 +155,6 @@ ru:
       shared_inbox_url: URL общих входящих
       show:
         created_reports: Жалобы, отправленные этим аккаунтом
-        report: жалоба
         targeted_reports: Жалобы на этот аккаунт
       silence: Глушение
       statuses: Статусы

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -158,7 +158,6 @@ sk:
       shared_inbox_url: URL zdieľanej schránky
       show:
         created_reports: Reportované týmto používateľom
-        report: report
         targeted_reports: Nahlásenia pre tento účet
       silence: Stíšiť
       silenced: Utíšení

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -118,7 +118,6 @@ sr-Latn:
       shared_inbox_url: Adresa deljenog sandučeta
       show:
         created_reports: Prijave koje je napravio ovaj nalog
-        report: prijava
         targeted_reports: Prijave napravljene o ovom nalogu
       silence: Ućutkaj
       statuses: Statusi

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -158,7 +158,6 @@ sr:
       shared_inbox_url: Адреса дељеног сандучета
       show:
         created_reports: Пријаве које је направио овај налог
-        report: пријава
         targeted_reports: Пријаве направљене о овом налогу
       silence: Ућуткај
       silenced: Ућуткан

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -130,7 +130,6 @@ sv:
       shared_inbox_url: Delad inkorg URL
       show:
         created_reports: Anmälningar som skapats av det här kontot
-        report: anmäla
         targeted_reports: Anmälningar gjorda om detta konto
       silence: Tystnad
       statuses: Status

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -61,7 +61,6 @@ th:
       salmon_url: Salmon URL
       show:
         created_reports: รายงานที่ถูกสร้างโดย แอคเคาท์นี้
-        report: รายงาน
         targeted_reports: รายงานเกี่ยวกับแอคเคาท์นี้
       silence: ปิดเสียง
       statuses: สถานะ

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -60,7 +60,6 @@ tr:
       salmon_url: Salmon Linki
       show:
         created_reports: Bu hesap tarafından gelen şikayetler
-        report: şikayet
         targeted_reports: Bu hesaba gelen şikayetler
       silence: Sustur
       statuses: Durumlar

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -135,7 +135,6 @@ uk:
       shared_inbox_url: URL спільного вхідного кошика
       show:
         created_reports: Скарги створені цим аккаунтом
-        report: скарга
         targeted_reports: Скарги щодо цього аккаунту
       silence: Глушення
       statuses: Статуси

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -141,7 +141,6 @@ zh-CN:
       shared_inbox_url: 公用收件箱（Shared Inbox）URL
       show:
         created_reports: 这个帐户提交的举报
-        report: 个举报
         targeted_reports: 针对这个帐户的举报
       silence: 隐藏
       statuses: 嘟文

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -130,7 +130,6 @@ zh-HK:
       shared_inbox_url: 公共收件箱（Shared Inbox）URL
       show:
         created_reports: 此用戶所提舉報的紀錄
-        report: 舉報
         targeted_reports: 此用戶被舉報的紀錄
       silence: 靜音
       statuses: 文章

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -135,7 +135,6 @@ zh-TW:
       shared_inbox_url: 公共收件箱 (Shared Inbox) URL
       show:
         created_reports: 這個使用者提交的檢舉
-        report: 檢舉
         targeted_reports: 針對這個使用者的檢舉
       silence: 靜音
       statuses: 嘟文


### PR DESCRIPTION
- Avatar, header, display name, username, and domain are now displayed more naturally in a card
- Show most important data in grid view, like on dashboard
- Show who invited user (if an invite was used)
- Show the user's preferred language
- Remove useless information about OStatus/ActivityPub, leave only inbox URLs
- Indicate if inbox URLs are considered unavailable due to delivery failures
- Change "refresh avatar" into "refresh profile" that fully re-fetches the profile, incl. avatar/header
- Remove most UI elements for locally deleted accounts that nothing can be done with
- Show when user joined (resolve #9603)
___

Remote account:

![image](https://user-images.githubusercontent.com/184731/50494855-a4fec480-0a1d-11e9-82de-f892de21270a.png)

Local account:

![image](https://user-images.githubusercontent.com/184731/50494617-4dac2480-0a1c-11e9-9261-9810f1a0c107.png)

Deleted account:

![image](https://user-images.githubusercontent.com/184731/50494630-5f8dc780-0a1c-11e9-8fe7-de702deebe86.png)
