### PR TITLE
Fix Poll fetchPoll action not being debounced.

### DIFF
--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -4,7 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
-import { vote, fetchPoll } from 'mastodon/actions/polls';
+import { vote } from 'mastodon/actions/polls';
 import Motion from 'mastodon/features/ui/util/optional_motion';
 import spring from 'react-motion/lib/spring';
 import escapeTextContentForBrowser from 'escape-html';

--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -30,6 +30,7 @@ class Poll extends ImmutablePureComponent {
     intl: PropTypes.object.isRequired,
     dispatch: PropTypes.func,
     disabled: PropTypes.bool,
+    refresh: PropTypes.func,
   };
 
   state = {
@@ -108,7 +109,7 @@ class Poll extends ImmutablePureComponent {
       return;
     }
 
-    this.props.dispatch(fetchPoll(this.props.poll.get('id')));
+    this.props.refresh();
   };
 
   renderOption (option, optionIndex, showResults) {

--- a/app/javascript/mastodon/containers/poll_container.js
+++ b/app/javascript/mastodon/containers/poll_container.js
@@ -1,8 +1,21 @@
 import { connect } from 'react-redux';
+import { debounce } from 'lodash';
+
 import Poll from 'mastodon/components/poll';
+import { fetchPoll } from 'mastodon/actions/polls';
+
+const mapDispatchToProps = (dispatch, { pollId }) => ({
+  refresh: debounce(
+    () => {
+      dispatch(fetchPoll(pollId));
+    },
+    1000,
+    { leading: true },
+  ),
+});
 
 const mapStateToProps = (state, { pollId }) => ({
   poll: state.getIn(['polls', pollId]),
 });
 
-export default connect(mapStateToProps)(Poll);
+export default connect(mapStateToProps, mapDispatchToProps)(Poll);


### PR DESCRIPTION
`handleRefresh` function in `app/javascript/mastodon/components/poll.js` was dispatching `fetchPoll` action, but since it was not debounced it was sending a request everytime a user clicked on refresh.

I've added `refresh` prop which is a debounced `fetchPoll` function.

---

This is my first PR on Mastodon, I looked at contributing guidelines but if I've done something incorrectly please mention it so I can fix it.