### PR TITLE
Add mechanisms to reduce registration spam

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 class AboutController < ApplicationController
+  include RegistrationSpamConcern
+
   layout 'public'
 
   before_action :require_open_federation!, only: [:show, :more]
   before_action :set_body_classes, only: :show
   before_action :set_instance_presenter
-  before_action :set_expires_in, only: [:show, :more, :terms]
+  before_action :set_expires_in, only: [:more, :terms]
+  before_action :set_registration_form_time, only: :show
 
   skip_before_action :require_functional!, only: [:more, :terms]
 

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -54,7 +54,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
 
   def configure_sign_up_params
     devise_parameter_sanitizer.permit(:sign_up) do |u|
-      u.permit({ account_attributes: [:username], invite_request_attributes: [:text] }, :email, :password, :password_confirmation, :invite_code, :agreement)
+      u.permit({ account_attributes: [:username], invite_request_attributes: [:text] }, :email, :password, :password_confirmation, :invite_code, :agreement, :website, :confirm_password)
     end
   end
 

--- a/app/controllers/concerns/registration_spam_concern.rb
+++ b/app/controllers/concerns/registration_spam_concern.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RegistrationSpamConcern
+  extend ActiveSupport::Concern
+
+  REGISTRATION_FORM_MIN_TIME = 3.seconds.freeze
+
+  def set_registration_form_time
+    session[:registration_form_time] = Time.now.utc
+  end
+
+  def valid_registration_time?
+    session[:registration_form_time].present? && session[:registration_form_time] < REGISTRATION_FORM_MIN_TIME.ago
+  end
+end

--- a/app/controllers/concerns/registration_spam_concern.rb
+++ b/app/controllers/concerns/registration_spam_concern.rb
@@ -3,13 +3,7 @@
 module RegistrationSpamConcern
   extend ActiveSupport::Concern
 
-  REGISTRATION_FORM_MIN_TIME = 3.seconds.freeze
-
   def set_registration_form_time
     session[:registration_form_time] = Time.now.utc
-  end
-
-  def valid_registration_time?
-    session[:registration_form_time].present? && session[:registration_form_time] < REGISTRATION_FORM_MIN_TIME.ago
   end
 end

--- a/app/javascript/packs/public.js
+++ b/app/javascript/packs/public.js
@@ -280,6 +280,17 @@ function main() {
       target.style.display = 'block';
     }
   });
