### PR TITLE
Fix code referencing wrong class

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -158,7 +158,7 @@ class ActivityPub::Activity
   end
 
   def follow_from_object
-    @follow ||= Follow.find_by(target_account: @account, uri: object_uri) unless object_uri.nil?
+    @follow ||= ::Follow.find_by(target_account: @account, uri: object_uri) unless object_uri.nil?
   end
 
   def fetch_remote_original_status


### PR DESCRIPTION
For some reason, I have seen this only triggered here:
https://circleci.com/gh/tootsuite/mastodon/98324?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link

But Follow.find_by referenced the ActivityPub::Activity::Follow class
instead of the model class.