### PR TITLE
Reduce chances of race conditions when processing deleted toots

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -5,10 +5,12 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   CONVERTED_TYPES = %w(Image Video Article Page).freeze
 
   def perform
-    return if delete_arrived_first?(object_uri) || unsupported_object_type? || invalid_origin?(@object['id'])
+    return if unsupported_object_type? || invalid_origin?(@object['id'])
 
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?
+        return if delete_arrived_first?(object_uri)
+
         @status = find_existing_status
 
         if @status.nil?

--- a/app/lib/activitypub/activity/delete.rb
+++ b/app/lib/activitypub/activity/delete.rb
@@ -21,10 +21,10 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
   def delete_note
     return if object_uri.nil?
 
+    delete_later!(object_uri)
+
     @status   = Status.find_by(uri: object_uri, account: @account)
     @status ||= Status.find_by(uri: @object['atomUri'], account: @account) if @object.is_a?(Hash) && @object['atomUri'].present?
-
-    delete_later!(object_uri)
 
     return if @status.nil?
 

--- a/app/lib/activitypub/activity/delete.rb
+++ b/app/lib/activitypub/activity/delete.rb
@@ -21,7 +21,9 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
   def delete_note
     return if object_uri.nil?
 
-    delete_later!(object_uri)
+    RedisLock.acquire(lock_options) do |_lock|
+      delete_later!(object_uri)
+    end
 
     @status   = Status.find_by(uri: object_uri, account: @account)
     @status ||= Status.find_by(uri: @object['atomUri'], account: @account) if @object.is_a?(Hash) && @object['atomUri'].present?
@@ -67,5 +69,9 @@ class ActivityPub::Activity::Delete < ActivityPub::Activity
 
   def payload
     @payload ||= Oj.dump(@json)
+  end
+
+  def lock_options
+    { redis: Redis.current, key: "create:#{object_uri}" }
   end
 end


### PR DESCRIPTION
I have noticed that sometimes, toots are not correctly deleted across instances (despite a direct Follow relationship).

One of those cases may be because of a race condition between the processing of `Create` and `Delete` when a toot is quickly created then deleted.

This PR reduces chances of such a race condition happening, but does not eliminate it. It should be possible to avoid this race condition completely by moving the `delete_arrived_first?` check into the locked block, and lock the `delete_later!` call as well, but I'm not sure about the performances impact.