### PR TITLE
Add clean error message when RAILS_ENV is unset

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,8 @@
+unless ENV.key?('RAILS_ENV')
+  STDERR.puts 'ERROR: Missing RAILS_ENV environment variable, please set it to "production", "development", or "test".'
+  exit 1
+end
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.


### PR DESCRIPTION
By default, an unset RAILS_ENV is understood as RAILS_ENV=development.

However, this is not what most people expect, and due to development-only dependencies, users are often left with confusing error messages.

This commit changes it so that an explicit RAILS_ENV is required, and failing that, an error message is displayed before loading the app.