### PR TITLE
Add config of multipart threshold for S3

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -115,6 +115,20 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # S3_ENDPOINT=
 # S3_SIGNATURE_VERSION=
 
+# Google Cloud Storage (optional)
+# Use S3 compatible API. Since GCS does not support Multipart Upload,
+# increase the value of S3_MULTIPART_THRESHOLD to disable Multipart Upload.
+# The attachment host must allow cross origin request - see the description
+# above.
+# S3_ENABLED=true
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# S3_REGION=
+# S3_PROTOCOL=https
+# S3_HOSTNAME=storage.googleapis.com
+# S3_ENDPOINT=https://storage.googleapis.com
+# S3_MULTIPART_THRESHOLD=52428801 # 50.megabytes
+
 # Swift (optional)
 # The attachment host must allow cross origin request - see the description
 # above.

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -25,6 +25,7 @@ if ENV['S3_ENABLED'] == 'true'
     s3_protocol: s3_protocol,
     s3_host_name: s3_hostname,
     s3_headers: {
+      'X-Amz-Multipart-Threshold' => ENV.fetch('S3_MULTIPART_THRESHOLD') { 15.megabytes },
       'Cache-Control' => 'public, max-age=315576000, immutable',
     },
     s3_permissions: ENV.fetch('S3_PERMISSION') { 'public-read' },

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -135,7 +135,7 @@ namespace :mastodon do
       prompt.say "\n"
 
       if prompt.yes?('Do you want to store uploaded files on the cloud?', default: false)
-        case prompt.select('Provider', ['Amazon S3', 'Wasabi', 'Minio'])
+        case prompt.select('Provider', ['Amazon S3', 'Wasabi', 'Minio', 'Google Cloud Storage'])
         when 'Amazon S3'
           env['S3_ENABLED']  = 'true'
           env['S3_PROTOCOL'] = 'https'
@@ -214,6 +214,34 @@ namespace :mastodon do
           end
 
           env['AWS_SECRET_ACCESS_KEY'] = prompt.ask('Minio secret key:') do |q|
+            q.required true
+            q.modify :strip
+          end
+        when 'Google Cloud Storage'
+          env['S3_ENABLED']             = 'true'
+          env['S3_PROTOCOL']            = 'https'
+          env['S3_HOSTNAME']            = 'storage.googleapis.com'
+          env['S3_ENDPOINT']            = 'https://storage.googleapis.com'
+          env['S3_MULTIPART_THRESHOLD'] = 50.megabytes
+
+          env['S3_BUCKET'] = prompt.ask('GCS bucket name:') do |q|
+            q.required true
+            q.default "files.#{env['LOCAL_DOMAIN']}"
+            q.modify :strip
+          end
+
+          env['S3_REGION'] = prompt.ask('GCS region:') do |q|
+            q.required true
+            q.default 'us-west1'
+            q.modify :strip
+          end
+
+          env['AWS_ACCESS_KEY_ID'] = prompt.ask('GCS access key:') do |q|
+            q.required true
+            q.modify :strip
+          end
+
+          env['AWS_SECRET_ACCESS_KEY'] = prompt.ask('GCS secret key:') do |q|
             q.required true
             q.modify :strip
           end


### PR DESCRIPTION
aws-sdk-s3 will try Multipart Upload if the file size is larger than multipart_threshold. However, some providers with S3-compatible APIs such as Google Cloud Storage do not support Multipart Upload. Add an option to change the multipart_thresold from the setting.