### PR TITLE
Treat meta[property] as a space-separated list

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -165,7 +165,7 @@ class FetchLinkCardService < BaseService
   end
 
   def meta_property(page, property)
-    page.at_xpath("//meta[@property=\"#{property}\"]")&.attribute('content')&.value || page.at_xpath("//meta[@name=\"#{property}\"]")&.attribute('content')&.value
+    page.at_xpath("//meta[contains(concat(' ', normalize-space(@property), ' '), ' #{property} ')]")&.attribute('content')&.value || page.at_xpath("//meta[@name=\"#{property}\"]")&.attribute('content')&.value
   end
 
   def lock_options


### PR DESCRIPTION
The `@property` attribute in HTML is a space-separated list of values (like `@class` and `@rel`). This change normalizes whitespace and finds the desired value in the list instead of requiring an exact single-value match.

Here is an example of an element that will match after this change:

    <meta property="dc:title og:title twitter:title"
          content="A document title expressed in multiple vocabularies." />

More details:
https://www.ctrl.blog/entry/rdfa-socialmedia-metadata.html