### PR TITLE
Remove Hindi from language options

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -57,7 +57,6 @@ module Mastodon
       :ga,
       :gl,
       :he,
-      :hi,
       :hr,
       :hu,
       :hy,


### PR DESCRIPTION
Fix #10570

The Hindi localization is an empty file and it crashes the entire website when selected.
https://github.com/tootsuite/mastodon/blob/master/config/locales/hi.yml