### PR TITLE
List columns within the method for a migration

### DIFF
--- a/db/migrate/20170918125918_ids_to_bigints.rb
+++ b/db/migrate/20170918125918_ids_to_bigints.rb
@@ -5,70 +5,70 @@ class IdsToBigints < ActiveRecord::Migration[5.1]
 
   disable_ddl_transaction!
 
-  INCLUDED_COLUMNS = [
-    [:account_domain_blocks, :account_id],
-    [:account_domain_blocks, :id],
-    [:accounts, :id],
-    [:blocks, :account_id],
-    [:blocks, :id],
-    [:blocks, :target_account_id],
-    [:conversation_mutes, :account_id],
-    [:conversation_mutes, :id],
-    [:domain_blocks, :id],
-    [:favourites, :account_id],
-    [:favourites, :id],
-    [:favourites, :status_id],
-    [:follow_requests, :account_id],
-    [:follow_requests, :id],
-    [:follow_requests, :target_account_id],
-    [:follows, :account_id],
-    [:follows, :id],
-    [:follows, :target_account_id],
-    [:imports, :account_id],
-    [:imports, :id],
-    [:media_attachments, :account_id],
-    [:media_attachments, :id],
-    [:mentions, :account_id],
-    [:mentions, :id],
-    [:mutes, :account_id],
-    [:mutes, :id],
-    [:mutes, :target_account_id],
-    [:notifications, :account_id],
-    [:notifications, :from_account_id],
-    [:notifications, :id],
-    [:oauth_access_grants, :application_id],
-    [:oauth_access_grants, :id],
-    [:oauth_access_grants, :resource_owner_id],
-    [:oauth_access_tokens, :application_id],
-    [:oauth_access_tokens, :id],
-    [:oauth_access_tokens, :resource_owner_id],
-    [:oauth_applications, :id],
-    [:oauth_applications, :owner_id],
-    [:reports, :account_id],
-    [:reports, :action_taken_by_account_id],
-    [:reports, :id],
-    [:reports, :target_account_id],
-    [:session_activations, :access_token_id],
-    [:session_activations, :user_id],
-    [:session_activations, :web_push_subscription_id],
-    [:settings, :id],
-    [:settings, :thing_id],
-    [:statuses, :account_id],
-    [:statuses, :application_id],
-    [:statuses, :in_reply_to_account_id],
-    [:stream_entries, :account_id],
-    [:stream_entries, :id],
-    [:subscriptions, :account_id],
-    [:subscriptions, :id],
-    [:tags, :id],
-    [:users, :account_id],
-    [:users, :id],
-    [:web_settings, :id],
-    [:web_settings, :user_id],
-  ]
-  INCLUDED_COLUMNS << [:deprecated_preview_cards, :id] if table_exists?(:deprecated_preview_cards)
-
   def migrate_columns(to_type)
+    included_columns = [
+      [:account_domain_blocks, :account_id],
+      [:account_domain_blocks, :id],
+      [:accounts, :id],
+      [:blocks, :account_id],
+      [:blocks, :id],
+      [:blocks, :target_account_id],
+      [:conversation_mutes, :account_id],
+      [:conversation_mutes, :id],
+      [:domain_blocks, :id],
+      [:favourites, :account_id],
+      [:favourites, :id],
+      [:favourites, :status_id],
+      [:follow_requests, :account_id],
+      [:follow_requests, :id],
+      [:follow_requests, :target_account_id],
+      [:follows, :account_id],
+      [:follows, :id],
+      [:follows, :target_account_id],
+      [:imports, :account_id],
+      [:imports, :id],
+      [:media_attachments, :account_id],
+      [:media_attachments, :id],
+      [:mentions, :account_id],
+      [:mentions, :id],
+      [:mutes, :account_id],
+      [:mutes, :id],
+      [:mutes, :target_account_id],
+      [:notifications, :account_id],
+      [:notifications, :from_account_id],
+      [:notifications, :id],
+      [:oauth_access_grants, :application_id],
+      [:oauth_access_grants, :id],
+      [:oauth_access_grants, :resource_owner_id],
+      [:oauth_access_tokens, :application_id],
+      [:oauth_access_tokens, :id],
+      [:oauth_access_tokens, :resource_owner_id],
+      [:oauth_applications, :id],
+      [:oauth_applications, :owner_id],
+      [:reports, :account_id],
+      [:reports, :action_taken_by_account_id],
+      [:reports, :id],
+      [:reports, :target_account_id],
+      [:session_activations, :access_token_id],
+      [:session_activations, :user_id],
+      [:session_activations, :web_push_subscription_id],
+      [:settings, :id],
+      [:settings, :thing_id],
+      [:statuses, :account_id],
+      [:statuses, :application_id],
+      [:statuses, :in_reply_to_account_id],
+      [:stream_entries, :account_id],
+      [:stream_entries, :id],
+      [:subscriptions, :account_id],
+      [:subscriptions, :id],
+      [:tags, :id],
+      [:users, :account_id],
+      [:users, :id],
+      [:web_settings, :id],
+      [:web_settings, :user_id],
+    ]
+    included_columns << [:deprecated_preview_cards, :id] if table_exists?(:deprecated_preview_cards)
+
     # Print out a warning that this will probably take a while.
     say ''
     say 'WARNING: This migration may take a *long* time for large instances'
@@ -86,7 +86,7 @@ class IdsToBigints < ActiveRecord::Migration[5.1]
       sleep 1
     end
 
-    tables = INCLUDED_COLUMNS.map(&:first).uniq
+    tables = included_columns.map(&:first).uniq
     table_sizes = {}
 
     # Sort tables by their size
@@ -94,7 +94,7 @@ class IdsToBigints < ActiveRecord::Migration[5.1]
       table_sizes[table] = estimate_rows_in_table(table)
     end
 
-    ordered_columns = INCLUDED_COLUMNS.sort_by do |col_parts|
+    ordered_columns = included_columns.sort_by do |col_parts|
       [-table_sizes[col_parts.first], col_parts.last]
     end
 


### PR DESCRIPTION
I tried creating a new server after a while and saw the exception below while running `rake db:migrate` for the first time. This change is to avoid this exception.

```
NoMethodError: undefined method `perform' for nil:NilClass
.../vendor/bundle/ruby/2.6.0/gems/strong_migrations-0.4.1/lib/strong_migrations/migration.rb:14:in `method_missing'
.../vendor/bundle/ruby/2.6.0/gems/activerecord-5.2.3/lib/active_record/migration.rb:604:in `method_missing'
.../db/migrate/20170918125918_ids_to_bigints.rb:69:in `<class:IdsToBigints>'
.../db/migrate/20170918125918_ids_to_bigints.rb:3:in `<top (required)>'
```