### PR TITLE
Highlight border when focusing poll-form footer

### DIFF
--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -177,6 +177,10 @@
     button,
     select {
       flex: 1 1 50%;
+
+      &:focus {
+        border-color: $highlight-text-color;
+      }
     }
   }
 


### PR DESCRIPTION
For now, keyboard operation is confusing.

![image](https://user-images.githubusercontent.com/5253290/70168013-55377b80-170b-11ea-9b80-4ce00e611025.png)
