### PR TITLE
Opt-In Flodgatt in docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,119 +1,117 @@
 FROM ubuntu:18.04 as build-dep
 
-# Use bash for the SHELL
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-RUN echo "Etc/UTC" > /etc/localtime && \
-	apt-get update && \
-	apt-get --no-install-recommends -y install apt-utils wget python ca-certificates
+# Use bash for the shell
+SHELL ["bash", "-c"]
 
 # Install Node v12 (LTS)
 ENV NODE_VER="12.16.1"
 RUN	ARCH= && \
-	dpkgArch="$(dpkg --print-architecture)" && \
-	case "${dpkgArch##*-}" in \
-		amd64) ARCH='x64';; \
-		ppc64el) ARCH='ppc64le';; \
-		s390x) ARCH='s390x';; \
-		arm64) ARCH='arm64';; \
-		armhf) ARCH='armv7l';; \
-		i386) ARCH='x86';; \
-		*) echo "unsupported architecture"; exit 1 ;; \
-	esac && \
+    dpkgArch="$(dpkg --print-architecture)" && \
+  case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac && \
+    echo "Etc/UTC" > /etc/localtime && \
+	apt update && \
+	apt -y install wget python && \
 	cd ~ && \
-	wget https://nodejs.org/download/release/v${NODE_VER}/node-v${NODE_VER}-linux-${ARCH}.tar.gz && \
-	tar xf node-v${NODE_VER}-linux-${ARCH}.tar.gz && \
-	rm node-v${NODE_VER}-linux-${ARCH}.tar.gz && \
-	mv node-v${NODE_VER}-linux-${ARCH} /opt/node
+	wget https://nodejs.org/download/release/v$NODE_VER/node-v$NODE_VER-linux-$ARCH.tar.gz && \
+	tar xf node-v$NODE_VER-linux-$ARCH.tar.gz && \
+	rm node-v$NODE_VER-linux-$ARCH.tar.gz && \
+	mv node-v$NODE_VER-linux-$ARCH /opt/node
 
 # Install jemalloc
 ENV JE_VER="5.2.1"
-RUN apt-get --no-install-recommends -y install make autoconf gcc g++ && \
+RUN apt update && \
+	apt -y install make autoconf gcc g++ && \
 	cd ~ && \
-	wget https://github.com/jemalloc/jemalloc/archive/${JE_VER}.tar.gz && \
-	tar xf ${JE_VER}.tar.gz && \
-	cd jemalloc-${JE_VER} && \
+	wget https://github.com/jemalloc/jemalloc/archive/$JE_VER.tar.gz && \
+	tar xf $JE_VER.tar.gz && \
+	cd jemalloc-$JE_VER && \
 	./autogen.sh && \
 	./configure --prefix=/opt/jemalloc && \
 	make -j$(nproc) > /dev/null && \
 	make install_bin install_include install_lib
 
-# Install Ruby
+# Install ruby
 ENV RUBY_VER="2.6.5"
 ENV CPPFLAGS="-I/opt/jemalloc/include"
 ENV LDFLAGS="-L/opt/jemalloc/lib/"
-RUN apt-get --no-install-recommends -y install build-essential bison libyaml-dev libgdbm-dev libreadline-dev \
-	libncurses5-dev libffi-dev zlib1g-dev libssl-dev && \
+RUN apt update && \
+	apt -y install build-essential \
+		bison libyaml-dev libgdbm-dev libreadline-dev \
+		libncurses5-dev libffi-dev zlib1g-dev libssl-dev && \
 	cd ~ && \
-	wget https://cache.ruby-lang.org/pub/ruby/${RUBY_VER%.*}/ruby-${RUBY_VER}.tar.gz && \
-	tar xf ruby-${RUBY_VER}.tar.gz && \
-	cd ruby-${RUBY_VER} && \
+	wget https://cache.ruby-lang.org/pub/ruby/${RUBY_VER%.*}/ruby-$RUBY_VER.tar.gz && \
+	tar xf ruby-$RUBY_VER.tar.gz && \
+	cd ruby-$RUBY_VER && \
 	./configure --prefix=/opt/ruby \
