### PR TITLE
Improved remote thread fetching

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -217,11 +217,10 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def fetch_replies(status)
     collection = @object['replies']
     return if collection.nil?
-    if collection.is_a?(Hash) && (collection['items'].is_a?(Array) || collection['orderedItems'].is_a?(Array))
-      ActivityPub::FetchRepliesService.new.call(status, collection)
-    else
-      ActivityPub::FetchRepliesWorker.perform_async(status.id, value_or_id(collection))
-    end
+    replies = ActivityPub::FetchRepliesService.new.call(status, collection, false)
+    return if replies.present?
+    uri = value_or_id(collection)
+    ActivityPub::FetchRepliesWorker.perform_async(status.id, uri) unless uri.nil?
   end
 
   def conversation_from_uri(uri)

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -217,8 +217,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def fetch_replies(status)
     collection = @object['replies']
     return if collection.nil?
-    if collection.is_a?(Hash)
-      return unless (collection['type'] == 'Collection' && collection['items'].is_a?(Array)) || (collection['type'] == 'OrderedCollection' && collection['orderedItems'].is_a?(Array))
+    if collection.is_a?(Hash) && (collection['items'].is_a?(Array) || collection['orderedItems'].is_a?(Array))
       ActivityPub::FetchRepliesService.new.call(status, collection)
     else
       ActivityPub::FetchRepliesWorker.perform_async(status.id, value_or_id(collection))

--- a/app/models/concerns/status_threading_concern.rb
+++ b/app/models/concerns/status_threading_concern.rb
@@ -11,6 +11,10 @@ module StatusThreadingConcern
     find_statuses_from_tree_path(descendant_ids(limit, max_child_id, since_child_id, depth), account, promote: true)
   end
 
+  def self_replies(limit)
+    account.statuses.where(in_reply_to_id: id, visibility: [:public, :unlisted]).reorder(id: :asc).limit(limit)
+  end
+
   private
 
   def ancestor_ids(limit)

--- a/app/presenters/activitypub/collection_presenter.rb
+++ b/app/presenters/activitypub/collection_presenter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ActivityPub::CollectionPresenter < ActiveModelSerializers::Model
-  attributes :id, :type, :size, :items, :part_of, :first, :last, :next, :prev
+  attributes :id, :type, :size, :items, :page, :part_of, :first, :last, :next, :prev
 end

--- a/app/serializers/activitypub/collection_serializer.rb
+++ b/app/serializers/activitypub/collection_serializer.rb
@@ -7,7 +7,8 @@ class ActivityPub::CollectionSerializer < ActiveModel::Serializer
     super
   end
 
-  attributes :id, :type
+  attribute :id, if: -> { object.id.present? }
+  attribute :type
   attribute :total_items, if: -> { object.size.present? }
   attribute :next, if: -> { object.next.present? }
   attribute :prev, if: -> { object.prev.present? }

--- a/app/serializers/activitypub/collection_serializer.rb
+++ b/app/serializers/activitypub/collection_serializer.rb
@@ -38,6 +38,6 @@ class ActivityPub::CollectionSerializer < ActiveModel::Serializer
   end
 
   def page?
-    object.part_of.present?
+    object.part_of.present? || object.page.present?
   end
 end

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -13,6 +13,8 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   has_many :media_attachments, key: :attachment
   has_many :virtual_tags, key: :tag
 
+  has_one :replies, serializer: ActivityPub::CollectionSerializer
+
   def id
     ActivityPub::TagManager.instance.uri_for(object)
   end
@@ -31,6 +33,13 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
 
   def content_map
     { object.language => Formatter.instance.format(object) }
+  end
+
+  def replies
+    ActivityPub::CollectionPresenter.new(
+      type: :unordered,
+      items: object.self_replies(5).map(&:uri)
+    )
   end
 
   def language?

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -38,7 +38,11 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
   def replies
     ActivityPub::CollectionPresenter.new(
       type: :unordered,
-      items: object.self_replies(5).map(&:uri)
+      first: ActivityPub::CollectionPresenter.new(
+        type: :unordered,
+        page: true,
+        items: object.self_replies(5).map(&:uri)
+      )
     )
   end
 

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -41,7 +41,7 @@ class ActivityPub::NoteSerializer < ActiveModel::Serializer
       first: ActivityPub::CollectionPresenter.new(
         type: :unordered,
         page: true,
-        items: object.self_replies(5).map(&:uri)
+        items: object.self_replies(5).pluck(:uri)
       )
     )
   end

