### PR TITLE
Add more accurate account search

### DIFF
--- a/app/chewy/accounts_index.rb
+++ b/app/chewy/accounts_index.rb
@@ -17,7 +17,7 @@ class AccountsIndex < Chewy::Index
     tokenizer: {
       edge_ngram: {
         type: 'edge_ngram',
-        min_gram: 2,
+        min_gram: 1,
         max_gram: 15,
       },
     },

--- a/app/chewy/accounts_index.rb
+++ b/app/chewy/accounts_index.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AccountsIndex < Chewy::Index
-  settings index: { refresh_interval: '15m' }, analysis: {
+  settings index: { refresh_interval: '5m' }, analysis: {
     analyzer: {
       content: {
         tokenizer: 'whitespace',
@@ -30,7 +30,7 @@ class AccountsIndex < Chewy::Index
       field :acct, type: 'text', analyzer: 'edge_ngram', search_analyzer: 'content', value: ->(account) { [account.username, account.domain].compact.join('@') }
       field :following_count, type: 'long', value: ->(account) { account.active_relationships.count }
       field :followers_count, type: 'long', value: ->(account) { account.passive_relationships.count }
-      field :last_status_at, type: 'date', value: ->(account) { account.last_status_at || account.updated_at }
+      field :last_status_at, type: 'date', value: ->(account) { account.last_status_at || account.created_at }
     end
   end
 end

--- a/app/chewy/accounts_index.rb
+++ b/app/chewy/accounts_index.rb
@@ -23,7 +23,7 @@ class AccountsIndex < Chewy::Index
     },
   }
 
-  define_type ::Account.searchable.includes(:account_stat) do
+  define_type ::Account.searchable.includes(:account_stat), delete_if: ->(account) { !account.searchable? } do
     root date_detection: false do
       field :id, type: 'long'
       field :display_name, type: 'text', analyzer: 'edge_ngram', search_analyzer: 'content'

--- a/app/chewy/accounts_index.rb
+++ b/app/chewy/accounts_index.rb
@@ -23,13 +23,13 @@ class AccountsIndex < Chewy::Index
     },
   }
 
-  define_type ::Account.searchable.includes(:account_stat), delete_if: ->(account) { !account.searchable? } do
+  define_type ::Account.searchable.includes(:account_stat), delete_if: ->(account) { account.destroyed? || !account.searchable? } do
     root date_detection: false do
       field :id, type: 'long'
       field :display_name, type: 'text', analyzer: 'edge_ngram', search_analyzer: 'content'
       field :acct, type: 'text', analyzer: 'edge_ngram', search_analyzer: 'content', value: ->(account) { [account.username, account.domain].compact.join('@') }
-      field :following_count, type: 'long'
-      field :followers_count, type: 'long'
+      field :following_count, type: 'long', value: ->(account) { account.active_relationships.count }
+      field :followers_count, type: 'long', value: ->(account) { account.passive_relationships.count }
       field :last_status_at, type: 'date', value: ->(account) { account.last_status_at || account.updated_at }
     end
   end

--- a/app/chewy/accounts_index.rb
+++ b/app/chewy/accounts_index.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AccountsIndex < Chewy::Index
+  settings index: { refresh_interval: '15m' }, analysis: {
+    analyzer: {
+      content: {
+        tokenizer: 'whitespace',
+        filter: %w(lowercase asciifolding cjk_width),
+      },
+
+      edge_ngram: {
+        tokenizer: 'edge_ngram',
+        filter: %w(lowercase asciifolding cjk_width),
+      },
+    },
+
+    tokenizer: {
+      edge_ngram: {
+        type: 'edge_ngram',
+        min_gram: 2,
+        max_gram: 15,
+      },
+    },
+  }
+
+  define_type ::Account.searchable.includes(:account_stat) do
+    root date_detection: false do
+      field :id, type: 'long'
+      field :display_name, type: 'text', analyzer: 'edge_ngram', search_analyzer: 'content'
+      field :acct, type: 'text', analyzer: 'edge_ngram', search_analyzer: 'content', value: ->(account) { [account.username, account.domain].compact.join('@') }
+      field :following_count, type: 'long'
+      field :followers_count, type: 'long'
+      field :last_status_at, type: 'date', value: ->(account) { account.last_status_at || account.updated_at }
+    end
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -127,6 +127,8 @@ class Account < ApplicationRecord
 
   delegate :chosen_languages, to: :user, prefix: false, allow_nil: true
 
