### PR TITLE
Add gemini to list of link protocols

### DIFF
--- a/app/lib/sanitize_config.rb
+++ b/app/lib/sanitize_config.rb
@@ -16,6 +16,7 @@ class Sanitize
       ipns
       ssb
       gopher
+      gemini
       xmpp
       magnet
     ).freeze


### PR DESCRIPTION
Gemini is a relatively new, gopher-like protocol: https://gemini.circumlunar.space/

This is an extremely small change; hopefully I'm doing it in the right place.