### PR TITLE
Fix DeliveryWorker not to call failure_tracker when @inbox_url is nil

### DIFF
--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -23,10 +23,12 @@ class ActivityPub::DeliveryWorker
 
     perform_request
   ensure
-    if @performed
-      failure_tracker.track_success!
-    else
-      failure_tracker.track_failure!
+    if @inbox_url.present?
+      if @performed
+        failure_tracker.track_success!
+      else
+        failure_tracker.track_failure!
+      end
     end
   end
 


### PR DESCRIPTION
Fix DeliveryWorker not to call failure_tracker when inbox_url is unavailable.