### PR TITLE
Fix workaround for Elasticsearch 7.x

### DIFF
--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -29,3 +29,22 @@ end
 # Mastodon is run with hidden services enabled, because
 # ElasticSearch is *not* supposed to be accessed through a proxy
 Faraday.ignore_env_proxy = true
+
+# Elasticsearch 7.x workaround
+Elasticsearch::Transport::Client.prepend Module.new {
+  def search(arguments = {})
+    arguments[:rest_total_hits_as_int] = true
+    super arguments
+  end
+}
+Elasticsearch::API::Indices::IndicesClient.prepend Module.new {
+  def create(arguments = {})
+    arguments[:include_type_name] = true
+    super arguments
+  end
+
+  def put_mapping(arguments = {})
+    arguments[:include_type_name] = true
+    super arguments
+  end
+}


### PR DESCRIPTION
Fix https://github.com/tootsuite/mastodon/issues/10664

Fix it so that Elasticsearch 7.x can be used.

This is a workaround.
It uses the monkey patch suggested by @darkleaf .
https://github.com/toptal/chewy/issues/673#issuecomment-631432562
