### PR TITLE
Disable LDSigning when AUTHORIZED_FETCH is set to true

### DIFF
--- a/app/services/concerns/payloadable.rb
+++ b/app/services/concerns/payloadable.rb
@@ -14,6 +14,6 @@ module Payloadable
   end
 
   def signing_enabled?
-    true
+    ENV['AUTHORIZED_FETCH'] != 'true'
   end
 end


### PR DESCRIPTION
Otherwise, replies and toots through relays will still end up on blocked instances