### PR TITLE
Bump wicg-inert to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "webpack-bundle-analyzer": "^3.7.0",
     "webpack-cli": "^3.3.11",
     "webpack-merge": "^4.2.1",
-    "wicg-inert": "^3.0.2"
+    "wicg-inert": "^3.0.3"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11306,10 +11306,10 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-wicg-inert@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/wicg-inert/-/wicg-inert-3.0.2.tgz#46d8b01142c1bda8f6fa5d78e2754ba56f6f70be"
-  integrity sha512-L2eSi1fx1M+WLLUccwzAulgK5hZtllRDvYk3UB/fe1ZqdkZS6dz718o6xfe3JUtBEJJnqvI6NF8m1bAHlg3JUg==
+wicg-inert@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/wicg-inert/-/wicg-inert-3.0.3.tgz#7d05eaed64176887ee4c66fc0c4d6fe4b38ccce5"
+  integrity sha512-XwXf8K0NN4cpagjBlZ2/j/5Sjf6dW3HNbfywEy1y6Z8PJKvSHVGiuc5Id/9RZ6EmGq+GQCGTo7B2SK0Misbr6g==
 
 wide-align@^1.1.0:
   version "1.1.3"


### PR DESCRIPTION
Not sure why dependabot hasn't made a PR for this yet, but there is a new
version of wicg-inert, which does not try to dynamically insert styles
anymore when those styles already exist. This will get rid of some of the
CSP violation warnings we get since getting rid of 'unsafe-inline'.