### PR TITLE
Add federation support for the "hide network" preference

### DIFF
--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
   end
 
   def hide_results?
-    (@account.user_hides_network? && current_account&.id != @account.id) || (current_account && @account.blocking?(current_account))
+    (@account.hides_followers? && current_account&.id != @account.id) || (current_account && @account.blocking?(current_account))
   end
 
   def default_accounts

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
   end
 
   def hide_results?
-    (@account.user_hides_network? && current_account&.id != @account.id) || (current_account && @account.blocking?(current_account))
+    (@account.hides_following? && current_account&.id != @account.id) || (current_account && @account.blocking?(current_account))
   end
 
   def default_accounts

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -28,7 +28,8 @@ class FollowerAccountsController < ApplicationController
         render json: collection_presenter,
                serializer: ActivityPub::CollectionSerializer,
                adapter: ActivityPub::Adapter,
-               content_type: 'application/activity+json'
+               content_type: 'application/activity+json',
+               fields: restrict_fields_to
       end
     end
   end
@@ -69,6 +70,14 @@ class FollowerAccountsController < ApplicationController
         size: @account.followers_count,
         first: page_url(1)
       )
+    end
+  end
+
+  def restrict_fields_to
+    if page_requested? || !@account.user_hides_network?
+      # Return all fields
+    else
+      %i(id type totalItems)
     end
   end
 end

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -28,7 +28,8 @@ class FollowingAccountsController < ApplicationController
         render json: collection_presenter,
                serializer: ActivityPub::CollectionSerializer,
                adapter: ActivityPub::Adapter,
-               content_type: 'application/activity+json'
+               content_type: 'application/activity+json',
+               fields: restrict_fields_to
       end
     end
   end
@@ -69,6 +70,14 @@ class FollowingAccountsController < ApplicationController
         size: @account.following_count,
         first: page_url(1)
       )
+    end
+  end
+
+  def restrict_fields_to
+    if page_requested? || !@account.user_hides_network?
+      # Return all fields
+    else
+      %i(id type totalItems)
     end
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,6 +46,8 @@
 #  silenced_at             :datetime
 #  suspended_at            :datetime
 #  trust_level             :integer
+#  hide_followers          :boolean
+#  hide_following          :boolean
 #
 
 class Account < ApplicationRecord
@@ -320,6 +322,14 @@ class Account < ApplicationRecord
     self.header = nil
 
     save!
+  end
+
+  def hides_followers?
+    hide_followers || user_hides_network?
+  end
+
+  def hides_following?
+    hide_following || user_hides_network?
   end
 
   def object_type

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -324,11 +324,11 @@ class Account < ApplicationRecord
   end
 
   def hides_followers?
-    hide_collections || user_hides_network?
+    hide_collections? || user_hides_network?
   end
 
   def hides_following?
-    hide_collections || user_hides_network?
+    hide_collections? || user_hides_network?
   end
 
   def object_type

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,8 +46,7 @@
 #  silenced_at             :datetime
 #  suspended_at            :datetime
 #  trust_level             :integer
-#  hide_followers          :boolean
-#  hide_following          :boolean
+#  hide_collections        :boolean
 #
 
 class Account < ApplicationRecord
@@ -325,11 +324,11 @@ class Account < ApplicationRecord
   end
 
   def hides_followers?
-    hide_followers || user_hides_network?
+    hide_collections || user_hides_network?
   end
 
   def hides_following?
-    hide_following || user_hides_network?
+    hide_collections || user_hides_network?
   end
 
   def object_type

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -94,6 +94,8 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.statuses_count    = outbox_total_items    if outbox_total_items.present?
     @account.following_count   = following_total_items if following_total_items.present?
     @account.followers_count   = followers_total_items if followers_total_items.present?
+    @account.hide_following    = following_private?
+    @account.hide_followers    = followers_private?
     @account.moved_to_account  = @json['movedTo'].present? ? moved_account : nil
   end
 
@@ -166,26 +168,36 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def outbox_total_items
-    collection_total_items('outbox')
+    collection_info('outbox')[0]
   end
 
   def following_total_items
-    collection_total_items('following')
+    collection_info('following')[0]
   end
 
   def followers_total_items
-    collection_total_items('followers')
+    collection_info('followers')[0]
   end
 
