### PR TITLE
Change compose-panel to scrollable

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2186,6 +2186,7 @@ a.account__display-name {
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow: auto;
 
   .search__input {
     line-height: 18px;


### PR DESCRIPTION
In my laptop environment, “TOOT” button may not fit on the screen via single column layout.
This may also occur in other small screen environments.

So I want to be able to scroll the "compose-panel".
What do you think about this?
![スクリーンショット 2019-05-30 0 50 03](https://user-images.githubusercontent.com/766076/58575117-6dba6b00-827c-11e9-8f89-ae946509191d.png)
