### PR TITLE
Mark the 410 gone response for suspended accounts as cachable

### DIFF
--- a/app/controllers/concerns/account_controller_concern.rb
+++ b/app/controllers/concerns/account_controller_concern.rb
@@ -69,6 +69,10 @@ module AccountControllerConcern
   end
 
   def check_account_suspension
-    gone if @account.suspended?
+    if @account.suspended?
+      skip_session!
+      expires_in(3.minutes, public: true)
+      gone
+    end
   end
 end


### PR DESCRIPTION
This will help a great deal with #9377 when a caching reverse proxy is
configured.