### PR TITLE
Revert bcrypt to 3.1.12, again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
-    bcrypt (3.1.13)
+    bcrypt (3.1.12)
     benchmark-ips (2.7.2)
     better_errors (2.5.1)
       coderay (>= 1.0.0)


### PR DESCRIPTION
Same reasons as in #11555