### PR TITLE
Change misleading metrics in admin instance view dashboard

### DIFF
--- a/app/controllers/admin/instances_controller.rb
+++ b/app/controllers/admin/instances_controller.rb
@@ -15,10 +15,10 @@ module Admin
     def show
       authorize :instance, :show?
 
-      @following_count = Follow.where(account: Account.where(domain: params[:id])).count
-      @followers_count = Follow.where(target_account: Account.where(domain: params[:id])).count
+      @following_count = Follow.where(account: Account.where(domain: params[:id])).distinct.count(:target_account_id)
+      @followers_count = Follow.where(target_account: Account.where(domain: params[:id])).distinct.count(:target_account_id)
       @reports_count   = Report.where(target_account: Account.where(domain: params[:id])).count
-      @blocks_count    = Block.where(target_account: Account.where(domain: params[:id])).count
+      @blocks_count    = Block.where(target_account: Account.where(domain: params[:id])).distinct.count(:target_account_id)
       @available       = DeliveryFailureTracker.available?(Account.select(:shared_inbox_url).where(domain: params[:id]).first&.shared_inbox_url)
       @media_storage   = MediaAttachment.where(account: Account.where(domain: params[:id])).sum(:file_file_size)
       @private_comment = @domain_block&.private_comment

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -359,9 +359,9 @@ en:
       private_comment: Private comment
       public_comment: Public comment
       title: Federation
-      total_blocked_by_us: Blocked by us
+      total_blocked_by_us: Blocked by local users
       total_followed_by_them: Followed by them
-      total_followed_by_us: Followed by us
+      total_followed_by_us: Followed by local users
       total_reported: Reports about them
       total_storage: Media attachments
     invites:


### PR DESCRIPTION
“Followed by them” was the number of follow relationships from them to local
users. Changed it to be the number of local users followed by at least one
of their users.

“Followed by us” was the number of follow relationships from local users
to them. Changed it to be the number of their users followed by at least one
of our local users.

“Blocked by us” was the number of user blocks from local users targetting
one of their users. Changed it to be the number of their users blocked by
at least one local user.

Also, change “… by us” strings to make it explicit that this is “by local users”, in particular for blocks where it could mislead admins into thinking it's about people they suspended.

## Before

![image](https://user-images.githubusercontent.com/384364/66706429-9fffcd00-ed32-11e9-9fc5-6e1976a02631.png)

## After

![image](https://user-images.githubusercontent.com/384364/66706479-54015800-ed33-11e9-8be8-d52559551b29.png)