+
+  // Empty the honeypot fields in JS in case something like an extension
+  // automatically filled them.
+  delegate(document, '#registration_new_user,#new_user', 'submit', () => {
+    ['user_website', 'user_confirm_password', 'registration_user_website', 'registration_user_confirm_password'].forEach(id => {
+      const field = document.getElementById(id);
+      if (field) {
+        field.value = '';
+      }
+    });
+  });
 }
 
 loadPolyfills()

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -354,6 +354,7 @@ code {
   input[type=number],
   input[type=email],
   input[type=password],
+  input[type=url],
   textarea {
     box-sizing: border-box;
     font-size: 16px;
@@ -993,4 +994,9 @@ code {
     display: flex;
     flex-direction: row;
   }
+}
+
+.input.user_confirm_password,
+.input.user_website {
+  display: none;
 }

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -998,5 +998,7 @@ code {
 
 .input.user_confirm_password,
 .input.user_website {
-  display: none;
+  &:not(.field_with_errors) {
+    display: none;
+  }
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,6 +89,12 @@ class User < ApplicationRecord
   validates_with EmailMxValidator, if: :validate_email_dns?
   validates :agreement, acceptance: { allow_nil: false, accept: [true, 'true', '1'] }, on: :create
 
+  # Those are honeypot fields
+  attr_accessor :website, :confirm_password
+
+  validates :website, absence: true, on: :create
+  validates :confirm_password, absence: true, on: :create
+
   scope :recent, -> { order(id: :desc) }
   scope :pending, -> { where(approved: false) }
   scope :approved, -> { where(approved: true) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,9 +89,10 @@ class User < ApplicationRecord
   validates_with EmailMxValidator, if: :validate_email_dns?
   validates :agreement, acceptance: { allow_nil: false, accept: [true, 'true', '1'] }, on: :create
 
-  # Those are honeypot fields
-  attr_accessor :website, :confirm_password
+  # Those are honeypot/antispam fields
+  attr_accessor :registration_form_time, :website, :confirm_password
 
+  validates_with RegistrationFormTimeValidator, on: :create
   validates :website, absence: true, on: :create
   validates :confirm_password, absence: true, on: :create
 

--- a/app/validators/registration_form_time_validator.rb
+++ b/app/validators/registration_form_time_validator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RegistrationFormTimeValidator < ActiveModel::Validator
+  REGISTRATION_FORM_MIN_TIME = 3.seconds.freeze
+
+  def validate(user)
+    user.errors.add(:base, I18n.t('auth.too_fast')) if user.registration_form_time.present? && user.registration_form_time > REGISTRATION_FORM_MIN_TIME.ago
+  end
+end

--- a/app/views/about/_registration.html.haml
+++ b/app/views/about/_registration.html.haml
@@ -10,6 +10,9 @@
       = f.input :password, placeholder: t('simple_form.labels.defaults.password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.password'), :autocomplete => 'off', :minlength => User.password_length.first, :maxlength => User.password_length.last }, hint: false, disabled: closed_registrations?
       = f.input :password_confirmation, placeholder: t('simple_form.labels.defaults.confirm_password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_password'), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
 
+      = f.input :confirm_password, as: :string, placeholder: t('simple_form.labels.defaults.password_honeypot'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.password_honeypot'), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
+      = f.input :website, as: :url, placeholder: t('simple_form.labels.defaults.honeypot'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot'), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
+
     - if approved_registrations?
       .fields-group
         = f.simple_fields_for :invite_request do |invite_request_fields|

--- a/app/views/about/_registration.html.haml
+++ b/app/views/about/_registration.html.haml
@@ -10,8 +10,8 @@
       = f.input :password, placeholder: t('simple_form.labels.defaults.password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.password'), :autocomplete => 'off', :minlength => User.password_length.first, :maxlength => User.password_length.last }, hint: false, disabled: closed_registrations?
       = f.input :password_confirmation, placeholder: t('simple_form.labels.defaults.confirm_password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_password'), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
 
-      = f.input :confirm_password, as: :string, placeholder: t('simple_form.labels.defaults.password_honeypot'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.password_honeypot'), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
-      = f.input :website, as: :url, placeholder: t('simple_form.labels.defaults.honeypot'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot'), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
+      = f.input :confirm_password, as: :string, placeholder: t('simple_form.labels.defaults.honeypot', label: t('simple_form.labels.defaults.password')), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot', label: t('simple_form.labels.defaults.password')), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
+      = f.input :website, as: :url, placeholder: t('simple_form.labels.defaults.honeypot', label: 'Website'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot', label: 'Website'), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
 
     - if approved_registrations?
       .fields-group

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -24,6 +24,9 @@
 
   .fields-group
     = f.input :password_confirmation, wrapper: :with_label, label: t('simple_form.labels.defaults.confirm_password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_password'), :autocomplete => 'off' }
+    = f.input :confirm_password, as: :string, wrapper: :with_label, label: t('simple_form.labels.defaults.password_honeypot'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.password_honeypot'), :autocomplete => 'off' }
+
+  = f.input :website, as: :url, wrapper: :with_label, label: t('simple_form.labels.defaults.honeypot'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot'), :autocomplete => 'off' }
 
   - if approved_registrations? && !@invite.present?
     .fields-group

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -24,9 +24,9 @@
 
   .fields-group
     = f.input :password_confirmation, wrapper: :with_label, label: t('simple_form.labels.defaults.confirm_password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_password'), :autocomplete => 'off' }
-    = f.input :confirm_password, as: :string, wrapper: :with_label, label: t('simple_form.labels.defaults.password_honeypot'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.password_honeypot'), :autocomplete => 'off' }
+    = f.input :confirm_password, as: :string, wrapper: :with_label, label: t('simple_form.labels.defaults.honeypot', label: t('simple_form.labels.defaults.password')), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot', label: t('simple_form.labels.defaults.password')), :autocomplete => 'off' }
 
-  = f.input :website, as: :url, wrapper: :with_label, label: t('simple_form.labels.defaults.honeypot'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot'), :autocomplete => 'off' }
+  = f.input :website, as: :url, wrapper: :with_label, label: t('simple_form.labels.defaults.honeypot', label: 'Website'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot', label: 'Website'), :autocomplete => 'off' }
 
   - if approved_registrations? && !@invite.present?
     .fields-group

--- a/app/views/shared/_error_messages.html.haml
+++ b/app/views/shared/_error_messages.html.haml
@@ -1,3 +1,6 @@
 - if object.errors.any?
   .flash-message.alert#error_explanation
     %strong= t('generic.validation_errors', count: object.errors.count)
+- object.errors[:base].each do |error|
+  .flash-message.alert
+    %strong= error

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -751,6 +751,7 @@ en:
       functional: Your account is fully operational.
       pending: Your application is pending review by our staff. This may take some time. You will receive an e-mail if your application is approved.
       redirecting_to: Your account is inactive because it is currently redirecting to %{acct}.
+    too_fast: Form submitted too fast, try again.
     trouble_logging_in: Trouble logging in?
     use_security_key: Use security key
   authorize_follow:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -126,6 +126,7 @@ en:
         expires_in: Expire after
         fields: Profile metadata
         header: Header
+        honeypot: Website (do not fill in)
         inbox_url: URL of the relay inbox
         irreversible: Drop instead of hide
         locale: Interface language
@@ -135,6 +136,7 @@ en:
         note: Bio
         otp_attempt: Two-factor code
         password: Password
+        password_honeypot: Password (do not fill in)
         phrase: Keyword or phrase
         setting_advanced_layout: Enable advanced web interface
         setting_aggregate_reblogs: Group boosts in timelines

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -126,7 +126,7 @@ en:
         expires_in: Expire after
         fields: Profile metadata
         header: Header
-        honeypot: Website (do not fill in)
+        honeypot: "%{label} (do not fill in)"
         inbox_url: URL of the relay inbox
         irreversible: Drop instead of hide
         locale: Interface language
@@ -136,7 +136,6 @@ en:
         note: Bio
         otp_attempt: Two-factor code
         password: Password
-        password_honeypot: Password (do not fill in)
         phrase: Keyword or phrase
         setting_advanced_layout: Enable advanced web interface
         setting_aggregate_reblogs: Group boosts in timelines

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -82,6 +82,10 @@ RSpec.describe Auth::RegistrationsController, type: :controller do
   describe 'POST #create' do
     let(:accept_language) { Rails.application.config.i18n.available_locales.sample.to_s }
 
+    before do
+      session[:registration_form_time] = 5.seconds.ago
+    end
+
     around do |example|
       current_locale = I18n.locale
       example.run


### PR DESCRIPTION
This PR introduces several techniques to limit registration spam:
- Honeypot fields which, when filled, automatically reject applications.
  To avoid legitimate users filling them in, they have distinctive labels/placeholders, have a `display: hidden` style, and are cleared via javascript on form submission.
- Submissions happening less than 3 seconds after the form was initially displayed are automatically rejected.

Those techniques have not been widely tested on Mastodon instances yet, so neither their efficiency or their downsides have been fully tested yet, but I expect it to significantly cut down on generic spam bots (which seem to be very prevalent on instances with approval-based registrations, because of the textarea).

Note that rejecting registration attempts is important for two reasons:
- lowering the workload on admins, especially when approval-based registrations are in effect
- lowering the mail of confirmation emails sent, especially during large spam waves