### PR TITLE
Add a featured link

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -28,6 +28,10 @@ class Form::AdminSettings
     thumbnail
     hero
     mascot
+    featured_link
+    featured_link_address
+    featured_link_title
+    featured_link_desc
   ).freeze
 
   BOOLEAN_KEYS = %i(
@@ -39,6 +43,7 @@ class Form::AdminSettings
     show_known_fediverse_at_about_page
     preview_sensitive_media
     profile_directory
+    featured_link
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -9,6 +9,9 @@ class InstancePresenter
     :site_extended_description,
     :site_terms,
     :closed_registrations_message,
+    :featured_link_address,
+    :featured_link_title,
+    :featured_link_desc,
     to: Setting
   )
 

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -43,6 +43,14 @@
               = fa_icon 'tablet fw'
               = t('about.get_apps')
               %small= t('about.apps_platforms')
+        
+        - if Setting.featured_link
+          .directory__tag
+            = link_to @instance_presenter.featured_link_address, target: '_blank', rel: 'noopener' do
+              %h4
+                = fa_icon 'external-link fw'
+                = @instance_presenter.featured_link_title
+                %small= @instance_presenter.featured_link_desc
 
     .landing__grid__column.landing__grid__column-login
       .box-widget

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -77,5 +77,13 @@
     = f.input :site_terms, wrapper: :with_block_label, as: :text, label: t('admin.settings.site_terms.title'), hint: t('admin.settings.site_terms.desc_html'), input_html: { rows: 8 }
     = f.input :custom_css, wrapper: :with_block_label, as: :text, input_html: { rows: 8 }, label: t('admin.settings.custom_css.title'), hint: t('admin.settings.custom_css.desc_html')
 
+  %hr.spacer/
+
+  .fields-group
+    = f.input :featured_link, as: :boolean, wrapper: :with_label, label: t('admin.settings.featured_link.title'), hint: t('admin.settings.featured_link.desc_html')
+    = f.input :featured_link_address, wrapper: :with_block_label, label: t('admin.settings.featured_link_address.title')
+    = f.input :featured_link_title, wrapper: :with_block_label, label: t('admin.settings.featured_link_title.title')
+    = f.input :featured_link_desc, wrapper: :with_block_label, label: t('admin.settings.featured_link_desc.title')
+
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -401,12 +401,12 @@ en:
       featured_link:
         desc_html: You can show a featured link on the frontpage.
         title: Featured link
+      featured_link_address:
+        title: Featured link URL
       featured_link_desc:
         title: Featured link description
       featured_link_title:
         title: Featured link title
-      featured_link_address:
-        title: Featured link URL
       hero:
         desc_html: Displayed on the frontpage. At least 600x100px recommended. When not set, falls back to server thumbnail
         title: Hero image

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,6 +398,15 @@ en:
       custom_css:
         desc_html: Modify the look with CSS loaded on every page
         title: Custom CSS
+      featured_link:
+        desc_html: You can show a featured link on the frontpage.
+        title: Featured link
+      featured_link_desc:
+        title: Featured link description
+      featured_link_title:
+        title: Featured link title
+      featured_link_address:
+        title: Featured link URL
       hero:
         desc_html: Displayed on the frontpage. At least 600x100px recommended. When not set, falls back to server thumbnail
         title: Hero image

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -401,12 +401,12 @@ ja:
       featured_link:
         desc_html: フロントページに独自のリンクボタンを置くことができます
         title: カスタムリンク
+      featured_link_address:
+        title: カスタムリンクのアドレス
       featured_link_desc:
         title: カスタムリンクの説明
       featured_link_title:
         title: カスタムリンクのタイトル
-      featured_link_address:
-        title: カスタムリンクのアドレス
       hero:
         desc_html: フロントページに表示されます。サイズは600x100px以上推奨です。未設定の場合、標準のサムネイルが使用されます
         title: ヒーローイメージ

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -398,6 +398,15 @@ ja:
       custom_css:
         desc_html: 全ページに適用されるCSSの編集
         title: カスタムCSS
+      featured_link:
+        desc_html: フロントページに独自のリンクボタンを置くことができます
+        title: カスタムリンク
+      featured_link_desc:
+        title: カスタムリンクの説明
+      featured_link_title:
+        title: カスタムリンクのタイトル
+      featured_link_address:
+        title: カスタムリンクのアドレス
       hero:
         desc_html: フロントページに表示されます。サイズは600x100px以上推奨です。未設定の場合、標準のサムネイルが使用されます
         title: ヒーローイメージ

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,6 +15,7 @@ defaults: &defaults
   open_deletion: true
   min_invite_role: 'admin'
   timeline_preview: true
+  featured_link: false
   show_staff_badge: true
   default_sensitive: false
   hide_network: false


### PR DESCRIPTION
## What's this request?

Add a featured link on the frontpage.  
It can be used for a link to a funding, a status page, a community wiki or something.  

## Screenshots
![clink2](https://user-images.githubusercontent.com/17561618/58372259-03d95300-7f56-11e9-82df-21d5223c6d76.png)  
![clink1](https://user-images.githubusercontent.com/17561618/58372260-03d95300-7f56-11e9-96e3-dc8f28adb58d.png)
