### PR TITLE
Rename package name to @tootsuite/mastodon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mastodon",
+  "name": "@tootsuite/mastodon",
   "license": "AGPL-3.0-or-later",
   "engines": {
     "node": ">=8.12 <13"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12539/65266195-83b2ab00-db4d-11e9-80e6-097eca91ff71.png)

I want to delete a wrong link on the GitHub UI. It's unclear if the name of this package is related, but it's suspicious.