### PR TITLE
Validate Web::PushSubscription

### DIFF
--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -20,6 +20,10 @@ class Web::PushSubscription < ApplicationRecord
 
   has_one :session_activation, foreign_key: 'web_push_subscription_id', inverse_of: :web_push_subscription
 
+  validates :endpoint, presence: true
+  validates :key_p256dh, presence: true
+  validates :key_auth, presence: true
+
   def push(notification)
     I18n.with_locale(associated_user&.locale || I18n.default_locale) do
       push_payload(payload_for_notification(notification), 48.hours.seconds)

--- a/db/post_migrate/20190927124642_remove_invalid_web_push_subscription.rb
+++ b/db/post_migrate/20190927124642_remove_invalid_web_push_subscription.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RemoveInvalidWebPushSubscription < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    invalid_web_push_subscriptions = Web::PushSubscription.where(endpoint: '')
+                                                          .or(Web::PushSubscription.where(key_p256dh: ''))
+                                                          .or(Web::PushSubscription.where(key_auth: ''))
+                                                          .preload(:session_activation)
+    invalid_web_push_subscriptions.find_each do |web_push_subscription|
+      web_push_subscription.session_activation&.update!(web_push_subscription_id: nil)
+      web_push_subscription.destroy!
+    end
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_17_213523) do
+ActiveRecord::Schema.define(version: 2019_09_27_124642) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
In order to send webpush, the endpoint, key_p256dh, and key_auth need to have values, but sometimes the values may be empty, so this PR will change to validate values. Also delete records whose values are empty.