### PR TITLE
Split relationships page strings

### DIFF
--- a/app/views/relationships/show.html.haml
+++ b/app/views/relationships/show.html.haml
@@ -8,8 +8,8 @@
   .filter-subset
     %strong= t 'relationships.relationship'
     %ul
-      %li= filter_link_to t('accounts.following', count: current_account.following_count), relationship: nil
-      %li= filter_link_to t('accounts.followers', count: current_account.followers_count), relationship: 'followed_by'
+      %li= filter_link_to t('relationships.following'), relationship: nil
+      %li= filter_link_to t('relationships.followers'), relationship: 'followed_by'
       %li= filter_link_to t('relationships.mutual'), relationship: 'mutual'
 
   .filter-subset

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -924,6 +924,8 @@ en:
   relationships:
     activity: Account activity
     dormant: Dormant
+    followers: Followers
+    following: Following
     last_active: Last active
     most_recent: Most recent
     moved: Moved


### PR DESCRIPTION
Before this moment relationships managing page was using strings from other context — from counters. But in order for translators to be able to translate it relatively to the page (as a tab there), it must use separate strings.

| English | Russian |
|:-------:|:-------:|
| ![Screenshot_20191130_131252](https://user-images.githubusercontent.com/10401817/69896527-39cb1a00-1373-11ea-9caa-0af0c179d259.png) | ![Screenshot_20191130_131316](https://user-images.githubusercontent.com/10401817/69896523-3172df00-1373-11ea-80d8-c189c1e08aee.png) |
| Strings shown normally (*kinda*) | Strings irrelevantly “pluralized” |

I've split the strings for "Following" and "Followers" and put them to "relationships" keyset in localization file. This should solve this issue.

Fixes #10863
