### PR TITLE
Fix multiple workers for the same scheduled status being queueable

### DIFF
--- a/app/workers/publish_scheduled_status_worker.rb
+++ b/app/workers/publish_scheduled_status_worker.rb
@@ -3,6 +3,8 @@
 class PublishScheduledStatusWorker
   include Sidekiq::Worker
 
+  sidekiq_options unique: :until_executed
+
   def perform(scheduled_status_id)
     scheduled_status = ScheduledStatus.find(scheduled_status_id)
     scheduled_status.destroy!


### PR DESCRIPTION
This shouldn't really happen because the scheduler can only be executed once as well, but I got reports of the same scheduled statis being published multiple times and I have no other explanation for that.