+  update_index('accounts#account', :self) if Chewy.enabled?
+
   def local?
     domain.nil?
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -169,6 +169,10 @@ class Account < ApplicationRecord
     subscription_expires_at.present?
   end
 
+  def searchable?
+    !(suspended? || moved?)
+  end
+
   def possibly_stale?
     last_webfingered_at.nil? || last_webfingered_at <= 1.day.ago
   end

--- a/app/models/account_stat.rb
+++ b/app/models/account_stat.rb
@@ -16,6 +16,8 @@
 class AccountStat < ApplicationRecord
   belongs_to :account, inverse_of: :account_stat
 
+  update_index('accounts#account') { account if account.searchable? } if Chewy.enabled?
+
   def increment_count!(key)
     update(attributes_for_increment(key))
   end

--- a/app/models/account_stat.rb
+++ b/app/models/account_stat.rb
@@ -16,7 +16,7 @@
 class AccountStat < ApplicationRecord
   belongs_to :account, inverse_of: :account_stat
 
-  update_index('accounts#account') { account if account.searchable? } if Chewy.enabled?
+  update_index('accounts#account', :account) if Chewy.enabled?
 
   def increment_count!(key)
     update(attributes_for_increment(key))

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -4,47 +4,134 @@ class AccountSearchService < BaseService
   attr_reader :query, :limit, :offset, :options, :account
 
   def call(query, account = nil, options = {})
-    @query   = query.strip
+    @query   = query.strip.gsub(/\A@/, '')
     @limit   = options[:limit].to_i
     @offset  = options[:offset].to_i
     @options = options
     @account = account
 
-    search_service_results
+    search_service_results.compact.uniq
   end
 
   private
 
   def search_service_results
-    return [] if query_blank_or_hashtag? || limit < 1
+    return [] if query.blank? || limit < 1
 
-    if resolving_non_matching_remote_account?
-      [ResolveAccountService.new.call("#{query_username}@#{query_domain}")].compact
-    else
-      search_results_and_exact_match.compact.uniq
+    [exact_match] + search_results
+  end
+
+  def exact_match
+    return unless offset.zero? && options[:resolve] && username_complete?
+
+    return @exact_match if defined?(@exact_match)
+
+    @exact_match = ResolveAccountService.new.call(query)
+  end
+
+  def search_results
+    return if limit_for_non_exact_results.zero?
+
+    @search_results ||= begin
+      if Chewy.enabled?
+        from_elasticsearch
+      else
+        from_database
+      end
     end
   end
 
-  def resolving_non_matching_remote_account?
-    offset.zero? && options[:resolve] && !exact_match? && !domain_is_local?
+  def from_database
+    if account
+      advanced_search_results
+    else
+      simple_search_results
+    end
   end
 
-  def search_results_and_exact_match
-    return search_results.to_a unless offset.zero?
-
-    results = [exact_match]
-
-    return results if exact_match? && limit == 1
-
-    results + search_results.to_a
+  def advanced_search_results
+    Account.advanced_search_for(terms_for_query, account, limit_for_non_exact_results, options[:following], offset)
   end
 
