### PR TITLE
increase allowable length of remote proof username

### DIFF
--- a/app/models/account_identity_proof.rb
+++ b/app/models/account_identity_proof.rb
@@ -18,7 +18,7 @@ class AccountIdentityProof < ApplicationRecord
   belongs_to :account
 
   validates :provider, inclusion: { in: ProofProvider::SUPPORTED_PROVIDERS }
-  validates :provider_username, format: { with: /\A[a-z0-9_]+\z/i }, length: { minimum: 2, maximum: 15 }
+  validates :provider_username, format: { with: /\A[a-z0-9_]+\z/i }, length: { minimum: 2, maximum: 30 }
   validates :provider_username, uniqueness: { scope: [:account_id, :provider] }
   validates :token, format: { with: /\A[a-f0-9]+\z/ }, length: { maximum: 66 }
 


### PR DESCRIPTION
keybase usernames can actually be up to 16 characters. i must have read it wrong from the beginning. i'm really sorry about this because the error message isn't great. 

and if i'm in here anyway, it's silly to bind this to keybase's username restrictions going forward, so i increased it to the mastodon allowable username character limit. 