### PR TITLE
Update fuubar dependency to 2.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
     fugit (1.1.6)
       et-orbi (~> 1.1, >= 1.1.6)
       raabro (~> 1.1)
-    fuubar (2.4.0)
+    fuubar (2.4.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
     get_process_mem (0.2.3)


### PR DESCRIPTION
This PR updates the `fuubar` gem to 2.4.1, as the version currently used (2.4.0) has been yanked from RubyGems.  (See also thekompanee/fuubar#111)

I noticed this while initially bundling some local Mastodon fork for the first time on a different machine:

```
% bundle install
Fetching gem metadata from https://rubygems.org/...........
Your bundle is locked to fuubar (2.4.0), but that version could not be found in any of the sources listed in your Gemfile. If you haven't changed sources, that means the author of fuubar (2.4.0) has removed it. You'll need to update your bundle to a version other than fuubar (2.4.0) that
hasn't been removed in order to install.
```