### PR TITLE
Exempt staff members from spam check

### DIFF
--- a/app/lib/spam_check.rb
+++ b/app/lib/spam_check.rb
@@ -143,7 +143,7 @@ class SpamCheck
   end
 
   def trusted?
-    @account.trust_level > Account::TRUST_LEVELS[:untrusted]
+    @account.trust_level > Account::TRUST_LEVELS[:untrusted] || (@account.local? && @account.user_staff?)
   end
 
   def no_unsolicited_mentions?


### PR DESCRIPTION
Consider admins and moderators as trusted, for the purpose of the
spam checker.

Fixes #12872