### PR TITLE
Fix trending counter width

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6006,12 +6006,12 @@ noscript {
 
     &__current {
       flex: 0 0 auto;
-      width: 100px;
       font-size: 24px;
       line-height: 36px;
       font-weight: 500;
       text-align: right;
       padding-right: 15px;
+      margin-left: 5px;
       color: $secondary-text-color;
     }
 


### PR DESCRIPTION
Trending counter used to be constant 100px in width, which caused
issues in languages like Russian, where because of that, "talking"
text was cut to the size where actual count is not visible at all:

> 6 people talking
> Популярно у...