### PR TITLE
Make puma bind address configurable with BIND env var

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@ threads threads_count, threads_count
 if ENV['SOCKET']
   bind "unix://#{ENV['SOCKET']}"
 else
-  bind "tcp://127.0.0.1:#{ENV.fetch('PORT', 3000)}"
+  bind "tcp://#{ENV.fetch('BIND', '127.0.0.1')}:#{ENV.fetch('PORT', 3000)}"
 end
 
 environment ENV.fetch('RAILS_ENV') { 'development' }


### PR DESCRIPTION
This makes it possible to keep `puma` running on Heroku with setting config var `BIND=0.0.0.0` like #11302 for streaming.