### PR TITLE
Not to create an account if already exist

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,8 @@
 Doorkeeper::Application.create!(name: 'Web', superapp: true, redirect_uri: Doorkeeper.configuration.native_redirect_uri, scopes: 'read write follow')
 
 domain = ENV['LOCAL_DOMAIN'] || Rails.configuration.x.local_domain
-Account.create!(id: -99, actor_type: 'Application', locked: true, username: domain)
+account = Account.find_or_initialize_by(id: -99, actor_type: 'Application', locked: true, username: domain)
+account.save!
 
 if Rails.env.development?
   admin  = Account.where(username: 'admin').first_or_initialize(username: 'admin')


### PR DESCRIPTION
`ActiveRecord::RecordNotUnique` raised when running test because of the same `Account` created in `db/seeds.rb`.

```
ActiveRecord::RecordNotUnique:
  PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "accounts_pkey"
  DETAIL:  Key (id)=(-99) already exists.
  : INSERT INTO "accounts" ("id", "username", "private_key", "public_key", "created_at", "updated_at", "locked", "actor_type") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"
```

Add instance actor (second take) #11321 