### PR TITLE
Fix unique username constraint for local users not being enforced in database

### DIFF
--- a/db/migrate/20200620164023_add_fixed_lowercase_index_to_accounts.rb
+++ b/db/migrate/20200620164023_add_fixed_lowercase_index_to_accounts.rb
@@ -1,0 +1,15 @@
+class AddFixedLowercaseIndexToAccounts < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    rename_index :accounts, 'index_accounts_on_username_and_domain_lower', 'old_index_accounts_on_username_and_domain_lower' unless index_name_exists?(:accounts, 'old_index_accounts_on_username_and_domain_lower')
+    add_index :accounts, "lower (username), COALESCE(lower(domain), '')", name: 'index_accounts_on_username_and_domain_lower', unique: true, algorithm: :concurrently
+    remove_index :accounts, name: 'old_index_accounts_on_username_and_domain_lower'
+  end
+
+  def down
+    add_index :accounts, 'lower (username), lower(domain)', name: 'old_index_accounts_on_username_and_domain_lower', unique: true, algorithm: :concurrently
+    remove_index :accounts, name: 'index_accounts_on_username_and_domain_lower'
+    rename_index :accounts, 'old_index_accounts_on_username_and_domain_lower', 'index_accounts_on_username_and_domain_lower'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_08_113046) do
+ActiveRecord::Schema.define(version: 2020_06_20_164023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -176,7 +176,7 @@ ActiveRecord::Schema.define(version: 2020_06_08_113046) do
     t.integer "header_storage_schema_version"
     t.string "devices_url"
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
-    t.index "lower((username)::text), lower((domain)::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
+    t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["moved_to_account_id"], name: "index_accounts_on_moved_to_account_id"
     t.index ["uri"], name: "index_accounts_on_uri"
     t.index ["url"], name: "index_accounts_on_url"


### PR DESCRIPTION
This should not be an issue in practice because of the Rails-level uniqueness
check, but local accounts having a NULL domain means the uniqueness constraint
did not apply to them (since no two NULL values are considered equal).

~~The migration is split in two because adding the index is done with `disable_ddl_transaction!`, meaning that if the rename were inside it and something happens during the `add_index`, the renaming would have already happened and re-running the migration would fail in confusing ways.~~