### PR TITLE
Fix cache digesting log noise on status embeds

### DIFF
--- a/app/views/statuses/embed.html.haml
+++ b/app/views/statuses/embed.html.haml
@@ -1,3 +1,2 @@
-- cache @status do
-  .activity-stream.activity-stream--headless
-    = render 'status', status: @status, centered: true, autoplay: @autoplay
+.activity-stream.activity-stream--headless
+  = render 'status', status: @status, centered: true, autoplay: @autoplay


### PR DESCRIPTION
This annoying log message:

> Couldn't find template for digesting: centereds/centered

We should rely on proxy caching for embeds anyway