### PR TITLE
Retry ActivityPub inbox delivery on HTTP 401 and 408 errors

### DIFF
--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -51,7 +51,7 @@ class ActivityPub::DeliveryWorker
   end
 
   def response_error_unsalvageable?(response)
-    (400...500).cover?(response.code) && response.code != 429
+    (400...500).cover?(response.code) && ![401, 408, 429].include?(response.code)
   end
 
   def failure_tracker


### PR DESCRIPTION
HTTP 401 responses returned by Mastodon's inbox controller may
be temporary if, for instance, the requesting user's actor/key json
could not be retrieved in a timely fashion. This changes allow retries
instead of dropping the message entirely.

Also added HTTP 408 as that error is by nature temporary.