### PR TITLE
Fixed ESLint error

### DIFF
--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -257,7 +257,7 @@ export function setupBrowserNotifications() {
     if ('Notification' in window && 'permissions' in navigator) {
       navigator.permissions.query({ name: 'notifications' }).then((status) => {
         status.onchange = () => dispatch(setBrowserPermission(Notification.permission));
-      });
+      }).catch(console.warn);
     }
   };
 }

--- a/app/javascript/mastodon/features/ui/components/focal_point_modal.js
+++ b/app/javascript/mastodon/features/ui/components/focal_point_modal.js
@@ -18,7 +18,9 @@ import { length } from 'stringz';
 import { Tesseract as fetchTesseract } from 'mastodon/features/ui/util/async-components';
 import GIFV from 'mastodon/components/gifv';
 import { me } from 'mastodon/initial_state';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import tesseractCorePath from 'tesseract.js-core/tesseract-core.wasm.js';
+// eslint-disable-next-line import/extensions
 import tesseractWorkerPath from 'tesseract.js/dist/worker.min.js';
 import { assetHost } from 'mastodon/utils/config';
 

--- a/app/javascript/mastodon/stream.js
+++ b/app/javascript/mastodon/stream.js
@@ -16,7 +16,7 @@ let sharedConnection;
  * @property {function(): void} onDisconnect
  */
 
- /**
+/**
   * @typedef StreamEvent
   * @property {string} event
   * @property {object} payload

--- a/app/javascript/mastodon/utils/notifications.js
+++ b/app/javascript/mastodon/utils/notifications.js
@@ -3,6 +3,7 @@
 
 const checkNotificationPromise = () => {
   try {
+    // eslint-disable-next-line promise/catch-or-return
     Notification.requestPermission().then();
   } catch(e) {
     return false;
@@ -22,7 +23,7 @@ const handlePermission = (permission, callback) => {
 
 export const requestNotificationPermission = (callback) => {
   if (checkNotificationPromise()) {
-    Notification.requestPermission().then((permission) => handlePermission(permission, callback));
+    Notification.requestPermission().then((permission) => handlePermission(permission, callback)).catch(console.warn);
   } else {
     Notification.requestPermission((permission) => handlePermission(permission, callback));
   }

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -230,13 +230,13 @@ const startWorker = (workerId) => {
   const FALSE_VALUES = [
     false,
     0,
-    "0",
-    "f",
-    "F",
-    "false",
-    "FALSE",
-    "off",
-    "OFF"
+    '0',
+    'f',
+    'F',
+    'false',
+    'FALSE',
+    'off',
+    'OFF',
   ];
 
   /**
@@ -475,7 +475,7 @@ const startWorker = (workerId) => {
         log.verbose(req.requestId, `Closing connection for ${req.accountId} due to expired access token`);
         eventHandlers.onKill();
       }
-    }
+    };
   };
 
   /**
@@ -1032,7 +1032,7 @@ const startWorker = (workerId) => {
       if (type === 'subscribe') {
         subscribeWebsocketToChannel(session, firstParam(stream), params);
       } else if (type === 'unsubscribe') {
-        unsubscribeWebsocketFromChannel(session, firstParam(stream), params)
+        unsubscribeWebsocketFromChannel(session, firstParam(stream), params);
       } else {
         // Unknown action type
       }

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -377,6 +377,8 @@ const startWorker = (workerId) => {
       return 'direct';
     case '/api/v1/streaming/list':
       return 'list';
+    default:
+      return undefined;
     }
   };
 
@@ -530,7 +532,8 @@ const startWorker = (workerId) => {
     log.error(req.requestId, err.toString());
 
     if (res.headersSent) {
-      return next(err);
+      next(err);
+      return;
     }
 
     res.writeHead(err.status || 500, { 'Content-Type': 'application/json' });


### PR DESCRIPTION

```
$ yarn test
yarn run v1.22.4
$ ${npm_execpath} run test:lint:js && ${npm_execpath} run test:jest
$ eslint --ext=js . --cache

/Users/abcang/repo/mastodon/app/javascript/mastodon/actions/notifications.js
  258:7  error  Expected catch() or return  promise/catch-or-return

/Users/abcang/repo/mastodon/app/javascript/mastodon/features/ui/components/focal_point_modal.js
  21:31  error  'tesseract.js-core' should be listed in the project's dependencies. Run 'npm i -S tesseract.js-core' to add it  import/no-extraneous-dependencies
  22:33  error  Unexpected use of file extension "js" for "tesseract.js/dist/worker.min.js"                                     import/extensions

/Users/abcang/repo/mastodon/app/javascript/mastodon/stream.js
  19:1  warning  Expected indentation of 0 spaces but found 1  indent

/Users/abcang/repo/mastodon/app/javascript/mastodon/utils/notifications.js
   6:5  error  Expected catch() or return  promise/catch-or-return
  25:5  error  Expected catch() or return  promise/catch-or-return

/Users/abcang/repo/mastodon/streaming/index.js
   233:5   error  Strings must use singlequote                             quotes
   234:5   error  Strings must use singlequote                             quotes
   235:5   error  Strings must use singlequote                             quotes
   236:5   error  Strings must use singlequote                             quotes
   237:5   error  Strings must use singlequote                             quotes
   238:5   error  Strings must use singlequote                             quotes
   239:5   error  Strings must use singlequote                             quotes
   239:10  error  Missing trailing comma                                   comma-dangle
   357:35  error  Expected to return a value at the end of arrow function  consistent-return
   478:6   error  Missing semicolon                                        semi
   529:49  error  Expected to return a value at the end of arrow function  consistent-return
  1035:77  error  Missing semicolon                                        semi

✖ 18 problems (17 errors, 1 warning)
  10 errors and 1 warning potentially fixable with the `--fix` option.
```