### PR TITLE
Add a default DB_HOST to .env.vagrant for enable the streaming

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -1,3 +1,4 @@
 VAGRANT=true
 LOCAL_DOMAIN=mastodon.local
 BIND=0.0.0.0
+DB_HOST=/var/run/postgresql/


### PR DESCRIPTION
Currently, Streaming is not working on Vagrant, and as below messages is output.

```
ERR! error: password authentication failed for user "vagrant"
```

According to my researching:
 - `vagrant` user is don't have password but PostgreSQL is not supporting no password authentication with default configuration.
- Rails is using Unix sockets in default for connecting to database but `node-postgres` is connecting to `localhost`

I think for the above reasons, This problem is occurred.
So I did added DB_HOST for using Unix sockets to .env.vagrant