### PR TITLE
Fix alt-based hotkeys interfering with normal input on MacOS

### DIFF
--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -379,7 +379,7 @@ class UI extends React.PureComponent {
 
   componentDidMount () {
     this.hotkeys.__mousetrap__.stopCallback = (e, element) => {
-      return ['TEXTAREA', 'SELECT', 'INPUT'].includes(element.tagName) && !e.altKey;
+      return ['TEXTAREA', 'SELECT', 'INPUT'].includes(element.tagName);
     };
   }
 


### PR DESCRIPTION
Fixes #14862

We used to ignore every hotkey on inputs etc. until #13987, which introduced a hotkey to toggle the Content Warning field.

Unfortunately, MacOS relies on the “alt” key for many things, including composing text (see #14862), therefore, even if that makes the CW toggle hotkey significantly less useful, it makes sense to not interfere with composing toots.