### PR TITLE
fix vagrant connection issue

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -1,2 +1,3 @@
 VAGRANT=true
 LOCAL_DOMAIN=mastodon.local
+BIND=0.0.0.0


### PR DESCRIPTION
This PR fixes the vagrant connection issue below.

when executing command `curl localhost:3000` after `vagrant up`, I got error `curl: (56) Recv failure: Connection reset by peer`.
This is because puma listen to tcp://127.0.0.1:3000.
This PR fixes this issue by changing the default ip address to listen to to tcp://0.0.0.0:3000.

