### PR TITLE
Change wording of media display preferences to be more intuitive

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -42,8 +42,8 @@ en:
         setting_aggregate_reblogs: Do not show new boosts for toots that have been recently boosted (only affects newly-received boosts)
         setting_default_sensitive: Sensitive media is hidden by default and can be revealed with a click
         setting_display_media_default: Hide media marked as sensitive
-        setting_display_media_hide_all: Always hide all media
-        setting_display_media_show_all: Always show media marked as sensitive
+        setting_display_media_hide_all: Always hide media
+        setting_display_media_show_all: Always show media
         setting_hide_network: Who you follow and who follows you will not be shown on your profile
         setting_noindex: Affects your public profile and status pages
         setting_show_application: The application you use to toot will be displayed in the detailed view of your toots


### PR DESCRIPTION
![before](https://user-images.githubusercontent.com/2446451/75836355-f04ef880-5dc1-11ea-86e0-7c89736f3159.png)

![after](https://user-images.githubusercontent.com/2446451/75836411-1b394c80-5dc2-11ea-8c00-739224d6e4c0.png)

- “Always show media marked as sensitive” is really a long sentence to simply say that I shows media in every case.
- “Always hide all media” combination of “Always” and “all” is strange, it feels like it’s meant to be the opposite of “Always hide media marked as sensitive”, which is not how the first option is named.

Now, Instead of having three different wordings, it’s clear that 2 and 3 are both absolute and opposite options, with the only difference being: show/hide.