### PR TITLE
Avoid creating invalid username for instance account

### DIFF
--- a/db/migrate/20190715164535_add_instance_actor.rb
+++ b/db/migrate/20190715164535_add_instance_actor.rb
@@ -1,6 +1,6 @@
 class AddInstanceActor < ActiveRecord::Migration[5.2]
   def up
-    Account.create!(id: -99, actor_type: 'Application', locked: true, username: Rails.configuration.x.local_domain)
+    Account.create!(id: -99, actor_type: 'Application', locked: true, username: Rails.configuration.x.local_domain.gsub(/:\d*/, ''))
   end
 
   def down

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 Doorkeeper::Application.create!(name: 'Web', superapp: true, redirect_uri: Doorkeeper.configuration.native_redirect_uri, scopes: 'read write follow push')
 
-domain = ENV['LOCAL_DOMAIN'] || Rails.configuration.x.local_domain
+domain = (ENV['LOCAL_DOMAIN'] || Rails.configuration.x.local_domain).gsub(/:\d*/, '')
 account = Account.find_or_initialize_by(id: -99, actor_type: 'Application', locked: true, username: domain)
 account.save!
 


### PR DESCRIPTION
If database is set up before setting `LOCAL_DOMAIN`, the instance account may be created with an invalid username:

```
> SELECT username FROM accounts WHERE id=-99;
    username
-----------------
 localhost:45208
(1 row)
```

This is to avoid such username with removing the port number part from Rails' local domain.