### PR TITLE
Change how unread announcements are handled

### DIFF
--- a/app/controllers/api/v1/announcements_controller.rb
+++ b/app/controllers/api/v1/announcements_controller.rb
@@ -19,11 +19,7 @@ class Api::V1::AnnouncementsController < Api::BaseController
 
   def set_announcements
     @announcements = begin
-      scope = Announcement.published
-
-      scope.merge!(Announcement.without_muted(current_account)) unless truthy_param?(:with_dismissed)
-
-      scope.chronological
+      Announcement.published.chronological
     end
   end
 

--- a/app/javascript/mastodon/actions/announcements.js
+++ b/app/javascript/mastodon/actions/announcements.js
@@ -7,6 +7,10 @@ export const ANNOUNCEMENTS_FETCH_FAIL    = 'ANNOUNCEMENTS_FETCH_FAIL';
 export const ANNOUNCEMENTS_UPDATE        = 'ANNOUNCEMENTS_UPDATE';
 export const ANNOUNCEMENTS_DELETE        = 'ANNOUNCEMENTS_DELETE';
 
+export const ANNOUNCEMENTS_DISMISS_REQUEST = 'ANNOUNCEMENTS_DISMISS_REQUEST';
+export const ANNOUNCEMENTS_DISMISS_SUCCESS = 'ANNOUNCEMENTS_DISMISS_SUCCESS';
+export const ANNOUNCEMENTS_DISMISS_FAIL    = 'ANNOUNCEMENTS_DISMISS_FAIL';
+
 export const ANNOUNCEMENTS_REACTION_ADD_REQUEST = 'ANNOUNCEMENTS_REACTION_ADD_REQUEST';
 export const ANNOUNCEMENTS_REACTION_ADD_SUCCESS = 'ANNOUNCEMENTS_REACTION_ADD_SUCCESS';
 export const ANNOUNCEMENTS_REACTION_ADD_FAIL    = 'ANNOUNCEMENTS_REACTION_ADD_FAIL';
@@ -54,6 +58,34 @@ export const fetchAnnouncementsFail= error => ({
 export const updateAnnouncements = announcement => ({
   type: ANNOUNCEMENTS_UPDATE,
   announcement: normalizeAnnouncement(announcement),
+});
+
+export const dismissAnnouncement = announcementId => (dispatch, getState) => {
+  dispatch(dismissAnnouncementRequest(announcementId));
+
+  api(getState).post(`/api/v1/announcements/${announcementId}/dismiss`).then(() => {
+    dispatch(dismissAnnouncementSuccess(announcementId));
+  }).catch(error => {
+    dispatch(dismissAnnouncementFail(announcementId, error));
+  }).finally(() => {
+    done();
+  });
+};
+
+export const dismissAnnouncementRequest = announcementId => ({
+  type: ANNOUNCEMENTS_DISMISS_REQUEST,
+  id: announcementId,
+});
+
+export const dismissAnnouncementSuccess = announcementId => ({
+  type: ANNOUNCEMENTS_DISMISS_SUCCESS,
+  id: announcementId,
+});
+
+export const dismissAnnouncementFail = (announcementId, error) => ({
+  type: ANNOUNCEMENTS_DISMISS_FAIL,
+  id: announcementId,
+  error,
 });
 
 export const addReaction = (announcementId, name) => (dispatch, getState) => {

--- a/app/javascript/mastodon/actions/announcements.js
+++ b/app/javascript/mastodon/actions/announcements.js
@@ -67,8 +67,6 @@ export const dismissAnnouncement = announcementId => (dispatch, getState) => {
     dispatch(dismissAnnouncementSuccess(announcementId));
   }).catch(error => {
     dispatch(dismissAnnouncementFail(announcementId, error));
-  }).finally(() => {
-    done();
   });
 };
 

--- a/app/javascript/mastodon/features/getting_started/containers/announcements_container.js
+++ b/app/javascript/mastodon/features/getting_started/containers/announcements_container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { addReaction, removeReaction } from 'mastodon/actions/announcements';
+import { addReaction, removeReaction, dismissAnnouncement } from 'mastodon/actions/announcements';
 import Announcements from '../components/announcements';
 import { createSelector } from 'reselect';
 import { Map as ImmutableMap } from 'immutable';
@@ -12,6 +12,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
+  dismissAnnouncement: id => dispatch(dismissAnnouncement(id)),
   addReaction: (id, name) => dispatch(addReaction(id, name)),
   removeReaction: (id, name) => dispatch(removeReaction(id, name)),
 });

