### PR TITLE
Change to always returns html document in error pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -136,9 +136,6 @@ class ApplicationController < ActionController::Base
   end
 
   def respond_with_error(code)
-    respond_to do |format|
-      format.any  { head code }
-      format.html { render "errors/#{code}", layout: 'error', status: code }
-    end
+    render "errors/#{code}", layout: 'error', status: code
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -22,11 +22,6 @@ describe ApplicationController, type: :controller do
   end
 
   shared_examples 'respond_with_error' do |code|
-    it "returns http #{code} for any" do
-      subject
-      expect(response).to have_http_status(code)
-    end
-
     it "returns http #{code} for http" do
       subject
       expect(response).to have_http_status(code)


### PR DESCRIPTION
Resolve #11672

I want to always return an HTML document to show a user-friendly error.