### PR TITLE
Fix one more inappropriate raise

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -58,8 +58,10 @@ class Request
   def perform
     begin
       response = http_client.public_send(@verb, @url.to_s, @options.merge(headers: headers))
-    rescue => e
-      raise e.class, "#{e.message} on #{@url}", e.backtrace[0]
+    rescue HTTP::ConnectionError, HTTP::TimeoutError => err
+      wrapper = err.class.new("#{err.message} on #{@url}")
+      wrapper.set_backtrace(err.backtrace)
+      raise wrapper
     end
 
     begin


### PR DESCRIPTION
Following #13120, it may necessary to eliminate one more inappropriate `raise` (with three args) that may break libraries that rescue exceptions raised here.