### PR TITLE
Add cashtags

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -51,7 +51,7 @@ export default class StatusContent extends React.PureComponent {
       if (mention) {
         link.addEventListener('click', this.onMentionClick.bind(this, mention), false);
         link.setAttribute('title', mention.get('acct'));
-      } else if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
+      } else if (['#', '$'].includes(link.textContent[0]) || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
         link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
       } else {
         link.setAttribute('title', link.href);
@@ -112,7 +112,7 @@ export default class StatusContent extends React.PureComponent {
   }
 
   onHashtagClick = (hashtag, e) => {
-    hashtag = hashtag.replace(/^#/, '');
+    hashtag = hashtag.replace(/^(#|\$)/, '');
 
     if (this.context.router && e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();

--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -121,6 +121,8 @@ class Formatter
         link_to_url(entity, options)
       elsif entity[:hashtag]
         link_to_hashtag(entity)
+      elsif entity[:cashtag]
+        link_to_cashtag(entity)
       elsif entity[:screen_name]
         link_to_mention(entity, accounts)
       end
@@ -283,6 +285,10 @@ class Formatter
     hashtag_html(entity[:hashtag])
   end
 
+  def link_to_cashtag(entity)
+    cashtag_html(entity[:cashtag])
+  end
+
   def link_html(url)
     url    = Addressable::URI.parse(url).to_s
     prefix = url.match(/\Ahttps?:\/\/(www\.)?/).to_s
@@ -295,6 +301,10 @@ class Formatter
 
   def hashtag_html(tag)
     "<a href=\"#{encode(tag_url(tag))}\" class=\"mention hashtag\" rel=\"tag\">#<span>#{encode(tag)}</span></a>"
+  end
+
+  def cashtag_html(tag)
+    "<a href=\"#{encode(tag_url(tag))}\" class=\"mention hashtag\" rel=\"tag\">$<span>#{encode(tag)}</span></a>"
   end
 
   def mention_html(account)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -24,7 +24,8 @@ class Tag < ApplicationRecord
   has_one :account_tag_stat, dependent: :destroy
 
   HASHTAG_NAME_RE = '([[:word:]_][[:word:]_·]*[[:alpha:]_·][[:word:]_·]*[[:word:]_])|([[:word:]_]*[[:alpha:]][[:word:]_]*)'
-  HASHTAG_RE = /(?:^|[^\/\)\w])#(#{HASHTAG_NAME_RE})/i
+  HASHTAG_RE = /(?:^|[^\/\)\w])#(#{HASHTAG_NAME_RE})/i.freeze
+  CASHTAG_RE = /(?:^|[^\/\)\w])\$([A-Z]{3,})/.freeze
 
   validates :name, presence: true, format: { with: /\A(#{HASHTAG_NAME_RE})\z/i }
   validate :validate_name_change, if: -> { !new_record? && name_changed? }

--- a/app/services/process_hashtags_service.rb
+++ b/app/services/process_hashtags_service.rb
@@ -2,7 +2,7 @@
 
 class ProcessHashtagsService < BaseService
   def call(status, tags = [])
-    tags    = Extractor.extract_hashtags(status.text) if status.local?
+    tags    = Extractor.extract_hashtags(status.text) + Extractor.extract_cashtags(status.text) if status.local?
     records = []
 
     Tag.find_or_create_by_names(tags) do |tag|


### PR DESCRIPTION
This may be unnecessary but it's rather easy to add and not disruptive... Cashtags are hashtags in the format `$ABC`, they only work for uppercase ascii letters and only exactly 3 characters long, mostly because those were the examples given in the feature request.

Fix #7634