### PR TITLE
Fix width of content text fluctuating over time

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -794,6 +794,10 @@
   cursor: pointer;
 }
 
+.status__content {
+  clear: both;
+}
+
 .status__content,
 .reply-indicator__content {
   position: relative;


### PR DESCRIPTION
Some languages ​​have different numbers of characters in time words.

Since #15053 , the width of the posted content may fluctuate over time in such languages.
It will confuse the user.

This PR fix it.

Before:
now
![2020-10-27 17 53 44](https://user-images.githubusercontent.com/766076/97279553-7b638e00-187e-11eb-9acf-1ccd671ed6bd.png)
10sec
![2020-10-27 17 53 54](https://user-images.githubusercontent.com/766076/97279569-80284200-187e-11eb-8d10-c0ebced12584.png)
1minute
![2020-10-27 17 54 44](https://user-images.githubusercontent.com/766076/97279577-83233280-187e-11eb-97d1-8bf3ef7d61e7.png)

After:
now
![2020-10-27 18 08 21](https://user-images.githubusercontent.com/766076/97280493-b0241500-187f-11eb-8ff5-da6f3772fb00.png)
10sec
![2020-10-27 18 08 05](https://user-images.githubusercontent.com/766076/97280518-bc0fd700-187f-11eb-9d43-3c097fda219f.png)
1minute
![2020-10-27 18 09 23](https://user-images.githubusercontent.com/766076/97280543-c4681200-187f-11eb-95af-e3faf4d2672b.png)
