### PR TITLE
Avoid using pluralize on moderation pages

### DIFF
--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -28,7 +28,7 @@
     .report-card__profile
       = account_link_to target_account, '', size: 36, path: admin_account_path(target_account.id)
       .report-card__profile__stats
-        = link_to pluralize(target_account.targeted_moderation_notes.count, t('admin.reports.account.note')), admin_account_path(target_account.id)
+        = link_to t('admin.reports.account.notes', count: target_account.targeted_moderation_notes.count), admin_account_path(target_account.id)
         %br/
         - if target_account.suspended?
           %span.red= t('admin.accounts.suspended')

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -25,16 +25,16 @@
       %tr
         %th= t('admin.reports.reported_account')
         %td= admin_account_link_to @report.target_account
-        %td= table_link_to 'flag', pluralize(@report.target_account.targeted_reports.count, t('admin.reports.account.report')), admin_reports_path(target_account_id: @report.target_account.id)
-        %td= table_link_to 'file', pluralize(@report.target_account.targeted_moderation_notes.count, t('admin.reports.account.note')), admin_reports_path(target_account_id: @report.target_account.id)
+        %td= table_link_to 'flag', t('admin.reports.account.reports', count: @report.target_account.targeted_reports.count), admin_reports_path(target_account_id: @report.target_account.id)
+        %td= table_link_to 'file', t('admin.reports.account.notes', count: @report.target_account.targeted_moderation_notes.count), admin_reports_path(target_account_id: @report.target_account.id)
       %tr
         %th= t('admin.reports.reported_by')
         - if @report.account.instance_actor?
           %td{ colspan: 3 }= site_hostname
         - elsif @report.account.local?
           %td= admin_account_link_to @report.account
-          %td= table_link_to 'flag', pluralize(@report.account.targeted_reports.count, t('admin.reports.account.report')), admin_reports_path(target_account_id: @report.account.id)
-          %td= table_link_to 'file', pluralize(@report.account.targeted_moderation_notes.count, t('admin.reports.account.note')), admin_reports_path(target_account_id: @report.account.id)
+          %td= table_link_to 'flag', t('admin.reports.account.reports', count: @report.account.targeted_reports.count), admin_reports_path(target_account_id: @report.account.id)
+          %td= table_link_to 'file', t('admin.reports.account.notes', count: @report.account.targeted_moderation_notes.count), admin_reports_path(target_account_id: @report.account.id)
         - else
           %td{ colspan: 3 }= @report.account.domain
       %tr

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -399,9 +399,6 @@ ar:
       created_msg: تم إنشاء ملاحظة الشكوى بنجاح!
       destroyed_msg: تم حذف ملاحظة الشكوى بنجاح!
     reports:
-      account:
-        note: ملحوظة
-        report: تقرير
       action_taken_by: تم اتخاذ الإجراء مِن طرف
       are_you_sure: هل أنت متأكد ؟
       assign_to_self: عين لي

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -398,9 +398,6 @@ ca:
       created_msg: La nota del informe s'ha creat correctament!
       destroyed_msg: La nota del informe s'ha esborrat correctament!
     reports:
-      account:
-        note: nota
-        report: informe
       action_taken_by: Mesures adoptades per
       are_you_sure: N'estàs segur?
       assign_to_self: Assignar-me

--- a/config/locales/co.yml
+++ b/config/locales/co.yml
@@ -398,9 +398,6 @@ co:
       created_msg: Nota di signalamentu creata!
       destroyed_msg: Nota di signalamentu sguassata!
     reports:
-      account:
-        note: nota
-        report: palisà
       action_taken_by: Intervenzione di
       are_you_sure: Site sicuru·a?
       assign_to_self: Assignallu à mè

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -410,9 +410,6 @@ cs:
       created_msg: Poznámka o nahlášení úspěšně vytvořena!
       destroyed_msg: Poznámka o nahlášení úspěšně smazána!
     reports:
-      account:
-        note: poznámka
-        report: nahlášení
       action_taken_by: Akci vykonal/a
       are_you_sure: Jste si jistý/á?
       assign_to_self: Přidělit ke mně

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -419,9 +419,6 @@ cy:
       created_msg: Llwyddwyd i greu nodyn adroddiad!
       destroyed_msg: Llwyddwyd i ddileu nodyn adroddiad!
     reports:
