### PR TITLE
Fix Serbian pluralization rules requiring a "many" key

### DIFF
--- a/config/locales/sr-Latn.rb
+++ b/config/locales/sr-Latn.rb
@@ -1,0 +1,3 @@
+require 'rails_i18n/common_pluralizations/romanian'
+
+::RailsI18n::Pluralization::Romanian.with_locale(:'sr-Latn')

--- a/config/locales/sr.rb
+++ b/config/locales/sr.rb
@@ -1,0 +1,3 @@
+require 'rails_i18n/common_pluralizations/romanian'
+
+::RailsI18n::Pluralization::Romanian.with_locale(:sr)


### PR DESCRIPTION
According to Unicode there is no "many" key in Serbian: https://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html