### PR TITLE
Add hashtag score for better sorting of autosuggestions

### DIFF
--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -153,9 +153,9 @@ const sortHashtagsByUse = (state, tags) => {
     if (usedA === usedB) {
       return 0;
     } else if (usedA && !usedB) {
-      return 1;
-    } else {
       return -1;
+    } else {
+      return 1;
     }
   });
 };

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -7,6 +7,7 @@
 #  name       :string           default(""), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  score      :integer
 #
 
 class Tag < ApplicationRecord
@@ -78,7 +79,7 @@ class Tag < ApplicationRecord
       pattern = sanitize_sql_like(normalize(term.strip)) + '%'
 
       Tag.where(arel_table[:name].lower.matches(pattern.mb_chars.downcase.to_s))
-         .order(:name)
+         .order(Arel.sql('length(name) ASC, score DESC, name USING ~<~'))
          .limit(limit)
          .offset(offset)
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -79,7 +79,7 @@ class Tag < ApplicationRecord
       pattern = sanitize_sql_like(normalize(term.strip)) + '%'
 
       Tag.where(arel_table[:name].lower.matches(pattern.mb_chars.downcase.to_s))
-         .order(Arel.sql('length(name) ASC, score DESC, name USING ~<~'))
+         .order(Arel.sql('length(name) ASC, score DESC, name ASC'))
          .limit(limit)
          .offset(offset)
     end

--- a/app/models/trending_tags.rb
+++ b/app/models/trending_tags.rb
@@ -48,10 +48,15 @@ class TrendingTags
         redis.zrem(key, tag_id.to_s)
       else
         score = ((observed - expected)**2) / expected
-        redis.zadd(key, score, tag_id.to_s)
+        added = redis.zadd(key, score, tag_id.to_s)
+        bump_tag_score!(tag_id) if added == 1
       end
 
       redis.expire(key, EXPIRE_TRENDS_AFTER)
+    end
+
+    def bump_tag_score!(tag_id)
+      Tag.where(id: tag_id).update_all('score = COALESCE(score, 0) + 1')
     end
 
     def disallowed_hashtags

--- a/db/migrate/20190729185330_add_score_to_tags.rb
+++ b/db/migrate/20190729185330_add_score_to_tags.rb
@@ -1,0 +1,5 @@
+class AddScoreToTags < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tags, :score, :int
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_28_084117) do
+ActiveRecord::Schema.define(version: 2019_07_29_185330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -659,6 +659,7 @@ ActiveRecord::Schema.define(version: 2019_07_28_084117) do
     t.string "name", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "score"
     t.index "lower((name)::text)", name: "index_tags_on_name_lower", unique: true
   end
 


### PR DESCRIPTION
Every time a hashtag enters the trending set (this happens at most once per day), its score is incremented by one. Hashtag search results are sorted by shortness first (closer to what the user typed), then by score (things that trended before are more interesting/relevant), then alphabetically.