### PR TITLE
Fix how links with unhandled schemes are rendered

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -290,27 +290,29 @@
   position: absolute;
 }
 
-.invisible {
-  font-size: 0;
-  line-height: 0;
-  display: inline-block;
-  width: 0;
-  height: 0;
-  position: absolute;
+a[href] {
+ .invisible {
+    font-size: 0;
+    line-height: 0;
+    display: inline-block;
+    width: 0;
+    height: 0;
+    position: absolute;
 
-  img,
-  svg {
-    margin: 0 !important;
-    border: 0 !important;
-    padding: 0 !important;
-    width: 0 !important;
-    height: 0 !important;
+    img,
+    svg {
+      margin: 0 !important;
+      border: 0 !important;
+      padding: 0 !important;
+      width: 0 !important;
+      height: 0 !important;
+    }
   }
-}
 
-.ellipsis {
-  &::after {
-    content: "…";
+  .ellipsis {
+    &::after {
+      content: "…";
+    }
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -809,7 +809,7 @@
     }
   }
 
-  a {
+  a[href] {
     color: $secondary-text-color;
     text-decoration: none;
 
@@ -836,7 +836,7 @@
     }
   }
 
-  a.unhandled-link {
+  a[href].unhandled-link {
     color: lighten($ui-highlight-color, 8%);
   }
 
@@ -1039,7 +1039,7 @@
     .status__content {
       color: $inverted-text-color;
 
-      a {
+      a[href] {
         color: $highlight-text-color;
       }
 
@@ -1255,7 +1255,7 @@
   color: $inverted-text-color;
   font-size: 14px;
 
-  a {
+  a[href] {
     color: $lighter-text-color;
   }
 }
@@ -4780,7 +4780,7 @@ a.status-card.compact:hover {
   overflow-y: auto;
   overflow-x: hidden;
 
-  .status__content a {
+  .status__content a[href] {
     color: $highlight-text-color;
   }
 
@@ -6304,7 +6304,7 @@ noscript {
     }
   }
 
-  a {
+  a[href] {
     color: inherit;
     text-decoration: underline;
 
@@ -6441,7 +6441,7 @@ noscript {
       margin: 0;
       border-top: 1px solid lighten($ui-base-color, 12%);
 
-      a {
+      a[href] {
         color: lighten($ui-highlight-color, 8%);
       }
 
@@ -6449,7 +6449,7 @@ noscript {
         border-radius: 0 4px 0 0;
       }
 
-      .verified a {
+      .verified a[href] {
         color: $valid-value-color;
       }
     }
@@ -6619,7 +6619,7 @@ noscript {
       flex-basis: 90px;
       flex-grow: 1;
 
-      a {
+      a[href] {
         color: $primary-text-color;
         text-decoration: none;
 


### PR DESCRIPTION
Currently, if Mastodon encounters a link to a scheme it doesn't allow, it will strip the `href` attribute, making it unclickable, but link will *appear* clickable and, if formatted as Mastodon formats it, will not appear in full.

This PR changes it so that link styling as well as `ellipsis` and `invisible` classes only apply to links with a defined `href`.

For instance, without magnet support, Mastodon still show Mastodon-authored magnet links as follows:
![Peek 03-02-2020 21-34](https://user-images.githubusercontent.com/384364/73688875-46e6eb00-46cd-11ea-9ae8-cf48c123c79b.gif)

With this PR, they would show up like this (if they were still unsupported):
![Screenshot_2020-02-03 Mastodon(1)](https://user-images.githubusercontent.com/384364/73688948-7269d580-46cd-11ea-8252-91c8e6038aca.png)
