### PR TITLE
Fix #12944 regressions

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5752,8 +5752,8 @@ a.status-card.compact:hover {
     text-align: center;
     text-decoration: none;
     position: relative;
-    overflow: hidden;
     width: 100%;
+    white-space: nowrap;
 
     &.active {
       color: $secondary-text-color;


### PR DESCRIPTION
 Fix regressions caused by #12961

This commit attempts to fix most of regressions caused by #12961pull request which added even spread of space between tabs. The following fixes were done:

- <details>
   <summary><strong>Don't hide overflow in tabs</strong></summary>

   As tabs use `::after` and `::before` pseudo-elements to create arrow on the bottom of selected tab, `overflow: hidden` will cause this arrow to look split from the bottom container.

   For the future we probably should use slider element instead, which would align according to currently selected tab, instead of relying on pseudo-elements. Such method would also allow smooth transitions.
   </details>

- <details>
   <summary><strong>Disallow wrapping tab text on insufficient space</strong></summary>

   This would fix some unwanted behavior<sup>[\[1\]][1]</sup> when on insufficient width, renderer might attempt wrapping text to not overtake others' space.

   [1]: https://mastodon.social/@Gargron/103546083813829165
   </details>