### PR TITLE
Update Elasticsearch from 6.1 to 6.8 in docker-compose.yml (Fix glitch-soc#1348)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,6 @@ services:
 #      - "cluster.name=es-mastodon"
 #      - "discovery.type=single-node"
 #      - "bootstrap.memory_lock=true"
-#    ports:
-#      - "127.0.0.1:9300:9300"
-#      - "127.0.0.1:9200:9200"
 #    networks:
 #      - internal_network
 #    healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,27 +22,27 @@ services:
     volumes:
       - ./redis:/data
 
-#   es:
-#     restart: always
-#     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.10
-#     environment:
-#       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-#       - "cluster.name=es-mastodon"
-#       - "discovery.type=single-node"
-#       - "bootstrap.memory_lock=true"
-#     ports:
-#       - "127.0.0.1:9300:9300"
-#       - "127.0.0.1:9200:9200"
-#     networks:
-#       - internal_network
-#     healthcheck:
-#       test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
-#     volumes:
-#       - ./elasticsearch:/usr/share/elasticsearch/data
-#     ulimits:
-#       memlock:
-#         soft: -1
-#         hard: -1
+#  es:
+#    restart: always
+#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.10
+#    environment:
+#      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+#      - "cluster.name=es-mastodon"
+#      - "discovery.type=single-node"
+#      - "bootstrap.memory_lock=true"
+#    ports:
+#      - "127.0.0.1:9300:9300"
+#      - "127.0.0.1:9200:9200"
+#    networks:
+#      - internal_network
+#    healthcheck:
+#      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+#    volumes:
+#      - ./elasticsearch:/usr/share/elasticsearch/data
+#    ulimits:
+#      memlock:
+#        soft: -1
+#        hard: -1
 
   web:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
 #   es:
 #     restart: always
-#     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.7.1
+#     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.10
 #     environment:
 #       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 #       - "cluster.name=es-mastodon"
@@ -38,7 +38,7 @@ services:
 #     healthcheck:
 #       test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
 #     volumes:
-#       - ./elasticsearch7:/usr/share/elasticsearch/data
+#       - ./elasticsearch:/usr/share/elasticsearch/data
 #     ulimits:
 #       memlock:
 #         soft: -1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,17 +22,27 @@ services:
     volumes:
       - ./redis:/data
 
-#  es:
-#    restart: always
-#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.3
-#    environment:
-#      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-#    networks:
-#      - internal_network
-#    healthcheck:
-#      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
-#    volumes:
-#      - ./elasticsearch:/usr/share/elasticsearch/data
+#   es:
+#     restart: always
+#     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.7.1
+#     environment:
+#       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+#       - "cluster.name=es-mastodon"
+#       - "discovery.type=single-node"
+#       - "bootstrap.memory_lock=true"
+#     ports:
+#       - "127.0.0.1:9300:9300"
+#       - "127.0.0.1:9200:9200"
+#     networks:
+#       - internal_network
+#     healthcheck:
+#       test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+#     volumes:
+#       - ./elasticsearch:/usr/share/elasticsearch/data
+#     ulimits:
+#       memlock:
+#         soft: -1
+#         hard: -1
 
   web:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 #     healthcheck:
 #       test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
 #     volumes:
-#       - ./elasticsearch:/usr/share/elasticsearch/data
+#       - ./elasticsearch7:/usr/share/elasticsearch/data
 #     ulimits:
 #       memlock:
 #         soft: -1


### PR DESCRIPTION
Fixes https://github.com/glitch-soc/mastodon/issues/1348

According to documentation. Elasticsearch 6.x supports rolling upgrades. https://www.elastic.co/guide/en/elasticsearch/reference/6.8/rolling-upgrades.html

Sadly, the 6.1 cannot to upgraded major versions using the rolling release method to 7+. So we're thinking two stage upgrade. 

6.1 -> 6.8 now... then 6.8 to 7.7 in the future.

ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html