### PR TITLE
Improve config serializer for Keybase

### DIFF
--- a/app/lib/proof_provider/keybase/config_serializer.rb
+++ b/app/lib/proof_provider/keybase/config_serializer.rb
@@ -2,6 +2,7 @@
 
 class ProofProvider::Keybase::ConfigSerializer < ActiveModel::Serializer
   include RoutingHelper
+  include ActionView::Helpers::TextHelper
 
   attributes :version, :domain, :display_name, :username,
              :brand_color, :logo, :description, :prefill_url,
@@ -29,11 +30,11 @@ class ProofProvider::Keybase::ConfigSerializer < ActiveModel::Serializer
   end
 
   def description
-    Setting.site_short_description.presence || Setting.site_description.presence || I18n.t('about.about_mastodon_html')
+    strip_tags(Setting.site_short_description.presence || I18n.t('about.about_mastodon_html'))
   end
 
   def username
-    { min: 1, max: 30, re: Account::USERNAME_RE.inspect }
+    { min: 1, max: 30, re: '[a-z0-9_]+([a-z0-9_\.-]+[a-z0-9_]+)?' }
   end
 
   def prefill_url

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -18,7 +18,7 @@ class ManifestSerializer < ActiveModel::Serializer
   end
 
   def description
-    strip_tags(object.site_description.presence || I18n.t('about.about_mastodon_html'))
+    strip_tags(object.site_short_description.presence || I18n.t('about.about_mastodon_html'))
   end
 
   def icons


### PR DESCRIPTION
- Regex must no longer be surrounded by `/`
- Description must be short and cannot contain HTML tags