### PR TITLE
 Don't delete periods when validating username uniqueness (#11392)

### DIFF
--- a/app/validators/unique_username_validator.rb
+++ b/app/validators/unique_username_validator.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+# See also: USERNAME_RE in the Account class
+
 class UniqueUsernameValidator < ActiveModel::Validator
   def validate(account)
     return if account.username.nil?
 
-    normalized_username = account.username.downcase.delete('.')
+    normalized_username = account.username.downcase
 
     scope = Account.where(domain: nil).where('lower(username) = ?', normalized_username)
     scope = scope.where.not(id: account.id) if account.persisted?

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -583,6 +583,12 @@ RSpec.describe Account, type: :model do
         expect(account.valid?).to be true
       end
 
+      it 'is valid if we are creating an instance actor account with a period' do
+        account_1 = Fabricate(:account, username: 'examplecom')
+        account_2 = Fabricate.build(:account, id: -99, actor_type: 'Application', locked: true, username: 'example.com')
+        expect(account_2.valid?).to be true
+      end
+
       it 'is invalid if the username doesn\'t only contains letters, numbers and underscores' do
         account = Fabricate.build(:account, username: 'the-doctor')
         account.valid?

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -584,6 +584,11 @@ RSpec.describe Account, type: :model do
       end
 
       it 'is valid if we are creating an instance actor account with a period' do
+        account = Fabricate.build(:account, id: -99, actor_type: 'Application', locked: true, username: 'example.com')
+        expect(account.valid?).to be true
+      end
+
+      it 'is valid if we are creating a possibly-conflicting instance actor account' do
         account_1 = Fabricate(:account, username: 'examplecom')
         account_2 = Fabricate.build(:account, id: -99, actor_type: 'Application', locked: true, username: 'example.com')
         expect(account_2.valid?).to be true

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -595,6 +595,12 @@ RSpec.describe Account, type: :model do
         expect(account).to model_have_error_on_field(:username)
       end
 
+      it 'is invalid if the username contains a period' do
+        account = Fabricate.build(:account, username: 'the.doctor')
+        account.valid?
+        expect(account).to model_have_error_on_field(:username)
+      end
+
       it 'is invalid if the username is longer then 30 characters' do
         account = Fabricate.build(:account, username: Faker::Lorem.characters(31))
         account.valid?
@@ -637,12 +643,6 @@ RSpec.describe Account, type: :model do
 
       it 'is invalid if the username doesn\'t only contains letters, numbers, underscores and hyphens' do
         account = Fabricate.build(:account, domain: 'domain', username: 'the doctor')
-        account.valid?
-        expect(account).to model_have_error_on_field(:username)
-      end
-
-      it 'is invalid if the username contains a period' do
-        account = Fabricate.build(:account, domain: 'domain', username: 'the.doctor')
         account.valid?
         expect(account).to model_have_error_on_field(:username)
       end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -635,6 +635,12 @@ RSpec.describe Account, type: :model do
         expect(account).to model_have_error_on_field(:username)
       end
 
+      it 'is invalid if the username contains a period' do
+        account = Fabricate.build(:account, domain: 'domain', username: 'the.doctor')
+        account.valid?
+        expect(account).to model_have_error_on_field(:username)
+      end
+
       it 'is valid even if the username is longer then 30 characters' do
         account = Fabricate.build(:account, domain: 'domain', username: Faker::Lorem.characters(31))
         account.valid?


### PR DESCRIPTION
The 20190715164535_add_instance_actor migration fails if there's already a username similar to the domain name, e.g. if you are 'vulpine.club' and have a user named 'vulpineclub', validation fails.

Upon further review, usernames with periods are dropped by the regular expression in the Account class, so we don't need to worry about it here.

Fixes #11392