### PR TITLE
Adds click-able div that expands status (#10733)

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -356,6 +356,7 @@ class Status extends ImmutablePureComponent {
           {prepend}
 
           <div className={classNames('status', `status-${status.get('visibility')}`, { 'status-reply': !!status.get('in_reply_to_id'), muted: this.props.muted, read: unread === false })} data-id={status.get('id')}>
+            <div className='status__expand' onClick={this.handleClick} role='presentation' />
             <div className='status__info'>
               <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener'><RelativeTimestamp timestamp={status.get('created_at')} /></a>
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1412,6 +1412,15 @@ a.account__display-name {
   width: 48px;
 }
 
+.status__expand {
+  width: 68px;
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  cursor: pointer;
+}
+
 .muted {
   .status__content p,
   .status__content a {


### PR DESCRIPTION
The clickable div is positioned under the account avatar and covers all empty space below it to the end of the status as shown in the image below.

![image](https://user-images.githubusercontent.com/1120797/57747173-58e9af00-76a2-11e9-88d8-8470a0f83b0a.png)

This is an alternate implementation to the one implemented in https://github.com/tootsuite/mastodon/pull/9492, as suggested in https://github.com/tootsuite/mastodon/issues/10733 and in the comments of https://github.com/tootsuite/mastodon/issues/8529.