### PR TITLE
Add users remember_token index

### DIFF
--- a/db/migrate/20190917213523_add_remember_token_index.rb
+++ b/db/migrate/20190917213523_add_remember_token_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddRememberTokenIndex < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :users, :remember_token, algorithm: :concurrently, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_04_222339) do
+ActiveRecord::Schema.define(version: 2019_09_17_213523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -743,6 +743,7 @@ ActiveRecord::Schema.define(version: 2019_09_04_222339) do
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_by_application_id"], name: "index_users_on_created_by_application_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["remember_token"], name: "index_users_on_remember_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
If `remember_token` is nil and devise `remember_me` is executed, generate remember token and run SQL to check if it is unique.

```sql
SELECT  "users".* FROM "users" WHERE "users"."remember_token" = 'xxxxx' ORDER BY "users"."id" ASC LIMIT 1
```

https://github.com/plataformatec/devise/blob/v4.7.1/lib/devise/models/rememberable.rb#L150

However, remember_token has no index, so the more users, the longer it takes to check. This problem happens when logging in for the first time and after logging out. Adding an index to remember_token prevents it from slowing down.