### PR TITLE
Fix first return value of FetchLinkCardService#html

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -47,11 +47,11 @@ class FetchLinkCardService < BaseService
 
     Request.new(:get, @url).add_headers('Accept' => 'text/html', 'User-Agent' => Mastodon::Version.user_agent + ' Bot').perform do |res|
       if res.code == 200 && res.mime_type == 'text/html'
-        @html = res.body_with_limit
         @html_charset = res.charset
+        @html = res.body_with_limit
       else
-        @html = nil
         @html_charset = nil
+        @html = nil
       end
     end
   end


### PR DESCRIPTION
In the first call, the html method returned a charset.
If the url does not return a charset, it will unintentionally fail.

(Actually, the code that uses this method calls the html method for checking and then gets the contents again, so it doesn't seem to be a problem)