### PR TITLE
Fix custom emoji compatibility in Misskey's display name

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -751,7 +751,7 @@
   font-size: inherit;
   vertical-align: middle;
   object-fit: contain;
-  margin: -.2ex .15em .2ex;
+  margin: -.2ex 0 .2ex;
   width: 16px;
   height: 16px;
 


### PR DESCRIPTION
In Misskey, you can use custom emoji in display_name without whitespace, but in Mastodon it will be displayed as a shortcode.

To remedy this incompatibility, insert zero width space before and after the shortcode. Only the shortcodes included in the emoji tag are targeted.

(There are no changes to Mastodon's rules)

![fix_emoji_displayname](https://user-images.githubusercontent.com/28195220/103488077-3d21b680-4e4d-11eb-83e0-93701c0ac69f.jpg)