### PR TITLE
Change emoji outline method from drop-shadows to SVG filter

### DIFF
--- a/app/javascript/images/filters.svg
+++ b/app/javascript/images/filters.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="0">
+  <defs>
+    <filter id="accessibility-outline">
+    	  <feGaussianBlur stdDeviation="1" />
+    	  <feComponentTransfer result="DILATED">
+      	  <feFuncA type="table" tableValues="0 0 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"/>
+  	    </feComponentTransfer>
+        <feFlood id="accessibility-outline-color" flood-color="#ffffff" flood-opacity="1" result="OUTLINE_COLOR"></feFlood>
+        <feComposite in="OUTLINE_COLOR" in2="DILATED" operator="in" result="OUTLINE"></feComposite>
+
+        <feMerge>
+            <feMergeNode in="OUTLINE" />
+            <feMergeNode in="SourceGraphic" />
+        </feMerge>
+    </filter>
+  </defs>
+</svg>

--- a/app/javascript/styles/mastodon/accessibility.scss
+++ b/app/javascript/styles/mastodon/accessibility.scss
@@ -1,7 +1,11 @@
 $black-emojis: '8ball' 'ant' 'back' 'black_circle' 'black_heart' 'black_large_square' 'black_medium_small_square' 'black_medium_square' 'black_nib' 'black_small_square' 'bomb' 'bowling' 'bust_in_silhouette' 'busts_in_silhouette' 'camera' 'camera_with_flash' 'clubs' 'copyright' 'curly_loop' 'currency_exchange' 'dark_sunglasses' 'eight_pointed_black_star' 'electric_plug' 'end' 'female-guard' 'film_projector' 'fried_egg' 'gorilla' 'guardsman' 'heavy_check_mark' 'heavy_division_sign' 'heavy_dollar_sign' 'heavy_minus_sign' 'heavy_multiplication_x' 'heavy_plus_sign' 'hocho' 'hole' 'joystick' 'kaaba' 'lower_left_ballpoint_pen' 'lower_left_fountain_pen' 'male-guard' 'microphone' 'mortar_board' 'movie_camera' 'musical_score' 'on' 'registered' 'soon' 'spades' 'speaking_head_in_silhouette' 'spider' 'telephone_receiver' 'tm' 'top' 'tophat' 'turkey' 'vhs' 'video_camera' 'video_game' 'water_buffalo' 'waving_black_flag' 'wavy_dash';
 
+#accessibility-outline-color {
+  flood-color: $primary-text-color;
+}
+
 %white-emoji-outline {
-  filter: drop-shadow(1px 1px 0 $white) drop-shadow(-1px 1px 0 $white) drop-shadow(1px -1px 0 $white) drop-shadow(-1px -1px 0 $white);
+  filter: url('#accessibility-outline');
   transform: scale(.71);
 }
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -36,6 +36,7 @@
   %body{ class: body_classes }
     = content_for?(:content) ? yield(:content) : yield
 
+    = render file: Rails.root.join('app', 'javascript', 'images', 'filters.svg')
     .logo-resources
       = render file: Rails.root.join('app', 'javascript', 'images', 'logo_transparent.svg')
       = render file: Rails.root.join('app', 'javascript', 'images', 'logo_full.svg')

--- a/app/views/layouts/embedded.html.haml
+++ b/app/views/layouts/embedded.html.haml
@@ -19,5 +19,6 @@
   %body.embed
     = yield
 
+    = render file: Rails.root.join('app', 'javascript', 'images', 'filters.svg')
     .logo-resources
       = render file: Rails.root.join('app', 'javascript', 'images', 'logo_transparent.svg')


### PR DESCRIPTION
This has only been tested on Firefox 76 and Firefox 57 so far, it probably needs testing with other browsers, especially older ones.

## Screenshots

<details>
<summary>Firefox 76 (and 57)</summary>

(Firefox 57 has sensibly the same results)

### Before

![image](https://user-images.githubusercontent.com/384364/82127731-23e0d280-97b6-11ea-951b-176de6927ae1.png)

### After

![image](https://user-images.githubusercontent.com/384364/82127750-42df6480-97b6-11ea-9086-e55dc7858fe3.png)

</details>

<details>
<summary>Chromium 81.0.4044.92</summary>

## Before

![before](https://user-images.githubusercontent.com/384364/82128137-1416bd80-97b9-11ea-802c-fa31baa3973f.png)

## After

![after](https://user-images.githubusercontent.com/384364/82128124-0a8d5580-97b9-11ea-9a77-0b9f6de25ece.png)

</details>

<details>
<summary>Midori 7</summary>

## Before

![midori-before](https://user-images.githubusercontent.com/384364/82128247-f4cc6000-97b9-11ea-8881-9d53970421d6.png)

## After

![midori-after](https://user-images.githubusercontent.com/384364/82128266-26452b80-97ba-11ea-9037-2e711eb05694.png)

</details>