### PR TITLE
Show announcements in reverse chronological order

### DIFF
--- a/app/javascript/mastodon/features/getting_started/components/announcements.js
+++ b/app/javascript/mastodon/features/getting_started/components/announcements.js
@@ -437,7 +437,7 @@ class Announcements extends ImmutablePureComponent {
                 selected={index === idx}
                 disabled={disableSwiping}
               />
-            ))}
+            )).reverse()}
           </ReactSwipeableViews>
 
           {announcements.size > 1 && (


### PR DESCRIPTION
On my server we often have many server-wide events that we announce using the (great) announcements tool. We often have four or five announcements for upcoming events at a time. As it currently stands, the announcements are rendered in the home timeline announcement widget with the oldest announcement being the first one shown, and then you page through until you get to the newest announcement at the end of the list. This means that when a new announcement is made, the user sees the dot on the megaphone icon, clicks on it, then has to page through a bunch of things to get to the new thing.

This PR simply reverses the rendering order so that the newest item is first, and as you page through they get older and older until you hit the oldest at the end of the list. My users requested this change and so far it's a hit with everyone.