### PR TITLE
Add a placeholder for POSTGRES_PASSWORD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
   db:
     restart: always
     image: postgres:9.6-alpine
+    environment:
+      POSTGRES_PASSWORD: "set the database password here"
     shm_size: 256mb
     networks:
       - internal_network


### PR DESCRIPTION
It's a required environment variable, the postgresql container
crashes without it.