### PR TITLE
Change default to single column UI

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -31,7 +31,7 @@ defaults: &defaults
   noindex: false
   theme: 'default'
   aggregate_reblogs: true
-  advanced_layout: true
+  advanced_layout: false
   notification_emails:
     follow: false
     reblog: false

--- a/db/migrate/20190529143559_preserve_old_layout_for_existing_users.rb
+++ b/db/migrate/20190529143559_preserve_old_layout_for_existing_users.rb
@@ -1,0 +1,17 @@
+class PreserveOldLayoutForExistingUsers < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    # Assume that currently active users are already using the layout that they
+    # want to use, therefore ensure that it is saved explicitly and not based
+    # on the to-be-changed default
+
+    User.where(User.arel_table[:current_sign_in_at].gteq(1.month.ago)).find_each do |user|
+      next if Setting.unscoped.where(thing_type: 'User', thing_id: user.id, var: 'advanced_layout').exists?
+      user.settings.advanced_layout = true
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_19_130537) do
+ActiveRecord::Schema.define(version: 2019_05_29_143559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Keeps current setting for people who have been active within the month preceding the database migration, if they were relying on the default value.