### PR TITLE
Fix slow query of federated timeline

### DIFF
--- a/db/migrate/20200119112504_add_public_index_to_statuses.rb
+++ b/db/migrate/20200119112504_add_public_index_to_statuses.rb
@@ -1,0 +1,11 @@
+class AddPublicIndexToStatuses < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    add_index :statuses, [:id, :account_id], name: :index_statuses_public_20200119, algorithm: :concurrently, order: { id: :desc }, where: 'deleted_at IS NULL AND visibility = 0 AND reblog_of_id IS NULL AND ((NOT reply) OR (in_reply_to_account_id = account_id))'
+  end
+
+  def down
+    remove_index :statuses, name: :index_statuses_public_20200119
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_12_003415) do
+ActiveRecord::Schema.define(version: 2020_01_19_112504) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -690,6 +690,7 @@ ActiveRecord::Schema.define(version: 2019_12_12_003415) do
     t.datetime "deleted_at"
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20190820", order: { id: :desc }, where: "(deleted_at IS NULL)"
     t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
+    t.index ["id", "account_id"], name: "index_statuses_public_20200119", order: { id: :desc }, where: "((deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["reblog_of_id", "account_id"], name: "index_statuses_on_reblog_of_id_and_account_id"


### PR DESCRIPTION
We had found that the federated timeline was slow after upgrading [our server](https://ichiji.social/) from v2.7.3 to v3.0.1. We found an almost the same issue (#11643) and its solution (#11648), but it fixes only the local timeline. This PR fixes also the federated timeline by creating a new index similar with #11648.

`EXPLAIN` results of our DB:

Query

```
SELECT  "statuses"."id", "statuses"."updated_at" FROM "statuses" LEFT OUTER JOIN "accounts" ON "accounts"."id" = "statuses"."account_id" WHERE "statuses"."visibility" = 0 AND (statuses.reblog_of_id IS NULL) AND (statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id) AND "statuses"."account_id" NOT IN (1) AND "statuses"."deleted_at" IS NULL AND "accounts"."silenced_at" IS NULL ORDER BY "statuses"."id" DESC, "statuses"."id" DESC LIMIT 10
```

Before

```
Limit  (cost=0.72..100659.04 rows=10 width=16)
  ->  Nested Loop Left Join  (cost=0.72..1107242.22 rows=110 width=16)
        Filter: (accounts.silenced_at IS NULL)
        ->  Index Scan Backward using statuses_pkey on statuses  (cost=0.43..1051835.02 rows=22060 width=24)
              Filter: ((reblog_of_id IS NULL) AND (deleted_at IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)) AND (account_id <> 1) AND (visibility = 0))
        ->  Index Scan using index_accounts_on_id on accounts  (cost=0.29..2.50 rows=1 width=16)
              Index Cond: (id = statuses.account_id)
```

After

```
Limit  (cost=0.72..9689.39 rows=10 width=16)
  ->  Nested Loop Left Join  (cost=0.72..106575.99 rows=110 width=16)
        Filter: (accounts.silenced_at IS NULL)
        ->  Index Scan using index_statuses_public_20200117 on statuses  (cost=0.43..51134.55 rows=22067 width=24)
              Filter: (account_id <> 1)
        ->  Index Scan using index_accounts_on_id on accounts  (cost=0.29..2.50 rows=1 width=16)
              Index Cond: (id = statuses.account_id)
```

CPU usage of our DB:

<img width="1148" alt="スクリーンショット 2020-01-17 20 12 07のコピー" src="https://user-images.githubusercontent.com/703759/72682131-4b2bd980-3b0d-11ea-9234-5c01182d4484.png">

We created the index at 17:00 and CPU usage decreased immediately.

I am not sure this is the best way to fix it. Please give me a review. Thank you!