### PR TITLE
Replace LibreSSL by OpenSSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apk -U upgrade \
     build-base \
     icu-dev \
     libidn-dev \
-    libressl \
+    openssl \
     libtool \
     libxml2-dev \
     libxslt-dev \


### PR DESCRIPTION
Alpine 3.9 has moved from LibreSSL to OpenSSL.

- https://lists.alpinelinux.org/alpine-devel/6308.html
- https://github.com/alpinelinux/aports/pull/5406#issuecomment-437837365
- https://alpinelinux.org/posts/Alpine-3.9.0-released.html

Fixes https://github.com/tootsuite/mastodon/pull/9965#issuecomment-460081232