### PR TITLE
Update translating platform has changed to crowdin (CONTRIBUTING.md)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,9 @@ Bug reports and feature suggestions can be submitted to [GitHub Issues](https://
 
 ## Translations
 
-You can submit translations via pull request.
+You can submit translations via [Crowdin](https://crowdin.com/project/mastodon). They are periodically merged into the codebase.
+
+[![Crowdin](https://d322cqt584bo4o.cloudfront.net/mastodon/localized.svg)][crowdin]
 
 ## Pull requests
 


### PR DESCRIPTION
Translating platform has changed to Crowdin from #11054 .

But some people send pull request to change sentences directly.
I thought about because it's not wrote in CONTRIBUTING.md.

So I restore and change from 89096860.