### PR TITLE
Add an icon denoting polls in the CW button

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -175,7 +175,7 @@ export default class StatusContent extends React.PureComponent {
         </Permalink>
       )).reduce((aggregate, item) => [...aggregate, item, ' '], []);
 
-      const toggleText = hidden ? <FormattedMessage id='status.show_more' defaultMessage='Show more' /> : <FormattedMessage id='status.show_less' defaultMessage='Show less' />;
+      const toggleText = hidden ? [<FormattedMessage id='status.show_more' defaultMessage='Show more' />, status.get('poll') ? <Icon id='tasks' className='status__content__spoiler-icon' fixedWidth /> : null] : [<FormattedMessage id='status.show_less' defaultMessage='Show less' />];
 
       if (hidden) {
         mentionsPlaceholder = <div>{mentionLinks}</div>;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -825,6 +825,15 @@
   vertical-align: middle;
 }
 
+.status__content__spoiler-icon {
+  display: inline-block;
+  margin: 0 0 0 5px;
+  border-left: 1px solid currentColor;
+  padding: 0 0 0 4px;
+  font-size: 16px;
+  vertical-align: -2px;
+}
+
 .status__wrapper--filtered {
   color: $dark-text-color;
   border: 0;

--- a/app/views/stream_entries/_detailed_status.html.haml
+++ b/app/views/stream_entries/_detailed_status.html.haml
@@ -19,7 +19,9 @@
     - if status.spoiler_text?
       %p{ :style => ('margin-bottom: 0' unless current_account&.user&.setting_expand_spoilers) }<
         %span.p-summary> #{Formatter.instance.format_spoiler(status, autoplay: autoplay)}&nbsp;
-        %button.status__content__spoiler-link= t('statuses.show_more')
+        %button.status__content__spoiler-link<
+          = t('statuses.show_more')
+          = fa_icon('tasks fw', class: 'status__content__spoiler-icon') if status.preloadable_poll
     .e-content{ lang: status.language, style: "display: #{!current_account&.user&.setting_expand_spoilers && status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl_status?(status) ? 'rtl' : 'ltr'}" }
       = Formatter.instance.format(status, custom_emojify: true, autoplay: autoplay)
       - if status.preloadable_poll

--- a/app/views/stream_entries/_simple_status.html.haml
+++ b/app/views/stream_entries/_simple_status.html.haml
@@ -23,7 +23,9 @@
     - if status.spoiler_text?
       %p{ :style => ('margin-bottom: 0' unless current_account&.user&.setting_expand_spoilers) }<
         %span.p-summary> #{Formatter.instance.format_spoiler(status, autoplay: autoplay)}&nbsp;
-        %button.status__content__spoiler-link= t('statuses.show_more')
+        %button.status__content__spoiler-link<
+          = t('statuses.show_more')
+          = fa_icon('tasks fw', class: 'status__content__spoiler-icon') if status.preloadable_poll
     .e-content{ lang: status.language, style: "display: #{!current_account&.user&.setting_expand_spoilers && status.spoiler_text? ? 'none' : 'block'}; direction: #{rtl_status?(status) ? 'rtl' : 'ltr'}" }
       = Formatter.instance.format(status, custom_emojify: true, autoplay: autoplay)
       - if status.preloadable_poll


### PR DESCRIPTION
Follow-up to #10983. I know you're not a fan of this design, @Gargron, but still opening this PR to keep track of that feature.