### PR TITLE
Check if document.getElementById('tabs-bar__portal') is null

### DIFF
--- a/app/javascript/mastodon/components/column_header.js
+++ b/app/javascript/mastodon/components/column_header.js
@@ -178,7 +178,9 @@ class ColumnHeader extends React.PureComponent {
     if (multiColumn || placeholder) {
       return component;
     } else {
-      return createPortal(component, document.getElementById('tabs-bar__portal'));
+      var e = document.getElementById('tabs-bar__portal');
+      if (e === null) return component;
+      return createPortal(component, e);
     }
   }
 


### PR DESCRIPTION
While viewing LTL or FTL in multi-column mode, Javascript raises TypeError while narrowing the window:


![shonbori](https://user-images.githubusercontent.com/30968/63237655-5dd67580-c232-11e9-8591-134cd60bc177.gif)

While I'm not fully sure what I'm doing, this change seems to prevent the error.