-      account:
-        note: nodyn
-        report: adroddiad
       action_taken_by: Gwnaethpwyd hyn gan
       are_you_sure: Ydych chi'n sicr?
       assign_to_self: Aseinio i mi

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -333,9 +333,6 @@ da:
       created_msg: Anmeldelse note blev oprettet!
       destroyed_msg: Anmeldelse note blev slettet!
     reports:
-      account:
-        note: notat
-        report: anmeld
       action_taken_by: Handling udført af
       are_you_sure: Er du sikker?
       assign_to_self: Tildel til mig

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -396,9 +396,6 @@ de:
       created_msg: Meldungs-Kommentar erfolgreich erstellt!
       destroyed_msg: Meldungs-Kommentar erfolgreich gelöscht!
     reports:
-      account:
-        note: Notiz
-        report: Meldung
       action_taken_by: Maßnahme ergriffen durch
       are_you_sure: Bist du dir sicher?
       assign_to_self: Mir zuweisen

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -398,9 +398,6 @@ el:
       created_msg: Επιτυχής δημιουργία σημείωσης καταγγελίας!
       destroyed_msg: Επιτυχής διαγραφή σημείωσης καταγγελίας!
     reports:
-      account:
-        note: σημείωση
-        report: καταγγελία
       action_taken_by: Ενέργεια από τον/την
       are_you_sure: Σίγουρα;
       assign_to_self: Ανάθεση σε μένα

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,8 +400,12 @@ en:
       destroyed_msg: Report note successfully deleted!
     reports:
       account:
-        note: note
-        report: report
+        notes:
+          one: "%{count} note"
+          other: "%{count} notes"
+        reports:
+          one: "%{count} report"
+          other: "%{count} reports"
       action_taken_by: Action taken by
       are_you_sure: Are you sure?
       assign_to_self: Assign to me

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -348,9 +348,6 @@ en_GB:
       created_msg: Report note successfully created!
       destroyed_msg: Report note successfully deleted!
     reports:
-      account:
-        note: note
-        report: report
       action_taken_by: Action taken by
       are_you_sure: Are you sure?
       assign_to_self: Assign to me

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -380,9 +380,6 @@ eo:
       created_msg: Signala noto sukcese kreita!
       destroyed_msg: Signala noto sukcese forigita!
     reports:
-      account:
-        note: noto
-        report: signalo
       action_taken_by: Ago farita de
       are_you_sure: Ĉu vi certas?
       assign_to_self: Asigni al mi

--- a/config/locales/es-AR.yml
+++ b/config/locales/es-AR.yml
@@ -395,9 +395,6 @@ es-AR:
       created_msg: "¡La nota de denuncia fue creada exitosamente!"
       destroyed_msg: "¡La nota de denuncia fue eliminada exitosamente!"
     reports:
-      account:
-        note: nota
-        report: denuncia
       action_taken_by: Acción tomada por
       are_you_sure: "¿Estás seguro?"
       assign_to_self: Asignármela a mí

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -398,9 +398,6 @@ es:
       created_msg: "¡El registro de la denuncia se ha creado correctamente!"
       destroyed_msg: "¡El registro de la denuncia se ha borrado correctamente!"
     reports:
-      account:
-        note: nota
-        report: denuncia
       action_taken_by: Acción tomada por
       are_you_sure: "¿Estás seguro?"
       assign_to_self: Asignármela a mí

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -401,9 +401,6 @@ et:
       created_msg: Teade edukalt koostatud!
       destroyed_msg: Teade edukalt kustutatud!
     reports:
-      account:
-        note: märkus
-        report: teavita
       action_taken_by: Meetmeid kasutanud
       are_you_sure: Olete kindel?
       assign_to_self: Määra mulle

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -398,9 +398,6 @@ eu:
       created_msg: Salaketa oharra ongi sortu da!
       destroyed_msg: Salaketa oharra ongi ezabatu da!
     reports:
