### PR TITLE
Fix Unable to build docker image, "Value "mastodon" invalid for option gid (number expected)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,8 @@ COPY --from=build-dep /opt/jemalloc /opt/jemalloc
 ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin"
 
 # Create the mastodon user
-ARG UID=991
-ARG GID=991
+ENV UID=991
+ENV GID=991
 RUN apt update && \
 	echo "Etc/UTC" > /etc/localtime && \
 	ln -s /opt/jemalloc/lib/* /usr/lib/ && \


### PR DESCRIPTION
While doing (https://www.howtoforge.com/how-to-install-mastodon-social-network-with-docker-on-ubuntu-1804/#step-create-your-mastodon-user) this tutorial, I meet "Fix Unable to build docker image, "Value "mastodon" invalid for option gid (number expected)"" error like https://github.com/tootsuite/mastodon/issues/13686 issue.


I just change ARG GID and ARG UID to ENV then docker-compose build is ended successfully.