### PR TITLE
Increase DNS timeouts

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -171,7 +171,7 @@ class Request
         outer_e = nil
 
         Resolv::DNS.open do |dns|
-          dns.timeouts = 1
+          dns.timeouts = 5
 
           addresses = dns.getaddresses(host).take(2)
           time_slot = 10.0 / addresses.size


### PR DESCRIPTION
Looking at my sidekiq logs, I have found very frequent instances of failure to deliver AP payloads to multiple instances.
Digging a bit, this is because `dns.getaddresses(host)` only returned a (sometimes empty) subset of the addresses of those domains.
Increasing the timeout got rid of all such errors.