### PR TITLE
Fix dismissing an announcement twice raising an obscure error

### DIFF
--- a/app/controllers/api/v1/announcements_controller.rb
+++ b/app/controllers/api/v1/announcements_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::AnnouncementsController < Api::BaseController
   end
 
   def dismiss
-    AnnouncementMute.create!(account: current_account, announcement: @announcement)
+    AnnouncementMute.find_or_create_by!(account: current_account, announcement: @announcement)
     render_empty
   end
 


### PR DESCRIPTION
This fixes the “422 Validation failed: Account has already been taken” ones get when, for instance, having the WebUI open twice