### PR TITLE
Split AccountsHelper from StatusesHelper

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module AccountsHelper
+  def display_name(account, **options)
+    if options[:custom_emojify]
+      Formatter.instance.format_display_name(account, options)
+    else
+      account.display_name.presence || account.username
+    end
+  end
+
+  def acct(account)
+    if account.local?
+      "@#{account.acct}@#{Rails.configuration.x.local_domain}"
+    else
+      "@#{account.acct}"
+    end
+  end
+
+  def account_action_button(account)
+    if user_signed_in?
+      if account.id == current_user.account_id
+        link_to settings_profile_url, class: 'button logo-button' do
+          safe_join([svg_logo, t('settings.edit_profile')])
+        end
+      elsif current_account.following?(account) || current_account.requested?(account)
+        link_to account_unfollow_path(account), class: 'button logo-button button--destructive', data: { method: :post } do
+          safe_join([svg_logo, t('accounts.unfollow')])
+        end
+      elsif !(account.memorial? || account.moved?)
+        link_to account_follow_path(account), class: "button logo-button#{account.blocking?(current_account) ? ' disabled' : ''}", data: { method: :post } do
+          safe_join([svg_logo, t('accounts.follow')])
+        end
+      end
+    elsif !(account.memorial? || account.moved?)
+      link_to account_remote_follow_path(account), class: 'button logo-button modal-button', target: '_new' do
+        safe_join([svg_logo, t('accounts.follow')])
+      end
+    end
+  end
+
+  def minimal_account_action_button(account)
+    if user_signed_in?
+      return if account.id == current_user.account_id
+
+      if current_account.following?(account) || current_account.requested?(account)
+        link_to account_unfollow_path(account), class: 'icon-button active', data: { method: :post }, title: t('accounts.unfollow') do
+          fa_icon('user-times fw')
+        end
+      elsif !(account.memorial? || account.moved?)
+        link_to account_follow_path(account), class: "icon-button#{account.blocking?(current_account) ? ' disabled' : ''}", data: { method: :post }, title: t('accounts.follow') do
+          fa_icon('user-plus fw')
+        end
+      end
+    elsif !(account.memorial? || account.moved?)
+      link_to account_remote_follow_path(account), class: 'icon-button modal-button', target: '_new', title: t('accounts.follow') do
+        fa_icon('user-plus fw')
+      end
+    end
+  end
+
+  def account_badge(account, all: false)
+    if account.bot?
+      content_tag(:div, content_tag(:div, t('accounts.roles.bot'), class: 'account-role bot'), class: 'roles')
+    elsif (Setting.show_staff_badge && account.user_staff?) || all
+      content_tag(:div, class: 'roles') do
+        if all && !account.user_staff?
+          content_tag(:div, t('admin.accounts.roles.user'), class: 'account-role')
+        elsif account.user_admin?
+          content_tag(:div, t('accounts.roles.admin'), class: 'account-role admin')
+        elsif account.user_moderator?
+          content_tag(:div, t('accounts.roles.moderator'), class: 'account-role moderator')
+        end
+      end
+    end
+  end
+
+  def account_description(account)
+    prepend_str = [
+      [
+        number_to_human(account.statuses_count, strip_insignificant_zeros: true),
+        I18n.t('accounts.posts', count: account.statuses_count),
+      ].join(' '),
+
+      [
+        number_to_human(account.following_count, strip_insignificant_zeros: true),
+        I18n.t('accounts.following', count: account.following_count),
+      ].join(' '),
+
+      [
+        number_to_human(account.followers_count, strip_insignificant_zeros: true),
+        I18n.t('accounts.followers', count: account.followers_count),
+      ].join(' '),
+    ].join(', ')
+
+    [prepend_str, account.note].join(' Â· ')
+  end
+
+  def svg_logo
+    content_tag(:svg, tag(:use, 'xlink:href' => '#mastodon-svg-logo'), 'viewBox' => '0 0 216.4144 232.00976')
+  end
+
+  def svg_logo_full
+    content_tag(:svg, tag(:use, 'xlink:href' => '#mastodon-svg-logo-full'), 'viewBox' => '0 0 713.35878 175.8678')
+  end
+end

--- a/app/helpers/statuses_helper.rb
+++ b/app/helpers/statuses_helper.rb
@@ -4,80 +4,6 @@ module StatusesHelper
   EMBEDDED_CONTROLLER = 'statuses'
   EMBEDDED_ACTION = 'embed'
 
