### PR TITLE
Hide the user count and status count from both /about pages when activity API is disabled

### DIFF
--- a/app/views/about/more.html.haml
+++ b/app/views/about/more.html.haml
@@ -15,14 +15,15 @@
     .landing-page__call-to-action{ dir: 'ltr' }
       .row
         .row__information-board
-          .information-board__section
-            %span= t 'about.user_count_before'
-            %strong= number_to_human @instance_presenter.user_count, strip_insignificant_zeros: true
-            %span= t 'about.user_count_after', count: @instance_presenter.user_count
-          .information-board__section
-            %span= t 'about.status_count_before'
-            %strong= number_to_human @instance_presenter.status_count, strip_insignificant_zeros: true
-            %span= t 'about.status_count_after', count: @instance_presenter.status_count
+          - if Setting.activity_api_enabled
+            .information-board__section
+              %span= t 'about.user_count_before'
+              %strong= number_to_human @instance_presenter.user_count, strip_insignificant_zeros: true
+              %span= t 'about.user_count_after', count: @instance_presenter.user_count
+            .information-board__section
+              %span= t 'about.status_count_before'
+              %strong= number_to_human @instance_presenter.status_count, strip_insignificant_zeros: true
+              %span= t 'about.status_count_after', count: @instance_presenter.status_count
         .row__mascot
           .landing-page__mascot
             = image_tag @instance_presenter.mascot&.file&.url || asset_pack_path('media/images/elephant_ui_plane.svg'), alt: ''

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -65,15 +65,16 @@
 
             = account_link_to @instance_presenter.contact_account
 
-          .hero-widget__footer__column
-            %h4= t 'about.server_stats'
+          - if Setting.activity_api_enabled
+            .hero-widget__footer__column
+              %h4= t 'about.server_stats'
 
-            .hero-widget__counters__wrapper
-              .hero-widget__counter
-                %strong= number_to_human @instance_presenter.user_count, strip_insignificant_zeros: true
-                %span= t 'about.user_count_after', count: @instance_presenter.user_count
-              .hero-widget__counter
-                %strong= number_to_human @instance_presenter.active_user_count, strip_insignificant_zeros: true
-                %span
-                  = t 'about.active_count_after'
-                  %abbr{ title: t('about.active_footnote') } *
+              .hero-widget__counters__wrapper
+                .hero-widget__counter
+                  %strong= number_to_human @instance_presenter.user_count, strip_insignificant_zeros: true
+                  %span= t 'about.user_count_after', count: @instance_presenter.user_count
+                .hero-widget__counter
+                  %strong= number_to_human @instance_presenter.active_user_count, strip_insignificant_zeros: true
+                  %span
+                    = t 'about.active_count_after'
+                    %abbr{ title: t('about.active_footnote') } *

--- a/spec/views/about/more.html.haml_spec.rb
+++ b/spec/views/about/more.html.haml_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'about/show.html.haml', without_verify_partial_doubles: true do
+describe 'about/more.html.haml', without_verify_partial_doubles: true do
   around do |example|
     activity_api_enabled = Setting.activity_api_enabled
     example.run
@@ -14,9 +14,11 @@ describe 'about/show.html.haml', without_verify_partial_doubles: true do
     allow(view).to receive(:site_title).and_return('example site')
     allow(view).to receive(:new_user).and_return(User.new)
     allow(view).to receive(:use_seamless_external_login?).and_return(false)
+    allow(view).to receive(:display_blocks?).and_return(false)
 
     instance_presenter = double(
       :instance_presenter,
+      site_contact_email: 'admin@example.com',
       site_title: 'something',
       site_short_description: 'something',
       site_description: 'something',
@@ -34,17 +36,7 @@ describe 'about/show.html.haml', without_verify_partial_doubles: true do
     )
 
     assign(:instance_presenter, instance_presenter)
-  end
-
-  it 'has valid open graph tags' do
-    render
-
-    header_tags = view.content_for(:header_tags)
-
-    expect(header_tags).to match(%r{<meta content=".+" property="og:title" />})
-    expect(header_tags).to match(%r{<meta content="website" property="og:type" />})
-    expect(header_tags).to match(%r{<meta content=".+" property="og:image" />})
-    expect(header_tags).to match(%r{<meta content="http://.+" property="og:url" />})
+    assign(:table_of_contents, [])
   end
 
   context 'when activity api is enabled' do
@@ -54,11 +46,14 @@ describe 'about/show.html.haml', without_verify_partial_doubles: true do
 
     it 'displays aggregate statistics about user activity' do
       render
-      expect(rendered).to have_css('.hero-widget__counters__wrapper .hero-widget__counter:nth-child(1) strong', text: '420')
-      expect(rendered).to have_css('.hero-widget__counters__wrapper .hero-widget__counter:nth-child(1) span', text: 'users')
 
-      expect(rendered).to have_css('.hero-widget__counters__wrapper .hero-widget__counter:nth-child(2) strong', text: '420')
-      expect(rendered).to have_css('.hero-widget__counters__wrapper .hero-widget__counter:nth-child(2) span', text: 'active')
+      expect(rendered).to have_css('.information-board__section:nth-child(1) *:nth-child(1)', text: 'Home to')
+      expect(rendered).to have_css('.information-board__section:nth-child(1) *:nth-child(2)', text: '420')
+      expect(rendered).to have_css('.information-board__section:nth-child(1) *:nth-child(3)', text: 'users')
+
+      expect(rendered).to have_css('.information-board__section:nth-child(2) *:nth-child(1)', text: 'Who authored')
+      expect(rendered).to have_css('.information-board__section:nth-child(2) *:nth-child(2)', text: '69')
+      expect(rendered).to have_css('.information-board__section:nth-child(2) *:nth-child(3)', text: 'statuses')
     end
   end
 
@@ -69,7 +64,7 @@ describe 'about/show.html.haml', without_verify_partial_doubles: true do
 
     it 'doesn\'t display aggregate statistics about user activity' do
       render
-      expect(rendered).to_not have_css('.hero-widget__counters__wrapper')
+      expect(rendered).to_not have_css('.information-board__section')
     end
   end
 end


### PR DESCRIPTION
I understand if this may already be working as intended, but I would greatly appreciate a way to hide these two stats from the about pages. If you'd prefer to make this a separate setting, or can think of a better solution, I'd love to make the necessary changes to my PR. Thanks so much!

This setting (`activity_api_enabled`) is labeled on [the admin screen](http://localhost:3000/admin/settings/edit) as “Publish aggregate statistics about user activity”.

![image](https://user-images.githubusercontent.com/401283/105619635-a3ea1e00-5dc2-11eb-91a8-b27f17f23da1.png)

This PR hides the user count and status count from `/about` and `/about/more` when it's disabled:

| Before | After |
| --  | -- |
| ![image](https://user-images.githubusercontent.com/401283/105619648-d85dda00-5dc2-11eb-803e-6bb8d6fbd7a8.png) | ![image](https://user-images.githubusercontent.com/401283/105619640-b95f4800-5dc2-11eb-9c66-32e7fb1562e0.png) |
| ![image](https://user-images.githubusercontent.com/401283/105619647-d4ca5300-5dc2-11eb-955a-9dfbdfa645ba.png) | ![image](https://user-images.githubusercontent.com/401283/105619644-ced47200-5dc2-11eb-8900-3fc3f06b303c.png) |