### PR TITLE
Fix display of alt-text when a media attachment is not available

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4747,7 +4747,6 @@ a.status-card.compact:hover {
   display: block;
   text-decoration: none;
   color: $secondary-text-color;
-  line-height: 0;
   position: relative;
   z-index: 1;
 


### PR DESCRIPTION
This dates back to #5054, but I could not find out what that line was for, and I have seen no regression removing it.

Not perfect, but still an improvement I think.

## Before

![image](https://user-images.githubusercontent.com/384364/59027650-e52e6280-8859-11e9-9683-b4ad10090816.png)

## After

![image](https://user-images.githubusercontent.com/384364/59027828-4d7d4400-885a-11e9-8357-fd982b13e0b8.png)
