### PR TITLE
Fix manual scrolling issue on Firefox/Windows

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2512,7 +2512,6 @@ a.account__display-name {
   overflow-x: hidden;
   flex: 1 1 auto;
   -webkit-overflow-scrolling: touch;
-  will-change: transform; // improves perf in mobile Chrome
 
   &.optionally-scrollable {
     overflow-y: auto;


### PR DESCRIPTION
Fixes #12607

`will-change: transform` apparently makes manual scrolling impossible on
Firefox/Windows. While this should probably be considered a Firefox bug,
`will-change: transform` seem like a very aggressive performance hint that
may possibly make the browser consume more resources than needed, especially
in multiple-column mode.

This was originally added to improve scrolling performances on mobile, but
I think this isn't necessary anymore, because of the two following reasons:
- `contain: paint` (which is implied by `contain: strict`, which we apply
  whenever the browser supports grids) should have similar effects
- in single-column mode, the scrolling container is the root element, which
  I believe is optimized in at least Chromium

Keep in mind that I have not been able to make in-depth benchmarks, and
especially not been able to try on mobile, so performances should probably
be investigated further…