### PR TITLE
Circleci - Upgrade to Buster images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 aliases:
   - &defaults
     docker:
-      - image: circleci/ruby:2.6-stretch-node
+      - image: circleci/ruby:2.6-buster-node
         environment: &ruby_environment
           BUNDLE_APP_CONFIG: ./.bundle/
           DB_HOST: localhost
@@ -105,14 +105,14 @@ jobs:
   install-ruby2.5:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.5-stretch-node
+      - image: circleci/ruby:2.5-buster-node
         environment: *ruby_environment
     <<: *install_ruby_dependencies
 
   install-ruby2.4:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.4-stretch-node
+      - image: circleci/ruby:2.4-buster-node
         environment: *ruby_environment
     <<: *install_ruby_dependencies
 
@@ -131,7 +131,7 @@ jobs:
   test-ruby2.6:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.6-stretch-node
+      - image: circleci/ruby:2.6-buster-node
         environment: *ruby_environment
       - image: circleci/postgres:10.6-alpine
         environment:
@@ -142,7 +142,7 @@ jobs:
   test-ruby2.5:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.5-stretch-node
+      - image: circleci/ruby:2.5-buster-node
         environment: *ruby_environment
       - image: circleci/postgres:10.6-alpine
         environment:
@@ -153,7 +153,7 @@ jobs:
   test-ruby2.4:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.4-stretch-node
+      - image: circleci/ruby:2.4-buster-node
         environment: *ruby_environment
       - image: circleci/postgres:10.6-alpine
         environment:
@@ -164,7 +164,7 @@ jobs:
   test-webui:
     <<: *defaults
     docker:
-      - image: circleci/node:12.9-stretch
+      - image: circleci/node:12.14-buster
     steps:
       - *attach_workspace
       - run: ./bin/retry yarn test:jest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
         name: Install system dependencies
         command: |
           sudo apt-get update
-          sudo apt-get install -y libicu-dev libidn11-dev libprotobuf-dev protobuf-compiler
+          sudo apt-get install -y libicu63 libicu-dev libidn11-dev libprotobuf-dev protobuf-compiler
 
   - &install_ruby_dependencies
       steps:
@@ -67,7 +67,6 @@ aliases:
 
         - run: ruby -e 'puts RUBY_VERSION' | tee /tmp/.ruby-version
         - *restore_ruby_dependencies
-        - run: bundle config build.charlock_holmes --with-icu-dir=/usr/local
         - run: bundle install --clean --jobs 16 --path ./vendor/bundle/ --retry 3 --with pam_authentication --without development production && bundle clean
         - save_cache:
             key: v2-ruby-dependencies-{{ checksum "/tmp/.ruby-version" }}-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
         name: Install system dependencies
         command: |
           sudo apt-get update
-          sudo apt-get install -y libicu63 libicu-dev libidn11-dev libprotobuf-dev protobuf-compiler
+          sudo apt-get install -y libicu-dev libidn11-dev libprotobuf-dev protobuf-compiler
 
   - &install_ruby_dependencies
       steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ aliases:
 
         - run: ruby -e 'puts RUBY_VERSION' | tee /tmp/.ruby-version
         - *restore_ruby_dependencies
+        - run: bundle config build.charlock_holmes --with-icu-dir=/usr/local
         - run: bundle install --clean --jobs 16 --path ./vendor/bundle/ --retry 3 --with pam_authentication --without development production && bundle clean
         - save_cache:
             key: v2-ruby-dependencies-{{ checksum "/tmp/.ruby-version" }}-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
The upcoming Ruby 2.7 Docker image and thus CircleCi images seem to only built with Buster.

This is to prepare for the other version upgrades related to dropping Ruby 2.4 in the future.