### PR TITLE
Rename page_heading_actions content variable

### DIFF
--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -4,7 +4,7 @@
 - content_for :page_title do
   = t('admin.reports.report', id: @report.id)
 
-- content_for :page_heading_actions do
+- content_for :heading_actions do
   - if @report.unresolved?
     = link_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(@report), method: :post, class: 'button'
   - else

--- a/app/views/filters/index.html.haml
+++ b/app/views/filters/index.html.haml
@@ -1,7 +1,7 @@
 - content_for :page_title do
   = t('filters.index.title')
 
-- content_for :page_heading_actions do
+- content_for :heading_actions do
   = link_to t('filters.new.title'), new_filter_path, class: 'button'
 
 - if @filters.count == 0

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -24,9 +24,9 @@
         .content-heading
           %h2= yield :page_title
 
-          - if :page_heading_actions
+          - if :heading_actions
             .content-heading-actions
-              = yield :page_heading_actions
+              = yield :heading_actions
 
         = render 'application/flashes'
 


### PR DESCRIPTION
Current name — `page_heading_actions`  is long and hard to remember, this pull request shortens it to just `heading_actions`, which is way more easier to remember and write, it's logical too.