### PR TITLE
Change how multiple choice poll percentages are calculated in web UI

### DIFF
--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -113,7 +113,7 @@ class Poll extends ImmutablePureComponent {
 
   renderOption (option, optionIndex, showResults) {
     const { poll, disabled, intl } = this.props;
-    const pollVotesCount  = poll.get('voters_count') || poll.get('votes_count');
+    const pollVotesCount  = poll.get('votes_count');
     const percent         = pollVotesCount === 0 ? 0 : (option.get('votes_count') / pollVotesCount) * 100;
     const leading         = poll.get('options').filterNot(other => other.get('title') === option.get('title')).every(other => option.get('votes_count') >= other.get('votes_count'));
     const active          = !!this.state.selected[`${optionIndex}`];

--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -87,16 +87,23 @@
       border-radius: 4px;
     }
 
-    &.active {
-      border-color: $valid-value-color;
-      background: $valid-value-color;
-    }
-
     &:active,
     &:focus,
     &:hover {
       border-width: 4px;
       background: none;
+    }
+
+    &.active {
+      border-color: $valid-value-color;
+      background: $valid-value-color;
+
+      &:active,
+      &:focus,
+      &:hover {
+        border-color: lighten($valid-value-color, 8%);
+        background: lighten($valid-value-color, 8%);
+      }
     }
 
     &::-moz-focus-inner {


### PR DESCRIPTION
Instead of calculating as `votes` / `unique people who voted`, calculate as `votes` / `total votes`, which is how it should have been all along and prevent issues where percentages don't add up to 100%.

Fix focused state erasing background of selected poll options