### PR TITLE
Change domain block behavior to update user records before deleting data

### DIFF
--- a/app/services/block_domain_service.rb
+++ b/app/services/block_domain_service.rb
@@ -20,13 +20,13 @@ class BlockDomainService < BaseService
   end
 
   def process_domain_block!
-    clear_media! if domain_block.reject_media?
-
     if domain_block.silence?
       silence_accounts!
     elsif domain_block.suspend?
       suspend_accounts!
     end
+
+    clear_media! if domain_block.reject_media?
   end
 
   def invalidate_association_caches!


### PR DESCRIPTION
When suspending or silencing a domain, one probably wants the silence or
suspend parts to take effect as soon as possible. Deleting media files can
take a while (possibly days), so perform silencing as soon as possible, and
clean up media afterwards.