### PR TITLE
Add periodic removal of older thumbnails for preview cards

### DIFF
--- a/app/workers/maintenance/uncache_preview_worker.rb
+++ b/app/workers/maintenance/uncache_preview_worker.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Maintenance::UncachePreviewWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'pull'
+
+  def perform(preview_card_id)
+    preview_card = PreviewCard.find(preview_card_id)
+
+    return if preview_card.image.blank?
+
+    preview_card.image.destroy
+    preview_card.save
+  rescue ActiveRecord::RecordNotFound
+    true
+  end
+end

--- a/app/workers/scheduler/preview_cards_cleanup_scheduler.rb
+++ b/app/workers/scheduler/preview_cards_cleanup_scheduler.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Scheduler::PreviewCardsCleanupScheduler
+  include Sidekiq::Worker
+
+  sidekiq_options unique: :until_executed, retry: 0
+
+  def perform
+    Maintenance::UncachePreviewWorker.push_bulk(recent_link_preview_cards.pluck(:id))
+    Maintenance::UncachePreviewWorker.push_bulk(older_preview_cards.pluck(:id))
+  end
+
+  private
+
+  def recent_link_preview_cards
+    PreviewCard.where(type: :link).where('updated_at < ?', 1.month.ago)
+  end
+
+  def older_preview_cards
+    PreviewCard.where('updated_at < ?', 6.months.ago)
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -27,6 +27,9 @@
   ip_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
     class: Scheduler::IpCleanupScheduler
+  preview_cards_cleanup_scheduler:
+    cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
+    class: Scheduler::PreviewCardsCleanupScheduler
   email_scheduler:
     cron: '0 10 * * 2'
     class: Scheduler::EmailScheduler


### PR DESCRIPTION
See also: #7056

- Remove thumbnails for link-type previews older than a month
- Remove thumbnails for other types of previews older than 6 months

Previews are re-fetched if posted again after 2 weeks, so recently used previews should not be affected.