### PR TITLE
Add `visibility` param to reblog REST API

### DIFF
--- a/app/controllers/api/v1/statuses/reblogs_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogs_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::Statuses::ReblogsController < Api::BaseController
   respond_to :json
 
   def create
-    @status = ReblogService.new.call(current_user.account, status_for_reblog)
+    @status = ReblogService.new.call(current_user.account, status_for_reblog, reblog_params)
     render json: @status, serializer: REST::StatusSerializer
   end
 
@@ -31,5 +31,9 @@ class Api::V1::Statuses::ReblogsController < Api::BaseController
 
   def status_for_destroy
     current_user.account.statuses.where(reblog_of_id: params[:status_id]).first!
+  end
+
+  def reblog_params
+    params.permit(:visibility)
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -70,6 +70,7 @@ class Status < ApplicationRecord
   validates_with StatusLengthValidator
   validates_with DisallowedHashtagsValidator
   validates :reblog, uniqueness: { scope: :account }, if: :reblog?
+  validates :visibility, exclusion: { in: %w(direct limited) }, if: :reblog?
   validates_associated :owned_poll
 
   default_scope { recent }


### PR DESCRIPTION
Fix #7322 

- Allow setting visibility for each reblog
- Changes the default to reblog with the default chosen visibility setting instead of public
- Use async worker for creating reblog notification to improve performance