### PR TITLE
Docker: Use precompiled nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,16 @@ FROM ubuntu:18.04 as build-dep
 SHELL ["bash", "-c"]
 
 # Install Node
-ENV NODE_VER="8.15.0"
 RUN	echo "Etc/UTC" > /etc/localtime && \
 	apt update && \
-	apt -y dist-upgrade && \
-	apt -y install wget make gcc g++ python && \
-	cd ~ && \
-	wget https://nodejs.org/download/release/v$NODE_VER/node-v$NODE_VER.tar.gz && \
-	tar xf node-v$NODE_VER.tar.gz && \
-	cd node-v$NODE_VER && \
-	./configure --prefix=/opt/node && \
-	make -j$(nproc) > /dev/null && \
-	make install
+	apt -y install wget && \
+	wget -O - https://deb.nodesource.com/setup_8.x | bash - && \
+	apt install -y nodejs
 
 # Install jemalloc
 ENV JE_VER="5.1.0"
 RUN apt update && \
-	apt -y install autoconf && \
+	apt -y install autoconf gcc make && \
 	cd ~ && \
 	wget https://github.com/jemalloc/jemalloc/archive/$JE_VER.tar.gz && \
 	tar xf $JE_VER.tar.gz && \
@@ -50,7 +43,7 @@ RUN apt update && \
 	make -j$(nproc) > /dev/null && \
 	make install
 
-ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin"
+ENV PATH="${PATH}:/opt/ruby/bin"
 
 RUN npm install -g yarn && \
 	gem install bundler && \
@@ -67,12 +60,11 @@ RUN cd /opt/mastodon && \
 FROM ubuntu:18.04
 
 # Copy over all the langs needed for runtime
-COPY --from=build-dep /opt/node /opt/node
 COPY --from=build-dep /opt/ruby /opt/ruby
 COPY --from=build-dep /opt/jemalloc /opt/jemalloc
 
 # Add more PATHs to the PATH
-ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin"
+ENV PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
 
 # Create the mastodon user
 ARG UID=991
@@ -87,12 +79,13 @@ RUN apt update && \
 	echo "mastodon:`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256`" | chpasswd
 
 # Install masto runtime deps
-RUN apt -y --no-install-recommends install \
-	  libssl1.1 libpq5 imagemagick ffmpeg \
-	  libicu60 libprotobuf10 libidn11 libyaml-0-2 \
+RUN wget -O - https://deb.nodesource.com/setup_8.x | bash - && \
+		apt -y --no-install-recommends install \
+	  libssl1.1 libpq5 imagemagick ffmpeg nodejs \
+	  libicu60 libprotobuf10 libidn11 libyaml-0-2 gcc \
 	  file ca-certificates tzdata libreadline7 && \
-	apt -y install gcc && \
 	ln -s /opt/mastodon /mastodon && \
+	npm install -g yarn && \
 	gem install bundler && \
 	rm -rf /var/cache && \
 	rm -rf /var/lib/apt


### PR DESCRIPTION
I replaced the manual compile of nodejs, which is not necessary in my opinion with precompiled packages from https://github.com/nodesource/distributions.

Original it took almost 7.5 minutes for node to compile.
````
 => [build-dep 2/7] RUN ECHO "Etc/UTC" > /etc/localtime &&  apt update &&  apt -y dist-upgrade &&  apt -y install w  444.2s
````
Now it takes about 0.5 minute.
````
 => [build-dep 2/7] RUN ECHO "Etc/UTC" > /etc/localtime &&  apt update &&  apt -y install wget &&  wget -O - https:/  32.2s
````
Keep it mind that we need to double that cause we need to reinstall nodejs in the production container. We could copy over nodejs but this is the saver way. Also I moved ``gcc`` and ``make`` to the ``jemalloc`` installation step. This needs possible to move again depending if my other PR gets merged first or at all. This makes the metrics a bit less convincing but still we should save around 5 minutes on a typical developer machine.

Testing done on a i7-4790 @ 3.60 GHz, 32 GB RAM, Samsung 860 EVO 1 TB, 25 Mbit down connection

Edit: This also install node 8.16.X. As this is a minor update I do not expect it to break anything. I saw other can run mastodon on node 10.X so this should be totally fine.