### PR TITLE
[Breaking] docker-compose.yml - Upgrade Elasticsearch 6.1 to 7.5 stable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
 #      - "cluster.name=es-mastodon"
 #      - "discovery.type=single-node"
 #      - "bootstrap.memory_lock=true"
+#     ports:
+#       - "127.0.0.1:9300:9300"
+#       - "127.0.0.1:9200:9200"
 #    networks:
 #      - internal_network
 #    healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,10 @@ services:
 #      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
 #    volumes:
 #      - ./elasticsearch:/usr/share/elasticsearch/data
+#    ulimits:
+#      memlock:
+#        soft: -1
+#        hard: -1
 
   web:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,9 @@ services:
 #    image: docker.elastic.co/elasticsearch/elasticsearch:7.5.2
 #    environment:
 #      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+#      - "cluster.name=es-mastodon"
 #      - "discovery.type=single-node"
+#      - "bootstrap.memory_lock=true"
 #    networks:
 #      - internal_network
 #    healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,10 @@ services:
 
 #  es:
 #    restart: always
-#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.3
+#    image: docker.elastic.co/elasticsearch/elasticsearch:7.5.2
 #    environment:
 #      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+#      - "discovery.type=single-node"
 #    networks:
 #      - internal_network
 #    healthcheck:


### PR DESCRIPTION
Currently set to elasticsearch 6.1.3 (Jan 2018)