### PR TITLE
Fix eslint error

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -7,7 +7,7 @@ import { me } from '../../../initial_state';
 
 const buildHashtagRE = () => {
   try {
-    const HASHTAG_SEPARATORS = "_\\u00b7\\u200c";
+    const HASHTAG_SEPARATORS = '_\\u00b7\\u200c';
     const ALPHA = '\\p{L}\\p{M}';
     const WORD = '\\p{L}\\p{M}\\p{N}\\p{Pc}';
     return new RegExp(
@@ -21,7 +21,7 @@ const buildHashtagRE = () => {
       '[' + WORD + '_]*' +
       '[' + ALPHA + ']' +
       '[' + WORD + '_]*' +
-      '))', 'iu'
+      '))', 'iu',
     );
   } catch {
     return /(?:^|[^\/\)\w])#(\w*[a-zA-Z·]\w*)/i;


### PR DESCRIPTION
Fixed error when running eslint.

```
$ yarn test:lint:js
yarn run v1.22.4
$ eslint --ext=js . --cache

/Users/abcang/repo/mastodon/app/javascript/mastodon/features/compose/containers/warning_container.js
  10:32  error  Strings must use singlequote  quotes
  24:17  error  Missing trailing comma        comma-dangle

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.

error Command failed with exit code 1.
```