### PR TITLE
Fix WebUI crash on sensitive preview card with no preview thumbnail

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -94,7 +94,7 @@ export default class Card extends React.PureComponent {
   componentDidMount () {
     window.addEventListener('resize', this.handleResize, { passive: true });
 
-    if (this.props.card && this.props.card.get('blurhash')) {
+    if (this.props.card && this.props.card.get('blurhash') && this.canvas) {
       this._decode();
     }
   }


### PR DESCRIPTION
Follow-up on #14260 which only fixed half the call sites