### PR TITLE
Add support for latest HTTP Signatures spec draft

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -21,7 +21,9 @@ module SignatureVerification
     rule(:bws)           { match('\s').repeat }
     rule(:param)         { (token.as(:key) >> bws >> str('=') >> bws >> (token | quoted_string).as(:value)).as(:param) }
     rule(:comma)         { bws >> str(',') >> bws }
-    rule(:params)        { (param >> (comma >> param).repeat).as(:params) }
+    # Old versions of node-http-signature add an incorrect "Signature " prefix to the header
+    rule(:buggy_prefix)  { str('Signature ') }
+    rule(:params)        { buggy_prefix.maybe >> (param >> (comma >> param).repeat).as(:params) }
     root(:params)
   end
 

--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -63,6 +63,8 @@ module SignatureVerification
 
   def signature_key_id
     signature_params['keyId']
+  rescue SignatureVerificationError
+    nil
   end
 
   def signature_algorithm

--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -125,7 +125,7 @@ module SignatureVerification
 
   def verify_signature_strength!
     raise SignatureVerificationError, 'Mastodon requires the Date header or (created) pseudo-header to be signed' unless signed_headers.include?('date') || signed_headers.include?('(created)')
-    raise SignatureVerificationError, 'Mastodon requires the (request-target) pseudo-header to be signed' unless signed_headers.include?(Request::REQUEST_TARGET)
+    raise SignatureVerificationError, 'Mastodon requires the Digest header or (request-target) pseudo-header to be signed' unless signed_headers.include?(Request::REQUEST_TARGET) || signed_headers.include?('digest')
     raise SignatureVerificationError, 'Mastodon requires the Host header to be signed' unless signed_headers.include?('host')
     raise SignatureVerificationError, 'Mastodon requires the Digest header to be signed when doing a POST request' if request.post? && !signed_headers.include?('digest')
   end

--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -106,7 +106,7 @@ module SignatureVerification
 
     return account unless verify_signature(account, signature, compare_signed_string).nil?
 
-    @signature_verification_failure_reason = "Verification failed for #{account.username}@#{account.domain} #{account.uri}"
+    @signature_verification_failure_reason = "Verification failed for #{account.username}@#{account.domain} #{account.uri} using rsa-sha256 (RSASSA-PKCS1-v1_5 with SHA-256)"
     @signed_request_account = nil
   rescue SignatureVerificationError => e
     @signature_verification_failure_reason = e.message


### PR DESCRIPTION
https://www.ietf.org/id/draft-ietf-httpbis-message-signatures-00.html

- rewrite signature params parsing to be much closer to the spec (most notably, do not require parameters to be in quoted strings)
- add support for the `hs2019` signature algorithm (**assumed to be equivalent to RSA-SHA256**, since we do not have a mechanism to specify the algorithm within the key metadata yet)
- add support for (created) and (expires) pseudo-headers and related signature parameters, when using the `hs2019` signature algorithm
- adjust default `headers` parameter while being backwards-compatible with previous implementation
- change the acceptable time window logic from 12 hours surrounding the `Date` header to accepting signatures created up to 1 hour in the future and expiring up to 1 hour in the past (but only allowing expiration dates up to 12 hours after the creation date)
  This doesn't conform with the current draft, as it doesn't permit accounting for clock skew. This, however, should be addressed in a next version of the draft:
  https://github.com/httpwg/http-extensions/pull/1235

Note that for non-hs2019 signatures, this changes the accepted time window from 12 hours surrounding the `Date` header to 1 hour surrounding it. 12 hours was not enough to account for all possible timezone disparities, yet we have never heard of it to be an issue. If it was an issue in practice, it would be rare enough to be unnoticed, and 1 hour should make any issue more obvious. If it never has been an issue, hopefully 1 hour won't be either.

It also adds a bunch of requirements for signatures, those requirements seem to be met by at least Mastodon, Pleroma, PeerTube and Hubzilla.

Error messages should also now be more specific and more informative, should other implementors run into them.