### PR TITLE
Improve Emoji import (fix #15429)

### DIFF
--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -41,9 +41,14 @@ module Mastodon
 
       Gem::Package::TarReader.new(Zlib::GzipReader.open(path)) do |tar|
         tar.each do |entry|
+          # File exists && Extension is PNG && not a macOS shadow file (begin with ._)
           next unless entry.file? && entry.full_name.end_with?('.png')
+          
+          filename = File.basename(entry.full_name, '.*')
+          
+          next if filename.start_with?('._')
 
-          shortcode    = [options[:prefix], File.basename(entry.full_name, '.*'), options[:suffix]].compact.join
+          shortcode    = [options[:prefix], filename, options[:suffix]].compact.join
           custom_emoji = CustomEmoji.local.find_by(shortcode: shortcode)
 
           if custom_emoji && !options[:overwrite]

--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -43,9 +43,9 @@ module Mastodon
         tar.each do |entry|
           # File exists && Extension is PNG && not a macOS shadow file (begin with ._)
           next unless entry.file? && entry.full_name.end_with?('.png')
-          
+
           filename = File.basename(entry.full_name, '.*')
-          
+
           next if filename.start_with?('._')
 
           shortcode    = [options[:prefix], filename, options[:suffix]].compact.join

--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -46,6 +46,7 @@ module Mastodon
 
           filename = File.basename(entry.full_name, '.*')
 
+          # Skip macOS shadow files
           next if filename.start_with?('._')
 
           shortcode    = [options[:prefix], filename, options[:suffix]].compact.join

--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -41,7 +41,6 @@ module Mastodon
 
       Gem::Package::TarReader.new(Zlib::GzipReader.open(path)) do |tar|
         tar.each do |entry|
-          # File exists && Extension is PNG && not a macOS shadow file (begin with ._)
           next unless entry.file? && entry.full_name.end_with?('.png')
 
           filename = File.basename(entry.full_name, '.*')


### PR DESCRIPTION
Skip macOS '._' shadow files in tar archive to speed up emoji importing. Basic testing showed it to work fine in distinguishing & ignoring shadow files.