### PR TITLE
Bind servers to 0.0.0.0 in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
-web: bundle exec puma -C config/puma.rb
+web: BIND=0.0.0.0 bundle exec puma -C config/puma.rb
+#web: BIND=0.0.0.0 node ./streaming # for streaming app
 worker: bundle exec sidekiq

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,14 @@
-web: BIND=0.0.0.0 bundle exec puma -C config/puma.rb
-#web: BIND=0.0.0.0 node ./streaming # for streaming app
+web: if [ "$RUN_STREAMING" != "true" ]; then BIND=0.0.0.0 bundle exec puma -C config/puma.rb; else BIND=0.0.0.0 node ./streaming; fi
 worker: bundle exec sidekiq
+
+# For the streaming API, you need a separate app that shares Postgres and Redis:
+#
+# heroku create
+# heroku buildpacks:add heroku/nodejs
+# heroku config:set RUN_STREAMING=true
+# heroku addons:attach <main-app>::DATABASE
+# heroku addons:attach <main-app>::REDIS
+#
+# and let the main app use the separate app:
+#
+# heroku config:set STREAMING_API_BASE_URL=wss://<streaming-app>.herokuapp.com -a <main-app>


### PR DESCRIPTION
Following #11302 and #11326, this change makes it easier to deploy Mastodon as a Heroku app.

The second line is to be used for a separate app to receive streaming requests.