### PR TITLE
Revert to table display of blocked instances

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -26,6 +26,7 @@ class AboutController < ApplicationController
 
   helper_method :display_blocks?
   helper_method :display_blocks_rationale?
+  helper_method :block_severity_text
   helper_method :public_fetch_mode?
   helper_method :new_user
 
@@ -41,6 +42,17 @@ class AboutController < ApplicationController
 
   def display_blocks_rationale?
     Setting.show_domain_blocks_rationale == 'all' || (Setting.show_domain_blocks_rationale == 'users' && user_signed_in?)
+  end
+
+  def block_severity_text(block)
+    if block.severity == 'suspend'
+      I18n.t('about.unavailable_content_severities.suspension')
+    else
+      limitations = []
+      limitations << I18n.t('about.unavailable_content_severities.media_block') if block.reject_media?
+      limitations << I18n.t('about.unavailable_content_severities.silence') if block.severity == 'silence'
+      limitations.join(', ')
+    end
   end
 
   def new_user

--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -55,19 +55,42 @@
 
             %p= t('about.unavailable_content_html')
 
-            - @blocks.each do |domain_block|
+            .table-wrapper
+              %table.blocks-table
+                %thead
+                  %tr
+                    %th= t('about.unavailable_content_domain')
+                    %th.severity-column= t('about.unavailable_content_severity')
+                    - if display_blocks_rationale?
+                      %th.button-column
+                %tbody
+                  - @blocks.each_with_index do |block, i|
+                    %tr{ class: i % 2 == 0 ? 'even': nil }
+                      %td{ title: block.domain }= block.domain
+                      %td= block_severity_text(block)
+                      - if display_blocks_rationale?
+                        %td
+                          - if block.public_comment.present?
+                            %button.icon-button{ title: t('domain_blocks.show_rationale'), 'aria-label' => t('domain_blocks.show_rationale') }
+                              = fa_icon 'chevron-down fw', 'aria-hidden' => true
+                    - if display_blocks_rationale? && block.public_comment.present?
+                      %tr.rationale.hidden
+                        %td{ colspan: 3 }= block.public_comment.presence
+
+            - if @blocks.any? { |block| block.reject_media? }
               %p
-                %strong= "#{domain_block.domain}:"
+                %strong= "#{t('about.unavailable_content_severities.media_block')}:"
+                = t('about.unavailable_content_description.rejecting_media')
 
-                - if domain_block.suspend?
-                  = t('about.unavailable_content_description.suspended')
-                - else
-                  = t('about.unavailable_content_description.silenced') if domain_block.silence?
-                  = t('about.unavailable_content_description.rejecting_media') if domain_block.reject_media?
+            - if @blocks.any? { |block| block.severity == 'silence' }
+              %p
+                %strong= "#{t('about.unavailable_content_severities.silence')}:"
+                = t('about.unavailable_content_description.silenced')
 
-                - if display_blocks_rationale? && domain_block.public_comment.present?
-                  %strong= t('about.unavailable_content_description.reason')
-                  = domain_block.public_comment
+            - if @blocks.any? { |block| block.severity == 'suspend' }
+              %p
+                %strong= "#{t('about.unavailable_content_severities.suspension')}:"
+                = t('about.unavailable_content_description.suspended')
 
   .column-4
     %ul.table-of-contents

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,11 +37,16 @@ en:
     terms: Terms of service
     unavailable_content: Unavailable content
     unavailable_content_description:
-      reason: 'Reason:'
-      rejecting_media: Media files from this server will not be processed and and no thumbnails will be displayed, requiring manual click-through to the other server.
-      silenced: Posts from this server will not show up anywhere except your home feed if you follow the author.
-      suspended: You won't be able to follow anyone from this server, and no data from it will be processed or stored, and no data exchanged.
-    unavailable_content_html: Mastodon generally allows you to view content from and interact with users from any other server in the fediverse. These are the exceptions that have been made on this particular server.
+      rejecting_media: Media files from those servers will not be processed and and no thumbnails will be displayed, requiring manual click-through to the other server.
+      silenced: Posts from those servers will not show up anywhere except your home feed if you follow the author.
+      suspended: You won't be able to follow anyone from those servers, and no data from it will be processed or stored, and no data exchanged.
+    unavailable_content_domain: Domain
+    unavailable_content_html: Mastodon generally allows you to view content from and interact with users from any other server in the fediverse. The following table lists the exceptions that have been made on this particular server. The meaning of each block severity can be found below the table.
+    unavailable_content_severities:
+      media_block: Media block
+      silence: Silence
+      suspension: Suspension
+    unavailable_content_severity: Severity
     user_count_after:
       one: user
       other: users


### PR DESCRIPTION
Revert to the table of blocked instances (keeping the severity descriptions from the latest redesign)

![image](https://user-images.githubusercontent.com/384364/65698949-9e20e300-e07d-11e9-860f-fb01bc466cf5.png)