### PR TITLE
Skip full text search if failed

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -14,8 +14,12 @@ class SearchService < BaseService
         results.merge!(url_resource_results) unless url_resource.nil?
       elsif query.present?
         results[:accounts] = perform_accounts_search! if account_searchable?
-        results[:statuses] = perform_statuses_search! if full_text_searchable?
         results[:hashtags] = perform_hashtags_search! if hashtag_searchable?
+        begin
+          results[:statuses] = perform_statuses_search! if full_text_searchable?
+        rescue Faraday::ConnectionFailed
+          results[:statuses] = []
+        end
       end
     end
   end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -14,12 +14,8 @@ class SearchService < BaseService
         results.merge!(url_resource_results) unless url_resource.nil?
       elsif query.present?
         results[:accounts] = perform_accounts_search! if account_searchable?
+        results[:statuses] = perform_statuses_search! if full_text_searchable?
         results[:hashtags] = perform_hashtags_search! if hashtag_searchable?
-        begin
-          results[:statuses] = perform_statuses_search! if full_text_searchable?
-        rescue Faraday::ConnectionFailed
-          results[:statuses] = []
-        end
       end
     end
   end
@@ -38,6 +34,8 @@ class SearchService < BaseService
                             .compact
 
     statuses.reject { |status| StatusFilter.new(status, account).filtered? }
+  rescue Faraday::ConnectionFailed
+    []
   end
 
   def perform_hashtags_search!


### PR DESCRIPTION
Sometimes, ES server are dead while main server is live.
We should give general search results(accounts, hashtags) even if ES server is dead.