### PR TITLE
Fix webfinger resolution not working from "real" to "canonical"

### DIFF
--- a/app/lib/webfinger.rb
+++ b/app/lib/webfinger.rb
@@ -14,6 +14,10 @@ class Webfinger
       @json['subject']
     end
 
+    def aliases
+      @json['aliases']
+    end
+
     def link(rel, attribute)
       links.dig(rel, attribute)
     end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -188,6 +188,10 @@ class Account < ApplicationRecord
     "acct:#{local_username_and_domain}"
   end
 
+  def to_webfinger_aliases
+    (Rails.configuration.x.alternate_domains + [Rails.configuration.x.web_domain]).map { |alternate_domain| "acct:#{username}@#{alternate_domain}" }.uniq - [to_webfinger_s]
+  end
+
   def subscribed?
     subscription_expires_at.present?
   end

--- a/app/serializers/webfinger_serializer.rb
+++ b/app/serializers/webfinger_serializer.rb
@@ -13,7 +13,7 @@ class WebfingerSerializer < ActiveModel::Serializer
     if object.instance_actor?
       [instance_actor_url]
     else
-      [short_account_url(object), account_url(object)]
+      object.to_webfinger_aliases + [short_account_url(object), account_url(object)]
     end
   end
 

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -82,7 +82,7 @@ class ResolveAccountService < BaseService
     @webfinger                           = webfinger!("acct:#{uri}")
     confirmed_username, confirmed_domain = @webfinger.subject.gsub(/\Aacct:/, '').split('@')
 
-    if confirmed_username.casecmp(@username).zero? && confirmed_domain.casecmp(@domain).zero?
+    if (confirmed_username.casecmp(@username).zero? && confirmed_domain.casecmp(@domain).zero?) || @webfinger.aliases.any? { |s| s.casecmp("acct:#{@username}@#{@domain}").zero? }
       @username = confirmed_username
       @domain   = confirmed_domain
       @uri      = uri


### PR DESCRIPTION
Normally you only need to resolve an account by its canonical handle, e.g. alice@example.com, which works even if alice's account
is actually on social.example.com. However, trying to resolve alice@social.example.com would raise an error even though that's
where the account actually is, because the webfinger response would claim only the canonical form and fail to include the real one.