### PR TITLE
Improve appearence consistency of settings pages

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -510,6 +510,16 @@ body,
   max-width: 100%;
 }
 
+.simple_form {
+  .actions {
+    margin-top: 15px;
+  }
+
+  .button {
+    font-size: 15px;
+  }
+}
+
 .batch-form-box {
   display: flex;
   flex-wrap: wrap;

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -171,9 +171,7 @@ $content-width: 840px;
   }
 
   .content {
-    padding: 20px 15px;
-    padding-top: 60px;
-    padding-left: 25px;
+    padding: 55px 15px 20px 25px;
 
     @media screen and (max-width: $no-columns-breakpoint) {
       max-width: none;
@@ -184,7 +182,7 @@ $content-width: 840px;
     &-heading {
       display: flex;
 
-      padding-bottom: 40px;
+      padding-bottom: 36px;
       border-bottom: 1px solid lighten($ui-base-color, 8%);
 
       margin: -15px -15px 40px 0;
@@ -215,7 +213,7 @@ $content-width: 840px;
     h2 {
       color: $secondary-text-color;
       font-size: 24px;
-      line-height: 28px;
+      line-height: 36px;
       font-weight: 400;
 
       @media screen and (max-width: $no-columns-breakpoint) {

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -38,7 +38,7 @@
           = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.accounts.#{key}")
 
     .actions
-      %button= t('admin.accounts.search')
+      %button.button= t('admin.accounts.search')
       = link_to t('admin.accounts.reset'), admin_accounts_path, class: 'button negative'
 
 .table-wrapper

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -33,7 +33,7 @@
         = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.custom_emojis.#{key}")
 
     .actions
-      %button= t('admin.accounts.search')
+      %button.button= t('admin.accounts.search')
       = link_to t('admin.accounts.reset'), admin_custom_emojis_path, class: 'button negative'
 
 = form_for(@form, url: batch_admin_custom_emojis_path) do |f|

--- a/app/views/admin/instances/index.html.haml
+++ b/app/views/admin/instances/index.html.haml
@@ -27,7 +27,7 @@
           = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.instances.#{key}")
 
       .actions
-        %button= t('admin.accounts.search')
+        %button.button= t('admin.accounts.search')
         = link_to t('admin.accounts.reset'), admin_instances_path, class: 'button negative'
 
 %hr.spacer/

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -18,7 +18,7 @@
         = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.reports.#{key}")
 
     .actions
-      %button= t('admin.accounts.search')
+      %button.button= t('admin.accounts.search')
       = link_to t('admin.accounts.reset'), admin_reports_path, class: 'button negative'
 
 - @reports.group_by(&:target_account_id).each do |target_account_id, reports|

--- a/app/views/admin/tags/index.html.haml
+++ b/app/views/admin/tags/index.html.haml
@@ -36,7 +36,7 @@
         = text_field_tag key, params[key], class: 'string optional', placeholder: I18n.t("admin.tags.#{key}")
 
     .actions
-      %button= t('admin.accounts.search')
+      %button.button= t('admin.accounts.search')
       = link_to t('admin.accounts.reset'), admin_tags_path, class: 'button negative'
 
 %hr.spacer/


### PR DESCRIPTION
## Forms

Put the buttons below a form in settings page at the same distance that’s used between inputs and use a smaller font size so that they look more like a part of the group.

Also, put the class `button` on the “Search” button too, so that styling is consistent between it and the “Reset” fake button (e.g.: right now, one has a transition for its `background-color` and the other hasn’t).

Before/after:
![Screenshot_2020-06-02 Custom emojis - Mastodon (Dev) 1](https://user-images.githubusercontent.com/2446451/83471751-c9b66180-a485-11ea-95d6-84a65d9d1bbf.png)
![Screenshot_2020-06-02 Custom emojis - Mastodon (Dev) 2](https://user-images.githubusercontent.com/2446451/83471752-ca4ef800-a485-11ea-9a92-451da2557277.png)

## Headers

In settings pages, the header doesn’t have exactly the same size depending on whether the header has a button in it or not.

Before/after:
![Screenshot_20200602_034751](https://user-images.githubusercontent.com/2446451/83471295-a8a14100-a484-11ea-8e64-284420540c8b.png)
![Screenshot_20200602_034811](https://user-images.githubusercontent.com/2446451/83471297-a939d780-a484-11ea-8784-742143ae2b70.png)

![Screenshot_20200602_034906](https://user-images.githubusercontent.com/2446451/83471298-a9d26e00-a484-11ea-8f7a-bcb9e7a8b5be.png)
![Screenshot_20200602_035609](https://user-images.githubusercontent.com/2446451/83471472-0c2b6e80-a485-11ea-80d5-dd8876ebfe3e.png)