-  def display_name(account, **options)
-    if options[:custom_emojify]
-      Formatter.instance.format_display_name(account, options)
-    else
-      account.display_name.presence || account.username
-    end
-  end
-
-  def account_action_button(account)
-    if user_signed_in?
-      if account.id == current_user.account_id
-        link_to settings_profile_url, class: 'button logo-button' do
-          safe_join([svg_logo, t('settings.edit_profile')])
-        end
-      elsif current_account.following?(account) || current_account.requested?(account)
-        link_to account_unfollow_path(account), class: 'button logo-button button--destructive', data: { method: :post } do
-          safe_join([svg_logo, t('accounts.unfollow')])
-        end
-      elsif !(account.memorial? || account.moved?)
-        link_to account_follow_path(account), class: "button logo-button#{account.blocking?(current_account) ? ' disabled' : ''}", data: { method: :post } do
-          safe_join([svg_logo, t('accounts.follow')])
-        end
-      end
-    elsif !(account.memorial? || account.moved?)
-      link_to account_remote_follow_path(account), class: 'button logo-button modal-button', target: '_new' do
-        safe_join([svg_logo, t('accounts.follow')])
-      end
-    end
-  end
-
-  def minimal_account_action_button(account)
-    if user_signed_in?
-      return if account.id == current_user.account_id
-
-      if current_account.following?(account) || current_account.requested?(account)
-        link_to account_unfollow_path(account), class: 'icon-button active', data: { method: :post }, title: t('accounts.unfollow') do
-          fa_icon('user-times fw')
-        end
-      elsif !(account.memorial? || account.moved?)
-        link_to account_follow_path(account), class: "icon-button#{account.blocking?(current_account) ? ' disabled' : ''}", data: { method: :post }, title: t('accounts.follow') do
-          fa_icon('user-plus fw')
-        end
-      end
-    elsif !(account.memorial? || account.moved?)
-      link_to account_remote_follow_path(account), class: 'icon-button modal-button', target: '_new', title: t('accounts.follow') do
-        fa_icon('user-plus fw')
-      end
-    end
-  end
-
-  def svg_logo
-    content_tag(:svg, tag(:use, 'xlink:href' => '#mastodon-svg-logo'), 'viewBox' => '0 0 216.4144 232.00976')
-  end
-
-  def svg_logo_full
-    content_tag(:svg, tag(:use, 'xlink:href' => '#mastodon-svg-logo-full'), 'viewBox' => '0 0 713.35878 175.8678')
-  end
-
-  def account_badge(account, all: false)
-    if account.bot?
-      content_tag(:div, content_tag(:div, t('accounts.roles.bot'), class: 'account-role bot'), class: 'roles')
-    elsif (Setting.show_staff_badge && account.user_staff?) || all
-      content_tag(:div, class: 'roles') do
-        if all && !account.user_staff?
-          content_tag(:div, t('admin.accounts.roles.user'), class: 'account-role')
-        elsif account.user_admin?
-          content_tag(:div, t('accounts.roles.admin'), class: 'account-role admin')
-        elsif account.user_moderator?
-          content_tag(:div, t('accounts.roles.moderator'), class: 'account-role moderator')
-        end
-      end
-    end
-  end
-
   def link_to_more(url)
     link_to t('statuses.show_more'), url, class: 'load-more load-gap'
   end
@@ -86,27 +12,6 @@ module StatusesHelper
     content_tag(:div, class: "nothing-here #{extra_classes}") do
       t('accounts.nothing_here')
     end
-  end
-
-  def account_description(account)
-    prepend_str = [
-      [
-        number_to_human(account.statuses_count, strip_insignificant_zeros: true),
-        I18n.t('accounts.posts', count: account.statuses_count),
-      ].join(' '),
-
-      [
-        number_to_human(account.following_count, strip_insignificant_zeros: true),
-        I18n.t('accounts.following', count: account.following_count),
-      ].join(' '),
-
-      [
-        number_to_human(account.followers_count, strip_insignificant_zeros: true),
-        I18n.t('accounts.followers', count: account.followers_count),
-      ].join(' '),
-    ].join(', ')
-
-    [prepend_str, account.note].join(' · ')
   end
 
   def media_summary(status)
@@ -152,14 +57,6 @@ module StatusesHelper
 
   def stream_link_target
     embedded_view? ? '_blank' : nil
-  end
-
-  def acct(account)
-    if account.local?
-      "@#{account.acct}@#{Rails.configuration.x.local_domain}"
-    else
-      "@#{account.acct}"
-    end
   end
 
   def style_classes(status, is_predecessor, is_successor, include_threads)

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -3,7 +3,7 @@
 class AdminMailer < ApplicationMailer
   layout 'plain_mailer'
 
-  helper :statuses
+  helper :accounts
 
   def new_report(recipient, report)
     @report   = report

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class NotificationMailer < ApplicationMailer
+  helper :accounts
   helper :statuses
 
   add_template_helper RoutingHelper

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,9 +3,9 @@
 class UserMailer < Devise::Mailer
   layout 'mailer'
 
+  helper :accounts
   helper :application
   helper :instance
-  helper :statuses
 
   add_template_helper RoutingHelper
 

--- a/app/serializers/rss/account_serializer.rb
+++ b/app/serializers/rss/account_serializer.rb
@@ -2,7 +2,7 @@
 
 class RSS::AccountSerializer
   include ActionView::Helpers::NumberHelper
-  include StatusesHelper
+  include AccountsHelper
   include RoutingHelper
 
   def render(account, statuses, tag)

--- a/app/serializers/rss/tag_serializer.rb
+++ b/app/serializers/rss/tag_serializer.rb
@@ -3,7 +3,6 @@
 class RSS::TagSerializer
   include ActionView::Helpers::NumberHelper
   include ActionView::Helpers::SanitizeHelper
