### PR TITLE
Replace incorrect use of distinct with group

### DIFF
--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -30,9 +30,7 @@ class Api::V1::Timelines::PublicController < Api::BaseController
     )
 
     if truthy_param?(:only_media)
-      # `SELECT DISTINCT id, updated_at` is too slow, so pluck ids at first, and then select id, updated_at with ids.
-      status_ids = statuses.joins(:media_attachments).distinct(:id).pluck(:id)
-      statuses.where(id: status_ids)
+      statuses.joins(:media_attachments).group(:id)
     else
       statuses
     end


### PR DESCRIPTION
Refer to https://github.com/tootsuite/mastodon/pull/14662#pullrequestreview-474405956.

Some uses of `ActiveRecord::QueryMethods#distinct` pass field names but they are incorrect for the current version of Rails.

`ActiveRecord::QueryMethods#group` provides the expected behavior and benefits performance. See commit 6da24aad4cafdef8d8a2c92bac2002a5fc2fe9c8.