### PR TITLE
Improved unlisted toot visibility

### DIFF
--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -309,6 +309,8 @@ class StatusActionBar extends ImmutablePureComponent {
       reblogIcon = 'envelope';
     } else if (status.get('visibility') === 'private') {
       reblogIcon = 'lock';
+    } else if (status.get('visibility') === 'unlisted') {
+      reblogIcon = 'unlock';
     }
 
     if (status.get('in_reply_to_id', null) === null) {

--- a/app/javascript/mastodon/features/status/components/action_bar.js
+++ b/app/javascript/mastodon/features/status/components/action_bar.js
@@ -264,6 +264,7 @@ class ActionBar extends React.PureComponent {
     let reblogIcon = 'retweet';
     if (status.get('visibility') === 'direct') reblogIcon = 'envelope';
     else if (status.get('visibility') === 'private') reblogIcon = 'lock';
+    else if (status.get('visibility') === 'unlisted') reblogIcon = 'unlock';
 
     return (
       <div className='detailed-status__action-bar'>

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -165,6 +165,8 @@ export default class DetailedStatus extends ImmutablePureComponent {
       reblogIcon = 'envelope';
     } else if (status.get('visibility') === 'private') {
       reblogIcon = 'lock';
+    } else if (status.get('visibility') === 'unlisted') {
+      reblogIcon = 'unlock';
     }
 
     if (['private', 'direct'].includes(status.get('visibility'))) {

--- a/app/views/statuses/_detailed_status.html.haml
+++ b/app/views/statuses/_detailed_status.html.haml
@@ -69,7 +69,10 @@
         = fa_icon('lock')
     - else
       = link_to remote_interaction_path(status, type: :reblog), class: 'modal-button detailed-status__link' do
-        = fa_icon('retweet')
+        - if status.public_visibility?
+          = fa_icon('retweet')
+        - else
+          = fa_icon('unlock')
         %span.detailed-status__reblogs>= number_to_human status.reblogs_count, strip_insignificant_zeros: true
         = " "
     ·

--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -58,8 +58,10 @@
           = fa_icon 'reply-all fw'
       .status__action-bar__counter__label= obscured_counter status.replies_count
     = link_to remote_interaction_path(status, type: :reblog), class: 'status__action-bar-button icon-button modal-button' do
-      - if status.distributable?
+      - if status.public_visibility?
         = fa_icon 'retweet fw'
+      - elsif status.unlisted_visibility?
+        = fa_icon 'unlock fw'
       - elsif status.private_visibility? || status.limited_visibility?
         = fa_icon 'lock fw'
       - else


### PR DESCRIPTION
This PR improves the visibility of "unlisted toot".
I think there are pros and cons to this, and there are many other ways to achieve this.

I think some people don't like this visual or feature.
I would like to hear various opinions about this.

<img width="348" alt="スクリーンショット 2020-06-22 23 29 02" src="https://user-images.githubusercontent.com/766076/85301272-94c88800-b4e2-11ea-9f72-c2e570be906a.png">
<img width="970" alt="スクリーンショット_2020-06-22_23_26_20" src="https://user-images.githubusercontent.com/766076/85301306-9db95980-b4e2-11ea-8458-a71535b248da.png">
<img width="664" alt="スクリーンショット_2020-06-22_23_26_33" src="https://user-images.githubusercontent.com/766076/85301313-a01bb380-b4e2-11ea-8a7c-3167760825d8.png">

I think some people would like to distinguish between "public toot" and "unlisted toot."
I've written this as one way to do that.

I think one option is to leave this unmerged.