### PR TITLE
Fix weekly usage not being displayed correctly in hashtag admin UI

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -71,7 +71,7 @@ module Admin
       now = Time.now.utc.beginning_of_day.to_date
 
       (Date.commercial(now.cwyear, now.cweek)..now).map do |date|
-        date.to_time.utc.beginning_of_day.to_i
+        date.to_time(:utc).beginning_of_day.to_i
       end
     end
   end

--- a/app/models/trending_tags.rb
+++ b/app/models/trending_tags.rb
@@ -6,6 +6,7 @@ class TrendingTags
   EXPIRE_TRENDS_AFTER  = 1.day.seconds
   THRESHOLD            = 5
   LIMIT                = 10
+  REVIEW_THRESHOLD     = 3
 
   class << self
     include Redisable
@@ -60,7 +61,7 @@ class TrendingTags
         old_rank = redis.zrevrank(key, tag.id)
 
         redis.zadd(key, score, tag.id)
-        request_review!(tag) if (old_rank.nil? || old_rank > LIMIT) && redis.zrevrank(key, tag.id) <= LIMIT && !tag.trendable? && tag.requires_review? && !tag.requested_review?
+        request_review!(tag) if (old_rank.nil? || old_rank > REVIEW_THRESHOLD) && redis.zrevrank(key, tag.id) <= REVIEW_THRESHOLD && !tag.trendable? && tag.requires_review? && !tag.requested_review?
       end
 
       redis.expire(key, EXPIRE_TRENDS_AFTER)

--- a/app/views/admin/tags/show.html.haml
+++ b/app/views/admin/tags/show.html.haml
@@ -41,5 +41,5 @@
       - @usage_by_domain.each do |(domain, count)|
         %tr
           %th= domain || site_hostname
-          %td= "#{number_with_delimiter((count.to_f / @tag.history[0][:uses].to_f) * 100)}%"
+          %td= number_to_percentage((count / @tag.history[0][:uses].to_f) * 100)
           %td= number_with_delimiter count


### PR DESCRIPTION
Fix percentages in usage breakdown having too many digits

Change trending hashtags to only ask for review if a hashtag enters the top 3 position in the set, since it's the only items shown in the default web UI