### PR TITLE
Fix OEmbed discovery not handling different URL variants in query

### DIFF
--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -58,7 +58,7 @@ class FetchOEmbedService
     url_domain = Addressable::URI.parse(@url).normalized_host
 
     endpoint_hash = {
-      endpoint: @endpoint_url.gsub(URI.encode_www_form_component(@url), '{url}'),
+      endpoint: @endpoint_url.gsub(/(=(http[s]?(%3A|:)(\/\/|%2F%2F)))([^&]*)/i, '={url}'),
       format: @format,
     }
 


### PR DESCRIPTION
Fix #12433