### PR TITLE
Enable style_src: unsafe_inline csp to about page

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -11,7 +11,7 @@ class AboutController < ApplicationController
   skip_before_action :require_functional!, only: [:more, :terms]
 
   content_security_policy do |p|
-    p.style_src :self, :unsafe_inline, assets_host
+    p.style_src *p.style_src, :unsafe_inline
   end
 
   def show; end

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -11,7 +11,7 @@ class AboutController < ApplicationController
   skip_before_action :require_functional!, only: [:more, :terms]
 
   content_security_policy do |p|
-    p.style_src *p.style_src, :unsafe_inline
+    p.style_src(*p.style_src, :unsafe_inline)
   end
 
   def show; end

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -10,6 +10,10 @@ class AboutController < ApplicationController
 
   skip_before_action :require_functional!, only: [:more, :terms]
 
+  content_security_policy do |p|
+    p.style_src :self, :unsafe_inline, assets_host
+  end
+
   def show; end
 
   def more

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -51,7 +51,3 @@ PgHero::HomeController.content_security_policy do |p|
   p.script_src :self, :unsafe_inline, assets_host
   p.style_src  :self, :unsafe_inline, assets_host
 end
-
-AboutController.content_security_policy do |p|
-  p.style_src :self, :unsafe_inline, assets_host
-end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -51,3 +51,7 @@ PgHero::HomeController.content_security_policy do |p|
   p.script_src :self, :unsafe_inline, assets_host
   p.style_src  :self, :unsafe_inline, assets_host
 end
+
+AboutController.content_security_policy do |p|
+  p.style_src :self, :unsafe_inline, assets_host
+end


### PR DESCRIPTION
So that admin can embed css on `/about` and `/about/more` page