### PR TITLE
Update postgres version, add envvars to prevent postgres from rebooting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,12 @@ services:
 
   db:
     restart: always
-    image: postgres:9.6-alpine
+    image: postgres:12.4-alpine
     shm_size: 256mb
+    environment:
+        - POSTGRES_DB=postgres
+        - POSTGRES_USER=postgres
+        - POSTGRES_PASSWORD=postgres
     networks:
       - internal_network
     healthcheck:


### PR DESCRIPTION
Without the environment variables, Postgres doesn't know what to do and will go into an infinite restart loop. At the very least you'll have a basic config with docker-compose :) 