### PR TITLE
Reduce padding around logo on landing page

### DIFF
--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -657,7 +657,7 @@ $small-breakpoint: 960px;
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: 100px;
+    padding: 50px;
 
     img {
       height: 52px;


### PR DESCRIPTION
# Before

![Screenshot_2019-03-16 Mastodon](https://user-images.githubusercontent.com/384364/54477778-46bad400-480b-11e9-95a6-fab4d1fd721f.png)

# After

![Screenshot_2019-03-16 Mastodon(1)](https://user-images.githubusercontent.com/384364/54477781-4cb0b500-480b-11e9-8a17-925c990646cb.png)
