### PR TITLE
Add explanations to user block confirmation dialog and add stealth blocks

### DIFF
--- a/app/controllers/account_follow_controller.rb
+++ b/app/controllers/account_follow_controller.rb
@@ -6,7 +6,7 @@ class AccountFollowController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    FollowService.new.call(current_user.account, @account, with_rate_limit: true)
+    FollowService.new.call(current_user.account, @account, with_rate_limit: true) unless @account.stealth_blocking?(current_user.account)
     redirect_to account_path(@account)
   end
 end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -23,7 +23,7 @@ class AccountsController < ApplicationController
         @endorsed_accounts = @account.endorsed_accounts.to_a.sample(4)
         @featured_hashtags = @account.featured_tags.order(statuses_count: :desc)
 
-        if current_account && @account.blocking?(current_account)
+        if current_account && @account.hard_blocking?(current_account)
           @statuses = []
           return
         end

--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
   end
 
   def hide_results?
-    @account.suspended? || (@account.hides_followers? && current_account&.id != @account.id) || (current_account && @account.blocking?(current_account))
+    @account.suspended? || (@account.hides_followers? && current_account&.id != @account.id) || (current_account && @account.hard_blocking?(current_account))
   end
 
   def default_accounts

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
   end
 
   def hide_results?
-    @account.suspended? || (@account.hides_following? && current_account&.id != @account.id) || (current_account && @account.blocking?(current_account))
+    @account.suspended? || (@account.hides_following? && current_account&.id != @account.id) || (current_account && @account.hard_blocking?(current_account))
   end
 
   def default_accounts

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def block
-    BlockService.new.call(current_user.account, @account, truthy_param?(:stealth_block))
+    BlockService.new.call(current_user.account, @account, stealth: truthy_param?(:stealth_block))
     render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships
   end
 

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -31,7 +31,15 @@ class Api::V1::AccountsController < Api::BaseController
 
   def follow
     follow  = FollowService.new.call(current_user.account, @account, reblogs: params.key?(:reblogs) ? truthy_param?(:reblogs) : nil, notify: params.key?(:notify) ? truthy_param?(:notify) : nil, with_rate_limit: true)
-    options = @account.locked? || current_user.account.silenced? ? {} : { following_map: { @account.id => { reblogs: follow.show_reblogs?, notify: follow.notify? } }, requested_map: { @account.id => false } }
+    options = begin
+      if @account.locked? || current_user.account.silenced?
+        {}
+      elsif follow.nil?
+        { following_map: { @account.id => { reblogs: truthy_param?(:reblogs), notify: truthy_param?(:notify) } }, requested_map: { @account.id => false } }
+      else
+        { following_map: { @account.id => { reblogs: follow.show_reblogs?, notify: follow.notify? } }, requested_map: { @account.id => false } }
+      end
+    end
 
     render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships(options)
   end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def block
-    BlockService.new.call(current_user.account, @account)
+    BlockService.new.call(current_user.account, @account, truthy_param?(:stealth_block))
     render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships
   end
 

--- a/app/controllers/api/v2/blocks_controller.rb
+++ b/app/controllers/api/v2/blocks_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Api::V2::BlocksController < Api::V1::BlocksController
+  def index
+    @blocks = load_blocks
+    render json: @blocks, each_serializer: REST::BlockSerializer
+  end
+
+  def load_blocks
+    paginated_blocks.to_a
+  end
+end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -28,7 +28,7 @@ module AccountsHelper
           safe_join([svg_logo, t('accounts.unfollow')])
         end
       elsif !(account.memorial? || account.moved?)
-        link_to account_follow_path(account), class: "button logo-button#{account.blocking?(current_account) ? ' disabled' : ''}", data: { method: :post } do
+        link_to account_follow_path(account), class: "button logo-button#{account.hard_blocking?(current_account) ? ' disabled' : ''}", data: { method: :post } do
           safe_join([svg_logo, t('accounts.follow')])
         end
       end
@@ -48,7 +48,7 @@ module AccountsHelper
           fa_icon('user-times fw')
         end
       elsif !(account.memorial? || account.moved?)
