### PR TITLE
Add some caching for HTML versions of statuses pages

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -27,7 +27,10 @@ class StatusesController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        mark_cacheable! unless user_signed_in?
+        unless user_signed_in?
+          skip_session!
+          expires_in 10.seconds, public: true
+        end
 
         @body_classes = 'with-modals'
 

--- a/app/controllers/stream_entries_controller.rb
+++ b/app/controllers/stream_entries_controller.rb
@@ -15,6 +15,11 @@ class StreamEntriesController < ApplicationController
   def show
     respond_to do |format|
       format.html do
+        unless user_signed_in?
+          skip_session!
+          expires_in 5.minutes, public: true
+        end
+
         redirect_to short_account_status_url(params[:account_username], @stream_entry.activity) if @type == 'status'
       end
 


### PR DESCRIPTION
Cache public HTML status pages for 10 seconds to avoid situations where multiple instances request the HTML pages at around the same time.

The benefits of this will be lower than our other caching strategies, since ActivityPub-based software trying to fetch the toot as such will go through the other codepath. However, it should yield some improvement regarding legacy OStatus software, as well as in other situations, such as being on the receiving end of Mastodon's link preview crawler.