### PR TITLE
Use different strings on exports page

### DIFF
--- a/app/views/settings/exports/show.html.haml
+++ b/app/views/settings/exports/show.html.haml
@@ -9,11 +9,11 @@
         %td= number_to_human_size @export.total_storage
         %td
       %tr
-        %th= t('accounts.posts', count: @export.total_statuses)
+        %th= t('accounts.posts_tab_heading')
         %td= number_with_delimiter @export.total_statuses
         %td
       %tr
-        %th= t('exports.follows')
+        %th= t('admin.accounts.follows')
         %td= number_with_delimiter @export.total_follows
         %td= table_link_to 'download', t('exports.csv'), settings_exports_follows_path(format: :csv)
       %tr
@@ -21,7 +21,7 @@
         %td= number_with_delimiter @export.total_lists
         %td= table_link_to 'download', t('exports.csv'), settings_exports_lists_path(format: :csv)
       %tr
-        %th= t('accounts.followers', count: @export.total_followers)
+        %th= t('admin.accounts.followers')
         %td= number_with_delimiter @export.total_followers
         %td
       %tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -718,7 +718,6 @@ en:
     blocks: You block
     csv: CSV
     domain_blocks: Domain blocks
-    follows: You follow
     lists: Lists
     mutes: You mute
     storage: Media storage


### PR DESCRIPTION
Currently the page re-uses strings from other contexts which doesn't fit very well - strings incorrectly lowercase-d and pluralized, when they don't need to be, because it's a table.

This PR changes page to re-use `accounts.toots.other` directly, and `admin.accounts` for "Following" and "Follows". This should look more aesthetically pleasing.

I cannot set up local testing Mastodon instance, so please **carefully review the changes** or test them on your local instance. Thanks!