### PR TITLE
Fix undefined method error when batch-removing statuses with ElasticSearch on

### DIFF
--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -31,7 +31,7 @@ class BatchedRemoveStatusService < BaseService
 
     # Since we skipped all callbacks, we also need to manually
     # deindex the statuses
-    Chewy.strategy.current.update(StatusesIndex, statuses_and_reblogs) if Chewy.enabled?
+    Chewy.strategy.current.update(StatusesIndex::Status, statuses_and_reblogs) if Chewy.enabled?
 
     return if options[:skip_side_effects]
 

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -187,7 +187,7 @@ class DeleteAccountService < BaseService
     @account.favourites.in_batches do |favourites|
       ids = favourites.pluck(:status_id)
       StatusStat.where(status_id: ids).update_all('favourites_count = GREATEST(0, favourites_count - 1)')
-      Chewy.strategy.current.update(StatusesIndex, ids) if Chewy.enabled?
+      Chewy.strategy.current.update(StatusesIndex::Status, ids) if Chewy.enabled?
       # Rails.cache.delete_multi would be better, but we don't have it yet
       ids.each { |id| Rails.cache.delete("statuses/#{id}") }
       favourites.delete_all
@@ -196,7 +196,7 @@ class DeleteAccountService < BaseService
 
   def purge_bookmarks!
     @account.bookmarks.in_batches do |bookmarks|
-      Chewy.strategy.current.update(StatusesIndex, bookmarks.pluck(:status_id)) if Chewy.enabled?
+      Chewy.strategy.current.update(StatusesIndex::Status, bookmarks.pluck(:status_id)) if Chewy.enabled?
       bookmarks.delete_all
     end
   end


### PR DESCRIPTION
This didn't come up during testing because the urgent strategy used by Rails console does not call the method.