### PR TITLE
Fix some emojis in profile metadata labels are not emojified.

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -506,7 +506,7 @@ class Account < ApplicationRecord
   end
 
   def emojifiable_text
-    [note, display_name, fields.map(&:value)].join(' ')
+    [note, display_name, fields.map(&:name), fields.map(&:value)].join(' ')
   end
 
   def clean_feed_manager


### PR DESCRIPTION
To use emojis in the profile, the emojis returned by /api/v1/accounts/:id must contain it.