### PR TITLE
Fix Gemfile.lock breaking CI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -804,9 +804,3 @@ DEPENDENCIES
   webpacker (~> 5.2)
   webpush
   xorcist (~> 1.1)
-
-RUBY VERSION
-   ruby 2.7.2p137
-
-BUNDLED WITH
-   2.1.4


### PR DESCRIPTION
Unnecessary Ruby and Bundler version constraints got included in #15230