### PR TITLE
Add Iframe full screen button

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -190,7 +190,7 @@ class Card extends React.PureComponent {
   }
 
   renderVideo () {
-    const { card }  = this.props;
+    const { card, intl }  = this.props;
     const content   = { __html: this.addAutoPlay(card.get('html')) };
     const { width } = this.state;
     const ratio     = card.get('width') / card.get('height');
@@ -225,7 +225,7 @@ class Card extends React.PureComponent {
   }
 
   render () {
-    const { card, maxDescription, compact, intl } = this.props;
+    const { card, maxDescription, compact } = this.props;
     const { width, embedded, revealed } = this.state;
 
     if (card === null) {

--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -158,7 +158,7 @@ class Card extends React.PureComponent {
     const iframe = document.querySelector('iframe');
 
     if (iframe) {
-      this.setState({isIframe: true});
+      this.setState({ isIframe: true });
 
       if (iframe.src.indexOf('?') !== -1) {
         iframe.src += '&';
@@ -209,14 +209,14 @@ class Card extends React.PureComponent {
         />
         {fullscreenEnabled && isIframe ? (
           <IconButton
-            className={`fullscreen-iframe-button`}
+            className={'fullscreen-iframe-button'}
             title={intl.formatMessage(messages.fullscreen)}
-            icon={`arrows-alt`}
+            icon={'arrows-alt'}
             onClick={this.handleIframeFullscreen}
             size={18}
             style={{
-              width: `unset`,
-              height: `unset`,
+              width: 'unset',
+              height: 'unset',
             }}
           />
         ) : null}

--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import punycode from 'punycode';
 import classnames from 'classnames';
 import Icon from 'mastodon/components/icon';
@@ -38,7 +38,12 @@ const trim = (text, len) => {
 
 const domParser = new DOMParser();
 
-export default class Card extends React.PureComponent {
+const messages = defineMessages({
+  fullscreen: { id: 'status.fullscreen', defaultMessage: 'Expand to full screen view' },
+});
+
+export default @injectIntl
+class Card extends React.PureComponent {
 
   static propTypes = {
     card: ImmutablePropTypes.map,
@@ -48,6 +53,7 @@ export default class Card extends React.PureComponent {
     defaultWidth: PropTypes.number,
     cacheWidth: PropTypes.func,
     sensitive: PropTypes.bool,
+    intl: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -190,7 +196,7 @@ export default class Card extends React.PureComponent {
     const ratio     = card.get('width') / card.get('height');
     const height    = width / ratio;
 
-    const fullscreenModeAvailable = (document.fullscreenEnabled || document.webkitFullscreenEnabled || document.mozFullScreenEnabled || document.msFullscreenEnabled) ? true : false;
+    const fullscreenEnabled = (document.fullscreenEnabled || document.webkitFullscreenEnabled || document.mozFullScreenEnabled || document.msFullscreenEnabled) ? true : false;
     const isIframe = this.state.isIframe;
 
     return (
@@ -201,11 +207,11 @@ export default class Card extends React.PureComponent {
           dangerouslySetInnerHTML={content}
           style={{ height }}
         />
-        {fullscreenModeAvailable && isIframe ? (
+        {fullscreenEnabled && isIframe ? (
           <IconButton
             className={`fullscreen-iframe-button`}
-            title={`fullscreen`}
-            icon={`expand-wide:fad`}
+            title={intl.formatMessage(messages.fullscreen)}
+            icon={`arrows-alt`}
             onClick={this.handleIframeFullscreen}
             size={18}
             style={{
@@ -219,7 +225,7 @@ export default class Card extends React.PureComponent {
   }
 
   render () {
-    const { card, maxDescription, compact } = this.props;
+    const { card, maxDescription, compact, intl } = this.props;
     const { width, embedded, revealed } = this.state;
 
     if (card === null) {

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -2686,6 +2686,10 @@
       {
         "defaultMessage": "Sensitive content",
         "id": "status.sensitive_warning"
+      },
+      {
+        "defaultMessage": "Expand to full screen view",
+        "id": "status.fullscreen"
       }
     ],
     "path": "app/javascript/mastodon/features/status/components/card.json"

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -402,6 +402,7 @@
   "status.embed": "Embed",
   "status.favourite": "Favourite",
   "status.filtered": "Filtered",
+  "status.fullscreen": "Expand to full screen view",
   "status.load_more": "Load more",
   "status.media_hidden": "Media hidden",
   "status.mention": "Mention @{name}",

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -25,6 +25,16 @@ html {
   }
 }
 
+.status-card-video__container {
+  .fullscreen-iframe-button {
+    color: rgba($white, 0.8);
+
+    &:hover {
+      color: $white;
+    }
+  }
+}
+
 // Change default background colors of columns
 .column > .scrollable,
 .getting-started,

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3108,6 +3108,30 @@ a.status-card {
   }
 }
 
+.status-card-video__container {
+  .fullscreen-iframe-button {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    padding: 6px;
+    border-radius: 8px 0 0 8px;
+    color: $secondary-text-color;
+    background: rgba($base-shadow-color, 0.6);
+    transform: translate(100%, -50%);
+    transition: transform 0.5s;
+
+    &:hover {
+      color: $primary-text-color;
+    }
+  }
+
+  &:hover {
+    .fullscreen-iframe-button {
+      transform: translate(0, -50%);
+    }
+  }
+}
+
 .status-card__title {
   display: block;
   font-weight: 500;


### PR DESCRIPTION
Full screen button (like YouTube shows: **Full screen is unavailable. [Learn More](https://support.google.com/youtube/answer/72689)**) inside `<iframe>` won't work. So we may consider adding a button on our page to expand the `<iframe>` container. See below (the button on right center):
![image](https://user-images.githubusercontent.com/16148054/104023019-04426280-51fc-11eb-998d-da9c01a5945a.png)

And some more necessary condition (Advanced UI):
![image](https://user-images.githubusercontent.com/16148054/104025484-add72300-51ff-11eb-8f43-b5d3572fdd9c.png)

