### PR TITLE
minor server-sent events fixes

### DIFF
--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -92,6 +92,7 @@ export default function getStream(streamingAPIBaseURL, accessToken, stream, { co
     return ws;
   }
 
+  stream = stream.replace(/:/g, '/');
   params.push(`access_token=${accessToken}`);
   const es = new EventSource(`${streamingAPIBaseURL}/api/v1/streaming/${stream}?${params.join('&')}`);
 

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -438,6 +438,8 @@ const startWorker = (workerId) => {
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Transfer-Encoding', 'chunked');
 
+    res.write(':)\n');
+
     const heartbeat = setInterval(() => res.write(':thump\n'), 15000);
 
     req.on('close', () => {

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -436,6 +436,7 @@ const startWorker = (workerId) => {
     const accountId = req.accountId || req.remoteAddress;
 
     res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-store');
     res.setHeader('Transfer-Encoding', 'chunked');
 
     res.write(':)\n');


### PR DESCRIPTION
Send output on the server-sent events stream immediately so the client sees that it was successfully opened even if it doesn't have any messages.

Fix transparent SSE streaming for the public:local and hashtag:local stream types.