### PR TITLE
Ensure blocked user unfollows blocker if Block/Undo Block are processed out of order

### DIFF
--- a/app/lib/activitypub/activity/block.rb
+++ b/app/lib/activitypub/activity/block.rb
@@ -4,9 +4,10 @@ class ActivityPub::Activity::Block < ActivityPub::Activity
   def perform
     target_account = account_from_uri(object_uri)
 
-    return if target_account.nil? || !target_account.local? || delete_arrived_first?(@json['id']) || @account.blocking?(target_account)
+    return if target_account.nil? || !target_account.local? || @account.blocking?(target_account)
 
     UnfollowService.new.call(target_account, @account) if target_account.following?(@account)
-    @account.block!(target_account, uri: @json['id'])
+
+    @account.block!(target_account, uri: @json['id']) unless delete_arrived_first?(@json['id'])
   end
 end


### PR DESCRIPTION
`Block` + `Undo Block` have been used for a while to remove followers (even though Mastodon now also handles the cleaner `Undo Accept` + `Reject Follow`, but that flow is not explicitly defined in the AP spec).

However, such activities are processed in (and even sent from) sidekiq queues and could therefore be processed out-of-order, in which case the current code skips the `Block` entirely, which could cause the `Block` + `Undo Block` routine to fail from removing the follow relationship on the receiving end, meaning the temporarily blocked user would still receive private toots if there is another follower on the same instance.

This commit fixes that.