### PR TITLE
Improve error reporting and logging when processing remote accounts

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -101,7 +101,7 @@ module SignatureVerification
   rescue HTTP::Error, OpenSSL::SSL::SSLError => e
     @signature_verification_failure_reason = "Failed to fetch remote data: #{e.message}"
     @signed_request_account = nil
-  rescue Mastodon::UnexptectedResponseError
+  rescue Mastodon::UnexpectedResponseError
     @signature_verification_failure_reason = "Failed to fetch remote data (got unexpected reply from server)"
     @signed_request_account = nil
   rescue Stoplight::Error::RedLight

--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -99,9 +99,9 @@ module SignatureVerification
   rescue HTTP::Error, OpenSSL::SSL::SSLError => e
     fail_with! "Failed to fetch remote data: #{e.message}"
   rescue Mastodon::UnexptectedResponseError
-    fail_with! "Failed to fetch remote data (got unexpected reply from server)"
+    fail_with! 'Failed to fetch remote data (got unexpected reply from server)'
   rescue Stoplight::Error::RedLight
-    fail_with! "Fetching attempt skipped because of recent connection failure"
+    fail_with! 'Fetching attempt skipped because of recent connection failure'
   end
 
   def request_body

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -196,7 +196,7 @@ class Request
 
         addresses.each do |address|
           begin
-            check_private_address(address)
+            check_private_address(address, host)
 
             sock     = ::Socket.new(address.is_a?(Resolv::IPv6) ? ::Socket::AF_INET6 : ::Socket::AF_INET, ::Socket::SOCK_STREAM, 0)
             sockaddr = ::Socket.pack_sockaddr_in(port, address.to_s)
@@ -252,10 +252,10 @@ class Request
 
       alias new open
 
-      def check_private_address(address)
+      def check_private_address(address, host)
         addr = IPAddr.new(address.to_s)
         return if private_address_exceptions.any? { |range| range.include?(addr) }
-        raise Mastodon::HostValidationError if PrivateAddressCheck.private_address?(addr)
+        raise Mastodon::PrivateNetworkAddressError.new(host) if PrivateAddressCheck.private_address?(addr)
       end
 
       def private_address_exceptions

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -255,7 +255,7 @@ class Request
       def check_private_address(address, host)
         addr = IPAddr.new(address.to_s)
         return if private_address_exceptions.any? { |range| range.include?(addr) }
-        raise Mastodon::PrivateNetworkAddressError.new(host) if PrivateAddressCheck.private_address?(addr)
+        raise Mastodon::PrivateNetworkAddressError, host if PrivateAddressCheck.private_address?(addr)
       end
 
       def private_address_exceptions

--- a/app/lib/webfinger.rb
+++ b/app/lib/webfinger.rb
@@ -3,7 +3,7 @@
 class Webfinger
   class Error < StandardError; end
   class GoneError < Error; end
-  class RedirectError < StandardError; end
+  class RedirectError < Error; end
 
   class Response
     attr_reader :uri

--- a/app/services/activitypub/fetch_remote_account_service.rb
+++ b/app/services/activitypub/fetch_remote_account_service.rb
@@ -27,7 +27,7 @@ class ActivityPub::FetchRemoteAccountService < BaseService
     raise Error, "Error fetching actor JSON at #{uri}" if @json.nil?
     raise Error, "Unsupported JSON-LD context for document #{uri}" unless supported_context?
     raise Error, "Unexpected object type for actor #{uri} (expected any of: #{SUPPORTED_TYPES})" unless expected_type?
-    raise Error, "Actor #{uri} has moved to #{@json['movedTo']}" if (break_on_redirect && @json['movedTo'].present?)
+    raise Error, "Actor #{uri} has moved to #{@json['movedTo']}" if break_on_redirect && @json['movedTo'].present?
 
     @uri      = @json['id']
     @username = @json['preferredUsername']

--- a/app/services/activitypub/fetch_remote_account_service.rb
+++ b/app/services/activitypub/fetch_remote_account_service.rb
@@ -21,10 +21,10 @@ class ActivityPub::FetchRemoteAccountService < BaseService
         body_to_json(prefetched_body, compare_id: id ? uri : nil)
       end
     rescue Oj::ParseError
-      raise ParsingError
+      raise Error, "Error parsing JSON-LD document #{uri}"
     end
 
-    raise Error, 'Error fetching actor JSON' if @json.nil?
+    raise Error, "Error fetching actor JSON at #{uri}" if @json.nil?
     raise Error, "Unsupported JSON-LD context for document #{uri}" unless supported_context?
     raise Error, "Unexpected object type for actor #{uri} (expected any of: #{SUPPORTED_TYPES})" unless expected_type?
     raise Error, "Actor #{uri} has moved to #{@json['movedTo']}" if (break_on_redirect && @json['movedTo'].present?)

--- a/app/services/activitypub/fetch_remote_account_service.rb
+++ b/app/services/activitypub/fetch_remote_account_service.rb
@@ -37,7 +37,7 @@ class ActivityPub::FetchRemoteAccountService < BaseService
 
     ActivityPub::ProcessAccountService.new.call(@username, @domain, @json, only_key: only_key, verified_webfinger: !only_key)
   rescue Error => e
