### PR TITLE
Add type, limit, offset, min_id, max_id, account_id to search API

### DIFF
--- a/app/chewy/statuses_index.rb
+++ b/app/chewy/statuses_index.rb
@@ -48,6 +48,7 @@ class StatusesIndex < Chewy::Index
     end
 
     root date_detection: false do
+      field :id, type: 'long'
       field :account_id, type: 'long'
 
       field :text, type: 'text', value: ->(status) { [status.spoiler_text, Formatter.instance.plaintext(status)].concat(status.media_attachments.map(&:description)).join("\n\n") } do
@@ -55,7 +56,6 @@ class StatusesIndex < Chewy::Index
       end
 
       field :searchable_by, type: 'long', value: ->(status, crutches) { status.searchable_by(crutches) }
-      field :created_at, type: 'date'
     end
   end
 end

--- a/app/controllers/api/v1/accounts/search_controller.rb
+++ b/app/controllers/api/v1/accounts/search_controller.rb
@@ -16,10 +16,11 @@ class Api::V1::Accounts::SearchController < Api::BaseController
   def account_search
     AccountSearchService.new.call(
       params[:q],
-      limit_param(DEFAULT_ACCOUNTS_LIMIT),
       current_account,
+      limit: limit_param(DEFAULT_ACCOUNTS_LIMIT),
       resolve: truthy_param?(:resolve),
-      following: truthy_param?(:following)
+      following: truthy_param?(:following),
+      offset: params[:offset]
     )
   end
 end

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -3,7 +3,7 @@
 class Api::V1::SearchController < Api::BaseController
   include Authorization
 
-  RESULTS_LIMIT = 5
+  RESULTS_LIMIT = 20
 
   before_action -> { doorkeeper_authorize! :read, :'read:search' }
   before_action :require_user!
@@ -11,30 +11,22 @@ class Api::V1::SearchController < Api::BaseController
   respond_to :json
 
   def index
-    @search = Search.new(search)
+    @search = Search.new(search_results)
     render json: @search, serializer: REST::SearchSerializer
   end
 
   private
 
-  def search
-    search_results.tap do |search|
-      search[:statuses].keep_if do |status|
-        begin
-          authorize status, :show?
-        rescue Mastodon::NotPermittedError
-          false
-        end
-      end
-    end
-  end
-
   def search_results
     SearchService.new.call(
       params[:q],
-      RESULTS_LIMIT,
-      truthy_param?(:resolve),
-      current_account
+      current_account,
+      limit_param(RESULTS_LIMIT),
+      search_params.merge(resolve: truthy_param?(:resolve))
     )
+  end
+
+  def search_params
+    params.permit(:type, :offset, :min_id, :max_id, :account_id)
   end
 end

--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V2::SearchController < Api::V1::SearchController
   def index
-    @search = Search.new(search)
+    @search = Search.new(search_results)
     render json: @search, serializer: REST::V2::SearchSerializer
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -386,7 +386,7 @@ class Account < ApplicationRecord
       DeliveryFailureTracker.filter(urls)
     end
 
-    def search_for(terms, limit = 10)
+    def search_for(terms, limit = 10, offset = 0)
       textsearch, query = generate_query_for_search(terms)
 
       sql = <<-SQL.squish
@@ -398,15 +398,15 @@ class Account < ApplicationRecord
           AND accounts.suspended = false
           AND accounts.moved_to_account_id IS NULL
         ORDER BY rank DESC
-        LIMIT ?
+        LIMIT ? OFFSET ?
       SQL
 
-      records = find_by_sql([sql, limit])
+      records = find_by_sql([sql, limit, offset])
       ActiveRecord::Associations::Preloader.new.preload(records, :account_stat)
       records
     end
 
-    def advanced_search_for(terms, account, limit = 10, following = false)
+    def advanced_search_for(terms, account, limit = 10, following = false, offset = 0)
       textsearch, query = generate_query_for_search(terms)
 
       if following
