### PR TITLE
Pleroma-style emoji reactions

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -56,6 +56,8 @@ class ActivityPub::Activity
         ActivityPub::Activity::Remove
       when 'Move'
         ActivityPub::Activity::Move
+      when 'EmojiReact'
+        ActivityPub::Activity::EmojiReact
       end
     end
   end

--- a/app/lib/activitypub/activity/emoji_react.rb
+++ b/app/lib/activitypub/activity/emoji_react.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ActivityPub::Activity::EmojiReact < ActivityPub::Activity
+  def perform
+    original_status = status_from_uri(object_uri)
+
+    return if original_status.nil? || !original_status.account.local? || delete_arrived_first?(@json['id']) || @account.reacted?(original_status, @json['content'])
+
+    reaction = original_status.emoji_reactions.create!(account: @account, name: @json['content'])
+    #TODO: NotifyService.new.call(original_status.account, reaction)
+  end
+end

--- a/app/lib/activitypub/activity/undo.rb
+++ b/app/lib/activitypub/activity/undo.rb
@@ -13,6 +13,8 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
       undo_like
     when 'Block'
       undo_block
+    when 'EmojiReact'
+      undo_react
     end
   end
 
@@ -57,6 +59,19 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
     if @account.favourited?(status)
       favourite = status.favourites.where(account: @account).first
       favourite&.destroy
+    else
+      delete_later!(object_uri)
+    end
+  end
+
+  def undo_react
+    status = status_from_uri(target_uri)
+
+    return if status.nil? || !status.account.local?
+
+    if @account.reacted?(status, @json['content'])
+      reaction = status.emoji_reactions.where(account: @account, name: @json['content']).first
+      reaction&.destroy
     else
       delete_later!(object_uri)
     end

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -199,6 +199,10 @@ module AccountInteractions
     status.proper.favourites.where(account: self).exists?
   end
 
+  def reacted?(status, name)
+    status.proper.emoji_reactions.where(account: self, name: name).exists?
+  end
+
   def bookmarked?(status)
     status.proper.bookmarks.where(account: self).exists?
   end

--- a/app/models/emoji_reaction.rb
+++ b/app/models/emoji_reaction.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: emoji_reactions
+#
+#  id         :bigint(8)        not null, primary key
+#  account_id :bigint(8)
+#  status_id  :bigint(8)
+#  name       :string           default(""), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class EmojiReaction < ApplicationRecord
+  belongs_to :account
+  belongs_to :status, inverse_of: :reactions
+  belongs_to :custom_emoji, optional: true
+
+  validates :name, presence: true
+  validates_with EmojiReactionValidator
+
+  # For now, don't support custom emoji, but use the same validation code
+  def custom_emoji_id
+    nil
+  end
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -58,6 +58,7 @@ class Status < ApplicationRecord
 
   has_many :favourites, inverse_of: :status, dependent: :destroy
   has_many :bookmarks, inverse_of: :status, dependent: :destroy
+  has_many :emoji_reactions, inverse_of: :status, dependent: :destroy
   has_many :reblogs, foreign_key: 'reblog_of_id', class_name: 'Status', inverse_of: :reblog, dependent: :destroy
   has_many :replies, foreign_key: 'in_reply_to_id', class_name: 'Status', inverse_of: :thread
   has_many :mentions, dependent: :destroy, inverse_of: :status

--- a/app/validators/emoji_reaction_validator.rb
+++ b/app/validators/emoji_reaction_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class EmojiReactionValidator < ActiveModel::Validator
+  def validate(reaction)
+    return if reaction.name.blank?
+
+    reaction.errors.add(:name, I18n.t('reactions.errors.unrecognized_emoji')) if reaction.custom_emoji_id.blank? && !unicode_emoji?(reaction.name)
+  end
+
+  private
+
+  def unicode_emoji?(name)
+    ReactionValidator::SUPPORTED_EMOJIS.include?(name)
+  end
+end

--- a/db/migrate/20200318135004_create_emoji_reactions.rb
+++ b/db/migrate/20200318135004_create_emoji_reactions.rb
@@ -1,0 +1,15 @@
+class CreateEmojiReactions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :emoji_reactions do |t|
+      t.belongs_to :account, foreign_key: { on_delete: :cascade, index: false }
+      t.belongs_to :status, foreign_key: { on_delete: :cascade }
+
+      t.string :name, null: false, default: ''
+
+      t.timestamps
+    end
+
+    add_index :emoji_reactions, [:account_id, :status_id, :name], unique: true, name: :index_emoji_reactions_on_account_id_and_status_id
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_12_185443) do
+ActiveRecord::Schema.define(version: 2020_03_18_135004) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -348,6 +348,17 @@ ActiveRecord::Schema.define(version: 2020_03_12_185443) do
     t.index ["account_id", "id"], name: "index_favourites_on_account_id_and_id"
     t.index ["account_id", "status_id"], name: "index_favourites_on_account_id_and_status_id", unique: true
     t.index ["status_id"], name: "index_favourites_on_status_id"
+  end
+
+  create_table "emoji_reactions", force: :cascade do |t|
+    t.bigint "account_id"
+    t.bigint "status_id"
+    t.string "name", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "status_id", "name"], name: "index_emoji_reactions_on_account_id_and_status_id", unique: true
+    t.index ["account_id"], name: "index_emoji_reactions_on_account_id"
+    t.index ["status_id"], name: "index_emoji_reactions_on_status_id"
   end
 
   create_table "featured_tags", force: :cascade do |t|
@@ -871,6 +882,8 @@ ActiveRecord::Schema.define(version: 2020_03_12_185443) do
   add_foreign_key "conversation_mutes", "conversations", on_delete: :cascade
   add_foreign_key "custom_filters", "accounts", on_delete: :cascade
   add_foreign_key "email_domain_blocks", "email_domain_blocks", column: "parent_id", on_delete: :cascade
+  add_foreign_key "emoji_reactions", "accounts", on_delete: :cascade
+  add_foreign_key "emoji_reactions", "statuses", on_delete: :cascade
   add_foreign_key "favourites", "accounts", name: "fk_5eb6c2b873", on_delete: :cascade
   add_foreign_key "favourites", "statuses", name: "fk_b0e856845e", on_delete: :cascade
   add_foreign_key "featured_tags", "accounts", on_delete: :cascade


### PR DESCRIPTION
Allows reacting to toots with emojis, like with announcements.

Pleroma does it with a new activity `EmojiReact` in the LitePub namespace with the emoji as `content`. It currently only allows unicode emoji, no custom emoji, although they aim to support them as well.

Misskey has the same feature, but does it by using `Like`s with an extra `_misskey_reaction` attribute.

Note that Pleroma does not serialize the current tallies nor does it offer any synchronization mechanism. This works just as favs/likes do.

- [x] Create model
- [x] Accept emoji reactions over ActivityPub (Pleroma style)
- [x] Accept undoing reactions over ActivityPub (Pleroma style)
- [ ] Serialize in the REST API
- [ ] Rest API to add/remove reactions
- [ ] Display on public pages
- [ ] Web UI
- [ ] Maybe support Misskey-style custom emoji?
- [ ] Notification/streaming API
- [ ] Add tests