### PR TITLE
perf: remove stats.json generation in webpack

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -57,7 +57,7 @@ module.exports = merge(sharedConfig, {
       cache: true,
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf|map)$/,
     }),
-    new BundleAnalyzerPlugin({ // generates report.html and stats.json
+    new BundleAnalyzerPlugin({ // generates report.html
       analyzerMode: 'static',
       openAnalyzer: false,
       logLevel: 'silent', // do not bother Webpacker, who runs with --json and parses stdout

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -59,11 +59,6 @@ module.exports = merge(sharedConfig, {
     }),
     new BundleAnalyzerPlugin({ // generates report.html and stats.json
       analyzerMode: 'static',
-      generateStatsFile: true,
-      statsOptions: {
-        // allows usage with http://chrisbateman.github.io/webpack-visualizer/
-        chunkModules: true,
-      },
       openAnalyzer: false,
       logLevel: 'silent', // do not bother Webpacker, who runs with --json and parses stdout
     }),


### PR DESCRIPTION
This makes it so webpack's `BundleAnalyzerPlugin` doesn't output a `stats.json` file.

By my measure, this reduces the time for asset precompilation from **71s** to **53s**, an **18s improvement**. (I took the median of 5 runs to be sure, see raw results below.)

`stats.json` is only useful for tools like [webpack analyse](http://webpack.github.io/analyse/) and [webpack visualizer](https://chrisbateman.github.io/webpack-visualizer/), and I'll bet nobody was looking at these.

<details>
<summary>click for raw results</summary>

```
before

1m12.509s
1m11.164s
1m16.499s
1m7.246s
1m6.841s

after

0m55.038s
0m52.712s
1m3.872s
0m52.329s
0m52.770s
```

</details>