### PR TITLE
Fix hardcoded non-breaking space in public view

### DIFF
--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -17,7 +17,7 @@
         %span.display-name
           %bdi
             %strong.display-name__html.p-name.emojify= display_name(status.account, custom_emojify: true, autoplay: autoplay)
-          &nbsp;
+          = ' '
           %span.display-name__account
             = acct(status.account)
             = fa_icon('lock') if status.account.locked?


### PR DESCRIPTION
It makes sense to have a space here, but it does not make sense for this space to be non-breaking.
Making it a breaking space is more logical and makes it easier to apply custom styling.