### PR TITLE
Fix more uncaught query param encoding errors

### DIFF
--- a/app/middleware/handle_bad_encoding_middleware.rb
+++ b/app/middleware/handle_bad_encoding_middleware.rb
@@ -1,16 +1,33 @@
 # frozen_string_literal: true
-# See: https://jamescrisp.org/2018/05/28/fixing-invalid-query-parameters-invalid-encoding-in-a-rails-app/
 
 class HandleBadEncodingMiddleware
+  SANITIZE_ENV_KEYS = %w(
+    HTTP_REFERER
+    PATH_INFO
+    REQUEST_URI
+    REQUEST_PATH
+    QUERY_STRING
+  ).freeze
+
   def initialize(app)
     @app = app
   end
 
   def call(env)
+    SANITIZE_ENV_KEYS.each do |key|
+      str = CGI.unescape(env[key].to_s).force_encoding('UTF-8')
+      return [400, {}, ['Bad request']] unless str.valid_encoding?
+    end
+
     begin
-      Rack::Utils.parse_nested_query(env['QUERY_STRING'].to_s)
-    rescue Rack::Utils::InvalidParameterError
-      env['QUERY_STRING'] = ''
+      request = Rack::Request.new(env.dup)
+      request.params
+    rescue ArgumentError => e
+      if e.message =~ /invalid %-encoding/
+        return [400, {}, ['Bad request']]
+      else
+        raise e
+      end
     end
 
     @app.call(env)

--- a/spec/middleware/handle_bad_encoding_middleware_spec.rb
+++ b/spec/middleware/handle_bad_encoding_middleware_spec.rb
@@ -4,18 +4,33 @@ RSpec.describe HandleBadEncodingMiddleware do
   let(:app) { double() }
   let(:middleware) { HandleBadEncodingMiddleware.new(app) }
 
-  it "request with query string is unchanged" do
-    expect(app).to receive(:call).with("PATH" => "/some/path", "QUERY_STRING" => "name=fred")
-    middleware.call("PATH" => "/some/path", "QUERY_STRING" => "name=fred")
+  it 'passes requests with normal query parameters' do
+    env = env_for('/some/path?name=fred')
+    expect(app).to receive(:call).with(env)
+    middleware.call(env)
   end
 
-  it "request with no query string is unchanged" do
-    expect(app).to receive(:call).with("PATH" => "/some/path")
-    middleware.call("PATH" => "/some/path")
+  it 'passes requests with no query parameters' do
+    env = env_for('/some/path')
+    expect(app).to receive(:call).with(env)
+    middleware.call(env)
   end
 
-  it "request with invalid encoding in query string drops query string" do
-    expect(app).to receive(:call).with("QUERY_STRING" => "", "PATH" => "/some/path")
-    middleware.call("QUERY_STRING" => "q=%2Fsearch%2Fall%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at", "PATH" => "/some/path")
+  it 'drops requests with invalid %-encoding in parameters' do
+    env = env_for('/some/path')
+    env['QUERY_STRING'] = 'q=%2Fsearch%2Fall%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at'
+    response = middleware.call(env)
+    expect(response).to eq [400, {}, ['Bad request']]
+  end
+
+  it 'drops requests with invalid encoding in parameters' do
+    env = env_for('/some/path')
+    env['QUERY_STRING'] = 'info_hash=f%e5u6%ac%5d%df%c8S%fc%9c7%b3%ff%26A%c3y%85%a3&peer_id=-TR2840-tgshmuspym9s&port=51413&uploaded=0&downloaded=0&left=11675&numwant=0&key=1a314ff6&compact=1&supportcrypto=1&event=stopped'
+    response = middleware.call(env)
+    expect(response).to eq [400, {}, ['Bad request']]
+  end
+
+  def env_for(url, opts = {})
+    Rack::MockRequest.env_for(url, opts)
   end
 end


### PR DESCRIPTION
There's two classes of errors this code catches: Invalid %-encoding, and invalid UTF-8 encoding. While Rails does seem to return HTTP 400 on those exceptions in production environment (but not in development, it seems), the stacktraces still appear in the logs.

Here are some of the log entries:

```
Rack::QueryParser::InvalidParameterError (invalid %-encoding ("1.0" encoding="utf-8" ?>

config/initializers/rack_attack.rb:37:in `paging_request?'
config/initializers/rack_attack.rb:78:in `block in <class:Attack>'

Rack::QueryParser::InvalidParameterError (invalid %-encoding ( 【#界面新闻 】◾ 券商股走强，中原证券直线拉升一度涨近9%◾ https://m.jiemian.com/article/3837807.html)):

config/initializers/rack_attack.rb:10:in `authenticated_token'
config/initializers/rack_attack.rb:21:in `authenticated_user_id'
config/initializers/rack_attack.rb:54:in `block in <class:Attack>'

Rack::QueryParser::InvalidParameterError (Invalid encoding for parameter: 98981039773206183_���u�\�{^�):

Rack::QueryParser::InvalidParameterError (Invalid encoding for parameter: @linux/98827768545822771/_&m�]y�(�ק):
```

This is a draft until I figure out if this is an actually good approach to the solution... Or if maybe the errors should be left alone.