### PR TITLE
Add test for removing endorsed accounts on account deletion/suspension

### DIFF
--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe SuspendAccountService, type: :service do
     let!(:passive_relationship) { Fabricate(:follow, target_account: account) }
     let!(:remote_alice) { Fabricate(:account, inbox_url: 'https://alice.com/inbox', protocol: :activitypub) }
     let!(:remote_bob) { Fabricate(:account, inbox_url: 'https://bob.com/inbox', protocol: :activitypub) }
+    let!(:endorsment) { Fabricate(:account_pin, account: passive_relationship.account, target_account: account) }
 
     it 'deletes associated records' do
       is_expected.to change {
@@ -30,8 +31,9 @@ RSpec.describe SuspendAccountService, type: :service do
           account.favourites,
           account.active_relationships,
           account.passive_relationships,
+          AccountPin.where(target_account: account),
         ].map(&:count)
-      }.from([1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0])
+      }.from([1, 1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0, 0])
     end
 
     it 'sends a delete actor activity to all known inboxes' do


### PR DESCRIPTION
I thought the endorsements weren't cleaned up but they should through `Follow`'s `after_destroy` hooks.
A test wouldn't hurt, though.