### PR TITLE
Use heading actions and placeholders in settings

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -878,3 +878,7 @@ a.name-tag,
     color: $primary-text-color;
   }
 }
+
+.center-text {
+  text-align: center;
+}

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -4,6 +4,9 @@
 - content_for :header_tags do
   = javascript_pack_tag 'admin', integrity: true, async: true, crossorigin: 'anonymous'
 
+- content_for :heading_actions do
+  = link_to t('admin.custom_emojis.upload'), new_admin_custom_emoji_path, class: 'button'
+
 .filters
   .filter-subset
     %strong= t('admin.accounts.location.title')
@@ -81,6 +84,3 @@
 
 = paginate @custom_emojis
 
-%hr.spacer/
-
-= link_to t('admin.custom_emojis.upload'), new_admin_custom_emoji_path, class: 'button'

--- a/app/views/admin/email_domain_blocks/index.html.haml
+++ b/app/views/admin/email_domain_blocks/index.html.haml
@@ -1,14 +1,19 @@
 - content_for :page_title do
   = t('admin.email_domain_blocks.title')
 
-.table-wrapper
-  %table.table
-    %thead
-      %tr
-        %th= t('admin.email_domain_blocks.domain')
-        %th
-    %tbody
-      = render @email_domain_blocks
+- content_for :heading_actions do
+  = link_to t('admin.email_domain_blocks.add_new'), new_admin_email_domain_block_path, class: 'button'
+
+- if @email_domain_blocks.count == 0
+  %div.muted-hint.center-text=t 'admin.email_domain_blocks.empty'
+- else
+  .table-wrapper
+    %table.table
+      %thead
+        %tr
+          %th= t('admin.email_domain_blocks.domain')
+          %th
+      %tbody
+        = render @email_domain_blocks
 
 = paginate @email_domain_blocks
-= link_to t('admin.email_domain_blocks.add_new'), new_admin_email_domain_block_path, class: 'button'

--- a/app/views/filters/index.html.haml
+++ b/app/views/filters/index.html.haml
@@ -5,8 +5,7 @@
   = link_to t('filters.new.title'), new_filter_path, class: 'button'
 
 - if @filters.count == 0
-  %div{ style: 'display: flex; justify-content: center' }
-    %div.muted-hint= t 'filters.index.empty'
+  %div.muted-hint.center-text= t 'filters.index.empty'
 - else
   .table-wrapper
     %table.table

--- a/app/views/settings/applications/index.html.haml
+++ b/app/views/settings/applications/index.html.haml
@@ -1,20 +1,25 @@
 - content_for :page_title do
   = t('doorkeeper.applications.index.title')
 
-.table-wrapper
-  %table.table
-    %thead
-      %tr
-        %th= t('doorkeeper.applications.index.application')
-        %th= t('doorkeeper.applications.index.scopes')
-        %th
-    %tbody
-      - @applications.each do |application|
+- content_for :heading_actions do
+  = link_to t('doorkeeper.applications.index.new'), new_settings_application_path, class: 'button'
+
+- if @applications.count == 0
+  %div.muted-hint.center-text=t 'doorkeeper.applications.index.empty'
+- else
+  .table-wrapper
+    %table.table
+      %thead
         %tr
-          %td= link_to application.name, settings_application_path(application)
-          %th= application.scopes
-          %td
-            = table_link_to 'times', t('doorkeeper.applications.index.delete'), settings_application_path(application), method: :delete, data: { confirm: t('doorkeeper.applications.confirmations.destroy') }
+          %th= t('doorkeeper.applications.index.application')
+          %th= t('doorkeeper.applications.index.scopes')
+          %th
+      %tbody
+        - @applications.each do |application|
+          %tr
+            %td= link_to application.name, settings_application_path(application)
+            %th= application.scopes
+            %td
+              = table_link_to 'times', t('doorkeeper.applications.index.delete'), settings_application_path(application), method: :delete, data: { confirm: t('doorkeeper.applications.confirmations.destroy') }
 
 = paginate @applications
-= link_to t('doorkeeper.applications.index.new'), new_settings_application_path, class: 'button'

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -38,6 +38,7 @@ en:
         application: Application
         callback_url: Callback URL
         delete: Delete
+        empty: You have no applications.
         name: Name
         new: New application
         scopes: Scopes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -339,6 +339,7 @@ en:
       delete: Delete
       destroyed_msg: Successfully deleted e-mail domain from blacklist
       domain: Domain
+      empty: No e-mail domains currenly blacklisted.
       new:
         create: Add domain
         title: New e-mail blacklist entry


### PR DESCRIPTION
This pull request improves some index pages to use more placeholders in place of empty tables and moves action buttons to the heading actions content block.

<p align=center>
<img src="https://user-images.githubusercontent.com/10401817/71960654-1d4eb700-3228-11ea-9a48-a86df1a00ac3.png" alt="Demo screenshot">
</p>

**This merge request depends on #12799** and until it's merge this one present as draft and is not squashed for easier review.