### PR TITLE
Fix wrong param name in scheduled statuses and return params in API

### DIFF
--- a/app/serializers/rest/scheduled_status_serializer.rb
+++ b/app/serializers/rest/scheduled_status_serializer.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 class REST::ScheduledStatusSerializer < ActiveModel::Serializer
-  attributes :id, :scheduled_at
+  attributes :id, :scheduled_at, :params
 
   has_many :media_attachments, serializer: REST::MediaAttachmentSerializer
 
   def id
     object.id.to_s
+  end
+
+  def params
+    object.params.without(:application_id)
   end
 end

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -167,10 +167,10 @@ class PostStatusService < BaseService
 
   def scheduled_options
     @options.tap do |options_hash|
-      options_hash[:in_reply_to_status_id] = options_hash.delete(:thread)&.id
-      options_hash[:application_id]        = options_hash.delete(:application)&.id
-      options_hash[:scheduled_at]          = nil
-      options_hash[:idempotency]           = nil
+      options_hash[:in_reply_to_id] = options_hash.delete(:thread)&.id
+      options_hash[:application_id] = options_hash.delete(:application)&.id
+      options_hash[:scheduled_at]   = nil
+      options_hash[:idempotency]    = nil
     end
   end
 end

--- a/app/workers/publish_scheduled_status_worker.rb
+++ b/app/workers/publish_scheduled_status_worker.rb
@@ -18,7 +18,7 @@ class PublishScheduledStatusWorker
   def options_with_objects(options)
     options.tap do |options_hash|
       options_hash[:application] = Doorkeeper::Application.find(options_hash.delete(:application_id)) if options[:application_id]
-      options_hash[:thread]      = Status.find(options_hash.delete(:in_reply_to_status_id)) if options_hash[:in_reply_to_status_id]
+      options_hash[:thread]      = Status.find(options_hash.delete(:in_reply_to_id)) if options_hash[:in_reply_to_id]
     end
   end
 end


### PR DESCRIPTION
The database column and API param are called in_reply_to_id, not in_reply_to_status_id, so it makes no sense to encode it that way