### PR TITLE
Add Sidekiq Prometheus Metrics Endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,3 +155,5 @@ end
 
 gem 'concurrent-ruby', require: false
 gem 'connection_pool', require: false
+
+gem 'sidekiq-prometheus-exporter', '~> 0.1.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -585,6 +585,8 @@ GEM
       redis (>= 3.3.5, < 5)
     sidekiq-bulk (0.2.0)
       sidekiq
+    sidekiq-prometheus-exporter (0.1.12)
+      sidekiq (>= 3.3.1)
     sidekiq-scheduler (3.0.0)
       redis (>= 3, < 5)
       rufus-scheduler (~> 3.2)
@@ -783,6 +785,7 @@ DEPENDENCIES
   sanitize (~> 5.1)
   sidekiq (~> 5.2)
   sidekiq-bulk (~> 0.2.0)
+  sidekiq-prometheus-exporter (~> 0.1.12)
   sidekiq-scheduler (~> 3.0)
   sidekiq-unique-jobs (~> 6.0)
   simple-navigation (~> 4.1)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,12 +2,14 @@
 
 require 'sidekiq/web'
 require 'sidekiq-scheduler/web'
+require 'sidekiq/prometheus/exporter'
 
 Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
 
 Rails.application.routes.draw do
   root 'home#index'
 
+  mount Sidekiq::Prometheus::Exporter, at: 'sidekiq_metrics'
   mount LetterOpenerWeb::Engine, at: 'letter_opener' if Rails.env.development?
 
   health_check_routes


### PR DESCRIPTION
There are probably better ways of doing this, and I was hoping if there is, people can advise how.

I am exposing metrics on /sidekiq_metrics, and using nginx to control who can access the page.