### PR TITLE
Fix undefined method error in sidekiq

### DIFF
--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -43,7 +43,7 @@ class FetchOEmbedService
       res.code != 200 ? nil : res.body_with_limit
     end
 
-    validate(parse_for_format(body)) unless body.blank?
+    validate(parse_for_format(body)) if body.present?
   rescue Oj::ParseError, Ox::ParseError
     nil
   end

--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -43,7 +43,7 @@ class FetchOEmbedService
       res.code != 200 ? nil : res.body_with_limit
     end
 
-    validate(parse_for_format(body)) unless body.nil?
+    validate(parse_for_format(body)) unless body.blank?
   rescue Oj::ParseError, Ox::ParseError
     nil
   end

--- a/spec/fixtures/requests/oembed_json_empty.html
+++ b/spec/fixtures/requests/oembed_json_empty.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link href='https://host.test/empty_provider.json' rel='alternate' type='application/json+oembed'>
+  </head>
+  <body></body>
+</html>

--- a/spec/services/fetch_oembed_service_spec.rb
+++ b/spec/services/fetch_oembed_service_spec.rb
@@ -8,6 +8,7 @@ describe FetchOEmbedService, type: :service do
   before do
     stub_request(:get, "https://host.test/provider.json").to_return(status: 404)
     stub_request(:get, "https://host.test/provider.xml").to_return(status: 404)
+    stub_request(:get, "https://host.test/empty_provider.json").to_return(status: 200)
   end
 
   describe 'discover_provider' do
@@ -93,6 +94,23 @@ describe FetchOEmbedService, type: :service do
           expect(subject.call('https://host.test/oembed.html')).to be_nil
         end
       end
+
+      context 'Empty JSON provider is discoverable' do
+        before do
+          stub_request(:get, 'https://host.test/oembed.html').to_return(
+            status: 200,
+            headers: { 'Content-Type': 'text/html' },
+            body: request_fixture('oembed_json_empty.html')
+          )
+        end
+
+        it 'returns new OEmbed::Provider for JSON provider' do
+          subject.call('https://host.test/oembed.html')
+          expect(subject.endpoint_url).to eq 'https://host.test/empty_provider.json'
+          expect(subject.format).to eq :json
+        end
+      end
+
     end
 
     context 'when status code is not 200' do


### PR DESCRIPTION
Body can be not nil but still be empty, which causes a `NoMethodError: undefined method `[]' for nil:NilClass` further in the code. This checks for an empty body to avoid the issue.