### PR TITLE
Fix RefollowWorker not keeping show_reblogs setting

### DIFF
--- a/app/workers/refollow_worker.rb
+++ b/app/workers/refollow_worker.rb
@@ -7,7 +7,7 @@ class RefollowWorker
 
   def perform(target_account_id)
     target_account = Account.find(target_account_id)
-    return unless target_account.protocol == :activitypub
+    return unless target_account.activitypub?
 
     target_account.passive_relationships.where(account: Account.where(domain: nil)).includes(:account).reorder(nil).find_each do |follow|
       reblogs = follow.show_reblogs?

--- a/spec/workers/refollow_worker_spec.rb
+++ b/spec/workers/refollow_worker_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RefollowWorker do
+  subject { described_class.new }
+  let(:account) { Fabricate(:account, domain: 'example.org', protocol: :activitypub) }
+  let(:alice)   { Fabricate(:account, domain: nil, username: 'alice') }
+  let(:bob)     { Fabricate(:account, domain: nil, username: 'bob') }
+
+  describe 'perform' do
+    let(:service) { double }
+
+    before do
+      allow(FollowService).to receive(:new).and_return(service)
+      allow(service).to receive(:call)
+
+      alice.follow!(account, reblogs: true)
+      bob.follow!(account, reblogs: false)
+    end
+
+    it 'calls FollowService for local followers' do
+      result = subject.perform(account.id)
+
+      expect(result).to be_nil
+      expect(service).to have_received(:call).with(alice, account, reblogs: true)
+      expect(service).to have_received(:call).with(bob, account, reblogs: false)
+    end
+  end
+end


### PR DESCRIPTION
Fix `RefollowWorker`.

It was supposed to run whenever encountering an unexpected key change, and would re-send follow requests to avoid inconsistencies in case a server went down and was set up again with the same accounts but no database.

However, I think it never actually ran.