### PR TITLE
Fix audio player on Safari

### DIFF
--- a/app/javascript/mastodon/features/audio/index.js
+++ b/app/javascript/mastodon/features/audio/index.js
@@ -115,6 +115,10 @@ class Audio extends React.PureComponent {
   }
 
   togglePlay = () => {
+    if (!this.audioContext) {
+      this._initAudioContext();
+    }
+
     if (this.state.paused) {
       this.setState({ paused: false }, () => this.audio.play());
     } else {
@@ -132,10 +136,6 @@ class Audio extends React.PureComponent {
 
   handlePlay = () => {
     this.setState({ paused: false });
-
-    if (this.canvas && !this.audioContext) {
-      this._initAudioContext();
-    }
 
     if (this.audioContext && this.audioContext.state === 'suspended') {
       this.audioContext.resume();


### PR DESCRIPTION
Audio context creation only works in a user event handler, so move the context creation from `handlePlay` to `togglePlay`.

I have got reports that this fixes the audio player on desktop Safari as well as iOS 13.6 and iOS 14. I have an iOS 13.5.1 device where this still doesn't work, but since I don't have MacOS, I am not sure how to investigate further at the moment.