### PR TITLE
Fix rubocop config and warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-rails
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: disable
   Exclude:
   - 'spec/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.4
+  NewCops: disable
   Exclude:
   - 'spec/**/*'
   - 'db/**/*'

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -385,15 +385,17 @@ class Account < ApplicationRecord
   end
 
   class Field < ActiveModelSerializers::Model
-    attributes :name, :value, :verified_at, :account, :errors
+    attributes :name, :value, :verified_at, :account
 
     def initialize(account, attributes)
-      @account     = account
-      @attributes  = attributes
-      @name        = attributes['name'].strip[0, string_limit]
-      @value       = attributes['value'].strip[0, string_limit]
-      @verified_at = attributes['verified_at']&.to_datetime
-      @errors      = {}
+      @original_field = attributes
+      string_limit = account.local? ? 255 : 2047
+      super(
+        account:     account,
+        name:        attributes['name'].strip[0, string_limit],
+        value:       attributes['value'].strip[0, string_limit],
+        verified_at: attributes['verified_at']&.to_datetime,
+      )
     end
 
     def verified?
@@ -415,22 +417,12 @@ class Account < ApplicationRecord
     end
 
     def mark_verified!
-      @verified_at = Time.now.utc
-      @attributes['verified_at'] = @verified_at
+      self.verified_at = Time.now.utc
+      @original_field['verified_at'] = @verified_at
     end
 
     def to_h
-      { name: @name, value: @value, verified_at: @verified_at }
-    end
-
-    private
-
-    def string_limit
-      if account.local?
-        255
-      else
-        2047
-      end
+      { name: name, value: value, verified_at: verified_at }
     end
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -418,7 +418,7 @@ class Account < ApplicationRecord
 
     def mark_verified!
       self.verified_at = Time.now.utc
-      @original_field['verified_at'] = @verified_at
+      @original_field['verified_at'] = verified_at
     end
 
     def to_h

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -2,12 +2,11 @@
 
 class HomeFeed < Feed
   def initialize(account)
-    @type    = :home
-    @id      = account.id
     @account = account
+    super(:home, account.id)
   end
 
   def regenerating?
-    redis.exists?("account:#{@id}:regeneration")
+    redis.exists?("account:#{@account.id}:regeneration")
   end
 end

--- a/app/models/list_feed.rb
+++ b/app/models/list_feed.rb
@@ -2,7 +2,6 @@
 
 class ListFeed < Feed
   def initialize(list)
-    @type    = :list
-    @id      = list.id
+    super(:list, list.id)
   end
 end

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -73,10 +73,12 @@ class Poll < ApplicationRecord
     attributes :id, :title, :votes_count, :poll
 
     def initialize(poll, id, title, votes_count)
-      @poll        = poll
-      @id          = id
-      @title       = title
-      @votes_count = votes_count
+      super(
+        poll:        poll,
+        id:          id,
+        title:       title,
+        votes_count: votes_count,
+      )
     end
   end
 

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PublicFeed < Feed
+class PublicFeed
   # @param [Account] account
   # @param [Hash] options
   # @option [Boolean] :with_replies
@@ -33,28 +33,30 @@ class PublicFeed < Feed
 
   private
 
+  attr_reader :account, :options
+
   def with_reblogs?
-    @options[:with_reblogs]
+    options[:with_reblogs]
   end
 
   def with_replies?
-    @options[:with_replies]
+    options[:with_replies]
   end
 
   def local_only?
-    @options[:local]
+    options[:local]
   end
 
   def remote_only?
-    @options[:remote]
+    options[:remote]
   end
 
   def account?
-    @account.present?
+    account.present?
   end
 
   def media_only?
-    @options[:only_media]
+    options[:only_media]
   end
 
   def public_scope
@@ -82,9 +84,9 @@ class PublicFeed < Feed
   end
 
   def account_filters_scope
-    Status.not_excluded_by_account(@account).tap do |scope|
-      scope.merge!(Status.not_domain_blocked_by_account(@account)) unless local_only?
-      scope.merge!(Status.in_chosen_languages(@account)) if @account.chosen_languages.present?
+    Status.not_excluded_by_account(account).tap do |scope|
+      scope.merge!(Status.not_domain_blocked_by_account(account)) unless local_only?
+      scope.merge!(Status.in_chosen_languages(account)) if account.chosen_languages.present?
     end
   end
 end

--- a/app/models/tag_feed.rb
+++ b/app/models/tag_feed.rb
@@ -13,9 +13,8 @@ class TagFeed < PublicFeed
   # @option [Boolean] :remote
   # @option [Boolean] :only_media
   def initialize(tag, account, options = {})
-    @tag     = tag
-    @account = account
-    @options = options
+    @tag = tag
+    super(account, options)
   end
 
   # @param [Integer] limit
