### PR TITLE
Use codeblock for native redirect URI

### DIFF
--- a/app/views/settings/applications/_fields.html.haml
+++ b/app/views/settings/applications/_fields.html.haml
@@ -7,7 +7,7 @@
 .fields-group
   = f.input :redirect_uri, wrapper: :with_block_label, label: t('activerecord.attributes.doorkeeper/application.redirect_uri'), hint: t('doorkeeper.applications.help.redirect_uri')
 
-  %p.hint= t('doorkeeper.applications.help.native_redirect_uri', native_redirect_uri: Doorkeeper.configuration.native_redirect_uri)
+  %p.hint= t('doorkeeper.applications.help.native_redirect_uri', native_redirect_uri: content_tag(:code, Doorkeeper.configuration.native_redirect_uri)).html_safe
 
 .field-group
   .input.with_block_label


### PR DESCRIPTION
This PR changes how `doorkeeper.applications.help.native_redirect_uri` string is being formatted, to use `<code>` tag for `native_redirect_uri` placeholder. This makes the URI look more distinguishable:

| How it looks now | How it supposed to look |
|:----------------:|:-----------------------:|
| ![Screenshot of actual page](https://user-images.githubusercontent.com/10401817/70395713-10298700-1a34-11ea-9933-27c88d5d481b.png) | ![Screenshot of page edited using developer tools](https://user-images.githubusercontent.com/10401817/70395714-11f34a80-1a34-11ea-93a7-b74e36cc6a60.png) |

This only changes how string is generated, so there is no need to change any of locale files.

Before merging, please **carefully review and test** this to ensure it works as expected. Thanks!