### PR TITLE
Change remote interaction dialog to use specific actions

### DIFF
--- a/app/controllers/remote_interaction_controller.rb
+++ b/app/controllers/remote_interaction_controller.rb
@@ -5,6 +5,7 @@ class RemoteInteractionController < ApplicationController
 
   layout 'modal'
 
+  before_action :set_interaction_type
   before_action :set_status
   before_action :set_body_classes
 
@@ -44,5 +45,9 @@ class RemoteInteractionController < ApplicationController
   def set_body_classes
     @body_classes = 'modal-layout'
     @hide_header  = true
+  end
+
+  def set_interaction_type
+    @interaction_type = %w(reply reblog favourite).include?(params[:type]) ? params[:type] : 'reply'
   end
 end

--- a/app/views/remote_follow/new.html.haml
+++ b/app/views/remote_follow/new.html.haml
@@ -16,4 +16,6 @@
     .actions
       = f.button :button, t('remote_follow.proceed'), type: :submit
 
-    %p.hint.subtle-hint= t('remote_follow.no_account_html', sign_up_path: open_registrations? ? new_user_registration_path : 'https://joinmastodon.org/#getting-started')
+    %p.hint.subtle-hint
+      = t('remote_follow.reason_html', instance: site_hostname)
+      = t('remote_follow.no_account_html', sign_up_path: open_registrations? ? new_user_registration_path : 'https://joinmastodon.org/#getting-started')

--- a/app/views/remote_interaction/new.html.haml
+++ b/app/views/remote_interaction/new.html.haml
@@ -1,6 +1,6 @@
 .form-container
   .follow-prompt
-    %h2= t('remote_interaction.prompt')
+    %h2= t("remote_interaction.#{@interaction_type}.prompt")
 
     .public-layout
       .activity-stream.activity-stream--highlighted
@@ -9,9 +9,13 @@
   = simple_form_for @remote_follow, as: :remote_follow, url: remote_interaction_path(@status) do |f|
     = render 'shared/error_messages', object: @remote_follow
 
+    = hidden_field_tag :type, @interaction_type
+
     = f.input :acct, placeholder: t('remote_follow.acct'), input_html: { autocapitalize: 'none', autocorrect: 'off' }
 
     .actions
-      = f.button :button, t('remote_interaction.proceed'), type: :submit
+      = f.button :button, t("remote_interaction.#{@interaction_type}.proceed"), type: :submit
 
-    %p.hint.subtle-hint= t('remote_follow.no_account_html', sign_up_path: open_registrations? ? new_user_registration_path : 'https://joinmastodon.org/#getting-started')
+    %p.hint.subtle-hint
+      = t('remote_follow.reason_html', instance: site_hostname)
+      = t('remote_follow.no_account_html', sign_up_path: open_registrations? ? new_user_registration_path : 'https://joinmastodon.org/#getting-started')

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -43,7 +43,7 @@
       - else
         = link_to status.application.name, status.application.website, class: 'detailed-status__application', target: '_blank', rel: 'noopener'
       ·
-    = link_to remote_interaction_path(status), class: 'modal-button detailed-status__link' do
+    = link_to remote_interaction_path(status, type: :reply), class: 'modal-button detailed-status__link' do
       = fa_icon('reply')
       %span.detailed-status__reblogs>= number_to_human status.replies_count, strip_insignificant_zeros: true
       = " "
@@ -55,12 +55,12 @@
       %span.detailed-status__link<
         = fa_icon('lock')
     - else
-      = link_to remote_interaction_path(status), class: 'modal-button detailed-status__link' do
+      = link_to remote_interaction_path(status, type: :reblog), class: 'modal-button detailed-status__link' do
         = fa_icon('retweet')
         %span.detailed-status__reblogs>= number_to_human status.reblogs_count, strip_insignificant_zeros: true
         = " "
     ·
-    = link_to remote_interaction_path(status), class: 'modal-button detailed-status__link' do
+    = link_to remote_interaction_path(status, type: :favourite), class: 'modal-button detailed-status__link' do
       = fa_icon('star')
       %span.detailed-status__favorites>= number_to_human status.favourites_count, strip_insignificant_zeros: true
       = " "

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -37,15 +37,15 @@
 
   .status__action-bar
     .status__action-bar__counter
-      = link_to remote_interaction_path(status), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
+      = link_to remote_interaction_path(status, type: :reply), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
         = fa_icon 'reply fw'
       .status__action-bar__counter__label= obscured_counter status.replies_count
-    = link_to remote_interaction_path(status), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
+    = link_to remote_interaction_path(status, type: :reblog), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
       - if status.public_visibility? || status.unlisted_visibility?
         = fa_icon 'retweet fw'
       - elsif status.private_visibility?
         = fa_icon 'lock fw'
       - else
         = fa_icon 'envelope fw'
