### PR TITLE
Fix counter sizing

### DIFF
--- a/app/javascript/styles/mastodon/containers.scss
+++ b/app/javascript/styles/mastodon/containers.scss
@@ -646,7 +646,7 @@
         }
 
         .counter {
-          width: 33.3%;
+          min-width: 33.3%;
           box-sizing: border-box;
           flex: 0 0 auto;
           color: $darker-text-color;


### PR DESCRIPTION
Counter size is currently set to strict 33.3% width, but with it counters may break in other languages than English. For example it is already broken on Gargron's profile on mastodon.social using Russian locale:

<p align="center">
<img src="https://user-images.githubusercontent.com/10401817/69436754-96777500-0d74-11ea-96d5-bc955215ced1.png" alt="Example screenshot of broken counter">
</p>

This commit changes "width" to "min-width", so counters still displayed correctly, but if they need more width to fit text, they are now allowed to take as many width as they need:

<p align="center">
<img src="https://user-images.githubusercontent.com/10401817/69436793-a7c08180-0d74-11ea-8546-3d5451536186.png" alt="Example screenshot of fixed counter">
</p>
