### PR TITLE
Remove custom emojis on "tootctl domains purge"

### DIFF
--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -34,8 +34,9 @@ module Mastodon
       say("Removed #{removed} accounts#{dry_run}", :green)
 
       custom_emojis = CustomEmoji.where(domain: domain)
-      say("Removing #{custom_emojis.count} custom emojis", :green)
+      custom_emojis_count = custom_emojis.count
       custom_emojis.destroy_all unless options[:dry_run]
+      say("Removed #{custom_emojis_count} custom emojis", :green)
     end
 
     option :concurrency, type: :numeric, default: 50, aliases: [:c]

--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -28,10 +28,14 @@ module Mastodon
         say('.', :green, false)
       end
 
-      DomainBlock.where(domain: domain).destroy_all
+      DomainBlock.where(domain: domain).destroy_all unless options[:dry_run]
 
       say
       say("Removed #{removed} accounts#{dry_run}", :green)
+
+      custom_emojis = CustomEmoji.where(domain: domain)
+      say("Removing #{custom_emojis.count} custom emojis", :green)
+      custom_emojis.destroy_all unless options[:dry_run]
     end
 
     option :concurrency, type: :numeric, default: 50, aliases: [:c]


### PR DESCRIPTION
There is no reason to leaving custom emojis from purged instance.
Additionally, `DomainBlock` should not be removed on dry run