### PR TITLE
Parse query string for the database URL

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -24,7 +24,7 @@ const dbUrlToConfig = (dbUrl) => {
     return {};
   }
 
-  const params = url.parse(dbUrl);
+  const params = url.parse(dbUrl, true);
   const config = {};
 
   if (params.auth) {


### PR DESCRIPTION
Make it possible for the streaming process to connect to Postgres with SSL enabled when `DATABASE_URL` has `?ssl=true` query.