### PR TITLE
Updated dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,18 @@
 
 version: 2
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
     open-pull-requests-limit: 99
     allow:
-      - dependency-type: all
+      - dependency-type: "all"
 
-  - package-ecosystem: bundler
+  - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
     open-pull-requests-limit: 99
     allow:
-      - dependency-type: all
+      - dependency-type: "all"


### PR DESCRIPTION
Followed the recently updated dependabot documentation for the new Github migration.
Strings must be double quoted now.

note to self: This doesn't apply to the `versioning-strategy` strings.