### PR TITLE
Fix IntersectionObserverArticle not hiding some out-of-view items

### DIFF
--- a/app/javascript/mastodon/components/intersection_observer_article.js
+++ b/app/javascript/mastodon/components/intersection_observer_article.js
@@ -65,7 +65,7 @@ export default class IntersectionObserverArticle extends React.Component {
   }
 
   updateStateAfterIntersection = (prevState) => {
-    if (prevState.isIntersecting && !this.entry.isIntersecting) {
+    if (prevState.isIntersecting !== false && !this.entry.isIntersecting) {
       scheduleIdleTask(this.hideIfNotIntersecting);
     }
     return {


### PR DESCRIPTION
IntersectionObserverArticle is made to save on RAM by avoiding fully rendering
items that are far out of view. However, it did not work for items spawned
outside the intersection observer.