### PR TITLE
Make sure the instance banner is never cropped

### DIFF
--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -4,7 +4,6 @@
 
   &__img {
     width: 100%;
-    height: 167px;
     position: relative;
     overflow: hidden;
     border-radius: 4px 4px 0 0;


### PR DESCRIPTION
I don't know if there was a real reason for this limit to be here, but it seems it can be removed without breaking anything.

Example on eldritch.cafe:

| Before            | After        |
|-------------------|--------------|
| ![Screenshot_2019-05-04 Eldritch Café(2)](https://user-images.githubusercontent.com/16254623/57185311-c5092d80-6ec0-11e9-8ed1-f4d80e3927ca.png) | ![Screenshot_2019-05-04 Eldritch Café(1)](https://user-images.githubusercontent.com/16254623/57185315-d3efe000-6ec0-11e9-9a40-d466b94e42dc.png) |
