### PR TITLE
Wrap long text in placeholder widget

### DIFF
--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -554,6 +554,7 @@ $fluid-breakpoint: $maximum-width + 20px;
     text-decoration: none;
     font-weight: 500;
     color: $ui-highlight-color;
+    display: inline-block;
 
     &:hover,
     &:focus,


### PR DESCRIPTION
This makes longer text appear better on some screen sizes.