### PR TITLE
perf: remove zopfli to speed up webpack

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -7,7 +7,6 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const OfflinePlugin = require('offline-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
-const zopfli = require('@gfx/zopfli');
 const { output } = require('./configuration');
 const sharedConfig = require('./shared');
 
@@ -55,9 +54,6 @@ module.exports = merge(sharedConfig, {
   plugins: [
     new CompressionPlugin({
       filename: '[path].gz[query]',
-      algorithm(input, compressionOptions, callback) {
-        return zopfli.gzip(input, compressionOptions, callback);
-      },
       cache: true,
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf|map)$/,
     }),

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.3.4",
-    "@gfx/zopfli": "^1.0.11",
     "array-includes": "^3.0.3",
     "autoprefixer": "^9.4.10",
     "axios": "^0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -846,13 +846,6 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
   integrity sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA==
 
-"@gfx/zopfli@^1.0.11":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@gfx/zopfli/-/zopfli-1.0.11.tgz#6ced06b4566a5feb0036fe6a1e0262ce6cb1d6c5"
-  integrity sha512-wW+hi+bqdYCpBIvL8g7RYub9YXf5crhZK9SNk/VZmbF177Em1VwFv488qyh8iBpCo6GptcP1Zam0bJfY3VmMbg==
-  dependencies:
-    base64-js "^1.3.0"
-
 "@jest/console@^24.3.0":
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.3.0.tgz#7bd920d250988ba0bf1352c4493a48e1cb97671e"
@@ -1690,7 +1683,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2, base64-js@^1.3.0:
+base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==


### PR DESCRIPTION
This PR removes zopfli compression, speeding up webpack compilation in production by **~7.5x** (6m36s -> 0m53s).

## Analysis

I did some profiling of the command:

```bash
RAILS_ENV=production bundle exec rails assets:precompile
```

after some digging, I found I could debug webpack using: 

```bash
RAILS_ENV=production NODE_ENV=production node --inspect-brk /home/nolan/workspace/mastodon/node_modules/.bin/webpack --config /home/nolan/workspace/mastodon/config/webpack/production.js
```

So I took a trace. I think the screenshot speaks for itself:

![Screenshot from 2019-03-15 19-00-50](https://user-images.githubusercontent.com/283842/54469731-54178600-4759-11e9-8eed-82e94d146d68.png)


## Benchmark

My benchmark is the following:

```bash
rm -fr tmp/
RAILS_ENV=production bundle exec rails assets:precompile
```

Then I use the `time` command to time it.

Without the fix, this takes **6m36.437s** in real time on my Dell XPS 13. With the fix, it takes **0m52.958s** (**~7.5x** improvement).

## Explanation

Zopfli outputs a very compact gzip format, but it's slow. Removing it speeds things up considerably.

Even though nginx's default gzip output may be less efficient than zopfli, I don't think it's reasonable to force every instance admin to run this command which takes a very long time. Maybe some admins aren't even using gzip &ndash; maybe they're using Brotli. They can also configure the gzip options in nginx, or run zopfli themselves.


As a future improvement, I don't think generating `.gz` files is even strictly necessary. Given [this config](https://github.com/tootsuite/mastodon/blob/782b622f5f295fc9d91bb2461dc049f55766af9c/dist/nginx.conf#L37-L44), nginx should serve gzipped content no matter what &ndash; it's just that we don't necessarily control the gzip output.