### PR TITLE
Add streaming API updates for announcements being modified or deleted

### DIFF
--- a/app/javascript/mastodon/actions/announcements.js
+++ b/app/javascript/mastodon/actions/announcements.js
@@ -5,6 +5,7 @@ export const ANNOUNCEMENTS_FETCH_REQUEST = 'ANNOUNCEMENTS_FETCH_REQUEST';
 export const ANNOUNCEMENTS_FETCH_SUCCESS = 'ANNOUNCEMENTS_FETCH_SUCCESS';
 export const ANNOUNCEMENTS_FETCH_FAIL    = 'ANNOUNCEMENTS_FETCH_FAIL';
 export const ANNOUNCEMENTS_UPDATE        = 'ANNOUNCEMENTS_UPDATE';
+export const ANNOUNCEMENTS_DELETE        = 'ANNOUNCEMENTS_DELETE';
 
 export const ANNOUNCEMENTS_REACTION_ADD_REQUEST = 'ANNOUNCEMENTS_REACTION_ADD_REQUEST';
 export const ANNOUNCEMENTS_REACTION_ADD_SUCCESS = 'ANNOUNCEMENTS_REACTION_ADD_SUCCESS';
@@ -139,8 +140,11 @@ export const updateReaction = reaction => ({
   reaction,
 });
 
-export function toggleShowAnnouncements() {
-  return dispatch => {
-    dispatch({ type: ANNOUNCEMENTS_TOGGLE_SHOW });
-  };
-}
+export const toggleShowAnnouncements = () => ({
+  type: ANNOUNCEMENTS_TOGGLE_SHOW,
+});
+
+export const deleteAnnouncement = id => ({
+  type: ANNOUNCEMENTS_DELETE,
+  id,
+});

--- a/app/javascript/mastodon/actions/streaming.js
+++ b/app/javascript/mastodon/actions/streaming.js
@@ -8,7 +8,12 @@ import {
 } from './timelines';
 import { updateNotifications, expandNotifications } from './notifications';
 import { updateConversations } from './conversations';
-import { fetchAnnouncements, updateAnnouncements, updateReaction as updateAnnouncementsReaction } from './announcements';
+import {
+  fetchAnnouncements,
+  updateAnnouncements,
+  updateReaction as updateAnnouncementsReaction,
+  deleteAnnouncement,
+} from './announcements';
 import { fetchFilters } from './filters';
 import { getLocale } from '../locales';
 
@@ -50,6 +55,9 @@ export function connectTimelineStream (timelineId, path, pollingRefresh = null, 
           break;
         case 'announcement.reaction':
           dispatch(updateAnnouncementsReaction(JSON.parse(data.payload)));
+          break;
+        case 'announcement.delete':
+          dispatch(deleteAnnouncement(data.payload));
           break;
         }
       },

--- a/app/javascript/mastodon/components/animated_number.js
+++ b/app/javascript/mastodon/components/animated_number.js
@@ -27,7 +27,8 @@ export default class AnimatedNumber extends React.PureComponent {
     }
 
     const styles = [{
-      key: value,
+      key: `${value}`,
+      data: value,
       style: { y: spring(0, { damping: 35, stiffness: 400 }) },
     }];
 
