### PR TITLE
Eagerly load statuses with the main query in Api::V1::BookmarksController

### DIFF
--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -17,14 +17,11 @@ class Api::V1::BookmarksController < Api::BaseController
   end
 
   def cached_bookmarks
-    cache_collection(
-      Status.reorder(nil).joins(:bookmarks).merge(results),
-      Status
-    )
+    cache_collection(results.map(&:status), Status)
   end
 
   def results
-    @_results ||= account_bookmarks.paginate_by_id(
+    @_results ||= account_bookmarks.eager_load(:status).paginate_by_id(
       limit_param(DEFAULT_STATUSES_LIMIT),
       params_slice(:max_id, :since_id, :min_id)
     )


### PR DESCRIPTION
This is same with commit 552e886b648faa2a2229d86c7fd9abc8bb5ff99c except that it was for `Api::V1::FavouritesController` while this is for `Api::V1::BookmarksController`.