### PR TITLE
Fix sample SAML_ACS_URL, SAML_ISSUER

### DIFF
--- a/.env.nanobox
+++ b/.env.nanobox
@@ -231,8 +231,8 @@ SMTP_FROM_ADDRESS=notifications@${APP_NAME}.nanoapp.io
 
 # Optional SAML authentication (cf. omniauth-saml)
 # SAML_ENABLED=true
-# SAML_ACS_URL=
-# SAML_ISSUER=http://localhost:3000/auth/auth/saml/callback
+# SAML_ACS_URL=http://localhost:3000/auth/auth/saml/callback
+# SAML_ISSUER=https://example.com
 # SAML_IDP_SSO_TARGET_URL=https://idp.testshib.org/idp/profile/SAML2/Redirect/SSO
 # SAML_IDP_CERT=
 # SAML_IDP_CERT_FINGERPRINT=

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -226,8 +226,8 @@ STREAMING_CLUSTER_NUM=1
 
 # Optional SAML authentication (cf. omniauth-saml)
 # SAML_ENABLED=true
-# SAML_ACS_URL=
-# SAML_ISSUER=http://localhost:3000/auth/auth/saml/callback
+# SAML_ACS_URL=http://localhost:3000/auth/auth/saml/callback
+# SAML_ISSUER=https://example.com
 # SAML_IDP_SSO_TARGET_URL=https://idp.testshib.org/idp/profile/SAML2/Redirect/SSO
 # SAML_IDP_CERT=
 # SAML_IDP_CERT_FINGERPRINT=


### PR DESCRIPTION
The values of SAML_ACS and SAML_ISSUER in the sample .env file are strange.

"http://localhost:3000/auth/auth/saml/callback" should be written as a sample value for SAML_ACS.

In addition, since SAML_ISSUER is a unique value representing the service provider, it is better to enter a domain name unless otherwise specified by IdP.

When actually setting up SAML, the user needs to overwrite it, so it gets confused if strange values are listed.
Thankyou!