### PR TITLE
Improve account deletion performances further

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -230,6 +230,36 @@ class FeedManager
     end
   end
 
+  # Completely clear multiple feeds at once
+  # @param [Symbol] type
+  # @param [Array<Integer>] ids
+  # @return [void]
+  def clean_feeds!(type, ids)
+    reblogged_id_sets = {}
+
+    redis.pipelined do
+      ids.each do |feed_id|
+        redis.del(key(type, feed_id))
+        reblog_key = key(type, feed_id, 'reblogs')
+        # We collect a future for this: we don't block while getting
+        # it, but we can iterate over it later.
+        reblogged_id_sets[feed_id] = redis.zrange(reblog_key, 0, -1)
+        redis.del(reblog_key)
+      end
+    end
+
+    # Remove all of the reblog tracking keys we just removed the
+    # references to.
+    redis.pipelined do
+      reblogged_id_sets.each do |feed_id, future|
+        future.value.each do |reblogged_id|
+          reblog_set_key = key(type, feed_id, "reblogs:#{reblogged_id}")
+          redis.del(reblog_set_key)
+        end
+      end
+    end
+  end
+
   private
 
   # Trim a feed to maximum size by removing older items

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -578,17 +578,6 @@ class Account < ApplicationRecord
   end
 
   def clean_feed_manager
-    reblog_key       = FeedManager.instance.key(:home, id, 'reblogs')
-    reblogged_id_set = Redis.current.zrange(reblog_key, 0, -1)
-
-    Redis.current.pipelined do
-      Redis.current.del(FeedManager.instance.key(:home, id))
-      Redis.current.del(reblog_key)
-
-      reblogged_id_set.each do |reblogged_id|
-        reblog_set_key = FeedManager.instance.key(:home, id, "reblogs:#{reblogged_id}")
-        Redis.current.del(reblog_set_key)
-      end
-    end
+    FeedManager.instance.clean_feeds!(:home, [id])
   end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -34,17 +34,6 @@ class List < ApplicationRecord
   private
 
   def clean_feed_manager
-    reblog_key       = FeedManager.instance.key(:list, id, 'reblogs')
-    reblogged_id_set = Redis.current.zrange(reblog_key, 0, -1)
-
-    Redis.current.pipelined do
-      Redis.current.del(FeedManager.instance.key(:list, id))
-      Redis.current.del(reblog_key)
-
-      reblogged_id_set.each do |reblogged_id|
-        reblog_set_key = FeedManager.instance.key(:list, id, "reblogs:#{reblogged_id}")
-        Redis.current.del(reblog_set_key)
-      end
-    end
+    FeedManager.instance.clean_feeds!(:list, [id])
   end
 end

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -50,7 +50,7 @@ class BatchedRemoveStatusService < BaseService
     # Cannot be batched
     @status_id_cutoff = Mastodon::Snowflake.id_at(2.weeks.ago)
     redis.pipelined do
-      statuses_and_reblogs.each do |status|
+      statuses.each do |status|
         unpush_from_public_timelines(status)
       end
     end

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -64,12 +64,6 @@ class BatchedRemoveStatusService < BaseService
         FeedManager.instance.unpush_from_home(follower, status)
       end
     end
-
-    return unless account.local?
-
-    statuses.each do |status|
-      FeedManager.instance.unpush_from_home(account, status)
-    end
   end
 
   def unpush_from_list_timelines(account, statuses)

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -27,7 +27,7 @@ class BatchedRemoveStatusService < BaseService
     # transaction lock the database, but we use the delete method instead
     # of destroy to avoid all callbacks. We rely on foreign keys to
     # cascade the delete faster without loading the associations.
-    statuses_and_reblogs.each(&:delete)
+    statuses_and_reblogs.each_slice(50) { |slice| Status.where(id: slice.map(&:id)).delete_all }
 
     # Since we skipped all callbacks, we also need to manually
     # deindex the statuses

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -48,6 +48,7 @@ class BatchedRemoveStatusService < BaseService
     end
 
     # Cannot be batched
+    @status_id_cutoff = Mastodon::Snowflake.id_at(2.weeks.ago)
     redis.pipelined do
       statuses_and_reblogs.each do |status|
         unpush_from_public_timelines(status)
@@ -80,7 +81,7 @@ class BatchedRemoveStatusService < BaseService
   end
 
   def unpush_from_public_timelines(status)
-    return unless status.public_visibility?
+    return unless status.public_visibility? && status.id > @status_id_cutoff
 
     payload = Oj.dump(event: :delete, payload: status.id.to_s)
 

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -145,6 +145,7 @@ class DeleteAccountService < BaseService
     purge_media_attachments!
     purge_polls!
     purge_generated_notifications!
+    purge_feeds!
     purge_other_associations!
 
     @account.destroy unless keep_account_record?
@@ -179,6 +180,13 @@ class DeleteAccountService < BaseService
     associations_for_destruction.each do |association_name|
       purge_association(association_name)
     end
+  end
+
+  def purge_feeds!
+    return unless @account.local?
+
+    FeedManager.instance.clean_feeds!(:home, [@account.id])
+    FeedManager.instance.clean_feeds!(:list, @account.owned_lists.pluck(:id))
   end
 
   def purge_profile!

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -46,10 +46,12 @@ class DeleteAccountService < BaseService
     featured_tags
     follow_requests
     identity_proofs
+    list_accounts
     migrations
     mute_relationships
     muted_by_relationships
     notifications
+    owned_lists
     scheduled_statuses
     status_pins
   )

