### PR TITLE
setRef callback param may be null

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -164,7 +164,9 @@ class SwitchingColumnsArea extends React.PureComponent {
   }
 
   setRef = c => {
-    this.node = c.getWrappedInstance();
+    if (c) {
+      this.node = c.getWrappedInstance();
+    }
   }
 
   render () {


### PR DESCRIPTION
callback of React's `ref` may be `null` when update component ([doc](https://reactjs.org/docs/refs-and-the-dom.html#caveats-with-callback-refs)).

This may fix #12195. (but I cannot reproduce that.) 