### PR TITLE
increase the postgres container shm_size from 64M to 256M (Docker)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   db:
     restart: always
     image: postgres:9.6-alpine
+    shm_size: 256mb
     networks:
       - internal_network
     healthcheck:


### PR DESCRIPTION
Increases the /dev/shm size from 64M to 256M for the Postgres Docker container, since the default size of 64M means that if there's a large amount of queries in flight, one runs the risk of seeing `no space left on device` on tmpfs. 

I've ran with a resized  shm of 256M with no further issues, hence the chooses value. 
