### PR TITLE
Fix batch actions being hidden from mobile view

### DIFF
--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -149,10 +149,6 @@ a.table-action-link {
           margin-top: 0;
         }
       }
-
-      @media screen and (max-width: $no-gap-breakpoint) {
-        display: none;
-      }
     }
 
     &__actions,
@@ -174,10 +170,6 @@ a.table-action-link {
       text-align: right;
       padding-right: 16px - 5px;
     }
-
-    @media screen and (max-width: $no-gap-breakpoint) {
-      display: none;
-    }
   }
 
   &__form {
@@ -198,7 +190,7 @@ a.table-action-link {
     background: darken($ui-base-color, 4%);
 
     @media screen and (max-width: $no-gap-breakpoint) {
-      &:first-child {
+      .optional &:first-child {
         border-top: 1px solid darken($ui-base-color, 8%);
       }
     }
@@ -261,6 +253,13 @@ a.table-action-link {
         background: transparent;
         border-radius: 0;
       }
+    }
+  }
+
+  &.optional .batch-table__toolbar,
+  &.optional .batch-table__row__select {
+    @media screen and (max-width: $no-gap-breakpoint) {
+      display: none;
     }
   }
 

--- a/app/views/admin/tags/index.html.haml
+++ b/app/views/admin/tags/index.html.haml
@@ -48,7 +48,7 @@
   - Admin::FilterHelper::TAGS_FILTERS.each do |key|
     = hidden_field_tag key, params[key] if params[key].present?
 
-  .batch-table
+  .batch-table.optional
     .batch-table__toolbar
       %label.batch-table__toolbar__select.batch-checkbox-all
         = check_box_tag :batch_checkbox_all, nil, false


### PR DESCRIPTION
On mobile, batch actions are hidden from the settings/admin interface,
but there are several places those actions can only be performed through
batch actions.

This may not look great, but at least it makes the actions available again.