### PR TITLE
Paperclip styles syntax

### DIFF
--- a/app/models/concerns/account_avatar.rb
+++ b/app/models/concerns/account_avatar.rb
@@ -18,7 +18,7 @@ module AccountAvatar
 
   included do
     # Avatar upload
-    has_attached_file :avatar, styles: ->(f) { avatar_styles(f) }, convert_options: { all: '-strip' }, processors: [:lazy_thumbnail]
+    has_attached_file :avatar, style: ->(f) { avatar_styles(f) }, convert_options: { all: '-strip' }, processors: [:lazy_thumbnail]
     validates_attachment_content_type :avatar, content_type: IMAGE_MIME_TYPES
     validates_attachment_size :avatar, less_than: LIMIT
     remotable_attachment :avatar, LIMIT

--- a/app/models/concerns/account_header.rb
+++ b/app/models/concerns/account_header.rb
@@ -19,7 +19,7 @@ module AccountHeader
 
   included do
     # Header upload
-    has_attached_file :header, styles: ->(f) { header_styles(f) }, convert_options: { all: '-strip' }, processors: [:lazy_thumbnail]
+    has_attached_file :header, style: ->(f) { header_styles(f) }, convert_options: { all: '-strip' }, processors: [:lazy_thumbnail]
     validates_attachment_content_type :header, content_type: IMAGE_MIME_TYPES
     validates_attachment_size :header, less_than: LIMIT
     remotable_attachment :header, LIMIT


### PR DESCRIPTION
I was running into an issue where Sidekiq was getting jobs stuck indefinitely when attempting to import a new account header. Doing the manual regenerate via the web interface also failed.

After digging around, I found that it only happened on header files using animated gifs that needed conversion/rescaling and only on instances using Docker.

What worked for me was changing `styles` to `style` on paperclip calls as mentioned here: https://github.com/thoughtbot/paperclip/issues/1405#issuecomment-222613309 

This puzzles me because PaperClip is deprecated and according to that user (in 2016) `style` was the new syntax. Also, can't understand why it only affects Dockers installs.

So, I don't know if this will break for others (not using Docker) and it would be great if someone tested it as I don't have a non Docker test setup.

Also, https://github.com/tootsuite/mastodon/blob/master/app/models/preview_card.rb also uses `styles` but haven't tested it and didn't what to PR before I do.