### PR TITLE
Fix relationship caches being broken as result of a follow request

### DIFF
--- a/app/presenters/account_relationships_presenter.rb
+++ b/app/presenters/account_relationships_presenter.rb
@@ -6,7 +6,7 @@ class AccountRelationshipsPresenter
               :endorsed
 
   def initialize(account_ids, current_account_id, **options)
-    @account_ids        = account_ids.map { |a| a.is_a?(Account) ? a.id : a }
+    @account_ids        = account_ids.map { |a| a.is_a?(Account) ? a.id : a.to_i }
     @current_account_id = current_account_id
 
     @following       = cached[:following].merge(Account.following_map(@uncached_account_ids, @current_account_id))


### PR DESCRIPTION
When accepting or rejecting a follow request, the `RelationshipPresenter` would receive strings as account identifiers. This would cause it to call `Account.following_map` etc. just fine, but those would use an integer as key, while `cache_uncached!` would use a string as the key and thus get and save `nil`.

This PR makes sure every id is actually an integer.