### PR TITLE
Fix styling issue on /about when server admin has a long username

### DIFF
--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -732,6 +732,7 @@ $small-breakpoint: 960px;
 
       &__column {
         flex: 1 1 50%;
+        overflow-x: hidden;
       }
     }
 


### PR DESCRIPTION
This can occur when using non-latin characters (as in the screenshot below, using the full-width “Ａ”) or increasing the default username length limits.

## Before

![Screenshot_2020-12-18 Mastodon](https://user-images.githubusercontent.com/384364/102592196-6931fd80-4113-11eb-9b10-d6b43d2d7105.png)

## After

![image](https://user-images.githubusercontent.com/384364/102592164-5fa89580-4113-11eb-9e52-54d7081d7225.png)