### PR TITLE
Remove unused dependency on wavesurfer.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "throng": "^4.0.0",
     "tiny-queue": "^0.2.1",
     "uuid": "^8.1.0",
-    "wavesurfer.js": "^3.3.3",
     "webpack": "^4.43.0",
     "webpack-assets-manifest": "^3.1.1",
     "webpack-bundle-analyzer": "^3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11279,11 +11279,6 @@ watchpack@^1.6.1:
     chokidar "^3.4.0"
     watchpack-chokidar2 "^2.0.0"
 
-wavesurfer.js@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/wavesurfer.js/-/wavesurfer.js-3.3.3.tgz#9b16a62335c6bd13a3d55deb895a336d027ccb51"
-  integrity sha512-meko20S9in+V5xBLSVV/9uYVBSbx5AsJNkAslZ+a5yYIeFGYwcCo4Yd1sUpSGaiNnyflzrJwC7x7TdJFYrdT8w==
-
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"


### PR DESCRIPTION
It's not used anymore now that the audio player design has changed again.