### PR TITLE
Move the account dropdown menubar to the right, make sure it doesn't move

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -219,9 +219,9 @@ class Header extends ImmutablePureComponent {
             <div className='spacer' />
 
             <div className='account__header__tabs__buttons'>
-              <DropdownMenuContainer items={menu} icon='ellipsis-v' size={24} direction='right' />
-
               {actionBtn}
+
+              <DropdownMenuContainer items={menu} icon='ellipsis-v' size={24} direction='right' />
             </div>
           </div>
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5300,7 +5300,7 @@ noscript {
     .avatar {
       display: block;
       flex: 0 0 auto;
-      width: 90px;
+      width: 94px;
       margin-left: -2px;
 
       .account__avatar {
@@ -5319,6 +5319,7 @@ noscript {
       display: flex;
       align-items: center;
       padding-top: 55px;
+      overflow: hidden;
 
       .icon-button {
         border: 1px solid lighten($ui-base-color, 12%);

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5326,6 +5326,9 @@ noscript {
         border-radius: 4px;
         box-sizing: content-box;
         padding: 2px;
+      }
+
+      .button {
         margin: 0 8px;
       }
     }


### PR DESCRIPTION
This moves the dropdown menubar on profile pages to the right, as suggested in https://github.com/tootsuite/mastodon/pull/10337#issuecomment-475949250

This improves consistency with other places such menus appear, and additionally ensures the button doesn't move while the relationships are loading.

## Before

![Screenshot_2019-03-26 Dev instance(1)](https://user-images.githubusercontent.com/384364/55032484-3d064d00-5011-11e9-8d0e-2d9db943f70a.png)

![before](https://user-images.githubusercontent.com/384364/55032413-1d6f2480-5011-11e9-8e6b-c016b00d29ce.png)
(This one is an animated PNG)

## After

![Screenshot_2019-03-26 Dev instance](https://user-images.githubusercontent.com/384364/55032489-41326a80-5011-11e9-973f-5c724cb0fbe7.png)

![after](https://user-images.githubusercontent.com/384364/55032297-e13bc400-5010-11e9-9302-4c9c86fb532a.png)
(This one is an animated PNG)