### PR TITLE
Hide domain filter in admin page when “local” filter is active

### DIFF
--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -26,8 +26,9 @@
         = hidden_field_tag key, params[key]
 
     - %i(username by_domain display_name email ip).each do |key|
-      .input.string.optional
-        = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.accounts.#{key}")
+      - unless key == :by_domain && params[:remote].blank?
+        .input.string.optional
+          = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.accounts.#{key}")
 
     .actions
       %button= t('admin.accounts.search')


### PR DESCRIPTION
Since the “domain” field is ignored in this case.

![screenshot_2019-02-18 accounts - dev instance](https://user-images.githubusercontent.com/384364/52947980-83b0b980-3378-11e9-811c-15ba01e763e2.png)
![screenshot_2019-02-18 accounts - dev instance 1](https://user-images.githubusercontent.com/384364/52947985-87444080-3378-11e9-9a47-1e7368bc1f9a.png)
