### PR TITLE
helm: fix default storage values for PVCs

### DIFF
--- a/chart/values.yaml.template
+++ b/chart/values.yaml.template
@@ -104,12 +104,12 @@ persistence:
     accessMode: ReadWriteOnce
     resources:
       requests:
-        storage: 100Gi
+        storage: 10Gi
   system:
     accessMode: ReadWriteOnce
     resources:
       requests:
-        storage: 10Gi
+        storage: 100Gi
 
 service:
   type: ClusterIP


### PR DESCRIPTION
I got `assets` and `system` mixed up; this is a much more sensible set of defaults.