-      account:
-        note: oharra
-        report: salaketa
       action_taken_by: Neurrien hartzailea
       are_you_sure: Ziur zaude?
       assign_to_self: Esleitu niri

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -396,9 +396,6 @@ fa:
       created_msg: یادداشت گزارش با موفقیت ساخته شد!
       destroyed_msg: یادداشت گزارش با موفقیت حذف شد!
     reports:
-      account:
-        note: یادداشت
-        report: گزارش
       action_taken_by: انجام‌دهنده
       are_you_sure: آیا مطمئن هستید؟
       assign_to_self: به عهدهٔ من بگذار

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -270,9 +270,6 @@ fi:
       created_msg: Muistiinpano onnistuneesti lisätty raporttiin!
       destroyed_msg: Muistiinpano onnistuneesti poistettu raportista!
     reports:
-      account:
-        note: muistiinpano
-        report: raportti
       action_taken_by: Toimenpiteen tekijä
       are_you_sure: Oletko varma?
       assign_to_self: Ota tehtäväksi

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -398,9 +398,6 @@ fr:
       created_msg: Note de signalement créée avec succès !
       destroyed_msg: Note de signalement effacée avec succès !
     reports:
-      account:
-        note: note
-        report: signalement(s)
       action_taken_by: Intervention de
       are_you_sure: Êtes vous certain⋅e ?
       assign_to_self: Me l’assigner

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -396,9 +396,6 @@ gl:
       created_msg: Creouse correctamente a nota do informe!
       destroyed_msg: Nota do informe eliminouse con éxito!
     reports:
-      account:
-        note: nota
-        report: informe
       action_taken_by: Acción tomada por
       are_you_sure: Está segura?
       assign_to_self: Asignarmo

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -400,9 +400,6 @@ hu:
       created_msg: Bejelentési feljegyzés létrehozva!
       destroyed_msg: Bejelentési feljegyzés törölve!
     reports:
-      account:
-        note: feljegyzés
-        report: bejelentés
       action_taken_by: 'Kezelte:'
       are_you_sure: Biztos vagy benne?
       assign_to_self: Magamhoz rendelés

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -391,9 +391,6 @@ id:
       created_msg: Catatan laporan berhasil dibuat!
       destroyed_msg: Catatan laporan berhasil dihapus!
     reports:
-      account:
-        note: catatan
-        report: lapor
       action_taken_by: Aksi dilakukan oleh
       are_you_sure: Apakah Anda yakin?
       assign_to_self: Tugaskan kpd saya

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -394,9 +394,6 @@ it:
       created_msg: Nota rapporto creata!
       destroyed_msg: Nota rapporto cancellata!
     reports:
-      account:
-        note: note
-        report: rapporto
       action_taken_by: Azione intrapresa da
       are_you_sure: Sei sicuro?
       assign_to_self: Assegna a me

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -392,9 +392,6 @@ ja:
       created_msg: 通報メモを書き込みました！
       destroyed_msg: 通報メモを削除しました！
     reports:
-      account:
-        note: メモ
-        report: 通報
       action_taken_by: 通報処理者
       are_you_sure: 本当に実行しますか？
       assign_to_self: 担当になる

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -267,9 +267,6 @@ ka:
       created_msg: რეპორტის ჩანაწერი წარმატებით შეიქმნა!
       destroyed_msg: რეპორტის ჩანაწერი წარმატებით გაუქმდა!
     reports:
-      account:
-        note: ჩანაწერი
-        report: რეპორტი
       action_taken_by: მოქმედება შეასრულა
       are_you_sure: დარწმუნებული ხარ?
       assign_to_self: დანიშნე ჩემზე

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -398,9 +398,6 @@ kk:
       created_msg: Шағым жазбасы сәтті құрылды!
       destroyed_msg: Шағым жазбасы сәтті өшірілді!
     reports:
-      account:
-        note: жазба
-        report: шағым
       action_taken_by: Белсенділік жасаған
       are_you_sure: Шынымен бе?
       assign_to_self: Мені тағайындау

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -392,9 +392,6 @@ ko:
       created_msg: 리포트 노트가 성공적으로 작성되었습니다!
       destroyed_msg: 리포트 노트가 성공적으로 삭제되었습니다!
     reports:
