### PR TITLE
Fix boosting & unboosting preventing a boost from appearing in the TL

### DIFF
--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -247,6 +247,23 @@ RSpec.describe FeedManager do
         expect(FeedManager.instance.push_to_home(account, reblogs.last)).to be false
       end
 
+      it 'saves a new reblog of a recently-reblogged status when previous reblog has been deleted' do
+        account = Fabricate(:account)
+        reblogged = Fabricate(:status)
+        old_reblog = Fabricate(:status, reblog: reblogged)
+
+        # The first reblog should be accepted
+        expect(FeedManager.instance.push_to_home(account, old_reblog)).to be true
+
+        # The first reblog should be successfully removed
+        expect(FeedManager.instance.unpush_from_home(account, old_reblog)).to be true
+
+        reblog = Fabricate(:status, reblog: reblogged)
+
+        # The second reblog should be accepted
+        expect(FeedManager.instance.push_to_home(account, reblog)).to be true
+      end
+
       it 'does not save a new reblog of a multiply-reblogged-then-unreblogged status' do
         account   = Fabricate(:account)
         reblogged = Fabricate(:status)


### PR DESCRIPTION
Currently, if the person being the first to boost a toot in your TL unboosts it, that toot cannot appear in your TL anymore until the origin boost id falls of the 40 toots thing. This fixes that.

When aggregating boosts, if the boost that ended up in the TL is deleted, the code will reinsert the oldest boost known, but any streaming client won't know about it. I am not convinced this behavior makes sense, but it's not new, and I'm not sure how it should be handled exactly.