### PR TITLE
Add loglevel fatal to video and audio styles

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -57,6 +57,7 @@ class MediaAttachment < ApplicationRecord
     small: {
       convert_options: {
         output: {
+          'loglevel' => 'fatal',
           vf: 'scale=\'min(400\, iw):min(400\, ih)\':force_original_aspect_ratio=decrease',
         },
       },
@@ -70,6 +71,7 @@ class MediaAttachment < ApplicationRecord
       keep_same_format: true,
       convert_options: {
         output: {
+          'loglevel' => 'fatal',
           'map_metadata' => '-1',
           'c:v' => 'copy',
           'c:a' => 'copy',
@@ -84,6 +86,7 @@ class MediaAttachment < ApplicationRecord
       content_type: 'audio/mpeg',
       convert_options: {
         output: {
+          'loglevel' => 'fatal',
           'q:a' => 2,
         },
       },


### PR DESCRIPTION
This fixes the same problem that was happening on #9368 "ffmpeg processing sometimes stalling due to overfilled stdout buffer".

I have ran into this on v3.0.0 for audio/mp3 transcoding and added the loglevel fatal to the audio_styles output and not sure it is necessary but just to be safe added it also to video_styles.