### PR TITLE
Rescue SSL error in verify link service

### DIFF
--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -10,7 +10,7 @@ class VerifyLinkService < BaseService
     return unless link_back_present?
 
     field.mark_verified!
-  rescue HTTP::Error, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError => e
+  rescue OpenSSL::SSL::SSLError, HTTP::Error, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError => e
     Rails.logger.debug "Error fetching link #{@url}: #{e}"
     nil
   end


### PR DESCRIPTION
If the first link to be verified contains a rel=me link with a SSL error, the VerifyAccountLinksWorker will fail and not try the following links. This rescues the SSL error when fetching the link, avoiding this issue.