### PR TITLE
Use the bundled Capistrano version

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lock '3.10.2'
+lock '3.11.0'
 
 set :repo_url, ENV.fetch('REPO', 'https://github.com/tootsuite/mastodon.git')
 set :branch, ENV.fetch('BRANCH', 'master')


### PR DESCRIPTION
Currently Capistrano complains about loaded and locked version mismatch:
```
Capfile locked at 3.10.2, but 3.11.0 is loaded
```