### PR TITLE
Fix an eslint warning

### DIFF
--- a/app/javascript/mastodon/features/compose/components/poll_form.js
+++ b/app/javascript/mastodon/features/compose/components/poll_form.js
@@ -144,7 +144,7 @@ class PollForm extends ImmutablePureComponent {
         <div className='poll__footer'>
           <button disabled={options.size >= 4} className='button button-secondary' onClick={this.handleAddOption}><Icon id='plus' /> <FormattedMessage {...messages.add_option} /></button>
 
-          <select value={expiresIn} onChange={this.handleSelectDuration}>
+          <select value={expiresIn} onBlur={this.handleSelectDuration}>
             <option value={300}>{intl.formatMessage(messages.minutes, { number: 5 })}</option>
             <option value={1800}>{intl.formatMessage(messages.minutes, { number: 30 })}</option>
             <option value={3600}>{intl.formatMessage(messages.hours, { number: 1 })}</option>


### PR DESCRIPTION
Found this will running eslint, not sure if it's the right fix:

```
$ eslint --ext=js .
/mastodon/app/javascript/mastodon/features/compose/components/poll_form.js
  147:11  warning  onBlur must be used instead of onchange, unless absolutely necessary and it causes no negative consequences for keyboard only or screen reader users  jsx-a11y/no-onchange
```
