### PR TITLE
Fix audio player controls color in mastodon-light theme

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -767,10 +767,3 @@ html {
 .compose-form .compose-form__warning {
   box-shadow: none;
 }
-
-.audio-player .video-player__controls button,
-.audio-player .video-player__time-sep,
-.audio-player .video-player__time-current,
-.audio-player .video-player__time-total {
-  color: $primary-text-color;
-}


### PR DESCRIPTION
Fixes #14337
 
The new audio player sets the background and foreground colors automatically      
based on the thumbnail of the audio file, but the mastodon-light theme 
overrides the controls' colors with a hardcoded color, which sometimes make
them unreadable.