### PR TITLE
Fix modal items cannot scroll on touch devices

### DIFF
--- a/app/javascript/mastodon/features/ui/components/actions_modal.js
+++ b/app/javascript/mastodon/features/ui/components/actions_modal.js
@@ -64,7 +64,7 @@ export default class ActionsModal extends ImmutablePureComponent {
       <div className='modal-root__modal actions-modal'>
         {status}
 
-        <ul>
+        <ul className={classNames({ 'with-status': !!status })}>
           {this.props.actions.map(this.renderAction)}
         </ul>
       </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4085,6 +4085,11 @@ a.status-card.compact:hover {
   ul {
     overflow-y: auto;
     flex-shrink: 0;
+    max-height: 80vh;
+
+    &.with-status {
+      max-height: calc(80vh - 75px);
+    }
 
     li:empty {
       margin: 0;


### PR DESCRIPTION
This PR fixes the actions-modal to allow scrolling items on touch devices which are short in height.

before:
![cannot-scroll](https://user-images.githubusercontent.com/32974885/56427138-b124cf80-62f5-11e9-9156-cba55b2699ee.gif)

after:
![can-scroll](https://user-images.githubusercontent.com/32974885/56427143-b84bdd80-62f5-11e9-8aa7-efcdf5d21666.gif)

without-status:
![can-scroll-without-status](https://user-images.githubusercontent.com/32974885/56427308-563fa800-62f6-11e9-9aef-a20e8eb9ebc0.gif)

different sizing:
![can-scroll-diff-sizing](https://user-images.githubusercontent.com/32974885/56427413-ba626c00-62f6-11e9-9ba3-7ce374c0b3c9.gif)
