### PR TITLE
Fix SUPERUSER postgres command

### DIFF
--- a/lib/mastodon/migration_helpers.rb
+++ b/lib/mastodon/migration_helpers.rb
@@ -889,7 +889,7 @@ table #{table}.
 If you are using PostgreSQL you can solve this by logging in to the GitLab
 database (#{dbname}) using a super user and running:
 
-    ALTER #{user} WITH SUPERUSER
+    ALTER USER #{user} WITH SUPERUSER
 
 For MySQL you instead need to run:
 


### PR DESCRIPTION
See: https://stackoverflow.com/a/10757486/6945353

```
mastodon=# ALTER mastodon WITH SUPERUSER;
ERROR:  syntax error at or near "mastodon"
LINE 1: ALTER mastodon WITH SUPERUSER;
              ^
mastodon=# ALTER USER mastodon WITH SUPERUSER;
ALTER ROLE
```