### PR TITLE
Ignore development specific env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ public/packs
 public/packs-test
 .env
 .env.production
+.env.development
 node_modules/
 build/
 


### PR DESCRIPTION
Developers will often use a `.env.development` as adviced in [dotenv loading order](https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use). 

To avoid accidentally committing keys or other secrets, this should probably be ignored by default.

This PR does that.