### PR TITLE
Add email previews for WebAuthn emails

### DIFF
--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -33,6 +33,28 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.two_factor_recovery_codes_changed(User.first)
   end
 
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/webauthn_enabled
+  def webauthn_enabled
+    UserMailer.webauthn_enabled(User.first)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/webauthn_disabled
+  def webauthn_disabled
+    UserMailer.webauthn_disabled(User.first)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/webauthn_credential_added
+  def webauthn_credential_added
+    webauthn_credential = WebauthnCredential.new(nickname: 'USB Key')
+    UserMailer.webauthn_credential_added(User.first, webauthn_credential)
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/webauthn_credential_deleted
+  def webauthn_credential_deleted
+    webauthn_credential = WebauthnCredential.new(nickname: 'USB Key')
+    UserMailer.webauthn_credential_deleted(User.first, webauthn_credential)
+  end
+
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/reconfirmation_instructions
   def reconfirmation_instructions
     user = User.first


### PR DESCRIPTION
## What

This is a leftover for the work done in #14466.

## Screenshots

### Webauthn enabled

<img width="1440" alt="Screen Shot 2020-08-24 at 12 04 06 PM" src="https://user-images.githubusercontent.com/46354312/91060918-ec2dc600-e601-11ea-8a08-19fc8779156b.png">

### Webauthn disabled

<img width="1439" alt="Screen Shot 2020-08-24 at 12 05 20 PM" src="https://user-images.githubusercontent.com/46354312/91061065-17181a00-e602-11ea-9e2e-fb7149d3f250.png">

### Webauthn Credential added

<img width="1438" alt="Screen Shot 2020-08-24 at 12 05 41 PM" src="https://user-images.githubusercontent.com/46354312/91061096-2303dc00-e602-11ea-9383-e4aba5951c84.png">

### Webauthn Credential deleted

<img width="1438" alt="Screen Shot 2020-08-24 at 12 06 06 PM" src="https://user-images.githubusercontent.com/46354312/91061146-31ea8e80-e602-11ea-8325-d6c6d25bb782.png">