### PR TITLE
Fix an error when ActivityPub::FetchRemoteStatusService url is called…

### DIFF
--- a/app/services/fetch_remote_status_service.rb
+++ b/app/services/fetch_remote_status_service.rb
@@ -9,6 +9,6 @@ class FetchRemoteStatusService < BaseService
       resource_options = { prefetched_body: prefetched_body }
     end
 
-    ActivityPub::FetchRemoteStatusService.new.call(resource_url, **resource_options)
+    ActivityPub::FetchRemoteStatusService.new.call(resource_url, **resource_options) unless resource_url.nil?
   end
 end


### PR DESCRIPTION
Fix an error when ActivityPub::FetchRemoteStatusService url is called with nil.

This is the fix for #12173.