### PR TITLE
Change half-life of trend decay

### DIFF
--- a/app/models/trending_tags.rb
+++ b/app/models/trending_tags.rb
@@ -7,8 +7,8 @@ class TrendingTags
   THRESHOLD            = 5
   LIMIT                = 10
   REVIEW_THRESHOLD     = 3
-  MAX_SCORE_COOLDOWN   = 3.days.freeze
-  MAX_SCORE_HALFLIFE   = 6.hours.freeze
+  MAX_SCORE_COOLDOWN   = 2.days.freeze
+  MAX_SCORE_HALFLIFE   = 2.hours.freeze
 
   class << self
     include Redisable
@@ -83,6 +83,7 @@ class TrendingTags
       # Trim older items
 
       redis.zremrangebyrank(KEY, 0, -(LIMIT + 1))
+      redis.zremrangebyscore(KEY, '(0.3', '-inf')
     end
 
     def get(limit, filtered: true)


### PR DESCRIPTION
- Reset max score to 0 after 2 days instead of 3
- Lower half-life of score decay from 6 hours to 2 hours
- Remove trends with a score lower than 0.3