### PR TITLE
Add ActivityPub secure mode

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -40,7 +40,7 @@ class AccountsController < ApplicationController
       end
 
       format.json do
-        expires_in 3.minutes, public: true unless secure_mode_enabled? && signed_request_account.present?
+        expires_in 3.minutes, public: !(authorized_fetch_mode? && signed_request_account.present?)
         render json: @account, content_type: 'application/activity+json', serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter, fields: fields_selection
       end
     end
@@ -135,7 +135,7 @@ class AccountsController < ApplicationController
   end
 
   def fields_selection
-    if signed_request_account.present? || !secure_mode_enabled?
+    if signed_request_account.present? || !authorized_fetch_mode?
       # Return all fields
     else
       %i(id type preferred_username inbox public_key endpoints)

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -41,7 +41,7 @@ class AccountsController < ApplicationController
 
       format.json do
         expires_in 3.minutes, public: !(authorized_fetch_mode? && signed_request_account.present?)
-        render json: @account, content_type: 'application/activity+json', serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter, fields: fields_selection
+        render json: @account, content_type: 'application/activity+json', serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter, fields: restrict_fields_to
       end
     end
   end
@@ -134,7 +134,7 @@ class AccountsController < ApplicationController
     end
   end
 
-  def fields_selection
+  def restrict_fields_to
     if signed_request_account.present? || !authorized_fetch_mode?
       # Return all fields
     else

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -4,6 +4,7 @@ class AccountsController < ApplicationController
   PAGE_SIZE = 20
 
   include AccountControllerConcern
+  include SignatureAuthentication
 
   before_action :set_cache_headers
   before_action :set_body_classes
@@ -39,8 +40,8 @@ class AccountsController < ApplicationController
       end
 
       format.json do
-        expires_in 3.minutes, public: true
-        render json: @account, content_type: 'application/activity+json', serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter
+        expires_in 3.minutes, public: true unless secure_mode_enabled? && signed_request_account.present?
+        render json: @account, content_type: 'application/activity+json', serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter, fields: fields_selection
       end
     end
   end
@@ -130,6 +131,14 @@ class AccountsController < ApplicationController
       filtered_statuses.paginate_by_min_id(PAGE_SIZE, params[:min_id]).reverse
     else
       filtered_statuses.paginate_by_max_id(PAGE_SIZE, params[:max_id], params[:since_id]).to_a
+    end
+  end
+
+  def fields_selection
+    if signed_request_account.present? || !secure_mode_enabled?
+      # Return all fields
+    else
+      %i(id type preferred_username inbox public_key endpoints)
     end
   end
 end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -135,7 +135,7 @@ class AccountsController < ApplicationController
   end
 
   def restrict_fields_to
-    if signed_request_account.present? || !authorized_fetch_mode?
+    if signed_request_account.present? || public_fetch_mode?
       # Return all fields
     else
       %i(id type preferred_username inbox public_key endpoints)

--- a/app/controllers/activitypub/collections_controller.rb
+++ b/app/controllers/activitypub/collections_controller.rb
@@ -4,12 +4,13 @@ class ActivityPub::CollectionsController < Api::BaseController
   include SignatureVerification
   include AccountOwnedConcern
 
+  before_action :require_signature!, if: :secure_mode_enabled?
   before_action :set_size
   before_action :set_statuses
   before_action :set_cache_headers
 
   def show
-    expires_in 3.minutes, public: true
+    expires_in 3.minutes, public: true unless secure_mode_enabled?
     render json: collection_presenter, content_type: 'application/activity+json', serializer: ActivityPub::CollectionSerializer, adapter: ActivityPub::Adapter, skip_activities: true
   end
 

--- a/app/controllers/activitypub/collections_controller.rb
+++ b/app/controllers/activitypub/collections_controller.rb
@@ -4,13 +4,13 @@ class ActivityPub::CollectionsController < Api::BaseController
   include SignatureVerification
   include AccountOwnedConcern
 
