### PR TITLE
Update to Node.js-12.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:20.04 as build-dep
 SHELL ["/usr/bin/bash", "-c"]
 
 # Install Node v12 (LTS)
-ENV NODE_VER="12.20.0"
+ENV NODE_VER="12.20.1"
 RUN ARCH= && \
     dpkgArch="$(dpkg --print-architecture)" && \
   case "${dpkgArch##*-}" in \


### PR DESCRIPTION
This is a security release. You can read the announce at
https://nodejs.org/en/blog/vulnerability/january-2021-security-releases/