### PR TITLE
Always send subscribe request when connecting to streaming

### DIFF
--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -58,9 +58,7 @@ const subscribe = ({ channelName, params, onConnect }) => {
 
   subscriptionCounters[key] = subscriptionCounters[key] || 0;
 
-  if (subscriptionCounters[key] === 0) {
-    sharedConnection.send(JSON.stringify({ type: 'subscribe', stream: channelName, ...params }));
-  }
+  sharedConnection.send(JSON.stringify({ type: 'subscribe', stream: channelName, ...params }));
 
   subscriptionCounters[key] += 1;
   onConnect();


### PR DESCRIPTION
I noticed my browser stops receiving notifications after the streaming server restarts. This change makes the browser to send subscribe request every time after the WebSocket is reconnected so that the browser keeps receiving notifications when the streaming server comes back.