### PR TITLE
Precise that home timeline filters also apply to lists

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -855,7 +855,7 @@ en:
   filters:
     contexts:
       account: Profiles
-      home: Home timeline
+      home: Home and lists
       notifications: Notifications
       public: Public timelines
       thread: Conversations

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -600,7 +600,7 @@ en_GB:
       limit: You have already featured the maximum amount of hashtags
   filters:
     contexts:
-      home: Home timeline
+      home: Home and lists
       notifications: Notifications
       public: Public timelines
       thread: Conversations


### PR DESCRIPTION
It’s not obvious from a user point of view that filters on home also applies on lists.

I changed the English string “Home timeline” to “Home and lists”

![image](https://user-images.githubusercontent.com/2446451/98715635-b8557780-238a-11eb-83fd-a81a53d30e5b.png)
![image](https://user-images.githubusercontent.com/2446451/98715778-e1760800-238a-11eb-87c7-0b67ffa9593d.png)