-        link_to account_follow_path(account), class: "icon-button#{account.blocking?(current_account) ? ' disabled' : ''}", data: { method: :post }, title: t('accounts.follow') do
+        link_to account_follow_path(account), class: "icon-button#{account.hard_blocking?(current_account) ? ' disabled' : ''}", data: { method: :post }, title: t('accounts.follow') do
           fa_icon('user-plus fw')
         end
       end

--- a/app/javascript/mastodon/actions/accounts.js
+++ b/app/javascript/mastodon/actions/accounts.js
@@ -188,11 +188,11 @@ export function unfollowAccountFail(error) {
   };
 };
 
-export function blockAccount(id) {
+export function blockAccount(id, hard_block = false) {
   return (dispatch, getState) => {
     dispatch(blockAccountRequest(id));
 
-    api(getState).post(`/api/v1/accounts/${id}/block`).then(response => {
+    api(getState).post(`/api/v1/accounts/${id}/block`, { stealth_block: !hard_block }).then(response => {
       // Pass in entire statuses map so we can use it to filter stuff in different parts of the reducers
       dispatch(blockAccountSuccess(response.data, getState().get('statuses')));
     }).catch(error => {

--- a/app/javascript/mastodon/actions/blocks.js
+++ b/app/javascript/mastodon/actions/blocks.js
@@ -11,7 +11,8 @@ export const BLOCKS_EXPAND_REQUEST = 'BLOCKS_EXPAND_REQUEST';
 export const BLOCKS_EXPAND_SUCCESS = 'BLOCKS_EXPAND_SUCCESS';
 export const BLOCKS_EXPAND_FAIL    = 'BLOCKS_EXPAND_FAIL';
 
-export const BLOCKS_INIT_MODAL = 'BLOCKS_INIT_MODAL';
+export const BLOCKS_INIT_MODAL        = 'BLOCKS_INIT_MODAL';
+export const BLOCKS_TOGGLE_HARD_BLOCK = 'BLOCKS_TOGGLE_HARD_BLOCK';
 
 export function fetchBlocks() {
   return (dispatch, getState) => {
@@ -95,5 +96,11 @@ export function initBlockModal(account) {
     });
 
     dispatch(openModal('BLOCK'));
+  };
+}
+
+export function toggleHardBlock() {
+  return dispatch => {
+    dispatch({ type: BLOCKS_TOGGLE_HARD_BLOCK });
   };
 }

--- a/app/javascript/mastodon/reducers/blocks.js
+++ b/app/javascript/mastodon/reducers/blocks.js
@@ -2,11 +2,13 @@ import Immutable from 'immutable';
 
 import {
   BLOCKS_INIT_MODAL,
+  BLOCKS_TOGGLE_HARD_BLOCK,
 } from '../actions/blocks';
 
 const initialState = Immutable.Map({
   new: Immutable.Map({
     account_id: null,
+    hard_block: false,
   }),
 });
 
@@ -15,7 +17,10 @@ export default function mutes(state = initialState, action) {
   case BLOCKS_INIT_MODAL:
     return state.withMutations((state) => {
       state.setIn(['new', 'account_id'], action.account.get('id'));
+      state.setIn(['new', 'hard_block'], false);
     });
+  case BLOCKS_TOGGLE_HARD_BLOCK:
+    return state.updateIn(['new', 'hard_block'], (old) => !old);
   default:
     return state;
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4958,6 +4958,18 @@ a.status-card.compact:hover {
   margin-bottom: 29px;
 }
 
+.block-modal {
+  .setting-toggle {
+    margin-top: 20px;
+    margin-bottom: 24px;
+
+    &__label {
+      color: $inverted-text-color;
+      font-size: 14px;
+    }
+  }
+}
+
 .report-modal__comment {
   padding: 20px;
   border-right: 1px solid $ui-secondary-color;

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -6,7 +6,7 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
   def perform
     target_account = account_from_uri(object_uri)
 
-    return if target_account.nil? || !target_account.local? || delete_arrived_first?(@json['id']) || @account.requested?(target_account)
+    return if target_account.nil? || !target_account.local? || delete_arrived_first?(@json['id']) || @account.requested?(target_account) || target_account.stealth_blocking?(@account)
 
     if target_account.blocking?(@account) || target_account.domain_blocking?(@account.domain) || target_account.moved? || target_account.instance_actor?
       reject_follow_request!(target_account)

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -9,6 +9,7 @@
 #  account_id        :bigint(8)        not null
 #  target_account_id :bigint(8)        not null
 #  uri               :string
+#  stealth           :boolean
 #
 
 class Block < ApplicationRecord

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -125,9 +125,9 @@ module AccountInteractions
     rel
   end
 
-  def block!(other_account, uri: nil)
+  def block!(other_account, uri: nil, stealth: false)
     remove_potential_friendship(other_account)
-    block_relationships.create_with(uri: uri)
+    block_relationships.create_with(uri: uri, stealth: stealth)
                        .find_or_create_by!(target_account: other_account)
   end
 
@@ -186,6 +186,10 @@ module AccountInteractions
 
   def blocking?(other_account)
     block_relationships.where(target_account: other_account).exists?
+  end
+
+  def stealth_blocking?(other_account)
+    block_relationships.where(target_account: other_account, stealth: true).exists?
   end
 
   def domain_blocking?(other_domain)

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -22,7 +22,7 @@ module AccountInteractions
     end
 
     def blocked_by_map(target_account_ids, account_id)
-      follow_mapping(Block.where(account_id: target_account_ids, target_account_id: account_id), :account_id)
+      follow_mapping(Block.where(account_id: target_account_ids, target_account_id: account_id).where(stealth: [nil, false]), :account_id)
     end
 
     def muting_map(target_account_ids, account_id)
@@ -84,7 +84,7 @@ module AccountInteractions
     # Block relationships
     has_many :block_relationships, class_name: 'Block', foreign_key: 'account_id', dependent: :destroy
     has_many :blocking, -> { order('blocks.id desc') }, through: :block_relationships, source: :target_account
-    has_many :blocked_by_relationships, class_name: 'Block', foreign_key: :target_account_id, dependent: :destroy
+    has_many :blocked_by_relationships, -> { where(stealth: [nil, false]) }, class_name: 'Block', foreign_key: :target_account_id, dependent: :destroy
     has_many :blocked_by, -> { order('blocks.id desc') }, through: :blocked_by_relationships, source: :account
 
     # Mute relationships
@@ -190,6 +190,10 @@ module AccountInteractions
 
   def stealth_blocking?(other_account)
     block_relationships.where(target_account: other_account, stealth: true).exists?
+  end
+
+  def hard_blocking?(other_account)
+    block_relationships.where(target_account: other_account).where(stealth: [nil, false]).exists?
   end
 
   def domain_blocking?(other_domain)

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -18,7 +18,11 @@ class Export
   end
 
   def to_blocked_accounts_csv
-    to_csv account.blocking.select(:username, :domain)
+    CSV.generate(headers: ['Account address', 'Stealth'], write_headers: true) do |csv|
+      account.block_relationships.includes(:target_account).reorder(id: :desc).each do |block|
+        csv << [acct(block.target_account), block.stealth]
+      end
+    end
   end
 
   def to_muted_accounts_csv

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -322,7 +322,7 @@ class Status < ApplicationRecord
 
       if account.nil?
         where(visibility: visibility)
-      elsif target_account.blocking?(account) || (account.domain.present? && target_account.domain_blocking?(account.domain)) # get rid of blocked peeps
+      elsif target_account.hard_blocking?(account) || (account.domain.present? && target_account.domain_blocking?(account.domain)) # get rid of blocked peeps
         none
       elsif account.id == target_account.id # author can see own stuff
         all

--- a/app/policies/status_policy.rb
+++ b/app/policies/status_policy.rb
@@ -80,7 +80,7 @@ class StatusPolicy < ApplicationPolicy
   def author_blocking?
     return false if current_account.nil?
 
-    @preloaded_relations[:blocked_by] ? @preloaded_relations[:blocked_by][author.id] : author.blocking?(current_account)
+    @preloaded_relations[:blocked_by] ? @preloaded_relations[:blocked_by][author.id] : author.hard_blocking?(current_account)
   end
 
   def following_author?

--- a/app/serializers/rest/block_serializer.rb
+++ b/app/serializers/rest/block_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class REST::BlockSerializer < ActiveModel::Serializer
+  attributes :stealth
+
+  belongs_to :target_account, serializer: REST::AccountSerializer
+
+  def stealth
+    object.stealth?
+  end
+end

--- a/app/services/block_service.rb
+++ b/app/services/block_service.rb
@@ -3,7 +3,7 @@
 class BlockService < BaseService
   include Payloadable
 
-  def call(account, target_account, stealth = false)
+  def call(account, target_account, stealth: false)
     return if account.id == target_account.id
 
     UnfollowService.new.call(account, target_account) if account.following?(target_account)

--- a/app/services/import_service.rb
+++ b/app/services/import_service.rb
@@ -32,7 +32,7 @@ class ImportService < BaseService
 
   def import_blocks!
     parse_import_data!(['Account address'])
-    import_relationships!('block', 'unblock', @account.blocking, ROWS_PROCESSING_LIMIT)
+    import_relationships!('block', 'unblock', @account.blocking, ROWS_PROCESSING_LIMIT, stealth: { header: 'Stealth', default: false })
   end
 
   def import_mutes!

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -29,7 +29,7 @@
         = active_link_to t('accounts.posts_with_replies'), short_account_with_replies_url(@account)
         = active_link_to t('accounts.media'), short_account_media_url(@account)
 
-      - if user_signed_in? && @account.blocking?(current_account)
+      - if user_signed_in? && @account.hard_blocking?(current_account)
         .nothing-here.nothing-here--under-tabs= t('accounts.unavailable')
       - elsif @statuses.empty?
         = nothing_here 'nothing-here--under-tabs'

--- a/app/workers/import/relationship_worker.rb
+++ b/app/workers/import/relationship_worker.rb
@@ -19,7 +19,7 @@ class Import::RelationshipWorker
     when 'unfollow'
       UnfollowService.new.call(from_account, target_account)
     when 'block'
-      BlockService.new.call(from_account, target_account)
+      BlockService.new.call(from_account, target_account, options)
     when 'unblock'
       UnblockService.new.call(from_account, target_account)
     when 'mute'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -502,6 +502,8 @@ Rails.application.routes.draw do
     namespace :v2 do
       resources :media, only: [:create]
       get '/search', to: 'search#index', as: :search
+
+      resources :blocks,       only: [:index]
     end
 
     namespace :web do

--- a/db/migrate/20190929210127_add_stealth_to_blocks.rb
+++ b/db/migrate/20190929210127_add_stealth_to_blocks.rb
@@ -1,0 +1,6 @@
+class AddStealthToBlocks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :blocks, :stealth, :boolean
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -268,6 +268,7 @@ ActiveRecord::Schema.define(version: 2020_12_18_054746) do
     t.bigint "account_id", null: false
     t.bigint "target_account_id", null: false
     t.string "uri"
+    t.boolean "stealth"
     t.index ["account_id", "target_account_id"], name: "index_blocks_on_account_id_and_target_account_id", unique: true
     t.index ["target_account_id"], name: "index_blocks_on_target_account_id"
   end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -150,6 +150,47 @@ RSpec.describe AccountsController, type: :controller do
           end
         end
 
+        context 'when user is stealthily blocked' do
+          before do
+            account.block!(user.account, stealth: true)
+            get :show, params: { username: account.username, format: format }
+          end
+
+          it_behaves_like 'common response characteristics'
+
+          it 'renders public status' do
+            expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status))
+          end
+
+          it 'renders self-reply' do
+            expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_self_reply))
+          end
+
+          it 'renders status with media' do
+            expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_media))
+          end
+
+          it 'renders reblog' do
+            expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_reblog.reblog))
+          end
+
+          it 'renders pinned status' do
+            expect(response.body).to include(I18n.t('stream_entries.pinned'))
+          end
+
+          it 'does not render private status' do
+            expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_private))
+          end
+
+          it 'does not render direct status' do
+            expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_direct))
+          end
+
+          it 'does not render reply to someone else' do
+            expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reply))
+          end
+        end
+
         context 'when user is blocked' do
           before do
             account.block!(user.account)

