### PR TITLE
Change S3 ACL in "tootctl media remove-orphans --fix-permissions" from fixed value to environment file's value.

### DIFF
--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -67,6 +67,7 @@ module Mastodon
       when :s3
         paperclip_instance = MediaAttachment.new.file
         s3_interface       = paperclip_instance.s3_interface
+        s3_permissions     = Paperclip::Attachment.default_options[:s3_permissions]
         bucket             = s3_interface.bucket(Paperclip::Attachment.default_options[:s3_credentials][:bucket])
         last_key           = options[:start_after]
 
@@ -87,7 +88,7 @@ module Mastodon
           record_map = preload_records_from_mixed_objects(objects)
 
           objects.each do |object|
-            object.acl.put(acl: 'public-read') if options[:fix_permissions] && !options[:dry_run]
+            object.acl.put(acl: s3_permissions) if options[:fix_permissions] && !options[:dry_run]
 
             path_segments = object.key.split('/')
             path_segments.delete('cache')


### PR DESCRIPTION
It's possible to set S3 ACL value from the environment file.