### PR TITLE
Fix account note border radius

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6627,7 +6627,6 @@ noscript {
     padding: 15px;
     padding-bottom: 10px;
     color: $primary-text-color;
-    border-radius: 4px;
     font-size: 14px;
     font-weight: 400;
     border-bottom: 1px solid lighten($ui-base-color, 12%);


### PR DESCRIPTION
Seems to be leftover from previous design, does not look good.

<p align="center"><img src="https://user-images.githubusercontent.com/10401817/86771979-581d9480-c07d-11ea-8a40-5536435ff8ba.png" alt="Screenshot showing incorrect border radius"></p>