@@ -427,10 +427,10 @@ class Account < ApplicationRecord
             AND accounts.moved_to_account_id IS NULL
           GROUP BY accounts.id
           ORDER BY rank DESC
-          LIMIT ?
+          LIMIT ? OFFSET ?
         SQL
 
-        records = find_by_sql([sql, account.id, account.id, account.id, limit])
+        records = find_by_sql([sql, account.id, account.id, account.id, limit, offset])
       else
         sql = <<-SQL.squish
           SELECT
@@ -443,10 +443,10 @@ class Account < ApplicationRecord
             AND accounts.moved_to_account_id IS NULL
           GROUP BY accounts.id
           ORDER BY rank DESC
-          LIMIT ?
+          LIMIT ? OFFSET ?
         SQL
 
-        records = find_by_sql([sql, account.id, account.id, limit])
+        records = find_by_sql([sql, account.id, account.id, limit, offset])
       end
 
       ActiveRecord::Associations::Preloader.new.preload(records, :account_stat)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -64,9 +64,13 @@ class Tag < ApplicationRecord
   end
 
   class << self
-    def search_for(term, limit = 5)
+    def search_for(term, limit = 5, offset = 0)
       pattern = sanitize_sql_like(term.strip) + '%'
-      Tag.where('lower(name) like lower(?)', pattern).order(:name).limit(limit)
+
+      Tag.where('lower(name) like lower(?)', pattern)
+         .order(:name)
+         .limit(limit)
+         .offset(offset)
     end
   end
 

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class AccountSearchService < BaseService
-  attr_reader :query, :limit, :options, :account
+  attr_reader :query, :limit, :offset, :options, :account
 
-  def call(query, limit, account = nil, options = {})
+  def call(query, account = nil, options = {})
     @query   = query.strip
-    @limit   = limit
+    @limit   = options[:limit].to_i
+    @offset  = options[:offset].to_i
     @options = options
     @account = account
 
@@ -83,11 +84,11 @@ class AccountSearchService < BaseService
   end
 
   def advanced_search_results
-    Account.advanced_search_for(terms_for_query, account, limit, options[:following])
+    Account.advanced_search_for(terms_for_query, account, limit, options[:following], offset)
   end
 
   def simple_search_results
-    Account.search_for(terms_for_query, limit)
+    Account.search_for(terms_for_query, limit, offset)
   end
 
   def terms_for_query

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -6,7 +6,7 @@ class SearchService < BaseService
     @account = account
     @options = options
     @limit   = limit.to_i
-    @offset  = options[:offset].to_i
+    @offset  = options[:type].blank? ? 0 : options[:offset].to_i
     @resolve = options[:resolve] || false
 
     default_results.tap do |results|

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 class SearchService < BaseService
-  attr_accessor :query, :account, :limit, :resolve
-
-  def call(query, limit, resolve = false, account = nil)
+  def call(query, account, limit, options = {})
     @query   = query.strip
     @account = account
+    @options = options
     @limit   = limit
-    @resolve = resolve
+    @offset  = options[:offset]
+    @resolve = options[:resolve] || false
 
     default_results.tap do |results|
       if url_query?
         results.merge!(url_resource_results) unless url_resource.nil?
-      elsif query.present?
+      elsif @query.present?
         results[:accounts] = perform_accounts_search! if account_searchable?
         results[:statuses] = perform_statuses_search! if full_text_searchable?
         results[:hashtags] = perform_hashtags_search! if hashtag_searchable?
@@ -23,23 +23,41 @@ class SearchService < BaseService
   private
 
   def perform_accounts_search!
-    AccountSearchService.new.call(query, limit, account, resolve: resolve)
+    AccountSearchService.new.call(@query, @limit, @account, resolve: @resolve)
   end
 
   def perform_statuses_search!
