### PR TITLE
Bring back crossed eye icon on sensitive media

### DIFF
--- a/app/javascript/mastodon/features/account_gallery/components/media_item.js
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+import Icon from 'mastodon/components/icon';
 import { autoPlayGif, displayMedia } from 'mastodon/initial_state';
 import classNames from 'classnames';
 import { decode } from 'blurhash';
@@ -91,6 +92,7 @@ export default class MediaItem extends ImmutablePureComponent {
     const title = status.get('spoiler_text') || attachment.get('description');
 
     let thumbnail = '';
+    let icon;
 
     if (attachment.get('type') === 'unknown') {
       // Skip
@@ -132,11 +134,20 @@ export default class MediaItem extends ImmutablePureComponent {
       );
     }
 
+    if (!visible) {
+      icon = (
+        <span className='account-gallery__item__icons'>
+          <Icon id='eye-slash' />
+        </span>
+      );
+    }
+
     return (
       <div className='account-gallery__item' style={{ width, height }}>
         <a className='media-gallery__item-thumbnail' href={status.get('url')} target='_blank' onClick={this.handleClick} title={title}>
           <canvas width={32} height={32} ref={this.setCanvasRef} className={classNames('media-gallery__preview', { 'media-gallery__preview--hidden': visible && loaded })} />
           {visible && thumbnail}
+          {!visible && icon}
         </a>
       </div>
     );

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4829,6 +4829,14 @@ a.status-card.compact:hover {
   border-radius: 4px;
   overflow: hidden;
   margin: 2px;
+
+  &__icons {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 24px;
+  }
 }
 
 .notification__filter-bar,


### PR DESCRIPTION
About account media gallery:

On 2.8.0, there were crossed eye icon on sensitive media
![Screenshot from 2019-05-06 13-37-49](https://user-images.githubusercontent.com/5047683/57207845-086fb300-700b-11e9-8420-7e5157005a80.png)

But since 2.8.1, crossed eye icon is removed due to blurhash, But old media don't have blurhash. So it look like this:
![Screenshot from 2019-05-06 13-38-01](https://user-images.githubusercontent.com/5047683/57207889-4e2c7b80-700b-11e9-9e0d-a196ab3f5e6c.png)
This looks very ugly, And user cannot know that image is just broken or sensitive image

So bring back that crossed eye image to tell "this is a sensitive image, you have to click to view image thumbnail" like this:
![image](https://user-images.githubusercontent.com/5047683/57207923-88961880-700b-11e9-958b-f2c504e60f0a.png)

