### PR TITLE
Change "Edit profile" menu item name to match page title

### DIFF
--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -5,7 +5,7 @@ SimpleNavigation::Configuration.run do |navigation|
     n.item :web, safe_join([fa_icon('chevron-left fw'), t('settings.back')]), root_url
 
     n.item :profile, safe_join([fa_icon('user fw'), t('settings.profile')]), settings_profile_url do |s|
-      s.item :profile, safe_join([fa_icon('pencil fw'), t('settings.appearance')]), settings_profile_url, highlights_on: %r{/settings/profile|/settings/migration}
+      s.item :profile, safe_join([fa_icon('pencil fw'), t('settings.edit_profile')]), settings_profile_url, highlights_on: %r{/settings/profile|/settings/migration}
       s.item :featured_tags, safe_join([fa_icon('hashtag fw'), t('settings.featured_tags')]), settings_featured_tags_url
       s.item :identity_proofs, safe_join([fa_icon('key fw'), t('settings.identity_proofs')]), settings_identity_proofs_path, highlights_on: %r{/settings/identity_proofs*}, if: proc { current_account.identity_proofs.exists? }
     end


### PR DESCRIPTION
This PR matches the "Edit Profile" menu item with the page title.

This change will confuse translators once.
However, I believe that this change will make it easier to translate "appearance" by #10977 and #10988.

before: 
![スクリーンショット_2019-06-08_19_42_00](https://user-images.githubusercontent.com/766076/59147265-65a8bb00-8a34-11e9-8052-a4f74fc24b83.png)

after: 
![スクリーンショット_2019-06-08_19_43_24](https://user-images.githubusercontent.com/766076/59147274-73f6d700-8a34-11e9-9b47-ac68d037a049.png)
