### PR TITLE
Upgrade to Redis 6 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   redis:
     restart: always
-    image: redis:5.0-alpine
+    image: redis:6.0-alpine
     networks:
       - internal_network
     healthcheck:


### PR DESCRIPTION
Tested without issue for the last week... Redis 6.0.1 was released recently with no major bug fixes.