### PR TITLE
Use summary as summary for converted ActivityPub objects

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -61,7 +61,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         account: @account,
         text: text_from_content || '',
         language: detected_language,
-        spoiler_text: text_from_summary || '',
+        spoiler_text: converted_object_type? ? '' : (text_from_summary || ''),
         created_at: @object['published'],
         override_timestamps: @options[:override_timestamps],
         reply: @object['inReplyTo'].present?,
@@ -256,7 +256,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def text_from_content
-    return Formatter.instance.linkify([text_from_name, object_url || @object['id']].join(' ')) if converted_object_type?
+    return Formatter.instance.linkify([[text_from_name, text_from_summary.presence].compact.join("\n\n"), object_url || @object['id']].join(' ')) if converted_object_type?
 
     if @object['content'].present?
       @object['content']


### PR DESCRIPTION
For non-Note objects, `summary` has a slightly different semantic meaning, and it doesn't make sense to use it as a content warning hiding the title and link to the article. So, for converted object types, display the title, then summary, then the link to the article.

Fix #8609