### PR TITLE
perf: run node directly when streaming

### DIFF
--- a/dist/mastodon-streaming.service
+++ b/dist/mastodon-streaming.service
@@ -9,7 +9,7 @@ WorkingDirectory=/home/mastodon/live
 Environment="NODE_ENV=production"
 Environment="PORT=4000"
 Environment="STREAMING_CLUSTER_NUM=1"
-ExecStart=/usr/bin/npm run start
+ExecStart=/usr/bin/node ./streaming
 TimeoutSec=15
 Restart=always
 


### PR DESCRIPTION
Based on some research I did in https://github.com/nolanlawson/pinafore/issues/971 it seems that, somewhat surprisingly, running `node` directly instead of using `npm run [script]` consumes significantly less memory.

I'm testing this out in production right now, and for my server running malfunctioning.technology, freedom.horse, and toot.cafe, I previously saw these `npm` processes taking up 57728 kilobytes total of RSS (Resident Set Size), and all `node`/`npm` processes combined were taking 354168. After this change, that drops to 291588 and the `npm` processes are gone.

You can test this yourself by running something like:

```bash
ps aux | grep 'node\|npm'
```

You should see output like:

```
malftech 16962  0.0  0.2 1114420 18472 ?       Ssl  Feb06   0:00 npm
malftech 17021  0.0  0.0   4636   740 ?        S    Feb06   0:00 sh -c node ./streaming/index.js
malftech 17023  0.0  0.3 900956 31700 ?        Sl   Feb06   0:00 node ./streaming/index.js
malftech 17029  0.0  0.4 1199032 38392 ?       Sl   Feb06   0:05 /usr/bin/node /home/malftech/live/streaming/index.js
```

Directly running `node` should remove that `npm` process using 18472kB of RSS.

BTW I am not a Linux perf guru, so I am happy to have someone with more devops experience take a look at this first.