### PR TITLE
Add sponsor button to GitHub web UI

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+patreon: mastodon
+open_collective: mastodon


### PR DESCRIPTION
- https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository

Requires enable sponsorships from [Settings](https://github.com/tootsuite/mastodon/settings).