### PR TITLE
Add label for admin theme selector

### DIFF
--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -9,7 +9,7 @@
 
   .fields-row
     .fields-row__column.fields-row__column-6.fields-group
-      = f.input :theme, collection: Themes.instance.names, label_method: lambda { |theme| I18n.t("themes.#{theme}", default: theme) }, wrapper: :with_label, include_blank: false
+      = f.input :theme, collection: Themes.instance.names, label: t('simple_form.labels.defaults.setting_theme'), label_method: lambda { |theme| I18n.t("themes.#{theme}", default: theme) }, wrapper: :with_label, include_blank: false
     .fields-row__column.fields-row__column-6.fields-group
       = f.input :registrations_mode, collection: %w(open approved none), wrapper: :with_label, label: t('admin.settings.registrations_mode.title'), include_blank: false, label_method: lambda { |mode| I18n.t("admin.settings.registrations_mode.modes.#{mode}") }
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -110,6 +110,7 @@ en:
         setting_theme: Site theme
         setting_unfollow_modal: Show confirmation dialog before unfollowing someone
         severity: Severity
+        theme: Theme
         type: Import type
         username: Username
         username_or_email: Username or Email

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -110,7 +110,6 @@ en:
         setting_theme: Site theme
         setting_unfollow_modal: Show confirmation dialog before unfollowing someone
         severity: Severity
-        theme: Theme
         type: Import type
         username: Username
         username_or_email: Username or Email


### PR DESCRIPTION
Fixes the "theme" label in Administration/Site settings not having a translation string, and thus falling back to `human_attribute_name`. As an example:
![image](https://user-images.githubusercontent.com/26982181/59756054-4c500c00-9289-11e9-9988-69a04300376b.png)