### PR TITLE
Simplify culling and fix race condition

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -236,11 +236,7 @@ module Mastodon
         end
 
         if [404, 410].include?(code)
-          unless options[:dry_run]
-            SuspendAccountService.new.call(account)
-            account.destroy
-          end
-
+          SuspendAccountService.new.call(account, destroy: true) unless options[:dry_run]
           culled += 1
           say('+', :green, false)
         else


### PR DESCRIPTION
`tootctl accounts cull` command raises error sometimes like this:
```
/app/vendor/bundle/ruby/2.6.0/gems/activerecord-5.2.3/lib/active_record/connection_adapters/postgresql_adapter.rb:611:in `async_exec_params': PG::ForeignKeyViolation: ERROR: insert or update on table "account_stats" violates foreign key constraint "fk_rails_215bb31ff1" (ActiveRecord::InvalidForeignKey) DETAIL: Key (account_id)=(17008) is not present in table "accounts". : INSERT INTO "account_stats" ("account_id", "created_at", "updated_at") VALUES ($1, $2, $3) RETURNING "id"
from /app/vendor/ruby-2.6.1/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
from /app/vendor/ruby-2.6.1/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
from /app/app/services/suspend_account_service.rb:103:in `purge_profile!'
from /app/app/services/suspend_account_service.rb:46:in `call'
from /app/lib/mastodon/accounts_cli.rb:240:in `block in cull'
from /app/lib/mastodon/accounts_cli.rb:225:in `cull'
from /app/vendor/ruby-2.6.1/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
from /app/vendor/ruby-2.6.1/lib/ruby/2.6.0/monitor.rb:230:in `mon_synchronize'
from /app/app/services/suspend_account_service.rb:103:in `purge_profile!'
from /app/app/services/suspend_account_service.rb:46:in `call'
from /app/lib/mastodon/accounts_cli.rb:240:in `block in cull'
from /app/lib/mastodon/accounts_cli.rb:225:in `cull'
```

This commit will fix this and simplify code