### PR TITLE
Use Contact User as Relay, Report, Subscribe.

### DIFF
--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -5,7 +5,7 @@ module AccountFinderConcern
 
   class_methods do
     def representative!
-      find_remote(Setting.site_contact_username.gsub(/\A@/, ''), nil) || raise(ActiveRecord::RecordNotFound)
+      find_local!(Setting.site_contact_username.gsub(/\A@/, ''))
     end
 
     def find_local!(username)
@@ -17,7 +17,7 @@ module AccountFinderConcern
     end
 
     def representative
-      find_remote(Setting.site_contact_username.gsub(/\A@/, ''), nil)
+      find_local(Setting.site_contact_username.gsub(/\A@/, ''))
     end
 
     def find_local(username)

--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -13,7 +13,7 @@ module AccountFinderConcern
     end
 
     def representative
-      find_local(Setting.site_contact_username.gsub(/\A@/, ''))
+      find_local(Setting.site_contact_username.gsub(/\A@/, '')) || Account.local.find_by(suspended: false)
     end
 
     def find_local(username)

--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -4,10 +4,6 @@ module AccountFinderConcern
   extend ActiveSupport::Concern
 
   class_methods do
-    def representative!
-      find_local!(Setting.site_contact_username.gsub(/\A@/, ''))
-    end
-
     def find_local!(username)
       find_local(username) || raise(ActiveRecord::RecordNotFound)
     end

--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -4,12 +4,20 @@ module AccountFinderConcern
   extend ActiveSupport::Concern
 
   class_methods do
+    def representative!
+      find_remote(Setting.site_contact_username.gsub(/\A@/, ''), nil) || raise(ActiveRecord::RecordNotFound)
+    end
+
     def find_local!(username)
       find_local(username) || raise(ActiveRecord::RecordNotFound)
     end
 
     def find_remote!(username, domain)
       find_remote(username, domain) || raise(ActiveRecord::RecordNotFound)
+    end
+
+    def representative
+      find_remote(Setting.site_contact_username.gsub(/\A@/, ''), nil)
     end
 
     def find_local(username)

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -68,7 +68,7 @@ class Relay < ApplicationRecord
   end
 
   def some_local_account
-    @some_local_account ||= Account.representative || Account.local.find_by(suspended: false)
+    @some_local_account ||= Account.representative
   end
 
   def ensure_disabled

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -68,7 +68,7 @@ class Relay < ApplicationRecord
   end
 
   def some_local_account
-    @some_local_account ||= Account.find_local(Setting.site_contact_username.gsub(/\A@/, '')) || Account.local.find_by(suspended: false)
+    @some_local_account ||= Account.representative || Account.local.find_by(suspended: false)
   end
 
   def ensure_disabled

--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -68,7 +68,7 @@ class Relay < ApplicationRecord
   end
 
   def some_local_account
-    @some_local_account ||= Account.local.find_by(suspended: false)
+    @some_local_account ||= Account.find_local(Setting.site_contact_username.gsub(/\A@/, '')) || Account.local.find_by(suspended: false)
   end
 
   def ensure_disabled

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -52,6 +52,6 @@ class ReportService < BaseService
   end
 
   def some_local_account
-    @some_local_account ||= Account.representative || Account.local.where(suspended: false).first
+    @some_local_account ||= Account.representative
   end
 end

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -52,6 +52,6 @@ class ReportService < BaseService
   end
 
   def some_local_account
-    @some_local_account ||= Account.local.where(suspended: false).first
+    @some_local_account ||= Account.find_local(Setting.site_contact_username.gsub(/\A@/, '')) || Account.local.where(suspended: false).first
   end
 end

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -52,6 +52,6 @@ class ReportService < BaseService
   end
 
   def some_local_account
-    @some_local_account ||= Account.find_local(Setting.site_contact_username.gsub(/\A@/, '')) || Account.local.where(suspended: false).first
+    @some_local_account ||= Account.representative || Account.local.where(suspended: false).first
   end
 end

--- a/app/services/subscribe_service.rb
+++ b/app/services/subscribe_service.rb
@@ -43,7 +43,7 @@ class SubscribeService < BaseService
   end
 
   def some_local_account
-    @some_local_account ||= Account.representative || Account.local.where(suspended: false).first
+    @some_local_account ||= Account.local.where(suspended: false).first
   end
 
   # Any response in the 3xx or 4xx range, except for 429 (rate limit)

--- a/app/services/subscribe_service.rb
+++ b/app/services/subscribe_service.rb
@@ -43,7 +43,7 @@ class SubscribeService < BaseService
   end
 
   def some_local_account
-    @some_local_account ||= Account.find_local(Setting.site_contact_username.gsub(/\A@/, '')) || Account.local.where(suspended: false).first
+    @some_local_account ||= Account.representative || Account.local.where(suspended: false).first
   end
 
   # Any response in the 3xx or 4xx range, except for 429 (rate limit)

--- a/app/services/subscribe_service.rb
+++ b/app/services/subscribe_service.rb
@@ -43,7 +43,7 @@ class SubscribeService < BaseService
   end
 
   def some_local_account
-    @some_local_account ||= Account.local.where(suspended: false).first
+    @some_local_account ||= Account.find_local(Setting.site_contact_username.gsub(/\A@/, '')) || Account.local.where(suspended: false).first
   end
 
   # Any response in the 3xx or 4xx range, except for 429 (rate limit)


### PR DESCRIPTION
Following relay, sending report and subscribing are used user selected by `Account.local.where(suspend: false)` in Mastodon.
This method may give responsibility someone who does not know anything.
Use Contact User if set.