### PR TITLE
Improve status pin query

### DIFF
--- a/app/controllers/activitypub/collections_controller.rb
+++ b/app/controllers/activitypub/collections_controller.rb
@@ -33,9 +33,9 @@ class ActivityPub::CollectionsController < ActivityPub::BaseController
   def scope_for_collection
     case params[:id]
     when 'featured'
-      @account.statuses.permitted_for(@account, signed_request_account).tap do |scope|
-        scope.merge!(@account.pinned_statuses)
-      end
+      return Status.none if @account.blocking?(signed_request_account)
+
+      @account.pinned_statuses
     else
       raise ActiveRecord::RecordNotFound
     end

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -57,6 +57,8 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   end
 
   def pinned_scope
+    return Status.none if @account.blocking?(current_account)
+
     @account.pinned_statuses
   end
 


### PR DESCRIPTION
Fix slow query executed on `/users/:username/collections/featured`. Also fixed a bug where blocked accounts could get pinned status.

before:
```sql
SELECT "statuses"."id", "statuses"."updated_at" FROM "statuses" INNER JOIN "status_pins" ON "statuses"."id" = "status_pins"."status_id" WHERE "statuses"."account_id" ='xxxxxx' AND ("statuses"."visibility" IN (0, 1) OR "statuses"."id" IN (SELECT "mentions"."status_id" FROM "mentions" WHERE "mentions"."account_id" = 'yyyyy')) AND "status_pins"."account_id" ='xxxxxx' ORDER BY status_pins.created_at DESC
```

```
Sort  (cost=5205.18..5205.18 rows=1 width=24) (actual time=3094.317..3094.318 rows=5 loops=1)
  Sort Key: status_pins.created_at DESC
  Sort Method: quicksort  Memory: 25kB
  ->  Merge Join  (cost=4434.05..5205.17 rows=1 width=24) (actual time=741.979..3094.303 rows=5 loops=1)
        Merge Cond: (statuses.id = status_pins.status_id)
        ->  Index Only Scan Backward using index_statuses_20180106 on statuses  (cost=4433.55..5152.07 rows=9619 width=16) (actual time=0.020..3067.354 rows=104536 loops=1)
              Index Cond: (account_id = 'xxxxxx')
              Filter: ((visibility = ANY ('{0,1}'::integer[])) OR (hashed SubPlan 1))
              Rows Removed by Filter: 6937
              Heap Fetches: 3990
              SubPlan 1
                ->  Index Only Scan using index_mentions_on_account_id_and_status_id on mentions  (cost=0.56..4428.77 rows=1683 width=8) (actual time=0.024..0.024 rows=0 loops=1)
                      Index Cond: (account_id = 'yyyyy')
                      Heap Fetches: 0
        ->  Index Scan using index_status_pins_on_account_id_and_status_id on status_pins  (cost=0.42..29.02 rows=9 width=16) (actual time=0.011..0.027 rows=5 loops=1)
              Index Cond: (account_id = 'xxxxxx')
Planning time: 0.424 ms
Execution time: 3094.382 ms
```

after:
```sql
SELECT "statuses"."id", "statuses"."updated_at" FROM "statuses" INNER JOIN "status_pins" ON "statuses"."id" = "status_pins"."status_id" WHERE "status_pins"."account_id" = 'xxxxxx' ORDER BY status_pins.created_at DESC
```

```
Sort  (cost=88.54..88.56 rows=9 width=24) (actual time=3.095..3.098 rows=5 loops=1)
  Sort Key: status_pins.created_at DESC
  Sort Method: quicksort  Memory: 25kB
  ->  Nested Loop  (cost=0.99..88.40 rows=9 width=24) (actual time=0.589..3.085 rows=5 loops=1)
        ->  Index Scan using index_status_pins_on_account_id_and_status_id on status_pins  (cost=0.42..29.02 rows=9 width=16) (actual time=0.009..0.019 rows=5 loops=1)
              Index Cond: (account_id ='xxxxxx')
        ->  Index Scan using statuses_pkey on statuses  (cost=0.57..6.59 rows=1 width=16) (actual time=0.610..0.610 rows=1 loops=5)
              Index Cond: (id = status_pins.status_id)
Planning time: 0.206 ms
Execution time: 3.120 ms
```