### PR TITLE
Fix emoji-button appearing above privacy-dropdown

### DIFF
--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
@@ -129,7 +129,7 @@ class PrivacyDropdownMenu extends React.PureComponent {
           // It should not be transformed when mounting because the resulting
           // size will be used to determine the coordinate of the menu by
           // react-overlays
-          <div className={`privacy-dropdown__dropdown ${placement}`} style={{ ...style, opacity: opacity, transform: mounted ? `scale(${scaleX}, ${scaleY})` : null }} role='listbox' ref={this.setRef}>
+          <div className={`privacy-dropdown__dropdown ${placement}`} style={{ ...style, opacity: opacity, transform: mounted ? `scale(${scaleX}, ${scaleY})` : null, zIndex: 2 }} role='listbox' ref={this.setRef}>
             {items.map(item => (
               <div role='option' tabIndex='0' key={item.value} data-index={item.value} onKeyDown={this.handleKeyDown} onClick={this.handleClick} className={classNames('privacy-dropdown__option', { active: item.value === value })} aria-selected={item.value === value} ref={item.value === value ? this.setFocusRef : null}>
                 <div className='privacy-dropdown__option__icon'>


### PR DESCRIPTION
This PR fixed the problem that the emoji button is displayed in front of the privacy dropdown.

I made this referring to #10978 .

before:
<img width="295" alt="スクリーンショット 2019-06-10 15 20 01" src="https://user-images.githubusercontent.com/766076/59176503-3741f180-8b94-11e9-9797-b76147350f8a.png">

after:
<img width="294" alt="スクリーンショット 2019-06-10 14 59 57" src="https://user-images.githubusercontent.com/766076/59176515-3e68ff80-8b94-11e9-88b2-149f08b3a664.png">