### PR TITLE
Better manage subscriptionCounters

### DIFF
--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -112,11 +112,10 @@ const sharedCallbacks = {
   },
 
   disconnected () {
-    subscriptions.forEach(({ onDisconnect }) => onDisconnect());
+    subscriptions.forEach(subscription => unsubscribe(subscription));
   },
 
   reconnected () {
-    subscriptions.forEach(subscription => subscribe(subscription));
   },
 };
 
@@ -252,15 +251,8 @@ const createConnection = (streamingAPIBaseURL, accessToken, channelName, { conne
 
   const es = new EventSource(`${streamingAPIBaseURL}/api/v1/streaming/${channelName}?${params.join('&')}`);
 
-  let firstConnect = true;
-
   es.onopen = () => {
-    if (firstConnect) {
-      firstConnect = false;
-      connected();
-    } else {
-      reconnected();
-    }
+    connected();
   };
 
   KNOWN_EVENT_TYPES.forEach(type => {


### PR DESCRIPTION
Before this change:
- `unsubscribe()` was not called for a disconnection
- `subscriptionCounters` were incremented twice for a single reconnection, first from `connected()` and second from `reconnected()`. It seems that `WebSocketClient` calls both `connected()` and `reconnected()` when a reconnection happens.

This might be a an additional change to #14579 to recover subscriptions after a reconnect.