### PR TITLE
Change the groupings of menu items in settings navigation

### DIFF
--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -6,6 +6,7 @@
   %li= link_to t('preferences.publishing'), '#settings_publishing'
   %li= link_to t('preferences.other'), '#settings_other'
   %li= link_to t('preferences.web'), '#settings_web'
+  %li= link_to t('settings.notifications'), settings_notifications_path
 
 = simple_form_for current_user, url: settings_preferences_path, html: { method: :put } do |f|
   = render 'shared/error_messages', object: current_user

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -812,9 +812,7 @@ ar:
     migrate: تهجير الحساب
     notifications: الإخطارات
     preferences: التفضيلات
-    settings: الإعدادات
     two_factor_authentication: المُصادقة بخُطوَتَيْن
-    your_apps: تطبيقاتك
   statuses:
     attached:
       description: 'مُرفَق : %{attached}'

--- a/config/locales/ast.yml
+++ b/config/locales/ast.yml
@@ -300,7 +300,6 @@ ast:
     import: Importación
     notifications: Avisos
     preferences: Preferencies
-    settings: Axustes
     two_factor_authentication: Autenticación en dos pasos
   statuses:
     attached:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -122,7 +122,6 @@ bg:
     export: Експортиране на данни
     import: Импортиране
     preferences: Предпочитания
-    settings: Настройки
     two_factor_authentication: Двустепенно удостоверяване
   statuses:
     open_in_web: Отвори в уеб

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -867,9 +867,7 @@ ca:
     notifications: Notificacions
     preferences: Preferències
     relationships: Seguits i seguidors
-    settings: Configuració
     two_factor_authentication: Autenticació de dos factors
-    your_apps: Les teves aplicacions
   statuses:
     attached:
       description: 'Adjunt: %{attached}'

--- a/config/locales/co.yml
+++ b/config/locales/co.yml
@@ -873,9 +873,7 @@ co:
     notifications: Nutificazione
     preferences: Priferenze
     relationships: Abbunamenti è abbunati
-    settings: Parametri
     two_factor_authentication: Identificazione à dui fattori
-    your_apps: E vostre applicazione
   statuses:
     attached:
       description: 'Aghjuntu: %{attached}'

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -883,9 +883,7 @@ cs:
     notifications: Oznámení
     preferences: Předvolby
     relationships: Sledovaní a sledující
-    settings: Nastavení
     two_factor_authentication: Dvoufázové ověřování
-    your_apps: Vaše aplikace
   statuses:
     attached:
       description: 'Přiloženo: %{attached}'

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -812,9 +812,7 @@ cy:
     migrate: Mudo cyfrif
     notifications: Hysbysiadau
     preferences: Dewisiadau
-    settings: Gosodiadau
     two_factor_authentication: Awdurdodi dau-gam
-    your_apps: Eich rhaglenni
   statuses:
     attached:
       description: 'Ynghlwm: %{attached}'

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -700,9 +700,7 @@ da:
     migrate: Konto migrering
     notifications: Notifikationer
     preferences: Præferencer
-    settings: Indstillinger
     two_factor_authentication: To-faktor godkendelse
-    your_apps: Dine applikationer
   statuses:
     attached:
       description: 'Vedhæftede: %{attached}'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -868,9 +868,7 @@ de:
     notifications: Benachrichtigungen
     preferences: Einstellungen
     relationships: Folgende und Follower
-    settings: Einstellungen
     two_factor_authentication: Zwei-Faktor-Auth
-    your_apps: Deine Anwendungen
   statuses:
     attached:
       description: 'Angehängt: %{attached}'

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -859,9 +859,7 @@ el:
     notifications: Ειδοποιήσεις
     preferences: Προτιμήσεις
     relationships: Ακολουθεί και ακολουθείται
-    settings: Ρυθμίσεις
     two_factor_authentication: Πιστοποίηση 2 παραγόντων (2FA)
-    your_apps: Οι εφαρμογές σου
   statuses:
     attached:
       description: 'Συνημμένα: %{attached}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -877,9 +877,7 @@ en:
     preferences: Preferences
     profile: Profile
     relationships: Follows and followers
