### PR TITLE
correct opt-out showing application

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -245,7 +245,7 @@ class User < ApplicationRecord
   end
 
   def shows_application?
-    @shows_application ||= settings.shows_application
+    @shows_application ||= settings.show_application
   end
 
   def token_for_app(a)

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -39,7 +39,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def show_application?
-    object.account.user_shows_application? || (current_user? && current_user.account_id == object.account_id)
+    object.account.user&.setting_show_application || (current_user? && current_user.account_id == object.account_id)
   end
 
   def visibility

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -39,7 +39,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   end
 
   def show_application?
-    object.account.user&.setting_show_application || (current_user? && current_user.account_id == object.account_id)
+    object.account.user_shows_application? || (current_user? && current_user.account_id == object.account_id)
   end
 
   def visibility


### PR DESCRIPTION
in #9994, api response of status was not correct opted-out _without save settings_. (`/@user/:status` is correct.)