### PR TITLE
Added underlines to links in toots

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -670,7 +670,7 @@
 
   a {
     color: $secondary-text-color;
-    text-decoration: none;
+    text-decoration: underline;
 
     &:hover {
       text-decoration: underline;


### PR DESCRIPTION
Link text color is #f1ebff, surrounding text is #ffffff. They have a contrast ratio of 1.2:1. Not only is hard to see links that are so close in color to the text, they also require a pointing device (mouse) to quickly scan for links. Instead of having to meet a 4.5:1 contrast ratio, adding the underline will allow this to pass a WCAG check.