### PR TITLE
Add optional cross-instance media processing synchronization mechanism

### DIFF
--- a/app/lib/remote_synchronization_manager.rb
+++ b/app/lib/remote_synchronization_manager.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'singleton'
+
+class RemoteSynchronizationManager
+  include Singleton
+  include RoutingHelper
+
+  PROCESSING_VALUE = '!processing'
+  LOCK_TIME        = 5.minutes.seconds
+  CACHE_TIME       = 1.day.seconds
+
+  def get_processed_url(remote_url)
+    redis = synchronization_redis
+    return if redis.nil?
+
+    lock_options = { redis: redis, key: "process:#{remote_url}" }
+
+    RedisLock.acquire(lock_options) do |lock|
+      if lock.acquired?
+        url = redis.get("processed_media_url:#{remote_url}")
+        redis.setex("processed_media_url:#{remote_url}", LOCK_TIME, PROCESSING_VALUE) if url.nil?
+        url
+      end
+    end
+  rescue Redis::BaseError => e
+    Rails.logger.warn "Error during synchronization: #{e}"
+    nil
+  end
+
+  def set_processed_url(remote_url, object_url)
+    redis = synchronization_redis
+    return if redis.nil?
+
+    if object_url.nil?
+      redis.del("processed_media_url:#{remote_url}")
+    else
+      redis.setex("processed_media_url:#{remote_url}", CACHE_TIME, full_asset_url(object_url))
+    end
+  rescue Redis::BaseError => e
+    Rails.logger.warn "Error during synchronization: #{e}"
+
+    nil
+  end
+
+  private
+
+  def synchronization_redis
+    return @synchronization_redis if defined?(@synchronization_redis)
+
+    redis_url = Rails.configuration.x.synchronization_redis_url
+    return if redis_url.blank?
+
+    redis_connection = Redis.new(
+      url: redis_url,
+      driver: :hiredis
+    )
+
+    namespace = Rails.configuration.x.synchronization_redis_namespace
+
+    @synchronization_redis = namespace ? Redis::Namespace.new(namespace, redis: redis_connection) : redis_connection
+  end
+end

--- a/app/lib/remote_synchronization_manager.rb
+++ b/app/lib/remote_synchronization_manager.rb
@@ -28,6 +28,19 @@ class RemoteSynchronizationManager
     nil
   end
 
+  def wait_for_processed_url(remote_url, retry_timeout: 30.seconds, retry_sleep: 0.1)
+    stop_retrying = retry_timeout.from_now
+    url = PROCESSING_VALUE
+
+    while Time.now < stop_retrying
+      url = get_processed_url(remote_url)
+      return url unless url == PROCESSING_VALUE
+      sleep retry_sleep
+    end
+
+    url
+  end
+
   def set_processed_url(remote_url, object_url)
     redis = synchronization_redis
     return if redis.nil?

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -26,7 +26,7 @@ module Remotable
 
         if processed_url == RemoteSynchronizationManager::PROCESSING_VALUE
           public_send("#{attachment_name}=", nil) if public_send("#{attachment_name}_file_name").present?
-          raise Mastodon::UnexpectedResponseError unless suppress_errors
+          raise HTTP::TimeoutError unless suppress_errors
           return
         end
 

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -26,11 +26,11 @@ module Remotable
 
         # If a file is likely to go through ffmpeg, try the synchronization mechanisms
         needs_synchronization = (MediaAttachment::VIDEO_FILE_EXTENSIONS + ['.gif']).include?(File.extname(parsed_url.basename).downcase)
-        processed_url = RemoteSynchronizationManager.instance.get_processed_url(url) if needs_synchronization
+        processed_url = RemoteSynchronizationManager.instance.wait_for_processed_url(url) if needs_synchronization
 
         if processed_url == RemoteSynchronizationManager::PROCESSING_VALUE
+          public_send("#{attachment_name}=", nil) if public_send("#{attachment_name}_file_name").present?
           raise Mastodon::UnexpectedResponseError unless suppress_errors
-
           return
         end
 

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -76,13 +76,14 @@ module Remotable
   def synchronize_remote_attachment!(name)
     return unless defined?(@synchronizable_remote_attachments)
 
-    @synchronizable_remote_attachments.each do |url, attachment_name|
-      next unless attachment_name == name
-
-      cached_url = public_send(attachment_name).blank? ? nil : public_send(attachment_name).url(:original)
-      RemoteSynchronizationManager.instance.set_processed_url(url, cached_url)
+    @synchronizable_remote_attachments.keep_if do |url, attachment_name|
+      if attachment_name == name
+        cached_url = public_send(attachment_name).blank? ? nil : public_send(attachment_name).url(:original)
+        RemoteSynchronizationManager.instance.set_processed_url(url, cached_url)
+        false
+      else
+        true
+      end
     end
-
-    @synchronizable_remote_attachments = {}
   end
 end

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -3,6 +3,10 @@
 module Remotable
   extend ActiveSupport::Concern
 
+  included do
+    after_save :synchronize_remote_attachments!
+  end
+
   class_methods do
     def remotable_attachment(attachment_name, limit, suppress_errors: true, download_on_assign: true, attribute_name: nil)
       attribute_name ||= "#{attachment_name}_remote_url".to_sym
@@ -20,8 +24,19 @@ module Remotable
 
         return if !%w(http https).include?(parsed_url.scheme) || parsed_url.host.blank?
 
