### PR TITLE
Use ruby-2.6.0 on Heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -771,7 +771,7 @@ DEPENDENCIES
   webpush
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.6.0p0
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Modify Ruby version on Gemfile.lock to let Heroku pick it up.