### PR TITLE
Fix 404 when undoing a boost/bookmark that doesn't exist

### DIFF
--- a/app/controllers/api/v1/statuses/bookmarks_controller.rb
+++ b/app/controllers/api/v1/statuses/bookmarks_controller.rb
@@ -17,8 +17,8 @@ class Api::V1::Statuses::BookmarksController < Api::BaseController
     @status = requested_status
     @bookmarks_map = { @status.id => false }
 
-    bookmark = Bookmark.find_by!(account: current_user.account, status: @status)
-    bookmark.destroy!
+    bookmark = Bookmark.find_by(account: current_user.account, status: @status)
+    bookmark&.destroy!
 
     render json: @status, serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new([@status], current_user&.account_id, bookmarks_map: @bookmarks_map)
   end


### PR DESCRIPTION
Returning a 404 when trying to unboost or unbookmark a non-boosted or
non-bookmarked toot is arguably fine, but the Web UI (and possibly other
clients) error out and do not update the state of a status when such an
action fails.