### PR TITLE
Update Postgres 9.6 to 12.2 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   db:
     restart: always
-    image: postgres:12-alpine
+    image: postgres:12.2-alpine
     networks:
       - internal_network
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   db:
     restart: always
-    image: postgres:9.6-alpine
+    image: postgres:12-alpine
     networks:
       - internal_network
     healthcheck:


### PR DESCRIPTION
Postgres 9.6 is still in support until November 11, 2021... but Postgres 12 offers a lot of functionality that's worth the upgrade.

The only problem is the best upgrade path. There are tools to assist with the pg_upgrade process, as it requires the binaries for the old and new DB.
> https://github.com/tianon/docker-postgres-upgrade

I'm going to test and confirm these are safe -- but backup, backup, backup!