-    settings: Settings
     two_factor_authentication: Two-factor Auth
-    your_apps: Your applications
   statuses:
     attached:
       description: 'Attached: %{attached}'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -860,6 +860,8 @@ en:
     revoke_success: Session successfully revoked
     title: Sessions
   settings:
+    account: Account
+    account_settings: Account settings
     authorized_apps: Authorized apps
     back: Back to Mastodon
     delete: Account deletion
@@ -869,9 +871,11 @@ en:
     featured_tags: Featured hashtags
     identity_proofs: Identity proofs
     import: Import
+    import_and_export: Import and export
     migrate: Account migration
     notifications: Notifications
     preferences: Preferences
+    profile: Profile
     relationships: Follows and followers
     settings: Settings
     two_factor_authentication: Two-factor Auth

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -854,9 +854,7 @@ en_GB:
     notifications: Notifications
     preferences: Preferences
     relationships: Follows and followers
-    settings: Settings
     two_factor_authentication: Two-factor Auth
-    your_apps: Your applications
   statuses:
     attached:
       description: 'Attached: %{attached}'

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -869,9 +869,7 @@ eo:
     notifications: Sciigoj
     preferences: Preferoj
     relationships: Follows and followers
-    settings: Agordoj
     two_factor_authentication: Dufaktora aŭtentigo
-    your_apps: Viaj aplikaĵoj
   statuses:
     attached:
       description: 'Ligita: %{attached}'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -705,9 +705,7 @@ es:
     migrate: Migración de cuenta
     notifications: Notificaciones
     preferences: Preferencias
-    settings: Ajustes
     two_factor_authentication: Autenticación de dos factores
-    your_apps: Tus aplicaciones
   statuses:
     attached:
       description: 'Adjunto: %{attached}'

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -787,9 +787,7 @@ eu:
     migrate: Kontuaren migrazioa
     notifications: Jakinarazpenak
     preferences: Hobespenak
-    settings: Ezarpenak
     two_factor_authentication: Bi faktoreetako autentifikazioa
-    your_apps: Zure aplikazioak
   statuses:
     attached:
       description: 'Erantsita: %{attached}'

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -860,9 +860,7 @@ fa:
     notifications: اعلان‌ها
     preferences: ترجیحات
     relationships: پیگیری‌ها و پیگیران
-    settings: تنظیمات
     two_factor_authentication: ورود دومرحله‌ای
-    your_apps: برنامهٔ شما
   statuses:
     attached:
       description: 'پیوست‌شده: %{attached}'

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -613,9 +613,7 @@ fi:
     migrate: Tilin muutto muualle
     notifications: Ilmoitukset
     preferences: Ominaisuudet
-    settings: Asetukset
     two_factor_authentication: Kaksivaiheinen todentaminen
-    your_apps: Omat sovellukset
   statuses:
     attached:
       description: 'Liitetty: %{attached}'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -798,9 +798,7 @@ fr:
     migrate: Migration de compte
     notifications: Notifications
     preferences: Préférences
-    settings: Réglages
     two_factor_authentication: Identification à deux facteurs
-    your_apps: Vos applications
   statuses:
     attached:
       description: 'Attaché : %{attached}'

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -855,9 +855,7 @@ gl:
     notifications: Notificacións
     preferences: Preferencias
     relationships: Seguindo e seguidoras
-    settings: Axustes
     two_factor_authentication: Validar Doble Factor
-    your_apps: As súas aplicacións
   statuses:
     attached:
       description: 'Axenado: %{attached}'

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -310,7 +310,6 @@ he:
     export: יצוא מידע
     import: יבוא
     preferences: העדפות
-    settings: הגדרות
     two_factor_authentication: אימות דו-שלבי
   statuses:
     open_in_web: פתח ברשת

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -115,7 +115,6 @@ hr:
     export: Izvoz podataka
     import: Uvezi
     preferences: Postavke
-    settings: Podešenja
     two_factor_authentication: Dvo-faktorska Autentifikacija
   statuses:
     open_in_web: Otvori na webu

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -533,9 +533,7 @@ hu:
     migrate: Fiók átirányítása
     notifications: Értesítések
     preferences: Általános beállítások
