### PR TITLE
Little improvements to filters settings page

### DIFF
--- a/app/views/filters/index.html.haml
+++ b/app/views/filters/index.html.haml
@@ -1,20 +1,25 @@
 - content_for :page_title do
   = t('filters.index.title')
 
-.table-wrapper
-  %table.table
-    %thead
-      %tr
-        %th= t('simple_form.labels.defaults.phrase')
-        %th= t('simple_form.labels.defaults.context')
-        %th
-    %tbody
-      - @filters.each do |filter|
-        %tr
-          %td= filter.phrase
-          %td= filter.context.map { |context| I18n.t("filters.contexts.#{context}") }.join(', ')
-          %td
-            = table_link_to 'pencil', t('filters.edit.title'), edit_filter_path(filter)
-            = table_link_to 'times', t('filters.index.delete'), filter_path(filter), method: :delete
+- content_for :page_heading_actions do
+  = link_to t('filters.new.title'), new_filter_path, class: 'button'
 
-= link_to t('filters.new.title'), new_filter_path, class: 'button'
+- if @filters.count == 0
+  %div{ style: 'display: flex; justify-content: center' }
+    %div.muted-hint= t 'filters.index.empty'
+- else
+  .table-wrapper
+    %table.table
+      %thead
+        %tr
+          %th= t('simple_form.labels.defaults.phrase')
+          %th= t('simple_form.labels.defaults.context')
+          %th
+      %tbody
+        - @filters.each do |filter|
+          %tr
+            %td= filter.phrase
+            %td= filter.context.map { |context| I18n.t("filters.contexts.#{context}") }.join(', ')
+            %td
+              = table_link_to 'pencil', t('filters.edit.title'), edit_filter_path(filter)
+              = table_link_to 'times', t('filters.index.delete'), filter_path(filter), method: :delete

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -744,6 +744,7 @@ en:
       invalid_irreversible: Irreversible filtering only works with home or notifications context
     index:
       delete: Delete
+      empty: You have no filters.
       title: Filters
     new:
       title: Add new filter


### PR DESCRIPTION
When you have many filters, it may be hard for you to reach the button to create yet another one. This PR moves creation button to the heading, leaving the page just for the list.

On the other hand, when there are no filters, page looks kind of strange with the empty table. So text stating obvious fact that user has no filters was added in this PR too.

<p align=center>
<img src="https://user-images.githubusercontent.com/10401817/71873885-f2defa00-3152-11ea-9d68-726a73198120.png" alt="Demo screenshot">
</p>


Closes #11020
Closes #12790