### PR TITLE
Change ActivityPub endpoints to only return public objects

### DIFF
--- a/app/controllers/api/v1/polls_controller.rb
+++ b/app/controllers/api/v1/polls_controller.rb
@@ -21,6 +21,6 @@ class Api::V1::PollsController < Api::BaseController
   end
 
   def refresh_poll
-    ActivityPub::FetchRemotePollService.new.call(@poll, current_account) if user_signed_in? && @poll.possibly_stale?
+    ActivityPub::FetchRemotePollService.new.call(@poll) if user_signed_in? && @poll.possibly_stale?
   end
 end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -10,6 +10,7 @@ class StatusesController < ApplicationController
 
   before_action :require_signature!, only: :show, if: -> { request.format == :json && authorized_fetch_mode? }
   before_action :set_status
+  before_action :require_public_status!, if: -> { request.format == :json }
   before_action :set_instance_presenter
   before_action :set_link_headers
   before_action :redirect_to_original, only: :show
@@ -69,6 +70,10 @@ class StatusesController < ApplicationController
     authorize @status, :show?
   rescue Mastodon::NotPermittedError
     not_found
+  end
+
+  def require_public_status!
+    not_found if @status.hidden?
   end
 
   def set_instance_presenter

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -168,7 +168,7 @@ class ActivityPub::Activity
   def fetch_remote_original_status
     if object_uri.start_with?('http')
       return if ActivityPub::TagManager.instance.local_uri?(object_uri)
-      ActivityPub::FetchRemoteStatusService.new.call(object_uri, id: true, on_behalf_of: @account.followers.local.first)
+      ActivityPub::FetchRemoteStatusService.new.call(object_uri, id: true)
     elsif @object['url'].present?
       ::FetchRemoteStatusService.new.call(@object['url'])
     end

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -26,6 +26,8 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
   attribute :voters_count, if: :poll_and_voters_count?
 
   def id
+    raise Mastodon::NotPermittedError if !instance_options[:allow_private] && object.hidden?
+
     ActivityPub::TagManager.instance.uri_for(object)
   end
 

--- a/app/services/activitypub/fetch_remote_poll_service.rb
+++ b/app/services/activitypub/fetch_remote_poll_service.rb
@@ -3,8 +3,8 @@
 class ActivityPub::FetchRemotePollService < BaseService
   include JsonLdHelper
 
-  def call(poll, on_behalf_of = nil)
-    json = fetch_resource(poll.status.uri, true, on_behalf_of)
+  def call(poll)
+    json = fetch_resource(poll.status.uri, true)
 
     return unless supported_context?(json)
 

--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -153,7 +153,8 @@ class BackupService < BaseService
     ActiveModelSerializers::SerializableResource.new(
       object,
       serializer: serializer,
-      adapter: ActivityPub::Adapter
+      adapter: ActivityPub::Adapter,
+      allow_private: true
     ).as_json
   end
 

--- a/app/services/concerns/payloadable.rb
+++ b/app/services/concerns/payloadable.rb
@@ -4,7 +4,7 @@ module Payloadable
   def serialize_payload(record, serializer, options = {})
     signer    = options.delete(:signer)
     sign_with = options.delete(:sign_with)
-    payload   = ActiveModelSerializers::SerializableResource.new(record, options.merge(serializer: serializer, adapter: ActivityPub::Adapter)).as_json
+    payload   = ActiveModelSerializers::SerializableResource.new(record, options.merge(serializer: serializer, adapter: ActivityPub::Adapter, allow_private: true)).as_json
 
     if (record.respond_to?(:sign?) && record.sign?) && signer && signing_enabled?
       ActivityPub::LinkedDataSignature.new(payload).sign!(signer, sign_with: sign_with)

--- a/app/views/statuses/_status.html.haml
+++ b/app/views/statuses/_status.html.haml
@@ -1,4 +1,5 @@
 :ruby
+  allow_private   ||= false
   pinned          ||= false
   include_threads ||= false
   is_predecessor  ||= false
