### PR TITLE
improve UX of Direct Messages column

### DIFF
--- a/app/javascript/mastodon/components/avatar_composite.js
+++ b/app/javascript/mastodon/components/avatar_composite.js
@@ -6,6 +6,7 @@ import { autoPlayGif } from '../initial_state';
 export default class AvatarComposite extends React.PureComponent {
 
   static propTypes = {
+    account: ImmutablePropTypes.map.isRequired,
     accounts: ImmutablePropTypes.list.isRequired,
     animate: PropTypes.bool,
     size: PropTypes.number.isRequired,
@@ -35,35 +36,35 @@ export default class AvatarComposite extends React.PureComponent {
 
     if (size === 2) {
       if (index === 0) {
-        right = '2px';
+        right = '0px';
       } else {
-        left = '2px';
+        left = '0px';
       }
     } else if (size === 3) {
       if (index === 0) {
-        right = '2px';
+        right = '0px';
       } else if (index > 0) {
-        left = '2px';
+        left = '0px';
       }
 
       if (index === 1) {
-        bottom = '2px';
+        bottom = '0px';
       } else if (index > 1) {
-        top = '2px';
+        top = '0px';
       }
     } else if (size === 4) {
       if (index === 0 || index === 2) {
-        right = '2px';
+        right = '0px';
       }
 
       if (index === 1 || index === 3) {
-        left = '2px';
+        left = '0px';
       }
 
       if (index < 2) {
-        bottom = '2px';
+        bottom = '0px';
       } else {
-        top = '2px';
+        top = '0px';
       }
     }
 
@@ -84,11 +85,18 @@ export default class AvatarComposite extends React.PureComponent {
   }
 
   render() {
-    const { accounts, size } = this.props;
+    const { account, accounts, size } = this.props;
+
+    const baseStyle = {
+      backgroundImage: `url(${account.get('avatar_static')})`,
+    };
 
     return (
-      <div className='account__avatar-composite' style={{ width: `${size}px`, height: `${size}px` }}>
-        {accounts.take(4).map((account, i) => this.renderItem(account, accounts.size, i))}
+      <div className='account__avatar-overlay'>
+        <div className='account__avatar-overlay-base' style={baseStyle} />
+        <div className='account__avatar-overlay-overlay account__avatar-composite' >
+          {accounts.take(4).map((dm_account, i) => this.renderItem(dm_account, accounts.size, i))}
+        </div>
       </div>
     );
   }

--- a/app/javascript/mastodon/components/avatar_composite.js
+++ b/app/javascript/mastodon/components/avatar_composite.js
@@ -9,7 +9,6 @@ export default class AvatarComposite extends React.PureComponent {
     account: ImmutablePropTypes.map.isRequired,
     accounts: ImmutablePropTypes.list.isRequired,
     animate: PropTypes.bool,
-    size: PropTypes.number.isRequired,
   };
 
   static defaultProps = {
@@ -85,7 +84,7 @@ export default class AvatarComposite extends React.PureComponent {
   }
 
   render() {
-    const { account, accounts, size } = this.props;
+    const { account, accounts } = this.props;
 
     const baseStyle = {
       backgroundImage: `url(${account.get('avatar_static')})`,

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -323,8 +323,7 @@ class Status extends ImmutablePureComponent {
 
       account = status.get('account');
       status  = status.get('reblog');
-    } else if (status.get('visibility') === 'direct') {
-
+    } else if (otherAccounts && otherAccounts.size > 0) {
       prepend = (
         <div className='status__prepend'>
           <div className='status__prepend-icon-wrapper'><Icon id='users' className='status__prepend-icon' fixedWidth /></div>

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -323,6 +323,14 @@ class Status extends ImmutablePureComponent {
 
       account = status.get('account');
       status  = status.get('reblog');
+    } else if (status.get('visibility') === 'direct') {
+
+      prepend = (
+        <div className='status__prepend'>
+          <div className='status__prepend-icon-wrapper'><Icon id='users' className='status__prepend-icon' fixedWidth /></div>
+          <DisplayName account={status.get('account')} others={otherAccounts} />
+        </div>
+      );
     }
 
     if (status.get('media_attachments').size > 0) {
@@ -387,7 +395,7 @@ class Status extends ImmutablePureComponent {
     }
 
     if (otherAccounts && otherAccounts.size > 0) {
-      statusAvatar = <AvatarComposite accounts={otherAccounts} size={48} />;
+      statusAvatar = <AvatarComposite account={status.get('account')} accounts={otherAccounts} />;
     } else if (account === undefined || account === null) {
       statusAvatar = <Avatar account={status.get('account')} size={48} />;
     } else {
@@ -422,7 +430,7 @@ class Status extends ImmutablePureComponent {
                   {statusAvatar}
                 </div>
 
-                <DisplayName account={status.get('account')} others={otherAccounts} />
+                <DisplayName account={status.get('account')} others='' />
               </a>
             </div>
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1199,7 +1199,7 @@
 
     & > div {
       @include avatar-radius;
-      border-radius: 0px;
+      border-radius: 0;
       float: left;
       position: relative;
       box-sizing: border-box;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1199,6 +1199,7 @@
 
     & > div {
       @include avatar-radius;
+      border-radius: 0px;
       float: left;
       position: relative;
       box-sizing: border-box;


### PR DESCRIPTION
This commit aims to preserve the "conversation view" intent of the current DM column while making correct attribution easier to identify, using the same UI solutions as with Boosts.

The primary icon is the author of the visible status, with the conversation composite as an overlay.

The display name is the author of the visible status, with the conversation list as a status prepend.

![image](https://user-images.githubusercontent.com/51038201/64897565-22687480-d641-11e9-9c1c-dccf7d9aafba.png)
