### PR TITLE
Evenly spread space between tabs

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5731,6 +5731,8 @@ a.status-card.compact:hover {
     text-align: center;
     text-decoration: none;
     position: relative;
+    overflow: hidden;
+    width: 100%;
 
     &.active {
       color: $secondary-text-color;


### PR DESCRIPTION
This PR fixes uneven spread of space between the tabs in profiles or notifications (filters). The problem was that links and buttons shown as blocks had their width determined according to the content inside of them, so if one tab has more text content than another, it is going to take over others space, which is uneven and results in incorrectly aligned (?) tabs display. 

By specifying the size of 100% for each tab, parent container will be forced to divide available space by the number of elements and evenly give each child fixed space, "text-align: center" then doing its best job to keep tabs text centered in that space. This relatively fixes the problem, but will introduce another one - when the block has more content that its width allows to have, in this scenario the text should be wrapped or will be displayed over the other elements, but I see this more as translators' problem. Still, for this case "overflow: hidden" is added and any unfitting text will be cut out.

​

<p align=center>
<img src="https://user-images.githubusercontent.com/10401817/73094428-24a5de00-3f13-11ea-8125-362eab1397f3.gif" alt="GIF of comparison between changed display and current">
</p>

<p align=center>
<i>Centered according to images below = with fix</i>
</p>