### PR TITLE
Fix old migration script not being able to run if it fails midway

### DIFF
--- a/db/migrate/20200620164023_add_fixed_lowercase_index_to_accounts.rb
+++ b/db/migrate/20200620164023_add_fixed_lowercase_index_to_accounts.rb
@@ -2,9 +2,14 @@ class AddFixedLowercaseIndexToAccounts < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def up
-    rename_index :accounts, 'index_accounts_on_username_and_domain_lower', 'old_index_accounts_on_username_and_domain_lower' unless index_name_exists?(:accounts, 'old_index_accounts_on_username_and_domain_lower')
+    if index_name_exists?(:accounts, 'old_index_accounts_on_username_and_domain_lower') && index_name_exists?(:accounts, 'index_accounts_on_username_and_domain_lower')
+      remove_index :accounts, name: 'index_accounts_on_username_and_domain_lower'
+    elsif index_name_exists?(:accounts, 'index_accounts_on_username_and_domain_lower')
+      rename_index :accounts, 'index_accounts_on_username_and_domain_lower', 'old_index_accounts_on_username_and_domain_lower'
+    end
+
     add_index :accounts, "lower (username), COALESCE(lower(domain), '')", name: 'index_accounts_on_username_and_domain_lower', unique: true, algorithm: :concurrently
-    remove_index :accounts, name: 'old_index_accounts_on_username_and_domain_lower'
+    remove_index :accounts, name: 'old_index_accounts_on_username_and_domain_lower' if index_name_exists?(:accounts, 'old_index_accounts_on_username_and_domain_lower')
   end
 
   def down

--- a/db/migrate/20200620164023_add_fixed_lowercase_index_to_accounts.rb
+++ b/db/migrate/20200620164023_add_fixed_lowercase_index_to_accounts.rb
@@ -1,6 +1,16 @@
 class AddFixedLowercaseIndexToAccounts < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
+  class CorruptionError < StandardError
+    def cause
+      nil
+    end
+
+    def backtrace
+      []
+    end
+  end
+
   def up
     if index_name_exists?(:accounts, 'old_index_accounts_on_username_and_domain_lower') && index_name_exists?(:accounts, 'index_accounts_on_username_and_domain_lower')
       remove_index :accounts, name: 'index_accounts_on_username_and_domain_lower'
@@ -8,7 +18,12 @@ class AddFixedLowercaseIndexToAccounts < ActiveRecord::Migration[5.2]
       rename_index :accounts, 'index_accounts_on_username_and_domain_lower', 'old_index_accounts_on_username_and_domain_lower'
     end
 
-    add_index :accounts, "lower (username), COALESCE(lower(domain), '')", name: 'index_accounts_on_username_and_domain_lower', unique: true, algorithm: :concurrently
+    begin
+      add_index :accounts, "lower (username), COALESCE(lower(domain), '')", name: 'index_accounts_on_username_and_domain_lower', unique: true, algorithm: :concurrently
+    rescue ActiveRecord::RecordNotUnique
+      raise CorruptionError, 'Migration failed because of index corruption, see https://docs.joinmastodon.org/admin/troubleshooting/index-corruption/#fixing'
+    end
+
     remove_index :accounts, name: 'old_index_accounts_on_username_and_domain_lower' if index_name_exists?(:accounts, 'old_index_accounts_on_username_and_domain_lower')
   end
 


### PR DESCRIPTION
Fixes #14443

- fix old migration script not being able to run if it fails midway (https://github.com/tootsuite/mastodon/issues/14443#issuecomment-664215462)
- improve readability of migration failure message in case of index corruption, pointing at documentation to fix said corruption