### PR TITLE
Fix BackupService crashing when an attachment is missing

### DIFF
--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -142,5 +142,7 @@ class BackupService < BaseService
         io.write(buffer)
       end
     end
+  rescue Errno::ENOENT
+    Rails.logger.warn "Error making a backup for attachment #{attachment}"
   end
 end

--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -143,6 +143,6 @@ class BackupService < BaseService
       end
     end
   rescue Errno::ENOENT
-    Rails.logger.warn "Error making a backup for attachment #{attachment}"
+    Rails.logger.warn "Could not backup file #{filename}: file not found"
   end
 end


### PR DESCRIPTION
For various reasons such as admin error or out-of-sync media and
database backups, it might be possible for local attachments to be lost.

This commit allows the BackupService to continue its work even if some media
file is missing.