### PR TITLE
Fix blur behind closed registration message

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -513,6 +513,10 @@ code {
   &__overlay-area {
     position: relative;
 
+    &__blurred form {
+      filter: blur(2px);
+    }
+
     &__overlay {
       position: absolute;
       top: 0;
@@ -523,7 +527,6 @@ code {
       justify-content: center;
       align-items: center;
       background: rgba($ui-base-color, 0.65);
-      backdrop-filter: blur(2px);
       border-radius: 4px;
 
       &__content {

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -528,6 +528,9 @@ code {
       align-items: center;
       background: rgba($ui-base-color, 0.65);
       border-radius: 4px;
+      margin-left: -4px;
+      margin-top: -4px;
+      padding: 4px;
 
       &__content {
         text-align: center;

--- a/app/views/about/_registration.html.haml
+++ b/app/views/about/_registration.html.haml
@@ -1,5 +1,5 @@
-= simple_form_for(new_user, url: user_registration_path, namespace: 'registration') do |f|
-  .simple_form__overlay-area
+.simple_form__overlay-area{ class: (closed_registrations? && @instance_presenter.closed_registrations_message.present?) ? 'simple_form__overlay-area__blurred' : '' }
+  = simple_form_for(new_user, url: user_registration_path, namespace: 'registration') do |f|
     %p.lead= t('about.federation_hint_html', instance: content_tag(:strong, site_hostname))
 
     .fields-group
@@ -21,8 +21,8 @@
     .actions
       = f.button :button, sign_up_message, type: :submit, class: 'button button-primary', disabled: closed_registrations?
 
-    - if closed_registrations? && @instance_presenter.closed_registrations_message.present?
-      .simple_form__overlay-area__overlay
-        .simple_form__overlay-area__overlay__content.rich-formatting
-          .block-icon= fa_icon 'warning'
-          = @instance_presenter.closed_registrations_message.html_safe
+  - if closed_registrations? && @instance_presenter.closed_registrations_message.present?
+    .simple_form__overlay-area__overlay
+      .simple_form__overlay-area__overlay__content.rich-formatting
+        .block-icon= fa_icon 'warning'
+        = @instance_presenter.closed_registrations_message.html_safe


### PR DESCRIPTION
Fixes #12425

Use `filter: blur(2px)` which is widely supported, instead of `backdrop-filter: blur(2px)` which is only supported by a handful browsers. Also increase margins and avoid weird cut-offs.

![image](https://user-images.githubusercontent.com/384364/69374909-6c0bb600-0ca7-11ea-8355-f032d455918c.png)
