### PR TITLE
Add “translate” class to other user strings

### DIFF
--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -153,7 +153,7 @@ class Poll extends ImmutablePureComponent {
           </span>}
 
           <span
-            className='poll__option__text'
+            className='poll__option__text translate'
             dangerouslySetInnerHTML={{ __html: titleEmojified }}
           />
 

--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -340,7 +340,7 @@ class Header extends ImmutablePureComponent {
 
               {account.get('id') !== me && !suspended && <AccountNoteContainer account={account} />}
 
-              {account.get('note').length > 0 && account.get('note') !== '<p></p>' && <div className='account__header__content' dangerouslySetInnerHTML={content} className='translate' />}
+              {account.get('note').length > 0 && account.get('note') !== '<p></p>' && <div className='account__header__content translate' dangerouslySetInnerHTML={content} />}
             </div>
 
             {!suspended && (

--- a/app/javascript/mastodon/features/compose/components/reply_indicator.js
+++ b/app/javascript/mastodon/features/compose/components/reply_indicator.js
@@ -56,7 +56,7 @@ class ReplyIndicator extends ImmutablePureComponent {
           </a>
         </div>
 
-        <div className='reply-indicator__content' dangerouslySetInnerHTML={content} />
+        <div className='reply-indicator__content translate' dangerouslySetInnerHTML={content} />
 
         {status.get('media_attachments').size > 0 && (
           <AttachmentList

--- a/app/javascript/mastodon/features/directory/components/account_card.js
+++ b/app/javascript/mastodon/features/directory/components/account_card.js
@@ -241,7 +241,7 @@ class AccountCard extends ImmutablePureComponent {
 
         <div className='directory__card__extra' ref={this.setRef}>
           <div
-            className='account__header__content'
+            className='account__header__content translate'
             dangerouslySetInnerHTML={{ __html: account.get('note_emojified') }}
           />
         </div>

--- a/app/javascript/mastodon/features/follow_requests/components/account_authorize.js
+++ b/app/javascript/mastodon/features/follow_requests/components/account_authorize.js
@@ -35,7 +35,7 @@ class AccountAuthorize extends ImmutablePureComponent {
             <DisplayName account={account} />
           </Permalink>
 
-          <div className='account__header__content' dangerouslySetInnerHTML={content} />
+          <div className='account__header__content translate' dangerouslySetInnerHTML={content} />
         </div>
 
         <div className='account--panel'>


### PR DESCRIPTION
Follow-up to #15610.

Allow Google Translate to work on more user content:
- poll options
- reply indicator (contents of the status being replied to)
- directory account cards
- account note in follow requests list

Also fixes a styling regression in #15610.