### PR TITLE
Improve swipe experience

### DIFF
--- a/app/javascript/mastodon/features/ui/components/columns_area.js
+++ b/app/javascript/mastodon/features/ui/components/columns_area.js
@@ -182,7 +182,7 @@ class ColumnsArea extends ImmutablePureComponent {
       const floatingActionButton = shouldHideFAB(this.context.router.history.location.pathname) ? null : <Link key='floating-action-button' to='/statuses/new' className='floating-action-button' aria-label={intl.formatMessage(messages.publish)}><Icon id='pencil' /></Link>;
 
       const content = columnIndex !== -1 ? (
-        <ReactSwipeableViews key='content' index={columnIndex} onChangeIndex={this.handleSwipe} onTransitionEnd={this.handleAnimationEnd} animateTransitions={shouldAnimate} springConfig={{ duration: '400ms', delay: '0s', easeFunction: 'ease' }} style={{ height: '100%' }}>
+        <ReactSwipeableViews key='content' hysteresis={0.2} threshold={15} index={columnIndex} onChangeIndex={this.handleSwipe} onTransitionEnd={this.handleAnimationEnd} animateTransitions={shouldAnimate} springConfig={{ duration: '400ms', delay: '0s', easeFunction: 'ease' }} style={{ height: '100%' }}>
           {links.map(this.renderView)}
         </ReactSwipeableViews>
       ) : (


### PR DESCRIPTION
Currently the swipe is too sensitive on mobile devices. Related issues: #4038 and #4035.
The `react-swipeable-views` changed a lot since 2017 so the previous commit no longer works.

Changes:
`threshold={15}` sets the speed threshold to be three times less sensitive than default to be identified as a quick-swipe. The default value is 5, which is too sensitive according users' feedback.
`hysteresis={0.2}` sets the delta threshold to be 20% of width to swipe for a slow swipe. By default this value is 0.6, which means users have to swipe 60% of the width to switch to another page during slow-swipes. The default value does not make sense.

I have tested these values and saw no side-effect.

Reference:
[1] `react-swipeable-views` API document: https://react-swipeable-views.com/api/api/
