### PR TITLE
Fix some colors of high contrast theme

### DIFF
--- a/app/javascript/styles/contrast/diff.scss
+++ b/app/javascript/styles/contrast/diff.scss
@@ -67,3 +67,7 @@
     text-decoration: none;
   }
 }
+
+.nothing-here {
+  color: $darker-text-color;
+}

--- a/app/javascript/styles/contrast/diff.scss
+++ b/app/javascript/styles/contrast/diff.scss
@@ -71,3 +71,7 @@
 .nothing-here {
   color: $darker-text-color;
 }
+
+.public-layout .public-account-header__tabs__tabs .counter.active::after {
+  border-bottom: 4px solid $ui-highlight-color;
+}


### PR DESCRIPTION
- Fix "nothing here" text color because it is hard to see.
- Fix counter border color to highlight-color.

**Before:**

![image](https://user-images.githubusercontent.com/14953122/57198045-666bae80-6fa9-11e9-88b6-756885494080.png)

**After:**

![image](https://user-images.githubusercontent.com/14953122/57198048-6e2b5300-6fa9-11e9-93f3-d47976ec2e98.png)
