### PR TITLE
Make displaying application used to toot opt-in

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -48,6 +48,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_theme,
       :setting_hide_network,
       :setting_aggregate_reblogs,
+      :setting_show_application,
       notification_emails: %i(follow follow_request reblog favourite mention digest report),
       interactions: %i(must_be_follower must_be_following)
     )

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -32,6 +32,7 @@ class UserSettingsDecorator
     user.settings['theme']               = theme_preference if change?('setting_theme')
     user.settings['hide_network']        = hide_network_preference if change?('setting_hide_network')
     user.settings['aggregate_reblogs']   = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
+    user.settings['show_application']    = show_application_preference if change?('setting_show_application')
   end
 
   def merged_notification_emails
@@ -88,6 +89,10 @@ class UserSettingsDecorator
 
   def hide_network_preference
     boolean_cast_setting 'setting_hide_network'
+  end
+
+  def show_application_preference
+    boolean_cast_setting 'setting_show_application'
   end
 
   def theme_preference

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -109,6 +109,7 @@ class Account < ApplicationRecord
            :staff?,
            :locale,
            :hides_network?,
+           :shows_application?,
            to: :user,
            prefix: true,
            allow_nil: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,7 +100,7 @@ class User < ApplicationRecord
 
   delegate :auto_play_gif, :default_sensitive, :unfollow_modal, :boost_modal, :delete_modal,
            :reduce_motion, :system_font_ui, :noindex, :theme, :display_media, :hide_network,
-           :expand_spoilers, :default_language, :aggregate_reblogs, to: :settings, prefix: :setting, allow_nil: false
+           :expand_spoilers, :default_language, :aggregate_reblogs, :show_application, to: :settings, prefix: :setting, allow_nil: false
 
   attr_reader :invite_code
 
@@ -242,6 +242,10 @@ class User < ApplicationRecord
 
   def aggregates_reblogs?
     @aggregates_reblogs ||= settings.aggregate_reblogs
+  end
+
+  def shows_application?
+    @shows_application ||= settings.shows_application
   end
 
   def token_for_app(a)

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -12,7 +12,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attribute :pinned, if: :pinnable?
 
   belongs_to :reblog, serializer: REST::StatusSerializer
-  belongs_to :application
+  belongs_to :application, if: :user_shows_application?
   belongs_to :account, serializer: REST::AccountSerializer
 
   has_many :media_attachments, serializer: REST::MediaAttachmentSerializer
@@ -36,6 +36,10 @@ class REST::StatusSerializer < ActiveModel::Serializer
 
   def current_user?
     !current_user.nil?
+  end
+
+  def user_shows_application?
+    object.account.user_shows_application?
   end
 
   def visibility

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -12,7 +12,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attribute :pinned, if: :pinnable?
 
   belongs_to :reblog, serializer: REST::StatusSerializer
-  belongs_to :application, if: :user_shows_application?
+  belongs_to :application, if: :show_application?
   belongs_to :account, serializer: REST::AccountSerializer
 
   has_many :media_attachments, serializer: REST::MediaAttachmentSerializer
@@ -38,8 +38,8 @@ class REST::StatusSerializer < ActiveModel::Serializer
     !current_user.nil?
   end
 
-  def user_shows_application?
-    object.account.user_shows_application?
+  def show_application?
+    object.account.user_shows_application? || (current_user? && current_user.account_id == object.account_id)
   end
 
   def visibility

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -22,6 +22,7 @@ class PostStatusService < BaseService
     @options     = options
     @text        = @options[:text] || ''
     @in_reply_to = @options[:thread]
+    @options.delete(:application) unless @account.user&.setting_show_application
 
     return idempotency_duplicate if idempotency_given? && idempotency_duplicate?
 

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -22,7 +22,6 @@ class PostStatusService < BaseService
     @options     = options
     @text        = @options[:text] || ''
     @in_reply_to = @options[:thread]
-    @options.delete(:application) unless @account.user&.setting_show_application
 
     return idempotency_duplicate if idempotency_given? && idempotency_duplicate?
 

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -34,6 +34,9 @@
   .fields-group
     = f.input :setting_hide_network, as: :boolean, wrapper: :with_label
 
+  .fields-group
+    = f.input :setting_show_application, as: :boolean, wrapper: :with_label
+
   %hr#settings_web/
 
   .fields-row

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -39,7 +39,7 @@
     = link_to TagManager.instance.url_for(status), class: 'detailed-status__datetime u-url u-uid', target: stream_link_target, rel: 'noopener' do
       %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
     ·
-    - if status.application
+    - if status.application && @account.user&.setting_show_application
       - if status.application.website.blank?
         %strong.detailed-status__application= status.application.name
       - else

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -33,6 +33,7 @@ en:
         setting_display_media_show_all: Always show media marked as sensitive
         setting_hide_network: Who you follow and who follows you will not be shown on your profile
         setting_noindex: Affects your public profile and status pages
+        setting_show_application: The application you use to toot will be displayed in the detailed view of your toots
         setting_theme: Affects how Mastodon looks when you're logged in from any device.
         username: Your username will be unique on %{domain}
         whole_word: When the keyword or phrase is alphanumeric only, it will only be applied if it matches the whole word
@@ -100,6 +101,7 @@ en:
         setting_hide_network: Hide your network
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
+        setting_show_application: Disclose application used to send toots
         setting_system_font_ui: Use system's default font
         setting_theme: Site theme
         setting_unfollow_modal: Show confirmation dialog before unfollowing someone

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,6 +26,7 @@ defaults: &defaults
   expand_spoilers: false
   preview_sensitive_media: false
   reduce_motion: false
+  show_application: false
   system_font_ui: false
   noindex: false
   theme: 'default'


### PR DESCRIPTION
This PR introduces a setting to control whether an the application used to post toots is ~~stored and~~ displayed, and makes it opt-in (thus changing the default behavior).

The reasoning for this is that this information has little legitimate use, but may be used to get private information about the user (are they posting from their computer or a phone app? Do they use a very little-used app? If so, can we identify them across accounts?)