### PR TITLE
Fix rubocop warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,10 @@ Layout/EmptyLineAfterMagicComment:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
 
+Lint/UselessAccessModifier:
+  ContextCreatingMethods:
+    - class_methods
+
 Metrics/AbcSize:
   Max: 100
 

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -46,6 +46,7 @@ class Auth::SessionsController < Devise::SessionsController
       user   = User.authenticate_with_ldap(user_params) if Devise.ldap_authentication
       user ||= User.authenticate_with_pam(user_params) if Devise.pam_authentication
       user ||= User.find_for_authentication(email: user_params[:email])
+      user
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -26,7 +26,8 @@ class TagsController < ApplicationController
       format.rss do
         expires_in 0, public: true
 
-        @statuses = HashtagQueryService.new.call(@tag, filter_params, nil, @local).limit(PAGE_SIZE)
+        limit     = params[:limit].present? ? [params[:limit].to_i, PAGE_SIZE_MAX].min : PAGE_SIZE
+        @statuses = HashtagQueryService.new.call(@tag, filter_params, nil, @local).limit(limit)
         @statuses = cache_collection(@statuses, Status)
 
         render xml: RSS::TagSerializer.render(@tag, @statuses)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -26,7 +26,6 @@ class TagsController < ApplicationController
       format.rss do
         expires_in 0, public: true
 
-        limit     = params[:limit].present? ? [params[:limit].to_i, PAGE_SIZE_MAX].min : PAGE_SIZE
         @statuses = HashtagQueryService.new.call(@tag, filter_params, nil, @local).limit(PAGE_SIZE)
         @statuses = cache_collection(@statuses, Status)
 

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -45,7 +45,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?
-        return if delete_arrived_first?(object_uri) || poll_vote?
+        return if delete_arrived_first?(object_uri) || poll_vote? # rubocop:disable Lint/NonLocalExitFromIterator
 
         @status = find_existing_status
 

--- a/app/lib/proof_provider/keybase/config_serializer.rb
+++ b/app/lib/proof_provider/keybase/config_serializer.rb
@@ -55,7 +55,7 @@ class ProofProvider::Keybase::ConfigSerializer < ActiveModel::Serializer
   end
 
   def profile_url
-    CGI.unescape(short_account_url('%{username}')) # rubocop:disable Style/FormatStringToken
+    CGI.unescape(short_account_url('%{username}'))
   end
 
   def check_url

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -231,6 +231,7 @@ class Request
             begin
               sock.connect_nonblock(addr_by_socket[sock])
             rescue Errno::EISCONN
+              # Do nothing
             rescue => e
               sock.close
               outer_e = e

--- a/app/lib/settings/scoped_settings.rb
+++ b/app/lib/settings/scoped_settings.rb
@@ -11,7 +11,7 @@ module Settings
       @object = object
     end
 
-    # rubocop:disable Style/MethodMissing
+    # rubocop:disable Style/MethodMissingSuper
     def method_missing(method, *args)
       method_name = method.to_s
       # set a value for a variable
@@ -24,7 +24,7 @@ module Settings
         self[method_name]
       end
     end
-    # rubocop:enable Style/MethodMissing
+    # rubocop:enable Style/MethodMissingSuper
 
     def respond_to_missing?(*)
       true
@@ -48,7 +48,6 @@ module Settings
       record.update!(value: value)
 
       Rails.cache.write(Setting.cache_key(key, @object), value)
-      value
     end
 
     def [](key)

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -234,7 +234,7 @@ module AccountInteractions
          .where('users.current_sign_in_at > ?', User::ACTIVE_DURATION.ago)
   end
 
-  private # rubocop:disable Lint/UselessAccessModifier
+  private
 
   def remove_potential_friendship(other_account, mutual = false)
     PotentialFriendshipTracker.remove(id, other_account.id)

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -234,7 +234,7 @@ module AccountInteractions
          .where('users.current_sign_in_at > ?', User::ACTIVE_DURATION.ago)
   end
 
