### PR TITLE
Fix remove number sign from account_featured_tags

### DIFF
--- a/app/serializers/rest/account_featured_tag_serializer.rb
+++ b/app/serializers/rest/account_featured_tag_serializer.rb
@@ -9,10 +9,6 @@ class REST::AccountFeaturedTagSerializer < ActiveModel::Serializer
     object.tag.id.to_s
   end
 
-  def name
-    "##{object.name}"
-  end
-
   def url
     short_account_tag_url(object.account, object.tag)
   end


### PR DESCRIPTION
In response to the REST API, it was incorrect for the featured_tags name to contain a number sign.