-  def collection_total_items(type)
-    return if @json[type].blank?
+  def following_private?
+    !collection_info('following')[1]
+  end
+
+  def followers_private?
+    !collection_info('followers')[1]
+  end
+
+  def collection_info(type)
+    return [nil, nil] if @json[type].blank?
     return @collections[type] if @collections.key?(type)
 
     collection = fetch_resource_without_id_validation(@json[type])
 
-    @collections[type] = collection.is_a?(Hash) && collection['totalItems'].present? && collection['totalItems'].is_a?(Numeric) ? collection['totalItems'] : nil
+    total_items = collection.is_a?(Hash) && collection['totalItems'].present? && collection['totalItems'].is_a?(Numeric) ? collection['totalItems'] : nil
+    has_first_page = collection.is_a?(Hash) && collection['first'].present?
+    @collections[type] = [total_items, has_first_page]
   rescue HTTP::Error, OpenSSL::SSL::SSLError
-    @collections[type] = nil
+    @collections[type] = [nil, nil]
   end
 
   def moved_account

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -94,8 +94,7 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.statuses_count    = outbox_total_items    if outbox_total_items.present?
     @account.following_count   = following_total_items if following_total_items.present?
     @account.followers_count   = followers_total_items if followers_total_items.present?
-    @account.hide_following    = following_private?
-    @account.hide_followers    = followers_private?
+    @account.hide_collections  = following_private? || followers_private?
     @account.moved_to_account  = @json['movedTo'].present? ? moved_account : nil
   end
 

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -167,23 +167,23 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def outbox_total_items
-    collection_info('outbox')[0]
+    collection_info('outbox').first
   end
 
   def following_total_items
-    collection_info('following')[0]
+    collection_info('following').first
   end
 
   def followers_total_items
-    collection_info('followers')[0]
+    collection_info('followers').first
   end
 
   def following_private?
-    !collection_info('following')[1]
+    !collection_info('following').last
   end
 
   def followers_private?
-    !collection_info('followers')[1]
+    !collection_info('followers').last
   end
 
   def collection_info(type)

--- a/db/migrate/20191212163405_add_hide_collections_to_accounts.rb
+++ b/db/migrate/20191212163405_add_hide_collections_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddHideCollectionsToAccounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :accounts, :hide_collections, :boolean
+  end
+end

--- a/db/migrate/20191212163405_add_hide_followers_and_following_to_accounts.rb
+++ b/db/migrate/20191212163405_add_hide_followers_and_following_to_accounts.rb
@@ -1,6 +1,0 @@
-class AddHideFollowersAndFollowingToAccounts < ActiveRecord::Migration[5.2]
-  def change
-    add_column :accounts, :hide_followers, :boolean
-    add_column :accounts, :hide_following, :boolean
-  end
-end

--- a/db/migrate/20191212163405_add_hide_followers_and_following_to_accounts.rb
+++ b/db/migrate/20191212163405_add_hide_followers_and_following_to_accounts.rb
@@ -1,0 +1,6 @@
+class AddHideFollowersAndFollowingToAccounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :accounts, :hide_followers, :boolean
+    add_column :accounts, :hide_following, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,6 +170,8 @@ ActiveRecord::Schema.define(version: 2020_01_26_203551) do
     t.datetime "silenced_at"
     t.datetime "suspended_at"
     t.integer "trust_level"
+    t.boolean "hide_followers"
+    t.boolean "hide_following"
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), lower((domain)::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["moved_to_account_id"], name: "index_accounts_on_moved_to_account_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,8 +170,7 @@ ActiveRecord::Schema.define(version: 2020_01_26_203551) do
     t.datetime "silenced_at"
     t.datetime "suspended_at"
     t.integer "trust_level"
-    t.boolean "hide_followers"
-    t.boolean "hide_following"
+    t.boolean "hide_collections"
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), lower((domain)::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["moved_to_account_id"], name: "index_accounts_on_moved_to_account_id"


### PR DESCRIPTION
Listing an URL that will error out is not helpful.
Furthermore, Pleroma uses this to figure out whether someone's followers should be displayed or not.

~~(Marking as draft because I'm working on a second part, which would be to check that field and hide the followers accordingly in API queries)~~