### PR TITLE
Change content-type to be always computed from file data

### DIFF
--- a/lib/paperclip/response_with_limit_adapter.rb
+++ b/lib/paperclip/response_with_limit_adapter.rb
@@ -19,7 +19,7 @@ module Paperclip
       @original_filename = filename_from_content_disposition || filename_from_path || 'data'
       @size = @target.response.content_length
       @tempfile = copy_to_tempfile(@target)
-      @content_type = @target.response.mime_type || ContentTypeDetector.new(@tempfile.path).detect
+      @content_type = ContentTypeDetector.new(@tempfile.path).detect
     end
 
     def copy_to_tempfile(source)

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ActivityPub::Activity::Create do
 
     stub_request(:get, 'http://example.com/attachment.png').to_return(request_fixture('avatar.txt'))
     stub_request(:get, 'http://example.com/emoji.png').to_return(body: attachment_fixture('emojo.png'))
+    stub_request(:get, 'http://example.com/emojib.png').to_return(body: attachment_fixture('emojo.png'), headers: { 'Content-Type' => 'application/octet-stream' })
   end
 
   describe '#perform' do
@@ -448,6 +449,32 @@ RSpec.describe ActivityPub::Activity::Create do
 
           expect(status).to_not be_nil
           expect(status.emojis.map(&:shortcode)).to include('tinking')
+        end
+      end
+
+      context 'with emojis served with invalid content-type' do
+        let(:object_json) do
+          {
+            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+            type: 'Note',
+            content: 'Lorem ipsum :tinkong:',
+            tag: [
+              {
+                type: 'Emoji',
+                icon: {
+                  url: 'http://example.com/emojib.png',
+                },
+                name: 'tinkong',
+              },
+            ],
+          }
+        end
+
+        it 'creates status' do
+          status = sender.statuses.first
+
+          expect(status).to_not be_nil
+          expect(status.emojis.map(&:shortcode)).to include('tinkong')
         end
       end
 


### PR DESCRIPTION
Restore previous behavior, detecting the content-type isn't very expensive, and some instances may serve files as application/octet-stream regardless of their true type, making fetching media from them fail, while it used to work pre-3.2.0.