### PR TITLE
Fix invalid votes from the API being accepted

### DIFF
--- a/app/services/vote_service.rb
+++ b/app/services/vote_service.rb
@@ -20,7 +20,7 @@ class VoteService < BaseService
 
         ApplicationRecord.transaction do
           @choices.each do |choice|
-            @votes << @poll.votes.create!(account: @account, choice: choice)
+            @votes << @poll.votes.create!(account: @account, choice: Integer(choice))
           end
         end
       else

--- a/app/validators/vote_validator.rb
+++ b/app/validators/vote_validator.rb
@@ -16,6 +16,6 @@ class VoteValidator < ActiveModel::Validator
   private
 
   def invalid_choice?(vote)
-    vote.choice < 0 || vote.choice >= vote.poll.options.size
+    vote.choice.negative? || vote.choice >= vote.poll.options.size
   end
 end

--- a/app/validators/vote_validator.rb
+++ b/app/validators/vote_validator.rb
@@ -4,10 +4,18 @@ class VoteValidator < ActiveModel::Validator
   def validate(vote)
     vote.errors.add(:base, I18n.t('polls.errors.expired')) if vote.poll.expired?
 
+    vote.errors.add(:base, I18n.t('polls.errors.invalid_choice')) if invalid_choice?(vote)
+
     if vote.poll.multiple? && vote.poll.votes.where(account: vote.account, choice: vote.choice).exists?
       vote.errors.add(:base, I18n.t('polls.errors.already_voted'))
     elsif !vote.poll.multiple? && vote.poll.votes.where(account: vote.account).exists?
       vote.errors.add(:base, I18n.t('polls.errors.already_voted'))
     end
+  end
+
+  private
+
+  def invalid_choice?(vote)
+    vote.choice < 0 || vote.choice >= vote.poll.options.size
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -916,6 +916,7 @@ en:
       duration_too_long: is too far into the future
       duration_too_short: is too soon
       expired: The poll has already ended
+      invalid_choice: The chosen vote option does not exist
       over_character_limit: cannot be longer than %{max} characters each
       too_few_options: must have more than one item
       too_many_options: can't contain more than %{max} items


### PR DESCRIPTION
Fixes #12556

- Ensure `choice` is an integer instead of silently converting to 0
- Ensure `choice` corresponds to an actual choice of the poll