### PR TITLE
In basic UI, bring 2-column view to the center

### DIFF
--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -136,5 +136,6 @@ button {
     align-items: center;
     justify-content: center;
     outline: 0 !important;
+    overflow-x: auto;
   }
 }

--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -38,7 +38,7 @@ body {
     width: 100%;
     height: 100%;
     padding: 0;
-    background: $ui-base-color;
+    background: darken($ui-base-color, 7%);
 
     &.with-modals--active {
       overflow-y: hidden;
@@ -132,7 +132,6 @@ button {
   &,
   & > div {
     display: flex;
-    width: 100%;
     height: 100%;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Fix the layout of the new basic UI where columns are justified to the right when 2 columns are shown.