### PR TITLE
Fix incoming federation in whitelist mode

### DIFF
--- a/app/controllers/activitypub/inboxes_controller.rb
+++ b/app/controllers/activitypub/inboxes_controller.rb
@@ -7,6 +7,7 @@ class ActivityPub::InboxesController < ActivityPub::BaseController
 
   before_action :skip_unknown_actor_delete
   before_action :require_signature!
+  skip_before_action :authenticate_user!
 
   def create
     upgrade_account


### PR DESCRIPTION
… posting to the AP inbox required a logged-in local user…