-  before_action :require_signature!, if: :secure_mode_enabled?
+  before_action :require_signature!, if: :authorized_fetch_mode?
   before_action :set_size
   before_action :set_statuses
   before_action :set_cache_headers
 
   def show
-    expires_in 3.minutes, public: true unless secure_mode_enabled?
+    expires_in 3.minutes, public: !authorized_fetch_mode?
     render json: collection_presenter, content_type: 'application/activity+json', serializer: ActivityPub::CollectionSerializer, adapter: ActivityPub::Adapter, skip_activities: true
   end
 

--- a/app/controllers/activitypub/collections_controller.rb
+++ b/app/controllers/activitypub/collections_controller.rb
@@ -10,7 +10,7 @@ class ActivityPub::CollectionsController < Api::BaseController
   before_action :set_cache_headers
 
   def show
-    expires_in 3.minutes, public: !authorized_fetch_mode?
+    expires_in 3.minutes, public: public_fetch_mode?
     render json: collection_presenter, content_type: 'application/activity+json', serializer: ActivityPub::CollectionSerializer, adapter: ActivityPub::Adapter, skip_activities: true
   end
 

--- a/app/controllers/activitypub/outboxes_controller.rb
+++ b/app/controllers/activitypub/outboxes_controller.rb
@@ -11,7 +11,7 @@ class ActivityPub::OutboxesController < Api::BaseController
   before_action :set_cache_headers
 
   def show
-    expires_in page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode?
+    expires_in(page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode?)
     render json: outbox_presenter, serializer: ActivityPub::OutboxSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'
   end
 

--- a/app/controllers/activitypub/outboxes_controller.rb
+++ b/app/controllers/activitypub/outboxes_controller.rb
@@ -6,12 +6,12 @@ class ActivityPub::OutboxesController < Api::BaseController
   include SignatureVerification
   include AccountOwnedConcern
 
-  before_action :require_signature!, if: :secure_mode_enabled?
+  before_action :require_signature!, if: :authorized_fetch_mode?
   before_action :set_statuses
   before_action :set_cache_headers
 
   def show
-    expires_in 1.minute, public: true unless page_requested? || secure_mode_enabled?
+    expires_in page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode?
     render json: outbox_presenter, serializer: ActivityPub::OutboxSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'
   end
 

--- a/app/controllers/activitypub/outboxes_controller.rb
+++ b/app/controllers/activitypub/outboxes_controller.rb
@@ -11,7 +11,7 @@ class ActivityPub::OutboxesController < Api::BaseController
   before_action :set_cache_headers
 
   def show
-    expires_in(page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode?)
+    expires_in(page_requested? ? 0 : 3.minutes, public: public_fetch_mode?)
     render json: outbox_presenter, serializer: ActivityPub::OutboxSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'
   end
 

--- a/app/controllers/activitypub/outboxes_controller.rb
+++ b/app/controllers/activitypub/outboxes_controller.rb
@@ -6,12 +6,12 @@ class ActivityPub::OutboxesController < Api::BaseController
   include SignatureVerification
   include AccountOwnedConcern
 
+  before_action :require_signature!, if: :secure_mode_enabled?
   before_action :set_statuses
   before_action :set_cache_headers
 
   def show
-    expires_in 1.minute, public: true unless page_requested?
-
+    expires_in 1.minute, public: true unless page_requested? || secure_mode_enabled?
     render json: outbox_presenter, serializer: ActivityPub::OutboxSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'
   end
 

--- a/app/controllers/activitypub/replies_controller.rb
+++ b/app/controllers/activitypub/replies_controller.rb
@@ -7,13 +7,13 @@ class ActivityPub::RepliesController < Api::BaseController
 
   DESCENDANTS_LIMIT = 60
 
-  before_action :require_signature!, if: :secure_mode_enabled?
+  before_action :require_signature!, if: :authorized_fetch_mode?
   before_action :set_status
   before_action :set_cache_headers
   before_action :set_replies
 
   def index
-    expires_in 0, public: true unless secure_mode_enabled?
+    expires_in 0, public: !authorized_fetch_mode?
     render json: replies_collection_presenter, serializer: ActivityPub::CollectionSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json', skip_activities: true
   end
 

