### PR TITLE
fix: support KaiOS arrow navigation on public pages

### DIFF
--- a/app/javascript/mastodon/load_keyboard_extensions.js
+++ b/app/javascript/mastodon/load_keyboard_extensions.js
@@ -1,0 +1,16 @@
+// On KaiOS, we may not be able to use a mouse cursor or navigate using Tab-based focus, so we install
+// special left/right focus navigation keyboard listeners, at least on public pages (i.e. so folks
+// can at least log in using KaiOS devices).
+
+function importArrowKeyNavigation() {
+  return import(/* webpackChunkName: "arrow-key-navigation" */ 'arrow-key-navigation');
+}
+
+export default function loadKeyboardExtensions() {
+  if (/KAIOS/.test(navigator.userAgent)) {
+    return importArrowKeyNavigation().then(arrowKeyNav => {
+      arrowKeyNav.register();
+    });
+  }
+  return Promise.resolve();
+}

--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -2,6 +2,7 @@ import escapeTextContentForBrowser from 'escape-html';
 import loadPolyfills from '../mastodon/load_polyfills';
 import ready from '../mastodon/ready';
 import { start } from '../mastodon/common';
+import loadKeyboardExtensions from '../mastodon/load_keyboard_extensions';
 
 start();
 
@@ -259,6 +260,9 @@ function main() {
   });
 }
 
-loadPolyfills().then(main).catch(error => {
-  console.error(error);
-});
+loadPolyfills()
+  .then(main)
+  .then(loadKeyboardExtensions)
+  .catch(error => {
+    console.error(error);
+  });

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@babel/runtime": "^7.5.4",
     "@clusterws/cws": "^0.15.2",
     "array-includes": "^3.0.3",
+    "arrow-key-navigation": "^1.0.2",
     "autoprefixer": "^9.6.1",
     "axios": "^0.19.0",
     "babel-loader": "^8.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1657,6 +1657,11 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
+arrow-key-navigation@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/arrow-key-navigation/-/arrow-key-navigation-1.0.2.tgz#c1b5886240819db6c0b2b84702de1313786ce53e"
+  integrity sha512-Wj67sJpfK7vrj0/aOstIsRMsUQtpVODBTQDcRaDvvPZdzZMotj8oYGsEsoYiDohShDlDU6ywVkHLtXGH4TfEtQ==
+
 asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"


### PR DESCRIPTION
## Background

I've been working on adapting Pinafore to support [KaiOS](https://developer.kaiostech.com). So far the biggest hurdle is that KaiOS devices only have left/right/up/down arrow keys for navigation.

The solution I'm using is to use the left/right keys as focus-changing keys (similar to Tab/Shift+Tab). I've extracted this logic into a standalone library, [arrow-key-navigation](https://github.com/nolanlawson/arrow-key-navigation/).

So far I can handle everything entirely within Pinafore, which is fine, until it comes to the Mastodon login flow. At the very least, I would need these pages to be keyboard-accessible to KaiOS users.

## Solution

This PR adds `arrow-key-navigation` as a dynamic dependency which is only loaded for KaiOS user agents (although the library is [only ~1k minified](https://bundlephobia.com/result?p=arrow-key-navigation@1.0.2), so it's really not a big deal).

I only added it for public pages, but only because it didn't seem to make much sense to me to add it to the Mastodon web app unless we go all the way and add full KaiOS support (which is [much more involved](https://nolanlawson.com/2019/09/22/the-joy-and-challenge-of-developing-for-kaios/), e.g. supporting the tiny screen size and handling some odd Firefox 48-ish bugs).

## Future work

There are still some nice-to-haves which aren't addressed in this PR:

- the focus styles on the buttons are a bit hard to see
- the `<input type=email>` input does not support selectionStart/SelectionEnd, so you can't press left/right inside of them and have the library intelligently know to avoid handling focus like it can with other inputs. Since this is [just how the web works](http://www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#do-not-apply), the only reasonable solution I can see is to switch to `<input type=text inputmode=email>`.

However, I've confirmed that with this PR, a KaiOS user would at least be able to log in to their Mastodon account using the OAuth flow from Pinafore.