### PR TITLE
Remove 'unsafe-inline' from Content-Security-Policy style-src

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,6 +26,8 @@
     = javascript_pack_tag "locale_#{I18n.locale}", integrity: true, crossorigin: 'anonymous'
     = csrf_meta_tags
 
+    = stylesheet_link_tag '/inert.css', skip_pipeline: true, media: 'all', id: 'inert-style'
+
     - if Setting.custom_css.present?
       = stylesheet_link_tag custom_css_path, media: 'all'
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -22,7 +22,7 @@ Rails.application.config.content_security_policy do |p|
   p.frame_ancestors :none
   p.font_src        :self, assets_host
   p.img_src         :self, :https, :data, :blob, assets_host
-  p.style_src       :self, :unsafe_inline, assets_host
+  p.style_src       :self, assets_host
   p.media_src       :self, :https, :data, assets_host
   p.frame_src       :self, :https
   p.manifest_src    :self, assets_host

--- a/public/inert.css
+++ b/public/inert.css
@@ -1,0 +1,11 @@
+[inert] {
+  pointer-events: none;
+  cursor: default;
+}
+
+[inert], [inert] * {
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}


### PR DESCRIPTION
Add wicg-inert's dynamically-inserted CSS rules to a static stylesheet, and remove 'unsafe-inline' from the style-src directive.
Until wicg-inert is fixed (https://github.com/WICG/inert/pull/148), it will still attempt to dynamically insert those rules, leading to a warning, but no loss in functionality.