### PR TITLE
allow pagination by min_id and max_id

### DIFF
--- a/app/models/account_conversation.rb
+++ b/app/models/account_conversation.rb
@@ -38,15 +38,16 @@ class AccountConversation < ApplicationRecord
   class << self
     def to_a_paginated_by_id(limit, options = {})
       if options[:min_id]
-        paginate_by_min_id(limit, options[:min_id]).reverse
+        paginate_by_min_id(limit, options[:min_id], options[:max_id]).reverse
       else
         paginate_by_max_id(limit, options[:max_id], options[:since_id]).to_a
       end
     end
 
-    def paginate_by_min_id(limit, min_id = nil)
+    def paginate_by_min_id(limit, min_id = nil, max_id = nil)
       query = order(arel_table[:last_status_id].asc).limit(limit)
       query = query.where(arel_table[:last_status_id].gt(min_id)) if min_id.present?
+      query = query.where(arel_table[:last_status_id].lt(max_id)) if max_id.present?
       query
     end
 

--- a/app/models/concerns/paginable.rb
+++ b/app/models/concerns/paginable.rb
@@ -14,15 +14,16 @@ module Paginable
     # Differs from :paginate_by_max_id in that it gives the results immediately following min_id,
     # whereas since_id gives the items with largest id, but with since_id as a cutoff.
     # Results will be in ascending order by id.
-    scope :paginate_by_min_id, ->(limit, min_id = nil) {
+    scope :paginate_by_min_id, ->(limit, min_id = nil, max_id = nil) {
       query = reorder(arel_table[:id]).limit(limit)
       query = query.where(arel_table[:id].gt(min_id)) if min_id.present?
+      query = query.where(arel_table[:id].lt(max_id)) if max_id.present?
       query
     }
 
     def self.to_a_paginated_by_id(limit, options = {})
       if options[:min_id].present?
-        paginate_by_min_id(limit, options[:min_id]).reverse
+        paginate_by_min_id(limit, options[:min_id], options[:max_id]).reverse
       else
         paginate_by_max_id(limit, options[:max_id], options[:since_id]).to_a
       end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -20,12 +20,12 @@ class Feed
   protected
 
   def from_redis(limit, max_id, since_id, min_id)
+    max_id = '+inf' if max_id.blank?
     if min_id.blank?
-      max_id     = '+inf' if max_id.blank?
       since_id   = '-inf' if since_id.blank?
       unhydrated = redis.zrevrangebyscore(key, "(#{max_id}", "(#{since_id}", limit: [0, limit], with_scores: true).map(&:first).map(&:to_i)
     else
-      unhydrated = redis.zrangebyscore(key, "(#{min_id}", '+inf', limit: [0, limit], with_scores: true).map(&:first).map(&:to_i)
+      unhydrated = redis.zrangebyscore(key, "(#{min_id}", "(#{max_id}", limit: [0, limit], with_scores: true).map(&:first).map(&:to_i)
     end
 
     Status.where(id: unhydrated).cache_ids


### PR DESCRIPTION
I want to add "read gap from bottom" feature to my app.

but current API does not support both min_id and max_id is specified.

example:
```
://mstdn.jp/api/v1/timelines/public?limit=80&min_id=104851024371243870&max_id=104851024489466483
104851024489466483 (max_id parameter)
104851024371243870 (min_id parameter)

response is not in min-max range.
104851030810789863
104851030584864650
104851030520828910
104851030397708486
104851030354767343
```

Pagination in some Mastodon APIs has no relation between the content ID and the pagination ID.
(example: user's follow list is paginated by follow.id, but it is not exposed in the response.)
in this case the app cannot filter the data using the content ID and pagination ID.