### PR TITLE
refactored package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "browserslist": [
     "last 2 versions",
     "IE >= 11",
-    "iOS >= 9"
+    "iOS >= 9",
+    "not dead"
   ],
   "private": true,
   "dependencies": {


### PR DESCRIPTION
added `not dead` to browserslist config, because the previous config covered e.g. IE Versions, that are not maintained + IE >= 11. 

considering [browserslist best practice guide](https://github.com/browserslist/browserslist/blob/master/README.md#best-practices)