### PR TITLE
add ability to use a users preferred theme on public pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -137,7 +137,10 @@ class ApplicationController < ActionController::Base
   end
 
   def current_theme
+    return @account&.user&.setting_theme unless @account&.user&.setting_theme.nil? || @account&.user&.setting_show_preferred_theme.nil? || !@account&.user&.setting_show_preferred_theme
+
     return Setting.theme unless Themes.instance.names.include? current_user&.setting_theme
+
     current_user.setting_theme
   end
 

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -47,6 +47,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_display_media,
       :setting_expand_spoilers,
       :setting_reduce_motion,
+      :setting_show_preferred_theme,
       :setting_system_font_ui,
       :setting_noindex,
       :setting_theme,

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -15,29 +15,30 @@ class UserSettingsDecorator
   private
 
   def process_update
-    user.settings['notification_emails'] = merged_notification_emails if change?('notification_emails')
-    user.settings['interactions']        = merged_interactions if change?('interactions')
-    user.settings['default_privacy']     = default_privacy_preference if change?('setting_default_privacy')
-    user.settings['default_sensitive']   = default_sensitive_preference if change?('setting_default_sensitive')
-    user.settings['default_language']    = default_language_preference if change?('setting_default_language')
-    user.settings['unfollow_modal']      = unfollow_modal_preference if change?('setting_unfollow_modal')
-    user.settings['boost_modal']         = boost_modal_preference if change?('setting_boost_modal')
-    user.settings['delete_modal']        = delete_modal_preference if change?('setting_delete_modal')
-    user.settings['auto_play_gif']       = auto_play_gif_preference if change?('setting_auto_play_gif')
-    user.settings['display_media']       = display_media_preference if change?('setting_display_media')
-    user.settings['expand_spoilers']     = expand_spoilers_preference if change?('setting_expand_spoilers')
-    user.settings['reduce_motion']       = reduce_motion_preference if change?('setting_reduce_motion')
-    user.settings['system_font_ui']      = system_font_ui_preference if change?('setting_system_font_ui')
-    user.settings['noindex']             = noindex_preference if change?('setting_noindex')
-    user.settings['theme']               = theme_preference if change?('setting_theme')
-    user.settings['hide_network']        = hide_network_preference if change?('setting_hide_network')
-    user.settings['aggregate_reblogs']   = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
-    user.settings['show_application']    = show_application_preference if change?('setting_show_application')
-    user.settings['advanced_layout']     = advanced_layout_preference if change?('setting_advanced_layout')
-    user.settings['use_blurhash']        = use_blurhash_preference if change?('setting_use_blurhash')
-    user.settings['use_pending_items']   = use_pending_items_preference if change?('setting_use_pending_items')
-    user.settings['trends']              = trends_preference if change?('setting_trends')
-    user.settings['crop_images']         = crop_images_preference if change?('setting_crop_images')
+    user.settings['notification_emails']  = merged_notification_emails if change?('notification_emails')
+    user.settings['interactions']         = merged_interactions if change?('interactions')
+    user.settings['default_privacy']      = default_privacy_preference if change?('setting_default_privacy')
+    user.settings['default_sensitive']    = default_sensitive_preference if change?('setting_default_sensitive')
+    user.settings['default_language']     = default_language_preference if change?('setting_default_language')
+    user.settings['unfollow_modal']       = unfollow_modal_preference if change?('setting_unfollow_modal')
+    user.settings['boost_modal']          = boost_modal_preference if change?('setting_boost_modal')
+    user.settings['delete_modal']         = delete_modal_preference if change?('setting_delete_modal')
+    user.settings['auto_play_gif']        = auto_play_gif_preference if change?('setting_auto_play_gif')
+    user.settings['display_media']        = display_media_preference if change?('setting_display_media')
+    user.settings['expand_spoilers']      = expand_spoilers_preference if change?('setting_expand_spoilers')
+    user.settings['reduce_motion']        = reduce_motion_preference if change?('setting_reduce_motion')
+    user.settings['show_preferred_theme'] = show_preferred_theme_preference if change?('setting_show_preferred_theme')
+    user.settings['system_font_ui']       = system_font_ui_preference if change?('setting_system_font_ui')
+    user.settings['noindex']              = noindex_preference if change?('setting_noindex')
+    user.settings['theme']                = theme_preference if change?('setting_theme')
+    user.settings['hide_network']         = hide_network_preference if change?('setting_hide_network')
+    user.settings['aggregate_reblogs']    = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
+    user.settings['show_application']     = show_application_preference if change?('setting_show_application')
+    user.settings['advanced_layout']      = advanced_layout_preference if change?('setting_advanced_layout')
+    user.settings['use_blurhash']         = use_blurhash_preference if change?('setting_use_blurhash')
+    user.settings['use_pending_items']    = use_pending_items_preference if change?('setting_use_pending_items')
+    user.settings['trends']               = trends_preference if change?('setting_trends')
+    user.settings['crop_images']          = crop_images_preference if change?('setting_crop_images')
   end
 
   def merged_notification_emails
