### PR TITLE
Fix column swiping animation logic

### DIFF
--- a/app/javascript/mastodon/features/ui/components/columns_area.js
+++ b/app/javascript/mastodon/features/ui/components/columns_area.js
@@ -75,7 +75,9 @@ class ColumnsArea extends ImmutablePureComponent {
   }
 
   componentWillReceiveProps() {
-    this.setState({ shouldAnimate: false });
+    if (typeof this.pendingIndex !== 'number' && this.lastIndex !== getIndex(this.context.router.history.location.pathname)) {
+      this.setState({ shouldAnimate: false });
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
From the start, swiping columns was highly unreliable because the logic could change `ReactSwipeableViews`'s `animateTransitions` property mid-swipe.

PR #11200 partially fixed this, but at the unintended cost of disabling the swipe animation altogether.

This PR changes the logic behind `shouldAnimate` to only disable the swiping animation at the end of a column change not initiated by `ReactSwipeableViews`.