### PR TITLE
Handle blank poll options more gracefully

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -234,7 +234,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     @account.polls.new(
       multiple: multiple,
       expires_at: expires_at,
-      options: items.map { |item| item['name'].presence || item['content'] },
+      options: items.map { |item| item['name'].presence || item['content'] }.compact,
       cached_tallies: items.map { |item| item.dig('replies', 'totalItems') || 0 }
     )
   end


### PR DESCRIPTION
Pleroma currently allows (erroneously imho) empty poll options, that is,
options with an empty (but existing) `name`.

In that case, `item['name'].presence || item['content']` returns `nil`, which
causes an error during validation. Using `item['name'] || item['content']`
instead will still use `item['content']` when `item['name']` is not set at all,
but return an empty string in Pleroma's case, which will nicely reject the
blank option without raising an error.