### PR TITLE
Change streaming server to treat blank redis password as password-less auth

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -118,7 +118,7 @@ const startWorker = (workerId) => {
     host:     process.env.REDIS_HOST     || '127.0.0.1',
     port:     process.env.REDIS_PORT     || 6379,
     db:       process.env.REDIS_DB       || 0,
-    password: process.env.REDIS_PASSWORD,
+    password: process.env.REDIS_PASSWORD || undefined,
   };
 
   if (redisNamespace) {


### PR DESCRIPTION
Fixes #14131

Our `mastodon:setup` task defaults to a blank password rather than the
absence of password, but some versions of Redis reject blank password
authentication when authentication is possible without a password.

The Ruby code only uses the Redis password when it's not blank, so
do the same for the node.js part.