### PR TITLE
Use quality values in Accept field to explicitly prefer JSON over HTML

### DIFF
--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -3,7 +3,7 @@
 class FetchResourceService < BaseService
   include JsonLdHelper
 
-  ACCEPT_HEADER = 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams", text/html'
+  ACCEPT_HEADER = 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams", text/html;q=0.1'
 
   def call(url)
     return if url.blank?


### PR DESCRIPTION
I don't actually know if there's *any* AP-capable software out there that would prefer the `text/html` version to one of the AP content-types with the current headers, and would do otherwise with a quality value, but I assume this shouldn't hurt