### PR TITLE
Add follow selected followers button

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -49,7 +49,9 @@ class RelationshipsController < ApplicationController
   end
 
   def action_from_button
-    if params[:unfollow]
+    if params[:follow]
+      'follow'
+    elsif params[:unfollow]
       'unfollow'
     elsif params[:remove_from_followers]
       'remove_from_followers'

--- a/app/models/form/account_batch.rb
+++ b/app/models/form/account_batch.rb
@@ -9,6 +9,8 @@ class Form::AccountBatch
 
   def save
     case action
+    when 'follow'
+      follow!
     when 'unfollow'
       unfollow!
     when 'remove_from_followers'
@@ -23,6 +25,12 @@ class Form::AccountBatch
   end
 
   private
+
+  def follow!
+    accounts.find_each do |target_account|
+      follow = FollowService.new.call(current_account, target_account)
+    end
+  end
 
   def unfollow!
     accounts.find_each do |target_account|

--- a/app/models/form/account_batch.rb
+++ b/app/models/form/account_batch.rb
@@ -28,7 +28,7 @@ class Form::AccountBatch
 
   def follow!
     accounts.find_each do |target_account|
-      follow = FollowService.new.call(current_account, target_account)
+      FollowService.new.call(current_account, target_account)
     end
   end
 

--- a/app/views/relationships/show.html.haml
+++ b/app/views/relationships/show.html.haml
@@ -42,6 +42,8 @@
       %label.batch-table__toolbar__select.batch-checkbox-all
         = check_box_tag :batch_checkbox_all, nil, false
       .batch-table__toolbar__actions
+        = f.button safe_join([fa_icon('user-plus'), t('relationships.follow_selected_followers')]), name: :follow, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') } if followed_by_relationship? && !mutual_relationship?
+
         = f.button safe_join([fa_icon('user-times'), t('relationships.remove_selected_follows')]), name: :unfollow, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') } unless followed_by_relationship?
 
         = f.button safe_join([fa_icon('trash'), t('relationships.remove_selected_followers')]), name: :remove_from_followers, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') } unless following_relationship?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1075,8 +1075,8 @@ en:
   relationships:
     activity: Account activity
     dormant: Dormant
-    followers: Followers
     follow_selected_followers: Follow selected followers
+    followers: Followers
     following: Following
     invited: Invited
     last_active: Last active

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1076,6 +1076,7 @@ en:
     activity: Account activity
     dormant: Dormant
     followers: Followers
+    follow_selected_followers: Follow selected followers
     following: Following
     invited: Invited
     last_active: Last active


### PR DESCRIPTION
From the list of followers, add a button to follow in bulk.

Combined with "non-mutual followers" at https://github.com/tootsuite/mastodon/pull/14917, you can easily follow up followers you forgot to follow.

![follow_selected_followers](https://user-images.githubusercontent.com/28195220/98931065-da80fe00-2520-11eb-80b0-ea559234a308.png)
