### PR TITLE
Switch to Ubuntu for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,89 +1,126 @@
-FROM node:8.15-alpine as node
-FROM ruby:2.6-alpine3.9
+FROM ubuntu:18.04 as build-dep
 
-LABEL maintainer="https://github.com/tootsuite/mastodon" \
-      description="Your self-hosted, globally interconnected microblogging community"
+# Use bash for the shell
+SHELL ["bash", "-c"]
 
+# Install Node
+ENV NODE_VER="8.15.0"
+RUN	echo "Etc/UTC" > /etc/localtime && \
+	apt update && \
+	apt -y dist-upgrade && \
+	apt -y install wget make gcc g++ python && \
+	cd ~ && \
+	wget https://nodejs.org/download/release/v$NODE_VER/node-v$NODE_VER.tar.gz && \
+	tar xf node-v$NODE_VER.tar.gz && \
+	cd node-v$NODE_VER && \
+	./configure --prefix=/opt/node && \
+	make -j$(nproc) > /dev/null && \
+	make install
+
+# Install jemalloc
+ENV JE_VER="5.1.0"
+RUN apt -y install autoconf && \
+	cd ~ && \
+	wget https://github.com/jemalloc/jemalloc/archive/$JE_VER.tar.gz && \
+	tar xf $JE_VER.tar.gz && \
+	cd jemalloc-$JE_VER && \
+	./autogen.sh && \
+	./configure --prefix=/opt/jemalloc && \
+	make -j$(nproc) > /dev/null && \
+	make install_bin install_include install_lib
+
+# Install ruby
+ENV RUBY_VER="2.6.1"
+ENV CPPFLAGS="-I/opt/jemalloc/include"
+ENV LDFLAGS="-L/opt/jemalloc/lib/"
+RUN apt -y install build-essential \
+		bison libyaml-dev libgdbm-dev libreadline-dev \
+		libncurses5-dev libffi-dev zlib1g-dev libssl-dev && \
+	cd ~ && \
+	wget https://cache.ruby-lang.org/pub/ruby/${RUBY_VER%.*}/ruby-$RUBY_VER.tar.gz && \
+	tar xf ruby-$RUBY_VER.tar.gz && \
+	cd ruby-$RUBY_VER && \
+	./configure --prefix=/opt/ruby \
+	  --with-jemalloc \
+	  --with-shared \
+	  --disable-install-doc && \
+	ln -s /opt/jemalloc/lib/* /usr/lib/ && \
+	make -j$(nproc) > /dev/null && \
+	make install
+
+ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin"
+
+RUN npm install -g yarn && \
+	gem install bundler
+
+COPY . /opt/mastodon
+
+RUN apt -y install git libicu-dev libidn11-dev \
+	libpq-dev libprotobuf-dev protobuf-compiler && \
+	cd /opt/mastodon && \
+	bundle install -j$(nproc) --deployment --without development test && \
+	yarn install --pure-lockfile
+
+FROM ubuntu:18.04
+
+# Copy over all the langs needed for runtime
+COPY --from=build-dep /opt/node /opt/node
+COPY --from=build-dep /opt/ruby /opt/ruby
+COPY --from=build-dep /opt/jemalloc /opt/jemalloc
+
+# Add more PATHs to the PATH
+ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin"
+
+# Create the mastodon user
 ARG UID=991
 ARG GID=991
+RUN apt update && \
+	echo "Etc/UTC" > /etc/localtime && \
+	ln -s /opt/jemalloc/lib/* /usr/lib/ && \
+	apt -y dist-upgrade && \
+	apt install -y whois && \
+	addgroup --gid $GID mastodon && \
+	useradd -m -u $UID -g $GID -d /opt/mastodon mastodon && \
+	echo "mastodon:`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256`" | chpasswd
 
-ENV PATH=/mastodon/bin:$PATH \
-    RAILS_SERVE_STATIC_FILES=true \
-    RAILS_ENV=production \
-    NODE_ENV=production
+# Copy over masto source from building and set permissions
+COPY --from=build-dep --chown=mastodon:mastodon /opt/mastodon /opt/mastodon
 
-ARG LIBICONV_VERSION=1.15
-ARG LIBICONV_DOWNLOAD_SHA256=ccf536620a45458d26ba83887a983b96827001e92a13847b45e4925cc8913178
+# Install masto runtime deps
+RUN apt -y --no-install-recommends install \
+	  libssl1.1 libpq5 imagemagick ffmpeg \
+	  libicu60 libprotobuf10 libidn11 libyaml-0-2 \
+	  file ca-certificates tzdata libreadline7 && \
+	apt -y install gcc && \
+	ln -s /opt/mastodon /mastodon && \
+	gem install bundler
 
-EXPOSE 3000 4000
+# Clean up more dirs
+RUN rm -rf /var/cache && \
+	rm -rf /var/apt
 
-WORKDIR /mastodon
+# Add tini
+ENV TINI_VERSION="0.18.0"
+ENV TINI_SUM="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
+ADD https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini /tini
+RUN echo "$TINI_SUM tini" | sha256sum -c -
+RUN chmod +x /tini
 
-COPY --from=node /usr/local/bin/node /usr/local/bin/node
-COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
-COPY --from=node /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=node /opt/yarn-* /opt/yarn
+# Run masto services in prod mode
+ENV RAILS_ENV="production"
+ENV NODE_ENV="production"
 
-RUN apk add --no-cache -t build-dependencies \
-    build-base \
-    icu-dev \
-    libidn-dev \
-    openssl \
-    libtool \
-    libxml2-dev \
-    libxslt-dev \
-    postgresql-dev \
-    protobuf-dev \
-    python \
- && apk add --no-cache \
-    ca-certificates \
-    ffmpeg \
-    file \
-    git \
-    icu-libs \
-    imagemagick \
-    libidn \
-    libpq \
-    libxml2 \
-    libxslt \
-    protobuf \
-    tini \
-    tzdata \
- && update-ca-certificates \
- && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
- && ln -s /opt/yarn/bin/yarnpkg /usr/local/bin/yarnpkg \
- && mkdir -p /tmp/src /opt \
- && wget -O libiconv.tar.gz "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-$LIBICONV_VERSION.tar.gz" \
- && echo "$LIBICONV_DOWNLOAD_SHA256 *libiconv.tar.gz" | sha256sum -c - \
- && tar -xzf libiconv.tar.gz -C /tmp/src \
- && rm libiconv.tar.gz \
- && cd /tmp/src/libiconv-$LIBICONV_VERSION \
- && ./configure --prefix=/usr/local \
- && make -j$(getconf _NPROCESSORS_ONLN)\
- && make install \
- && libtool --finish /usr/local/lib \
- && cd /mastodon \
- && rm -rf /tmp/*
+# Tell rails to serve static files
+ENV RAILS_SERVE_STATIC_FILES="true"
 
-COPY Gemfile Gemfile.lock package.json yarn.lock .yarnclean /mastodon/
-
-RUN bundle config build.nokogiri --use-system-libraries --with-iconv-lib=/usr/local/lib --with-iconv-include=/usr/local/include \
- && bundle install -j$(getconf _NPROCESSORS_ONLN) --deployment --without test development \
- && yarn install --pure-lockfile --ignore-engines \
- && yarn cache clean
-
-RUN addgroup -g ${GID} mastodon && adduser -h /mastodon -s /bin/sh -D -G mastodon -u ${UID} mastodon \
- && mkdir -p /mastodon/public/system /mastodon/public/assets /mastodon/public/packs \
- && chown -R mastodon:mastodon /mastodon/public
-
-COPY . /mastodon
-
-RUN chown -R mastodon:mastodon /mastodon
-
-VOLUME /mastodon/public/system
-
+# Set the run user
 USER mastodon
 
-RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder bundle exec rails assets:precompile
+# Precompile assets
+RUN cd ~ && \
+	OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile && \
+	yarn cache clean
 
-ENTRYPOINT ["/sbin/tini", "--"]
+# Set the work dir and the container entry point
+WORKDIR /opt/mastodon
+ENTRYPOINT ["/tini", "--"]


### PR DESCRIPTION
* Based on my image [Here](https://git.sergal.org/Sir-Boops/docker-mastodon/src/branch/master/Dockerfile)
* 200~ish MB smaller then the current build ( When built right )
* Build with jemalloc for slightly less ram usage
* /Should/ be an exact drop in replacement ( I've been told by other that switched to using this image that's a complete drop in replacement and I don't see any reason it wouldn't be but another confirmation would be nice :smile:  )
* Only real downfall of this image is it has to be built using --squash ( docker beta feature ) or the image size will be huge from all the individual RUNs