### PR TITLE
Fix the wrong full documentation link in the .env.production.sample file

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -2,7 +2,7 @@
 # with the `rake mastodon:setup` interactive setup wizard, but to customize
 # your setup even further, you'll need to edit it manually. This sample does
 # not demonstrate all available configuration options. Please look at
-# https://docs.joinmastodon/admin/config/ for the full documentation.
+# https://docs.joinmastodon.org/admin/config/ for the full documentation.
 
 # Federation
 # ----------


### PR DESCRIPTION
Hello, I found the full documentation link in the .env.production.sample file is wrong, so I fixed it.

This is not a serious problem, but it may be better to correct it