### PR TITLE
Fix reported statuses not being included in warning e-mail

### DIFF
--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -142,7 +142,7 @@ class Admin::AccountAction
   end
 
   def status_ids
-    @report.status_ids if @report && include_statuses
+    report.status_ids if report && include_statuses
   end
 
   def reports


### PR DESCRIPTION
The method was not using the getter that loads the actual report...