### PR TITLE
Style column scrollbars

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1861,6 +1861,13 @@ a.account__display-name {
 
   > .scrollable {
     background: $ui-base-color;
+    scrollbar-width: thin;
+    scrollbar-color: lighten($ui-base-color, 4%) rgba($base-overlay-background, 0.1);
+    transition: scrollbar-color 0.2s;
+
+    &:hover {
+      scrollbar-color: lighten($ui-base-color, 6%) $ui-base-color;
+    }
   }
 }
 


### PR DESCRIPTION
Style column scrollbars with latest spec properties.  
See: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scrollbars  

This will work for Firefox >= 64 (current), as well as spec compliant browsers.

I reused the colors from the `::-webkit-scrollbar` rules in `reset.scss`.  

### Before
![screenshot_2018-12-28 la quadrature du net - mastodon - media federe 1](https://user-images.githubusercontent.com/335467/50517297-15562600-0ab0-11e9-9358-81bd9fd4832a.png)

### After 
![screenshot_2018-12-28 la quadrature du net - mastodon - media federe](https://user-images.githubusercontent.com/335467/50517304-20a95180-0ab0-11e9-8249-421a3431dad4.png)

NB: screenshot on a Gnome env.  


