### PR TITLE
Remove fallback to long description on sidebar and meta description

### DIFF
--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -52,13 +52,12 @@
         .hero-widget__img
           = image_tag @instance_presenter.hero&.file&.url || @instance_presenter.thumbnail&.file&.url || asset_pack_path('media/images/preview.jpg'), alt: @instance_presenter.site_title
 
-        - if @instance_presenter.site_short_description.present?
-          .hero-widget__text
-            %p
-              = @instance_presenter.site_short_description.html_safe.presence
-              = link_to about_more_path do
-                = t('about.learn_more')
-                = fa_icon 'angle-double-right'
+        .hero-widget__text
+          %p
+            = @instance_presenter.site_short_description.html_safe.presence || t('about.about_mastodon_html')
+            = link_to about_more_path do
+              = t('about.learn_more')
+              = fa_icon 'angle-double-right'
 
         .hero-widget__footer
           .hero-widget__footer__column

--- a/app/views/application/_sidebar.html.haml
+++ b/app/views/application/_sidebar.html.haml
@@ -3,7 +3,7 @@
     = image_tag @instance_presenter.hero&.file&.url || @instance_presenter.thumbnail&.file&.url || asset_pack_path('media/images/preview.jpg'), alt: @instance_presenter.site_title
 
   .hero-widget__text
-    %p= @instance_presenter.site_short_description.html_safe.presence || @instance_presenter.site_description.html_safe.presence || t('about.generic_description', domain: site_hostname)
+    %p= @instance_presenter.site_short_description.html_safe.presence || t('about.about_mastodon_html')
 
 - if Setting.trends && !(user_signed_in? && !current_user.setting_trends)
   - trends = TrendingTags.get(3)

--- a/app/views/shared/_og.html.haml
+++ b/app/views/shared/_og.html.haml
@@ -1,5 +1,5 @@
 - thumbnail     = @instance_presenter.thumbnail
-- description ||= strip_tags(@instance_presenter.site_short_description.presence || @instance_presenter.site_description.presence || t('about.about_mastodon_html'))
+- description ||= strip_tags(@instance_presenter.site_short_description.presence || t('about.about_mastodon_html'))
 
 %meta{ name: 'description', content: description }/
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   about:
     about_hashtag_html: These are public toots tagged with <strong>#%{hashtag}</strong>. You can interact with them if you have an account anywhere in the fediverse.
-    about_mastodon_html: Mastodon is a social network based on open web protocols and free, open-source software. It is decentralized like e-mail.
+    about_mastodon_html: 'The social network of the future: No ads, no corporate surveillance, ethical design, and decentralization! Own your data with Mastodon!'
     about_this: About
     active_count_after: active
     active_footnote: Monthly Active Users (MAU)
@@ -18,7 +18,6 @@ en:
     discover_users: Discover users
     documentation: Documentation
     federation_hint_html: With an account on %{instance} you'll be able to follow people on any Mastodon server and beyond.
-    generic_description: "%{domain} is one server in the network"
     get_apps: Try a mobile app
     hosted_on: Mastodon hosted on %{domain}
     instance_actor_flash: |


### PR DESCRIPTION
Fix #12114

This makes behaviour consistent. The long description is returned from API only. Sidebar, meta tags, and frontpage display short description or fallback to a string about Mastodon. That string used to be:

> Mastodon is a social network based on open web protocols and free, open-source software. It is decentralized like e-mail.

But I feel like that is very dry and too technical, so I am replacing it with the slogan we use in other places:

> The social network of the future: No ads, no corporate surveillance, ethical design, and decentralization! Own your data with Mastodon!

Small benefit: The "Learn more" button leading to the extended description page is now always displayed on the frontpage.