### PR TITLE
Remove useless argument in RegenerationWorker#perform

### DIFF
--- a/app/workers/regeneration_worker.rb
+++ b/app/workers/regeneration_worker.rb
@@ -5,7 +5,7 @@ class RegenerationWorker
 
   sidekiq_options unique: :until_executed
 
-  def perform(account_id, _ = :home)
+  def perform(account_id)
     account = Account.find(account_id)
     PrecomputeFeedService.new.call(account)
   rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
# Description

`RegenerationWorker.perform_async` is used with only one argument now.
So I remove useless argument ` _ = :home` for readability.