### PR TITLE
Remove quotes in `LDAP_SEARCH_FILTER` example

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -178,7 +178,7 @@ STREAMING_CLUSTER_NUM=1
 # LDAP_BIND_DN=
 # LDAP_PASSWORD=
 # LDAP_UID=cn
-# LDAP_SEARCH_FILTER="%{uid}=%{email}"
+# LDAP_SEARCH_FILTER=%{uid}=%{email}
 
 # PAM authentication (optional)
 # PAM authentication uses for the email generation the "email" pam variable


### PR DESCRIPTION
:wrench: Remove quotes in LDAP search filter

Keeping the double quotes in the `.env.production` would generate an invalid search filter exception.