-	--with-jemalloc \
-	--with-shared \
-	--disable-install-doc && \
+	  --with-jemalloc \
+	  --with-shared \
+	  --disable-install-doc && \
 	ln -s /opt/jemalloc/lib/* /usr/lib/ && \
 	make -j$(nproc) > /dev/null && \
 	make install
 
-# Update PATH
-ENV PATH="/opt/ruby/bin:/opt/node/bin:${PATH}"
+ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin"
 
-# Install mastodon install deps
 RUN npm install -g yarn && \
 	gem install bundler && \
-	apt-get --no-install-recommends -y install git libicu-dev libidn11-dev libpq-dev libprotobuf-dev protobuf-compiler
+	apt update && \
+	apt -y install git libicu-dev libidn11-dev \
+	libpq-dev libprotobuf-dev protobuf-compiler
 
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
 RUN cd /opt/mastodon && \
-	bundle config set deployment 'true' && \
-	bundle config set without 'development test' && \
+  bundle config set deployment 'true' && \
+  bundle config set without 'development test' && \
 	bundle install -j$(nproc) && \
 	yarn install --pure-lockfile
 
-##-------------------------------------------------
 FROM ubuntu:18.04
-
-# Use bash for the SHELL
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-RUN echo "Etc/UTC" > /etc/localtime && \
-	apt-get update && \
-	apt-get --no-install-recommends -y install apt-utils wget whois ca-certificates
 
 # Copy over all the langs needed for runtime
 COPY --from=build-dep /opt/node /opt/node
 COPY --from=build-dep /opt/ruby /opt/ruby
 COPY --from=build-dep /opt/jemalloc /opt/jemalloc
-RUN ln -s /opt/jemalloc/lib/* /usr/lib/
 
-# Update PATH
-ENV PATH="/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin:${PATH}"
+# Add more PATHs to the PATH
+ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin"
 
 # Create the mastodon user
 ARG UID=991
 ARG GID=991
-RUN addgroup --gid ${GID} mastodon && \
-	useradd -m -u ${UID} -g ${GID} -d /opt/mastodon mastodon && \
-	echo "mastodon:$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256)" | chpasswd
+RUN apt update && \
+	echo "Etc/UTC" > /etc/localtime && \
+	ln -s /opt/jemalloc/lib/* /usr/lib/ && \
+	apt install -y whois wget && \
+	addgroup --gid $GID mastodon && \
+	useradd -m -u $UID -g $GID -d /opt/mastodon mastodon && \
+	echo "mastodon:`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256`" | chpasswd
 
 # Install mastodon runtime deps
-RUN apt-get --no-install-recommends -y install \
-	libssl1.1 libpq5 imagemagick ffmpeg \
-	libicu60 libprotobuf10 libidn11 libyaml-0-2 \
-	file ca-certificates tzdata libreadline7 gcc && \
+RUN apt -y --no-install-recommends install \
+	  libssl1.1 libpq5 imagemagick ffmpeg \
+	  libicu60 libprotobuf10 libidn11 libyaml-0-2 \
+	  file ca-certificates tzdata libreadline7 && \
+	apt -y install gcc && \
 	ln -s /opt/mastodon /mastodon && \
 	gem install bundler && \
 	rm -rf /var/cache && \
 	rm -rf /var/lib/apt/lists/*
 
-# Install tini
+# Add tini
 ENV TINI_VERSION="0.18.0"
 ENV TINI_SUM="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ADD https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini /tini
-RUN echo "${TINI_SUM} tini" | sha256sum -c - && \
-	chmod +x /tini
+RUN echo "$TINI_SUM tini" | sha256sum -c -
+RUN chmod +x /tini
 
 # Copy over mastodon source, and dependencies from building, and set permissions
 COPY --chown=mastodon:mastodon . /opt/mastodon
@@ -138,4 +136,4 @@ RUN cd ~ && \
 # Set the work dir and the container entry point
 WORKDIR /opt/mastodon
 ENTRYPOINT ["/tini", "--"]
-EXPOSE 3000
+EXPOSE 3000 4000

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN apt update && \
 	make -j$(nproc) > /dev/null && \
 	make install_bin install_include install_lib
 
-# Install ruby
+# Install Ruby
 ENV RUBY_VER="2.6.5"
 ENV CPPFLAGS="-I/opt/jemalloc/include"
 ENV LDFLAGS="-L/opt/jemalloc/lib/"
@@ -58,8 +58,10 @@ RUN apt update && \
 	make -j$(nproc) > /dev/null && \
 	make install
 
-ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin"
+# Update PATH
+ENV PATH="/opt/ruby/bin:/opt/node/bin:${PATH}"
 
+# Install mastodon install deps
 RUN npm install -g yarn && \
 	gem install bundler && \
 	apt update && \
@@ -74,6 +76,7 @@ RUN cd /opt/mastodon && \
 	bundle install -j$(nproc) && \
 	yarn install --pure-lockfile
 
+##-------------------------------------------------
 FROM ubuntu:18.04
 
 # Copy over all the langs needed for runtime
@@ -81,8 +84,8 @@ COPY --from=build-dep /opt/node /opt/node
 COPY --from=build-dep /opt/ruby /opt/ruby
 COPY --from=build-dep /opt/jemalloc /opt/jemalloc
 
-# Add more PATHs to the PATH
-ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin"
+# Update PATH
+ENV PATH="/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin:${PATH}"
 
 # Create the mastodon user
 ARG UID=991
@@ -136,4 +139,4 @@ RUN cd ~ && \
 # Set the work dir and the container entry point
 WORKDIR /opt/mastodon
 ENTRYPOINT ["/tini", "--"]
-EXPOSE 3000 4000
+EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,38 @@
 FROM ubuntu:18.04 as build-dep
 
-# Use bash for the shell
-SHELL ["bash", "-c"]
+# Use bash for the SHELL
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN echo "Etc/UTC" > /etc/localtime && \
+	apt-get update && \
+    apt-get --no-install-recommends -y install apt-utils wget python ca-certificates
 
 # Install Node v12 (LTS)
 ENV NODE_VER="12.16.1"
 RUN	ARCH= && \
     dpkgArch="$(dpkg --print-architecture)" && \
-  case "${dpkgArch##*-}" in \
-    amd64) ARCH='x64';; \
-    ppc64el) ARCH='ppc64le';; \
-    s390x) ARCH='s390x';; \
-    arm64) ARCH='arm64';; \
-    armhf) ARCH='armv7l';; \
-    i386) ARCH='x86';; \
-    *) echo "unsupported architecture"; exit 1 ;; \
-  esac && \
-    echo "Etc/UTC" > /etc/localtime && \
-	apt update && \
-	apt -y install wget python && \
+	case "${dpkgArch##*-}" in \
+		amd64) ARCH='x64';; \
+		ppc64el) ARCH='ppc64le';; \
+		s390x) ARCH='s390x';; \
+		arm64) ARCH='arm64';; \
+		armhf) ARCH='armv7l';; \
+		i386) ARCH='x86';; \
+		*) echo "unsupported architecture"; exit 1 ;; \
+	esac && \
 	cd ~ && \
-	wget https://nodejs.org/download/release/v$NODE_VER/node-v$NODE_VER-linux-$ARCH.tar.gz && \
-	tar xf node-v$NODE_VER-linux-$ARCH.tar.gz && \
-	rm node-v$NODE_VER-linux-$ARCH.tar.gz && \
-	mv node-v$NODE_VER-linux-$ARCH /opt/node
+	wget https://nodejs.org/download/release/v${NODE_VER}/node-v${NODE_VER}-linux-${ARCH}.tar.gz && \
+	tar xf node-v${NODE_VER}-linux-${ARCH}.tar.gz && \
+	rm node-v${NODE_VER}-linux-${ARCH}.tar.gz && \
+	mv node-v${NODE_VER}-linux-${ARCH} /opt/node
 
 # Install jemalloc
 ENV JE_VER="5.2.1"
-RUN apt update && \
-	apt -y install make autoconf gcc g++ && \
+RUN apt-get --no-install-recommends -y install make autoconf gcc g++ && \
 	cd ~ && \
-	wget https://github.com/jemalloc/jemalloc/archive/$JE_VER.tar.gz && \
-	tar xf $JE_VER.tar.gz && \
-	cd jemalloc-$JE_VER && \
+	wget https://github.com/jemalloc/jemalloc/archive/${JE_VER}.tar.gz && \
+	tar xf ${JE_VER}.tar.gz && \
+	cd jemalloc-${JE_VER} && \
 	./autogen.sh && \
 	./configure --prefix=/opt/jemalloc && \
 	make -j$(nproc) > /dev/null && \
@@ -42,18 +42,18 @@ RUN apt update && \
 ENV RUBY_VER="2.6.5"
 ENV CPPFLAGS="-I/opt/jemalloc/include"
 ENV LDFLAGS="-L/opt/jemalloc/lib/"
-RUN apt update && \
-	apt -y install build-essential \
-		bison libyaml-dev libgdbm-dev libreadline-dev \
-		libncurses5-dev libffi-dev zlib1g-dev libssl-dev && \
+RUN apt-get update && \
+	apt-get --no-install-recommends -y install build-essential \
+	bison libyaml-dev libgdbm-dev libreadline-dev \
+	libncurses5-dev libffi-dev zlib1g-dev libssl-dev && \
 	cd ~ && \
-	wget https://cache.ruby-lang.org/pub/ruby/${RUBY_VER%.*}/ruby-$RUBY_VER.tar.gz && \
-	tar xf ruby-$RUBY_VER.tar.gz && \
-	cd ruby-$RUBY_VER && \
+	wget https://cache.ruby-lang.org/pub/ruby/${RUBY_VER%.*}/ruby-${RUBY_VER}.tar.gz && \
+	tar xf ruby-${RUBY_VER}.tar.gz && \
+	cd ruby-${RUBY_VER} && \
 	./configure --prefix=/opt/ruby \
-	  --with-jemalloc \
-	  --with-shared \
-	  --disable-install-doc && \
+	--with-jemalloc \
+	--with-shared \
+	--disable-install-doc && \
 	ln -s /opt/jemalloc/lib/* /usr/lib/ && \
 	make -j$(nproc) > /dev/null && \
 	make install
@@ -64,25 +64,33 @@ ENV PATH="/opt/ruby/bin:/opt/node/bin:${PATH}"
 # Install mastodon install deps
 RUN npm install -g yarn && \
 	gem install bundler && \
-	apt update && \
-	apt -y install git libicu-dev libidn11-dev \
+	apt-get update && \
+	apt-get --no-install-recommends -y install git libicu-dev libidn11-dev \
 	libpq-dev libprotobuf-dev protobuf-compiler
 
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
 RUN cd /opt/mastodon && \
-  bundle config set deployment 'true' && \
-  bundle config set without 'development test' && \
+	bundle config set deployment 'true' && \
+	bundle config set without 'development test' && \
 	bundle install -j$(nproc) && \
 	yarn install --pure-lockfile
 
 ##-------------------------------------------------
 FROM ubuntu:18.04
 
+# Use bash for the SHELL
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN echo "Etc/UTC" > /etc/localtime && \
+	apt-get update && \
+    apt-get --no-install-recommends -y install apt-utils wget whois ca-certificates
+
 # Copy over all the langs needed for runtime
 COPY --from=build-dep /opt/node /opt/node
 COPY --from=build-dep /opt/ruby /opt/ruby
 COPY --from=build-dep /opt/jemalloc /opt/jemalloc
+RUN ln -s /opt/jemalloc/lib/* /usr/lib/
 
 # Update PATH
 ENV PATH="/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin:${PATH}"
@@ -90,20 +98,15 @@ ENV PATH="/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin:${PATH}"
 # Create the mastodon user
 ARG UID=991
 ARG GID=991
-RUN apt update && \
-	echo "Etc/UTC" > /etc/localtime && \
-	ln -s /opt/jemalloc/lib/* /usr/lib/ && \
-	apt install -y whois wget && \
-	addgroup --gid $GID mastodon && \
-	useradd -m -u $UID -g $GID -d /opt/mastodon mastodon && \
-	echo "mastodon:`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256`" | chpasswd
+RUN addgroup --gid ${GID} mastodon && \
+	useradd -m -u ${UID} -g ${GID} -d /opt/mastodon mastodon && \
+	echo "mastodon:$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256)" | chpasswd
 
 # Install mastodon runtime deps
-RUN apt -y --no-install-recommends install \
-	  libssl1.1 libpq5 imagemagick ffmpeg \
-	  libicu60 libprotobuf10 libidn11 libyaml-0-2 \
-	  file ca-certificates tzdata libreadline7 && \
-	apt -y install gcc && \
+RUN apt-get --no-install-recommends -y install \
+	libssl1.1 libpq5 imagemagick ffmpeg \
+	libicu60 libprotobuf10 libidn11 libyaml-0-2 \
+	file ca-certificates tzdata libreadline7 gcc && \
 	ln -s /opt/mastodon /mastodon && \
 	gem install bundler && \
 	rm -rf /var/cache && \
@@ -113,8 +116,8 @@ RUN apt -y --no-install-recommends install \
 ENV TINI_VERSION="0.18.0"
 ENV TINI_SUM="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ADD https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini /tini
-RUN echo "$TINI_SUM tini" | sha256sum -c -
-RUN chmod +x /tini
+RUN echo "${TINI_SUM} tini" | sha256sum -c - && \
+    chmod +x /tini
 
 # Copy over mastodon source, and dependencies from building, and set permissions
 COPY --chown=mastodon:mastodon . /opt/mastodon

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN echo "Etc/UTC" > /etc/localtime && \
 	apt-get update && \
-    apt-get --no-install-recommends -y install apt-utils wget python ca-certificates
+	apt-get --no-install-recommends -y install apt-utils wget python ca-certificates
 
 # Install Node v12 (LTS)
 ENV NODE_VER="12.16.1"
 RUN	ARCH= && \
-    dpkgArch="$(dpkg --print-architecture)" && \
+	dpkgArch="$(dpkg --print-architecture)" && \
 	case "${dpkgArch##*-}" in \
 		amd64) ARCH='x64';; \
 		ppc64el) ARCH='ppc64le';; \
@@ -84,7 +84,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN echo "Etc/UTC" > /etc/localtime && \
 	apt-get update && \
-    apt-get --no-install-recommends -y install apt-utils wget whois ca-certificates
+	apt-get --no-install-recommends -y install apt-utils wget whois ca-certificates
 
 # Copy over all the langs needed for runtime
 COPY --from=build-dep /opt/node /opt/node
@@ -117,7 +117,7 @@ ENV TINI_VERSION="0.18.0"
 ENV TINI_SUM="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ADD https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini /tini
 RUN echo "${TINI_SUM} tini" | sha256sum -c - && \
-    chmod +x /tini
+	chmod +x /tini
 
 # Copy over mastodon source, and dependencies from building, and set permissions
 COPY --chown=mastodon:mastodon . /opt/mastodon

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,7 @@ RUN apt-get --no-install-recommends -y install make autoconf gcc g++ && \
 ENV RUBY_VER="2.6.5"
 ENV CPPFLAGS="-I/opt/jemalloc/include"
 ENV LDFLAGS="-L/opt/jemalloc/lib/"
-RUN apt-get update && \
-	apt-get --no-install-recommends -y install build-essential \
-	bison libyaml-dev libgdbm-dev libreadline-dev \
+RUN apt-get --no-install-recommends -y install build-essential bison libyaml-dev libgdbm-dev libreadline-dev \
 	libncurses5-dev libffi-dev zlib1g-dev libssl-dev && \
 	cd ~ && \
 	wget https://cache.ruby-lang.org/pub/ruby/${RUBY_VER%.*}/ruby-${RUBY_VER}.tar.gz && \
@@ -64,9 +62,7 @@ ENV PATH="/opt/ruby/bin:/opt/node/bin:${PATH}"
 # Install mastodon install deps
 RUN npm install -g yarn && \
 	gem install bundler && \
-	apt-get update && \
-	apt-get --no-install-recommends -y install git libicu-dev libidn11-dev \
-	libpq-dev libprotobuf-dev protobuf-compiler
+	apt-get --no-install-recommends -y install git libicu-dev libidn11-dev libpq-dev libprotobuf-dev protobuf-compiler
 
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
@@ -112,7 +108,7 @@ RUN apt-get --no-install-recommends -y install \
 	rm -rf /var/cache && \
 	rm -rf /var/lib/apt/lists/*
 
-# Add tini
+# Install tini
 ENV TINI_VERSION="0.18.0"
 ENV TINI_SUM="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ADD https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini /tini

--- a/Dockerfile.flodgatt
+++ b/Dockerfile.flodgatt
@@ -24,8 +24,8 @@ RUN echo "${TINI_SUM} tini" | sha256sum -c - && \
 	chmod +x /tini
 
 # Install Flodgatt
-ENV FG_VER="v0.6.5"
-ENV FG_SUM="7ea9331ce58fc049d2c840355dd60fea3492c3f55b271eed59f2c007975eca53"
+ENV FG_VER="v0.8.2"
+ENV FG_SUM="bd9528547cef70cbcf6ce2a22b190c7ca2db9a1544d23c56baad31d062a79ab1"
 ADD --chown=mastodon:mastodon https://github.com/tootsuite/flodgatt/releases/download/${FG_VER}/flodgatt /flodgatt 
 RUN echo "${FG_SUM} /flodgatt" | sha256sum -c - && \
 	chmod +x /flodgatt

--- a/Dockerfile.flodgatt
+++ b/Dockerfile.flodgatt
@@ -24,8 +24,8 @@ RUN echo "${TINI_SUM} tini" | sha256sum -c - && \
 	chmod +x /tini
 
 # Install Flodgatt
-ENV FG_VER="v0.6.4"
-ENV FG_SUM="72715103b889a8e5c2fb9088c657fe32ae30ad0a735e86d9de9bdeaf09e478d0"
+ENV FG_VER="v0.6.5"
+ENV FG_SUM="7ea9331ce58fc049d2c840355dd60fea3492c3f55b271eed59f2c007975eca53"
 ADD --chown=mastodon:mastodon https://github.com/tootsuite/flodgatt/releases/download/${FG_VER}/flodgatt /flodgatt 
 RUN echo "${FG_SUM} /flodgatt" | sha256sum -c - && \
 	chmod +x /flodgatt

--- a/Dockerfile.flodgatt
+++ b/Dockerfile.flodgatt
@@ -16,7 +16,7 @@ RUN addgroup --gid ${GID} mastodon && \
 	useradd -m -u ${UID} -g ${GID} -d /opt/mastodon mastodon && \
 	echo "mastodon:$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256)" | chpasswd
 
-# Add tini
+# Install tini
 ENV TINI_VERSION="v0.18.0"
 ENV TINI_SUM="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini

--- a/Dockerfile.flodgatt
+++ b/Dockerfile.flodgatt
@@ -1,30 +1,34 @@
 FROM ubuntu:18.04
 
+# Use bash for the SHELL
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN echo "Etc/UTC" > /etc/localtime && \
+	apt-get update && \
+    apt-get --no-install-recommends -y install apt-utils wget whois ca-certificates && \
+	rm -rf /var/cache && \
+	rm -rf /var/lib/apt/lists/*
+
 # Create the mastodon user
 ARG UID=991
 ARG GID=991
-RUN apt update && \
-	echo "Etc/UTC" > /etc/localtime && \
-	apt install -y whois wget && \
-	addgroup --gid $GID mastodon && \
-	useradd -m -u $UID -g $GID -d /opt/mastodon mastodon && \
-	echo "mastodon:`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256`" | chpasswd && \
-	rm -rf /var/cache && \
-	rm -rf /var/lib/apt/lists/*
+RUN addgroup --gid ${GID} mastodon && \
+	useradd -m -u ${UID} -g ${GID} -d /opt/mastodon mastodon && \
+	echo "mastodon:$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256)" | chpasswd
 
 # Add tini
 ENV TINI_VERSION="v0.18.0"
 ENV TINI_SUM="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN echo "$TINI_SUM tini" | sha256sum -c -
-RUN chmod +x /tini
+RUN echo "${TINI_SUM} tini" | sha256sum -c - && \
+    chmod +x /tini
 
 # Install Flodgatt
 ENV FG_VER="v0.6.3"
 ENV FG_SUM="71eeae1784542edd06cd8b2aa35b3bbc87b037f197e866dfe67e451f99776622"
-ADD --chown=mastodon:mastodon https://github.com/tootsuite/flodgatt/releases/download/$FG_VER/flodgatt /flodgatt 
-RUN echo "$FG_SUM /flodgatt" | sha256sum -c -
-RUN chmod +x /flodgatt
+ADD --chown=mastodon:mastodon https://github.com/tootsuite/flodgatt/releases/download/${FG_VER}/flodgatt /flodgatt 
+RUN echo "${FG_SUM} /flodgatt" | sha256sum -c - && \
+    chmod +x /flodgatt
 
 ENV BIND="0.0.0.0"
 

--- a/Dockerfile.flodgatt
+++ b/Dockerfile.flodgatt
@@ -1,0 +1,37 @@
+FROM ubuntu:18.04
+
+# Create the mastodon user
+ARG UID=991
+ARG GID=991
+RUN apt update && \
+	echo "Etc/UTC" > /etc/localtime && \
+	apt install -y whois wget && \
+	addgroup --gid $GID mastodon && \
+	useradd -m -u $UID -g $GID -d /opt/mastodon mastodon && \
+	echo "mastodon:`head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256`" | chpasswd && \
+	rm -rf /var/cache && \
+	rm -rf /var/lib/apt/lists/*
+
+# Add tini
+ENV TINI_VERSION="v0.18.0"
+ENV TINI_SUM="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN echo "$TINI_SUM tini" | sha256sum -c -
+RUN chmod +x /tini
+
+# Install Flodgatt
+ENV FG_VER="v0.6.3"
+ENV FG_SUM="71eeae1784542edd06cd8b2aa35b3bbc87b037f197e866dfe67e451f99776622"
+ADD --chown=mastodon:mastodon https://github.com/tootsuite/flodgatt/releases/download/$FG_VER/flodgatt /flodgatt 
+RUN echo "$FG_SUM /flodgatt" | sha256sum -c -
+RUN chmod +x /flodgatt
+
+ENV BIND="0.0.0.0"
+
+# Set the run user
+USER mastodon
+
+# Set the work dir and the container entry point
+WORKDIR /
+ENTRYPOINT ["/tini", "--"]
+EXPOSE 4000

--- a/Dockerfile.flodgatt
+++ b/Dockerfile.flodgatt
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN echo "Etc/UTC" > /etc/localtime && \
 	apt-get update && \
-    apt-get --no-install-recommends -y install apt-utils wget whois ca-certificates && \
+	apt-get --no-install-recommends -y install apt-utils wget whois ca-certificates && \
 	rm -rf /var/cache && \
 	rm -rf /var/lib/apt/lists/*
 
@@ -21,14 +21,14 @@ ENV TINI_VERSION="v0.18.0"
 ENV TINI_SUM="12d20136605531b09a2c2dac02ccee85e1b874eb322ef6baf7561cd93f93c855"
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN echo "${TINI_SUM} tini" | sha256sum -c - && \
-    chmod +x /tini
+	chmod +x /tini
 
 # Install Flodgatt
 ENV FG_VER="v0.6.3"
 ENV FG_SUM="71eeae1784542edd06cd8b2aa35b3bbc87b037f197e866dfe67e451f99776622"
 ADD --chown=mastodon:mastodon https://github.com/tootsuite/flodgatt/releases/download/${FG_VER}/flodgatt /flodgatt 
 RUN echo "${FG_SUM} /flodgatt" | sha256sum -c - && \
-    chmod +x /flodgatt
+	chmod +x /flodgatt
 
 ENV BIND="0.0.0.0"
 

--- a/Dockerfile.flodgatt
+++ b/Dockerfile.flodgatt
@@ -24,8 +24,8 @@ RUN echo "${TINI_SUM} tini" | sha256sum -c - && \
 	chmod +x /tini
 
 # Install Flodgatt
-ENV FG_VER="v0.6.3"
-ENV FG_SUM="71eeae1784542edd06cd8b2aa35b3bbc87b037f197e866dfe67e451f99776622"
+ENV FG_VER="v0.6.4"
+ENV FG_SUM="72715103b889a8e5c2fb9088c657fe32ae30ad0a735e86d9de9bdeaf09e478d0"
 ADD --chown=mastodon:mastodon https://github.com/tootsuite/flodgatt/releases/download/${FG_VER}/flodgatt /flodgatt 
 RUN echo "${FG_SUM} /flodgatt" | sha256sum -c - && \
 	chmod +x /flodgatt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-
+## Database and Cache (postgres and redis)
   db:
     restart: always
     image: postgres:9.6-alpine
@@ -21,18 +21,7 @@ services:
     volumes:
       - ./redis:/data
 
-#  es:
-#    restart: always
-#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.3
-#    environment:
-#      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-#    networks:
-#      - internal_network
-#    healthcheck:
-#      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
-#    volumes:
-#      - ./elasticsearch:/usr/share/elasticsearch/data
-
+## Mastodon Frontend
   web:
     build: .
     image: tootsuite/mastodon
@@ -53,6 +42,23 @@ services:
     volumes:
       - ./public/system:/mastodon/public/system
 
+## Mastodon Backend
+  sidekiq:
+    build: .
+    image: tootsuite/mastodon
+    restart: always
+    env_file: .env.production
+    command: bundle exec sidekiq
+    depends_on:
+      - db
+      - redis
+    networks:
+      - external_network
+      - internal_network
+    volumes:
+      - ./public/system:/mastodon/public/system
+
+## Node Streaming (Legacy)
   streaming:
     build: .
     image: tootsuite/mastodon
@@ -70,29 +76,45 @@ services:
       - db
       - redis
 
-  sidekiq:
-    build: .
-    image: tootsuite/mastodon
-    restart: always
-    env_file: .env.production
-    command: bundle exec sidekiq
-    depends_on:
-      - db
-      - redis
-    networks:
-      - external_network
-      - internal_network
-    volumes:
-      - ./public/system:/mastodon/public/system
-## Uncomment to enable federation with tor instances along with adding the following ENV variables
-## http_proxy=http://privoxy:8118
-## ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
+## Flodgatt Streaming (work in progress)
+#   flodgatt:
+#     image: tootsuite/flodgatt
+#     build:
+#       context: .
+#       dockerfile: Dockerfile.flodgatt
+#     restart: always
+#     env_file: .env.production
+#     command: /flodgatt
+#     networks:
+#       - external_network
+#       - internal_network
+#     healthcheck:
+#       test: ["CMD-SHELL", "wget -q --spider --proxy=off localhost:4000/api/v1/streaming/health || exit 1"]
+#     ports:
+#       - "127.0.0.1:4000:4000"
+#     depends_on:
+#       - db
+#       - redis
+
+## Optional Full Text Search (elasticsearch)
+#  es:
+#    restart: always
+#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.3
+#    environment:
+#      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+#    networks:
+#      - internal_network
+#    healthcheck:
+#      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+#    volumes:
+#      - ./elasticsearch:/usr/share/elasticsearch/data
+
+## Optional Onion Hidden Service (Tor)
 #  tor:
 #    image: sirboops/tor
 #    networks:
 #      - external_network
 #      - internal_network
-#
 #  privoxy:
 #    image: sirboops/privoxy
 #    volumes:
@@ -100,6 +122,9 @@ services:
 #    networks:
 #      - external_network
 #      - internal_network
+## Uncomment to enable federation with tor instances along with adding the following ENV variables
+## http_proxy=http://privoxy:8118
+## ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
 
 networks:
   external_network:


### PR DESCRIPTION
This is my configuration currently running on aus.social using the precompiled binary.
If we want to compile from source instead, I'll make a patch to build using the Rust compiler later.

* Hey @Gargron, this is Opt-In. I'm happy for this to be merged soon after some additional testing and approval from yourself/other stakeholders, and you can default it later.
* Everybody else, Please feel free to test this on your environment and keep @codesections updated with any errors or issues. https://github.com/tootsuite/flodgatt

**Upgrade**: 
* Comment the NodeJS streaming part from docker-compose.yml
* Uncomment the Flodgatt streaming part from docker-compose.yml
* `docker-compose build flodgatt --pull`
* `docker-compose up -d --remove-orphans`

**Rollback**: 
* Uncomment the NodeJS streaming part from docker-compose.yml
* Comment the Flodgatt streaming part from docker-compose.yml
* `docker-compose up -d --remove-orphans`

