### PR TITLE
Improvements to signature verification

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -83,6 +83,8 @@ module SignatureVerification
       @signed_request_account = account
       @signed_request_account
     end
+  rescue OpenSSL::PKey::RSAError
+    nil
   end
 
   def build_signed_string(signed_headers)

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -33,8 +33,10 @@ class ActivityPub::ProcessAccountService < BaseService
 
     after_protocol_change! if protocol_changed?
     after_key_change! if key_changed? && !@options[:signed_with_known_key]
-    check_featured_collection! if @account.featured_collection_url.present?
-    check_links! unless @account.fields.empty?
+    unless @options[:only_key]
+      check_featured_collection! if @account.featured_collection_url.present?
+      check_links! unless @account.fields.empty?
+    end
 
     @account
   rescue Oj::ParseError
@@ -54,11 +56,11 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def update_account
-    @account.last_webfingered_at = Time.now.utc
+    @account.last_webfingered_at = Time.now.utc unless @options[:only_key]
     @account.protocol            = :activitypub
 
     set_immediate_attributes!
-    set_fetchable_attributes!
+    set_fetchable_attributes! unless @options[:only_keys]
 
     @account.save_with_optional_media!
   end


### PR DESCRIPTION
- Fix stored invalid keys preventing from updating account data
- Always re-fetch keys if signature verification fails, albeit avoiding webfinger roundtrip and additional HTTP queries
- Extend stoplight to account/key refresh too

This part of the code is a bit hairy, this should be thoroughly reviewed, and tests should probably be added.