### PR TITLE
Change color of links in toots to have higher contrast

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -669,15 +669,11 @@
   }
 
   a {
-    color: $secondary-text-color;
+    color: lighten($ui-highlight-color, 12%);
     text-decoration: none;
 
     &:hover {
       text-decoration: underline;
-
-      .fa {
-        color: lighten($dark-text-color, 7%);
-      }
     }
 
     &.mention {
@@ -689,13 +685,10 @@
         }
       }
     }
-
-    .fa {
-      color: $dark-text-color;
-    }
   }
 
   .status__content__spoiler-link {
+    color: $secondary-text-color;
     background: $action-button-color;
 
     &:hover {
@@ -731,7 +724,7 @@
   display: block;
   font-size: 15px;
   line-height: 20px;
-  color: lighten($ui-highlight-color, 8%);
+  color: lighten($ui-highlight-color, 12%);
   border: 0;
   background: transparent;
   padding: 0;
@@ -1065,6 +1058,10 @@
 
   a {
     color: $lighter-text-color;
+
+    &:not(.mention) {
+      color: $lighter-text-color;
+    }
   }
 }
 


### PR DESCRIPTION
Alternative to #9898. Improve ability to distinguish links from other text.

|With color|Grayscale|
|------------|--------------|
|![links-color](https://user-images.githubusercontent.com/184731/51994141-1233c880-24a8-11e9-82f9-e5e45a84b01c.png)|![links-grayscale](https://user-images.githubusercontent.com/184731/51994142-12cc5f00-24a8-11e9-87f5-ebd9f22dfda3.png)|

Unlike underlines, it keeps visual noise down in an otherwise busy interface. Unlike text links in articles, links in toots are associated with specific syntax (@ for mentions, # for hashtags, example.com for URLs), and their primary function is to be read in the text, rather than clicked on. Contrast ensures the distinction works even for colorblind people (tested with [this tool](https://www.color-blindness.com/coblis-color-blindness-simulator/))