### PR TITLE
Add share button to own profile

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -11,6 +11,7 @@ import Avatar from 'mastodon/components/avatar';
 import { shortNumberFormat } from 'mastodon/utils/numbers';
 import { NavLink } from 'react-router-dom';
 import DropdownMenuContainer from 'mastodon/containers/dropdown_menu_container';
+import IconButton from '../../../components/icon_button';
 
 const messages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },
@@ -45,6 +46,7 @@ const messages = defineMessages({
   unendorse: { id: 'account.unendorse', defaultMessage: 'Don\'t feature on profile' },
   add_or_remove_from_list: { id: 'account.add_or_remove_from_list', defaultMessage: 'Add or Remove from lists' },
   admin_account: { id: 'status.admin_account', defaultMessage: 'Open moderation interface for @{name}' },
+  share_profile: { id: 'profile.share', defaultMessage: 'Share profile' },
 });
 
 const dateFormatOptions = {
@@ -64,6 +66,7 @@ class Header extends ImmutablePureComponent {
     identity_props: ImmutablePropTypes.list,
     onFollow: PropTypes.func.isRequired,
     onBlock: PropTypes.func.isRequired,
+    onShare: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
     domain: PropTypes.string.isRequired,
   };
@@ -129,6 +132,7 @@ class Header extends ImmutablePureComponent {
     }
 
     let info        = [];
+    let shareBtn    = '';
     let actionBtn   = '';
     let lockedIcon  = '';
     let menu        = [];
@@ -156,6 +160,8 @@ class Header extends ImmutablePureComponent {
         actionBtn = <Button className='logo-button' text={intl.formatMessage(messages.unblock, { name: account.get('username') })} onClick={this.props.onBlock} />;
       }
     } else {
+      shareBtn = <IconButton icon='share' title={intl.formatMessage(messages.share_profile)} size={24} style={{ marginRight: '5px' }}onClick={this.props.onShare} />;
+
       actionBtn = <Button className='logo-button' text={intl.formatMessage(messages.edit_profile)} onClick={this.openEditProfile} />;
     }
 
@@ -270,6 +276,7 @@ class Header extends ImmutablePureComponent {
 
             <div className='account__header__tabs__buttons'>
               {actionBtn}
+              {shareBtn}
 
               <DropdownMenuContainer items={menu} icon='ellipsis-v' size={24} direction='right' />
             </div>

--- a/app/javascript/mastodon/features/account_timeline/components/header.js
+++ b/app/javascript/mastodon/features/account_timeline/components/header.js
@@ -23,6 +23,7 @@ export default class Header extends ImmutablePureComponent {
     onUnblockDomain: PropTypes.func.isRequired,
     onEndorseToggle: PropTypes.func.isRequired,
     onAddToList: PropTypes.func.isRequired,
+    onShare: PropTypes.func.isRequired,
     hideTabs: PropTypes.bool,
     domain: PropTypes.string.isRequired,
   };
@@ -83,6 +84,10 @@ export default class Header extends ImmutablePureComponent {
     this.props.onAddToList(this.props.account);
   }
 
+  handleShare = () => {
+    this.props.onShare(this.props.account, this.props.domain);
+  }
+
   render () {
     const { account, hideTabs, identity_proofs } = this.props;
 
@@ -108,6 +113,7 @@ export default class Header extends ImmutablePureComponent {
           onUnblockDomain={this.handleUnblockDomain}
           onEndorseToggle={this.handleEndorseToggle}
           onAddToList={this.handleAddToList}
+          onShare={this.handleShare}
           domain={this.props.domain}
         />
 

--- a/app/javascript/mastodon/features/account_timeline/containers/header_container.js
+++ b/app/javascript/mastodon/features/account_timeline/containers/header_container.js
@@ -120,6 +120,14 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     }));
   },
 
+  onShare(account, domain) {
+    dispatch(openModal('SHARE_PROFILE', {
+      url: account.get('url'),
+      handle: account.get('acct'),
+      domain,
+    }));
+  },
+
 });
 
 export default injectIntl(connect(makeMapStateToProps, mapDispatchToProps)(Header));

