### PR TITLE
fix root element of IntersectionObserver

### DIFF
--- a/app/javascript/mastodon/components/scrollable_list.js
+++ b/app/javascript/mastodon/components/scrollable_list.js
@@ -210,10 +210,13 @@ export default class ScrollableList extends PureComponent {
   }
 
   attachIntersectionObserver () {
-    this.intersectionObserverWrapper.connect({
+    let nodeOptions = {
       root: this.node,
       rootMargin: '300% 0px',
-    });
+    };
+
+    this.intersectionObserverWrapper
+      .connect(this.props.bindToDocument ? {} : nodeOptions);
   }
 
   detachIntersectionObserver () {


### PR DESCRIPTION
was previously using the <ScrollableList element, rather than the browser viewport, meaning
• hideIfNotIntersecting was never called
• when going <Back from a status update to a list view (e.g. home timeline), handleIntersection was called on ALL statuses (however many of them) at once, since they were all intersecting with the <ScrollableList element (rather than just the few in the browser viewport)