-    = link_to remote_interaction_path(status), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
+    = link_to remote_interaction_path(status, type: :favourite), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do
       = fa_icon 'star fw'

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -730,9 +730,6 @@ ar:
     no_account_html: أليس عندك حساب بعدُ ؟ يُمْكنك <a href='%{sign_up_path}' target='_blank'>التسجيل مِن هنا</a>
     proceed: أكمل المتابعة
     prompt: 'إنك  بصدد متابعة :'
-  remote_interaction:
-    proceed: إبدأ التفاعل
-    prompt: 'تريد التفاعُل مع هذا التبويق:'
   remote_unfollow:
     error: خطأ
     title: العنوان

--- a/config/locales/ast.yml
+++ b/config/locales/ast.yml
@@ -268,9 +268,6 @@ ast:
     no_account_html: "¿Nun tienes una cuenta? Pues <a href='%{sign_up_path}' target='_blank'>rexistrate equí</a>"
     proceed: Siguir
     prompt: 'Vas siguir a:'
-  remote_interaction:
-    proceed: Interactuar
-    prompt: 'Quies interactuar con esti toot:'
   remote_unfollow:
     error: Fallu
   sessions:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -702,9 +702,6 @@ ca:
     no_account_html: No tens cap compte? Pots <a href='%{sign_up_path}' target='_blank'>registrar-te aquí</a>
     proceed: Comença a seguir
     prompt: 'Seguiràs a:'
-  remote_interaction:
-    proceed: Procedeix a interactuar
-    prompt: 'Vols interactuar amb aquest toot:'
   remote_unfollow:
     error: Error
     title: Títol

--- a/config/locales/co.yml
+++ b/config/locales/co.yml
@@ -704,9 +704,6 @@ co:
     no_account_html: Ùn avete micca un contu? Pudete <a href='%{sign_up_path}' target='_blank'>arregistravi quì</a>
     proceed: Cuntinuà per siguità
     prompt: 'Avete da siguità:'
-  remote_interaction:
-    proceed: Cunfirmà l'interazzione
-    prompt: 'Vulete interagisce cù u statutu:'
   remote_unfollow:
     error: Errore
     title: Titulu

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -714,9 +714,6 @@ cs:
     no_account_html: Ještě nemáte účet? Můžete se <a href='%{sign_up_path}' target='_blank'>registrovat zde</a>
     proceed: Pokračovat ke sledování
     prompt: 'Budete sledovat:'
-  remote_interaction:
-    proceed: Pokračovat k interakci
-    prompt: 'Chcete interagovat s tímto tootem:'
   remote_unfollow:
     error: Chyba
     title: Nadpis

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -660,9 +660,6 @@ cy:
     no_account_html: Heb gyfrif? Mae modd i chi <a href='%{sign_up_path}' target='_blank'>gofrestru yma</a>
     proceed: Ymlaen i ddilyn
     prompt: 'Yr ydych am ddilyn:'
-  remote_interaction:
-    proceed: Ymlaen i ryngweithio
-    prompt: 'Rydych eisiau rhyngweithio a''r tŵt hwn:'
   remote_unfollow:
     error: Gwall
     title: Teitl

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -675,9 +675,6 @@ da:
     no_account_html: Har du ikke en konto? Du kan <a href='%{sign_up_path}' target='_blank'>oprette dig her</a>
     proceed: Fortsæt for at følge
     prompt: 'Du er ved at følge:'
-  remote_interaction:
-    proceed: Fortsæt for at interagere
-    prompt: 'Du ønsker at interagere med dette trut:'
   remote_unfollow:
     error: Fejl
     title: Titel

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -704,9 +704,6 @@ de:
     no_account_html: Noch keinen Account? Du kannst dich <a href='%{sign_up_path}' target='_blank'>hier anmelden</a>
     proceed: Weiter
     prompt: 'Du wirst dieser Person folgen:'
-  remote_interaction:
-    proceed: Fortfahren zum Interagieren
-    prompt: 'Du wirst mit diesem Beitrag interagieren:'
   remote_unfollow:
     error: Fehler
     title: Titel

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -703,9 +703,6 @@ el:
     no_account_html: Δεν έχεις λογαριασμό; Μπορείς <a href='%{sign_up_path}' target='_blank'>να γραφτείς εδώ</a>
     proceed: Συνέχισε για να ακολουθήσεις
     prompt: 'Θα ακολουθήσεις:'
