### PR TITLE
Fix handling of Reject Follow when a matching follow relationship exists

### DIFF
--- a/app/lib/activitypub/activity/reject.rb
+++ b/app/lib/activitypub/activity/reject.rb
@@ -4,7 +4,7 @@ class ActivityPub::Activity::Reject < ActivityPub::Activity
   def perform
     return reject_follow_for_relay if relay_follow?
     return follow_request_from_object.reject! unless follow_request_from_object.nil?
-    return UnfollowService.new.call(follow_from_object.target_account, @account) unless follow_from_object.nil?
+    return UnfollowService.new.call(follow_from_object.account, @account) unless follow_from_object.nil?
 
     case @object['type']
     when 'Follow'


### PR DESCRIPTION
Fix regression from #12199 causing `Reject Follow` not being correctly processed when a follow relationship matching the `uri` exists (for instance, when removing remote followers from the relationship manager).