### PR TITLE
Fix poll options not being selectable via keyboard

### DIFF
--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -87,9 +87,9 @@ class Poll extends ImmutablePureComponent {
     this._toggleOption(value);
   };
 
-  handleOptionKeyPress = (optionIndex, e) => {
+  handleOptionKeyPress = (e) => {
     if (e.key === 'Enter' || e.key === ' ') {
-      this._toggleOption(optionIndex);
+      this._toggleOption(e.target.getAttribute('data-index'));
       e.stopPropagation();
       e.preventDefault();
     }
@@ -150,9 +150,10 @@ class Poll extends ImmutablePureComponent {
               className={classNames('poll__input', { checkbox: poll.get('multiple'), active })}
               tabIndex='0'
               role={poll.get('multiple') ? 'checkbox' : 'radio'}
-              onKeyPress={this.handleOptionKeyPress.bind(this, optionIndex)}
+              onKeyPress={this.handleOptionKeyPress}
               aria-checked={active}
               aria-label={option.get('title')}
+              data-index={optionIndex}
             />
           )}
           {showResults && <span className='poll__number'>

--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -67,9 +67,7 @@ class Poll extends ImmutablePureComponent {
     }
   }
 
-  handleOptionChange = e => {
-    const { target: { value } } = e;
-
+  _toggleOption = value => {
     if (this.props.poll.get('multiple')) {
       const tmp = { ...this.state.selected };
       if (tmp[value]) {
@@ -83,7 +81,19 @@ class Poll extends ImmutablePureComponent {
       tmp[value] = true;
       this.setState({ selected: tmp });
     }
+  }
+
+  handleOptionChange = ({ target: { value } }) => {
+    this._toggleOption(value);
   };
+
+  handleOptionKeyPress = (optionIndex, e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      this._toggleOption(optionIndex);
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  }
 
   handleVote = () => {
     if (this.props.disabled) {
@@ -135,7 +145,16 @@ class Poll extends ImmutablePureComponent {
             disabled={disabled}
           />
 
-          {!showResults && <span className={classNames('poll__input', { checkbox: poll.get('multiple'), active })} />}
+          {!showResults && (
+            <span
+              className={classNames('poll__input', { checkbox: poll.get('multiple'), active })}
+              tabIndex='0'
+              role='button'
+              onKeyPress={this.handleOptionKeyPress.bind(this, optionIndex)}
+              aria-pressed={active}
+              aria-label={option.get('title')}
+            />
+          )}
           {showResults && <span className='poll__number'>
             {!!voted && <Icon id='check' className='poll__vote__mark' title={intl.formatMessage(messages.voted)} />}
             {Math.round(percent)}%

--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -149,7 +149,7 @@ class Poll extends ImmutablePureComponent {
             <span
               className={classNames('poll__input', { checkbox: poll.get('multiple'), active })}
               tabIndex='0'
-              role={ poll.get('multiple') ? 'checkbox' : 'radio' }
+              role={poll.get('multiple') ? 'checkbox' : 'radio'}
               onKeyPress={this.handleOptionKeyPress.bind(this, optionIndex)}
               aria-checked={active}
               aria-label={option.get('title')}

--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -149,9 +149,9 @@ class Poll extends ImmutablePureComponent {
             <span
               className={classNames('poll__input', { checkbox: poll.get('multiple'), active })}
               tabIndex='0'
-              role='button'
+              role={ poll.get('multiple') ? 'checkbox' : 'radio' }
               onKeyPress={this.handleOptionKeyPress.bind(this, optionIndex)}
-              aria-pressed={active}
+              aria-checked={active}
               aria-label={option.get('title')}
             />
           )}

--- a/app/javascript/mastodon/features/compose/components/poll_form.js
+++ b/app/javascript/mastodon/features/compose/components/poll_form.js
@@ -13,6 +13,8 @@ const messages = defineMessages({
   add_option: { id: 'compose_form.poll.add_option', defaultMessage: 'Add a choice' },
   remove_option: { id: 'compose_form.poll.remove_option', defaultMessage: 'Remove this choice' },
   poll_duration: { id: 'compose_form.poll.duration', defaultMessage: 'Poll duration' },
+  switchToMultiple: { id: 'compose_form.poll.switch_to_multiple', defaultMessage: 'Change poll to allow multiple choices' },
+  switchToSingle: { id: 'compose_form.poll.switch_to_single', defaultMessage: 'Change poll to allow for a single choice' },
   minutes: { id: 'intervals.full.minutes', defaultMessage: '{number, plural, one {# minute} other {# minutes}}' },
   hours: { id: 'intervals.full.hours', defaultMessage: '{number, plural, one {# hour} other {# hours}}' },
   days: { id: 'intervals.full.days', defaultMessage: '{number, plural, one {# day} other {# days}}' },
@@ -50,6 +52,12 @@ class Option extends React.PureComponent {
     e.stopPropagation();
   };
 
+  handleCheckboxKeypress = e => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      this.handleToggleMultiple(e);
+    }
+  }
+
   onSuggestionsClearRequested = () => {
     this.props.onClearSuggestions();
   }
@@ -71,8 +79,11 @@ class Option extends React.PureComponent {
           <span
             className={classNames('poll__input', { checkbox: isPollMultiple })}
             onClick={this.handleToggleMultiple}
+            onKeyPress={this.handleCheckboxKeypress}
             role='button'
             tabIndex='0'
+            title={intl.formatMessage(isPollMultiple ? messages.switchToMultiple : messages.switchToSingle)}
+            aria-label={intl.formatMessage(isPollMultiple ? messages.switchToMultiple : messages.switchToSingle)}
           />
 
           <AutosuggestInput

--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -91,6 +91,23 @@
       border-color: $valid-value-color;
       background: $valid-value-color;
     }
+
+    &:active,
+    &:focus,
+    &:hover {
+      border-width: 4px;
+      background: none;
+    }
+
+    &::-moz-focus-inner {
+      outline: 0 !important;
+      border: 0;
+    }
+
+    &:focus,
+    &:active {
+      outline: 0 !important;
+    }
   }
 
   &__number {


### PR DESCRIPTION
Fixes #12384

Also allow switching from single-option to multiple-option poll with keyboard and add a tooltip explaining that.

Changes the styling of hovered/focused/active checkboxes/radios as following:
![Peek 02-12-2019 18-56](https://user-images.githubusercontent.com/384364/69982907-cde4df00-1535-11ea-9826-3ac59671c48c.gif)