-    settings: Beállítások
     two_factor_authentication: Kétlépcsős azonosítás
-    your_apps: Alkalmazásaid
   statuses:
     open_in_web: Megnyitás a weben
     over_character_limit: Túllépted a maximális %{max} karakteres keretet

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -334,7 +334,6 @@ id:
     export: Expor data
     import: Impor
     preferences: Pilihan
-    settings: Pengaturan
     two_factor_authentication: Autentikasi Two-factor
   statuses:
     open_in_web: Buka di web

--- a/config/locales/io.yml
+++ b/config/locales/io.yml
@@ -235,7 +235,6 @@ io:
     export: Exportacar datumi
     import: Importacar
     preferences: Preferi
-    settings: Settings
     two_factor_authentication: Dufaktora autentikigo
   statuses:
     open_in_web: Apertar retnavigile

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -762,9 +762,7 @@ it:
     migrate: Migrazione dell'account
     notifications: Notifiche
     preferences: Preferenze
-    settings: Impostazioni
     two_factor_authentication: Autenticazione a due fattori
-    your_apps: Le tue applicazioni
   statuses:
     attached:
       description: 'Allegato: %{attached}'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -871,9 +871,7 @@ ja:
     notifications: 通知
     preferences: ユーザー設定
     relationships: フォロー・フォロワー
-    settings: 設定
     two_factor_authentication: 二段階認証
-    your_apps: アプリ
   statuses:
     attached:
       description: '添付: %{attached}'

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -668,9 +668,7 @@ ka:
     migrate: ანგარიშის მიგრაცია
     notifications: შეტყობინებები
     preferences: პრეფერენციები
-    settings: პარამეტრები
     two_factor_authentication: მეორე-ფაქტორის აუტენტიფიკაცია
-    your_apps: თქვენი აპლიკაციები
   statuses:
     attached:
       description: 'თან დართული: %{attached}'

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -797,9 +797,7 @@ kk:
     migrate: Аккаунт көшіру
     notifications: Ескертпелер
     preferences: Таңдаулар
-    settings: Баптаулар
     two_factor_authentication: Екі-факторлы авторизация
-    your_apps: Қосымшалар
   statuses:
     attached:
       description: 'Жүктелді: %{attached}'

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -874,9 +874,7 @@ ko:
     notifications: 알림
     preferences: 사용자 설정
     relationships: 팔로잉과 팔로워
-    settings: 설정
     two_factor_authentication: 2단계 인증
-    your_apps: 애플리케이션
   statuses:
     attached:
       description: '첨부: %{attached}'

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -800,9 +800,7 @@ lt:
     migrate: Paskyros migracija
     notifications: Pranešimai
     preferences: Preferencijos
-    settings: Nustatymai
     two_factor_authentication: Dviejų veiksnių autentikacija
-    your_apps: Jūsų aplikacijos
   statuses:
     attached:
       description: 'Pridėta: %{attached}'

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -856,9 +856,7 @@ nl:
     notifications: Meldingen
     preferences: Voorkeuren
     relationships: Volgers en gevolgden
-    settings: Instellingen
     two_factor_authentication: Tweestapsverificatie
-    your_apps: Jouw toepassingen
   statuses:
     attached:
       description: 'Bijlagen: %{attached}'

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -533,9 +533,7 @@
     migrate: Kontomigrering
     notifications: Varslinger
     preferences: Preferanser
-    settings: Innstillinger
     two_factor_authentication: Tofaktorautentisering
-    your_apps: Dine applikasjoner
   statuses:
     open_in_web: Åpne i nettleser
     over_character_limit: grense på %{max} tegn overskredet

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -890,9 +890,7 @@ oc:
     notifications: Notificacions
     preferences: Preferéncias
     relationships: Abonaments e seguidors
-    settings: Paramètres
     two_factor_authentication: Autentificacion en dos temps
-    your_apps: Vòstras aplicacions
   statuses:
     attached:
       description: 'Ajustat : %{attached}'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -889,9 +889,7 @@ pl:
     notifications: Powiadomienia
     preferences: Preferencje
     relationships: Śledzeni i śledzący
