### PR TITLE
Fix password change/reset not immediately invalidating other sessions

### DIFF
--- a/app/controllers/auth/passwords_controller.rb
+++ b/app/controllers/auth/passwords_controller.rb
@@ -6,6 +6,12 @@ class Auth::PasswordsController < Devise::PasswordsController
 
   layout 'auth'
 
+  def update
+    super do |resource|
+      resource.session_activations.destroy_all if resource.errors.empty?
+    end
+  end
+
   private
 
   def check_validity_of_reset_password_token

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -22,10 +22,17 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     not_found
   end
 
+  def update
+    super do |resource|
+      resource.clear_other_sessions(current_session.session_id) if resource.saved_change_to_encrypted_password?
+    end
+  end
+
   protected
 
   def update_resource(resource, params)
     params[:password] = nil if Devise.pam_authentication && resource.encrypted_password.blank?
+
     super
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -247,7 +247,7 @@ class User < ApplicationRecord
                                  ip: request.remote_ip).session_id
   end
 
-  def exclusive_session(id)
+  def clear_other_sessions(id)
     session_activations.exclusive(id)
   end
 


### PR DESCRIPTION
While making browser requests in the other sessions after a password change or reset does not allow you to be logged in and correctly invalidates the session making the request, sessions have API tokens
associated with them, which can still be used until that session is invalidated.

This is a security issue for accounts that were already compromised some other way because it makes it harder to throw out the hijacker.