### PR TITLE
Fix poll options checkboxes/radio buttons not being vertically centered

### DIFF
--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -79,6 +79,9 @@
     top: -1px;
     border-radius: 50%;
     vertical-align: middle;
+    margin-top: auto;
+    margin-bottom: auto;
+    flex: 0 0 18px;
 
     &.checkbox {
       border-radius: 4px;


### PR DESCRIPTION
Overlooked from the multi-line poll options PR, checkboxes/radio buttons weren't centered. This fixes it.