### PR TITLE
Extend AUTHORIZED_FETCH mode to user blocks as well

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -64,7 +64,6 @@ class StatusesController < ApplicationController
   def set_status
     @status = @account.statuses.find(params[:id])
     authorize @status, :show?
-    raise Mastodon::NotPermittedError if current_account&.domain&.present? && @account.domain_blocking?(current_account.domain)
   rescue Mastodon::NotPermittedError
     raise ActiveRecord::RecordNotFound
   end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -64,6 +64,7 @@ class StatusesController < ApplicationController
   def set_status
     @status = @account.statuses.find(params[:id])
     authorize @status, :show?
+    raise Mastodon::NotPermittedError if current_account&.domain&.present? && @account.domain_blocking?(current_account.domain)
   rescue Mastodon::NotPermittedError
     raise ActiveRecord::RecordNotFound
   end

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -17,7 +17,7 @@ class StatusPolicy < ApplicationPolicy
     elsif private?
       owned? || following_author? || mention_exists?
     else
-      current_account.nil? || !author_blocking?
+      current_account.nil? || (!author_blocking? && !author_blocking_domain?)
     end
   end
 
@@ -61,6 +61,12 @@ class StatusPolicy < ApplicationPolicy
     else
       record.mentions.where(account: current_account).exists?
     end
+  end
+
+  def author_blocking_domain?
+    return false if current_account.nil? || current_account.domain.nil?
+
+    author.blocking_domain?(current_account.domain)
   end
 
   def blocking_author?


### PR DESCRIPTION
We might hold off merging that until we see what cwebber has in mind, but I think it makes sense to make sure instances blocked by an user don't get to see their toots.