### PR TITLE
Change default interface of web and streaming from 0.0.0.0 to 127.0.0.1

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -2,9 +2,9 @@ threads_count = ENV.fetch('MAX_THREADS') { 5 }.to_i
 threads threads_count, threads_count
 
 if ENV['SOCKET']
-  bind 'unix://' + ENV['SOCKET']
+  bind "unix://#{ENV['SOCKET']}"
 else
-  port ENV.fetch('PORT') { 3000 }
+  bind "tcp://127.0.0.1:#{ENV.fetch('PORT', 3000)}"
 end
 
 environment ENV.fetch('RAILS_ENV') { 'development' }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: yarn start
+    command: BIND=0.0.0.0 node ./streaming
     networks:
       - external_network
       - internal_network

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -672,7 +672,7 @@ const attachServerWithConfig = (server, onSuccess) => {
       }
     });
   } else {
-    server.listen(+process.env.PORT || 4000, process.env.BIND || '0.0.0.0', () => {
+    server.listen(+process.env.PORT || 4000, process.env.BIND || '127.0.0.1', () => {
       if (onSuccess) {
         onSuccess(`${server.address().address}:${server.address().port}`);
       }


### PR DESCRIPTION
`0.0.0.0` was initially chosen because of Docker, but now docker-compose.yml specifies that option explicitly so that's no longer needed. Even though our documentation tells people how to setup a firewall some people in the wild haven't done that so this change will help them. Accessing web/streaming without nginx is not a super big deal (all the information is the same), but nginx offers caching so it should ideally not be circumvented.