### PR TITLE
Make hashtag search results link to the hashtag URL

### DIFF
--- a/app/javascript/mastodon/components/hashtag.js
+++ b/app/javascript/mastodon/components/hashtag.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import { Sparklines, SparklinesCurve } from 'react-sparklines';
-import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import Permalink from './permalink';
 import { shortNumberFormat } from '../utils/numbers';
 
 const Hashtag = ({ hashtag }) => (
   <div className='trends__item'>
     <div className='trends__item__name'>
-      <Link to={`/timelines/tag/${hashtag.get('name')}`}>
+      <Permalink href={hashtag.get('url')} to={`/timelines/tag/${hashtag.get('name')}`}>
         #<span>{hashtag.get('name')}</span>
-      </Link>
+      </Permalink>
 
       <FormattedMessage id='trends.count_by_accounts' defaultMessage='{count} {rawCount, plural, one {person} other {people}} talking' values={{ rawCount: hashtag.getIn(['history', 0, 'accounts']), count: <strong>{shortNumberFormat(hashtag.getIn(['history', 0, 'accounts']))}</strong> }} />
     </div>


### PR DESCRIPTION
Currently, middle-clicking on a hashtag search result will open a new
instance of the WebUI, which is inconsistent with middle-clicking on
an account result, or a hashtag in a toot.