-  def query_blank_or_hashtag?
-    query.blank? || query.start_with?('#')
+  def simple_search_results
+    Account.search_for(terms_for_query, limit_for_non_exact_results, offset)
+  end
+
+  def from_elasticsearch
+    must_clauses   = [{ multi_match: { query: terms_for_query, fields: %w(acct display_name), type: 'best_fields' } }]
+    should_clauses = []
+
+    must_clauses   << { terms: { id: following_ids } } if account && options[:following]
+    should_clauses << { terms: { id: following_ids, boost: 2 } } if account
+
+    query     = { bool: { must: must_clauses, should: should_clauses } }
+    functions = [reputation_score_function, followers_score_function, time_distance_function]
+
+    records = AccountsIndex.query(function_score: { query: query, functions: functions, score_mode: 'avg' })
+                           .limit(limit_for_non_exact_results)
+                           .offset(offset)
+                           .objects
+                           .compact
+
+    ActiveRecord::Associations::Preloader.new.preload(records, :account_stat)
+
+    records
+  end
+
+  def reputation_score_function
+    {
+      script_score: {
+        script: {
+          source: "doc['followers_count'].value / (doc['followers_count'].value + doc['following_count'].value + 1)",
+        },
+      },
+    }
+  end
+
+  def followers_score_function
+    {
+      script_score: {
+        script: {
+          source: "Math.log(2 + doc['followers_count'].value)",
+        },
+      },
+    }
+  end
+
+  def time_distance_function
+    {
+      gauss: {
+        last_status_at: {
+          scale: '3d',
+          offset: '1d',
+          decay: 0.3,
+        },
+      },
+    }
+  end
+
+  def following_ids
+    account.active_relationships.pluck(:target_account_id)
+  end
+
+  def limit_for_non_exact_results
+    if exact_match?
+      limit - 1
+    else
+      limit
+    end
+  end
+
+  def terms_for_query
+    if domain_is_local?
+      query_username
+    else
+      query
+    end
   end
 
   def split_query_string
-    @split_query_string ||= query.gsub(/\A@/, '').split('@')
+    @split_query_string ||= query.split('@')
   end
 
   def query_username
@@ -63,57 +150,11 @@ class AccountSearchService < BaseService
     @domain_is_local ||= TagManager.instance.local_domain?(query_domain)
   end
 
-  def search_from
-    options[:following] && account ? account.following : Account
-  end
-
   def exact_match?
     exact_match.present?
   end
 
-  def exact_match
-    return @exact_match if defined?(@exact_match)
-
-    @exact_match = begin
-      if domain_is_local?
-        search_from.without_suspended.find_local(query_username)
-      else
-        search_from.without_suspended.find_remote(query_username, query_domain)
-      end
-    end
-  end
-
-  def search_results
-    @search_results ||= begin
-      if account
-        advanced_search_results
-      else
-        simple_search_results
-      end
-    end
-  end
-
-  def advanced_search_results
-    Account.advanced_search_for(terms_for_query, account, limit_for_non_exact_results, options[:following], offset)
-  end
-
-  def simple_search_results
-    Account.search_for(terms_for_query, limit_for_non_exact_results, offset)
-  end
-
-  def limit_for_non_exact_results
-    if offset.zero? && exact_match?
-      limit - 1
-    else
-      limit
-    end
-  end
-
-  def terms_for_query
-    if domain_is_local?
-      query_username
-    else
-      "#{query_username} #{query_domain}"
-    end
+  def username_complete?
+    query.include?('@') && "@#{query}" =~ Account::MENTION_RE
   end
 end

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -83,7 +83,7 @@ class AccountSearchService < BaseService
     query     = { bool: { must: must_clauses, should: should_clauses } }
     functions = [reputation_score_function, followers_score_function, time_distance_function]
 
-    records = AccountsIndex.query(function_score: { query: query, functions: functions, score_mode: 'avg' })
+    records = AccountsIndex.query(function_score: { query: query, functions: functions, boost_mode: 'multiply', score_mode: 'avg' })
                            .limit(limit_for_non_exact_results)
                            .offset(offset)
                            .objects
@@ -98,7 +98,7 @@ class AccountSearchService < BaseService
     {
       script_score: {
         script: {
-          source: "doc['followers_count'].value / (doc['followers_count'].value + doc['following_count'].value + 1)",
+          source: "(doc['followers_count'].value + 0.0) / (doc['followers_count'].value + doc['following_count'].value + 1)",
         },
       },
     }

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -1,126 +1,56 @@
 require 'rails_helper'
 
 describe AccountSearchService, type: :service do
