### PR TITLE
Fix b, i, strong tag styling in content

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -824,6 +824,16 @@
     color: lighten($ui-highlight-color, 8%);
   }
 
+  b,
+  strong {
+    font-weight: 700;
+  }
+
+  i,
+  em {
+    font-style: italic;
+  }
+
   .status__content__spoiler-link {
     background: $action-button-color;
 


### PR DESCRIPTION
Because of 'reset.css' `b`, `i`, `strong` tags are styled incorrectly.
This commit fixes that