### PR TITLE
Dereference object URIs in Create and Update messages

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -157,6 +157,38 @@ class ActivityPub::Activity
     fetch_remote_original_status
   end
 
+  def dereference_object!
+    return unless @object.is_a?(String) && object_uri.start_with?('https://', 'http://')
+    return if ActivityPub::TagManager.instance.local_uri?(object_uri)
+
+    object = fetch_resource(@object, true, signed_fetch_account)
+    return unless object.present? && object.is_a?(Hash) && supported_context?(object) && equals_or_includes_any?(object['type'], SUPPORTED_TYPES + CONVERTED_TYPES)
+
+    actor_id = value_or_id(first_of_value(object['attributedTo']))
+    return if actor_id.nil? || object['id'].nil?
+    return unless Addressable::URI.parse(object['id']).normalized_host.casecmp(Addressable::URI.parse(actor_id).normalized_host).zero?
+
+    @object = object
+  end
+
+  def signed_fetch_account
+    first_mentioned_local_account || first_local_follower
+  end
+
+  def first_mentioned_local_account
+    audience = (as_array(@json['to']) + as_array(@json['cc'])).uniq
+    local_usernames = audience.select { |uri| ActivityPub::TagManager.instance.local_uri?(uri) }
+                              .map { |uri| ActivityPub::TagManager.instance.uri_to_local_id(uri, :username) }
+
+    return if local_usernames.empty?
+
+    Account.local.where(username: local_usernames).first
+  end
+
+  def first_local_follower
+    @account.followers.local.first
+  end
+
   def follow_request_from_object
     @follow_request ||= FollowRequest.find_by(target_account: @account, uri: object_uri) unless object_uri.nil?
   end

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -158,15 +158,11 @@ class ActivityPub::Activity
   end
 
   def dereference_object!
-    return unless @object.is_a?(String) && object_uri.start_with?('https://', 'http://')
-    return if ActivityPub::TagManager.instance.local_uri?(object_uri)
+    return unless @object.is_a?(String)
+    return if invalid_origin?(@object)
 
     object = fetch_resource(@object, true, signed_fetch_account)
-    return unless object.present? && object.is_a?(Hash) && supported_context?(object) && equals_or_includes_any?(object['type'], SUPPORTED_TYPES + CONVERTED_TYPES)
-
-    actor_id = value_or_id(first_of_value(object['attributedTo']))
-    return if actor_id.nil? || object['id'].nil?
-    return unless Addressable::URI.parse(object['id']).normalized_host.casecmp(Addressable::URI.parse(actor_id).normalized_host).zero?
+    return unless object.present? && object.is_a?(Hash) && supported_context?(object)
 
     @object = object
   end

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -2,6 +2,8 @@
 
 class ActivityPub::Activity::Create < ActivityPub::Activity
   def perform
+    dereference_object!
+
     case @object['type']
     when 'EncryptedMessage'
       create_encrypted_message

--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -4,6 +4,8 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
   SUPPORTED_TYPES = %w(Application Group Organization Person Service).freeze
 
   def perform
+    dereference_object!
+
     if equals_or_includes_any?(@object['type'], SUPPORTED_TYPES)
       update_account
     elsif equals_or_includes_any?(@object['type'], %w(Question))


### PR DESCRIPTION
Fixes #14353

This is directly a commit cherry-picked from Monsterpit, as I figured it should be enough.

To my understanding, their scheme does not provide any benefit *right now*, but it provides an opportunity for the sending server to check the receiving actor's key has not changed and is still controlled by that person, among other things: https://the.monsterpit.net/@firedemon/104541374145521914

I am not sure this is a trade-off that makes sense to Mastodon itself, as that's an added round-trip for each `Create`/`Update` activity, but supporting `Create` and `Update` activities which object is not inlined is probably fine, and falls within the AP spec.

~~The code does duplicate a few bits from the ActivityPub resource fetching code, so maybe it could be refactored a bit, but otherwise it seems fine to me.~~