### PR TITLE
Completely hide toots matched by “irreversible” filters even if they got to the client

### DIFF
--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -48,8 +48,13 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
     let filtered = false;
 
     if (notification.type === 'mention') {
+      const dropRegex   = regexFromFilters(filters.filter(filter => filter.get('irreversible')));
       const regex       = regexFromFilters(filters);
       const searchIndex = notification.status.spoiler_text + '\n' + unescapeHTML(notification.status.content);
+
+      if (dropRegex && dropRegex.test(searchIndex)) {
+        return;
+      }
 
       filtered = regex && regex.test(searchIndex);
     }

--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -84,8 +84,13 @@ export const makeGetStatus = () => {
         statusReblog = null;
       }
 
-      const regex    = (accountReblog || accountBase).get('id') !== me && regexFromFilters(filters);
-      const filtered = regex && regex.test(statusBase.get('reblog') ? statusReblog.get('search_index') : statusBase.get('search_index'));
+      const dropRegex = (accountReblog || accountBase).get('id') !== me && regexFromFilters(filters.filter(filter => filter.get('irreversible')));
+      if (dropRegex && dropRegex.test(statusBase.get('reblog') ? statusReblog.get('search_index') : statusBase.get('search_index'))) {
+        return null;
+      }
+
+      const regex     = (accountReblog || accountBase).get('id') !== me && regexFromFilters(filters);
+      const filtered  = regex && regex.test(statusBase.get('reblog') ? statusReblog.get('search_index') : statusBase.get('search_index'));
 
       return statusBase.withMutations(map => {
         map.set('reblog', statusReblog);


### PR DESCRIPTION
Fixes #11090