### PR TITLE
Upgrade new Web Share Target API

### DIFF
--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -59,7 +59,7 @@ class ManifestSerializer < ActiveModel::Serializer
         title: 'title',
         text: 'text',
         url: 'url',
-      }
+      },
     }
   end
 end

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -52,6 +52,14 @@ class ManifestSerializer < ActiveModel::Serializer
   end
 
   def share_target
-    { url_template: 'share?title={title}&text={text}&url={url}' }
+    {
+      url_template: 'share?title={title}&text={text}&url={url}',
+      action: 'share',
+      params: {
+        title: 'title',
+        text: 'text',
+        url: 'url',
+      }
+    }
   end
 end


### PR DESCRIPTION
Update #6278
"url_template" key has been replaced with "action" and "param".
ref. https://wicg.github.io/web-share-target/#usage-example

I'm testing on latest Chrome for Android (Chrome 71.0.3578.99).