### PR TITLE
[UI] Fix whitespace being applied to div instead of p

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -661,6 +661,7 @@
 
   p {
     margin-bottom: 20px;
+    white-space: pre-wrap;
 
     &:last-child {
       margin-bottom: 0;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -638,7 +638,6 @@
   font-weight: 400;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: pre-wrap;
   padding-top: 2px;
   color: $primary-text-color;
 


### PR DESCRIPTION
Before: ![image](https://user-images.githubusercontent.com/10606431/52191448-455cbb80-280a-11e9-9163-725762b39cef.png)

After: 
![image](https://user-images.githubusercontent.com/10606431/52191456-5b6a7c00-280a-11e9-9882-8bf19793b121.png)

`white-space: pre-wrap` is an unnecessary rule, and removing it fixes the issue without introducing any noticeable side effects. The large gap was occurring mainly in posts from Pleroma, which would add the white space *and* also add `margin-bottom: 20px`, which led to effectively two line breaks for every new `p` element.