### PR TITLE
fix RSS enclosure length

### DIFF
--- a/app/serializers/rss/account_serializer.rb
+++ b/app/serializers/rss/account_serializer.rb
@@ -25,7 +25,7 @@ class RSS::AccountSerializer
             .description(status.spoiler_text.presence || Formatter.instance.format(status, inline_poll_options: true).to_str)
 
         status.media_attachments.each do |media|
-          item.enclosure(full_asset_url(media.file.url(:original, false)), media.file.content_type, length: media.file.size)
+          item.enclosure(full_asset_url(media.file.url(:original, false)), media.file.content_type, media.file.size)
         end
       end
     end

--- a/app/serializers/rss/tag_serializer.rb
+++ b/app/serializers/rss/tag_serializer.rb
@@ -23,7 +23,7 @@ class RSS::TagSerializer
             .description(status.spoiler_text.presence || Formatter.instance.format(status).to_str)
 
         status.media_attachments.each do |media|
-          item.enclosure(full_asset_url(media.file.url(:original, false)), media.file.content_type, length: media.file.size)
+          item.enclosure(full_asset_url(media.file.url(:original, false)), media.file.content_type, media.file.size)
         end
       end
     end


### PR DESCRIPTION
enclosures in RSS feeds currently have an invalid length

![Screenshot_2019-09-19_12-37-15](https://user-images.githubusercontent.com/1386595/65238154-6b567800-dadc-11e9-8fd0-b87c78732daa.png)
