### PR TITLE
Suppress Redis#exists(key) warning

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+Redis.exists_returns_integer = false
+
 redis_connection = Redis.new(
   url: ENV['REDIS_URL'],
   driver: :hiredis


### PR DESCRIPTION
After #14038, Sidekiq will output the following message to the log:

    `Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0. (/home/mastodon/live/vendor/bundle/ruby/2.6.0/gems/sidekiq-6.0.7/lib/sidekiq/launcher.rb:160:in `block (2 levels) in ❤')

ref: https://github.com/mperham/sidekiq/issues/4591

From redis-rb v4.3, `Redis#exists(key)` seems to return integer.
ref: https://github.com/redis/redis-rb/blob/master/CHANGELOG.md

redis-rb v4.2.1 it returns a Boolean value if there is only one key, but many warnings are generated.
ref: [screenshot](https://media.taruntarun.net/Mastodon/media_attachments/files/000/847/170/original/7023c38b1f9b00fa.png)

This PR suppresses that warning, but this isn't a fundamental solution.

Also, even if set to `Redis.exists_returns_integer = false` , the warning is output only once when Sidekiq starts.
However, setting `Redis.exists returns integer = true` suppresses everything, but the return value turns into an integer (Sidekiq doesn't return an error, but couldn't display the HTL).

Also, this PR cannot suppress the warning that is output when executing `rake assets: precompile`.