### PR TITLE
Change flash alert contrast color for better readability

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -587,7 +587,7 @@ code {
 
   &.alert {
     border: 1px solid rgba($error-value-color, 0.5);
-    background: rgba($error-value-color, 0.25);
+    background: rgba($error-value-color, 0.1);
     color: $error-value-color;
   }
 


### PR DESCRIPTION
Saw that #9410 addresses a contrast issue with the flash message error.
Here are some suggestions for the contrasts to make it more readable:

Current:
![_25](https://user-images.githubusercontent.com/19676120/83346158-df355b00-a2ce-11ea-9716-f29155380230.png)

Reduce the opacity of background from `.25` to `.1`. (Current commit on PR)
![Screen Shot 2020-05-30 at 11 44 03 PM](https://user-images.githubusercontent.com/19676120/83346230-7b5f6200-a2cf-11ea-93af-80d55b37fa51.png)

Keep the opacity at `.25` and change the text color to white:
![white](https://user-images.githubusercontent.com/19676120/83346173-fe33ed00-a2ce-11ea-8439-6cf74c74b06a.png)

resolves #9410 