### PR TITLE
don't show outline of full-screen video

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5194,6 +5194,7 @@ a.status-card.compact:hover {
       max-height: 100% !important;
       width: 100% !important;
       height: 100% !important;
+      outline: 0;
     }
   }
 


### PR DESCRIPTION
Prevent show focus outline when playing video with fullscreen. 
This is happen on Android Chrome.

## before
![full screen video with outline](https://user-images.githubusercontent.com/5253290/66943009-4296b380-f085-11e9-8905-117e03858c6a.png)

## after
![full screen video without outline](https://user-images.githubusercontent.com/5253290/66943016-488c9480-f085-11e9-894d-e8ed4a7ccf36.png)
