### PR TITLE
Remove dependency on history

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "file-loader": "^3.0.1",
     "font-awesome": "^4.7.0",
     "glob": "^7.1.1",
-    "history": "^4.7.2",
     "http-link-header": "^1.0.2",
     "immutable": "^3.8.2",
     "imports-loader": "^0.8.0",


### PR DESCRIPTION
`history` is an unnecessary dependency because another package depends on it.

Close #10909