@@ -86,6 +87,10 @@ class UserSettingsDecorator
 
   def reduce_motion_preference
     boolean_cast_setting 'setting_reduce_motion'
+  end
+
+  def show_preferred_theme_preference
+    boolean_cast_setting 'setting_show_preferred_theme'
   end
 
   def noindex_preference

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,7 +107,7 @@ class User < ApplicationRecord
   has_many :session_activations, dependent: :destroy
 
   delegate :auto_play_gif, :default_sensitive, :unfollow_modal, :boost_modal, :delete_modal,
-           :reduce_motion, :system_font_ui, :noindex, :theme, :display_media, :hide_network,
+           :reduce_motion, :show_preferred_theme, :system_font_ui, :noindex, :theme, :display_media, :hide_network,
            :expand_spoilers, :default_language, :aggregate_reblogs, :show_application,
            :advanced_layout, :use_blurhash, :use_pending_items, :trends, :crop_images,
            to: :settings, prefix: :setting, allow_nil: false

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -25,20 +25,21 @@ class InitialStateSerializer < ActiveModel::Serializer
     }
 
     if object.current_account
-      store[:me]                = object.current_account.id.to_s
-      store[:unfollow_modal]    = object.current_account.user.setting_unfollow_modal
-      store[:boost_modal]       = object.current_account.user.setting_boost_modal
-      store[:delete_modal]      = object.current_account.user.setting_delete_modal
-      store[:auto_play_gif]     = object.current_account.user.setting_auto_play_gif
-      store[:display_media]     = object.current_account.user.setting_display_media
-      store[:expand_spoilers]   = object.current_account.user.setting_expand_spoilers
-      store[:reduce_motion]     = object.current_account.user.setting_reduce_motion
-      store[:advanced_layout]   = object.current_account.user.setting_advanced_layout
-      store[:use_blurhash]      = object.current_account.user.setting_use_blurhash
-      store[:use_pending_items] = object.current_account.user.setting_use_pending_items
-      store[:is_staff]          = object.current_account.user.staff?
-      store[:trends]            = Setting.trends && object.current_account.user.setting_trends
-      store[:crop_images]       = object.current_account.user.setting_crop_images
+      store[:me]                   = object.current_account.id.to_s
+      store[:unfollow_modal]       = object.current_account.user.setting_unfollow_modal
+      store[:boost_modal]          = object.current_account.user.setting_boost_modal
+      store[:delete_modal]         = object.current_account.user.setting_delete_modal
+      store[:auto_play_gif]        = object.current_account.user.setting_auto_play_gif
+      store[:display_media]        = object.current_account.user.setting_display_media
+      store[:expand_spoilers]      = object.current_account.user.setting_expand_spoilers
+      store[:reduce_motion]        = object.current_account.user.setting_reduce_motion
+      store[:show_preferred_theme] = object.current_account.user.setting_show_preferred_theme
+      store[:advanced_layout]      = object.current_account.user.setting_advanced_layout
+      store[:use_blurhash]         = object.current_account.user.setting_use_blurhash
+      store[:use_pending_items]    = object.current_account.user.setting_use_pending_items
+      store[:is_staff]             = object.current_account.user.staff?
+      store[:trends]               = Setting.trends && object.current_account.user.setting_trends
+      store[:crop_images]          = object.current_account.user.setting_crop_images
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -29,6 +29,7 @@
 
   .fields-group
     = f.input :setting_auto_play_gif, as: :boolean, wrapper: :with_label, recommended: true
