### PR TITLE
Use Status.group instead of Status.distinct in HashQueryService

### DIFF
--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -33,9 +33,7 @@ class Api::V1::Timelines::TagController < Api::BaseController
       )
 
       if truthy_param?(:only_media)
-        # `SELECT DISTINCT id, updated_at` is too slow, so pluck ids at first, and then select id, updated_at with ids.
-        status_ids = statuses.joins(:media_attachments).distinct(:id).pluck(:id)
-        statuses.where(id: status_ids)
+        statuses.joins(:media_attachments)
       else
         statuses
       end

--- a/app/services/hashtag_query_service.rb
+++ b/app/services/hashtag_query_service.rb
@@ -8,7 +8,7 @@ class HashtagQueryService < BaseService
     all  = tags_for(params[:all])
     none = tags_for(params[:none])
 
-    Status.distinct
+    Status.group(:id)
           .as_tag_timeline(tags, account, local)
           .tagged_with_all(all)
           .tagged_with_none(none)


### PR DESCRIPTION
Hi, it's been a while since I made a pull request the last time.

Pawoo is finally updated to 2.9.4 today and we are appreciating lots of improvements. I want to contribute a change made for Pawoo in the process of updating the instance.

The below is the description of this change which is also in the commit message:

DISTINCT clause removes duplicated records according to all the selected attributes. In reality, it can remove duplicated records only looking at `statuses.id`, but the clause confuses the query planner and yields insufficient performance.
The behavior is also problematic if the scope produced by `HashQueryService` is used to query columns without id (using pluck method, for example). The scope is expected to contain unique statuses, but the uniquness will be evaluated with some arbitrary columns other than id.

GROUP BY clause resolves those problem by explicitly specifying the column to take into account for the record distinction.

A workaround for the problem of DISTINCT clause in `Api::V1::Timelines::TagController` is no longer necessary and removed.