### PR TITLE
Use prebuilt node.js on Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,19 +7,17 @@ SHELL ["bash", "-c"]
 ENV NODE_VER="12.9.1"
 RUN	echo "Etc/UTC" > /etc/localtime && \
 	apt update && \
-	apt -y install wget make gcc g++ python && \
+	apt -y install wget python && \
 	cd ~ && \
-	wget https://nodejs.org/download/release/v$NODE_VER/node-v$NODE_VER.tar.gz && \
-	tar xf node-v$NODE_VER.tar.gz && \
-	cd node-v$NODE_VER && \
-	./configure --prefix=/opt/node && \
-	make -j$(nproc) > /dev/null && \
-	make install
+	wget https://nodejs.org/download/release/v$NODE_VER/node-v$NODE_VER-linux-x64.tar.gz && \
+	tar xf node-v$NODE_VER-linux-x64.tar.gz && \
+	rm node-v$NODE_VER-linux-x64.tar.gz && \
+	mv node-v$NODE_VER-linux-x64 /opt/node
 
 # Install jemalloc
 ENV JE_VER="5.2.1"
 RUN apt update && \
-	apt -y install autoconf && \
+	apt -y install make autoconf gcc g++ && \
 	cd ~ && \
 	wget https://github.com/jemalloc/jemalloc/archive/$JE_VER.tar.gz && \
 	tar xf $JE_VER.tar.gz && \


### PR DESCRIPTION
Uses too much CPU resources and memory when building Node.js from source code. This may cause the Docker image build to fail in an environment with insufficient resources.

Since Node.js has an official prebuilt binary, change it to use it.
