### PR TITLE
Add post-deployment migration script to delete public-boosts-of-private boosts

### DIFF
--- a/db/post_migrate/20190519130537_remove_boosts_widening_audience.rb
+++ b/db/post_migrate/20190519130537_remove_boosts_widening_audience.rb
@@ -1,0 +1,23 @@
+class RemoveBoostsWideningAudience < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    public_boosts = Status.find_by_sql(<<-SQL)
+      SELECT boost.id
+      FROM statuses AS boost
+      LEFT JOIN statuses AS boosted ON boost.reblog_of_id = boosted.id
+      WHERE
+        boost.id > 101746055577600000
+        AND (boost.local = TRUE OR boost.uri IS NULL)
+        AND boost.visibility IN (0, 1)
+        AND boost.reblog_of_id IS NOT NULL
+        AND boosted.visibility = 2
+    SQL
+
+    RemovalWorker.push_bulk(public_boosts.pluck(:id))
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_11_152737) do
+ActiveRecord::Schema.define(version: 2019_05_19_130537) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
~~I have *not* tried the migration script yet.~~