### PR TITLE
Fix getting-started-footer in single column mode not being clickable

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2884,6 +2884,7 @@ a.account__display-name {
     flex: 0 0 auto;
     padding: 10px;
     padding-top: 20px;
+    z-index: 1;
 
     ul {
       margin-bottom: 10px;


### PR DESCRIPTION
Fixed an issue where getting-started-footer could not be clicked in Safari because the compose-form was overlaid.
Affects single column mode only.

By the way, this special invisible overlay is an area that displays 4 account and hashtag input candidates.
![getting-started-footer](https://user-images.githubusercontent.com/28195220/103658643-d2888c00-4fae-11eb-9fc4-ad02ebe06481.png)
