### PR TITLE
Fix crash when clearing uninitialized timeline

### DIFF
--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -88,7 +88,7 @@ const deleteStatus = (state, id, accountId, references) => {
 };
 
 const clearTimeline = (state, timeline) => {
-  return state.updateIn([timeline, 'items'], list => list.clear());
+  return state.set(timeline, initialTimeline);
 };
 
 const filterTimelines = (state, relationship, statuses) => {


### PR DESCRIPTION
Fixes a crash that occurs when successively opening different hashtags in the dynamic column.