### PR TITLE
Ignore toot language

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -36,6 +36,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_default_privacy,
       :setting_default_sensitive,
       :setting_default_language,
+      :setting_ignore_toot_language,
       :setting_unfollow_modal,
       :setting_boost_modal,
       :setting_delete_modal,

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -17,7 +17,7 @@ import { HotKeys } from 'react-hotkeys';
 import classNames from 'classnames';
 import Icon from 'mastodon/components/icon';
 import PollContainer from 'mastodon/containers/poll_container';
-import { displayMedia } from '../initial_state';
+import { displayMedia, ignoreLanguage } from '../initial_state';
 
 // We use the component (and not the container) since we do not want
 // to use the progress bar to show download progress
@@ -424,7 +424,7 @@ class Status extends ImmutablePureComponent {
               </a>
             </div>
 
-            <StatusContent status={status} onClick={this.handleClick} expanded={!status.get('hidden')} onExpandedToggle={this.handleExpandedToggle} collapsable />
+            <StatusContent status={status} ignoreLang={ignoreLanguage} onClick={this.handleClick} expanded={!status.get('hidden')} onExpandedToggle={this.handleExpandedToggle} collapsable />
 
             {media}
 

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -17,6 +17,7 @@ export default class StatusContent extends React.PureComponent {
 
   static propTypes = {
     status: ImmutablePropTypes.map.isRequired,
+    ignoreLang: PropTypes.bool,
     expanded: PropTypes.bool,
     onExpandedToggle: PropTypes.func,
     onClick: PropTypes.func,
@@ -138,7 +139,7 @@ export default class StatusContent extends React.PureComponent {
   }
 
   render () {
-    const { status } = this.props;
+    const { status, ignoreLang } = this.props;
 
     if (status.get('content').length === 0) {
       return null;
@@ -183,14 +184,14 @@ export default class StatusContent extends React.PureComponent {
       return (
         <div className={classNames} ref={this.setRef} tabIndex='0' style={directionStyle} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp}>
           <p style={{ marginBottom: hidden && status.get('mentions').isEmpty() ? '0px' : null }}>
-            <span dangerouslySetInnerHTML={spoilerContent} lang={status.get('language')} />
+            <span dangerouslySetInnerHTML={spoilerContent} lang={ignoreLang ? '' : status.get('language')} />
             {' '}
             <button tabIndex='0' className={`status__content__spoiler-link ${hidden ? 'status__content__spoiler-link--show-more' : 'status__content__spoiler-link--show-less'}`} onClick={this.handleSpoilerClick}>{toggleText}</button>
           </p>
 
           {mentionsPlaceholder}
 
-          <div tabIndex={!hidden ? 0 : null} className={`status__content__text ${!hidden ? 'status__content__text--visible' : ''}`} style={directionStyle} dangerouslySetInnerHTML={content} lang={status.get('language')} />
+          <div tabIndex={!hidden ? 0 : null} className={`status__content__text ${!hidden ? 'status__content__text--visible' : ''}`} style={directionStyle} dangerouslySetInnerHTML={content} lang={ignoreLang ? '' : status.get('language')} />
         </div>
       );
     } else if (this.props.onClick) {
@@ -202,7 +203,7 @@ export default class StatusContent extends React.PureComponent {
           className={classNames}
           style={directionStyle}
           dangerouslySetInnerHTML={content}
-          lang={status.get('language')}
+          lang={ignoreLang ? '' : status.get('language')}
           onMouseDown={this.handleMouseDown}
           onMouseUp={this.handleMouseUp}
         />,
@@ -221,7 +222,7 @@ export default class StatusContent extends React.PureComponent {
           className='status__content'
           style={directionStyle}
           dangerouslySetInnerHTML={content}
-          lang={status.get('language')}
+          lang={ignoreLang ? '' : status.get('language')}
         />
       );
     }

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -6,6 +6,7 @@ const getMeta = (prop) => initialState && initialState.meta && initialState.meta
 export const reduceMotion = getMeta('reduce_motion');
 export const autoPlayGif = getMeta('auto_play_gif');
 export const displayMedia = getMeta('display_media');
+export const ignoreLanguage = getMeta('ignore_toot_language');
 export const expandSpoilers = getMeta('expand_spoilers');
 export const unfollowModal = getMeta('unfollow_modal');
 export const boostModal = getMeta('boost_modal');

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -10,30 +10,35 @@ class UserSettingsDecorator
   def update(settings)
     @settings = settings
     process_update
+    process_update_language
   end
 
   private
 
   def process_update
-    user.settings['notification_emails'] = merged_notification_emails if change?('notification_emails')
-    user.settings['interactions']        = merged_interactions if change?('interactions')
-    user.settings['default_privacy']     = default_privacy_preference if change?('setting_default_privacy')
-    user.settings['default_sensitive']   = default_sensitive_preference if change?('setting_default_sensitive')
-    user.settings['default_language']    = default_language_preference if change?('setting_default_language')
-    user.settings['unfollow_modal']      = unfollow_modal_preference if change?('setting_unfollow_modal')
-    user.settings['boost_modal']         = boost_modal_preference if change?('setting_boost_modal')
-    user.settings['delete_modal']        = delete_modal_preference if change?('setting_delete_modal')
-    user.settings['auto_play_gif']       = auto_play_gif_preference if change?('setting_auto_play_gif')
-    user.settings['display_media']       = display_media_preference if change?('setting_display_media')
-    user.settings['expand_spoilers']     = expand_spoilers_preference if change?('setting_expand_spoilers')
-    user.settings['reduce_motion']       = reduce_motion_preference if change?('setting_reduce_motion')
-    user.settings['system_font_ui']      = system_font_ui_preference if change?('setting_system_font_ui')
-    user.settings['noindex']             = noindex_preference if change?('setting_noindex')
-    user.settings['theme']               = theme_preference if change?('setting_theme')
-    user.settings['hide_network']        = hide_network_preference if change?('setting_hide_network')
-    user.settings['aggregate_reblogs']   = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
-    user.settings['show_application']    = show_application_preference if change?('setting_show_application')
-    user.settings['advanced_layout']     = advanced_layout_preference if change?('setting_advanced_layout')
+    user.settings['notification_emails']  = merged_notification_emails if change?('notification_emails')
+    user.settings['interactions']         = merged_interactions if change?('interactions')
+    user.settings['default_privacy']      = default_privacy_preference if change?('setting_default_privacy')
+    user.settings['default_sensitive']    = default_sensitive_preference if change?('setting_default_sensitive')
+    user.settings['unfollow_modal']       = unfollow_modal_preference if change?('setting_unfollow_modal')
+    user.settings['boost_modal']          = boost_modal_preference if change?('setting_boost_modal')
+    user.settings['delete_modal']         = delete_modal_preference if change?('setting_delete_modal')
+    user.settings['auto_play_gif']        = auto_play_gif_preference if change?('setting_auto_play_gif')
+    user.settings['display_media']        = display_media_preference if change?('setting_display_media')
+    user.settings['expand_spoilers']      = expand_spoilers_preference if change?('setting_expand_spoilers')
+    user.settings['reduce_motion']        = reduce_motion_preference if change?('setting_reduce_motion')
+    user.settings['system_font_ui']       = system_font_ui_preference if change?('setting_system_font_ui')
+    user.settings['noindex']              = noindex_preference if change?('setting_noindex')
+    user.settings['theme']                = theme_preference if change?('setting_theme')
+    user.settings['hide_network']         = hide_network_preference if change?('setting_hide_network')
+    user.settings['aggregate_reblogs']    = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
+    user.settings['show_application']     = show_application_preference if change?('setting_show_application')
+    user.settings['advanced_layout']      = advanced_layout_preference if change?('setting_advanced_layout')
+  end
+
+  def process_update_language
+    user.settings['default_language']     = default_language_preference if change?('setting_default_language')
+    user.settings['ignore_toot_language'] = ignore_toot_language_preference if change?('setting_ignore_toot_language')
   end
 
   def merged_notification_emails
@@ -102,6 +107,10 @@ class UserSettingsDecorator
 
   def default_language_preference
     settings['setting_default_language']
+  end
+
+  def ignore_toot_language_preference
+    boolean_cast_setting 'setting_ignore_toot_language'
   end
 
   def aggregate_reblogs_preference

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -104,8 +104,8 @@ class User < ApplicationRecord
 
   delegate :auto_play_gif, :default_sensitive, :unfollow_modal, :boost_modal, :delete_modal,
            :reduce_motion, :system_font_ui, :noindex, :theme, :display_media, :hide_network,
-           :expand_spoilers, :default_language, :aggregate_reblogs, :show_application,
-           :advanced_layout, to: :settings, prefix: :setting, allow_nil: false
+           :expand_spoilers, :default_language, :ignore_toot_language, :aggregate_reblogs,
+           :show_application, :advanced_layout, to: :settings, prefix: :setting, allow_nil: false
 
   attr_reader :invite_code
   attr_writer :external

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -23,16 +23,17 @@ class InitialStateSerializer < ActiveModel::Serializer
     }
 
     if object.current_account
-      store[:me]              = object.current_account.id.to_s
-      store[:unfollow_modal]  = object.current_account.user.setting_unfollow_modal
-      store[:boost_modal]     = object.current_account.user.setting_boost_modal
-      store[:delete_modal]    = object.current_account.user.setting_delete_modal
-      store[:auto_play_gif]   = object.current_account.user.setting_auto_play_gif
-      store[:display_media]   = object.current_account.user.setting_display_media
-      store[:expand_spoilers] = object.current_account.user.setting_expand_spoilers
-      store[:reduce_motion]   = object.current_account.user.setting_reduce_motion
-      store[:advanced_layout] = object.current_account.user.setting_advanced_layout
-      store[:is_staff]        = object.current_account.user.staff?
+      store[:me]                   = object.current_account.id.to_s
+      store[:unfollow_modal]       = object.current_account.user.setting_unfollow_modal
+      store[:boost_modal]          = object.current_account.user.setting_boost_modal
+      store[:delete_modal]         = object.current_account.user.setting_delete_modal
+      store[:auto_play_gif]        = object.current_account.user.setting_auto_play_gif
+      store[:display_media]        = object.current_account.user.setting_display_media
+      store[:ignore_toot_language] = object.current_account.user.setting_ignore_toot_language
+      store[:expand_spoilers]      = object.current_account.user.setting_expand_spoilers
+      store[:reduce_motion]        = object.current_account.user.setting_reduce_motion
+      store[:advanced_layout]      = object.current_account.user.setting_advanced_layout
+      store[:is_staff]             = object.current_account.user.staff?
     end
 
     store

--- a/app/views/settings/preferences/show.html.haml
+++ b/app/views/settings/preferences/show.html.haml
@@ -20,6 +20,9 @@
   .fields-group
     = f.input :chosen_languages, collection: filterable_languages.sort, wrapper: :with_block_label, include_blank: false, label_method: lambda { |locale| human_locale(locale) }, required: false, as: :check_boxes, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
 
+  .fields-group
+    = f.input :setting_ignore_toot_language, as: :boolean, wrapper: :with_label
+
   %hr#settings_publishing/
 
   .fields-group

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -105,7 +105,7 @@ en:
         setting_display_media_show_all: Show all
         setting_expand_spoilers: Always expand toots marked with content warnings
         setting_hide_network: Hide your network
-        setting_ignore_toot_language: Ignore language information of toots
+        setting_ignore_toot_language: Show toots without their language attributes (for CJK language)
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send toots

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -105,6 +105,7 @@ en:
         setting_display_media_show_all: Show all
         setting_expand_spoilers: Always expand toots marked with content warnings
         setting_hide_network: Hide your network
+        setting_ignore_toot_language: Ignore language information of toots
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send toots

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -105,6 +105,7 @@ ja:
         setting_display_media_show_all: 表示
         setting_expand_spoilers: 閲覧注意としてマークされたトゥートを常に展開する
         setting_hide_network: 繋がりを隠す
+        setting_ignore_toot_language: トゥートの言語情報を無視する
         setting_noindex: 検索エンジンによるインデックスを拒否する
         setting_reduce_motion: アニメーションの動きを減らす
         setting_show_application: トゥートの送信に使用したアプリを開示する


### PR DESCRIPTION
# What's this?
Ignore `language` in status when WebUI rendering(rendering without HTML `lang` attr).  
When tooting in CJK(Chinese, Japanese, Korean), Mastodon sometimes detects wrong language.  
So, Japanese people often see  toots written in Japanese with Chinese fonts, which they are not used to.  
However, I think it may be a feature only for Japanese...