### PR TITLE
Add request pool to improve delivery performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,3 +148,4 @@ group :production do
 end
 
 gem 'concurrent-ruby', require: false
+gem 'connection_pool', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -666,6 +666,7 @@ DEPENDENCIES
   cld3 (~> 3.2.4)
   climate_control (~> 0.2)
   concurrent-ruby
+  connection_pool
   derailed_benchmarks
   devise (~> 4.6)
   devise-two-factor (~> 3.0)

--- a/app/lib/connection_pool/shared_connection_pool.rb
+++ b/app/lib/connection_pool/shared_connection_pool.rb
@@ -10,7 +10,7 @@ class ConnectionPool::SharedConnectionPool < ConnectionPool
     @available = ConnectionPool::SharedTimedStack.new(@size, &block)
   end
 
-  delegate :each_connection, :delete, :size, :empty?, to: :@available
+  delegate :size, :flush, to: :@available
 
   def with(preferred_tag, options = {})
     Thread.handle_interrupt(Exception => :never) do

--- a/app/lib/connection_pool/shared_connection_pool.rb
+++ b/app/lib/connection_pool/shared_connection_pool.rb
@@ -4,11 +4,34 @@ require 'connection_pool'
 require_relative './shared_timed_stack'
 
 class ConnectionPool::SharedConnectionPool < ConnectionPool
-  def initialize(shared_size, options = {}, &block)
+  def initialize(options = {}, &block)
     super(options, &block)
 
-    @available = ConnectionPool::SharedTimedStack.new(shared_size, @size, &block)
+    @available = ConnectionPool::SharedTimedStack.new(@size, &block)
   end
 
   delegate :each_connection, :delete, :size, :empty?, to: :@available
+
+  def with(preferred_tag, options = {})
+    Thread.handle_interrupt(Exception => :never) do
+      conn = checkout(preferred_tag, options)
+      begin
+        Thread.handle_interrupt(Exception => :immediate) do
+          yield conn
+        end
+      ensure
+        checkin
+      end
+    end
+  end
+
+  def checkout(preferred_tag, options = {})
+    if ::Thread.current[@key]
+      ::Thread.current[@key_count] += 1
+      ::Thread.current[@key]
+    else
+      ::Thread.current[@key_count] = 1
+      ::Thread.current[@key] = @available.pop(preferred_tag, options[:timeout] || @timeout)
+    end
+  end
 end

--- a/app/lib/connection_pool/shared_connection_pool.rb
+++ b/app/lib/connection_pool/shared_connection_pool.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'connection_pool'
+require_relative './shared_timed_stack'
 
 class ConnectionPool::SharedConnectionPool < ConnectionPool
   def initialize(shared_size, options = {}, &block)

--- a/app/lib/connection_pool/shared_connection_pool.rb
+++ b/app/lib/connection_pool/shared_connection_pool.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'connection_pool'
+
+class ConnectionPool::SharedConnectionPool < ConnectionPool
+  def initialize(shared_size, options = {}, &block)
+    super(options, &block)
+
+    @available = ConnectionPool::SharedTimedStack.new(shared_size, @size, &block)
+  end
+
+  delegate :each_connection, :delete, :size, :empty?, to: :@available
+end

--- a/app/lib/connection_pool/shared_timed_stack.rb
+++ b/app/lib/connection_pool/shared_timed_stack.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class ConnectionPool::SharedTimedStack
+  def initialize(shared_size, max = 0, &block)
+    @create_block = block
+    @shared_size  = shared_size
+    @max          = max
+    @que          = []
+    @mutex        = Mutex.new
+    @resource     = ConditionVariable.new
+  end
+
+  def push(connection)
+    @mutex.synchronize do
+      @que.push(connection)
+      @resource.broadcast
+    end
+  end
+
+  alias << push
+
+  def pop(timeout = 5.0)
+    deadline = current_time + timeout
+
+    @mutex.synchronize do
+      loop do
+        return @que.pop unless @que.empty?
+
+        connection = try_create
+        return connection if connection
+
+        to_wait = deadline - current_time
+        raise Timeout::Error, "Waited #{timeout} sec" if to_wait <= 0
+
+        @resource.wait(@mutex, to_wait)
+      end
+    end
+  end
+
+  def empty?
+    size.zero?
+  end
+
+  def delete(connection)
+    @mutex.synchronize do
+      @que.delete(connection)
+      @shared_size.decrement
+    end
+  end
+
+  def size
+    @mutex.synchronize do
+      @que.size
+    end
+  end
+
+  def each_connection(&block)
+    @mutex.synchronize do
+      @que.each(&block)
+    end
+  end
+
+  private
+
+  def try_create
+    unless @shared_size.value == @max
+      object = @create_block.call
+      @shared_size.increment
+      object
+    end
+  end
+
+  def current_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+end

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -17,15 +17,21 @@ end
 class Request
   REQUEST_TARGET = '(request-target)'
 
