### PR TITLE
Add SMTP reply_to option

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -69,6 +69,7 @@ SMTP_PORT=587
 SMTP_LOGIN=
 SMTP_PASSWORD=
 SMTP_FROM_ADDRESS=notifications@example.com
+#SMTP_REPLY_TO=
 #SMTP_DOMAIN= # defaults to LOCAL_DOMAIN
 #SMTP_DELIVERY_METHOD=smtp # delivery method can also be sendmail
 #SMTP_AUTH_METHOD=plain

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,10 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # E-mails
-  config.action_mailer.default_options = { from: ENV.fetch('SMTP_FROM_ADDRESS', 'notifications@localhost') }
+  config.action_mailer.default_options = {
+    from: ENV.fetch('SMTP_FROM_ADDRESS', 'notifications@localhost'),
+    reply_to: ENV['SMTP_REPLY_TO']
+  }
 
   config.action_mailer.smtp_settings = {
     :port                 => ENV['SMTP_PORT'],


### PR DESCRIPTION
This adds the option to set the reply address to be different than the from address in SMTP. 

It's helpful in setups like mine where the email address used to send rejects all received email. This way even in a situation like that, there is a way to set a reply email address so users can reply to notification emails.