### PR TITLE
Fix media modal buttons not showing up on mobile

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7194,21 +7194,6 @@ noscript {
   .audio-player {
     border-radius: 0;
   }
-
-  @media screen and (max-width: 415px) {
-    width: 210px;
-    bottom: 10px;
-    right: 10px;
-
-    &__footer {
-      display: none;
-    }
-
-    .video-player,
-    .audio-player {
-      border-radius: 0 0 4px 4px;
-    }
-  }
 }
 
 .picture-in-picture-placeholder {


### PR DESCRIPTION
Fixes #15374

When the pop-out player was introduced, it had tweaks for the mobile view, but it's now disabled in mobile mode and the styling was reused for modals, causing the footer to be hidden on mobile without a good reason.