### PR TITLE
Fix error when sending moderation notification

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,6 +6,7 @@ class UserMailer < Devise::Mailer
   helper :accounts
   helper :application
   helper :instance
+  helper :statuses
 
   add_template_helper RoutingHelper
 


### PR DESCRIPTION
Since the statuses helper is not loaded, the rtl helper cannot be found and the email cannot be sent.