### PR TITLE
Fix ogg vorbis files with a cover art not being correctly processed

### DIFF
--- a/lib/paperclip/media_type_spoof_detector_extensions.rb
+++ b/lib/paperclip/media_type_spoof_detector_extensions.rb
@@ -2,8 +2,16 @@
 
 module Paperclip
   module MediaTypeSpoofDetectorExtensions
-    def calculated_content_type
-      @calculated_content_type ||= type_from_mime_magic || type_from_file_command
+    def mapping_override_mismatch?
+      !Array(mapped_content_type).include?(calculated_content_type) && !Array(mapped_content_type).include?(type_from_mime_magic)
+    end
+
+    def calculated_media_type_from_mime_magic
+      @calculated_media_type_from_mime_magic ||= type_from_mime_magic.split('/').first
+    end
+
+    def calculated_type_mismatch?
+      !media_types_from_name.include?(calculated_media_type) && !media_types_from_name.include?(calculated_media_type_from_mime_magic)
     end
 
     def type_from_mime_magic


### PR DESCRIPTION
Paperclip runs files through a “spoof detector” to figure out whether they correspond to their advertised content-type.

In #14184, we have overridden part of that detection because it relied on the `file` utility which returns `application/octet-stream` for some mp3 files, and used `MimeMagic` instead.

However, `MimeMagic` detects Ogg Vorbis files with a cover art as `video/ogg`, while `file` correctly detects it as `audio/ogg`. This causes a mismatch when the file has an `.oga` extension, which is explicitly `audio/ogg`.

Furthermore, this leads to Ogg Vorbis files submitted with the `.ogg` and a cover art to not be correctly processed, failing to extract a thumbnail and converting them to `.mp3`. This is because the first validation passes interpreting it as a `video/ogg` file while our code later constructs a `.oga` extension based on the correctly detected `audio/ogg`, causing the actual processing to be skipped because of the mismatch.

This PR changes the detector to allow the validation to pass if it matches either `FileMagic` or `file`'s output.