### PR TITLE
Fix public posts from silenced accounts not being changed to unlisted visibility

### DIFF
--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -49,7 +49,7 @@ class PostStatusService < BaseService
   def preprocess_attributes!
     @text         = @options.delete(:spoiler_text) if @text.blank? && @options[:spoiler_text].present?
     @visibility   = @options[:visibility] || @account.user&.setting_default_privacy
-    @visibility   = :unlisted if @visibility == :public && @account.silenced?
+    @visibility   = :unlisted if @visibility&.to_sym == :public && @account.silenced?
     @scheduled_at = @options[:scheduled_at]&.to_datetime
     @scheduled_at = nil if scheduled_in_the_past?
   rescue ArgumentError


### PR DESCRIPTION
That line never worked, as it at that point, the visibility parameter is a string.

This wasn't a big issue, as we handle silenced accounts down the line too, hiding their public posts.
However, that line should be either fixed or removed.

Fixing it will let the silenced people know they are silenced, by having their public toots become unlisted. But they already have various ways of knowing.