### PR TITLE
IPv6 support in email validator

### DIFF
--- a/app/validators/email_mx_validator.rb
+++ b/app/validators/email_mx_validator.rb
@@ -24,6 +24,7 @@ class EmailMxValidator < ActiveModel::Validator
 
       ([domain] + hostnames).uniq.each do |hostname|
         ips.concat(dns.getresources(hostname, Resolv::DNS::Resource::IN::A).to_a.map { |e| e.address.to_s })
+        ips.concat(dns.getresources(hostname, Resolv::DNS::Resource::IN::AAAA).to_a.map { |e| e.address.to_s })
       end
     end
 


### PR DESCRIPTION
When MX for a domain only have IPv6 address, then domain is considered as invalid.

IPv6 only MXes are not so common, but it can happen in "split dns" situations where only IPv6 MX address is exposed to some (generally internal) networks.
