### PR TITLE
Fix type mismatch on building feeds

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -153,7 +153,7 @@ class FeedManager
       crutches = build_crutches(account.id, statuses)
 
       statuses.each do |status|
-        next if filter_from_home?(status, account, crutches)
+        next if filter_from_home?(status, account.id, crutches)
 
         add_to_feed(:home, account.id, status, aggregate)
       end


### PR DESCRIPTION
The code was passing the function `filter_from_home` a whole account object rather than the expected id for its second argument.

This was [causing an issue with feed regeneration in tootctl](https://github.com/hometown-fork/hometown/issues/24), and @davefp fixed the issue while debugging Hometown.