### PR TITLE
Bump httplog from 1.4.0 to 1.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'htmlentities', '~> 4.3'
 gem 'http', '~> 4.3'
 gem 'http_accept_language', '~> 2.1'
 gem 'http_parser.rb', '~> 0.6', git: 'https://github.com/tmm1/http_parser.rb', ref: '54b17ba8c7d8d20a16dfc65d1775241833219cf2', submodules: true
-gem 'httplog', '~> 1.4'
+gem 'httplog', '~> 1.4.1'
 gem 'idn-ruby', require: 'idn'
 gem 'kaminari', '~> 1.1'
 gem 'link_header', '~> 0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,7 @@ GEM
     http-parser (1.2.1)
       ffi-compiler (>= 1.0, < 2.0)
     http_accept_language (2.1.1)
-    httplog (1.4.0)
+    httplog (1.4.1)
       rack (>= 1.0)
       rainbow (>= 2.0.0)
     i18n (1.8.2)
@@ -709,7 +709,7 @@ DEPENDENCIES
   http (~> 4.3)
   http_accept_language (~> 2.1)
   http_parser.rb (~> 0.6)!
-  httplog (~> 1.4)
+  httplog (~> 1.4.1)
   i18n-tasks (~> 0.9)
   idn-ruby
   iso-639


### PR DESCRIPTION
httplog 1.4.0 is yanked.
https://rubygems.org/gems/httplog/versions/1.4.0

So `bundle install` in v3.1.0rc2 fails in the environment where httplog hasn't been updated yet.
This PR will fix that problem.