### PR TITLE
Fix mentions not being deleted efficiently

### DIFF
--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -142,6 +142,7 @@ class DeleteAccountService < BaseService
     purge_user!
     purge_profile!
     purge_statuses!
+    purge_mentions!
     purge_media_attachments!
     purge_polls!
     purge_generated_notifications!
@@ -157,6 +158,10 @@ class DeleteAccountService < BaseService
     @account.statuses.reorder(nil).where.not(id: reported_status_ids).in_batches do |statuses|
       BatchedRemoveStatusService.new.call(statuses, skip_side_effects: skip_side_effects?)
     end
+  end
+
+  def purge_mentions!
+    @account.mentions.reorder(nil).where.not(status_id: reported_status_ids).in_batches.delete_all
   end
 
   def purge_media_attachments!


### PR DESCRIPTION
To further validate the speed gains from our recent optimizations, I tried running `time ./bin/tootctl domains purge mastodon.social -c 1 --verbose` with the old and new code.

The old code raised:
> Removed 12223 accounts
> Removed 66 custom emojis
> 
> real	103m18.756s
> user	83m44.863s
> sys	1m20.069s

while I had to stop the new one because it was still stuck at the third account after more than 40 minutes.

It turns out, as a regression from the recent optimizations, mentions were left untouched until `account.destroy`, which would then delete them individually, and executing queries to find and delete associated notifications, resulting in a massive slowdown.

With this change, running `tootctl domains purge` raises:
> Removed 12223 accounts
> Removed 66 custom emojis
> 
> real	22m52.500s
> user	12m9.713s
> sys	0m28.972s