### PR TITLE
Allow Ctrl-click to keep EmojiPicker window open

### DIFF
--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
@@ -199,12 +199,13 @@ class EmojiPickerMenu extends React.PureComponent {
     };
   }
 
-  handleClick = emoji => {
+  handleClick = (emoji, event) => {
     if (!emoji.native) {
       emoji.native = emoji.colons;
     }
-
-    this.props.onClose();
+    if (!event.ctrlKey) {
+      this.props.onClose();
+    }
     this.props.onPick(emoji);
   }
 


### PR DESCRIPTION
Discord has a feature where you can hold Shift to keep the emoji picker window open, thought it might be cool if Mastodon FE had that. I went with Ctrl here because shift-clicking causes some selection weirdness I can't seem to figure out.