### PR TITLE
Add PERSISTENT_TIMEOUT option

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+persistent_timeout ENV.fetch('PERSISTENT_TIMEOUT') { 20 }.to_i
+
 threads_count = ENV.fetch('MAX_THREADS') { 5 }.to_i
 threads threads_count, threads_count
 


### PR DESCRIPTION
Add environment variable to so `persistent_timeout` option of puma can be changed.

[Application Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) and [Cloud Load Balancing](https://cloud.google.com/load-balancing/) return a Bud Gateway if the timeout is short.

ref: [Tuning NGINX behind Google Cloud Platform HTTP(S) Load Balancer](https://blog.percy.io/tuning-nginx-behind-google-cloud-platform-http-s-load-balancer-305982ddb340)