### PR TITLE
Dockerfile: add support for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN	ARCH= && \
     s390x) ARCH='s390x';; \
     arm64) ARCH='arm64';; \
     armhf) ARCH='armv7l';; \
+    arm64) ARCH='arm64';; \
     i386) ARCH='x86';; \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac && \


### PR DESCRIPTION
I've used this to successfully build an image for an aarch64 device.

It would be nice if someone could publish an arm64 image to Dockerhub btw :smile: 