### PR TITLE
Fix design issues with sensitive preview cards

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -248,15 +248,15 @@ export default class Card extends React.PureComponent {
                 </div>
               </div>
             )}
+            {!revealed && spoilerButton}
           </div>
         );
       }
 
       return (
-        <div className={className} ref={this.setRef}>
+        <div className={className} ref={this.setRef} onClick={this.handleReveal}>
           {embed}
           {!compact && description}
-          {!revealed && spoilerButton}
         </div>
       );
     } else if (card.get('image')) {

--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -164,8 +164,10 @@ export default class Card extends React.PureComponent {
     this.setState({ previewLoaded: true });
   }
 
-  handleReveal = () => {
+  handleReveal = e => {
     this.setState({ revealed: true });
+    e.preventDefault();
+    e.stopPropagation();
   }
 
   renderVideo () {
@@ -246,7 +248,6 @@ export default class Card extends React.PureComponent {
                 </div>
               </div>
             )}
-            {!revealed && spoilerButton}
           </div>
         );
       }
@@ -255,6 +256,7 @@ export default class Card extends React.PureComponent {
         <div className={className} ref={this.setRef}>
           {embed}
           {!compact && description}
+          {!revealed && spoilerButton}
         </div>
       );
     } else if (card.get('image')) {
@@ -262,14 +264,12 @@ export default class Card extends React.PureComponent {
         <div className='status-card__image'>
           {canvas}
           {thumbnail}
-          {!revealed && spoilerButton}
         </div>
       );
     } else {
       embed = (
         <div className='status-card__image'>
           <Icon id='file-text' />
-          {!revealed && spoilerButton}
         </div>
       );
     }
@@ -278,6 +278,7 @@ export default class Card extends React.PureComponent {
       <a href={card.get('url')} className={className} target='_blank' rel='noopener noreferrer' ref={this.setRef}>
         {embed}
         {description}
+        {!revealed && spoilerButton}
       </a>
     );
   }

--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -165,9 +165,9 @@ export default class Card extends React.PureComponent {
   }
 
   handleReveal = e => {
-    this.setState({ revealed: true });
     e.preventDefault();
     e.stopPropagation();
+    this.setState({ revealed: true });
   }
 
   renderVideo () {
@@ -254,7 +254,7 @@ export default class Card extends React.PureComponent {
       }
 
       return (
-        <div className={className} ref={this.setRef} onClick={this.handleReveal}>
+        <div className={className} ref={this.setRef} onClick={revealed ? null : this.handleReveal} role={revealed ? 'button' : null}>
           {embed}
           {!compact && description}
         </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3003,6 +3003,7 @@ a.account__display-name {
 }
 
 .status-card {
+  position: relative;
   display: flex;
   font-size: 14px;
   border: 1px solid lighten($ui-base-color, 8%);


### PR DESCRIPTION
## Before

The “sensitive” button is centered on the image part, which is somewhat sensible for media cards, but not for cards which only have a small image to their side.

Furthermore, clicking outside that image area would not do anything in the case of a media card, and clicking *anywhere* would also trigger the link in the other case.

![image](https://user-images.githubusercontent.com/384364/85390450-210d9600-b549-11ea-9a2c-68a25f90249e.png)

## After

The “sensitive” button is changed to cover the whole preview card, regardless of the preview type.
Clicking a sensitive preview card anywhere now reveals it, without opening the link behind it.

![image](https://user-images.githubusercontent.com/384364/85390907-c163ba80-b549-11ea-9aed-e4028404334b.png)
