### PR TITLE
Fix wrong color for ellipsis in boost confirmation dialog in Web UI

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1028,12 +1028,10 @@
     }
 
     .display-name {
+      color: $light-text-color;
+
       strong {
         color: $inverted-text-color;
-      }
-
-      span {
-        color: $light-text-color;
       }
     }
 


### PR DESCRIPTION
Before:
![Screenshot_2020-03-31 Mastodon](https://user-images.githubusercontent.com/2446451/77969259-9fabbc00-72e9-11ea-9f17-5051aa58ea5f.png)

After:
![Screenshot_2020-03-31 Mastodon_2](https://user-images.githubusercontent.com/2446451/77969261-a0445280-72e9-11ea-9e06-3783b65e41a2.png)
