### PR TITLE
Change unread notifications to be reset 5s after mounting component in web UI

### DIFF
--- a/app/javascript/mastodon/features/notifications/index.js
+++ b/app/javascript/mastodon/features/notifications/index.js
@@ -83,6 +83,7 @@ class Notifications extends React.PureComponent {
 
   componentWillMount() {
     this.props.dispatch(mountNotifications());
+    setTimeout(() => this.handleMarkAsRead(), 5000);
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
If I am viewing home timeline, then new notifications appear and I click on notifications, I expect unread notifications to be marked as read, with some delay so I get an idea of what's new. I believe making people always manually click on the checkmark button in the header would be too annoying. It's especially annoying when you navigate away from notifications and they're still marked as unread.