### PR TITLE
Improve Preferences Page

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -12,6 +12,14 @@ code {
 }
 
 .simple_form {
+
+  .heading {
+    font-size: 25px;
+    margin-bottom: 20px;
+    color: $darker-text-color;
+    font-weight: 700;
+  }
+
   .input {
     margin-bottom: 15px;
     overflow: hidden;

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -22,6 +22,7 @@
 #  application_id         :bigint(8)
 #  in_reply_to_account_id :bigint(8)
 #  poll_id                :bigint(8)
+#  local_only             :boolean
 #
 
 class Status < ApplicationRecord

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -2,25 +2,19 @@
   = t('settings.preferences')
 
 %ul.quick-nav
-  %li= link_to t('preferences.languages'), '#settings_languages'
   %li= link_to t('preferences.publishing'), '#settings_publishing'
   %li= link_to t('preferences.other'), '#settings_other'
   %li= link_to t('preferences.web'), '#settings_web'
+  %li= link_to t('preferences.languages'), '#settings_languages'
   %li= link_to t('settings.notifications'), settings_notifications_path
 
 = simple_form_for current_user, url: settings_preferences_path, html: { method: :put } do |f|
   = render 'shared/error_messages', object: current_user
 
-  .fields-row#settings_languages
-    .fields-group.fields-row__column.fields-row__column-6
-      = f.input :locale, collection: I18n.available_locales, wrapper: :with_label, include_blank: false, label_method: lambda { |locale| human_locale(locale) }, selected: I18n.locale
-    .fields-group.fields-row__column.fields-row__column-6
-      = f.input :setting_default_language, collection: [nil] + filterable_languages.sort, wrapper: :with_label, label_method: lambda { |locale| locale.nil? ? I18n.t('statuses.language_detection') : human_locale(locale) }, required: false, include_blank: false
-
-  .fields-group
-    = f.input :chosen_languages, collection: filterable_languages.sort, wrapper: :with_block_label, include_blank: false, label_method: lambda { |locale| human_locale(locale) }, required: false, as: :check_boxes, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
-
   %hr#settings_publishing/
+
+  .heading
+    = t('preferences.publishing')
 
   .fields-group
     = f.input :setting_default_privacy, collection: Status.selectable_visibilities, wrapper: :with_floating_label, include_blank: false, label_method: lambda { |visibility| safe_join([I18n.t("statuses.visibilities.#{visibility}"), content_tag(:span, I18n.t("statuses.visibilities.#{visibility}_long"), class: 'hint')]) }, required: false, as: :radio_buttons, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
@@ -28,6 +22,9 @@
     = f.input :setting_default_sensitive, as: :boolean, wrapper: :with_label
 
   %hr#settings_other/
+
+  .heading
+    = t('preferences.other')
 
   .fields-group
     = f.input :setting_noindex, as: :boolean, wrapper: :with_label
@@ -39,6 +36,9 @@
     = f.input :setting_show_application, as: :boolean, wrapper: :with_label
 
   %hr#settings_web/
+
+  .heading
+    = t('preferences.web')
 
   .fields-row
     .fields-group.fields-row__column.fields-row__column-6
@@ -62,6 +62,20 @@
     = f.input :setting_expand_spoilers, as: :boolean, wrapper: :with_label
     = f.input :setting_reduce_motion, as: :boolean, wrapper: :with_label
     = f.input :setting_system_font_ui, as: :boolean, wrapper: :with_label
+
+  %hr#settings_languages
+
+  .heading
+    = t('preferences.languages')
+
+  .fields-row
+    .fields-group.fields-row__column.fields-row__column-6
+      = f.input :locale, collection: I18n.available_locales, wrapper: :with_label, include_blank: false, label_method: lambda { |locale| human_locale(locale) }, selected: I18n.locale
+    .fields-group.fields-row__column.fields-row__column-6
+      = f.input :setting_default_language, collection: [nil] + filterable_languages.sort, wrapper: :with_label, label_method: lambda { |locale| locale.nil? ? I18n.t('statuses.language_detection') : human_locale(locale) }, required: false, include_blank: false
+
+  .fields-group
+    = f.input :chosen_languages, collection: filterable_languages.sort, wrapper: :with_block_label, include_blank: false, label_method: lambda { |locale| human_locale(locale) }, required: false, as: :check_boxes, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_19_130537) do
+ActiveRecord::Schema.define(version: 2019_05_24_221356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -382,9 +382,9 @@ ActiveRecord::Schema.define(version: 2019_05_19_130537) do
   create_table "mutes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "hide_notifications", default: true, null: false
     t.bigint "account_id", null: false
     t.bigint "target_account_id", null: false
+    t.boolean "hide_notifications", default: true, null: false
     t.index ["account_id", "target_account_id"], name: "index_mutes_on_account_id_and_target_account_id", unique: true
     t.index ["target_account_id"], name: "index_mutes_on_target_account_id"
   end
@@ -625,6 +625,7 @@ ActiveRecord::Schema.define(version: 2019_05_19_130537) do
     t.bigint "application_id"
     t.bigint "in_reply_to_account_id"
     t.bigint "poll_id"
+    t.boolean "local_only"
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20180106", order: { id: :desc }
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"


### PR DESCRIPTION
To a novice user, the preferences page can seem like a huge wall of disorganized options.

This PR improves that with two major changes:
- With language options on top, the user is confronted with a huge wall of checkboxes, which most of the time they just have to scroll past to get to options they may want to change more often.  This moves those options to the bottom so they are out of the way, since they will likely only need to be changed once, on initial setup of your account.
- Each section in the preferences pane is now given header text to help clarify what settings are what and make it easier to identify.

I'm not too familiar with haml, so let me know if I'm doing anything funky with the haml here.

![alt text](https://www.dropbox.com/s/s2tqoz3en4q71h7/Screenshot%202019-05-26%2023.18.40.png?raw=1 "Screenshot of the changes")