### PR TITLE
Display how many people blocked or muted users in the admin settings

### DIFF
--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -26,6 +26,18 @@
       .dashboard__counters__label= t '.targeted_reports'
   %div
     %div
+      .dashboard__counters__num= number_with_delimiter @account.muted_by.count
+      .dashboard__counters__label= t '.muted_by'
+  %div
+    %div
+      .dashboard__counters__num= number_with_delimiter @account.blocked_by.count
+      .dashboard__counters__label= t '.blocked_by'
+  %div
+    %div
+      .dashboard__counters__num= number_with_delimiter @account.blocked_by.local.count
+      .dashboard__counters__label= t '.blocked_by_local'
+  %div
+    %div
       .dashboard__counters__text
         - if @account.local? && @account.user.nil?
           %span.neutral= t('admin.accounts.deleted')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,7 +163,10 @@ en:
       search: Search
       shared_inbox_url: Shared inbox URL
       show:
+        blocked_by: Blocked by users
+        blocked_by_local: Blocked by local users
         created_reports: Made reports
+        muted_by: Muted by local users
         targeted_reports: Reported by others
       silence: Silence
       silenced: Silenced


### PR DESCRIPTION
I think this information could be useful. I am afraid this would make the “dashboard” a bit too noisy though.

![Screenshot_2019-03-24 thib - Dev instance](https://user-images.githubusercontent.com/384364/54879821-df6dd700-4e3d-11e9-9422-00c0bd9d2ba7.png)

Additionally, it could be interesting to be able to sort users by the number of blocks. This could be useful to let admins investigate accounts who are blocked a lot, even in the absence of actual reports.