### PR TITLE
Add thumbnail_remote_url in MediaAttachment REST response

### DIFF
--- a/app/serializers/rest/media_attachment_serializer.rb
+++ b/app/serializers/rest/media_attachment_serializer.rb
@@ -4,7 +4,7 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
   include RoutingHelper
 
   attributes :id, :type, :url, :preview_url,
-             :remote_url, :thumbnail_remote_url, :text_url, :meta,
+             :remote_url, :preview_remote_url, :text_url, :meta,
              :description, :blurhash
 
   def id
@@ -35,7 +35,7 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
     end
   end
 
-  def thumbnail_remote_url
+  def preview_remote_url
     object.thumbnail_remote_url.presence
   end
 

--- a/app/serializers/rest/media_attachment_serializer.rb
+++ b/app/serializers/rest/media_attachment_serializer.rb
@@ -4,7 +4,7 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
   include RoutingHelper
 
   attributes :id, :type, :url, :preview_url,
-             :remote_url, :text_url, :meta,
+             :remote_url, :thumbnail_remote_url, :text_url, :meta,
              :description, :blurhash
 
   def id
@@ -33,6 +33,10 @@ class REST::MediaAttachmentSerializer < ActiveModel::Serializer
     elsif object.file.styles.key?(:small)
       full_asset_url(object.file.url(:small))
     end
+  end
+
+  def thumbnail_remote_url
+    object.thumbnail_remote_url.presence
   end
 
   def text_url


### PR DESCRIPTION
It helps the client app to handle non-standard thumbnail formats. Just like remote_url.