### PR TITLE
Support clock drift in Omniauth SAML provider

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -60,6 +60,7 @@ Devise.setup do |config|
     saml_options[:attribute_statements][:verified] = [ENV['SAML_ATTRIBUTES_STATEMENTS_VERIFIED']] if ENV['SAML_ATTRIBUTES_STATEMENTS_VERIFIED']
     saml_options[:attribute_statements][:verified_email] = [ENV['SAML_ATTRIBUTES_STATEMENTS_VERIFIED_EMAIL']] if ENV['SAML_ATTRIBUTES_STATEMENTS_VERIFIED_EMAIL']
     saml_options[:uid_attribute] = ENV['SAML_UID_ATTRIBUTE'] if ENV['SAML_UID_ATTRIBUTE']
+    saml_options[:allowed_clock_drift] = ENV['SAML_ALLOWED_CLOCK_DRIFT'] if ENV['SAML_ALLOWED_CLOCK_DRIFT']
     config.omniauth :saml, saml_options
   end
 end


### PR DESCRIPTION
Currently, if the SP and IDP are a couple seconds apart, authentication will fail due to the SAML assertion being either too old, or received too early by the SP. This is a common issue with any signature-based authentication scheme (including X509 certificates, and in our case, SAML). When the issue is very sensitive due to short signature lifetime, the verifier may have some configurable tolerance to avoid suffering from clock skew.

The setting is not well documented by the Omniauth SAML provider, but allows for clock skew between SP and IDP, see:
https://github.com/omniauth/omniauth-saml/blob/master/spec/omniauth/strategies/saml_spec.rb

This PR simply exposes this setting as an environment variable for Mastodon, allowing for Mastodon and the IDP to survive clock skew when using SAML.