### PR TITLE
Add search and sort functions to hashtag admin UI

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -2,7 +2,6 @@
 
 module Admin
   class TagsController < BaseController
-    before_action :set_tags, only: :index
     before_action :set_tag, except: [:index, :batch, :approve_all, :reject_all]
     before_action :set_usage_by_domain, except: [:index, :batch, :approve_all, :reject_all]
     before_action :set_counters, except: [:index, :batch, :approve_all, :reject_all]
@@ -10,6 +9,7 @@ module Admin
     def index
       authorize :tag, :index?
 
+      @tags = filtered_tags.page(params[:page])
       @form = Form::TagBatch.new
     end
 
@@ -48,10 +48,6 @@ module Admin
 
     private
 
-    def set_tags
-      @tags = filtered_tags.page(params[:page])
-    end
-
     def set_tag
       @tag = Tag.find(params[:id])
     end
@@ -78,11 +74,14 @@ module Admin
       scope = scope.unreviewed if filter_params[:review] == 'unreviewed'
       scope = scope.reviewed.order(reviewed_at: :desc) if filter_params[:review] == 'reviewed'
       scope = scope.pending_review.order(requested_review_at: :desc) if filter_params[:review] == 'pending_review'
-      scope.order(max_score: :desc)
+      scope = scope.matches_name(filter_params[:name].to_s.strip) unless filter_params[:name].nil?
+      scope = scope.order('max_score DESC NULLS LAST') if filter_params[:order] == 'popular'
+      scope = scope.order('last_status_at DESC NULLS LAST') if filter_params[:order] == 'active'
+      scope.order(id: :desc)
     end
 
     def filter_params
-      params.slice(:context, :review, :page).permit(:context, :review, :page)
+      params.slice(:context, :review, :page, :name, :order).permit(:context, :review, :page, :name, :order)
     end
 
     def tag_params

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -69,15 +69,7 @@ module Admin
     end
 
     def filtered_tags
-      scope = Tag
-      scope = scope.discoverable if filter_params[:context] == 'directory'
-      scope = scope.unreviewed if filter_params[:review] == 'unreviewed'
-      scope = scope.reviewed.order(reviewed_at: :desc) if filter_params[:review] == 'reviewed'
-      scope = scope.pending_review.order(requested_review_at: :desc) if filter_params[:review] == 'pending_review'
-      scope = scope.matches_name(filter_params[:name].to_s.strip) unless filter_params[:name].nil?
-      scope = scope.order('max_score DESC NULLS LAST') if filter_params[:order] == 'popular'
-      scope = scope.order('last_status_at DESC NULLS LAST') if filter_params[:order] == 'active'
-      scope.order(id: :desc)
+      TagFilter.new(filter_params).results
     end
 
     def filter_params

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -73,7 +73,7 @@ module Admin
     end
 
     def filter_params
-      params.slice(:context, :review, :page, :name, :order).permit(:context, :review, :page, :name, :order)
+      params.slice(:directory, :reviewed, :unreviewed, :pending_review, :page, :popular, :active, :name).permit(:directory, :reviewed, :unreviewed, :pending_review, :page, :popular, :active, :name)
     end
 
     def tag_params

--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -5,7 +5,7 @@ module Admin::FilterHelper
   REPORT_FILTERS       = %i(resolved account_id target_account_id).freeze
   INVITE_FILTER        = %i(available expired).freeze
   CUSTOM_EMOJI_FILTERS = %i(local remote by_domain shortcode).freeze
-  TAGS_FILTERS         = %i(context review).freeze
+  TAGS_FILTERS         = %i(context review name order).freeze
   INSTANCES_FILTERS    = %i(limited by_domain).freeze
   FOLLOWERS_FILTERS    = %i(relationship status by_domain activity order).freeze
 

--- a/app/helpers/admin/filter_helper.rb
+++ b/app/helpers/admin/filter_helper.rb
@@ -5,7 +5,7 @@ module Admin::FilterHelper
   REPORT_FILTERS       = %i(resolved account_id target_account_id).freeze
   INVITE_FILTER        = %i(available expired).freeze
   CUSTOM_EMOJI_FILTERS = %i(local remote by_domain shortcode).freeze
