### PR TITLE
Add support for M4V

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -31,7 +31,7 @@ class MediaAttachment < ApplicationRecord
   AUDIO_FILE_EXTENSIONS = ['.ogg', '.oga', '.mp3', '.wav', '.flac', '.opus'].freeze
 
   IMAGE_MIME_TYPES             = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'].freeze
-  VIDEO_MIME_TYPES             = ['video/webm', 'video/mp4', 'video/quicktime', 'video/ogg'].freeze
+  VIDEO_MIME_TYPES             = ['video/webm', 'video/mp4', 'video/x-m4v', 'video/quicktime', 'video/ogg'].freeze
   VIDEO_CONVERTIBLE_MIME_TYPES = ['video/webm', 'video/quicktime'].freeze
   AUDIO_MIME_TYPES             = ['audio/wave', 'audio/wav', 'audio/x-wav', 'audio/x-pn-wave', 'audio/ogg', 'audio/mpeg', 'audio/mp3', 'audio/webm', 'audio/flac'].freeze
 


### PR DESCRIPTION
Some MP4 movie ( H.264/AAC )'s MIME type seem to be recognized as `video/x-m4v`.
In v2.9.2, it can't upload with the following error message:
`422 Validation failed: File content type is invalid, File is invalid.`

Before #11151 that format was also an uploadable format.
This change makes it possible to upload files of that type again.

I haven't yet conducted other formats of testing.

Please see also: https://en.wikipedia.org/wiki/M4V