### PR TITLE
Remove nodejs buildpack from buildpacks

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,3 @@
 https://github.com/heroku/heroku-buildpack-apt
 https://github.com/Scalingo/ffmpeg-buildpack
-https://github.com/Scalingo/nodejs-buildpack
 https://github.com/Scalingo/ruby-buildpack


### PR DESCRIPTION
Related: #14341
As scalingo buildpack has same problem, Stop using nodejs buildpacks from buildpacks too