### PR TITLE
Encrypt direct messages with Tanker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,11 @@ gem 'cld3', '~> 3.2.4'
 gem 'devise', '~> 4.7'
 gem 'devise-two-factor', '~> 3.1'
 
+# Warning: need to install libsodium for this gem to work
+# More info:
+# https://github.com/crypto-rb/rbnacl/wiki/Installing-libsodium
+gem 'tanker-identity', git: 'https://github.com/TankerHQ/identity-ruby'
+
 group :pam_authentication, optional: true do
   gem 'devise_pam_authenticatable2', '~> 9.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/TankerHQ/identity-ruby
+  revision: d646cbc7b89b176fa55443a77cf8c82340f09a3b
+  specs:
+    tanker-identity (0.1.0)
+      rbnacl (~> 6.0.1)
+
+GIT
   remote: https://github.com/ianheggie/health_check
   revision: 0b799ead604f900ed50685e9b2d469cd2befba5b
   ref: 0b799ead604f900ed50685e9b2d469cd2befba5b
@@ -504,6 +511,8 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    rbnacl (6.0.1)
+      ffi
     rdf (3.0.12)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
@@ -794,6 +803,7 @@ DEPENDENCIES
   stoplight (~> 2.2.0)
   streamio-ffmpeg (~> 3.0)
   strong_migrations (~> 0.4)
+  tanker-identity!
   thor (~> 0.20)
   tty-command (~> 0.9)
   tty-prompt (~> 0.19)

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -45,7 +45,8 @@ class Api::V1::StatusesController < Api::BaseController
                                          application: doorkeeper_token.application,
                                          poll: status_params[:poll],
                                          idempotency: request.headers['Idempotency-Key'],
-                                         encrypted: status_params[:encrypted])
+                                         encrypted: status_params[:encrypted],
+                                         mentions: status_params[:mentions])
 
     render json: @status, serializer: @status.is_a?(ScheduledStatus) ? REST::ScheduledStatusSerializer : REST::StatusSerializer
   end
@@ -78,6 +79,7 @@ class Api::V1::StatusesController < Api::BaseController
       :visibility,
       :scheduled_at,
       :encrypted,
+      mentions: [],
       media_ids: [],
       poll: [
         :multiple,

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -44,7 +44,8 @@ class Api::V1::StatusesController < Api::BaseController
                                          scheduled_at: status_params[:scheduled_at],
                                          application: doorkeeper_token.application,
                                          poll: status_params[:poll],
-                                         idempotency: request.headers['Idempotency-Key'])
+                                         idempotency: request.headers['Idempotency-Key'],
+                                         encrypted: status_params[:encrypted])
 
     render json: @status, serializer: @status.is_a?(ScheduledStatus) ? REST::ScheduledStatusSerializer : REST::StatusSerializer
   end
@@ -76,6 +77,7 @@ class Api::V1::StatusesController < Api::BaseController
       :spoiler_text,
       :visibility,
       :scheduled_at,
