### PR TITLE
Fix typos in nl translation of setting_crop_images

### DIFF
--- a/config/locales/simple_form.nl.yml
+++ b/config/locales/simple_form.nl.yml
@@ -125,7 +125,7 @@ nl:
         setting_aggregate_reblogs: Boosts in tijdlijnen groeperen
         setting_auto_play_gif: Speel geanimeerde GIF's automatisch af
         setting_boost_modal: Vraag voor het boosten van een toot een bevestiging
-        setting_crop_images: Afbeeldingen tot 16x9 besnijden in niet uitgebreide toots
+        setting_crop_images: Afbeeldingen tot 16x9 bijsnijden in niet-uitgebreide toots
         setting_default_language: Taal van jouw toots
         setting_default_privacy: Standaardzichtbaarheid van jouw toots
         setting_default_sensitive: Media altijd als gevoelig markeren


### PR DESCRIPTION
There were two mistakes in this translation:

  1. The translation of to crop is bijsnijden. While besnijden is a Dutch word,
     its meaning is left as an exercise to the reader.

  2. To negate an adjective, a hyphen is needed between “niet” and the adjective.
     See https://taaladvies.net/taal/advies/vraag/1843.