### PR TITLE
Fix cursor type in statuses

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -992,7 +992,7 @@
   position: relative;
   min-height: 54px;
   border-bottom: 1px solid lighten($ui-base-color, 8%);
-  cursor: default;
+  cursor: auto;
 
   @supports (-ms-overflow-style: -ms-autohiding-scrollbar) {
     // Add margin to avoid Edge auto-hiding scrollbar appearing over content.


### PR DESCRIPTION
As pointed by @lf94 at #14025 the default pointer was being used at statuses. This PR fix it changing the cursor type to auto. 


![After cursor change](https://im3.ezgif.com/tmp/ezgif-3-a689d8b55de9.gif)