### PR TITLE
Revert "Avoid using uppercase text-transform"

### DIFF
--- a/app/javascript/styles/mastodon/_mixins.scss
+++ b/app/javascript/styles/mastodon/_mixins.scss
@@ -34,8 +34,9 @@
   box-shadow: 2px 4px 15px rgba($base-shadow-color, 0.4);
 
   h4 {
+    text-transform: uppercase;
     color: $light-text-color;
-    font-size: 14px;
+    font-size: 13px;
     font-weight: 500;
     margin-bottom: 10px;
   }

--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -719,8 +719,9 @@ $small-breakpoint: 960px;
 
     h4 {
       padding: 10px;
+      text-transform: uppercase;
       font-weight: 700;
-      font-size: 14px;
+      font-size: 13px;
       color: $darker-text-color;
     }
 

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -129,6 +129,7 @@
 
   .older,
   .newer {
+    text-transform: uppercase;
     color: $secondary-text-color;
   }
 

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -232,7 +232,8 @@ $content-width: 840px;
     }
 
     h4 {
-      font-size: 14px;
+      text-transform: uppercase;
+      font-size: 13px;
       font-weight: 700;
       color: $darker-text-color;
       padding-bottom: 8px;
@@ -407,7 +408,8 @@ body,
 
     strong {
       font-weight: 500;
-      font-size: 13px;
+      text-transform: uppercase;
+      font-size: 12px;
 
       @each $lang in $cjk-langs {
         &:lang(#{$lang}) {
@@ -420,7 +422,8 @@ body,
       display: inline-block;
       color: $darker-text-color;
       text-decoration: none;
-      font-size: 13px;
+      text-transform: uppercase;
+      font-size: 12px;
       font-weight: 500;
       border-bottom: 2px solid $ui-base-color;
 
@@ -754,6 +757,7 @@ a.name-tag,
       flex: 0 0 auto;
       font-weight: 500;
       color: $darker-text-color;
+      text-transform: uppercase;
       text-align: right;
 
       a {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -41,7 +41,7 @@
   cursor: pointer;
   display: inline-block;
   font-family: inherit;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 500;
   height: 36px;
   letter-spacing: 0;
@@ -50,6 +50,7 @@
   padding: 0 16px;
   position: relative;
   text-align: center;
+  text-transform: uppercase;
   text-decoration: none;
   text-overflow: ellipsis;
   transition: all 100ms ease-in;
@@ -936,8 +937,9 @@
   border: 0;
   color: $inverted-text-color;
   font-weight: 700;
-  font-size: 12px;
+  font-size: 11px;
   padding: 0 6px;
+  text-transform: uppercase;
   line-height: 20px;
   cursor: pointer;
   vertical-align: middle;
@@ -1460,7 +1462,8 @@ a .account__avatar {
 
   & > span {
     display: block;
-    font-size: 12px;
+    text-transform: uppercase;
+    font-size: 11px;
     color: $darker-text-color;
   }
 
@@ -2808,8 +2811,9 @@ a.account__display-name {
   background: $ui-base-color;
   color: $dark-text-color;
   padding: 8px 20px;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
+  text-transform: uppercase;
   cursor: default;
 }
 
@@ -2874,7 +2878,8 @@ a.account__display-name {
     margin-top: 10px;
 
     h4 {
-      font-size: 13px;
+      font-size: 12px;
+      text-transform: uppercase;
       color: $darker-text-color;
       padding: 10px;
       font-weight: 500;
@@ -3404,8 +3409,9 @@ a.status-card.compact:hover {
 
 .loading-indicator {
   color: $dark-text-color;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 400;
+  text-transform: uppercase;
   overflow: visible;
   position: absolute;
   top: 50%;
@@ -3769,7 +3775,8 @@ a.status-card.compact:hover {
   display: block;
   vertical-align: top;
   background-color: $base-overlay-background;
-  font-size: 12px;
+  text-transform: uppercase;
+  font-size: 11px;
   font-weight: 500;
   padding: 4px;
   border-radius: 4px;
@@ -4021,7 +4028,8 @@ a.status-card.compact:hover {
   }
 
   span {
-    font-size: 13px;
+    font-size: 12px;
+    text-transform: uppercase;
     font-weight: 500;
     display: block;
   }
@@ -4620,7 +4628,8 @@ a.status-card.compact:hover {
     font-weight: 500;
     color: $inverted-text-color;
     margin-bottom: 5px;
-    font-size: 13px;
+    text-transform: uppercase;
+    font-size: 12px;
   }
 
   &__case {

--- a/app/javascript/styles/mastodon/footer.scss
+++ b/app/javascript/styles/mastodon/footer.scss
@@ -94,6 +94,7 @@
     }
 
     h4 {
+      text-transform: uppercase;
       font-weight: 700;
       margin-bottom: 8px;
       color: $darker-text-color;

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -420,6 +420,7 @@ code {
     line-height: inherit;
     height: auto;
     padding: 10px;
+    text-transform: uppercase;
     text-decoration: none;
     text-align: center;
     box-sizing: border-box;
@@ -662,6 +663,7 @@ code {
 
   a {
     color: $highlight-text-color;
+    text-transform: uppercase;
     text-decoration: none;
     font-weight: 700;
 

--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -76,8 +76,9 @@
 
   h4 {
     padding: 10px;
+    text-transform: uppercase;
     font-weight: 700;
-    font-size: 14px;
+    font-size: 13px;
     color: $darker-text-color;
   }
 
@@ -138,8 +139,9 @@
 
   h4 {
     padding: 10px;
+    text-transform: uppercase;
     font-weight: 700;
-    font-size: 14px;
+    font-size: 13px;
     color: $darker-text-color;
   }
 
@@ -406,6 +408,7 @@
 
   thead th {
     text-align: center;
+    text-transform: uppercase;
     color: $darker-text-color;
     font-weight: 700;
     padding: 10px;


### PR DESCRIPTION
Reverts tootsuite/mastodon#12684

It doesn't look as good without uppercase to differentiate elements.