### PR TITLE
Fix empty poll options not being filtered on remote poll update

### DIFF
--- a/app/services/activitypub/process_poll_service.rb
+++ b/app/services/activitypub/process_poll_service.rb
@@ -30,7 +30,7 @@ class ActivityPub::ProcessPollService < BaseService
 
     voters_count = @json['votersCount']
 
-    latest_options = items.map { |item| item['name'].presence || item['content'] }
+    latest_options = items.map { |item| item['name'].presence || item['content'] }.compact
 
     # If for some reasons the options were changed, it invalidates all previous
     # votes, so we need to remove them


### PR DESCRIPTION
If a poll contains empty options (which is apparently possible on Pleroma),
it is created without them. However, the poll update code doesn't filter
empty options, and thus:
1. Clear known votes, as it assumes the set of options has changed
2. Errors out because it tries adding empty options, which fails validation

This commit fixes that by filtering them out the same way they are filtered
out at poll creation time.