### PR TITLE
Improve poll link accessibility

### DIFF
--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -114,10 +114,13 @@
     text-decoration: underline;
     font-size: inherit;
 
-    &:hover,
-    &:focus,
-    &:active {
+    &:hover {
       text-decoration: none;
+    }
+
+    &:active,
+    &:focus {
+      background-color: rgba($dark-text-color, .1);
     }
   }
 


### PR DESCRIPTION
* Add distinction between hover and active/focus states
* Resolves #10198

Currently on the poll link, both hover and active/focus states are the same, meaning once you click on such link the underline disappears. This creates a confusing situation as described in #10198. I have added a light background color to distinguish between hover and active/focust states.