### PR TITLE
Sort filters by “keyword or phrase” in Settings

### DIFF
--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -9,7 +9,7 @@ class FiltersController < ApplicationController
   before_action :set_body_classes
 
   def index
-    @filters = current_account.custom_filters
+    @filters = current_account.custom_filters.order(:phrase)
   end
 
   def new


### PR DESCRIPTION
Filters today are sorted in an arbitrary order, usually by time where it has been added but not systematically (I already added a filter and it was put in the middle of the list). Now, it’s sorted alphabetically (case-insensitive) so it’s easy to find the filters I’m looking for and I can compare easily my filters between my different accounts to synchronize them.