### PR TITLE
Fix "tootctl accounts fix-duplicates"

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -245,10 +245,10 @@ module Mastodon
       domain configuration.
     LONG_DESC
     def fix_duplicates
-      Account.remote.select(:uri, 'count(*)').group(:uri).having('count(*) > 1').pluck_each(:uri) do |uri|
+      Account.remote.select(:uri, 'count(*)').group(:uri).having('count(*) > 1').pluck(:uri).each do |uri|
         say("Duplicates found for #{uri}")
         begin
-          ActivityPub::FetchRemotAccountService.new.call(uri) unless options[:dry_run]
+          ActivityPub::FetchRemoteAccountService.new.call(uri) unless options[:dry_run]
         rescue => e
           say("Error processing #{uri}: #{e}", :red)
         end


### PR DESCRIPTION
- `pluck_each` cannot be used this way with `group`
- typo

Sorry about those :weary: 