### PR TITLE
Allow muted users to appear in lists

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -186,7 +186,7 @@ class FeedManager
 
     return true if check_for_blocks.any? { |target_account_id| crutches[:blocking][target_account_id] || crutches[:muting][target_account_id] }
 
-    return filter_from_list?(status, receiver_id, crutches)
+    filter_from_list?(status, receiver_id, crutches)
   end
 
   def filter_from_list?(status, receiver_id, crutches)

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -20,7 +20,7 @@ class FeedManager
   def filter?(timeline_type, status, receiver_id)
     if timeline_type == :home
       filter_from_home?(status, receiver_id, build_crutches(receiver_id, [status]))
-    if timeline_type == :list
+    elsif timeline_type == :list
       filter_from_list?(status, receiver_id, build_crutches(receiver_id, [status]))
     elsif timeline_type == :mentions
       filter_from_mentions?(status, receiver_id)

--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -27,9 +27,7 @@ class FeedInsertWorker
   end
 
   def feed_filtered?
-    # Note: Lists are a variation of home, so the filtering rules
-    # of home apply to both
-    FeedManager.instance.filter?(:home, @status, @follower.id)
+    FeedManager.instance.filter?(@type, @status, @follower.id)
   end
 
   def perform_push


### PR DESCRIPTION
If you add a user to a list and mute them their posts will continue to show in the list. Previously, if you muted an account and put them in a list their posts would not appear in the list.

This is helpful to allow users you don't want in your home feed to have their own separate feed. I use this on my instance to have a "Bots" list containing muted bot accounts so they don't appear in my home feed.

Adds a feed manager filter function specifically for lists which does the same thing as the home filter minus the "is muted" check. Since the home filter and list filter are mostly the same, the home filter just checks for blocks/mutes and calls the list filter.

Closes #10346