### PR TITLE
Fix duplicate “description” meta tag on accounts public pages

### DIFF
--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -2,8 +2,6 @@
   = "#{display_name(@account)} (@#{@account.local_username_and_domain})"
 
 - content_for :header_tags do
-  %meta{ name: 'description', content: account_description(@account) }/
-
   - if @account.user&.setting_noindex
     %meta{ name: 'robots', content: 'noindex, noarchive' }/
 


### PR DESCRIPTION
Fixes #12920