### PR TITLE
Set BUNDLE_PATH in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ aliases:
       - image: circleci/ruby:2.7-buster-node
         environment: &ruby_environment
           BUNDLE_APP_CONFIG: ./.bundle/
+          BUNDLE_PATH: ./vendor/bundle/
           DB_HOST: localhost
           DB_USER: root
           RAILS_ENV: test


### PR DESCRIPTION
Previously, #12995 migrated from using command line arguments to `bundle` to setting configuration with `bundle config set`. However, the path of `./vendor/bundle/` did not make the transition. As a result, the CircleCI builds now depend on the presence and contents of `.bundle/config` from the cache.

If a CircleCI build starts with an empty cache (I encountered this when using my own personal CircleCI account) then the `bundle install` command will attempt to install gems into system directories, and it will refuse to finish installation, with this prompt.

> Cleaning all the gems on your system is dangerous! If you're sure you want to remove every system gem not in this bundle, run `bundle clean --force`.

Builds that start with a populated cache, such as those in the tootsuite account, will pick up `BUNDLE_PATH: ./vendor/bundle/`, which was stored in `.bundle/config` by the previous `bundle install ... --path ./vendor/bundle/ ...` command line, and they will continue to work as they did before.

This PR fixes this situation by setting the path through an environment variable in the `defaults` alias. I briefly explored adding a `bundle config set path './vendor/bundle/'` line to the `install_ruby_dependencies` alias, but this caused problems. `install_ruby_dependencies` is only used in the three `install-ruby2.x` jobs, and it seems whatever configuration file `bundle config set` writes is not captured by the workspace. The bundle path is needed for commands such as `./bin/rails` and `bundle exec i18n-tasks` in other downstream jobs. Moreover, the `install-ruby2.5` and `install-ruby2.6` jobs seem to use a version of bundler that does not support the `bundle config set` syntax, because they report things like, `You are replacing the current global value of set, which is currently "without development production"`.