### PR TITLE
Drop filtered messages if the filter is “irreversible”

### DIFF
--- a/app/javascript/mastodon/actions/importer/normalizer.js
+++ b/app/javascript/mastodon/actions/importer/normalizer.js
@@ -10,6 +10,12 @@ const makeEmojiMap = record => record.emojis.reduce((obj, emoji) => {
   return obj;
 }, {});
 
+export function searchTextFromRawStatus (status) {
+  const spoilerText   = status.spoiler_text || '';
+  const searchContent = ([spoilerText, status.content].concat((status.poll && status.poll.options) ? status.poll.options.map(option => option.title) : [])).join('\n\n').replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n');
+  return domParser.parseFromString(searchContent, 'text/html').documentElement.textContent;
+}
+
 export function normalizeAccount(account) {
   account = { ...account };
 

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -14,6 +14,7 @@ import { unescapeHTML } from '../utils/html';
 import { getFiltersRegex } from '../selectors';
 import { usePendingItems as preferPendingItems } from 'mastodon/initial_state';
 import compareId from 'mastodon/compare_id';
+import { searchTextFromRawStatus } from 'mastodon/actions/importer/normalizer';
 
 export const NOTIFICATIONS_UPDATE      = 'NOTIFICATIONS_UPDATE';
 export const NOTIFICATIONS_UPDATE_NOOP = 'NOTIFICATIONS_UPDATE_NOOP';
@@ -60,7 +61,7 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
     if (notification.type === 'mention') {
       const dropRegex   = filters[0];
       const regex       = filters[1];
-      const searchIndex = notification.status.spoiler_text + '\n' + unescapeHTML(notification.status.content);
+      const searchIndex = searchTextFromRawStatus(notification.status);
 
       if (dropRegex && dropRegex.test(searchIndex)) {
         return;

--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -30,12 +30,14 @@ export function updateTimeline(timeline, status, accept) {
       return;
     }
 
-    const dropRegex = getFiltersRegex(getState(), { contextType: timeline })[0];
+    const filters   = getFiltersRegex(getState(), { contextType: timeline });
+    const dropRegex = filters[0];
+    const regex     = filters[1];
+    const text      = searchTextFromRawStatus(status);
+    let filtered    = false;
 
-    if (dropRegex && status.account.id !== me) {
-      if (dropRegex.test(searchTextFromRawStatus(status))) {
-        return;
-      }
+    if (status.account.id !== me) {
+      filtered = (dropRegex && dropRegex.test(text)) || (regex && regex.test(text));
     }
 
     dispatch(importFetchedStatus(status));
@@ -45,6 +47,7 @@ export function updateTimeline(timeline, status, accept) {
       timeline,
       status,
       usePendingItems: preferPendingItems,
+      filtered,
     });
   };
 };
@@ -107,12 +110,8 @@ export function expandTimeline(timelineId, path, params = {}, done = noOp) {
     api(getState).get(path, { params }).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
 
-      const dropRegex = getFiltersRegex(getState(), { contextType: timelineId })[0];
-
-      const statuses = dropRegex ? response.data.filter(status => status.account.id === me || !dropRegex.test(searchTextFromRawStatus(status))) : response.data;
-
-      dispatch(importFetchedStatuses(statuses));
-      dispatch(expandTimelineSuccess(timelineId, statuses, next ? next.uri : null, response.status === 206, isLoadingRecent, isLoadingMore, isLoadingRecent && preferPendingItems));
+      dispatch(importFetchedStatuses(response.data));
+      dispatch(expandTimelineSuccess(timelineId, response.data, next ? next.uri : null, response.status === 206, isLoadingRecent, isLoadingMore, isLoadingRecent && preferPendingItems));
       done();
     }).catch(error => {
       dispatch(expandTimelineFail(timelineId, error, isLoadingMore));

--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -4,8 +4,7 @@ import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
 import compareId from 'mastodon/compare_id';
 import { me, usePendingItems as preferPendingItems } from 'mastodon/initial_state';
 import { getFiltersRegex } from 'mastodon/selectors';
-
-const domParser = new DOMParser();
+import { searchTextFromRawStatus } from 'mastodon/actions/importer/normalizer';
 
 export const TIMELINE_UPDATE  = 'TIMELINE_UPDATE';
 export const TIMELINE_DELETE  = 'TIMELINE_DELETE';
@@ -19,12 +18,6 @@ export const TIMELINE_SCROLL_TOP   = 'TIMELINE_SCROLL_TOP';
 export const TIMELINE_LOAD_PENDING = 'TIMELINE_LOAD_PENDING';
 export const TIMELINE_DISCONNECT   = 'TIMELINE_DISCONNECT';
 export const TIMELINE_CONNECT      = 'TIMELINE_CONNECT';
-
-const searchTextFromRawStatus = (status) => {
-  const spoilerText   = status.spoiler_text || '';
-  const searchContent = ([spoilerText, status.content].concat((status.poll && status.poll.options) ? status.poll.options.map(option => option.title) : [])).join('\n\n').replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n');
-  return domParser.parseFromString(searchContent, 'text/html').documentElement.textContent;
-}
 
 export const loadPending = timeline => ({
   type: TIMELINE_LOAD_PENDING,

--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -2,7 +2,10 @@ import { importFetchedStatus, importFetchedStatuses } from './importer';
 import api, { getLinks } from 'mastodon/api';
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
 import compareId from 'mastodon/compare_id';
-import { usePendingItems as preferPendingItems } from 'mastodon/initial_state';
+import { me, usePendingItems as preferPendingItems } from 'mastodon/initial_state';
+import { getFiltersRegex } from 'mastodon/selectors';
+
+const domParser = new DOMParser();
 
 export const TIMELINE_UPDATE  = 'TIMELINE_UPDATE';
 export const TIMELINE_DELETE  = 'TIMELINE_DELETE';
@@ -17,15 +20,29 @@ export const TIMELINE_LOAD_PENDING = 'TIMELINE_LOAD_PENDING';
 export const TIMELINE_DISCONNECT   = 'TIMELINE_DISCONNECT';
 export const TIMELINE_CONNECT      = 'TIMELINE_CONNECT';
 
+const searchTextFromRawStatus = (status) => {
+  const spoilerText   = status.spoiler_text || '';
+  const searchContent = ([spoilerText, status.content].concat((status.poll && status.poll.options) ? status.poll.options.map(option => option.title) : [])).join('\n\n').replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n');
+  return domParser.parseFromString(searchContent, 'text/html').documentElement.textContent;
+}
+
 export const loadPending = timeline => ({
   type: TIMELINE_LOAD_PENDING,
   timeline,
 });
 
 export function updateTimeline(timeline, status, accept) {
-  return dispatch => {
+  return (dispatch, getState) => {
     if (typeof accept === 'function' && !accept(status)) {
       return;
+    }
+
+    const dropRegex = getFiltersRegex(getState(), { contextType: timeline })[0];
+
+    if (dropRegex && status.account.id !== me) {
+      if (dropRegex.test(searchTextFromRawStatus(status))) {
+        return;
+      }
     }
 
     dispatch(importFetchedStatus(status));
@@ -96,8 +113,13 @@ export function expandTimeline(timelineId, path, params = {}, done = noOp) {
 
     api(getState).get(path, { params }).then(response => {
       const next = getLinks(response).refs.find(link => link.rel === 'next');
-      dispatch(importFetchedStatuses(response.data));
-      dispatch(expandTimelineSuccess(timelineId, response.data, next ? next.uri : null, response.status === 206, isLoadingRecent, isLoadingMore, isLoadingRecent && preferPendingItems));
+
+      const dropRegex = getFiltersRegex(getState(), { contextType: timelineId })[0];
+
+      const statuses = dropRegex ? response.data.filter(status => status.account.id === me || !dropRegex.test(searchTextFromRawStatus(status))) : response.data;
+
+      dispatch(importFetchedStatuses(statuses));
+      dispatch(expandTimelineSuccess(timelineId, statuses, next ? next.uri : null, response.status === 206, isLoadingRecent, isLoadingMore, isLoadingRecent && preferPendingItems));
       done();
     }).catch(error => {
       dispatch(expandTimelineFail(timelineId, error, isLoadingMore));

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -61,7 +61,7 @@ const expandNormalizedTimeline = (state, timeline, statuses, next, isPartial, is
   }));
 };
 
-const updateTimeline = (state, timeline, status, usePendingItems) => {
+const updateTimeline = (state, timeline, status, usePendingItems, filtered) => {
   const top = state.getIn([timeline, 'top']);
 
   if (usePendingItems || !state.getIn([timeline, 'pendingItems']).isEmpty()) {
@@ -69,7 +69,13 @@ const updateTimeline = (state, timeline, status, usePendingItems) => {
       return state;
     }
 
-    return state.update(timeline, initialTimeline, map => map.update('pendingItems', list => list.unshift(status.get('id'))).update('unread', unread => unread + 1));
+    state = state.update(timeline, initialTimeline, map => map.update('pendingItems', list => list.unshift(status.get('id'))));
+
+    if (!filtered) {
+      state = state.update('unread', unread => unread + 1);
+    }
+
+    return state;
   }
 
   const ids        = state.getIn([timeline, 'items'], ImmutableList());
@@ -83,7 +89,7 @@ const updateTimeline = (state, timeline, status, usePendingItems) => {
   let newIds = ids;
 
   return state.update(timeline, initialTimeline, map => map.withMutations(mMap => {
-    if (!top) mMap.set('unread', unread + 1);
+    if (!top && !filtered) mMap.set('unread', unread + 1);
     if (top && ids.size > 40) newIds = newIds.take(20);
     mMap.set('items', newIds.unshift(status.get('id')));
   }));
@@ -148,7 +154,7 @@ export default function timelines(state = initialState, action) {
   case TIMELINE_EXPAND_SUCCESS:
     return expandNormalizedTimeline(state, action.timeline, fromJS(action.statuses), action.next, action.partial, action.isLoadingRecent, action.usePendingItems);
   case TIMELINE_UPDATE:
-    return updateTimeline(state, action.timeline, fromJS(action.status), action.usePendingItems);
+    return updateTimeline(state, action.timeline, fromJS(action.status), action.usePendingItems, action.filtered);
   case TIMELINE_DELETE:
     return deleteStatus(state, action.id, action.accountId, action.references, action.reblogOf);
   case TIMELINE_CLEAR:


### PR DESCRIPTION
… instead of adding them to the timelines and then not showing them.
This fixes timelines showing new items when the only new items are “irreversibly” filtered toots, as well as such items taking space in the client-side lists.

This is actually an edge case in Mastodon itself, but the normal case in Pleroma, which can be used with a Mastodon front-end but does not apply filters server-side.