### PR TITLE
Fix account JSON/RSS not being cacheable due to wrong mime type comparison

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -9,7 +9,7 @@ class AccountsController < ApplicationController
   before_action :set_cache_headers
   before_action :set_body_classes
 
-  skip_around_action :set_locale, if: -> { [:json, :rss].include?(request.format) }
+  skip_around_action :set_locale, if: -> { [:json, :rss].include?(request.format&.to_sym) }
   skip_before_action :require_functional!
 
   def show


### PR DESCRIPTION
`request.format` is not a symbol but a `Mime::Type`, so the condition actually
never matched, and a session was created even for those requests, preventing
caching.