### PR TITLE
Add ES_PREFIX in .env.production.sample

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -10,6 +10,7 @@ DB_NAME=postgres
 DB_PASS=
 DB_PORT=5432
 # Optional ElasticSearch configuration
+# You may also set ES_PREFIX to share the same cluster between multiple Mastodon servers (falls back to REDIS_NAMESPACE if not set)
 # ES_ENABLED=true
 # ES_HOST=es
 # ES_PORT=9200


### PR DESCRIPTION
If both `REDIS_NAMESPACE` and `ES_PREFIX` are not set and multiple Mastodon instances use the same ES cluster, then will use the same index.

https://discourse.joinmastodon.org/t/shared-elasticsearch-index-for-multiple-mastodon-instances/1738/3