### PR TITLE
Add a visibility icon to status

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -77,6 +77,16 @@ module ApplicationHelper
     content_tag(:i, nil, attributes.merge(class: class_names.join(' ')))
   end
 
+  def visibility_icon(status)
+    if status.unlisted_visibility?
+      fa_icon('unlock', title: I18n.t('statuses.visibilities.unlisted'))
+    elsif status.private_visibility? || status.limited_visibility?
+      fa_icon('lock', title: I18n.t('statuses.visibilities.private'))
+    elsif status.direct_visibility?
+      fa_icon('envelope', title: I18n.t('statuses.visibilities.direct'))
+    end
+  end
+
   def custom_emoji_tag(custom_emoji, animate = true)
     if animate
       image_tag(custom_emoji.image.url, class: 'emojione', alt: ":#{custom_emoji.shortcode}:")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,7 +78,9 @@ module ApplicationHelper
   end
 
   def visibility_icon(status)
-    if status.unlisted_visibility?
+    if status.public_visibility?
+      fa_icon('globe', title: I18n.t('statuses.visibilities.public'))
+    elsif status.unlisted_visibility?
       fa_icon('unlock', title: I18n.t('statuses.visibilities.unlisted'))
     elsif status.private_visibility? || status.limited_visibility?
       fa_icon('lock', title: I18n.t('statuses.visibilities.private'))

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -10,7 +10,7 @@ import StatusContent from './status_content';
 import StatusActionBar from './status_action_bar';
 import AttachmentList from './attachment_list';
 import Card from '../features/status/components/card';
-import { injectIntl, FormattedMessage } from 'react-intl';
+import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { MediaGallery, Video, Audio } from '../features/ui/util/async-components';
 import { HotKeys } from 'react-hotkeys';
@@ -50,6 +50,12 @@ export const defaultMediaVisibility = (status) => {
 
   return (displayMedia !== 'hide_all' && !status.get('sensitive') || displayMedia === 'show_all');
 };
+
+const messages = defineMessages({
+  unlisted_short: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
+  private_short: { id: 'privacy.private.short', defaultMessage: 'Followers-only' },
+  direct_short: { id: 'privacy.direct.short', defaultMessage: 'Direct' },
+});
 
 export default @injectIntl
 class Status extends ImmutablePureComponent {
@@ -417,6 +423,15 @@ class Status extends ImmutablePureComponent {
       statusAvatar = <AvatarOverlay account={status.get('account')} friend={account} />;
     }
 
+    const visibilityIconInfo = {
+      'public': null,
+      'unlisted': { icon: 'unlock', text: intl.formatMessage(messages.unlisted_short) },
+      'private': { icon: 'lock', text: intl.formatMessage(messages.private_short) },
+      'direct': { icon: 'envelope', text: intl.formatMessage(messages.direct_short) },
+    };
+
+    const visibilityIcon = visibilityIconInfo[status.get('visibility')];
+
     return (
       <HotKeys handlers={handlers}>
         <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), read: unread === false, focusable: !this.props.muted })} tabIndex={this.props.muted ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader(intl, status, rebloggedByText)} ref={this.handleRef}>
