### PR TITLE
Fix mastodon:setup not running properly when some environment variables are set

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -367,7 +367,7 @@ namespace :mastodon do
           prompt.say 'Running `RAILS_ENV=production rails db:setup` ...'
           prompt.say "\n\n"
 
-          if cmd.run!({ RAILS_ENV: 'production', SAFETY_ASSURED: 1 }, :rails, 'db:setup').failure?
+          if cmd.run!(env.merge({ RAILS_ENV: 'production', SAFETY_ASSURED: 1 }), :rails, 'db:setup').failure?
             prompt.error 'That failed! Perhaps your configuration is not right'
           else
             prompt.ok 'Done!'
@@ -382,7 +382,7 @@ namespace :mastodon do
           prompt.say 'Running `RAILS_ENV=production rails assets:precompile` ...'
           prompt.say "\n\n"
 
-          if cmd.run!({ RAILS_ENV: 'production' }, :rails, 'assets:precompile').failure?
+          if cmd.run!(env.merge({ RAILS_ENV: 'production' }), :rails, 'assets:precompile').failure?
             prompt.error 'That failed! Maybe you need swap space?'
           else
             prompt.say 'Done!'


### PR DESCRIPTION
When using one of the docker-compose containers, mastodon:setup will use the
existing .env.production rather than the generated one during the setup steps.

This is because dotenv does not overwrite env variables that are alreayd
defined, and the docker-compose.yml file loads the environment variables
from .env.production.