### PR TITLE
Fix failing keybase-related test

### DIFF
--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
     end
 
     it 'parses out of attachment' do
+      allow(ProofProvider::Keybase::Worker).to receive(:perform_async)
+
       account = subject.call('alice', 'example.com', payload)
 
       expect(account.identity_proofs.count).to eq 1


### PR DESCRIPTION
I'm not sure why this doesn't seem to occur in tootsuite, but tests fail in glitch-soc, as some network request is attempted, while it is not stubbed.

```
ActivityPub::ProcessAccountService identity proofs parses out of attachment
     Failure/Error: response = http_client.headers(headers).public_send(@verb, @url.to_s, @options)
     
     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: GET https://keybase.io/_/api/1.0/sig/proof_live.json?domain=cb6e6126.ngrok.io&kb_username=Alice&sig_hash=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&username=alice with headers {'Accept-Encoding'=>'gzip', 'Connection'=>'close', 'Date'=>'Sat, 30 Mar 2019 12:10:26 GMT', 'Host'=>'keybase.io', 'User-Agent'=>'http.rb/3.3.0 (Mastodon/2.8.0rc1+glitch; +https://cb6e6126.ngrok.io/)'}
     
       You can stub this request with the following snippet:
     
       stub_request(:get, "https://keybase.io/_/api/1.0/sig/proof_live.json?domain=cb6e6126.ngrok.io&kb_username=Alice&sig_hash=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&username=alice").
         with(
           headers: {
       	  'Accept-Encoding'=>'gzip',
       	  'Connection'=>'close',
       	  'Date'=>'Sat, 30 Mar 2019 12:10:26 GMT',
       	  'Host'=>'keybase.io',
       	  'User-Agent'=>'http.rb/3.3.0 (Mastodon/2.8.0rc1+glitch; +https://cb6e6126.ngrok.io/)'
           }).
         to_return(status: 200, body: "", headers: {})
     
       registered request stubs:
     
       stub_request(:get, "https://w3id.org/security/v1")
       stub_request(:get, "https://w3id.org/identity/v1")
       stub_request(:get, "https://www.w3.org/ns/activitystreams")
     
       ============================================================
     # ./app/lib/request.rb:53:in `public_send'
     # ./app/lib/request.rb:53:in `perform'
     # ./app/lib/proof_provider/keybase/verifier.rb:35:in `status'
     # ./app/lib/proof_provider/keybase/worker.rb:24:in `perform'
     # ./app/models/account_identity_proof.rb:40:in `queue_worker'
     # ./app/services/activitypub/process_account_service.rb:274:in `process_identity_proof'
     # ./app/services/activitypub/process_account_service.rb:243:in `block in process_attachments'
     # ./app/services/activitypub/process_account_service.rb:241:in `each'
     # ./app/services/activitypub/process_account_service.rb:241:in `process_attachments'
     # ./app/services/activitypub/process_account_service.rb:27:in `block in call'
     # ./app/services/activitypub/process_account_service.rb:18:in `call'
     # ./spec/services/activitypub/process_account_service_spec.rb:45:in `block (3 levels) in <top (required)>'

```