### PR TITLE
Dockerfile: put back EXPOSE directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,3 +123,4 @@ RUN cd ~ && \
 # Set the work dir and the container entry point
 WORKDIR /opt/mastodon
 ENTRYPOINT ["/tini", "--"]
+EXPOSE 3000 4000


### PR DESCRIPTION
[Rkt](https://coreos.com/rkt) doesn't allow ports to be exposed to containers unless they are declared in the container manifest. Re-adding EXPOSE back in (removed in 1dbf993bce5627e2c3fcab6e9c63b5279dff018a) allows the container to be used on rkt based systems.