### PR TITLE
Fix very wide media attachments resulting in too thin a thumbnail

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5203,6 +5203,7 @@ a.status-card.compact:hover {
   border-radius: 4px;
   position: relative;
   width: 100%;
+  min-height: 64px;
 }
 
 .media-gallery__item {


### PR DESCRIPTION
Fixes #14094

Without that change, very wide media attachments have a preview that's only a few pixels of height, making them practically invisible at worst, or truncating the “sensitive” button in awkward ways at best.

This PR attempts to fix that by setting a minimum height so that the “sensitive” button always has the necessary space to be displayed without being cropped.

![image](https://user-images.githubusercontent.com/384364/85408764-3d1f3080-b565-11ea-96a2-0d8b6f85898d.png)
![image](https://user-images.githubusercontent.com/384364/85409064-9ab37d00-b565-11ea-9486-af2f0bab80b8.png)

The `object-fit: cover` thing means in that case that the media preview will be cropped (instead of, for instance, being letterboxed), but considering those are extreme cases, I think that is fine: letterboxing them would not make them more readable since they'd have only a few pixels of height anyway.