### PR TITLE
Fix various issues with account migration

### DIFF
--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -8,7 +8,7 @@ class FollowService < BaseService
   # @param [Account] source_account From which to follow
   # @param [String, Account] uri User URI to follow in the form of username@domain (or account record)
   # @param [true, false, nil] reblogs Whether or not to show reblogs, defaults to true
-  def call(source_account, target_account, reblogs: nil)
+  def call(source_account, target_account, reblogs: nil, bypass_locked: false)
     reblogs = true if reblogs.nil?
     target_account = ResolveAccountService.new.call(target_account, skip_webfinger: true)
 
@@ -30,7 +30,7 @@ class FollowService < BaseService
 
     ActivityTracker.increment('activity:interactions')
 
-    if target_account.locked? || source_account.silenced? || target_account.activitypub?
+    if (target_account.locked? && !bypass_locked) || source_account.silenced? || target_account.activitypub?
       request_follow(source_account, target_account, reblogs: reblogs)
     elsif target_account.local?
       direct_follow(source_account, target_account, reblogs: reblogs)

--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -21,6 +21,7 @@ class MoveWorker
   def rewrite_follows!
     @source_account.passive_relationships
                    .where(account: Account.local)
+                   .where.not(account_id: @target_account.id)
                    .in_batches
                    .update_all(target_account_id: @target_account.id)
   end

--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -21,6 +21,7 @@ class MoveWorker
   def rewrite_follows!
     @source_account.passive_relationships
                    .where(account: Account.local)
+                   .where.not(account: @target_account.followers.local)
                    .where.not(account_id: @target_account.id)
                    .in_batches
                    .update_all(target_account_id: @target_account.id)

--- a/app/workers/unfollow_follow_worker.rb
+++ b/app/workers/unfollow_follow_worker.rb
@@ -5,12 +5,12 @@ class UnfollowFollowWorker
 
   sidekiq_options queue: 'pull'
 
-  def perform(follower_account_id, old_target_account_id, new_target_account_id)
+  def perform(follower_account_id, old_target_account_id, new_target_account_id, bypass_locked = false)
     follower_account   = Account.find(follower_account_id)
     old_target_account = Account.find(old_target_account_id)
     new_target_account = Account.find(new_target_account_id)
 
-    FollowService.new.call(follower_account, new_target_account)
+    FollowService.new.call(follower_account, new_target_account, bypass_locked: bypass_locked)
     UnfollowService.new.call(follower_account, old_target_account, skip_unmerge: true)
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     true

--- a/app/workers/unfollow_follow_worker.rb
+++ b/app/workers/unfollow_follow_worker.rb
@@ -10,7 +10,10 @@ class UnfollowFollowWorker
     old_target_account = Account.find(old_target_account_id)
     new_target_account = Account.find(new_target_account_id)
 
-    FollowService.new.call(follower_account, new_target_account, bypass_locked: bypass_locked)
+    follow = follower_account.active_relationships.find_by(target_account: old_target_account)
+    reblogs = follow&.show_reblogs?
+
+    FollowService.new.call(follower_account, new_target_account, reblogs: reblogs, bypass_locked: bypass_locked)
     UnfollowService.new.call(follower_account, old_target_account, skip_unmerge: true)
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     true

--- a/spec/workers/move_worker_spec.rb
+++ b/spec/workers/move_worker_spec.rb
@@ -27,6 +27,19 @@ describe MoveWorker do
     let(:target_account) { Fabricate(:user, email: 'alice@example.com', account: Fabricate(:account, username: 'alice')).account }
 
     describe 'perform' do
+      it 'calls UnfollowFollowWorker' do
+        allow(UnfollowFollowWorker).to receive(:push_bulk)
+        subject.perform(source_account.id, target_account.id)
+        expect(UnfollowFollowWorker).to have_received(:push_bulk).with([local_follower.id])
+      end
+    end
+  end
+
+  context 'both target and source accounts are local' do
+    let(:target_account) { Fabricate(:user, email: 'alice@example.com', account: Fabricate(:account, username: 'alice')).account }
+    let(:source_account) { Fabricate(:user, email: 'alice_@example.com', account: Fabricate(:account, username: 'alice_')).account }
+
+    describe 'perform' do
       it 'calls makes local followers follow the target account' do
         subject.perform(source_account.id, target_account.id)
         expect(local_follower.following?(target_account)).to be true

