### PR TITLE
Put “Add new domain block” button on /admin/instances in header

### DIFF
--- a/app/views/admin/instances/index.html.haml
+++ b/app/views/admin/instances/index.html.haml
@@ -1,6 +1,12 @@
 - content_for :page_title do
   = t('admin.instances.title')
 
+- content_for :heading_actions do
+  - if whitelist_mode?
+    = link_to t('admin.domain_allows.add_new'), new_admin_domain_allow_path, class: 'button'
+  - else
+    = link_to t('admin.domain_blocks.add_new'), new_admin_domain_block_path, class: 'button'
+
 .filters
   .filter-subset
     %strong= t('admin.instances.moderation.title')
@@ -9,12 +15,6 @@
 
       - unless whitelist_mode?
         %li= filter_link_to t('admin.instances.moderation.limited'), limited: '1'
-
-  %div.special-action-button
-    - if whitelist_mode?
-      = link_to t('admin.domain_allows.add_new'), new_admin_domain_allow_path, class: 'button'
-    - else
-      = link_to t('admin.domain_blocks.add_new'), new_admin_domain_block_path, class: 'button'
 
 - unless whitelist_mode?
   = form_tag admin_instances_url, method: 'GET', class: 'simple_form' do


### PR DESCRIPTION
In `/admin/instances`, the main action button is currently in the page itself, making me believe it was acting on what was filled in the text field. Also, this pattern is used on several other pages (“Save changes” in several pages, “Upload” in `/admin/custom_emojis`, etc.).

Before:
![Screenshot_2020-06-01 Federation - Mastodon (Dev) 1](https://user-images.githubusercontent.com/2446451/83448435-40d20280-a452-11ea-8842-3e069d256aed.png)

After:
![Screenshot_2020-06-01 Federation - Mastodon (Dev) 2](https://user-images.githubusercontent.com/2446451/83448437-416a9900-a452-11ea-9b24-f4ee701b7413.png)