### PR TITLE
Set max-width and max-height to gif video

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5575,6 +5575,13 @@ a.status-card.compact:hover {
   }
 }
 
+.gifv {
+  video {
+    max-width: 100vw;
+    max-height: 80vh;
+  }
+}
+
 .directory {
   &__list {
     width: 100%;


### PR DESCRIPTION
Normally, GIFs are only uploaded up to the equivalent of 1280x720px in size, but they may exceed that if uploaded as a soundless MP4.

https://stellaria.network/@Eai/104044341722432998

## Before

![2020-04-23_06-27-09_chrome](https://user-images.githubusercontent.com/3516343/80035755-86cea900-852b-11ea-946d-88286cd761ec.png)

## After

![2020-04-23_06-27-27_chrome](https://user-images.githubusercontent.com/3516343/80035773-8b935d00-852b-11ea-839d-3a343d1a5dd5.png)
