### PR TITLE
Fix batch actions on non-pending tags in admin interface

### DIFF
--- a/app/views/admin/tags/_tag.html.haml
+++ b/app/views/admin/tags/_tag.html.haml
@@ -1,6 +1,7 @@
 .batch-table__row
-  %label.batch-table__row__select.batch-table__row__select--aligned.batch-checkbox
-    = f.check_box :tag_ids, { multiple: true, include_hidden: false }, tag.id
+  - if batch_available
+    %label.batch-table__row__select.batch-table__row__select--aligned.batch-checkbox
+      = f.check_box :tag_ids, { multiple: true, include_hidden: false }, tag.id
 
   .directory__tag
     = link_to admin_tag_path(tag.id) do

--- a/app/views/admin/tags/index.html.haml
+++ b/app/views/admin/tags/index.html.haml
@@ -50,25 +50,26 @@
 
   .batch-table.optional
     .batch-table__toolbar
-      %label.batch-table__toolbar__select.batch-checkbox-all
-        = check_box_tag :batch_checkbox_all, nil, false
-      .batch-table__toolbar__actions
-        - if params[:pending_review] == '1'
+      - if params[:pending_review] == '1' || params[:unreviewed] == '1'
+        %label.batch-table__toolbar__select.batch-checkbox-all
+          = check_box_tag :batch_checkbox_all, nil, false
+        .batch-table__toolbar__actions
           = f.button safe_join([fa_icon('check'), t('admin.accounts.approve')]), name: :approve, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
           = f.button safe_join([fa_icon('times'), t('admin.accounts.reject')]), name: :reject, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
-        - else
+      - else
+        .batch-table__toolbar__actions
           %span.neutral-hint= t('generic.no_batch_actions_available')
 
     .batch-table__body
       - if @tags.empty?
         = nothing_here 'nothing-here--under-tabs'
       - else
-        = render partial: 'tag', collection: @tags, locals: { f: f }
+        = render partial: 'tag', collection: @tags, locals: { f: f, batch_available: params[:pending_review] == '1' || params[:unreviewed] == '1' }
 
 = paginate @tags
 
-- if params[:pending_review] == '1'
+- if params[:pending_review] == '1' || params[:unreviewed] == '1'
   %hr.spacer/
 
   %div{ style: 'overflow: hidden' }


### PR DESCRIPTION
Currently, the Hashtag admin page shows batch action checkboxes on every page but only actually show action buttons on the “pending review” tab. This is confusing and unnecessary, and frustrating when one checks every tag then figures out they can't act on them.

This PR changes that to:
- Allow batch actions on unreviewed tags
- Hide checkboxes when batch actions aren't available (“all” and “reviewed” tabs)

I wonder about that last part: should we allow to override the state even for reviewed tags? If so we could just show the batch actions in all cases.

![image](https://user-images.githubusercontent.com/384364/69975276-3082ae80-1527-11ea-93c2-876377a10a53.png)