### PR TITLE
Avoid YouTube Captcha

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -97,6 +97,7 @@ class FetchLinkCardService < BaseService
     end
     if embed.nil?
       html
+      return if @html.nil?
       embed = service.call(@url, html: @html)
     end
     
@@ -142,6 +143,7 @@ class FetchLinkCardService < BaseService
     
     if @html.nil?
       html
+      return if @html.nil?
     end
     guess      = detector.detect(@html, @html_charset)
     encoding   = guess&.fetch(:confidence, 0).to_i > 60 ? guess&.fetch(:encoding, nil) : nil

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -59,7 +59,7 @@ class FetchLinkCardService < BaseService
       youtube_formats.find { |format| @url =~ format } and $1
       video_id = $1
       if video_id && (video_id.length == 11)
-          @oembed_endpoint_url = "http://www.youtube.com/oembed?url=http%3A//youtube.com/watch%3Fv%3D#{$1}&format=json"
+          @oembed_endpoint_url = "https://www.youtube.com/oembed?url=https%3A//youtube.com/watch%3Fv%3D#{$1}&format=json"
           attempt_oembed
       end
     end

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -48,7 +48,8 @@ class FetchLinkCardService < BaseService
   end
 
   def try_oembed_endpoint
-    if Addressable::URI.parse(@url).host == 'youtube.com' || 'www.youtube.com' || 'youtu.be'
+    url_domain=Addressable::URI.parse(@url).host
+    if url_domain == 'youtube.com' || url_domain == 'www.youtube.com' || url_domain == 'youtu.be'
       youtube_formats = [
         %r(https?://youtu\.be/(.+)),
         %r(https?://www\.youtube\.com/watch\?v=(.*?)(&|#|$)),

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -52,8 +52,6 @@ class FetchLinkCardService < BaseService
         @html_charset = nil
       end
     end
-
-    return if @html.nil?  
   end
 
   def attach_card
@@ -95,7 +93,7 @@ class FetchLinkCardService < BaseService
     url_domain=Addressable::URI.parse(@url).host
     cached_endpoint=Rails.cache.read('oembed_endpoint_#{url_domain}')
     unless cached_endpoint.nil?
-	  embed = service.call(@url, cached_endpoint: cached_endpoint)
+	    embed = service.call(@url, cached_endpoint: cached_endpoint)
     end
     if embed.nil?
       html

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -97,7 +97,7 @@ class FetchLinkCardService < BaseService
     end
     if embed.nil?
       html
-      return if @html.nil?
+      return false if @html.nil?
       embed = service.call(@url, html: @html)
     end
     

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -48,9 +48,7 @@ class FetchLinkCardService < BaseService
   end
 
   def try_oembed_endpoint
-
     if Addressable::URI.parse(@url).host == 'youtube.com' || 'www.youtube.com' || 'youtu.be'
-
       youtube_formats = [
         %r(https?://youtu\.be/(.+)),
         %r(https?://www\.youtube\.com/watch\?v=(.*?)(&|#|$)),
@@ -58,7 +56,6 @@ class FetchLinkCardService < BaseService
         %r(https?://www\.youtube\.com/v/(.*?)(#|\?|$)),
         %r(https?://www\.youtube\.com/user/.*?#\w/\w/\w/\w/(.+)\b)
       ]
-
       youtube_formats.find { |format| @url =~ format } and $1
       video_id = $1
       if video_id && (video_id.length == 11)
@@ -69,7 +66,6 @@ class FetchLinkCardService < BaseService
   end
 
   def get_html
-
     Request.new(:get, @url).perform do |res|
       if res.code == 200 && res.mime_type == 'text/html'
         @html = res.body_with_limit

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -91,7 +91,7 @@ class FetchLinkCardService < BaseService
     service = FetchOEmbedService.new
     
     url_domain=Addressable::URI.parse(@url).host
-    cached_endpoint=Rails.cache.read('oembed_endpoint_#{url_domain}')
+    cached_endpoint=Rails.cache.read("oembed_endpoint_#{url_domain}")
     unless cached_endpoint.nil?
 	    embed = service.call(@url, cached_endpoint: cached_endpoint)
     end

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -61,7 +61,7 @@ class FetchLinkCardService < BaseService
 
       youtube_formats.find { |format| @url =~ format } and $1
       video_id = $1
-      unless video_id.nil? || video_id.length != 11
+      if video_id && (video_id.length == 11)
           @oembed_endpoint_url = "http://www.youtube.com/oembed?url=http%3A//youtube.com/watch%3Fv%3D#{$1}&format=json"
           attempt_oembed
       end

--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -43,14 +43,17 @@ class FetchOEmbedService
   end
   
   def parse_cache_endpoint!
-	cached=@options[:cached_endpoint]
-	return if cached["endpoint"].nil? || cached["format"].nil?
-	url_encoded=URI.encode_www_form_component(@url)
-	if cached["append"].nil?
-	  @endpoint_url = cached["endpoint"]+url_encoded
-	else
-	  @endpoint_url = cached["endpoint"]+url_encoded+"%26format%3D"+cached["append"]
-	end
+    return if @options[:cached_endpoint].nil?
+
+    cached=@options[:cached_endpoint]
+	  return if cached["endpoint"].nil? || cached["format"].nil?
+    
+	  url_encoded=URI.encode_www_form_component(@url)
+	  if cached["append"].nil?
+	    @endpoint_url = cached["endpoint"]+url_encoded
+	  else
+	    @endpoint_url = cached["endpoint"]+url_encoded+"%26format%3D"+cached["append"]
+	  end
     @format = cached["format"]
   end
   
@@ -58,8 +61,8 @@ class FetchOEmbedService
     url_domain=Addressable::URI.parse(@url).host
     endpoint=@endpoint_url.match(/^.*(?=(http[s]?(%3A|:)(\/\/|%2F%2F)))/).to_s
     unless endpoint.nil?
-	  if @endpoint_url.match(/format(=|%3D)json$/)
-		endpoint_hash={"endpoint" => endpoint,"format" => @format,"append" => "json"}
+	    if @endpoint_url.match(/format(=|%3D)json$/)
+		    endpoint_hash={"endpoint" => endpoint,"format" => @format,"append" => "json"}
       elsif @endpoint_url.match(/format(=|%3D)xml$/)
       	endpoint_hash={"endpoint" => endpoint,"format" => @format,"append" => "xml"}
       else

--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -68,7 +68,7 @@ class FetchOEmbedService
       else
         endpoint_hash={"endpoint" => endpoint,"format" => @format}
       end
-      Rails.cache.write('oembed_endpoint_#{url_domain}', endpoint_hash, :expires_in => 24.hours)
+      Rails.cache.write("oembed_endpoint_#{url_domain}", endpoint_hash, :expires_in => 24.hours)
     end
   end
 

--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -7,7 +7,13 @@ class FetchOEmbedService
     @url     = url
     @options = options
 
-    discover_endpoint!
+    if @options[:oembed_endpoint_url].nil?
+      discover_endpoint!
+    else
+      @endpoint_url = @options[:oembed_endpoint_url]
+      @format       = :json
+    end
+
     fetch!
   end
 

--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -7,13 +7,11 @@ class FetchOEmbedService
     @url     = url
     @options = options
 
-    if @options[:oembed_endpoint_url].nil?
-      discover_endpoint!
+    if @options[:html].nil?
+      parse_cache_endpoint!
     else
-      @endpoint_url = @options[:oembed_endpoint_url]
-      @format       = :json
+      discover_endpoint!
     end
-
     fetch!
   end
 
@@ -38,8 +36,37 @@ class FetchOEmbedService
     return if @endpoint_url.blank?
 
     @endpoint_url = (Addressable::URI.parse(@url) + @endpoint_url).to_s
+    
+    cache_endpoint
   rescue Addressable::URI::InvalidURIError
     @endpoint_url = nil
+  end
+  
+  def parse_cache_endpoint!
+	cached=@options[:cached_endpoint]
+	return if cached["endpoint"].nil? || cached["format"].nil?
+	url_encoded=URI.encode_www_form_component(@url)
+	if cached["append"].nil?
+	  @endpoint_url = cached["endpoint"]+url_encoded
+	else
+	  @endpoint_url = cached["endpoint"]+url_encoded+"%26format%3D"+cached["append"]
+	end
+    @format = cached["format"]
+  end
+  
+  def cache_endpoint
+    url_domain=Addressable::URI.parse(@url).host
+    endpoint=@endpoint_url.match(/^.*(?=(http[s]?(%3A|:)(\/\/|%2F%2F)))/).to_s
+    unless endpoint.nil?
+	  if @endpoint_url.match(/format(=|%3D)json$/)
+		endpoint_hash={"endpoint" => endpoint,"format" => @format,"append" => "json"}
+      elsif @endpoint_url.match(/format(=|%3D)xml$/)
+      	endpoint_hash={"endpoint" => endpoint,"format" => @format,"append" => "xml"}
+      else
+        endpoint_hash={"endpoint" => endpoint,"format" => @format}
+      end
+      Rails.cache.write('oembed_endpoint_#{url_domain}', endpoint_hash, :expires_in => 24.hours)
+    end
   end
 
   def fetch!


### PR DESCRIPTION
Gradually during the past week some of my servers started running into an issue with YouTube where the preview_cards for videos were failing. 

After doing some debugging I noticed that the HTML that is fetched on `fetch_link_card_service.rb` was returning a YouTube reCaptcha page instead of the video page. On this page there is no `link[@type="application/json+oembed"]` or `link[@type="text/xml+oembed"]` present so the link to oembed is never found.

I think this is related to the number of requests my servers do to YouTube and what Google calls [automated traffic](https://support.google.com/websearch/answer/86640?hl=en).

This is a work around to bypass the problem. I know it's not ideal and it creates an exception/hardcode for YouTube but that was all I could think to solve the issue.

I am not a Rails coder and please do double check and suggest corrections to what I have done.

For both of these reasons I completely understand if this is never merged to master but decided to share this in case someone else runs into the same issue or to see if we can find a better solution.