### PR TITLE
Setup: Fix SMTP /w OpenSSL verify peer unable to get local issuer certificate

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -285,6 +285,7 @@ namespace :mastodon do
             domain:               env['LOCAL_DOMAIN'],
             authentication:       env['SMTP_AUTH_METHOD'] == 'none' ? nil : env['SMTP_AUTH_METHOD'] || :plain,
             openssl_verify_mode:  env['SMTP_OPENSSL_VERIFY_MODE'],
+            ca_file:              '/etc/ssl/certs/ca-certificates.crt',
             enable_starttls_auto: true,
           }
 


### PR DESCRIPTION
When I tried setup SMTP in the Docker container I kept getting this Error:
````
E-mail could not be sent with this configuration, try again.
SSL_connect returned=1 errno=0 state=error: certificate verify failed (unable to get local issuer certificate)
````
I know for a fact that my SMTP configuration was correct as I use it for another service.
I found this fix https://stackoverflow.com/a/36526541/4446318 and this in the code https://github.com/tootsuite/mastodon/search?q=SMTP_CA_FILE&unscoped_q=SMTP_CA_FILE .

I am unsure if we should set this to a ``ENV`` and ask the user about the file? The last one would support self signed certificated on the SMTP server side but this is quite niche and could overwhelm the end user.