### PR TITLE
Add fallback section ID with ToC

### DIFF
--- a/app/lib/toc_generator.rb
+++ b/app/lib/toc_generator.rb
@@ -45,7 +45,7 @@ class TOCGenerator
     parsed_html.traverse do |node|
       next unless TARGET_ELEMENTS.include?(node.name)
 
-      anchor = node['id'] || node.text.parameterize
+      anchor = node['id'] || node.text.parameterize.presence || 'sec'
       @slugs[anchor] += 1
       anchor = "#{anchor}-#{@slugs[anchor]}" if @slugs[anchor] > 1
 


### PR DESCRIPTION
```ruby
'日本語'.parameterize # -> ""
```

String#parameterize skips CJK strings. For CJK-only headings, the ID is empty. To address this, add a fallback string.