### PR TITLE
Improve wording and add titles on moderated servers section in /about/more

### DIFF
--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -56,12 +56,15 @@
             %p= t('about.unavailable_content_html')
 
             - if (blocks = @blocks.select(&:reject_media?)) && !blocks.empty?
+              %h3= t('about.unavailable_content_description.rejecting_media_title')
               %p= t('about.unavailable_content_description.rejecting_media')
               = render partial: 'domain_blocks', locals: { domain_blocks: blocks }
             - if (blocks = @blocks.select(&:silence?)) && !blocks.empty?
+              %h3= t('about.unavailable_content_description.silenced_title')
               %p= t('about.unavailable_content_description.silenced')
               = render partial: 'domain_blocks', locals: { domain_blocks: blocks }
             - if (blocks = @blocks.select(&:suspend?)) && !blocks.empty?
+              %h3= t('about.unavailable_content_description.suspended_title')
               %p= t('about.unavailable_content_description.suspended')
               = render partial: 'domain_blocks', locals: { domain_blocks: blocks }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,13 +35,16 @@ en:
     status_count_before: Who authored
     tagline: Follow friends and discover new ones
     terms: Terms of service
-    unavailable_content: Unavailable content
+    unavailable_content: Moderated servers
     unavailable_content_description:
       domain: Server
       reason: Reason
       rejecting_media: 'Media files from these servers will not be processed or stored, and no thumbnails will be displayed, requiring manual click-through to the original file:'
-      silenced: 'Posts from these servers will be hidden in public timelines and conversations, and no notifications will be generated from their users'' interactions, unless you are following them:'
+      rejecting_media_title: Filtered media
+      silenced: 'Posts from these servers will be hidden in public timelines and conversations, and no notifications will be generated from their users interactions, unless you are following them:'
+      silenced_title: Silenced servers
       suspended: 'No data from these servers will be processed, stored or exchanged, making any interaction or communication with users from these servers impossible:'
+      suspended_title: Suspended servers
     unavailable_content_html: Mastodon generally allows you to view content from and interact with users from any other server in the fediverse. These are the exceptions that have been made on this particular server.
     user_count_after:
       one: user


### PR DESCRIPTION
With the current design:

- “Unavailable Content” sounds more like an error returned from the server than a title and doesn’t tell it’s about moderation and servers
- It’s hard to see that the first paragraph applies to the whole block, and the second paragraph applies only to the following paragraph
- It’s hard to see if a paragraph applies to the next or previous table, since there’s no obvious separation
- There’s no easy way to search in the page for a specific type of moderation, either with a search function in a browser or visually, one needs to at least identify the paragraph before a table and read the beginning.

Before:
![Screenshot_2020-06-01 Mastodon](https://user-images.githubusercontent.com/2446451/83437003-44a85980-a43f-11ea-853a-9b54832b33a0.png)

After:
![Screenshot_2020-06-01 Mastodon 2](https://user-images.githubusercontent.com/2446451/83437006-4540f000-a43f-11ea-9e5a-c689ab6b88a2.png)
