### PR TITLE
Fix missing Action Creator for NOTIFICATIONS_MARK_AS_READ

### DIFF
--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -234,3 +234,7 @@ export const mountNotifications = () => ({
 export const unmountNotifications = () => ({
   type: NOTIFICATIONS_UNMOUNT,
 });
+
+export const markNotificationsAsRead = () => ({
+  type: NOTIFICATIONS_MARK_AS_READ,
+});


### PR DESCRIPTION
Fix https://github.com/tootsuite/mastodon/pull/14818

Now the "mark as read" button works.