--- a/app/services/activitypub/fetch_replies_service.rb
+++ b/app/services/activitypub/fetch_replies_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class ActivityPub::FetchRepliesService < BaseService
+  include JsonLdHelper
+
+  def call(parent_status, collection_or_uri)
+    @account = parent_status.account
+
+    @items = collection_items(collection_or_uri)
+
+    if @items.nil?
+      uri = value_or_id(collection_or_uri)
+      return if invalid_origin?(uri)
+      collection = fetch_resource_without_id_validation(uri)
+      raise Mastodon::UnexpectedResponseError if collection.nil?
+      @items = collection_items(collection)
+      return if @items.nil?
+    end
+
+    FetchReplyWorker.push_bulk(filtered_replies)
+  end
+
+  private
+
+  def collection_items(collection)
+    return unless collection.is_a?(Hash)
+    case collection['type']
+    when 'Collection', 'CollectionPage'
+      collection['items']
+    when 'OrderedCollection', 'OrderedCollectionPage'
+      collection['orderedItems']
+    end
+  end
+
+  def filtered_replies
+    # Only fetch replies to the same server as the original status to avoid
+    # amplification attacks.
+
+    # Also limit to 5 fetched replies to limit potential for DoS.
+    @items.map { |item| value_or_id(item) }.reject { |uri| invalid_origin?(uri) }.take(5)
+  end
+
+  def invalid_origin?(url)
+    return true if unsupported_uri_scheme?(url)
+
+    needle   = Addressable::URI.parse(url).host
+    haystack = Addressable::URI.parse(@account.uri).host
+
+    !haystack.casecmp(needle).zero?
+  end
+end

--- a/app/workers/activitypub/fetch_replies_worker.rb
+++ b/app/workers/activitypub/fetch_replies_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ActivityPub::FetchRepliesWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'pull', retry: 3
+
+  sidekiq_retry_in do |count|
+    15 + 10 * (count**4) + rand(10 * (count**4))
+  end
+
+  def perform(parent_status_id, replies_uri)
+    ActivityPub::FetchRepliesService.new.call(Status.find(parent_status_id), replies_uri)
+  end
+end

--- a/app/workers/activitypub/fetch_replies_worker.rb
+++ b/app/workers/activitypub/fetch_replies_worker.rb
@@ -2,12 +2,9 @@
 
 class ActivityPub::FetchRepliesWorker
   include Sidekiq::Worker
+  include ExponentialBackoff
 
   sidekiq_options queue: 'pull', retry: 3
-
-  sidekiq_retry_in do |count|
-    15 + 10 * (count**4) + rand(10 * (count**4))
-  end
 
   def perform(parent_status_id, replies_uri)
     ActivityPub::FetchRepliesService.new.call(Status.find(parent_status_id), replies_uri)

--- a/app/workers/concerns/exponential_backoff.rb
+++ b/app/workers/concerns/exponential_backoff.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ExponentialBackoff
+  extend ActiveSupport::Concern
+
+  included do
+    sidekiq_retry_in do |count|
+      15 + 10 * (count**4) + rand(10 * (count**4))
+    end
+  end
+end

--- a/app/workers/fetch_reply_worker.rb
+++ b/app/workers/fetch_reply_worker.rb
@@ -2,12 +2,9 @@
 
 class FetchReplyWorker
   include Sidekiq::Worker
+  include ExponentialBackoff
 
   sidekiq_options queue: 'pull', retry: 3
-
-  sidekiq_retry_in do |count|
-    15 + 10 * (count**4) + rand(10 * (count**4))
-  end
 
   def perform(child_url)
     FetchRemoteStatusService.new.call(child_url)

--- a/app/workers/fetch_reply_worker.rb
+++ b/app/workers/fetch_reply_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FetchReplyWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'pull', retry: 3
+
+  sidekiq_retry_in do |count|
+    15 + 10 * (count**4) + rand(10 * (count**4))
+  end
+
+  def perform(child_url)
+    FetchRemoteStatusService.new.call(child_url)
+  end
+end

--- a/app/workers/thread_resolve_worker.rb
+++ b/app/workers/thread_resolve_worker.rb
@@ -2,12 +2,9 @@
 
 class ThreadResolveWorker
   include Sidekiq::Worker
+  include ExponentialBackoff
 
   sidekiq_options queue: 'pull', retry: 3
-
-  sidekiq_retry_in do |count|
-    15 + 10 * (count**4) + rand(10 * (count**4))
-  end
 
   def perform(child_status_id, parent_url)
     child_status  = Status.find(child_status_id)

