### PR TITLE
Fix batch actions not working on pending accounts

### DIFF
--- a/app/controllers/admin/pending_accounts_controller.rb
+++ b/app/controllers/admin/pending_accounts_controller.rb
@@ -8,11 +8,11 @@ module Admin
       @form = Form::AccountBatch.new
     end
 
-    def update
+    def batch
       @form = Form::AccountBatch.new(form_account_batch_params.merge(current_account: current_account, action: action_from_button))
       @form.save
     rescue ActionController::ParameterMissing
-      # Do nothing
+      flash[:alert] = I18n.t('admin.accounts.no_account_selected')
     ensure
       redirect_to admin_pending_accounts_path(current_params)
     end

--- a/app/views/admin/pending_accounts/index.html.haml
+++ b/app/views/admin/pending_accounts/index.html.haml
@@ -4,7 +4,7 @@
 - content_for :header_tags do
   = javascript_pack_tag 'admin', integrity: true, async: true, crossorigin: 'anonymous'
 
-= form_for(@form, url: admin_pending_accounts_path, method: :patch) do |f|
+= form_for(@form, url: batch_admin_pending_accounts_path) do |f|
   = hidden_field_tag :page, params[:page] || 1
 
   .batch-table

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,7 @@ en:
       moderation_notes: Moderation notes
       most_recent_activity: Most recent activity
       most_recent_ip: Most recent IP
+      no_account_selected: No accounts were changed as none were selected
       no_limits_imposed: No limits imposed
       not_subscribed: Not subscribed
       outbox_url: Outbox URL

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,10 +214,11 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :pending_accounts, only: [:index, :update] do
+    resources :pending_accounts, only: [:index] do
       collection do
         post :approve_all
         post :reject_all
+        post :batch
       end
     end
 


### PR DESCRIPTION
`:update` works on individual collection members, not on the collection itself, so use a new route for batch actions.
Also make it clear when no accounts were selected.