### PR TITLE
Removed disabling comments for Style/MethodMissingSuper

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,7 +30,7 @@ plugins:
     channel: eslint-7
   rubocop:
     enabled: true
-    channel: rubocop-0-88
+    channel: rubocop-0-92
   sass-lint:
     enabled: true
 exclude_patterns:

--- a/app/lib/settings/scoped_settings.rb
+++ b/app/lib/settings/scoped_settings.rb
@@ -11,7 +11,6 @@ module Settings
       @object = object
     end
 
-    # rubocop:disable Style/MethodMissingSuper
     def method_missing(method, *args)
       method_name = method.to_s
       # set a value for a variable
@@ -24,7 +23,6 @@ module Settings
         self[method_name]
       end
     end
-    # rubocop:enable Style/MethodMissingSuper
 
     def respond_to_missing?(*)
       true


### PR DESCRIPTION
```
app/lib/settings/scoped_settings.rb:14:5: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of Style/MethodMissingSuper (did you mean Style/RedundantAssignment?).
    # rubocop:disable Style/MethodMissingSuper
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

`Style/MethodMissingSuper` cop no longer exists.
https://github.com/rubocop-hq/rubocop/pull/8376/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR24

And the new `Lint/MissingSuper` cop didn't cause an error, so I just deleted it.