### PR TITLE
Fix Paperclip using deprecated URI.escape function

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 require_relative '../app/lib/exceptions'
+require_relative '../lib/paperclip/url_generator_extensions'
 require_relative '../lib/paperclip/attachment_extensions'
 require_relative '../lib/paperclip/lazy_thumbnail'
 require_relative '../lib/paperclip/gif_transcoder'

--- a/lib/paperclip/url_generator_extensions.rb
+++ b/lib/paperclip/url_generator_extensions.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Paperclip
+  module UrlGeneratorExtensions
+    # Monkey-patch Paperclip to use Addressable::URI's normalization instead
+    # of the long-deprecated URI.esacpe
+    def escape_url(url)
+      if url.respond_to?(:escape)
+        url.escape
+      else
+        Addressable::URI.parse(url).normalize.to_str.gsub(escape_regex) { |m| "%#{m.ord.to_s(16).upcase}" }
+      end
+    end
+  end
+end
+
+Paperclip::UrlGenerator.prepend(Paperclip::UrlGeneratorExtensions)


### PR DESCRIPTION
Monkey-patch Paperclip to perform URL escaping in a slightly more
appropriate way, and get rid of the runtime deprecation warning spam.

`URI.escape` has been deprecated ages ago because it applies the same escaping process to the whole string, regardless of the individual URI components, which is, in general, not what one wants.
Ruby 2.7 has added a noisy deprecation warning, which causes Mastodon to continuously display “warning: URI.escape is obsolete” in the logs.

I am not sure in which cases the output from the old (https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/url_generator.rb#L64-L70) and new function differ, so some testing may be needed. It may possibly differ in the presence of a fragment identifier (hash part), but arguably, the original behavior was incorrect, and hash parts are unlikely to ever occur in Paperclip-manipulated URLs?