### PR TITLE
Add support for reversible suspensions through ActivityPub 

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -102,6 +102,10 @@ class AccountsController < ApplicationController
     params[:username]
   end
 
+  def skip_temporary_suspension_response?
+    request.format == :json
+  end
+
   def rss_url
     if tag_requested?
       short_account_tag_url(@account, params[:tag], format: 'rss')

--- a/app/controllers/activitypub/base_controller.rb
+++ b/app/controllers/activitypub/base_controller.rb
@@ -8,4 +8,8 @@ class ActivityPub::BaseController < Api::BaseController
   def set_cache_headers
     response.headers['Vary'] = 'Signature' if authorized_fetch_mode?
   end
+
+  def skip_temporary_suspension_response?
+    false
+  end
 end

--- a/app/controllers/activitypub/inboxes_controller.rb
+++ b/app/controllers/activitypub/inboxes_controller.rb
@@ -33,6 +33,10 @@ class ActivityPub::InboxesController < ActivityPub::BaseController
     params[:account_username].present?
   end
 
+  def skip_temporary_suspension_response?
+    true
+  end
+
   def body
     return @body if defined?(@body)
 

--- a/app/controllers/activitypub/replies_controller.rb
+++ b/app/controllers/activitypub/replies_controller.rb
@@ -31,7 +31,7 @@ class ActivityPub::RepliesController < ActivityPub::BaseController
   end
 
   def set_replies
-    @replies = only_other_accounts? ? Status.where.not(account_id: @account.id) : @account.statuses
+    @replies = only_other_accounts? ? Status.where.not(account_id: @account.id).joins(:account).merge(Account.without_suspended) : @account.statuses
     @replies = @replies.where(in_reply_to_id: @status.id, visibility: [:public, :unlisted])
     @replies = @replies.paginate_by_min_id(DESCENDANTS_LIMIT, params[:min_id])
   end

--- a/app/controllers/concerns/account_owned_concern.rb
+++ b/app/controllers/concerns/account_owned_concern.rb
@@ -29,6 +29,24 @@ module AccountOwnedConcern
   end
 
   def check_account_suspension
-    expires_in(3.minutes, public: true) && gone if @account.suspended?
+    if @account.suspended_permanently?
+      permanent_suspension_response
+    elsif @account.suspended? && !skip_temporary_suspension_response?
+      temporary_suspension_response
+    end
+  end
+
+  def skip_temporary_suspension_response?
+    false
+  end
+
+  def permanent_suspension_response
+    expires_in(3.minutes, public: true)
+    gone
+  end
+
+  def temporary_suspension_response
+    expires_in(3.minutes, public: true)
+    forbidden
   end
 end

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -52,6 +52,14 @@ class FollowerAccountsController < ApplicationController
     account_followers_url(@account, page: page) unless page.nil?
   end
 
