### PR TITLE
Fix crowdin badge display in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Bug reports and feature suggestions can be submitted to [GitHub Issues](https://
 
 You can submit translations via [Crowdin](https://crowdin.com/project/mastodon). They are periodically merged into the codebase.
 
-[![Crowdin](https://d322cqt584bo4o.cloudfront.net/mastodon/localized.svg)][crowdin]
+![Crowdin](https://d322cqt584bo4o.cloudfront.net/mastodon/localized.svg)
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Bug reports and feature suggestions can be submitted to [GitHub Issues](https://
 
 You can submit translations via [Crowdin](https://crowdin.com/project/mastodon). They are periodically merged into the codebase.
 
-![Crowdin](https://d322cqt584bo4o.cloudfront.net/mastodon/localized.svg)
+[![Crowdin](https://d322cqt584bo4o.cloudfront.net/mastodon/localized.svg)](https://crowdin.com/project/mastodon)
 
 ## Pull requests
 


### PR DESCRIPTION
The Crowdin localization badge in `CONTRIBUTING.md` appeared to have the wrong markup around it. This manifested in some extra brackets and an unformatted `crowdin` string.