### PR TITLE
Bumps copyright year in README.md to 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can open issues for bugs you've found or features you think are missing. You
 
 ## License
 
-Copyright (C) 2016-2018 Eugen Rochko & other Mastodon contributors (see [AUTHORS.md](AUTHORS.md))
+Copyright (C) 2016-2019 Eugen Rochko & other Mastodon contributors (see [AUTHORS.md](AUTHORS.md))
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 


### PR DESCRIPTION
This is so incredibly small, but assuming this is a needed change. Might want to check year in other files.