### PR TITLE
Stop installing libssl-dev for build

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -5,7 +5,6 @@ libidn11
 libidn11-dev
 libpq-dev
 libprotobuf-dev
-libssl-dev
 libxdamage1
 libxfixes3
 protobuf-compiler


### PR DESCRIPTION
libssl-dev is provided with the stack image in build time and
conflicts in building openssl Gem for webauthn Gem added with #14466.