### PR TITLE
helm: add examples of annotation for NGINX upload limits

### DIFF
--- a/chart/values.yaml.template
+++ b/chart/values.yaml.template
@@ -16,6 +16,12 @@ ingress:
     kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
     # cert-manager.io/cluster-issuer: "letsencrypt"
+    #
+    # ensure that NGINX's upload size matches Mastodon's
+    #   for the K8s ingress controller:
+    # nginx.ingress.kubernetes.io/proxy-body-size: 40m
+    #   for the NGINX ingress controller:
+    # nginx.org/client-max-body-size: 40m
   # this value is used for LOCAL_DOMAIN
   hostname: mastodon.local
   tls:


### PR DESCRIPTION
Probably the two most common ingress controllers are the ones maintained by NGINX (https://github.com/nginxinc/kubernetes-ingress) and by K8s (https://github.com/kubernetes/ingress-nginx); the example annotations are for those.