### PR TITLE
Limit "tootctl accounts follow" to local accounts

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -314,11 +314,15 @@ module Mastodon
 
     desc 'follow ACCT', 'Make all local accounts follow account specified by ACCT'
     long_desc <<-LONG_DESC
-      Make all local accounts follow an account specified by ACCT. ACCT can be
-      a simple username, in case of a local user. It can also be in the format
-      username@domain, in case of a remote user.
+      Make all local accounts follow another local account specified by ACCT.
+      ACCT should be the username only.
     LONG_DESC
     def follow(acct)
+      if acct.include? '@'
+        say('Target account name should not contain a target instance, since it has to be a local account.', :red)
+        exit(1)
+      end
+
       target_account = ResolveAccountService.new.call(acct)
       processed      = 0
       failed         = 0


### PR DESCRIPTION
To (somewhat) limit mass remote follow: #11360.

I don't know if the code is good, I figured it's the simplest way to prevent remote follows.

But after all, the code is already out there. So "attackers" can modify this file themselves, make their own fork, not update, revert this commit, etc. It does not actually fix this mass follow issue. 

But is this feature actually useful in the first place? I mean it is useful for local accounts, but I don't see why an admin would force a remote follow.

Anyway I made this PR for fun so feel free to discard it ✌️ 