### PR TITLE
Allow blocking TLDs, and fix TLD blocks not being editable

### DIFF
--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -54,7 +54,7 @@ class DomainBlock < ApplicationRecord
       segments = uri.normalized_host.split('.')
       variants = segments.map.with_index { |_, i| segments[i..-1].join('.') }
 
-      where(domain: variants[0..-2]).order(Arel.sql('char_length(domain) desc')).first
+      where(domain: variants).order(Arel.sql('char_length(domain) desc')).first
     end
   end
 

--- a/spec/models/domain_block_spec.rb
+++ b/spec/models/domain_block_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe DomainBlock, type: :model do
       block = Fabricate(:domain_block, domain: 'sub.example.com')
       expect(DomainBlock.rule_for('sub.example.com')).to eq block
     end
+
+    it 'returns a rule matching a blocked TLD' do
+      block = Fabricate(:domain_block, domain: 'google')
+      expect(DomainBlock.rule_for('google')).to eq block
+    end
+
+    it 'returns a rule matching a subdomain of a blocked TLD' do
+      block = Fabricate(:domain_block, domain: 'google')
+      expect(DomainBlock.rule_for('maps.google')).to eq block
+    end
   end
 
   describe '#stricter_than?' do


### PR DESCRIPTION
Fixes #12795

It was already possible to create domain blocks for TLDs, but those
weren't enforced, nor editable. This PR changes it so that they
are enforced and editable.