### PR TITLE
config/locales: fixed small typo in catalan

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -987,7 +987,7 @@ ca:
     account: Compte
     account_settings: Ajustos del compte
     aliases: Àlies de compte
-    appearance: Aparènça
+    appearance: Aparença
     authorized_apps: Aplicacions autoritzades
     back: Torna a Mastodon
     delete: Eliminació del compte


### PR DESCRIPTION
In catalan "appearance" should be translated as "aparença", not
"aparènça".

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>