### PR TITLE
Reject existing Follows when suspending a remote account

### DIFF
--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -41,12 +41,21 @@ class SuspendAccountService < BaseService
     @account = account
     @options = options
 
+    reject_follows!
     purge_user!
     purge_profile!
     purge_content!
   end
 
   private
+
+  def reject_follows!
+    return if @account.local? || !@account.activitypub?
+
+    ActivityPub::DeliveryWorker.push_bulk(Follow.where(account: @account)) do |follow|
+      [build_reject_json(follow), follow.target_account_id, follow.account.inbox_url]
+    end
+  end
 
   def purge_user!
     return if !@account.local? || @account.user.nil?
@@ -118,6 +127,14 @@ class SuspendAccountService < BaseService
     ).as_json
 
     @delete_actor_json = Oj.dump(ActivityPub::LinkedDataSignature.new(payload).sign!(@account))
+  end
+
+  def build_reject_json(follow)
+    ActiveModelSerializers::SerializableResource.new(
+      follow,
+      serializer: ActivityPub::RejectFollowSerializer,
+      adapter: ActivityPub::Adapter
+    ).to_json
   end
 
   def delivery_inboxes

--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SuspendAccountService, type: :service do
-  describe '#call' do
+  describe '#call on local account' do
     before do
       stub_request(:post, "https://alice.com/inbox").to_return(status: 201)
       stub_request(:post, "https://bob.com/inbox").to_return(status: 201)
@@ -41,6 +41,48 @@ RSpec.describe SuspendAccountService, type: :service do
       subject.call
       expect(a_request(:post, "https://alice.com/inbox")).to have_been_made.once
       expect(a_request(:post, "https://bob.com/inbox")).to have_been_made.once
+    end
+  end
+
+  describe '#call on remote account' do
+    before do
+      stub_request(:post, "https://alice.com/inbox").to_return(status: 201)
+      stub_request(:post, "https://bob.com/inbox").to_return(status: 201)
+    end
+
+    subject do
+      -> { described_class.new.call(remote_bob) }
+    end
+
+    let!(:account) { Fabricate(:account) }
+    let!(:remote_alice) { Fabricate(:account, inbox_url: 'https://alice.com/inbox', protocol: :activitypub) }
+    let!(:remote_bob) { Fabricate(:account, inbox_url: 'https://bob.com/inbox', protocol: :activitypub) }
+    let!(:status) { Fabricate(:status, account: remote_bob) }
+    let!(:media_attachment) { Fabricate(:media_attachment, account: remote_bob) }
+    let!(:notification) { Fabricate(:notification, account: remote_bob) }
+    let!(:favourite) { Fabricate(:favourite, account: remote_bob) }
+    let!(:active_relationship) { Fabricate(:follow, account: remote_bob, target_account: account) }
+    let!(:passive_relationship) { Fabricate(:follow, target_account: remote_bob) }
+    let!(:subscription) { Fabricate(:subscription, account: remote_bob) }
+
+    it 'deletes associated records' do
+      is_expected.to change {
+        [
+          remote_bob.statuses,
+          remote_bob.media_attachments,
+          remote_bob.stream_entries,
+          remote_bob.notifications,
+          remote_bob.favourites,
+          remote_bob.active_relationships,
+          remote_bob.passive_relationships,
+          remote_bob.subscriptions
+        ].map(&:count)
+      }.from([1, 1, 1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0, 0, 0])
+    end
+
+    it 'sends a reject follow to follwer inboxes' do
+      subject.call
+      expect(a_request(:post, remote_bob.inbox_url)).to have_been_made.once
     end
   end
 end


### PR DESCRIPTION
Partial fix to #10229 

This is only a partial fix because it addresses *new* remote user suspensions and not existing ones, for which the list of followers is already lost