### PR TITLE
Fix duplicate accounts being created when fetching an account for its key only

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -18,9 +18,10 @@ class ActivityPub::ProcessAccountService < BaseService
 
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?
-        @account        = Account.find_remote(@username, @domain)
-        @old_public_key = @account&.public_key
-        @old_protocol   = @account&.protocol
+        @account          = Account.remote.find_by(uri: @uri) if @options[:only_key]
+        @account        ||= Account.find_remote(@username, @domain)
+        @old_public_key   = @account&.public_key
+        @old_protocol     = @account&.protocol
 
         create_account if @account.nil?
         update_account


### PR DESCRIPTION
Fixes #13136

When a user's canonical acct domain is different from its id's domain
(WEB_DOMAIN ≠ LOCAL_DOMAIN), two webfinger queries are required to find the
canonical domain from the URI. However, we skip webfinger queries when
updating only the key of a remote user, which led to the creation of a
duplicate account, using the URI's domain instead of the canonical acct: one.