### PR TITLE
Fix possible race condition when processing statuses

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -267,7 +267,11 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   def conversation_from_uri(uri)
     return nil if uri.nil?
     return Conversation.find_by(id: OStatus::TagManager.instance.unique_tag_to_local_id(uri, 'Conversation')) if OStatus::TagManager.instance.local_id?(uri)
-    Conversation.find_by(uri: uri) || Conversation.create(uri: uri)
+    begin
+      Conversation.find_or_create_by!(uri: uri)
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+      retry
+    end
   end
 
   def visibility_from_audience


### PR DESCRIPTION
Fixes a possible race condition that could potentially lead to silently dropped statuses if two statuses of a same conversation are processed together.

I am not completely sure this is actually why some jobs used to fail with `ActiveRecord::RecordInvalid: Validation failed: Uri has already been taken` (and are now ignored because of `ActiveRecord::RecordInvalid` is ignored), but my hunch is the following:
- `Conversation.find_by(uri: uri) || Conversation.create(uri: uri)` validation occasionally fails, returning an initialized but not saved object outside the main transaction
- `Status.create!` raised the error because the `Conversation` object would fail validation

In that case, the status would not be saved to the database, and the job wouldn't rerun because `ActiveRecord::RecordInvalid` is silently discarded (honestly, this kind of stuff is why I was against *silently* discarding them). A rerun in this case would work because `Conversation.find_by(uri: uri) || Conversation.create(uri: uri)` would find the pre-existing conversation.

This PR makes sure the `Conversation` object is created before passing it to `Status.create!` in the main transaction.