### PR TITLE
Fix react/jsx-no-duplicate-props

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -330,7 +330,7 @@ class Header extends ImmutablePureComponent {
                     <dl key={i}>
                       <dt dangerouslySetInnerHTML={{ __html: pair.get('name_emojified') }} title={pair.get('name')} className='translate' />
 
-                      <dd className={pair.get('verified_at') && 'verified'} title={pair.get('value_plain')} className='translate'>
+                      <dd className={`${pair.get('verified_at') ? 'verified' : ''} translate`} title={pair.get('value_plain')}>
                         {pair.get('verified_at') && <span title={intl.formatMessage(messages.linkVerifiedOn, { date: intl.formatDate(pair.get('verified_at'), dateFormatOptions) })}><Icon id='check' className='verified__mark' /></span>} <span dangerouslySetInnerHTML={{ __html: pair.get('value_emojified') }} />
                       </dd>
                     </dl>


### PR DESCRIPTION
Fixed a duplicate className due to a change in https://github.com/tootsuite/mastodon/pull/15610 .

```
yarn test:lint
yarn run v1.22.5
$ ${npm_execpath} run test:lint:js && ${npm_execpath} run test:lint:sass
$ eslint --ext=js . --cache

/__w/mastodon/mastodon/app/javascript/mastodon/features/account/components/header.js
  333:109  error  No duplicate props allowed  react/jsx-no-duplicate-props

✖ 1 problem (1 error, 0 warnings)
```
