### PR TITLE
Increase dependabot dependencies scope from security-only.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,15 +4,25 @@ update_configs:
   - package_manager: "ruby:bundler"
     directory: "/"
     update_schedule: "weekly"
-    version_requirement_updates: auto
+    # Supported update schedule: live daily weekly monthly
+    version_requirement_updates: "auto"
+    # Supported version requirements: auto widen_ranges increase_versions increase_versions_if_necessary
     allowed_updates:
       - match:
+          dependency_type: "all"
+          # Supported dependency types: all indirect direct production development
           update_type: "all"
+          # Supported update types: all security
 
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "weekly"
-    version_requirement_updates: auto
+    # Supported update schedule: live daily weekly monthly
+    version_requirement_updates: "auto"
+    # Supported version requirements: auto widen_ranges increase_versions increase_versions_if_necessary
     allowed_updates:
       - match:
+          dependency_type: "all"
+          # Supported dependency types: all indirect direct production development
           update_type: "all"
+          # Supported update types: all security

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,3 +16,19 @@ update_configs:
     allowed_updates:
       - match:
           update_type: "all"
+
+
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "live"
+    version_requirement_updates: auto
+    allowed_updates:
+      - match:
+          update_type: "security"
+
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    allowed_updates:
+      - match:
+          update_type: "security"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,19 +16,3 @@ update_configs:
     allowed_updates:
       - match:
           update_type: "all"
-
-
-  - package_manager: "ruby:bundler"
-    directory: "/"
-    update_schedule: "live"
-    version_requirement_updates: auto
-    allowed_updates:
-      - match:
-          update_type: "security"
-
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "live"
-    allowed_updates:
-      - match:
-          update_type: "security"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,7 +4,15 @@ update_configs:
   - package_manager: "ruby:bundler"
     directory: "/"
     update_schedule: "weekly"
+    version_requirement_updates: auto
+    allowed_updates:
+      - match:
+          update_type: "all"
 
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "weekly"
+    version_requirement_updates: auto
+    allowed_updates:
+      - match:
+          update_type: "all"


### PR DESCRIPTION
Doco: https://dependabot.com/docs/config-file/

The default dependabot is "(indirect/sub-dependencies are only updated if they include security fixes)". -- Resulting in multiple packages missing from the weekly run.