-    Rails.logger.debug "Fetching account #{uri} failed: e.message"
+    Rails.logger.debug "Fetching account #{uri} failed: #{e.message}"
     raise unless suppress_errors
   end
 

--- a/app/services/activitypub/fetch_remote_account_service.rb
+++ b/app/services/activitypub/fetch_remote_account_service.rb
@@ -60,10 +60,10 @@ class ActivityPub::FetchRemoteAccountService < BaseService
     end
 
     raise Error, "Webfinger response for #{@username}@#{@domain} does not loop back to #{@uri}" if webfinger.link('self', 'href') != @uri
-  rescue Webfinger::Error
-    raise Error, "Webfinger error when resolving #{@username}@#{@domain}"
   rescue Webfinger::RedirectError => e
     raise Error, e.message
+  rescue Webfinger::Error => e
+    raise Error, "Webfinger error when resolving #{@username}@#{@domain}: #{e.message}"
   end
 
   def split_acct(acct)

--- a/app/services/activitypub/fetch_remote_key_service.rb
+++ b/app/services/activitypub/fetch_remote_key_service.rb
@@ -3,9 +3,11 @@
 class ActivityPub::FetchRemoteKeyService < BaseService
   include JsonLdHelper
 
+  class Error < StandardError; end
+
   # Returns account that owns the key
-  def call(uri, id: true, prefetched_body: nil)
-    return if uri.blank?
+  def call(uri, id: true, prefetched_body: nil, suppress_errors: true)
+    raise Error, "No key URI given" if uri.blank?
 
     if prefetched_body.nil?
       if id
@@ -13,7 +15,7 @@ class ActivityPub::FetchRemoteKeyService < BaseService
         if person?
           @json = fetch_resource(@json['id'], true)
         elsif uri != @json['id']
-          return
+          raise Error, "Fetched URI #{uri} has wrong id #{@json['id']}"
         end
       else
         @json = fetch_resource(uri, id)
@@ -22,21 +24,29 @@ class ActivityPub::FetchRemoteKeyService < BaseService
       @json = body_to_json(prefetched_body, compare_id: id ? uri : nil)
     end
 
-    return unless supported_context?(@json) && expected_type?
-    return find_account(@json['id'], @json) if person?
+    raise Error, "Unable to fetch key JSON at #{uri}" if @json.nil?
+    raise Error, "Unsupported JSON-LD context for document #{uri}" unless supported_context?(@json)
+    raise Error, "Unexpected object type for key #{uri}" unless expected_type?
+    return find_account(@json['id'], @json, suppress_errors) if person?
 
     @owner = fetch_resource(owner_uri, true)
 
-    return unless supported_context?(@owner) && confirmed_owner?
+    raise Error, "Unable to fetch actor JSON #{owner_uri}" if @owner.nil?
+    raise Error, "Unsupported JSON-LD context for document #{owner_uri}" unless supported_context?(@owner)
+    raise Error, "Unexpected object type for actor #{owner_uri} (expected any of: #{SUPPORTED_TYPES})" unless expected_owner_type?
+    raise Error, "publicKey id for #{owner_uri} does not correspond to #{@json['id']}" unless confirmed_owner?
 
-    find_account(owner_uri, @owner)
+    find_account(owner_uri, @owner, suppress_errors)
+  rescue Error => e
+    Rails.logger.debug "Fetching key #{uri} failed: #{e.message}"
+    raise unless suppress_errors
   end
 
   private
 
-  def find_account(uri, prefetched_body)
+  def find_account(uri, prefetched_body, suppress_errors)
     account   = ActivityPub::TagManager.instance.uri_to_resource(uri, Account)
-    account ||= ActivityPub::FetchRemoteAccountService.new.call(uri, prefetched_body: prefetched_body)
+    account ||= ActivityPub::FetchRemoteAccountService.new.call(uri, prefetched_body: prefetched_body, suppress_errors: suppress_errors)
     account
   end
 
@@ -56,7 +66,11 @@ class ActivityPub::FetchRemoteKeyService < BaseService
     @owner_uri ||= value_or_id(@json['owner'])
   end
 
+  def expected_owner_type?
+    equals_or_includes_any?(@owner['type'], ActivityPub::FetchRemoteAccountService::SUPPORTED_TYPES)
+  end
+
   def confirmed_owner?
-    equals_or_includes_any?(@owner['type'], ActivityPub::FetchRemoteAccountService::SUPPORTED_TYPES) && value_or_id(@owner['publicKey']) == @json['id']
+    value_or_id(@owner['publicKey']) == @json['id']
   end
 end

--- a/app/services/activitypub/fetch_remote_key_service.rb
+++ b/app/services/activitypub/fetch_remote_key_service.rb
@@ -7,7 +7,7 @@ class ActivityPub::FetchRemoteKeyService < BaseService
 
   # Returns account that owns the key
   def call(uri, id: true, prefetched_body: nil, suppress_errors: true)
