### PR TITLE
Change CircleCI config to build assets with NODE_ENV=test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ aliases:
           DB_HOST: localhost
           DB_USER: root
           RAILS_ENV: test
+          NODE_ENV: test
           PARALLEL_TEST_PROCESSORS: 4
           ALLOW_NOPAM: true
           CONTINUOUS_INTEGRATION: true


### PR DESCRIPTION
This should avoid minimization and other expensive webpack
transformations which aren't useful for running tests.

On the other hand, we may want to keep generating assets with an environment close to production, I don't know.

EDIT: Actually I'm not sure it makes a difference, something else seems off.