### PR TITLE
Fix defaultProps of frameRate to string

### DIFF
--- a/app/javascript/mastodon/features/video/index.js
+++ b/app/javascript/mastodon/features/video/index.js
@@ -125,7 +125,7 @@ class Video extends React.PureComponent {
   };
 
   static defaultProps = {
-    frameRate: 25,
+    frameRate: '25',
   };
 
   state = {


### PR DESCRIPTION
This defaultProps isn't used because the frameRate is explicitly set everywhere, but we'll fix it.