### PR TITLE
Remove dependency on fibers

### DIFF
--- a/config/webpack/rules/css.js
+++ b/config/webpack/rules/css.js
@@ -21,7 +21,6 @@ module.exports = {
     {
       loader: 'sass-loader',
       options: {
-        fiber: require('fibers'),
         implementation: require('sass'),
         sourceMap: true,
       },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "escape-html": "^1.0.3",
     "exif-js": "^2.3.0",
     "express": "^4.17.1",
-    "fibers": "^3.1.1",
     "file-loader": "^3.0.1",
     "font-awesome": "^4.7.0",
     "glob": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,7 +3014,7 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
-detect-libc@^1.0.2, detect-libc@^1.0.3:
+detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -3809,13 +3809,6 @@ fbjs@^0.8.4:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
-
-fibers@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fibers/-/fibers-3.1.1.tgz#0238902ca938347bd779523692fbeefdf4f688ab"
-  integrity sha512-dl3Ukt08rHVQfY8xGD0ODwyjwrRALtaghuqGH2jByYX1wpY+nAnRQjJ6Dbqq0DnVgNVQ9yibObzbF4IlPyiwPw==
-  dependencies:
-    detect-libc "^1.0.3"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"


### PR DESCRIPTION
While dart-sass uses fibers to speed up the synchronization process, dart-sass normally performs asynchronous processing. fibers will need to be built at install time, so remove unnecessary dependencies.