### PR TITLE
Fix mark as read in notifications to be saved immediately

### DIFF
--- a/app/javascript/mastodon/actions/markers.js
+++ b/app/javascript/mastodon/actions/markers.js
@@ -103,7 +103,7 @@ export function submitMarkersSuccess({ home, notifications }) {
 export function submitMarkers(params = {}) {
   const result = (dispatch, getState) => debouncedSubmitMarkers(dispatch, getState);
   if (params.immediate === true) {
-    debouncedSubmitMarkers.flush()
+    debouncedSubmitMarkers.flush();
   }
   return result;
 };

--- a/app/javascript/mastodon/actions/markers.js
+++ b/app/javascript/mastodon/actions/markers.js
@@ -100,8 +100,12 @@ export function submitMarkersSuccess({ home, notifications }) {
   };
 };
 
-export function submitMarkers() {
-  return (dispatch, getState) => debouncedSubmitMarkers(dispatch, getState);
+export function submitMarkers(params = {}) {
+  const result = (dispatch, getState) => debouncedSubmitMarkers(dispatch, getState);
+  if (params.immediate === true) {
+    debouncedSubmitMarkers.flush()
+  }
+  return result;
 };
 
 export const fetchMarkers = () => (dispatch, getState) => {

--- a/app/javascript/mastodon/features/notifications/index.js
+++ b/app/javascript/mastodon/features/notifications/index.js
@@ -12,6 +12,7 @@ import {
   unmountNotifications,
   markNotificationsAsRead,
 } from '../../actions/notifications';
+import { submitMarkers } from '../../actions/markers';
 import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
 import NotificationContainer from './containers/notification_container';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
@@ -162,6 +163,7 @@ class Notifications extends React.PureComponent {
 
   handleMarkAsRead = () => {
     this.props.dispatch(markNotificationsAsRead());
+    this.props.dispatch(submitMarkers({ immediate: true }));
   };
 
   render () {

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -266,7 +266,7 @@ class UI extends React.PureComponent {
 
   handleWindowFocus = () => {
     this.props.dispatch(focusApp());
-    this.props.dispatch(submitMarkers());
+    this.props.dispatch(submitMarkers({ immediate: true }));
   }
 
   handleWindowBlur = () => {


### PR DESCRIPTION
This fix immediately calls the POST /api/v1/markers API when you press the ✓ button in the notification column header and when AppFocus.

Reason:

Currently, if the home timeline is updated within 30 seconds, debounce will postpone the marker POST, so many users are not doing the marker POST until the WebUI is unloaded.

POST (debounce flash) at the time of unloading often did not work as expected on mobile, and as a result, the marker was not updated. The same phenomenon occurs in Safari on PC.

A workaround to perform the unload is to switch from the WebUI to the user settings and back to the WebUI :-)

This also means that the home timeline marker may not be saved. It may be better to call regularly by throttle instead of debounce so that the state is not lost, but this PR does not deal with it.