### PR TITLE
Add translation project promotion link

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -8,6 +8,10 @@
     .fields-group.fields-row__column.fields-row__column-6
       = f.input :setting_theme, collection: Themes.instance.names, label_method: lambda { |theme| I18n.t("themes.#{theme}", default: theme) }, wrapper: :with_label, include_blank: false, hint: false
 
+  - unless I18n.locale == :en
+    .flash-message{ style: "text-align: unset; color: unset" }
+      #{t 'appearance.localization.body'} #{content_tag(:a, t('appearance.localization.guide_link_text'), href: t('appearance.localization.guide_link'), target: "_blank", rel: "noopener", style: "text-decoration: underline")}
+
   %h4= t 'appearance.advanced_web_interface'
 
   %p.hint= t 'appearance.advanced_web_interface_hint'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -581,6 +581,10 @@ en:
     animations_and_accessibility: Animations and accessibility
     confirmation_dialogs: Confirmation dialogs
     discovery: Discovery
+    localization:
+      body: Mastodon is translated by volunteers.
+      guide_link: https://crowdin.com/project/mastodon
+      guide_link_text: Everyone can contribute.
     sensitive_content: Sensitive content
     toot_layout: Toot layout
   application_mailer:


### PR DESCRIPTION
This PR adds promotional notice on appearance settings about translation project if any other locale than English is used. It allows users to learn and contribute translations to Mastodon.

<p align=center><img src="https://user-images.githubusercontent.com/10401817/71605497-a700e380-2b9b-11ea-8985-14730911a25a.png" alt="Example screenshot"></p>

**Step ahead**, in this commit one unusual string is added — link to a guide. By default it refers to Crowdin project itself, but if any of Mastodon localization teams established their own guide, they can refer it. Or, if Crowdin supports localized domain for language, it can also be put there (e.g. https://fr.crowdin.com/...).