### PR TITLE
Make 'Mark media as sensitive' accessible

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -358,7 +358,12 @@
     }
 
     input[type=checkbox] {
-      display: none;
+      position: absolute;
+      height: 16px;
+      width: 16px;
+      margin: 0 0 0 1px;
+      pointer-events: none;
+      appearance: none;
     }
 
     .checkbox {


### PR DESCRIPTION
Tested on Chromium (Edge) and Firefox.
![An image showing Mastodon post composer with a correctly focused 'Mark media as sensitive' label](https://user-images.githubusercontent.com/21127288/104847009-f9fc2480-58dd-11eb-8cf4-aad2a1842a89.png)
