### PR TITLE
Revert "Bump react-redux-loading-bar from 4.0.8 to 4.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "react-notification": "^6.8.4",
     "react-overlays": "^0.8.3",
     "react-redux": "^6.0.1",
-    "react-redux-loading-bar": "^4.2.0",
+    "react-redux-loading-bar": "^4.0.8",
     "react-router-dom": "^4.1.1",
     "react-router-scroll-4": "^1.0.0-beta.1",
     "react-select": "^2.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7827,10 +7827,10 @@ react-overlays@^0.8.3:
     react-transition-group "^2.2.0"
     warning "^3.0.0"
 
-react-redux-loading-bar@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/react-redux-loading-bar/-/react-redux-loading-bar-4.2.0.tgz#491469bcdcbc54366f502e1a6a685b324807a45a"
-  integrity sha512-UkdBa7973LtJu86Aq9v0sdoBPuMR5S3hgQj3prpBUvz4IZjxh11ZP2gc4rzotr4atmKCdQoN1WRuBnazUAq5/A==
+react-redux-loading-bar@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/react-redux-loading-bar/-/react-redux-loading-bar-4.0.8.tgz#e84d59d1517b79f53b0f39c8ddb40682af648c1b"
+  integrity sha512-BpR1tlYrYKFtGhxa7nAKc0dpcV33ZgXJ/jKNLpDDaxu2/cCxbkWQt9YlWT+VLw1x/7qyNYY4DH48bZdtmciSpg==
   dependencies:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.2"


### PR DESCRIPTION
Reverts tootsuite/mastodon#10897

see https://github.com/tootsuite/mastodon/commit/9ab053a4b47f971192be1e4215eaf0b2fa2f69b7#commitcomment-33762504