--- a/spec/controllers/api/v2/blocks_controller_spec.rb
+++ b/spec/controllers/api/v2/blocks_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V2::BlocksController, type: :controller do
       stealth_block = Fabricate(:block, account: user.account, stealth: true)
       get :index
       result = body_as_json.each_with_object({}) { |v, h| h[v[:target_account][:id]] = v[:stealth] }
-      expect(result[block.target_account_id.to_s]).to eq false
+      expect(result[block.target_account_id.to_s]).to_not eq true
       expect(result[stealth_block.target_account_id.to_s]).to eq true
     end
 

--- a/spec/controllers/api/v2/blocks_controller_spec.rb
+++ b/spec/controllers/api/v2/blocks_controller_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::BlocksController, type: :controller do
+  render_views
+
+  let(:user)   { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:scopes) { 'read:blocks' }
+  let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+
+  before { allow(controller).to receive(:doorkeeper_token) { token } }
+
+  describe 'GET #index' do
+    it 'returns correct stealth mode attribute' do
+      block = Fabricate(:block, account: user.account)
+      stealth_block = Fabricate(:block, account: user.account, stealth: true)
+      get :index
+      result = body_as_json.each_with_object({}) { |v, h| h[v[:target_account][:id]] = v[:stealth] }
+      expect(result[block.target_account_id.to_s]).to eq false
+      expect(result[stealth_block.target_account_id.to_s]).to eq true
+    end
+
+    it 'limits according to limit parameter' do
+      2.times.map { Fabricate(:block, account: user.account) }
+      get :index, params: { limit: 1 }
+      expect(body_as_json.size).to eq 1
+    end
+
+    it 'queries blocks in range according to max_id' do
+      blocks = 2.times.map { Fabricate(:block, account: user.account) }
+
+      get :index, params: { max_id: blocks[1] }
+
+      expect(body_as_json.size).to eq 1
+      expect(body_as_json[0][:target_account][:id]).to eq blocks[0].target_account_id.to_s
+    end
+
+    it 'queries blocks in range according to since_id' do
+      blocks = 2.times.map { Fabricate(:block, account: user.account) }
+
+      get :index, params: { since_id: blocks[0] }
+
+      expect(body_as_json.size).to eq 1
+      expect(body_as_json[0][:target_account][:id]).to eq blocks[1].target_account_id.to_s
+    end
+
+    it 'sets pagination header for next path' do
+      blocks = 2.times.map { Fabricate(:block, account: user.account) }
+      get :index, params: { limit: 1, since_id: blocks[0] }
+      expect(response.headers['Link'].find_link(['rel', 'next']).href).to eq api_v1_blocks_url(limit: 1, max_id: blocks[1])
+    end
+
+    it 'sets pagination header for previous path' do
+      block = Fabricate(:block, account: user.account)
+      get :index
+      expect(response.headers['Link'].find_link(['rel', 'prev']).href).to eq api_v1_blocks_url(since_id: block)
+    end
+
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status(200)
+    end
+
+    context 'with wrong scopes' do
+      let(:scopes) { 'write:blocks' }
+
+      it 'returns http forbidden' do
+        get :index
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+end

