### PR TITLE
Remove confusing “You are already signed in.” flash message

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -111,6 +111,13 @@ class Auth::SessionsController < Devise::SessionsController
     render :two_factor
   end
 
+  def require_no_authentication
+    super
+    # Delete flash message that isn't entirely useful and may be confusing in
+    # most cases because /web doesn't display/clear flash messages.
+    flash.delete(:alert) if flash[:alert] == I18n.t('devise.failure.already_authenticated')
+  end
+
   private
 
   def set_instance_presenter


### PR DESCRIPTION
When attempting to access the log-in page while already logged in,
Devise's `require_no_authentication` kicks in and sets a flash
message “You are already signed in.”

In almost all cases, this also causes a redirect to /web, which
does not display or clear flash messages, thus leaving the message
to a potentially much later date, like for instance, accessing
/preferences several minutes after being redirected to /web.