### PR TITLE
Fix confusing error when failing to add an alias to an unknown account

### DIFF
--- a/app/models/account_alias.rb
+++ b/app/models/account_alias.rb
@@ -16,7 +16,6 @@ class AccountAlias < ApplicationRecord
   belongs_to :account
 
   validates :acct, presence: true, domain: { acct: true }
-  validates :uri, presence: true
   validates :uri, uniqueness: { scope: :account_id }
   validate :validate_target_account
 
@@ -47,7 +46,7 @@ class AccountAlias < ApplicationRecord
   end
 
   def validate_target_account
-    if uri.nil?
+    if uri.blank?
       errors.add(:acct, I18n.t('migrations.errors.not_found'))
     elsif ActivityPub::TagManager.instance.uri_for(account) == uri
       errors.add(:acct, I18n.t('migrations.errors.move_to_self'))


### PR DESCRIPTION
Follow-up to #13452, fixing broken `uri.nil?` test.

Also remove the separate check for `uri` presence, as that would result
in a “Please review 2 errors below” while only one would be listed.