### PR TITLE
Fix following restriction not working when exact match in account search

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -27,7 +27,7 @@ class AccountSearchService < BaseService
 
     return @exact_match if defined?(@exact_match)
 
-    @exact_match = begin
+    match = begin
       if options[:resolve]
         ResolveAccountService.new.call(query)
       elsif domain_is_local?
@@ -36,6 +36,10 @@ class AccountSearchService < BaseService
         Account.find_remote(query_username, query_domain)
       end
     end
+
+    match = nil if !match.nil? && !account.nil? && options[:following] && !account.following?(match)
+
+    @exact_match = match
   end
 
   def search_results


### PR DESCRIPTION
When adding a user to the list, if the account name is an exact match, the account that you do not follow will appear in the search results. I will fix this.