-    settings: Ustawienia
     two_factor_authentication: Uwierzytelnianie dwuetapowe
-    your_apps: Twoje aplikacje
   statuses:
     attached:
       description: 'Załączono: %{attached}'

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -867,9 +867,7 @@ pt-BR:
     notifications: Notificações
     preferences: Preferências
     relationships: Seguindo e seguidores
-    settings: Configurações
     two_factor_authentication: Autenticação em dois passos
-    your_apps: Seus aplicativos
   statuses:
     attached:
       description: 'Anexado: %{attached}'

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -800,9 +800,7 @@ pt:
     migrate: Migração de conta
     notifications: Notificações
     preferences: Preferências
-    settings: Configurações
     two_factor_authentication: Autenticação em dois passos
-    your_apps: As tuas aplicações
   statuses:
     attached:
       description: 'Anexadas: %{attached}'

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -698,9 +698,7 @@ ru:
     migrate: Перенос аккаунта
     notifications: Уведомления
     preferences: Настройки
-    settings: Опции
     two_factor_authentication: Двухфакторная аутентификация
-    your_apps: Ваши приложения
   statuses:
     attached:
       description: 'Вложение: %{attached}'

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -831,9 +831,7 @@ sk:
     migrate: Presunutie účtu
     notifications: Oznámenia
     preferences: Voľby
-    settings: Nastavenia
     two_factor_authentication: Dvoj-faktorové overenie
-    your_apps: Tvoje aplikácie
   statuses:
     attached:
       description: 'Priložené: %{attached}'

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -784,9 +784,7 @@ sq:
     migrate: Migrim llogarie
     notifications: Njoftime
     preferences: Parapëlqime
-    settings: Rregullime
     two_factor_authentication: Mirëfilltësim Dyfaktorësh
-    your_apps: Aplikacionet tuaja
   statuses:
     attached:
       description: 'Bashkëngjitur: %{attached}'

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -523,9 +523,7 @@ sr-Latn:
     migrate: Prebacivanje naloga
     notifications: Obaveštenja
     preferences: Podešavanja
-    settings: Postavke
     two_factor_authentication: Dvofaktorska identifikacija
-    your_apps: Vaše aplikacije
   statuses:
     open_in_web: Otvori u vebu
     over_character_limit: ograničenje od %{max} karaktera prekoračeno

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -792,9 +792,7 @@ sr:
     migrate: Пребацивање налога
     notifications: Обавештења
     preferences: Подешавања
-    settings: Поставке
     two_factor_authentication: Двофакторска идентификација
-    your_apps: Ваше апликације
   statuses:
     attached:
       description: 'У прилогу: %{attached}'

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -600,9 +600,7 @@ sv:
     migrate: Kontoflytt
     notifications: Meddelanden
     preferences: Inställningar
-    settings: Inställningar
     two_factor_authentication: Tvåstegsautentisering
-    your_apps: Dina applikationer
   statuses:
     attached:
       description: 'Bifogad: %{attached}'

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -590,9 +590,7 @@ th:
     notifications: การแจ้งเตือน
     preferences: การกำหนดลักษณะ
     relationships: การติดตามและผู้ติดตาม
-    settings: การตั้งค่า
     two_factor_authentication: การรับรองความถูกต้องด้วยสองปัจจัย
-    your_apps: แอปพลิเคชันของคุณ
   statuses:
     attached:
       description: 'แนบ: %{attached}'

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -347,7 +347,6 @@ tr:
     export: Dışa aktar
     import: İçe aktar
     preferences: Tercihler
-    settings: Ayarlar
     two_factor_authentication: İki-faktörlü doğrulama
   statuses:
     open_in_web: Web sayfasında aç

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -648,9 +648,7 @@ uk:
     migrate: Міграція акаунту
     notifications: Сповіщення
     preferences: Налаштування
-    settings: Опції
     two_factor_authentication: Двофакторна авторизація
-    your_apps: Ваші затосунки
   statuses:
     attached:
       description: 'Прикріплено: %{attached}'

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -670,9 +670,7 @@ zh-CN:
     migrate: 帐户迁移
     notifications: 通知
     preferences: 首选项
-    settings: 设置
     two_factor_authentication: 双重认证
