### PR TITLE
Assume remote polls expire in a year when expiration date not set

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -219,7 +219,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       elsif !@object['closed'].nil? && !@object['closed'].is_a?(FalseClass)
         Time.now.utc
       else
-        @object['endTime']
+        @object['endTime'] || 1.year.from_now
       end
     end
 

--- a/app/services/activitypub/fetch_remote_poll_service.rb
+++ b/app/services/activitypub/fetch_remote_poll_service.rb
@@ -14,7 +14,7 @@ class ActivityPub::FetchRemotePollService < BaseService
       elsif !@json['closed'].nil? && !@json['closed'].is_a?(FalseClass)
         Time.now.utc
       else
-        @json['endTime']
+        @json['endTime'] || 1.year.from_now
       end
     end
 


### PR DESCRIPTION
This allows compatibility with remote polls without a set expiration date
without changing our internal logic.