--- a/spec/workers/move_worker_spec.rb
+++ b/spec/workers/move_worker_spec.rb
@@ -32,6 +32,14 @@ describe MoveWorker do
         expect(local_follower.following?(target_account)).to be true
       end
 
+      it 'does not fail when a local user is already following both accounts' do
+        double_follower = Fabricate(:user, email: 'eve@example.com', account: Fabricate(:account, username: 'eve')).account
+        double_follower.follow!(source_account)
+        double_follower.follow!(target_account)
+        subject.perform(source_account.id, target_account.id)
+        expect(local_follower.following?(target_account)).to be true
+      end
+
       it 'does not allow the moved account to follow themselves' do
         source_account.follow!(target_account)
         subject.perform(source_account.id, target_account.id)

--- a/spec/workers/move_worker_spec.rb
+++ b/spec/workers/move_worker_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MoveWorker do
+  let(:local_follower)   { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+  let(:source_account)   { Fabricate(:account, protocol: :activitypub, domain: 'example.com') }
+  let(:target_account)   { Fabricate(:account, protocol: :activitypub, domain: 'example.com') }
+
+  subject { described_class.new }
+
+  before do
+    local_follower.follow!(source_account)
+  end
+
+  context 'both accounts are distant' do
+    describe 'perform' do
+      it 'calls UnfollowFollowWorker' do
+        allow(UnfollowFollowWorker).to receive(:push_bulk)
+        subject.perform(source_account.id, target_account.id)
+        expect(UnfollowFollowWorker).to have_received(:push_bulk).with([local_follower.id])
+      end
+    end
+  end
+
+  context 'target account is local' do
+    let(:target_account) { Fabricate(:user, email: 'alice@example.com', account: Fabricate(:account, username: 'alice')).account }
+
+    describe 'perform' do
+      it 'calls makes local followers follow the target account' do
+        subject.perform(source_account.id, target_account.id)
+        expect(local_follower.following?(target_account)).to be true
+      end
+
+      it 'does not allow the moved account to follow themselves' do
+        source_account.follow!(target_account)
+        subject.perform(source_account.id, target_account.id)
+        expect(target_account.following?(target_account)).to be false
+      end
+    end
+  end
+end

--- a/spec/workers/unfollow_follow_worker_spec.rb
+++ b/spec/workers/unfollow_follow_worker_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UnfollowFollowWorker do
+  let(:local_follower)   { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+  let(:source_account)   { Fabricate(:account) }
+  let(:target_account)   { Fabricate(:account) }
+  let(:show_reblogs)     { true }
+
+  subject { described_class.new }
+
+  before do
+    local_follower.follow!(source_account, reblogs: show_reblogs)
+  end
+
+  context 'when show_reblogs is true' do
+    let(:show_reblogs) { true }
+
+    describe 'perform' do
+      it 'unfollows source account and follows target account' do
+        subject.perform(local_follower.id, source_account.id, target_account.id)
+        expect(local_follower.following?(source_account)).to be false
+        expect(local_follower.following?(target_account)).to be true
+      end
+
+      it 'preserves show_reblogs' do
+        subject.perform(local_follower.id, source_account.id, target_account.id)
+        expect(Follow.find_by(account: local_follower, target_account: target_account).show_reblogs?).to be show_reblogs
+      end
+    end
+  end
+
+  context 'when show_reblogs is false' do
+    let(:show_reblogs) { false }
+
+    describe 'perform' do
+      it 'unfollows source account and follows target account' do
+        subject.perform(local_follower.id, source_account.id, target_account.id)
+        expect(local_follower.following?(source_account)).to be false
+        expect(local_follower.following?(target_account)).to be true
+      end
+
+      it 'preserves show_reblogs' do
+        subject.perform(local_follower.id, source_account.id, target_account.id)
+        expect(Follow.find_by(account: local_follower, target_account: target_account).show_reblogs?).to be show_reblogs
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes a bunch of issues:
- Moving to an account that was following the source account resulting in the target account following itself (fixed by not updating that follow relation)
- The move handler failing on the target account's instance whenever a local follower already followed the target account (fixed by excluding local followers of the target account)
- Source account's instance not getting `Unfollow` from followers residing on the target account's instance (fixed by switching back to the generic `UnfollowFollowWorker` when at least one account is remote, but changed it so that the fact the account is locked is bypassed)
- Preserve `show_reblogs` attribute of follow in `UnfollowFollowWorker`