### PR TITLE
Allow getting-started to scroll on short screens

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2336,6 +2336,7 @@ a.account__display-name {
 
 .getting-started {
   color: $dark-text-color;
+  overflow: auto;
 
   &__footer {
     flex: 0 0 auto;


### PR DESCRIPTION
At 480px height, there is not enough space to fully display the footer.

Before | After
--- | ---
![firefox_2019-02-18_10-39-57](https://user-images.githubusercontent.com/10606431/52965445-6d9bfc80-336a-11e9-874b-d5a2f4c7524a.png) | ![firefox_2019-02-18_10-40-29](https://user-images.githubusercontent.com/10606431/52965446-6f65c000-336a-11e9-8e25-ba473f9eb385.png)