### PR TITLE
Return `discoverable` via REST API (fix #12507)

### DIFF
--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -3,7 +3,7 @@
 class REST::AccountSerializer < ActiveModel::Serializer
   include RoutingHelper
 
-  attributes :id, :username, :acct, :display_name, :locked, :bot, :created_at,
+  attributes :id, :username, :acct, :display_name, :locked, :bot, :discoverable, :created_at,
              :note, :url, :avatar, :avatar_static, :header, :header_static,
              :followers_count, :following_count, :statuses_count, :last_status_at
 


### PR DESCRIPTION
I think this should fix it?

https://github.com/tootsuite/mastodon/blob/master/app/serializers/rest/credential_account_serializer.rb is another place that it could be returned instead, but I think in the long-term it is valuable to know whether an account is discoverable even if it is not your own account. 