@@ -40,15 +39,15 @@ class TagFeed < PublicFeed
   private
 
   def tagged_with_any_scope
-    Status.group(:id).tagged_with(tags_for(Array(@tag.name) | Array(@options[:any])))
+    Status.group(:id).tagged_with(tags_for(Array(@tag.name) | Array(options[:any])))
   end
 
   def tagged_with_all_scope
-    Status.group(:id).tagged_with_all(tags_for(@options[:all]))
+    Status.group(:id).tagged_with_all(tags_for(options[:all]))
   end
 
   def tagged_with_none_scope
-    Status.group(:id).tagged_with_none(tags_for(@options[:none]))
+    Status.group(:id).tagged_with_none(tags_for(options[:none]))
   end
 
   def tags_for(names)

--- a/app/services/keys/claim_service.rb
+++ b/app/services/keys/claim_service.rb
@@ -8,11 +8,13 @@ class Keys::ClaimService < BaseService
                :key, :signature
 
     def initialize(account, device_id, key_attributes = {})
-      @account   = account
-      @device_id = device_id
-      @key_id    = key_attributes[:key_id]
-      @key       = key_attributes[:key]
-      @signature = key_attributes[:signature]
+      super(
+        account:   account,
+        device_id: device_id,
+        key_id:    key_attributes[:key_id],
+        key:       key_attributes[:key],
+        signature: key_attributes[:signature],
+      )
     end
   end
 

--- a/app/services/keys/query_service.rb
+++ b/app/services/keys/query_service.rb
@@ -7,8 +7,10 @@ class Keys::QueryService < BaseService
     attributes :account, :devices
 
     def initialize(account, devices)
-      @account = account
-      @devices = devices || []
+      super(
+        account: account,
+        devices: devices || [],
+      )
     end
 
     def find(device_id)
@@ -20,11 +22,13 @@ class Keys::QueryService < BaseService
     attributes :device_id, :name, :identity_key, :fingerprint_key
 
     def initialize(attributes = {})
-      @device_id       = attributes[:device_id]
-      @name            = attributes[:name]
-      @identity_key    = attributes[:identity_key]
-      @fingerprint_key = attributes[:fingerprint_key]
-      @claim_url       = attributes[:claim_url]
+      super(
+        device_id:       attributes[:device_id],
+        name:            attributes[:name],
+        identity_key:    attributes[:identity_key],
+        fingerprint_key: attributes[:fingerprint_key],
+      )
+      @claim_url = attributes[:claim_url]
     end
 
     def valid_claim_url?

--- a/lib/paperclip/color_extractor.rb
+++ b/lib/paperclip/color_extractor.rb
@@ -142,7 +142,7 @@ module Paperclip
       g = 0.0
       b = 0.0
 
-      if s == 0.0
+      if s.zero?
         r = l.to_f
         g = l.to_f
         b = l.to_f # achromatic


### PR DESCRIPTION
Due to the version upgrade of rubocop, the number of new warnings has increased.

```
$ be rubocop --fail-level W --display-only-fail-level-offenses --parallel
Inspecting 723 files
.......................................................................................................................................................................................................................................................................................................W.............................................................................W.........W.......W..W................W................................................................................................................................................WW.................................................................................................................................................W...................

Offenses:

app/models/account.rb:390:5: W: Lint/MissingSuper: Call super to initialize state of the parent class.
    def initialize(account, attributes) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/home_feed.rb:4:3: W: Lint/MissingSuper: Call super to initialize state of the parent class.
  def initialize(account) ...
  ^^^^^^^^^^^^^^^^^^^^^^^
app/models/list_feed.rb:4:3: W: Lint/MissingSuper: Call super to initialize state of the parent class.
  def initialize(list) ...
  ^^^^^^^^^^^^^^^^^^^^
app/models/poll.rb:75:5: W: Lint/MissingSuper: Call super to initialize state of the parent class.
    def initialize(poll, id, title, votes_count) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/public_feed.rb:11:3: W: Lint/MissingSuper: Call super to initialize state of the parent class.
  def initialize(account, options = {}) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/tag_feed.rb:15:3: W: Lint/MissingSuper: Call super to initialize state of the parent class.
  def initialize(tag, account, options = {}) ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/services/keys/claim_service.rb:10:5: W: Lint/MissingSuper: Call super to initialize state of the parent class.
    def initialize(account, device_id, key_attributes = {}) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/services/keys/query_service.rb:9:5: W: Lint/MissingSuper: Call super to initialize state of the parent class.
    def initialize(account, devices) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/services/keys/query_service.rb:22:5: W: Lint/MissingSuper: Call super to initialize state of the parent class.
    def initialize(attributes = {}) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/paperclip/color_extractor.rb:145:10: W: Lint/FloatComparison: Avoid (in)equality comparisons of floats as they are unreliable.
      if s == 0.0
         ^^^^^^^^

723 files inspected, 10 offenses detected
```