### PR TITLE
Make Array-creation behavior of Paginable more predictable

### DIFF
--- a/app/controllers/api/v1/admin/accounts_controller.rb
+++ b/app/controllers/api/v1/admin/accounts_controller.rb
@@ -79,7 +79,7 @@ class Api::V1::Admin::AccountsController < Api::BaseController
   private
 
   def set_accounts
-    @accounts = filtered_accounts.order(id: :desc).includes(user: [:invite_request, :invite]).paginate_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
+    @accounts = filtered_accounts.order(id: :desc).includes(user: [:invite_request, :invite]).to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
   def set_account

--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -63,7 +63,7 @@ class Api::V1::Admin::ReportsController < Api::BaseController
   private
 
   def set_reports
-    @reports = filtered_reports.order(id: :desc).with_accounts.paginate_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
+    @reports = filtered_reports.order(id: :desc).with_accounts.to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
   def set_report

--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::BookmarksController < Api::BaseController
   end
 
   def results
-    @_results ||= account_bookmarks.eager_load(:status).paginate_by_id(
+    @_results ||= account_bookmarks.eager_load(:status).to_a_paginated_by_id(
       limit_param(DEFAULT_STATUSES_LIMIT),
       params_slice(:max_id, :since_id, :min_id)
     )

--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -32,7 +32,7 @@ class Api::V1::ConversationsController < Api::BaseController
 
   def paginated_conversations
     AccountConversation.where(account: current_account)
-                       .paginate_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
+                       .to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
   def insert_pagination_headers

--- a/app/controllers/api/v1/crypto/encrypted_messages_controller.rb
+++ b/app/controllers/api/v1/crypto/encrypted_messages_controller.rb
@@ -26,7 +26,7 @@ class Api::V1::Crypto::EncryptedMessagesController < Api::BaseController
   end
 
   def set_encrypted_messages
-    @encrypted_messages = @current_device.encrypted_messages.paginate_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
+    @encrypted_messages = @current_device.encrypted_messages.to_a_paginated_by_id(limit_param(LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
   def insert_pagination_headers

--- a/app/controllers/api/v1/favourites_controller.rb
+++ b/app/controllers/api/v1/favourites_controller.rb
@@ -21,7 +21,7 @@ class Api::V1::FavouritesController < Api::BaseController
   end
 
   def results
-    @_results ||= account_favourites.eager_load(:status).paginate_by_id(
+    @_results ||= account_favourites.eager_load(:status).to_a_paginated_by_id(
       limit_param(DEFAULT_STATUSES_LIMIT),
       params_slice(:max_id, :since_id, :min_id)
     )

--- a/app/controllers/api/v1/scheduled_statuses_controller.rb
+++ b/app/controllers/api/v1/scheduled_statuses_controller.rb
@@ -32,7 +32,7 @@ class Api::V1::ScheduledStatusesController < Api::BaseController
   private
 
   def set_statuses
-    @statuses = current_account.scheduled_statuses.paginate_by_id(limit_param(DEFAULT_STATUSES_LIMIT), params_slice(:max_id, :since_id, :min_id))
+    @statuses = current_account.scheduled_statuses.to_a_paginated_by_id(limit_param(DEFAULT_STATUSES_LIMIT), params_slice(:max_id, :since_id, :min_id))
   end
 
   def set_status

--- a/app/controllers/concerns/cache_concern.rb
+++ b/app/controllers/concerns/cache_concern.rb
@@ -49,6 +49,6 @@ module CacheConcern
   end
 
   def cache_collection_paginated_by_id(raw, klass, limit, options)
-    cache_collection raw.cache_ids.paginate_by_id(limit, options), klass
+    cache_collection raw.cache_ids.to_a_paginated_by_id(limit, options), klass
   end
 end

--- a/app/models/account_conversation.rb
+++ b/app/models/account_conversation.rb
@@ -36,11 +36,11 @@ class AccountConversation < ApplicationRecord
   end
 
   class << self
-    def paginate_by_id(limit, options = {})
+    def to_a_paginated_by_id(limit, options = {})
       if options[:min_id]
         paginate_by_min_id(limit, options[:min_id]).reverse
       else
-        paginate_by_max_id(limit, options[:max_id], options[:since_id])
+        paginate_by_max_id(limit, options[:max_id], options[:since_id]).to_a
       end
     end
 

--- a/app/models/concerns/paginable.rb
+++ b/app/models/concerns/paginable.rb
@@ -20,12 +20,12 @@ module Paginable
       query
     }
 
-    scope :to_a_paginated_by_id, ->(limit, options = {}) {
+    def self.to_a_paginated_by_id(limit, options = {})
       if options[:min_id].present?
         paginate_by_min_id(limit, options[:min_id]).reverse
       else
         paginate_by_max_id(limit, options[:max_id], options[:since_id]).to_a
       end
-    }
+    end
   end
 end

--- a/app/models/concerns/paginable.rb
+++ b/app/models/concerns/paginable.rb
@@ -20,11 +20,11 @@ module Paginable
       query
     }
 
-    scope :paginate_by_id, ->(limit, options = {}) {
+    scope :to_a_paginated_by_id, ->(limit, options = {}) {
       if options[:min_id].present?
         paginate_by_min_id(limit, options[:min_id]).reverse
       else
-        paginate_by_max_id(limit, options[:max_id], options[:since_id])
+        paginate_by_max_id(limit, options[:max_id], options[:since_id]).to_a
       end
     }
   end


### PR DESCRIPTION
`Paginable.paginate_by_id` usually returns `ActiveRecord::Relation`, but it returns an `Array` if `min_id` option is present. The behavior caused problems fixed with the following commits:
- 552e886b648faa2a2229d86c7fd9abc8bb5ff99c
- b63ede5005d33b52266650ec716d345f166e2df0
- 64ef37b89de806f49cc59e011aa0ee2039c82c46

To prevent from recurring similar problems, this commit introduces two changes:
- The scope now always returns an `Array` whether min_id option is present or not.
- The scope is renamed to `to_a_paginated_by_id` to clarify it returns an `Array`.