### PR TITLE
Add thumbnail, hero, and mascot back to Form::AdminSettings::KEYS

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -25,6 +25,9 @@ class Form::AdminSettings
     preview_sensitive_media
     custom_css
     profile_directory
+    thumbnail
+    hero
+    mascot
   ).freeze
 
   BOOLEAN_KEYS = %i(


### PR DESCRIPTION
These symbols were (mistakenly?) removed from `KEYS` in 555c4e11baf58401c1bdd915e4ecef679e6ae514, which prevents them from being updated.

Adding them back will allow these images to be uploaded again.