### PR TITLE
Add alt text to the lightbox for accessibility.

### DIFF
--- a/app/javascript/mastodon/features/ui/components/zoomable_image.js
+++ b/app/javascript/mastodon/features/ui/components/zoomable_image.js
@@ -133,6 +133,7 @@ export default class ZoomableImage extends React.PureComponent {
         ref={this.setContainerRef}
         style={{ overflow }}
       >
+	<figure>
         <img
           role='presentation'
           ref={this.setImageRef}
@@ -145,6 +146,8 @@ export default class ZoomableImage extends React.PureComponent {
           }}
           onClick={this.handleClick}
         />
+	<figcaption style={{textAlign: 'center'}}>{alt}</figcaption>
+	</figure>
       </div>
     );
   }


### PR DESCRIPTION
Regarding issue #8237, I put together a simple proof of concept for how alt text could be added to the lightbox in images. This solution would require images with alt text to be scaled down slightly smaller, both for aesthetic reasons and to prevent images with long alt text from being pushed off the screen. I don't understand the code well enough to implement the scaling here, but I hope it helps.

![image](https://user-images.githubusercontent.com/10965841/50810280-9c2fad80-12bd-11e9-82cf-39f646994be0.png)
