### PR TITLE
Improve IP cleanup query

### DIFF
--- a/app/workers/scheduler/ip_cleanup_scheduler.rb
+++ b/app/workers/scheduler/ip_cleanup_scheduler.rb
@@ -9,7 +9,7 @@ class Scheduler::IpCleanupScheduler
 
   def perform
     time_ago = RETENTION_PERIOD.ago
-    SessionActivation.where('updated_at < ?', time_ago).destroy_all
-    User.where('last_sign_in_at < ?', time_ago).update_all(last_sign_in_ip: nil)
+    SessionActivation.where('updated_at < ?', time_ago).in_batches.destroy_all
+    User.where('last_sign_in_at < ?', time_ago).where.not(last_sign_in_ip: nil).in_batches.update_all(last_sign_in_ip: nil)
   end
 end


### PR DESCRIPTION
- Changed to delete SessionActivation every 1000
- Do not update users whose `last_sign_in_ip` is already null
- Split select and update because update process that changes last_sign_in_ip to null is slow

before
 ```
User Update All (4.1ms)  UPDATE "users" SET "last_sign_in_ip" = NULL WHERE (last_sign_in_at < '2018-09-17 03:21:18.721436')
```
after:
```
(3.7ms)  SELECT  "users"."id" FROM "users" WHERE (last_sign_in_at < '2018-09-17 03:21:18.721436') AND "users"."last_sign_in_ip" IS NOT NULL ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1000]]
User Update All (20.1ms)  UPDATE "users" SET "last_sign_in_ip" = NULL WHERE (last_sign_in_at < '2018-09-17 03:21:18.721436') AND "users"."last_sign_in_ip" IS NOT NULL AND "users"."id" IN ($1, $2, $3, $4, $5, $6)  [["id", 7], ["id", 8], ["id", 9], ["id", 10], ["id", 13], ["id", 14]]
```