### PR TITLE
Fix some issues with SAML account creation

### DIFF
--- a/app/models/concerns/omniauthable.rb
+++ b/app/models/concerns/omniauthable.rb
@@ -68,7 +68,6 @@ module Omniauthable
     def user_params_from_auth(email, auth)
       {
         email: email || "#{TEMP_EMAIL_PREFIX}-#{auth.uid}-#{auth.provider}.com",
-        password: Devise.friendly_token[0, 20],
         agreement: true,
         external: true,
         account_attributes: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -456,6 +456,6 @@ class User < ApplicationRecord
   end
 
   def validate_email_dns?
-    email_changed? && !(Rails.env.test? || Rails.env.development?)
+    email_changed? && !external? && !(Rails.env.test? || Rails.env.development?)
   end
 end


### PR DESCRIPTION
Fix #15216 

- Do not generate random password on external accounts to avoid showing end-user password challenges
- Do not run MX validation for external accounts