### PR TITLE
Fix already-known remote private toots not being searchable by URL

### DIFF
--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -24,6 +24,12 @@ class ResolveURLService < BaseService
       status = FetchRemoteStatusService.new.call(resource_url, body, protocol)
       authorize_with @on_behalf_of, status, :show? unless status.nil?
       status
+    elsif fetched_resource.nil? && @on_behalf_of.present?
+      # It may happen that the resource is a private toot, and thus not fetchable,
+      # but we can return the toot if we already know about it.
+      status = Status.find_by(id: @url) || Status.find_by(url: @url)
+      authorize_with @on_behalf_of, status, :show? unless status.nil?
+      status
     end
   end
 

--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -27,7 +27,7 @@ class ResolveURLService < BaseService
     elsif fetched_resource.nil? && @on_behalf_of.present?
       # It may happen that the resource is a private toot, and thus not fetchable,
       # but we can return the toot if we already know about it.
-      status = Status.find_by(id: @url) || Status.find_by(url: @url)
+      status = Status.find_by(uri: @url) || Status.find_by(url: @url)
       authorize_with @on_behalf_of, status, :show? unless status.nil?
       status
     end


### PR DESCRIPTION
Whenever an URL search fails, and an account is provided, try getting a
private status matching that URL from database.

Drawbacks of this approach:
- Only works for toots that are already known (but this should be fine in most cases, as in most cases, people who would have access to the toot would have followed the person and received already—this wouldn't be the case for significantly old toots, though), does not fetch them
- While it shouldn't be the case in practice, the `url` attribute may not be unique, as that cannot be enforced without fetching it. Thus, a misbehaving server may cause an URL to resolve in non-deterministic ways. I can't see any reason for someone to do that, though.
- The search may be slow, as there is no index on `url`.