### PR TITLE
Fix account merging in maintenance script

### DIFF
--- a/app/models/concerns/account_merging.rb
+++ b/app/models/concerns/account_merging.rb
@@ -15,7 +15,7 @@ module AccountMerging
       Status, StatusPin, MediaAttachment, Poll, Report, Tombstone, Favourite,
       Follow, FollowRequest, Block, Mute, AccountIdentityProof,
       AccountModerationNote, AccountPin, AccountStat, ListAccount,
-      PollVote, Mention
+      PollVote, Mention, AccountDeletionRequest, AccountNote
     ]
 
     owned_classes.each do |klass|
@@ -28,7 +28,10 @@ module AccountMerging
       end
     end
 
-    target_classes = [Follow, FollowRequest, Block, Mute, AccountModerationNote, AccountPin]
+    target_classes = [
+      Follow, FollowRequest, Block, Mute, AccountModerationNote, AccountPin,
+      AccountNote
+    ]
 
     target_classes.each do |klass|
       klass.where(target_account_id: other_account.id).find_each do |record|


### PR DESCRIPTION
Also include `AccountNote` and `AccountDeletionRequest` to the list of classes needing to be reassigned the merged account.

This re-introduces code duplication, but it appears necessary to make sure the database maintenance script can actually run on multiple versions of the database schema.