@@ -14,12 +15,14 @@
   mf_classes        = microformats_classes(status, is_direct_parent, is_direct_child)
   entry_classes     = h_class + ' ' + mf_classes + ' ' + style_classes
 
+  raise Mastodon::NotPermittedError if !allow_private && status.hidden?
+
 - if status.reply? && include_threads
   - if @next_ancestor
     .entry{ class: entry_classes }
       = link_to_more ActivityPub::TagManager.instance.url_for(@next_ancestor)
 
-  = render partial: 'statuses/status', collection: @ancestors, as: :status, locals: { is_predecessor: true, direct_reply_id: status.in_reply_to_id }, autoplay: autoplay
+  = render partial: 'statuses/status', collection: @ancestors, as: :status, locals: { is_predecessor: true, direct_reply_id: status.in_reply_to_id, allow_private: allow_private }, autoplay: autoplay
 
 .entry{ class: entry_classes }
 
@@ -46,7 +49,7 @@
     .entry{ class: entry_classes }
       = link_to_more short_account_status_url(status.account.username, status, max_descendant_thread_id: @since_descendant_thread_id + 1)
   - @descendant_threads.each do |thread|
-    = render partial: 'statuses/status', collection: thread[:statuses], as: :status, locals: { is_successor: true, parent_id: status.id }, autoplay: autoplay
+    = render partial: 'statuses/status', collection: thread[:statuses], as: :status, locals: { is_successor: true, parent_id: status.id, allow_private: allow_private }, autoplay: autoplay
 
     - if thread[:next_status]
       .entry{ class: entry_classes }

--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -19,6 +19,6 @@
 .grid
   .column-0
     .activity-stream.h-entry
-      = render partial: 'status', locals: { status: @status, include_threads: true }
+      = render partial: 'status', locals: { status: @status, include_threads: true, allow_private: current_user&.functional? }
   .column-1
     = render 'application/sidebar'

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -258,29 +258,8 @@ describe StatusesController do
           context 'as JSON' do
             let(:format) { 'json' }
 
-            it 'returns http success' do
-              expect(response).to have_http_status(200)
-            end
-
-            it 'returns Link header' do
-              expect(response.headers['Link'].to_s).to include 'activity+json'
-            end
-
-            it 'returns Vary header' do
-              expect(response.headers['Vary']).to eq 'Accept'
-            end
-
-            it 'returns private Cache-Control header' do
-              expect(response.headers['Cache-Control']).to include 'private'
-            end
-
-            it 'returns Content-Type header' do
-              expect(response.headers['Content-Type']).to include 'application/activity+json'
-            end
-
-            it 'renders ActivityPub Note object' do
-              json = body_as_json
-              expect(json[:content]).to include status.text
+            it 'returns http not found' do
+              expect(response).to have_http_status(404)
             end
           end
         end
@@ -345,29 +324,8 @@ describe StatusesController do
           context 'as JSON' do
             let(:format) { 'json' }
 
-            it 'returns http success' do
-              expect(response).to have_http_status(200)
-            end
-
-            it 'returns Link header' do
-              expect(response.headers['Link'].to_s).to include 'activity+json'
-            end
-
-            it 'returns Vary header' do
-              expect(response.headers['Vary']).to eq 'Accept'
-            end
-
-            it 'returns private Cache-Control header' do
-              expect(response.headers['Cache-Control']).to include 'private'
-            end
-
-            it 'returns Content-Type header' do
-              expect(response.headers['Content-Type']).to include 'application/activity+json'
-            end
-
-            it 'renders ActivityPub Note object' do
-              json = body_as_json
-              expect(json[:content]).to include status.text
+            it 'returns http not found' do
+              expect(response).to have_http_status(404)
             end
           end
         end
@@ -522,29 +480,8 @@ describe StatusesController do
           context 'as JSON' do
             let(:format) { 'json' }
 
