### PR TITLE
Add `reason` param to `POST /api/v1/accounts` REST API

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -78,7 +78,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def account_params
-    params.permit(:username, :email, :password, :agreement, :locale)
+    params.permit(:username, :email, :password, :agreement, :locale, :reason)
   end
 
   def check_enabled_registrations

--- a/app/services/app_sign_up_service.rb
+++ b/app/services/app_sign_up_service.rb
@@ -4,9 +4,10 @@ class AppSignUpService < BaseService
   def call(app, params)
     return unless allowed_registrations?
 
-    user_params    = params.slice(:email, :password, :agreement, :locale)
-    account_params = params.slice(:username)
-    user           = User.create!(user_params.merge(created_by_application: app, password_confirmation: user_params[:password], account_attributes: account_params))
+    user_params           = params.slice(:email, :password, :agreement, :locale)
+    account_params        = params.slice(:username)
+    invite_request_params = { text: params[:reason] }
+    user                  = User.create!(user_params.merge(created_by_application: app, password_confirmation: user_params[:password], account_attributes: account_params, invite_request_attributes: invite_request_params))
 
     Doorkeeper::AccessToken.create!(application: app,
                                     resource_owner_id: user.id,

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe AppSignUpService, type: :service do
       user = User.find_by(id: access_token.resource_owner_id)
       expect(user).to_not be_nil
       expect(user.account).to_not be_nil
+      expect(user.invite_request).to be_nil
+    end
+
+    it 'creates an account with invite request text' do
+      access_token = subject.call(app, good_params.merge(reason: 'Foo bar'))
+      expect(access_token).to_not be_nil
+      user = User.find_by(id: access_token.resource_owner_id)
+      expect(user).to_not be_nil
+      expect(user.invite_request&.text).to eq 'Foo bar'
     end
   end
 end


### PR DESCRIPTION
For approval-required registrations mode