-    statuses = StatusesIndex.filter(term: { searchable_by: account.id })
-                            .query(multi_match: { type: 'most_fields', query: query, operator: 'and', fields: %w(text text.stemmed) })
-                            .limit(limit)
-                            .objects
-                            .compact
+    definition = StatusesIndex.query do |q|
+      q.filtered do |q|
+        q.filter do |q|
+          q.term searchable_by: @account.id
 
-    statuses.reject { |status| StatusFilter.new(status, account).filtered? }
+          q.term account_id: @options[:account_id] if @options[:account_id].present?
+
+          q.range :_id do |q|
+            q.gt @options[:min_id] if @options[:min_id].present?
+            q.lt @options[:max_id] if @options[:max_id].present?
+          end
+        end
+
+        q.query do |q|
+          q.multi_match type: 'most_fields', query: @query, operator: 'and', fields: %w(text text.stemmed)
+        end
+      end
+    end
+
+    results             = definition.limit(@limit).offset(@offset).objects.compact
+    account_ids         = results.map(&:account_id)
+    account_domains     = results.map(&:account_domain)
+    preloaded_relations = relations_map_for_account(@account, account_ids, account_domains)
+
+    results.reject { |status| StatusFilter.new(status, @account, preloaded_relations).filtered? }
   rescue Faraday::ConnectionFailed
     []
   end
 
   def perform_hashtags_search!
