### PR TITLE
Add cache buster feature for media files

### DIFF
--- a/app/lib/cache_buster.rb
+++ b/app/lib/cache_buster.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CacheBuster
+  def initialize(options = {})
+    @secret_header = options[:secret_header] || 'Secret-Header'
+    @secret        = options[:secret] || 'True'
+  end
+
+  def bust(url)
+    site = Addressable::URI.parse(url).normalized_site
+
+    request_pool.with(site) do |http_client|
+      build_request(url, http_client).perform
+    end
+  end
+
+  private
+
+  def request_pool
+    RequestPool.current
+  end
+
+  def build_request(url, http_client)
+    Request.new(:get, url, http_client: http_client).tap do |request|
+      request.add_headers(@secret_header => @secret)
+    end
+  end
+end

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -78,6 +78,8 @@ class SuspendAccountService < BaseService
               Rails.logger.warn "Tried to change permission on non-existent file #{attachment.path(style)}"
             end
           end
+
+          CacheBusterWorker.perform_async(attachment.path(style)) if Rails.configuration.x.cache_buster_enabled
         end
       end
     end

--- a/app/services/unsuspend_account_service.rb
+++ b/app/services/unsuspend_account_service.rb
@@ -69,6 +69,8 @@ class UnsuspendAccountService < BaseService
               Rails.logger.warn "Tried to change permission on non-existent file #{attachment.path(style)}"
             end
           end
+
+          CacheBusterWorker.perform_async(attachment.path(style)) if Rails.configuration.x.cache_buster_enabled
         end
       end
     end

--- a/app/workers/cache_buster_worker.rb
+++ b/app/workers/cache_buster_worker.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CacheBusterWorker
+  include Sidekiq::Worker
+  include RoutingHelper
+
+  sidekiq_options queue: 'pull'
+
+  def perform(path)
+    cache_buster.bust(full_asset_url(path))
+  end
+
+  private
+
+  def cache_buster
+    CacheBuster.new(Rails.configuration.x.cache_buster)
+  end
+end

--- a/config/initializers/cache_buster.rb
+++ b/config/initializers/cache_buster.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.x.cache_buster_enabled = ENV['CACHE_BUSTER_ENABLED'] == 'true'
+
+  config.x.cache_buster = {
+    secret_header: ENV['CACHE_BUSTER_SECRET_HEADER'],
+    secret: ENV['CACHE_BUSTER_SECRET'],
+  }
+end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -107,7 +107,6 @@ elsif ENV['SWIFT_ENABLED'] == 'true'
 else
   Paperclip::Attachment.default_options.merge!(
     storage: :filesystem,
-    use_timestamp: true,
     path: File.join(ENV.fetch('PAPERCLIP_ROOT_PATH', File.join(':rails_root', 'public', 'system')), ':prefix_path:class', ':attachment', ':id_partition', ':style', ':filename'),
     url: ENV.fetch('PAPERCLIP_ROOT_URL', '/system') + '/:prefix_url:class/:attachment/:id_partition/:style/:filename',
   )


### PR DESCRIPTION
Nginx can be configured to bypass proxy cache when a special header is in the request. If the response is cacheable, it will replace
the cache for that request. Proxy caching of media files is desirable when using object storage as a way of minimizing bandwidth
costs, but has the drawback of leaving deleted media files for a configured amount of cache time. A cache buster can make those
media files immediately unavailable. This especially makes sense when suspending and unsuspending an account.

Configuration (trivial):

```bash
CACHE_BUSTER_ENABLED=true
CACHE_BUSTER_SECRET_HEADER=secret-header
CACHE_BUSTER_SECRET=true
```

In nginx (trivial):

```nginx
location @s3 {
  // ...
  proxy_cache_bypass $http_secret_header;
  // ...
}
```

Of course, letting anyone bypass your cache is an abuse vector for increasing your object storage bandwidth bill, so in reality you would want to actually secure it. You see, `$http_secret_header` is not a special variable -- all HTTP headers can be accessed using this variable structure. So it's just accessing the raw value of a HTTP header "secret-header". Furthermore, the `proxy_cache_bypass` directive works by treating an empty string or `0` value as `false` and everything else as `true`. So what we can do is define a `map` from a better named header (like `Cache-Bypass`, though it can be anything you want) to our own variable, and make it return 0 for every value except a generated secret value.

```nginx
map $http_cache_bypass $authorized_cache_bypass {
  default 0;
  YOUR_SECRET_HERE 1;
}

// ...

server {
  // ...
  location @s3 {
    // ...
    proxy_cache_bypass $authorized_cache_bypass;
    // ...
  }
}
```

Then in Mastodon's configuration, it would simply be:

```bash
CACHE_BUSTER_ENABLED=true
CACHE_BUSTER_SECRET_HEADER=Cache-Bypass
CACHE_BUSTER_SECRET=YOUR_SECRET_HERE
```