### PR TITLE
Fix processing of incoming Block activities

### DIFF
--- a/app/lib/activitypub/activity/block.rb
+++ b/app/lib/activitypub/activity/block.rb
@@ -11,8 +11,13 @@ class ActivityPub::Activity::Block < ActivityPub::Activity
       return
     end
 
+    UnfollowService.new.call(@account, target_account) if @account.following?(target_account)
     UnfollowService.new.call(target_account, @account) if target_account.following?(@account)
+    RejectFollowService.new.call(target_account, @account) if target_account.requested?(@account)
 
-    @account.block!(target_account, uri: @json['id']) unless delete_arrived_first?(@json['id'])
+    unless delete_arrived_first?(@json['id'])
+      BlockWorker.perform_async(@account.id, target_account.id)
+      @account.block!(target_account, uri: @json['id'])
+    end
   end
 end


### PR DESCRIPTION
Unlike locally-issued blocks, they weren't clearing follow relationships in both directions, follow requests or notifications.

(To clarify, this didn't mean cross-instance blocks were inherently broken, but they did have some confusing behaviors that locally-issued blocks did not have)