### PR TITLE
Fix media open hotkey on boosted status

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -215,7 +215,8 @@ class Status extends ImmutablePureComponent {
   }
 
   handleHotkeyOpenMedia = e => {
-    const { status, onOpenMedia, onOpenVideo } = this.props;
+    const { onOpenMedia, onOpenVideo } = this.props;
+    const status = this._properStatus();
 
     e.preventDefault();
 

--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -282,7 +282,7 @@ class Status extends ImmutablePureComponent {
   }
 
   handleHotkeyOpenMedia = e => {
-    const { status } = this.props;
+    const status = this._properStatus();
 
     e.preventDefault();
 


### PR DESCRIPTION
In #11076 use `_properStatus()` to get proper status if status is boost.
This PR fixes #12498 open media hotkey on boosted statuses.