### PR TITLE
Fix processing poll Updates

### DIFF
--- a/app/services/activitypub/fetch_remote_poll_service.rb
+++ b/app/services/activitypub/fetch_remote_poll_service.rb
@@ -5,6 +5,7 @@ class ActivityPub::FetchRemotePollService < BaseService
 
   def call(poll, on_behalf_of = nil)
     json = fetch_resource(poll.status.uri, true, on_behalf_of)
+    return unless supported_context?(json)
     ActivityPub::ProcessPollService.new.call(poll, json)
   end
 end

--- a/app/services/activitypub/process_poll_service.rb
+++ b/app/services/activitypub/process_poll_service.rb
@@ -5,7 +5,7 @@ class ActivityPub::ProcessPollService < BaseService
 
   def call(poll, json)
     @json = json
-    return unless supported_context? && expected_type?
+    return unless expected_type?
 
     previous_expires_at = poll.expires_at
 
@@ -53,10 +53,6 @@ class ActivityPub::ProcessPollService < BaseService
   end
 
   private
-
-  def supported_context?
-    super(@json)
-  end
 
   def expected_type?
     equals_or_includes_any?(@json['type'], %w(Question))


### PR DESCRIPTION
ActivityPub::ProcessPollService was checking the JSON-LD context although
it was passed only the `Question` object embedded in the `Update` activity.