### PR TITLE
Fix OCR not working on Safari because of unsupported worker-src CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -32,10 +32,12 @@ Rails.application.config.content_security_policy do |p|
 
     p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url, *webpacker_urls
     p.script_src  :self, :unsafe_inline, :unsafe_eval, assets_host
+    p.child_src   :self, :blob, assets_host
     p.worker_src  :self, :blob, assets_host
   else
     p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url
     p.script_src  :self, assets_host
+    p.child_src   :self, :blob, assets_host
     p.worker_src  :self, :blob, assets_host
   end
 end


### PR DESCRIPTION
Fixes #13321