### PR TITLE
node v12 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mastodon",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=8.12 <12"
+    "node": ">=8.12 <13"
   },
   "scripts": {
     "postversion": "git push --tags",


### PR DESCRIPTION
Previously, fibers v3.x could not be installed on node v12, but since  fibers were removed by #10902, Mastodon can now be run on node v12.