### PR TITLE
Disable backtrace silencers

### DIFF
--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -4,4 +4,4 @@
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
-# Rails.backtrace_cleaner.remove_silencers!
+Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
Backtrace silencers have made things confusing and difficult to debug more than once.