### PR TITLE
Set X-Forwarded-Proto to request scheme (#15310)

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -73,7 +73,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Proxy "";
     proxy_pass_header Server;
 
@@ -98,7 +98,7 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Proxy "";
 
     proxy_pass http://streaming;


### PR DESCRIPTION
This fixes a bug that prevents logins to mastodon onion services. The
nginx directive assumed all requests were made over https, causing a
domain mismatch for onion services that have https redirects disabled.
The fix more correctly sets X-Forwarded-Proto to the actual scheme used
in the request.