### PR TITLE
Allow Accept/Reject with a non-embedded object

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -153,6 +153,14 @@ class ActivityPub::Activity
     fetch_remote_original_status
   end
 
+  def follow_request_from_object
+    @follow_request ||= FollowRequest.find_by(target_account: @account, uri: object_uri) unless object_uri.nil?
+  end
+
+  def follow_from_object
+    @follow ||= Follow.find_by(target_account: @account, uri: object_uri) unless object_uri.nil?
+  end
+
   def fetch_remote_original_status
     if object_uri.start_with?('http')
       return if ActivityPub::TagManager.instance.local_uri?(object_uri)

--- a/app/lib/activitypub/activity/accept.rb
+++ b/app/lib/activitypub/activity/accept.rb
@@ -2,17 +2,18 @@
 
 class ActivityPub::Activity::Accept < ActivityPub::Activity
   def perform
+    return accept_follow_for_relay if relay_follow?
+    return follow_request_from_object.authorize! unless follow_request_from_object.nil?
+
     case @object['type']
     when 'Follow'
-      accept_follow
+      accept_embedded_follow
     end
   end
 
   private
 
-  def accept_follow
-    return accept_follow_for_relay if relay_follow?
-
+  def accept_embedded_follow
     target_account = account_from_uri(target_uri)
 
     return if target_account.nil? || !target_account.local?

--- a/app/lib/activitypub/activity/reject.rb
+++ b/app/lib/activitypub/activity/reject.rb
@@ -2,17 +2,19 @@
 
 class ActivityPub::Activity::Reject < ActivityPub::Activity
   def perform
+    return reject_follow_for_relay if relay_follow?
+    return follow_request_from_object.reject! unless follow_request_from_object.nil?
+    return UnfollowService.new.call(follow_from_object.target_account, @account) unless follow_from_object.nil?
+
     case @object['type']
     when 'Follow'
-      reject_follow
+      reject_embedded_follow
     end
   end
 
   private
 
-  def reject_follow
-    return reject_follow_for_relay if relay_follow?
-
+  def reject_embedded_follow
     target_account = account_from_uri(target_uri)
 
     return if target_account.nil? || !target_account.local?


### PR DESCRIPTION
Some ActivityPub servers refuse to embed remote objects into their own output. This is because they are not the authoritative source for these objects, and as such embedding them is always a waste of space. The follow request and follow models contain a URI, so this can be used to match them.

Fixes #12133