### PR TITLE
Allow modal secondary button to shrink and allow wider confirmation modals

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3961,14 +3961,6 @@ a.status-card.compact:hover {
   font-size: 14px;
 }
 
-.confirmation-modal {
-  max-width: 85vw;
-
-  @media screen and (min-width: 480px) {
-    max-width: 380px;
-  }
-}
-
 .mute-modal {
   line-height: 24px;
 }
@@ -4146,6 +4138,10 @@ a.status-card.compact:hover {
     &:active {
       color: darken($lighter-text-color, 4%);
     }
+  }
+
+  .confirmation-modal__secondary-button {
+    flex-shrink: 1;
   }
 }
 


### PR DESCRIPTION
Fixes #10531

For some reason, confirmation modals were narrower than other modals. Changed that.

Furthermore, allowed the secondary (middle) modal button to shrink if needed.

![image](https://user-images.githubusercontent.com/384364/56152219-5f0d4280-5fb3-11e9-8fc8-97bc6cad876a.png)
