### PR TITLE
Dismiss reverse-order announcements in the correct order

### DIFF
--- a/app/javascript/mastodon/features/getting_started/components/announcements.js
+++ b/app/javascript/mastodon/features/getting_started/components/announcements.js
@@ -396,7 +396,7 @@ class Announcements extends ImmutablePureComponent {
   _markAnnouncementAsRead () {
     const { dismissAnnouncement, announcements } = this.props;
     const { index } = this.state;
-    const announcement = announcements.get(index);
+    const announcement = announcements.get(announcements.size - 1 - index);
     if (!announcement.get('read')) dismissAnnouncement(announcement.get('id'));
   }
 


### PR DESCRIPTION
This fixes a bug in #15065 where the "read" indicator was not getting correctly set in non-trivial cases. The ID of a dismissed announcement is now correct.