### PR TITLE
Fix "tootctl media remove-orphans" crashing on “Import” files

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -19,4 +19,6 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'ActivityStreams'
   inflect.acronym 'JsonLd'
   inflect.acronym 'NodeInfo'
+
+  inflect.singular 'data', 'data'
 end

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -144,7 +144,14 @@ module Mastodon
           begin
             size = File.size(path)
 
-            File.delete(path) unless options[:dry_run]
+            unless options[:dry_run]
+              File.delete(path)
+              begin
+                FileUtils.rmdir(File.dirname(path), parents: true)
+              rescue Errno::ENOTEMPTY
+                # OK
+              end
+            end
 
             reclaimed_bytes += size
             removed += 1


### PR DESCRIPTION
Paperclip pluralizes attachment names, so we use `String#singularize` to recover the field, except “data” is already plural and `'data.singularize'` is “datum”, which doesn't correspond to the field name.