### PR TITLE
Fix potential private status leak

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -27,7 +27,7 @@ class StatusesController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        unless user_signed_in?
+        if current_account.nil?
           skip_session!
           expires_in 10.seconds, public: true
         end


### PR DESCRIPTION
Fix potential leak of private statuses when the HTML view of a status is requested by a remote account with valid HTTP signature.

This is fairly minor as that leak would only happen if all the following conditions are met:
1. a request is made with a valid HTTP signature for a remote account
2. this requests yields the HTML representation and not the ActivityStreams or atom one
3. the requested status is public/unlisted
4. the requested status is either in reply to a private status viewable by the requesting account or has private replies viewable by the requesting account
5. a second query, from someone not allowed to view these toots, is made while the cache is valid (10-seconds timeframe)

I do not believe that 1 & 2 can currently occur simultaneously in the wild, and the other conditions are very unlikely, but it doesn't hurt to fix it.