+  # We enforce a 1s timeout on DNS resolving, 10s timeout on socket opening
+  # and 5s timeout on the TLS handshake, meaning the worst case should take
+  # about 16s in total
+  TIMEOUT = { connect: 5, read: 10, write: 10 }.freeze
+
   include RoutingHelper
 
   def initialize(verb, url, **options)
     raise ArgumentError if url.blank?
 
-    @verb    = verb
-    @url     = Addressable::URI.parse(url).normalize
-    @options = options.merge(use_proxy? ? Rails.configuration.x.http_client_proxy : { socket_class: Socket })
-    @headers = {}
+    @verb        = verb
+    @url         = Addressable::URI.parse(url).normalize
+    @http_client = options.delete(:http_client)
+    @options     = options.merge(use_proxy? ? Rails.configuration.x.http_client_proxy : { socket_class: Socket })
+    @headers     = {}
 
     raise Mastodon::HostValidationError, 'Instance does not support hidden service connections' if block_hidden_service?
 
@@ -50,15 +56,24 @@ class Request
 
   def perform
     begin
-      response = http_client.headers(headers).public_send(@verb, @url.to_s, @options)
+      response = http_client.public_send(@verb, @url.to_s, @options.merge(headers: headers))
     rescue => e
       raise e.class, "#{e.message} on #{@url}", e.backtrace[0]
     end
 
     begin
-      yield response.extend(ClientLimit) if block_given?
+      response = response.extend(ClientLimit)
+
+      # If we are using a persistent connection, we have to
+      # read every response to be able to move forward at all.
+      # However, simply calling #to_s or #flush may not be safe,
+      # as the response body, if malicious, could be too big
+      # for our memory. So we use the #body_with_limit method
+      response.body_with_limit if http_client.persistent?
+
+      yield response if block_given?
     ensure
-      http_client.close
+      http_client.close unless http_client.persistent?
     end
   end
 
@@ -75,6 +90,10 @@ class Request
       end
 
       %w(http https).include?(parsed_url.scheme) && parsed_url.host.present?
+    end
+
+    def http_client
+      HTTP.use(:auto_inflate).timeout(:per_operation, TIMEOUT.dup).follow(max_hops: 2)
     end
   end
 
@@ -116,16 +135,8 @@ class Request
     end
   end
 
-  def timeout
-    # We enforce a 1s timeout on DNS resolving, 10s timeout on socket opening
-    # and 5s timeout on the TLS handshake, meaning the worst case should take
-    # about 16s in total
-
-    { connect: 5, read: 10, write: 10 }
-  end
-
   def http_client
-    @http_client ||= HTTP.use(:auto_inflate).timeout(:per_operation, timeout).follow(max_hops: 2)
+    @http_client ||= Request.http_client
   end
 
   def use_proxy?

--- a/app/lib/request_pool.rb
+++ b/app/lib/request_pool.rb
@@ -99,22 +99,25 @@ class RequestPool
 
       begin
         yield @http_client
-      rescue HTTP::ConnectionError => e
+      rescue HTTP::ConnectionError
         # It's possible the connection was closed, so let's
         # try re-opening it once
 
+        close
+
         if retries.positive?
-          raise e
+          raise
         else
           @http_client = http_client
           retry
         end
-      rescue StandardError => e
+      rescue StandardError
         # If this connection raises errors of any kind, it's
         # better if it gets reaped as soon as possible
 
+        close
         @dead = true
-        raise e
+        raise
       end
     ensure
       @in_use = false

--- a/app/lib/request_pool.rb
+++ b/app/lib/request_pool.rb
@@ -78,7 +78,7 @@ class RequestPool
     end
   end
 
-  MAX_IDLE_TIME = 300
+  MAX_IDLE_TIME = 90
 
   class Connection
     attr_reader :last_used_at, :created_at, :in_use, :dead, :fresh

