### PR TITLE
Fix old migrations failing because of strong_migrations update

### DIFF
--- a/db/migrate/20170711225116_fix_null_booleans.rb
+++ b/db/migrate/20170711225116_fix_null_booleans.rb
@@ -1,17 +1,19 @@
 class FixNullBooleans < ActiveRecord::Migration[5.1]
   def change
-    change_column_default :domain_blocks, :reject_media, false
-    change_column_null :domain_blocks, :reject_media, false, false
+    safety_assured do
+      change_column_default :domain_blocks, :reject_media, false
+      change_column_null :domain_blocks, :reject_media, false, false
 
-    change_column_default :imports, :approved, false
-    change_column_null :imports, :approved, false, false
+      change_column_default :imports, :approved, false
+      change_column_null :imports, :approved, false, false
 
-    change_column_null :statuses, :sensitive, false, false
-    change_column_null :statuses, :reply, false, false
+      change_column_null :statuses, :sensitive, false, false
+      change_column_null :statuses, :reply, false, false
 
-    change_column_null :users, :admin, false, false
+      change_column_null :users, :admin, false, false
 
-    change_column_default :users, :otp_required_for_login, false
-    change_column_null :users, :otp_required_for_login, false, false
+      change_column_default :users, :otp_required_for_login, false
+      change_column_null :users, :otp_required_for_login, false, false
+    end
   end
 end

--- a/db/migrate/20171010025614_change_accounts_nonnullable_in_account_moderation_notes.rb
+++ b/db/migrate/20171010025614_change_accounts_nonnullable_in_account_moderation_notes.rb
@@ -1,6 +1,8 @@
 class ChangeAccountsNonnullableInAccountModerationNotes < ActiveRecord::Migration[5.1]
   def change
-    change_column_null :account_moderation_notes, :account_id, false
-    change_column_null :account_moderation_notes, :target_account_id, false
+    safety_assured do
+      change_column_null :account_moderation_notes, :account_id, false
+      change_column_null :account_moderation_notes, :target_account_id, false
+    end
   end
 end

--- a/db/migrate/20171201000000_change_account_id_nonnullable_in_lists.rb
+++ b/db/migrate/20171201000000_change_account_id_nonnullable_in_lists.rb
@@ -1,5 +1,7 @@
 class ChangeAccountIdNonnullableInLists < ActiveRecord::Migration[5.1]
   def change
-    change_column_null :lists, :account_id, false
+    safety_assured do
+      change_column_null :lists, :account_id, false
+    end
   end
 end

--- a/db/migrate/20180310000000_change_columns_in_notifications_nonnullable.rb
+++ b/db/migrate/20180310000000_change_columns_in_notifications_nonnullable.rb
@@ -1,8 +1,10 @@
 class ChangeColumnsInNotificationsNonnullable < ActiveRecord::Migration[5.1]
   def change
-    change_column_null :notifications, :activity_id, false
-    change_column_null :notifications, :activity_type, false
-    change_column_null :notifications, :account_id, false
-    change_column_null :notifications, :from_account_id, false
+    safety_assured do
+      change_column_null :notifications, :activity_id, false
+      change_column_null :notifications, :activity_type, false
+      change_column_null :notifications, :account_id, false
+      change_column_null :notifications, :from_account_id, false
+    end
   end
 end


### PR DESCRIPTION
Fixes #12690

The `strong_migrations` update from ba2eac8824a85aa9541f8070ed7bcd22b9982cc8
introduced a check for `change_column_null` specific to Postgres. This rejects
old migrations.

This commit just wraps old migrations with `safety_assured` to bypass this
check. Alternatives would have been to:
- Disable that check entirely (a possibility added in that same
  `strong_migrations` version) for Mastodon, but it makes sense to write new
  migrations without such a strong lock.
- Rewrite the old migrations to do it in a way that do not require an exclusive
  lock. I thought fixing those old migrations for performance wasn't worth the
  pain. Also, if I understand correctly, the next version of
  `strong_migrations` is going to include a helper to do that. We could update
  those migrations at that point.