### PR TITLE
Fix thumbnail color extraction

### DIFF
--- a/lib/paperclip/color_extractor.rb
+++ b/lib/paperclip/color_extractor.rb
@@ -77,8 +77,8 @@ module Paperclip
     private
 
     def w3c_contrast(color1, color2)
-      luminance1 = (0.2126 * color1.r + 0.7152 * color1.g + 0.0722 * color1.b) + 0.05
-      luminance2 = (0.2126 * color2.r + 0.7152 * color2.g + 0.0722 * color2.b) + 0.05
+      luminance1 = color1.to_xyz.y * 0.01 + 0.05
+      luminance2 = color2.to_xyz.y * 0.01 + 0.05
 
       if luminance1 > luminance2
         luminance1 / luminance2

--- a/lib/paperclip/color_extractor.rb
+++ b/lib/paperclip/color_extractor.rb
@@ -26,8 +26,9 @@ module Paperclip
 
       foreground_palette.each do |color|
         distance = ColorDiff.between(background_color, color)
+        contrast = w3c_contrast(background_color, color)
 
-        if distance > max_distance
+        if distance > max_distance && contrast >= MIN_CONTRAST
           max_distance = distance
           max_distance_color = color
         end

--- a/lib/paperclip/color_extractor.rb
+++ b/lib/paperclip/color_extractor.rb
@@ -5,6 +5,7 @@ require 'mime/types/columnar'
 module Paperclip
   class ColorExtractor < Paperclip::Processor
     MIN_CONTRAST        = 3.0
+    ACCENT_MIN_CONTRAST = 2.0
     FREQUENCY_THRESHOLD = 0.01
 
     def make
@@ -28,7 +29,7 @@ module Paperclip
         distance = ColorDiff.between(background_color, color)
         contrast = w3c_contrast(background_color, color)
 
-        if distance > max_distance && contrast >= MIN_CONTRAST
+        if distance > max_distance && contrast >= ACCENT_MIN_CONTRAST
           max_distance = distance
           max_distance_color = color
         end


### PR DESCRIPTION
There were two obvious issues with color extraction:
- luminance calculation was done assuming an incorrect colorspace, causing all computed contrasts to be way off (making `#000000` and `#010101` acceptably contrasted colors)
- the first color selection did not have a contrast requirement, so if the thumbnail had only `#000000` and `#010101` as colors, both would have been picked up, and only one extra, properly-contrasted color would have been computed from the background

Those two cases together mean that from thumbnail with only three colors such as `#000000`, `#010101` and `#020202`, the extracted colors would be just those three, leading to a near pitch-black player, including the UI.