-    raise Error, "No key URI given" if uri.blank?
+    raise Error, 'No key URI given' if uri.blank?
 
     if prefetched_body.nil?
       if id

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -32,8 +32,6 @@ class ActivityPub::ProcessAccountService < BaseService
       process_duplicate_accounts! if @options[:verified_webfinger]
     end
 
-    return if @account.nil?
-
     after_protocol_change! if protocol_changed?
     after_key_change! if key_changed? && !@options[:signed_with_known_key]
     clear_tombstones! if key_changed?

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -95,7 +95,7 @@ class ResolveAccountService < BaseService
     @username, @domain = split_acct(@webfinger.subject)
 
     unless confirmed_username.casecmp(@username).zero? && confirmed_domain.casecmp(@domain).zero?
-      raise Webfinger::RedirectError, "The URI #{uri} tries to hijack #{@username}@#{@domain}"
+      raise Webfinger::RedirectError, "Too many webfinger redirects for URI #{uri} (stopped at #{@username}@#{@domain})"
     end
   rescue Webfinger::GoneError
     @gone = true

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ResolveAccountService < BaseService
-  include JsonLdHelper
   include DomainControlHelper
   include WebfingerHelper
   include Redisable

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -52,7 +52,7 @@ class ResolveAccountService < BaseService
     # either needs to be created, or updated from fresh data
 
     fetch_account!
-  rescue Webfinger::Error, Oj::ParseError => e
+  rescue Webfinger::Error => e
     Rails.logger.debug "Webfinger query for #{@uri} failed: #{e}"
     nil
   end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -25,4 +25,12 @@ module Mastodon
       end
     end
   end
+
+  class PrivateNetworkAddressError < HostValidationError
+    attr_reader :host
+
+    def initialize(host)
+      @host = host
+    end
+  end
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -31,6 +31,7 @@ module Mastodon
 
     def initialize(host)
       @host = host
+      super()
     end
   end
 end

--- a/spec/services/activitypub/fetch_remote_account_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_account_service_spec.rb
@@ -119,6 +119,58 @@ RSpec.describe ActivityPub::FetchRemoteAccountService, type: :service do
       include_examples 'sets profile data'
     end
 
+    context 'when WebFinger returns a different URI' do
+      let!(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/bob' }] } }
+
+      before do
+        stub_request(:get, 'https://example.com/alice').to_return(body: Oj.dump(actor))
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: Oj.dump(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+      end
+
+      it 'fetches resource' do
+        account
+        expect(a_request(:get, 'https://example.com/alice')).to have_been_made.once
+      end
+
+      it 'looks up webfinger' do
+        account
+        expect(a_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com')).to have_been_made.once
+      end
+
+      it 'does not create account' do
+        expect(account).to be_nil
+      end
+    end
+
+    context 'when WebFinger returns a different URI after a redirection' do
+      let!(:webfinger) { { subject: 'acct:alice@iscool.af', links: [{ rel: 'self', href: 'https://example.com/bob' }] } }
+
+      before do
+        stub_request(:get, 'https://example.com/alice').to_return(body: Oj.dump(actor))
+        stub_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com').to_return(body: Oj.dump(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+        stub_request(:get, 'https://iscool.af/.well-known/webfinger?resource=acct:alice@iscool.af').to_return(body: Oj.dump(webfinger), headers: { 'Content-Type': 'application/jrd+json' })
+      end
+
+      it 'fetches resource' do
+        account
+        expect(a_request(:get, 'https://example.com/alice')).to have_been_made.once
+      end
+
+      it 'looks up webfinger' do
+        account
+        expect(a_request(:get, 'https://example.com/.well-known/webfinger?resource=acct:alice@example.com')).to have_been_made.once
+      end
+
+      it 'looks up "redirected" webfinger' do
+        account
+        expect(a_request(:get, 'https://iscool.af/.well-known/webfinger?resource=acct:alice@iscool.af')).to have_been_made.once
+      end
+
+      it 'does not create account' do
+        expect(account).to be_nil
+      end
+    end
+
     context 'with wrong id' do
       it 'does not create account' do
         expect(subject.call('https://fake.address/@foo', prefetched_body: Oj.dump(actor))).to be_nil

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe ResolveAccountService, type: :service do
       stub_request(:get, 'https://evil.example.com/.well-known/webfinger?resource=acct:foo@evil.example.com').to_return(body: Oj.dump(webfinger2), headers: { 'Content-Type': 'application/jrd+json' })
     end
 
-    it 'returns new remote account' do
-      expect { subject.call('Foo@redirected.example.com') }.to raise_error Webfinger::RedirectError
+    it 'does not return a new remote account' do
+      expect(subject.call('Foo@redirected.example.com')).to be_nil
     end
   end
 


### PR DESCRIPTION
When discovering/fetching/processing a remote account fails, without adding additional instrumentation to the code, users, developers and admins alike get very few information on the actual reason behind the failure.

This is especially troublesome for fediverse server developers that get very few feedback from Mastodon regarding what exactly failed.

This PR reworks the error handling in the `SignatureVerification` concern, `ResolveAccountService` and `ActivityPub::FetchRemoteAccountService` services, as well as related classes to return meaningful error messages to ActivityPub queries and log additional information at the “debug” loglevel.