### PR TITLE
Fix migration 20200407202420_migrate_unavailable_inboxes

### DIFF
--- a/db/migrate/20200407202420_migrate_unavailable_inboxes.rb
+++ b/db/migrate/20200407202420_migrate_unavailable_inboxes.rb
@@ -4,8 +4,13 @@ class MigrateUnavailableInboxes < ActiveRecord::Migration[5.2]
   def up
     urls = Redis.current.smembers('unavailable_inboxes')
 
-    urls.each do |url|
-      host = Addressable::URI.parse(url).normalized_host
+    hosts = urls.map do |url|
+      Addressable::URI.parse(url).normalized_host
+    end.compact.uniq
+
+    UnavailableDomain.delete_all
+
+    hosts.each do |host|
       UnavailableDomain.create(domain: host)
     end
 


### PR DESCRIPTION
FIx #13437 .

Migration 20200407202420_migrate_unavailable_inboxes fails due to a duplicate host name and nil.