-  private
+  private # rubocop:disable Lint/UselessAccessModifier
 
   def remove_potential_friendship(other_account, mutual = false)
     PotentialFriendshipTracker.remove(id, other_account.id)

--- a/app/models/concerns/omniauthable.rb
+++ b/app/models/concerns/omniauthable.rb
@@ -57,7 +57,7 @@ module Omniauthable
 
       user = User.new(user_params_from_auth(email, auth))
 
-      user.account.avatar_remote_url = auth.info.image if auth.info.image =~ /\A#{URI.regexp(%w(http https))}\z/
+      user.account.avatar_remote_url = auth.info.image if auth.info.image =~ /\A#{URI::DEFAULT_PARSER.make_regexp(%w(http https))}\z/
       user.skip_confirmation!
       user.save!
       user


### PR DESCRIPTION
Even if Code Climate doesn't tell me when I make a pull request, I get a warning when I run rubocop when developing locally.
So I fixed it or added an explicit disable comment.

```
$ bundle exec rubocop --fail-level W --display-only-fail-level-offenses
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Layout/EmptyLinesAroundAttributeAccessor (0.83)
 - Layout/SpaceAroundMethodCallOperator (0.82)
 - Lint/DeprecatedOpenSSLConstant (0.84)
 - Lint/MixedRegexpCaptureTypes (0.85)
 - Lint/RaiseException (0.81)
 - Lint/StructNewOverride (0.81)
 - Style/ExponentialNotation (0.82)
 - Style/HashEachMethods (0.80)
 - Style/HashTransformKeys (0.80)
 - Style/HashTransformValues (0.80)
 - Style/RedundantFetchBlock (0.86)
 - Style/RedundantRegexpCharacterClass (0.85)
 - Style/RedundantRegexpEscape (0.85)
 - Style/SlicingWithRange (0.83)
For more information: https://docs.rubocop.org/rubocop/versioning.html
Inspecting 679 files
..............................................................................................................................W.................................................................W...........................W.................................W....W........W............................................W.....W.......................................................................................................................................................................................................................................................................................................................................................................
Offenses:
app/controllers/auth/sessions_controller.rb:48:7: W: Lint/UselessAssignment: Useless assignment to variable - user.
      user ||= User.find_for_authentication(email: user_params[:email])
      ^^^^
app/controllers/tags_controller.rb:29:9: W: Lint/UselessAssignment: Useless assignment to variable - limit.
        limit     = params[:limit].present? ? [params[:limit].to_i, PAGE_SIZE_MAX].min : PAGE_SIZE
        ^^^^^
app/lib/activitypub/activity/create.rb:48:9: W: Lint/NonLocalExitFromIterator: Non-local exit from iterator, without return value. next, break, Array#find, Array#any?, etc. is preferred.
        return if delete_arrived_first?(object_uri) || poll_vote?
        ^^^^^^
app/lib/proof_provider/keybase/config_serializer.rb:58:52: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/FormatStringToken.
    CGI.unescape(short_account_url('%{username}')) # rubocop:disable Style/FormatStringToken
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/lib/request.rb:233:13: W: Lint/SuppressedException: Do not suppress exceptions.
            rescue Errno::EISCONN
            ^^^^^^^^^^^^^^^^^^^^^
app/lib/settings/scoped_settings.rb:14:5: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/MethodMissing (did you mean Style/MethodMissingSuper?).
    # rubocop:disable Style/MethodMissing
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/lib/settings/scoped_settings.rb:51:7: W: Lint/Void: Variable value used in void context.
      value
      ^^^^^
app/models/concerns/account_interactions.rb:237:3: W: Lint/UselessAccessModifier: Useless private access modifier.
  private
  ^^^^^^^
app/models/concerns/omniauthable.rb:60:87: W: Lint/UriRegexp: URI.regexp(%w(http https)) is obsolete and should not be used. Instead, use URI::DEFAULT_PARSER.make_regexp(%w(http https)).
      user.account.avatar_remote_url = auth.info.image if auth.info.image =~ /\A#{URI.regexp(%w(http https))}\z/
                                                                                      ^^^^^^
679 files inspected, 9 offenses detected
```