### PR TITLE
Change signature verification to ignore signatures with invalid host

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -160,6 +160,8 @@ module SignatureVerification
       account ||= stoplight_wrap_request { ActivityPub::FetchRemoteKeyService.new.call(key_id, id: false) }
       account
     end
+  rescue Mastodon::HostValidationError
+    nil
   end
 
   def stoplight_wrap_request(&block)


### PR DESCRIPTION
Instead of returning a signature verification error, pretend there was no signature (i.e., this does not allow access to resources that need a valid signature), so public resources can still be fetched

Fix #13011