-    Tag.search_for(query.gsub(/\A#/, ''), limit)
+    Tag.search_for(@query.gsub(/\A#/, ''), @limit)
   end
 
   def default_results
@@ -47,7 +65,7 @@ class SearchService < BaseService
   end
 
   def url_query?
-    query =~ /\Ahttps?:\/\//
+    @options[:type].blank? && @query =~ /\Ahttps?:\/\//
   end
 
   def url_resource_results
@@ -55,7 +73,7 @@ class SearchService < BaseService
   end
 
   def url_resource
-    @_url_resource ||= ResolveURLService.new.call(query, on_behalf_of: @account)
+    @_url_resource ||= ResolveURLService.new.call(@query, on_behalf_of: @account)
   end
 
   def url_resource_symbol
@@ -64,14 +82,37 @@ class SearchService < BaseService
 
   def full_text_searchable?
     return false unless Chewy.enabled?
-    !account.nil? && !((query.start_with?('#') || query.include?('@')) && !query.include?(' '))
+
+    statuses_search? && !@account.nil? && !((@query.start_with?('#') || @query.include?('@')) && !@query.include?(' '))
   end
 
   def account_searchable?
-    !(query.include?('@') && query.include?(' '))
+    account_search? && !(@query.include?('@') && @query.include?(' '))
   end
 
   def hashtag_searchable?
-    !query.include?('@')
+    hashtag_search? && !@query.include?('@')
+  end
+
+  def account_search?
+    @options[:type].blank? || @options[:type] == 'accounts'
+  end
+
+  def hashtag_search?
+    @options[:type].blank? || @options[:type] == 'hashtags'
+  end
+
+  def statuses_search?
+    @options[:type].blank? || @options[:type] == 'statuses'
+  end
+
+  def relations_map_for_account(account, account_ids, domains)
+    {
+      blocking: Account.blocking_map(account_ids, account.id),
+      blocked_by: Account.blocked_by_map(account_ids, account.id),
+      muting: Account.muting_map(account_ids, account.id),
+      following: Account.following_map(account_ids, account.id),
+      domain_blocking_by_domain: Account.domain_blocking_map_by_domain(domains, account.id),
+    }
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,26 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Mass Assignment",
+      "warning_code": 105,
+      "fingerprint": "0117d2be5947ea4e4fbed9c15f23c6615b12c6892973411820c83d079808819d",
+      "check_name": "PermitAttributes",
+      "message": "Potentially dangerous key allowed for mass assignment",
+      "file": "app/controllers/api/v1/search_controller.rb",
+      "line": 30,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit(:type, :offset, :min_id, :max_id, :account_id)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Api::V1::SearchController",
+        "method": "search_params"
+      },
+      "user_input": ":account_id",
+      "confidence": "High",
+      "note": ""
+    },
+    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "04dbbc249b989db2e0119bbb0f59c9818e12889d2b97c529cdc0b1526002ba4b",
@@ -21,32 +41,13 @@
       "note": ""
     },
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "0adbe361b91afff22ba51e5fc2275ec703cc13255a0cb3eecd8dab223ab9f61e",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
-      "file": "app/views/admin/accounts/show.html.haml",
-      "line": 167,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(Account.find(params[:id]).inbox_url, Account.find(params[:id]).inbox_url)",
-      "render_path": [{"type":"controller","class":"Admin::AccountsController","method":"show","line":18,"file":"app/controllers/admin/accounts_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "admin/accounts/show"
-      },
-      "user_input": "Account.find(params[:id]).inbox_url",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "19df3740b8d02a9fe0eb52c939b4b87d3a2a591162a6adfa8d64e9c26aeebe6d",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/status.rb",
-      "line": 84,
+      "line": 87,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "result.joins(\"INNER JOIN statuses_tags t#{id} ON t#{id}.status_id = statuses.id AND t#{id}.tag_id = #{id}\")",
       "render_path": null,
@@ -60,51 +61,13 @@
       "note": ""
     },
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "1fc29c578d0c89bf13bd5476829d272d54cd06b92ccf6df18568fa1f2674926e",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
-      "file": "app/views/admin/accounts/show.html.haml",
-      "line": 173,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(Account.find(params[:id]).shared_inbox_url, Account.find(params[:id]).shared_inbox_url)",
-      "render_path": [{"type":"controller","class":"Admin::AccountsController","method":"show","line":18,"file":"app/controllers/admin/accounts_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "admin/accounts/show"
-      },
-      "user_input": "Account.find(params[:id]).shared_inbox_url",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "2129d4c1e63a351d28d8d2937ff0b50237809c3df6725c0c5ef82b881dbb2086",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
-      "file": "app/views/admin/accounts/show.html.haml",
-      "line": 75,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(Account.find(params[:id]).url, Account.find(params[:id]).url)",
-      "render_path": [{"type":"controller","class":"Admin::AccountsController","method":"show","line":18,"file":"app/controllers/admin/accounts_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "admin/accounts/show"
-      },
-      "user_input": "Account.find(params[:id]).url",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
       "fingerprint": "28d81cc22580ef76e912b077b245f353499aa27b3826476667224c00227af2a9",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/admin/reports_controller.rb",
-      "line": 80,
+      "line": 56,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit(:account_id, :resolved, :target_account_id)",
       "render_path": null,
@@ -127,7 +90,7 @@
       "line": 4,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => Admin::ActionLog.page(params[:page]), {})",
-      "render_path": [{"type":"controller","class":"Admin::ActionLogsController","method":"index","line":7,"file":"app/controllers/admin/action_logs_controller.rb"}],
+      "render_path": [{"type":"controller","class":"Admin::ActionLogsController","method":"index","line":7,"file":"app/controllers/admin/action_logs_controller.rb","rendered":{"name":"admin/action_logs/index","file":"/home/eugr/Projects/mastodon/app/views/admin/action_logs/index.html.haml"}}],
       "location": {
         "type": "template",
         "template": "admin/action_logs/index"
@@ -143,7 +106,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/remote_interaction_controller.rb",
-      "line": 20,
+      "line": 21,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(RemoteFollow.new(resource_params).interact_address_for(Status.find(params[:id])))",
       "render_path": null,
@@ -157,25 +120,6 @@
       "note": ""
     },
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "64b5b2a02ede9c2b3598881eb5a466d63f7d27fe0946aa00d570111ec7338d2e",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
-      "file": "app/views/admin/accounts/show.html.haml",
-      "line": 176,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(Account.find(params[:id]).followers_url, Account.find(params[:id]).followers_url)",
-      "render_path": [{"type":"controller","class":"Admin::AccountsController","method":"show","line":18,"file":"app/controllers/admin/accounts_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "admin/accounts/show"
-      },
-      "user_input": "Account.find(params[:id]).followers_url",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "67afc0d5f7775fa5bd91d1912e1b5505aeedef61876347546fa20f92fd6915e6",
@@ -185,7 +129,7 @@
       "line": 3,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => \"stream_entries/#{Account.find_local!(params[:account_username]).statuses.find(params[:id]).stream_entry.activity_type.downcase}\", { Account.find_local!(params[:account_username]).statuses.find(params[:id]).stream_entry.activity_type.downcase.to_sym => Account.find_local!(params[:account_username]).statuses.find(params[:id]).stream_entry.activity, :centered => true, :autoplay => ActiveModel::Type::Boolean.new.cast(params[:autoplay]) })",
-      "render_path": [{"type":"controller","class":"StatusesController","method":"embed","line":59,"file":"app/controllers/statuses_controller.rb"}],
+      "render_path": [{"type":"controller","class":"StatusesController","method":"embed","line":63,"file":"app/controllers/statuses_controller.rb","rendered":{"name":"stream_entries/embed","file":"/home/eugr/Projects/mastodon/app/views/stream_entries/embed.html.haml"}}],
       "location": {
         "type": "template",
         "template": "stream_entries/embed"
@@ -201,7 +145,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/status.rb",
-      "line": 89,
+      "line": 92,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "result.joins(\"LEFT OUTER JOIN statuses_tags t#{id} ON t#{id}.status_id = statuses.id AND t#{id}.tag_id = #{id}\")",
       "render_path": null,
@@ -215,25 +159,6 @@
       "note": ""
     },
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "82f7b0d09beb3ab68e0fa16be63cedf4e820f2490326e9a1cec05761d92446cd",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
-      "file": "app/views/admin/accounts/show.html.haml",
-      "line": 149,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(Account.find(params[:id]).salmon_url, Account.find(params[:id]).salmon_url)",
-      "render_path": [{"type":"controller","class":"Admin::AccountsController","method":"show","line":18,"file":"app/controllers/admin/accounts_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "admin/accounts/show"
-      },
-      "user_input": "Account.find(params[:id]).salmon_url",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "8d843713d99e8403f7992f3e72251b633817cf9076ffcbbad5613859d2bbc127",
@@ -243,7 +168,7 @@
       "line": 45,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => filtered_custom_emojis.eager_load(:local_counterpart).page(params[:page]), {})",
-      "render_path": [{"type":"controller","class":"Admin::CustomEmojisController","method":"index","line":11,"file":"app/controllers/admin/custom_emojis_controller.rb"}],
+      "render_path": [{"type":"controller","class":"Admin::CustomEmojisController","method":"index","line":11,"file":"app/controllers/admin/custom_emojis_controller.rb","rendered":{"name":"admin/custom_emojis/index","file":"/home/eugr/Projects/mastodon/app/views/admin/custom_emojis/index.html.haml"}}],
       "location": {
         "type": "template",
         "template": "admin/custom_emojis/index"
@@ -279,10 +204,10 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/admin/accounts/index.html.haml",
-      "line": 67,
+      "line": 47,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => filtered_accounts.page(params[:page]), {})",
-      "render_path": [{"type":"controller","class":"Admin::AccountsController","method":"index","line":12,"file":"app/controllers/admin/accounts_controller.rb"}],
+      "render_path": [{"type":"controller","class":"Admin::AccountsController","method":"index","line":12,"file":"app/controllers/admin/accounts_controller.rb","rendered":{"name":"admin/accounts/index","file":"/home/eugr/Projects/mastodon/app/views/admin/accounts/index.html.haml"}}],
       "location": {
         "type": "template",
         "template": "admin/accounts/index"
@@ -298,7 +223,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/media_controller.rb",
-      "line": 10,
+      "line": 14,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(MediaAttachment.attached.find_by!(:shortcode => ((params[:id] or params[:medium_id]))).file.url(:original))",
       "render_path": null,
@@ -309,25 +234,6 @@
       },
       "user_input": "MediaAttachment.attached.find_by!(:shortcode => ((params[:id] or params[:medium_id]))).file.url(:original)",
       "confidence": "High",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "bb0ad5c4a42e06e3846c2089ff5269c17f65483a69414f6ce65eecf2bb11fab7",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
-      "file": "app/views/admin/accounts/show.html.haml",
-      "line": 138,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(Account.find(params[:id]).remote_url, Account.find(params[:id]).remote_url)",
-      "render_path": [{"type":"controller","class":"Admin::AccountsController","method":"show","line":18,"file":"app/controllers/admin/accounts_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "admin/accounts/show"
-      },
-      "user_input": "Account.find(params[:id]).remote_url",
-      "confidence": "Weak",
       "note": ""
     },
     {
@@ -351,32 +257,13 @@
       "note": ""
     },
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "e04aafe1e06cf8317fb6ac0a7f35783e45aa1274272ee6eaf28d39adfdad489b",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in link_to href",
-      "file": "app/views/admin/accounts/show.html.haml",
-      "line": 170,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(Account.find(params[:id]).outbox_url, Account.find(params[:id]).outbox_url)",
-      "render_path": [{"type":"controller","class":"Admin::AccountsController","method":"show","line":18,"file":"app/controllers/admin/accounts_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "admin/accounts/show"
-      },
-      "user_input": "Account.find(params[:id]).outbox_url",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
       "warning_type": "Mass Assignment",
       "warning_code": 105,
       "fingerprint": "e867661b2c9812bc8b75a5df12b28e2a53ab97015de0638b4e732fe442561b28",
       "check_name": "PermitAttributes",
       "message": "Potentially dangerous key allowed for mass assignment",
       "file": "app/controllers/api/v1/reports_controller.rb",
-      "line": 37,
+      "line": 36,
       "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
       "code": "params.permit(:account_id, :comment, :forward, :status_ids => ([]))",
       "render_path": null,
@@ -399,7 +286,7 @@
       "line": 23,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(partial => \"stream_entries/#{Account.find_local!(params[:account_username]).statuses.find(params[:id]).stream_entry.activity_type.downcase}\", { :locals => ({ Account.find_local!(params[:account_username]).statuses.find(params[:id]).stream_entry.activity_type.downcase.to_sym => Account.find_local!(params[:account_username]).statuses.find(params[:id]).stream_entry.activity, :include_threads => true }) })",
-      "render_path": [{"type":"controller","class":"StatusesController","method":"show","line":30,"file":"app/controllers/statuses_controller.rb"}],
+      "render_path": [{"type":"controller","class":"StatusesController","method":"show","line":34,"file":"app/controllers/statuses_controller.rb","rendered":{"name":"stream_entries/show","file":"/home/eugr/Projects/mastodon/app/views/stream_entries/show.html.haml"}}],
       "location": {
         "type": "template",
         "template": "stream_entries/show"
@@ -409,6 +296,6 @@
       "note": ""
     }
   ],
-  "updated": "2018-10-20 23:24:45 +1300",
-  "brakeman_version": "4.2.1"
+  "updated": "2019-02-21 02:30:29 +0100",
+  "brakeman_version": "4.4.0"
 }

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -68,7 +68,7 @@ describe SearchService, type: :service do
           allow(AccountSearchService).to receive(:new).and_return(service)
 
           results = subject.call(query, nil, 10)
-          expect(service).to have_received(:call).with(query, 10, nil, resolve: false)
+          expect(service).to have_received(:call).with(query, nil, limit: 10, offset: 0, resolve: false)
           expect(results).to eq empty_results.merge(accounts: [account])
         end
       end
@@ -77,10 +77,10 @@ describe SearchService, type: :service do
         it 'includes the tag in the results' do
           query = '#tag'
           tag = Tag.new
-          allow(Tag).to receive(:search_for).with('tag', 10).and_return([tag])
+          allow(Tag).to receive(:search_for).with('tag', 10, 0).and_return([tag])
 
           results = subject.call(query, nil, 10)
-          expect(Tag).to have_received(:search_for).with('tag', 10)
+          expect(Tag).to have_received(:search_for).with('tag', 10, 0)
           expect(results).to eq empty_results.merge(hashtags: [tag])
         end
         it 'does not include tag when starts with @ character' do

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -10,7 +10,7 @@ describe SearchService, type: :service do
       it 'returns empty results without searching' do
         allow(AccountSearchService).to receive(:new)
         allow(Tag).to receive(:search_for)
-        results = subject.call('', 10)
+        results = subject.call('', nil, 10)
 
         expect(results).to eq(empty_results)
         expect(AccountSearchService).not_to have_received(:new)
@@ -27,7 +27,7 @@ describe SearchService, type: :service do
         it 'returns the empty results' do
           service = double(call: nil)
           allow(ResolveURLService).to receive(:new).and_return(service)
-          results = subject.call(@query, 10)
+          results = subject.call(@query, nil, 10)
 
           expect(service).to have_received(:call).with(@query, on_behalf_of: nil)
           expect(results).to eq empty_results
@@ -40,7 +40,7 @@ describe SearchService, type: :service do
           service = double(call: account)
           allow(ResolveURLService).to receive(:new).and_return(service)
 
-          results = subject.call(@query, 10)
+          results = subject.call(@query, nil, 10)
           expect(service).to have_received(:call).with(@query, on_behalf_of: nil)
           expect(results).to eq empty_results.merge(accounts: [account])
         end
@@ -52,7 +52,7 @@ describe SearchService, type: :service do
           service = double(call: status)
           allow(ResolveURLService).to receive(:new).and_return(service)
 
-          results = subject.call(@query, 10)
+          results = subject.call(@query, nil, 10)
           expect(service).to have_received(:call).with(@query, on_behalf_of: nil)
           expect(results).to eq empty_results.merge(statuses: [status])
         end
@@ -67,7 +67,7 @@ describe SearchService, type: :service do
           service = double(call: [account])
           allow(AccountSearchService).to receive(:new).and_return(service)
 
-          results = subject.call(query, 10)
+          results = subject.call(query, nil, 10)
           expect(service).to have_received(:call).with(query, 10, nil, resolve: false)
           expect(results).to eq empty_results.merge(accounts: [account])
         end
@@ -79,7 +79,7 @@ describe SearchService, type: :service do
           tag = Tag.new
           allow(Tag).to receive(:search_for).with('tag', 10).and_return([tag])
 
-          results = subject.call(query, 10)
+          results = subject.call(query, nil, 10)
           expect(Tag).to have_received(:search_for).with('tag', 10)
           expect(results).to eq empty_results.merge(hashtags: [tag])
         end
@@ -87,7 +87,7 @@ describe SearchService, type: :service do
           query = '@username'
           allow(Tag).to receive(:search_for)
 
-          results = subject.call(query, 10)
+          results = subject.call(query, nil, 10)
           expect(Tag).not_to have_received(:search_for)
           expect(results).to eq empty_results
         end


### PR DESCRIPTION
Fix #8939

> **Note**: The search controller was running `authorize` on each status, but `SearchService` already runs `StatusFilter` on each status, which calls `StatusPolicy` internally, so the same work was done twice.

`type` allows specifying what kind of results you expect back, to omit the unneeded ones. Now customizable `limit` (previously: always 5; now: 0-40), as well as `offset` allows paginating. The following params are only available for statuses search: `min_id` and `max_id` allow filtering results by date ranges, and `account_id` allows narrowing down results by author.