--- a/app/javascript/mastodon/features/ui/components/modal_root.js
+++ b/app/javascript/mastodon/features/ui/components/modal_root.js
@@ -19,6 +19,7 @@ import {
   EmbedModal,
   ListEditor,
   ListAdder,
+  ShareProfileModal,
 } from '../../../features/ui/util/async-components';
 
 const MODAL_COMPONENTS = {
@@ -35,6 +36,7 @@ const MODAL_COMPONENTS = {
   'LIST_EDITOR': ListEditor,
   'FOCAL_POINT': () => Promise.resolve({ default: FocalPointModal }),
   'LIST_ADDER':ListAdder,
+  'SHARE_PROFILE': ShareProfileModal,
 };
 
 export default class ModalRoot extends React.PureComponent {

--- a/app/javascript/mastodon/features/ui/components/share_profile_modal.js
+++ b/app/javascript/mastodon/features/ui/components/share_profile_modal.js
@@ -1,0 +1,191 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import IconButton from '../../../components/icon_button';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import Icon from '../../../components/icon';
+
+const messages = defineMessages({
+  close: { id: 'lightbox.close', defaultMessage: 'Close' },
+  twitterText: { id: 'profile.share.twitter_text', defaultMessage: 'I\'m {handle} on Mastodon, follow me:' },
+  twitterHashtag: { id: 'profile.share.twitter_hashtag', defaultMessage: 'ImOnMastodon' },
+  shareFacebook: { id: 'profile.share.share_facebook', defaultMessage: 'Share on Facebook' },
+  shareTwitter: { id: 'profile.share.share_twitter', defaultMessage: 'Share on Twitter' },
+  shareVK: { id: 'profile.share.share_vk', defaultMessage: 'Share on VK' },
+  shareClipboard: { id: 'profile.share.share_clipboard', defaultMessage: 'Copy to clipboard' },
+});
+
+export default @injectIntl
+class ShareProfileModal extends ImmutablePureComponent {
+
+  static propTypes = {
+    url: PropTypes.string.isRequired,
+    handle: PropTypes.string.isRequired,
+    domain: PropTypes.string.isRequired,
+    onClose: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+  };
+
+  handleTextareClick = (e) => {
+    e.target.select();
+  }
+
+  getFullHandle = () => {
+    const { handle, domain } = this.props;
+
+    return `@${handle}@${domain}`;
+  }
+
+  getFacebookShareLink = () => {
+    const { url } = this.props;
+
+    const fbLink = new URL('https://facebook.com/sharer/sharer.php');
+
+    fbLink.searchParams.set('u', url);
+
+    return fbLink.href;
+  }
+
+  getTwitterShareLink = () => {
+    const { url, intl } = this.props;
+
+    const twitterLink = new URL('https://twitter.com/intent/tweet');
+
+    const postText = intl.formatMessage(messages.twitterText, {
+      handle: this.getFullHandle(),
+    });
+
+    const postHashtags = ['Mastodon', intl.formatMessage(messages.twitterHashtag)];
+
+    twitterLink.searchParams.set('text', postText);
+    twitterLink.searchParams.set('url', url);
+
+    twitterLink.searchParams.set('hashtags', postHashtags.join(','));
+
+    return twitterLink.href;
+  }
+
+  getVKShareLink = () => {
+    const { url } = this.props;
+
+    const vkLink = new URL('https://vk.com/share.php');
+
+    vkLink.searchParams.set('url', url);
+
+    return vkLink.href;
+  }
+
+  onSocialShare = (href) => (e) => {
+    e.preventDefault();
+
+    const windowFeatures = [
+      'noreferrer',
+      'width=600',
+      'height=400',
+      'resizable',
+      'menubar=no',
+      'toolbar=no',
+      'location=no',
+      'scrollbars',
+    ];
+
+    window.open(href, 'share_dialog', windowFeatures.join(', '));
+  }
+
+  clipboardCopy = () => {
+    const { urlField, clipboardButton } = this;
+
+    if (!urlField) return;
+
+    urlField.select();
+
+    document.execCommand('copy');
+
+    if (clipboardButton) {
+      clipboardButton.focus();
+
+      clipboardButton.classList.add('copied');
+
+      setTimeout(() => {
+        clipboardButton.classList.remove('copied');
+      }, 100);
+    }
+  }
+
+  setField = (field) => {
+    this.urlField = field;
+  }
+
+  setClipboardButton = (button) => {
+    this.clipboardButton = button;
+  }
+
+  render() {
+    const { url, handle, domain } = this.props;
+
+    if (!url || !handle || !domain) {
+      return null;
+    }
+
+    const { intl, onClose } = this.props;
+
+    const twitterLink = this.getTwitterShareLink();
+    const facebookLink = this.getFacebookShareLink();
+    const vkLink = this.getVKShareLink();
+
+    return (
+      <div className='modal-root__modal report-modal embed-modal share-profile-modal'>
+        <div className='report-modal__target'>
+          <IconButton className='media-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={16} />
+          <FormattedMessage id='profile.share.title' defaultMessage='Share profile' />
+        </div>
+
+        <div className='report-modal__container embed-modal__container share-profile-modal__container' style={{ display: 'block' }}>
+
+          <p className='hint center-text'>
+            <FormattedMessage id='profile.share.handle' defaultMessage='This is your full handle:' />
+          </p>
+
+          <input
+            type='text'
+            className='share-profile-modal__handle'
+            readOnly
+            value={`@${handle}@${domain}`}
+            onClick={this.handleTextareClick}
+          />
+
+          <p className='hint center-text'>
+            <FormattedMessage id='profile.share.instructions' defaultMessage='Use the link below to share your profile:' />
+          </p>
+
+          <input
+            type='text'
+            className='embed-modal__html'
+            readOnly
+            value={url}
+            onClick={this.handleTextareClick}
+            ref={this.setField}
+          />
+
+          <p className='center-text share-profile-modal__socials'>
+            <a href={twitterLink} className='share-twitter' onClick={this.onSocialShare(twitterLink)} title={intl.formatMessage(messages.shareTwitter)} target='_blank' rel='noreferrer'>
+              <Icon id='twitter fa-fw' />
+            </a>
+            {intl.locale !== 'ru'
+              ? <a href={facebookLink} className='share-facebook' onClick={this.onSocialShare(facebookLink)} title={intl.formatMessage(messages.shareFacebook)} target='_blank' rel='noreferrer'>
+                <Icon id='facebook fa-fw' />
+              </a>
+              : <a href={vkLink} className='share-vk' onClick={this.onSocialShare(vkLink)} title={intl.formatMessage(messages.shareVK)} target='_blank' rel='noreferrer'>
+                <Icon id='vk fa-fw' />
+              </a>}
+            <button className='share-clipboard' onClick={this.clipboardCopy} title={intl.formatMessage(messages.shareClipboard)} ref={this.setClipboardButton}>
+              <Icon id='clipboard fa-fw' />
+            </button>
+          </p>
+
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -153,3 +153,7 @@ export function Audio () {
 export function Directory () {
   return import(/* webpackChunkName: "features/directory" */'../../directory');
 }
+
+export function ShareProfileModal() {
+  return import(/* webpackChunkName: "modals/share_profile_modal" */'../components/share_profile_modal');
+}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6042,6 +6042,75 @@ noscript {
   }
 }
 
+.share-profile-modal {
+  $modal: &;
+
+  &__container {
+    padding: 15px 25px !important;
+
+    #{$modal}__handle {
+      box-sizing: border-box;
+      background: none;
+      border: 0;
+      text-align: center;
+      width: 100%;
+      font-size: 18px;
+      margin: -15px 0 15px;
+    }
+
+    #{$modal}__socials {
+      & > a,
+      & > button {
+        $size: 42px;
+
+        display: inline-block;
+
+        font-size: 32px;
+
+        width: $size;
+        height: $size;
+
+        text-align: center;
+        line-height: $size;
+        vertical-align: middle;
+
+        background: none;
+
+        box-sizing: border-box;
+
+        margin: 10px;
+        padding: 0;
+
+        border: 0;
+      }
+
+      .share {
+        &-twitter {
+          color: #1da1f2;
+        }
+
+        &-facebook {
+          color: #3b5998;
+        }
+
+        &-vk {
+          color: #4680c2;
+        }
+
+        &-clipboard {
+          font-size: 26px !important;
+          transition: .5s ease;
+
+          &.copied {
+            color: #006400;
+            transition: none;
+          }
+        }
+      }
+    }
+  }
+}
+
 .account__moved-note {
   padding: 14px 10px;
   padding-bottom: 16px;


### PR DESCRIPTION
This PR adds share button to own profile, which opens modal with full account handle (incl. domain), URL to the profile itself and buttons to share profile to Twitter or Facebook, allowing users to easily share their profiles in old social networks they used.

If Russian locale is used, Facebook share link replaced with VK, as it is more popular within the potential auditory of Mastodon in Russia.

<p align=center>
<img src="https://user-images.githubusercontent.com/10401817/73579641-8935df80-44b5-11ea-8014-0346ad166d88.png" alt="Screenshot of the button">
</p>
<p align=center><i>Looks like button...</i></p>

​

<p align=center>
<img src="https://user-images.githubusercontent.com/10401817/73579276-85ee2400-44b4-11ea-8833-b3c7b9fa33ab.png" alt="Screenshot of the dialog">
</p>
<p align=center><i>What a design!</i></p>

### Social share texts:

| Service | Example content | Note |
|:-----:|:------|:------|
| Facebook | http://localhost:3000/@admin | Won't allow anything else |
| VK | http://localhost:3000/@admin | Can use title/image, but they automatically gathered from the attached URL |
| Twitter | I'm @admin@localhost:3000 on Mastodon, follow me: http://localhost:3000/@admin #Mastodon #ImOnMastodon | Content and `#ImOnMastodon` hashtag are localizable |
