### PR TITLE
Fixed NotificationMailer failing with mentions

### DIFF
--- a/app/views/notification_mailer/_status.html.haml
+++ b/app/views/notification_mailer/_status.html.haml
@@ -36,7 +36,10 @@
                                 - if status.media_attachments.size > 0
                                   %p
                                     - status.media_attachments.each do |a|
-                                      = link_to medium_url(a), medium_url(a)
+                                      - if status.local?
+                                        = link_to medium_url(a), medium_url(a)
+                                      - else
+                                        = link_to a.remote_url, a.remote_url
 
                               %p.status-footer
                                 = link_to l(status.created_at), web_url("statuses/#{status.id}")


### PR DESCRIPTION
If you receive a mention with media from a remote instance, the following error may occur.

```
Job: NotificationMailer#mention
Class: ActionView::Template::Error
Message: No route matches {:action=>"show", :controller=>"media", :id=>#<MediaAttachment id: xxxxx, status_id: xxxxx, file_file_name: “xxxxx.png", file_content_type: "image/png", file_file_size: xxxxx, file_updated_at: "2019-09-04 12:57:35", remote_url: "https://example.com/…”, account_id: xxxxx, created_at: "2019-09-04 12:57:35", updated_at: "2019-09-04 12:57:36", shortcode: nil, type: "image", file_meta: {"original"=>{"width"=>346, "height"=>309, "size"=>"346x309", "aspect"=>1.1197411003236246}, "small"=>{"width"=>346, "height"=>309, "size"=>"346x309", "aspect"=>1.1197411003236246}}, description: nil, scheduled_status_id: nil, blurhash: "U268U2?IogRk_4%MadIos:xtaJIV%Nt6ofR+">}, possible unmatched constraints: [:id]
```

This happens with accounts that have email notifications enabled for mentions.

This PR fix it.