### PR TITLE
Bring 2-column view to the center without side effect

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1794,7 +1794,6 @@ a.account__display-name {
     height: 100%;
 
     &__pane {
-      flex: 1 1 auto;
       height: 100%;
       overflow: hidden;
       pointer-events: none;


### PR DESCRIPTION
Fix the layout of the new basic UI where columns are justified to the right when 2 columns are shown, removing all side effects caused by https://github.com/tootsuite/mastodon/pull/10843 .