### PR TITLE
Include capistrano tasks that reload the services after deploying.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,3 +12,21 @@ set :migration_role, :app
 
 append :linked_files, '.env.production', 'public/robots.txt'
 append :linked_dirs, 'vendor/bundle', 'node_modules', 'public/system'
+
+namespace :systemd do
+  %i[sidekiq streaming web].each do |service|
+    %i[reload restart status].each do |action|
+      desc "Perform a #{action} on #{service} service"
+      task "#{service}:#{action}".to_sym do
+        on roles(:app) do
+          # runs e.g. "sudo restart mastodon-sidekiq.service"
+          sudo :systemctl, action, "#{fetch(:application)}-#{service}.service"
+        end
+      end
+    end
+  end
+end
+
+after 'deploy:publishing', 'systemd:web:reload'
+after 'deploy:publishing', 'systemd:sidekiq:restart'
+after 'deploy:publishing', 'systemd:streaming:restart'


### PR DESCRIPTION
After a successfull deploy, I need the services to switch over to use the
new code. I need to (re)start the services. Also, often, I need to inspect whether the services are running or why they crashed.

The capistrano tasks in this PR do that.

I'm not certain whether this is useful to mastodon at all. 

1. It requires the server to be set up using these services AND
2. Requires the "deploy" user to be allowed to run those commands with passwordless sudo.

Please let me know what you think about this PR. Is it useful to Mastodon? Would it be useful if I make some changes? Or should it simply be closed?

It might be more appropriate in the specific environment-deploy files for example: `config/deploy/production.rb`. Otherwise, I probably need to add documentation (but where?) and a PR in the ansible-repo to set this up properly.

On my server, using ansible, I configure the deploy user to be allowed to restart services. Without such a configuration, the deploy will fail with this setup.

    - name: "Allow deploy-user to reload the services"
      lineinfile:
        dest: /etc/sudoers
        state: present
        line: "%{{ deploy_user }} ALL=NOPASSWD: /bin/systemctl reload {{ item }}.service"
        validate: 'visudo -cf %s'
      with_items:
        - mastodon-web
        - mastodon-streaming
        - mastodon-sidekiq

    - name: "Allow deploy-user to check the service"
      lineinfile:
        dest: /etc/sudoers
        state: present
        line: "%{{  deploy_user }} ALL=NOPASSWD: /bin/systemctl status {{ item }}.service"
        validate: 'visudo -cf %s'
      with_items:
        - mastodon-web
        - mastodon-streaming
        - mastodon-sidekiq


EDIT: additional detail, is that it depends on the service and its setup whether it can be reloaded.  I have set up my units on my server such that they can be reloaded but with the service-examples in `/dist` of this repo, for example, Sidekiq cannot be reloaded, only restarted.