### PR TITLE
Remove unused option from tootctl accounts cull

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -211,7 +211,6 @@ module Mastodon
     end
 
     option :concurrency, type: :numeric, default: 5, aliases: [:c]
-    option :verbose, type: :boolean, aliases: [:v]
     option :dry_run, type: :boolean
     desc 'cull', 'Remove remote accounts that no longer exist'
     long_desc <<-LONG_DESC


### PR DESCRIPTION
Since `tootctl accounts cull` uses parallel job, verbose option is meaningless.