### PR TITLE
Docker-Compose Sidekiq Seperation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bundle exec sidekiq
+    command: bundle exec sidekiq -q default -q mailer
     depends_on:
       - db
       - redis
@@ -85,6 +85,37 @@ services:
       - internal_network
     volumes:
       - ./public/system:/mastodon/public/system
+
+  sidekiq-pull:
+    build: .
+    image: tootsuite/mastodon
+    restart: always
+    env_file: .env.production
+    command: bundle exec sidekiq -q pull
+    depends_on:
+      - db
+      - redis
+    networks:
+      - external_network
+      - internal_network
+    volumes:
+      - ./public/system:/mastodon/public/system
+
+  sidekiq-push:
+    build: .
+    image: tootsuite/mastodon
+    restart: always
+    env_file: .env.production
+    command: bundle exec sidekiq -q push
+    depends_on:
+      - db
+      - redis
+    networks:
+      - external_network
+      - internal_network
+    volumes:
+      - ./public/system:/mastodon/public/system
+
 ## Uncomment to enable federation with tor instances along with adding the following ENV variables
 ## http_proxy=http://privoxy:8118
 ## ALLOW_ACCESS_TO_HIDDEN_SERVICE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bundle exec sidekiq -q default -q mailer
+    command: bundle exec sidekiq -q default -q mailers
     depends_on:
       - db
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bundle exec sidekiq -q default -q mailers
+    command: bundle exec sidekiq -q default,1 -q mailers,2 -c 10
     depends_on:
       - db
       - redis
@@ -91,7 +91,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bundle exec sidekiq -q pull
+    command: bundle exec sidekiq -q pull -c 10
     depends_on:
       - db
       - redis
@@ -106,7 +106,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bundle exec sidekiq -q push
+    command: bundle exec sidekiq -q push -c 10
     depends_on:
       - db
       - redis


### PR DESCRIPTION
I'm running this on my instance.. the memory usage is about 220MB per sidekiq (If you're running this on a super lowend box - consider not?).

<img width="542" alt="image" src="https://user-images.githubusercontent.com/17537000/81965996-6b971b00-964b-11ea-853c-ac24f194b30c.png">

This is a non-breaking change... Anybody got an opinion on this?