### PR TITLE
Exclude statuses from index that is not searchable by local user

### DIFF
--- a/app/chewy/statuses_index.rb
+++ b/app/chewy/statuses_index.rb
@@ -31,7 +31,7 @@ class StatusesIndex < Chewy::Index
     },
   }
 
-  define_type ::Status.unscoped.without_reblogs.includes(:media_attachments) do
+  define_type ::Status.unscoped.without_reblogs.includes(:media_attachments), delete_if: ->(status) { status.searchable_by.empty? } do
     crutch :mentions do |collection|
       data = ::Mention.where(status_id: collection.map(&:id)).pluck(:status_id, :account_id)
       data.each.with_object({}) { |(id, name), result| (result[id] ||= []).push(name) }

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -141,7 +141,7 @@ class Status < ApplicationRecord
       ids += preloaded.reblogs[id] || []
     end
 
-    ids.uniq
+    Account.where('id in (?)', ids.uniq).filter(&:local?).map(&:id)
   end
 
   def reply?


### PR DESCRIPTION
Currently, `searchable_by` field contains all related accounts that contains remote user.
But remote user cannot perform a search on local instance.

This PR makes that ES index only contain statuses that searchable by at least one **local** user.
This slightly increase DB query at insert a status, But decrease ES volume massively(because most of remote status doesn't containing a mention to local user)