+  def next_page_url
+    page_url(follows.next_page) if follows.respond_to?(:next_page)
+  end
+
+  def prev_page_url
+    page_url(follows.prev_page) if follows.respond_to?(:prev_page)
+  end
+
   def collection_presenter
     if page_requested?
       ActivityPub::CollectionPresenter.new(
@@ -60,8 +68,8 @@ class FollowerAccountsController < ApplicationController
         size: @account.followers_count,
         items: follows.map { |f| ActivityPub::TagManager.instance.uri_for(f.account) },
         part_of: account_followers_url(@account),
-        next: page_url(follows.next_page),
-        prev: page_url(follows.prev_page)
+        next: next_page_url,
+        prev: prev_page_url
       )
     else
       ActivityPub::CollectionPresenter.new(

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -52,6 +52,14 @@ class FollowingAccountsController < ApplicationController
     account_following_index_url(@account, page: page) unless page.nil?
   end
 
+  def next_page_url
+    page_url(follows.next_page) if follows.respond_to?(:next_page)
+  end
+
+  def prev_page_url
+    page_url(follows.prev_page) if follows.respond_to?(:prev_page)
+  end
+
   def collection_presenter
     if page_requested?
       ActivityPub::CollectionPresenter.new(
@@ -60,8 +68,8 @@ class FollowingAccountsController < ApplicationController
         size: @account.following_count,
         items: follows.map { |f| ActivityPub::TagManager.instance.uri_for(f.target_account) },
         part_of: account_following_index_url(@account),
-        next: page_url(follows.next_page),
-        prev: page_url(follows.prev_page)
+        next: next_page_url,
+        prev: prev_page_url
       )
     else
       ActivityPub::CollectionPresenter.new(

--- a/app/controllers/settings/deletes_controller.rb
+++ b/app/controllers/settings/deletes_controller.rb
@@ -42,7 +42,7 @@ class Settings::DeletesController < Settings::BaseController
   end
 
   def destroy_account!
-    current_account.suspend!
+    current_account.suspend!(origin: :local)
     AccountDeletionWorker.perform_async(current_user.account_id)
     sign_out
   end

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -35,7 +35,7 @@ module WellKnown
     end
 
     def check_account_suspension
-      expires_in(3.minutes, public: true) && gone if @account.suspended?
+      expires_in(3.minutes, public: true) && gone if @account.suspended_permanently?
     end
 
     def bad_request

--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -2,6 +2,10 @@
   margin-bottom: 10px;
   box-shadow: 0 0 15px rgba($base-shadow-color, 0.2);
 
+  &:last-child {
+    margin-bottom: 0;
+  }
+
   &__img {
     width: 100%;
     position: relative;

--- a/app/lib/activitypub/adapter.rb
+++ b/app/lib/activitypub/adapter.rb
@@ -23,6 +23,7 @@ class ActivityPub::Adapter < ActiveModelSerializers::Adapter::Base
     discoverable: { 'toot' => 'http://joinmastodon.org/ns#', 'discoverable' => 'toot:discoverable' },
     voters_count: { 'toot' => 'http://joinmastodon.org/ns#', 'votersCount' => 'toot:votersCount' },
     olm: { 'toot' => 'http://joinmastodon.org/ns#', 'Device' => 'toot:Device', 'Ed25519Signature' => 'toot:Ed25519Signature', 'Ed25519Key' => 'toot:Ed25519Key', 'Curve25519Key' => 'toot:Curve25519Key', 'EncryptedMessage' => 'toot:EncryptedMessage', 'publicKeyBase64' => 'toot:publicKeyBase64', 'deviceId' => 'toot:deviceId', 'claim' => { '@type' => '@id', '@id' => 'toot:claim' }, 'fingerprintKey' => { '@type' => '@id', '@id' => 'toot:fingerprintKey' }, 'identityKey' => { '@type' => '@id', '@id' => 'toot:identityKey' }, 'devices' => { '@type' => '@id', '@id' => 'toot:devices' }, 'messageFranking' => 'toot:messageFranking', 'messageType' => 'toot:messageType', 'cipherText' => 'toot:cipherText' },
+    suspended: { 'toot' => 'http://joinmastodon.org/ns#', 'suspended' => 'toot:suspended' },
   }.freeze
 
   def self.default_key_transform

--- a/app/lib/webfinger.rb
+++ b/app/lib/webfinger.rb
@@ -2,6 +2,8 @@
 
 class Webfinger
   class Error < StandardError; end
+  class GoneError < Error; end
+  class RedirectError < StandardError; end
 
   class Response
     def initialize(body)
@@ -47,6 +49,8 @@ class Webfinger
         res.body_with_limit
       elsif res.code == 404 && use_fallback
         body_from_host_meta
+      elsif res.code == 410
+        raise Webfinger::GoneError, "#{@uri} is gone from the server"
       else
         raise Webfinger::Error, "Request for #{@uri} returned HTTP #{res.code}"
       end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -51,6 +51,7 @@
 #  header_storage_schema_version :integer
 #  devices_url                   :string
 #  sensitized_at                 :datetime
+#  suspension_origin             :integer
 #
 
 class Account < ApplicationRecord
@@ -73,6 +74,7 @@ class Account < ApplicationRecord
   }.freeze
 
   enum protocol: [:ostatus, :activitypub]
+  enum suspension_origin: [:local, :remote], _prefix: true
 
   validates :username, presence: true
   validates_with UniqueUsernameValidator, if: -> { will_save_change_to_username? }
@@ -222,17 +224,25 @@ class Account < ApplicationRecord
     suspended_at.present?
   end
 
-  def suspend!(date = Time.now.utc)
+  def suspended_permanently?
+    suspended? && deletion_request.nil?
+  end
+
+  def suspended_temporarily?
+    suspended? && deletion_request.present?
+  end
+
+  def suspend!(date: Time.now.utc, origin: :local)
     transaction do
       create_deletion_request!
-      update!(suspended_at: date)
+      update!(suspended_at: date, suspension_origin: origin)
     end
   end
 
   def unsuspend!
     transaction do
       deletion_request&.destroy!
-      update!(suspended_at: nil)
+      update!(suspended_at: nil, suspension_origin: nil)
     end
   end
 

--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -127,7 +127,7 @@ class Admin::AccountAction
   def handle_suspend!
     authorize(target_account, :suspend?)
     log_action(:suspend, target_account)
-    target_account.suspend!
+    target_account.suspend!(origin: :local)
   end
 
   def text_for_warning

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -18,11 +18,11 @@ class AccountPolicy < ApplicationPolicy
   end
 
   def destroy?
-    record.suspended? && record.deletion_request.present? && admin?
+    record.suspended_temporarily? && admin?
   end
 
   def unsuspend?
-    staff?
+    staff? && record.suspension_origin_local?
   end
 
   def sensitive?

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -7,7 +7,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
 
   context_extensions :manually_approves_followers, :featured, :also_known_as,
                      :moved_to, :property_value, :identity_proof,
-                     :discoverable, :olm
+                     :discoverable, :olm, :suspended
 
   attributes :id, :type, :following, :followers,
              :inbox, :outbox, :featured, :featured_tags,
@@ -23,6 +23,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
   attribute :devices, unless: :instance_actor?
   attribute :moved_to, if: :moved?
   attribute :also_known_as, if: :also_known_as?
+  attribute :suspended, if: :suspended?
 
   class EndpointsSerializer < ActivityPub::Serializer
     include RoutingHelper
@@ -39,7 +40,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
   has_one :icon,  serializer: ActivityPub::ImageSerializer, if: :avatar_exists?
   has_one :image, serializer: ActivityPub::ImageSerializer, if: :header_exists?
 
-  delegate :moved?, :instance_actor?, to: :object
+  delegate :suspended?, :instance_actor?, to: :object
 
   def id
     object.instance_actor? ? instance_actor_url : account_url(object)
@@ -93,12 +94,16 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
     object.username
   end
 
+  def discoverable
+    object.suspended? ? false : (object.discoverable || false)
+  end
+
   def name
-    object.display_name
+    object.suspended? ? '' : object.display_name
   end
 
   def summary
-    Formatter.instance.simplified_format(object)
+    object.suspended? ? '' : Formatter.instance.simplified_format(object)
   end
 
   def icon
@@ -113,36 +118,44 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
     object
   end
 
+  def suspended
+    object.suspended?
+  end
+
   def url
     object.instance_actor? ? about_more_url(instance_actor: true) : short_account_url(object)
   end
 
   def avatar_exists?
-    object.avatar?
+    !object.suspended? && object.avatar?
   end
 
   def header_exists?
-    object.header?
+    !object.suspended? && object.header?
   end
 
   def manually_approves_followers
-    object.locked
+    object.suspended? ? false : object.locked
   end
 
   def virtual_tags
-    object.emojis + object.tags
+    object.suspended? ? [] : (object.emojis + object.tags)
   end
 
   def virtual_attachments
-    object.fields + object.identity_proofs.active
+    object.suspended? ? [] : (object.fields + object.identity_proofs.active)
   end
 
   def moved_to
     ActivityPub::TagManager.instance.uri_for(object.moved_to_account)
   end
 
+  def moved?
+    !object.suspended? && object.moved?
+  end
+
   def also_known_as?
-    !object.also_known_as.empty?
+    !object.suspended? && !object.also_known_as.empty?
   end
 
   class CustomEmojiSerializer < ActivityPub::EmojiSerializer

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -18,10 +18,11 @@ class ActivityPub::ProcessAccountService < BaseService
 
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?
-        @account          = Account.remote.find_by(uri: @uri) if @options[:only_key]
-        @account        ||= Account.find_remote(@username, @domain)
-        @old_public_key   = @account&.public_key
-        @old_protocol     = @account&.protocol
+        @account            = Account.remote.find_by(uri: @uri) if @options[:only_key]
+        @account          ||= Account.find_remote(@username, @domain)
+        @old_public_key     = @account&.public_key
+        @old_protocol       = @account&.protocol
+        @suspension_changed = false
 
         create_account if @account.nil?
         update_account
@@ -37,8 +38,9 @@ class ActivityPub::ProcessAccountService < BaseService
     after_protocol_change! if protocol_changed?
     after_key_change! if key_changed? && !@options[:signed_with_known_key]
     clear_tombstones! if key_changed?
+    after_suspension_change! if suspension_changed?
 
-    unless @options[:only_key]
+    unless @options[:only_key] || @account.suspended?
       check_featured_collection! if @account.featured_collection_url.present?
       check_links! unless @account.fields.empty?
     end
@@ -52,20 +54,23 @@ class ActivityPub::ProcessAccountService < BaseService
 
   def create_account
     @account = Account.new
-    @account.protocol     = :activitypub
-    @account.username     = @username
-    @account.domain       = @domain
-    @account.private_key  = nil
-    @account.suspended_at = domain_block.created_at if auto_suspend?
-    @account.silenced_at  = domain_block.created_at if auto_silence?
+    @account.protocol          = :activitypub
+    @account.username          = @username
+    @account.domain            = @domain
+    @account.private_key       = nil
+    @account.suspended_at      = domain_block.created_at if auto_suspend?
+    @account.suspension_origin = :local if auto_suspend?
+    @account.silenced_at       = domain_block.created_at if auto_silence?
+    @account.save
   end
 
   def update_account
     @account.last_webfingered_at = Time.now.utc unless @options[:only_key]
     @account.protocol            = :activitypub
 
-    set_immediate_attributes!
-    set_fetchable_attributes! unless @options[:only_keys]
+    set_suspension!
+    set_immediate_attributes! unless @account.suspended?
+    set_fetchable_attributes! unless @options[:only_keys] || @account.suspended?
 
     @account.save_with_optional_media!
   end
@@ -99,12 +104,32 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.moved_to_account  = @json['movedTo'].present? ? moved_account : nil
   end
 
+  def set_suspension!
+    return if @account.suspended? && @account.suspension_origin_local?
+
+    if @account.suspended? && !@json['suspended']
+      @account.unsuspend!
+      @suspension_changed = true
+    elsif !@account.suspended? && @json['suspended']
+      @account.suspend!(origin: :remote)
+      @suspension_changed = true
+    end
+  end
+
   def after_protocol_change!
     ActivityPub::PostUpgradeWorker.perform_async(@account.domain)
   end
 
   def after_key_change!
     RefollowWorker.perform_async(@account.id)
+  end
+
+  def after_suspension_change!
+    if @account.suspended?
+      Admin::SuspensionWorker.perform_async(@account.id)
+    else
+      Admin::UnsuspensionWorker.perform_async(@account.id)
+    end
   end
 
   def check_featured_collection!
@@ -225,6 +250,10 @@ class ActivityPub::ProcessAccountService < BaseService
 
   def key_changed?
     !@old_public_key.nil? && @old_public_key != @account.public_key
+  end
+
+  def suspension_changed?
+    @suspension_changed
   end
 
   def clear_tombstones!

--- a/app/services/block_domain_service.rb
+++ b/app/services/block_domain_service.rb
@@ -16,7 +16,7 @@ class BlockDomainService < BaseService
     scope = Account.by_domain_and_subdomains(domain_block.domain)
 
     scope.where(silenced_at: domain_block.created_at).in_batches.update_all(silenced_at: nil) unless domain_block.silence?
-    scope.where(suspended_at: domain_block.created_at).in_batches.update_all(suspended_at: nil) unless domain_block.suspend?
+    scope.where(suspended_at: domain_block.created_at).in_batches.update_all(suspended_at: nil, suspension_origin: nil) unless domain_block.suspend?
   end
 
   def process_domain_block!
@@ -34,7 +34,8 @@ class BlockDomainService < BaseService
   end
 
   def suspend_accounts!
-    blocked_domain_accounts.without_suspended.in_batches.update_all(suspended_at: @domain_block.created_at)
+    blocked_domain_accounts.without_suspended.in_batches.update_all(suspended_at: @domain_block.created_at, suspension_origin: :local)
+
     blocked_domain_accounts.where(suspended_at: @domain_block.created_at).reorder(nil).find_each do |account|
       DeleteAccountService.new.call(account, reserve_username: true, suspended_at: @domain_block.created_at)
     end

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -5,8 +5,6 @@ class ResolveAccountService < BaseService
   include DomainControlHelper
   include WebfingerHelper
 
-  class WebfingerRedirectError < StandardError; end
-
   # Find or create an account record for a remote user. When creating,
   # look up the user's webfinger and fetch ActivityPub data
   # @param [String, Account] uri URI in the username@domain format or account record
@@ -40,13 +38,18 @@ class ResolveAccountService < BaseService
 
     @account ||= Account.find_remote(@username, @domain)
 
-    return @account if @account&.local? || !webfinger_update_due?
+    if gone_from_origin? && not_yet_deleted?
+      queue_deletion!
+      return
+    end
+
+    return @account if @account&.local? || gone_from_origin? || !webfinger_update_due?
 
     # Now it is certain, it is definitely a remote account, and it
     # either needs to be created, or updated from fresh data
 
     process_account!
-  rescue Webfinger::Error, WebfingerRedirectError, Oj::ParseError => e
+  rescue Webfinger::Error, Oj::ParseError => e
     Rails.logger.debug "Webfinger query for #{@uri} failed: #{e}"
     nil
   end
@@ -86,10 +89,12 @@ class ResolveAccountService < BaseService
     elsif !redirected
       return process_webfinger!("#{confirmed_username}@#{confirmed_domain}", true)
     else
-      raise WebfingerRedirectError, "The URI #{uri} tries to hijack #{@username}@#{@domain}"
+      raise Webfinger::RedirectError, "The URI #{uri} tries to hijack #{@username}@#{@domain}"
     end
 
     @domain = nil if TagManager.instance.local_domain?(@domain)
+  rescue Webfinger::GoneError
+    @gone = true
   end
 
   def process_account!
@@ -129,6 +134,18 @@ class ResolveAccountService < BaseService
 
     json        = fetch_resource(actor_url, false)
     @actor_json = supported_context?(json) && equals_or_includes_any?(json['type'], ActivityPub::FetchRemoteAccountService::SUPPORTED_TYPES) ? json : nil
+  end
+
+  def gone_from_origin?
+    @gone
+  end
+
+  def not_yet_deleted?
+    @account.present? && !@account.local?
+  end
+
+  def queue_deletion!
+    AccountDeletionWorker.perform_async(@account.id, reserve_username: false)
   end
 
   def lock_options

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class SuspendAccountService < BaseService
+  include Payloadable
+
   def call(account)
     @account = account
 
     suspend!
+    reject_remote_follows!
+    distribute_update_actor!
     unmerge_from_home_timelines!
     unmerge_from_list_timelines!
     privatize_media_attachments!
@@ -14,6 +18,31 @@ class SuspendAccountService < BaseService
 
   def suspend!
     @account.suspend! unless @account.suspended?
+  end
+
+  def reject_remote_follows!
+    return if @account.local? || !@account.activitypub?
+
+    # When suspending a remote account, the account obviously doesn't
+    # actually become suspended on its origin server, i.e. unlike a
+    # locally suspended account it continues to have access to its home
+    # feed and other content. To prevent it from being able to continue
+    # to access toots it would receive because it follows local accounts,
+    # we have to force it to unfollow them. Unfortunately, there is no
+    # counterpart to this operation, i.e. you can't then force a remote
+    # account to re-follow you, so this part is not reversible.
+
+    follows = Follow.where(account: @account).to_a
+
+    ActivityPub::DeliveryWorker.push_bulk(follows) do |follow|
+      [Oj.dump(serialize_payload(follow, ActivityPub::RejectFollowSerializer)), follow.target_account_id, @account.inbox_url]
+    end
+
+    follows.in_batches.destroy_all
+  end
+
+  def distribute_update_actor!
+    ActivityPub::UpdateDistributionWorker.perform_async(@account.id) if @account.local?
   end
 
   def unmerge_from_home_timelines!

--- a/app/services/unblock_domain_service.rb
+++ b/app/services/unblock_domain_service.rb
@@ -13,6 +13,6 @@ class UnblockDomainService < BaseService
     scope = Account.by_domain_and_subdomains(domain_block.domain)
 
     scope.where(silenced_at: domain_block.created_at).in_batches.update_all(silenced_at: nil) unless domain_block.noop?
-    scope.where(suspended_at: domain_block.created_at).in_batches.update_all(suspended_at: nil) if domain_block.suspend?
+    scope.where(suspended_at: domain_block.created_at).in_batches.update_all(suspended_at: nil, suspension_origin: nil) if domain_block.suspend?
   end
 end

--- a/app/workers/account_deletion_worker.rb
+++ b/app/workers/account_deletion_worker.rb
@@ -5,8 +5,8 @@ class AccountDeletionWorker
 
   sidekiq_options queue: 'pull'
 
-  def perform(account_id)
-    DeleteAccountService.new.call(Account.find(account_id), reserve_username: true, reserve_email: false)
+  def perform(account_id, reserve_username: true)
+    DeleteAccountService.new.call(Account.find(account_id), reserve_username: reserve_username, reserve_email: false)
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/db/migrate/20201017233919_add_suspension_origin_to_accounts.rb
+++ b/db/migrate/20201017233919_add_suspension_origin_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddSuspensionOriginToAccounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :accounts, :suspension_origin, :integer
+  end
+end

--- a/db/post_migrate/20201017234926_fill_account_suspension_origin.rb
+++ b/db/post_migrate/20201017234926_fill_account_suspension_origin.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class FillAccountSuspensionOrigin < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    Account.suspended.where(suspension_origin: nil).in_batches.update_all(suspension_origin: :local)
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_08_220312) do
+ActiveRecord::Schema.define(version: 2020_10_17_234926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -189,6 +189,7 @@ ActiveRecord::Schema.define(version: 2020_10_08_220312) do
     t.integer "avatar_storage_schema_version"
     t.integer "header_storage_schema_version"
     t.string "devices_url"
+    t.integer "suspension_origin"
     t.datetime "sensitized_at"
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true

--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -245,7 +245,7 @@ module Mastodon
         end
 
         if [404, 410].include?(code)
-          SuspendAccountService.new.call(account, reserve_username: false) unless options[:dry_run]
+          DeleteAccountService.new.call(account, reserve_username: false) unless options[:dry_run]
           1
         else
           # Touch account even during dry run to avoid getting the account into the window again

--- a/spec/controllers/account_follow_controller_spec.rb
+++ b/spec/controllers/account_follow_controller_spec.rb
@@ -16,17 +16,49 @@ describe AccountFollowController do
       allow(service).to receive(:call)
     end
 
-    it 'does not create for user who is not signed in' do
-      subject
-      expect(FollowService).not_to receive(:new)
+    context 'when account is permanently suspended' do
+      before do
+        alice.suspend!
+        alice.deletion_request.destroy
+        subject
+      end
+
+      it 'returns http gone' do
+        expect(response).to have_http_status(410)
+      end
     end
 
-    it 'redirects to account path' do
-      sign_in(user)
-      subject
+    context 'when account is temporarily suspended' do
+      before do
+        alice.suspend!
+        subject
+      end
 
-      expect(service).to have_received(:call).with(user.account, alice, with_rate_limit: true)
-      expect(response).to redirect_to(account_path(alice))
+      it 'returns http forbidden' do
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context 'when signed out' do
+      before do
+        subject
+      end
+
+      it 'does not follow' do
+        expect(FollowService).not_to receive(:new)
+      end
+    end
+
+    context 'when signed in' do
+      before do
+        sign_in(user)
+        subject
+      end
+
+      it 'redirects to account path' do
+        expect(service).to have_received(:call).with(user.account, alice, with_rate_limit: true)
+        expect(response).to redirect_to(account_path(alice))
+      end
     end
   end
 end

--- a/spec/controllers/account_unfollow_controller_spec.rb
+++ b/spec/controllers/account_unfollow_controller_spec.rb
@@ -16,17 +16,49 @@ describe AccountUnfollowController do
       allow(service).to receive(:call)
     end
 
-    it 'does not create for user who is not signed in' do
-      subject
-      expect(UnfollowService).not_to receive(:new)
+    context 'when account is permanently suspended' do
+      before do
+        alice.suspend!
+        alice.deletion_request.destroy
+        subject
+      end
+
+      it 'returns http gone' do
+        expect(response).to have_http_status(410)
+      end
     end
 
-    it 'redirects to account path' do
-      sign_in(user)
-      subject
+    context 'when account is temporarily suspended' do
+      before do
+        alice.suspend!
+        subject
+      end
 
-      expect(service).to have_received(:call).with(user.account, alice)
-      expect(response).to redirect_to(account_path(alice))
+      it 'returns http forbidden' do
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context 'when signed out' do
+      before do
+        subject
+      end
+
+      it 'does not unfollow' do
+        expect(UnfollowService).not_to receive(:new)
+      end
+    end
+
+    context 'when signed in' do
+      before do
+        sign_in(user)
+        subject
+      end
+
+      it 'redirects to account path' do
+        expect(service).to have_received(:call).with(user.account, alice)
+        expect(response).to redirect_to(account_path(alice))
+      end
     end
   end
 end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -48,10 +48,17 @@ RSpec.describe AccountsController, type: :controller do
           expect(response).to have_http_status(404)
         end
       end
+    end
 
-      context 'when account is suspended' do
+    context 'as HTML' do
+      let(:format) { 'html' }
+
+      it_behaves_like 'preliminary checks'
+
+      context 'when account is permanently suspended' do
         before do
           account.suspend!
+          account.deletion_request.destroy
         end
 
         it 'returns http gone' do
@@ -59,12 +66,17 @@ RSpec.describe AccountsController, type: :controller do
           expect(response).to have_http_status(410)
         end
       end
-    end
 
-    context 'as HTML' do
-      let(:format) { 'html' }
+      context 'when account is temporarily suspended' do
+        before do
+          account.suspend!
+        end
 
-      it_behaves_like 'preliminary checks'
+        it 'returns http forbidden' do
+          get :show, params: { username: account.username, format: format }
+          expect(response).to have_http_status(403)
+        end
+      end
 
       shared_examples 'common response characteristics' do
         it 'returns http success' do
@@ -325,6 +337,29 @@ RSpec.describe AccountsController, type: :controller do
 
       it_behaves_like 'preliminary checks'
 
+      context 'when account is suspended permanently' do
+        before do
+          account.suspend!
+          account.deletion_request.destroy
+        end
+
+        it 'returns http gone' do
+          get :show, params: { username: account.username, format: format }
+          expect(response).to have_http_status(410)
+        end
+      end
+
+      context 'when account is suspended temporarily' do
+        before do
+          account.suspend!
+        end
+
+        it 'returns http success' do
+          get :show, params: { username: account.username, format: format }
+          expect(response).to have_http_status(200)
+        end
+      end
+
       context do
         before do
           get :show, params: { username: account.username, format: format }
@@ -434,6 +469,29 @@ RSpec.describe AccountsController, type: :controller do
       let(:format) { 'rss' }
 
       it_behaves_like 'preliminary checks'
+
+      context 'when account is permanently suspended' do
+        before do
+          account.suspend!
+          account.deletion_request.destroy
+        end
+
+        it 'returns http gone' do
+          get :show, params: { username: account.username, format: format }
+          expect(response).to have_http_status(410)
+        end
+      end
+
+      context 'when account is temporarily suspended' do
+        before do
+          account.suspend!
+        end
+
+        it 'returns http forbidden' do
+          get :show, params: { username: account.username, format: format }
+          expect(response).to have_http_status(403)
+        end
+      end
 
       shared_examples 'common response characteristics' do
         it 'returns http success' do

--- a/spec/controllers/activitypub/collections_controller_spec.rb
+++ b/spec/controllers/activitypub/collections_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ActivityPub::CollectionsController, type: :controller do
     end
 
     it 'does not set sessions' do
+      response
       expect(session).to be_empty
     end
 
@@ -34,9 +35,8 @@ RSpec.describe ActivityPub::CollectionsController, type: :controller do
       context 'without signature' do
         let(:remote_account) { nil }
 
-        before do
-          get :show, params: { id: 'featured', account_username: account.username }
-        end
+        subject(:response) { get :show, params: { id: 'featured', account_username: account.username } }
+        subject(:body) { body_as_json }
 
         it 'returns http success' do
           expect(response).to have_http_status(200)
@@ -49,9 +49,29 @@ RSpec.describe ActivityPub::CollectionsController, type: :controller do
         it_behaves_like 'cachable response'
 
         it 'returns orderedItems with pinned statuses' do
-          json = body_as_json
-          expect(json[:orderedItems]).to be_an Array
-          expect(json[:orderedItems].size).to eq 2
+          expect(body[:orderedItems]).to be_an Array
+          expect(body[:orderedItems].size).to eq 2
+        end
+
+        context 'when account is permanently suspended' do
+          before do
+            account.suspend!
+            account.deletion_request.destroy
+          end
+
+          it 'returns http gone' do
+            expect(response).to have_http_status(410)
+          end
+        end
+
+        context 'when account is temporarily suspended' do
+          before do
+            account.suspend!
+          end
+
+          it 'returns http forbidden' do
+            expect(response).to have_http_status(403)
+          end
         end
       end
 

--- a/spec/controllers/activitypub/inboxes_controller_spec.rb
+++ b/spec/controllers/activitypub/inboxes_controller_spec.rb
@@ -20,6 +20,33 @@ RSpec.describe ActivityPub::InboxesController, type: :controller do
       it 'returns http accepted' do
         expect(response).to have_http_status(202)
       end
+
+      context 'for a specific account' do
+        let(:account) { Fabricate(:account) }
+
+        subject(:response) { post :create, params: { account_username: account.username }, body: '{}' }
+
+        context 'when account is permanently suspended' do
+          before do
+            account.suspend!
+            account.deletion_request.destroy
+          end
+
+          it 'returns http gone' do
+            expect(response).to have_http_status(410)
+          end
+        end
+
+        context 'when account is temporarily suspended' do
+          before do
+            account.suspend!
+          end
+
+          it 'returns http accepted' do
+            expect(response).to have_http_status(202)
+          end
+        end
+      end
     end
 
     context 'with Collection-Synchronization header' do

--- a/spec/controllers/api/v1/admin/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/accounts_controller_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Api::V1::Admin::AccountsController, type: :controller do
 
   describe 'POST #unsuspend' do
     before do
-      account.touch(:suspended_at)
+      account.suspend!
       post :unsuspend, params: { id: account.id }
     end
 

--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -14,6 +14,27 @@ describe FollowerAccountsController do
     context 'when format is html' do
       subject(:response) { get :index, params: { account_username: alice.username, format: :html } }
 
+      context 'when account is permanently suspended' do
+        before do
+          alice.suspend!
+          alice.deletion_request.destroy
+        end
+
+        it 'returns http gone' do
+          expect(response).to have_http_status(410)
+        end
+      end
+
+      context 'when account is temporarily suspended' do
+        before do
+          alice.suspend!
+        end
+
+        it 'returns http forbidden' do
+          expect(response).to have_http_status(403)
+        end
+      end
+
       it 'assigns follows' do
         expect(response).to have_http_status(200)
 
@@ -48,6 +69,27 @@ describe FollowerAccountsController do
           expect(body['totalItems']).to eq 2
           expect(body['partOf']).to be_present
         end
+
+        context 'when account is permanently suspended' do
+          before do
+            alice.suspend!
+            alice.deletion_request.destroy
+          end
+
+          it 'returns http gone' do
+            expect(response).to have_http_status(410)
+          end
+        end
+
+        context 'when account is temporarily suspended' do
+          before do
+            alice.suspend!
+          end
+
+          it 'returns http forbidden' do
+            expect(response).to have_http_status(403)
+          end
+        end
       end
 
       context 'without page' do
@@ -57,6 +99,27 @@ describe FollowerAccountsController do
           expect(response).to have_http_status(200)
           expect(body['totalItems']).to eq 2
           expect(body['partOf']).to be_blank
+        end
+
+        context 'when account is permanently suspended' do
+          before do
+            alice.suspend!
+            alice.deletion_request.destroy
+          end
+
+          it 'returns http gone' do
+            expect(response).to have_http_status(410)
+          end
+        end
+
+        context 'when account is temporarily suspended' do
+          before do
+            alice.suspend!
+          end
+
+          it 'returns http forbidden' do
+            expect(response).to have_http_status(403)
+          end
         end
       end
     end

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -14,6 +14,27 @@ describe FollowingAccountsController do
     context 'when format is html' do
       subject(:response) { get :index, params: { account_username: alice.username, format: :html } }
 
+      context 'when account is permanently suspended' do
+        before do
+          alice.suspend!
+          alice.deletion_request.destroy
+        end
+
+        it 'returns http gone' do
+          expect(response).to have_http_status(410)
+        end
+      end
+
+      context 'when account is temporarily suspended' do
+        before do
+          alice.suspend!
+        end
+
+        it 'returns http forbidden' do
+          expect(response).to have_http_status(403)
+        end
+      end
+
       it 'assigns follows' do
         expect(response).to have_http_status(200)
 
@@ -48,6 +69,27 @@ describe FollowingAccountsController do
           expect(body['totalItems']).to eq 2
           expect(body['partOf']).to be_present
         end
+
+        context 'when account is permanently suspended' do
+          before do
+            alice.suspend!
+            alice.deletion_request.destroy
+          end
+
+          it 'returns http gone' do
+            expect(response).to have_http_status(410)
+          end
+        end
+
+        context 'when account is temporarily suspended' do
+          before do
+            alice.suspend!
+          end
+
+          it 'returns http forbidden' do
+            expect(response).to have_http_status(403)
+          end
+        end
       end
 
       context 'without page' do
@@ -57,6 +99,27 @@ describe FollowingAccountsController do
           expect(response).to have_http_status(200)
           expect(body['totalItems']).to eq 2
           expect(body['partOf']).to be_blank
+        end
+
+        context 'when account is permanently suspended' do
+          before do
+            alice.suspend!
+            alice.deletion_request.destroy
+          end
+
+          it 'returns http gone' do
+            expect(response).to have_http_status(410)
+          end
+        end
+
+        context 'when account is temporarily suspended' do
+          before do
+            alice.suspend!
+          end
+
+          it 'returns http forbidden' do
+            expect(response).to have_http_status(403)
+          end
         end
       end
     end

--- a/spec/controllers/remote_follow_controller_spec.rb
+++ b/spec/controllers/remote_follow_controller_spec.rb
@@ -94,21 +94,42 @@ describe RemoteFollowController do
     end
   end
 
-  describe 'with a suspended account' do
+  context 'with a permanently suspended account' do
     before do
-      @account = Fabricate(:account, suspended: true)
+      @account = Fabricate(:account)
+      @account.suspend!
+      @account.deletion_request.destroy
     end
 
-    it 'returns 410 gone on GET to #new' do
+    it 'returns http gone on GET to #new' do
       get :new, params: { account_username: @account.to_param }
 
-      expect(response).to have_http_status(:gone)
+      expect(response).to have_http_status(410)
     end
 
-    it 'returns 410 gone on POST to #create' do
+    it 'returns http gone on POST to #create' do
       post :create, params: { account_username: @account.to_param }
 
-      expect(response).to have_http_status(:gone)
+      expect(response).to have_http_status(410)
+    end
+  end
+
+  context 'with a temporarily suspended account' do
+    before do
+      @account = Fabricate(:account)
+      @account.suspend!
+    end
+
+    it 'returns http forbidden on GET to #new' do
+      get :new, params: { account_username: @account.to_param }
+
+      expect(response).to have_http_status(403)
+    end
+
+    it 'returns http forbidden on POST to #create' do
+      post :create, params: { account_username: @account.to_param }
+
+      expect(response).to have_http_status(403)
     end
   end
 end

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -24,15 +24,28 @@ describe StatusesController do
     let(:account) { Fabricate(:account) }
     let(:status)  { Fabricate(:status, account: account) }
 
-    context 'when account is suspended' do
-      let(:account) { Fabricate(:account, suspended: true) }
-
+    context 'when account is permanently suspended' do
       before do
+        account.suspend!
+        account.deletion_request.destroy
+
         get :show, params: { account_username: account.username, id: status.id }
       end
 
       it 'returns http gone' do
         expect(response).to have_http_status(410)
+      end
+    end
+
+    context 'when account is temporarily suspended' do
+      before do
+        account.suspend!
+
+        get :show, params: { account_username: account.username, id: status.id }
+      end
+
+      it 'returns http forbidden' do
+        expect(response).to have_http_status(403)
       end
     end
 
@@ -676,15 +689,28 @@ describe StatusesController do
     let(:account) { Fabricate(:account) }
     let(:status)  { Fabricate(:status, account: account) }
 
-    context 'when account is suspended' do
-      let(:account) { Fabricate(:account, suspended: true) }
-
+    context 'when account is permanently suspended' do
       before do
+        account.suspend!
+        account.deletion_request.destroy
+
         get :activity, params: { account_username: account.username, id: status.id }
       end
 
       it 'returns http gone' do
         expect(response).to have_http_status(410)
+      end
+    end
+
+    context 'when account is temporarily suspended' do
+      before do
+        account.suspend!
+
+        get :activity, params: { account_username: account.username, id: status.id }
+      end
+
+      it 'returns http forbidden' do
+        expect(response).to have_http_status(403)
       end
     end
 

--- a/spec/controllers/well_known/webfinger_controller_spec.rb
+++ b/spec/controllers/well_known/webfinger_controller_spec.rb
@@ -4,95 +4,134 @@ describe WellKnown::WebfingerController, type: :controller do
   render_views
 
   describe 'GET #show' do
-    let(:alice) do
-      Fabricate(:account, username: 'alice')
-    end
-
-    before do
-      alice.private_key = <<-PEM
------BEGIN RSA PRIVATE KEY-----
-MIICXQIBAAKBgQDHgPoPJlrfMZrVcuF39UbVssa8r4ObLP3dYl9Y17Mgp5K4mSYD
-R/Y2ag58tSi6ar2zM3Ze3QYsNfTq0NqN1g89eAu0MbSjWqpOsgntRPJiFuj3hai2
-X2Im8TBrkiM/UyfTRgn8q8WvMoKbXk8Lu6nqv420eyqhhLxfUoCpxuem1QIDAQAB
-AoGBAIKsOh2eM7spVI8mdgQKheEG/iEsnPkQ2R8ehfE9JzjmSbXbqghQJDaz9NU+
-G3Uu4R31QT0VbCudE9SSA/UPFl82GeQG4QLjrSE+PSjSkuslgSXelJHfAJ+ycGax
-ajtPyiQD0e4c2loagHNHPjqK9OhHx9mFnZWmoagjlZ+mQGEpAkEA8GtqfS65IaRQ
-uVhMzpp25rF1RWOwaaa+vBPkd7pGdJEQGFWkaR/a9UkU+2C4ZxGBkJDP9FApKVQI
-RANEwN3/hwJBANRuw5+es6BgBv4PD387IJvuruW2oUtYP+Lb2Z5k77J13hZTr0db
-Oo9j1UbbR0/4g+vAcsDl4JD9c/9LrGYEpcMCQBon9Yvs+2M3lziy7JhFoc3zXIjS
-Ea1M4M9hcqe78lJYPeIH3z04o/+vlcLLgQRlmSz7NESmO/QtGkEcAezhuh0CQHji
-pzO4LeO/gXslut3eGcpiYuiZquOjToecMBRwv+5AIKd367Che4uJdh6iPcyGURvh
-IewfZFFdyZqnx20ui90CQQC1W2rK5Y30wAunOtSLVA30TLK/tKrTppMC3corjKlB
-FTX8IvYBNTbpEttc1VCf/0ccnNpfb0CrFNSPWxRj7t7D
------END RSA PRIVATE KEY-----
-PEM
-
-      alice.public_key = <<-PEM
------BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHgPoPJlrfMZrVcuF39UbVssa8
-r4ObLP3dYl9Y17Mgp5K4mSYDR/Y2ag58tSi6ar2zM3Ze3QYsNfTq0NqN1g89eAu0
-MbSjWqpOsgntRPJiFuj3hai2X2Im8TBrkiM/UyfTRgn8q8WvMoKbXk8Lu6nqv420
-eyqhhLxfUoCpxuem1QIDAQAB
------END PUBLIC KEY-----
-PEM
-
-      alice.save!
-    end
+    let(:alternate_domains) { [] }
+    let(:alice) { Fabricate(:account, username: 'alice') }
+    let(:resource) { nil }
 
     around(:each) do |example|
-      before = Rails.configuration.x.alternate_domains
+      tmp = Rails.configuration.x.alternate_domains
+      Rails.configuration.x.alternate_domains = alternate_domains
       example.run
-      Rails.configuration.x.alternate_domains = before
+      Rails.configuration.x.alternate_domains = tmp
     end
 
-    it 'returns JSON when account can be found' do
-      get :show, params: { resource: alice.to_webfinger_s }, format: :json
-
-      json = body_as_json
-
-      expect(response).to have_http_status(200)
-      expect(response.content_type).to eq 'application/jrd+json'
-      expect(json[:subject]).to eq 'acct:alice@cb6e6126.ngrok.io'
-      expect(json[:aliases]).to include('https://cb6e6126.ngrok.io/@alice', 'https://cb6e6126.ngrok.io/users/alice')
+    subject do
+      get :show, params: { resource: resource }, format: :json
     end
 
-    it 'returns http not found when account cannot be found' do
-      get :show, params: { resource: 'acct:not@existing.com' }, format: :json
+    shared_examples 'a successful response' do
+      it 'returns http success' do
+        expect(response).to have_http_status(200)
+      end
 
-      expect(response).to have_http_status(:not_found)
+      it 'returns application/jrd+json' do
+        expect(response.content_type).to eq 'application/jrd+json'
+      end
+
+      it 'returns links for the account' do
+        json = body_as_json
+        expect(json[:subject]).to eq 'acct:alice@cb6e6126.ngrok.io'
+        expect(json[:aliases]).to include('https://cb6e6126.ngrok.io/@alice', 'https://cb6e6126.ngrok.io/users/alice')
+      end
     end
 
-    it 'returns JSON when account can be found with alternate domains' do
-      Rails.configuration.x.alternate_domains = ['foo.org']
-      username, = alice.to_webfinger_s.split('@')
+    context 'when an account exists' do
+      let(:resource) { alice.to_webfinger_s }
 
-      get :show, params: { resource: "#{username}@foo.org" }, format: :json
+      before do
+        subject
+      end
 
-      json = body_as_json
-
-      expect(response).to have_http_status(200)
-      expect(response.content_type).to eq 'application/jrd+json'
-      expect(json[:subject]).to eq 'acct:alice@cb6e6126.ngrok.io'
-      expect(json[:aliases]).to include('https://cb6e6126.ngrok.io/@alice', 'https://cb6e6126.ngrok.io/users/alice')
+      it_behaves_like 'a successful response'
     end
 
-    it 'returns http not found when account can not be found with alternate domains' do
-      Rails.configuration.x.alternate_domains = ['foo.org']
-      username, = alice.to_webfinger_s.split('@')
+    context 'when an account is temporarily suspended' do
+      let(:resource) { alice.to_webfinger_s }
 
-      get :show, params: { resource: "#{username}@bar.org" }, format: :json
+      before do
+        alice.suspend!
+        subject
+      end
 
-      expect(response).to have_http_status(:not_found)
+      it_behaves_like 'a successful response'
     end
 
-    it 'returns http bad request when not given a resource parameter' do
-      get :show, params: { }, format: :json
-      expect(response).to have_http_status(:bad_request)
+    context 'when an account is permanently suspended or deleted' do
+      let(:resource) { alice.to_webfinger_s }
+
+      before do
+        alice.suspend!
+        alice.deletion_request.destroy
+        subject
+      end
+
+      it 'returns http gone' do
+        expect(response).to have_http_status(410)
+      end
     end
 
-    it 'returns http bad request when given a nonsense parameter' do
-      get :show, params: { resource: 'df/:dfkj' }
-      expect(response).to have_http_status(:bad_request)
+    context 'when an account is not found' do
+      let(:resource) { 'acct:not@existing.com' }
+
+      before do
+        subject
+      end
+
+      it 'returns http not found' do
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'with an alternate domain' do
+      let(:alternate_domains) { ['foo.org'] }
+
+      before do
+        subject
+      end
+
+      context 'when an account exists' do
+        let(:resource) do
+          username, = alice.to_webfinger_s.split('@')
+          "#{username}@foo.org"
+        end
+
+        it_behaves_like 'a successful response'
+      end
+
+      context 'when the domain is wrong' do
+        let(:resource) do
+          username, = alice.to_webfinger_s.split('@')
+          "#{username}@bar.org"
+        end
+
+        it 'returns http not found' do
+          expect(response).to have_http_status(404)
+        end
+      end
+    end
+
+    context 'with no resource parameter' do
+      let(:resource) { nil }
+
+      before do
+        subject
+      end
+
+      it 'returns http bad request' do
+        expect(response).to have_http_status(400)
+      end
+    end
+
+    context 'with a nonsense parameter' do
+      let(:resource) { 'df/:dfkj' }
+
+      before do
+        subject
+      end
+
+      it 'returns http bad request' do
+        expect(response).to have_http_status(400)
+      end
     end
   end
 end

--- a/spec/policies/account_policy_spec.rb
+++ b/spec/policies/account_policy_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe AccountPolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
   let(:john)    { Fabricate(:user).account }
+  let(:alice)   { Fabricate(:user).account }
 
-  permissions :index?, :show?, :unsuspend?, :unsensitive?, :unsilence?, :remove_avatar?, :remove_header? do
+  permissions :index? do
     context 'staff' do
       it 'permits' do
         expect(subject).to permit(admin)
@@ -18,6 +19,38 @@ RSpec.describe AccountPolicy do
     context 'not staff' do
       it 'denies' do
         expect(subject).to_not permit(john)
+      end
+    end
+  end
+
+  permissions :show?, :unsilence?, :unsensitive?, :remove_avatar?, :remove_header? do
+    context 'staff' do
+      it 'permits' do
+        expect(subject).to permit(admin, alice)
+      end
+    end
+
+    context 'not staff' do
+      it 'denies' do
+        expect(subject).to_not permit(john, alice)
+      end
+    end
+  end
+
+  permissions :unsuspend? do
+    before do
+      alice.suspend!
+    end
+
+    context 'staff' do
+      it 'permits' do
+        expect(subject).to permit(admin, alice)
+      end
+    end
+
+    context 'not staff' do
+      it 'denies' do
+        expect(subject).to_not permit(john, alice)
       end
     end
   end

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -73,4 +73,84 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
       expect(ProofProvider::Keybase::Worker).to have_received(:perform_async)
     end
   end
+
+  context 'when account is not suspended' do
+    let!(:account) { Fabricate(:account, username: 'alice', domain: 'example.com') }
+
+    let(:payload) do
+      {
+        id: 'https://foo.test',
+        type: 'Actor',
+        inbox: 'https://foo.test/inbox',
+        suspended: true,
+      }.with_indifferent_access
+    end
+
+    before do
+      allow(Admin::SuspensionWorker).to receive(:perform_async)
+    end
+
+    subject { described_class.new.call('alice', 'example.com', payload) }
+
+    it 'suspends account remotely' do
+      expect(subject.suspended?).to be true
+      expect(subject.suspension_origin_remote?).to be true
+    end
+
+    it 'queues suspension worker' do
+      subject
+      expect(Admin::SuspensionWorker).to have_received(:perform_async)
+    end
+  end
+
+  context 'when account is suspended' do
+    let!(:account) { Fabricate(:account, username: 'alice', domain: 'example.com', display_name: '') }
+
+    let(:payload) do
+      {
+        id: 'https://foo.test',
+        type: 'Actor',
+        inbox: 'https://foo.test/inbox',
+        suspended: false,
+        name: 'Hoge',
+      }.with_indifferent_access
+    end
+
+    before do
+      allow(Admin::UnsuspensionWorker).to receive(:perform_async)
+
+      account.suspend!(origin: suspension_origin)
+    end
+
+    subject { described_class.new.call('alice', 'example.com', payload) }
+
+    context 'locally' do
+      let(:suspension_origin) { :local }
+
+      it 'does not unsuspend it' do
+        expect(subject.suspended?).to be true
+      end
+
+      it 'does not update any attributes' do
+        expect(subject.display_name).to_not eq 'Hoge'
+      end
+    end
+
+    context 'remotely' do
+      let(:suspension_origin) { :remote }
+
+      it 'unsuspends it' do
+        expect(subject.suspended?).to be false
+      end
+
+      it 'queues unsuspension worker' do
+        subject
+        expect(Admin::UnsuspensionWorker).to have_received(:perform_async)
+      end
+
+      it 'updates attributes' do
+        expect(subject.display_name).to eq 'Hoge'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to #14726

- Change reversibly suspended accounts to return empty data instead of HTTP 410 (while those that cannot be restored will still return HTTP 410)
- Change Webfinger resolution to queue full account deletion when it encounters a HTTP 410 error for an account that's still in the database

Suspension is expressed through boolean `suspended` attribute on the actor, and changes are distributed using the standard `Update` activity. This means that handling suspended accounts works pretty much the same if you receive the event live or encounter the suspended account in the wild. Accounts that were suspended locally cannot be unsuspended remotely. On the other hand, we no longer ignore `Update`, `Undo`, `Reject`, and `Delete` events for accounts that were suspended.