### PR TITLE
Stop gifv timeline preview explicitly when open the media gallery

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -51,6 +51,10 @@ class Item extends React.PureComponent {
     const { index, onClick } = this.props;
 
     if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
+      if (this.hoverToPlay()) {
+        e.target.pause();
+        e.target.currentTime = 0;
+      }
       e.preventDefault();
       onClick(index);
     }


### PR DESCRIPTION
Currently, timeline gifv preview does not stop when click and open the media gallery on Firefox.

![firefox-min](https://user-images.githubusercontent.com/32974885/50772552-90e67d00-12d1-11e9-91d2-184e64ae24a6.gif)


However,  on Safari, gifv preview stops when move the cursor after open the media gallery.

![safari-min](https://user-images.githubusercontent.com/32974885/50772561-9774f480-12d1-11e9-992d-d8d130bb33ed.gif)


On Chrome, gifv preview stops immediately when click.

![chrome-min_1](https://user-images.githubusercontent.com/32974885/50772572-9d6ad580-12d1-11e9-8203-6b924d042d2e.gif)



I confirmed same behavior with Win7, Arch Linux and MacOS Mojave.

This PR makes to stop gifv preview on the timeline explicitly when open media gallery and unifies the behavior.