### PR TITLE
Dockerfile upgraded docker images for node 8.15/ruby 2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:8.14.0-alpine as node
-FROM ruby:2.4.5-alpine3.8
+FROM node:8.15.0-alpine as node
+FROM ruby:2.5.3-alpine3.8
 
 LABEL maintainer="https://github.com/tootsuite/mastodon" \
       description="Your self-hosted, globally interconnected microblogging community"


### PR DESCRIPTION
We need to test this - I believe the sigfault with sidekiq was resolved months ago.

If you're running 2.5 and sidekiq container has not crashed after 48 hours.... please comment