### PR TITLE
Downgrade react-redux-loading-bar to 4.0.8 to fix media modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "react-notification": "^6.8.4",
     "react-overlays": "^0.8.3",
     "react-redux": "^6.0.0",
-    "react-redux-loading-bar": "^4.1.0",
+    "react-redux-loading-bar": "^4.0.8",
     "react-router-dom": "^4.1.1",
     "react-router-scroll-4": "^1.0.0-beta.1",
     "react-select": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7624,10 +7624,10 @@ react-overlays@^0.8.3:
     react-transition-group "^2.2.0"
     warning "^3.0.0"
 
-react-redux-loading-bar@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/react-redux-loading-bar/-/react-redux-loading-bar-4.1.0.tgz#3ca460569d979450d9d1dc992328efa449c10a7a"
-  integrity sha512-9L51ZvPqnlPs97j44FZLio6maQ/2BMP8xXFPArDWxByyLyGYs2fXpSZw+Lby9qr8Px3SsH9dylfC8HfQrmc/Mw==
+react-redux-loading-bar@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/react-redux-loading-bar/-/react-redux-loading-bar-4.0.8.tgz#e84d59d1517b79f53b0f39c8ddb40682af648c1b"
+  integrity sha512-BpR1tlYrYKFtGhxa7nAKc0dpcV33ZgXJ/jKNLpDDaxu2/cCxbkWQt9YlWT+VLw1x/7qyNYY4DH48bZdtmciSpg==
   dependencies:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.2"


### PR DESCRIPTION
The only change between 4.0.8 and 4.1.0 is the following, which breaks the loading bar in the media modal:
https://github.com/mironov/react-redux-loading-bar/commit/fd2aaf520e419abe2c9afe2c5e41ea852450030c