### PR TITLE
Add "Show thread" button to public profiles

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -923,6 +923,7 @@
   background: transparent;
   padding: 0;
   padding-top: 8px;
+  text-decoration: none;
 
   &:hover,
   &:active {

--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -45,6 +45,10 @@
   - elsif status.preview_card
     = react_component :card, 'maxDescription': 160, card: ActiveModelSerializers::SerializableResource.new(status.preview_card, serializer: REST::PreviewCardSerializer).as_json
 
+  - if !status.in_reply_to_id.nil? && status.in_reply_to_account_id == status.account.id
+    = link_to ActivityPub::TagManager.instance.url_for(status), class: 'status__content__read-more-button', target: stream_link_target, rel: 'noopener noreferrer' do
+      = t 'statuses.show_thread'
+
   .status__action-bar
     .status__action-bar__counter
       = link_to remote_interaction_path(status, type: :reply), class: 'status__action-bar-button icon-button modal-button', style: 'font-size: 18px; width: 23.1429px; height: 23.1429px; line-height: 23.15px;' do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1088,6 +1088,7 @@ en:
         other: "%{count} votes"
       vote: Vote
     show_more: Show more
+    show_thread: Show thread
     sign_in_to_participate: Sign in to participate in the conversation
     title: '%{name}: "%{quote}"'
     visibilities:


### PR DESCRIPTION
This adds "Show thread" button to the status view which is used in profiles. The logic to display the button is mimicking logic in web app available at [app/javascript/mastodon/components/status.js#L439](https://github.com/tootsuite/mastodon/blob/master/app/javascript/mastodon/components/status.js#L439):

https://github.com/tootsuite/mastodon/blob/60e160a02d47c4b3825dc1fd249ee5b4847022c5/app/javascript/mastodon/components/status.js#L439-L443

*The little change in components CSS required to remove enforced underline for all links on public pages on our button.*

<p align=center>
<img src="https://user-images.githubusercontent.com/10401817/73314924-47146000-4261-11ea-89ed-0a29c8a5d6ad.jpg" alt="Screenshot demonstrating the button with red arrow pointing at it with text on white backgroud “Slick button” and WordArd “Wow” at the right bottom">
</p>