--- a/spec/serializers/activitypub/note_spec.rb
+++ b/spec/serializers/activitypub/note_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ActivityPub::NoteSerializer do
+  let!(:account) { Fabricate(:account) }
+  let!(:other)   { Fabricate(:account) }
+  let!(:parent)  { Fabricate(:status, account: account, visibility: :public) }
+  let!(:reply1)  { Fabricate(:status, account: account, thread: parent, visibility: :public) }
+  let!(:reply2)  { Fabricate(:status, account: account, thread: parent, visibility: :public) }
+  let!(:reply3)  { Fabricate(:status, account: other, thread: parent, visibility: :public) }
+  let!(:reply4)  { Fabricate(:status, account: account, thread: parent, visibility: :public) }
+  let!(:reply5)  { Fabricate(:status, account: account, thread: parent, visibility: :direct) }
+
+  before(:each) do
+    @serialization = ActiveModelSerializers::SerializableResource.new(parent, serializer: ActivityPub::NoteSerializer, adapter: ActivityPub::Adapter)
+  end
+
+  subject { JSON.parse(@serialization.to_json) }
+
+  it 'has a Note type' do
+    expect(subject['type']).to eql('Note')
+  end
+
+  it 'has a replies collection' do
+    expect(subject['replies']['type']).to eql('Collection')
+  end
+
+  it 'includes public self-replies in its replies collection' do
+    expect(subject['replies']['items']).to include(reply1.uri, reply2.uri, reply4.uri)
+  end
+
+  it 'does not include replies from others in its replies collection' do
+    expect(subject['replies']['items']).to_not include(reply3.uri)
+  end
+
+  it 'does not include replies with direct visibility in its replies collection' do
+    expect(subject['replies']['items']).to_not include(reply5.uri)
+  end
+end

--- a/spec/serializers/activitypub/note_spec.rb
+++ b/spec/serializers/activitypub/note_spec.rb
@@ -26,15 +26,19 @@ describe ActivityPub::NoteSerializer do
     expect(subject['replies']['type']).to eql('Collection')
   end
 
+  it 'has a replies collection with a first Page' do
+    expect(subject['replies']['first']['type']).to eql('CollectionPage')
+  end
+
   it 'includes public self-replies in its replies collection' do
-    expect(subject['replies']['items']).to include(reply1.uri, reply2.uri, reply4.uri)
+    expect(subject['replies']['first']['items']).to include(reply1.uri, reply2.uri, reply4.uri)
   end
 
   it 'does not include replies from others in its replies collection' do
-    expect(subject['replies']['items']).to_not include(reply3.uri)
+    expect(subject['replies']['first']['items']).to_not include(reply3.uri)
   end
 
   it 'does not include replies with direct visibility in its replies collection' do
-    expect(subject['replies']['items']).to_not include(reply5.uri)
+    expect(subject['replies']['first']['items']).to_not include(reply5.uri)
   end
 end

--- a/spec/services/activitypub/fetch_replies_service_spec.rb
+++ b/spec/services/activitypub/fetch_replies_service_spec.rb
@@ -5,45 +5,117 @@ RSpec.describe ActivityPub::FetchRepliesService, type: :service do
   let(:status)         { Fabricate(:status, account: actor) }
   let(:collection_uri) { 'http://example.com/replies/1' }
 
+  let(:items) do
+    [
+      'http://example.com/self-reply-1',
+      'http://example.com/self-reply-2',
+      'http://example.com/self-reply-3',
+      'http://other.com/other-reply-1',
+      'http://other.com/other-reply-2',
+      'http://other.com/other-reply-3',
+      'http://example.com/self-reply-4',
+      'http://example.com/self-reply-5',
+      'http://example.com/self-reply-6',
+    ]
+  end
+
   let(:payload) do
     {
       '@context': 'https://www.w3.org/ns/activitystreams',
       type: 'Collection',
       id: collection_uri,
-      items: [
-        'http://example.com/self-reply-1',
-        'http://example.com/self-reply-2',
-        'http://example.com/self-reply-3',
-        'http://other.com/other-reply-1',
-        'http://other.com/other-reply-2',
-        'http://other.com/other-reply-3',
-        'http://example.com/self-reply-4',
-        'http://example.com/self-reply-5',
-        'http://example.com/self-reply-6',
-      ],
+      items: items,
     }.with_indifferent_access
   end
 
   subject { described_class.new }
 
   describe '#call' do
