### PR TITLE
Filter incoming Announce activities by relation to local activity

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -138,11 +138,13 @@ class ActivityPub::Activity
   def status_from_object
     # If the status is already known, return it
     status = status_from_uri(object_uri)
+
     return status unless status.nil?
 
     # If the boosted toot is embedded and it is a self-boost, handle it like a Create
     unless unsupported_object_type?
       actor_id = value_or_id(first_of_value(@object['attributedTo'])) || @account.uri
+
       if actor_id == @account.uri
         return ActivityPub::Activity.factory({ 'type' => 'Create', 'actor' => actor_id, 'object' => @object }, @account).perform
       end
@@ -165,5 +167,17 @@ class ActivityPub::Activity
     yield if redis.set(key, true, nx: true, ex: expire_after)
   ensure
     redis.del(key)
+  end
+
+  def fetch?
+    !@options[:delivery]
+  end
+
+  def followed_by_local_accounts?
+    @account.passive_relationships.exists?
+  end
+
+  def requested_through_relay?
+    @options[:relayed_through_account] && Relay.find_by(inbox_url: @options[:relayed_through_account].inbox_url)&.enabled?
   end
 end

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -341,18 +341,6 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       responds_to_followed_account? || addresses_local_accounts?
   end
 
-  def fetch?
-    !@options[:delivery]
-  end
-
-  def followed_by_local_accounts?
-    @account.passive_relationships.exists?
-  end
-
-  def requested_through_relay?
-    @options[:relayed_through_account] && Relay.find_by(inbox_url: @options[:relayed_through_account].inbox_url)&.enabled?
-  end
-
   def responds_to_followed_account?
     !replied_to_status.nil? && (replied_to_status.account.local? || replied_to_status.account.passive_relationships.exists?)
   end

--- a/spec/lib/activitypub/activity/announce_spec.rb
+++ b/spec/lib/activitypub/activity/announce_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ActivityPub::Activity::Announce do
   subject { described_class.new(json, sender) }
 
   before do
+    Fabricate(:account).follow!(sender)
     sender.update(uri: ActivityPub::TagManager.instance.uri_for(sender))
   end
 


### PR DESCRIPTION
Reject if announcer is not followed by local accounts, and is not
from an enabled relay, and the object is not a local status

Follow-up to #10005