### PR TITLE
Fix `alerts` booleans not being typecast correctly in push subscription

### DIFF
--- a/app/serializers/rest/web_push_subscription_serializer.rb
+++ b/app/serializers/rest/web_push_subscription_serializer.rb
@@ -4,7 +4,7 @@ class REST::WebPushSubscriptionSerializer < ActiveModel::Serializer
   attributes :id, :endpoint, :alerts, :server_key
 
   def alerts
-    object.data&.dig('alerts') || {}
+    (object.data&.dig('alerts') || {}).each_with_object({}) { |(k, v), h| h[k] => ActiveModel::Type::Boolean.new.cast(v) }
   end
 
   def server_key

--- a/app/serializers/rest/web_push_subscription_serializer.rb
+++ b/app/serializers/rest/web_push_subscription_serializer.rb
@@ -4,7 +4,7 @@ class REST::WebPushSubscriptionSerializer < ActiveModel::Serializer
   attributes :id, :endpoint, :alerts, :server_key
 
   def alerts
-    (object.data&.dig('alerts') || {}).each_with_object({}) { |(k, v), h| h[k] => ActiveModel::Type::Boolean.new.cast(v) }
+    (object.data&.dig('alerts') || {}).each_with_object({}) { |(k, v), h| h[k] = ActiveModel::Type::Boolean.new.cast(v) }
   end
 
   def server_key


### PR DESCRIPTION
Fix #10789