### PR TITLE
Add option to exclude suspended domains/subdomains from tootctl domains crawl

### DIFF
--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -86,7 +86,7 @@ module Mastodon
       failed          = Concurrent::AtomicFixnum.new(0)
       start_at        = Time.now.to_f
       seed            = start ? [start] : Account.remote.domains
-      blocked_domains = options[:exclude_suspended] ? Regexp.new('\\.?' + DomainBlock.where(severity: 1).pluck(:domain).join('|') + '$') : ''
+      blocked_domains = Regexp.new('\\.?' + DomainBlock.where(severity: 1).pluck(:domain).join('|') + '$')
 
       pool = Concurrent::ThreadPoolExecutor.new(min_threads: 0, max_threads: options[:concurrency], idletime: 10, auto_terminate: true, max_queue: 0)
 

--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -58,6 +58,7 @@ module Mastodon
     option :concurrency, type: :numeric, default: 50, aliases: [:c]
     option :silent, type: :boolean, default: false, aliases: [:s]
     option :format, type: :string, default: 'summary', aliases: [:f]
+    option :exclude_suspended, type: :boolean, default: false, aliases: [:x]
     desc 'crawl [START]', 'Crawl all known peers, optionally beginning at START'
     long_desc <<-LONG_DESC
       Crawl the fediverse by using the Mastodon REST API endpoints that expose
@@ -74,18 +75,24 @@ module Mastodon
       default (`summary`), a summary of the statistics is returned. The other options
       are `domains`, which returns a newline-delimited list of all discovered peers,
       and `json`, which dumps all the aggregated data raw.
+
+      The --exclude-suspended (-x) option means that domains that are suspended
+      instance-wide do not appear in the output and are not included in summaries.
+      This also excludes subdomains of any of those domains.
     LONG_DESC
     def crawl(start = nil)
-      stats     = Concurrent::Hash.new
-      processed = Concurrent::AtomicFixnum.new(0)
-      failed    = Concurrent::AtomicFixnum.new(0)
-      start_at  = Time.now.to_f
-      seed      = start ? [start] : Account.remote.domains
+      stats           = Concurrent::Hash.new
+      processed       = Concurrent::AtomicFixnum.new(0)
+      failed          = Concurrent::AtomicFixnum.new(0)
+      start_at        = Time.now.to_f
+      seed            = start ? [start] : Account.remote.domains
+      blocked_domains = options[:exclude_suspended] ? DomainBlock.where(severity: 1).pluck(:domain) : []
 
       pool = Concurrent::ThreadPoolExecutor.new(min_threads: 0, max_threads: options[:concurrency], idletime: 10, auto_terminate: true, max_queue: 0)
 
       work_unit = ->(domain) do
         next if stats.key?(domain)
+        next if blocked_domains.any?{ |blocked| domain.match(Regexp.new("\\.?"+blocked+"$")) }
         stats[domain] = nil
         processed.increment
 

--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -92,7 +92,8 @@ module Mastodon
 
       work_unit = ->(domain) do
         next if stats.key?(domain)
-        next if blocked_domains.any?{ |blocked| domain.match(Regexp.new("\\.?"+blocked+"$")) }
+        next if blocked_domains.any? { |blocked| domain.match(Regexp.new('\\.?' + blocked + '$')) }
+
         stats[domain] = nil
         processed.increment
 


### PR DESCRIPTION
I encountered an issue on crawling the fediverse via `tootctl domains crawl` where there are about 185,000 spam instances of the format

```
xyza1sietvv739ur5bujjc.gab.best
xyzhnpydyv0cyiglhaoexo2.gab.best
xyzpr0aazvaj2.gab.best
xyzwiib6iw9378p.gab.best
```

I'd like more accurate stats. This new option ignores any instances suspended server-wide as well as their associated subdomains. So as an admin, I simply add `gab.best` to my domain blocks, and then run

`tootctl domains crawl --exclude-suspended`

to get stats excluding all 185k of those domains. This also significantly improves execution time for the crawl because it doesn't have to make three GET requests per each of those 185k domains.

### Implementation notes

This queries all domain suspensions up front, then runs a regexp on each domain to see if it matches the subdomain. This improves performance over what may be the obvious implementation, which is to ask `DomainBlocks.blocked?(domain)` for each domain -- this method hits the DB once per domain checked, slowing things down considerably.