-            it 'returns http success' do
-              expect(response).to have_http_status(200)
-            end
-
-            it 'returns Link header' do
-              expect(response.headers['Link'].to_s).to include 'activity+json'
-            end
-
-            it 'returns Vary header' do
-              expect(response.headers['Vary']).to eq 'Accept'
-            end
-
-            it 'returns private Cache-Control header' do
-              expect(response.headers['Cache-Control']).to include 'private'
-            end
-
-            it 'returns Content-Type header' do
-              expect(response.headers['Content-Type']).to include 'application/activity+json'
-            end
-
-            it 'renders ActivityPub Note object' do
-              json = body_as_json
-              expect(json[:content]).to include status.text
+            it 'returns http not found' do
+              expect(response).to have_http_status(404)
             end
           end
         end
@@ -609,29 +546,8 @@ describe StatusesController do
           context 'as JSON' do
             let(:format) { 'json' }
 
-            it 'returns http success' do
-              expect(response).to have_http_status(200)
-            end
-
-            it 'returns Link header' do
-              expect(response.headers['Link'].to_s).to include 'activity+json'
-            end
-
-            it 'returns Vary header' do
-              expect(response.headers['Vary']).to eq 'Accept'
-            end
-
-            it 'returns private Cache-Control header' do
-              expect(response.headers['Cache-Control']).to include 'private'
-            end
-
-            it 'returns Content-Type header' do
-              expect(response.headers['Content-Type']).to include 'application/activity+json'
-            end
-
-            it 'renders ActivityPub Note object' do
-              json = body_as_json
-              expect(json[:content]).to include status.text
+            it 'returns http not found' do
+              expect(response).to have_http_status(404)
             end
           end
         end

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -455,25 +455,8 @@ describe StatusesController do
           context 'as HTML' do
             let(:format) { 'html' }
 
-            it 'returns http success' do
-              expect(response).to have_http_status(200)
-            end
-
-            it 'returns Link header' do
-              expect(response.headers['Link'].to_s).to include 'activity+json'
-            end
-
-            it 'returns Vary header' do
-              expect(response.headers['Vary']).to eq 'Accept'
-            end
-
-            it 'returns no Cache-Control header' do
-              expect(response.headers).to_not include 'Cache-Control'
-            end
-
-            it 'renders status' do
-              expect(response).to render_template(:show)
-              expect(response.body).to include status.text
+            it 'returns http not authorized' do
+              expect(response).to have_http_status(403)
             end
           end
 
@@ -521,25 +504,8 @@ describe StatusesController do
           context 'as HTML' do
             let(:format) { 'html' }
 
-            it 'returns http success' do
-              expect(response).to have_http_status(200)
-            end
-
-            it 'returns Link header' do
-              expect(response.headers['Link'].to_s).to include 'activity+json'
-            end
-
-            it 'returns Vary header' do
-              expect(response.headers['Vary']).to eq 'Accept'
-            end
-
-            it 'returns no Cache-Control header' do
-              expect(response.headers).to_not include 'Cache-Control'
-            end
-
-            it 'renders status' do
-              expect(response).to render_template(:show)
-              expect(response.body).to include status.text
+            it 'returns http not authorized' do
+              expect(response).to have_http_status(403)
             end
           end
 


### PR DESCRIPTION
Currently, Mastodon may return follower-only/direct toots to some ActivityPub queries signed by actors who have access to such toots. That should not be an issue, but it is not necessary anymore, so it wouldn't hurt getting rid of it.

The main changes are:
- remove follower-only toots and DMs from the outbox. I do not think any current ActivityPub implementation makes sensible use of that.
- stop fetching boosts on behalf of an end-user (that hasn't been needed in ages now that Mastodon and Pleroma inline self-boosts)
- stop fetching polls on behalf of the user when refreshing them (breaks on-demand refresh of remote private polls, but `Update`s should be pushed anyway within 3 minutes of new votes)
- do not ever return non-public toots over ActivityPub
- add some hardening to raise an exception when rendering a private toot in a codepath where it is not supposed to be possible