### PR TITLE
Fix csv upload

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -17,7 +17,7 @@
 #
 
 class Import < ApplicationRecord
-  FILE_TYPES = %w(text/plain text/csv).freeze
+  FILE_TYPES = %w(text/plain text/csv application/csv).freeze
   MODES = %i(merge overwrite).freeze
 
   self.inheritance_column = false

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -111,3 +111,5 @@ else
     url: ENV.fetch('PAPERCLIP_ROOT_URL', '/system') + '/:prefix_url:class/:attachment/:id_partition/:style/:filename',
   )
 end
+
+Paperclip.options[:content_type_mappings] = { csv: Import::FILE_TYPES }


### PR DESCRIPTION
Because the mime type of csv returned by the `file` command is changed, the upload of csv files fails. (It happens with newer distributions, such as Ubuntu 20.04.)

Fix it by adding `application/csv` to the corresponding mime type.

```
file -b -i following_accounts.csv
```

Before file-5.27
```
text/plain; charset=us-ascii
```

file-5.38
```
application/csv; charset=us-ascii
```
see: https://github.com/file/file/commit/6b8e0e606fe1296e974e57242e322c562d82439b
