### PR TITLE
follow-up "Fix restored words from toot to status"

### DIFF
--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -372,7 +372,7 @@
   "status.bookmark": "Bookmark",
   "status.cancel_reblog_private": "Unboost",
   "status.cannot_reblog": "This post cannot be boosted",
-  "status.copy": "Copy link to status",
+  "status.copy": "Copy link to toot",
   "status.delete": "Delete",
   "status.detailed_status": "Detailed conversation view",
   "status.direct": "Direct message @{name}",


### PR DESCRIPTION
I'm sorry, I overlooked this at #14204 .


By the way, should these be changed to "toot" in the explanation of API access scope, too?

/about/more
![2020-07-06 19 04 07](https://user-images.githubusercontent.com/766076/86581795-93f02580-bfbb-11ea-87fb-cbbc8f01fe5e.png)

/settings/applications/*
( https://github.com/tootsuite/mastodon/blob/master/config/locales/doorkeeper.en.yml#L138-L151 )
![2020-07-06 18 51 22](https://user-images.githubusercontent.com/766076/86580513-ca2ca580-bfb9-11ea-9c72-b783f171870f.png)

/admin/accounts/*
![2020-07-06 18 59 08](https://user-images.githubusercontent.com/766076/86581416-0ad8ee80-bfbb-11ea-90c7-17f32fbc7029.png)
