### PR TITLE
Fix resource_owner_from_credentials in Doorkeeper initializer

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -8,20 +8,15 @@ Doorkeeper.configure do
   end
 
   resource_owner_from_credentials do |_routes|
-    if Devise.ldap_authentication
-      user = User.authenticate_with_ldap({ :email => request.params[:username], :password => request.params[:password] })
-    end
-
-    if Devise.pam_authentication
-      user ||= User.authenticate_with_ldap({ :email => request.params[:username], :password => request.params[:password] })
-    end
+    user   = User.authenticate_with_ldap(email: request.params[:username], password: request.params[:password]) if Devise.ldap_authentication
+    user ||= User.authenticate_with_pam(email: request.params[:username], password: request.params[:password]) if Devise.pam_authentication
 
     if user.nil?
       user = User.find_by(email: request.params[:username])
-      user = nil unless user.valid_password?(request.params[:password])
+      user = nil unless user&.valid_password?(request.params[:password])
     end
 
-    user if !user&.otp_required_for_login?
+    user unless user&.otp_required_for_login?
   end
 
   # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.


### PR DESCRIPTION
- Nil error when e-mail not found
- LDAP authentication used in place of PAM authentication