### PR TITLE
Fix BatchedRemoveStatusService not working without ES in rails console

### DIFF
--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -31,7 +31,7 @@ class BatchedRemoveStatusService < BaseService
 
     # Since we skipped all callbacks, we also need to manually
     # deindex the statuses
-    Chewy.strategy.current.update(StatusesIndex, statuses_and_reblogs)
+    Chewy.strategy.current.update(StatusesIndex, statuses_and_reblogs) if Chewy.enabled?
 
     return if options[:skip_side_effects]
 


### PR DESCRIPTION
Not a huge deal but may cause surprising failures in custom scripts and development.

Also fixes ordering in some queries.