### PR TITLE
Adjust admin UI right panel size

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1,4 +1,6 @@
 $no-columns-breakpoint: 600px;
+$sidebar-width: 240px;
+$content-width: 840px;
 
 .admin-wrapper {
   display: flex;
@@ -6,7 +8,7 @@ $no-columns-breakpoint: 600px;
   height: 100%;
 
   .sidebar-wrapper {
-    flex: 1;
+    flex: 1 1 $siebar-width;
     height: 100%;
     background: $ui-base-color;
     display: flex;
@@ -14,7 +16,7 @@ $no-columns-breakpoint: 600px;
   }
 
   .sidebar {
-    width: 240px;
+    width: $sidebar-width;
     height: 100%;
     padding: 0;
     overflow-y: auto;
@@ -95,12 +97,12 @@ $no-columns-breakpoint: 600px;
   }
 
   .content-wrapper {
-    flex: 2;
+    flex: 2 1 $content-width;
     overflow: auto;
   }
 
   .content {
-    max-width: 700px;
+    max-width: $content-width;
     padding: 20px 15px;
     padding-top: 60px;
     padding-left: 25px;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -8,7 +8,7 @@ $content-width: 840px;
   height: 100%;
 
   .sidebar-wrapper {
-    flex: 1 1 $siebar-width;
+    flex: 1 1 $sidebar-width;
     height: 100%;
     background: $ui-base-color;
     display: flex;


### PR DESCRIPTION
Before:
![screenshot from 2019-01-09 17-46-38](https://user-images.githubusercontent.com/5047683/50887709-42eb8980-1437-11e9-8934-e5f4eaf780d9.png)
After:
![screenshot from 2019-01-09 17-58-15](https://user-images.githubusercontent.com/5047683/50888133-50554380-1438-11e9-9c67-42617944eac1.png)


Admin UI was too narrow to display columns in a row