### PR TITLE
Fix the hashtag judgment in the compose form to be the same as the server side

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -5,7 +5,22 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { me } from '../../../initial_state';
 
-const APPROX_HASHTAG_RE = /(?:^|[^\/\)\w])#(\w*[a-zA-Z·]\w*)/i;
+const HASHTAG_SEPARATORS = "_\\u00b7\\u200c";
+const ALPHA = '\\p{L}\\p{M}';
+const WORD = '\\p{L}\\p{M}\\p{N}\\p{Pc}';
+const APPROX_HASHTAG_RE = new RegExp(
+  '(?:^|[^\\/\\)\\w])#((' +
+  '[' + WORD + '_]' +
+  '[' + WORD + HASHTAG_SEPARATORS + ']*' +
+  '[' + ALPHA + HASHTAG_SEPARATORS + ']' +
+  '[' + WORD + HASHTAG_SEPARATORS +']*' +
+  '[' + WORD + '_]' +
+  ')|(' +
+  '[' + WORD + '_]*' +
+  '[' + ALPHA + ']' +
+  '[' + WORD + '_]*' +
+  '))', 'iu'
+);
 
 const mapStateToProps = state => ({
   needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),


### PR DESCRIPTION
This PR fixes the warning display control when the status is not public visibility and contains hashtag.

Currently, character strings that are judged as hashtag is ASCII characters only.

![warning-current](https://user-images.githubusercontent.com/32974885/89116818-43dd8380-d4d3-11ea-8bf3-8a1e8971d87a.gif)


This PR changes the criteria to be the same as on the server side.

![warning-pr](https://user-images.githubusercontent.com/32974885/89116821-4b049180-d4d3-11ea-9f7c-3cc59e7209aa.gif)

Ruby's `[:word:]` represents a character in one of the following Unicode general categories `Letter`, `Mark`, `Number`, `Connector_Punctuation`.
Ruby's `[:alpha:]` represents a character in the Unicode general categories `Letter` or `Mark`.

On the server side (modify for readability):

```rb
HASHTAG_SEPARATORS = "_\u00B7\u200c"
HASHTAG_NAME_RE    = "(
  [[:word:]_]
  [[:word:]#{HASHTAG_SEPARATORS}]*
  [[:alpha:]#{HASHTAG_SEPARATORS}]
  [[:word:]#{HASHTAG_SEPARATORS}]*
  [[:word:]_]
)|(
  [[:word:]_]*
  [[:alpha:]]
  [[:word:]_]*
)"
HASHTAG_RE         = /(?:^|[^\/\)\w])#(#{HASHTAG_NAME_RE})/i
```

I simply mapped these classes in JS:

- Letter: `\p{L}`
- Mark: `\p{M}`
- Number: `\p{N}`
- Connector_Punctuation: `\p{Pc}`
