### PR TITLE
Add rel='noopener' to redesigned profile column header avatar link

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -212,7 +212,7 @@ class Header extends ImmutablePureComponent {
 
         <div className='account__header__bar'>
           <div className='account__header__tabs'>
-            <a className='avatar' href={account.get('url')} target='_blank'>
+            <a className='avatar' href={account.get('url')} rel='noopener' target='_blank'>
               <Avatar account={account} size={90} />
             </a>
 


### PR DESCRIPTION
Standard addition to prevent `window.opener` hijacking: described in https://mathiasbynens.github.io/rel-noopener, if you don't know.