### PR TITLE
Replace Ruby 2.3 with 2.6 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,13 +116,6 @@ jobs:
         environment: *ruby_environment
     <<: *install_ruby_dependencies
 
-  install-ruby2.3:
-    <<: *defaults
-    docker:
-      - image: circleci/ruby:2.3.7-stretch-node
-        environment: *ruby_environment
-    <<: *install_ruby_dependencies
-
   build:
     <<: *defaults
     steps:
@@ -168,17 +161,6 @@ jobs:
       - image: circleci/redis:4.0.9-alpine
     <<: *test_steps
 
-  test-ruby2.3:
-    <<: *defaults
-    docker:
-      - image: circleci/ruby:2.3.7-stretch-node
-        environment: *ruby_environment
-      - image: circleci/postgres:10.3-alpine
-        environment:
-          POSTGRES_USER: root
-      - image: circleci/redis:4.0.9-alpine
-    <<: *test_steps
-
   test-webui:
     <<: *defaults
     docker:
@@ -212,10 +194,6 @@ workflows:
           requires:
             - install
             - install-ruby2.5
-      - install-ruby2.3:
-          requires:
-            - install
-            - install-ruby2.5
       - build:
           requires:
             - install-ruby2.5
@@ -230,10 +208,6 @@ workflows:
       - test-ruby2.4:
           requires:
             - install-ruby2.4
-            - build
-      - test-ruby2.3:
-          requires:
-            - install-ruby2.3
             - build
       - test-webui:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 aliases:
   - &defaults
     docker:
-      - image: circleci/ruby:2.5.1-stretch-node
+      - image: circleci/ruby:2.6.0-stretch-node
         environment: &ruby_environment
           BUNDLE_APP_CONFIG: ./.bundle/
           DB_HOST: localhost
@@ -100,19 +100,19 @@ jobs:
 
   install-ruby2.6:
     <<: *defaults
-    docker:
-      - image: circleci/ruby:2.6.0-stretch-node
-        environment: *ruby_environment
     <<: *install_ruby_dependencies
 
   install-ruby2.5:
     <<: *defaults
+    docker:
+      - image: circleci/ruby:2.5.3-stretch-node
+        environment: *ruby_environment
     <<: *install_ruby_dependencies
 
   install-ruby2.4:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.4.4-stretch-node
+      - image: circleci/ruby:2.4.5-stretch-node
         environment: *ruby_environment
     <<: *install_ruby_dependencies
 
@@ -133,7 +133,7 @@ jobs:
     docker:
       - image: circleci/ruby:2.6.0-stretch-node
         environment: *ruby_environment
-      - image: circleci/postgres:10.3-alpine
+      - image: circleci/postgres:10.6-alpine
         environment:
           POSTGRES_USER: root
       - image: circleci/redis:5.0.3-alpine3.8
@@ -142,29 +142,29 @@ jobs:
   test-ruby2.5:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.5.1-stretch-node
+      - image: circleci/ruby:2.5.3-stretch-node
         environment: *ruby_environment
-      - image: circleci/postgres:10.3-alpine
+      - image: circleci/postgres:10.6-alpine
         environment:
           POSTGRES_USER: root
-      - image: circleci/redis:4.0.9-alpine
+      - image: circleci/redis:4.0.12-alpine
     <<: *test_steps
 
   test-ruby2.4:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.4.4-stretch-node
+      - image: circleci/ruby:2.4.5-stretch-node
         environment: *ruby_environment
-      - image: circleci/postgres:10.3-alpine
+      - image: circleci/postgres:10.6-alpine
         environment:
           POSTGRES_USER: root
-      - image: circleci/redis:4.0.9-alpine
+      - image: circleci/redis:4.0.12-alpine
     <<: *test_steps
 
   test-webui:
     <<: *defaults
     docker:
-      - image: circleci/node:8.11.1-stretch
+      - image: circleci/node:8.15.0-stretch
     steps:
       - *attach_workspace
       - run: ./bin/retry yarn test:jest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,13 @@ jobs:
     <<: *defaults
     <<: *install_steps
 
+  install-ruby2.6:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.6.0-stretch-node
+        environment: *ruby_environment
+    <<: *install_ruby_dependencies
+
   install-ruby2.5:
     <<: *defaults
     <<: *install_ruby_dependencies
@@ -127,6 +134,17 @@ jobs:
           paths:
               - ./mastodon/public/assets
               - ./mastodon/public/packs-test/
+
+  test-ruby2.6:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.6.0-stretch-node
+        environment: *ruby_environment
+      - image: circleci/postgres:10.3-alpine
+        environment:
+          POSTGRES_USER: root
+      - image: circleci/redis:5.0.3-alpine3.8
+    <<: *test_steps
 
   test-ruby2.5:
     <<: *defaults
@@ -183,6 +201,10 @@ workflows:
   build-and-test:
     jobs:
       - install
+      - install-ruby2.6:
+          requires:
+            - install
+            - install-ruby2.5
       - install-ruby2.5:
           requires:
             - install
@@ -197,6 +219,10 @@ workflows:
       - build:
           requires:
             - install-ruby2.5
+      - test-ruby2.6:
+          requires:
+            - install-ruby2.6
+            - build
       - test-ruby2.5:
           requires:
             - install-ruby2.5

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 2.3.0', '< 2.6.0'
+ruby '>= 2.3.0', '< 2.7.0'
 
 gem 'pkg-config', '~> 1.3'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 2.3.0', '< 2.7.0'
+ruby '>= 2.4.0', '< 2.7.0'
 
 gem 'pkg-config', '~> 1.3'
 


### PR DESCRIPTION
* Added Ruby 2.6 and Redis 5
* Dropped Ruby 2.3 due to upcoming EOL
* Updated Docker Images with most recent versions