### PR TITLE
Add attachment list fallback to public pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -69,8 +69,12 @@ module ApplicationHelper
     tag(:meta, content: content, property: property)
   end
 
-  def react_component(name, props = {})
-    content_tag(:div, nil, data: { component: name.to_s.camelcase, props: Oj.dump(props) })
+  def react_component(name, props = {}, &block)
+    if block.nil?
+      content_tag(:div, nil, data: { component: name.to_s.camelcase, props: Oj.dump(props) })
+    else
+      content_tag(:div, data: { component: name.to_s.camelcase, props: Oj.dump(props) }, &block)
+    end
   end
 
   def body_classes

--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -83,6 +83,12 @@ function main() {
     if (reactComponents.length > 0) {
       import(/* webpackChunkName: "containers/media_container" */ '../mastodon/containers/media_container')
         .then(({ default: MediaContainer }) => {
+          [].forEach.call(reactComponents, (component) => {
+            [].forEach.call(component.children, (child) => {
+              component.removeChild(child);
+            });
+          });
+
           const content = document.createElement('div');
 
           ReactDOM.render(<MediaContainer locale={locale} components={reactComponents} />, content);

--- a/app/views/stream_entries/_attachment_list.html.haml
+++ b/app/views/stream_entries/_attachment_list.html.haml
@@ -1,0 +1,8 @@
+.attachment-list
+  .attachment-list__icon
+    = fa_icon 'link'
+  %ul.attachment-list__list
+    - attachments.each do |media|
+      %li
+        - url = media.remote_url.presence || media.file.url
+        = link_to File.basename(url), url, title: media.description

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -26,22 +26,10 @@
     - if status.media_attachments.first.video?
       - video = status.media_attachments.first
       = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, width: 670, height: 380, detailed: true, inline: true, alt: video.description do
-        .attachment-list
-          .attachment-list__icon
-            = fa_icon 'link'
-          %ul.attachment-list__list
-            - status.media_attachments.each do |media|
-              %li
-                = link_to File.basename(media.remote_url.presence || media.file.url), (media.remote_url.presence || media.file.url), title: media.description
+        = render partial: 'stream_entries/attachment_list', locals: { attachments: status.media_attachments }
     - else
       = react_component :media_gallery, height: 380, sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, standalone: true, 'autoPlayGif': current_account&.user&.setting_auto_play_gif || autoplay, 'reduceMotion': current_account&.user&.setting_reduce_motion, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json } do
-        .attachment-list
-          .attachment-list__icon
-            = fa_icon 'link'
-          %ul.attachment-list__list
-            - status.media_attachments.each do |media|
-              %li
-                = link_to File.basename(media.remote_url.presence || media.file.url), (media.remote_url.presence || media.file.url), title: media.description
+        = render partial: 'stream_entries/attachment_list', locals: { attachments: status.media_attachments }
   - elsif status.preview_card
     = react_component :card, 'maxDescription': 160, card: ActiveModelSerializers::SerializableResource.new(status.preview_card, serializer: REST::PreviewCardSerializer).as_json
 

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -25,9 +25,23 @@
   - if !status.media_attachments.empty?
     - if status.media_attachments.first.video?
       - video = status.media_attachments.first
-      = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, width: 670, height: 380, detailed: true, inline: true, alt: video.description
+      = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, width: 670, height: 380, detailed: true, inline: true, alt: video.description do
+        .attachment-list
+          .attachment-list__icon
+            = fa_icon 'link'
+          %ul.attachment-list__list
+            - status.media_attachments.each do |media|
+              %li
+                = link_to File.basename(media.remote_url.presence || media.file.url), (media.remote_url.presence || media.file.url), title: media.description
     - else
-      = react_component :media_gallery, height: 380, sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, standalone: true, 'autoPlayGif': current_account&.user&.setting_auto_play_gif || autoplay, 'reduceMotion': current_account&.user&.setting_reduce_motion, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json }
+      = react_component :media_gallery, height: 380, sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, standalone: true, 'autoPlayGif': current_account&.user&.setting_auto_play_gif || autoplay, 'reduceMotion': current_account&.user&.setting_reduce_motion, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json } do
+        .attachment-list
+          .attachment-list__icon
+            = fa_icon 'link'
+          %ul.attachment-list__list
+            - status.media_attachments.each do |media|
+              %li
+                = link_to File.basename(media.remote_url.presence || media.file.url), (media.remote_url.presence || media.file.url), title: media.description
   - elsif status.preview_card
     = react_component :card, 'maxDescription': 160, card: ActiveModelSerializers::SerializableResource.new(status.preview_card, serializer: REST::PreviewCardSerializer).as_json
 

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -29,9 +29,23 @@
   - if !status.media_attachments.empty?
     - if status.media_attachments.first.video?
       - video = status.media_attachments.first
-      = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, width: 610, height: 343, inline: true, alt: video.description
+      = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, width: 610, height: 343, inline: true, alt: video.description do
+        .attachment-list
+          .attachment-list__icon
+            = fa_icon 'link'
+          %ul.attachment-list__list
+            - status.media_attachments.each do |media|
+              %li
+                = link_to File.basename(media.remote_url.presence || media.file.url), (media.remote_url.presence || media.file.url), title: media.description
     - else
-      = react_component :media_gallery, height: 343, sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, 'autoPlayGif': current_account&.user&.setting_auto_play_gif || autoplay, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json }
+      = react_component :media_gallery, height: 343, sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, 'autoPlayGif': current_account&.user&.setting_auto_play_gif || autoplay, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json } do
+        .attachment-list
+          .attachment-list__icon
+            = fa_icon 'link'
+          %ul.attachment-list__list
+            - status.media_attachments.each do |media|
+              %li
+                = link_to File.basename(media.remote_url.presence || media.file.url), (media.remote_url.presence || media.file.url), title: media.description
   - elsif status.preview_card
     = react_component :card, 'maxDescription': 160, card: ActiveModelSerializers::SerializableResource.new(status.preview_card, serializer: REST::PreviewCardSerializer).as_json
 

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -30,22 +30,10 @@
     - if status.media_attachments.first.video?
       - video = status.media_attachments.first
       = react_component :video, src: video.file.url(:original), preview: video.file.url(:small), sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, width: 610, height: 343, inline: true, alt: video.description do
