### PR TITLE
Close registration before self-destruct

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -96,6 +96,8 @@ module Mastodon
 
       prompt.warn('Do NOT interrupt this process...')
 
+      Setting.registrations_mode = 'none'
+
       Account.local.without_suspended.find_each do |account|
         payload = ActiveModelSerializers::SerializableResource.new(
           account,


### PR DESCRIPTION
To prevent new join in self-destruct sequence is running, Close registration first.