### PR TITLE
add og:published_time to opengraph meta tags

### DIFF
--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -12,6 +12,7 @@
   = opengraph 'og:type', 'article'
   = opengraph 'og:title', "#{display_name(@account)} (#{acct(@account)})"
   = opengraph 'og:url', short_account_status_url(@account, @status)
+  = opengraph 'og:published_time', @status.created_at.iso8601
 
   = render 'og_description', activity: @status
   = render 'og_image', activity: @status, account: @account


### PR DESCRIPTION
This e.g. shows up on Slack:

![A Mastodon status shown in Slack with a "Yesterday at 12:09 PM" label at the bottom](https://user-images.githubusercontent.com/172800/94195781-512a4500-fe68-11ea-8fcd-c09a120d220a.png)
