### PR TITLE
Fix whitelist federation for subdomains

### DIFF
--- a/app/helpers/domain_control_helper.rb
+++ b/app/helpers/domain_control_helper.rb
@@ -6,7 +6,7 @@ module DomainControlHelper
 
     domain = begin
       if uri_or_domain.include?('://')
-        Addressable::URI.parse(uri_or_domain).domain
+        Addressable::URI.parse(uri_or_domain).host
       else
         uri_or_domain
       end


### PR DESCRIPTION
If I add something like `instance.masto.host` to it it doesn't actually allow `instance.masto.host`, because it just checks whether `masto.host` is on the list, which doesn't match, this fixes that