### PR TITLE
Remove 'Weblate' from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,7 @@ Bug reports and feature suggestions can be submitted to [GitHub Issues](https://
 
 ## Translations
 
-You can submit translations via [Weblate](https://weblate.joinmastodon.org/). They are periodically merged into the codebase.
-
-[![Mastodon translation statistics by language](https://weblate.joinmastodon.org/widgets/mastodon/-/multi-auto.svg)](https://weblate.joinmastodon.org/)
+You can submit translations via pull request.
 
 ## Pull requests
 


### PR DESCRIPTION
The mastodon project no longer used weblate to translate UI sentences. (ref #10385)

## ref
- #10776