### PR TITLE
LDAP & PAM added to OAuth password grant strategy

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -8,8 +8,20 @@ Doorkeeper.configure do
   end
 
   resource_owner_from_credentials do |_routes|
-    user = User.find_by(email: request.params[:username])
-    user if !user&.otp_required_for_login? && user&.valid_password?(request.params[:password])
+    if Devise.ldap_authentication
+      user = User.authenticate_with_ldap({ :email => request.params[:username], :password => request.params[:password] })
+    end
+
+    if Devise.pam_authentication
+      user ||= User.authenticate_with_ldap({ :email => request.params[:username], :password => request.params[:password] })
+    end
+
+    if user.nil?
+      user = User.find_by(email: request.params[:username])
+      user = nil unless user.valid_password?(request.params[:password])
+    end
+
+    user if !user&.otp_required_for_login?
   end
 
   # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.


### PR DESCRIPTION
Resolves #7999

When authenticating via OAuth, the resource owner password grant
strategy is allowed by Mastodon, but (without this PR), it does not
attempt to authenticate against LDAP or PAM. As a result, LDAP or PAM
authenticated users cannot sign in to Mastodon with their
email/password credentials via OAuth (for instance, for native/mobile
app users).

This PR fleshes out the authentication strategy supplied to doorkeeper
in its initializer by looking up the user with LDAP and/or PAM when
devise is configured to use LDAP/PAM backends. It attempts to follow the
same logic as the Auth::SessionsController for handling email/password
credentials.

Note #1: Since this pull request affects an initializer, it's unclear
how to add test automation.

Note #2: The PAM authentication path has not been manually tested. It
was added for completeness sake, and it is hoped that it can be manually
tested before merging.