-    context 'when passing the collection itself' do
-      it 'spawns workers for up to 5 replies on the same server' do
-        allow(FetchReplyWorker).to receive(:push_bulk)
-        subject.call(status, payload)
-        expect(FetchReplyWorker).to have_received(:push_bulk).with(['http://example.com/self-reply-1', 'http://example.com/self-reply-2', 'http://example.com/self-reply-3', 'http://example.com/self-reply-4', 'http://example.com/self-reply-5'])
+    context 'when the payload is a Collection with inlined replies' do
+      context 'when passing the collection itself' do
+        it 'spawns workers for up to 5 replies on the same server' do
+          allow(FetchReplyWorker).to receive(:push_bulk)
+          subject.call(status, payload)
+          expect(FetchReplyWorker).to have_received(:push_bulk).with(['http://example.com/self-reply-1', 'http://example.com/self-reply-2', 'http://example.com/self-reply-3', 'http://example.com/self-reply-4', 'http://example.com/self-reply-5'])
+        end
+      end
+
+      context 'when passing the URL to the collection' do
+        before do
+          stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload))
+        end
+
+        it 'spawns workers for up to 5 replies on the same server' do
+          allow(FetchReplyWorker).to receive(:push_bulk)
+          subject.call(status, collection_uri)
+          expect(FetchReplyWorker).to have_received(:push_bulk).with(['http://example.com/self-reply-1', 'http://example.com/self-reply-2', 'http://example.com/self-reply-3', 'http://example.com/self-reply-4', 'http://example.com/self-reply-5'])
+        end
       end
     end
 
-    context 'when passing the URL to the collection' do
-      before do
-        stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload))
+    context 'when the payload is an OrderedCollection with inlined replies' do
+      let(:payload) do
+        {
+          '@context': 'https://www.w3.org/ns/activitystreams',
+          type: 'OrderedCollection',
+          id: collection_uri,
+          orderedItems: items,
+        }.with_indifferent_access
       end
 
-      it 'spawns workers for up to 5 replies on the same server' do
-        allow(FetchReplyWorker).to receive(:push_bulk)
-        subject.call(status, collection_uri)
-        expect(FetchReplyWorker).to have_received(:push_bulk).with(['http://example.com/self-reply-1', 'http://example.com/self-reply-2', 'http://example.com/self-reply-3', 'http://example.com/self-reply-4', 'http://example.com/self-reply-5'])
+      context 'when passing the collection itself' do
+        it 'spawns workers for up to 5 replies on the same server' do
+          allow(FetchReplyWorker).to receive(:push_bulk)
+          subject.call(status, payload)
+          expect(FetchReplyWorker).to have_received(:push_bulk).with(['http://example.com/self-reply-1', 'http://example.com/self-reply-2', 'http://example.com/self-reply-3', 'http://example.com/self-reply-4', 'http://example.com/self-reply-5'])
+        end
+      end
+
+      context 'when passing the URL to the collection' do
+        before do
+          stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload))
+        end
+
+        it 'spawns workers for up to 5 replies on the same server' do
+          allow(FetchReplyWorker).to receive(:push_bulk)
+          subject.call(status, collection_uri)
+          expect(FetchReplyWorker).to have_received(:push_bulk).with(['http://example.com/self-reply-1', 'http://example.com/self-reply-2', 'http://example.com/self-reply-3', 'http://example.com/self-reply-4', 'http://example.com/self-reply-5'])
+        end
+      end
+    end
+
+    context 'when the payload is a paginated Collection with inlined replies' do
+      let(:payload) do
+        {
+          '@context': 'https://www.w3.org/ns/activitystreams',
+          type: 'Collection',
+          id: collection_uri,
+          first: {
+            type: 'CollectionPage',
+            partOf: collection_uri,
+            items: items,
+          }
+        }.with_indifferent_access
+      end
+
+      context 'when passing the collection itself' do
+        it 'spawns workers for up to 5 replies on the same server' do
+          allow(FetchReplyWorker).to receive(:push_bulk)
+          subject.call(status, payload)
+          expect(FetchReplyWorker).to have_received(:push_bulk).with(['http://example.com/self-reply-1', 'http://example.com/self-reply-2', 'http://example.com/self-reply-3', 'http://example.com/self-reply-4', 'http://example.com/self-reply-5'])
+        end
+      end
+
+      context 'when passing the URL to the collection' do
+        before do
+          stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload))
+        end
+
+        it 'spawns workers for up to 5 replies on the same server' do
+          allow(FetchReplyWorker).to receive(:push_bulk)
+          subject.call(status, collection_uri)
+          expect(FetchReplyWorker).to have_received(:push_bulk).with(['http://example.com/self-reply-1', 'http://example.com/self-reply-2', 'http://example.com/self-reply-3', 'http://example.com/self-reply-4', 'http://example.com/self-reply-5'])
+        end
       end
     end
   end