--- a/spec/controllers/settings/exports/blocked_accounts_controller_spec.rb
+++ b/spec/controllers/settings/exports/blocked_accounts_controller_spec.rb
@@ -11,7 +11,7 @@ describe Settings::Exports::BlockedAccountsController do
       sign_in user, scope: :user
       get :index, format: :csv
 
-      expect(response.body).to eq "username@domain\n"
+      expect(response.body).to eq "Account address,Stealth\nusername@domain,false\n"
     end
   end
 end

--- a/spec/fixtures/files/block-imports.txt
+++ b/spec/fixtures/files/block-imports.txt
@@ -1,0 +1,4 @@
+bob
+
+eve@example.com
+

--- a/spec/fixtures/files/new-block-imports.txt
+++ b/spec/fixtures/files/new-block-imports.txt
@@ -1,0 +1,4 @@
+Account address,Stealth
+bob,true
+eve@example.com,false
+

--- a/spec/models/concerns/account_interactions_spec.rb
+++ b/spec/models/concerns/account_interactions_spec.rb
@@ -59,6 +59,30 @@ describe AccountInteractions do
     end
   end
 
+  describe '.blocked_by_map' do
+    subject { Account.blocked_by_map(target_account_ids, account_id) }
+
+    context 'account with non-stealth Block' do
+      it 'returns { target_account_id => true }' do
+        Fabricate(:block, account: target_account, target_account: account, stealth: false)
+        is_expected.to eq(target_account_id => true)
+      end
+    end
+
+    context 'account without Block' do
+      it 'returns {}' do
+        is_expected.to eq({})
+      end
+    end
+
+    context 'account with stealth Block' do
+      it 'returns {}' do
+        Fabricate(:block, account: target_account, target_account: account, stealth: true)
+        is_expected.to eq({})
+      end
+    end
+  end
+
   describe '.muting_map' do
     subject { Account.muting_map(target_account_ids, account_id) }
 
