### PR TITLE
Increase default privacy settings for new users

### DIFF
--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -4,7 +4,7 @@
 %ul.quick-nav
   %li= link_to t('preferences.languages'), '#settings_languages'
   %li= link_to t('preferences.publishing'), '#settings_publishing'
-  %li= link_to t('preferences.other'), '#settings_other'
+  %li= link_to t('preferences.privacy'), '#settings_privacy'
   %li= link_to t('preferences.web'), '#settings_web'
   %li= link_to t('settings.notifications'), settings_notifications_path
 
@@ -27,7 +27,7 @@
 
     = f.input :setting_default_sensitive, as: :boolean, wrapper: :with_label
 
-  %hr#settings_other/
+  %hr#settings_privacy/
 
   .fields-group
     = f.input :setting_noindex, as: :boolean, wrapper: :with_label

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -4,7 +4,7 @@
 %ul.quick-nav
   %li= link_to t('preferences.languages'), '#settings_languages'
   %li= link_to t('preferences.publishing'), '#settings_publishing'
-  %li= link_to t('preferences.privacy'), '#settings_privacy'
+  %li= link_to t('preferences.other'), '#settings_other'
   %li= link_to t('preferences.web'), '#settings_web'
   %li= link_to t('settings.notifications'), settings_notifications_path
 
@@ -27,7 +27,7 @@
 
     = f.input :setting_default_sensitive, as: :boolean, wrapper: :with_label
 
-  %hr#settings_privacy/
+  %hr#settings_other/
 
   .fields-group
     = f.input :setting_noindex, as: :boolean, wrapper: :with_label

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -778,7 +778,7 @@ en:
       too_many_options: can't contain more than %{max} items
   preferences:
     languages: Languages
-    other: Other
+    privacy: Privacy
     publishing: Publishing
     web: Web
   relationships:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -778,7 +778,7 @@ en:
       too_many_options: can't contain more than %{max} items
   preferences:
     languages: Languages
-    privacy: Privacy
+    other: Privacy
     publishing: Publishing
     web: Web
   relationships:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,7 +17,7 @@ defaults: &defaults
   timeline_preview: true
   show_staff_badge: true
   default_sensitive: false
-  hide_network: false
+  hide_network: true
   unfollow_modal: false
   boost_modal: false
   delete_modal: true
@@ -28,7 +28,7 @@ defaults: &defaults
   reduce_motion: false
   show_application: true
   system_font_ui: false
-  noindex: false
+  noindex: true
   theme: 'default'
   aggregate_reblogs: true
   advanced_layout: true


### PR DESCRIPTION
New users to Mastodon may not realize that their toots may be indexed by search engines, nor that the list of who they choose to follow or who follows them will be made public.  This can lead to users that want this behavior not realizing they can change these options.

For those users that care about this, let's default to a higher level of privacy, so that they can be safer.  Users that want to expose their data can change these options later.

Also changed the "Other" section in Preferences to be named "Privacy" since that's closer to what these 3 options are.