-        .attachment-list
-          .attachment-list__icon
-            = fa_icon 'link'
-          %ul.attachment-list__list
-            - status.media_attachments.each do |media|
-              %li
-                = link_to File.basename(media.remote_url.presence || media.file.url), (media.remote_url.presence || media.file.url), title: media.description
+        = render partial: 'stream_entries/attachment_list', locals: { attachments: status.media_attachments }
     - else
       = react_component :media_gallery, height: 343, sensitive: !current_account&.user&.show_all_media? && status.sensitive? || current_account&.user&.hide_all_media?, 'autoPlayGif': current_account&.user&.setting_auto_play_gif || autoplay, media: status.media_attachments.map { |a| ActiveModelSerializers::SerializableResource.new(a, serializer: REST::MediaAttachmentSerializer).as_json } do
-        .attachment-list
-          .attachment-list__icon
-            = fa_icon 'link'
-          %ul.attachment-list__list
-            - status.media_attachments.each do |media|
-              %li
-                = link_to File.basename(media.remote_url.presence || media.file.url), (media.remote_url.presence || media.file.url), title: media.description
+        = render partial: 'stream_entries/attachment_list', locals: { attachments: status.media_attachments }
   - elsif status.preview_card
     = react_component :card, 'maxDescription': 160, card: ActiveModelSerializers::SerializableResource.new(status.preview_card, serializer: REST::PreviewCardSerializer).as_json
 


### PR DESCRIPTION
Fixes #6714

I'm not too familiar with HAML, so I'm not sure if the fallback-as-a-block pattern makes a lot of sense.
Also, the code for rendering the list should probably be moved into another fragment or a helper.

Looks like this when the JS part hasn't loaded yet / if it doesn't load:
![screenshot_2019-01-10 thib thib mastodev sitedethib com](https://user-images.githubusercontent.com/384364/50977027-a639f200-14f1-11e9-9ff7-4a139af890b7.png)
