### PR TITLE
Fix performance of follow import

### DIFF
--- a/app/services/import_service.rb
+++ b/app/services/import_service.rb
@@ -81,7 +81,9 @@ class ImportService < BaseService
       end
     end
 
-    Import::RelationshipWorker.push_bulk(items) do |acct, extra|
+    head_items = items.uniq { |acct, _| acct.split('@')[1] }
+    tail_items = items - head_items
+    Import::RelationshipWorker.push_bulk(head_items + tail_items) do |acct, extra|
       [@account.id, acct, action, extra]
     end
   end

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -112,6 +112,8 @@ class ResolveAccountService < BaseService
   end
 
   def webfinger_update_due?
+    return false if @options[:check_delivery_availability] && !DeliveryFailureTracker.available?(@domain)
+
     @account.nil? || ((!@options[:skip_webfinger] || @account.ostatus?) && @account.possibly_stale?)
   end
 


### PR DESCRIPTION
Fixed the performance of follow import.

- The timeout time of WebFinger is too long, so it is changed to the same 5 seconds as Request
- Giving up the request to the server that failed to connect (5 minutes using stoplight)
- Do not make requests to non-deliverable servers (using DeliveryFailureTracker)
- Make one request for each domain first and do the rest later (to increase the effectiveness of stoplight)
