### PR TITLE
Fix profile picture preview

### DIFF
--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -68,6 +68,7 @@
         margin: 0;
         border-radius: 4px;
         background: darken($ui-base-color, 8%);
+        object-fit: cover;
       }
     }
 


### PR DESCRIPTION
Profile picture is "cropped" after upload.
Preview was resized using "fill" strategy. Not cropped.

| Before | After |
|:--:|:--:|
| ![image](https://user-images.githubusercontent.com/5047683/58763574-5985af00-8597-11e9-9e60-f1789620a6e3.png) | ![image](https://user-images.githubusercontent.com/5047683/58763582-6bffe880-8597-11e9-8803-c9de2274075f.png) |