### PR TITLE
Fix own following/followers not showing muted users

### DIFF
--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
     return [] if hide_results?
 
     scope = default_accounts
-    scope = scope.where.not(id: current_account.excluded_from_timeline_account_ids) unless current_account.nil?
+    scope = scope.where.not(id: current_account.excluded_from_timeline_account_ids) unless current_account.nil? || current_account.id == @account.id
     scope.merge(paginated_follows).to_a
   end
 

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -20,7 +20,7 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
     return [] if hide_results?
 
     scope = default_accounts
-    scope = scope.where.not(id: current_account.excluded_from_timeline_account_ids) unless current_account.nil?
+    scope = scope.where.not(id: current_account.excluded_from_timeline_account_ids) unless current_account.nil? || current_account.id == @account.id
     scope.merge(paginated_follows).to_a
   end
 

--- a/spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb
@@ -36,5 +36,28 @@ describe Api::V1::Accounts::FollowerAccountsController do
       expect(body_as_json.size).to eq 1
       expect(body_as_json[0][:id]).to eq alice.id.to_s
     end
+
+    context 'when requesting user is blocked' do
+      before do
+        account.block!(user.account)
+      end
+
+      it 'hides results' do
+        get :index, params: { account_id: account.id, limit: 2 }
+        expect(body_as_json.size).to eq 0
+      end
+    end
+
+    context 'when requesting user is the account owner' do
+      let(:user) { Fabricate(:user, account: account) }
+
+      it 'returns all accounts, including muted accounts' do
+        user.account.mute!(bob)
+        get :index, params: { account_id: account.id, limit: 2 }
+
+        expect(body_as_json.size).to eq 2
+        expect([body_as_json[0][:id], body_as_json[1][:id]]).to match_array([alice.id.to_s, bob.id.to_s])
+      end
+    end
   end
 end

--- a/spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb
@@ -36,5 +36,28 @@ describe Api::V1::Accounts::FollowingAccountsController do
       expect(body_as_json.size).to eq 1
       expect(body_as_json[0][:id]).to eq alice.id.to_s
     end
+
+    context 'when requesting user is blocked' do
+      before do
+        account.block!(user.account)
+      end
+
+      it 'hides results' do
+        get :index, params: { account_id: account.id, limit: 2 }
+        expect(body_as_json.size).to eq 0
+      end
+    end
+
+    context 'when requesting user is the account owner' do
+      let(:user) { Fabricate(:user, account: account) }
+
+      it 'returns all accounts, including muted accounts' do
+        user.account.mute!(bob)
+        get :index, params: { account_id: account.id, limit: 2 }
+
+        expect(body_as_json.size).to eq 2
+        expect([body_as_json[0][:id], body_as_json[1][:id]]).to match_array([alice.id.to_s, bob.id.to_s])
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #13612

An alternative, maybe more consistent, would be to only filter out blocked people, and not muted ones, but that would require another new cached collection per user, I am unsure whether this is worth it.