-  include StatusesHelper
   include RoutingHelper
 
   def render(tag, statuses)

--- a/spec/helpers/accounts_helper_spec.rb
+++ b/spec/helpers/accounts_helper_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe AccountsHelper, type: :helper do
+  def set_not_embedded_view
+    params[:controller] = "not_#{StatusesHelper::EMBEDDED_CONTROLLER}"
+    params[:action] = "not_#{StatusesHelper::EMBEDDED_ACTION}"
+  end
+
+  def set_embedded_view
+    params[:controller] = StatusesHelper::EMBEDDED_CONTROLLER
+    params[:action] = StatusesHelper::EMBEDDED_ACTION
+  end
+
+  describe '#display_name' do
+    it 'uses the display name when it exists' do
+      account = Account.new(display_name: "Display", username: "Username")
+
+      expect(helper.display_name(account)).to eq "Display"
+    end
+
+    it 'uses the username when display name is nil' do
+      account = Account.new(display_name: nil, username: "Username")
+
+      expect(helper.display_name(account)).to eq "Username"
+    end
+  end
+
+  describe '#acct' do
+    it 'is fully qualified for embedded local accounts' do
+      allow(Rails.configuration.x).to receive(:local_domain).and_return('local_domain')
+      set_embedded_view
+      account = Account.new(domain: nil, username: 'user')
+
+      acct = helper.acct(account)
+
+      expect(acct).to eq '@user@local_domain'
+    end
+
+    it 'is fully qualified for embedded foreign accounts' do
+      set_embedded_view
+      account = Account.new(domain: 'foreign_server.com', username: 'user')
+
+      acct = helper.acct(account)
+
+      expect(acct).to eq '@user@foreign_server.com'
+    end
+
+    it 'is fully qualified for non embedded foreign accounts' do
+      set_not_embedded_view
+      account = Account.new(domain: 'foreign_server.com', username: 'user')
+
+      acct = helper.acct(account)
+
+      expect(acct).to eq '@user@foreign_server.com'
+    end
+
+    it 'is fully qualified for non embedded local accounts' do
+      allow(Rails.configuration.x).to receive(:local_domain).and_return('local_domain')
+      set_not_embedded_view
+      account = Account.new(domain: nil, username: 'user')
+
+      acct = helper.acct(account)
+
+      expect(acct).to eq '@user@local_domain'
+    end
+  end
+end

--- a/spec/helpers/admin/account_moderation_notes_helper_spec.rb
+++ b/spec/helpers/admin/account_moderation_notes_helper_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Admin::AccountModerationNotesHelper, type: :helper do
-  include StatusesHelper
+  include AccountsHelper
 
   describe '#admin_account_link_to' do
     context 'account is nil' do

--- a/spec/helpers/statuses_helper_spec.rb
+++ b/spec/helpers/statuses_helper_spec.rb
@@ -1,20 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe StatusesHelper, type: :helper do
-  describe '#display_name' do
-    it 'uses the display name when it exists' do
-      account = Account.new(display_name: "Display", username: "Username")
-
-      expect(helper.display_name(account)).to eq "Display"
-    end
-
-    it 'uses the username when display name is nil' do
-      account = Account.new(display_name: nil, username: "Username")
-
-      expect(helper.display_name(account)).to eq "Username"
-    end
-  end
-
   describe '#stream_link_target' do
     it 'returns nil if it is not an embedded view' do
       set_not_embedded_view
@@ -26,46 +12,6 @@ RSpec.describe StatusesHelper, type: :helper do
       set_embedded_view
 
       expect(helper.stream_link_target).to eq '_blank'
-    end
-  end
-
-  describe '#acct' do
-    it 'is fully qualified for embedded local accounts' do
-      allow(Rails.configuration.x).to receive(:local_domain).and_return('local_domain')
-      set_embedded_view
-      account = Account.new(domain: nil, username: 'user')
-
-      acct = helper.acct(account)
-
-      expect(acct).to eq '@user@local_domain'
-    end
-
-    it 'is fully qualified for embedded foreign accounts' do
-      set_embedded_view
-      account = Account.new(domain: 'foreign_server.com', username: 'user')
-
-      acct = helper.acct(account)
-
-      expect(acct).to eq '@user@foreign_server.com'
-    end
-
-    it 'is fully qualified for non embedded foreign accounts' do
-      set_not_embedded_view
-      account = Account.new(domain: 'foreign_server.com', username: 'user')
-
-      acct = helper.acct(account)
-
-      expect(acct).to eq '@user@foreign_server.com'
-    end
-
-    it 'is fully qualified for non embedded local accounts' do
-      allow(Rails.configuration.x).to receive(:local_domain).and_return('local_domain')
-      set_not_embedded_view
-      account = Account.new(domain: nil, username: 'user')
-
-      acct = helper.acct(account)
-
-      expect(acct).to eq '@user@local_domain'
     end
   end
 


### PR DESCRIPTION
Refactoring that divides StatusesHelper into functions.

It's getting long, and when I try to add a line, rubocop gives a warning `Module has too many lines.`