### PR TITLE
Fix Move handler queuing jobs that will fail if account is suspended

### DIFF
--- a/app/workers/unfollow_follow_worker.rb
+++ b/app/workers/unfollow_follow_worker.rb
@@ -11,7 +11,7 @@ class UnfollowFollowWorker
     new_target_account = Account.find(new_target_account_id)
 
     FollowService.new.call(follower_account, new_target_account)
-    UnfollowService.new.call(follower_account, old_target_account)
+    UnfollowService.new.call(follower_account, old_target_account, skip_unmerge: true)
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     true
   end


### PR DESCRIPTION
- If target account is suspended, exit early instead of queueing jobs that will fail / retry
- Always set moved-to account in case it's a different than the one before
- If Move handler could not execute, reset cooldown, to allow trying again
- Do not unmerge old account from home timelines