### PR TITLE
Make the column header of toot/thread view look like the others

### DIFF
--- a/app/javascript/mastodon/features/account/components/profile_column_header.js
+++ b/app/javascript/mastodon/features/account/components/profile_column_header.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ColumnHeader from '../../../components/column_header';
+import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  profile: { id: 'column_header.profile', defaultMessage: 'Profile' },
+});
+
+export default @injectIntl
+class ProfileColumnHeader extends React.PureComponent {
+
+  static propTypes = {
+    intl: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { intl } = this.props;
+
+    return (
+      <ColumnHeader
+        icon='user-circle'
+        title={intl.formatMessage(messages.profile)}
+        showBackButton
+      >
+      </ColumnHeader>
+    )
+  }
+}

--- a/app/javascript/mastodon/features/account/components/profile_column_header.js
+++ b/app/javascript/mastodon/features/account/components/profile_column_header.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ColumnHeader from '../../../components/column_header';
-import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
+import { injectIntl, defineMessages } from 'react-intl';
 
 const messages = defineMessages({
   profile: { id: 'column_header.profile', defaultMessage: 'Profile' },
@@ -22,8 +22,8 @@ class ProfileColumnHeader extends React.PureComponent {
         icon='user-circle'
         title={intl.formatMessage(messages.profile)}
         showBackButton
-      >
-      </ColumnHeader>
-    )
+      />
+    );
   }
+
 }

--- a/app/javascript/mastodon/features/account_gallery/index.js
+++ b/app/javascript/mastodon/features/account_gallery/index.js
@@ -6,7 +6,7 @@ import { fetchAccount } from '../../actions/accounts';
 import { expandAccountMediaTimeline } from '../../actions/timelines';
 import LoadingIndicator from '../../components/loading_indicator';
 import Column from '../ui/components/column';
-import ColumnBackButton from '../../components/column_back_button';
+import ProfileColumnHeader from '../account/components/profile_column_header';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { getAccountGallery } from '../../selectors';
 import MediaItem from './components/media_item';
