### PR TITLE
Change silences to always require approval on follow

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::AccountsController < Api::BaseController
   def follow
     FollowService.new.call(current_user.account, @account, reblogs: truthy_param?(:reblogs))
 
-    options = @account.locked? ? {} : { following_map: { @account.id => { reblogs: truthy_param?(:reblogs) } }, requested_map: { @account.id => false } }
+    options = @account.locked? || current_user.account.silenced? ? {} : { following_map: { @account.id => { reblogs: truthy_param?(:reblogs) } }, requested_map: { @account.id => false } }
 
     render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships(options)
   end

--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -77,16 +77,14 @@ class GettingStarted extends ImmutablePureComponent {
   };
 
   componentDidMount () {
-    const { myAccount, fetchFollowRequests, multiColumn } = this.props;
+    const { fetchFollowRequests, multiColumn } = this.props;
 
     if (!multiColumn && window.innerWidth >= NAVIGATION_PANEL_BREAKPOINT) {
       this.context.router.history.replace('/timelines/home');
       return;
     }
 
-    if (myAccount.get('locked')) {
-      fetchFollowRequests();
-    }
+    fetchFollowRequests();
   }
 
   render () {
@@ -134,7 +132,7 @@ class GettingStarted extends ImmutablePureComponent {
 
     height += 48*3;
 
-    if (myAccount.get('locked')) {
+    if (myAccount.get('locked') || unreadFollowRequests > 0) {
       navItems.push(<ColumnLink key={i++} icon='user-plus' text={intl.formatMessage(messages.follow_requests)} badge={badgeDisplay(unreadFollowRequests, 40)} to='/follow_requests' />);
       height += 48;
     }

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -21,7 +21,7 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
 
     follow_request = FollowRequest.create!(account: @account, target_account: target_account, uri: @json['id'])
 
-    if target_account.locked?
+    if target_account.locked? || @account.silenced?
       NotifyService.new.call(target_account, follow_request)
     else
       AuthorizeFollowService.new.call(@account, target_account)

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -21,7 +21,7 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
 
     follow_request = FollowRequest.create!(account: @account, target_account: target_account, uri: @json['id'])
 
-    if target_account.locked? || @account.silenced? || target_account.muting?(@account)
+    if target_account.locked? || @account.silenced?
       NotifyService.new.call(target_account, follow_request)
     else
       AuthorizeFollowService.new.call(@account, target_account)

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -21,7 +21,7 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
 
     follow_request = FollowRequest.create!(account: @account, target_account: target_account, uri: @json['id'])
 
-    if target_account.locked? || @account.silenced?
+    if target_account.locked? || @account.silenced? || target_account.muting?(@account)
       NotifyService.new.call(target_account, follow_request)
     else
       AuthorizeFollowService.new.call(@account, target_account)

--- a/app/serializers/rest/credential_account_serializer.rb
+++ b/app/serializers/rest/credential_account_serializer.rb
@@ -12,6 +12,7 @@ class REST::CredentialAccountSerializer < REST::AccountSerializer
       language: user.setting_default_language,
       note: object.note,
       fields: object.fields.map(&:to_h),
+      follow_requests_count: FollowRequest.where(target_account: object).limit(40).count,
     }
   end
 end

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -30,7 +30,7 @@ class FollowService < BaseService
 
     ActivityTracker.increment('activity:interactions')
 
-    if target_account.locked? || target_account.activitypub?
+    if target_account.locked? || source_account.silenced? || target_account.activitypub?
       request_follow(source_account, target_account, reblogs: reblogs)
     elsif target_account.local?
       direct_follow(source_account, target_account, reblogs: reblogs)

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -30,7 +30,7 @@ class FollowService < BaseService
 
     ActivityTracker.increment('activity:interactions')
 
-    if target_account.locked? || source_account.silenced? || target_account.activitypub?
+    if target_account.locked? || source_account.silenced? || target_account.muting?(source_account) || target_account.activitypub?
       request_follow(source_account, target_account, reblogs: reblogs)
     elsif target_account.local?
       direct_follow(source_account, target_account, reblogs: reblogs)

--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -30,7 +30,7 @@ class FollowService < BaseService
 
     ActivityTracker.increment('activity:interactions')
 
-    if target_account.locked? || source_account.silenced? || target_account.muting?(source_account) || target_account.activitypub?
+    if target_account.locked? || source_account.silenced? || target_account.activitypub?
       request_follow(source_account, target_account, reblogs: reblogs)
     elsif target_account.local?
       direct_follow(source_account, target_account, reblogs: reblogs)

--- a/app/services/update_account_service.rb
+++ b/app/services/update_account_service.rb
@@ -21,7 +21,7 @@ class UpdateAccountService < BaseService
 
   def authorize_all_follow_requests(account)
     follow_requests = FollowRequest.where(target_account: account)
-    follow_requests = follow_requests.select { |req| !req.account.silenced? && !account.muting?(req.account) }
+    follow_requests = follow_requests.select { |req| !req.account.silenced? }
     AuthorizeFollowWorker.push_bulk(follow_requests) do |req|
       [req.account_id, req.target_account_id]
     end

--- a/app/services/update_account_service.rb
+++ b/app/services/update_account_service.rb
@@ -20,7 +20,9 @@ class UpdateAccountService < BaseService
   private
 
   def authorize_all_follow_requests(account)
-    AuthorizeFollowWorker.push_bulk(FollowRequest.where(target_account: account).select(:account_id, :target_account_id)) do |req|
+    follow_requests = FollowRequest.where(target_account: account)
+    follow_requests = follow_requests.select { |req| !req.account.silenced? && !account.muting?(req.account) }
+    AuthorizeFollowWorker.push_bulk(follow_requests) do |req|
       [req.account_id, req.target_account_id]
     end
   end

--- a/spec/lib/activitypub/activity/follow_spec.rb
+++ b/spec/lib/activitypub/activity/follow_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe ActivityPub::Activity::Follow do
         subject.perform
       end
 
-      it 'does not create a follow from sender to recipient' do
-        expect(sender.following?(recipient)).to be false
+      it 'creates a follow from sender to recipient' do
+        expect(sender.following?(recipient)).to be true
       end
 
-      it 'creates a follow request' do
-        expect(sender.requested?(recipient)).to be true
+      it 'does not create a follow request' do
+        expect(sender.requested?(recipient)).to be false
       end
     end
 

--- a/spec/lib/activitypub/activity/follow_spec.rb
+++ b/spec/lib/activitypub/activity/follow_spec.rb
@@ -31,6 +31,36 @@ RSpec.describe ActivityPub::Activity::Follow do
       end
     end
 
+    context 'silenced account following an unlocked account' do
+      before do
+        sender.touch(:silenced_at)
+        subject.perform
+      end
+
+      it 'does not create a follow from sender to recipient' do
+        expect(sender.following?(recipient)).to be false
+      end
+
+      it 'creates a follow request' do
+        expect(sender.requested?(recipient)).to be true
+      end
+    end
+
+    context 'unlocked account muting the sender' do
+      before do
+        recipient.mute!(sender)
+        subject.perform
+      end
+
+      it 'does not create a follow from sender to recipient' do
+        expect(sender.following?(recipient)).to be false
+      end
+
+      it 'creates a follow request' do
+        expect(sender.requested?(recipient)).to be true
+      end
+    end
+
     context 'locked account' do
       before do
         recipient.update(locked: true)

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -51,8 +51,9 @@ RSpec.describe FollowService, type: :service do
         subject.call(sender, bob.acct)
       end
 
-      it 'creates a follow request with reblogs' do
-        expect(FollowRequest.find_by(account: sender, target_account: bob, show_reblogs: true)).to_not be_nil
+      it 'creates a following relation with reblogs' do
+        expect(sender.following?(bob)).to be true
+        expect(sender.muting_reblogs?(bob)).to be false
       end
     end
 

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -30,6 +30,32 @@ RSpec.describe FollowService, type: :service do
       end
     end
 
+    describe 'unlocked account, from silenced account' do
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+
+      before do
+        sender.touch(:silenced_at)
+        subject.call(sender, bob.acct)
+      end
+
+      it 'creates a follow request with reblogs' do
+        expect(FollowRequest.find_by(account: sender, target_account: bob, show_reblogs: true)).to_not be_nil
+      end
+    end
+
+    describe 'unlocked account, from a muted account' do
+      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+
+      before do
+        bob.mute!(sender)
+        subject.call(sender, bob.acct)
+      end
+
+      it 'creates a follow request with reblogs' do
+        expect(FollowRequest.find_by(account: sender, target_account: bob, show_reblogs: true)).to_not be_nil
+      end
+    end
+
     describe 'unlocked account' do
       let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
 

--- a/spec/services/update_account_service_spec.rb
+++ b/spec/services/update_account_service_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe UpdateAccountService, type: :service do
       expect(bob.requested?(account)).to be true
     end
 
-    it 'does not auto-accept pending follow requests from muted users' do
-      expect(eve.following?(account)).to be false
-      expect(eve.requested?(account)).to be true
+    it 'auto-accepts pending follow requests from muted users so as to not leak mute' do
+      expect(eve.following?(account)).to be true
+      expect(eve.requested?(account)).to be false
     end
   end
 end

--- a/spec/services/update_account_service_spec.rb
+++ b/spec/services/update_account_service_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe UpdateAccountService, type: :service do
+  subject { UpdateAccountService.new }
+
+  describe 'switching form locked to unlocked accounts' do
+    let(:account) { Fabricate(:account, locked: true) }
+    let(:alice)   { Fabricate(:user, email: 'alice@example.com', account: Fabricate(:account, username: 'alice')).account }
+    let(:bob)     { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:eve)     { Fabricate(:user, email: 'eve@example.com', account: Fabricate(:account, username: 'eve')).account }
+
+    before do
+      bob.touch(:silenced_at)
+      account.mute!(eve)
+
+      FollowService.new.call(alice, account)
+      FollowService.new.call(bob, account)
+      FollowService.new.call(eve, account)
+
+      subject.call(account, { locked: false })
+    end
+
+    it 'auto-accepts pending follow requests' do
+      expect(alice.following?(account)).to be true
+      expect(alice.requested?(account)).to be false
+    end
+
+    it 'does not auto-accept pending follow requests from silenced users' do
+      expect(bob.following?(account)).to be false
+      expect(bob.requested?(account)).to be true
+    end
+
+    it 'does not auto-accept pending follow requests from muted users' do
+      expect(eve.following?(account)).to be false
+      expect(eve.requested?(account)).to be true
+    end
+  end
+end


### PR DESCRIPTION
So far, silenced (mutes decided by an instance moderator) and user-muted accounts can follow local users just like any other account. The only difference being that they would not generate notifications when doing so.

Having silenced accounts silently follow users may be misleading and undesirable.

This PR changes the following:
- **Silenced accounts** (whether individually or through domain silence) will always generate a follow request, which won't be auto-accepted, regardless of whether the target account is locked. The rationale for this can be found in #11958. One downside though is that “follow spam” would not be prevented by silencing an instance.
- ~~**User-muted accounts** will always generate a follow request, which won't be auto-accepted, regardless of whether the target account is locked. Indeed, the question “should a muted user be able to follow the person muting them?” has been brought up repeatedly, and both answers to that have disadvantages. But requesting approval for such follows would solve unexpected follows while not changing the current behavior too drastically. In case a muted users sends repeated follow requests, #11562 would enable silently discarding them.~~ Removed to avoid leaking user mutes
- Add `follow_requests_count` to `/api/v1/verify_credentials` (fixes #11958)
- Make the WebUI check for pending follow requests regardless of whether the account is locked
- Make the API result for follows not assume the follow went through if the following account is locally silenced