### PR TITLE
Fix overflow on conversations

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6418,13 +6418,17 @@ noscript {
     flex: 1 1 auto;
     padding: 10px 5px;
     padding-right: 15px;
+    word-break: break-all;
+    overflow: hidden;
 
     &__info {
       overflow: hidden;
+      display: flex;
+      flex-direction: row-reverse;
+      justify-content: space-between;
     }
 
     &__relative-time {
-      float: right;
       font-size: 15px;
       color: $darker-text-color;
       padding-left: 15px;
@@ -6437,6 +6441,8 @@ noscript {
       overflow: hidden;
       text-overflow: ellipsis;
       margin-bottom: 4px;
+      flex-basis: 170px;
+      flex-shrink: 1000;
 
       a {
         color: $primary-text-color;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6418,6 +6418,7 @@ noscript {
     flex: 1 1 auto;
     padding: 10px 5px;
     padding-right: 15px;
+    word-break: break-all;
 
     &__info {
       overflow: hidden;


### PR DESCRIPTION
# What?
Conversations(DMs) layout not to overflow.
## Before
![image](https://user-images.githubusercontent.com/17561618/65708127-d863a200-e0c8-11e9-988c-7de1b0f07495.png)
## After
![image](https://user-images.githubusercontent.com/17561618/65708174-f03b2600-e0c8-11e9-8b2e-6abb5be88773.png)  
Use Flexbox instead of using float around name and timestamp.

