### PR TITLE
Change Dockerfile to bind to 0.0.0.0 instead of docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ ENV NODE_ENV="production"
 
 # Tell rails to serve static files
 ENV RAILS_SERVE_STATIC_FILES="true"
+ENV BIND="0.0.0.0"
 
 # Set the run user
 USER mastodon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000"
     networks:
       - external_network
       - internal_network
@@ -58,7 +58,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: BIND=0.0.0.0 node ./streaming
+    command: node ./streaming
     networks:
       - external_network
       - internal_network


### PR DESCRIPTION
Since there is no real way to use these things from Docker if they don't bind to 0.0.0.0, the interface should be defined in the Dockerfile instead of being overriden in the docker-compose.yml file. This helps people who may run Docker containers with a different tool.