### PR TITLE
Fix the display to only discoverable accounts

### DIFF
--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -34,7 +34,7 @@ class InstancePresenter
   end
 
   def sample_accounts
-    Rails.cache.fetch('sample_accounts', expires_in: 12.hours) { Account.local.searchable.joins(:account_stat).popular.limit(3) }
+    Rails.cache.fetch('sample_accounts', expires_in: 12.hours) { Account.discoverable.popular.limit(3) }
   end
 
   def version_number


### PR DESCRIPTION
Limit the users displayed in "Discover users" on the new landing page to those who have approved to display on the Profile Directory.

I do not know if this limit is the best.
Please let me know if there is a better way.