### PR TITLE
Fix frontend crash when deleting announcements

### DIFF
--- a/app/javascript/mastodon/features/getting_started/components/announcements.js
+++ b/app/javascript/mastodon/features/getting_started/components/announcements.js
@@ -389,7 +389,7 @@ class Announcements extends ImmutablePureComponent {
   _markAnnouncementAsRead () {
     const { dismissAnnouncement, announcements } = this.props;
     const { index } = this.state;
-    const announcement = announcements.get(index);
+    const announcement = announcements.get(index) || announcements.get(index - 1);
     if (!announcement.get('read')) dismissAnnouncement(announcement.get('id'));
   }
 
@@ -407,7 +407,7 @@ class Announcements extends ImmutablePureComponent {
 
   render () {
     const { announcements, intl } = this.props;
-    const { index } = this.state;
+    const index = this.state.index < announcements.size ? this.state.index : announcements.size - 1;
 
     if (announcements.isEmpty()) {
       return null;


### PR DESCRIPTION
This two-line PR fixes a crash in the front end that occurred under the following circumstances (as previously discussed in the development Discord):
 *  A server had more than one announcement,
 *  A user was displaying the announcements, and
 *  An announcement was deleted (or unpublished, which amounts to
    the same thing.)

As might be expected, the bug was caused by attempting to access a notification using an index value outside the bounds of the existing announcements.  Specifically, in two places.  First,
`_markAnnouncementAsRead` attempts to modify announcements based on the current index.  This is what caused the front end crash.  Second, when rendering the `Announcements` component, the code paginates the announcements and displays the current one.  This did not cause a crash, but caused the front end to confusingly display a blank announcement (in situations that would have caused a crash) with no way for the user to navigate back to previous announcements.

This PR fixes both issues by adding a check to ensure that the code never attempts to access an announcement with an index greater than or equal to the number of announcements present.