### PR TITLE
Change GIF label to be displayed even when autoplay is enabled in web UI

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5058,12 +5058,6 @@ a.status-card.compact:hover {
 }
 
 .media-gallery__gifv {
-  &.autoplay {
-    .media-gallery__gifv__label {
-      display: none;
-    }
-  }
-
   &:hover {
     .media-gallery__gifv__label {
       opacity: 1;


### PR DESCRIPTION
I think this is important especially to make clear to the user that the media file is not a video. I have seen people not knowing what a GIF is and this indicator is important especially for these people.