### PR TITLE
Fix whitelist mode setting not appearing in admin dashboard

### DIFF
--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -103,7 +103,7 @@
         %li
           = feature_hint(t('admin.dashboard.authorized_fetch_mode'), @authorized_fetch)
         %li
-          = feature_hint(t('admin.dashboard.whitelist_mode'), @whitelist_mode)
+          = feature_hint(t('admin.dashboard.whitelist_mode'), @whitelist_enabled)
         %li
           = feature_hint('LDAP', @ldap_enabled)
         %li


### PR DESCRIPTION
ref: https://github.com/tootsuite/mastodon/blob/master/app/controllers/admin/dashboard_controller.rb#L34