### PR TITLE
Fix account aliases page

### DIFF
--- a/app/models/account_alias.rb
+++ b/app/models/account_alias.rb
@@ -18,6 +18,7 @@ class AccountAlias < ApplicationRecord
   validates :acct, presence: true, domain: { acct: true }
   validates :uri, presence: true
   validates :uri, uniqueness: { scope: :account_id }
+  validate :validate_target_account
 
   before_validation :set_uri
   after_create :add_to_account
@@ -43,5 +44,13 @@ class AccountAlias < ApplicationRecord
 
   def remove_from_account
     account.update(also_known_as: account.also_known_as.reject { |x| x == uri })
+  end
+
+  def validate_target_account
+    if uri.nil?
+      errors.add(:acct, I18n.t('migrations.errors.not_found'))
+    elsif ActivityPub::TagManager.instance.uri_for(account) == uri
+      errors.add(:acct, I18n.t('migrations.errors.move_to_self'))
+    end
   end
 end

--- a/app/views/settings/aliases/index.html.haml
+++ b/app/views/settings/aliases/index.html.haml
@@ -23,7 +23,11 @@
         %th= t('simple_form.labels.account_alias.acct')
         %th
     %tbody
-      - @aliases.each do |account_alias|
+      - if @aliases.empty?
         %tr
-          %td= account_alias.acct
-          %td= table_link_to 'trash', t('aliases.remove'), settings_alias_path(account_alias), data: { method: :delete }
+          %td.muted-hint{ colspan: 2 }= t('aliases.empty')
+      - else
+        - @aliases.each do |account_alias|
+          %tr
+            %td= account_alias.acct
+            %td= table_link_to 'trash', t('aliases.remove'), settings_alias_path(account_alias), data: { method: :delete }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -635,6 +635,7 @@ en:
     add_new: Create alias
     created_msg: Successfully created a new alias. You can now initiate the move from the old account.
     deleted_msg: Successfully remove the alias. Moving from that account to this one will no longer be possible.
+    empty: You have no aliases.
     hint_html: If you want to move from another account to this one, here you can create an alias, which is required before you can proceed with moving followers from the old account to this one. This action by itself is <strong>harmless and reversible</strong>. <strong>The account migration is initiated from the old account</strong>.
     remove: Unlink alias
   appearance:


### PR DESCRIPTION
- Fix errors not being displayed under the “Handle of the old account” field
- Add clearer error messages
- Add error case when adding an alias to the same account
- Make the empty list show “You have no aliases.”

![image](https://user-images.githubusercontent.com/384364/79075564-ec34c580-7cf3-11ea-9e52-089c3b149ffc.png)
![image](https://user-images.githubusercontent.com/384364/79075570-f5be2d80-7cf3-11ea-9d4c-ed0a2e194b67.png)
![image](https://user-images.githubusercontent.com/384364/79075553-dd4e1300-7cf3-11ea-9de7-181a5e2973ff.png)