### PR TITLE
Add indication to admin UI of whether a report has been forwarded

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -14,6 +14,7 @@
 #  target_account_id          :bigint(8)        not null
 #  assigned_account_id        :bigint(8)
 #  uri                        :string
+#  forwarded                  :boolean
 #
 
 class Report < ApplicationRecord

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -24,7 +24,8 @@ class ReportService < BaseService
       target_account: @target_account,
       status_ids: @status_ids,
       comment: @comment,
-      uri: @options[:uri]
+      uri: @options[:uri],
+      forwarded: ActiveModel::Type::Boolean.new.cast(@options[:forward])
     )
   end
 

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -59,6 +59,10 @@
                 = fa_icon('camera')
                 = report.media_attachments.count
 
+              - if report.forwarded?
+                %span.report-card__summary__item__content__icon{ title: t('admin.reports.forwarded') }
+                  = fa_icon('share')
+
           .report-card__summary__item__assigned
             - if report.assigned_account.present?
               = admin_account_link_to report.assigned_account

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -60,8 +60,8 @@
                 = report.media_attachments.count
 
               - if report.forwarded?
-                %span.report-card__summary__item__content__icon{ title: t('admin.reports.forwarded') }
-                  = fa_icon('share')
+                ·
+                = t('admin.reports.forwarded_to', domain: target_account.domain)
 
           .report-card__summary__item__assigned
             - if report.assigned_account.present?

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -46,6 +46,16 @@
         %td{ colspan: 2 }
           - if @report.action_taken?
             = table_link_to 'envelope-open', t('admin.reports.reopen'), admin_report_path(@report, outcome: 'reopen'), method: :put
+      - unless @report.target_account.local?
+        %tr
+          %th= t('admin.reports.forwarded')
+          %td{ colspan: 3 }
+            - if @report.forwarded.nil?
+              = t('admin.reports.forwarded_unknown')
+            - elsif @report.forwarded?
+              = t('simple_form.yes')
+            - else
+              = t('simple_form.no')
       - if !@report.action_taken_by_account.nil?
         %tr
           %th= t('admin.reports.action_taken_by')

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -51,7 +51,7 @@
           %th= t('admin.reports.forwarded')
           %td{ colspan: 3 }
             - if @report.forwarded.nil?
-              = t('admin.reports.forwarded_unknown')
+              \-
             - elsif @report.forwarded?
               = t('simple_form.yes')
             - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -514,6 +514,8 @@ en:
       comment:
         none: None
       created_at: Reported
+      forwarded: Forwarded
+      forwarded_unknown: Unknown (reported before the information was recorded)
       mark_as_resolved: Mark as resolved
       mark_as_unresolved: Mark as unresolved
       notes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -515,7 +515,7 @@ en:
         none: None
       created_at: Reported
       forwarded: Forwarded
-      forwarded_unknown: Unknown (reported before the information was recorded)
+      forwarded_to: Forwarded to %{domain}
       mark_as_resolved: Mark as resolved
       mark_as_unresolved: Mark as unresolved
       notes:

--- a/db/migrate/20200309150742_add_forwarded_to_reports.rb
+++ b/db/migrate/20200309150742_add_forwarded_to_reports.rb
@@ -1,0 +1,5 @@
+class AddForwardedToReports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :reports, :forwarded, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -717,6 +717,7 @@ ActiveRecord::Schema.define(version: 2020_10_17_234926) do
     t.bigint "target_account_id", null: false
     t.bigint "assigned_account_id"
     t.string "uri"
+    t.boolean "forwarded"
     t.index ["account_id"], name: "index_reports_on_account_id"
     t.index ["target_account_id"], name: "index_reports_on_target_account_id"
   end


### PR DESCRIPTION
## Reports list

In the lists of reports, an arrow (fontawesome's “share”) is displayed when the report is known to have been forwarded.

![image](https://user-images.githubusercontent.com/384364/76235077-e3e7f700-622a-11ea-9369-9f1640f31ef3.png)

## Report

For reports about remote users, the table will show either of those according to the situation:
- Forwarded: Yes
- Forwarded: No
- Forwarded: Unknown (reported before the information was recorded)

![image](https://user-images.githubusercontent.com/384364/76235240-1db8fd80-622b-11ea-800f-af977de83162.png)