### PR TITLE
Fix typo in login feature-test.

### DIFF
--- a/spec/features/log_in_spec.rb
+++ b/spec/features/log_in_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Log in" do
-  given(:email)        { "test@examle.com" }
+  given(:email)        { "test@example.com" }
   given(:password)     { "password" }
   given(:confirmed_at) { Time.zone.now }
 


### PR DESCRIPTION
Tiny typo in the domain-name in tests.

It did not fail because of this, nothing changes other than the string itself.