### PR TITLE
Add warning when replying with a lower privacy than the parent toot

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -2,24 +2,54 @@ import React from 'react';
 import { connect } from 'react-redux';
 import Warning from '../components/warning';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { me } from '../../../initial_state';
 
 const APPROX_HASHTAG_RE = /(?:^|[^\/\)\w])#(\w*[a-zA-Z·]\w*)/i;
 
-const mapStateToProps = state => ({
-  needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),
-  hashtagWarning: state.getIn(['compose', 'privacy']) !== 'public' && APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])),
-  directMessageWarning: state.getIn(['compose', 'privacy']) === 'direct',
+const messages = defineMessages({
+  public: { id: 'privacy.public.short', defaultMessage: 'Public' },
+  unlisted: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
+  private: { id: 'privacy.private.short', defaultMessage: 'Followers-only' },
+  direct: { id: 'privacy.direct.short', defaultMessage: 'Direct' },
 });
 
-const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning }) => {
+const mapStateToProps = state => {
+  const privacy = state.getIn(['compose', 'privacy']);
+  const inReplyTo = state.getIn(['compose', 'in_reply_to']);
+  const parentPrivacy = inReplyTo ? state.getIn(['statuses', inReplyTo, 'visibility']) : undefined;
+  const order = ['public', 'unlisted', 'private', 'direct'];
+  const privacyDowngrade = parentPrivacy && order.indexOf(privacy) < order.indexOf(parentPrivacy);
+
+  return {
+    needsLockWarning: privacy === 'private' && !state.getIn(['accounts', me, 'locked']),
+    hashtagWarning: privacy !== 'public' && APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])),
+    directMessageWarning: privacy === 'direct',
+    privacyDowngradeWarning: privacyDowngrade,
+    privacy: privacy,
+    parentPrivacy: parentPrivacy,
+  };
+};
+
+const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning, privacyDowngradeWarning, privacy, parentPrivacy, intl }) => {
+  const warnings = [];
+
   if (needsLockWarning) {
-    return <Warning message={<FormattedMessage id='compose_form.lock_disclaimer' defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.' values={{ locked: <a href='/settings/profile'><FormattedMessage id='compose_form.lock_disclaimer.lock' defaultMessage='locked' /></a> }} />} />;
+    warnings.push(
+      <Warning
+        key='needslock-warning'
+        message={<FormattedMessage id='compose_form.lock_disclaimer' defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.' values={{ locked: <a href='/settings/profile'><FormattedMessage id='compose_form.lock_disclaimer.lock' defaultMessage='locked' /></a> }} />}
+      />,
+    );
   }
 
   if (hashtagWarning) {
-    return <Warning message={<FormattedMessage id='compose_form.hashtag_warning' defaultMessage="This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag." />} />;
+    warnings.push(
+      <Warning
+        key='hashtag-warning'
+        message={<FormattedMessage id='compose_form.hashtag_warning' defaultMessage="This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag." />}
+      />,
+    );
   }
 
   if (directMessageWarning) {
@@ -29,16 +59,33 @@ const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning
       </span>
     );
 
-    return <Warning message={message} />;
+    warnings.push(
+      <Warning
+        key='direct-warning'
+        message={message}
+      />,
+    );
   }
 
-  return null;
+  if (privacyDowngradeWarning) {
+    warnings.push(
+      <Warning
+        key='privacydowngrade-warning'
+        message={<FormattedMessage id='compose_form.privacy_downgrade_warning' defaultMessage='You are replying with a lower privacy setting ({privacy}) than the toot you are replying to ({parent_privacy}).' values={{ privacy: intl.formatMessage(messages[privacy]), parent_privacy: intl.formatMessage(messages[parentPrivacy]) }} />}
+      />,
+    );
+  }
+
+  return warnings;
 };
 
 WarningWrapper.propTypes = {
   needsLockWarning: PropTypes.bool,
   hashtagWarning: PropTypes.bool,
   directMessageWarning: PropTypes.bool,
+  privacyDowngradeWarning: PropTypes.bool,
+  privacy: PropTypes.string,
+  parentPrivacy: PropTypes.string,
 };
 
-export default connect(mapStateToProps)(WarningWrapper);
+export default injectIntl(connect(mapStateToProps)(WarningWrapper));


### PR DESCRIPTION
Also allows multiple warnings to be displayed at once.

Use cases:
- people changing their minds about the privacy of a reply, and not remembering the visibility of the original post
- people defaulting to followers-only, replying to a public toot and wanting to match its visibility (while “public” and “unlisted” have the same effect for replies on Mastodon, this isn't the case of pleroma which lists public toots in the public TL even if they are replies)

![image](https://user-images.githubusercontent.com/384364/79750168-c66d7900-8310-11ea-8235-8e2dced1b463.png)