### PR TITLE
Update Vagrant box to Bionic

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,7 +91,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "ubuntu/bionic64"
 
   config.vm.provider :virtualbox do |vb|
     vb.name = "mastodon"


### PR DESCRIPTION
Sidekiq 6.x requires Redis v4.0.0 or greater.
But Can't install Redis v4.0.0 or greater from apt when Xenial.
And Ubuntu 18.04 is seems recommended on documentation [here](https://docs.joinmastodon.org/admin/install/).

I confirm all tests passed.