### PR TITLE
make draggingOver state off correctly

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -259,6 +259,7 @@ class UI extends React.PureComponent {
     e.preventDefault();
 
     this.setState({ draggingOver: false });
+    this.dragTargets = [];
 
     if (e.dataTransfer && e.dataTransfer.files.length === 1) {
       this.props.dispatch(uploadCompose(e.dataTransfer.files));

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -269,6 +269,11 @@ class UI extends React.PureComponent {
     e.preventDefault();
     e.stopPropagation();
 
+    if (e.relatedTarget === null) {
+      this.setState({ draggingOver: false });
+      return;
+    }
+
     this.dragTargets = this.dragTargets.filter(el => el !== e.target && this.node.contains(el));
 
     if (this.dragTargets.length > 0) {

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -269,7 +269,7 @@ class UI extends React.PureComponent {
     e.preventDefault();
     e.stopPropagation();
 
-    if (e.relatedTarget === null && e.fromElement !== null) {
+    if (e.relatedTarget === null) {
       this.setState({ draggingOver: false });
       return;
     }

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -269,11 +269,6 @@ class UI extends React.PureComponent {
     e.preventDefault();
     e.stopPropagation();
 
-    if (e.relatedTarget === null) {
-      this.setState({ draggingOver: false });
-      return;
-    }
-
     this.dragTargets = this.dragTargets.filter(el => el !== e.target && this.node.contains(el));
 
     if (this.dragTargets.length > 0) {

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -269,7 +269,7 @@ class UI extends React.PureComponent {
     e.preventDefault();
     e.stopPropagation();
 
-    if (e.relatedTarget === null) {
+    if (e.relatedTarget === null && e.fromElement !== null) {
       this.setState({ draggingOver: false });
       return;
     }


### PR DESCRIPTION
Sometimes, `.upload-area` could not close when dragging leave to out of window.

![image](https://user-images.githubusercontent.com/5253290/51090735-e89a5200-17c3-11e9-94a7-6fa94d04924a.png)

## How to reproduce
1. **drag and drop** *any* contents (Image, Text, and other) on Mastodon window (to same window).
1. Try drag and drop any file from any file manager to Mastodon window, and cancel (non drop, or drop in original or other location).

## Tested on
Chrome and Firefox (macOS, Linux)

**Edge and Safari** has the same problem reproducibility, ~~but it does not seem to work well.~~
-> I found the simple way.
