### PR TITLE
Fix new audio player features not working on Safari

### DIFF
--- a/app/javascript/mastodon/features/audio/index.js
+++ b/app/javascript/mastodon/features/audio/index.js
@@ -269,8 +269,9 @@ class Audio extends React.PureComponent {
   }
 
   _initAudioContext () {
-    const context  = new AudioContext();
-    const source   = context.createMediaElementSource(this.audio);
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
+    const context      = new AudioContext();
+    const source       = context.createMediaElementSource(this.audio);
 
     this.visualizer.setAudioContext(context, source);
     source.connect(context.destination);


### PR DESCRIPTION
Fixes #14462

Note that from a quick glance, that should be enough, but there might be other API discrepancies I'm not aware of, and I don't have access to Safari to actually make sure this works.