### PR TITLE
Stop using heroku-buildpack-nodejs

### DIFF
--- a/app.json
+++ b/app.json
@@ -89,9 +89,6 @@
       "url": "https://github.com/heroku/heroku-buildpack-apt"
     },
     {
-      "url": "heroku/nodejs"
-    },
-    {
       "url": "heroku/ruby"
     }
   ],


### PR DESCRIPTION
heroku-buildpack-ruby started to install Node 12 by default.
This makes it possible to run Mastodon without heroku-buildpack-nodejs.