### PR TITLE
[Security] Update Dockerfile for Ruby 2.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ RUN apt update && \
 	make -j$(nproc) > /dev/null && \
 	make install_bin install_include install_lib
 
-# Install ruby
-ENV RUBY_VER="2.6.5"
+# Install Ruby
+ENV RUBY_VER="2.6.6"
 ENV CPPFLAGS="-I/opt/jemalloc/include"
 ENV LDFLAGS="-L/opt/jemalloc/lib/"
 RUN apt update && \


### PR DESCRIPTION
Ruby 2.6.6 has been released.

This release includes security fixes.
CVE-2020-16255: Unsafe Object Creation Vulnerability in JSON (Additional fix)
CVE-2020-10933: Heap exposure vulnerability in the socket library