### PR TITLE
Fix new accent color not refreshing when changing thumbnail for audio uploads

### DIFF
--- a/app/javascript/mastodon/features/audio/index.js
+++ b/app/javascript/mastodon/features/audio/index.js
@@ -103,7 +103,7 @@ class Audio extends React.PureComponent {
   }
 
   componentDidUpdate (prevProps, prevState) {
-    if (prevProps.src !== this.props.src || this.state.width !== prevState.width || this.state.height !== prevState.height) {
+    if (prevProps.src !== this.props.src || this.state.width !== prevState.width || this.state.height !== prevState.height || prevProps.accentColor !== this.props.accentColor) {
       this._clear();
       this._draw();
     }


### PR DESCRIPTION
The props are correctly passed down to the audio player, but the canvas doesn't get redrawn unless it is currently playing.
This PR changes that.