-  TAGS_FILTERS         = %i(context review name order).freeze
+  TAGS_FILTERS         = %i(directory reviewed unreviewed pending_review popular active name).freeze
   INSTANCES_FILTERS    = %i(limited by_domain).freeze
   FOLLOWERS_FILTERS    = %i(relationship status by_domain activity order).freeze
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -39,6 +39,7 @@ class Tag < ApplicationRecord
   scope :listable, -> { where(listable: [true, nil]) }
   scope :discoverable, -> { listable.joins(:account_tag_stat).where(AccountTagStat.arel_table[:accounts_count].gt(0)).order(Arel.sql('account_tag_stats.accounts_count desc')) }
   scope :most_used, ->(account) { joins(:statuses).where(statuses: { account: account }).group(:id).order(Arel.sql('count(*) desc')) }
+  scope :matches_name, ->(value) { where(arel_table[:name].matches("#{value}%")) }
 
   delegate :accounts_count,
            :accounts_count=,

--- a/app/models/tag_filter.rb
+++ b/app/models/tag_filter.rb
@@ -23,40 +23,22 @@ class TagFilter
 
   def scope_for(key, value)
     case key.to_s
-    when 'context'
-      Tag.discoverable if value == 'directory'
-    when 'name'
-      Tag.matches_name(value)
-    when 'order'
-      scope_for_order(value)
-    when 'review'
-      scope_for_review(value)
-    else
-      raise "Unknown filter: #{key}"
-    end
-  end
-
-  def scope_for_order(order)
-    case order
-    when 'popular'
-      Tag.order('max_score DESC NULLS LAST')
-    when 'active'
-      Tag.order('last_status_at DESC NULLS LAST')
-    else
-      raise "Unknown filter: #{order}"
-    end
-  end
-
-  def scope_for_review(review)
-    case review
+    when 'directory'
+      Tag.discoverable
     when 'reviewed'
       Tag.reviewed.order(reviewed_at: :desc)
     when 'unreviewed'
       Tag.unreviewed
     when 'pending_review'
       Tag.pending_review.order(requested_review_at: :desc)
+    when 'popular'
+      Tag.order('max_score DESC NULLS LAST')
+    when 'active'
+      Tag.order('last_status_at DESC NULLS LAST')
+    when 'name'
+      Tag.matches_name(value)
     else
-      raise "Unknown filter: #{review}"
+      raise "Unknown filter: #{key}"
     end
   end
 end

--- a/app/models/tag_filter.rb
+++ b/app/models/tag_filter.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class TagFilter
+  attr_reader :params
+
+  def initialize(params)
+    @params = params
+  end
+
+  def results
+    scope = Tag.unscoped
+
+    params.each do |key, value|
+      next if key.to_s == 'page'
+
+      scope.merge!(scope_for(key, value.to_s.strip)) if value.present?
+    end
+
+    scope.order(id: :desc)
+  end
+
+  private
+
+  def scope_for(key, value)
+    case key.to_s
+    when 'context'
+      Tag.discoverable if value == 'directory'
+    when 'name'
+      Tag.matches_name(value)
+    when 'order'
+      set_order(value)
+    when 'review'
+      set_review(value)
+    else
+      raise "Unknown filter: #{key}"
+    end
+  end
+
+  def set_order(order)
+    case order
+    when 'popular'
+      Tag.order('max_score DESC NULLS LAST')
+    when 'active'
+      Tag.order('last_status_at DESC NULLS LAST')
+    else
+      raise "Unknown filter: #{order}"
+    end
+  end
+
+  def set_review(review)
+    case review
+    when 'reviewed'
+      Tag.reviewed.order(reviewed_at: :desc)
+    when 'unreviewed'
+      Tag.unreviewed
+    when 'pending_review'
+      Tag.pending_review.order(requested_review_at: :desc)
+    else
+      raise "Unknown filter: #{review}"
+    end
+  end
+end

--- a/app/models/tag_filter.rb
+++ b/app/models/tag_filter.rb
@@ -28,15 +28,15 @@ class TagFilter
     when 'name'
       Tag.matches_name(value)
     when 'order'
-      set_order(value)
+      scope_for_order(value)
     when 'review'
-      set_review(value)
+      scope_for_review(value)
     else
       raise "Unknown filter: #{key}"
     end
   end
 
-  def set_order(order)
+  def scope_for_order(order)
     case order
     when 'popular'
       Tag.order('max_score DESC NULLS LAST')
@@ -47,7 +47,7 @@ class TagFilter
     end
   end
 
-  def set_review(review)
+  def scope_for_review(review)
     case review
     when 'reviewed'
       Tag.reviewed.order(reviewed_at: :desc)

--- a/app/views/admin/tags/index.html.haml
+++ b/app/views/admin/tags/index.html.haml
@@ -19,6 +19,26 @@
       %li= filter_link_to t('admin.tags.reviewed'), review: 'reviewed'
       %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{Tag.pending_review.count})"], ' '), review: 'pending_review'
 
