### PR TITLE
Fix statuses being rejected because of invalid hashtag names

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -149,7 +149,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     return if tag['name'].blank?
 
     Tag.find_or_create_by_names(tag['name']) do |hashtag|
-      @tags << hashtag unless @tags.include?(hashtag)
+      @tags << hashtag unless @tags.include?(hashtag) || !hashtag.valid?
     end
   rescue ActiveRecord::RecordInvalid
     nil


### PR DESCRIPTION
Fixes #11618

This was caused by `Tag#find_or_create_by_names` using `create` and not `create!` as previously.
I could also have changed that, but `find_or_create_by_names` is used in more places I haven't investigated yet.