### PR TITLE
Change the retry limit in error of web push notification

### DIFF
--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -3,7 +3,7 @@
 class Web::PushNotificationWorker
   include Sidekiq::Worker
 
-  sidekiq_options backtrace: true
+  sidekiq_options backtrace: true, retry: 5
 
   def perform(subscription_id, notification_id)
     subscription = ::Web::PushSubscription.find(subscription_id)


### PR DESCRIPTION
In the error handling of Web::PushNotificationWorker, when status 40x is returned by 
notification destination server, the job will not be retried. However, in case of status 50x, the web push job will be retries at 25 times by sidekiq. However, if destination server is heavy loaded, Web::PushNotificationWorker will retry it many times. Because the job is located at default queue, other important jobs may be delayed.

To avoid this, the maximum number of retry should be reduced. In my opinion, because the user who use the web push features requires real-time capability, the repeated retries of web push are not important. Improving the response of other jobs which is located at default queue may be prioritized than the "late" coming notification.