### PR TITLE
Specify gzip required in tootctl emoji help

### DIFF
--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -15,9 +15,9 @@ module Mastodon
     option :suffix
     option :overwrite, type: :boolean
     option :unlisted, type: :boolean
-    desc 'import PATH', 'Import emoji from a TAR archive at PATH'
+    desc 'import PATH', 'Import emoji from a TAR GZIP archive at PATH'
     long_desc <<-LONG_DESC
-      Imports custom emoji from a TAR archive specified by PATH.
+      Imports custom emoji from a TAR GZIP archive specified by PATH.
 
       Existing emoji will be skipped unless the --overwrite option
       is provided, in which case they will be overwritten.


### PR DESCRIPTION
I was using the bulk emoji import command in `tootctl`. I hit an error telling me that the tar archive needed to be gzipped, but it wasn't specified in the help text. This makes the help text clearer about that.