+  .filter-subset
+    %strong= t('generic.order_by')
+    %ul
+      %li= filter_link_to t('admin.tags.most_recent'), order: nil
+      %li= filter_link_to t('admin.tags.most_popular'), order: 'popular'
+      %li= filter_link_to t('admin.tags.last_active'), order: 'active'
+
+= form_tag admin_tags_url, method: 'GET', class: 'simple_form' do
+  .fields-group
+    - Admin::FilterHelper::TAGS_FILTERS.each do |key|
+      = hidden_field_tag key, params[key] if params[key].present?
+
+    - %i(name).each do |key|
+      .input.string.optional
+        = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.tags.#{key}")
+
+    .actions
+      %button= t('admin.accounts.search')
+      = link_to t('admin.accounts.reset'), admin_tags_path, class: 'button negative'
+
 %hr.spacer/
 
 = form_for(@form, url: batch_admin_tags_path) do |f|

--- a/app/views/admin/tags/index.html.haml
+++ b/app/views/admin/tags/index.html.haml
@@ -8,23 +8,23 @@
   .filter-subset
     %strong= t('admin.tags.context')
     %ul
-      %li= filter_link_to t('generic.all'), context: nil
-      %li= filter_link_to t('admin.tags.directory'), context: 'directory'
+      %li= filter_link_to t('generic.all'), directory: nil
+      %li= filter_link_to t('admin.tags.directory'), directory: '1'
 
   .filter-subset
     %strong= t('admin.tags.review')
     %ul
-      %li= filter_link_to t('generic.all'), review: nil
-      %li= filter_link_to t('admin.tags.unreviewed'), review: 'unreviewed'
-      %li= filter_link_to t('admin.tags.reviewed'), review: 'reviewed'
-      %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{Tag.pending_review.count})"], ' '), review: 'pending_review'
+      %li= filter_link_to t('generic.all'), reviewed: nil, unreviewed: nil, pending_review: nil
+      %li= filter_link_to t('admin.tags.unreviewed'), unreviewed: '1', reviewed: nil, pending_review: nil
+      %li= filter_link_to t('admin.tags.reviewed'), reviewed: '1', unreviewed: nil, pending_review: nil
+      %li= filter_link_to safe_join([t('admin.accounts.moderation.pending'), "(#{Tag.pending_review.count})"], ' '), pending_review: '1', reviewed: nil, unreviewed: nil
 
   .filter-subset
     %strong= t('generic.order_by')
     %ul
-      %li= filter_link_to t('admin.tags.most_recent'), order: nil
-      %li= filter_link_to t('admin.tags.most_popular'), order: 'popular'
-      %li= filter_link_to t('admin.tags.last_active'), order: 'active'
+      %li= filter_link_to t('admin.tags.most_recent'), popular: nil, active: nil
+      %li= filter_link_to t('admin.tags.most_popular'), popular: '1', active: nil
+      %li= filter_link_to t('admin.tags.last_active'), active: '1', popular: nil
 
 = form_tag admin_tags_url, method: 'GET', class: 'simple_form' do
   .fields-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,6 +521,10 @@ en:
       context: Context
       directory: In directory
       in_directory: "%{count} in directory"
+      last_active: Last active
+      most_popular: Most popular
+      most_recent: Most recent
+      name: Hashtag
       review: Review status
       reviewed: Reviewed
       title: Hashtags

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -131,6 +131,8 @@ en:
         must_be_follower: Block notifications from non-followers
         must_be_following: Block notifications from people you don't follow
         must_be_following_dm: Block direct messages from people you don't follow
+      invite:
+        comment: Comment
       invite_request:
         text: Why do you want to join?
       notification_emails:


### PR DESCRIPTION
Add search and sort features to the hashtag page of the Admin UI.

![2019-09-13 21 17 02](https://user-images.githubusercontent.com/766076/64873238-9cb9e880-d683-11e9-811c-ef8d9e3cd73d.jpg)

In the "ORDER BY" field "MOST RECENT", "MOST POPULAR", and "LAST ACTIVE" do not know if this name is best.
Also, is this order appropriate?

They are sorted for the following reasons:

- MOST RECENT
  Sorted in order from the newly received hashtag by the server

- MOST POPULAR
  Sort in order from biggest "max_score"

- LAST ACTIVE
  Sorted in order from newest "last_status_at"


I think I should write a test too.
However, there are a lot of things I don't understand yet and I haven't built a test environment.