### PR TITLE
Avoid race condition when streaming deleted statuses

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -5,36 +5,27 @@ class FanOutOnWriteService < BaseService
   # @param [Status] status
   def call(status)
     raise Mastodon::RaceConditionError if status.visibility.nil?
-    @status_id = status.id
 
-    RedisLock.acquire(lock_options) do |lock|
-      if lock.acquired?
-        return if Redis.current.exists("delete_upon_arrival:#{@status_id}")
+    render_anonymous_payload(status)
 
-        render_anonymous_payload(status)
-
-        if status.direct_visibility?
-          deliver_to_own_conversation(status)
-        elsif status.limited_visibility?
-          deliver_to_mentioned_followers(status)
-        else
-          deliver_to_self(status) if status.account.local?
-          deliver_to_followers(status)
-          deliver_to_lists(status)
-        end
-
-        return if status.account.silenced? || !status.public_visibility? || status.reblog?
-
-        deliver_to_hashtags(status)
-
-        return if status.reply? && status.in_reply_to_account_id != status.account_id
-
-        deliver_to_public(status)
-        deliver_to_media(status) if status.media_attachments.any?
-      else
-        raise Mastodon::RaceConditionError
-      end
+    if status.direct_visibility?
+      deliver_to_own_conversation(status)
+    elsif status.limited_visibility?
+      deliver_to_mentioned_followers(status)
+    else
+      deliver_to_self(status) if status.account.local?
+      deliver_to_followers(status)
+      deliver_to_lists(status)
     end
+
+    return if status.account.silenced? || !status.public_visibility? || status.reblog?
+
+    deliver_to_hashtags(status)
+
+    return if status.reply? && status.in_reply_to_account_id != status.account_id
+
+    deliver_to_public(status)
+    deliver_to_media(status) if status.media_attachments.any?
   end
 
   private
@@ -102,9 +93,5 @@ class FanOutOnWriteService < BaseService
 
   def deliver_to_own_conversation(status)
     AccountConversation.add_status(status.account, status)
-  end
-
-  def lock_options
-    { redis: Redis.current, key: "distribute:#{@status_id}" }
   end
 end

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -16,8 +16,6 @@ class RemoveStatusService < BaseService
 
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?
-        redis.setex("delete_status:#{status.id}", 10.minutes.seconds, status.id.to_s)
-
         remove_from_self if status.account.local?
         remove_from_followers
         remove_from_lists

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -14,16 +14,24 @@ class RemoveStatusService < BaseService
     @stream_entry = status.stream_entry
     @options      = options
 
-    remove_from_self if status.account.local?
-    remove_from_followers
-    remove_from_lists
-    remove_from_affected
-    remove_reblogs
-    remove_from_hashtags
-    remove_from_public
-    remove_from_media if status.media_attachments.any?
+    RedisLock.acquire(lock_options) do |lock|
+      if lock.acquired?
+        redis.setex("delete_status:#{status.id}", 10.minutes.seconds, status.id.to_s)
 
-    @status.destroy!
+        remove_from_self if status.account.local?
+        remove_from_followers
+        remove_from_lists
+        remove_from_affected
+        remove_reblogs
+        remove_from_hashtags
+        remove_from_public
+        remove_from_media if status.media_attachments.any?
+
+        @status.destroy!
+      else
+        raise Mastodon::RaceConditionError
+      end
+    end
 
     # There is no reason to send out Undo activities when the
     # cause is that the original object has been removed, since
@@ -155,5 +163,9 @@ class RemoveStatusService < BaseService
 
     redis.publish('timeline:public:media', @payload)
     redis.publish('timeline:public:local:media', @payload) if @status.local?
+  end
+
+  def lock_options
+    { redis: Redis.current, key: "distribute:#{@status.id}" }
   end
 end

--- a/app/workers/distribution_worker.rb
+++ b/app/workers/distribution_worker.rb
@@ -4,7 +4,13 @@ class DistributionWorker
   include Sidekiq::Worker
 
   def perform(status_id)
-    FanOutOnWriteService.new.call(Status.find(status_id))
+    RedisLock.acquire(redis: Redis.current, key: "distribute:#{status_id}") do |lock|
+      if lock.acquired?
+        FanOutOnWriteService.new.call(Status.find(status_id))
+      else
+        raise Mastodon::RaceConditionError
+      end
+    end
   rescue ActiveRecord::RecordNotFound
     true
   end


### PR DESCRIPTION
This relies on new redis locks and values so I'm not sure how efficient that is.
But I can't see other ways to prevent those race conditions (basically, `DistributeWorker` doing its job while a status has been/is being deleted, resulting in the status being pushed to timelines *after* it was deleted).