### PR TITLE
Fix audit log error when custom emoji is copied from remote server

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -63,7 +63,7 @@ class CustomEmoji < ApplicationRecord
   def copy!
     copy = self.class.find_or_initialize_by(domain: nil, shortcode: shortcode)
     copy.image = image
-    copy.save!
+    copy.tap(&:save!)
   end
 
   class << self


### PR DESCRIPTION
### Expected behaviour

When I copy custom emojis from remote server, 
- Custom emoji can be copied.
- This action is recorded to audit logs.

### Actual behaviour

When I copy custom emojis from remote server, 
- Custom emoji can be copied.
- This action is NOT recorded to audit logs.

### Steps to reproduce the problem

In admin/custom_emojis pages, check some custom emoji and click "copy" button.

### Specifications

master branch