### PR TITLE
Change window resize handler to switch to/from mobile layout as soon as needed

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -141,14 +141,24 @@ class SwitchingColumnsArea extends React.PureComponent {
     return location.state !== previewMediaState && location.state !== previewVideoState;
   }
 
-  handleResize = debounce(() => {
+  handleLayoutChange = debounce(() => {
     // The cached heights are no longer accurate, invalidate
     this.props.onLayoutChange();
-
-    this.setState({ mobile: isMobile(window.innerWidth) });
   }, 500, {
     trailing: true,
-  });
+  })
+
+  handleResize = () => {
+    const mobile = isMobile(window.innerWidth);
+
+    if (mobile !== this.state.mobile) {
+      this.handleLayoutChange.cancel();
+      this.props.onLayoutChange();
+      this.setState({ mobile });
+    } else {
+      this.handleLayoutChange();
+    }
+  }
 
   setRef = c => {
     this.node = c.getWrappedInstance();


### PR DESCRIPTION
Until this PR, window resizing events were handled half a second after the last resizing event, which makes the UI feels laggy when changing screen orientation are reducing the window size.

As it is unlikely that a string of resize events will cross the mobile threshold repeatedly, apply layout changes as soon as crossing that threshold, and otherwise keep delaying height cache clearing to half a second after the last resizing event.