### PR TITLE
Fix spurious error and incorrect state change when adding a reaction twice

### DIFF
--- a/app/javascript/mastodon/actions/announcements.js
+++ b/app/javascript/mastodon/actions/announcements.js
@@ -56,12 +56,27 @@ export const updateAnnouncements = announcement => ({
 });
 
 export const addReaction = (announcementId, name) => (dispatch, getState) => {
-  dispatch(addReactionRequest(announcementId, name));
+  const announcement = getState().getIn(['announcements', 'items']).find(x => x.get('id') === announcementId);
+
+  let alreadyAdded = false;
+
+  if (announcement) {
+    const reaction = announcement.get('reactions').find(x => x.get('name') === name);
+    if (reaction && reaction.get('me')) {
+      alreadyAdded = true;
+    }
+  }
+
+  if (!alreadyAdded) {
+    dispatch(addReactionRequest(announcementId, name, alreadyAdded));
+  }
 
   api(getState).put(`/api/v1/announcements/${announcementId}/reactions/${name}`).then(() => {
-    dispatch(addReactionSuccess(announcementId, name));
+    dispatch(addReactionSuccess(announcementId, name, alreadyAdded));
   }).catch(err => {
-    dispatch(addReactionFail(announcementId, name, err));
+    if (!alreadyAdded) {
+      dispatch(addReactionFail(announcementId, name, err));
+    }
   });
 };
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6632,7 +6632,6 @@ noscript {
 
 .announcements {
   background: lighten($ui-base-color, 8%);
-  border-top: 1px solid $ui-base-color;
   font-size: 13px;
   display: flex;
   align-items: flex-end;


### PR DESCRIPTION
From the emoji picker, it's easy to add an already-added reaction. Doing so results in the front-end optimistically upping the number, then decrementing it on error, and worse, marking the reaction as not voted by ourselves.

This PR avoids that if we believe we have already voted (this may be out of sync if several clients are involved, so we still try the request—in the worst case, we fail in the same way as before, in other cases we fail gracefully instead of adding distracting visual changes, an error popup, and an incorrect end state)

Also fix the box having an unneeded top border