### PR TITLE
Remove flags from version.rb; just use pre

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -20,16 +20,12 @@ module Mastodon
       nil
     end
 
-    def flags
-      ''
-    end
-
     def to_a
       [major, minor, patch, pre].compact
     end
 
     def to_s
-      [to_a.join('.'), flags].join
+      [[major, minor, patch].join('.'), pre].join
     end
 
     def repository


### PR DESCRIPTION
It appears that the `pre` variable is never used, and that the `flags` variable is used for RC suffixes. This removes the flags variable and uses `pre` for this purpose instead.