@@ -104,6 +128,18 @@ describe AccountInteractions do
       expect do
         expect(account.block!(target_account)).to be_kind_of Block
       end.to change { account.block_relationships.count }.by 1
+    end
+
+    it 'affects blocked_by_relationships' do
+      expect do
+        account.block!(target_account)
+      end.to change { target_account.blocked_by_relationships.count }.by 1
+    end
+
+    it 'does not affect blocked_by_relationships when stealth' do
+      expect do
+        account.block!(target_account, stealth: true)
+      end.to_not change { target_account.blocked_by_relationships.count }
     end
   end
 

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -11,10 +11,11 @@ describe Export do
       target_accounts.each(&account.method(:block!))
 
       export = Export.new(account).to_blocked_accounts_csv
-      results = export.strip.split
+      results = export.strip.split("\n")
 
-      expect(results.size).to eq 2
-      expect(results.first).to eq 'one@local.host'
+      expect(results.size).to eq 3
+      expect(results.first).to eq 'Account address,Stealth'
+      expect(results.second).to eq 'one@local.host,false'
     end
 
     it 'returns a csv of the muted accounts' do

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -302,6 +302,16 @@ RSpec.describe Status, type: :model do
       it { is_expected.to be_empty }
     end
 
+    context 'given stealth-blocked account' do
+      let(:direct_status) { nil }
+
+      before do
+        target_account.block!(account, stealth: true)
+      end
+
+      it { is_expected.to eq(%w(unlisted public)) }
+    end
+
     context 'given same account' do
       let(:account) { target_account }
       it { is_expected.to eq(%w(direct direct private unlisted public)) }

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -18,10 +18,16 @@ RSpec.describe StatusPolicy, type: :model do
 
     it 'denies access when viewer is blocked' do
       block = Fabricate(:block)
