### PR TITLE
Fix S3 adapter retrying failing uploads with exponential backoff

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -40,6 +40,7 @@ if ENV['S3_ENABLED'] == 'true'
       http_open_timeout: 5,
       http_read_timeout: 5,
       http_idle_timeout: 5,
+      retry_limit: 0,
     }
   )
 


### PR DESCRIPTION
The default limit of 10 retries with exponential backoff meant
that if the S3 server was timing out, you would be stuck with it
for much, much longer than the 5 second read timeout we expect.

The uploading happens within a database transaction, which means
a failing S3 server could negatively affect database performance