### PR TITLE
Fix some account media gallery items having empty labels

### DIFF
--- a/app/javascript/mastodon/features/account_gallery/components/media_item.js
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.js
@@ -122,7 +122,7 @@ export default class MediaItem extends ImmutablePureComponent {
         <div className='media-gallery__gifv'>
           {content}
 
-          <span className='media-gallery__gifv__label'>{label}</span>
+          {label && <span className='media-gallery__gifv__label'>{label}</span>}
         </div>
       );
     }


### PR DESCRIPTION
Remove the labels entirely for images instead of putting an empty label.