### PR TITLE
Fix admins being able to suspend their instance actor

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -14,6 +14,8 @@ module Admin
     def show
       authorize @account, :show?
 
+      flash.now[:notice] = I18n.t('accounts.instance_actor_flash') if @account.instance_actor?
+
       @deletion_request        = @account.deletion_request
       @account_moderation_note = current_account.account_moderation_notes.new(target_account: @account)
       @moderation_notes        = @account.targeted_moderation_notes.latest

--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -14,8 +14,6 @@ module Admin
     def show
       authorize @account, :show?
 
-      flash.now[:notice] = I18n.t('accounts.instance_actor_flash') if @account.instance_actor?
-
       @deletion_request        = @account.deletion_request
       @account_moderation_note = current_account.account_moderation_notes.new(target_account: @account)
       @moderation_notes        = @account.targeted_moderation_notes.latest

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -222,7 +222,7 @@ class Account < ApplicationRecord
   end
 
   def suspended?
-    suspended_at.present?
+    suspended_at.present? && !instance_actor?
   end
 
   def suspended_permanently?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -100,6 +100,7 @@ class Account < ApplicationRecord
   scope :sensitized, -> { where.not(sensitized_at: nil) }
   scope :without_suspended, -> { where(suspended_at: nil) }
   scope :without_silenced, -> { where(silenced_at: nil) }
+  scope :without_instance_actor, -> { where.not(id: -99) }
   scope :recent, -> { reorder(id: :desc) }
   scope :bots, -> { where(actor_type: %w(Application Service)) }
   scope :groups, -> { where(actor_type: 'Group') }

--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -45,7 +45,7 @@ class AccountFilter
   def scope_for(key, value)
     case key.to_s
     when 'local'
-      Account.local
+      Account.local.without_instance_actor
     when 'remote'
       Account.remote
     when 'by_domain'

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -14,7 +14,7 @@ class AccountPolicy < ApplicationPolicy
   end
 
   def suspend?
-    staff? && !record.user&.staff?
+    staff? && !record.user&.staff? && !record.instance_actor?
   end
 
   def destroy?
@@ -62,6 +62,6 @@ class AccountPolicy < ApplicationPolicy
   end
 
   def memorialize?
-    admin? && !record.user&.admin?
+    admin? && !record.user&.admin? && !record.instance_actor?
   end
 end

--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -1,6 +1,10 @@
 - content_for :page_title do
   = @account.acct
 
+- if @account.instance_actor?
+  .flash-message.notice
+    %strong= t('accounts.instance_actor_flash')
+
 = render 'application/card', account: @account
 
 - account = @account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,7 @@ en:
       one: Follower
       other: Followers
     following: Following
+    instance_actor_flash: This account is a virtual actor used to represent the server itself and not any individual user. It is used for federation purposes and should not be suspended.
     joined: Joined %{date}
     last_active: last active
     link_verified_on: Ownership of this link was checked on %{date}

--- a/spec/models/account_filter_spec.rb
+++ b/spec/models/account_filter_spec.rb
@@ -5,7 +5,7 @@ describe AccountFilter do
     it 'defaults to recent local not-suspended account list' do
       filter = described_class.new({})
 
-      expect(filter.results).to eq Account.local.recent.without_suspended
+      expect(filter.results).to eq Account.local.without_instance_actor.recent.without_suspended
     end
   end
 


### PR DESCRIPTION
I'm not sure how, but I've seen a couple admins manage to suspend their instance actor (which cause federation issues).

This PR:
- makes `Account#suspend!` do nothing on the instance actor
- makes `Account#suspend?` return false no matter what on the instance actor
- makes a flash appear on the admin interface to reduce confusion

![image](https://user-images.githubusercontent.com/384364/90030085-ecea6200-dcbb-11ea-9c85-23399976e0e5.png)