### PR TITLE
Remove dependency on unused and unmaintained http_parser.rb gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,6 @@ gem 'health_check', git: 'https://github.com/ianheggie/health_check', ref: '0b79
 gem 'htmlentities', '~> 4.3'
 gem 'http', '~> 4.4'
 gem 'http_accept_language', '~> 2.1'
-gem 'http_parser.rb', '~> 0.6', git: 'https://github.com/tmm1/http_parser.rb', ref: '54b17ba8c7d8d20a16dfc65d1775241833219cf2', submodules: true
 gem 'httplog', '~> 1.4.3'
 gem 'idn-ruby', require: 'idn'
 gem 'kaminari', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,6 @@ GIT
       rails (>= 4.0)
 
 GIT
-  remote: https://github.com/tmm1/http_parser.rb
-  revision: 54b17ba8c7d8d20a16dfc65d1775241833219cf2
-  ref: 54b17ba8c7d8d20a16dfc65d1775241833219cf2
-  submodules: true
-  specs:
-    http_parser.rb (0.6.1)
-
-GIT
   remote: https://github.com/witgo/nilsimsa
   revision: fd184883048b922b176939f851338d0a4971a532
   ref: fd184883048b922b176939f851338d0a4971a532
@@ -706,7 +698,6 @@ DEPENDENCIES
   htmlentities (~> 4.3)
   http (~> 4.4)
   http_accept_language (~> 2.1)
-  http_parser.rb (~> 0.6)!
   httplog (~> 1.4.3)
   i18n-tasks (~> 0.9)
   idn-ruby


### PR DESCRIPTION
It seems that years ago, the “http” gem dependend on the “http_parser.rb” gem (it now depends on the “http-parser” gem), and, still years ago, we pulled it from git in order to benefit from a bugfix that wasn't released yet (#7467).

Haven't actually tested it yet, hence the draft status of the PR, but I don't see this gem being used by anything, we should get rid of it.