### PR TITLE
Disallow numeric-only hashtags

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -17,10 +17,10 @@ class Tag < ApplicationRecord
   has_many :featured_tags, dependent: :destroy, inverse_of: :tag
   has_one :account_tag_stat, dependent: :destroy
 
-  HASHTAG_NAME_RE = '[[:word:]_][[:word:]_]*[[:alpha:]_·]*[[:word:]_·]*[[:word:]_]'
+  HASHTAG_NAME_RE = '([[:word:]_][[:word:]_·]*[[:alpha:]_·][[:word:]_·]*[[:word:]_])|([[:word:]_]*[[:alpha:]][[:word:]_]*)'
   HASHTAG_RE = /(?:^|[^\/\)\w])#(#{HASHTAG_NAME_RE})/i
 
-  validates :name, presence: true, uniqueness: true, format: { with: /\A#{HASHTAG_NAME_RE}\z/i }
+  validates :name, presence: true, uniqueness: true, format: { with: /\A(#{HASHTAG_NAME_RE})\z/i }
 
   scope :discoverable, -> { joins(:account_tag_stat).where(AccountTagStat.arel_table[:accounts_count].gt(0)).where(account_tag_stats: { hidden: false }).order(Arel.sql('account_tag_stats.accounts_count desc')) }
   scope :hidden, -> { where(account_tag_stats: { hidden: true }) }

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe Tag, type: :model do
     it 'does not match middle dots at the end' do
       expect(subject.match('hello #one·two·three·').to_s).to eq ' #one·two·three'
     end
+
+    it 'does not match purely-numeric hashtags' do
+      expect(subject.match('hello #0123456')).to be_nil
+    end
   end
 
   describe '#to_param' do


### PR DESCRIPTION
It is my understanding that we intend to disallow numeric-only hashtags, but #11345 changed that.

This PR makes sure to reject numeric-only hashtags.