### PR TITLE
Add SOURCE_TAG to show source repository's tag

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -42,7 +42,7 @@ module Mastodon
 
     # specify git tag or commit hash here
     def source_tag
-      nil
+      ENV.fetch('SOURCE_TAG') { nil }
     end
 
     def source_url


### PR DESCRIPTION
Use an environment variable `SOURCE_TAG` to show the tag of the source repository.