### PR TITLE
Fix unnecessary gap under of video modal

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5361,6 +5361,7 @@ a.status-card.compact:hover {
   }
 
   video {
+    display: block;
     max-width: 100vw;
     max-height: 80vh;
     z-index: 1;


### PR DESCRIPTION
This PR is fix unnecessary gap under of video modal.

Please see below screen shots for confirm unnecessary gap.

![Screenshot_20200620_164834](https://user-images.githubusercontent.com/54523771/85197022-4320d180-b319-11ea-8ebd-73703d94c182.png)

This screen shot is using adjusted styles for easy to confirm.
Actually difficult to confirm because background color is black.