### PR TITLE
Fix followings list order by last activity | Issue #13538

### DIFF
--- a/app/models/relationship_filter.rb
+++ b/app/models/relationship_filter.rb
@@ -23,7 +23,7 @@ class RelationshipFilter
     scope = scope_for('relationship', params['relationship'].to_s.strip)
 
     params.each do |key, value|
-      next if key.to_s == 'page'
+      next if %w(relationship page).include?(key)
 
       scope.merge!(scope_for(key.to_s, value.to_s.strip)) if value.present?
     end

--- a/spec/models/relationship_filter_spec.rb
+++ b/spec/models/relationship_filter_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RelationshipFilter do
+  let(:account) { Fabricate(:account) }
+
+  describe '#results' do
+    context 'when default params are used' do
+      let(:subject) do
+        RelationshipFilter.new(account, 'order' => 'active').results
+      end
+
+      before do
+        add_following_account_with(last_status_at: 7.days.ago)
+        add_following_account_with(last_status_at: 1.day.ago)
+        add_following_account_with(last_status_at: 3.days.ago)
+      end
+
+      it 'returns followings ordered by last activity' do
+        expected_result = account.following.eager_load(:account_stat).reorder(nil).by_recent_status
+
+        expect(subject).to eq expected_result
+      end
+    end
+  end
+
+  def add_following_account_with(last_status_at:)
+    following_account = Fabricate(:account)
+    Fabricate(:account_stat, account: following_account,
+                             last_status_at: last_status_at,
+                             statuses_count: 1,
+                             following_count: 0,
+                             followers_count: 0)
+    Fabricate(:follow, account: account, target_account: following_account).account
+  end
+end


### PR DESCRIPTION
Fix #13538
The issue is caused by double call of `relationship` scope (first time on line 23 and then in the loop).