### PR TITLE
Add `tootctl emoji export`

### DIFF
--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -23,7 +23,7 @@ module Mastodon
       Existing emoji will be skipped unless the --overwrite option
       is provided, in which case they will be overwritten.
 
-      You can specifiy a --category under which the emojis will be
+      You can specify a --category under which the emojis will be
       grouped together.
 
       With the --prefix option, a prefix can be added to all
@@ -33,17 +33,18 @@ module Mastodon
       With the --unlisted option, the processed emoji will not be
       visible in the emoji picker (but still usable via other means)
     LONG_DESC
+
     def import(path)
       imported = 0
-      skipped  = 0
-      failed   = 0
+      skipped = 0
+      failed = 0
       category = options[:category] ? CustomEmojiCategory.find_or_create_by(name: options[:category]) : nil
 
       Gem::Package::TarReader.new(Zlib::GzipReader.open(path)) do |tar|
         tar.each do |entry|
           next unless entry.file? && entry.full_name.end_with?('.png')
 
-          shortcode    = [options[:prefix], File.basename(entry.full_name, '.*'), options[:suffix]].compact.join
+          shortcode = [options[:prefix], File.basename(entry.full_name, '.*'), options[:suffix]].compact.join
           custom_emoji = CustomEmoji.local.find_by(shortcode: shortcode)
 
           if custom_emoji && !options[:overwrite]
@@ -72,6 +73,60 @@ module Mastodon
       say("Imported #{imported}, skipped #{skipped}, failed to import #{failed}", color(imported, skipped, failed))
     end
 
+    option :category
+    option :shortcode, type: :boolean
+    option :overwrite, type: :boolean
+    desc 'export PATH', 'Export emoji to a TAR GZIP archive at PATH'
+    long_desc <<-LONG_DESC
+      Exports custom emoji to 'export.tar.gz' at PATH.
+
+      The --category option dumps only the specified category. If the given category doesn't exist, all emoji will be exported.
+
+      The --overwrite option will overwrite an existing archive.
+    LONG_DESC
+
+    def export(path)
+      exported = 0
+      skipped = 0
+      failed = 0
+      category = options[:category] ? CustomEmojiCategory.find_by(name: options[:category]) : nil
+
+      export_file_name = File.join(path, 'export.tar.gz')
+      if options[:overwrite] || !File.file?(export_file_name)
+        File.open(export_file_name, 'wb') do |file|
+          Zlib::GzipWriter.wrap(file) do |gzip|
+            Gem::Package::TarWriter.new(gzip) do |tar|
+              if category.nil?
+                say('Dumping all emoji...')
+                CustomEmoji.local.all? do |emoji|
+                  emoji_file_name = export_file_name(emoji)
+                  say("Adding '#{emoji.shortcode}' as '#{emoji_file_name}'...")
+                  tar.add_file_simple(emoji_file_name, 00644, emoji.image_file_size) do |io|
+                    io.write Paperclip.io_adapters.for(emoji.image).read
+                    exported += 1
+                  end
+                end
+              else
+                say("Dumping only '#{category.name}'...")
+                category.emojis&.each do |emoji|
+                  emoji_file_name = export_file_name(emoji)
+                  say("Adding '#{emoji.shortcode}' as '#{emoji_file_name}'...")
+                  tar.add_file_simple(emoji_file_name, 00644, emoji.image_file_size) do |io|
+                    io.write Paperclip.io_adapters.for(emoji.image).read
+                    exported += 1
+                  end
+                end
+              end
+            end
+          end
+        end
+        puts
+        say("Exported #{exported}", color(exported, skipped, failed))
+      else
+        say("Archive already exists! Use '--overwrite' to force!")
+      end
+    end
+
     option :remote_only, type: :boolean
     desc 'purge', 'Remove all custom emoji'
     long_desc <<-LONG_DESC
@@ -79,6 +134,7 @@ module Mastodon
 
       With the --remote-only option, only remote emoji will be deleted.
     LONG_DESC
+
     def purge
       scope = options[:remote_only] ? CustomEmoji.remote : CustomEmoji
       scope.in_batches.destroy_all
@@ -94,6 +150,14 @@ module Mastodon
         :yellow
       else
         :red
+      end
+    end
+
+    def export_file_name(emoji)
+      if options[:shortcode]
+        emoji.shortcode + '.png'
+      else
+        emoji.image_file_name
       end
     end
   end

--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -108,7 +108,7 @@ module Mastodon
                 end
               else
                 say("Unable to find category '#{options[:category]}'!")
-                failed + 1
+                exit 1
               end
             end
           end

