### PR TITLE
Fix following_counter plural to include "one" 

### DIFF
--- a/app/javascript/mastodon/components/common_counter.js
+++ b/app/javascript/mastodon/components/common_counter.js
@@ -37,7 +37,7 @@ export function counterRenderer(counterType, isBold = true) {
     return (displayNumber, pluralReady) => (
       <FormattedMessage
         id='account.following_counter'
-        defaultMessage='{count, plural, other {{counter} Following}}'
+        defaultMessage='{count, plural, one {{counter} Following} other {{counter} Following}}'
         values={{
           count: pluralReady,
           counter: renderCounter(displayNumber),


### PR DESCRIPTION
That should've worked just fine, but unfortunately, Crowdin wasn't able to pick up on our non-existent "one" category, thus appending empty translation block to people's translations. Empty block WILL BE used by any ICU FormatMessage library, thus resulting in an empty translation for "one" category, and that requires immediate fix.

This commit duplicates contents of the "other" plural category.