### PR TITLE
Store rspec statuses in .cache/rspec

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ end
 gc_counter = -1
 
 RSpec.configure do |config|
+  config.example_status_persistence_file_path = ".cache/rspec"
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
This allows using rspec with `--only-failures`, which I find quite useful while debugging test failures