### PR TITLE
microformat mentions can have an implicit url property

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -84,7 +84,7 @@ class FetchLinkCardService < BaseService
 
   def skip_link?(a)
     # Avoid links for hashtags and mentions (microformats)
-    a['rel']&.include?('tag') || a['class']&.include?('u-url') || mention_link?(a)
+    a['rel']&.include?('tag') || a['class']&.match?(/u-url|h-card/) || mention_link?(a)
   end
 
   def attempt_oembed


### PR DESCRIPTION
See the first example here: http://microformats.org/wiki/microformats2#hyperlinked_person

> Simple hyperlinked person reference
> `<a class="h-card" href="http://benward.me">Ben Ward</a>`
> 
> Parsed JSON:
> ```json
> {
>   "items": [{ 
>     "type": ["h-card"],
>     "properties": {
>       "name": ["Ben Ward"],
>       "url": ["http://benward.me"]
>    }
>   }]
> }

see http://microformats.org/wiki/microformats2-parsing#parsing_for_implied_properties for a more detailed list of implicit property parsing rules.

We might also want to change the HTML mastodon generates at some point, since having an extra span element feels awkward to me.