### PR TITLE
Migrate from uws to cws

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mastodon",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=8 <11"
+    "node": ">=8.12 <12"
   },
   "scripts": {
     "postversion": "git push --tags",
@@ -69,6 +69,7 @@
     "@babel/preset-env": "^7.3.4",
     "@babel/preset-react": "^7.0.0",
     "@babel/runtime": "^7.3.4",
+    "@clusterws/cws": "^0.14.0",
     "array-includes": "^3.0.3",
     "autoprefixer": "^9.4.10",
     "axios": "^0.18.0",
@@ -157,7 +158,6 @@
     "tiny-queue": "^0.2.1",
     "uglifyjs-webpack-plugin": "^2.1.2",
     "uuid": "^3.1.0",
-    "uws": "10.148.0",
     "webpack": "^4.29.6",
     "webpack-assets-manifest": "^3.1.1",
     "webpack-bundle-analyzer": "^3.1.0",

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -7,7 +7,7 @@ const redis = require('redis');
 const pg = require('pg');
 const log = require('npmlog');
 const url = require('url');
-const WebSocket = require('uws');
+const { WebSocketServer } = require('@clusterws/cws');
 const uuid = require('uuid');
 const fs = require('fs');
 
@@ -536,19 +536,12 @@ const startWorker = (workerId) => {
     });
   });
 
-  const wss = new WebSocket.Server({ server, verifyClient: wsVerifyClient });
+  const wss = new WebSocketServer({ server, verifyClient: wsVerifyClient });
 
-  wss.on('connection', ws => {
-    const req      = ws.upgradeReq;
+  wss.on('connection', (ws, req) => {
     const location = url.parse(req.url, true);
     req.requestId  = uuid.v4();
     req.remoteAddress = ws._socket.remoteAddress;
-
-    ws.isAlive = true;
-
-    ws.on('pong', () => {
-      ws.isAlive = true;
-    });
 
     let channel;
 
@@ -610,17 +603,7 @@ const startWorker = (workerId) => {
     }
   });
 
-  setInterval(() => {
-    wss.clients.forEach(ws => {
-      if (ws.isAlive === false) {
-        ws.terminate();
-        return;
-      }
-
-      ws.isAlive = false;
-      ws.ping('', false, true);
-    });
-  }, 30000);
+  wss.startAutoPing(30000);
 
   attachServerWithConfig(server, address => {
     log.info(`Worker ${workerId} now listening on ${address}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,6 +782,11 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@clusterws/cws@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@clusterws/cws/-/cws-0.14.0.tgz#242824b6884454001340222a836db6f6c5e62bfb"
+  integrity sha512-knZj3KZNHIAGsX7TUc/0Q5gcx2bKMMcTPsAOZomLKdK5a4o/umKFlttWRH84Yr1nVlQy+UMO23qfDR8gRZ/4cw==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"
@@ -9268,11 +9273,6 @@ uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
-
-uws@10.148.0:
-  version "10.148.0"
-  resolved "https://registry.yarnpkg.com/uws/-/uws-10.148.0.tgz#3fcd35f083ca515e091cd33b2d78f0f51a666215"
-  integrity sha512-aJpFgMMyxubiE/ll4nj9nWoQbv0HzZZDWXfwyu78nuFObX0Zoyv3TWjkqKPQ1vb2sMPZoz67tri7QNE6dybNmQ==
 
 v8-compile-cache@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Since uws is no longer maintained, we suggest using cws, which is a fork of uws instead. Since cws requires node v8.12 or later, the lower limit of node is changed.
The upper limit is changed to less than node v12 because installation of fibers fails on node v12. Updating the fibers version to v4 is expected to enable installation on node v12, but fibers v4 requires node v10 or higher. So, this PR only makes changes related to cws.
