### PR TITLE
Fix serialization of replies when some of them are URIs

### DIFF
--- a/app/serializers/activitypub/collection_serializer.rb
+++ b/app/serializers/activitypub/collection_serializer.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 class ActivityPub::CollectionSerializer < ActivityPub::Serializer
+  class StringSerializer < ActiveModel::Serializer
+    # Despite the name, it does not return a hash, but the same can be said of
+    # the ActiveModel::Serializer::CollectionSerializer class which handles
+    # arrays.
+    def serializable_hash(*_args)
+      object
+    end
+  end
+
   def self.serializer_for(model, options)
     case model.class.name
     when 'Status'
@@ -9,6 +18,8 @@ class ActivityPub::CollectionSerializer < ActivityPub::Serializer
       ActivityPub::DeviceSerializer
     when 'ActivityPub::CollectionPresenter'
       ActivityPub::CollectionSerializer
+    when 'String'
+      StringSerializer
     else
       super
     end


### PR DESCRIPTION
Fixes #13956

This happens because Active Model Serializer's `CollectionSerializer` (automatically used for arrays) does not allow mixing primitives (such as strings, like the URIs here) and raises `:no_serializer` whenever one of the items is a primitive, making the whole thing fall back to `to_json`.

This PR introduces a `StringSerializer` to allow mixing strings with serializable objects. This messes a bit with the fact that AMS serializers are geared towards rendering actual JSON **object**, but that was already the case of the built-in `ActiveModel::Serializer::CollectionSerializer`.