### PR TITLE
Circleci - Upgrade to Buster Images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 aliases:
   - &defaults
     docker:
-      - image: circleci/ruby:2.6-stretch-node
+      - image: circleci/ruby:2.6-buster-node
         environment: &ruby_environment
           BUNDLE_APP_CONFIG: ./.bundle/
           DB_HOST: localhost
@@ -39,7 +39,6 @@ aliases:
     steps:
       - checkout
       - *attach_workspace
-
       - restore_cache:
           keys:
             - v1-node-dependencies-{{ checksum "yarn.lock" }}
@@ -49,7 +48,6 @@ aliases:
           key: v1-node-dependencies-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules/
-
       - *persist_to_workspace
 
   - &install_system_dependencies
@@ -58,13 +56,17 @@ aliases:
         command: |
           sudo apt-get update
           sudo apt-get install -y libicu-dev libidn11-dev libprotobuf-dev protobuf-compiler
+          
+          ## TODO: FIX THESE BUSTER DEPENDANCES
+          sudo wget http://ftp.au.debian.org/debian/pool/main/i/icu/libicu57_57.1-6+deb9u3_amd64.deb
+          sudo dpkg -i libicu57_57.1-6+deb9u3_amd64.deb
+          sudo wget http://ftp.au.debian.org/debian/pool/main/p/protobuf/libprotobuf10_3.0.0-9_amd64.deb
+          sudo dpkg -i libprotobuf10_3.0.0-9_amd64.deb
 
   - &install_ruby_dependencies
       steps:
         - *attach_workspace
-
         - *install_system_dependencies
-
         - run: ruby -e 'puts RUBY_VERSION' | tee /tmp/.ruby-version
         - *restore_ruby_dependencies
         - run: bundle install --clean --jobs 16 --path ./vendor/bundle/ --retry 3 --with pam_authentication --without development production && bundle clean
@@ -82,10 +84,8 @@ aliases:
   - &test_steps
       steps:
         - *attach_workspace
-
         - *install_system_dependencies
         - run: sudo apt-get install -y ffmpeg
-
         - run:
             name: Prepare Tests
             command: ./bin/rails parallel:create parallel:load_schema parallel:prepare
@@ -105,14 +105,14 @@ jobs:
   install-ruby2.5:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.5-stretch-node
+      - image: circleci/ruby:2.5-buster-node
         environment: *ruby_environment
     <<: *install_ruby_dependencies
 
   install-ruby2.4:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.4-stretch-node
+      - image: circleci/ruby:2.4-buster-node
         environment: *ruby_environment
     <<: *install_ruby_dependencies
 
@@ -131,7 +131,7 @@ jobs:
   test-ruby2.6:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.6-stretch-node
+      - image: circleci/ruby:2.6-buster-node
         environment: *ruby_environment
       - image: circleci/postgres:10.6-alpine
         environment:
@@ -142,7 +142,7 @@ jobs:
   test-ruby2.5:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.5-stretch-node
+      - image: circleci/ruby:2.5-buster-node
         environment: *ruby_environment
       - image: circleci/postgres:10.6-alpine
         environment:
@@ -153,7 +153,7 @@ jobs:
   test-ruby2.4:
     <<: *defaults
     docker:
-      - image: circleci/ruby:2.4-stretch-node
+      - image: circleci/ruby:2.4-buster-node
         environment: *ruby_environment
       - image: circleci/postgres:10.6-alpine
         environment:
@@ -164,7 +164,7 @@ jobs:
   test-webui:
     <<: *defaults
     docker:
-      - image: circleci/node:12.9-stretch
+      - image: circleci/node:12-buster
     steps:
       - *attach_workspace
       - run: ./bin/retry yarn test:jest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -803,9 +803,3 @@ DEPENDENCIES
   webmock (~> 3.7)
   webpacker (~> 4.2)
   webpush
-
-RUBY VERSION
-   ruby 2.6.5p114
-
-BUNDLED WITH
-   1.17.3


### PR DESCRIPTION
This should be safe to merge anytime.

The upcoming Ruby 2.7 Docker image and thus CircleCi images seem to only built with Buster. This is in preparation for the future 2.7 upgrade.

Note: I've fixed two dependence issues with ICU and Protobuf in Buster Debian.
1. libicudata.57 is not available in buster (63). https://packages.debian.org/buster/libicu-dev
2. Protobuf.10 is not avaiable in buster (17). https://packages.debian.org/buster/libprotobuf-dev