-      status.visibility = :private
       status.account = block.target_account
 
       expect(subject).to_not permit(block.account, status)
+    end
+
+    it 'grants access when viewer is stealth-blocked' do
+      block = Fabricate(:block, stealth: true)
+      status.account = block.target_account
+
+      expect(subject).to permit(block.account, status)
     end
   end
 

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -18,16 +18,16 @@ RSpec.describe StatusPolicy, type: :model do
 
     it 'denies access when viewer is blocked' do
       block = Fabricate(:block)
-      status.account = block.target_account
+      status.account = block.account
 
-      expect(subject).to_not permit(block.account, status)
+      expect(subject).to_not permit(block.target_account, status)
     end
 
     it 'grants access when viewer is stealth-blocked' do
       block = Fabricate(:block, stealth: true)
-      status.account = block.target_account
+      status.account = block.account
 
-      expect(subject).to permit(block.account, status)
+      expect(subject).to permit(block.target_account, status)
     end
   end
 

--- a/spec/services/block_service_spec.rb
+++ b/spec/services/block_service_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe BlockService, type: :service do
       let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
 
       before do
-        subject.call(sender, bob, true)
+        subject.call(sender, bob, stealth: true)
       end
 
       it 'creates a blocking relation' do
@@ -67,7 +67,7 @@ RSpec.describe BlockService, type: :service do
 
       before do
         stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
