### PR TITLE
Change number format on about page from full to shortened

### DIFF
--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -17,11 +17,11 @@
         .row__information-board
           .information-board__section
             %span= t 'about.user_count_before'
-            %strong= number_with_delimiter @instance_presenter.user_count
+            %strong= number_to_human @instance_presenter.user_count, strip_insignificant_zeros: true
             %span= t 'about.user_count_after', count: @instance_presenter.user_count
           .information-board__section
             %span= t 'about.status_count_before'
-            %strong= number_with_delimiter @instance_presenter.status_count
+            %strong= number_to_human @instance_presenter.status_count, strip_insignificant_zeros: true
             %span= t 'about.status_count_after', count: @instance_presenter.status_count
         .row__mascot
           .landing-page__mascot


### PR DESCRIPTION
The numbers are getting big and nobody needs single digit precision when you're in the millions range.