--- a/app/lib/request_pool.rb
+++ b/app/lib/request_pool.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require 'connection_pool'
+
+class ConnectionPool::UnlimitedTimedStack < ConnectionPool::TimedStack
+  def each_connection(&block)
+    @mutex.synchronize do
+      @que.each(&block)
+    end
+  end
+
+  def delete(connection)
+    @mutex.synchronize do
+      @que.delete(connection)
+      @created -= 1
+    end
+  end
+
+  def size
+    @mutex.synchronize do
+      @que.size
+    end
+  end
+
+  def try_create(*)
+    object = @create_block.call
+    @created += 1
+    object
+  end
+end
+
+class ManagedConnectionPool < ConnectionPool
+  def initialize(&block)
+    super
+
+    @available = ConnectionPool::UnlimitedTimedStack.new(&block)
+  end
+
+  def each_connection(&block)
+    @available.each_connection(&block)
+  end
+
+  def delete(connection)
+    @available.delete(connection)
+  end
+
+  def size
+    @available.size
+  end
+
+  def empty?
+    size.zero?
+  end
+end
+
+class RequestPool
+  def self.current
+    @current ||= RequestPool.new
+  end
+
+  class Reaper
+    attr_reader :pool, :frequency
+
+    def initialize(pool, frequency)
+      @pool      = pool
+      @frequency = frequency
+    end
+
+    def run
+      return unless frequency&.positive?
+
+      Thread.new(frequency, pool) do |t, p|
+        loop do
+          sleep t
+          p.flush
+        end
+      end
+    end
+  end
+
+  MAX_IDLE_TIME = 300
+
+  class Connection
+    attr_reader :last_used_at, :created_at, :in_use, :dead
+
+    def initialize(site)
+      @site         = site
+      @http_client  = http_client
+      @last_used_at = nil
+      @created_at   = Time.now.utc
+      @dead         = false
+    end
+
+    def use
+      @last_used_at = Time.now.utc
+      @in_use       = true
+
+      retries = 0
+
+      begin
+        yield @http_client
+      rescue HTTP::ConnectionError => e
+        # It's possible the connection was closed, so let's
+        # try re-opening it once
+
+        if retries.positive?
+          raise e
+        else
+          @http_client = http_client
+          retry
+        end
+      rescue StandardError => e
+        # If this connection raises errors of any kind, it's
+        # better if it gets reaped as soon as possible
+
+        @dead = true
+        raise e
+      end
+    ensure
+      @in_use = false
+    end
+
+    def seconds_idle
+      (Time.now.utc - (@last_used_at || @created_at)).seconds
+    end
+
+    def close
+      @http_client.close
+    end
+
+    private
+
+    def http_client
+      Request.http_client.persistent(@site, timeout: MAX_IDLE_TIME)
+    end
+  end
+
+  def initialize
+    @pools  = Concurrent::Map.new
+    @reaper = Reaper.new(self, 60)
+    @reaper.run
+  end
+
+  def with(site, &block)
+    connection_pool_for(site).with do |connection|
+      connection.use(&block)
+    end
+  end
+
+  def flush
+    idle_pools = []
+
+    @pools.each_pair do |site, pool|
+      idle_connections = []
+
+      pool.each_connection do |connection|
+        next unless !connection.in_use && (connection.dead || connection.seconds_idle >= MAX_IDLE_TIME)
+
+        connection.close
+        idle_connections << connection
+      end
+
+      idle_connections.each do |connection|
+        pool.delete(connection)
+      end
+
+      idle_pools << site if pool.empty?
+    end
+
+    idle_pools.each do |site|
+      @pools.delete(site)
+    end
+  end
+
+  def size
+    @pools.values.sum(&:size)
+  end
+
+  private
+
+  def connection_pool_for(site)
+    @pools.fetch_or_store(site) do
+      ManagedConnectionPool.new { Connection.new(site) }
+    end
+  end
+end

--- a/app/lib/request_pool.rb
+++ b/app/lib/request_pool.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './connection_pool/shared_connection_pool'
+
 class RequestPool
   def self.current
     @current ||= RequestPool.new

--- a/app/lib/request_pool.rb
+++ b/app/lib/request_pool.rb
@@ -27,7 +27,7 @@ class RequestPool
     end
   end
 
-  MAX_IDLE_TIME = 90
+  MAX_IDLE_TIME = 30
   WAIT_TIMEOUT  = 5
   MAX_POOL_SIZE = ENV.fetch('MAX_REQUEST_POOL_SIZE', 512).to_i
 
@@ -99,7 +99,7 @@ class RequestPool
   def initialize
     @shared_size = Concurrent::AtomicFixnum.new
     @pools       = Concurrent::Map.new
-    @reaper      = Reaper.new(self, 60)
+    @reaper      = Reaper.new(self, 30)
     @reaper.run
   end
 

