### PR TITLE
Some wording changes for the new homepage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   about:
     about_hashtag_html: These are public toots tagged with <strong>#%{hashtag}</strong>. You can interact with them if you have an account anywhere in the fediverse.
-    about_mastodon_html: Mastodon is a social network based on open web protocols and free, open-source software. It is decentralized like e-mail.
+    about_mastodon_html: Mastodon is a social networking server based on open web protocols and free, open-source software. It is decentralized like e-mail.
     about_this: About
     active_count_after: active
     active_footnote: Monthly Active Users (MAU)
@@ -20,9 +20,9 @@ en:
     extended_description_html: |
       <h3>A good place for rules</h3>
       <p>The extended description has not been set up yet.</p>
-    federation_hint_html: With an account on %{instance} you'll be able to follow people on any Mastodon server and beyond.
+    federation_hint_html: With an account on %{instance} you'll be able to follow people on any Mastodon server, or within the Fediverse.
     generic_description: "%{domain} is one server in the network"
-    get_apps: Try a mobile app
+    get_apps: Try a mobile, or desktop app
     hosted_on: Mastodon hosted on %{domain}
     learn_more: Learn more
     privacy_policy: Privacy policy
@@ -614,7 +614,7 @@ en:
     edit:
       title: Edit filter
     errors:
-      invalid_context: None or invalid context supplied
+      invalid_context: None, or invalid context supplied
       invalid_irreversible: Irreversible filtering only works with home or notifications context
     index:
       delete: Delete


### PR DESCRIPTION
- mentions the Fediverse
- Mastodon is not just a social network, but rather a social networking server