-    your_apps: 你的应用
   statuses:
     attached:
       description: 附加媒体：%{attached}

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -597,9 +597,7 @@ zh-HK:
     migrate: 帳戶遷移
     notifications: 通知
     preferences: 偏好設定
-    settings: 設定
     two_factor_authentication: 雙重認證
-    your_apps: 你的應用程式
   statuses:
     attached:
       description: 附件： %{attached}

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -666,9 +666,7 @@ zh-TW:
     migrate: 帳戶搬遷
     notifications: 通知
     preferences: 偏好設定
-    settings: 設定
     two_factor_authentication: 兩階段認證
-    your_apps: 你的應用程式
   statuses:
     attached:
       description: 附件： %{attached}

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -1,50 +1,53 @@
 # frozen_string_literal: true
 
 SimpleNavigation::Configuration.run do |navigation|
-  navigation.items do |primary|
-    primary.item :web, safe_join([fa_icon('chevron-left fw'), t('settings.back')]), root_url
+  navigation.items do |n|
+    n.item :web, safe_join([fa_icon('chevron-left fw'), t('settings.back')]), root_url
 
-    primary.item :settings, safe_join([fa_icon('cog fw'), t('settings.settings')]), settings_profile_url do |settings|
-      settings.item :profile, safe_join([fa_icon('user fw'), t('settings.edit_profile')]), settings_profile_url, highlights_on: %r{/settings/profile|/settings/migration}
-      settings.item :featured_tags, safe_join([fa_icon('hashtag fw'), t('settings.featured_tags')]), settings_featured_tags_url
-      settings.item :preferences, safe_join([fa_icon('sliders fw'), t('settings.preferences')]), settings_preferences_url
-      settings.item :notifications, safe_join([fa_icon('bell fw'), t('settings.notifications')]), settings_notifications_url
-      settings.item :password, safe_join([fa_icon('lock fw'), t('auth.security')]), edit_user_registration_url, highlights_on: %r{/auth/edit|/settings/delete}
-      settings.item :two_factor_authentication, safe_join([fa_icon('mobile fw'), t('settings.two_factor_authentication')]), settings_two_factor_authentication_url, highlights_on: %r{/settings/two_factor_authentication}
-      settings.item :import, safe_join([fa_icon('cloud-upload fw'), t('settings.import')]), settings_import_url
-      settings.item :export, safe_join([fa_icon('cloud-download fw'), t('settings.export')]), settings_export_url
-      settings.item :authorized_apps, safe_join([fa_icon('list fw'), t('settings.authorized_apps')]), oauth_authorized_applications_url
-      settings.item :identity_proofs, safe_join([fa_icon('key fw'), t('settings.identity_proofs')]), settings_identity_proofs_path, highlights_on: %r{/settings/identity_proofs*}, if: proc { current_account.identity_proofs.exists? }
+    n.item :profile, safe_join([fa_icon('user fw'), t('settings.profile')]), settings_profile_url do |s|
+      s.item :profile, safe_join([fa_icon('pencil fw'), t('settings.appearance')]), settings_profile_url, highlights_on: %r{/settings/profile|/settings/migration}
+      s.item :featured_tags, safe_join([fa_icon('hashtag fw'), t('settings.featured_tags')]), settings_featured_tags_url
+      s.item :identity_proofs, safe_join([fa_icon('key fw'), t('settings.identity_proofs')]), settings_identity_proofs_path, highlights_on: %r{/settings/identity_proofs*}, if: proc { current_account.identity_proofs.exists? }
     end
 
-    primary.item :relationships, safe_join([fa_icon('users fw'), t('settings.relationships')]), relationships_url
-    primary.item :filters, safe_join([fa_icon('filter fw'), t('filters.index.title')]), filters_path, highlights_on: %r{/filters}
-    primary.item :invites, safe_join([fa_icon('user-plus fw'), t('invites.title')]), invites_path, if: proc { Setting.min_invite_role == 'user' }
+    n.item :preferences, safe_join([fa_icon('cog fw'), t('settings.preferences')]), settings_preferences_url, highlights_on: %r{/settings/preferences|/settings/notifications}
+    n.item :relationships, safe_join([fa_icon('users fw'), t('settings.relationships')]), relationships_url
+    n.item :filters, safe_join([fa_icon('filter fw'), t('filters.index.title')]), filters_path, highlights_on: %r{/filters}
 
