### PR TITLE
Compatibility with less friendly activitypub setups

### DIFF
--- a/app/helpers/jsonld_helper.rb
+++ b/app/helpers/jsonld_helper.rb
@@ -40,7 +40,7 @@ module JsonLdHelper
   end
 
   def supported_context?(json)
-    !json.nil? && equals_or_includes?(json['@context'], ActivityPub::TagManager::CONTEXT)
+    !json.nil? && equals_or_includes?(json['@context'], ActivityPub::TagManager::CONTEXT) && !(json['@context'].is_a?(Array) ? (json['@context'].any? {|c| !c['gab'].nil? && c['gab'].include? 'gab.com' }) : false)
   end
 
   def unsupported_uri_scheme?(uri)


### PR DESCRIPTION
Some activity pub instances have seen fit to mess with the contexts. Since Mastodon fails to reject these obviously broken objects that do not have valid contexts, I've added a quick patch to check for them. [Example of a broken one, note the context field](https://develop.gab.com/users/robcolbert.json)