### PR TITLE
Fix to add RedisLock to handle Announce activity

### DIFF
--- a/app/lib/activitypub/activity/announce.rb
+++ b/app/lib/activitypub/activity/announce.rb
@@ -4,25 +4,32 @@ class ActivityPub::Activity::Announce < ActivityPub::Activity
   def perform
     return reject_payload! if delete_arrived_first?(@json['id']) || !related_to_local_activity?
 
-    original_status = status_from_object
+    RedisLock.acquire(lock_options) do |lock|
+      if lock.acquired?
+        original_status = status_from_object
 
-    return reject_payload! if original_status.nil? || !announceable?(original_status)
+        return reject_payload! if original_status.nil? || !announceable?(original_status)
 
-    status = Status.find_by(account: @account, reblog: original_status)
+        @status = Status.find_by(account: @account, reblog: original_status)
 
-    return status unless status.nil?
+        return @status unless @status.nil?
 
-    status = Status.create!(
-      account: @account,
-      reblog: original_status,
-      uri: @json['id'],
-      created_at: @json['published'],
-      override_timestamps: @options[:override_timestamps],
-      visibility: visibility_from_audience
-    )
+        @status = Status.create!(
+          account: @account,
+          reblog: original_status,
+          uri: @json['id'],
+          created_at: @json['published'],
+          override_timestamps: @options[:override_timestamps],
+          visibility: visibility_from_audience
+        )
 
-    distribute(status)
-    status
+        distribute(@status)
+      else
+        raise Mastodon::RaceConditionError
+      end
+    end
+
+    @status
   end
 
   private
@@ -53,5 +60,9 @@ class ActivityPub::Activity::Announce < ActivityPub::Activity
 
   def reblog_of_local_status?
     status_from_uri(object_uri)&.account&.local?
+  end
+
+  def lock_options
+    { redis: Redis.current, key: "announce:#{@object['id']}" }
   end
 end


### PR DESCRIPTION
Since RecordNotUnique often occurs during the processing of Announce activity, add RedisLock.

It tends to occur when multiple relays using Announce are connected.