-    primary.item :development, safe_join([fa_icon('code fw'), t('settings.development')]), settings_applications_url do |development|
-      development.item :your_apps, safe_join([fa_icon('list fw'), t('settings.your_apps')]), settings_applications_url, highlights_on: %r{/settings/applications}
+    n.item :security, safe_join([fa_icon('lock fw'), t('settings.account')]), edit_user_registration_url do |s|
+      s.item :password, safe_join([fa_icon('lock fw'), t('settings.account_settings')]), edit_user_registration_url, highlights_on: %r{/auth/edit|/settings/delete}
+      s.item :two_factor_authentication, safe_join([fa_icon('mobile fw'), t('settings.two_factor_authentication')]), settings_two_factor_authentication_url, highlights_on: %r{/settings/two_factor_authentication}
+      s.item :authorized_apps, safe_join([fa_icon('list fw'), t('settings.authorized_apps')]), oauth_authorized_applications_url
     end
 
-    primary.item :moderation, safe_join([fa_icon('gavel fw'), t('moderation.title')]), admin_reports_url, if: proc { current_user.staff? } do |admin|
-      admin.item :action_logs, safe_join([fa_icon('bars fw'), t('admin.action_logs.title')]), admin_action_logs_url
-      admin.item :reports, safe_join([fa_icon('flag fw'), t('admin.reports.title')]), admin_reports_url, highlights_on: %r{/admin/reports}
-      admin.item :accounts, safe_join([fa_icon('users fw'), t('admin.accounts.title')]), admin_accounts_url, highlights_on: %r{/admin/accounts|/admin/pending_accounts}
-      admin.item :invites, safe_join([fa_icon('user-plus fw'), t('admin.invites.title')]), admin_invites_path
-      admin.item :tags, safe_join([fa_icon('tag fw'), t('admin.tags.title')]), admin_tags_path
-      admin.item :instances, safe_join([fa_icon('cloud fw'), t('admin.instances.title')]), admin_instances_url(limited: '1'), highlights_on: %r{/admin/instances|/admin/domain_blocks}, if: -> { current_user.admin? }
-      admin.item :email_domain_blocks, safe_join([fa_icon('envelope fw'), t('admin.email_domain_blocks.title')]), admin_email_domain_blocks_url, highlights_on: %r{/admin/email_domain_blocks}, if: -> { current_user.admin? }
+    n.item :data, safe_join([fa_icon('cloud-download fw'), t('settings.import_and_export')]), settings_export_url do |s|
+      s.item :import, safe_join([fa_icon('cloud-upload fw'), t('settings.import')]), settings_import_url
+      s.item :export, safe_join([fa_icon('cloud-download fw'), t('settings.export')]), settings_export_url
     end
 
