### PR TITLE
Fix WebUI crash when processing accounts before page is loaded

### DIFF
--- a/app/javascript/mastodon/features/emoji/emoji.js
+++ b/app/javascript/mastodon/features/emoji/emoji.js
@@ -11,7 +11,7 @@ const darkEmoji = '🎱🐜⚫🖤⬛◼️◾◼️✒️▪️💣🎳📷📸
 const lightEmoji = '👽⚾🐔☁️💨🕊️👀🍥👻🐐❕❔⛸️🌩️🔊🔇📃🌧️🐏🍚🍙🐓🐑💀☠️🌨️🔉🔈💬💭🏐🏳️⚪⬜◽◻️▫️';
 
 const emojiFilename = (filename, match) => {
-  const borderedEmoji = document.body.classList.contains('theme-mastodon-light') ? lightEmoji : darkEmoji;
+  const borderedEmoji = (document.body && document.body.classList.contains('theme-mastodon-light')) ? lightEmoji : darkEmoji;
   return borderedEmoji.includes(match) ? (filename + '_border') : filename;
 };
 


### PR DESCRIPTION
Fix regression from #13772

The code newly added decides which emoji to outline based on the document body's classes. However, the user's account may be processed before the document body is loaded, thus leading to a crash.

It's more a workaround than a fix, because it means the code cannot make the proper decision of which emojis to outline in that context, although in practice it's much more likely to be the dark emoji (which were the only ones to be outlined before that change anyway).