### PR TITLE
Fix suspended account's fields being set as empty dict instead of list

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -241,6 +241,7 @@ class Account < ApplicationRecord
   def fields_attributes=(attributes)
     fields     = []
     old_fields = self[:fields] || []
+    old_fields = [] if old_fields.is_a?(Hash)
 
     if attributes.is_a?(Hash)
       attributes.each_value do |attr|

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -84,7 +84,7 @@ class SuspendAccountService < BaseService
     @account.locked           = false
     @account.display_name     = ''
     @account.note             = ''
-    @account.fields           = {}
+    @account.fields           = []
     @account.statuses_count   = 0
     @account.followers_count  = 0
     @account.following_count  = 0


### PR DESCRIPTION
Fixes #10177