### PR TITLE
Fix scroll position resetting when opening media modals in web UI

### DIFF
--- a/app/javascript/mastodon/containers/mastodon.js
+++ b/app/javascript/mastodon/containers/mastodon.js
@@ -12,6 +12,8 @@ import { hydrateStore } from '../actions/store';
 import { connectUserStream } from '../actions/streaming';
 import { IntlProvider, addLocaleData } from 'react-intl';
 import { getLocale } from '../locales';
+import { previewState as previewMediaState } from 'mastodon/features/ui/components/media_modal';
+import { previewState as previewVideoState } from 'mastodon/features/ui/components/video_modal';
 import initialState from '../initial_state';
 import ErrorBoundary from '../components/error_boundary';
 
@@ -35,6 +37,10 @@ class MastodonMount extends React.PureComponent {
     showIntroduction: PropTypes.bool,
   };
 
+  shouldUpdateScroll (_, { location }) {
+    return location.state !== previewMediaState && location.state !== previewVideoState;
+  }
+
   render () {
     const { showIntroduction } = this.props;
 
@@ -44,7 +50,7 @@ class MastodonMount extends React.PureComponent {
 
     return (
       <BrowserRouter basename='/web'>
-        <ScrollContext>
+        <ScrollContext shouldUpdateScroll={this.shouldUpdateScroll}>
           <Route path='/' component={UI} />
         </ScrollContext>
       </BrowserRouter>


### PR DESCRIPTION
When `shouldUpdateScroll` is passed into `<ScrollContainer />` component, it only works if what's inside the container is really scrollable. In single column mode, it is not. Instead, the whole page scrolls. The main `<ScrollContext />` is responsible for that, so we need to pass it the correct `shouldUpdateScroll` too.