### PR TITLE
Fix larger video files not being transcoded

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -165,6 +165,9 @@ class MediaAttachment < ApplicationRecord
                     processors: ->(f) { file_processors f },
                     convert_options: GLOBAL_CONVERT_OPTIONS
 
+  before_file_post_process :set_type_and_extension
+  before_file_post_process :check_video_dimensions
+
   validates_attachment_content_type :file, content_type: IMAGE_MIME_TYPES + VIDEO_MIME_TYPES + AUDIO_MIME_TYPES
   validates_attachment_size :file, less_than: IMAGE_LIMIT, unless: :larger_media_format?
   validates_attachment_size :file, less_than: VIDEO_LIMIT, if: :larger_media_format?
@@ -256,9 +259,6 @@ class MediaAttachment < ApplicationRecord
   before_create :set_processing
 
   after_post_process :set_meta
-
-  before_file_post_process :set_type_and_extension
-  before_file_post_process :check_video_dimensions
 
   class << self
     def supported_mime_types


### PR DESCRIPTION
Since #14145, the `set_type_and_extension` has been moved from
`before_post_process` to `before_file_post_process`, but while the former
runs before all validations performed by Paperclip, the latter is dependent
on the order validations and hooks are defined.

In our case, this meant video files could be checked against the generic 10MB
limit, causing validation failures, which, internally, make Paperclip skip
post-processing, and thus, transcoding of the video file.

The actual validation would then happen after the type is correctly set, so
the large file would pass validation, but without being transcoded first.

This commit moves the hook definition so that it is run before checking for
the file size.