--- a/spec/services/activitypub/fetch_replies_service_spec.rb
+++ b/spec/services/activitypub/fetch_replies_service_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe ActivityPub::FetchRepliesService, type: :service do
+  let(:actor)          { Fabricate(:account, domain: 'example.com', uri: 'http://example.com/account') }
+  let(:status)         { Fabricate(:status, account: actor) }
+  let(:collection_uri) { 'http://example.com/replies/1' }
+
+  let(:payload) do
+    {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Collection',
+      id: collection_uri,
+      items: [
+        'http://example.com/self-reply-1',
+        'http://example.com/self-reply-2',
+        'http://example.com/self-reply-3',
+        'http://other.com/other-reply-1',
+        'http://other.com/other-reply-2',
+        'http://other.com/other-reply-3',
+        'http://example.com/self-reply-4',
+        'http://example.com/self-reply-5',
+        'http://example.com/self-reply-6',
+      ],
+    }.with_indifferent_access
+  end
+
+  subject { described_class.new }
+
+  describe '#call' do
+    context 'when passing the collection itself' do
+      it 'spawns workers for up to 5 replies on the same server' do
+        allow(FetchReplyWorker).to receive(:push_bulk)
+        subject.call(status, payload)
+        expect(FetchReplyWorker).to have_received(:push_bulk).with(['http://example.com/self-reply-1', 'http://example.com/self-reply-2', 'http://example.com/self-reply-3', 'http://example.com/self-reply-4', 'http://example.com/self-reply-5'])
+      end
+    end
+
+    context 'when passing the URL to the collection' do
+      before do
+        stub_request(:get, collection_uri).to_return(status: 200, body: Oj.dump(payload))
+      end
+
+      it 'spawns workers for up to 5 replies on the same server' do
+        allow(FetchReplyWorker).to receive(:push_bulk)
+        subject.call(status, collection_uri)
+        expect(FetchReplyWorker).to have_received(:push_bulk).with(['http://example.com/self-reply-1', 'http://example.com/self-reply-2', 'http://example.com/self-reply-3', 'http://example.com/self-reply-4', 'http://example.com/self-reply-5'])
+      end
+    end
+  end
+end

--- a/spec/workers/activitypub/fetch_replies_worker_spec.rb
+++ b/spec/workers/activitypub/fetch_replies_worker_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ActivityPub::FetchRepliesWorker do
+  subject { described_class.new }
+
+  let(:account) { Fabricate(:account, uri: 'https://example.com/user/1') }
+  let(:status)  { Fabricate(:status, account: account) }
+
+  let(:payload) do
+    {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: 'https://example.com/statuses_replies/1',
+      type: 'Collection',
+      items: [],
+    }
+  end
+
+  let(:json) { Oj.dump(payload) }
+
+  describe 'perform' do
+    it 'performs a request if the collection URI is from the same host' do
+      stub_request(:get, 'https://example.com/statuses_replies/1').to_return(status: 200, body: json)
+      subject.perform(status.id, 'https://example.com/statuses_replies/1')
+      expect(a_request(:get, 'https://example.com/statuses_replies/1')).to have_been_made.once
+    end
+
+    it 'does not perform a request if the collection URI is from a different host' do
+      stub_request(:get, 'https://other.com/statuses_replies/1').to_return(status: 200)
+      subject.perform(status.id, 'https://other.com/statuses_replies/1')
+      expect(a_request(:get, 'https://other.com/statuses_replies/1')).to_not have_been_made
+    end
+
+    it 'raises when request fails' do
+      stub_request(:get, 'https://example.com/statuses_replies/1').to_return(status: 500)
+      expect { subject.perform(status.id, 'https://example.com/statuses_replies/1') }.to raise_error Mastodon::UnexpectedResponseError
+    end
+  end
+end


### PR DESCRIPTION
So far, Mastodon only fetches *ancestors* of newly-discovered toots, which means in order to make sure a thread is known by all your followers, you would need to boost the *last* status of the thread, instead (or in addition to) the first one.

This PR aims to change that by fetching a limited number of same-server toots for every newly-discovered remote toot, and announcing a limited number of public self-replies on toots. This way, provided that a thread is already complete, boosting its first status will cause remote Mastodon servers to fetch its self-replies, and so on, fetching the whole thread.