### PR TITLE
Change home timeline to never filter own toots

### DIFF
--- a/app/javascript/mastodon/features/ui/containers/status_list_container.js
+++ b/app/javascript/mastodon/features/ui/containers/status_list_container.js
@@ -17,6 +17,8 @@ const makeGetStatusIds = (pending = false) => createSelector([
     const statusForId = statuses.get(id);
     let showStatus    = true;
 
+    if (statusForId.get('account') === me) return true;
+
     if (columnSettings.getIn(['shows', 'reblog']) === false) {
       showStatus = showStatus && statusForId.get('reblog') === null;
     }


### PR DESCRIPTION
When “show replies” is unchecked, even replies from the user themself are filtered out, which is not particularly useful and may be confusing.

Same thing for boosts.

This PR changes it so that toots from the user are always visible in their Home TL.