### PR TITLE
Require at least 1 accepted follow from the remote domain for AUTHORIZED_FETCH mode.

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -61,6 +61,12 @@ module SignatureVerification
       return
     end
 
+    unless Follow.where(account: Account.where(domain: account.domain)).exists?
+      @signature_verification_failure_reason = "No trusted users found from the domain of key ID #{signature_params['keyId']}"
+      @signed_request_account = nil
+      return
+    end
+
     signature             = Base64.decode64(signature_params['signature'])
     compare_signed_string = build_signed_string(signature_params['headers'])
 

--- a/spec/controllers/concerns/signature_verification_spec.rb
+++ b/spec/controllers/concerns/signature_verification_spec.rb
@@ -39,6 +39,7 @@ describe ApplicationController, type: :controller do
 
   context 'with signature header' do
     let!(:author) { Fabricate(:account, domain: 'example.com', uri: 'https://example.com/actor') }
+    let!(:follows_local_user) { Fabricate(:follow, account: author) }
 
     context 'without body' do
       before do


### PR DESCRIPTION
This means that remote instances will at least be *visible* to the admin.