### PR TITLE
Fix support for HTTP proxies

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -184,7 +184,12 @@ class Request
         Resolv::DNS.open do |dns|
           dns.timeouts = 5
 
-          addresses = dns.getaddresses(host).take(2)
+          addresses = []
+          begin
+            addresses = [IPAddr.new(host)]
+          rescue IPAddr::InvalidAddressError
+            addresses = dns.getaddresses(host).take(2)
+          end
 
           addresses.each do |address|
             begin

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -177,8 +177,6 @@ class Request
   class Socket < TCPSocket
     class << self
       def open(host, *args)
-        return super(host, *args) if thru_hidden_service?(host)
-
         outer_e = nil
         port    = args.first
 
@@ -229,10 +227,6 @@ class Request
       end
 
       alias new open
-
-      def thru_hidden_service?(host)
-        Rails.configuration.x.access_to_hidden_service && /\.(onion|i2p)$/.match(host)
-      end
     end
   end
 


### PR DESCRIPTION
The `Request::Socket` class implements its own logic for connection timeouts, to give us a bit more control, and because `http.rb` uses the ill-advised `Timeout::timeout`. That latter mechanism is bypassed entirely. Therefore, *not* using our `Socket` class means we do not have proper handling of connection timeouts.

This PR changes that by using our custom class for both direct connections and connections through a proxy—in which case the socket class is used to connect to the *proxy*.

Additionally, since the socket is used to connect to the *proxy*, it will never get used with a hidden service as `host`, so removed the additional check.

Also added support for IP addresses in addition to hostnames.