### PR TITLE
Add clearer error when/if gpg fails

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,18 @@ sudo apt-get install \
 
 # Install rvm
 read RUBY_VERSION < .ruby-version
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+
+gpg_command="gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
+$($gpg_command)
+if [ $? -ne 0 ];then
+  echo "GPG command failed, This prevented RVM from installing."
+  echo "Retrying once..." && $($gpg_command)
+  if [ $? -ne 0 ];then
+    echo "GPG failed for the second time, please ensure network connectivity."
+    echo "Exiting..." && exit 1
+  fi
+fi
+
 curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer | bash -s stable --ruby=$RUBY_VERSION
 source /home/vagrant/.rvm/scripts/rvm
 


### PR DESCRIPTION
When attempting to use Mastodon via Vagrant for development, the following line failed:

gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
(This happens sometimes because keys.gnupg.net occasionally times out, or so I gather; when I ran the command manually it worked fine.)

This prevented RVM from installing and naturally meant that any of the following steps which required ruby didn't work.

However, there was no clear indication that this was the problem, making it somewhat difficult to debug. If RVM fails to install, the provisioning script should terminate immediately and notify the user to probably just try again.

This P.R. solve this issue : #7226

Vagrant exits when script failed after retrying one time:
<img width="620" alt="Capture d’écran 2019-03-10 à 12 52 58" src="https://user-images.githubusercontent.com/20232956/54084782-74001180-4335-11e9-8fe9-96482fcf7e04.png">
And when it succeed it does nothing special: 
<img width="959" alt="Capture d’écran 2019-03-10 à 13 03 12" src="https://user-images.githubusercontent.com/20232956/54084785-7b271f80-4335-11e9-8f9e-5f42db0259b1.png">




