### PR TITLE
FIX: filters ignore media descriptions

### DIFF
--- a/app/javascript/mastodon/actions/importer/normalizer.js
+++ b/app/javascript/mastodon/actions/importer/normalizer.js
@@ -12,7 +12,7 @@ const makeEmojiMap = record => record.emojis.reduce((obj, emoji) => {
 
 export function searchTextFromRawStatus (status) {
   const spoilerText   = status.spoiler_text || '';
-  const searchContent = ([spoilerText, status.content].concat((status.poll && status.poll.options) ? status.poll.options.map(option => option.title) : [])).join('\n\n').replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n');
+  const searchContent = ([spoilerText, status.content].concat((status.poll && status.poll.options) ? status.poll.options.map(option => option.title) : [])).concat(status.media_attachments.map(att => att.description)).join('\n\n').replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n');
   return domParser.parseFromString(searchContent, 'text/html').documentElement.textContent;
 }
 

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -248,7 +248,8 @@ class FeedManager
 
     !combined_regex.match(Formatter.instance.plaintext(status)).nil? ||
       (status.spoiler_text.present? && !combined_regex.match(status.spoiler_text).nil?) ||
-      (status.preloadable_poll && !combined_regex.match(status.preloadable_poll.options.join("\n\n")).nil?)
+      (status.preloadable_poll && !combined_regex.match(status.preloadable_poll.options.join("\n\n")).nil?) ||
+      (!combined_regex.match(status.media_attachments.map(&:description).join("\n\n")).nil?)
   end
 
   # Adds a status to an account's feed, returning true if a status was

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -246,10 +246,14 @@ class FeedManager
     combined_regex = active_filters.reduce { |memo, obj| Regexp.union(memo, obj) }
     status         = status.reblog if status.reblog?
 
-    !combined_regex.match(Formatter.instance.plaintext(status)).nil? ||
-      (status.spoiler_text.present? && !combined_regex.match(status.spoiler_text).nil?) ||
-      (status.preloadable_poll && !combined_regex.match(status.preloadable_poll.options.join("\n\n")).nil?) ||
-      !combined_regex.match(status.media_attachments.map(&:description).join("\n\n")).nil?
+    combined_text = [
+        Formatter.instance.plaintext(status),
+        status.spoiler_text,
+        status.preloadable_poll ? status.preloadable_poll.options.join("\n\n") : nil,
+        status.media_attachments.map(&:description).join("\n\n")
+    ].filter.join("\n\n")
+
+    !combined_regex.match(combined_text).nil?
   end
 
   # Adds a status to an account's feed, returning true if a status was

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -249,7 +249,7 @@ class FeedManager
     !combined_regex.match(Formatter.instance.plaintext(status)).nil? ||
       (status.spoiler_text.present? && !combined_regex.match(status.spoiler_text).nil?) ||
       (status.preloadable_poll && !combined_regex.match(status.preloadable_poll.options.join("\n\n")).nil?) ||
-      (!combined_regex.match(status.media_attachments.map(&:description).join("\n\n")).nil?)
+      !combined_regex.match(status.media_attachments.map(&:description).join("\n\n")).nil?
   end
 
   # Adds a status to an account's feed, returning true if a status was

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -247,11 +247,11 @@ class FeedManager
     status         = status.reblog if status.reblog?
 
     combined_text = [
-        Formatter.instance.plaintext(status),
-        status.spoiler_text,
-        status.preloadable_poll ? status.preloadable_poll.options.join("\n\n") : nil,
-        status.media_attachments.map(&:description).join("\n\n")
-    ].filter.join("\n\n")
+      Formatter.instance.plaintext(status),
+      status.spoiler_text,
+      status.preloadable_poll ? status.preloadable_poll.options.join("\n\n") : nil,
+      status.media_attachments.map(&:description).join("\n\n"),
+    ].compact.join("\n\n")
 
     !combined_regex.match(combined_text).nil?
   end


### PR DESCRIPTION
filters already consider polls and content warnings, but they do not look at media descriptions