### PR TITLE
Remove border around avatar on profile column

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5308,7 +5308,7 @@ noscript {
       margin-left: -2px;
 
       .account__avatar {
-        border: 2px solid lighten($ui-base-color, 4%);
+        padding: 2px;
       }
     }
   }


### PR DESCRIPTION
Borders do not play nice with transparent avatars.

## Before

![Screenshot_2019-03-28 Dev instance(9)](https://user-images.githubusercontent.com/384364/55186131-1887ad80-5196-11e9-88c1-533c1d9f30da.png)

## After

![Screenshot_2019-03-28 Dev instance(10)](https://user-images.githubusercontent.com/384364/55186178-33f2b880-5196-11e9-8cfc-5f5435cfc694.png)
