### PR TITLE
Improve report page structure

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -181,18 +181,39 @@ $content-width: 840px;
       padding-top: 30px;
     }
 
+    &-heading {
+      display: flex;
+
+      padding-bottom: 40px;
+      border-bottom: 1px solid lighten($ui-base-color, 8%);
+      margin-bottom: 40px;
+
+      flex-wrap: wrap;
+      align-items: center;
+
+      justify-content: space-between;
+
+      &-actions {
+        display: inline-flex;
+
+        & > * {
+          margin-left: 5px;
+        }
+      }
+
+      @media screen and (max-width: $no-columns-breakpoint) {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+    }
+
     h2 {
       color: $secondary-text-color;
       font-size: 24px;
       line-height: 28px;
       font-weight: 400;
-      padding-bottom: 40px;
-      border-bottom: 1px solid lighten($ui-base-color, 8%);
-      margin-bottom: 40px;
 
       @media screen and (max-width: $no-columns-breakpoint) {
-        border-bottom: 0;
-        padding-bottom: 0;
         font-weight: 700;
       }
     }

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -10,17 +10,6 @@
   - else
     = link_to t('admin.reports.mark_as_unresolved'), reopen_admin_report_path(@report), method: :post, class: 'button'
 
-%div{ style: 'overflow: hidden; margin-bottom: 20px' }
-  - if @report.unresolved?
-    %div{ style: 'float: right' }
-      - if @report.target_account.local?
-        = link_to t('admin.accounts.warn'), new_admin_account_action_path(@report.target_account_id, type: 'none', report_id: @report.id), class: 'button'
-        = link_to t('admin.accounts.disable'), new_admin_account_action_path(@report.target_account_id, type: 'disable', report_id: @report.id), class: 'button button--destructive'
-      = link_to t('admin.accounts.silence'), new_admin_account_action_path(@report.target_account_id, type: 'silence', report_id: @report.id), class: 'button button--destructive'
-      = link_to t('admin.accounts.perform_full_suspension'), new_admin_account_action_path(@report.target_account_id, type: 'suspend', report_id: @report.id), class: 'button button--destructive'
-
-%hr.spacer
-
 .table-wrapper
   %table.table.inline-table
     %tbody
@@ -76,6 +65,17 @@
           %td
             - if !@report.assigned_account.nil?
               = table_link_to 'trash', t('admin.reports.unassign'), unassign_admin_report_path(@report), method: :post
+
+%hr.spacer
+
+%div{ style: 'overflow: hidden; margin-bottom: 20px; clear: both' }
+  - if @report.unresolved?
+    %div{ style: 'float: right' }
+      - if @report.target_account.local?
+        = link_to t('admin.accounts.warn'), new_admin_account_action_path(@report.target_account_id, type: 'none', report_id: @report.id), class: 'button'
+        = link_to t('admin.accounts.disable'), new_admin_account_action_path(@report.target_account_id, type: 'disable', report_id: @report.id), class: 'button button--destructive'
+      = link_to t('admin.accounts.silence'), new_admin_account_action_path(@report.target_account_id, type: 'silence', report_id: @report.id), class: 'button button--destructive'
+      = link_to t('admin.accounts.perform_full_suspension'), new_admin_account_action_path(@report.target_account_id, type: 'suspend', report_id: @report.id), class: 'button button--destructive'
 
 %hr.spacer
 

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -4,6 +4,12 @@
 - content_for :page_title do
   = t('admin.reports.report', id: @report.id)
 
+- content_for :page_heading_actions do
+  - if @report.unresolved?
+    = link_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(@report), method: :post, class: 'button'
+  - else
+    = link_to t('admin.reports.mark_as_unresolved'), reopen_admin_report_path(@report), method: :post, class: 'button'
+
 %div{ style: 'overflow: hidden; margin-bottom: 20px' }
   - if @report.unresolved?
     %div{ style: 'float: right' }
@@ -12,10 +18,6 @@
         = link_to t('admin.accounts.disable'), new_admin_account_action_path(@report.target_account_id, type: 'disable', report_id: @report.id), class: 'button button--destructive'
       = link_to t('admin.accounts.silence'), new_admin_account_action_path(@report.target_account_id, type: 'silence', report_id: @report.id), class: 'button button--destructive'
       = link_to t('admin.accounts.perform_full_suspension'), new_admin_account_action_path(@report.target_account_id, type: 'suspend', report_id: @report.id), class: 'button button--destructive'
-    %div{ style: 'float: left' }
-      = link_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(@report), method: :post, class: 'button'
-  - else
-    = link_to t('admin.reports.mark_as_unresolved'), reopen_admin_report_path(@report), method: :post, class: 'button'
 
 %hr.spacer
 

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -21,7 +21,12 @@
 
     .content-wrapper
       .content
-        %h2= yield :page_title
+        .content-heading
+          %h2= yield :page_title
+
+          - if :page_heading_actions
+            .content-heading-actions
+              = yield :page_heading_actions
 
         = render 'application/flashes'
 


### PR DESCRIPTION
This PR is dedicated to slightly improve report page structure. In overall, it:

- **Moves "Mark as resolved" button to the heading of the page**
   <details>
   <summary>Commit description</summary>
   This is one of the commits on improving overall reports page structure It changes where resolved button is located, moving it to the heading, right next to the "Report #n" header, so-called "hot-place" to look at. <br><br>
  
   To accomplish this we have to declare one more content variable, change admin dashboard template to respect it and CSS files for minor styling, so buttons are inlined and centrally aligned according to the heading.
  </details>

- **Moves actions buttons below the report table**
   <details>
   <summary>Commit description</summary>
   I believe that actions to react on report should not be located at the top of the page, instead they should be either after the table or reporter's comment. This is just a logical sign that you should not react to the report without reading all the details first.
  </details>

| Visually, with changes it looks like this: |
|:----------:|
| ![Screenshot of the page](https://user-images.githubusercontent.com/10401817/70856857-93584a80-1f16-11ea-8f69-01ce5ac1c772.png) |