-  remote_interaction:
-    proceed: Συνέχισε για να αλληλεπιδράσεις
-    prompt: 'Θέλεις να αλληλεπιδράσεις με αυτό το τουτ:'
   remote_unfollow:
     error: Σφάλμα
     title: Τίτλος

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -723,9 +723,17 @@ en:
     no_account_html: Don't have an account? You can <a href='%{sign_up_path}' target='_blank'>sign up here</a>
     proceed: Proceed to follow
     prompt: 'You are going to follow:'
+    reason_html: "<strong>Why is this step necessary?</strong> <code>%{instance}</code> might not be the server where you are registered, so we need to redirect you to your home server first."
   remote_interaction:
-    proceed: Proceed to interact
-    prompt: 'You want to interact with this toot:'
+    favourite:
+      proceed: Proceed to favourite
+      prompt: 'You want to favourite this toot:'
+    reblog:
+      proceed: Proceed to boost
+      prompt: 'You want to boost this toot:'
+    reply:
+      proceed: Proceed to reply
+      prompt: 'You want to reply to this toot:'
   remote_unfollow:
     error: Error
     title: Title

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -696,9 +696,6 @@ eo:
     no_account_html: Ĉu vi ne havas konton? Vi povas <a href='%{sign_up_path}' target='_blank'>registriĝi tie</a>
     proceed: Daŭrigi por eksekvi
     prompt: 'Vi eksekvos:'
-  remote_interaction:
-    proceed: Efektivigi la interagon
-    prompt: 'Vi volas interagi kun ĉi tiu mesaĝo:'
   remote_unfollow:
     error: Eraro
     title: Titolo

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -681,9 +681,6 @@ es:
     no_account_html: "¿No tienes una cuenta? Puedes <a href='%{sign_up_path}' target='_blank'>registrarte aqui</a>"
     proceed: Proceder a seguir
     prompt: 'Vas a seguir a:'
-  remote_interaction:
-    proceed: Proceder para interactuar
-    prompt: 'Quieres interactuar con este toot:'
   remote_unfollow:
     error: Error
     title: Título

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -698,9 +698,6 @@ eu:
     no_account_html: Ez duzu konturik? <a href='%{sign_up_path}' target='_blank'>Izena eman</a> dezakezu
     proceed: Ekin jarraitzeari
     prompt: 'Hau jarraituko duzu:'
-  remote_interaction:
-    proceed: Jarraitu interakziora
-    prompt: 'Toot honekin interakzioa nahi duzu:'
   remote_unfollow:
     error: Errorea
     title: Izenburua

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -681,9 +681,6 @@ fa:
     no_account_html: هنوز عضو نیستید؟ <a href='%{sign_up_path}' target='_blank'>این‌جا می‌توانید حساب باز کنید</a>
     proceed: درخواست پیگیری
     prompt: 'شما قرار است این حساب را پیگیری کنید:'
-  remote_interaction:
-    proceed: ادامهٔ برهم‌کنش
-    prompt: 'شما می‌خواهید دربارهٔ این بوق کاری کنید:'
   remote_unfollow:
     error: خطا
     title: عنوان

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -704,9 +704,6 @@ fr:
     no_account_html: Vous n’avez pas de compte ? Vous pouvez <a href='%{sign_up_path}' target='_blank'>vous inscrire ici</a>
     proceed: Confirmer l’abonnement
     prompt: 'Vous allez suivre :'
-  remote_interaction:
-    proceed: Confirmer l’interaction
-    prompt: 'Vous désirez interagir avec ce pouet :'
   remote_unfollow:
     error: Erreur
     title: Titre

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -704,9 +704,6 @@ gl:
     no_account_html: Non ten unha conta? Pode <a href='%{sign_up_path}' target='_blank'>rexistrarse aquí</a>
     proceed: Proceda para seguir
     prompt: 'Vostede vai seguir:'
-  remote_interaction:
-    proceed: Proceda para interactuar
-    prompt: 'Vostede quere interactuar con este toot:'
   remote_unfollow:
     error: Fallo
     title: Título

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -660,9 +660,6 @@ it:
     no_account_html: Non hai un account? Puoi <a href='%{sign_up_path}' target='_blank'>iscriverti qui</a>
     proceed: Conferma
     prompt: 'Stai per seguire:'
-  remote_interaction:
-    proceed: Continua per interagire
-    prompt: 'Vuoi interagire con questo toot:'
   remote_unfollow:
     error: Errore
     title: Titolo

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -703,9 +703,6 @@ ja:
     no_account_html: アカウントをお持ちではないですか？<a href='%{sign_up_path}' target='_blank'>こちら</a>からサインアップできます
     proceed: フォローする
     prompt: 'フォローしようとしています:'
-  remote_interaction:
-    proceed: 進む
-    prompt: 'このトゥートに返信しようとしています:'
   remote_unfollow:
     error: エラー
     title: タイトル

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -651,9 +651,6 @@ ka:
     no_account_html: არ გაქვთ ანგარიში? შეგიძლიათ <a href='%{sign_up_path}' target='_blank'>დარეგისტრირდეთ აქ</a>
     proceed: გააგრძელეთ გასაყოლად
     prompt: 'თქვენ გაჰყვებით:'
