### PR TITLE
Change vote results to display tied leading options as leading

### DIFF
--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -103,7 +103,7 @@ class Poll extends ImmutablePureComponent {
   renderOption (option, optionIndex, showResults) {
     const { poll, disabled, intl } = this.props;
     const percent = poll.get('votes_count') === 0 ? 0 : (option.get('votes_count') / poll.get('votes_count')) * 100;
-    const leading = poll.get('options').filterNot(other => other.get('title') === option.get('title')).every(other => option.get('votes_count') > other.get('votes_count'));
+    const leading = poll.get('options').filterNot(other => other.get('title') === option.get('title')).every(other => option.get('votes_count') >= other.get('votes_count'));
     const active  = !!this.state.selected[`${optionIndex}`];
     const voted   = option.get('voted') || (poll.get('own_votes') && poll.get('own_votes').includes(optionIndex));
 


### PR DESCRIPTION
Currently, if two options are, say, at 20%, and other options are below that, no option will be shown as leading. It may make sense to list both 20% options as leading, though, which this PR do.