+        # If a file is likely to go through ffmpeg, try the synchronization mechanisms
+        needs_synchronization = (MediaAttachment::VIDEO_FILE_EXTENSIONS + ['.gif']).include?(File.extname(parsed_url.basename).downcase)
+        processed_url = RemoteSynchronizationManager.instance.get_processed_url(url) if needs_synchronization
+
+        if processed_url == RemoteSynchronizationManager::PROCESSING_VALUE
+          raise Mastodon::UnexpectedResponseError unless suppress_errors
+
+          return
+        end
+
         begin
-          Request.new(:get, url).perform do |response|
+          Request.new(:get, processed_url || url).perform do |response|
+            RemoteSynchronizationManager.instance.set_processed_url(url, nil) if processed_url.present? && response.code == 404
             raise Mastodon::UnexpectedResponseError, response unless (200...300).cover?(response.code)
 
             public_send("#{attachment_name}=", ResponseWithLimit.new(response, limit))
@@ -29,10 +44,18 @@ module Remotable
         rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, OpenSSL::SSL::SSLError => e
           Rails.logger.debug "Error fetching remote #{attachment_name}: #{e}"
           public_send("#{attachment_name}=", nil) if public_send("#{attachment_name}_file_name").present?
+          # We failed processing, release lock on processing media
+          RemoteSynchronizationManager.instance.set_processed_url(url, nil) if processed_url.nil? && needs_synchronization
           raise e unless suppress_errors
         rescue Paperclip::Errors::NotIdentifiedByImageMagickError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, Paperclip::Error, Mastodon::DimensionsValidationError, Mastodon::StreamValidationError => e
           Rails.logger.debug "Error fetching remote #{attachment_name}: #{e}"
           public_send("#{attachment_name}=", nil) if public_send("#{attachment_name}_file_name").present?
+        end
+
+        # File successfuly processed, get its url
+        if processed_url.nil? && needs_synchronization
+          @synchronizable_remote_attachments ||= {}
+          @synchronizable_remote_attachments[url] = attachment_name
         end
 
         nil
@@ -48,5 +71,18 @@ module Remotable
 
       alias_method("reset_#{attachment_name}!", "download_#{attachment_name}!")
     end
+  end
+
+  private
+
+  def synchronize_remote_attachments!
+    return unless defined?(@synchronizable_remote_attachments)
+
+    @synchronizable_remote_attachments.each do |url, attachment_name|
+      cached_url = public_send(attachment_name).blank? ? nil : public_send(attachment_name).url(:original)
+      RemoteSynchronizationManager.instance.set_processed_url(url, cached_url)
+    end
+
+    @synchronizable_remote_attachments = {}
   end
 end

--- a/config/initializers/remote_synchro.rb
+++ b/config/initializers/remote_synchro.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.x.synchronization_redis_url       = ENV['SYNCHRO_REDIS_URL']
+  config.x.synchronization_redis_namespace = ENV['SYNCHRO_REDIS_NAMESPACE']
+end

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -23,6 +23,7 @@ end
 setup_redis_env_url
 setup_redis_env_url(:cache, false)
 setup_redis_env_url(:sidekiq, false)
+setup_redis_env_url(:synchro, false) if ENV['SYNCHRO_REDIS_HOST'].present?
 
 namespace         = ENV.fetch('REDIS_NAMESPACE', nil)
 cache_namespace   = namespace ? namespace + '_cache' : 'cache'

--- a/spec/models/concerns/remotable_spec.rb
+++ b/spec/models/concerns/remotable_spec.rb
@@ -4,6 +4,14 @@ require 'rails_helper'
 
 RSpec.describe Remotable do
   class Foo
+    include ActiveSupport::Callbacks
+
+    define_callbacks :save
+
+    def self.after_save(*filters, &blk)
+      set_callback(:save, :after, *filters, &blk)
+    end
+
     def initialize
       @attrs = {}
     end


### PR DESCRIPTION
This PR is about upstreaming work that has been done for Masto.host (see: https://masto.host/custom-processing-of-videos-and-gifs/)

It allows a group of trusted instances to collaborate to avoid transcoding remote media files twice, and avoid doing so at the same time. This requires absolute trust between the instances (on a technical side—no trust is needed on the content moderation side), and makes the most sense when those instances are hosted on the same machine, sharing CPU/RAM resources, so this is most suited for people hosting multiple Mastodon instances, not for the general use.

## Description and configuration

When a Redis server is specified by the following environment variables, remote media files that matches one of the video extensions allowed by Mastodon, or .gif, will result in Mastodon using the Redis server to synchronize between instances such as only one instance processes the same media at a time, with the output of the first instance to process it used as input for the other ones.

```
SYNCHRO_REDIS_HOST=
SYNCHRO_REDIS_PORT=
SYNCHRO_REDIS_PASSWORD=
SYNCHRO_REDIS_NAMESPACE=
```

## Error handling

This patch is designed to gracefully fallback to normal behavior with minimal impact if the Redis server or collaborating instances are brought down at any point. In particular:
- If the Redis server is unreachable when checking if an instance has processed the file already, the check will fail fast and  proceed to local processing. The instance will attempt to use Redis again to indicate it has processed the file, failing fast if it does not work.
- If the Redis host drops packets, the check will fail after a few seconds, and the instance will still attempt to indicate it has processed the file possibly stalling a few more seconds.
- If another instance is currently processing the requested media, an error will be raised, similar to when there is a temporary network failure when fetching the remote media file.
- If an instance fails to process a media within 5 minutes, it will release the lock.
- If the Redis server holds an URL for a remote URL and that local URL returns a 404, this clears Redis entry for that URL, and throws an error.