--- a/app/controllers/activitypub/replies_controller.rb
+++ b/app/controllers/activitypub/replies_controller.rb
@@ -13,7 +13,7 @@ class ActivityPub::RepliesController < Api::BaseController
   before_action :set_replies
 
   def index
-    expires_in 0, public: !authorized_fetch_mode?
+    expires_in 0, public: public_fetch_mode?
     render json: replies_collection_presenter, serializer: ActivityPub::CollectionSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json', skip_activities: true
   end
 

--- a/app/controllers/activitypub/replies_controller.rb
+++ b/app/controllers/activitypub/replies_controller.rb
@@ -7,11 +7,13 @@ class ActivityPub::RepliesController < Api::BaseController
 
   DESCENDANTS_LIMIT = 60
 
+  before_action :require_signature!, if: :secure_mode_enabled?
   before_action :set_status
   before_action :set_cache_headers
   before_action :set_replies
 
   def index
+    expires_in 0, public: true unless secure_mode_enabled?
     render json: replies_collection_presenter, serializer: ActivityPub::CollectionSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json', skip_activities: true
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,10 @@ class ApplicationController < ActionController::Base
     ENV['AUTHORIZED_FETCH'] == 'true'
   end
 
+  def public_fetch_mode?
+    !authorized_fetch_mode?
+  end
+
   def store_current_location
     store_location_for(:user, request.url) unless request.format == :json
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,6 +36,10 @@ class ApplicationController < ActionController::Base
     Rails.env.production?
   end
 
+  def secure_mode_enabled?
+    ENV['SECURE_MODE'] == 'true'
+  end
+
   def store_current_location
     store_location_for(:user, request.url) unless request.format == :json
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -156,6 +156,6 @@ class ApplicationController < ActionController::Base
   end
 
   def set_cache_headers
-    response.headers['Vary'] = 'Accept'
+    response.headers['Vary'] = 'Accept, Signature'
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,8 +36,8 @@ class ApplicationController < ActionController::Base
     Rails.env.production?
   end
 
-  def secure_mode_enabled?
-    ENV['SECURE_MODE'] == 'true'
+  def authorized_fetch_mode?
+    ENV['AUTHORIZED_FETCH'] == 'true'
   end
 
   def store_current_location

--- a/app/controllers/concerns/account_controller_concern.rb
+++ b/app/controllers/concerns/account_controller_concern.rb
@@ -11,7 +11,7 @@ module AccountControllerConcern
     layout 'public'
 
     before_action :set_instance_presenter
-    before_action :set_link_headers
+    before_action :set_link_headers, if: -> { request.format.nil? || request.format == :html }
   end
 
   private

--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -7,12 +7,20 @@ module SignatureVerification
 
   include DomainControlHelper
 
+  def require_signature!
+    render plain: signature_verification_failure_reason, status: signature_verification_failure_code unless signed_request_account
+  end
+
   def signed_request?
     request.headers['Signature'].present?
   end
 
   def signature_verification_failure_reason
-    return @signature_verification_failure_reason if defined?(@signature_verification_failure_reason)
+    @signature_verification_failure_reason
+  end
+
+  def signature_verification_failure_code
+    @signature_verification_failure_code || 401
   end
 
   def signed_request_account
@@ -125,11 +133,16 @@ module SignatureVerification
   end
 
   def account_from_key_id(key_id)
+    domain = key_id.start_with?('acct:') ? key_id.split('@').last : key_id
+
+    if domain_not_allowed?(domain)
+      @signature_verification_failure_code = 403
+      return
+    end
+
     if key_id.start_with?('acct:')
       stoplight_wrap_request { ResolveAccountService.new.call(key_id.gsub(/\Aacct:/, '')) }
     elsif !ActivityPub::TagManager.instance.local_uri?(key_id)
