### PR TITLE
Use libvpx >= 5

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -22,7 +22,7 @@ libpixman-1-0
 librsvg2-2
 libthai-data
 libthai0
-libvpx5
+libvpx[5-9]
 libxcb-render0
 libxcb-shm0
 libxrender1


### PR DESCRIPTION
Ubuntu 18.04 provides libvpx5 while Ubuntu 20.04 does libvpx6