### PR TITLE
Change example nginx configuration to reduce downtime during server restarts

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -3,6 +3,14 @@ map $http_upgrade $connection_upgrade {
   ''      close;
 }
 
+upstream backend {
+    server 127.0.0.1:3000 fail_timeout=0;
+}
+
+upstream streaming {
+    server 127.0.0.1:4000 fail_timeout=0;
+}
+
 proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=CACHE:10m inactive=7d max_size=1g;
 
 server {
@@ -69,7 +77,7 @@ server {
     proxy_set_header Proxy "";
     proxy_pass_header Server;
 
-    proxy_pass http://127.0.0.1:3000;
+    proxy_pass http://backend;
     proxy_buffering on;
     proxy_redirect off;
     proxy_http_version 1.1;
@@ -93,7 +101,7 @@ server {
     proxy_set_header X-Forwarded-Proto https;
     proxy_set_header Proxy "";
 
-    proxy_pass http://127.0.0.1:4000;
+    proxy_pass http://streaming;
     proxy_buffering off;
     proxy_redirect off;
     proxy_http_version 1.1;


### PR DESCRIPTION
> Inspired by https://blog.winricklabs.com/(2-08-2020)-fixing-nginx-502-gateway-timeout-with-proxy_pass-during-deployments.html

http://nginx.org/en/docs/http/ngx_http_upstream_module.html