### PR TITLE
Fix an error when file_file_size is nil in tootctl media remove

### DIFF
--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -31,7 +31,7 @@ module Mastodon
       processed, aggregate = parallelize_with_progress(MediaAttachment.cached.where.not(remote_url: '').where('created_at < ?', time_ago)) do |media_attachment|
         next if media_attachment.file.blank?
 
-        size = media_attachment.file_file_size + (media_attachment.thumbnail_file_size || 0)
+        size = (media_attachment.file_file_size || 0) + (media_attachment.thumbnail_file_size || 0)
 
         unless options[:dry_run]
           media_attachment.file.destroy


### PR DESCRIPTION
Fix https://github.com/tootsuite/mastodon/issues/14398

Often, a MediaAttachment with an unknown file type may appear to hold some file, but in fact it does not, and has no size and other information. In such cases, assume the size is zero and destroy the file.