### PR TITLE
Fix remote convertible media attachments not being saved

### DIFF
--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -36,8 +36,8 @@ module Remotable
 
             basename = SecureRandom.hex(8)
 
-            send("#{attachment_name}=", StringIO.new(response.body_with_limit(limit)))
             send("#{attachment_name}_file_name=", basename + extname)
+            send("#{attachment_name}=", StringIO.new(response.body_with_limit(limit)))
 
             self[attribute_name] = url if has_attribute?(attribute_name)
           end


### PR DESCRIPTION
Because the file name was set after loading the file, Paperclip
was flagging the differing file extension as content type spoofing

Fix #12938