### PR TITLE
Change order of announcements in admin page to sort them newest-first

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -71,7 +71,7 @@ class Admin::AnnouncementsController < Admin::BaseController
   private
 
   def set_announcements
-    @announcements = AnnouncementFilter.new(filter_params).results.order(id: :desc).page(params[:page])
+    @announcements = AnnouncementFilter.new(filter_params).results.reverse_chronological.page(params[:page])
   end
 
   def set_announcement

--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -71,7 +71,7 @@ class Admin::AnnouncementsController < Admin::BaseController
   private
 
   def set_announcements
-    @announcements = AnnouncementFilter.new(filter_params).results.page(params[:page])
+    @announcements = AnnouncementFilter.new(filter_params).results.order(id: :desc).page(params[:page])
   end
 
   def set_announcement

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -22,6 +22,7 @@ class Announcement < ApplicationRecord
   scope :published, -> { where(published: true) }
   scope :without_muted, ->(account) { joins("LEFT OUTER JOIN announcement_mutes ON announcement_mutes.announcement_id = announcements.id AND announcement_mutes.account_id = #{account.id}").where('announcement_mutes.id IS NULL') }
   scope :chronological, -> { order(Arel.sql('COALESCE(announcements.starts_at, announcements.scheduled_at, announcements.published_at, announcements.created_at) ASC')) }
+  scope :reverse_chronological, -> { order(Arel.sql('COALESCE(announcements.starts_at, announcements.scheduled_at, announcements.published_at, announcements.created_at) DESC')) }
 
   has_many :announcement_mutes, dependent: :destroy
   has_many :announcement_reactions, dependent: :destroy


### PR DESCRIPTION
Fixes #15090

The reverse-chronological scope is potentially slower than sorting by `id` only, but that should not matter much for announcements, which I expect to have a reduced number.