### PR TITLE
Skip some methods in BatchedRemoveStatusService when account is nil

### DIFF
--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -35,12 +35,12 @@ class BatchedRemoveStatusService < BaseService
     statuses.group_by(&:account_id).each_value do |account_statuses|
       account = account_statuses.first.account
 
-      if account
-        unpush_from_home_timelines(account, account_statuses)
-        unpush_from_list_timelines(account, account_statuses)
+      next unless account
 
-        batch_stream_entries(account, account_statuses) if account.local?
-      end
+      unpush_from_home_timelines(account, account_statuses)
+      unpush_from_list_timelines(account, account_statuses)
+
+      batch_stream_entries(account, account_statuses) if account.local?
     end
 
     # Cannot be batched

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -35,10 +35,12 @@ class BatchedRemoveStatusService < BaseService
     statuses.group_by(&:account_id).each_value do |account_statuses|
       account = account_statuses.first.account
 
-      unpush_from_home_timelines(account, account_statuses)
-      unpush_from_list_timelines(account, account_statuses)
+      if account
+        unpush_from_home_timelines(account, account_statuses)
+        unpush_from_list_timelines(account, account_statuses)
 
-      batch_stream_entries(account, account_statuses) if account.local?
+        batch_stream_entries(account, account_statuses) if account.local?
+      end
     end
 
     # Cannot be batched


### PR DESCRIPTION
Sometimes `bin/tootctl accounts cull` fails with below error:

```
undefined method `followers_for_local_distribution' for nil:NilClass (NoMethodError)
```

This PR makes `BatchedRemoveStatusService.new.call()` to skip below methods when
`account` in it is nil:

- `unpush_from_home_timelines()`
- `unpush_from_list_timelines()`
- `batch_stream_entries()`