-  describe '.call' do
-    describe 'with a query to ignore' do
+  describe '#call' do
+    context 'with a query to ignore' do
       it 'returns empty array for missing query' do
         results = subject.call('', nil, limit: 10)
 
         expect(results).to eq []
       end
-      it 'returns empty array for hashtag query' do
-        results = subject.call('#tag', nil, limit: 10)
 
-        expect(results).to eq []
-      end
       it 'returns empty array for limit zero' do
         Fabricate(:account, username: 'match')
+
         results = subject.call('match', nil, limit: 0)
 
         expect(results).to eq []
       end
     end
 
-    describe 'searching for a simple term that is not an exact match' do
+    context 'searching for a simple term that is not an exact match' do
       it 'does not return a nil entry in the array for the exact match' do
-        match = Fabricate(:account, username: 'matchingusername')
-
+        account = Fabricate(:account, username: 'matchingusername')
         results = subject.call('match', nil, limit: 5)
-        expect(results).to eq [match]
+
+        expect(results).to eq [account]
       end
     end
 
-    describe 'searching local and remote users' do
-      describe "when only '@'" do
-        before do
-          allow(Account).to receive(:find_local)
-          allow(Account).to receive(:search_for)
-          subject.call('@', nil, limit: 10)
-        end
-
-        it 'uses find_local with empty query to look for local accounts' do
-          expect(Account).to have_received(:find_local).with('')
-        end
-      end
-
-      describe 'when no domain' do
-        before do
-          allow(Account).to receive(:find_local)
-          allow(Account).to receive(:search_for)
-          subject.call('one', nil, limit: 10)
-        end
-
-        it 'uses find_local to look for local accounts' do
-          expect(Account).to have_received(:find_local).with('one')
-        end
-
-        it 'uses search_for to find matches' do
-          expect(Account).to have_received(:search_for).with('one', 10, 0)
-        end
-      end
-
-      describe 'when there is a domain' do
-        before do
-          allow(Account).to receive(:find_remote)
-        end
-
-        it 'uses find_remote to look for remote accounts' do
-          subject.call('two@example.com', nil, limit: 10)
-          expect(Account).to have_received(:find_remote).with('two', 'example.com')
-        end
-
-        describe 'and there is no account provided' do
-          it 'uses search_for to find matches' do
-            allow(Account).to receive(:search_for)
-            subject.call('two@example.com', nil, limit: 10, resolve: false)
-
-            expect(Account).to have_received(:search_for).with('two example.com', 10, 0)
-          end
-        end
-
-        describe 'and there is an account provided' do
-          it 'uses advanced_search_for to find matches' do
-            account = Fabricate(:account)
-            allow(Account).to receive(:advanced_search_for)
-            subject.call('two@example.com', account, limit: 10, resolve: false)
-
-            expect(Account).to have_received(:advanced_search_for).with('two example.com', account, 10, nil, 0)
-          end
-        end
-      end
-    end
-
-    describe 'with an exact match' do
-      it 'returns exact match first, and does not return duplicates' do
-        partial = Fabricate(:account, username: 'exactness')
-        exact = Fabricate(:account, username: 'exact')
-
-        results = subject.call('exact', nil, limit: 10)
-        expect(results.size).to eq 2
-        expect(results).to eq [exact, partial]
-      end
-    end
-
-    describe 'when there is a local domain' do
+    context 'when there is a local domain' do
       around do |example|
         before = Rails.configuration.x.local_domain
+
         example.run
+
         Rails.configuration.x.local_domain = before
       end
 
       it 'returns exact match first' do
         remote     = Fabricate(:account, username: 'a', domain: 'remote', display_name: 'e')
         remote_too = Fabricate(:account, username: 'b', domain: 'remote', display_name: 'e')
-        exact = Fabricate(:account, username: 'e')
+        exact      = Fabricate(:account, username: 'e')
+
         Rails.configuration.x.local_domain = 'example.com'
 
         results = subject.call('e@example.com', nil, limit: 2)