-      account:
-        note: 노트
-        report: 리포트
       action_taken_by: 신고 처리자
       are_you_sure: 정말로 실행하시겠습니까?
       assign_to_self: 나에게 할당하기

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -309,9 +309,6 @@ lt:
       created_msg: Skundo žinutė sekmingai sukurta!
       destroyed_msg: Skundo žinutė sekmingai ištrinta!
     reports:
-      account:
-        note: raštelis
-        report: skundas
       action_taken_by: Veiksmo ėmėsi
       are_you_sure: Ar tu įsitikinęs?
       assign_to_self: Paskirti man

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -276,9 +276,6 @@ ms:
       created_msg: Nota laporan berjaya dicipta!
       destroyed_msg: Nota laporan berjaya dipadam!
     reports:
-      account:
-        note: nota
-        report: laporan
       action_taken_by: Tindakan oleh
       are_you_sure: Anda pasti?
       assign_to_self: Berikan pada saya

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -396,9 +396,6 @@ nl:
       created_msg: Opmerking bij rapportage succesvol aangemaakt!
       destroyed_msg: Opmerking bij rapportage succesvol verwijderd!
     reports:
-      account:
-        note: opmerking
-        report: rapportage
       action_taken_by: Actie uitgevoerd door
       are_you_sure: Weet je het zeker?
       assign_to_self: Aan mij toewijzen

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -383,9 +383,6 @@ oc:
       created_msg: Nòta de moderacion corrèctament creada !
       destroyed_msg: Nòta de moderacion corrèctament suprimida !
     reports:
-      account:
-        note: nòta
-        report: rapòrt
       action_taken_by: Mesura menada per
       are_you_sure: Es segur ?
       assign_to_self: Me l’assignar

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -403,9 +403,6 @@ pl:
       created_msg: Pomyslnie utworzono notatkę moderacyjną.
       destroyed_msg: Pomyślnie usunięto notatkę moderacyjną.
     reports:
-      account:
-        note: notatka
-        report: zgłoszenie
       action_taken_by: Działanie podjęte przez
       are_you_sure: Czy na pewno?
       assign_to_self: Przypisz do siebie

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -368,9 +368,6 @@ pt-BR:
       created_msg: Nota de denúncia criada com sucesso!
       destroyed_msg: Nota de denúncia excluída com sucesso!
     reports:
-      account:
-        note: nota
-        report: denúncia
       action_taken_by: Ação realizada por
       are_you_sure: Você tem certeza?
       assign_to_self: Designar para mim

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -346,9 +346,6 @@ pt-PT:
       created_msg: Relatório criado com sucesso!
       destroyed_msg: Relatório apagado com sucesso!
     reports:
-      account:
-        note: nota
-        report: relatório
       action_taken_by: Ação tomada por
       are_you_sure: Tens a certeza?
       assign_to_self: Atribuí-me a mim

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -410,9 +410,6 @@ ru:
       created_msg: Примечание жалобы создано!
       destroyed_msg: Примечание жалобы удалено!
     reports:
-      account:
-        note: заметок
-        report: жалоб
       action_taken_by: 'Действие предпринято:'
       are_you_sure: Вы уверены?
       assign_to_self: Назначить себе

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -403,9 +403,6 @@ sk:
       created_msg: Poznámka o nahlásení úspešne vytvorená!
       destroyed_msg: Poznámka o nahlásení úspešne vymazaná!
     reports:
-      account:
-        note: poznámka
-        report: nahlás
       action_taken_by: Zákrok vykonal/a
       are_you_sure: Si si istý/á?
       assign_to_self: Priraď sebe

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -375,9 +375,6 @@ sl:
       created_msg: Opomba o prijavi je uspešno ustvarjena!
       destroyed_msg: Opomba o prijavi je uspešno izbrisana!
     reports:
-      account:
-        note: opomba
-        report: prijava
       action_taken_by: Dejanje, ki ga je sprejel
       are_you_sure: Ali ste prepričani?
       assign_to_self: Dodeli meni

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -315,9 +315,6 @@ sq:
       created_msg: Shënimi i raportimit u krijua me sukses!
       destroyed_msg: Shënimi i raportimit u fshi me sukses!
     reports:
