### PR TITLE
Improve notifications settings

### DIFF
--- a/app/views/settings/preferences/notifications/show.html.haml
+++ b/app/views/settings/preferences/notifications/show.html.haml
@@ -4,6 +4,10 @@
 = simple_form_for current_user, url: settings_preferences_notifications_path, html: { method: :put } do |f|
   = render 'shared/error_messages', object: current_user
 
+  %h4= t('notifications.email_events')
+
+  %p.hint = t('notifications.email_events_hint')
+
   .fields-group
     = f.simple_fields_for :notification_emails, hash_to_object(current_user.settings.notification_emails) do |ff|
       = ff.input :follow, as: :boolean, wrapper: :with_label
@@ -20,6 +24,8 @@
   .fields-group
     = f.simple_fields_for :notification_emails, hash_to_object(current_user.settings.notification_emails) do |ff|
       = ff.input :digest, as: :boolean, wrapper: :with_label
+
+  %h4 = t('notifications.other_settings')
 
   .fields-group
     = f.simple_fields_for :interactions, hash_to_object(current_user.settings.interactions) do |ff|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -886,6 +886,10 @@ en:
       body: 'Your status was boosted by %{name}:'
       subject: "%{name} boosted your status"
       title: New boost
+  notifications:
+    email_events: Events for e-mail notifications
+    email_events_hint: 'Select events that you want to receive notifications for:'
+    other_settings: Other notifications settings
   number:
     human:
       decimal_units:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -150,14 +150,14 @@ en:
         text: Why do you want to join?
       notification_emails:
         digest: Send digest e-mails
-        favourite: Send e-mail when someone favourites your status
-        follow: Send e-mail when someone follows you
-        follow_request: Send e-mail when someone requests to follow you
-        mention: Send e-mail when someone mentions you
-        pending_account: Send e-mail when a new account needs review
-        reblog: Send e-mail when someone boosts your status
-        report: Send e-mail when a new report is submitted
-        trending_tag: Send e-mail when an unreviewed hashtag is trending
+        favourite: Someone favourited your status
+        follow: Someone followed you
+        follow_request: Someone requested to follow you
+        mention: Someone mentioned you
+        pending_account: New account needs review
+        reblog: Someone boosted your status
+        report: New report is submitted
+        trending_tag: An unreviewed hashtag is trending
       tag:
         listable: Allow this hashtag to appear in searches and on the profile directory
         name: Hashtag


### PR DESCRIPTION
### Motivation

Currently notifications page seems a bit cluttered with no clear separation between e-mail and filtering settings. This PR tries to address them by adding clear separation with headers, hints and removing continuously reused texts for events checkboxes.

### Visual Comparison:

*(click to see full sized pictures)*

| Before | After |
|:------:|:-----:|
| ![Screenshot of "cluttered" settings before these fixes](https://user-images.githubusercontent.com/10401817/69829861-689e9e80-1254-11ea-9e39-875306881ec0.png) | ![Screenshot of settings after, highlighting new headings hints and changed checkboxes texts](https://user-images.githubusercontent.com/10401817/69829859-64728100-1254-11ea-958d-4580f7c0bd86.png) |

<details>
<summary>Warning about visuals</summary>

Please note, that due to my technical inability to set up Mastodon instance to test these changes, screenshots above were made with browser's developer tools, using the texts from files and placing new elements at expected places. If that does not satisfy you, you may set up your own instance and review changes manually.

</details>


### A word about PR

I'm nowhere familiar with what “HAML” is and not explored it yet, because this commit is so small, the changes primarily were made by reviewing other files in project and guessing the syntax. I expect maintainers (or reviewers) to test it and suggest what to fix and how. Thanks!
