### PR TITLE
Fix hashtag search performing account search as well

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -94,7 +94,7 @@ class SearchService < BaseService
   end
 
   def account_searchable?
-    account_search? && !(@query.include?('@') && @query.include?(' '))
+    account_search? && !(@query.start_with?('#') || (@query.include?('@') && @query.include?(' ')))
   end
 
   def hashtag_searchable?

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -91,6 +91,14 @@ describe SearchService, type: :service do
           expect(Tag).not_to have_received(:search_for)
           expect(results).to eq empty_results
         end
+        it 'does not include account when starts with # character' do
+          query = '#tag'
+          allow(AccountSearchService).to receive(:new)
+
+          results = subject.call(query, nil, 10)
+          expect(AccountSearchService).to_not have_received(:new)
+          expect(results).to eq empty_results
+        end
       end
     end
   end


### PR DESCRIPTION
Unless ElasticSearch is enabled, hashtag search may return account results, which is unexpected.