--- a/app/javascript/mastodon/features/home_timeline/index.js
+++ b/app/javascript/mastodon/features/home_timeline/index.js
@@ -24,7 +24,7 @@ const mapStateToProps = state => ({
   hasUnread: state.getIn(['timelines', 'home', 'unread']) > 0,
   isPartial: state.getIn(['timelines', 'home', 'isPartial']),
   hasAnnouncements: !state.getIn(['announcements', 'items']).isEmpty(),
-  unreadAnnouncements: state.getIn(['announcements', 'unread']).size,
+  unreadAnnouncements: state.getIn(['announcements', 'items']).count(item => !item.get('read')),
   showAnnouncements: state.getIn(['announcements', 'show']),
 });
 

--- a/app/javascript/mastodon/reducers/announcements.js
+++ b/app/javascript/mastodon/reducers/announcements.js
@@ -10,7 +10,7 @@ import {
   ANNOUNCEMENTS_REACTION_REMOVE_FAIL,
   ANNOUNCEMENTS_TOGGLE_SHOW,
   ANNOUNCEMENTS_DELETE,
-  ANNOUNCEMENTS_DISMISS_SUCCESS
+  ANNOUNCEMENTS_DISMISS_SUCCESS,
 } from '../actions/announcements';
 import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 
@@ -85,7 +85,7 @@ export default function announcementsReducer(state = initialState, action) {
   case ANNOUNCEMENTS_REACTION_ADD_FAIL:
     return removeReaction(state, action.id, action.name);
   case ANNOUNCEMENTS_DISMISS_SUCCESS:
-    return updateAnnouncement(state, fromJS({'id': action.id, 'read': true}));
+    return updateAnnouncement(state, fromJS({ 'id': action.id, 'read': true }));
   case ANNOUNCEMENTS_DELETE:
     return state.update('items', list => {
       const idx = list.findIndex(x => x.get('id') === action.id);

--- a/app/javascript/mastodon/reducers/announcements.js
+++ b/app/javascript/mastodon/reducers/announcements.js
@@ -10,6 +10,7 @@ import {
   ANNOUNCEMENTS_REACTION_REMOVE_FAIL,
   ANNOUNCEMENTS_TOGGLE_SHOW,
   ANNOUNCEMENTS_DELETE,
+  ANNOUNCEMENTS_DISMISS_SUCCESS
 } from '../actions/announcements';
 import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 
@@ -83,6 +84,8 @@ export default function announcementsReducer(state = initialState, action) {
   case ANNOUNCEMENTS_REACTION_REMOVE_REQUEST:
   case ANNOUNCEMENTS_REACTION_ADD_FAIL:
     return removeReaction(state, action.id, action.name);
+  case ANNOUNCEMENTS_DISMISS_SUCCESS:
+    return updateAnnouncement(state, fromJS({'id': action.id, 'read': true}));
   case ANNOUNCEMENTS_DELETE:
     return state.update('items', list => {
       const idx = list.findIndex(x => x.get('id') === action.id);

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6694,6 +6694,18 @@ noscript {
       font-weight: 500;
       margin-bottom: 10px;
     }
+
+    &__unread {
+      position: absolute;
+      top: 15px;
+      right: 15px;
+      display: inline-block;
+      background: $highlight-text-color;
+      border-radius: 50%;
+      width: 0.625rem;
+      height: 0.625rem;
+      margin: 0 .15em;
+    }
   }
 
   &__pagination {

--- a/app/serializers/rest/announcement_serializer.rb
+++ b/app/serializers/rest/announcement_serializer.rb
@@ -4,13 +4,23 @@ class REST::AnnouncementSerializer < ActiveModel::Serializer
   attributes :id, :content, :starts_at, :ends_at, :all_day,
              :published_at, :updated_at
 
+  attribute :read, if: :current_user?
+
   has_many :mentions
   has_many :tags, serializer: REST::StatusSerializer::TagSerializer
   has_many :emojis, serializer: REST::CustomEmojiSerializer
   has_many :reactions, serializer: REST::ReactionSerializer
 
+  def current_user?
+    !current_user.nil?
+  end
+
   def id
     object.id.to_s
+  end
+
+  def read
+    object.announcement_mutes.where(account: current_user.account).exists?
   end
 
   def content


### PR DESCRIPTION
- Change the effect of the “dismiss” API call to mark announcements as read instead of hiding them
- Display the badge with count of unread announcements even when the announcement box is open
- Display an “unread” or “new” marker the first time an announcement is shown
- Mark announcements as shown when they are displayed

![Peek 01-02-2020 16-27](https://user-images.githubusercontent.com/384364/73594606-1d349500-4510-11ea-9796-6e2897b5bf57.gif)