-        subject.call(sender, bob, true)
+        subject.call(sender, bob, stealth: true)
       end
 
       it 'creates a blocking relation' do

--- a/spec/services/block_service_spec.rb
+++ b/spec/services/block_service_spec.rb
@@ -5,45 +5,78 @@ RSpec.describe BlockService, type: :service do
 
   subject { BlockService.new }
 
-  describe 'local' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+  context 'not stealth' do
+    describe 'local' do
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
 
-    before do
-      subject.call(sender, bob)
+      before do
+        subject.call(sender, bob)
+      end
+
+      it 'creates a blocking relation' do
+        expect(sender.blocking?(bob)).to be true
+      end
     end
 
-    it 'creates a blocking relation' do
-      expect(sender.blocking?(bob)).to be true
+    describe 'remote OStatus' do
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', domain: 'example.com', salmon_url: 'http://salmon.example.com')).account }
+
+      before do
+        stub_request(:post, "http://salmon.example.com/").to_return(:status => 200, :body => "", :headers => {})
+        subject.call(sender, bob)
+      end
+
+      it 'creates a blocking relation' do
+        expect(sender.blocking?(bob)).to be true
+      end
+    end
+
+    describe 'remote ActivityPub' do
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox')).account }
+
+      before do
+        stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
+        subject.call(sender, bob)
+      end
+
+      it 'creates a blocking relation' do
+        expect(sender.blocking?(bob)).to be true
+      end
+
+      it 'sends a block activity' do
+        expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
+      end
     end
   end
 
-  describe 'remote OStatus' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', domain: 'example.com', salmon_url: 'http://salmon.example.com')).account }
+  context 'stealth' do
+    describe 'local' do
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
 
-    before do
-      stub_request(:post, "http://salmon.example.com/").to_return(:status => 200, :body => "", :headers => {})
-      subject.call(sender, bob)
+      before do
+        subject.call(sender, bob, true)
+      end
+
+      it 'creates a blocking relation' do
+        expect(sender.blocking?(bob)).to be true
+      end
     end
 
-    it 'creates a blocking relation' do
-      expect(sender.blocking?(bob)).to be true
-    end
-  end
+    describe 'remote ActivityPub' do
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox')).account }
 
-  describe 'remote ActivityPub' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox')).account }
+      before do
+        stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
+        subject.call(sender, bob, true)
+      end
 
-    before do
-      stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
-      subject.call(sender, bob)
-    end
+      it 'creates a blocking relation' do
+        expect(sender.blocking?(bob)).to be true
+      end
 
-    it 'creates a blocking relation' do
-      expect(sender.blocking?(bob)).to be true
-    end
-
-    it 'sends a block activity' do
-      expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
+      it 'does not send a block activity' do
+        expect(a_request(:post, 'http://example.com/inbox')).not_to have_been_made
+      end
     end
   end
 end


### PR DESCRIPTION
Add some explanation to the block confirmation dialog, and make the effects most visible to the blocked person optional.

The block dialog text is now dependent on whether:
- the person to be blocked follows the user (in which case it will mention that the block will force-remove them from their followers)
- the person to be blocked is on the same instance or a remote one (in which case the toggle description mentions the remote instance being notified and asked to honor the block)

## Blocking a local follower

![image](https://user-images.githubusercontent.com/384364/65838592-edc51000-e304-11e9-9d78-ed1528224e9e.png)

## Blocking a remote non-follower

![image](https://user-images.githubusercontent.com/384364/65838496-08e35000-e304-11e9-9ba0-09064b8d3056.png)


## Stealth blocks

- [x] Add `stealth` parameter to user blocks
- [x] Do not disclose block to remote stealthily-blocked users
- [x] Do not hide public info to local stealthily-blocked users
- [x] Allow export of the `stealth` attribute when exporting blocks
- [x] Allow importing the `stealth` attribute when importing blocks
- [x] Add API to create stealth blocks
- [x] Add UI to create stealth blocks
- [x] Add API to list blocks with info about stealth
- [ ] Add UI to list stealth blocks with info about stealth