+
         expect(results.size).to eq 2
         expect(results).to eq([exact, remote]).or eq([exact, remote_too])
       end
     end
 
-    describe 'when there is a domain but no exact match' do
+    context 'when there is a domain but no exact match' do
       it 'follows the remote account when resolve is true' do
         service = double(call: nil)
         allow(ResolveAccountService).to receive(:new).and_return(service)
@@ -138,23 +68,21 @@ describe AccountSearchService, type: :service do
       end
     end
 
-    describe 'should not include suspended accounts' do
-      it 'returns the fuzzy match first, and does not return suspended exacts' do
-        partial = Fabricate(:account, username: 'exactness')
-        exact = Fabricate(:account, username: 'exact', suspended: true)
+    it 'returns the fuzzy match first, and does not return suspended exacts' do
+      partial = Fabricate(:account, username: 'exactness')
+      exact   = Fabricate(:account, username: 'exact', suspended: true)
+      results = subject.call('exact', nil, limit: 10)
 
-        results = subject.call('exact', nil, limit: 10)
-        expect(results.size).to eq 1
-        expect(results).to eq [partial]
-      end
+      expect(results.size).to eq 1
+      expect(results).to eq [partial]
+    end
 
-      it "does not return suspended remote accounts" do
-        remote = Fabricate(:account, username: 'a', domain: 'remote', display_name: 'e', suspended: true)
+    it "does not return suspended remote accounts" do
+      remote  = Fabricate(:account, username: 'a', domain: 'remote', display_name: 'e', suspended: true)
+      results = subject.call('a@example.com', nil, limit: 2)
 
-        results = subject.call('a@example.com', nil, limit: 2)
-        expect(results.size).to eq 0
-        expect(results).to eq []
-      end
+      expect(results.size).to eq 0
+      expect(results).to eq []
     end
   end
 end


### PR DESCRIPTION
When ElasticSearch is available, a more accurate search is implemented:

- Using edge n-gram index for acct and display name
- Using asciifolding and cjk width normalization on display names
- Using Gaussian decay on account activity for additional scoring (recency)
- Using followers/friends ratio for additional scoring (spamminess)
- Using followers number for additional scoring (size)

Additionally, the previous behaviour is also kept:

- Prioritizing people you follow (closeness)

The exact match precedence only takes effect when the input conforms to the username format and the username part of it is complete, i.e. when the user started typing the domain part.

**What does this mean?** Searching for people who have unicode characters in their display names, such as accents and umlauts, has become possible without entering those characters (asciifolding); likewise, you no longer need to use the exact flavour of CJK characters (full-width/half-width) to get the same results; accounts that haven't been active in a long time are less likely to appear near the top; accounts that are follow-botting are less likely to appear near the top (spamminess), and more established accounts (by followers number) are more likely to appear higher (but mind, that's within specific searches). Like before, the biggest factor is whether you're following someone.

___

### Evaluations

I decided to run different queries for the same search term to see the differences between results and how they are scored. The queries did not consider follow relationships because a user that is followed by the searching user will universally appear at the top of the results.

#### Search term "garg"

Expecting to find: "Gargron"

Here is the status quo, search results from PostgreSQL for comparison:

|Document score|Completion|
|--------------|----------|
|0.583333|Gargy|
|0.583333|gargosoft@instance.business|
|0.583333|Gargo@kinky.business|
|0.583333|gargath@canislupus.im|
|0.583333|gargantia@peertube.mastodon.host|
|0.583333|gargoyle@witchcraft.cafe|
|0.583333|gargamel@botsin.space|
|0.583333|Gargantia|
|0.583333|gargronbot|
|0.5|AnvitZero|

The first result is a dead account, the rest are mostly bots.

Now, let's begin with a simple query without any additional scoring:

|Document score|Completion|
|--------------|----------|
|26.223595|garg|
|24.804735|Gargy|
|23.99578|gargan|
|23.249702|Gargron|
|22.583332|gargle|
|22.343393|gargrant|
|22.343393|Gargabob|
|21.893581|Gargoyle|
|21.849594|Garg0yle|
|21.849594|gargirl_|

