### PR TITLE
Note that media can be broken on remote when not to set S3_ALIAS_HOST

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -94,6 +94,8 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # LOCAL_DOMAIN if WEB_DOMAIN is not set. For example, the server may have the
 # following header field:
 # Access-Control-Allow-Origin: https://192.168.1.123:9000/
+# WARNING: Note that S3_ALIAS_HOST should be set permanently, Otherwise your old media
+# cannot be fetch into remote instance after you changed Storage provider.
 # S3_ENABLED=true
 # S3_BUCKET=
 # AWS_ACCESS_KEY_ID=


### PR DESCRIPTION
## Reason

Since Mastodon doesn't use media proxy for attachments (#9880) on AP protocol, Remote instances cannot re-fetch attachment after Object Storage provider has changed.
So, Take a note to set `S3_ALIAS_HOST` properly and permanently.

>@kaniini i suspect there is a regression
without using a bounce URL, it is impossible to change CDN providers
> @kaniini
several instances changed from wasabi recently, and broke their old media in the process (as observed by Pleroma instances anyway)
if a CNAME is used for the bucket, it would be safe indeed