### PR TITLE
add S3_READ_TIMEOUT environment variable

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -62,7 +62,7 @@ if ENV['S3_ENABLED'] == 'true'
     s3_options: {
       signature_version: ENV.fetch('S3_SIGNATURE_VERSION') { 'v4' },
       http_open_timeout: ENV.fetch('S3_OPEN_TIMEOUT'){ '5' }.to_i,
-      http_read_timeout: 5,
+      http_read_timeout: ENV.fetch('S3_READ_TIMEOUT'){ '5' }.to_i,
       http_idle_timeout: 5,
       retry_limit: 0,
     }


### PR DESCRIPTION
When using `tootctl media remove` or media upload from WebUI or client, 
I saw many `Net::ReadTimeout with #<TCPSocket:(closed)>` .
5s default value is too short for cheap storage service.
This PR add S3_READ_TIMEOUT environment variable to configure read timeout.

See also: https://github.com/tootsuite/mastodon/pull/12459

