### PR TITLE
Fix slow local timeline query

### DIFF
--- a/db/migrate/20190823221802_add_local_index_to_statuses.rb
+++ b/db/migrate/20190823221802_add_local_index_to_statuses.rb
@@ -1,0 +1,11 @@
+class AddLocalIndexToStatuses < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    add_index :statuses, [:id, :account_id], name: :index_statuses_local_20190824, algorithm: :concurrently, order: { id: :desc }, where: '(local OR (uri IS NULL)) AND deleted_at IS NULL AND visibility = 0 AND reblog_of_id IS NULL AND ((NOT reply) OR (in_reply_to_account_id = account_id))'
+  end
+
+  def down
+    remove_index :statuses, name: :index_statuses_local_20190824
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_20_003045) do
+ActiveRecord::Schema.define(version: 2019_08_23_221802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -646,6 +646,7 @@ ActiveRecord::Schema.define(version: 2019_08_20_003045) do
     t.bigint "poll_id"
     t.datetime "deleted_at"
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20190820", order: { id: :desc }, where: "(deleted_at IS NULL)"
+    t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["reblog_of_id", "account_id"], name: "index_statuses_on_reblog_of_id_and_account_id"


### PR DESCRIPTION
Fix #11643

#### Before

```
Limit  (cost=39150.63..39150.68 rows=20 width=396) (actual time=6520.485..6520.489 rows=20 loops=1)
  ->  Sort  (cost=39150.63..39150.84 rows=84 width=396) (actual time=6520.484..6520.486 rows=20 loops=1)
        Sort Key: statuses.id DESC
        Sort Method: top-N heapsort  Memory: 33kB
        ->  Nested Loop Left Join  (cost=0.98..39148.39 rows=84 width=396) (actual time=0.332..6515.107 rows=16240 loops=1)
              Filter: (accounts.silenced_at IS NULL)
              Rows Removed by Filter: 544
              ->  Index Scan using index_statuses_20190820 on statuses  (cost=0.56..38891.15 rows=101 width=396) (actual time=0.326..6476.242 rows=16784 loops=1)
                    Index Cond: (visibility = 0)
                    Filter: ((local OR (uri IS NULL)) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)) AND (account_id <> ALL ('{61919,125171,111310,77076,100948,103833,1633,1181,505,19662,7254,12537,12749,884,3033,645}'::bigint[])))
                    Rows Removed by Filter: 7290950
              ->  Index Scan using index_accounts_on_id on accounts  (cost=0.42..2.54 rows=1 width=16) (actual time=0.002..0.002 rows=1 loops=16784)
                    Index Cond: (id = statuses.account_id)
Planning time: 0.232 ms
Execution time: 6520.514 ms
```

#### After

```
Limit  (cost=0.70..78.49 rows=20 width=396) (actual time=0.048..0.410 rows=20 loops=1)
  ->  Nested Loop Left Join  (cost=0.70..327.40 rows=84 width=396) (actual time=0.048..0.407 rows=20 loops=1)
        Filter: (accounts.silenced_at IS NULL)
        Rows Removed by Filter: 1
        ->  Index Scan using index_statuses_local_20190824 on statuses  (cost=0.29..70.15 rows=101 width=396) (actual time=0.029..0.208 rows=21 loops=1)
              Filter: (account_id <> ALL ('{61919,125171,111310,77076,100948,103833,1633,1181,505,19662,7254,12537,12749,884,3033,645}'::bigint[]))
        ->  Index Scan using index_accounts_on_id on accounts  (cost=0.42..2.54 rows=1 width=16) (actual time=0.009..0.009 rows=1 loops=21)
              Index Cond: (id = statuses.account_id)
Planning time: 0.812 ms
Execution time: 0.443 ms
```