### PR TITLE
[Breaking] docker-compose.yml - Upgrade Postgres image from 9.6 to 12.2 stable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   db:
     restart: always
-    image: postgres:9.6-alpine
+    image: postgres:12.2-alpine
     networks:
       - internal_network
     healthcheck:


### PR DESCRIPTION
As mentioned in #13281, this is a breaking change. I'll write a guide to migrate from 9 to 12 in docker.