### PR TITLE
Fix custom emoji category creation silently erroring out on duplicate category

### DIFF
--- a/app/models/form/custom_emoji_batch.rb
+++ b/app/models/form/custom_emoji_batch.rb
@@ -40,7 +40,7 @@ class Form::CustomEmojiBatch
       if category_id.present?
         CustomEmojiCategory.find(category_id)
       elsif category_name.present?
-        CustomEmojiCategory.create!(name: category_name)
+        CustomEmojiCategory.find_or_create_by!(name: category_name)
       end
     end
 


### PR DESCRIPTION
I decided to *not* error out, and instead, just re-use the existing category if any. I think this is more helpful this way, and it is also easier to write.

Fixes #12608