### PR TITLE
Fix default domain value for keybase proof config

### DIFF
--- a/app/lib/proof_provider/keybase.rb
+++ b/app/lib/proof_provider/keybase.rb
@@ -2,7 +2,7 @@
 
 class ProofProvider::Keybase
   BASE_URL = ENV.fetch('KEYBASE_BASE_URL', 'https://keybase.io')
-  DOMAIN   = ENV.fetch('KEYBASE_DOMAIN', Rails.configuration.x.local_domain)
+  DOMAIN   = ENV.fetch('KEYBASE_DOMAIN', Rails.configuration.x.web_domain)
 
   class Error < StandardError; end
 


### PR DESCRIPTION
Default to the web domain (eg. mastodon.lubar.me) instead of the local domain (eg. lubar.me) for keybase proofs