The third result is an active account, the rest, not so much. They're also all local accounts.

Same query with follower ratio affecting the score:

|Document score|Completion|Follower ratio|
|--------------|----------|--------------|
|23.213722|Gargron|0.9984334183049349|
|16.653728|gargamel@botsin.space|0.9487179487179487|
|16.490458|gargron@mastodon.cloud|0.9615384615384616|
|16.437838|gargronbot|0.8095238095238095|
|15.444919|gargron@social.tchncs.de|0.9444444444444444|
|14.700065|Gargron@not.phrack.fyi|0.8571428571428571|
|12.664553|Gargron@workshop.chaurocks.com|0.7368421052631579|
|12.636898|Gargoyle89@bear.community|0.7368421052631579|
|11.447411|Gargron@pixelfed.social|0.7|
|11.301861|Garg0yle|0.5172413793103449|

There are more interesting results here. Some accounts are bots/inactive/fake, however. The follower ratio isn't very insightful alone because it behaves wildly at low numbers.

Same query, but with followers number affecting the score:

|Document score|Completion|Followers|
|--------------|----------|---------|
|125.62445|Gargron|253021|
|46.84463|Gargron@tooting.ai|730|
|39.91339|Gargron@gonext.gg|208|
|37.98905|Gargy|32|
|37.80327|Gargantia|75|
|34.1727|Gargron@icosahedron.website|91|
|31.940203|gargosoft@instance.business|64|
|27.929485|gargamel@botsin.space|37|
|27.49409|gargath@canislupus.im|46|
|26.885624|Garg0yle|15|

These are pretty interesting results. The first two accounts are real and active. The third is real, but belongs to an instance that's been dead for a year. The fourth is a dead account. The fifth and sixth accounts are real and active.

Same query, but with last activity affecting the score:

|Document score|Completion|Last activity|
|--------------|----------|-------------|
|23.993477|gargan|2019-07-14T09:13:39.612Z|
|23.250185|Gargron|2019-08-13T15:54:40.449Z|
|20.651749|gargle|2019-07-06T12:17:49.275Z|
|20.038937|Gargantia|2019-08-13T14:32:59.966Z|
|17.35989|gargan@mstdn.onl|2019-08-09T16:02:42.902Z|
|17.35989|Gargron@icosahedron.website|2019-08-11T22:36:35.678Z|
|17.150051|gargron@mastodon.cloud|2019-07-28T06:02:13.118Z|
|16.35344|gargron@social.tchncs.de|2019-07-28T05:42:18.582Z|
|16.35344|gargaml@mamot.fr|2019-07-25T05:42:19.984Z|
|16.35344|Gargron@tooting.ai|2019-08-12T18:55:56.475Z|

These results seem a bit nonsense. At the very least, they're neither all local, nor is the long inactive gonext.gg account among them.

Now, same query, but combining all 3 scoring modifiers:

|Document score|Completion|
|--------------|----------|
|57.362843|Gargron|
|24.647789|Gargron@tooting.ai|
|22.533825|Gargantia|
|20.086798|Gargron@icosahedron.website|
|19.396187|gargron@mastodon.cloud|
|17.570133|gargron@social.tchncs.de|
|16.815432|gargath@canislupus.im|
|15.135833|Gargy|
|14.861097|gargamel@botsin.space|
|14.809118|Gargron@gonext.gg|

The first 4 results are real and active accounts. The fifth is fake, the sixth is inactive, the rest are dead. Seeing these suggestions, the user could press ENTER to get the desired completion immediately.

### Search term "electro"

Expected to find "electroCutie@beach.city"

Status quo from PostgreSQL:

|Document score|Completion|
|--------------|----------|
|0.583333|6klop_electronix@peertube.mastodon.host|
|0.583333|electronicbites|
|0.583333|electroniclife@zotum.net|
|0.583333|electronicfix|
|0.583333|electromeca|
|0.583333|Electrospaces|
|0.583333|electronlover|
|0.583333|ElectronKnight|
|0.583333|electropure@switter.at|
|0.583333|ElectronicOpus@mastodon.land|