-  remote_interaction:
-    proceed: გააგრძელეთ ურთიერთქმედება
-    prompt: 'თქვენ გსურთ ურთიერთქმედება ამ ტუტთან:'
   remote_unfollow:
     error: შეცდომა
     title: სათაური

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -706,9 +706,6 @@ ko:
     no_account_html: 계정이 없나요? <a href='%{sign_up_path}' target='_blank'>여기에서 가입 할 수 있습니다</a>
     proceed: 팔로우 하기
     prompt: '팔로우 하려 하고 있습니다:'
-  remote_interaction:
-    proceed: 진행
-    prompt: '이 게시물에 상호작용하려 하고 있습니다:'
   remote_unfollow:
     error: 에러
     title: 타이틀

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -704,9 +704,6 @@ nl:
     no_account_html: Heb je geen account? Je kunt er <a href='%{sign_up_path}' target='_blank'>hier een registreren</a>
     proceed: Ga verder om te volgen
     prompt: 'Jij gaat volgen:'
-  remote_interaction:
-    proceed: Ga de interactie aan
-    prompt: 'Jij wilt de interactie aangaan met deze toot:'
   remote_unfollow:
     error: Fout
     title: Titel

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -760,9 +760,6 @@ oc:
     no_account_html: Avètz pas cap de compte ? Podètz <a href='%{sign_up_path}' target='_blank'>vos marcar aquí</a>
     proceed: Clicatz per sègre
     prompt: 'Sètz per sègre :'
-  remote_interaction:
-    proceed: Confirmar l’interaccion
-    prompt: 'Volètz interagir amb aqueste tut :'
   remote_unfollow:
     error: Error
     title: Títol

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -715,9 +715,6 @@ pl:
     no_account_html: Nie masz konta? Możesz <a href='%{sign_up_path}' target='_blank'>zarejestrować się tutaj</a>
     proceed: Śledź
     prompt: 'Zamierzasz śledzić:'
-  remote_interaction:
-    proceed: Przejdź do interakcji
-    prompt: 'Chcesz dokonać interakcji z tym wpisem:'
   remote_unfollow:
     error: Błąd
     title: Tytuł

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -702,9 +702,6 @@ pt-BR:
     no_account_html: Não tem uma conta? Você pode <a href='%{sign_up_path}' target='_blank'>cadastrar-se aqui</a>
     proceed: Prosseguir para seguir
     prompt: 'Você irá seguir:'
-  remote_interaction:
-    proceed: Continue para interagir
-    prompt: 'Você quer interagir com este toot:'
   remote_unfollow:
     error: Erro
     title: Título

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -683,9 +683,6 @@ ru:
     no_account_html: Нет учётной записи? Вы можете <a href='%{sign_up_path}' target='_blank'>зарегистрироваться здесь</a>
     proceed: Продолжить подписку
     prompt: 'Вы хотите подписаться на:'
-  remote_interaction:
-    proceed: Продолжить
-    prompt: 'Вы собираетесь взаимодействовать со статусом:'
   remote_unfollow:
     error: Ошибка
     title: Заголовок

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -714,9 +714,6 @@ sk:
     no_account_html: Nemáš ešte účet? Môžeš sa <a href='%{sign_up_path}' target='_blank'>zaregistrovať tu</a>
     proceed: Začni následovať
     prompt: 'Budeš sledovať:'
-  remote_interaction:
-    proceed: Pokračuj k interakcii
-    prompt: 'Chceš narábať s týmto príspevkom:'
   remote_unfollow:
     error: Chyba
     title: Názov

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -130,8 +130,6 @@ sl:
       most_recent_activity: Zadnja aktivnost
       most_recent_ip: Zadnji IP
       promote: Spodbujanje
-  remote_interaction:
-    prompt: 'Želite interakcijo s tem trobom:'
   statuses:
     pin_errors:
       ownership: Trob nekoga drugega ne more biti pripet

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -701,9 +701,6 @@ sr:
     no_account_html: Немате налог? Можете се <a href='%{sign_up_path}' target='_blank'>пријавити овде</a>
     proceed: Наставите да би сте запратили
     prompt: 'Запратићете:'
-  remote_interaction:
-    proceed: Наставите за интеракцију
-    prompt: 'Желите да интерактирате са овом трубом:'
   remote_unfollow:
     error: Грешка
     title: Наслов


### PR DESCRIPTION
Instead of just "interact", use different strings based on whether it's a reply, reblog or favourite. Add explanation why the step is necessary in the first place