### PR TITLE
Fix Mastodon logo style on hover on public pages' footer

### DIFF
--- a/app/javascript/styles/mastodon/footer.scss
+++ b/app/javascript/styles/mastodon/footer.scss
@@ -128,7 +128,7 @@
       &:hover,
       &:focus,
       &:active {
-        svg path {
+        svg {
           fill: lighten($ui-base-color, 38%);
         }
       }


### PR DESCRIPTION
Fixes #11690