### PR TITLE
Add ability to silence or lower the volume of the notification sound

### DIFF
--- a/app/controllers/settings/notifications_controller.rb
+++ b/app/controllers/settings/notifications_controller.rb
@@ -26,6 +26,7 @@ class Settings::NotificationsController < Settings::BaseController
   def user_settings_params
     params.require(:user).permit(
       notification_emails: %i(follow follow_request reblog favourite mention digest report),
+      notification_sounds: %i(setting_notif_sound setting_notif_volume),
       interactions: %i(must_be_follower must_be_following must_be_following_dm)
     )
   end

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -50,6 +50,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_aggregate_reblogs,
       :setting_show_application,
       notification_emails: %i(follow follow_request reblog favourite mention digest report),
+      notification_sounds: %i(setting_notif_volume setting_notif_sound),
       interactions: %i(must_be_follower must_be_following)
     )
   end

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -17,5 +17,7 @@ export const version = getMeta('version');
 export const mascot = getMeta('mascot');
 export const profile_directory = getMeta('profile_directory');
 export const isStaff = getMeta('is_staff');
+export const lowerNotificationSoundVolume = getMeta('notif_volume');
+export const notificationSoundEnabled = getMeta('notif_sound');
 
 export default initialState;

--- a/app/javascript/mastodon/middleware/sounds.js
+++ b/app/javascript/mastodon/middleware/sounds.js
@@ -1,3 +1,5 @@
+import { notificationSoundEnabled, lowerNotificationSoundVolume } from '../initial_state';
+
 const createAudio = sources => {
   const audio = new Audio();
   sources.forEach(({ type, src }) => {
@@ -18,7 +20,11 @@ const play = audio => {
       audio.currentTime = 0;
     }
   }
-
+  if(lowerNotificationSoundVolume) {
+    audio.volume = 0.2;
+  } else {
+    audio.volume = 1.0;
+  }
   audio.play();
 };
 
@@ -37,7 +43,7 @@ export default function soundsMiddleware() {
   };
 
   return () => next => action => {
-    if (action.meta && action.meta.sound && soundCache[action.meta.sound]) {
+    if (action.meta && action.meta.sound && soundCache[action.meta.sound] && notificationSoundEnabled) {
       play(soundCache[action.meta.sound]);
     }
 

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -29,6 +29,7 @@ class UserSettingsDecorator
     user.settings['reduce_motion']       = reduce_motion_preference if change?('setting_reduce_motion')
     user.settings['system_font_ui']      = system_font_ui_preference if change?('setting_system_font_ui')
     user.settings['noindex']             = noindex_preference if change?('setting_noindex')
+    user.settings['notification_sounds'] = merged_notification_sounds if change?('notification_sounds')
     user.settings['theme']               = theme_preference if change?('setting_theme')
     user.settings['hide_network']        = hide_network_preference if change?('setting_hide_network')
     user.settings['aggregate_reblogs']   = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
@@ -41,6 +42,10 @@ class UserSettingsDecorator
 
   def merged_interactions
     user.settings['interactions'].merge coerced_settings('interactions').to_h
+  end
+
+  def merged_notification_sounds
+    user.settings['notification_sounds'].merge coerced_settings('notification_sounds').to_h
   end
 
   def default_privacy_preference

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -29,6 +29,8 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:display_media]   = object.current_account.user.setting_display_media
       store[:expand_spoilers] = object.current_account.user.setting_expand_spoilers
       store[:reduce_motion]   = object.current_account.user.setting_reduce_motion
+      store[:notif_sound]     = object.current_account.user.settings.notification_sounds['setting_notif_sound']
+      store[:notif_volume]    = object.current_account.user.settings.notification_sounds['setting_notif_volume']
       store[:is_staff]        = object.current_account.user.staff?
     end
 

--- a/app/views/settings/notifications/show.html.haml
+++ b/app/views/settings/notifications/show.html.haml
@@ -25,5 +25,10 @@
       = ff.input :must_be_following, as: :boolean, wrapper: :with_label
       = ff.input :must_be_following_dm, as: :boolean, wrapper: :with_label
 
+  .fields-group
+    = f.simple_fields_for :notification_sounds, hash_to_object(current_user.settings.notification_sounds) do |ff|
+      = ff.input :setting_notif_volume, as: :boolean, wrapper: :with_label
+      = ff.input :setting_notif_sound, as: :boolean, wrapper: :with_label
+
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.de.yml
+++ b/config/locales/simple_form.de.yml
@@ -102,6 +102,8 @@ de:
         setting_expand_spoilers: Beiträge mit Inhaltswarnungen immer ausklappen
         setting_hide_network: Blende dein Netzwerk aus
         setting_noindex: Suchmaschinen-Indexierung verhindern
+        setting_notif_sound: Benachrichtigungston abspielen
+        setting_notif_volume: Lautstärke des Benachrichtigungstons verringern
         setting_reduce_motion: Bewegung in Animationen verringern
         setting_show_application: Anwendung preisgeben, die benutzt wurde um Beiträge zu versenden
         setting_system_font_ui: Standardschriftart des Systems verwenden

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -102,6 +102,8 @@ en:
         setting_expand_spoilers: Always expand toots marked with content warnings
         setting_hide_network: Hide your network
         setting_noindex: Opt-out of search engine indexing
+        setting_notif_sound: Enable notification sound
+        setting_notif_volume: Lower notification sound volume
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send toots
         setting_system_font_ui: Use system's default font

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,6 +29,9 @@ defaults: &defaults
   show_application: true
   system_font_ui: false
   noindex: false
+  notification_sounds:
+    setting_notif_sound: true
+    setting_notif_volume: false
   theme: 'default'
   aggregate_reblogs: true
   notification_emails:

--- a/spec/controllers/settings/notifications_controller_spec.rb
+++ b/spec/controllers/settings/notifications_controller_spec.rb
@@ -20,10 +20,12 @@ describe Settings::NotificationsController do
     it 'updates notifications settings' do
       user.settings['notification_emails'] = user.settings['notification_emails'].merge('follow' => false)
       user.settings['interactions'] = user.settings['interactions'].merge('must_be_follower' => true)
+      user.settings['notification_sounds'] = user.settings['notification_sounds'].merge('setting_notif_sound' => false)
 
       put :update, params: {
         user: {
           notification_emails: { follow: '1' },
+          notification_sounds: { setting_notif_sound: '1' },
           interactions: { must_be_follower: '0' },
         }
       }
@@ -31,6 +33,7 @@ describe Settings::NotificationsController do
       expect(response).to redirect_to(settings_notifications_path)
       user.reload
       expect(user.settings['notification_emails']['follow']).to be true
+      expect(user.settings['notification_sounds']['setting_notif_sound']).to be true
       expect(user.settings['interactions']['must_be_follower']).to be false
     end
   end

--- a/spec/lib/user_settings_decorator_spec.rb
+++ b/spec/lib/user_settings_decorator_spec.rb
@@ -14,6 +14,13 @@ describe UserSettingsDecorator do
       expect(user.settings['notification_emails']['follow']).to eq true
     end
 
+    it 'updates the user settings value for notification sounds' do
+      values = { 'notification_sounds' => { 'settings_notif_sound' => '0' } }
+
+      settings.update(values)
+      expect(user.settings['notification_sounds']['settings_notif_sound']).to eq false
+    end
+
     it 'updates the user settings value for interactions' do
       values = { 'interactions' => { 'must_be_follower' => '0' } }
 


### PR DESCRIPTION
This PR adds the ability to either silence or lower the volume of the notification sound. It's implemented by adding two new checkboxes to `Settings > Notifications`.

<img width="304" alt="screenshot of the new checkboxes" src="https://user-images.githubusercontent.com/5144843/55580788-9cecaa00-571b-11e9-972c-cb5f8f0d1d2a.png">

The defaults are as before: 
- lower volume: `false`
- sound activated: `true`