### PR TITLE
Fix PostgreSQL load when linking in announcements

### DIFF
--- a/app/lib/entity_cache.rb
+++ b/app/lib/entity_cache.rb
@@ -9,8 +9,7 @@ class EntityCache
 
   def status(url)
     Rails.cache.fetch(to_key(:status, url), expires_in: MAX_EXPIRATION) do
-      scope = Status.select(:id, :url, :uri, :visibility)
-      scope.find_by(uri: url) || scope.find_by(url: url)
+      FetchRemoteStatusService.new.call(url)
     end
   end
 

--- a/app/lib/entity_cache.rb
+++ b/app/lib/entity_cache.rb
@@ -8,9 +8,7 @@ class EntityCache
   MAX_EXPIRATION = 7.days.freeze
 
   def status(url)
-    Rails.cache.fetch(to_key(:status, url), expires_in: MAX_EXPIRATION) do
-      FetchRemoteStatusService.new.call(url)
-    end
+    Rails.cache.fetch(to_key(:status, url), expires_in: MAX_EXPIRATION) { FetchRemoteStatusService.new.call(url) }
   end
 
   def mention(username, domain)

--- a/app/lib/entity_cache.rb
+++ b/app/lib/entity_cache.rb
@@ -7,6 +7,13 @@ class EntityCache
 
   MAX_EXPIRATION = 7.days.freeze
 
+  def status(url)
+    Rails.cache.fetch(to_key(:status, url), expires_in: MAX_EXPIRATION) do
+      scope = Status.select(:id, :url, :uri, :visibility)
+      scope.find_by(uri: url) || scope.find_by(url: url)
+    end
+  end
+
   def mention(username, domain)
     Rails.cache.fetch(to_key(:mention, username, domain), expires_in: MAX_EXPIRATION) { Account.select(:id, :username, :domain, :url).find_remote(username, domain) }
   end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -14,6 +14,7 @@
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #  published_at :datetime
+#  status_ids   :bigint           is an Array
 #
 
 class Announcement < ApplicationRecord
@@ -31,6 +32,7 @@ class Announcement < ApplicationRecord
 
   before_validation :set_all_day
   before_validation :set_published, on: :create
+  before_validation :set_status_ids
 
   def publish!
     update!(published: true, published_at: Time.now.utc, scheduled_at: nil)
@@ -49,7 +51,9 @@ class Announcement < ApplicationRecord
   end
 
   def statuses
-    @statuses ||= Status.from_text(text)
+    return [] if status_ids.nil?
+
+    @statuses ||= Status.where(id: status_ids, visibility: [:public, :unlisted])
   end
 
   def tags
@@ -86,5 +90,9 @@ class Announcement < ApplicationRecord
 
     self.published = true
     self.published_at = Time.now.utc
+  end
+
+  def set_status_ids
+    self.status_ids = Status.from_text(text).map(&:id)
   end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -32,7 +32,6 @@ class Announcement < ApplicationRecord
 
   before_validation :set_all_day
   before_validation :set_published, on: :create
-  before_validation :set_status_ids
 
   def publish!
     update!(published: true, published_at: Time.now.utc, scheduled_at: nil)
@@ -79,6 +78,11 @@ class Announcement < ApplicationRecord
     records
   end
 
+  def refresh_status_ids!
+    self.status_ids = Status.from_text(text).map(&:id)
+    save
+  end
+
   private
 
   def set_all_day
@@ -90,9 +94,5 @@ class Announcement < ApplicationRecord
 
     self.published = true
     self.published_at = Time.now.utc
-  end
-
-  def set_status_ids
-    self.status_ids = Status.from_text(text).map(&:id)
   end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -50,9 +50,13 @@ class Announcement < ApplicationRecord
   end
 
   def statuses
-    return [] if status_ids.nil?
-
-    @statuses ||= Status.where(id: status_ids, visibility: [:public, :unlisted])
+    @statuses ||= begin
+      if status_ids.nil?
+        []
+      else
+        Status.where(id: status_ids, visibility: [:public, :unlisted])
+      end
+    end
   end
 
   def tags
@@ -76,11 +80,6 @@ class Announcement < ApplicationRecord
 
     ActiveRecord::Associations::Preloader.new.preload(records, :custom_emoji)
     records
-  end
-
-  def refresh_status_ids!
-    self.status_ids = Status.from_text(text).map(&:id)
-    save
   end
 
   private

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -379,7 +379,7 @@ class Status < ApplicationRecord
           if TagManager.instance.local_url?(url)
             ActivityPub::TagManager.instance.uri_to_resource(url, Status)
           else
-            Status.find_by(uri: url) || Status.find_by(url: url)
+            EntityCache.instance.status(url)
           end
         end
         status&.distributable? ? status : nil

--- a/app/workers/publish_scheduled_announcement_worker.rb
+++ b/app/workers/publish_scheduled_announcement_worker.rb
@@ -5,17 +5,24 @@ class PublishScheduledAnnouncementWorker
   include Redisable
 
   def perform(announcement_id)
-    announcement = Announcement.find(announcement_id)
+    @announcement = Announcement.find(announcement_id)
 
-    announcement.refresh_status_ids!
+    refresh_status_ids!
 
-    announcement.publish! unless announcement.published?
+    @announcement.publish! unless @announcement.published?
 
-    payload = InlineRenderer.render(announcement, nil, :announcement)
+    payload = InlineRenderer.render(@announcement, nil, :announcement)
     payload = Oj.dump(event: :announcement, payload: payload)
 
     FeedManager.instance.with_active_accounts do |account|
       redis.publish("timeline:#{account.id}", payload) if redis.exists("subscribed:timeline:#{account.id}")
     end
+  end
+
+  private
+
+  def refresh_status_ids!
+    @announcement.status_ids = Status.from_text(@announcement.text).map(&:id)
+    @announcement.save
   end
 end

--- a/app/workers/publish_scheduled_announcement_worker.rb
+++ b/app/workers/publish_scheduled_announcement_worker.rb
@@ -7,6 +7,8 @@ class PublishScheduledAnnouncementWorker
   def perform(announcement_id)
     announcement = Announcement.find(announcement_id)
 
+    announcement.refresh_status_ids!
+
     announcement.publish! unless announcement.published?
 
     payload = InlineRenderer.render(announcement, nil, :announcement)

--- a/db/migrate/20200312162302_add_status_ids_to_announcements.rb
+++ b/db/migrate/20200312162302_add_status_ids_to_announcements.rb
@@ -1,0 +1,6 @@
+class AddStatusIdsToAnnouncements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :announcements, :status_ids, :bigint, array: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -231,6 +231,7 @@ ActiveRecord::Schema.define(version: 2020_03_12_185443) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "published_at"
+    t.bigint "status_ids", array: true
   end
 
   create_table "backups", force: :cascade do |t|


### PR DESCRIPTION
Fixes #13245 by caching status lookups

Since statuses are supposed to be known already and we only
need their URLs and a few other things, caching them should
be fine.

Since it's only used by announcements so far, there won't
be much statuses to cache.