### PR TITLE
Resync Nanobox files with the 2.9.0 release

### DIFF
--- a/boxfile.yml
+++ b/boxfile.yml
@@ -64,8 +64,9 @@ deploy.config:
       - |-
           if [[ "${ES_ENABLED}" != "false" ]]
           then
-            bundle exec rake chewy:deploy
+            bin/tootctl search deploy
           fi
+      - bin/tootctl cache clear
 
 
 web.web:
@@ -118,77 +119,6 @@ worker.sidekiq:
   network_dirs:
     data.storage:
       - public/system
-
-
-worker.cron_only:
-  start: sleep 365d
-
-  writable_dirs:
-    - tmp
-
-  log_watch:
-    rake: 'log/production.log'
-
-  network_dirs:
-    data.storage:
-      - public/system
-
-  cron:
-    # 20:00 (8 pm), server time: send out the daily digest emails to everyone
-    # who opted to receive one
-    - id: send_digest_emails
-      schedule: '00 20 * * *'
-      command: 'bundle exec rake mastodon:emails:digest'
-
-    # 00:10 (ten past midnight), server time: remove local copies of remote
-    # users' media once they are older than a certain age (use NUM_DAYS evar to
-    # change this from the default of 7 days)
-    - id: clear_remote_media
-      schedule: '10 00 * * *'
-      command: 'bundle exec rake mastodon:media:remove_remote'
-
-    # 00:20 (twenty past midnight), server time: remove subscriptions to remote
-    # users that nobody follows locally (anymore)
-    - id: clear_unfollowed_subs
-      schedule: '20 00 * * *'
-      command: 'bundle exec rake mastodon:push:clear'
-
-    # 00:30 (half past midnight), server time: update local copies of remote
-    # users' avatars to match whatever they currently have set on their profile
-    - id: update_remote_avatars
-      schedule: '30 00 * * *'
-      command: 'bundle exec rake mastodon:media:redownload_avatars'
-
-    ############################################################################
-    # This task is one you might want to enable, or might not. It keeps disk
-    # usage low, but makes "shadow bans" (scenarios where the user is silenced,
-    # but not intended to be made aware that the silencing has occurred) much
-    # more difficult to put in place, as users would then notice their media is
-    # vanishing on a regular basis. Enable it if you aren't worried about users
-    # knowing they've been silenced (on the instance level), and want to save
-    # disk space. Leave it disabled otherwise.
-    ############################################################################
-    # # 00:00 (midnight), server time: remove media posted by silenced users
-    # - id: clear_silenced_media
-    #   schedule: '00 00 * * *'
-    #   command: 'bundle exec rake mastodon:media:remove_silenced'
-
-    ############################################################################
-    # The following two tasks can be uncommented to automatically open and close
-    # registrations on a schedule. The format of 'schedule' is a standard cron
-    # time expression: minute hour day month day-of-week; search for "cron
-    # time expressions" for more info on how to set these up. The examples here
-    # open registration only from 8 am to 4 pm, server time.
-    ############################################################################
-    # # 08:00 (8 am), server time: open registrations so new users can join
-    # - id: open_registrations
-    #   schedule: '00 08 * * *'
-    #   command: 'bundle exec rake mastodon:settings:open_registrations'
-    #
-    # # 16:00 (4 pm), server time: close registrations so new users *can't* join
-    # - id: close_registrations
-    #   schedule: '00 16 * * *'
-    #   command: 'bundle exec rake mastodon:settings:close_registrations'
 
 
 data.db:

