### PR TITLE
update codeclimate-rubocop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -30,7 +30,7 @@ plugins:
     channel: eslint-7
   rubocop:
     enabled: true
-    channel: rubocop-0-92
+    channel: rubocop-1-70
   sass-lint:
     enabled: true
 exclude_patterns:


### PR DESCRIPTION
A new version of rubocop is now available with codeclimate-rubocop

https://github.com/codeclimate/codeclimate-rubocop/tree/channel/rubocop-1-70