### PR TITLE
Change move handler to carry blocks over

### DIFF
--- a/app/workers/activitypub/move_distribution_worker.rb
+++ b/app/workers/activitypub/move_distribution_worker.rb
@@ -24,7 +24,7 @@ class ActivityPub::MoveDistributionWorker
   private
 
   def inboxes
-    @inboxes ||= @migration.account.followers.inboxes
+    @inboxes ||= (@migration.account.followers.inboxes + @migration.account.blocked_by.inboxes).uniq
   end
 
   def signed_payload

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -60,6 +60,7 @@ ignore_unused:
   - 'admin.accounts.roles.*'
   - 'admin.action_logs.actions.*'
   - 'statuses.attached.*'
+  - 'move_handler.carry_{mutes,blocks}_over_text'
 
 ignore_inconsistent_interpolations:
   - '*.one'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -941,6 +941,8 @@ en:
   moderation:
     title: Moderation
   move_handler:
+    carry_blocks_over_text: This user moved from %{acct}, which you had blocked.
+    carry_mutes_over_text: This user moved from %{acct}, which you had muted.
     copy_account_note_text: 'This user moved from %{acct}, here were your previous notes about them:'
   notification_mailer:
     digest:

--- a/spec/fabricators/account_migration_fabricator.rb
+++ b/spec/fabricators/account_migration_fabricator.rb
@@ -1,6 +1,6 @@
 Fabricator(:account_migration) do
   account
-  target_account
+  target_account { |attrs| Fabricate(:account, also_known_as: [ActivityPub::TagManager.instance.uri_for(attrs[:account])]) }
+  acct           { |attrs| attrs[:target_account].acct }
   followers_count 1234
-  acct 'test@example.com'
 end

--- a/spec/workers/activitypub/move_distribution_worker_spec.rb
+++ b/spec/workers/activitypub/move_distribution_worker_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe ActivityPub::MoveDistributionWorker do
+  subject { described_class.new }
+
+  let(:migration)   { Fabricate(:account_migration) }
+  let(:follower) { Fabricate(:account, protocol: :activitypub, inbox_url: 'http://example.com') }
+  let(:blocker) { Fabricate(:account, protocol: :activitypub, inbox_url: 'http://example2.com') }
+
+  describe '#perform' do
+    before do
+      allow(ActivityPub::DeliveryWorker).to receive(:push_bulk)
+      follower.follow!(migration.account)
+      blocker.block!(migration.account)
+    end
+
+    it 'delivers to followers and known blockers' do
+      subject.perform(migration.id)
+        expect(ActivityPub::DeliveryWorker).to have_received(:push_bulk).with(['http://example.com', 'http://example2.com'])
+    end
+  end
+end

--- a/spec/workers/move_worker_spec.rb
+++ b/spec/workers/move_worker_spec.rb
@@ -43,14 +43,16 @@ describe MoveWorker do
   end
 
   shared_examples 'block and mute handling' do
-    it 'makes blocks carry over' do
+    it 'makes blocks carry over and add a note' do
       subject.perform(source_account.id, target_account.id)
       expect(block_service).to have_received(:call).with(blocking_account, target_account)
+      expect(AccountNote.find_by(account: blocking_account, target_account: target_account).comment).to include(source_account.acct)
     end
 
-    it 'makes mutes carry over' do
+    it 'makes mutes carry over and add a note' do
       subject.perform(source_account.id, target_account.id)
       expect(muting_account.muting?(target_account)).to be true
+      expect(AccountNote.find_by(account: muting_account, target_account: target_account).comment).to include(source_account.acct)
     end
   end
 

