### PR TITLE
Improve keyboard navigation across columns

### DIFF
--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.js
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.js
@@ -76,22 +76,24 @@ class KeyboardShortcuts extends ImmutablePureComponent {
                 <td><kbd>down</kbd>, <kbd>j</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.down' defaultMessage='to move down in the list' /></td>
               </tr>
-              <tr>
-                <td><kbd>1</kbd>-<kbd>9</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.column' defaultMessage='to focus a status in one of the columns' /></td>
-              </tr>
-              <tr>
-                <td><kbd>left</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.left' defaultMessage='to focus the column on the left' /></td>
-              </tr>
-              <tr>
-                <td><kbd>right</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.right' defaultMessage='to focus the column on the right' /></td>
-              </tr>
-              <tr>
-                <td><kbd>$</kbd></td>
-                <td><FormattedMessage id='keyboard_shortcuts.last_column' defaultMessage='to focus the last column' /></td>
-              </tr>
+              {multiColumn && [
+                <tr>
+                  <td><kbd>1</kbd>-<kbd>9</kbd></td>
+                  <td><FormattedMessage id='keyboard_shortcuts.column' defaultMessage='to focus a status in one of the columns' /></td>
+                </tr>,
+                <tr>
+                  <td><kbd>left</kbd></td>
+                  <td><FormattedMessage id='keyboard_shortcuts.left' defaultMessage='to focus a status in the column on the left' /></td>
+                </tr>,
+                <tr>
+                  <td><kbd>right</kbd></td>
+                  <td><FormattedMessage id='keyboard_shortcuts.right' defaultMessage='to focus a status in the column on the right' /></td>
+                </tr>,
+                <tr>
+                  <td><kbd>$</kbd></td>
+                  <td><FormattedMessage id='keyboard_shortcuts.last_column' defaultMessage='to focus a status in the last column' /></td>
+                </tr>,
+              ]}
               <tr>
                 <td><kbd>n</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.compose' defaultMessage='to focus the compose textarea' /></td>

--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.js
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.js
@@ -89,6 +89,10 @@ class KeyboardShortcuts extends ImmutablePureComponent {
                 <td><FormattedMessage id='keyboard_shortcuts.right' defaultMessage='to focus the column on the right' /></td>
               </tr>
               <tr>
+                <td><kbd>$</kbd></td>
+                <td><FormattedMessage id='keyboard_shortcuts.last_column' defaultMessage='to focus the last column' /></td>
+              </tr>
+              <tr>
                 <td><kbd>n</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.compose' defaultMessage='to focus the compose textarea' /></td>
               </tr>

--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.js
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.js
@@ -81,6 +81,14 @@ class KeyboardShortcuts extends ImmutablePureComponent {
                 <td><FormattedMessage id='keyboard_shortcuts.column' defaultMessage='to focus a status in one of the columns' /></td>
               </tr>
               <tr>
+                <td><kbd>left</kbd></td>
+                <td><FormattedMessage id='keyboard_shortcuts.left' defaultMessage='to focus the column on the left' /></td>
+              </tr>
+              <tr>
+                <td><kbd>right</kbd></td>
+                <td><FormattedMessage id='keyboard_shortcuts.right' defaultMessage='to focus the column on the right' /></td>
+              </tr>
+              <tr>
                 <td><kbd>n</kbd></td>
                 <td><FormattedMessage id='keyboard_shortcuts.compose' defaultMessage='to focus the compose textarea' /></td>
               </tr>

--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -181,6 +181,10 @@ class Status extends ImmutablePureComponent {
 
   componentDidMount () {
     attachFullscreenListener(this.onFullScreenChange);
+
+    if (this.statusNode) {
+      this.statusNode.focus({ preventScroll: true });
+    }
   }
 
   componentWillReceiveProps (nextProps) {
@@ -465,15 +469,23 @@ class Status extends ImmutablePureComponent {
     this.node = c;
   }
 
-  componentDidUpdate () {
+  setStatusRef = c => {
+    this.statusNode = c;
+  }
+
+  componentDidUpdate (prevProps) {
     if (this._scrolledIntoView) {
       return;
     }
 
     const { status, ancestorsIds } = this.props;
 
+    if (status && (!prevProps.status || prevProps.status.get('id') !== status.get('id'))) {
+      this.statusNode.focus({ preventScroll: true });
+    }
+
     if (status && ancestorsIds && ancestorsIds.size > 0) {
-      const element = this.node.querySelectorAll('.focusable')[ancestorsIds.size - 1];
+      const element = this.statusNode;
 
       window.requestAnimationFrame(() => {
         element.scrollIntoView(true);
@@ -540,7 +552,7 @@ class Status extends ImmutablePureComponent {
             {ancestors}
 
             <HotKeys handlers={handlers}>
-              <div className={classNames('focusable', 'detailed-status__wrapper')} tabIndex='0' aria-label={textForScreenReader(intl, status, false)}>
+              <div className={classNames('focusable', 'detailed-status__wrapper')} tabIndex='0' aria-label={textForScreenReader(intl, status, false)} ref={this.setStatusRef}>
                 <DetailedStatus
                   key={`details-${status.get('id')}`}
                   status={status}

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -86,6 +86,8 @@ const keyMap = {
   openProfile: 'p',
   moveDown: ['down', 'j'],
   moveUp: ['up', 'k'],
+  moveLeft: 'left',
+  moveRight: 'right',
   back: 'backspace',
   goToHome: 'g h',
   goToNotifications: 'g n',
@@ -371,6 +373,8 @@ class UI extends React.PureComponent {
     this.props.dispatch(expandHomeTimeline());
     this.props.dispatch(expandNotifications());
 
+    this.isRtlLayout = document.getElementsByTagName('body')[0].classList.contains('rtl');
+
     setTimeout(() => this.props.dispatch(fetchFilters()), 500);
   }
 
@@ -429,6 +433,43 @@ class UI extends React.PureComponent {
   handleHotkeyFocusColumn = e => {
     const index  = (e.key * 1) + 1; // First child is drawer, skip that
     const column = this.node.querySelector(`.column:nth-child(${index})`);
+    this._selectColumn(column);
+  }
+
+  handleHotkeyMoveLeft = e => {
+    const direction = this.isRtlLayout ? -1 : 1;
+    const index = this._findColumn(e.target);
+    if (index === -1) {
+      return;
+    }
+    const column = this.node.querySelectorAll('.column')[index - direction];
+    this._selectColumn(column);
+  }
+
+  handleHotkeyMoveRight = e => {
+    const direction = this.isRtlLayout ? -1 : 1;
+    const index = this._findColumn(e.target);
+    if (index === -1) {
+      return;
+    }
+    const column = this.node.querySelectorAll('.column')[index + direction];
+    this._selectColumn(column);
+  }
+
+  _findColumn = element => {
+    const columns = Array.from(this.node.querySelectorAll('.column'));
+
+    while (element) {
+      if (element.classList.contains('column')) {
+        return columns.indexOf(element);
+      }
+      element = element.parentNode;
+    }
+
+    return -1;
+  }
+
+  _selectColumn = column => {
     if (!column) return;
     const container = column.querySelector('.scrollable');
 
@@ -523,6 +564,8 @@ class UI extends React.PureComponent {
       forceNew: this.handleHotkeyForceNew,
       toggleComposeSpoilers: this.handleHotkeyToggleComposeSpoilers,
       focusColumn: this.handleHotkeyFocusColumn,
+      moveLeft: this.handleHotkeyMoveLeft,
+      moveRight: this.handleHotkeyMoveRight,
       back: this.handleHotkeyBack,
       goToHome: this.handleHotkeyGoToHome,
       goToNotifications: this.handleHotkeyGoToNotifications,

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -88,6 +88,7 @@ const keyMap = {
   moveUp: ['up', 'k'],
   moveLeft: 'left',
   moveRight: 'right',
+  moveLast: '$',
   back: 'backspace',
   goToHome: 'g h',
   goToNotifications: 'g n',
@@ -456,6 +457,13 @@ class UI extends React.PureComponent {
     this._selectColumn(column);
   }
 
+  handleHotkeyMoveLast = () => {
+    const columns = Array.from(this.node.querySelectorAll('.column'));
+    // Find last column with something selectable
+    const column = columns.reverse().find((column) => column.querySelector('.scrollable .focusable'));
+    this._selectColumn(column);
+  };
+
   _findColumn = element => {
     const columns = Array.from(this.node.querySelectorAll('.column'));
 
@@ -566,6 +574,7 @@ class UI extends React.PureComponent {
       focusColumn: this.handleHotkeyFocusColumn,
       moveLeft: this.handleHotkeyMoveLeft,
       moveRight: this.handleHotkeyMoveRight,
+      moveLast: this.handleHotkeyMoveLast,
       back: this.handleHotkeyBack,
       goToHome: this.handleHotkeyGoToHome,
       goToNotifications: this.handleHotkeyGoToNotifications,


### PR DESCRIPTION
Fixes #13871

- Add `left` and `right` keyboard handlers to move between columns
- Add `$` to target the last column with statuses/notifications
- Hide column navigation-specific keyboard shortcut descriptions in single-column view
- Focus detailed toot when opened (this is the thing I'm the least sure about)