### PR TITLE
Fixes featured hashtag setting page erroring out instead of rejecting invalid tags

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -149,7 +149,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     return if tag['name'].blank?
 
     Tag.find_or_create_by_names(tag['name']) do |hashtag|
-      @tags << hashtag unless @tags.include?(hashtag)
+      @tags << hashtag unless @tags.include?(hashtag) || !hashtag.valid?
     end
   rescue ActiveRecord::RecordInvalid
     nil

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -117,7 +117,7 @@ class Tag < ApplicationRecord
   class << self
     def find_or_create_by_names(name_or_names)
       Array(name_or_names).map(&method(:normalize)).uniq { |str| str.mb_chars.downcase.to_s }.map do |normalized_name|
-        tag = matching_name(normalized_name).first || create!(name: normalized_name)
+        tag = matching_name(normalized_name).first || create(name: normalized_name)
 
         yield tag if block_given?
 

--- a/spec/controllers/settings/featured_tags_controller_spec.rb
+++ b/spec/controllers/settings/featured_tags_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe Settings::FeaturedTagsController do
+  render_views
+
+  shared_examples 'authenticate user' do
+    it 'redirects to sign_in page' do
+      is_expected.to redirect_to new_user_session_path
+    end
+  end
+
+  describe 'POST #create' do
+    context 'when user is not sign in' do
+      subject { post :create }
+
+      it_behaves_like 'authenticate user'
+    end
+
+    context 'when user is sign in' do
+      subject { post :create, params: { featured_tag: params } }
+
+      let(:user) { Fabricate(:user, password: '12345678') }
+
+      before { sign_in user, scope: :user }
+
+      context 'when parameter is valid' do
+        let(:params) { { name: 'test' } }
+
+        it 'creates featured tag' do
+          expect { subject }.to change { user.account.featured_tags.count }.by(1)
+        end
+      end
+
+      context 'when parameter is invalid' do
+        let(:params) { { name: 'test, #foo !bleh' } }
+
+        it 'renders new' do
+          expect(subject).to render_template :index
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -378,6 +378,28 @@ RSpec.describe ActivityPub::Activity::Create do
         end
       end
 
+      context 'with hashtags invalid name' do
+        let(:object_json) do
+          {
+            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+            type: 'Note',
+            content: 'Lorem ipsum',
+            tag: [
+              {
+                type: 'Hashtag',
+                href: 'http://example.com/blah',
+                name: 'foo, #eh !',
+              },
+            ],
+          }
+        end
+
+        it 'creates status' do
+          status = sender.statuses.first
+          expect(status).to_not be_nil
+        end
+      end
+
       context 'with emojis' do
         let(:object_json) do
           {


### PR DESCRIPTION
Fixes #12386

This was caused by `Tag#find_or_create_by_names` raising a validation error because of a `create!` call, instead of deferring the validation to `save` as usual.

This PR reverts #11621 and applies #11622 instead, as I think `Tag#find_or_create_by_names` should behave as `find_or_create` and such and *not* call `create!`.