--- a/spec/workers/move_worker_spec.rb
+++ b/spec/workers/move_worker_spec.rb
@@ -4,20 +4,29 @@ require 'rails_helper'
 
 describe MoveWorker do
   let(:local_follower)   { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+  let(:blocking_account) { Fabricate(:user, email: 'bar@example.com', account: Fabricate(:account, username: 'bar')).account }
+  let(:muting_account)   { Fabricate(:user, email: 'foo@example.com', account: Fabricate(:account, username: 'foo')).account }
   let(:source_account)   { Fabricate(:account, protocol: :activitypub, domain: 'example.com') }
   let(:target_account)   { Fabricate(:account, protocol: :activitypub, domain: 'example.com') }
   let(:local_user)       { Fabricate(:user) }
   let!(:account_note)    { Fabricate(:account_note, account: local_user.account, target_account: source_account) }
 
+  let(:block_service) { double }
+
   subject { described_class.new }
 
   before do
     local_follower.follow!(source_account)
+    blocking_account.block!(source_account)
+    muting_account.mute!(source_account)
+
+    allow(UnfollowFollowWorker).to receive(:push_bulk)
+    allow(BlockService).to receive(:new).and_return(block_service)
+    allow(block_service).to receive(:call)
   end
 
   shared_examples 'user note handling' do
     it 'copies user note' do
-      allow(UnfollowFollowWorker).to receive(:push_bulk)
       subject.perform(source_account.id, target_account.id)
       expect(AccountNote.find_by(account: account_note.account, target_account: target_account).comment).to include(source_account.acct)
       expect(AccountNote.find_by(account: account_note.account, target_account: target_account).comment).to include(account_note.comment)
@@ -26,7 +35,6 @@ describe MoveWorker do
     it 'merges user notes when needed' do
       new_account_note = AccountNote.create!(account: account_note.account, target_account: target_account, comment: 'new note prior to move')
 
-      allow(UnfollowFollowWorker).to receive(:push_bulk)
       subject.perform(source_account.id, target_account.id)
       expect(AccountNote.find_by(account: account_note.account, target_account: target_account).comment).to include(source_account.acct)
       expect(AccountNote.find_by(account: account_note.account, target_account: target_account).comment).to include(account_note.comment)
@@ -34,15 +42,27 @@ describe MoveWorker do
     end
   end
 
+  shared_examples 'block and mute handling' do
+    it 'makes blocks carry over' do
+      subject.perform(source_account.id, target_account.id)
+      expect(block_service).to have_received(:call).with(blocking_account, target_account)
+    end
+
+    it 'makes mutes carry over' do
+      subject.perform(source_account.id, target_account.id)
+      expect(muting_account.muting?(target_account)).to be true
+    end
+  end
+
   context 'both accounts are distant' do
     describe 'perform' do
       it 'calls UnfollowFollowWorker' do
-        allow(UnfollowFollowWorker).to receive(:push_bulk)
         subject.perform(source_account.id, target_account.id)
         expect(UnfollowFollowWorker).to have_received(:push_bulk).with([local_follower.id])
       end
 
       include_examples 'user note handling'
+      include_examples 'block and mute handling'
     end
   end
 
@@ -51,12 +71,12 @@ describe MoveWorker do
 
     describe 'perform' do
       it 'calls UnfollowFollowWorker' do
-        allow(UnfollowFollowWorker).to receive(:push_bulk)
         subject.perform(source_account.id, target_account.id)
         expect(UnfollowFollowWorker).to have_received(:push_bulk).with([local_follower.id])
       end
 
       include_examples 'user note handling'
+      include_examples 'block and mute handling'
     end
   end
 
@@ -71,6 +91,7 @@ describe MoveWorker do
       end
 
       include_examples 'user note handling'
+      include_examples 'block and mute handling'
 
       it 'does not fail when a local user is already following both accounts' do
         double_follower = Fabricate(:user, email: 'eve@example.com', account: Fabricate(:account, username: 'eve')).account


### PR DESCRIPTION
When user A blocks (or mutes) user B and B moves to a new account C, make A block (or mute) C accordingly.

Note that it only works if A's instance is aware of the Move, (that is, if B is on A's instance or has followers there, or, if we accept the following change, the person has actually sent a Block activity).

This is to reduce the odds of people making accidentally “evading” blocks by moving to a new account (of course, this doesn't prevent malicious users from creating accounts that are not linked with the blocked ones).

I am not sure if there is any downside to this (except, in the case of blocks, sending `Block` activities, which technically notifies the blocked user, but they would know already, and that's an issue with blocks anyway—stealth blocks would solve this and are not incompatible with this feature).

Also extended the `ActivityPub::MoveDistributionWorker` to send the `Move` activity to people who issued a `Block` activity about that person (this means it wouldn't be as reliable with stealth block, but that's a best-effort thing anyway).