### PR TITLE
Change OpenGraph description on sign-up page to reflect invite

### DIFF
--- a/app/helpers/instance_helper.rb
+++ b/app/helpers/instance_helper.rb
@@ -8,4 +8,16 @@ module InstanceHelper
   def site_hostname
     @site_hostname ||= Addressable::URI.parse("//#{Rails.configuration.x.local_domain}").display_uri.host
   end
+
+  def description_for_sign_up
+    prefix = begin
+      if @invite.present?
+        I18n.t('auth.description.prefix_invited_by_user', name: @invite.user.account.username)
+      else
+        I18n.t('auth.description.prefix_sign_up')
+      end
+    end
+
+    safe_join([prefix, I18n.t('auth.description.suffix')], ' ')
+  end
 end

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -2,7 +2,7 @@
   = t('auth.register')
 
 - content_for :header_tags do
-  = render partial: 'shared/og'
+  = render partial: 'shared/og', locals: { description: description_for_sign_up }
 
 = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = render 'shared/error_messages', object: resource

--- a/app/views/shared/_og.html.haml
+++ b/app/views/shared/_og.html.haml
@@ -1,5 +1,5 @@
-- thumbnail = @instance_presenter.thumbnail
-- description = strip_tags(@instance_presenter.site_short_description.presence || @instance_presenter.site_description.presence || t('about.about_mastodon_html'))
+- thumbnail     = @instance_presenter.thumbnail
+- description ||= strip_tags(@instance_presenter.site_short_description.presence || @instance_presenter.site_description.presence || t('about.about_mastodon_html'))
 
 %meta{ name: 'description', content: description }/
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -569,6 +569,10 @@ en:
     checkbox_agreement_without_rules_html: I agree to the <a href="%{terms_path}" target="_blank">terms of service</a>
     delete_account: Delete account
     delete_account_html: If you wish to delete your account, you can <a href="%{path}">proceed here</a>. You will be asked for confirmation.
+    description:
+      prefix_invited_by_user: "@%{name} invites you to join this server of Mastodon!"
+      prefix_sign_up: Sign up on Mastodon today!
+      suffix: With an account, you will be able to follow people, post updates and exchange messages with users from any Mastodon server and more!
     didnt_get_confirmation: Didn't receive confirmation instructions?
     forgot_password: Forgot your password?
     invalid_reset_password_token: Password reset token is invalid or expired. Please request a new one.


### PR DESCRIPTION
**Invite:** @%{name} invites you to join this server of Mastodon! With an account, you will be able to follow people, post updates and exchange messages with users from any Mastodon server and more!

**No invite:** Sign up on Mastodon today! With an account, you will be able to follow people, post updates and exchange messages with users from any Mastodon server and more!
