### PR TITLE
Require nodejs 10.13 as minimum release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Mastodon acts as an OAuth2 provider so 3rd party apps can use the REST and Strea
 - **PostgreSQL** 9.5+
 - **Redis**
 - **Ruby** 2.4+
-- **Node.js** 8+
+- **Node.js** 10.13+
 
 The repository includes deployment configurations for **Docker and docker-compose**, but also a few specific platforms like **Heroku**, **Scalingo**, and **Nanobox**. The [**stand-alone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the documentation.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tootsuite/mastodon",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=8.12 <13"
+    "node": ">=10.13 <13"
   },
   "scripts": {
     "postversion": "git push --tags",


### PR DESCRIPTION
nodejs 8 is EOL.

This can be merged as is now whenever the Big G feels the need.