+      :encrypted,
       media_ids: [],
       poll: [
         :multiple,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -140,6 +140,7 @@ module ApplicationHelper
       state_params[:settings]          = state_params[:settings].merge(Web::Setting.find_by(user: current_user)&.data || {})
       state_params[:push_subscription] = current_account.user.web_push_subscription(current_session)
       state_params[:current_account]   = current_account
+      state_params[:tanker_identity]   = current_account.user.tanker_identity
       state_params[:token]             = current_session.token
       state_params[:admin]             = Account.find_local(Setting.site_contact_username.strip.gsub(/\A@/, ''))
     end

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -126,7 +126,7 @@ export function directCompose(account, routerHistory) {
 
 export function submitCompose(routerHistory) {
   return async function (dispatch, getState, { tankerService }) {
-    const status = getState().getIn(['compose', 'text'], '');
+    let status = getState().getIn(['compose', 'text'], '');
     const media  = getState().getIn(['compose', 'media_attachments']);
 
     if ((!status || !status.length) && media.size === 0) {
@@ -138,8 +138,7 @@ export function submitCompose(routerHistory) {
     const shouldEncrypt = (visibility === 'direct');
 
     if (shouldEncrypt) {
-      const encryptedText = await tankerService.encrypt(status);
-      console.log('about to send encrypted text', encryptedText);
+      status = await tankerService.encrypt(status);
     }
 
     dispatch(submitComposeRequest());
@@ -152,6 +151,7 @@ export function submitCompose(routerHistory) {
       spoiler_text: getState().getIn(['compose', 'spoiler']) ? getState().getIn(['compose', 'spoiler_text'], '') : '',
       visibility,
       poll: getState().getIn(['compose', 'poll'], null),
+      encrypted: shouldEncrypt,
     }, {
       headers: {
         'Idempotency-Key': getState().getIn(['compose', 'idempotencyKey']),

--- a/app/javascript/mastodon/actions/statuses.js
+++ b/app/javascript/mastodon/actions/statuses.js
@@ -10,6 +10,8 @@ export const STATUS_FETCH_REQUEST = 'STATUS_FETCH_REQUEST';
 export const STATUS_FETCH_SUCCESS = 'STATUS_FETCH_SUCCESS';
 export const STATUS_FETCH_FAIL    = 'STATUS_FETCH_FAIL';
 
+export const STATUS_UPDATE_CONTENT = 'STATUS_UPDATE_CONTENT';
+
 export const STATUS_DELETE_REQUEST = 'STATUS_DELETE_REQUEST';
 export const STATUS_DELETE_SUCCESS = 'STATUS_DELETE_SUCCESS';
 export const STATUS_DELETE_FAIL    = 'STATUS_DELETE_FAIL';
@@ -79,6 +81,16 @@ function getFromDB(dispatch, getState, accountIndex, index, id) {
       resolve(Promise.all(promises));
     };
   });
+}
+
+
+export function updateStatusContent(id, content, contentHtml) {
+  return {
+    type: STATUS_UPDATE_CONTENT,
+    id,
+    content,
+    contentHtml,
+  };
 }
 
 export function fetchStatus(id) {

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -178,8 +178,17 @@ export default class StatusContent extends React.PureComponent {
     }
 
     const hidden = this.props.onExpandedToggle ? !this.props.expanded : this.state.hidden;
+    const encrypted = status.get('encrypted');
 
-    const content = { __html: status.get('contentHtml') };
+    let contentHtml;
+    if (encrypted) {
+      contentHtml = '<i class="fa fa-lock" aria-hidden="true"></i>&nbsp;' + status.get('contentHtml');
+    } else {
+      contentHtml = status.get('contentHtml');
+    }
+
+    const content = { __html: contentHtml };
+
     const spoilerContent = { __html: status.get('spoilerHtml') };
     const directionStyle = { direction: 'ltr' };
     const classNames = classnames('status__content', {

--- a/app/javascript/mastodon/features/compose/containers/navigation_container.js
+++ b/app/javascript/mastodon/features/compose/containers/navigation_container.js
@@ -16,12 +16,13 @@ const mapStateToProps = state => {
   };
 };
 
+
 const mapDispatchToProps = (dispatch, { intl }) => ({
   onLogout () {
     dispatch(openModal('CONFIRM', {
       message: intl.formatMessage(messages.logoutMessage),
       confirm: intl.formatMessage(messages.logoutConfirm),
-      onConfirm: () => logOut(),
+      onConfirm: () => dispatch(logOut()),
     }));
   },
 });

--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -74,7 +74,7 @@ class Compose extends React.PureComponent {
     dispatch(openModal('CONFIRM', {
       message: intl.formatMessage(messages.logoutMessage),
       confirm: intl.formatMessage(messages.logoutConfirm),
-      onConfirm: () => logOut(),
+      onConfirm: () => dispatch(logOut()),
     }));
 
     return false;

--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -14,6 +14,7 @@ import NavigationBar from '../compose/components/navigation_bar';
 import Icon from 'mastodon/components/icon';
 import LinkFooter from 'mastodon/features/ui/components/link_footer';
 import TrendsContainer from './containers/trends_container';
+import { logOut } from 'mastodon/utils/log_out';
 
 const messages = defineMessages({
   home_timeline: { id: 'tabs_bar.home', defaultMessage: 'Home' },
@@ -45,6 +46,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   fetchFollowRequests: () => dispatch(fetchFollowRequests()),
+  onLogout: () => dispatch(logOut()),
 });
 
 const badgeDisplay = (number, limit) => {
@@ -161,7 +163,7 @@ class GettingStarted extends ImmutablePureComponent {
 
         <div className='getting-started'>
           <div className='getting-started__wrapper' style={{ height }}>
-            {!multiColumn && <NavigationBar account={myAccount} />}
+            {!multiColumn && <NavigationBar account={myAccount} onLogout={this.props.onLogout} />}
             {navItems}
           </div>
 

--- a/app/javascript/mastodon/features/ui/components/link_footer.js
+++ b/app/javascript/mastodon/features/ui/components/link_footer.js
@@ -17,7 +17,7 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     dispatch(openModal('CONFIRM', {
       message: intl.formatMessage(messages.logoutMessage),
       confirm: intl.formatMessage(messages.logoutConfirm),
-      onConfirm: () => logOut(),
+      onConfirm: () => dispatch(logOut()),
     }));
   },
 });

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -25,5 +25,8 @@ export const usePendingItems = getMeta('use_pending_items');
 export const showTrends = getMeta('trends');
 export const title = getMeta('title');
 export const cropImages = getMeta('crop_images');
+export const tankerAppId = getMeta('tanker_app_id');
+export const tankerIdentity = getMeta('tanker_identity');
+export const email = getMeta('email');
 
 export default initialState;

--- a/app/javascript/mastodon/reducers/statuses.js
+++ b/app/javascript/mastodon/reducers/statuses.js
@@ -12,6 +12,7 @@ import {
   STATUS_UNMUTE_SUCCESS,
   STATUS_REVEAL,
   STATUS_HIDE,
+  STATUS_UPDATE_CONTENT,
 } from '../actions/statuses';
 import { TIMELINE_DELETE } from '../actions/timelines';
 import { STATUS_IMPORT, STATUSES_IMPORT } from '../actions/importer';
@@ -57,6 +58,9 @@ export default function statuses(state = initialState, action) {
     return state.setIn([action.id, 'muted'], true);
   case STATUS_UNMUTE_SUCCESS:
     return state.setIn([action.id, 'muted'], false);
+  case STATUS_UPDATE_CONTENT:
+    const { content, contentHtml, id } = action;
+    return state.update(id, (status) => status.merge({ content, contentHtml }));
   case STATUS_REVEAL:
     return state.withMutations(map => {
       action.ids.forEach(id => {

--- a/app/javascript/mastodon/store/configureStore.js
+++ b/app/javascript/mastodon/store/configureStore.js
@@ -1,9 +1,18 @@
 import { createStore, applyMiddleware, compose } from 'redux';
-import thunk from 'redux-thunk';
+import thunkMiddleWare from 'redux-thunk';
 import appReducer from '../reducers';
 import loadingBarMiddleware from '../middleware/loading_bar';
 import errorsMiddleware from '../middleware/errors';
 import soundsMiddleware from '../middleware/sounds';
+import {
+  email,
+  tankerIdentity,
+  tankerAppId,
+} from '../initial_state';
+import TankerService from '../tanker';
+
+const tankerService = new TankerService({ email, tankerIdentity, tankerAppId });
+const thunk = thunkMiddleWare.withExtraArgument({ tankerService });
 
 export default function configureStore() {
   return createStore(appReducer, compose(applyMiddleware(

--- a/app/javascript/mastodon/tanker/index.js
+++ b/app/javascript/mastodon/tanker/index.js
@@ -1,0 +1,53 @@
+import { fromBase64, toBase64, Tanker } from '@tanker/client-browser';
+import { VerificationUI } from '@tanker/verification-ui';
+
+export default class TankerService {
+
+  constructor({ email, tankerIdentity, tankerAppId }) {
+    this.email = email;
+    this.tankerIdentity = tankerIdentity;
+    this.tanker = new Tanker({ appId: tankerAppId });
+    this.verificationUI = new VerificationUI(this.tanker);
+  }
+
+  encrypt = async (clearText) => {
+    await this.lazyStart();
+
+    const encryptedData = await this.tanker.encrypt(clearText);
+    const encryptedText = toBase64(encryptedData);
+    return encryptedText;
+  }
+
+  decrypt = async (encryptedText) => {
+    await this.lazyStart();
+
+    const encryptedData = fromBase64(encryptedText);
+    const clearText = await this.tanker.decrypt(encryptedData);
+    return clearText;
+  }
+
+  stop = async() => {
+    await this.tanker.stop();
+  }
+
+  lazyStart = async () => {
+
+    if (this.tanker.status !== Tanker.statuses.STOPPED) {
+      return;
+    }
+
+    if (!this.startPromise) {
+      this.startPromise = this.verificationUI.start(this.email, this.tankerIdentity);
+    }
+
+    try {
+      await this.startPromise;
+      delete this.startPromise;
+    } catch(e) {
+      delete this.startPromise;
+      throw e;
+    }
+
+  }
+
+}

--- a/app/javascript/mastodon/tanker/index.js
+++ b/app/javascript/mastodon/tanker/index.js
@@ -10,10 +10,10 @@ export default class TankerService {
     this.verificationUI = new VerificationUI(this.tanker);
   }
 
-  encrypt = async (clearText) => {
+  encrypt = async (clearText, encryptOptions) => {
     await this.lazyStart();
 
-    const encryptedData = await this.tanker.encrypt(clearText);
+    const encryptedData = await this.tanker.encrypt(clearText, encryptOptions);
     const encryptedText = toBase64(encryptedData);
     return encryptedText;
   }

--- a/app/javascript/mastodon/utils/log_out.js
+++ b/app/javascript/mastodon/utils/log_out.js
@@ -1,6 +1,14 @@
 import Rails from 'rails-ujs';
 
-export const logOut = () => {
+
+export function logOut() {
+  return async (dispatch, getState, { tankerService }) => {
+    await tankerService.stop();
+    logOutImpl();
+  };
+}
+
+const logOutImpl = () => {
   const form = document.createElement('form');
 
   const methodInput = document.createElement('input');

--- a/app/lib/tanker_identity.rb
+++ b/app/lib/tanker_identity.rb
@@ -4,5 +4,9 @@ module TankerIdentity
   def self.create(user_id)
     Tanker::Identity.create_identity(ENV["TANKER_APP_ID"], ENV["TANKER_APP_SECRET"], user_id.to_s)
   end
+
+  def self.get_public_identity(private_identity)
+    Tanker::Identity.get_public_identity(private_identity)
+  end
 end
 

--- a/app/lib/tanker_identity.rb
+++ b/app/lib/tanker_identity.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module TankerIdentity
+  def self.create(user_id)
+    Tanker::Identity.create_identity(ENV["TANKER_APP_ID"], ENV["TANKER_APP_SECRET"], user_id.to_s)
+  end
+end
+

--- a/app/lib/tanker_identity.rb
+++ b/app/lib/tanker_identity.rb
@@ -2,11 +2,10 @@
 
 module TankerIdentity
   def self.create(user_id)
-    Tanker::Identity.create_identity(ENV["TANKER_APP_ID"], ENV["TANKER_APP_SECRET"], user_id.to_s)
+    Tanker::Identity.create_identity(ENV['TANKER_APP_ID'], ENV['TANKER_APP_SECRET'], user_id.to_s)
   end
 
   def self.get_public_identity(private_identity)
     Tanker::Identity.get_public_identity(private_identity)
   end
 end
-

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -123,6 +123,8 @@ class Account < ApplicationRecord
            :locale,
            :hides_network?,
            :shows_application?,
+           :tanker_identity,
+           :tanker_public_identity,
            to: :user,
            prefix: true,
            allow_nil: true

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -23,6 +23,7 @@
 #  in_reply_to_account_id :bigint(8)
 #  poll_id                :bigint(8)
 #  deleted_at             :datetime
+#  encrypted              :boolean          default(FALSE), not null
 #
 
 class Status < ApplicationRecord

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,6 +151,10 @@ class User < ApplicationRecord
     end
   end
 
+  def tanker_public_identity
+    TankerIdentity::get_public_identity tanker_identity
+  end
+
   def confirm!
     new_user      = !confirmed?
     self.approved = true if open_registrations?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@
 #  chosen_languages          :string           is an Array
 #  created_by_application_id :bigint(8)
 #  approved                  :boolean          default(TRUE), not null
+#  tanker_identity           :string
 #
 
 class User < ApplicationRecord
@@ -97,6 +98,7 @@ class User < ApplicationRecord
 
   before_validation :sanitize_languages
   before_create :set_approved
+  after_create :set_tanker_identity
 
   # This avoids a deprecation warning from Rails 5.1
   # It seems possible that a future release of devise-two-factor will
@@ -296,6 +298,11 @@ class User < ApplicationRecord
   end
 
   private
+
+  def set_tanker_identity
+    self.tanker_identity = TankerIdentity.create(self.id)
+    self.update_attribute :tanker_identity, self.tanker_identity
+  end
 
   def set_approved
     self.approved = open_registrations? || valid_invitation? || external?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -152,7 +152,7 @@ class User < ApplicationRecord
   end
 
   def tanker_public_identity
-    TankerIdentity::get_public_identity tanker_identity
+    TankerIdentity.get_public_identity tanker_identity
   end
 
   def confirm!
@@ -304,8 +304,8 @@ class User < ApplicationRecord
   private
 
   def set_tanker_identity
-    self.tanker_identity = TankerIdentity.create(self.id)
-    self.update_attribute :tanker_identity, self.tanker_identity
+    self.tanker_identity = TankerIdentity.create(id)
+    update_attribute :tanker_identity, tanker_identity
   end
 
   def set_approved

--- a/app/presenters/initial_state_presenter.rb
+++ b/app/presenters/initial_state_presenter.rb
@@ -2,5 +2,6 @@
 
 class InitialStatePresenter < ActiveModelSerializers::Model
   attributes :settings, :push_subscription, :token,
-             :current_account, :admin, :text
+             :current_account, :admin, :text,
+             :tanker_identity, :email, :tanker_app_id
 end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 class InitialStateSerializer < ActiveModel::Serializer
   attributes :meta, :compose, :accounts,
              :media_attachments, :settings
@@ -39,6 +38,9 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:is_staff]          = object.current_account.user.staff?
       store[:trends]            = Setting.trends && object.current_account.user.setting_trends
       store[:crop_images]       = object.current_account.user.setting_crop_images
+      store[:email]             = object.current_account.user.email
+      store[:tanker_identity]   = object.current_account.user.tanker_identity
+      store[:tanker_app_id]     = ENV["TANKER_APP_ID"]
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -24,23 +24,7 @@ class InitialStateSerializer < ActiveModel::Serializer
     }
 
     if object.current_account
-      store[:me]                = object.current_account.id.to_s
-      store[:unfollow_modal]    = object.current_account.user.setting_unfollow_modal
-      store[:boost_modal]       = object.current_account.user.setting_boost_modal
-      store[:delete_modal]      = object.current_account.user.setting_delete_modal
-      store[:auto_play_gif]     = object.current_account.user.setting_auto_play_gif
-      store[:display_media]     = object.current_account.user.setting_display_media
-      store[:expand_spoilers]   = object.current_account.user.setting_expand_spoilers
-      store[:reduce_motion]     = object.current_account.user.setting_reduce_motion
-      store[:advanced_layout]   = object.current_account.user.setting_advanced_layout
-      store[:use_blurhash]      = object.current_account.user.setting_use_blurhash
-      store[:use_pending_items] = object.current_account.user.setting_use_pending_items
-      store[:is_staff]          = object.current_account.user.staff?
-      store[:trends]            = Setting.trends && object.current_account.user.setting_trends
-      store[:crop_images]       = object.current_account.user.setting_crop_images
-      store[:email]             = object.current_account.user.email
-      store[:tanker_identity]   = object.current_account.user.tanker_identity
-      store[:tanker_app_id]     = ENV["TANKER_APP_ID"]
+      configure_meta_with_account(store, object.current_account)
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media
@@ -81,5 +65,25 @@ class InitialStateSerializer < ActiveModel::Serializer
 
   def instance_presenter
     @instance_presenter ||= InstancePresenter.new
+  end
+
+  def configure_meta_with_account(meta, account)
+    meta[:me]                = account.id.to_s
+    meta[:unfollow_modal]    = account.user.setting_unfollow_modal
+    meta[:boost_modal]       = account.user.setting_boost_modal
+    meta[:delete_modal]      = account.user.setting_delete_modal
+    meta[:auto_play_gif]     = account.user.setting_auto_play_gif
+    meta[:display_media]     = account.user.setting_display_media
+    meta[:expand_spoilers]   = account.user.setting_expand_spoilers
+    meta[:reduce_motion]     = account.user.setting_reduce_motion
+    meta[:advanced_layout]   = account.user.setting_advanced_layout
+    meta[:use_blurhash]      = account.user.setting_use_blurhash
+    meta[:use_pending_items] = account.user.setting_use_pending_items
+    meta[:is_staff]          = account.user.staff?
+    meta[:trends]            = Setting.trends && account.user.setting_trends
+    meta[:crop_images]       = account.user.setting_crop_images
+    meta[:email]             = account.user.email
+    meta[:tanker_identity]   = account.user.tanker_identity
+    meta[:tanker_app_id]     = ENV['TANKER_APP_ID']
   end
 end

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -5,7 +5,8 @@ class REST::AccountSerializer < ActiveModel::Serializer
 
   attributes :id, :username, :acct, :display_name, :locked, :bot, :created_at,
              :note, :url, :avatar, :avatar_static, :header, :header_static,
-             :followers_count, :following_count, :statuses_count, :last_status_at
+             :followers_count, :following_count, :statuses_count, :last_status_at,
+             :tanker_public_identity
 
   has_one :moved_to_account, key: :moved, serializer: REST::AccountSerializer, if: :moved_and_not_nested?
   has_many :emojis, serializer: REST::CustomEmojiSerializer
@@ -22,6 +23,10 @@ class REST::AccountSerializer < ActiveModel::Serializer
 
   def id
     object.id.to_s
+  end
+
+  def tanker_public_identity
+    object.user_tanker_public_identity
   end
 
   def note

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -4,7 +4,8 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attributes :id, :created_at, :in_reply_to_id, :in_reply_to_account_id,
              :sensitive, :spoiler_text, :visibility, :language,
              :uri, :url, :replies_count, :reblogs_count,
-             :favourites_count
+             :favourites_count,
+             :encrypted
 
   attribute :favourited, if: :current_user?
   attribute :reblogged, if: :current_user?

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -20,12 +20,14 @@ class PostStatusService < BaseService
   # @option [Doorkeeper::Application] :application
   # @option [String] :idempotency Optional idempotency key
   # @option [Boolean] :encrypted
+  # @option [Array] :mentions list of usernames in case the text is encrypted
   # @return [Status]
   def call(account, options = {})
     @account     = account
     @options     = options
     @text        = @options[:text] || ''
     @encrypted   = @options[:encrypted] || false
+    @mentions    = @options[:mentions] || []
     @in_reply_to = @options[:thread]
 
     return idempotency_duplicate if idempotency_given? && idempotency_duplicate?
@@ -67,7 +69,8 @@ class PostStatusService < BaseService
     end
 
     process_hashtags_service.call(@status)
-    process_mentions_service.call(@status)
+    options = { usernames: @mentions }
+    process_mentions_service.call(@status, options)
   end
 
   def schedule_status!

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -19,11 +19,13 @@ class PostStatusService < BaseService
   # @option [Enumerable] :media_ids Optional array of media IDs to attach
   # @option [Doorkeeper::Application] :application
   # @option [String] :idempotency Optional idempotency key
+  # @option [Boolean] :encrypted
   # @return [Status]
   def call(account, options = {})
     @account     = account
     @options     = options
     @text        = @options[:text] || ''
+    @encrypted   = @options[:encrypted] || false
     @in_reply_to = @options[:thread]
 
     return idempotency_duplicate if idempotency_given? && idempotency_duplicate?
@@ -160,6 +162,7 @@ class PostStatusService < BaseService
       visibility: @visibility,
       language: language_from_option(@options[:language]) || @account.user&.setting_default_language&.presence || LanguageDetector.instance.detect(@text, @account),
       application: @options[:application],
+      encrypted: @encrypted,
     }.compact
   end
 

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -18,7 +18,7 @@ class ProcessMentionsService < BaseService
       # TODO: Make sure username matches a *local* account
       usernames.each do |username|
         account = Account.find_by!(username: username)
-        mentions << Mention.create!(status: @status, account:account)
+        mentions << Mention.create!(status: @status, account: account)
       end
     else
       status.text = status.text.gsub(Account::MENTION_RE) do |match|

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -27,14 +27,18 @@ Rails.application.config.content_security_policy do |p|
   p.frame_src       :self, :https
   p.manifest_src    :self, assets_host
 
+  allowed_sources = [:self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url]
+  # for @tanker/client-browser
+  allowed_sources += ["wss://api.tanker.io", "https://api.tanker.io"]
   if Rails.env.development?
     webpacker_urls = %w(ws http).map { |protocol| "#{protocol}#{Webpacker.dev_server.https? ? 's' : ''}://#{Webpacker.dev_server.host_with_port}" }
-
-    p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url, *webpacker_urls
+    allowed_sources += webpacker_urls
+  end
+  p.connect_src *allowed_sources
+  if Rails.env.development?
     p.script_src  :self, :unsafe_inline, :unsafe_eval, assets_host
     p.worker_src  :self, :blob, assets_host
   else
-    p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url
     p.script_src  :self, assets_host
     p.worker_src  :self, :blob, assets_host
   end

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -107,5 +107,9 @@ module.exports = {
     // Called by http-link-header in an API we never use, increases
     // bundle size unnecessarily
     Buffer: false,
+    // `fs` and `crypto` are not used by libsodium when
+    // ran in the browser
+    fs: 'empty',
+    crypto: 'empty',
   },
 };

--- a/db/migrate/20190909112533_add_tanker_identities_to_users.rb
+++ b/db/migrate/20190909112533_add_tanker_identities_to_users.rb
@@ -1,0 +1,5 @@
+class AddTankerIdentitiesToUsers < ActiveRecord::Migration[5.2]
+  def change
+      add_column :users, :tanker_identity, :string
+  end
+end

--- a/db/migrate/20190913090225_add_encrypted_to_statuses.rb
+++ b/db/migrate/20190913090225_add_encrypted_to_statuses.rb
@@ -1,0 +1,5 @@
+class AddEncryptedToStatuses < ActiveRecord::Migration[5.2]
+  def change
+      add_column :statuses, :encrypted, :bool, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -688,6 +688,7 @@ ActiveRecord::Schema.define(version: 2019_10_31_163205) do
     t.bigint "in_reply_to_account_id"
     t.bigint "poll_id"
     t.datetime "deleted_at"
+    t.boolean "encrypted"
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20190820", order: { id: :desc }, where: "(deleted_at IS NULL)"
     t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -796,6 +796,7 @@ ActiveRecord::Schema.define(version: 2019_10_31_163205) do
     t.string "chosen_languages", array: true
     t.bigint "created_by_application_id"
     t.boolean "approved", default: true, null: false
+    t.string "tanker_identity"
     t.index ["account_id"], name: "index_users_on_account_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_by_application_id"], name: "index_users_on_created_by_application_id"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "@babel/preset-react": "^7.7.0",
     "@babel/runtime": "^7.7.2",
     "@clusterws/cws": "^0.16.0",
+    "@tanker/client-browser": "^2.2.3",
+    "@tanker/verification-ui": "^2.2.3",
     "array-includes": "^3.0.3",
     "arrow-key-navigation": "^1.0.2",
     "autoprefixer": "^9.6.1",

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -62,6 +62,11 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
     it 'returns http success' do
       expect(response).to have_http_status(200)
+      json = body_as_json
+      tanker_public_identity = json[:tanker_public_identity]
+      expect(tanker_public_identity).to_not be_nil
+      # Private identity should be different from the public one!
+      expect(tanker_public_identity).to_not eq(user.tanker_identity)
     end
 
     it_behaves_like 'forbidden for wrong scope', 'write:statuses'

--- a/spec/controllers/api/v1/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses_controller_spec.rb
@@ -60,6 +60,21 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
       end
     end
 
+    describe 'POST #create encrypted status with mentions' do
+      let(:scopes) { 'write:statuses' }
+      let(:alice) { Fabricate(:user) }
+      let(:bob) { Fabricate(:user) }
+      let(:names) { [alice, bob].map { |user| user.account.username } }
+
+      before do
+        post :create, params: { status: 'Hello world', encrypted: true, mentions: names }
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
     describe 'DELETE #destroy' do
       let(:scopes) { 'write:statuses' }
       let(:status) { Fabricate(:status, account: user.account) }

--- a/spec/controllers/api/v1/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses_controller_spec.rb
@@ -48,6 +48,18 @@ RSpec.describe Api::V1::StatusesController, type: :controller do
       end
     end
 
+    describe 'POST #create encrypted status' do
+      let(:scopes) { 'write:statuses' }
+
+      before do
+        post :create, params: { status: 'Hello world', encrypted: true }
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
     describe 'DELETE #destroy' do
       let(:scopes) { 'write:statuses' }
       let(:status) { Fabricate(:status, account: user.account) }

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe Auth::RegistrationsController, type: :controller do
         user = User.find_by(email: 'test@example.com')
         expect(user).to_not be_nil
         expect(user.locale).to eq(accept_language)
+        expect(user.tanker_identity).to_not be_nil
       end
     end
 

--- a/spec/fabricators/status_fabricator.rb
+++ b/spec/fabricators/status_fabricator.rb
@@ -1,6 +1,7 @@
 Fabricator(:status) do
   account
   text "Lorem ipsum dolor sit amet"
+  encrypted false
 
   after_build do |status|
     status.uri = Faker::Internet.device_token if !status.account.local? && status.uri.nil?

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe AppSignUpService, type: :service do
       expect(user.confirmed?).to be false
     end
 
+    it 'creates a user with a Tanker identity' do
+      access_token = subject.call(app, good_params)
+      user = User.find_by(id: access_token.resource_owner_id)
+      expect(user.tanker_identity).to_not be_nil
+    end
+
     it 'creates access token with the app\'s scopes' do
       access_token = subject.call(app, good_params)
       expect(access_token).to_not be_nil

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -13,6 +13,27 @@ RSpec.describe PostStatusService, type: :service do
     expect(status.text).to eq text
   end
 
+  specify 'statuses are not encrypted by default' do
+    account = Fabricate(:account)
+    text = "test status update"
+
+    status = subject.call(account, text: text)
+
+    expect(status).to be_persisted
+    expect(status.encrypted).to be_falsey
+  end
+
+  it 'can create a new encrypted status' do
+    account = Fabricate(:account)
+    text = "test status update"
+
+    status = subject.call(account, text: text, encrypted: true)
+
+    expect(status).to be_persisted
+    expect(status.text).to eq text
+    expect(status.encrypted).to be_truthy
+  end
+
   it 'creates a new response status' do
     in_reply_to_status = Fabricate(:status)
     account = Fabricate(:account)

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe ProcessMentionsService, type: :service do
     end
   end
 
+  context 'Enycrypted status' do
+    let(:remote_user) { Fabricate(:account, username: 'remote_user', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
+    let(:recipient) { Fabricate(:user) }
+    let(:encrypted_status)     { Fabricate(:status, account: account, text: "base64-encrypted-status", visibility: :public, encrypted: true) }
+
+    subject { ProcessMentionsService.new }
+
+    it 'kicks a local notification worker' do
+      expect(recipient.account).to be_local
+      subject.call(encrypted_status, {usernames: [recipient.account.username]} )
+      expect(encrypted_status.mentions[0].account_id).to eq recipient.account.id
+      # TODO: write the assertion here!
+    end
+  end
+
   context 'Temporarily-unreachable ActivityPub user' do
     let(:remote_user) { Fabricate(:account, username: 'remote_user', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox', last_webfingered_at: nil) }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -809,6 +809,14 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/runtime-corejs2@^7.4.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.6.0.tgz#6fcd37c2580070817d62f219db97f67e26f50f9c"
+  integrity sha512-zbPQzlbyJab2xCYb6VaESn8Tk/XiVpQJU7WvIKiQCwlFyc2NSCzKjqtBXCvpZBbiTOHCx10s2656REVnySwb+A==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
@@ -912,6 +920,18 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.3.tgz#a166882c81c0c6040975dd30df24fae8549bd96f"
   integrity sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==
 
+"@emotion/is-prop-valid@^0.8.1":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.2.tgz#b9692080da79041683021fcc32f96b40c54c59dc"
+  integrity sha512-ZQIMAA2kLUWiUeMZNJDTeCwYRx1l8SQL0kHktze4COT22occKpDML1GDUXP5/sxhOMrZO8vZw773ni4H5Snrsg==
+  dependencies:
+    "@emotion/memoize" "0.7.2"
+
+"@emotion/memoize@0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.2.tgz#7f4c71b7654068dfcccad29553520f984cc66b30"
+  integrity sha512-hnHhwQzvPCW1QjBWFyBtsETdllOM92BfrKWbUTmh9aeOlcVOiXvlPsK4104xH8NsaKfg86PTFsWkueQeUfMA/w==
+
 "@emotion/memoize@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
@@ -938,7 +958,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.4.tgz#6c51afdf1dd0d73666ba09d2eb6c25c220d6fe4c"
   integrity sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==
 
-"@emotion/unitless@0.7.4":
+"@emotion/unitless@0.7.4", "@emotion/unitless@^0.7.0":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
@@ -1119,7 +1139,160 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@types/babel__core@^7.1.0", "@types/babel__core@^7.1.2":
+"@tanker/client-browser@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/client-browser/-/client-browser-2.2.3.tgz#d10ca8feeae685cdd971d89c55e98cc29f1a5121"
+  integrity sha512-bR4A2uesR1gXGbXmnKcaXGM2wWL0qUBqyFLYNn4h2nMCRbW9u8ec5yR+3v5gkvis/SX6L/GBK/PvFruV3zIYOA==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/core" "2.2.3"
+    "@tanker/datastore-dexie-browser" "2.2.3"
+
+"@tanker/core@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/core/-/core-2.2.3.tgz#db7698eddfc12d9be19ced08d0f6286f241a402d"
+  integrity sha512-cOFAuLbKine7ORfK4sTbCkc6y285gpDhypl1tBTHx51CCfGZLN3DtY6oLad2cgAj5UqMmSFGPUIAkonPgWGAsA==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/crypto" "2.2.3"
+    "@tanker/datastore-base" "2.2.3"
+    "@tanker/errors" "2.2.3"
+    "@tanker/file-ponyfill" "2.2.3"
+    "@tanker/global-this" "2.2.3"
+    "@tanker/identity" "2.2.3"
+    "@tanker/stream-base" "2.2.3"
+    "@tanker/stream-cloud-storage" "2.2.3"
+    "@tanker/types" "2.2.3"
+    array-find "^1.0.0"
+    engine.io-client "git+https://github.com/TankerHQ/engine.io-client.git#2996c2d746d4695742cbc3f8fb47c60d4c5757f7"
+    socket.io-client "git+https://github.com/TankerHQ/socket.io-client.git#4f71b8dda24bea5e4949c37fec6b790795615c25"
+    varint "^5.0.0"
+
+"@tanker/crypto@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/crypto/-/crypto-2.2.3.tgz#d03a10b07d4b4207e14fd20e6534d83921c1f2e0"
+  integrity sha512-JkFZ0BG81JSmwxwINTi1k4agH0MKbZnMB6PcSsIp1uHhBqf8+2Kf9+keeWV3xNX0QD7/lHpzr1bgZyXmRQbMgw==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/errors" "2.2.3"
+    libsodium-wrappers "^0.5.1"
+    varint "^5.0.0"
+
+"@tanker/datastore-base@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/datastore-base/-/datastore-base-2.2.3.tgz#1a37eac23555558f23eb9ae9afdfd47f59a76942"
+  integrity sha512-LGnbf5HVu9FpCcc8oRY0/GaEDFIuTrAeRu9j6YU9pXcTp+mWho7T3+qwBXtWWZSg0a0JIBhh5wjOFkFdMrJRSw==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/crypto" "2.2.3"
+
+"@tanker/datastore-dexie-browser@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/datastore-dexie-browser/-/datastore-dexie-browser-2.2.3.tgz#2a12b3584cb6129b53bb273bf770ecfc75534120"
+  integrity sha512-RReUkVaky+iVaAlH85uNs9QH7UfgtC0aiNoPOhRYpopPG0K0tOVxipRyECjD5pcue59+tdCgLaiFZrLw8t0SBg==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/datastore-base" "2.2.3"
+    dexie "^2.0.4"
+
+"@tanker/errors@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/errors/-/errors-2.2.3.tgz#d940bbfe140258c26a3d220b98365bea62f00bb5"
+  integrity sha512-c3mlcqM+tG1VKdmQIXqqL51PwoYv+tzVauFAVyGxaDs09wIK+quWjVLLncBnQW2IR5NDjt3LEE2xyl0ua1gwiw==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+
+"@tanker/file-ponyfill@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/file-ponyfill/-/file-ponyfill-2.2.3.tgz#b145fc91f15e8781d844fa1e9831749e5c36f946"
+  integrity sha512-f8eeDOI3X35fynq5yFJ/PkkXsccuTLsu0gFhUjdTdRgn1ndIbyfEjSkaTfMiZZ1KmCbPd/TgNS6nL97d3PHJxw==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/global-this" "2.2.3"
+
+"@tanker/file-reader@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/file-reader/-/file-reader-2.2.3.tgz#503aaa0f259d78dbfc0a679aec4278bb7481a25a"
+  integrity sha512-8LWANAYJONpyPDoNVt7HaIL5c6F26N0F3lfnDb1T7R7AYWqzZVzWXauonFe4vVBTNOumcowTxf7YbIuREqYjqw==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/global-this" "2.2.3"
+
+"@tanker/global-this@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/global-this/-/global-this-2.2.3.tgz#4cc8d9f25040fadaa84bcf1d4b5a3f50a8957aee"
+  integrity sha512-zqA7Wpjgs9J+dYeZk7ybqqkzv59DQwXOYY/4F5l+/tPUoZj1zl7jj8Pr+Gk0idMdx+rqqIgA0eBNYcFIZdqW9g==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+
+"@tanker/identity@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/identity/-/identity-2.2.3.tgz#b6ca710daa971c16c1313dce8cfbc29350ca1c76"
+  integrity sha512-ZarK62/OKQ7qciVVDV7PpQo3up9dICswPL3/8yqMaSH/QEenB3X6ruX5Bd9CfVMZ9u0hAGVs3SAA7MOnsuJbDQ==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/crypto" "2.2.3"
+    "@tanker/errors" "2.2.3"
+
+"@tanker/stream-base@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/stream-base/-/stream-base-2.2.3.tgz#d1f964774b5cf5f1b909189799ffbad02c8c3c9d"
+  integrity sha512-xbc8SZNy4K7pxHzCrekoNadE/6wwoj585R2juWME6H/XMiaXTTjH8IAqdyB6o72inr6YskJdylCS8QHRaKtziw==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/errors" "2.2.3"
+    "@tanker/file-reader" "2.2.3"
+    "@tanker/types" "2.2.3"
+    readable-stream "^3.4.0"
+
+"@tanker/stream-cloud-storage@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/stream-cloud-storage/-/stream-cloud-storage-2.2.3.tgz#597e889ebdb44e009a52840a508d605672974c26"
+  integrity sha512-Jh6NADWbUIxQqB0YywfDFgdTSkbN+kIeoYjIXPh9TbxEIss2dHspYTpCGqLUssYfyRItQUx2CPmGJmHwpNbAQQ==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/errors" "2.2.3"
+    "@tanker/stream-base" "2.2.3"
+    fetch-ponyfill "^6.1.0"
+
+"@tanker/types@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/types/-/types-2.2.3.tgz#3adea5eb7f6975f177100afb951dde545bf78946"
+  integrity sha512-o5ibpkbQN9A5Uw+loVsla6ckHb7KN8J0AVUuVQHuWc1FaDPJKS97Bxu8ccITfoYZHQyweETlcBJiA5I9BUoZ3g==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/errors" "2.2.3"
+    "@tanker/file-ponyfill" "2.2.3"
+    "@tanker/file-reader" "2.2.3"
+    "@tanker/global-this" "2.2.3"
+
+"@tanker/verification-ui@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@tanker/verification-ui/-/verification-ui-2.2.3.tgz#204f66c05e7850030088a16ec32dd95627207c7c"
+  integrity sha512-RHmq0hVol2NTJCl24+H0KLu6UgC2+Qq2pof9+yo5TqMOMa9O2oyan0I11p21jZm7XVqcdZ2ig/DMnFlXXHmX0w==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.4.0"
+    "@tanker/errors" "2.2.3"
+    dumb-reducer "^2.0.2"
+    fetch-ponyfill "^6.1.0"
+    polished "^3.4.1"
+    react-hot-loader "^4.12.0"
+    react-motion "^0.5.2"
+    styled-components "^4.3.2"
+    styled-normalize "^8.0.6"
+
+"@types/babel__core@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.0.tgz#710f2487dda4dcfd010ca6abb2b4dc7394365c51"
+  integrity sha512-wJTeJRt7BToFx3USrCDs2BhEi4ijBInTQjOIukj6a/5tEkwpFMVZ+1ppgmE+Q/FQyc5P/VWUbx7I9NELrKruHA==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__core@^7.1.2":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
   integrity sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==
@@ -1449,6 +1622,11 @@ acorn@^7.0.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.0.0.tgz#26b8d1cd9a9b700350b71c0905546f64d1284e7a"
   integrity sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==
 
+after@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
+  integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
+
 aggregate-error@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
@@ -1637,6 +1815,11 @@ array-filter@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
   integrity sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=
 
+array-find@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
+  integrity sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -1688,6 +1871,11 @@ array.prototype.flat@^1.2.1:
     define-properties "^1.1.2"
     es-abstract "^1.10.0"
     function-bind "^1.1.1"
+
+arraybuffer.slice@~0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz#3bbc4275dd584cc1b10809b89d4e8b63a69e7675"
+  integrity sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -1935,6 +2123,16 @@ babel-plugin-react-intl@^3.4.1:
     fs-extra "^8.0.1"
     intl-messageformat-parser "^1.7.1"
 
+"babel-plugin-styled-components@>= 1":
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz#f8782953751115faf09a9f92431436912c34006b"
+  integrity sha512-gyQj/Zf1kQti66100PhrCRjI5ldjaze9O0M3emXRPAN80Zsf8+e1thpTpaXJXVHXtaM4/+dJEgZHyS9Its+8SA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
@@ -1961,6 +2159,11 @@ babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
+backo2@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
+
 backoff@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/backoff/-/backoff-2.5.0.tgz#f616eda9d3e4b66b8ca7fca79f695722c5f8e26f"
@@ -1972,6 +2175,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base64-arraybuffer@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
+  integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=
 
 base64-js@^1.0.2:
   version "1.3.1"
@@ -2003,6 +2211,13 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+better-assert@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
+  integrity sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=
+  dependencies:
+    callsite "1.0.0"
+
 bfj@^6.1.1:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.2.tgz#325c861a822bcb358a41c78a33b8e6e2086dde7f"
@@ -2032,6 +2247,11 @@ binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+
+blob@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
+  integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
 
 bluebird@^3.5.5:
   version "3.5.5"
@@ -2366,6 +2586,11 @@ caller-path@^2.0.0:
   dependencies:
     caller-callsite "^2.0.0"
 
+callsite@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+  integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
+
 callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
@@ -2385,6 +2610,11 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-api@^3.0.0:
   version "3.0.0"
@@ -2667,10 +2897,20 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-component-emitter@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
-  integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+component-bind@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
+  integrity sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=
+
+component-emitter@1.2.1, component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+  integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
+
+component-inherit@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
+  integrity sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=
 
 compressible@~2.0.16:
   version "2.0.17"
@@ -2834,6 +3074,11 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.1.tgz#87416ae817de957a3f249b3b5ca475d4aaed6042"
   integrity sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg==
 
+core-js@^2.6.5:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
+  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2945,6 +3190,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -3037,6 +3287,15 @@ css-system-font-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz#85c6f086aba4eb32c571a3086affc434b84823ed"
   integrity sha1-hcbwhquk6zLFcaMIav/ENLhII+0=
+
+css-to-react-native@^2.2.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.2.tgz#e75e2f8f7aa385b4c3611c52b074b70a002f2e7d"
+  integrity sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^3.3.0"
 
 css-tree@1.0.0-alpha.28:
   version "1.0.0-alpha.28"
@@ -3222,7 +3481,7 @@ debug@2.6.9, debug@^2.1.1, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@=3.1.0:
+debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -3383,6 +3642,11 @@ detect-passive-events@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-passive-events/-/detect-passive-events-1.0.4.tgz#6ed477e6e5bceb79079735dcd357789d37f9a91a"
   integrity sha1-btR35uW863kHlzXc01d4nTf5qRo=
 
+dexie@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/dexie/-/dexie-2.0.4.tgz#6027a5e05879424e8f9979d8c14e7420f27e3a11"
+  integrity sha512-aQ/s1U2wHxwBKRrt2Z/mwFNHMQWhESerFsMYzE+5P5OsIe5o1kgpFMWkzKTtkvkyyEni6mWr/T4HUJuY9xIHLA==
+
 diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
@@ -3466,6 +3730,11 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+  integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -3527,6 +3796,11 @@ double-ended-queue@^2.1.0-0:
   version "2.1.0-0"
   resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
   integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
+
+dumb-reducer@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dumb-reducer/-/dumb-reducer-2.0.3.tgz#9fcc6223ccc7b58b20a76c8f9e277cd5eb08e127"
+  integrity sha512-ChHU7GZom+cLTsWK3DpQgLBYvCrDE3MXxFQBkudt+MuBD6WDNL/LmDOMYAW9MuMjGNBwLQcgd08L64yOJK9CdA==
 
 duplexer@^0.1.1:
   version "0.1.1"
@@ -3611,6 +3885,33 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+"engine.io-client@git+https://github.com/TankerHQ/engine.io-client.git#2996c2d746d4695742cbc3f8fb47c60d4c5757f7":
+  version "3.3.2"
+  resolved "git+https://github.com/TankerHQ/engine.io-client.git#2996c2d746d4695742cbc3f8fb47c60d4c5757f7"
+  dependencies:
+    component-emitter "1.2.1"
+    component-inherit "0.0.3"
+    debug "~3.1.0"
+    engine.io-parser "~2.1.1"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    ws "~6.1.0"
+    xmlhttprequest-ssl "~1.5.4"
+    yeast "0.1.2"
+
+engine.io-parser@~2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.1.3.tgz#757ab970fbf2dfb32c7b74b033216d5739ef79a6"
+  integrity sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==
+  dependencies:
+    after "0.8.2"
+    arraybuffer.slice "~0.0.7"
+    base64-arraybuffer "0.1.5"
+    blob "0.0.5"
+    has-binary2 "~1.0.2"
 
 enhanced-resolve@4.1.0, enhanced-resolve@^4.1.0:
   version "4.1.0"
@@ -4280,7 +4581,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -4318,6 +4619,13 @@ fbjs@^0.8.4:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
+
+fetch-ponyfill@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-6.1.0.tgz#d56cd1e6fc4e50aff8cd4b7701dc42a0cc26f476"
+  integrity sha512-bLc7JCjpJZZUXVxbgwUhd72Q19MAokrCXOg/Akq+wl0uFLFLklFdBkZo5OpQ3kLI0oGqrKdx6t5Zo3QwXBRmbQ==
+  dependencies:
+    node-fetch "~2.6.0"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -4778,6 +5086,14 @@ global-prefix@^3.0.0:
     kind-of "^6.0.2"
     which "^1.3.1"
 
+global@^4.3.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
+  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
+  dependencies:
+    min-document "^2.19.0"
+    process "^0.11.10"
+
 globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -4890,6 +5206,18 @@ has-ansi@^2.0.0:
   integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
+
+has-binary2@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-binary2/-/has-binary2-1.0.3.tgz#7776ac627f3ea77250cfc332dab7ddf5e4f5d11d"
+  integrity sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==
+  dependencies:
+    isarray "2.0.1"
+
+has-cors@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+  integrity sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=
 
 has-flag@^1.0.0:
   version "1.0.0"
@@ -5286,6 +5614,11 @@ indexes-of@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
   integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
+
+indexof@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
+  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
 infer-owner@^1.0.3, infer-owner@^1.0.4:
   version "1.0.4"
@@ -5773,6 +6106,11 @@ is-url@1.2.2:
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.2.tgz#498905a593bf47cc2d9e7f738372bbf7696c7f26"
   integrity sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=
 
+is-what@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.3.1.tgz#79502181f40226e2d8c09226999db90ef7c1bcbe"
+  integrity sha512-seFn10yAXy+yJlTRO+8VfiafC+0QJanGLMPTBWLrJm/QPauuchy0UXh8B6H5o9VA8BAzk0iYievt6mNp6gfaqA==
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -5792,6 +6130,11 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isarray@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
+  integrity sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -6474,6 +6817,18 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+libsodium-wrappers@^0.5.1:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.5.4.tgz#0059bf219c3a37b228f823342399b1607a4c5ba4"
+  integrity sha512-dAYsfQgh6XwR4I65y7T5qDgb2XNKDpzXEXz229sDplaJfnAuIBTHBYlQ44jL5DIS4cCUspE3+g0kF4/Xe8286A==
+  dependencies:
+    libsodium "0.5.4"
+
+libsodium@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.5.4.tgz#874413435ee40c512dd59ea6db9b75970f8aec02"
+  integrity sha512-s1TQ2V23JvGby1gnCQEQncTNTGck/rtJPPA8c0TiBo9z9TpT4eUk5zThte8H1TkdoKQznneqZqyoqdrwu2btWw==
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -6739,6 +7094,13 @@ memory-fs@^0.4.0, memory-fs@^0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+merge-anything@^2.2.4:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.4.1.tgz#e9bccaec1e49ec6cb5f77ca78c5770d1a35315e6"
+  integrity sha512-dYOIAl9GFCJNctSIHWOj9OJtarCjsD16P8ObCl6oxrujAG+kOvlwJuOD9/O9iYZ9aTi1RGpGTG9q9etIvuUikQ==
+  dependencies:
+    is-what "^3.3.1"
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
@@ -6834,6 +7196,13 @@ mimic-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
+  dependencies:
+    dom-walk "^0.1.0"
 
 mini-css-extract-plugin@^0.8.0:
   version "0.8.0"
@@ -7091,6 +7460,11 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@~2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-forge@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
@@ -7285,6 +7659,11 @@ object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-component@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
+  integrity sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -7701,6 +8080,20 @@ parse5@^3.0.1:
   dependencies:
     "@types/node" "*"
 
+parseqs@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
+  integrity sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=
+  dependencies:
+    better-assert "~1.0.0"
+
+parseuri@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz#80204a50d4dbb779bfdc6ebe2778d90e4bce320a"
+  integrity sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=
+  dependencies:
+    better-assert "~1.0.0"
+
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -7932,6 +8325,13 @@ pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
+
+polished@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.4.1.tgz#1eb5597ec1792206365635811d465751f5cbf71c"
+  integrity sha512-GflTnlP5rrpDoigjczEkS6Ye7NDA4sFvAnlr5hSDrEvjiVj97Xzev3hZlLi3UB27fpxyTS9rWU64VzVLWkG+mg==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
 
 portfinder@^1.0.25:
   version "1.0.25"
@@ -8282,7 +8682,7 @@ postcss-unique-selectors@^4.0.1:
     postcss "^7.0.0"
     uniqs "^2.0.0"
 
-postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.1:
+postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
@@ -8626,6 +9026,20 @@ react-event-listener@^0.6.0:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
+react-hot-loader@^4.12.0:
+  version "4.12.13"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.12.13.tgz#78dcb55f49f88ce3d4316c7c86a8c01fdd196cd2"
+  integrity sha512-4Byk3aVQhcmTnVCBvDHOEOUnMFMj81r2yRKZQSfLOG2yd/4hm/A3oK15AnCZilQExqSFSsHcK64lIIU+dU2zQQ==
+  dependencies:
+    fast-levenshtein "^2.0.6"
+    global "^4.3.0"
+    hoist-non-react-statics "^3.3.0"
+    loader-utils "^1.1.0"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
+    shallowequal "^1.1.0"
+    source-map "^0.7.3"
+
 react-hotkeys@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/react-hotkeys/-/react-hotkeys-1.1.4.tgz#a0712aa2e0c03a759fd7885808598497a4dace72"
@@ -8684,10 +9098,15 @@ react-intl@^2.9.0:
     intl-relativeformat "^2.1.0"
     invariant "^2.1.1"
 
-react-is@^16.10.2, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.10.2:
   version "16.11.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
   integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
+
+react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -8928,7 +9347,7 @@ read-pkg@^3.0.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6:
+readable-stream@^3.0.6, readable-stream@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
@@ -9604,6 +10023,11 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -9709,6 +10133,34 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+"socket.io-client@git+https://github.com/TankerHQ/socket.io-client.git#4f71b8dda24bea5e4949c37fec6b790795615c25":
+  version "2.2.0"
+  resolved "git+https://github.com/TankerHQ/socket.io-client.git#4f71b8dda24bea5e4949c37fec6b790795615c25"
+  dependencies:
+    backo2 "1.0.2"
+    base64-arraybuffer "0.1.5"
+    component-bind "1.0.0"
+    component-emitter "1.2.1"
+    debug "~3.1.0"
+    engine.io-client "git+https://github.com/TankerHQ/engine.io-client.git#2996c2d746d4695742cbc3f8fb47c60d4c5757f7"
+    has-binary2 "~1.0.2"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    object-component "0.0.3"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    socket.io-parser "~3.3.0"
+    to-array "0.1.4"
+
+socket.io-parser@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.0.tgz#2b52a96a509fdf31440ba40fed6094c7d4f1262f"
+  integrity sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==
+  dependencies:
+    component-emitter "1.2.1"
+    debug "~3.1.0"
+    isarray "2.0.1"
+
 sockjs-client@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.4.0.tgz#c9f2568e19c8fd8173b4997ea3420e0bb306c7d5"
@@ -9782,6 +10234,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -10072,6 +10529,30 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+styled-components@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.3.2.tgz#4ca81918c812d3006f60ac5fdec7d6b64a9509cc"
+  integrity sha512-NppHzIFavZ3TsIU3R1omtddJ0Bv1+j50AKh3ZWyXHuFvJq1I8qkQ5mZ7uQgD89Y8zJNx2qRo6RqAH1BmoVafHw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.8.1"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^5.0.0"
+    merge-anything "^2.2.4"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
+styled-normalize@^8.0.6:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/styled-normalize/-/styled-normalize-8.0.6.tgz#f27f87292f46aa79ad6db6339aff5db529df3c91"
+  integrity sha512-tOnAD1+wV04aiVy6chaQA4u/EtkGiGZPlIBYvEfWlZQBrDqRhu9EdPyXlFzLWxpOmANoQelJqSOMlV3QNCDKkw==
+
 stylehacks@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.1.tgz#3186595d047ab0df813d213e51c8b94e0b9010f2"
@@ -10080,6 +10561,16 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 substring-trie@^1.0.2:
   version "1.0.2"
@@ -10105,7 +10596,7 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -10329,6 +10820,11 @@ tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
   integrity sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+
+to-array@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
+  integrity sha1-F+bBH3PdTz10zaek/zI46a2b+JA=
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -10661,6 +11157,11 @@ value-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
+
+varint@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/varint/-/varint-5.0.0.tgz#d826b89f7490732fabc0c0ed693ed475dcb29ebf"
+  integrity sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8=
 
 vary@~1.1.2:
   version "1.1.2"
@@ -11054,10 +11555,22 @@ ws@^6.0.0, ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
+ws@~6.1.0:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.4.tgz#5b5c8800afab925e94ccb29d153c8d02c1776ef9"
+  integrity sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==
+  dependencies:
+    async-limiter "~1.0.0"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xmlhttprequest-ssl@~1.5.4:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
+  integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
@@ -11152,6 +11665,11 @@ yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
+
+yeast@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+  integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
 
 zlibjs@^0.3.1:
   version "0.3.1"


### PR DESCRIPTION
Hello, I've been using Mastodon since April 2017. One thing that always bugs me is that Mastodon administrators have access to direct messages between users.

I work at [Tanker.io](https://tanker.io) where we develop an end-to-end encryption solution and I recently decided to try and use it inside Mastodon. I wrote [a series on dev.to](https://dev.to/tanker/taking-mastodon-security-to-the-next-level-part-1-encrypt-your-toots-2p00) about it that you can read for more information.

This pull request is just a proof-of-concept and should not be merged as is, but it can be a good starting point for further discussion.

Feel free to browse the changes, comment on the patch or ask questions.

Cheers!