-      return if domain_not_allowed?(key_id)
-
       account   = ActivityPub::TagManager.instance.uri_to_resource(key_id, Account)
       account ||= stoplight_wrap_request { ActivityPub::FetchRemoteKeyService.new.call(key_id, id: false) }
       account

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -21,7 +21,7 @@ class FollowerAccountsController < ApplicationController
       format.json do
         raise Mastodon::NotPermittedError if page_requested? && @account.user_hides_network?
 
-        expires_in(page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode?)
+        expires_in(page_requested? ? 0 : 3.minutes, public: public_fetch_mode?)
 
         render json: collection_presenter,
                serializer: ActivityPub::CollectionSerializer,

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -4,7 +4,7 @@ class FollowerAccountsController < ApplicationController
   include AccountControllerConcern
   include SignatureVerification
 
-  before_action :require_signature!, if: -> { request.format == :json && secure_mode_enabled? }
+  before_action :require_signature!, if: -> { request.format == :json && authorized_fetch_mode? }
   before_action :set_cache_headers
 
   def index
@@ -19,9 +19,9 @@ class FollowerAccountsController < ApplicationController
       end
 
       format.json do
-        raise Mastodon::NotPermittedError if params[:page].present? && @account.user_hides_network?
+        raise Mastodon::NotPermittedError if page_requested? && @account.user_hides_network?
 
-        expires_in 3.minutes, public: true if params[:page].blank?
+        expires_in page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode?
 
         render json: collection_presenter,
                serializer: ActivityPub::CollectionSerializer,
@@ -37,12 +37,16 @@ class FollowerAccountsController < ApplicationController
     @follows ||= Follow.where(target_account: @account).recent.page(params[:page]).per(FOLLOW_PER_PAGE).preload(:account)
   end
 
+  def page_requested?
+    params[:page].present?
+  end
+
   def page_url(page)
     account_followers_url(@account, page: page) unless page.nil?
   end
 
   def collection_presenter