--- a/spec/lib/connection_pool/shared_connection_pool_spec.rb
+++ b/spec/lib/connection_pool/shared_connection_pool_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ConnectionPool::SharedConnectionPool do
+  let(:shared_size) { Concurrent::AtomicFixnum.new }
+
+  subject { described_class.new(shared_size, size: 5, timeout: 5) { Object.new } }
+
+  pending
+end

--- a/spec/lib/connection_pool/shared_connection_pool_spec.rb
+++ b/spec/lib/connection_pool/shared_connection_pool_spec.rb
@@ -3,9 +3,26 @@
 require 'rails_helper'
 
 describe ConnectionPool::SharedConnectionPool do
-  let(:shared_size) { Concurrent::AtomicFixnum.new }
+  class MiniConnection
+    attr_reader :site
 
-  subject { described_class.new(shared_size, size: 5, timeout: 5) { Object.new } }
+    def initialize(site)
+      @site = site
+    end
+  end
 
-  pending
+  subject { described_class.new(size: 5, timeout: 5) { |site| MiniConnection.new(site) } }
+
+  describe '#with' do
+    it 'runs a block with a connection' do
+      block_run = false
+
+      subject.with('foo') do |connection|
+        expect(connection).to be_a MiniConnection
+        block_run = true
+      end
+
+      expect(block_run).to be true
+    end
+  end
 end

--- a/spec/lib/connection_pool/shared_timed_stack_spec.rb
+++ b/spec/lib/connection_pool/shared_timed_stack_spec.rb
@@ -3,30 +3,41 @@
 require 'rails_helper'
 
 describe ConnectionPool::SharedTimedStack do
-  let(:shared_size) { Concurrent::AtomicFixnum.new }
+  class MiniConnection
+    attr_reader :site
 
-  subject { described_class.new(shared_size, 5) { Object.new } }
+    def initialize(site)
+      @site = site
+    end
+  end
+
+  subject { described_class.new(5) { |site| MiniConnection.new(site) } }
 
   describe '#push' do
     it 'keeps the connection in the stack' do
-      subject.push(Object.new)
+      subject.push(MiniConnection.new('foo'))
       expect(subject.size).to eq 1
     end
   end
 
   describe '#pop' do
     it 'returns a connection' do
-      expect(subject.pop).to be_an Object
+      expect(subject.pop('foo')).to be_a MiniConnection
     end
 
     it 'returns the same connection that was pushed in' do
-      connection = Object.new
+      connection = MiniConnection.new('foo')
       subject.push(connection)
-      expect(subject.pop).to be connection
+      expect(subject.pop('foo')).to be connection
     end
 
     it 'does not create more than maximum amount of connections' do
-      expect { 6.times { subject.pop(0) } }.to raise_error Timeout::Error
+      expect { 6.times { subject.pop('foo', 0) } }.to raise_error Timeout::Error
+    end
+
+    it 'repurposes a connection for a different site when maximum amount is reached' do
+      5.times { subject.push(MiniConnection.new('foo')) }
+      expect(subject.pop('bar')).to be_a MiniConnection
     end
   end
 
@@ -36,33 +47,33 @@ describe ConnectionPool::SharedTimedStack do
     end
 
     it 'returns false when there are connections on the stack' do
-      subject.push(Object.new)
+      subject.push(MiniConnection.new('foo'))
       expect(subject.empty?).to be false
     end
   end
 
   describe '#delete' do
     it 'removes a specific connection from the stack' do
-      connection = Object.new
+      connection = MiniConnection.new('foo')
       subject.push(connection)
-      subject.push(Object.new)
+      subject.push(MiniConnection.new('foo'))
       expect(subject.size).to eq 2
       subject.delete(connection)
       expect(subject.size).to eq 1
-      expect(subject.pop).to_not be connection
+      expect(subject.pop('foo')).to_not be connection
     end
   end
 
   describe '#size' do
     it 'returns the number of connections on the stack' do
-      2.times { subject.push(Object.new) }
+      2.times { subject.push(MiniConnection.new('foo')) }
       expect(subject.size).to eq 2
     end
   end
 
   describe '#each_connection' do
     it 'iterates over each connection on the stack' do
-      2.times { subject.push(Object.new) }
+      2.times { subject.push(MiniConnection.new('foo')) }
 
       touched = 0
 

--- a/spec/lib/connection_pool/shared_timed_stack_spec.rb
+++ b/spec/lib/connection_pool/shared_timed_stack_spec.rb
@@ -52,36 +52,10 @@ describe ConnectionPool::SharedTimedStack do
     end
   end
 
