### PR TITLE
Fix lock icon not being shown when locking account in profile settings

### DIFF
--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -207,10 +207,12 @@ function main() {
   delegate(document, '#account_locked', 'change', ({ target }) => {
     const lock = document.querySelector('.card .display-name i');
 
-    if (target.checked) {
-      lock.style.display = 'inline';
-    } else {
-      lock.style.display = 'none';
+    if (lock) {
+      if (target.checked) {
+        delete lock.dataset.hidden;
+      } else {
+        lock.dataset.hidden = 'true';
+      }
     }
   });
 

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -76,6 +76,10 @@
       margin-left: 15px;
       text-align: left;
 
+      i[data-hidden] {
+        display: none;
+      }
+
       strong {
         font-size: 15px;
         color: $primary-text-color;

--- a/app/views/application/_card.html.haml
+++ b/app/views/application/_card.html.haml
@@ -13,4 +13,4 @@
           %strong.emojify.p-name= display_name(account, custom_emojify: true)
         %span
           = acct(account)
-          = fa_icon('lock') if account.locked?
+          = fa_icon('lock', { :data => ({hidden: true} unless account.locked?)})


### PR DESCRIPTION
This is pretty minor, but if your account isn't locked and you go to your settings and change that, the javascript attempts to find the lock icon that has never been rendered and fails, while if you uncheck/check it on an account that is locked, it works as expected.

This PR renders the lock icon unconditionally, but sets an attribute to hide it when needed. This way, the javascript can properly toggle it in both cases.