### PR TITLE
Exclude dependency updates other than direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       interval: weekly
     open-pull-requests-limit: 99
     allow:
-      - dependency-type: all
+      - dependency-type: direct
 
   - package-ecosystem: bundler
     directory: "/"
@@ -19,4 +19,4 @@ updates:
       interval: weekly
     open-pull-requests-limit: 99
     allow:
-      - dependency-type: all
+      - dependency-type: direct


### PR DESCRIPTION
Mastodon has many dependencies of dependencies of dependencies of dependencies of dependencies...🤯

ref https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#allow