@@ -426,6 +441,7 @@ class Status extends ImmutablePureComponent {
             <div className='status__expand' onClick={this.handleExpandClick} role='presentation' />
             <div className='status__info'>
               <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener noreferrer'><RelativeTimestamp timestamp={status.get('created_at')} /></a>
+              {visibilityIcon && <span className='status__visibility-icon'><Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></span>}
 
               <a onClick={this.handleAccountClick} data-id={status.getIn(['account', 'id'])} href={status.getIn(['account', 'url'])} title={status.getIn(['account', 'acct'])} className='status__display-name' target='_blank' rel='noopener noreferrer'>
                 <div className='status__avatar'>

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -52,6 +52,7 @@ export const defaultMediaVisibility = (status) => {
 };
 
 const messages = defineMessages({
+  public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
   unlisted_short: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
   private_short: { id: 'privacy.private.short', defaultMessage: 'Followers-only' },
   direct_short: { id: 'privacy.direct.short', defaultMessage: 'Direct' },
@@ -424,7 +425,7 @@ class Status extends ImmutablePureComponent {
     }
 
     const visibilityIconInfo = {
-      'public': null,
+      'public': { icon: 'globe', text: intl.formatMessage(messages.public_short) },
       'unlisted': { icon: 'unlock', text: intl.formatMessage(messages.unlisted_short) },
       'private': { icon: 'lock', text: intl.formatMessage(messages.private_short) },
       'direct': { icon: 'envelope', text: intl.formatMessage(messages.direct_short) },
@@ -441,7 +442,7 @@ class Status extends ImmutablePureComponent {
             <div className='status__expand' onClick={this.handleExpandClick} role='presentation' />
             <div className='status__info'>
               <a href={status.get('url')} className='status__relative-time' target='_blank' rel='noopener noreferrer'><RelativeTimestamp timestamp={status.get('created_at')} /></a>
-              {visibilityIcon && <span className='status__visibility-icon'><Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></span>}
+              <span className='status__visibility-icon'><Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></span>
 
               <a onClick={this.handleAccountClick} data-id={status.getIn(['account', 'id'])} href={status.getIn(['account', 'url'])} title={status.getIn(['account', 'acct'])} className='status__display-name' target='_blank' rel='noopener noreferrer'>
                 <div className='status__avatar'>

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -17,6 +17,7 @@ import Icon from 'mastodon/components/icon';
 import AnimatedNumber from 'mastodon/components/animated_number';
 
 const messages = defineMessages({
+  public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
   unlisted_short: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },
   private_short: { id: 'privacy.private.short', defaultMessage: 'Followers-only' },
   direct_short: { id: 'privacy.direct.short', defaultMessage: 'Direct' },
@@ -107,7 +108,6 @@ class DetailedStatus extends ImmutablePureComponent {
 
     let media           = '';
     let applicationLink = '';
-    let visibilityLink = '';
     let reblogLink = '';
     let reblogIcon = 'retweet';
     let favouriteLink = '';
@@ -170,17 +170,14 @@ class DetailedStatus extends ImmutablePureComponent {
     }
 
     const visibilityIconInfo = {
-      'public': null,
+      'public': { icon: 'globe', text: intl.formatMessage(messages.public_short) },
       'unlisted': { icon: 'unlock', text: intl.formatMessage(messages.unlisted_short) },
       'private': { icon: 'lock', text: intl.formatMessage(messages.private_short) },
       'direct': { icon: 'envelope', text: intl.formatMessage(messages.direct_short) },
     };
 
     const visibilityIcon = visibilityIconInfo[status.get('visibility')];
-
-    if (visibilityIcon !== null) {
-      visibilityLink = <React.Fragment> · <Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></React.Fragment>;
-    }
+    const visibilityLink = <React.Fragment> · <Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></React.Fragment>;
 
     if (['private', 'direct'].includes(status.get('visibility'))) {
       reblogLink = '';

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -211,7 +211,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
 
     return (
       <div style={outerStyle}>
-        <div ref={this.setRef} className={classNames('detailed-status', { compact })}>
+        <div ref={this.setRef} className={classNames('detailed-status', `detailed-status-${status.get('visibility')}`, { compact })}>
           <a href={status.getIn(['account', 'url'])} onClick={this.handleAccountClick} className='detailed-status__display-name'>
             <div className='detailed-status__display-avatar'><Avatar account={status.get('account')} size={48} /></div>
             <DisplayName account={status.get('account')} localDomain={this.props.domain} />

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1019,7 +1019,8 @@
   }
 
   &.light {
-    .status__relative-time {
+    .status__relative-time,
+    .status__visibility-icon {
       color: $light-text-color;
     }
 
@@ -1052,29 +1053,6 @@
       }
     }
   }
-
-  &-unlisted .status__relative-time::before,
-  &-private .status__relative-time::before,
-  &-direct .status__relative-time::before {
-      display: inline-block;
-      text-align: center;
-      width: 14px;
-      height: 14px;
-      font: 14px/1 FontAwesome;
-      margin-right: 4px;
-  }
-
-  &-unlisted .status__relative-time::before {
-      content: "\f09C";
-  }
-
-  &-private .status__relative-time::before {
-      content: "\F023";
-  }
-
-  &-direct .status__relative-time::before {
-      content: "\F0E0";
-  }
 }
 
 .notification-favourite {
@@ -1088,10 +1066,16 @@
 }
 
 .status__relative-time,
+.status__visibility-icon,
 .notification__relative_time {
   color: $dark-text-color;
   float: right;
   font-size: 14px;
+}
+
+.status__visibility-icon {
+  margin-left: 4px;
+  margin-right: 4px;
 }
 
 .status__display-name {
@@ -1209,7 +1193,6 @@
 .detailed-status {
   background: lighten($ui-base-color, 4%);
   padding: 14px 10px;
-  position: relative;
 
   &--flex {
     display: flex;
@@ -1221,37 +1204,6 @@
     .detailed-status__meta {
       flex: 100%;
     }
-  }
-
-  &-unlisted::before,
-  &-private::before,
-  &-direct::before {
-    display: block;
-    position: absolute;
-    width: 14px;
-    height: 14px;
-    right: 10px;
-    top: 20px;
-    font: 14px/1 FontAwesome;
-    color: #606984;
-  }
-
-  &-unlisted .display-name,
-  &-private .display-name,
-  &-direct .display-name {
-    padding-right: 18px;
-  }
-
-  &-unlisted::before {
-      content: "\f09C";
-  }
-
-  &-private::before {
-      content: "\F023";
-  }
-
-  &-direct::before {
-      content: "\F0E0";
   }
 
   .status__content {
@@ -1610,7 +1562,6 @@ a.account__display-name {
 }
 
 .detailed-status .button.logo-button {
-  margin-right: 18px;
   margin-bottom: 15px;
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1052,6 +1052,29 @@
       }
     }
   }
+
+  &-unlisted .status__relative-time::before,
+  &-private .status__relative-time::before,
+  &-direct .status__relative-time::before {
+      display: inline-block;
+      text-align: center;
+      width: 14px;
+      height: 14px;
+      font: 14px/1 FontAwesome;
+      margin-right: 4px;
+  }
+
+  &-unlisted .status__relative-time::before {
+      content: "\f09C";
+  }
+
+  &-private .status__relative-time::before {
+      content: "\F023";
+  }
+
+  &-direct .status__relative-time::before {
+      content: "\F0E0";
+  }
 }
 
 .notification-favourite {
@@ -1186,6 +1209,7 @@
 .detailed-status {
   background: lighten($ui-base-color, 4%);
   padding: 14px 10px;
+  position: relative;
 
   &--flex {
     display: flex;
@@ -1197,6 +1221,37 @@
     .detailed-status__meta {
       flex: 100%;
     }
+  }
+
+  &-unlisted::before,
+  &-private::before,
+  &-direct::before {
+    display: block;
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    right: 10px;
+    top: 20px;
+    font: 14px/1 FontAwesome;
+    color: #606984;
+  }
+
+  &-unlisted .display-name,
+  &-private .display-name,
+  &-direct .display-name {
+    padding-right: 18px;
+  }
+
+  &-unlisted::before {
+      content: "\f09C";
+  }
+
+  &-private::before {
+      content: "\F023";
+  }
+
+  &-direct::before {
+      content: "\F0E0";
   }
 
   .status__content {
@@ -1555,6 +1610,7 @@ a.account__display-name {
 }
 
 .detailed-status .button.logo-button {
+  margin-right: 18px;
   margin-bottom: 15px;
 }
 

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -157,15 +157,6 @@ body.rtl {
     left: 0;
   }
 
-  .status {
-    &-unlisted .status__relative-time::before,
-    &-private .status__relative-time::before,
-    &-direct .status__relative-time::before {
-        margin-right: 0;
-        margin-left: 4px;
-    }
-  }
-
   .status__relative-time,
   .activity-stream .status.light .status__header .status__meta {
     float: left;
@@ -201,27 +192,6 @@ body.rtl {
   .privacy-dropdown__option__icon {
     margin-left: 10px;
     margin-right: 0;
-  }
-
-  .detailed-status {
-    &-unlisted::before,
-    &-private::before,
-    &-direct::before {
-      right: auto;
-      left: 10px;
-    }
-
-    &-unlisted .display-name,
-    &-private .display-name,
-    &-direct .display-name {
-      padding-right: 0;
-      padding-left: 18px;
-    }
-  }
-
-  .detailed-status .button.logo-button {
-    margin-right: 0;
-    margin-left: 18px;
   }
 
   .detailed-status__display-name .display-name {

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -157,6 +157,15 @@ body.rtl {
     left: 0;
   }
 
+  .status {
+    &-unlisted .status__relative-time::before,
+    &-private .status__relative-time::before,
+    &-direct .status__relative-time::before {
+        margin-right: 0;
+        margin-left: 4px;
+    }
+  }
+
   .status__relative-time,
   .activity-stream .status.light .status__header .status__meta {
     float: left;
@@ -192,6 +201,27 @@ body.rtl {
   .privacy-dropdown__option__icon {
     margin-left: 10px;
     margin-right: 0;
+  }
+
+  .detailed-status {
+    &-unlisted::before,
+    &-private::before,
+    &-direct::before {
+      right: auto;
+      left: 10px;
+    }
+
+    &-unlisted .display-name,
+    &-private .display-name,
+    &-direct .display-name {
+      padding-right: 0;
+      padding-left: 18px;
+    }
+  }
+
+  .detailed-status .button.logo-button {
+    margin-right: 0;
+    margin-left: 18px;
   }
 
   .detailed-status__display-name .display-name {

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -158,6 +158,7 @@ body.rtl {
   }
 
   .status__relative-time,
+  .status__visibility-icon,
   .activity-stream .status.light .status__header .status__meta {
     float: left;
   }

--- a/app/views/statuses/_detailed_status.html.haml
+++ b/app/views/statuses/_detailed_status.html.haml
@@ -47,6 +47,10 @@
     = link_to ActivityPub::TagManager.instance.url_for(status), class: 'detailed-status__datetime u-url u-uid', target: stream_link_target, rel: 'noopener noreferrer' do
       %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
     ·
+    - unless status.public_visibility?
+      %span.detailed-status__visibility-icon
+        = visibility_icon status
+      ·
     - if status.application && @account.user&.setting_show_application
       - if status.application.website.blank?
         %strong.detailed-status__application= status.application.name
@@ -61,18 +65,12 @@
       %span.detailed-status__reblogs>= number_to_human status.replies_count, strip_insignificant_zeros: true
       = " "
     ·
-    - if status.direct_visibility?
-      %span.detailed-status__link<
-        = fa_icon('envelope')
-    - elsif status.private_visibility? || status.limited_visibility?
-      %span.detailed-status__link<
-        = fa_icon('lock')
-    - else
+    - if status.public_visibility? || status.unlisted_visibility?
       = link_to remote_interaction_path(status, type: :reblog), class: 'modal-button detailed-status__link' do
         = fa_icon('retweet')
         %span.detailed-status__reblogs>= number_to_human status.reblogs_count, strip_insignificant_zeros: true
         = " "
-    ·
+      ·
     = link_to remote_interaction_path(status, type: :favourite), class: 'modal-button detailed-status__link' do
       = fa_icon('star')
       %span.detailed-status__favorites>= number_to_human status.favourites_count, strip_insignificant_zeros: true

--- a/app/views/statuses/_detailed_status.html.haml
+++ b/app/views/statuses/_detailed_status.html.haml
@@ -47,10 +47,9 @@
     = link_to ActivityPub::TagManager.instance.url_for(status), class: 'detailed-status__datetime u-url u-uid', target: stream_link_target, rel: 'noopener noreferrer' do
       %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
     ·
-    - unless status.public_visibility?
-      %span.detailed-status__visibility-icon
-        = visibility_icon status
-      ·
+    %span.detailed-status__visibility-icon
+      = visibility_icon status
+    ·
     - if status.application && @account.user&.setting_show_application
       - if status.application.website.blank?
         %strong.detailed-status__application= status.application.name

--- a/app/views/statuses/_detailed_status.html.haml
+++ b/app/views/statuses/_detailed_status.html.haml
@@ -1,4 +1,4 @@
-.detailed-status.detailed-status--flex
+.detailed-status.detailed-status--flex{ class: "detailed-status-#{status.visibility}" }
   .p-author.h-card
     = link_to ActivityPub::TagManager.instance.url_for(status.account), class: 'detailed-status__display-name u-url', target: stream_link_target, rel: 'noopener' do
       .detailed-status__display-avatar

--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -1,4 +1,4 @@
-.status
+.status{ class: "status-#{status.visibility}" }
   .status__info
     = link_to ActivityPub::TagManager.instance.url_for(status), class: 'status__relative-time u-url u-uid', target: stream_link_target, rel: 'noopener noreferrer' do
       %time.time-ago{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)

--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -3,6 +3,9 @@
     = link_to ActivityPub::TagManager.instance.url_for(status), class: 'status__relative-time u-url u-uid', target: stream_link_target, rel: 'noopener noreferrer' do
       %time.time-ago{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
     %data.dt-published{ value: status.created_at.to_time.iso8601 }
+    - unless status.public_visibility?
+      %span.status__visibility-icon
+        = visibility_icon status
 
     .p-author.h-card
       = link_to ActivityPub::TagManager.instance.url_for(status.account), class: 'status__display-name u-url', target: stream_link_target, rel: 'noopener noreferrer' do

--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -3,9 +3,8 @@
     = link_to ActivityPub::TagManager.instance.url_for(status), class: 'status__relative-time u-url u-uid', target: stream_link_target, rel: 'noopener noreferrer' do
       %time.time-ago{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
     %data.dt-published{ value: status.created_at.to_time.iso8601 }
-    - unless status.public_visibility?
-      %span.status__visibility-icon
-        = visibility_icon status
+    %span.status__visibility-icon
+      = visibility_icon status
 
     .p-author.h-card
       = link_to ActivityPub::TagManager.instance.url_for(status.account), class: 'status__display-name u-url', target: stream_link_target, rel: 'noopener noreferrer' do


### PR DESCRIPTION
Here's another implementation that deals with the same problem as https://github.com/tootsuite/mastodon/pull/14119

- Add a visibility icon to the top right (top left in RTL) of status
- It doesn't add anything to the public status (change as little as possible)
- It's looking for a balance between being fully identifiable and unobtrusive
- It uses CSS to describe the look and feel, so it's easy to change it in the theme
- Added some missing classes (you can even change the color of the entire status, depending on the theme)

On the timeline
![visibility-icon_a](https://user-images.githubusercontent.com/28195220/85341917-50f67280-b524-11ea-9357-1512acf2cce7.png)

View Details
![visibility-icon_b](https://user-images.githubusercontent.com/28195220/85341922-53f16300-b524-11ea-9b26-1635ef8bb077.png)
