### PR TITLE
Change the about.instance_actor_flash to be single-line

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,9 +21,7 @@ en:
     federation_hint_html: With an account on %{instance} you'll be able to follow people on any Mastodon server and beyond.
     get_apps: Try a mobile app
     hosted_on: Mastodon hosted on %{domain}
-    instance_actor_flash: |
-      This account is a virtual actor used to represent the server itself and not any individual user.
-      It is used for federation purposes and should not be blocked unless you want to block the whole instance, in which case you should use a domain block.
+    instance_actor_flash: This account is a virtual actor used to represent the server itself and not any individual user. It is used for federation purposes and should not be blocked unless you want to block the whole instance, in which case you should use a domain block.
     learn_more: Learn more
     privacy_policy: Privacy policy
     see_whats_happening: See what's happening


### PR DESCRIPTION
Some translations of that string are single-line, which somehow seems to make
Crowdin issue a blank newline at the end of those translations.

This, in turns, leads to different results when running “i18n-tasks normalize” depending on the version of libyaml installed, making the CI fail if it runs a different version than whoever ran “i18n-tasks normalize”.

Since there is no real reason for that source string to be multi-line (it is only displayed in HTML, without replacing newlines by <br/> tags), attempt to fix Crowdin export by making the source string single-line.