### PR TITLE
Do not set CSRF Token when no csrf header

### DIFF
--- a/app/javascript/mastodon/api.js
+++ b/app/javascript/mastodon/api.js
@@ -13,10 +13,14 @@ export const getLinks = response => {
 };
 
 let csrfHeader = {};
+
 function setCSRFHeader() {
-  const csrfToken = document.querySelector('meta[name=csrf-token]').content;
-  csrfHeader['X-CSRF-Token'] = csrfToken;
+  const csrfToken = document.querySelector('meta[name=csrf-token]');
+  if (csrfToken) {
+    csrfHeader['X-CSRF-Token'] = csrfToken.content;
+  }
 }
+
 ready(setCSRFHeader);
 
 export default getState => axios.create({


### PR DESCRIPTION
in the page there is no CSRF header like embed page( `@:user/:status/embed` ), API Request failed and cannot show content correctly. This PR fix it.

```
TypeError: Cannot read property 'content' of null
    at api.js:17
    at r (ready.js:3)
    at Object.<anonymous> (api.js:20)
    at d (bootstrap:83)
    at Object.<anonymous> (compose_form_container.js:67)
    at d (bootstrap:83)
    at Module.567 (media_container-af04476b3836bc406b24.chunk.js:1)
    at d (bootstrap:83)
```

![DeepinScreenshot_select-area_20190326151800](https://user-images.githubusercontent.com/5253290/54976470-c9971800-4fdd-11e9-8b68-54dd5627ba5b.png)
