### PR TITLE
Do not suggest to login into the GitLab database

### DIFF
--- a/lib/mastodon/migration_helpers.rb
+++ b/lib/mastodon/migration_helpers.rb
@@ -886,16 +886,12 @@ module Mastodon
 Your database user is not allowed to create, drop, or execute triggers on the
 table #{table}.
 
-If you are using PostgreSQL you can solve this by logging in to the GitLab
+If you are using PostgreSQL you can solve this by logging in to the Mastodon
 database (#{dbname}) using a super user and running:
 
     ALTER USER #{user} WITH SUPERUSER
 
-For MySQL you instead need to run:
-
-    GRANT ALL PRIVILEGES ON *.* TO #{user}@'%'
-
-Both queries will grant the user super user permissions, ensuring you don't run
+The query will grant the user super user permissions, ensuring you don't run
 into similar problems in the future (e.g. when new tables are created).
         EOF
       end


### PR DESCRIPTION
As pointed out on Discourse:

https://discourse.joinmastodon.org/t/obscure-wtf-error-message-running-migrations-for-3-1/2524

The message the administrators were getting was telling them
to log in to the "GitLab database" and also mentions MySQL