### PR TITLE
Update to current Node LTS for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:8.15-alpine as node
-FROM ruby:2.6-alpine3.8
+FROM node:10-alpine as node
+FROM ruby:2.6-alpine
 
 LABEL maintainer="https://github.com/tootsuite/mastodon" \
       description="Your self-hosted, globally interconnected microblogging community"


### PR DESCRIPTION
Ruby will use latest Alpine release, to match Node using the latest. This will need testing, but I have been using Node 10 for about 2 weeks, and uWS will build on the LTS.

Implementing what I commented in the PR on #9796. My current thinking is that this needs testing but nothing is breaking with streaming, and Webpack seems to respond just fine. There will also be no breaking changes to the Node 10 LTS (semantic versioning).

(Also, Ruby 2.6 itself seems stable on Docker, I'm not getting segfaults still. Yay!)