### PR TITLE
Remove audio metadata

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -87,6 +87,7 @@ class MediaAttachment < ApplicationRecord
       convert_options: {
         output: {
           'loglevel' => 'fatal',
+          'map_metadata' => '-1',
           'q:a' => 2,
         },
       },


### PR DESCRIPTION
I was running into an issue where some specific audio files got stuck in Sidekiq or were just ignored. The one that I have noticed was causing this everywhere I look was [this one](https://octodon.social/@mxsiege/102951182641300784). Eg: on Mastodon.social the audio file did not federate.

I have found that other audio files with metadata also randomly caused issues and I couldn't find any reason why because on some instances they federated fine and on others, using the same setup, they got stuck forever in Sidekiq.

The way I found to fix it was just to strip the metadata. I don't know if this is something that should be stripped or not for audio files in Mastodon but that was the only way I found to make this not a problem for my setup.