### PR TITLE
Fix uninformative error message when uploading unsupported image files

### DIFF
--- a/app/javascript/mastodon/utils/resize_image.js
+++ b/app/javascript/mastodon/utils/resize_image.js
@@ -138,7 +138,7 @@ const resizeImage = (img, type = 'image/png') => new Promise((resolve, reject) =
     .catch(reject);
 });
 
-export default inputFile => new Promise((resolve, reject) => {
+export default inputFile => new Promise((resolve) => {
   if (!inputFile.type.match(/image.*/) || inputFile.type === 'image/gif') {
     resolve(inputFile);
     return;
@@ -153,5 +153,5 @@ export default inputFile => new Promise((resolve, reject) => {
     resizeImage(img, inputFile.type)
       .then(resolve)
       .catch(() => resolve(inputFile));
-  }).catch(reject);
+  }).catch(() => resolve(inputFile));
 });


### PR DESCRIPTION
Attempting to upload image files that the browser is unable to load results
in “Oops! An unexpected error occurred.”

This commit changes the error handling so that an unprocessable image results
in the file being sent anyway, which might cover a few corner cases, and
provide a slightly better error message.

I'm not sure it's the best way to go about it, as it is very unlikely that such an error would mean the image won't be usable server-side either, but on the plus side, it would also allow us to accept more image types on the backend (since user-uploaded images are processed by imagemagick anyway), and may cover more corner cases in outdated/broken browsers/configs.