### PR TITLE
Fix invite request input not being shown on sign-up error if left empty

### DIFF
--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -27,7 +27,7 @@
 
   - if approved_registrations? && !@invite.present?
     .fields-group
-      = f.simple_fields_for :invite_request do |invite_request_fields|
+      = f.simple_fields_for :invite_request, resource.invite_request || resource.build_invite_request do |invite_request_fields|
         = invite_request_fields.input :text, as: :text, wrapper: :with_block_label, required: false
 
   = f.input :invite_code, as: :hidden


### PR DESCRIPTION
If the “Why do you want to join?” textarea is left empty and the entered params
do not validate, the textarea isn't shown again, unlike other fields.

This commit fixes that by populating an empty `UserInviteRequest` when needed.