### PR TITLE
Remove pre from version, add extra suffix variable

### DIFF
--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -16,20 +16,20 @@ module Mastodon
       2
     end
 
-    def pre
-      nil
-    end
-
     def flags
       ''
     end
 
+    def suffix
+      ''
+    end
+
     def to_a
-      [major, minor, patch, pre].compact
+      [major, minor, patch].compact
     end
 
     def to_s
-      [to_a.join('.'), flags].join
+      [to_a.join('.'), flags, suffix].join
     end
 
     def repository


### PR DESCRIPTION
Redone version of #11162. 

Because the `pre` variable is no longer used in new versions, this removes it. Because `flags` is often used to display RC versions, forks often add an additional `suffix` variable to add a custom suffix to indicate that they're forks. This adds this variable to the code but leaves it blank so that forks can add a distinguishing suffix without having to modify as much code from upstream.