### PR TITLE
Fix and remove ugly css around the conversation component

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6473,8 +6473,8 @@ noscript {
       overflow: hidden;
       text-overflow: ellipsis;
       margin-bottom: 4px;
-      flex-basis: 170px;
-      flex-shrink: 1000;
+      flex-basis: 90px;
+      flex-grow: 1;
 
       a {
         color: $primary-text-color;


### PR DESCRIPTION
# Why?
on #11965 , I wrote `flex-shrink: 1000` to fix overflow about their name and timestamp. It's not nice practice. 
That ugly commit left error like this:  
![image](https://user-images.githubusercontent.com/17561618/65889585-7662af80-e3dc-11e9-9f8e-3a6303130d3e.png)