### PR TITLE
Improve support of Audio, Video and Image AS objects

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -308,7 +308,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def text_from_content
-    return Formatter.instance.linkify([[text_from_name, text_from_summary.presence].compact.join("\n\n"), object_url || @object['id']].join(' ')) if converted_object_type?
+    return Formatter.instance.linkify([text_from_name, text_from_summary.presence, object_url || @object['id'], @object['type'] == 'Article' ? nil : @object['content'].presence].compact.join("\n\n")) if converted_object_type?
 
     if @object['content'].present?
       @object['content']

--- a/spec/services/activitypub/fetch_remote_status_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_status_service_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService, type: :service do
 
         expect(status).to_not be_nil
         expect(status.url).to eq "https://#{valid_domain}/watch?v=12345"
-        expect(strip_tags(status.text)).to eq "Nyan Cat 10 hours remix https://#{valid_domain}/watch?v=12345"
+        expect(strip_tags(status.text)).to eq "Nyan Cat 10 hours remixhttps://#{valid_domain}/watch?v=12345"
       end
     end
 
@@ -100,7 +100,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService, type: :service do
 
         expect(status).to_not be_nil
         expect(status.url).to eq "https://#{valid_domain}/watch?v=12345"
-        expect(strip_tags(status.text)).to eq "Nyan Cat 10 hours remix https://#{valid_domain}/watch?v=12345"
+        expect(strip_tags(status.text)).to eq "Nyan Cat 10 hours remixhttps://#{valid_domain}/watch?v=12345"
       end
     end
 


### PR DESCRIPTION
- If a `content` is available, display it after the link (typically, Peertube video descriptions)
- If the object's `url` points to some media we can use as attachment, do so

For Peertube videos, this does not change anything for videos above 40MB.
For videos smaller than that, it will download them and display them inline. I am not completely sure this is what we want, or if the 40MB cutoff is what we really want.

e.g, for https://tube.otter.sh/videos/watch/5dab27d6-1fff-46fb-9617-a16d26dba5c6 it renders
![Screenshot_2019-06-26 Mastodon(2)](https://user-images.githubusercontent.com/384364/60208279-28c42d00-9858-11e9-8f97-c9c6348ac91b.png)