### PR TITLE
[HelmChart] Fix postrgres secret name for cronjob

### DIFF
--- a/chart/templates/cronjob-media-remove.yaml
+++ b/chart/templates/cronjob-media-remove.yaml
@@ -55,7 +55,7 @@ spec:
                       {{- if .Values.postgresql.enabled }}
                       name: {{ .Release.Name }}-postgresql
                       {{- else }}
-                      name: {{ template "mastodon.fullname" . }}
+                      name: {{ template "mastodon.fullname" . }}-postgresql
                       {{- end }}
                       key: postgresql-password
                 - name: "REDIS_PASSWORD"


### PR DESCRIPTION
The cronjob tries to get key from `mastodon` secret instead of
`mastodon-postgresql` - so the cronjob fails with this error:

Error: couldn't find key postgresql-password in Secret [NS]/mastodon

Another solution is to save the postgres password in mastodon secret,
but that means that the password is placed in two places.

Postgresql uses `<fullname>-postgresql` name as secret name.