### PR TITLE
Change `tootctl media remove-orphans` to work for all classes

### DIFF
--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -15,6 +15,8 @@ class ActivityPub::TagManager
   def url_for(target)
     return target.url if target.respond_to?(:local?) && !target.local?
 
+    return unless target.respond_to?(:object_type)
+
     case target.object_type
     when :person
       target.instance_actor? ? about_more_url(instance_actor: true) : short_account_url(target)

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -184,19 +184,6 @@ class MediaAttachment < ApplicationRecord
     audio? || video?
   end
 
-  def variant?(other_file_name)
-    return true if file_file_name == other_file_name
-    return false if file_file_name.nil?
-
-    formats = file.styles.values.map(&:format).compact
-
-    return false if formats.empty?
-
-    extension = File.extname(other_file_name)
-
-    formats.include?(extension.delete('.')) && File.basename(other_file_name, extension) == File.basename(file_file_name, File.extname(file_file_name))
-  end
-
   def to_param
     shortcode
   end

--- a/lib/paperclip/attachment_extensions.rb
+++ b/lib/paperclip/attachment_extensions.rb
@@ -24,6 +24,19 @@ module Paperclip
         flush_deletes
       end
     end
+
+    def variant?(other_filename)
+      return true  if original_filename == other_filename
+      return false if original_filename.nil?
+
+      formats = styles.values.map(&:format).compact
+
+      return false if formats.empty?
+
+      other_extension = File.extname(other_filename)
+
+      formats.include?(other_extension.delete('.')) && File.basename(other_filename, other_extension) == File.basename(original_filename, File.extname(original_filename))
+    end
   end
 end
 


### PR DESCRIPTION
The command now takes an optional `--prefix` option, but otherwise traverses all files in the system, looking up corresponding records and removing orphaned files: avatars, headers, imports, backups, custom emojis, preview cards...

Also: **Change `tootctl media lookup` to not use an interactive prompt**

The command now simply has one argument, the URL. In case of failure, the command now exits with code 1, allowing the command to be used in other scripts.