### PR TITLE
remove port from dev admin mail address

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,5 +7,5 @@ account.save!
 if Rails.env.development?
   admin  = Account.where(username: 'admin').first_or_initialize(username: 'admin')
   admin.save(validate: false)
-  User.where(email: "admin@#{domain}").first_or_initialize(email: "admin@#{domain}", password: 'mastodonadmin', password_confirmation: 'mastodonadmin', confirmed_at: Time.now.utc, admin: true, account: admin, agreement: true, approved: true).save!
+  User.where(email: "admin@localhost").first_or_initialize(email: "admin@localhost", password: 'mastodonadmin', password_confirmation: 'mastodonadmin', confirmed_at: Time.now.utc, admin: true, account: admin, agreement: true, approved: true).save!
 end


### PR DESCRIPTION
This PR updates the development admin users mail address to `admin@localhost` because the previous email `admin@#{domain}` was resolved to `admin@localhost:3000` which [is invalid](https://en.wikipedia.org/wiki/Email_address#Syntax).

I found this while I was playing around with the `simple_form` validation and suddenly unable to log in because according to Chrome the mail address was invalid.