### PR TITLE
Improve account media query

### DIFF
--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -51,9 +51,9 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
     # Also, Avoid getting slow by not narrowing down by `statuses.account_id`.
     # When narrowing down by `statuses.account_id`, `index_statuses_20180106` will be used
     # and the table will be joined by `Merge Semi Join`, so the query will be slow.
-    Status.joins(:media_attachments).merge(@account.media_attachments).permitted_for(@account, current_account)
-          .paginate_by_max_id(limit_param(DEFAULT_STATUSES_LIMIT), params[:max_id], params[:since_id])
-          .reorder(id: :desc).distinct(:id).pluck(:id)
+    @account.statuses.joins(:media_attachments).merge(@account.media_attachments).permitted_for(@account, current_account)
+            .paginate_by_max_id(limit_param(DEFAULT_STATUSES_LIMIT), params[:max_id], params[:since_id])
+            .reorder(id: :desc).distinct(:id).pluck(:id)
   end
 
   def pinned_scope


### PR DESCRIPTION
By narrowing down by `statuses.account_id`, index_statuses_20180106 can be used and it becomes faster.


before:
```
SELECT  DISTINCT "statuses"."id" FROM "statuses" INNER JOIN "media_attachments" ON "media_attachments"."status_id" = "statuses"."id" WHERE "media_attachments"."account_id" = xxx AND ("statuses"."visibility" IN (0, 1) OR "statuses"."id" IN (SELECT "mentions"."status_id" FROM "mentions" WHERE "mentions"."account_id" = yyy)) AND (statuses.created_at <= '2019-02-26 09:21:23.846620') ORDER BY "statuses"."id" DESC LIMIT 20
```

```
Limit  (cost=3609.37..29375.14 rows=20 width=8)
  ->  Unique  (cost=3609.37..75266716.19 rows=58421 width=8)
        ->  Merge Join  (cost=3609.37..75266570.13 rows=58421 width=8)
              Merge Cond: (statuses.id = media_attachments.status_id)
              ->  Index Scan Backward using statuses_pkey on statuses  (cost=3374.35..74945413.91 rows=121241046 width=8)
                    Filter: ((created_at <= '2019-02-26 09:21:23.84662'::timestamp without time zone) AND ((visibility = ANY ('{0,1}'::integer[])) OR (hashed SubPlan 1)))
                    SubPlan 1
                      ->  Index Only Scan using index_mentions_on_account_id_and_status_id on mentions  (cost=0.56..3370.75 rows=1211 width=8)
                            Index Cond: (account_id = yyy)
              ->  Index Only Scan Backward using index_media_attachments_on_account_id_and_status_id on media_attachments  (cost=0.56..17317.88 rows=60723 width=8)
                    Index Cond: (account_id = xxx)
```


after:
```
SELECT  DISTINCT "statuses"."id" FROM "statuses" INNER JOIN "media_attachments" ON "media_attachments"."status_id" = "statuses"."id" WHERE "statuses"."account_id" = xxx AND "media_attachments"."account_id" = xxx AND ("statuses"."visibility" IN (0, 1) OR "statuses"."id" IN (SELECT "mentions"."status_id" FROM "mentions" WHERE "mentions"."account_id" = yyy)) AND (statuses.created_at <= '2019-02-26 09:21:23.846620') ORDER BY "statuses"."id" DESC LIMIT 20
```

```
Limit  (cost=3609.37..42304.73 rows=4 width=8)
  ->  Unique  (cost=3609.37..42304.73 rows=4 width=8)
        ->  Merge Join  (cost=3609.37..42304.72 rows=4 width=8)
              Merge Cond: (statuses.id = media_attachments.status_id)
              ->  Index Scan using index_statuses_20180106 on statuses  (cost=3374.35..24816.73 rows=7419 width=8)
                    Index Cond: (account_id = xxx)
                    Filter: ((created_at <= '2019-02-26 09:21:23.84662'::timestamp without time zone) AND ((visibility = ANY ('{0,1}'::integer[])) OR (hashed SubPlan 1)))
                    SubPlan 1
                      ->  Index Only Scan using index_mentions_on_account_id_and_status_id on mentions  (cost=0.56..3370.75 rows=1211 width=8)
                            Index Cond: (account_id = yyy)
              ->  Index Only Scan Backward using index_media_attachments_on_account_id_and_status_id on media_attachments  (cost=0.56..17317.88 rows=60723 width=8)
                    Index Cond: (account_id = xxx)
```