### PR TITLE
Decommission support for Ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 2.4.0', '< 3.0.0'
+ruby '>= 2.5.0', '< 3.0.0'
 
 gem 'pkg-config', '~> 1.4'
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Mastodon acts as an OAuth2 provider so 3rd party apps can use the REST and Strea
 **Requirements:**
 
 - **PostgreSQL** 9.5+
-- **Redis**
-- **Ruby** 2.4+
+- **Redis** 4+
+- **Ruby** 2.5+
 - **Node.js** 10.13+
 
 The repository includes deployment configurations for **Docker and docker-compose**, but also a few specific platforms like **Heroku**, **Scalingo**, and **Nanobox**. The [**stand-alone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the documentation.


### PR DESCRIPTION
2.4 has security support ends in a few days... It's time

Rails 6 and lots of other gems require 2.5 minimum.