### PR TITLE
Reject existing Follow in addition to sending a Block

### DIFF
--- a/spec/services/unfollow_service_spec.rb
+++ b/spec/services/unfollow_service_spec.rb
@@ -56,4 +56,22 @@ RSpec.describe UnfollowService, type: :service do
       expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
     end
   end
+
+  describe 'remote ActivityPub (reverse)' do
+    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox')).account }
+
+    before do
+      bob.follow!(sender)
+      stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
+      subject.call(bob, sender)
+    end
+
+    it 'destroys the following relation' do
+      expect(bob.following?(sender)).to be false
+    end
+
+    it 'sends a reject activity' do
+      expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
+    end
+  end
 end


### PR DESCRIPTION
Mastodon expects remote servers to remove follow relationships upon receiving
a Block. However, the spec only evokes Block activities in a C2S context, never
in a S2S context.

This PR, in addition to federating the Block, explicitly sends a Reject for any
affected follow relationship, which makes a bit more sense with regards to the
spec.

~~Marked Work in Progress as I have to check the generated Activity.~~