### PR TITLE
Add abilityto add oneself to lists

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -429,6 +429,8 @@ class Account < ApplicationRecord
             SELECT target_account_id
             FROM follows
             WHERE account_id = ?
+            UNION ALL
+            SELECT ?
           )
           SELECT
             accounts.*,
@@ -444,7 +446,7 @@ class Account < ApplicationRecord
           LIMIT ? OFFSET ?
         SQL
 
-        records = find_by_sql([sql, account.id, account.id, account.id, limit, offset])
+        records = find_by_sql([sql, account.id, account.id, account.id, account.id, limit, offset])
       else
         sql = <<-SQL.squish
           SELECT

--- a/app/models/list_account.rb
+++ b/app/models/list_account.rb
@@ -6,7 +6,7 @@
 #  id         :bigint(8)        not null, primary key
 #  list_id    :bigint(8)        not null
 #  account_id :bigint(8)        not null
-#  follow_id  :bigint(8)        not null
+#  follow_id  :bigint(8)
 #
 
 class ListAccount < ApplicationRecord
@@ -21,6 +21,6 @@ class ListAccount < ApplicationRecord
   private
 
   def set_follow
-    self.follow = Follow.find_by(account_id: list.account_id, target_account_id: account.id)
+    self.follow = Follow.find_by!(account_id: list.account_id, target_account_id: account.id) unless list.account_id == account.id
   end
 end

--- a/app/models/list_account.rb
+++ b/app/models/list_account.rb
@@ -12,7 +12,7 @@
 class ListAccount < ApplicationRecord
   belongs_to :list
   belongs_to :account
-  belongs_to :follow
+  belongs_to :follow, optional: true
 
   validates :account_id, uniqueness: { scope: :list_id }
 

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -127,7 +127,7 @@ class AccountSearchService < BaseService
   end
 
   def following_ids
-    @following_ids ||= account.active_relationships.pluck(:target_account_id)
+    @following_ids ||= account.active_relationships.pluck(:target_account_id) + [account.id]
   end
 
   def limit_for_non_exact_results

--- a/db/migrate/20191031163205_change_list_account_follow_nullable.rb
+++ b/db/migrate/20191031163205_change_list_account_follow_nullable.rb
@@ -1,0 +1,5 @@
+class ChangeListAccountFollowNullable < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :list_accounts, :follow_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_07_013357) do
+ActiveRecord::Schema.define(version: 2019_10_31_163205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -373,7 +373,7 @@ ActiveRecord::Schema.define(version: 2019_10_07_013357) do
   create_table "list_accounts", force: :cascade do |t|
     t.bigint "list_id", null: false
     t.bigint "account_id", null: false
-    t.bigint "follow_id", null: false
+    t.bigint "follow_id"
     t.index ["account_id", "list_id"], name: "index_list_accounts_on_account_id_and_list_id", unique: true
     t.index ["follow_id"], name: "index_list_accounts_on_follow_id"
     t.index ["list_id", "account_id"], name: "index_list_accounts_on_list_id_and_account_id"


### PR DESCRIPTION
This comes with a few changes:
- It is optional for a `ListAccount` to reference a `Follow` relationship (and thus, the `NOT NULL` constraint is dropped). A follow is still required when the added account is not the owner of the list though
- Advanced account search for people you follow also include yourself so that the list editor UI offers to add yourself to lists. I do not know if it's the best way to go about it though.