### PR TITLE
Fix it as tagged_request of accounts_controller is not addressable_uri

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -116,7 +116,7 @@ class AccountsController < ApplicationController
   end
 
   def tag_requested?
-    request.path.ends_with?("/tagged/#{params[:tag]}")
+    request.path.ends_with?(Addressable::URI.parse("/tagged/#{params[:tag]}").normalize)
   end
 
   def filtered_status_page(params)


### PR DESCRIPTION
Fixed a problem comparing tags without url encoding (eg Japanese tags do not match).