### PR TITLE
Fix safari post field display issue in single column layout

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1976,6 +1976,7 @@ a.account__display-name {
 .columns-area--mobile {
   flex-direction: column;
   width: 100%;
+  height: 100%;
   margin: 0 auto;
 
   .column,


### PR DESCRIPTION
Fix the problem that the post column is not displayed in safari (iOS and macOS) when the single column layout is displayed with the minimum width.