### PR TITLE
Alternative handling of private self-boosts

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -4,6 +4,9 @@ class ActivityPub::Activity
   include JsonLdHelper
   include Redisable
 
+  SUPPORTED_TYPES = %w(Note).freeze
+  CONVERTED_TYPES = %w(Image Video Article Page).freeze
+
   def initialize(json, account, **options)
     @json    = json
     @account = account
@@ -71,6 +74,18 @@ class ActivityPub::Activity
     @object_uri ||= value_or_id(@object)
   end
 
+  def unsupported_object_type?
+    @object.is_a?(String) || !(supported_object_type? || converted_object_type?)
+  end
+
+  def supported_object_type?
+    equals_or_includes_any?(@object['type'], SUPPORTED_TYPES)
+  end
+
+  def converted_object_type?
+    equals_or_includes_any?(@object['type'], CONVERTED_TYPES)
+  end
+
   def distribute(status)
     crawl_links(status)
 
@@ -118,6 +133,23 @@ class ActivityPub::Activity
 
   def delete_later!(uri)
     redis.setex("delete_upon_arrival:#{@account.id}:#{uri}", 6.hours.seconds, uri)
+  end
+
+  def status_from_object
+    # If the status is already known, return it
+    status = status_from_uri(object_uri)
+    return status unless status.nil?
+
+    # If the boosted toot is embedded and it is a self-boost, handle it like a Create
+    unless unsupported_object_type?
+      actor_id = value_or_id(first_of_value(@object['attributedTo'])) || @account.uri
+      if actor_id == @account.uri
+        return ActivityPub::Activity.factory({ 'type' => 'Create', 'actor' => actor_id, 'object' => @object }, @account).perform
+      end
+    end
+
+    # If the status is not from the actor, try to fetch it
+    return fetch_remote_original_status if value_or_id(first_of_value(@json['attributedTo'])) == @account.uri
   end
 
   def fetch_remote_original_status

--- a/app/lib/activitypub/activity/announce.rb
+++ b/app/lib/activitypub/activity/announce.rb
@@ -2,9 +2,7 @@
 
 class ActivityPub::Activity::Announce < ActivityPub::Activity
   def perform
-    original_status   = status_from_uri(object_uri)
-    original_status ||= fetch_remote_original_status
-
+    original_status = status_from_object
     return if original_status.nil? || delete_arrived_first?(@json['id']) || !announceable?(original_status)
 
     status = Status.find_by(account: @account, reblog: original_status)

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class ActivityPub::Activity::Create < ActivityPub::Activity
-  SUPPORTED_TYPES = %w(Note).freeze
-  CONVERTED_TYPES = %w(Image Video Article Page).freeze
-
   def perform
     return if unsupported_object_type? || invalid_origin?(@object['id'])
     return if Tombstone.exists?(uri: @object['id'])
@@ -318,20 +315,8 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     @object['nameMap'].is_a?(Hash) && !@object['nameMap'].empty?
   end
 
-  def unsupported_object_type?
-    @object.is_a?(String) || !(supported_object_type? || converted_object_type?)
-  end
-
   def unsupported_media_type?(mime_type)
     mime_type.present? && !(MediaAttachment::IMAGE_MIME_TYPES + MediaAttachment::VIDEO_MIME_TYPES).include?(mime_type)
-  end
-
-  def supported_object_type?
-    equals_or_includes_any?(@object['type'], SUPPORTED_TYPES)
-  end
-
-  def converted_object_type?
-    equals_or_includes_any?(@object['type'], CONVERTED_TYPES)
   end
 
   def skip_download?

--- a/app/serializers/activitypub/activity_serializer.rb
+++ b/app/serializers/activitypub/activity_serializer.rb
@@ -3,8 +3,8 @@
 class ActivityPub::ActivitySerializer < ActiveModel::Serializer
   attributes :id, :type, :actor, :published, :to, :cc
 
-  has_one :proper, key: :object, serializer: ActivityPub::NoteSerializer, unless: :announce?
-  attribute :proper_uri, key: :object, if: :announce?
+  has_one :proper, key: :object, serializer: ActivityPub::NoteSerializer, unless: :owned_announce?
+  attribute :proper_uri, key: :object, if: :owned_announce?
   attribute :atom_uri, if: :announce?
 
   def id
@@ -41,5 +41,9 @@ class ActivityPub::ActivitySerializer < ActiveModel::Serializer
 
   def announce?
     object.reblog?
+  end
+
+  def owned_announce?
+    announce? && object.account == object.proper.account
   end
 end

--- a/app/serializers/activitypub/activity_serializer.rb
+++ b/app/serializers/activitypub/activity_serializer.rb
@@ -44,6 +44,6 @@ class ActivityPub::ActivitySerializer < ActiveModel::Serializer
   end
 
   def owned_announce?
-    announce? && object.account == object.proper.account
+    announce? && object.account == object.proper.account && object.proper.private_visibility?
   end
 end


### PR DESCRIPTION
- Serialize the original toot when sending self-boosts over ActivityPub
- Whenever an Announce is received with valid object from the same author, process it instead of fetching it