### PR TITLE
Hide misleading “You will be sent a confirmation e-mail” hint from admin view

### DIFF
--- a/app/views/admin/change_emails/show.html.haml
+++ b/app/views/admin/change_emails/show.html.haml
@@ -3,7 +3,7 @@
 
 = simple_form_for @user, url: admin_account_change_email_path(@account.id) do |f|
   .fields-group
-    = f.input :email, wrapper: :with_label, disabled: true, label: t('admin.accounts.change_email.current_email')
+    = f.input :email, wrapper: :with_label, hint: false, disabled: true, label: t('admin.accounts.change_email.current_email')
 
   .fields-group
     = f.input :unconfirmed_email, wrapper: :with_label, label: t('admin.accounts.change_email.new_email')


### PR DESCRIPTION
Thanks @wryk for noticing this issue.

## Before

![screenshot_2019-02-04 change email for toto - dev instance](https://user-images.githubusercontent.com/384364/52265629-d7f97980-2934-11e9-9014-7b45c1354150.png)

## After

![screenshot_2019-02-04 change email for toto - dev instance 1](https://user-images.githubusercontent.com/384364/52265648-df208780-2934-11e9-9f96-5a8b65f5805d.png)
