### PR TITLE
Display notifications count on a new single column

### DIFF
--- a/app/javascript/mastodon/reducers/notifications.js
+++ b/app/javascript/mastodon/reducers/notifications.js
@@ -18,7 +18,7 @@ import compareId from '../compare_id';
 const initialState = ImmutableMap({
   items: ImmutableList(),
   hasMore: true,
-  top: true,
+  top: false,
   unread: 0,
   isLoading: false,
 });


### PR DESCRIPTION
The new single column has a function to display the number of notifications, but the number will not increase unless the notification screen has been opened once. When the notification column is opened, `top` changes to true, and when it moves to another column, `top` changes to false. The count is increased when `top` is false, so I changed the initial value to false.