Just like in the other example, there is no real logic to the results and what we expect to find isn't there at all.

No additional scoring:

|Document score|Completion|
|--------------|----------|
|20.166695|electronio|
|19.980896|Electrocutie|
|19.980896|Electropanda|
|19.51557|electround|
|19.51557|electrofin|
|19.32907|electronicfix|
|19.147978|electromeca|
|18.899029|electrovert|
|18.801424|electrofryed|
|18.500273|electrofelix|

While *a* "electrocutie" is the second result, that's a different account that was last active in 2017.

Follower ratio affecting the score:

|Document score|Completion|Follower ratio|
|--------------|----------|--------------|
|0.99934167|eff|0.9993416721527321|
|0.93073595|ElectronicOpus|0.9307359307359307|
|0.9216758|electronicfam|0.9216757741347905|
|0.8947368|electronicintifada@newsbots.eu|0.8947368421052632|
|0.8888889|KinkMuxer@monsterpit.net|0.8888888888888888|
|0.71428573|Electron@eldritch.cafe|0.7142857142857143|
|0.69430053|ElectronDance|0.694300518134715|
|0.68|Electrospaces|0.68|
|0.59375|electronic@mastodon.cloud|0.59375|
|0.57894737|Electronicfreak@chaos.social|0.5789473684210527|

What we expect to find isn't there at all. The first result is an active and popular bot, but most of the other results are inactive or fake.

Followers number affecting the score:

|Document score|Completion|Followers|
|--------------|----------|---------|
|48.421394|electronicfam|506|
|46.409096|ElectronicOpus|430|
|39.119625|Electron@social.art-software.fr|231|
|37.55837|ElectronDance|134|
|37.092392|electroCutie@beach.city|147|
|33.518337|Electrolux@switter.at|90|
|33.07969|electrotamitha@octodon.social|97|
|32.782784|Electronic_Bunny@todon.nl|93|
|25.746859|eff|3036|
|25.717287|Electrohead@switter.at|34|

The first two accounts are inactive. The third and fourth are real, and hey, it appears! What we expect to find is the 5th result.

Last activity affecting the score:

|Document score|Completion|Last activity|
|--------------|----------|-------------|
|20.166739|electronio|2019-07-24T22:11:32.799Z|
|19.147995|electromeca|2019-08-13T16:57:55.021Z|
|18.145172|ElectronikBrain@noagendasocial.com|2019-07-28T04:42:35.112Z|
|17.603788|ElectronDance|2019-07-18T11:26:13.697Z|
|17.068218|electrotamitha@toot.cat|2019-08-12T12:12:21.506Z|
|17.068218|electronic@mastodon.cloud|2019-07-29T04:42:14.630Z|
|17.068218|electroCutie@beach.city|2019-08-12T16:16:11.123Z|
|16.795864|electronicintifada@newsbots.eu|2019-08-12T19:35:13.601Z|
|16.795864|Electron@pix.diaspodon.fr|2019-08-07T19:47:17.972Z|
|16.57605|electrodnd21@todon.nl|2019-08-01T15:42:59.433Z|

All the accounts indeed have posted within the last two months, and one of them is the one we expect to find, however, it is low on the list.

All combined:

|Document score|Completion|
|--------------|----------|
|22.461493|ElectronDance|
|21.638235|electronicfam|
|20.932909|ElectronicOpus|
|20.93084|Electron@social.art-software.fr|
|20.209057|electroCutie@beach.city|
|19.339832|Electronic_Bunny@todon.nl|
|17.767172|electronicintifada@newsbots.eu|
|17.099651|ElectronikBrain@noagendasocial.com|
|16.590124|electronic@mastodon.cloud|
|16.419668|electromeca|

The first result is real. The second has never posted. The third is inactive. The fourth is real and active. The fifth is what we were looking to find. Seeing these suggestions, the user would have to type another "c" to get the desired result and press ENTER.