### PR TITLE
[legal] "No warranty" disclaimer for terms and privacy policy

### DIFF
--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -889,7 +889,10 @@ en_GB:
     sensitive_content: Sensitive content
   terms:
     body_html: |
-      <h2>Privacy Policy</h2>
+      <h1 id="disclaimer">Disclaimer</h1>
+      <p><strong>The following terms of service, privacy policy, and their translations are a placeholder provided ''AS IS''.</strong> Mastodon developers and translators make no warranties, express or implied, and hereby disclaim all implied warranties, including any warranty of fitness for a particular purpose. We encourage instance admins to replace the text of the current page with the terms of service and the privacy policy that fit their purposes. We hope that the following placeholder will help to understand Mastodon better.</p>
+
+      <h2 id="privacy">Privacy Policy</h2>
       <h3 id="collect">What information do we collect?</h3>
 
       <ul>


### PR DESCRIPTION
### Pitch

Insert a _**Disclaimer**_ paragraph at the top of the terms of service and privacy policy page.

### Motivation

The current page (as example: [here](https://mastodon.social/terms)) may induce instance admins to assume Mastodon developers make express or implied warranties. Also, it may prevent the translation of the page in other languages due to legal reasons.