-      account:
-        note: shënim
-        report: raportojeni
       action_taken_by: Veprimi i ndërmarrë nga
       are_you_sure: A jeni i sigurt?
       assign_to_self: Caktojani vetes

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -330,9 +330,6 @@ sr:
       created_msg: Белешка пријаве успешно направљена!
       destroyed_msg: Белешка пријаве успешно избрисана!
     reports:
-      account:
-        note: белешка
-        report: извештај
       action_taken_by: Акцију извео
       are_you_sure: Да ли сте сигурни?
       assign_to_self: Додели мени

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -318,9 +318,6 @@ sv:
       created_msg: Anmälningsanteckning har skapats!
       destroyed_msg: Anmälningsanteckning har raderats!
     reports:
-      account:
-        note: anteckning
-        report: anmälan
       action_taken_by: Åtgärder vidtagna av
       are_you_sure: Är du säker?
       assign_to_self: Tilldela till mig

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -310,9 +310,6 @@ th:
       created_msg: สร้างหมายเหตุรายงานสำเร็จ!
       destroyed_msg: ลบหมายเหตุรายงานสำเร็จ!
     reports:
-      account:
-        note: หมายเหตุ
-        report: รายงาน
       are_you_sure: คุณแน่ใจหรือไม่?
       assign_to_self: มอบหมายให้ฉัน
       assigned: ผู้ควบคุมที่ได้รับมอบหมาย

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -398,9 +398,6 @@ tr:
       created_msg: Şikayet notu başarıyla oluşturuldu!
       destroyed_msg: Şikayet notu başarıyla silindi!
     reports:
-      account:
-        note: not
-        report: şikayet
       action_taken_by: tarafından gerçekleştirilen eylem
       are_you_sure: Emin misiniz?
       assign_to_self: Bana ata

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -400,9 +400,6 @@ uk:
       created_msg: Скарга успішно створена!
       destroyed_msg: Скарга успішно видалена!
     reports:
-      account:
-        note: нотатка
-        report: скарга
       action_taken_by: Дія виконана
       are_you_sure: Ви впевнені?
       assign_to_self: Призначити мені

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -384,9 +384,6 @@ zh-CN:
       created_msg: 举报记录建立成功！
       destroyed_msg: 举报记录删除成功！
     reports:
-      account:
-        note: 条记录
-        report: 条举报
       action_taken_by: 操作执行者
       are_you_sure: 你确定吗？
       assign_to_self: 接管

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -233,9 +233,6 @@ zh-HK:
       created_msg: 舉報筆記已建立。
       destroyed_msg: 舉報筆記已刪除。
     reports:
-      account:
-        note: 筆記
-        report: 舉報
       action_taken_by: 操作執行者
       are_you_sure: 你確認嗎？
       assign_to_self: 指派給自己

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -323,9 +323,6 @@ zh-TW:
       created_msg: 檢舉記錄建立成功!
       destroyed_msg: 檢舉記錄刪除成功!
     reports:
-      account:
-        note: 條記錄
-        report: 條檢舉
       action_taken_by: 操作執行者
       are_you_sure: 你確定嗎?
       assign_to_self: 指派給自己


### PR DESCRIPTION
Pluralize function from Rails framework does not work with other languages than English, moreover it does not even work properly with English <sup>**[\[1\]][note_1]**</sup>. Not that the latest applies to this context, it's just a sign that we best to avoid this function, especially when there are more reliable ways.

This PR changes how reports pages generated in order to avoid usage of pluralize function, replacing it with default translation function, called with given counter. On top of that, we have to make strings pluralize-able, so have to change locale files.

[note_1]: https://medium.com/@anna7/b3927de2ca8e#6a60

<p align="center"><img src="https://user-images.githubusercontent.com/10401817/70447554-787a7600-1ad1-11ea-8474-07dcbf7a302d.png" alt="Screenshot of report page, showing notes and reports counters for both reporter and reported user"></p>
