### PR TITLE
Whitelisted federation mode for academic institutions

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -3,6 +3,7 @@
 class AboutController < ApplicationController
   layout 'public'
 
+  skip_before_action :check_access_requirements
   before_action :set_instance_presenter, only: [:show, :more, :terms]
 
   def show

--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::AppsController < Api::BaseController
+  skip_before_action :check_access_requirements
+
   def create
     @app = Doorkeeper::Application.create!(application_options)
     render json: @app, serializer: REST::ApplicationSerializer

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,7 @@ class ApplicationController < ActionController::Base
   rescue_from Mastodon::NotPermittedError, with: :forbidden
 
   before_action :store_current_location, except: :raise_not_found, unless: :devise_controller?
+  before_action :check_access_requirements
   before_action :check_user_permissions, if: :user_signed_in?
 
   def raise_not_found
@@ -34,6 +35,10 @@ class ApplicationController < ActionController::Base
 
   def https_enabled?
     Rails.env.production?
+  end
+
+  def whitelist_mode?
+    Rails.configuration.x.whitelist_mode
   end
 
   def store_current_location
@@ -50,6 +55,10 @@ class ApplicationController < ActionController::Base
 
   def check_user_permissions
     forbidden if current_user.disabled? || current_user.account.suspended?
+  end
+
+  def check_access_requirements
+    forbidden if whitelist_mode? && !current_account
   end
 
   def after_sign_out_path_for(_resource_or_scope)

--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -3,6 +3,8 @@
 class Auth::ConfirmationsController < Devise::ConfirmationsController
   layout 'auth'
 
+  skip_before_action :check_access_requirements
+
   before_action :set_body_classes
   before_action :set_user, only: [:finish_signup]
 

--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :check_access_requirements
   skip_before_action :verify_authenticity_token
 
   def self.provides_callback_for(provider)

--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Auth::PasswordsController < Devise::PasswordsController
+  skip_before_action :check_access_requirements
+
   before_action :check_validity_of_reset_password_token, only: :edit
   before_action :set_body_classes
 

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -3,6 +3,8 @@
 class Auth::RegistrationsController < Devise::RegistrationsController
   layout :determine_layout
 
+  skip_before_action :check_access_requirements
+
   before_action :set_invite, only: [:new, :create]
   before_action :check_enabled_registrations, only: [:new, :create]
   before_action :configure_sign_up_params, only: [:create]

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -7,7 +7,10 @@ class Auth::SessionsController < Devise::SessionsController
 
   skip_before_action :require_no_authentication, only: [:create]
   skip_before_action :check_user_permissions, only: [:destroy]
+  skip_before_action :check_access_requirements
+
   prepend_before_action :authenticate_with_two_factor, if: :two_factor_enabled?, only: [:create]
+
   before_action :set_instance_presenter, only: [:new]
   before_action :set_body_classes
 

--- a/app/controllers/custom_css_controller.rb
+++ b/app/controllers/custom_css_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class CustomCssController < ApplicationController
+  skip_before_action :check_access_requirements
   before_action :set_cache_headers
 
   def show

--- a/app/models/domain_allow.rb
+++ b/app/models/domain_allow.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # == Schema Information
 #
 # Table name: domain_allows

--- a/app/models/domain_allow.rb
+++ b/app/models/domain_allow.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: domain_allows
+#
+#  id         :bigint(8)        not null, primary key
+#  domain     :string           default(""), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class DomainAllow < ApplicationRecord
+  include DomainNormalizable
+
+  def self.allowed?(domain)
+    where(domain: domain).exists?
+  end
+end

