### PR TITLE
Fix the Dockerfile in case of Kaniko build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 as build-dep
 
 # Use bash for the shell
-SHELL ["bash", "-c"]
+SHELL ["/usr/bin/bash", "-c"]
 
 # Install Node v12 (LTS)
 ENV NODE_VER="12.20.0"


### PR DESCRIPTION
Kaniko does not support looking up binaries from $PATH, so we specify the full path to the bash binary.

This was tested and builds properly using Kaniko on amd64, the builds have been powering mastodon.tedomum.net for some months now.