### PR TITLE
Fix duplicate notification and delivery of mentions

### DIFF
--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -36,7 +36,8 @@ class ProcessMentionsService < BaseService
 
       next match if mention_undeliverable?(mentioned_account) || mentioned_account&.suspended?
 
-      mentions << mentioned_account.mentions.where(status: status).first_or_create(status: status)
+      mention = mentioned_account.mentions.new(status: status)
+      mentions << mention if mention.save
 
       "@#{mentioned_account.acct}"
     end


### PR DESCRIPTION
Fix duplicate notification and delivery when multiple mentions to the same account are specified in status text.