### PR TITLE
Show Twemoji on account notes

### DIFF
--- a/app/javascript/mastodon/features/account/components/account_note.js
+++ b/app/javascript/mastodon/features/account/components/account_note.js
@@ -98,23 +98,13 @@ class AccountNote extends ImmutablePureComponent {
 
   setEditable = () => {
     const { value } = this.state;
-    const sleep = (waitSeconds) => {
-      return new Promise(resolve => {
-        setTimeout(() => {
-          resolve();
-        }, waitSeconds);
-      });
-    };
     let my = this;
-    sleep(50)
-      .then(() => {
-        my.setState({ editable: true });
-        my.textarea.focus();
-        const len = value.length;
-        my.textarea.setSelectionRange(len, len);
-      }).catch(() => {
-        my.setState({ editable: false });
-      });
+    setTimeout(() => {
+      my.setState({ editable: true });
+      my.textarea.focus();
+      const len = value.length;
+      my.textarea.setSelectionRange(len, len);
+    }, 50);
   }
 
   setUnEditable = () => {
@@ -174,7 +164,7 @@ class AccountNote extends ImmutablePureComponent {
     const classNames = classnames('account__header__account-note__display', {
       'empty': !value,
     });
-    let emojifiedValue = emojify(escapeTextContentForBrowser(value), []).replace(/\r?\n/g, '<br />');
+    let emojifiedValue = emojify(escapeTextContentForBrowser(value), []);
 
     if (!account) {
       return null;

--- a/app/javascript/mastodon/features/account/components/account_note.js
+++ b/app/javascript/mastodon/features/account/components/account_note.js
@@ -114,7 +114,7 @@ class AccountNote extends ImmutablePureComponent {
       .then(() => {
         my.setState({ editable: true });
         my.textarea.focus();
-      }).catch((error) => {
+      }).catch(() => {
         my.setState({ editable: false });
       });
   }
@@ -199,7 +199,8 @@ class AccountNote extends ImmutablePureComponent {
           style={{ display: editable ? 'block' : 'none' }}
         />
         <div
-          role="button"
+          role='button'
+          tabIndex={0}
           className='account__header__account-note__show'
           onClick={this.setEditable}
           dangerouslySetInnerHTML={{ __html: emojifiedValue }}

--- a/app/javascript/mastodon/features/account/components/account_note.js
+++ b/app/javascript/mastodon/features/account/components/account_note.js
@@ -62,12 +62,6 @@ class AccountNote extends ImmutablePureComponent {
     editable: false,
   };
 
-  constructor (props) {
-    super(props);
-    this.setEditable = this.setEditable.bind(this);
-    this.unEditable = this.unEditable.bind(this);
-  }
-
   componentWillMount () {
     this._reset();
   }
@@ -102,23 +96,9 @@ class AccountNote extends ImmutablePureComponent {
   }
 
   setEditable () {
-    const sleep = (waitSeconds) => {
-      return new Promise(resolve => {
-        setTimeout(() => {
-          resolve();
-        }, waitSeconds);
-      });
-    };
-    let my = this;
-    sleep(50)
-      .then(() => {
-        my.setState({ editable: true });
-        my.textarea.focus();
-      }).catch(() => {
-        my.setState({ editable: false });
-      });
+    this.setState({ editable: true });
   }
-  unEditable () {
+  setUnEditable () {
     this.setState({ editable: false });
   }
 
@@ -150,7 +130,7 @@ class AccountNote extends ImmutablePureComponent {
     if (this._isDirty()) {
       this._save();
     }
-    this.unEditable();
+    this.setUnEditable();
   }
 
   _save (showMessage = true) {
@@ -168,6 +148,7 @@ class AccountNote extends ImmutablePureComponent {
   _isDirty () {
     return !this.state.saving && this.props.value !== null && this.state.value !== null && this.state.value !== this.props.value;
   }
+  
 
   render () {
     const { account, intl } = this.props;
@@ -183,37 +164,32 @@ class AccountNote extends ImmutablePureComponent {
         <label htmlFor={`account-note-${account.get('id')}`}>
           <FormattedMessage id='account.account_note_header' defaultMessage='Note' /> <InlineAlert show={saved} />
         </label>
-        <Textarea
-          id={`account-note-${account.get('id')}`}
-          className='account__header__account-note__content'
-          disabled={this.props.value === null || value === null}
-          placeholder={intl.formatMessage(messages.placeholder)}
-          value={value || ''}
-          onChange={this.handleChange}
-          onKeyDown={this.handleKeyDown}
-          onBlur={this.handleBlur}
-          ref={this.setTextareaRef}
-          style={{ display: editable ? 'block' : 'none' }}
-        />
-        {value ?
-          <div
-            role='button'
-            tabIndex={0}
-            className='account__header__account-note__show'
-            onClick={this.setEditable}
-            dangerouslySetInnerHTML={{ __html: emojifiedValue }}
-            style={{ display: editable ? 'none' : 'block' }}
-          />
+        {
+          editable ?
+            <Textarea
+              id={`account-note-${account.get('id')}`}
+              className='account__header__account-note__content'
+              disabled={this.props.value === null || value === null}
+              placeholder={intl.formatMessage(messages.placeholder)}
+              value={value || ''}
+              onChange={this.handleChange}
+              onKeyDown={this.handleKeyDown}
+              onBlur={this.handleBlur}
+              ref={this.setTextareaRef}
+              style={{ display: editable ? 'block' : 'none' }}
+              autoFocus={true}
+            />
           :
-          <div
-            role='button'
-            tabIndex={0}
-            className='account__header__account-note__empty'
-            style={{ display: editable ? 'none' : 'block' }}
-            onClick={this.setEditable}
-          >
-            {intl.formatMessage(messages.placeholder)}
-          </div>
+            <div
+              role='button'
+              tabIndex={0}
+              className={value ? 'account__header__account-note__display' : 'account__header__account-note__display-empty'}
+              onClick={() => this.setEditable()}
+              dangerouslySetInnerHTML={value ? { __html: emojifiedValue } : null}
+              style={{ display: editable ? 'none' : 'block' }}
+            >
+              {!value ? intl.formatMessage(messages.placeholder) : null}
+            </div>
         }
       </div>
     );

--- a/app/javascript/mastodon/features/account/components/account_note.js
+++ b/app/javascript/mastodon/features/account/components/account_note.js
@@ -106,7 +106,7 @@ class AccountNote extends ImmutablePureComponent {
       return new Promise(resolve => {
         setTimeout(() => {
           resolve();
-      }, waitSeconds);
+        }, waitSeconds);
       });
     };
     let my = this;
@@ -115,7 +115,7 @@ class AccountNote extends ImmutablePureComponent {
         my.setState({ editable: true });
         my.textarea.focus();
       }).catch((error) => {
-        console.log(error)
+        my.setState({ editable: false });
       });
   }
   unEditable () {
@@ -172,7 +172,7 @@ class AccountNote extends ImmutablePureComponent {
   render () {
     const { account, intl } = this.props;
     const { value, saved, editable } = this.state;
-    let emojifiedValue = emojify(escapeTextContentForBrowser(value), []).replace(/\r?\n/g,'<br />');
+    let emojifiedValue = emojify(escapeTextContentForBrowser(value), []).replace(/\r?\n/g, '<br />');
     if(!value) {
       emojifiedValue = intl.formatMessage(messages.placeholder);
     }
@@ -199,11 +199,12 @@ class AccountNote extends ImmutablePureComponent {
           style={{ display: editable ? 'block' : 'none' }}
         />
         <div
+          role="button"
           className='account__header__account-note__show'
           onClick={this.setEditable}
           dangerouslySetInnerHTML={{ __html: emojifiedValue }}
           style={{ display: editable ? 'none' : 'block' }}
-        /> 
+        />
       </div>
     );
   }

--- a/app/javascript/mastodon/features/account/components/account_note.js
+++ b/app/javascript/mastodon/features/account/components/account_note.js
@@ -195,7 +195,7 @@ class AccountNote extends ImmutablePureComponent {
           ref={this.setTextareaRef}
           style={{ display: editable ? 'block' : 'none' }}
         />
-        {value ? 
+        {value ?
           <div
             role='button'
             tabIndex={0}
@@ -203,13 +203,16 @@ class AccountNote extends ImmutablePureComponent {
             onClick={this.setEditable}
             dangerouslySetInnerHTML={{ __html: emojifiedValue }}
             style={{ display: editable ? 'none' : 'block' }}
-          /> 
+          />
           :
-          <div role='button'
+          <div
+            role='button'
             tabIndex={0}
             className='account__header__account-note__empty'
             style={{ display: editable ? 'none' : 'block' }}
-            onClick={this.setEditable}>{intl.formatMessage(messages.placeholder)}
+            onClick={this.setEditable}
+          >
+            {intl.formatMessage(messages.placeholder)}
           </div>
         }
       </div>

--- a/app/javascript/mastodon/features/account/components/account_note.js
+++ b/app/javascript/mastodon/features/account/components/account_note.js
@@ -59,7 +59,7 @@ class AccountNote extends ImmutablePureComponent {
     value: null,
     saving: false,
     saved: false,
-    editable: false
+    editable: false,
   };
 
   constructor (props) {
@@ -104,17 +104,19 @@ class AccountNote extends ImmutablePureComponent {
   setEditable () {
     const sleep = (waitSeconds) => {
       return new Promise(resolve => {
-          setTimeout(() => {
-        resolve()
-      }, waitSeconds)
-      })
-    }
+        setTimeout(() => {
+          resolve();
+      }, waitSeconds);
+      });
+    };
     let my = this;
     sleep(50)
       .then(() => {
-          my.setState({ editable: true });
-          my.textarea.focus();
-      })
+        my.setState({ editable: true });
+        my.textarea.focus();
+      }).catch((error) => {
+        console.log(error)
+      });
   }
   unEditable () {
     this.setState({ editable: false });
@@ -185,22 +187,23 @@ class AccountNote extends ImmutablePureComponent {
           <FormattedMessage id='account.account_note_header' defaultMessage='Note' /> <InlineAlert show={saved} />
         </label>
         <Textarea
-           id={`account-note-${account.get('id')}`}
-           className='account__header__account-note__content'
-           disabled={this.props.value === null || value === null}
-           placeholder={intl.formatMessage(messages.placeholder)}
-           value={value || ''}
-           onChange={this.handleChange}
-           onKeyDown={this.handleKeyDown}
-           onBlur={this.handleBlur}
-           ref={this.setTextareaRef}
-           style={{ display: editable ? 'block' : 'none' }}
-         />
-         <div className='account__header__account-note__show' onClick={this.setEditable}
+          id={`account-note-${account.get('id')}`}
+          className='account__header__account-note__content'
+          disabled={this.props.value === null || value === null}
+          placeholder={intl.formatMessage(messages.placeholder)}
+          value={value || ''}
+          onChange={this.handleChange}
+          onKeyDown={this.handleKeyDown}
+          onBlur={this.handleBlur}
+          ref={this.setTextareaRef}
+          style={{ display: editable ? 'block' : 'none' }}
+        />
+        <div
+          className='account__header__account-note__show'
+          onClick={this.setEditable}
           dangerouslySetInnerHTML={{ __html: emojifiedValue }}
           style={{ display: editable ? 'none' : 'block' }}
-         >
-        </div> 
+        /> 
       </div>
     );
   }

--- a/app/javascript/mastodon/features/account/components/account_note.js
+++ b/app/javascript/mastodon/features/account/components/account_note.js
@@ -195,16 +195,23 @@ class AccountNote extends ImmutablePureComponent {
           ref={this.setTextareaRef}
           style={{ display: editable ? 'block' : 'none' }}
         />
-        <div
-          role='button'
-          tabIndex={0}
-          className='account__header__account-note__show'
-          onClick={this.setEditable}
-          dangerouslySetInnerHTML={{ __html: emojifiedValue }}
-          style={{ display: editable ? 'none' : 'block' }}
-        >
-          {value ? null : <span>{intl.formatMessage(messages.placeholder)}</span>}
-        </div>
+        {value ? 
+          <div
+            role='button'
+            tabIndex={0}
+            className='account__header__account-note__show'
+            onClick={this.setEditable}
+            dangerouslySetInnerHTML={{ __html: emojifiedValue }}
+            style={{ display: editable ? 'none' : 'block' }}
+          /> 
+          :
+          <div role='button'
+            tabIndex={0}
+            className='account__header__account-note__empty'
+            style={{ display: editable ? 'none' : 'block' }}
+            onClick={this.setEditable}>{intl.formatMessage(messages.placeholder)}
+          </div>
+        }
       </div>
     );
   }

--- a/app/javascript/mastodon/features/account/components/account_note.js
+++ b/app/javascript/mastodon/features/account/components/account_note.js
@@ -7,6 +7,7 @@ import Textarea from 'react-textarea-autosize';
 import { is } from 'immutable';
 import emojify from '../../../features/emoji/emoji';
 import escapeTextContentForBrowser from 'escape-html';
+import classnames from 'classnames';
 
 const messages = defineMessages({
   placeholder: { id: 'account_note.placeholder', defaultMessage: 'Click to add a note' },
@@ -95,11 +96,28 @@ class AccountNote extends ImmutablePureComponent {
     this.textarea = c;
   }
 
-  setEditable () {
-    this.setState({ editable: true });
+  setEditable = () => {
+    const { value } = this.state;
+    const sleep = (waitSeconds) => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve();
+        }, waitSeconds);
+      });
+    };
+    let my = this;
+    sleep(50)
+      .then(() => {
+        my.setState({ editable: true });
+        my.textarea.focus();
+        const len = value.length;
+        my.textarea.setSelectionRange(len, len);
+      }).catch(() => {
+        my.setState({ editable: false });
+      });
   }
 
-  setUnEditable () {
+  setUnEditable = () => {
     this.setState({ editable: false });
   }
 
@@ -180,14 +198,13 @@ class AccountNote extends ImmutablePureComponent {
               onBlur={this.handleBlur}
               ref={this.setTextareaRef}
               style={{ display: editable ? 'block' : 'none' }}
-              autoFocus
             />
-          :
+            :
             <div
               role='button'
               tabIndex={0}
               className={classNames}
-              onClick={this.setEditable.bind(this)}
+              onClick={this.setEditable}
               dangerouslySetInnerHTML={value ? { __html: emojifiedValue } : null}
               style={{ display: editable ? 'none' : 'block' }}
             >

--- a/app/javascript/mastodon/features/account/components/account_note.js
+++ b/app/javascript/mastodon/features/account/components/account_note.js
@@ -173,9 +173,6 @@ class AccountNote extends ImmutablePureComponent {
     const { account, intl } = this.props;
     const { value, saved, editable } = this.state;
     let emojifiedValue = emojify(escapeTextContentForBrowser(value), []).replace(/\r?\n/g, '<br />');
-    if(!value) {
-      emojifiedValue = intl.formatMessage(messages.placeholder);
-    }
 
     if (!account) {
       return null;
@@ -205,7 +202,9 @@ class AccountNote extends ImmutablePureComponent {
           onClick={this.setEditable}
           dangerouslySetInnerHTML={{ __html: emojifiedValue }}
           style={{ display: editable ? 'none' : 'block' }}
-        />
+        >
+          {value ? null : <span>{intl.formatMessage(messages.placeholder)}</span>}
+        </div>
       </div>
     );
   }

--- a/app/javascript/mastodon/features/account/components/account_note.js
+++ b/app/javascript/mastodon/features/account/components/account_note.js
@@ -98,6 +98,7 @@ class AccountNote extends ImmutablePureComponent {
   setEditable () {
     this.setState({ editable: true });
   }
+
   setUnEditable () {
     this.setState({ editable: false });
   }
@@ -148,11 +149,13 @@ class AccountNote extends ImmutablePureComponent {
   _isDirty () {
     return !this.state.saving && this.props.value !== null && this.state.value !== null && this.state.value !== this.props.value;
   }
-  
 
   render () {
     const { account, intl } = this.props;
     const { value, saved, editable } = this.state;
+    const classNames = classnames('account__header__account-note__display', {
+      'empty': !value,
+    });
     let emojifiedValue = emojify(escapeTextContentForBrowser(value), []).replace(/\r?\n/g, '<br />');
 
     if (!account) {
@@ -177,14 +180,14 @@ class AccountNote extends ImmutablePureComponent {
               onBlur={this.handleBlur}
               ref={this.setTextareaRef}
               style={{ display: editable ? 'block' : 'none' }}
-              autoFocus={true}
+              autoFocus
             />
           :
             <div
               role='button'
               tabIndex={0}
-              className={value ? 'account__header__account-note__display' : 'account__header__account-note__display-empty'}
-              onClick={() => this.setEditable()}
+              className={classNames}
+              onClick={this.setEditable.bind(this)}
               dangerouslySetInnerHTML={value ? { __html: emojifiedValue } : null}
               style={{ display: editable ? 'none' : 'block' }}
             >

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6652,7 +6652,7 @@ noscript {
       padding: 10px;
       margin: 0 -10px;
 
-      &-empty {
+      &.empty {
         color: $darker-text-color;
       }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6653,6 +6653,7 @@ noscript {
       padding: 10px;
       margin: 0 -10px;
     }
+    
     textarea {
       display: block;
       box-sizing: border-box;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6651,6 +6651,7 @@ noscript {
       cursor: pointer;
       padding: 10px;
       margin: 0 -10px;
+      white-space: pre-wrap;
 
       &.empty {
         color: $darker-text-color;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6645,17 +6645,21 @@ noscript {
       margin-bottom: 5px;
     }
 
-    div {
+    &__show {
       font-size: 14px;
       font-weight: 500;
       cursor: pointer;
       padding: 10px;
       margin: 0 -10px;
+    }
 
-      span {
-        color: $darker-text-color;
-      }
-      
+    &__empty {
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      padding: 10px;
+      margin: 0 -10px;
+      color: $darker-text-color;
     }
 
     textarea {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6648,10 +6648,14 @@ noscript {
     div {
       font-size: 14px;
       font-weight: 500;
-      color: $darker-text-color;
       cursor: pointer;
       padding: 10px;
       margin: 0 -10px;
+
+      span {
+        color: $darker-text-color;
+      }
+      
     }
 
     textarea {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6650,7 +6650,6 @@ noscript {
       font-weight: 500;
       color: $darker-text-color;
       cursor: pointer;
-      min-height: 38px;
       padding: 10px;
       margin: 0 -10px;
     }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6645,6 +6645,15 @@ noscript {
       margin-bottom: 5px;
     }
 
+    div {
+      font-size: 14px;
+      font-weight: 500;
+      color: $darker-text-color;
+      cursor: pointer;
+      min-height: 38px;
+      padding: 10px;
+      margin: 0 -10px;
+    }
     textarea {
       display: block;
       box-sizing: border-box;
@@ -6669,6 +6678,7 @@ noscript {
         background: $ui-base-color;
       }
     }
+
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6645,21 +6645,17 @@ noscript {
       margin-bottom: 5px;
     }
 
-    &__show {
+    &__display {
       font-size: 14px;
       font-weight: 500;
       cursor: pointer;
       padding: 10px;
       margin: 0 -10px;
-    }
 
-    &__empty {
-      font-size: 14px;
-      font-weight: 500;
-      cursor: pointer;
-      padding: 10px;
-      margin: 0 -10px;
-      color: $darker-text-color;
+      &-empty {
+        color: $darker-text-color;
+      }
+
     }
 
     textarea {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6653,7 +6653,7 @@ noscript {
       padding: 10px;
       margin: 0 -10px;
     }
-    
+
     textarea {
       display: block;
       box-sizing: border-box;


### PR DESCRIPTION
Show `div` with Twemoji  
![image](https://user-images.githubusercontent.com/17561618/86950448-272b8580-c18b-11ea-93f1-7e4f5fa001e1.png)

Click div to show `textarea`(Windows standard emojis)  
![image](https://user-images.githubusercontent.com/17561618/86950512-33174780-c18b-11ea-9c43-83d2d2e099d3.png)

When only editing, the textarea will be shown. 