### PR TITLE
Fix ImportsController param to permit :mode

### DIFF
--- a/app/controllers/settings/imports_controller.rb
+++ b/app/controllers/settings/imports_controller.rb
@@ -29,6 +29,6 @@ class Settings::ImportsController < Settings::BaseController
   end
 
   def import_params
-    params.require(:import).permit(:data, :type)
+    params.require(:import).permit(:data, :type, :mode)
   end
 end


### PR DESCRIPTION
The import overwrite was not working because ImportsController did not permit the :mode parameter.