--- a/nanobox/nginx-local.conf
+++ b/nanobox/nginx-local.conf
@@ -10,10 +10,13 @@ http {
     sendfile on;
 
     gzip on;
-    gzip_http_version 1.0;
-    gzip_proxied any;
-    gzip_min_length 500;
     gzip_disable "MSIE [1-6]\.";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_min_length 500;
+    gzip_http_version 1.1;
     gzip_types text/plain text/xml text/javascript text/css text/comma-separated-values application/xml+rss application/xml application/x-javascript application/json application/javascript application/atom+xml;
 
     # Proxy upstream to the puma process
@@ -36,9 +39,12 @@ http {
         # Listen on port 8080
         listen 8080;
 
+        keepalive_timeout    70;
+        client_max_body_size 80M;
+
         root /app/public;
 
-        client_max_body_size 80M;
+        add_header Strict-Transport-Security "max-age=31536000";
 
         location / {
             try_files $uri @rails;
@@ -47,6 +53,10 @@ http {
         # Proxy connections to rails
         location @rails {
             proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header Proxy "";
             proxy_pass_header Server;
 
             proxy_pass http://rails;
@@ -62,6 +72,10 @@ http {
         # Proxy connections to node
         location /api/v1/streaming {
             proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header Proxy "";
 
             proxy_pass http://node;
             proxy_buffering off;

--- a/nanobox/nginx-stream.conf.erb
+++ b/nanobox/nginx-stream.conf.erb
@@ -10,10 +10,13 @@ http {
     sendfile on;
 
     gzip on;
-    gzip_http_version 1.1;
-    gzip_proxied any;
-    gzip_min_length 500;
     gzip_disable "MSIE [1-6]\.";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_min_length 500;
+    gzip_http_version 1.1;
     gzip_types text/plain text/xml text/javascript text/css text/comma-separated-values application/xml+rss application/xml application/x-javascript application/json application/javascript application/atom+xml;
 
     # Proxy upstream to the node process
@@ -31,10 +34,12 @@ http {
         # Listen on port 8080
         listen 8080;
 
-        add_header Strict-Transport-Security "max-age=31536000";
-        # add_header Content-Security-Policy "style-src 'self' 'unsafe-inline'; script-src 'self'; object-src 'self'; img-src data: https:; media-src data: https:; connect-src 'self' wss://<%= ENV["LOCAL_DOMAIN"] %>; upgrade-insecure-requests";
+        keepalive_timeout    70;
+        client_max_body_size 80M;
 
         root /app/public;
+
+        add_header Strict-Transport-Security "max-age=31536000";
 
         location / {
             try_files $uri @node;
@@ -43,6 +48,10 @@ http {
         # Proxy connections to node
         location @node {
             proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header Proxy "";
 
             proxy_pass http://node;
             proxy_buffering off;

--- a/nanobox/nginx-web.conf.erb
+++ b/nanobox/nginx-web.conf.erb
@@ -10,10 +10,13 @@ http {
     sendfile on;
 
     gzip on;
-    gzip_http_version 1.0;
-    gzip_proxied any;
-    gzip_min_length 500;
     gzip_disable "MSIE [1-6]\.";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_min_length 500;
+    gzip_http_version 1.1;
     gzip_types text/plain text/xml text/javascript text/css text/comma-separated-values application/xml+rss application/xml application/x-javascript application/json application/javascript application/atom+xml;
 
     # Proxy upstream to the puma process
@@ -31,12 +34,12 @@ http {
         # Listen on port 8080
         listen 8080;
 
-        add_header Strict-Transport-Security "max-age=31536000";
-        # add_header Content-Security-Policy "style-src 'self' 'unsafe-inline'; script-src 'self'; object-src 'self'; img-src data: https:; media-src data: https:; connect-src 'self' wss://<%= ENV["LOCAL_DOMAIN"] %>; upgrade-insecure-requests";
+        keepalive_timeout    70;
+        client_max_body_size 80M;
 
         root /app/public;
 
-        client_max_body_size 80M;
+        add_header Strict-Transport-Security "max-age=31536000";
 
         location / {
             try_files $uri @rails;
@@ -44,17 +47,23 @@ http {
 
         location /sw.js {
             add_header Cache-Control "public, max-age=0";
+            add_header Strict-Transport-Security "max-age=31536000";
             try_files $uri @rails;
         }
 
         location ~ ^/(emoji|packs|system/media_attachments/files|system/accounts/avatars) {
             add_header Cache-Control "public, max-age=31536000, immutable";
+            add_header Strict-Transport-Security "max-age=31536000";
             try_files $uri @rails;
         }
 
         # Proxy connections to rails
         location @rails {
             proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header Proxy "";
             proxy_pass_header Server;
 
             proxy_pass http://rails;
@@ -66,7 +75,10 @@ http {
 
             proxy_cache CACHE;
             proxy_cache_valid 200 7d;
+            proxy_cache_valid 410 24h;
             proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+            add_header Strict-Transport-Security "max-age=31536000";
+            add_header X-Cached $upstream_cache_status;
 
             tcp_nodelay on;
         }


### PR DESCRIPTION
We don't use Cron anymore (thanks, Sidekiq!), so it makes sense to remove that component entirely. Other configurations have been tweaked, slightly, to ensure smooth migrations to new versions without the need for manual intervention.