### PR TITLE
noindex=true

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,7 +28,7 @@ defaults: &defaults
   reduce_motion: false
   show_application: true
   system_font_ui: false
-  noindex: false
+  noindex: true
   theme: 'default'
   aggregate_reblogs: true
   advanced_layout: false


### PR DESCRIPTION
Following the discourse in the fediverse about search indexing, I think a lot of people would welcome it to change noindex to true by default. Of course it should be easier to change this to noindex=false in the admin interface