### PR TITLE
Fix sign-ups without checked user agreement being accepted through the web form

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -41,7 +41,6 @@ class Auth::RegistrationsController < Devise::RegistrationsController
 
     resource.locale             = I18n.locale
     resource.invite_code        = params[:invite_code] if resource.invite_code.blank?
-    resource.agreement          = true
     resource.current_sign_in_ip = request.remote_ip
 
     resource.build_account if resource.account.nil?

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -48,7 +48,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
 
   def configure_sign_up_params
     devise_parameter_sanitizer.permit(:sign_up) do |u|
-      u.permit({ account_attributes: [:username], invite_request_attributes: [:text] }, :email, :password, :password_confirmation, :invite_code)
+      u.permit({ account_attributes: [:username], invite_request_attributes: [:text] }, :email, :password, :password_confirmation, :invite_code, :agreement)
     end
   end
 


### PR DESCRIPTION
For some reason, the `agreement` param has been overridden since #9572, letting people register without checking the box, and registering them as having agreed anyway