### PR TITLE
Fix click range discrepancies in gifv

### DIFF
--- a/app/javascript/mastodon/components/gifv.js
+++ b/app/javascript/mastodon/components/gifv.js
@@ -54,8 +54,6 @@ export default class GIFV extends React.PureComponent {
 
         <video
           src={src}
-          width={width}
-          height={height}
           role='button'
           tabIndex='0'
           aria-label={alt}


### PR DESCRIPTION
Fix https://github.com/tootsuite/mastodon/pull/13533

When the size is reduced to the maximum size specified in the style sheet, the clickable areas do not match, so delete width and height.
https://stellaria.network/@Eai/104733558208220954