### PR TITLE
Enable promise/catch-or-return allowFinally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -199,6 +199,11 @@ module.exports = {
     'import/no-unresolved': 'error',
     'import/no-webpack-loader-syntax': 'error',
 
-    'promise/catch-or-return': 'error',
+    'promise/catch-or-return': [
+      'error',
+      {
+        allowFinally: true,
+      },
+    ],
   },
 };


### PR DESCRIPTION
When I run `yarn test:lint:js` locally I get an error.
Enable the `allowFinally` option of `promise/catch-or-return` and changed to not treat it as an error.

https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/catch-or-return.md#allowfinally

```
$ yarn test:lint:js
yarn run v1.22.4
$ eslint --ext=js . --cache

/Users/abcang/repo/mastodon/app/javascript/mastodon/actions/announcements.js
  31:3  error  Expected catch() or return  promise/catch-or-return

/Users/abcang/repo/mastodon/app/javascript/mastodon/actions/notifications.js
  155:5  error  Expected catch() or return  promise/catch-or-return

/Users/abcang/repo/mastodon/app/javascript/mastodon/actions/timelines.js
  102:5  error  Expected catch() or return  promise/catch-or-return

✖ 3 problems (3 errors, 0 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```