### PR TITLE
Fix text area above/right of emoji picker being accidentally clickable in web UI

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -388,8 +388,8 @@
 
   .emoji-picker-dropdown {
     position: absolute;
-    top: 5px;
-    right: 5px;
+    top: 0;
+    right: 0;
   }
 
   .compose-form__autosuggest-wrapper {
@@ -4060,10 +4060,7 @@ a.status-card.compact:hover {
 
 .emoji-button {
   display: block;
-  font-size: 24px;
-  line-height: 24px;
-  margin-left: 2px;
-  width: 24px;
+  padding: 5px 5px 2px 2px;
   outline: 0;
   cursor: pointer;
 
@@ -4079,7 +4076,6 @@ a.status-card.compact:hover {
     margin: 0;
     width: 22px;
     height: 22px;
-    margin-top: 2px;
   }
 
   &:hover,


### PR DESCRIPTION
Fix #13135

I put `2px` to the left so that it doesn’t make putting the cursor at the end of the line with the mouse more difficult.

There is no more 2 dead pixels to the left of the emoji button, so trying to click between the textarea and the left of the emoji button either clicks in the textarea or trigger the emoji button, as expected.