-    if params[:page].present?
+    if page_requested?
       ActivityPub::CollectionPresenter.new(
         id: account_followers_url(@account, page: params.fetch(:page, 1)),
         type: :ordered,

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -2,7 +2,9 @@
 
 class FollowerAccountsController < ApplicationController
   include AccountControllerConcern
+  include SignatureVerification
 
+  before_action :require_signature!, if: -> { request.format == :json && secure_mode_enabled? }
   before_action :set_cache_headers
 
   def index

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -21,7 +21,7 @@ class FollowerAccountsController < ApplicationController
       format.json do
         raise Mastodon::NotPermittedError if page_requested? && @account.user_hides_network?
 
-        expires_in page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode?
+        expires_in(page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode?)
 
         render json: collection_presenter,
                serializer: ActivityPub::CollectionSerializer,

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -21,7 +21,7 @@ class FollowingAccountsController < ApplicationController
       format.json do
         raise Mastodon::NotPermittedError if page_requested? && @account.user_hides_network?
 
-        expires_in(page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode?)
+        expires_in(page_requested? ? 0 : 3.minutes, public: public_fetch_mode?)
 
         render json: collection_presenter,
                serializer: ActivityPub::CollectionSerializer,

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -21,7 +21,7 @@ class FollowingAccountsController < ApplicationController
       format.json do
         raise Mastodon::NotPermittedError if page_requested? && @account.user_hides_network?
 
-        expires_in page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode? unless page_requested?
+        expires_in(page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode?)
 
         render json: collection_presenter,
                serializer: ActivityPub::CollectionSerializer,

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -2,7 +2,9 @@
 
 class FollowingAccountsController < ApplicationController
   include AccountControllerConcern
+  include SignatureVerification
 
+  before_action :require_signature!, if: -> { request.format == :json && secure_mode_enabled? }
   before_action :set_cache_headers
 
   def index

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -4,7 +4,7 @@ class FollowingAccountsController < ApplicationController
   include AccountControllerConcern
   include SignatureVerification
 
-  before_action :require_signature!, if: -> { request.format == :json && secure_mode_enabled? }
+  before_action :require_signature!, if: -> { request.format == :json && authorized_fetch_mode? }
   before_action :set_cache_headers
 
   def index
@@ -19,9 +19,9 @@ class FollowingAccountsController < ApplicationController
       end
 
       format.json do
-        raise Mastodon::NotPermittedError if params[:page].present? && @account.user_hides_network?
+        raise Mastodon::NotPermittedError if page_requested? && @account.user_hides_network?
 
-        expires_in 3.minutes, public: true if params[:page].blank?
+        expires_in page_requested? ? 0 : 3.minutes, public: !authorized_fetch_mode? unless page_requested?
 
         render json: collection_presenter,
                serializer: ActivityPub::CollectionSerializer,
@@ -37,12 +37,16 @@ class FollowingAccountsController < ApplicationController
     @follows ||= Follow.where(account: @account).recent.page(params[:page]).per(FOLLOW_PER_PAGE).preload(:target_account)
   end
 
+  def page_requested?
+    params[:page].present?
+  end
+
   def page_url(page)
     account_following_index_url(@account, page: page) unless page.nil?
   end
 
   def collection_presenter
-    if params[:page].present?
+    if page_requested?
       ActivityPub::CollectionPresenter.new(
         id: account_following_index_url(@account, page: params.fetch(:page, 1)),
         type: :ordered,

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -8,7 +8,7 @@ class StatusesController < ApplicationController
 
   layout 'public'
 
-  before_action :require_signature!, only: :show, if: -> { request.format == :json && secure_mode_enabled? }
+  before_action :require_signature!, only: :show, if: -> { request.format == :json && authorized_fetch_mode? }
   before_action :set_status
   before_action :set_instance_presenter
   before_action :set_link_headers
@@ -31,14 +31,14 @@ class StatusesController < ApplicationController
       end
 
       format.json do
-        expires_in 3.minutes, public: @status.distributable? unless secure_mode_enabled?
+        expires_in 3.minutes, public: @status.distributable? && !authorized_fetch_mode?
         render json: @status, content_type: 'application/activity+json', serializer: ActivityPub::NoteSerializer, adapter: ActivityPub::Adapter
       end
     end
   end
 
   def activity
-    expires_in 3.minutes, public: @status.distributable? unless secure_mode_enabled?
+    expires_in 3.minutes, public: @status.distributable? && !authorized_fetch_mode?
     render json: @status, content_type: 'application/activity+json', serializer: ActivityPub::ActivitySerializer, adapter: ActivityPub::Adapter
   end
 

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -8,11 +8,12 @@ class StatusesController < ApplicationController
 
   layout 'public'
 
+  before_action :require_signature!, only: :show, if: -> { request.format == :json && secure_mode_enabled? }
   before_action :set_status
   before_action :set_instance_presenter
   before_action :set_link_headers
-  before_action :redirect_to_original, only: [:show]
-  before_action :set_referrer_policy_header, only: [:show]
+  before_action :redirect_to_original, only: :show
+  before_action :set_referrer_policy_header, only: :show
   before_action :set_cache_headers
   before_action :set_body_classes
   before_action :set_autoplay, only: :embed
@@ -30,14 +31,14 @@ class StatusesController < ApplicationController
       end
 
       format.json do
-        expires_in 3.minutes, public: @status.distributable?
+        expires_in 3.minutes, public: @status.distributable? unless secure_mode_enabled?
         render json: @status, content_type: 'application/activity+json', serializer: ActivityPub::NoteSerializer, adapter: ActivityPub::Adapter
       end
     end
   end
 
   def activity
-    expires_in 3.minutes, public: @status.distributable?
+    expires_in 3.minutes, public: @status.distributable? unless secure_mode_enabled?
     render json: @status, content_type: 'application/activity+json', serializer: ActivityPub::ActivitySerializer, adapter: ActivityPub::Adapter
   end
 

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -31,14 +31,14 @@ class StatusesController < ApplicationController
       end
 
       format.json do
-        expires_in 3.minutes, public: @status.distributable? && !authorized_fetch_mode?
+        expires_in 3.minutes, public: @status.distributable? && public_fetch_mode?
         render json: @status, content_type: 'application/activity+json', serializer: ActivityPub::NoteSerializer, adapter: ActivityPub::Adapter
       end
     end
   end
 
   def activity
-    expires_in 3.minutes, public: @status.distributable? && !authorized_fetch_mode?
+    expires_in 3.minutes, public: @status.distributable? && public_fetch_mode?
     render json: @status, content_type: 'application/activity+json', serializer: ActivityPub::ActivitySerializer, adapter: ActivityPub::Adapter
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 class TagsController < ApplicationController
+  include SignatureVerification
+
   PAGE_SIZE = 20
 
   layout 'public'
 
+  before_action :require_signature!, if: -> { request.format == :json && secure_mode_enabled? }
   before_action :set_tag
   before_action :set_body_classes
   before_action :set_instance_presenter
@@ -30,7 +33,7 @@ class TagsController < ApplicationController
       end
 
       format.json do
-        expires_in 3.minutes, public: true
+        expires_in 3.minutes, public: true unless secure_mode_enabled?
 
         @statuses = HashtagQueryService.new.call(@tag, params.slice(:any, :all, :none), current_account, params[:local]).paginate_by_max_id(PAGE_SIZE, params[:max_id])
         @statuses = cache_collection(@statuses, Status)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -7,7 +7,7 @@ class TagsController < ApplicationController
 
   layout 'public'
 
-  before_action :require_signature!, if: -> { request.format == :json && secure_mode_enabled? }
+  before_action :require_signature!, if: -> { request.format == :json && authorized_fetch_mode? }
   before_action :set_tag
   before_action :set_body_classes
   before_action :set_instance_presenter
@@ -33,7 +33,7 @@ class TagsController < ApplicationController
       end
 
       format.json do
-        expires_in 3.minutes, public: true unless secure_mode_enabled?
+        expires_in 3.minutes, public: !authorized_fetch_mode?
 
         @statuses = HashtagQueryService.new.call(@tag, params.slice(:any, :all, :none), current_account, params[:local]).paginate_by_max_id(PAGE_SIZE, params[:max_id])
         @statuses = cache_collection(@statuses, Status)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -33,7 +33,7 @@ class TagsController < ApplicationController
       end
 
       format.json do
-        expires_in 3.minutes, public: !authorized_fetch_mode?
+        expires_in 3.minutes, public: public_fetch_mode?
 
         @statuses = HashtagQueryService.new.call(@tag, params.slice(:any, :all, :none), current_account, params[:local]).paginate_by_max_id(PAGE_SIZE, params[:max_id])
         @statuses = cache_collection(@statuses, Status)

--- a/app/lib/activitypub/adapter.rb
+++ b/app/lib/activitypub/adapter.rb
@@ -33,6 +33,7 @@ class ActivityPub::Adapter < ActiveModelSerializers::Adapter::Base
   def serializable_hash(options = nil)
     options         = serialization_options(options)
     serialized_hash = serializer.serializable_hash(options)
+    serialized_hash = serialized_hash.select { |k, _| options[:fields].include?(k) } if options[:fields]
     serialized_hash = self.class.transform_key_casing!(serialized_hash, instance_options)
 
     { '@context' => serialized_context }.merge(serialized_hash)

--- a/spec/controllers/activitypub/inboxes_controller_spec.rb
+++ b/spec/controllers/activitypub/inboxes_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe ActivityPub::InboxesController, type: :controller do
   describe 'POST #create' do
-    context 'if signed_request_account' do
+    context 'with signed_request_account' do
       it 'returns 202' do
         allow(controller).to receive(:signed_request_account) do
           Fabricate(:account)
@@ -15,7 +15,7 @@ RSpec.describe ActivityPub::InboxesController, type: :controller do
       end
     end
 
-    context 'not signed_request_account' do
+    context 'without signed_request_account' do
       it 'returns 401' do
         allow(controller).to receive(:signed_request_account) do
           false


### PR DESCRIPTION
- Controlled by `SECURE_MODE=true`
- Requires incoming GET requests to ActivityPub resources to be signed
- Actors can still be fetched without signature, but return only technical attributes
- Bug fix: Handle inbox requests without request body gracefully