### PR TITLE
Fix error when searching for URLs that contain the mention syntax

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -171,7 +171,7 @@ class AccountSearchService < BaseService
   end
 
   def username_complete?
-    query.include?('@') && "@#{query}" =~ Account::MENTION_RE
+    query.include?('@') && "@#{query}" =~ /\A#{Account::MENTION_RE}\Z/
   end
 
   def likely_acct?


### PR DESCRIPTION
Fixes #13150

I fixed it to what I believe was the original intent of the code. Another possibility would be to get the match data from the original regexp to get the account URI to resolve.