### PR TITLE
Add JS IDE helper

### DIFF
--- a/ide-helper.js
+++ b/ide-helper.js
@@ -1,0 +1,11 @@
+/*
+Preferences | Languages & Frameworks | JavaScript | Webpack | webpack configuration file
+jetbrains://WebStorm/settings?name=Languages+%26+Frameworks--JavaScript--Webpack
+*/
+module.exports = {
+  resolve: {
+    alias: {
+      'mastodon': path.resolve(__dirname, 'app/javascript/mastodon'),
+    }
+  }
+}

--- a/ide-helper.js
+++ b/ide-helper.js
@@ -1,3 +1,4 @@
+/* global path */
 /*
 Preferences | Languages & Frameworks | JavaScript | Webpack | webpack configuration file
 jetbrains://WebStorm/settings?name=Languages+%26+Frameworks--JavaScript--Webpack

--- a/ide-helper.js
+++ b/ide-helper.js
@@ -7,6 +7,6 @@ module.exports = {
   resolve: {
     alias: {
       'mastodon': path.resolve(__dirname, 'app/javascript/mastodon'),
-    }
-  }
-}
+    },
+  },
+};


### PR DESCRIPTION
In JetBrains IDE, like WebStorm or RubyMine, this import is not recognized as valid import:

```js
import Icon from 'mastodon/components/icon';
```

IDE [has Webpack support](https://www.jetbrains.com/help/idea/using-webpack.html#) but I don't know a way to set it up with complex Webpack configurations such as one used in this repository.

To let IDE know where is 'mastodon' alias is located, there is a trick: write fake Webpack config just for IDE, provide used aliases in form IDE understand, and select this file as Webpack config in IDE settings.