### PR TITLE
Fix crash in MergeWorker

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -106,7 +106,7 @@ class FeedManager
     crutches = build_crutches(into_account.id, statuses)
 
     statuses.each do |status|
-      next if filter_from_home?(status, into_account, crutches)
+      next if filter_from_home?(status, into_account.id, crutches)
 
       add_to_feed(:home, into_account.id, status, aggregate)
     end


### PR DESCRIPTION
Similarly to #12324, the code is passing an Account object where an id
is expected.