### PR TITLE
fix rubocop errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
   - 'spec/**/*'
   - 'db/**/*'
@@ -46,7 +46,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 25
 
-Metrics/LineLength:
+Layout/LineLength:
   AllowURI: true
   Enabled: false
 


### PR DESCRIPTION
When opening `.rb` files in RubyMIne, the following error occurs:

```
Error:Rubocop returned exit code: 2
stderr:
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
Error: RuboCop found unsupported Ruby version 2.3 in `TargetRubyVersion` parameter (in .rubocop.yml). 2.3-compatible analysis was dropped after version 0.82.
Supported versions: 2.4, 2.5, 2.6, 2.7
```

This PR lifts the target version to `2.4` (the minimum supported version) and [corrects](https://docs.rubocop.org/en/stable/cops_layout/#layoutlinelength) the `Metrics/LineLength` namespace.