### PR TITLE
Fix confusing confirmation modal when canceling a follow request

### DIFF
--- a/app/javascript/mastodon/containers/account_container.js
+++ b/app/javascript/mastodon/containers/account_container.js
@@ -17,6 +17,7 @@ import { unfollowModal } from '../initial_state';
 
 const messages = defineMessages({
   unfollowConfirm: { id: 'confirmations.unfollow.confirm', defaultMessage: 'Unfollow' },
+  cancelFollowRequestConfirm: { id: 'confirmations.cancel_follow.confirm', defaultMessage: 'Remove' },
 });
 
 const makeMapStateToProps = () => {
@@ -35,8 +36,12 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
       if (unfollowModal) {
         dispatch(openModal('CONFIRM', {
-          message: <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
-          confirm: intl.formatMessage(messages.unfollowConfirm),
+          message: account.getIn(['relationship', 'following']) ?
+            <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} /> :
+            <FormattedMessage id='confirmations.cancel_follow.message' defaultMessage='Are you sure you want to remove your pending request to follow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
+          confirm: account.getIn(['relationship', 'following']) ?
+            intl.formatMessage(messages.unfollowConfirm) :
+            intl.formatMessage(messages.cancelFollowRequestConfirm),
           onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
         }));
       } else {

--- a/app/javascript/mastodon/features/account_timeline/containers/header_container.js
+++ b/app/javascript/mastodon/features/account_timeline/containers/header_container.js
@@ -25,6 +25,7 @@ import { List as ImmutableList } from 'immutable';
 
 const messages = defineMessages({
   unfollowConfirm: { id: 'confirmations.unfollow.confirm', defaultMessage: 'Unfollow' },
+  cancelFollowRequestConfirm: { id: 'confirmations.cancel_follow.confirm', defaultMessage: 'Remove' },
   blockDomainConfirm: { id: 'confirmations.domain_block.confirm', defaultMessage: 'Hide entire domain' },
 });
 
@@ -46,8 +47,12 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
       if (unfollowModal) {
         dispatch(openModal('CONFIRM', {
-          message: <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
-          confirm: intl.formatMessage(messages.unfollowConfirm),
+          message: account.getIn(['relationship', 'following']) ?
+            <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} /> :
+            <FormattedMessage id='confirmations.cancel_follow.message' defaultMessage='Are you sure you want to remove your pending request to follow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
+          confirm: account.getIn(['relationship', 'following']) ?
+            intl.formatMessage(messages.unfollowConfirm) :
+            intl.formatMessage(messages.cancelFollowRequestConfirm),
           onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
         }));
       } else {

--- a/app/javascript/mastodon/features/directory/components/account_card.js
+++ b/app/javascript/mastodon/features/directory/components/account_card.js
@@ -23,6 +23,7 @@ const messages = defineMessages({
   unblock: { id: 'account.unblock', defaultMessage: 'Unblock @{name}' },
   unmute: { id: 'account.unmute', defaultMessage: 'Unmute @{name}' },
   unfollowConfirm: { id: 'confirmations.unfollow.confirm', defaultMessage: 'Unfollow' },
+  cancelFollowRequestConfirm: { id: 'confirmations.cancel_follow.confirm', defaultMessage: 'Remove' },
 });
 
 const makeMapStateToProps = () => {
@@ -41,8 +42,12 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
     if (account.getIn(['relationship', 'following']) || account.getIn(['relationship', 'requested'])) {
       if (unfollowModal) {
         dispatch(openModal('CONFIRM', {
-          message: <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
-          confirm: intl.formatMessage(messages.unfollowConfirm),
+          message: account.getIn(['relationship', 'following']) ?
+            <FormattedMessage id='confirmations.unfollow.message' defaultMessage='Are you sure you want to unfollow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} /> :
+            <FormattedMessage id='confirmations.cancel_follow.message' defaultMessage='Are you sure you want to remove your pending request to follow {name}?' values={{ name: <strong>@{account.get('acct')}</strong> }} />,
+          confirm: account.getIn(['relationship', 'following']) ?
+            intl.formatMessage(messages.unfollowConfirm) :
+            intl.formatMessage(messages.cancelFollowRequestConfirm),
           onConfirm: () => dispatch(unfollowAccount(account.get('id'))),
         }));
       } else {

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -99,6 +99,8 @@
   "confirmations.block.block_and_report": "Block & Report",
   "confirmations.block.confirm": "Block",
   "confirmations.block.message": "Are you sure you want to block {name}?",
+  "confirmations.cancel_follow.confirm": "Remove",
+  "confirmations.cancel_follow.message": "Are you sure you want to remove your pending request to follow {name}?",
   "confirmations.delete.confirm": "Delete",
   "confirmations.delete.message": "Are you sure you want to delete this status?",
   "confirmations.delete_list.confirm": "Delete",


### PR DESCRIPTION
Up until now, the confirmation modal when canceling a follow request has been the same as when unfollowing, which is confusing.

This PR adds a different message when canceling a follow request.
However, the exact wording may need more work, as we used “Remove” instead of “Cancel” so that it would not be confused with the “Cancel” button.

Alternatively, we could maybe rename the “Cancel” button to “Keep” or something like that, but there is no precedent for that and it may make sense to keep the exact “Cancel” message for that button throughout all confirmation dialogs. I don't know.

![image](https://user-images.githubusercontent.com/384364/79663872-4a125300-81b5-11ea-9964-a0a0f358a6c7.png)
