### PR TITLE
Change Redis#exists calls to Redis#exists? to avoid deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,36 +17,36 @@
 /log/*
 !/log/.keep
 /tmp
-coverage
-public/system
-public/assets
-public/packs
-public/packs-test
+/coverage
+/public/system
+/public/assets
+/public/packs
+/public/packs-test
 .env
 .env.production
 .env.development
-node_modules/
-build/
+/node_modules/
+/build/
 
 # Ignore Vagrant files
 .vagrant/
 
 # Ignore Capistrano customizations
-config/deploy/*
+/config/deploy/*
 
 # Ignore IDE files
 .vscode/
 .idea/
 
 # Ignore postgres + redis + elasticsearch volume optionally created by docker-compose
-postgres
-redis
-elasticsearch
+/postgres
+/redis
+/elasticsearch
 
 # ignore Helm lockfile, dependency charts, and local values file
-chart/Chart.lock
-chart/charts/*.tgz
-chart/values.yaml
+/chart/Chart.lock
+/chart/charts/*.tgz
+/chart/values.yaml
 
 # Ignore Apple files
 .DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,8 +444,6 @@ GEM
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-protection (2.0.8.1)
-      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -570,11 +568,10 @@ GEM
       nokogiri (>= 1.8.0)
       nokogumbo (~> 2.0)
     semantic_range (2.3.0)
-    sidekiq (6.0.7)
+    sidekiq (6.1.0)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+      redis (>= 4.2.0)
     sidekiq-bulk (0.2.0)
       sidekiq
     sidekiq-scheduler (3.0.1)

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -132,7 +132,7 @@ class ActivityPub::Activity
   end
 
   def delete_arrived_first?(uri)
-    redis.exists("delete_upon_arrival:#{@account.id}:#{uri}")
+    redis.exists?("delete_upon_arrival:#{@account.id}:#{uri}")
   end
 
   def delete_later!(uri)

--- a/app/lib/activitypub/activity/move.rb
+++ b/app/lib/activitypub/activity/move.rb
@@ -33,7 +33,7 @@ class ActivityPub::Activity::Move < ActivityPub::Activity
   end
 
   def processed?
-    redis.exists("move_in_progress:#{@account.id}")
+    redis.exists?("move_in_progress:#{@account.id}")
   end
 
   def mark_as_processing!

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -169,7 +169,7 @@ class FeedManager
   private
 
   def push_update_required?(timeline_id)
-    redis.exists("subscribed:#{timeline_id}")
+    redis.exists?("subscribed:#{timeline_id}")
   end
 
   def blocks_or_mutes?(receiver_id, account_ids, context)

--- a/app/models/account_conversation.rb
+++ b/app/models/account_conversation.rb
@@ -108,7 +108,7 @@ class AccountConversation < ApplicationRecord
   end
 
   def subscribed_to_timeline?
-    Redis.current.exists("subscribed:#{streaming_channel}")
+    Redis.current.exists?("subscribed:#{streaming_channel}")
   end
 
   def streaming_channel

--- a/app/models/encrypted_message.rb
+++ b/app/models/encrypted_message.rb
@@ -32,16 +32,13 @@ class EncryptedMessage < ApplicationRecord
   private
 
   def push_to_streaming_api
-    Rails.logger.info(streaming_channel)
-    Rails.logger.info(subscribed_to_timeline?)
-
     return if destroyed? || !subscribed_to_timeline?
 
     PushEncryptedMessageWorker.perform_async(id)
   end
 
   def subscribed_to_timeline?
-    Redis.current.exists("subscribed:#{streaming_channel}")
+    Redis.current.exists?("subscribed:#{streaming_channel}")
   end
 
   def streaming_channel

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -8,6 +8,6 @@ class HomeFeed < Feed
   end
 
   def regenerating?
-    redis.exists("account:#{@id}:regeneration")
+    redis.exists?("account:#{@id}:regeneration")
   end
 end

--- a/app/workers/publish_announcement_reaction_worker.rb
+++ b/app/workers/publish_announcement_reaction_worker.rb
@@ -14,7 +14,7 @@ class PublishAnnouncementReactionWorker
     payload = Oj.dump(event: :'announcement.reaction', payload: payload)
 
     FeedManager.instance.with_active_accounts do |account|
-      redis.publish("timeline:#{account.id}", payload) if redis.exists("subscribed:timeline:#{account.id}")
+      redis.publish("timeline:#{account.id}", payload) if redis.exists?("subscribed:timeline:#{account.id}")
     end
   rescue ActiveRecord::RecordNotFound
     true

--- a/app/workers/publish_scheduled_announcement_worker.rb
+++ b/app/workers/publish_scheduled_announcement_worker.rb
@@ -15,7 +15,7 @@ class PublishScheduledAnnouncementWorker
     payload = Oj.dump(event: :announcement, payload: payload)
 
     FeedManager.instance.with_active_accounts do |account|
-      redis.publish("timeline:#{account.id}", payload) if redis.exists("subscribed:timeline:#{account.id}")
+      redis.publish("timeline:#{account.id}", payload) if redis.exists?("subscribed:timeline:#{account.id}")
     end
   end
 

--- a/app/workers/unpublish_announcement_worker.rb
+++ b/app/workers/unpublish_announcement_worker.rb
@@ -8,7 +8,7 @@ class UnpublishAnnouncementWorker
     payload = Oj.dump(event: :'announcement.delete', payload: announcement_id.to_s)
 
     FeedManager.instance.with_active_accounts do |account|
-      redis.publish("timeline:#{account.id}", payload) if redis.exists("subscribed:timeline:#{account.id}")
+      redis.publish("timeline:#{account.id}", payload) if redis.exists?("subscribed:timeline:#{account.id}")
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 require_relative '../app/lib/exceptions'
+require_relative '../lib/redis/namespace_extensions'
 require_relative '../lib/paperclip/url_generator_extensions'
 require_relative '../lib/paperclip/attachment_extensions'
 require_relative '../lib/paperclip/media_type_spoof_detector_extensions'

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-Redis.exists_returns_integer = false
-
 redis_connection = Redis.new(
   url: ENV['REDIS_URL'],
   driver: :hiredis

--- a/lib/redis/namespace_extensions.rb
+++ b/lib/redis/namespace_extensions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Redis
+  module NamespaceExtensions
+    def exists?(*args, &block)
+      call_with_namespace('exists?', *args, &block)
+    end
+  end
+end
+
+Redis::Namespace::COMMANDS['exists?'] = [:first]
+Redis::Namespace.prepend(Redis::NamespaceExtensions)


### PR DESCRIPTION
Upgraded Sidekiq to 6.1.0.

Until resque/redis-namespace#172 is fixed I manually fixed the issue via monkey-patching. Without it, the `exists?` method is not namespaced and thus would fail in unpredictable ways for instances that use `REDIS_NAMESPACE`.