@@ -109,7 +109,7 @@ class AccountGallery extends ImmutablePureComponent {
 
     return (
       <Column>
-        <ColumnBackButton />
+        <ProfileColumnHeader />
 
         <ScrollContainer scrollKey='account_gallery' shouldUpdateScroll={shouldUpdateScroll}>
           <div className='scrollable scrollable--flex' onScroll={this.handleScroll}>

--- a/app/javascript/mastodon/features/account_timeline/index.js
+++ b/app/javascript/mastodon/features/account_timeline/index.js
@@ -7,8 +7,8 @@ import { expandAccountFeaturedTimeline, expandAccountTimeline } from '../../acti
 import StatusList from '../../components/status_list';
 import LoadingIndicator from '../../components/loading_indicator';
 import Column from '../ui/components/column';
+import ProfileColumnHeader from '../account/components/profile_column_header';
 import HeaderContainer from './containers/header_container';
-import ColumnBackButton from '../../components/column_back_button';
 import { List as ImmutableList } from 'immutable';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { FormattedMessage } from 'react-intl';
@@ -75,7 +75,7 @@ class AccountTimeline extends ImmutablePureComponent {
 
     return (
       <Column>
-        <ColumnBackButton />
+        <ProfileColumnHeader />
 
         <StatusList
           prepend={<HeaderContainer accountId={this.props.params.accountId} />}

--- a/app/javascript/mastodon/features/followers/index.js
+++ b/app/javascript/mastodon/features/followers/index.js
@@ -13,8 +13,8 @@ import {
 import { FormattedMessage } from 'react-intl';
 import AccountContainer from '../../containers/account_container';
 import Column from '../ui/components/column';
+import ProfileColumnHeader from '../account/components/profile_column_header';
 import HeaderContainer from '../account_timeline/containers/header_container';
-import ColumnBackButton from '../../components/column_back_button';
 import ScrollableList from '../../components/scrollable_list';
 
 const mapStateToProps = (state, props) => ({
@@ -64,7 +64,7 @@ class Followers extends ImmutablePureComponent {
 
     return (
       <Column>
-        <ColumnBackButton />
+        <ProfileColumnHeader />
 
         <ScrollableList
           scrollKey='followers'

--- a/app/javascript/mastodon/features/following/index.js
+++ b/app/javascript/mastodon/features/following/index.js
@@ -82,4 +82,5 @@ class Following extends ImmutablePureComponent {
       </Column>
     );
   }
+
 }

--- a/app/javascript/mastodon/features/following/index.js
+++ b/app/javascript/mastodon/features/following/index.js
@@ -13,8 +13,8 @@ import {
 import { FormattedMessage } from 'react-intl';
 import AccountContainer from '../../containers/account_container';
 import Column from '../ui/components/column';
+import ProfileColumnHeader from '../account/components/profile_column_header';
 import HeaderContainer from '../account_timeline/containers/header_container';
-import ColumnBackButton from '../../components/column_back_button';
 import ScrollableList from '../../components/scrollable_list';
 
 const mapStateToProps = (state, props) => ({
@@ -64,7 +64,7 @@ class Following extends ImmutablePureComponent {
 
     return (
       <Column>
-        <ColumnBackButton />
+        <ProfileColumnHeader />
 
         <ScrollableList
           scrollKey='following'
@@ -82,5 +82,4 @@ class Following extends ImmutablePureComponent {
       </Column>
     );
   }
-
 }

--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -56,6 +56,7 @@ const messages = defineMessages({
   detailedStatus: { id: 'status.detailed_status', defaultMessage: 'Detailed conversation view' },
   replyConfirm: { id: 'confirmations.reply.confirm', defaultMessage: 'Reply' },
   replyMessage: { id: 'confirmations.reply.message', defaultMessage: 'Replying now will overwrite the message you are currently composing. Are you sure you want to proceed?' },
+  tootHeading: { id: 'column.toot', defaultMessage: 'Toots and replies' },
 });
 
 const makeMapStateToProps = () => {
@@ -423,6 +424,8 @@ class Status extends ImmutablePureComponent {
     return (
       <Column label={intl.formatMessage(messages.detailedStatus)}>
         <ColumnHeader
+          icon='comment'
+          title={intl.formatMessage(messages.tootHeading)}
           showBackButton
           extraButton={(
             <button className='column-header__button' title={intl.formatMessage(status.get('hidden') ? messages.revealAll : messages.hideAll)} aria-label={intl.formatMessage(status.get('hidden') ? messages.revealAll : messages.hideAll)} onClick={this.handleToggleAll} aria-pressed={status.get('hidden') ? 'false' : 'true'}><i className={`fa fa-${status.get('hidden') ? 'eye-slash' : 'eye'}`} /></button>

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -58,6 +58,7 @@
   "column.notifications": "Notifications",
   "column.pins": "Pinned toots",
   "column.public": "Federated timeline",
+  "column.toot": "Toot and answers",
   "column_back_button.label": "Back",
   "column_header.hide_settings": "Hide settings",
   "column_header.moveLeft_settings": "Move column to the left",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -57,6 +57,7 @@
   "column.mutes": "Muted users",
   "column.notifications": "Notifications",
   "column.pins": "Pinned toots",
+  "column_header.profile": "Profile",
   "column.public": "Federated timeline",
   "column.toot": "Toot and answers",
   "column_back_button.label": "Back",


### PR DESCRIPTION
It makes the toot/thread column like the others column. The biggest benefit I see is that the back button is always at the same place.

![screenshot_2019-02-21 mastodon dev](https://user-images.githubusercontent.com/2446451/53190986-0486e400-360b-11e9-824c-7a9153ddf1c0.png)

Edit: also for profile:

![screenshot_2019-02-21 mastodon dev 2](https://user-images.githubusercontent.com/2446451/53203070-6b66c600-3628-11e9-80c9-efbc85df2725.png)
