### PR TITLE
Fix jumping of toot date when clicking spoiler button

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -731,7 +731,7 @@
     white-space: pre-wrap;
 
     &:last-child {
-      margin-bottom: 0px;
+      margin-bottom: 0;
     }
   }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -731,7 +731,7 @@
     white-space: pre-wrap;
 
     &:last-child {
-      margin-bottom: 2px;
+      margin-bottom: 0px;
     }
   }
 


### PR DESCRIPTION
Fix the weird behavior you can see in this gif:

![Peek 31-07-2019 02-53](https://user-images.githubusercontent.com/2446451/62175524-53654200-b33e-11e9-87bd-f815a59ced37.gif)

The date of the toot moves 2px down and up uselessly when clicking the spoiler button.