### PR TITLE
Fix to re-download avatars and headers that failed to download

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -52,6 +52,8 @@
 #  devices_url                   :string
 #  sensitized_at                 :datetime
 #  suspension_origin             :integer
+#  avatar_needs_download         :boolean          default(FALSE), not null
+#  header_needs_download         :boolean          default(FALSE), not null
 #
 
 class Account < ApplicationRecord

--- a/db/migrate/20210103071009_add_needs_download_to_account.rb
+++ b/db/migrate/20210103071009_add_needs_download_to_account.rb
@@ -1,0 +1,19 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddNeedsDownloadToAccount < ActiveRecord::Migration[5.2]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_column_with_default :accounts, :avatar_needs_download, :boolean, default: false
+      add_column_with_default :accounts, :header_needs_download, :boolean, default: false
+    end
+  end
+
+  def down
+    remove_column :accounts, :avatar_needs_download
+    remove_column :accounts, :header_needs_download
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_18_054746) do
+ActiveRecord::Schema.define(version: 2021_01_03_071009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -191,6 +191,8 @@ ActiveRecord::Schema.define(version: 2020_12_18_054746) do
     t.string "devices_url"
     t.integer "suspension_origin"
     t.datetime "sensitized_at"
+    t.boolean "avatar_needs_download", default: false, null: false
+    t.boolean "header_needs_download", default: false, null: false
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["moved_to_account_id"], name: "index_accounts_on_moved_to_account_id"


### PR DESCRIPTION
If the avatar and header download fails for a temporary reason, it will not be updated until the remote_url changes.

For this reason, the image was not updated when the remote account updated information other than the image or when the "REFRESH PROFILE" button was pressed on the moderation account page.

In this PR, if the download fails, it will be recorded in the "needs_download" flag so that it will be re-downloaded if necessary.

In addition to this, you may want to improve "tootctl accounts refresh" or re-download with a scheduled task.