### PR TITLE
Prevent publicly boosting own's private toots

### DIFF
--- a/app/services/reblog_service.rb
+++ b/app/services/reblog_service.rb
@@ -18,7 +18,9 @@ class ReblogService < BaseService
 
     return reblog unless reblog.nil?
 
-    reblog = account.statuses.create!(reblog: reblogged_status, text: '', visibility: options[:visibility] || account.user&.setting_default_privacy)
+    visibility = options[:visibility] || account.user&.setting_default_privacy
+    visibility = reblogged_status.visibility if reblogged_status.hidden?
+    reblog = account.statuses.create!(reblog: reblogged_status, text: '', visibility: visibility)
 
     DistributionWorker.perform_async(reblog.id)
     Pubsubhubbub::DistributionWorker.perform_async(reblog.stream_entry.id)

--- a/spec/services/reblog_service_spec.rb
+++ b/spec/services/reblog_service_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe ReblogService, type: :service do
   let(:alice)  { Fabricate(:account, username: 'alice') }
 
   context 'creates a reblog with appropriate visibility' do
-    let(:bob)               { Fabricate(:account, username: 'bob') }
     let(:visibility)        { :public }
     let(:reblog_visibility) { :public }
-    let(:status)            { Fabricate(:status, account: bob, visibility: visibility) }
+    let(:status)            { Fabricate(:status, account: alice, visibility: visibility) }
 
     subject { ReblogService.new }
 
@@ -17,6 +16,15 @@ RSpec.describe ReblogService, type: :service do
 
     describe 'boosting privately' do
       let(:reblog_visibility) { :private }
+
+      it 'reblogs privately' do
+        expect(status.reblogs.first.visibility).to eq 'private'
+      end
+    end
+
+    describe 'public reblogs of private toots should remain private' do
+      let(:visibility)        { :private }
+      let(:reblog_visibility) { :public }
 
       it 'reblogs privately' do
         expect(status.reblogs.first.visibility).to eq 'private'


### PR DESCRIPTION
Boost of self private toots will be private regardless of the API setting.

Ideally, existing public self-boosts of private toots should be hidden as well, but that's much more work and it would add overhead in various parts of Mastodon.