### PR TITLE
Fix NoMethodError in error handler

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -73,8 +73,6 @@ class Request
       response.body_with_limit if http_client.persistent?
 
       yield response if block_given?
-    rescue => e
-      raise e.class, e.message, e.backtrace[0]
     ensure
       http_client.close unless http_client.persistent?
     end

--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -54,8 +54,9 @@ class ActivityPub::DeliveryWorker
       light.with_threshold(STOPLIGHT_FAILURE_THRESHOLD)
            .with_cool_off_time(STOPLIGHT_COOLDOWN)
            .run
-    rescue Stoplight::Error::RedLight => e
-      raise e.class, e.message, e.backtrace.first(3)
+    rescue => e
+      e.set_backtrace(e.backtrace.first(3))
+      raise e
     end
   end
 


### PR DESCRIPTION
The aws-sdk-core gem can raise exceptions whose initializer expects
an exception, not a string. The error handling code was ignoring that,
causing the exception's initializer to call `#message` on the string object.

Also, this shortening of backtraces was introduced for the DeliveryWorker,
but affected other codepaths with more complex exception possibilities.

The other “rescue” block remains safe in principle as the exceptions it
can catch are limited to those raised by the http gem, but wrapping it may
be cleaner.

Fixes #13086