### PR TITLE
Clarify keyword arguments with **

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -3,7 +3,7 @@
 module AccountsHelper
   def display_name(account, **options)
     if options[:custom_emojify]
-      Formatter.instance.format_display_name(account, options)
+      Formatter.instance.format_display_name(account, **options)
     else
       account.display_name.presence || account.username
     end

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -21,7 +21,7 @@ class ActivityPub::Activity
   class << self
     def factory(json, account, **options)
       @json = json
-      klass&.new(json, account, options)
+      klass&.new(json, account, **options)
     end
 
     private

--- a/app/services/activitypub/process_collection_service.rb
+++ b/app/services/activitypub/process_collection_service.rb
@@ -37,7 +37,7 @@ class ActivityPub::ProcessCollectionService < BaseService
   end
 
   def process_item(item)
-    activity = ActivityPub::Activity.factory(item, @account, @options)
+    activity = ActivityPub::Activity.factory(item, @account, **@options)
     activity&.perform
   end
 


### PR DESCRIPTION
This change is to suppress the warning below on on ruby-2.7.0:

```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

reference: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/