+    = f.input :setting_show_preferred_theme, as: :boolean, wrapper: :with_label, recommended: true
     = f.input :setting_reduce_motion, as: :boolean, wrapper: :with_label
     = f.input :setting_system_font_ui, as: :boolean, wrapper: :with_label
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -45,6 +45,7 @@ en:
         setting_display_media_default: Hide media marked as sensitive
         setting_display_media_hide_all: Always hide media
         setting_display_media_show_all: Always show media
+        setting_show_preferred_theme: Uses the theme you use on your public profile and status pages.
         setting_hide_network: Who you follow and who follows you will not be shown on your profile
         setting_noindex: Affects your public profile and status pages
         setting_show_application: The application you use to toot will be displayed in the detailed view of your toots
@@ -139,6 +140,7 @@ en:
         setting_display_media_default: Default
         setting_display_media_hide_all: Hide all
         setting_display_media_show_all: Show all
+        setting_show_preferred_theme: Show preferred theme on public pages
         setting_expand_spoilers: Always expand toots marked with content warnings
         setting_hide_network: Hide your network
         setting_noindex: Opt-out of search engine indexing

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -45,10 +45,10 @@ en:
         setting_display_media_default: Hide media marked as sensitive
         setting_display_media_hide_all: Always hide media
         setting_display_media_show_all: Always show media
-        setting_show_preferred_theme: Uses the theme you use on your public profile and status pages.
         setting_hide_network: Who you follow and who follows you will not be shown on your profile
         setting_noindex: Affects your public profile and status pages
         setting_show_application: The application you use to toot will be displayed in the detailed view of your toots
+        setting_show_preferred_theme: Uses the theme you use on your public profile and status pages.
         setting_use_blurhash: Gradients are based on the colors of the hidden visuals but obfuscate any details
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
         username: Your username will be unique on %{domain}
@@ -140,12 +140,12 @@ en:
         setting_display_media_default: Default
         setting_display_media_hide_all: Hide all
         setting_display_media_show_all: Show all
-        setting_show_preferred_theme: Show preferred theme on public pages
         setting_expand_spoilers: Always expand toots marked with content warnings
         setting_hide_network: Hide your network
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send toots
+        setting_show_preferred_theme: Show preferred theme on public pages
         setting_system_font_ui: Use system's default font
         setting_theme: Site theme
         setting_trends: Show today's trends

--- a/spec/lib/settings/scoped_settings_spec.rb
+++ b/spec/lib/settings/scoped_settings_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Settings::ScopedSettings do
   let(:object)         { Fabricate(:user) }
   let(:scoped_setting) { described_class.new(object) }
   let(:val)            { 'whatever' }
-  let(:methods)        { %i(auto_play_gif default_sensitive unfollow_modal boost_modal delete_modal reduce_motion system_font_ui noindex theme) }
+  let(:methods)        { %i(auto_play_gif default_sensitive unfollow_modal boost_modal delete_modal reduce_motion show_preferred_theme system_font_ui noindex theme) }
 
   describe '.initialize' do
     it 'sets @object' do


### PR DESCRIPTION
Hi,
this PR adds a user preference where the user can decide to show the theme set in their account settings on their public profile page and their public status pages.

In case the setting is not set, the default theme (either a logged in users selected theme or the default instance theme) will be shown.