-  describe '#delete' do
-    it 'removes a specific connection from the stack' do
-      connection = MiniConnection.new('foo')
-      subject.push(connection)
-      subject.push(MiniConnection.new('foo'))
-      expect(subject.size).to eq 2
-      subject.delete(connection)
-      expect(subject.size).to eq 1
-      expect(subject.pop('foo')).to_not be connection
-    end
-  end
-
   describe '#size' do
     it 'returns the number of connections on the stack' do
       2.times { subject.push(MiniConnection.new('foo')) }
       expect(subject.size).to eq 2
-    end
-  end
-
-  describe '#each_connection' do
-    it 'iterates over each connection on the stack' do
-      2.times { subject.push(MiniConnection.new('foo')) }
-
-      touched = 0
-
-      subject.each_connection do |connection|
-        touched += 1 if connection
-      end
-
-      expect(touched).to eq 2
     end
   end
 end

--- a/spec/lib/connection_pool/shared_timed_stack_spec.rb
+++ b/spec/lib/connection_pool/shared_timed_stack_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ConnectionPool::SharedTimedStack do
+  let(:shared_size) { Concurrent::AtomicFixnum.new }
+
+  subject { described_class.new(shared_size, 5) { Object.new } }
+
+  describe '#push' do
+    it 'keeps the connection in the stack' do
+      subject.push(Object.new)
+      expect(subject.size).to eq 1
+    end
+  end
+
+  describe '#pop' do
+    it 'returns a connection' do
+      expect(subject.pop).to be_an Object
+    end
+
+    it 'returns the same connection that was pushed in' do
+      connection = Object.new
+      subject.push(connection)
+      expect(subject.pop).to be connection
+    end
+
+    it 'does not create more than maximum amount of connections' do
+      expect { 6.times { subject.pop(0) } }.to raise_error Timeout::Error
+    end
+  end
+
+  describe '#empty?' do
+    it 'returns true when no connections on the stack' do
+      expect(subject.empty?).to be true
+    end
+
+    it 'returns false when there are connections on the stack' do
+      subject.push(Object.new)
+      expect(subject.empty?).to be false
+    end
+  end
+
+  describe '#delete' do
+    it 'removes a specific connection from the stack' do
+      connection = Object.new
+      subject.push(connection)
+      subject.push(Object.new)
+      expect(subject.size).to eq 2
+      subject.delete(connection)
+      expect(subject.size).to eq 1
+      expect(subject.pop).to_not be connection
+    end
+  end
+
+  describe '#size' do
+    it 'returns the number of connections on the stack' do
+      2.times { subject.push(Object.new) }
+      expect(subject.size).to eq 2
+    end
+  end
+
+  describe '#each_connection' do
+    it 'iterates over each connection on the stack' do
+      2.times { subject.push(Object.new) }
+
+      touched = 0
+
+      subject.each_connection do |connection|
+        touched += 1 if connection
+      end
+
+      expect(touched).to eq 2
+    end
+  end
+end

--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RequestPool do
+  subject { described_class.current }
+
+  describe '#with' do
+    it 'returns a HTTP client for a host' do
+      subject.with('http://example.com') do |http_client|
+        expect(http_client).to be_a HTTP::Client
+      end
+    end
+
+    it 'returns the same instance of HTTP client within the same thread for the same host' do
+      test_client = nil
+
+      subject.with('http://example.com') { |http_client| test_client = http_client }
+      expect(test_client).to_not be_nil
+      subject.with('http://example.com') { |http_client| expect(http_client).to be test_client }
+    end
+
+    it 'returns different HTTP clients for different hosts' do
+      test_client = nil
+
+      subject.with('http://example.com') { |http_client| test_client = http_client }
+      expect(test_client).to_not be_nil
+      subject.with('http://example.org') { |http_client| expect(http_client).to_not be test_client }
+    end
+
+    it 'grows to the number of threads accessing it' do
+      stub_request(:get, 'http://example.com/').to_return(status: 200, body: 'Hello!')
+
+      threads = 20.times.map do |i|
+        Thread.new do
+          20.times do
+            RequestPool.current.with('http://example.com') do |http_client|
+              http_client.get('/').flush
+            end
+          end
+        end
+      end
+
+      threads.map(&:join)
+
+      expect(RequestPool.current.size).to be > 1
+    end
+  end
+end


### PR DESCRIPTION
Fix #7909 

Use keep-alive connections to each site, in connection pools, to reduce DNS/TCP/SSL handshake overhead. Keep connections for 300 idle seconds, then clean them up.

Benchmark: 400 `ActivityPub::DeliveryWorker` jobs addressed to the same inbox on 5 Sidekiq threads

|Before|After|
|---|---|
|18 s|8 s|