### PR TITLE
Install both rvm gpg keys in vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ sudo apt-get install \
 
 # Install rvm
 read RUBY_VERSION < .ruby-version
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer | bash -s stable --ruby=$RUBY_VERSION
 source /home/vagrant/.rvm/scripts/rvm
 


### PR DESCRIPTION
The first run of `vagrant up` fails to provision because the gpg step does not appear to be installing both relevant gpg keys.

Reference: https://rvm.io/rvm/security

Adding the second one here.