### PR TITLE
Change contrast of status links that are not mentions nor hashtags

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -55,6 +55,7 @@ export default class StatusContent extends React.PureComponent {
         link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
       } else {
         link.setAttribute('title', link.href);
+        link.classList.add('unhandled-link');
       }
 
       link.setAttribute('target', '_blank');

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -753,6 +753,10 @@
     }
   }
 
+  a.unhandled-link {
+    color: lighten($ui-highlight-color, 8%);
+  }
+
   .status__content__spoiler-link {
     background: $action-button-color;
 


### PR DESCRIPTION
This works regardless of how exactly originating software style the links, as long as they are not recognized as mentions or hashtags by Mastodon.

![image](https://user-images.githubusercontent.com/384364/61888963-e0566880-af04-11e9-82ff-f90ddb90141d.png)

On the other hand, this seems like it could easily be used to have fake “Show thread” links