### PR TITLE
Change robots.txt to exclude only media proxy URLs

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
 # To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Disallow: /media_proxy/

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,13 +1,5 @@
-User-Agent: *
-Disallow: /users/*/followers
-Disallow: /users/*/following
-Disallow: /@*/media
-Disallow: /@*/with_replies
-Disallow: /@*/tagged/*
-Disallow: /media_proxy/*
-Disallow: /emoji/*
-Disallow: /packs/*
-Disallow: /sounds/*
-Disallow: /system/*
-Disallow: /avatars/*
-Disallow: /headers/*
+# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+#
+# To ban all spiders from the entire site uncomment the next two lines:
+# User-agent: *
+# Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,4 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
+
 User-agent: *
 Disallow: /media_proxy/


### PR DESCRIPTION
Reverts tootsuite/mastodon#10037

This change as written prevents archive.org from effectively archiving or displaying archived mastodon sites.

If the concern is googlebot, then we should add specific googlebot rules.