### PR TITLE
Fix Firefox scrollbar color regression in #9210

### DIFF
--- a/app/javascript/styles/mastodon/reset.scss
+++ b/app/javascript/styles/mastodon/reset.scss
@@ -54,7 +54,7 @@ table {
 }
 
 html {
-  scrollbar-color: lighten($ui-base-color, 4%) transparent;
+  scrollbar-color: lighten($ui-base-color, 4%) rgba($base-overlay-background, 0.1);
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
In #9210 the track color was changed to transparent for no apparent reason. This PR restores the previous color selections implemented in #8653 while keeping the updated property name. Per https://github.com/tootsuite/mastodon/pull/9210#issuecomment-441788776 there is no particular reason for the color change in #9210.