### PR TITLE
Fix search in web UI not setting a limit, restore limit of 5

### DIFF
--- a/app/javascript/mastodon/actions/search.js
+++ b/app/javascript/mastodon/actions/search.js
@@ -37,6 +37,7 @@ export function submitSearch() {
       params: {
         q: value,
         resolve: true,
+        limit: 5,
       },
     }).then(response => {
       if (response.data.accounts) {


### PR DESCRIPTION
The search API now supports returning more results and pagination, but until the web UI implements pagination, it makes no sense to dump so many results at once. This fix restores the behaviour
before the API change