### PR TITLE
Add a preferences API so apps can share basic behaviours

### DIFF
--- a/app/controllers/api/v1/preferences_controller.rb
+++ b/app/controllers/api/v1/preferences_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Api::V1::PreferencesController < Api::BaseController
+  before_action -> { doorkeeper_authorize! :read, :'read:accounts' }
+  before_action :require_user!
+
+  respond_to :json
+
+  def index
+    render json: current_account, serializer: REST::PreferencesSerializer
+  end
+end

--- a/app/serializers/rest/preferences_serializer.rb
+++ b/app/serializers/rest/preferences_serializer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class REST::PreferencesSerializer < ActiveModel::Serializer
+  attribute :posting_default_privacy, key: 'posting:default:visibility'
+  attribute :posting_default_sensitive, key: 'posting:default:sensitive'
+  attribute :posting_default_language, key: 'posting:default:language'
+
+  attribute :reading_default_sensitive_media, key: 'reading:expand:media'
+  attribute :reading_default_sensitive_text, key: 'reading:expand:spoilers'
+
+  def posting_default_privacy
+    object.user.setting_default_privacy
+  end
+
+  def posting_default_sensitive
+    object.user.setting_default_sensitive
+  end
+
+  def posting_default_language
+    object.user.setting_default_language.presence
+  end
+
+  def reading_default_sensitive_media
+    object.user.setting_display_media
+  end
+
+  def reading_default_sensitive_text
+    object.user.setting_expand_spoilers
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,6 +282,7 @@ Rails.application.routes.draw do
       resources :custom_emojis, only: [:index]
       resources :suggestions, only: [:index, :destroy]
       resources :scheduled_statuses, only: [:index, :show, :update, :destroy]
+      resources :preferences, only: [:index]
 
       resources :conversations, only: [:index, :destroy] do
         member do


### PR DESCRIPTION
Resolve #9821

`GET /api/v1/preferences` example output:

```json
{
  "posting:default:visibility": "public",
  "posting:default:sensitive": false,
  "posting:default:language": null,
  "reading:expand:media": "default",
  "reading:expand:spoilers": false
}
```