### PR TITLE
Add nightly recounting of tag scores and account counters

### DIFF
--- a/app/models/trending_tags.rb
+++ b/app/models/trending_tags.rb
@@ -15,6 +15,8 @@ class TrendingTags
       increment_historical_use!(tag.id, at_time)
       increment_unique_use!(tag.id, account.id, at_time)
       increment_vote!(tag, at_time)
+
+      tag.touch(:last_status_at) if tag.last_status_at.nil? || tag.last_status_at < 24.hours.ago
     end
 
     def get(limit, filtered: true)

--- a/app/workers/scheduler/counting_scheduler.rb
+++ b/app/workers/scheduler/counting_scheduler.rb
@@ -13,7 +13,7 @@ class Scheduler::CountingScheduler
   private
 
   def recount_tag_scores!
-    Tag.find_each do |tag|
+    Tag.active.find_each do |tag|
       tag.score = Redis.current.pfcount(*(0..7).map { |i| "activity:tags:#{tag.id}:#{i.days.ago.beginning_of_day.to_i}:accounts" })
       tag.save if tag.changed?
     end

--- a/app/workers/scheduler/counting_scheduler.rb
+++ b/app/workers/scheduler/counting_scheduler.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Scheduler::CountingScheduler
+  include Sidekiq::Worker
+
+  sidekiq_options unique: :until_executed, retry: 0
+
+  def perform
+    recount_tag_scores!
+    recount_account_counters!
+  end
+
+  private
+
+  def recount_tag_scores!
+    Tag.find_each do |tag|
+      tag.score = Redis.current.pfcount(*(0..7).map { |i| "activity:tags:#{tag.id}:#{i.days.ago.beginning_of_day.to_i}:accounts" })
+      tag.save if tag.changed?
+    end
+  end
+
+  def recount_account_counters!
+    Account.joins(:user).merge(User.active).includes(:account_stat).find_each do |account|
+      account.account_stat.following_count = account.active_relationships.count
+      account.account_stat.followers_count = account.passive_relationships.count
+      account.account_stat.statuses_count  = account.statuses.where.not(visibility: :direct).count
+
+      account.account_stat.save if account.account_stat.changed?
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -31,7 +31,7 @@
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
     class: Scheduler::BackupCleanupScheduler
   counting_scheduler:
-    cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
+    cron: '<%= Random.rand(0..59) %> <%= Random.rand(20..0) %> * * *'
     class: Scheduler::CountingScheduler
   pghero_scheduler:
     cron: '0 0 * * *'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -30,6 +30,9 @@
   backup_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
     class: Scheduler::BackupCleanupScheduler
+  counting_scheduler:
+    cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
+    class: Scheduler::CountingScheduler
   pghero_scheduler:
     cron: '0 0 * * *'
     class: Scheduler::PgheroScheduler

--- a/db/migrate/20190806113401_add_last_status_at_to_tags.rb
+++ b/db/migrate/20190806113401_add_last_status_at_to_tags.rb
@@ -1,0 +1,5 @@
+class AddLastStatusAtToTags < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tags, :last_status_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_05_123746) do
+ActiveRecord::Schema.define(version: 2019_08_06_113401) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -665,6 +665,7 @@ ActiveRecord::Schema.define(version: 2019_08_05_123746) do
     t.boolean "listable"
     t.datetime "reviewed_at"
     t.datetime "requested_review_at"
+    t.datetime "last_status_at"
     t.index "lower((name)::text)", name: "index_tags_on_name_lower", unique: true
   end
 


### PR DESCRIPTION
In a daily scheduler, put the number of unique users of each hashtag from the past 7 days into the hashtags' score. Use a formula that uses both this score and the length difference between the input and the given result so that a high score could rank higher than a super short match.

Add `last_status_at` to hashtags and update it once per day to only recount the ones that had activity in the last 7 days.

Also, recount the number of followers, statuses, and follows for all active users to fix #11403.