### PR TITLE
Add toot source to delete result to ease Delete & Redraft

### DIFF
--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -65,7 +65,7 @@ class Api::V1::StatusesController < Api::BaseController
 
     RemovalWorker.perform_async(@status.id)
 
-    render_empty
+    render json: @status, serializer: REST::StatusSerializer, source_requested: true
   end
 
   private

--- a/app/javascript/mastodon/actions/statuses.js
+++ b/app/javascript/mastodon/actions/statuses.js
@@ -131,10 +131,11 @@ export function fetchStatusFail(id, error, skipLoading) {
   };
 };
 
-export function redraft(status) {
+export function redraft(status, raw_text) {
   return {
     type: REDRAFT,
     status,
+    raw_text,
   };
 };
 
@@ -148,13 +149,13 @@ export function deleteStatus(id, router, withRedraft = false) {
 
     dispatch(deleteStatusRequest(id));
 
-    api(getState).delete(`/api/v1/statuses/${id}`).then(() => {
+    api(getState).delete(`/api/v1/statuses/${id}`).then(response => {
       evictStatus(id);
       dispatch(deleteStatusSuccess(id));
       dispatch(deleteFromTimelines(id));
 
       if (withRedraft) {
-        dispatch(redraft(status));
+        dispatch(redraft(status, response.data.raw_content));
 
         if (!getState().getIn(['compose', 'mounted'])) {
           router.push('/statuses/new');

--- a/app/javascript/mastodon/actions/statuses.js
+++ b/app/javascript/mastodon/actions/statuses.js
@@ -155,7 +155,7 @@ export function deleteStatus(id, router, withRedraft = false) {
       dispatch(deleteFromTimelines(id));
 
       if (withRedraft) {
-        dispatch(redraft(status, response.data.raw_content));
+        dispatch(redraft(status, response.data.text));
 
         if (!getState().getIn(['compose', 'mounted'])) {
           router.push('/statuses/new');

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -329,7 +329,7 @@ export default function compose(state = initialState, action) {
       }));
   case REDRAFT:
     return state.withMutations(map => {
-      map.set('text', unescapeHTML(expandMentions(action.status)));
+      map.set('text', action.raw_content || unescapeHTML(expandMentions(action.status)));
       map.set('in_reply_to', action.status.get('in_reply_to_id'));
       map.set('privacy', action.status.get('visibility'));
       map.set('media_attachments', action.status.get('media_attachments'));

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -3,7 +3,7 @@
 class REST::StatusSerializer < ActiveModel::Serializer
   attributes :id, :created_at, :in_reply_to_id, :in_reply_to_account_id,
              :sensitive, :spoiler_text, :visibility, :language,
-             :uri, :content, :url, :replies_count, :reblogs_count,
+             :uri, :url, :replies_count, :reblogs_count,
              :favourites_count
 
   attribute :favourited, if: :current_user?
@@ -11,7 +11,8 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attribute :muted, if: :current_user?
   attribute :pinned, if: :pinnable?
 
-  attribute :raw_content, if: :source_requested?
+  attribute :content, unless: :source_requested?
+  attribute :text, if: :source_requested?
 
   belongs_to :reblog, serializer: REST::StatusSerializer
   belongs_to :application, if: :show_application?
@@ -62,10 +63,6 @@ class REST::StatusSerializer < ActiveModel::Serializer
 
   def content
     Formatter.instance.format(object)
-  end
-
-  def raw_content
-    object.text
   end
 
   def url

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -11,6 +11,8 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attribute :muted, if: :current_user?
   attribute :pinned, if: :pinnable?
 
+  attribute :raw_content, if: :source_requested?
+
   belongs_to :reblog, serializer: REST::StatusSerializer
   belongs_to :application, if: :show_application?
   belongs_to :account, serializer: REST::AccountSerializer
@@ -62,6 +64,10 @@ class REST::StatusSerializer < ActiveModel::Serializer
     Formatter.instance.format(object)
   end
 
+  def raw_content
+    object.text
+  end
+
   def url
     TagManager.instance.url_for(object)
   end
@@ -103,6 +109,10 @@ class REST::StatusSerializer < ActiveModel::Serializer
       current_user.account_id == object.account_id &&
       !object.reblog? &&
       %w(public unlisted).include?(object.visibility)
+  end
+
+  def source_requested?
+    instance_options[:source_requested]
   end
 
   def ordered_mentions


### PR DESCRIPTION
Currently, a client has to parse the formatted status when doing Delete & Redraft.
This is not trivial, and even the WebUI does not do it correctly for mention to users with weird URIs.

This PR returns the status in the `delete` reply with an additional `raw_content` field containing exactly the text that was initially input.