### PR TITLE
Fix unpermitted operations on custom emojis leading to cryptic errors

### DIFF
--- a/app/controllers/admin/custom_emojis_controller.rb
+++ b/app/controllers/admin/custom_emojis_controller.rb
@@ -33,6 +33,8 @@ module Admin
       @form.save
     rescue ActionController::ParameterMissing
       flash[:alert] = I18n.t('admin.accounts.no_account_selected')
+    rescue Mastodon::NotPermittedError
+      flash[:alert] = I18n.t('admin.custom_emojis.not_permitted')
     ensure
       redirect_to admin_custom_emojis_path(filter_params)
     end

--- a/app/views/admin/custom_emojis/index.html.haml
+++ b/app/views/admin/custom_emojis/index.html.haml
@@ -4,8 +4,9 @@
 - content_for :header_tags do
   = javascript_pack_tag 'admin', integrity: true, async: true, crossorigin: 'anonymous'
 
-- content_for :heading_actions do
-  = link_to t('admin.custom_emojis.upload'), new_admin_custom_emoji_path, class: 'button'
+- if can?(:create, :custom_emoji)
+  - content_for :heading_actions do
+    = link_to t('admin.custom_emojis.upload'), new_admin_custom_emoji_path, class: 'button'
 
 .filters
   .filter-subset
@@ -58,9 +59,10 @@
 
         = f.button safe_join([fa_icon('power-off'), t('admin.custom_emojis.disable')]), name: :disable, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
-        = f.button safe_join([fa_icon('times'), t('admin.custom_emojis.delete')]), name: :delete, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+        - if can?(:destroy, :custom_emoji)
+          = f.button safe_join([fa_icon('times'), t('admin.custom_emojis.delete')]), name: :delete, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
-        - unless params[:local] == '1'
+        - if can?(:copy, :custom_emoji) && params[:local] != '1'
           = f.button safe_join([fa_icon('copy'), t('admin.custom_emojis.copy')]), name: :copy, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
 
     - if params[:local] == '1'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,6 +309,7 @@ en:
       listed: Listed
       new:
         title: Add new custom emoji
+      not_permitted: You are not permitted to perform this action
       overwrite: Overwrite
       shortcode: Shortcode
       shortcode_hint: At least 2 characters, only alphanumeric characters and underscores


### PR DESCRIPTION
Fixes #13897

Also remove links to perform the unpermitted actions altogether.

An alternative would be to just allow moderators to handle custom emoji.