### PR TITLE
Fix hashtag timeline on mobile

### DIFF
--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -1041,10 +1041,6 @@ $small-breakpoint: 960px;
 
     .scrollable {
       height: 400px;
-
-      @media screen and (max-width: $column-breakpoint) {
-        height: 90vh;
-      }
     }
 
     p {
@@ -1271,8 +1267,7 @@ $small-breakpoint: 960px;
       }
 
       #mastodon-timeline {
-        display: block;
-        width: 100vw;
+        display: flex;
         height: 100vh;
         border-radius: 0;
       }


### PR DESCRIPTION
Instead of forcing 90vh for the scrollable part of the timeline's height as
in #9781 (which may be off), use `display: flex`, exactly like on desktop.