### PR TITLE
Add emphasis and code span syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'http_parser.rb', '~> 0.6', git: 'https://github.com/tmm1/http_parser.rb', r
 gem 'httplog', '~> 1.2'
 gem 'idn-ruby', require: 'idn'
 gem 'kaminari', '~> 1.1'
+gem 'kramdown', '~> 2.1'
 gem 'link_header', '~> 0.0'
 gem 'mime-types', '~> 3.2', require: 'mime/types/columnar'
 gem 'nokogiri', '~> 1.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,7 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    kramdown (2.1.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.7.0)
@@ -708,6 +709,7 @@ DEPENDENCIES
   json-ld (~> 3.0)
   json-ld-preloaded (~> 3.0)
   kaminari (~> 1.1)
+  kramdown (~> 2.1)
   letter_opener (~> 1.7)
   letter_opener_web (~> 1.3)
   link_header (~> 0.0)

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -714,6 +714,29 @@
     }
   }
 
+  strong,
+  b {
+    font-weight: 700;
+  }
+
+  em,
+  i {
+    font-style: italic;
+  }
+
+  code {
+    font-family: $font-monospace, monospace;
+    background-color: darken($ui-base-color, 8%);
+    border-radius: 3px;
+    font-size: 0.85em;
+    padding: 0.075em 0.4em;
+  }
+
+  del,
+  s {
+    text-decoration: line-through;
+  }
+
   a {
     color: $secondary-text-color;
     text-decoration: none;

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -18,10 +18,8 @@ class Formatter
     end
 
     raw_content = status.text
-
-    if options[:inline_poll_options] && status.preloadable_poll
-      raw_content = raw_content + "\n\n" + status.preloadable_poll.options.map { |title| "[ ] #{title}" }.join("\n")
-    end
+    raw_content = raw_content + "\n\n" + status.preloadable_poll.options.map { |title| "[ ] #{title}" }.join("\n") if options[:inline_poll_options] && status.preloadable_poll
+    raw_content = "RT @#{prepend_reblog} #{raw_content}" if prepend_reblog
 
     return '' if raw_content.blank?
 
@@ -31,17 +29,15 @@ class Formatter
       return html.html_safe # rubocop:disable Rails/OutputSafety
     end
 
-    linkable_accounts = status.active_mentions.map(&:account)
-    linkable_accounts << status.account
+    formatter_options = {
+      input: :mastodon,
+      entity_output: :as_input,
+      linkable_accounts: status.active_mentions.map(&:account) + [status.account],
+      custom_emojis: options[:custom_emojify] ? status.emojis : nil,
+      autoplay: options[:autoplay],
+    }
 
-    html = raw_content
-    html = "RT @#{prepend_reblog} #{html}" if prepend_reblog
-    html = encode_and_link_urls(html, linkable_accounts)
-    html = encode_custom_emojis(html, status.emojis, options[:autoplay]) if options[:custom_emojify]
-    html = simple_format(html, {}, sanitize: false)
-    html = html.delete("\n")
-
-    html.html_safe # rubocop:disable Rails/OutputSafety
+    Kramdown::Document.new(raw_content, formatter_options).to_mastodon.delete("\n").html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def reformat(html)

--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -20,7 +20,19 @@ class Sanitize
     end
 
     MASTODON_STRICT ||= freeze_config(
-      elements: %w(p br span a),
+      elements: %w(
+        p
+        br
+        span
+        a
+        em
+        i
+        strong
+        b
+        code
+        del
+        s
+      ),
 
       attributes: {
         'a'    => %w(href rel class),

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,8 @@ require_relative '../lib/paperclip/video_transcoder'
 require_relative '../lib/mastodon/snowflake'
 require_relative '../lib/mastodon/version'
 require_relative '../lib/devise/ldap_authenticatable'
+require_relative '../lib/kramdown/parser/mastodon'
+require_relative '../lib/kramdown/converter/mastodon'
 
 Dotenv::Railtie.load
 

--- a/lib/kramdown/converter/mastodon.rb
+++ b/lib/kramdown/converter/mastodon.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'kramdown/converter'
+
+module Kramdown
+  module Converter
+    class Mastodon < Html
+      def convert_text(element, _indent)
+        html = Formatter.instance.send(:encode_and_link_urls, element.value, @options[:linkable_accounts])
+
+        if @options[:custom_emojis]
+          Formatter.instance.send(:encode_custom_emojis, html, @options[:custom_emojis], @options[:autoplay])
+        else
+          html
+        end
+      end
+    end
+  end
+end

--- a/lib/kramdown/parser/mastodon.rb
+++ b/lib/kramdown/parser/mastodon.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'kramdown/parser'
+
+module Kramdown
+  module Parser
+    class Mastodon < Kramdown
+      def initialize(source, options)
+        super
+
+        @block_parsers = %i(blank_line paragraph)
+        @span_parsers  = %i(no_intra_emphasis codespan immediate_line_break escaped_chars)
+      end
+
+      def parse_immediate_line_break
+        @tree.children << Element.new(:br, nil, nil, location: @src.current_line_number)
+        @src.pos += @src.matched_size
+      end
+
+      define_parser(:immediate_line_break, /\n/, '\n')
+
+      def parse_no_intra_emphasis
+        start_line_number = @src.current_line_number
+        saved_pos         = @src.save_pos
+
+        result  = @src.scan(EMPHASIS_START)
+        element = (result.length == 2 ? :strong : :em)
+        type    = result[0..0]
+
+        if (@src.pre_match =~ /[[:alpha:]-]\z/) || @src.check(/\s/) || @tree.type == element || @stack.any? { |el, _| el.type == element }
+          add_text(result)
+          return
+        end
+
+        sub_parse = lambda do |delim, elem|
+          el      = Element.new(elem, nil, nil, location: start_line_number)
+          stop_re = /#{Regexp.escape(delim)}/
+
+          found = parse_spans(el, stop_re) do
+            (@src.pre_match[-1, 1] !~ /\s/) &&
+              (elem != :em || !@src.match?(/#{Regexp.escape(delim * 2)}(?!#{Regexp.escape(delim)})/)) &&
+              (type != '_' || !@src.match?(/#{Regexp.escape(delim)}[[:alnum:]]/)) && !el.children.empty?
+          end
+
+          [found, el, stop_re]
+        end
+
+        found, el, stop_re = sub_parse.call(result, element)
+
+        if !found && element == :strong && @tree.type != :em
+          @src.revert_pos(saved_pos)
+          @src.pos += 1
+          found, el, stop_re = sub_parse.call(type, :em)
+        end
+
+        if found
+          @src.scan(stop_re)
+          @tree.children << el
+        else
+          @src.revert_pos(saved_pos)
+          @src.pos += result.length
+          add_text(result)
+        end
+      end
+
+      define_parser(:no_intra_emphasis, EMPHASIS_START, '\*|_')
+    end
+  end
+end

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -220,10 +220,10 @@ RSpec.describe Formatter do
     end
 
     context 'given an invalid URL' do
-      let(:text) { 'http://www\.google\.com' }
+      let(:text) { 'http://www%.google%.com' }
 
       it 'outputs the raw URL' do
-        is_expected.to eq '<p>http://www\.google\.com</p>'
+        is_expected.to eq '<p>http://www%.google%.com</p>'
       end
     end
 
@@ -312,12 +312,83 @@ RSpec.describe Formatter do
       end
 
       context do
-        subject do
-          status = Fabricate(:status, text: text, uri: nil)
-          Formatter.instance.format(status)
+        let(:status) { Fabricate(:status, text: text, uri: nil) }
+
+        subject { Formatter.instance.format(status) }
+
+        context 'given a line break' do
+          let(:text) { "Foo\nbar" }
+
+          it 'creates a line break' do
+            is_expected.to eq '<p>Foo<br />bar</p>'
+          end
+        end
+
+        context 'given two line breaks' do
+          let(:text) { "Foo\n\nbar" }
+
+          it 'creates paragraphs' do
+            is_expected.to eq '<p>Foo</p><p>bar</p>'
+          end
         end
 
         include_examples 'encode and link URLs'
+
+        context 'given text surrounded by *' do
+          let(:text) { 'Foo *bar*' }
+
+          it 'creates emphasis' do
+            is_expected.to include '<em>bar</em>'
+          end
+        end
+
+        context 'given words that include *' do
+          let(:text) { 'Hello w*rl*' }
+
+          it 'leaves the * alone' do
+            is_expected.to include text
+          end
+        end
+
+        context 'given text surrounded by **' do
+          let(:text) { 'Foo **bar**' }
+
+          it 'creates strong emphasis' do
+            is_expected.to include '<strong>bar</strong>'
+          end
+        end
+
+        context 'given XSS surrounded by *' do
+          let(:text) { 'Foo *<script /> bar*' }
+
+          it 'escapes HTML in emphasis' do
+            is_expected.to include '<em>&lt;script /&gt; bar</em>'
+          end
+        end
+
+        context 'given text surrounded by `' do
+          let(:text) { 'Foo `bar`' }
+
+          it 'creates a code span' do
+            is_expected.to include '<code>bar</code>'
+          end
+        end
+
+        context 'given a mention surrounded by `' do
+          let(:status) { Fabricate(:status, text: 'Here is `@alice foo` for example', mentions: [ Fabricate(:mention, account: local_account) ]) }
+
+          it 'creates a code span with unlinked mention' do
+            is_expected.to include '<code>@alice foo</code>'
+          end
+        end
+
+        context 'given a hashtag surrounded by `' do
+          let(:text) { 'Foo `bar #baz`' }
+
+          it 'creates a code span with unlinked hashtag' do
+            is_expected.to include '<code>bar #baz</code>'
+          end
+        end
       end
 
       context 'given a post with custom_emojify option' do


### PR DESCRIPTION
The syntax for bold, italic, and monospace text should solve most use cases present within 500 character microblogs. A similar set of features is present in Facebook and Plurk. Discord and Google+ go beyond, but have a completely different flow. Visual clutter is minimal.

Syntax within code spans is not processed, as expected. Escaping special characters works.

Additionally, support for strike-through text from other platforms.

Fix #853