### PR TITLE
For sign up on another server, link directly to the instance selector

### DIFF
--- a/app/views/about/_forms.html.haml
+++ b/app/views/about/_forms.html.haml
@@ -1,7 +1,7 @@
 - if @instance_presenter.open_registrations
   = render 'registration'
 - else
-  = link_to t('auth.register_elsewhere'), 'https://joinmastodon.org', class: 'button button-primary'
+  = link_to t('auth.register_elsewhere'), 'https://joinmastodon.org/#getting-started', class: 'button button-primary'
 
   .closed-registrations-message
     - if @instance_presenter.closed_registrations_message.blank?

--- a/app/views/about/_links.html.haml
+++ b/app/views/about/_links.html.haml
@@ -11,6 +11,6 @@
         = link_to t('auth.login'), new_user_session_path, class: 'webapp-btn'
     %li= link_to t('about.about_this'), about_more_path
     %li
-      = link_to 'https://joinmastodon.org/' do
+      = link_to 'https://joinmastodon.org/#getting-started' do
         = "#{t('about.other_instances')}"
         %i.fa.fa-external-link{ style: 'padding-left: 5px;' }


### PR DESCRIPTION
The "Sign up on another server" button on invite-only instances links to the top of the joinmastodon.org site. This PR sends it directly to [the instance selection](https://joinmastodon.org/#getting-started) part of the page.
I'm doing it mainly because the sign up button on public pages already links to the #getting-started section.