--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -33,7 +33,6 @@ module Mastodon
       With the --unlisted option, the processed emoji will not be
       visible in the emoji picker (but still usable via other means)
     LONG_DESC
-
     def import(path)
       imported = 0
       skipped  = 0
@@ -44,7 +43,7 @@ module Mastodon
         tar.each do |entry|
           next unless entry.file? && entry.full_name.end_with?('.png')
 
-          shortcode = [options[:prefix], File.basename(entry.full_name, '.*'), options[:suffix]].compact.join
+          shortcode    = [options[:prefix], File.basename(entry.full_name, '.*'), options[:suffix]].compact.join
           custom_emoji = CustomEmoji.local.find_by(shortcode: shortcode)
 
           if custom_emoji && !options[:overwrite]
@@ -84,10 +83,9 @@ module Mastodon
 
       The --overwrite option will overwrite an existing archive.
     LONG_DESC
-
     def export(path)
-      exported = 0
-      category = CustomEmojiCategory.find_by(name: options[:category])
+      exported         = 0
+      category         = CustomEmojiCategory.find_by(name: options[:category])
       export_file_name = File.join(path, 'export.tar.gz')
 
       if File.file?(export_file_name) && !options[:overwrite]
@@ -123,7 +121,6 @@ module Mastodon
 
       With the --remote-only option, only remote emoji will be deleted.
     LONG_DESC
-
     def purge
       scope = options[:remote_only] ? CustomEmoji.remote : CustomEmoji
       scope.in_batches.destroy_all

--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -79,7 +79,7 @@ module Mastodon
     long_desc <<-LONG_DESC
       Exports custom emoji to 'export.tar.gz' at PATH.
 
-      The --category option dumps only the specified category. 
+      The --category option dumps only the specified category.
       If this option is not specified, all emoji will be exported.
 
       The --overwrite option will overwrite an existing archive.

--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -101,7 +101,7 @@ module Mastodon
                 CustomEmoji.local.all? do |emoji|
                   emoji_file_name = export_file_name(emoji)
                   say("Adding '#{emoji.shortcode}' as '#{emoji_file_name}'...")
-                  tar.add_file_simple(emoji_file_name, 00644, emoji.image_file_size) do |io|
+                  tar.add_file_simple(emoji_file_name, 0o644, emoji.image_file_size) do |io|
                     io.write Paperclip.io_adapters.for(emoji.image).read
                     exported += 1
                   end
@@ -111,7 +111,7 @@ module Mastodon
                 category.emojis&.each do |emoji|
                   emoji_file_name = export_file_name(emoji)
                   say("Adding '#{emoji.shortcode}' as '#{emoji_file_name}'...")
-                  tar.add_file_simple(emoji_file_name, 00644, emoji.image_file_size) do |io|
+                  tar.add_file_simple(emoji_file_name, 0o644, emoji.image_file_size) do |io|
                     io.write Paperclip.io_adapters.for(emoji.image).read
                     exported += 1
                   end

--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -96,7 +96,7 @@ module Mastodon
         File.open(export_file_name, 'wb') do |file|
           Zlib::GzipWriter.wrap(file) do |gzip|
             Gem::Package::TarWriter.new(gzip) do |tar|
-              if category.nil?
+              if !options[:category]
                 say('Dumping all emoji...')
                 CustomEmoji.local.all? do |emoji|
                   emoji_file_name = export_file_name(emoji)
@@ -106,7 +106,7 @@ module Mastodon
                     exported += 1
                   end
                 end
-              else
+              elsif !category.nil?
                 say("Dumping only '#{category.name}'...")
                 category.emojis&.each do |emoji|
                   emoji_file_name = export_file_name(emoji)
@@ -116,6 +116,9 @@ module Mastodon
                     exported += 1
                   end
                 end
+              else
+                say("Unable to find category '#{options[:category]}'!")
+                failed + 1
               end
             end
           end


### PR DESCRIPTION
Hi,
this PR adds the `tootctl emoji export` command. 
This command will export either all or only a specific category to a `export.tar.gz` file that can be imported using `tootctl`.

The usage (with all options) is as follows:
```bash
$ tootctl emoji export ~/foo --overwrite --shortcode --category bar
```
- `~/foo` will result in `~/foo/export.tar.gz` (path has to exist)
- `-- overwrite` will overwrite the export file if it exists
- `--shortcode` will use the configured shortcode as file name
    - ie. `thonking.png` instead of `9f2bf533eb0a7165.png`
- `--category <category>` will only export a specific category. If no matching category can be found, all emoji will be exported.

Additionally a typo in the documentation of the `import` command was fixed.