### PR TITLE
Allow event defaults on index for text data transfer drop events

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -243,6 +243,7 @@ class UI extends React.PureComponent {
   }
 
   handleDragOver = (e) => {
+    if (this.dataTransferIsText(e.dataTransfer)) return false;
     e.preventDefault();
     e.stopPropagation();
 
@@ -256,6 +257,7 @@ class UI extends React.PureComponent {
   }
 
   handleDrop = (e) => {
+    if (this.dataTransferIsText(e.dataTransfer)) return;
     e.preventDefault();
 
     this.setState({ draggingOver: false });
@@ -277,6 +279,10 @@ class UI extends React.PureComponent {
     }
 
     this.setState({ draggingOver: false });
+  }
+
+  dataTransferIsText = (dataTransfer) => {
+    return (dataTransfer && Array.from(dataTransfer.types).includes('text/plain') && dataTransfer.items.length === 1);
   }
 
   closeUploadModal = () => {


### PR DESCRIPTION
Addresses #5756. Adds a guard clause for drag over and drop handlers in `ui/index.js` to allow plain text data transfers to avoid file dropzone behaviors. Permits dragging and dropping text into compose, search, spoiler inputs. 