### PR TITLE
Fix to isolate the sidekiq process that runs the scheduler job

### DIFF
--- a/boxfile.yml
+++ b/boxfile.yml
@@ -110,6 +110,7 @@ worker.sidekiq:
     mailers: bundle exec sidekiq -c 5 -q mailers -L /app/log/sidekiq.log
     pull: bundle exec sidekiq -c 5 -q pull -L /app/log/sidekiq.log
     push: bundle exec sidekiq -c 5 -q push -L /app/log/sidekiq.log
+    scheduler: bundle exec sidekiq -c 5 -q scheduler -L /app/log/sidekiq.log
 
   writable_dirs:
     - tmp

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,37 +5,51 @@
   - [push, 4]
   - [mailers, 2]
   - [pull]
+  - [scheduler]
+:scheduler:
+  :listened_queues_only: true
 :schedule:
   scheduled_statuses_scheduler:
     every: '5m'
     class: Scheduler::ScheduledStatusesScheduler
+    queue: scheduler
   trending_tags_scheduler:
     every: '5m'
     class: Scheduler::TrendingTagsScheduler
+    queue: scheduler
   media_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
     class: Scheduler::MediaCleanupScheduler
+    queue: scheduler
   feed_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(0..2) %> * * *'
     class: Scheduler::FeedCleanupScheduler
+    queue: scheduler
   doorkeeper_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(0..2) %> * * 0'
     class: Scheduler::DoorkeeperCleanupScheduler
+    queue: scheduler
   user_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(4..6) %> * * *'
     class: Scheduler::UserCleanupScheduler
+    queue: scheduler
   ip_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
     class: Scheduler::IpCleanupScheduler
+    queue: scheduler
   email_scheduler:
     cron: '0 10 * * 2'
     class: Scheduler::EmailScheduler
+    queue: scheduler
   backup_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
     class: Scheduler::BackupCleanupScheduler
+    queue: scheduler
   pghero_scheduler:
     cron: '0 0 * * *'
     class: Scheduler::PgheroScheduler
+    queue: scheduler
   instance_refresh_scheduler:
     cron: '0 * * * *'
     class: Scheduler::InstanceRefreshScheduler
+    queue: scheduler


### PR DESCRIPTION
Fix https://github.com/tootsuite/mastodon/issues/14764

Introduce a scheduler queue that runs the scheduler job so that only the sidekiq process that processes this queue runs the schedule.

In the case of a single sidekiq process, everything is processed, including the schedule, as before.
``````
bundle exec sidekiq -c 25
``````

If you have multiple sidekiq processes running, only the process that handles the scheduler queue handles the schedule.
``````
bundle exec sidekiq -c 25 -q defalut, 6 -q mailers, 2
bundle exec sidekiq -c 25 -q push, 4 -q pull -q scheduler
``````

For existing configurations with multiple sidekiq processes running explicitly in the queue, this change prevents scheduled execution because there is no process to handle the scheduler queue.
``````
bundle exec sidekiq -c 25 -q defalut, 6 -q mailers, 2
bundle exec sidekiq -c 25 -q push, 4 -q pull
``````

The solution is to have one of the processes process the scheduler queue, or add a dedicated process for scheduled execution.
``````
bundle exec sidekiq -c 5 -q scheduler
``````