### PR TITLE
Add breakdown of usage by source to admin UI for hashtags

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -4,6 +4,8 @@ module Admin
   class TagsController < BaseController
     before_action :set_tags, only: :index
     before_action :set_tag, except: :index
+    before_action :set_usage_by_domain, except: :index
+    before_action :set_counters, except: :index
 
     def index
       authorize :tag, :index?
@@ -33,6 +35,21 @@ module Admin
       @tag = Tag.find(params[:id])
     end
 
+    def set_usage_by_domain
+      @usage_by_domain = @tag.statuses
+                             .where(visibility: :public)
+                             .where(Status.arel_table[:id].gteq(Mastodon::Snowflake.id_at(Time.now.utc.beginning_of_day)))
+                             .joins(:account)
+                             .group('accounts.domain')
+                             .reorder('statuses_count desc')
+                             .pluck('accounts.domain, count(*) AS statuses_count')
+    end
+
+    def set_counters
+      @accounts_today = @tag.history.first[:accounts]
+      @accounts_week  = Redis.current.pfcount(*current_week_days.map { |day| "activity:tags:#{@tag.id}:#{day}:accounts" })
+    end
+
     def filtered_tags
       scope = Tag
       scope = scope.discoverable if filter_params[:context] == 'directory'
@@ -48,6 +65,14 @@ module Admin
 
     def tag_params
       params.require(:tag).permit(:name, :trendable, :usable, :listable)
+    end
+
+    def current_week_days
+      now = Time.now.utc.beginning_of_day.to_date
+
+      (Date.commercial(now.cwyear, now.cweek)..now).map do |date|
+        date.to_time.utc.beginning_of_day.to_i
+      end
     end
   end
 end

--- a/app/views/admin/tags/show.html.haml
+++ b/app/views/admin/tags/show.html.haml
@@ -1,6 +1,22 @@
 - content_for :page_title do
   = "##{@tag.name}"
 
+.dashboard__counters
+  %div
+    = link_to web_url("timelines/tag/#{@tag.name}") do
+      .dashboard__counters__num= number_with_delimiter @accounts_today
+      .dashboard__counters__label= t 'admin.tags.accounts_today'
+  %div
+    %div
+      .dashboard__counters__num= number_with_delimiter @accounts_week
+      .dashboard__counters__label= t 'admin.tags.accounts_week'
+  %div
+    = link_to explore_hashtag_path(@tag) do
+      .dashboard__counters__num= number_with_delimiter @tag.accounts_count
+      .dashboard__counters__label= t 'admin.tags.directory'
+
+%hr.spacer/
+
 = simple_form_for @tag, url: admin_tag_path(@tag.id) do |f|
   = render 'shared/error_messages', object: @tag
 
@@ -14,3 +30,16 @@
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit
+
+%hr.spacer/
+
+%h3= t 'admin.tags.breakdown'
+
+.table-wrapper
+  %table.table
+    %tbody
+      - @usage_by_domain.each do |(domain, count)|
+        %tr
+          %th= domain || site_hostname
+          %td= "#{number_with_delimiter((count.to_f / @tag.history[0][:uses].to_f) * 100)}%"
+          %td= number_with_delimiter count

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,6 +490,9 @@ en:
       title: Account statuses
       with_media: With media
     tags:
+      accounts_today: Unique uses today
+      accounts_week: Unique uses this week
+      breakdown: Breakdown of today's usage by source
       context: Context
       directory: In directory
       in_directory: "%{count} in directory"


### PR DESCRIPTION
Allows determining where the majority of posts in a hashtag come from on a given day at a glance.

![image](https://user-images.githubusercontent.com/184731/62644057-8e243700-b949-11e9-94dc-1f5c64c046f5.png)
