### PR TITLE
Do not misattribute inlined boosts if `attributedTo` isn't present

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -143,7 +143,7 @@ class ActivityPub::Activity
 
     # If the boosted toot is embedded and it is a self-boost, handle it like a Create
     unless unsupported_object_type?
-      actor_id = value_or_id(first_of_value(@object['attributedTo'])) || @account.uri
+      actor_id = value_or_id(first_of_value(@object['attributedTo']))
 
       if actor_id == @account.uri
         return ActivityPub::Activity.factory({ 'type' => 'Create', 'actor' => actor_id, 'object' => @object }, @account).perform

--- a/spec/lib/activitypub/activity/announce_spec.rb
+++ b/spec/lib/activitypub/activity/announce_spec.rb
@@ -58,21 +58,6 @@ RSpec.describe ActivityPub::Activity::Announce do
         end
       end
 
-      context 'self-boost of a previously unknown status with missing attributedTo' do
-        let(:object_json) do
-          {
-            id: 'https://example.com/actor#bar',
-            type: 'Note',
-            content: 'Lorem ipsum',
-            to: 'http://example.com/followers',
-          }
-        end
-
-        it 'creates a reblog by sender of status' do
-          expect(sender.reblogged?(sender.statuses.first)).to be true
-        end
-      end
-
       context 'self-boost of a previously unknown status with correct attributedTo' do
         let(:object_json) do
           {
@@ -122,6 +107,7 @@ RSpec.describe ActivityPub::Activity::Announce do
             type: 'Note',
             content: 'Lorem ipsum',
             to: 'http://example.com/followers',
+            attributedTo: 'https://example.com/actor',
           }
         end
 
@@ -141,6 +127,7 @@ RSpec.describe ActivityPub::Activity::Announce do
             type: 'Note',
             content: 'Lorem ipsum',
             to: 'http://example.com/followers',
+            attributedTo: 'https://example.com/actor',
           }
         end
 
@@ -161,6 +148,7 @@ RSpec.describe ActivityPub::Activity::Announce do
           type: 'Note',
           content: 'Lorem ipsum',
           to: 'http://example.com/followers',
+          attributedTo: 'https://example.com/actor',
         }
       end
 


### PR DESCRIPTION
Fixes #10950

As of 6a5307a5733e7872e7827f32b27111434e0307c4, we accept boosts of inlined toots provided that they can be attributed to the actor boosting it. However, we assume that if no `attributedTo` field is present, then the object is to be attributed to the actor boosting it.

I guess that assumption might not be correct, although cases where that assumption would not be correct are cases where we cannot attribute the toot at all.