### PR TITLE
Remove unsupported ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 2.5.0', '< 3.0.0'
+ruby '>= 2.6.0', '< 3.0.0'
 
 gem 'pkg-config', '~> 1.4'
 


### PR DESCRIPTION
Tootctl's code uses newer function that is unsupported in 2.5.x so that is not working.
I think better to remove 2.5 that will be EOL soon.