### PR TITLE
Fix naming issue

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -10,7 +10,7 @@ Paperclip.interpolates :filename do |attachment, style|
   end
 end
 
-Paperclip.interpolates :path_prefix do |attachment, style|
+Paperclip.interpolates :prefix_path do |attachment, style|
   if attachment.storage_schema_version >= 1 && attachment.instance.respond_to?(:local?) && !attachment.instance.local?
     'cache' + File::SEPARATOR
   else
@@ -18,7 +18,7 @@ Paperclip.interpolates :path_prefix do |attachment, style|
   end
 end
 
-Paperclip.interpolates :url_prefix do |attachment, style|
+Paperclip.interpolates :prefix_url do |attachment, style|
   if attachment.storage_schema_version >= 1 && attachment.instance.respond_to?(:local?) && !attachment.instance.local?
     'cache/'
   else
@@ -28,7 +28,7 @@ end
 
 Paperclip::Attachment.default_options.merge!(
   use_timestamp: false,
-  path: ':url_prefix:class/:attachment/:id_partition/:style/:filename',
+  path: ':prefix_url:class/:attachment/:id_partition/:style/:filename',
   storage: :fog
 )
 
@@ -107,7 +107,7 @@ else
   Paperclip::Attachment.default_options.merge!(
     storage: :filesystem,
     use_timestamp: true,
-    path: File.join(ENV.fetch('PAPERCLIP_ROOT_PATH', File.join(':rails_root', 'public', 'system')), ':path_prefix:class', ':attachment', ':id_partition', ':style', ':filename'),
-    url: ENV.fetch('PAPERCLIP_ROOT_URL', '/system') + '/:url_prefix:class/:attachment/:id_partition/:style/:filename',
+    path: File.join(ENV.fetch('PAPERCLIP_ROOT_PATH', File.join(':rails_root', 'public', 'system')), ':prefix_path:class', ':attachment', ':id_partition', ':style', ':filename'),
+    url: ENV.fetch('PAPERCLIP_ROOT_URL', '/system') + '/:prefix_url:class/:attachment/:id_partition/:style/:filename',
   )
 end


### PR DESCRIPTION
Fixes an issue where attachment media URL are incorrect in environments using the object storage. (ref: https://github.com/tootsuite/mastodon/pull/12821#issuecomment-619681274)

I don't understand why this happens. If you have a better solution, please use that one.