### PR TITLE
Fix unlocalized dropdown button title

### DIFF
--- a/app/javascript/mastodon/features/status/components/action_bar.js
+++ b/app/javascript/mastodon/features/status/components/action_bar.js
@@ -19,6 +19,7 @@ const messages = defineMessages({
   cannot_reblog: { id: 'status.cannot_reblog', defaultMessage: 'This post cannot be boosted' },
   favourite: { id: 'status.favourite', defaultMessage: 'Favourite' },
   bookmark: { id: 'status.bookmark', defaultMessage: 'Bookmark' },
+  more: { id: 'status.more', defaultMessage: 'More' },
   mute: { id: 'status.mute', defaultMessage: 'Mute @{name}' },
   muteConversation: { id: 'status.mute_conversation', defaultMessage: 'Mute conversation' },
   unmuteConversation: { id: 'status.unmute_conversation', defaultMessage: 'Unmute conversation' },
@@ -275,7 +276,7 @@ class ActionBar extends React.PureComponent {
         <div className='detailed-status__button'><IconButton className='bookmark-icon' active={status.get('bookmarked')} title={intl.formatMessage(messages.bookmark)} icon='bookmark' onClick={this.handleBookmarkClick} /></div>
 
         <div className='detailed-status__action-bar-dropdown'>
-          <DropdownMenuContainer size={18} icon='ellipsis-h' status={status} items={menu} direction='left' title='More' />
+          <DropdownMenuContainer size={18} icon='ellipsis-h' status={status} items={menu} direction='left' title={intl.formatMessage(messages.more)} />
         </div>
       </div>
     );


### PR DESCRIPTION
In detailed status component, "More" action bar button wasn't localized.

This PR fixes it according to previously used code.

| In timeline | In detailed view |
|:---:|:---:|
| ![Screenshot of the button in timeline, localized title tooltip is seen](https://user-images.githubusercontent.com/10401817/73103959-d6e7a080-3f27-11ea-83fa-4c25a09e64b7.png) | ![Screenshot of the button in detailed post view, title tooltip is not localized](https://user-images.githubusercontent.com/10401817/73103949-d18a5600-3f27-11ea-8461-d9b49405f6e8.png) |
| Localized | …not. |


---
*Thanks to the user who reported this in our [Russian team] Matrix chat.*
