### PR TITLE
Limit the sample account icon to local only

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -20,7 +20,7 @@
 class Tag < ApplicationRecord
   has_and_belongs_to_many :statuses
   has_and_belongs_to_many :accounts
-  has_and_belongs_to_many :sample_accounts, -> { searchable.discoverable.popular.limit(3) }, class_name: 'Account'
+  has_and_belongs_to_many :sample_accounts, -> { local.discoverable.popular.limit(3) }, class_name: 'Account'
 
   has_many :featured_tags, dependent: :destroy, inverse_of: :tag
   has_one :account_tag_stat, dependent: :destroy

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -33,7 +33,7 @@ class InstancePresenter
   end
 
   def sample_accounts
-    Rails.cache.fetch('sample_accounts', expires_in: 12.hours) { Account.discoverable.popular.limit(3) }
+    Rails.cache.fetch('sample_accounts', expires_in: 12.hours) { Account.local.discoverable.popular.limit(3) }
   end
 
   def version_number


### PR DESCRIPTION
This PR restricts the account icons displayed in “Discover users” in “/about” to local accounts.

It may be better to use `by_recent_status` for `DirectoriesController`. ( ref: https://github.com/tootsuite/mastodon/blob/master/app/controllers/directories_controller.rb#L31 )
But "sample_accounts" was cached for 12 hours, so I thought it would not fit.

Also, `sample_accounts` in `app/models/tag.rb` seems not to be used now.
Is it still used somewhere? Or are there plans to use it?