### PR TITLE
Upgrade to Ruby 2.7 for CircleCI testing / Drop Ruby 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 aliases:
   - &defaults
     docker:
-      - image: circleci/ruby:2.6-buster-node
+      - image: circleci/ruby:2.7-buster-node
         environment: &ruby_environment
           BUNDLE_APP_CONFIG: ./.bundle/
           DB_HOST: localhost
@@ -98,21 +98,21 @@ jobs:
     <<: *defaults
     <<: *install_steps
 
+  install-ruby2.7:
+    <<: *defaults
+    <<: *install_ruby_dependencies
+
   install-ruby2.6:
     <<: *defaults
+    docker:
+      - image: circleci/ruby:2.6-buster-node
+        environment: *ruby_environment
     <<: *install_ruby_dependencies
 
   install-ruby2.5:
     <<: *defaults
     docker:
       - image: circleci/ruby:2.5-buster-node
-        environment: *ruby_environment
-    <<: *install_ruby_dependencies
-
-  install-ruby2.4:
-    <<: *defaults
-    docker:
-      - image: circleci/ruby:2.4-buster-node
         environment: *ruby_environment
     <<: *install_ruby_dependencies
 
@@ -127,6 +127,17 @@ jobs:
           paths:
               - ./mastodon/public/assets
               - ./mastodon/public/packs-test/
+
+  test-ruby2.7:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.7-buster-node
+        environment: *ruby_environment
+      - image: circleci/postgres:10.6-alpine
+        environment:
+          POSTGRES_USER: root
+      - image: circleci/redis:5-alpine
+    <<: *test_steps
 
   test-ruby2.6:
     <<: *defaults
@@ -143,17 +154,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/ruby:2.5-buster-node
-        environment: *ruby_environment
-      - image: circleci/postgres:10.6-alpine
-        environment:
-          POSTGRES_USER: root
-      - image: circleci/redis:5-alpine
-    <<: *test_steps
-
-  test-ruby2.4:
-    <<: *defaults
-    docker:
-      - image: circleci/ruby:2.4-buster-node
         environment: *ruby_environment
       - image: circleci/postgres:10.6-alpine
         environment:
@@ -184,20 +184,24 @@ workflows:
   build-and-test:
     jobs:
       - install
+      - install-ruby2.7:
+          requires:
+            - install
       - install-ruby2.6:
           requires:
             - install
+            - install-ruby2.7
       - install-ruby2.5:
           requires:
             - install
-            - install-ruby2.6
-      - install-ruby2.4:
-          requires:
-            - install
-            - install-ruby2.6
+            - install-ruby2.7
       - build:
           requires:
-            - install-ruby2.6
+            - install-ruby2.7
+      - test-ruby2.7:
+          requires:
+            - install-ruby2.7
+            - build
       - test-ruby2.6:
           requires:
             - install-ruby2.6
@@ -206,13 +210,9 @@ workflows:
           requires:
             - install-ruby2.5
             - build
-      - test-ruby2.4:
-          requires:
-            - install-ruby2.4
-            - build
       - test-webui:
           requires:
             - install
       - check-i18n:
           requires:
-            - install-ruby2.6
+            - install-ruby2.7

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'pkg-config', '~> 1.4'
 
 gem 'puma', '~> 4.3'
 gem 'rails', '~> 5.2.4'
-gem 'sprockets', '~> 3.7.2'
+gem 'sprockets', '~> 4.0.0'
 gem 'thor', '~> 0.20'
 
 gem 'thwait', '~> 0.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'sprockets', '~> 3.7.2'
 gem 'thor', '~> 0.20'
 
 gem 'thwait', '~> 0.1.0'
+gem 'e2mmap', '~> 0.1.0'
 
 gem 'hamlit-rails', '~> 0.2'
 gem 'pg', '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'pkg-config', '~> 1.4'
 
 gem 'puma', '~> 4.3'
 gem 'rails', '~> 5.2.4'
-gem 'sprockets', '~> 4.0.0'
+gem 'sprockets', '~> 3.7.2'
 gem 'thor', '~> 0.20'
 
 gem 'thwait', '~> 0.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 2.4.0', '< 2.7.0'
+ruby '>= 2.5.0', '< 3'
 
 gem 'pkg-config', '~> 1.4'
 
@@ -9,6 +9,8 @@ gem 'puma', '~> 4.3'
 gem 'rails', '~> 5.2.4'
 gem 'sprockets', '~> 3.7.2'
 gem 'thor', '~> 0.20'
+
+gem 'thwait', '~> 0.1.0'
 
 gem 'hamlit-rails', '~> 0.2'
 gem 'pg', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -605,7 +605,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -789,7 +789,7 @@ DEPENDENCIES
   simple-navigation (~> 4.1)
   simple_form (~> 5.0)
   simplecov (~> 0.17)
-  sprockets (~> 3.7.2)
+  sprockets (~> 4.0.0)
   sprockets-rails (~> 3.2)
   stackprof
   stoplight (~> 2.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -605,7 +605,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sprockets (4.0.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -789,7 +789,7 @@ DEPENDENCIES
   simple-navigation (~> 4.1)
   simple_form (~> 5.0)
   simplecov (~> 0.17)
-  sprockets (~> 4.0.0)
+  sprockets (~> 3.7.2)
   sprockets-rails (~> 3.2)
   stackprof
   stoplight (~> 2.2.0)

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Mastodon acts as an OAuth2 provider so 3rd party apps can use the REST and Strea
 **Requirements:**
 
 - **PostgreSQL** 9.5+
-- **Redis**
-- **Ruby** 2.4+
+- **Redis** 4+
+- **Ruby** 2.5+
 - **Node.js** 8+
 
 The repository includes deployment configurations for **Docker and docker-compose**, but also a few specific platforms like **Heroku**, **Scalingo**, and **Nanobox**. The [**stand-alone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the documentation.


### PR DESCRIPTION
The PR to match #12704. 

This can be merged as is now whenever the Big G feels the need.