### PR TITLE
Allow multiple domains for purge

### DIFF
--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -17,7 +17,7 @@ module Mastodon
     option :verbose, type: :boolean, aliases: [:v]
     option :dry_run, type: :boolean
     option :whitelist_mode, type: :boolean
-    desc 'purge [DOMAIN]', 'Remove accounts from a DOMAIN without a trace'
+    desc 'purge [DOMAIN...]', 'Remove accounts from a DOMAIN without a trace'
     long_desc <<-LONG_DESC
       Remove all accounts from a given DOMAIN without leaving behind any
       records. Unlike a suspension, if the DOMAIN still exists in the wild,
@@ -27,14 +27,14 @@ module Mastodon
       from a single domain, all accounts from domains that are not whitelisted
       are removed from the database.
     LONG_DESC
-    def purge(domain = nil)
+    def purge(*domains)
       dry_run = options[:dry_run] ? ' (DRY RUN)' : ''
 
       scope = begin
         if options[:whitelist_mode]
           Account.remote.where.not(domain: DomainAllow.pluck(:domain))
-        elsif domain.present?
-          Account.remote.where(domain: domain)
+        elsif domains.present?
+          Account.remote.where('domain in (?)', domains)
         else
           say('No domain given', :red)
           exit(1)
@@ -45,11 +45,11 @@ module Mastodon
         SuspendAccountService.new.call(account, reserve_username: false, skip_side_effects: true) unless options[:dry_run]
       end
 
-      DomainBlock.where(domain: domain).destroy_all unless options[:dry_run]
+      DomainBlock.where('domain in (?)', domains).destroy_all unless options[:dry_run]
 
       say("Removed #{processed} accounts#{dry_run}", :green)
 
-      custom_emojis = CustomEmoji.where(domain: domain)
+      custom_emojis = CustomEmoji.where('domain in (?)', domains)
       custom_emojis_count = custom_emojis.count
       custom_emojis.destroy_all unless options[:dry_run]
 

--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -34,7 +34,7 @@ module Mastodon
         if options[:whitelist_mode]
           Account.remote.where.not(domain: DomainAllow.pluck(:domain))
         elsif domains.present?
-          Account.remote.where('domain in (?)', domains)
+          Account.remote.where(domain: domains)
         else
           say('No domain given', :red)
           exit(1)

--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -36,7 +36,7 @@ module Mastodon
         elsif domains.present?
           Account.remote.where(domain: domains)
         else
-          say('No domain given', :red)
+          say('No domain(s) given', :red)
           exit(1)
         end
       end


### PR DESCRIPTION
This PR allows to do `tootctl domains purge a.com b.tld c.social`
Because tootctl's bootup is too slow, it is better than `for domain in {a.com,b.tld,c.social}; do tootctl domains purge $domain; done`