### PR TITLE
Add relationship filters for non-mutuals.

### DIFF
--- a/app/models/relationship_filter.rb
+++ b/app/models/relationship_filter.rb
@@ -61,8 +61,12 @@ class RelationshipFilter
     case value
     when 'following'
       account.following.eager_load(:account_stat).reorder(nil)
+    when 'nonmutual_following'
+      account.following.eager_load(:account_stat).reorder(nil).where.not(id: account.followers)
     when 'followed_by'
       account.followers.eager_load(:account_stat).reorder(nil)
+    when 'nonmutual_followed_by'
+      account.followers.eager_load(:account_stat).reorder(nil).where.not(id: account.following)
     when 'mutual'
       account.followers.eager_load(:account_stat).reorder(nil).merge(Account.where(id: account.following))
     when 'invited'

--- a/app/views/relationships/show.html.haml
+++ b/app/views/relationships/show.html.haml
@@ -9,7 +9,9 @@
     %strong= t 'relationships.relationship'
     %ul
       %li= filter_link_to t('relationships.following'), relationship: nil
+      %li= filter_link_to t('relationships.nonmutual-following'), relationship: 'nonmutual_following'
       %li= filter_link_to t('relationships.followers'), relationship: 'followed_by'
+      %li= filter_link_to t('relationships.nonmutual-followers'), relationship: 'nonmutual_followed_by'
       %li= filter_link_to t('relationships.mutual'), relationship: 'mutual'
 
   .filter-subset

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1051,6 +1051,8 @@ en:
     dormant: Dormant
     followers: Followers
     following: Following
+    nonmutual-followers: Non-Mutual Followers
+    nonmutual-following: Non-Mutual Following
     invited: Invited
     last_active: Last active
     most_recent: Most recent


### PR DESCRIPTION
Currently, the "following" and "followers" filters on the Relationships screen show just that: a list of people following you, and a list of people you're following. However, a common desire is to audit a list of one's non-mutual followers, in order to ensure that one's posts are only seen by the people they intend. This patch adds two new filters to the API and to the relationships screen: "nonmutual following" for people you follow who don't follow you back, and "nonmutual followers" for people who follow you but you don't follow back. 