### PR TITLE
Avoid cutting bottom of letters of last paragraph of statuses

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -710,7 +710,7 @@
     white-space: pre-wrap;
 
     &:last-child {
-      margin-bottom: 0;
+      margin-bottom: 2px;
     }
   }
 


### PR DESCRIPTION
Before/after:

![Screenshot_2019-05-24 Eldritch Café](https://user-images.githubusercontent.com/2446451/58357675-00719900-7e7c-11e9-98d3-d2a519b71b6b.png) ![Screenshot_2019-05-24 Eldritch Café (2)](https://user-images.githubusercontent.com/2446451/58357709-2b5bed00-7e7c-11e9-99b0-011ce4165f13.png)