@@ -35,8 +36,8 @@ export default class AnimatedNumber extends React.PureComponent {
       <TransitionMotion styles={styles} willEnter={this.willEnter} willLeave={this.willLeave}>
         {items => (
           <span className='animated-number'>
-            {items.map(({ key, style }) => (
-              <span key={key} style={{ position: style.y > 0 ? 'absolute' : 'static', transform: `translateY(${style.y * 100}%)` }}><FormattedNumber value={key} /></span>
+            {items.map(({ key, data, style }) => (
+              <span key={key} style={{ position: style.y > 0 ? 'absolute' : 'static', transform: `translateY(${style.y * 100}%)` }}><FormattedNumber value={data} /></span>
             ))}
           </span>
         )}

--- a/app/javascript/mastodon/features/getting_started/components/announcements.js
+++ b/app/javascript/mastodon/features/getting_started/components/announcements.js
@@ -367,11 +367,13 @@ class Announcements extends ImmutablePureComponent {
             ))}
           </ReactSwipeableViews>
 
-          <div className='announcements__pagination'>
-            <IconButton disabled={announcements.size === 1} title={intl.formatMessage(messages.previous)} icon='chevron-left' onClick={this.handlePrevClick} size={13} />
-            <span>{index + 1} / {announcements.size}</span>
-            <IconButton disabled={announcements.size === 1} title={intl.formatMessage(messages.next)} icon='chevron-right' onClick={this.handleNextClick} size={13} />
-          </div>
+          {announcements.size > 1 && (
+            <div className='announcements__pagination'>
+              <IconButton disabled={announcements.size === 1} title={intl.formatMessage(messages.previous)} icon='chevron-left' onClick={this.handlePrevClick} size={13} />
+              <span>{index + 1} / {announcements.size}</span>
+              <IconButton disabled={announcements.size === 1} title={intl.formatMessage(messages.next)} icon='chevron-right' onClick={this.handleNextClick} size={13} />
+            </div>
+          )}
         </div>
       </div>
     );

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -11,6 +11,10 @@ class FeedManager
   # Must be <= MAX_ITEMS or the tracking sets will grow forever
   REBLOG_FALLOFF = 40
 
+  def with_active_accounts(&block)
+    Account.joins(:user).where('users.current_sign_in_at > ?', User::ACTIVE_DURATION.ago).find_each(&block)
+  end
+
   def key(type, id, subtype = nil)
     return "feed:#{type}:#{id}" unless subtype
 

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -16,8 +16,6 @@
 #
 
 class Announcement < ApplicationRecord
-  after_commit :queue_publish, on: :create
-
   scope :unpublished, -> { where(published: false) }
   scope :published, -> { where(published: true) }
   scope :without_muted, ->(account) { joins("LEFT OUTER JOIN announcement_mutes ON announcement_mutes.announcement_id = announcements.id AND announcement_mutes.account_id = #{account.id}").where('announcement_mutes.id IS NULL') }
@@ -31,8 +29,11 @@ class Announcement < ApplicationRecord
   validates :ends_at, presence: true, if: -> { starts_at.present? }
 
   before_validation :set_all_day
-  before_validation :set_starts_at, on: :create
-  before_validation :set_ends_at, on: :create
+  before_validation :set_published, on: :create
+
+  def published_at
+    scheduled_at || created_at
+  end
 
   def time_range?
     starts_at.present? && ends_at.present?
@@ -71,15 +72,7 @@ class Announcement < ApplicationRecord
     self.all_day = false if starts_at.blank? || ends_at.blank?
   end
 
-  def set_starts_at
-    self.starts_at = starts_at.change(hour: 0, min: 0, sec: 0) if all_day? && starts_at.present?
-  end
-
-  def set_ends_at
-    self.ends_at = ends_at.change(hour: 23, min: 59, sec: 59) if all_day? && ends_at.present?
-  end
-
-  def queue_publish
-    PublishScheduledAnnouncementWorker.perform_async(id) if scheduled_at.blank?
+  def set_published
+    self.published = true if scheduled_at.blank? || scheduled_at.past?
   end
 end

--- a/app/serializers/rest/announcement_serializer.rb
+++ b/app/serializers/rest/announcement_serializer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class REST::AnnouncementSerializer < ActiveModel::Serializer
-  attributes :id, :content, :starts_at, :ends_at, :all_day
+  attributes :id, :content, :starts_at, :ends_at, :all_day,
+             :published_at, :updated_at
 
   has_many :mentions
   has_many :tags, serializer: REST::StatusSerializer::TagSerializer

--- a/app/workers/publish_announcement_reaction_worker.rb
+++ b/app/workers/publish_announcement_reaction_worker.rb
@@ -13,7 +13,7 @@ class PublishAnnouncementReactionWorker
     payload = InlineRenderer.render(reaction, nil, :reaction).tap { |h| h[:announcement_id] = announcement_id.to_s }
     payload = Oj.dump(event: :'announcement.reaction', payload: payload)
 
-    Account.joins(:user).where('users.current_sign_in_at > ?', User::ACTIVE_DURATION.ago).find_each do |account|
+    FeedManager.instance.with_active_accounts do |account|
       redis.publish("timeline:#{account.id}", payload) if redis.exists("subscribed:timeline:#{account.id}")
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/workers/unpublish_announcement_worker.rb
+++ b/app/workers/unpublish_announcement_worker.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-class PublishScheduledAnnouncementWorker
+class UnpublishAnnouncementWorker
   include Sidekiq::Worker
   include Redisable
 
   def perform(announcement_id)
-    announcement = Announcement.find(announcement_id)
-    announcement.update(published: true)
-
-    payload = InlineRenderer.render(announcement, nil, :announcement)
-    payload = Oj.dump(event: :announcement, payload: payload)
+    payload = Oj.dump(event: :'announcement.delete', payload: announcement_id.to_s)
 
     FeedManager.instance.with_active_accounts do |account|
       redis.publish("timeline:#{account.id}", payload) if redis.exists("subscribed:timeline:#{account.id}")


### PR DESCRIPTION
Change `all_day` to be a visual client-side cue only

Publish immediately if `scheduled_at` is in the past

Add `published_at` and `updated_at` to announcements JSON