### PR TITLE
Correct margins for heading actions

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -186,17 +186,22 @@ $content-width: 840px;
 
       padding-bottom: 40px;
       border-bottom: 1px solid lighten($ui-base-color, 8%);
-      margin-bottom: 40px;
+
+      margin: -15px -15px 40px 0;
 
       flex-wrap: wrap;
       align-items: center;
-
       justify-content: space-between;
+
+      & > * {
+        margin-top: 15px;
+        margin-right: 15px;
+      }
 
       &-actions {
         display: inline-flex;
 
-        & > * {
+        & > :not(:first-child) {
           margin-left: 5px;
         }
       }


### PR DESCRIPTION
This pull request changes margins of the page heading header, actions in order to fix displaying with low screen size and long enough header.

<p align=center>
<img src="https://user-images.githubusercontent.com/10401817/71939036-e787df00-31e3-11ea-9b90-84052a3c3dfb.png" alt="Demo screenshot">
</p>

<p align=center><i>… What language is that?</i></p>

It is working by giving heading and action buttons margin from top and then negating it in parent element. Whenever flex item wrap, the "negated" margin will be applied again, providing us nice space between header and action buttons.

This pull request also adds a margin to header, so it does not clamp with the heading actions and they wrap a little earlier (15px ahead). As well as the left margin is not anymore applied to the first action.