### PR TITLE
Widen allowed time windows for polls

### DIFF
--- a/app/validators/poll_validator.rb
+++ b/app/validators/poll_validator.rb
@@ -3,8 +3,8 @@
 class PollValidator < ActiveModel::Validator
   MAX_OPTIONS      = 4
   MAX_OPTION_CHARS = 25
-  MAX_EXPIRATION   = 7.days.freeze
-  MIN_EXPIRATION   = 1.day.freeze
+  MAX_EXPIRATION   = 1.month.freeze
+  MIN_EXPIRATION   = 5.minutes.freeze
 
   def validate(poll)
     current_time = Time.now.utc


### PR DESCRIPTION
Twitter allows polls to have a voting window as low as 5 minutes. This might be too short for federation in most cases, but it can still be useful for local polls.

With the current implementation, there is no real cost to long-running polls, so I don't see why not allow at least 1 month.