### PR TITLE
Fix link to documentation repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,4 +36,4 @@ The smaller the set of changes in the pull request is, the quicker it can be rev
 
 ## Documentation
 
-The [Mastodon documentation](https://docs.joinmastodon.org) is a statically generated site. You can [submit merge requests to mastodon/docs](https://source.joinmastodon.org/mastodon/docs).
+The [Mastodon documentation](https://docs.joinmastodon.org) is a statically generated site. You can [submit merge requests to tootsuite/documentation](https://github.com/tootsuite/documentation).


### PR DESCRIPTION
https://source.joinmastodon.org/mastodon/docs has been archived, so I updated the link in CONTRIBUTING.md to point to https://github.com/tootsuite/documentation