--- a/app/workers/scheduler/feed_cleanup_scheduler.rb
+++ b/app/workers/scheduler/feed_cleanup_scheduler.rb
@@ -14,37 +14,11 @@ class Scheduler::FeedCleanupScheduler
   private
 
   def clean_home_feeds!
-    clean_feeds!(inactive_account_ids, :home)
+    feed_manager.clean_feeds!(:home, inactive_account_ids)
   end
 
   def clean_list_feeds!
-    clean_feeds!(inactive_list_ids, :list)
-  end
-
-  def clean_feeds!(ids, type)
-    reblogged_id_sets = {}
-
-    redis.pipelined do
-      ids.each do |feed_id|
-        redis.del(feed_manager.key(type, feed_id))
-        reblog_key = feed_manager.key(type, feed_id, 'reblogs')
-        # We collect a future for this: we don't block while getting
-        # it, but we can iterate over it later.
-        reblogged_id_sets[feed_id] = redis.zrange(reblog_key, 0, -1)
-        redis.del(reblog_key)
-      end
-    end
-
-    # Remove all of the reblog tracking keys we just removed the
-    # references to.
-    redis.pipelined do
-      reblogged_id_sets.each do |feed_id, future|
-        future.value.each do |reblogged_id|
-          reblog_set_key = feed_manager.key(type, feed_id, "reblogs:#{reblogged_id}")
-          redis.del(reblog_set_key)
-        end
-      end
-    end
+    feed_manager.clean_feeds!(:list, inactive_list_ids)
   end
 
   def inactive_account_ids

--- a/spec/services/batched_remove_status_service_spec.rb
+++ b/spec/services/batched_remove_status_service_spec.rb
@@ -43,10 +43,6 @@ RSpec.describe BatchedRemoveStatusService, type: :service do
     expect(Redis.current).to have_received(:publish).with("timeline:#{jeff.id}", any_args).at_least(:once)
   end
 
-  it 'notifies streaming API of author' do
-    expect(Redis.current).to have_received(:publish).with("timeline:#{alice.id}", any_args).at_least(:once)
-  end
-
   it 'notifies streaming API of public timeline' do
     expect(Redis.current).to have_received(:publish).with('timeline:public', any_args).at_least(:once)
   end


### PR DESCRIPTION
## Benchmark

### Protocol

Before each test, the database is re-created with the same backup from my production instance (~single-user, a few local accounts for different purposes). Media files are **not** copied over.

The development environment does not have ElasticSearch enabled, and the database server runs locally.

The timing values are obtained by running the following code in a Rails console:

```ruby
Benchmark.measure do
  top_account_ids.each do |account_id|
    DeleteAccountService.new.call(Account.find(account_id), skip_activitypub: true)
  end
end
```

`top_account_ids` contains the identifier of the 5 accounts with the most toots known to my instance, they are broken down as follows:

| # | total toots | public toots | DMs | local? | favourites | reported toots |
| - | -- | -- | -- | -- | -- | -- |
| 1 | 105207 | 13044 | 48 | no | 1054 | 1 |
| 2 | 73196 | 66623 | 0 | no | 369 | 0 |
| 3 | 57971 | 19237 | 329 | no | 1921 | 0 |
| 4 | 56710 | 4067 | 1255 | yes | 37959 | 0 |
| 5 | 54403 | 31091 | 56 | no | 3148 | 0 |

The accounts are deleted in that order, and interact between them, so an account being cleared will slightly lower the number of toots (reblogs) to be processed in other accounts.

### Results

| commit | user | system | total | real |
| --- | --- | --- | --- | --- |
| 2334addfff285fc69d616c40ee0fb8a696fcd3f8 (without this PR) | 750.049139s (12min30s) |  55.861878s | 805.911017s (13min26s) | 2624.943940s (**43min45s**) |
| 8c70b012cdfd7a97082300275331c93bd402a7c6 (deletes statuses by batches of 50 instead of individually) | 606.902921s (10min07s) | 41.281127s | 648.184048s (10min48s) | 1549.474583s (**25min50s**) |
| e20b52ee43c4b17f78b807f960781f03a6f98695 (do not precompute values that are only used once) | 596.145949s (9min56s) | 42.301746s | 638.447695s (10min38s) | 1527.635537s (25min27s) |
| fb8ad0f6f8a0d9cb6ffb90fc1d285aac45b54b32 (do not generate redis events for toots older than two weeks) | 479.127842s (7min59s) | 40.115994s | 519.243836s (8min39s) | 1448.805232s (24min09s) |
| eff219a55eb59fa0465a81ecde4c8874a2c2ad4c (filter reported toots a priori) | 476.933216s (7min57s) | 39.721144s | 516.654360s (8min37s) | 1424.850713s (23min45s) |
| fc6a592d0426ed667ff45bc450581358487645a9 (do not process reblogs when cleaning up public timelines) | 477.414900s (7min57s) | 39.666471s | 517.081371s (8min37s) | 1426.631086s (23min47s) |
| d5da93708604efd209e1b55b0fd5610bddbbfe18 (clean up deleted account's feed in one go) | 477.063304s (7min57s) | 37.829388s | 514.892692s (8min35s) | 1413.292442s (23min33s) |
| f57ed408598a2dc6c9ff701c1a9d9efb4069be2e (delete rather than destroy a few more associations, tweak preloading) | 474.929086s (7min55s) | 38.475544s | 513.404630s (8min33s) | 1415.174932s (**23min35s**) |

The first few commits make a very sizable difference, then the benefits aren't that obvious on my example. Still, they make the logic a bit cleaner and I expect it to make a slightly bigger difference on instances with more accounts interacting with the deleted ones.