### PR TITLE
Display “Show newer” and “Show older” instead of “Show more” in public pages

### DIFF
--- a/app/helpers/statuses_helper.rb
+++ b/app/helpers/statuses_helper.rb
@@ -4,8 +4,12 @@ module StatusesHelper
   EMBEDDED_CONTROLLER = 'statuses'
   EMBEDDED_ACTION = 'embed'
 
-  def link_to_more(url)
-    link_to t('statuses.show_more'), url, class: 'load-more load-gap'
+  def link_to_newer(url)
+    link_to t('statuses.show_newer'), url, class: 'load-more load-gap'
+  end
+
+  def link_to_older(url)
+    link_to t('statuses.show_older'), url, class: 'load-more load-gap'
   end
 
   def nothing_here(extra_classes = '')

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -39,12 +39,12 @@
             = render partial: 'statuses/status', collection: @pinned_statuses, as: :status, locals: { pinned: true }
 
           - if @newer_url
-            .entry= link_to_more @newer_url
+            .entry= link_to_newer @newer_url
 
           = render partial: 'statuses/status', collection: @statuses, as: :status
 
           - if @older_url
-            .entry= link_to_more @older_url
+            .entry= link_to_older @older_url
 
   .column-1
     - if @account.memorial?

--- a/app/views/statuses/_status.html.haml
+++ b/app/views/statuses/_status.html.haml
@@ -17,7 +17,7 @@
 - if status.reply? && include_threads
   - if @next_ancestor
     .entry{ class: entry_classes }
-      = link_to_more ActivityPub::TagManager.instance.url_for(@next_ancestor)
+      = link_to_older ActivityPub::TagManager.instance.url_for(@next_ancestor)
 
   = render partial: 'statuses/status', collection: @ancestors, as: :status, locals: { is_predecessor: true, direct_reply_id: status.in_reply_to_id }, autoplay: autoplay
 
@@ -44,16 +44,16 @@
 - if include_threads
   - if @since_descendant_thread_id
     .entry{ class: entry_classes }
-      = link_to_more short_account_status_url(status.account.username, status, max_descendant_thread_id: @since_descendant_thread_id + 1)
+      = link_to_newer short_account_status_url(status.account.username, status, max_descendant_thread_id: @since_descendant_thread_id + 1)
   - @descendant_threads.each do |thread|
     = render partial: 'statuses/status', collection: thread[:statuses], as: :status, locals: { is_successor: true, parent_id: status.id }, autoplay: autoplay
 
     - if thread[:next_status]
       .entry{ class: entry_classes }
-        = link_to_more ActivityPub::TagManager.instance.url_for(thread[:next_status])
+        = link_to_newer ActivityPub::TagManager.instance.url_for(thread[:next_status])
   - if @next_descendant_thread
     .entry{ class: entry_classes }
-      = link_to_more short_account_status_url(status.account.username, status, since_descendant_thread_id: @max_descendant_thread_id - 1)
+      = link_to_newer short_account_status_url(status.account.username, status, since_descendant_thread_id: @max_descendant_thread_id - 1)
 
 - if include_threads && !embedded_view? && !user_signed_in?
   .entry{ class: entry_classes }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1203,6 +1203,8 @@ en:
         other: "%{count} votes"
       vote: Vote
     show_more: Show more
+    show_newer: Show newer
+    show_older: Show older
     show_thread: Show thread
     sign_in_to_participate: Sign in to participate in the conversation
     title: '%{name}: "%{quote}"'


### PR DESCRIPTION
It allows for better translations (it was limiting me in French) and it makes clearer what the “order” of the toots is.

On a profile page:
![image](https://user-images.githubusercontent.com/2446451/97212703-1007b680-17c1-11eb-83d8-4fa0444a02bf.png)
![image](https://user-images.githubusercontent.com/2446451/97212762-1d24a580-17c1-11eb-8c7d-2c712a76cfb9.png)

On a thread page:
![image](https://user-images.githubusercontent.com/2446451/97212635-f8c8c900-17c0-11eb-8617-dc186256e1fa.png)
![image](https://user-images.githubusercontent.com/2446451/97212532-d8990a00-17c0-11eb-8b95-c2d82aeea4af.png)