--- a/app/serializers/activitypub/bare_actor_serializer.rb
+++ b/app/serializers/activitypub/bare_actor_serializer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ActivityPub::BareActorSerializer < ActivityPub::Serializer
+  include RoutingHelper
+
+  context :security
+
+  attributes :id, :type, :inbox
+
+  has_one :public_key, serializer: ActivityPub::PublicKeySerializer
+  has_one :endpoints, serializer: ActivityPub::ActorSerializer::EndpointsSerializer
+
+  def id
+    account_url(object)
+  end
+
+  def type
+    object.bot? ? 'Service' : 'Person'
+  end
+
+  def inbox
+    account_inbox_url(object)
+  end
+
+  def endpoints
+    object
+  end
+
+  def preferred_username
+    object.username
+  end
+
+  def public_key
+    object
+  end
+end

--- a/app/services/concerns/payloadable.rb
+++ b/app/services/concerns/payloadable.rb
@@ -14,6 +14,6 @@ module Payloadable
   end
 
   def signing_enabled?
-    true
+    !Rails.configuration.x.whitelist_mode
   end
 end

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -48,7 +48,7 @@ class ResolveAccountService < BaseService
       return
     end
 
-    return if links_missing?
+    return if links_missing? || domain_not_whitelisted?
     return Account.find_local(@username) if TagManager.instance.local_domain?(@domain)
 
     RedisLock.acquire(lock_options) do |lock|
@@ -75,6 +75,10 @@ class ResolveAccountService < BaseService
 
   def links_missing?
     !(activitypub_ready? || ostatus_ready?)
+  end
+
+  def domain_not_whitelisted?
+    Rails.configuration.x.whitelist_mode && !DomainAllow.allowed?(@domain)
   end
 
   def ostatus_ready?

--- a/db/migrate/20190531113248_create_domain_allows.rb
+++ b/db/migrate/20190531113248_create_domain_allows.rb
@@ -1,0 +1,9 @@
+class CreateDomainAllows < ActiveRecord::Migration[5.2]
+  def change
+    create_table :domain_allows do |t|
+      t.string :domain, default: '', null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_29_143559) do
+ActiveRecord::Schema.define(version: 2019_05_31_113248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -234,6 +234,13 @@ ActiveRecord::Schema.define(version: 2019_05_29_143559) do
     t.datetime "updated_at", null: false
     t.boolean "whole_word", default: true, null: false
     t.index ["account_id"], name: "index_custom_filters_on_account_id"
+  end
+
+  create_table "domain_allows", force: :cascade do |t|
+    t.string "domain", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["domain"], name: "index_domain_allows_on_domain", unique: true
   end
 
   create_table "domain_blocks", force: :cascade do |t|

--- a/spec/fabricators/domain_allow_fabricator.rb
+++ b/spec/fabricators/domain_allow_fabricator.rb
@@ -1,0 +1,3 @@
+Fabricator(:domain_allow) do
+  domain "MyString"
+end

--- a/spec/models/domain_allow_spec.rb
+++ b/spec/models/domain_allow_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DomainAllow, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Schools and universities want to teach students how to use social media in a controlled environment. For the safety of the students, data in- and output must be tightly controlled.

In "whitelist mode":

- [x] Public pages cannot be viewed without authentication
- [x] API access is not possible without a user-owned access token (no app-only access)
- [x] ActivityPub resources cannot be accessed without a HTTP signature \*
- [x] Accounts that do not belong to a whitelisted domain are not processed
- [x] ActivityPub actor JSON remains public, but returns the bare minimum without authentication

The risk of this mode is if it gains widespread adoption in non-academic contexts, thereby making entering the federation with a new server impractical. That would lead to the centralization around a few existing servers in the long term.

My risk mitigation is that the mode should have a "penalty" in the form of a clearly distinguishable branding that makes it clear to any visitor that they are looking at a standalone space and not at the fediverse / open web / Mastodon network.

Fix #3880

___

Pathways that can still be accessed without authentication:

- Webfinger
- Host-meta
- App creation API
- About, terms
- Login, sign up, forgotten password, e-mail confirmation
- ActivityPub actor JSON (bare minimum version)

___

TODO:

- [ ] Authenticate GETs of actor JSON
- [ ] Change frontpage to clearly communicate it's not part of the wider fediverse when in this mode
- [ ] Add tests