### PR TITLE
Fix backups stopping due to read timeouts

### DIFF
--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -166,6 +166,7 @@ class BackupService < BaseService
       end
     end
   rescue Errno::ENOENT
+  rescue Seahorse::Client::NetworkingError
     Rails.logger.warn "Could not backup file #{filename}: file not found"
   end
 end

--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -165,8 +165,7 @@ class BackupService < BaseService
         io.write(buffer)
       end
     end
-  rescue Errno::ENOENT
-  rescue Seahorse::Client::NetworkingError
+  rescue Errno::ENOENT, Seahorse::Client::NetworkingError
     Rails.logger.warn "Could not backup file #{filename}: file not found"
   end
 end


### PR DESCRIPTION
If an attachment read times out, assume that the attachment is inaccessible and continue the backup without it. This fixes #12280.