### PR TITLE
Fix multiple boosts of a same toot erroneously appearing in TL

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -298,9 +298,7 @@ class FeedManager
       # delay of the worker deliverying the original status, the late addition
       # by merging timelines, and other reasons.
       # If such a reblog already exists, just do not re-insert it into the feed.
-      rank = redis.zrevrank(reblog_key, status.id)
-
-      return false unless rank.nil?
+      return false unless redis.zscore(reblog_key, status.id).nil?
 
       redis.zadd(timeline_key, status.id, status.id)
     end

--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -77,9 +77,11 @@ class FeedManager
 
     # Get the score of the REBLOG_FALLOFF'th item in our feed, and stop
     # tracking anything after it for deduplication purposes.
-    falloff_rank  = FeedManager::REBLOG_FALLOFF - 1
+    falloff_rank  = FeedManager::REBLOG_FALLOFF
     falloff_range = redis.zrevrange(timeline_key, falloff_rank, falloff_rank, with_scores: true)
-    falloff_score = falloff_range&.first&.last&.to_i || 0
+    falloff_score = falloff_range&.first&.last&.to_i
+
+    return if falloff_score.nil?
 
     # Get any reblogs we might have to clean up after.
     redis.zrangebyscore(reblog_key, 0, falloff_score).each do |reblogged_id|

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -444,8 +444,8 @@ RSpec.describe FeedManager do
       expect(Redis.current.exists?(reblog_set_key)).to be true
       expect(Redis.current.zrange(reblogs_key, 0, -1)).to eq [reblogged.id.to_s]
 
-      # Push everything off the end of the feed.
-      FeedManager::MAX_ITEMS.times do
+      # Push everything past the reblog falloff.
+      FeedManager::REBLOG_FALLOFF.times do
         FeedManager.instance.push_to_home(receiver, Fabricate(:status))
       end
 


### PR DESCRIPTION
I have seen and been reported (very rare) cases of multiple consecutive boosts of a same toot appearing in a timeline despite the the “aggregate reblogs” option being checked.

The only possible cause I have identified is the check for a toot having been recently boosted and adding that toot to the set of recently-boosted toots. I am unconvinced this would be the cause, as the time window for such a race condition is extremely narrow, but it would be it is a possible cause, consistent with the reports. I have fixed this race condition.

This is done by using [the `NX` option of Redis' `ZADD`](https://redis.io/commands/zadd#zadd-options-redis-302-or-greater). I am unsure about the performance implications, but as Redis' documentation does not mention anything related to performances, and that the check was formerly made with a Redis call as complex as `ZADD` itself (`ZREVRANK`), I think performances should be better when the posted item **is** a new reblog, and roughly the same otherwise.

Compatibility-wise, `ZADD`'s `NX` option has been added in Redis 3.0.2, and we currently require Redis 4 because of Sidekiq, so it should be fine to use.

This PR also includes minor fixups/cleanups/performance improvements.