### PR TITLE
CIrcleCI: Set bundle config in local file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,11 +72,12 @@ aliases:
         - run:
             name: Set bundler settings
             command: |
-              bundle config clean 'true'
-              bundle config deployment 'true'
-              bundle config with 'pam_authentication'
-              bundle config without 'development production'
-              bundle config frozen 'true'
+              bundle config --local clean 'true'
+              bundle config --local deployment 'true'
+              bundle config --local with 'pam_authentication'
+              bundle config --local without 'development production'
+              bundle config --local frozen 'true'
+              bundle config --local path $BUNDLE_PATH
         - run:
             name: Install bundler dependencies
             command: bundle check || (bundle install && bundle clean)


### PR DESCRIPTION
This is a further followup to #13214, to address issues encountered when CircleCI's cache is empty.

In the last PR, I had mentioned that I was setting `BUNDLE_PATH` via environment variables in all the jobs because `bundle config` was writing to a file that was not distributed to other jobs via cache or workspace. This worked at the time, but recently I ran into issues with the rails binstub not being able to find any gems. I suspect this is either due to rails/spring#545 or a similar issue, wherein the binstub unsets `BUNDLE_PATH` and other environment variables before invoking bundler.

To get these binstubs working again, it is necessary to write out the `./vendor/bundle/` path to the `.bundle/config` file, as was originally done by the now-deprecated `bundle install ... --path ./vendor/bundle/ ...` command line. This PR accomplishes that by adding the `--local` flag to all the `bundle config` commands in the Ruby install jobs. Thus, in a build with a fresh cache, these configuration settings can propagate from the install job to the migration test job, etc., and the binstub commands will work even if they ignore the `BUNDLE_PATH` environment variable.