### PR TITLE
Revert "Bump react-redux-loading-bar from 4.0.8 to 4.4.0 (#11609)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "react-notification": "^6.8.4",
     "react-overlays": "^0.8.3",
     "react-redux": "^7.1.0",
-    "react-redux-loading-bar": "^4.4.0",
+    "react-redux-loading-bar": "^4.0.8",
     "react-router-dom": "^4.1.1",
     "react-router-scroll-4": "^1.0.0-beta.1",
     "react-select": "^2.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8523,10 +8523,10 @@ react-overlays@^0.8.3:
     react-transition-group "^2.2.0"
     warning "^3.0.0"
 
-react-redux-loading-bar@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/react-redux-loading-bar/-/react-redux-loading-bar-4.4.0.tgz#630f1e3ada7a15d461021d58d8ea935901dba104"
-  integrity sha512-kcR+wT2eA3+bQD7Gpn7KcHcnANHkayLQGiePEU4JFnLq6sQqjlcE3n8DAUEGjTV+T+Gwlt3rMq/zfImq5yc0PA==
+react-redux-loading-bar@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/react-redux-loading-bar/-/react-redux-loading-bar-4.0.8.tgz#e84d59d1517b79f53b0f39c8ddb40682af648c1b"
+  integrity sha512-BpR1tlYrYKFtGhxa7nAKc0dpcV33ZgXJ/jKNLpDDaxu2/cCxbkWQt9YlWT+VLw1x/7qyNYY4DH48bZdtmciSpg==
   dependencies:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.2"


### PR DESCRIPTION
This reverts commit 2e44b81166cab3511fe505b11b8a90cadd773a05.

Same reason as usual, new versions don't bring much, but change how the loading bar is displayed in a way that breaks them in the media modal