### PR TITLE
Added account featured tags API

### DIFF
--- a/app/controllers/api/v1/accounts/featured_tags_controller.rb
+++ b/app/controllers/api/v1/accounts/featured_tags_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Api::V1::Accounts::FeaturedTagsController < Api::BaseController
+  before_action :set_account
+  before_action :set_featured_tags
+
+  respond_to :json
+
+  def index
+    render json: @featured_tags, each_serializer: REST::AccountFeaturedTagSerializer
+  end
+
+  private
+
+  def set_account
+    @account = Account.find(params[:account_id])
+  end
+
+  def set_featured_tags
+    @featured_tags = @account.featured_tags
+  end
+end

--- a/app/serializers/rest/account_featured_tag_serializer.rb
+++ b/app/serializers/rest/account_featured_tag_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class REST::AccountFeaturedTagSerializer < ActiveModel::Serializer
+  include RoutingHelper
+
+  attributes :id, :name, :url
+
+  def id
+    object.tag.id.to_s
+  end
+
+  def name
+    "##{object.name}"
+  end
+
+  def url
+    short_account_tag_url(object.account, object.tag)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -367,6 +367,7 @@ Rails.application.routes.draw do
         resources :following, only: :index, controller: 'accounts/following_accounts'
         resources :lists, only: :index, controller: 'accounts/lists'
         resources :identity_proofs, only: :index, controller: 'accounts/identity_proofs'
+        resources :featured_tags, only: :index, controller: 'accounts/featured_tags'
 
         member do
           post :follow


### PR DESCRIPTION
Only works with local accounts until https://github.com/tootsuite/mastodon/pull/11595 is merged.

- `GET /api/v1/accounts/:id/featured_tags`
- returns id of `Tag`, not `FeaturedTag`
- Since it can be obtained from the public profile without authentication, the API is also not authenticated

```
[{"id":"606","name":"#distsns","url":"https://fedibird.com/@noellabo/tagged/distsns"},{"id":"1069","name":"#リレーの話","url":"https://fedibird.com/@noellabo/tagged/%E3%83%AA%E3%83%AC%E3%83%BC%E3%81%AE%E8%A9%B1"},{"id":"611","name":"#test","url":"https://fedibird.com/@noellabo/tagged/test"},{"id":"1043","name":"#fedibird","url":"https://fedibird.com/@noellabo/tagged/fedibird"}]
```
