### PR TITLE
Revert bcrypt to 3.1.12

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
-    bcrypt (3.1.13)
+    bcrypt (3.1.12)
     benchmark-ips (2.7.2)
     better_errors (2.5.1)
       coderay (>= 1.0.0)


### PR DESCRIPTION
It fails to build on ARM (see https://github.com/codahale/bcrypt-ruby/issues/201), and based on the release notes (https://github.com/codahale/bcrypt-ruby/releases/tag/v3.1.12), I do not think 3.1.13 brings anything we're interested in.