### PR TITLE
Fix slightly cropped font on settings page dropdowns when using system font

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -419,7 +419,7 @@ code {
     background: darken($ui-base-color, 10%) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 14.933 18.467' height='19.698' width='15.929'><path d='M3.467 14.967l-3.393-3.5H14.86l-3.392 3.5c-1.866 1.925-3.666 3.5-4 3.5-.335 0-2.135-1.575-4-3.5zm.266-11.234L7.467 0 11.2 3.733l3.733 3.734H0l3.733-3.734z' fill='#{hex-color(lighten($ui-base-color, 12%))}'/></svg>") no-repeat right 8px center / auto 16px;
     border: 1px solid darken($ui-base-color, 14%);
     border-radius: 4px;
-    padding: 10px;
+    padding-left: 10px;
     padding-right: 30px;
     height: 41px;
   }


### PR DESCRIPTION
Before/after (using default font — slightly more centered):
![screenshot_2019-01-17 preferences - mastodon dev _defaultfont_before](https://user-images.githubusercontent.com/2446451/51350774-5c30ad80-1aa9-11e9-8d73-ad509e92b5d6.png)
![screenshot_2019-01-17 preferences - mastodon dev _2](https://user-images.githubusercontent.com/2446451/51350514-a06f7e00-1aa8-11e9-9a93-708ad72087df.png)

Before/after (using system font — much better):
![screenshot_2019-01-17 preferences - mastodon dev _systemfont_before](https://user-images.githubusercontent.com/2446451/51350775-5c30ad80-1aa9-11e9-8ffa-39b06675a13c.png)
![screenshot_2019-01-17 preferences - mastodon dev](https://user-images.githubusercontent.com/2446451/51350513-a06f7e00-1aa8-11e9-916e-6dac31cb2e65.png)