### PR TITLE
Fix messed up z-index when NoScript blocks media/previews

### DIFF
--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -229,3 +229,15 @@ button {
     }
   }
 }
+
+// NoScript adds a __ns__pop2top class to the full ancestry of blocked elements,
+// to set the z-index to a high value, which messes with modals and dropdowns.
+// Blocked elements can in theory only be media and frames/embeds, so they
+// should only appear in statuses, under divs and articles.
+body,
+div,
+article {
+  .__ns__pop2top {
+    z-index: unset !important;
+  }
+}


### PR DESCRIPTION
Fixes #13444

I'm not *sure* we should even bother with an extension messing up the CSS that badly, but of all extensions messing with DOM/CSS, it's one of the most likely to be used (we probably also have to do something for Chrome's translation thing).