### PR TITLE
Improve email address validation

### DIFF
--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -27,7 +27,7 @@ module Admin
           ips       = []
 
           Resolv::DNS.open do |dns|
-            dns.timeouts = 1
+            dns.timeouts = 5
 
             hostnames = dns.getresources(@email_domain_block.domain, Resolv::DNS::Resource::IN::MX).to_a.map { |e| e.exchange.to_s }
 

--- a/app/validators/blacklisted_email_validator.rb
+++ b/app/validators/blacklisted_email_validator.rb
@@ -6,7 +6,7 @@ class BlacklistedEmailValidator < ActiveModel::Validator
 
     @email = user.email
 
-    user.errors.add(:email, I18n.t('users.invalid_email')) if blocked_email?
+    user.errors.add(:email, I18n.t('users.blocked_email_provider')) if blocked_email?
   end
 
   private

--- a/app/validators/email_mx_validator.rb
+++ b/app/validators/email_mx_validator.rb
@@ -4,17 +4,33 @@ require 'resolv'
 
 class EmailMxValidator < ActiveModel::Validator
   def validate(user)
-    user.errors.add(:email, I18n.t('users.invalid_email')) if invalid_mx?(user.email)
+    domain = get_domain(user.email)
+
+    if domain.nil?
+      user.errors.add(:email, I18n.t('users.invalid_email'))
+    else
+      ips, hostnames = resolve_mx(domain)
+      if ips.empty?
+        user.errors.add(:email, I18n.t('users.invalid_email_mx'))
+      elsif on_blacklist?(hostnames + ips)
+        user.errors.add(:email, I18n.t('users.blocked_email_provider'))
+      end
+    end
   end
 
   private
 
-  def invalid_mx?(value)
+  def get_domain(value)
     _, domain = value.split('@', 2)
 
-    return true if domain.nil?
+    return nil if domain.nil?
 
-    domain    = TagManager.instance.normalize_domain(domain)
+    TagManager.instance.normalize_domain(domain)
+  rescue Addressable::URI::InvalidURIError
+    nil
+  end
+
+  def resolve_mx(domain)
     hostnames = []
     ips       = []
 
@@ -29,9 +45,7 @@ class EmailMxValidator < ActiveModel::Validator
       end
     end
 
-    ips.empty? || on_blacklist?(hostnames + ips)
-  rescue Addressable::URI::InvalidURIError
-    true
+    [ips, hostnames]
   end
 
   def on_blacklist?(values)

--- a/app/validators/email_mx_validator.rb
+++ b/app/validators/email_mx_validator.rb
@@ -19,7 +19,7 @@ class EmailMxValidator < ActiveModel::Validator
     ips       = []
 
     Resolv::DNS.open do |dns|
-      dns.timeouts = 1
+      dns.timeouts = 5
 
       hostnames = dns.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a.map { |e| e.exchange.to_s }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1325,9 +1325,11 @@ en:
       tips: Tips
       title: Welcome aboard, %{name}!
   users:
+    blocked_email_provider: This e-mail provider isn't allowed
     follow_limit_reached: You cannot follow more than %{limit} people
     generic_access_help_html: Trouble accessing your account? You may get in touch with %{email} for assistance
     invalid_email: The e-mail address is invalid
+    invalid_email_mx: The e-mail address does not seem to exist
     invalid_otp_token: Invalid two-factor code
     invalid_sign_in_token: Invalid security code
     otp_lost_help_html: If you lost access to both, you may get in touch with %{email}

--- a/lib/mastodon/email_domain_blocks_cli.rb
+++ b/lib/mastodon/email_domain_blocks_cli.rb
@@ -63,7 +63,7 @@ module Mastodon
         ips       = []
 
         Resolv::DNS.open do |dns|
-          dns.timeouts = 1
+          dns.timeouts = 5
           hostnames = dns.getresources(email_domain_block.domain, Resolv::DNS::Resource::IN::MX).to_a.map { |e| e.exchange.to_s }
 
           ([email_domain_block.domain] + hostnames).uniq.each do |hostname|

--- a/spec/validators/blacklisted_email_validator_spec.rb
+++ b/spec/validators/blacklisted_email_validator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe BlacklistedEmailValidator, type: :validator do
       let(:blocked_email) { true }
 
       it 'calls errors.add' do
-        expect(errors).to have_received(:add).with(:email, I18n.t('users.invalid_email'))
+        expect(errors).to have_received(:add).with(:email, I18n.t('users.blocked_email_provider'))
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe BlacklistedEmailValidator, type: :validator do
       let(:blocked_email) { false }
 
       it 'not calls errors.add' do
-        expect(errors).not_to have_received(:add).with(:email, I18n.t('users.invalid_email'))
+        expect(errors).not_to have_received(:add).with(:email, I18n.t('users.blocked_email_provider'))
       end
     end
   end


### PR DESCRIPTION
- Increase DNS timeouts from 1 second to 5 seconds, for consistency with the timeouts in `app/lib/request.rb`, and because 1 second is likely to cause issues for some domains when the result isn't in the resolver's cache
- Split “The e-mail address is invalid” to:
  - “The e-mail address is invalid” when the domain is missing or invalid
  - “The e-mail address does not seem to exist” (I'm not completely happy with that wording) when the DNS queries do not return any IP address
  - “This e-mail provider isn't allowed” when the provider (domain name or MXs) is blocked (or not allowed, in the case `EMAIL_DOMAIN_ALLOWLIST` is used)