### PR TITLE
Docker: Keep /var/lib/apt/ to keep apt working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN apt -y --no-install-recommends install \
 	ln -s /opt/mastodon /mastodon && \
 	gem install bundler && \
 	rm -rf /var/cache && \
-	rm -rf /var/lib/apt
+	rm -rf /var/lib/apt/lists/*
 
 # Add tini
 ENV TINI_VERSION="0.18.0"


### PR DESCRIPTION
I like to exec into containers to debug them. Almost all the time I need to install something with apt. If we remove ``/var/cache/apt/archives/partial`` apt complains about that and refuses to run until I create the directory. It is better to keep it and only remove ``/var/lib/apt/lists/*`` as it contains the cached lists. The remaining folders are less than 1MB in sum and this is considered best practice.