### PR TITLE
Upgrade yargs to v12.0

### DIFF
--- a/config/webpack/translationRunner.js
+++ b/config/webpack/translationRunner.js
@@ -48,8 +48,7 @@ Use yarn "manage:translations -- --help" for usage information
   }
 };
 
-const { argv } = require('yargs')
-  .usage(`Usage: yarn manage:translations -- [OPTIONS] [LANGUAGES]
+const usage = `Usage: yarn manage:translations [OPTIONS] [LANGUAGES]
 
 Manage JavaScript translation files in Mastodon. Generates and update translations in translationsDirectory: ${translationsDirectory}
 
@@ -58,16 +57,15 @@ The RFC5646 language tag for the language you want to test or fix. If you want t
 
 Available languages:
 ${availableLanguages.join(', ')}
-`)
-  .help('h', 'show this message')
-  .alias('h', 'help')
-  .options({
-    f: {
-      alias: 'force',
-      default: false,
-      describe: 'force using the provided languages. create files if not exists.',
-      type: 'boolean',
-    },
+`;
+
+const { argv } = require('yargs')
+  .usage(usage)
+  .option('f', {
+    alias: 'force',
+    default: false,
+    describe: 'force using the provided languages. create files if not exists.',
+    type: 'boolean',
   });
 
 // check if message directory exists

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "react-intl-translations-manager": "^5.0.3",
     "react-test-renderer": "^16.7.0",
     "webpack-dev-server": "^3.1.14",
-    "yargs": "^8.0.2"
+    "yargs": "^12.0.5"
   },
   "optionalDependencies": {
     "fsevents": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,15 +2046,6 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
-cliui@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
-  integrity sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wrap-ansi "^2.0.0"
-
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
@@ -9771,13 +9762,6 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
-  integrity sha1-jQrELxbqVd69MyyvTEA4s+P139k=
-  dependencies:
-    camelcase "^4.1.0"
-
 yargs-parser@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
@@ -9821,7 +9805,7 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^12.0.2:
+yargs@^12.0.2, yargs@^12.0.5:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
   integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
@@ -9838,22 +9822,3 @@ yargs@^12.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
-
-yargs@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
-  integrity sha1-YpmpBVsc78lp/355wdkY3Osiw2A=
-  dependencies:
-    camelcase "^4.1.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    read-pkg-up "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^7.0.0"


### PR DESCRIPTION
- [CHANGELOG](https://github.com/yargs/yargs/blob/v12.0.5/CHANGELOG.md)

> ### v12.0.0 (2018-06-26)
>
> #### BREAKING CHANGES
> 
> - Options absent from `argv` (not set via CLI argument) are now absent from the parsed result object rather than being set with `undefined`
> - drop Node 4 from testing matrix, such that we'll gradually start drifting away from supporting Node 4.
> - yargs-parser does not populate 'false' when boolean flag is not passed
> - tests that assert against help output will need to be updated
>
> ### 11.0.0 (2018-01-22)
>
> #### BREAKING CHANGES
> 
> - requiresArg now has significantly different error output, matching nargs.
>
> ### 10.0.0 (2017-10-18)
>
> #### BREAKING CHANGES
>
> - .usage() no longer accepts an options object as the second argument. It can instead be used as an alias for configuring a default command.
> - previously hidden options were simply implied using a falsy description
> - help command now only executes if it's the last positional in argv._
>
> ### 9.0.0 (2017-09-03)
>
> #### BREAKING CHANGES
>
> - version() and help() are now enabled by default, and show up in help output; the implicit help command can no longer be enabled/disabled independently from the help command itself (which can now be disabled).
> - parse() now behaves as an alias for .argv, unless a parseCallback is provided.