### PR TITLE
Change the hashtag link from WebUI to public page

### DIFF
--- a/app/views/admin/tags/show.html.haml
+++ b/app/views/admin/tags/show.html.haml
@@ -3,7 +3,7 @@
 
 .dashboard__counters
   %div
-    = link_to web_url("timelines/tag/#{@tag.name}") do
+    = link_to tag_url(@tag), target: '_blank', rel: 'noopener' do
       .dashboard__counters__num= number_with_delimiter @accounts_today
       .dashboard__counters__label= t 'admin.tags.accounts_today'
   %div


### PR DESCRIPTION
Currently, if you click “Unique users today” in red circle, the WebUI is opened and the hash tag column is displayed.
This PR changes the link destination to the public page of the hashtag.

This can reduce the time and unnecessary information required to open the page when checking the usage status of the hashtag.

![2019-09-15_21_47_29](https://user-images.githubusercontent.com/766076/64922345-50001a00-d809-11e9-8f15-329ba2172a9a.png)

