### PR TITLE
Add HTTP signature keyId to request log

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,6 +71,12 @@ Rails.application.configure do
   # Better log formatting
   config.lograge.enabled = true
 
+  config.lograge.custom_payload do |controller|
+    if controller.respond_to?(:signed_request?) && controller.signed_request?
+      { key: controller.signature_key_id }
+    end
+  end
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 


### PR DESCRIPTION
Also, the stoplight was not handling `OpenSSL::SSL::SSLError` exceptions.