### PR TITLE
Fix Tombstone.delete_all ArgumentError

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -212,7 +212,7 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def clear_tombstones!
-    Tombstone.delete_all(account_id: @account.id)
+    Tombstone.where(account_id: @account.id).delete_all
   end
 
   def protocol_changed?


### PR DESCRIPTION
Fixed a bug that caused `ArgumentError (wrong number of arguments (given 1, expected 0))` when executing `Tombstone.delete_all(account_id: @account.id)`.

Backtrace:

```
activerecord-5.2.2/lib/active_record/relation.rb:386→ delete_all
--
activerecord-5.2.2/lib/active_record/querying.rb:10→ delete_all
app/services/activitypub/process_account_service.rb:215→ clear_tombstones!
```