### PR TITLE
Fix detailed poll validation errors not being returned in the API

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -71,7 +71,8 @@ class Status < ApplicationRecord
   validates_with DisallowedHashtagsValidator
   validates :reblog, uniqueness: { scope: :account }, if: :reblog?
   validates :visibility, exclusion: { in: %w(direct limited) }, if: :reblog?
-  validates_associated :owned_poll
+
+  accepts_nested_attributes_for :owned_poll
 
   default_scope { recent }
 

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -29,7 +29,6 @@ class PostStatusService < BaseService
     return idempotency_duplicate if idempotency_given? && idempotency_duplicate?
 
     validate_media!
-    validate_poll!
     preprocess_attributes!
 
     if scheduled?
@@ -71,6 +70,7 @@ class PostStatusService < BaseService
 
   def schedule_status!
     status_for_validation = @account.statuses.build(status_attributes)
+
     if status_for_validation.valid?
       status_for_validation.destroy
 
@@ -101,12 +101,6 @@ class PostStatusService < BaseService
     @media = @account.media_attachments.where(status_id: nil).where(id: @options[:media_ids].take(4).map(&:to_i))
 
     raise Mastodon::ValidationError, I18n.t('media_attachments.validations.images_and_video') if @media.size > 1 && @media.find(&:video?)
-  end
-
-  def validate_poll!
-    return if @options[:poll].blank?
-
-    @poll = @account.polls.new(@options[:poll])
   end
 
   def language_from_option(str)
@@ -161,13 +155,13 @@ class PostStatusService < BaseService
       text: @text,
       media_attachments: @media || [],
       thread: @in_reply_to,
-      owned_poll: @poll,
+      owned_poll_attributes: poll_attributes,
       sensitive: (@options[:sensitive].nil? ? @account.user&.setting_default_sensitive : @options[:sensitive]) || @options[:spoiler_text].present?,
       spoiler_text: @options[:spoiler_text] || '',
       visibility: @visibility,
       language: language_from_option(@options[:language]) || @account.user&.setting_default_language&.presence || LanguageDetector.instance.detect(@text, @account),
       application: @options[:application],
-    }
+    }.compact
   end
 
   def scheduled_status_attributes
@@ -176,6 +170,12 @@ class PostStatusService < BaseService
       media_attachments: @media || [],
       params: scheduled_options,
     }
+  end
+
+  def poll_attributes
+    return if @options[:poll].blank?
+
+    @options[:poll].merge(account: @account)
   end
 
   def scheduled_options

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -1,6 +1,9 @@
 ---
 en:
   activerecord:
+    attributes:
+      status:
+        owned_poll: Poll
     errors:
       models:
         account:


### PR DESCRIPTION
No more "Owned poll is invalid"