### PR TITLE
Replace url with placeholder of equal length | Issue #12884

### DIFF
--- a/app/javascript/mastodon/features/compose/util/counter.js
+++ b/app/javascript/mastodon/features/compose/util/counter.js
@@ -1,9 +1,9 @@
 import { urlRegex } from './url_regex';
 
-const urlPlaceholder = 'xxxxxxxxxxxxxxxxxxxxxxx';
+const urlPlaceholderChar = 'x';
 
 export function countableText(inputText) {
   return inputText
-    .replace(urlRegex, urlPlaceholder)
+    .replace(urlRegex, m => urlPlaceholderChar.repeat(m.length))
     .replace(/(^|[^\/\w])@(([a-z0-9_]+)@[a-z0-9\.\-]+[a-z0-9]+)/ig, '$1@$3');
 };


### PR DESCRIPTION
Fix for the issue #12884

Actual behaviour is even worse than mentioned in the issue as link of any length is replaced with the same placeholder (and leads to the same counter change nevertheless which link you paste)