### PR TITLE
Fix modifier key to keep the EmojiPicker on macOS

### DIFF
--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.js
@@ -203,7 +203,7 @@ class EmojiPickerMenu extends React.PureComponent {
     if (!emoji.native) {
       emoji.native = emoji.colons;
     }
-    if (!event.ctrlKey) {
+    if (!(event.ctrlKey || event.metaKey)) {
       this.props.onClose();
     }
     this.props.onPick(emoji);


### PR DESCRIPTION
Fix https://github.com/tootsuite/mastodon/pull/13896

Added a modifier key to support macOS.