-    primary.item :admin, safe_join([fa_icon('cogs fw'), t('admin.title')]), admin_dashboard_url, if: proc { current_user.staff? } do |admin|
-      admin.item :dashboard, safe_join([fa_icon('tachometer fw'), t('admin.dashboard.title')]), admin_dashboard_url
-      admin.item :settings, safe_join([fa_icon('cogs fw'), t('admin.settings.title')]), edit_admin_settings_url, if: -> { current_user.admin? }, highlights_on: %r{/admin/settings}
-      admin.item :custom_emojis, safe_join([fa_icon('smile-o fw'), t('admin.custom_emojis.title')]), admin_custom_emojis_url, highlights_on: %r{/admin/custom_emojis}
-      admin.item :relays, safe_join([fa_icon('exchange fw'), t('admin.relays.title')]), admin_relays_url, if: -> { current_user.admin? }, highlights_on: %r{/admin/relays}
-      admin.item :subscriptions, safe_join([fa_icon('paper-plane-o fw'), t('admin.subscriptions.title')]), admin_subscriptions_url, if: -> { current_user.admin? }
-      admin.item :sidekiq, safe_join([fa_icon('diamond fw'), 'Sidekiq']), sidekiq_url, link_html: { target: 'sidekiq' }, if: -> { current_user.admin? }
-      admin.item :pghero, safe_join([fa_icon('database fw'), 'PgHero']), pghero_url, link_html: { target: 'pghero' }, if: -> { current_user.admin? }
+    n.item :invites, safe_join([fa_icon('user-plus fw'), t('invites.title')]), invites_path, if: proc { Setting.min_invite_role == 'user' }
+    n.item :development, safe_join([fa_icon('code fw'), t('settings.development')]), settings_applications_url
+
+    n.item :moderation, safe_join([fa_icon('gavel fw'), t('moderation.title')]), admin_reports_url, if: proc { current_user.staff? } do |s|
+      s.item :action_logs, safe_join([fa_icon('bars fw'), t('admin.action_logs.title')]), admin_action_logs_url
+      s.item :reports, safe_join([fa_icon('flag fw'), t('admin.reports.title')]), admin_reports_url, highlights_on: %r{/admin/reports}
+      s.item :accounts, safe_join([fa_icon('users fw'), t('admin.accounts.title')]), admin_accounts_url, highlights_on: %r{/admin/accounts|/admin/pending_accounts}
+      s.item :invites, safe_join([fa_icon('user-plus fw'), t('admin.invites.title')]), admin_invites_path
+      s.item :tags, safe_join([fa_icon('tag fw'), t('admin.tags.title')]), admin_tags_path
+      s.item :instances, safe_join([fa_icon('cloud fw'), t('admin.instances.title')]), admin_instances_url(limited: '1'), highlights_on: %r{/admin/instances|/admin/domain_blocks}, if: -> { current_user.admin? }
+      s.item :email_domain_blocks, safe_join([fa_icon('envelope fw'), t('admin.email_domain_blocks.title')]), admin_email_domain_blocks_url, highlights_on: %r{/admin/email_domain_blocks}, if: -> { current_user.admin? }
     end
 
-    primary.item :logout, safe_join([fa_icon('sign-out fw'), t('auth.logout')]), destroy_user_session_url, link_html: { 'data-method' => 'delete' }
+    n.item :admin, safe_join([fa_icon('cogs fw'), t('admin.title')]), admin_dashboard_url, if: proc { current_user.staff? } do |s|
+      s.item :dashboard, safe_join([fa_icon('tachometer fw'), t('admin.dashboard.title')]), admin_dashboard_url
+      s.item :settings, safe_join([fa_icon('cogs fw'), t('admin.settings.title')]), edit_admin_settings_url, if: -> { current_user.admin? }, highlights_on: %r{/admin/settings}
+      s.item :custom_emojis, safe_join([fa_icon('smile-o fw'), t('admin.custom_emojis.title')]), admin_custom_emojis_url, highlights_on: %r{/admin/custom_emojis}
+      s.item :relays, safe_join([fa_icon('exchange fw'), t('admin.relays.title')]), admin_relays_url, if: -> { current_user.admin? }, highlights_on: %r{/admin/relays}
+      s.item :subscriptions, safe_join([fa_icon('paper-plane-o fw'), t('admin.subscriptions.title')]), admin_subscriptions_url, if: -> { current_user.admin? }
+      s.item :sidekiq, safe_join([fa_icon('diamond fw'), 'Sidekiq']), sidekiq_url, link_html: { target: 'sidekiq' }, if: -> { current_user.admin? }
+      s.item :pghero, safe_join([fa_icon('database fw'), 'PgHero']), pghero_url, link_html: { target: 'pghero' }, if: -> { current_user.admin? }
+    end
+
+    n.item :logout, safe_join([fa_icon('sign-out fw'), t('auth.logout')]), destroy_user_session_url, link_html: { 'data-method' => 'delete' }
   end
 end


### PR DESCRIPTION
Fix #10307

- Profile
  - Appearance
  - Featured hashtags
  - (Identity proofs)
- Preferences (no children, link to notification settings now in quick navigation)
- Follows and followers
- Filters
- Account
  - Account settings
  - 2-factor authentication
  - Authorized applications
- Import and export
  - Import
  - Export
- (Invite people)
- Development (no children)
