### PR TITLE
Upgrade CircleCI testing to Ruby 2.4-2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 aliases:
   - &defaults
     docker:
-      - image: circleci/ruby:2.6-buster-node
+      - image: circleci/ruby:2.7-buster-node
         environment: &ruby_environment
           BUNDLE_APP_CONFIG: ./.bundle/
           DB_HOST: localhost
@@ -98,8 +98,15 @@ jobs:
     <<: *defaults
     <<: *install_steps
 
+  install-ruby2.7:
+    <<: *defaults
+    <<: *install_ruby_dependencies
+
   install-ruby2.6:
     <<: *defaults
+    docker:
+      - image: circleci/ruby:2.6-buster-node
+        environment: *ruby_environment
     <<: *install_ruby_dependencies
 
   install-ruby2.5:
@@ -127,6 +134,17 @@ jobs:
           paths:
               - ./mastodon/public/assets
               - ./mastodon/public/packs-test/
+
+  test-ruby2.7:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.7-buster-node
+        environment: *ruby_environment
+      - image: circleci/postgres:10.6-alpine
+        environment:
+          POSTGRES_USER: root
+      - image: circleci/redis:5-alpine
+    <<: *test_steps
 
   test-ruby2.6:
     <<: *defaults
@@ -184,20 +202,28 @@ workflows:
   build-and-test:
     jobs:
       - install
+      - install-ruby2.7:
+          requires:
+            - install
       - install-ruby2.6:
           requires:
             - install
+            - install-ruby2.7
       - install-ruby2.5:
           requires:
             - install
-            - install-ruby2.6
+            - install-ruby2.7
       - install-ruby2.4:
           requires:
             - install
-            - install-ruby2.6
+            - install-ruby2.7
       - build:
           requires:
-            - install-ruby2.6
+            - install-ruby2.7
+      - test-ruby2.7:
+          requires:
+            - install-ruby2.7
+            - build
       - test-ruby2.6:
           requires:
             - install-ruby2.6
@@ -215,4 +241,4 @@ workflows:
             - install
       - check-i18n:
           requires:
-            - install-ruby2.6
+            - install-ruby2.7

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 2.4.0', '< 2.7.0'
+ruby '>= 2.4.0', '< 3.0.0'
 
 gem 'pkg-config', '~> 1.4'
 
@@ -9,6 +9,9 @@ gem 'puma', '~> 4.3'
 gem 'rails', '~> 5.2.4'
 gem 'sprockets', '~> 3.7.2'
 gem 'thor', '~> 0.20'
+
+gem 'thwait', '~> 0.1.0'
+gem 'e2mmap', '~> 0.1.0'
 
 gem 'hamlit-rails', '~> 0.2'
 gem 'pg', '~> 1.2'


### PR DESCRIPTION
The PR to match #12704. Ruby 2.4 has been kept in testing.

This can be merged as is now whenever the Big G feels the need.