### PR TITLE
[Security] Bump Node.js from 12.14.0 to 12.16.1 in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:18.04 as build-dep
 SHELL ["bash", "-c"]
 
 # Install Node v12 (LTS)
-ENV NODE_VER="12.16.1"  
+ENV NODE_VER="12.16.1"
 RUN	ARCH= && \
     dpkgArch="$(dpkg --print-architecture)" && \
   case "${dpkgArch##*-}" in \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:18.04 as build-dep
 SHELL ["bash", "-c"]
 
 # Install Node v12 (LTS)
-ENV NODE_VER="12.14.0"  
+ENV NODE_VER="12.16.1"  
 RUN	ARCH= && \
     dpkgArch="$(dpkg --print-architecture)" && \
   case "${dpkgArch##*-}" in \


### PR DESCRIPTION
As noted by @danieljakots, these releases fixes security issues

CVE-2019-15606: HTTP header values do not have trailing OWS trimmed.
CVE-2019-15605: HTTP request smuggling using malformed
Transfer-Encoding header.
CVE-2019-15604: Remotely trigger an assertion on a TLS server with a
malformed certificate string.