### PR TITLE
Add test for leftover temporary files

### DIFF
--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -133,6 +133,10 @@ RSpec.describe MediaAttachment, type: :model do
       expect(media.file.meta["small"]["height"]).to eq 327
       expect(media.file.meta["small"]["aspect"]).to eq 490.0 / 327
     end
+
+    it 'does not leave temporary files behind' do
+      expect { media }.to_not change { Dir['/tmp/*.jpg'] }
+    end
   end
 
   describe 'descriptions for remote attachments' do


### PR DESCRIPTION
Paperclip *should* clean up after itself, but it seems not to. This can lead to "too many open files" after batch processing. It seems that closing the process does clean them up, but that's impractical.

I've got the test that shows the problem, but I couldn't find a solution.