### PR TITLE
Improved performance of notification preloading

### DIFF
--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -31,12 +31,13 @@ class Api::V1::NotificationsController < Api::BaseController
   private
 
   def load_notifications
-    cache_collection_paginated_by_id(
-      browserable_account_notifications,
-      Notification,
+    notifications = browserable_account_notifications.includes(from_account: :account_stat).to_a_paginated_by_id(
       limit_param(DEFAULT_NOTIFICATIONS_LIMIT),
       params_slice(:max_id, :since_id, :min_id)
     )
+    Notification.preload_cache_collection_target_statuses(notifications) do |target_statuses|
+      cache_collection(target_statuses, Status)
+    end
   end
 
   def browserable_account_notifications

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -349,10 +349,6 @@ describe ApplicationController, type: :controller do
       expect(C.new.cache_collection(raw, Object)).to eq raw
     end
 
-    context 'Notification' do
-      include_examples 'cacheable', :notification, Notification
-    end
-
     context 'Status' do
       include_examples 'cacheable', :status, Status
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -56,51 +56,6 @@ RSpec.describe Notification, type: :model do
     end
   end
 
-  describe '.reload_stale_associations!' do
-    context 'account_ids are empty' do
-      let(:cached_items) { [] }
-
-      subject { described_class.reload_stale_associations!(cached_items) }
-
-      it 'returns nil' do
-        is_expected.to be nil
-      end
-    end
-
-    context 'account_ids are present' do
-      before do
-        allow(accounts_with_ids).to receive(:[]).with(stale_account1.id).and_return(account1)
-        allow(accounts_with_ids).to receive(:[]).with(stale_account2.id).and_return(account2)
-        allow(Account).to receive_message_chain(:where, :includes, :index_by).and_return(accounts_with_ids)
-      end
-
-      let(:cached_items) do
-        [
-          Fabricate(:notification, activity: Fabricate(:status)),
-          Fabricate(:notification, activity: Fabricate(:follow)),
-        ]
-      end
-
-      let(:stale_account1) { cached_items[0].from_account }
-      let(:stale_account2) { cached_items[1].from_account }
-
-      let(:account1) { Fabricate(:account) }
-      let(:account2) { Fabricate(:account) }
-
-      let(:accounts_with_ids) { { account1.id => account1, account2.id => account2 } }
-
-      it 'reloads associations' do
-        expect(cached_items[0].from_account).to be stale_account1
-        expect(cached_items[1].from_account).to be stale_account2
-
-        described_class.reload_stale_associations!(cached_items)
-
-        expect(cached_items[0].from_account).to be account1
-        expect(cached_items[1].from_account).to be account2
-      end
-    end
-  end
-
   describe '.preload_cache_collection_target_statuses' do
     subject do
       described_class.preload_cache_collection_target_statuses(notifications) do |target_statuses|

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -100,4 +100,116 @@ RSpec.describe Notification, type: :model do
       end
     end
   end
+
+  describe '.preload_cache_collection_target_statuses' do
+    subject do
+      described_class.preload_cache_collection_target_statuses(notifications) do |target_statuses|
+        # preload account for testing instead of using cache_collection
+        Status.preload(:account).where(id: target_statuses.map(&:id))
+      end
+    end
+
+    context 'notifications are empty' do
+      let(:notifications) { [] }
+
+      it 'returns []' do
+        is_expected.to eq []
+      end
+    end
+
+    context 'notifications are present' do
+      before do
+        notifications.each(&:reload)
+      end
+
+      let(:mention) { Fabricate(:mention) }
+      let(:status) { Fabricate(:status) }
+      let(:reblog) { Fabricate(:status, reblog: Fabricate(:status)) }
+      let(:follow) { Fabricate(:follow) }
+      let(:follow_request) { Fabricate(:follow_request) }
+      let(:favourite) { Fabricate(:favourite) }
+      let(:poll) { Fabricate(:poll) }
+
+      let(:notifications) do
+        [
+          Fabricate(:notification, type: :mention, activity: mention),
+          Fabricate(:notification, type: :status, activity: status),
+          Fabricate(:notification, type: :reblog, activity: reblog),
+          Fabricate(:notification, type: :follow, activity: follow),
+          Fabricate(:notification, type: :follow_request, activity: follow_request),
+          Fabricate(:notification, type: :favourite, activity: favourite),
+          Fabricate(:notification, type: :poll, activity: poll),
+        ]
+      end
+
+      it 'preloads target status' do
+        # mention
+        expect(subject[0].type).to eq :mention
+        expect(subject[0].association(:mention)).to be_loaded
+        expect(subject[0].mention.association(:status)).to be_loaded
+
+        # status
+        expect(subject[1].type).to eq :status
+        expect(subject[1].association(:status)).to be_loaded
+
+        # reblog
+        expect(subject[2].type).to eq :reblog
+        expect(subject[2].association(:status)).to be_loaded
+        expect(subject[2].status.association(:reblog)).to be_loaded
+
+        # follow: nothing
+        expect(subject[3].type).to eq :follow
+        expect(subject[3].target_status).to be_nil
+
+        # follow_request: nothing
+        expect(subject[4].type).to eq :follow_request
+        expect(subject[4].target_status).to be_nil
+
+        # favourite
+        expect(subject[5].type).to eq :favourite
+        expect(subject[5].association(:favourite)).to be_loaded
+        expect(subject[5].favourite.association(:status)).to be_loaded
+
+        # poll
+        expect(subject[6].type).to eq :poll
+        expect(subject[6].association(:poll)).to be_loaded
+        expect(subject[6].poll.association(:status)).to be_loaded
+      end
+
+      it 'replaces to cached status' do
+        # mention
+        expect(subject[0].type).to eq :mention
+        expect(subject[0].target_status.association(:account)).to be_loaded
+        expect(subject[0].target_status).to eq mention.status
+
+        # status
+        expect(subject[1].type).to eq :status
+        expect(subject[1].target_status.association(:account)).to be_loaded
+        expect(subject[1].target_status).to eq status
+
+        # reblog
+        expect(subject[2].type).to eq :reblog
+        expect(subject[2].target_status.association(:account)).to be_loaded
+        expect(subject[2].target_status).to eq reblog.reblog
+
+        # follow: nothing
+        expect(subject[3].type).to eq :follow
+        expect(subject[3].target_status).to be_nil
+
+        # follow_request: nothing
+        expect(subject[4].type).to eq :follow_request
+        expect(subject[4].target_status).to be_nil
+
+        # favourite
+        expect(subject[5].type).to eq :favourite
+        expect(subject[5].target_status.association(:account)).to be_loaded
+        expect(subject[5].target_status).to eq favourite.status
+
+        # poll
+        expect(subject[6].type).to eq :poll
+        expect(subject[6].target_status.association(:account)).to be_loaded
+        expect(subject[6].target_status).to eq poll.status
+      end
+    end
+  end
 end


### PR DESCRIPTION
I optimized queries because many useless queries are being executed when loading notifications (for example, unnecessary associations and N + 1 queries).
Also, I improved to stop the notification cache and use the status cache. Since notifications are used only by the logged-in user, the cache effect is low. We hope that using the status cache will increase the effectiveness of the cache.

I have confirmed the change in the development environment with the following notification. (cache is off)
- favorite: 3
- reblog: 2
- follow: 1
- mention: 1

### before
query count: 67

```
Started GET "/api/v1/notifications?exclude_types[]=follow_request" for 127.0.0.1 at 2021-01-29 00:54:34 +0900
Processing by Api::V1::NotificationsController#index as HTML
  Parameters: {"exclude_types"=>["follow_request"]}
  Doorkeeper::AccessToken Load (1.7ms)  SELECT  "oauth_access_tokens".* FROM "oauth_access_tokens" WHERE "oauth_access_tokens"."token" = $1 LIMIT $2  [["token", "rS5uip_bRAIyzLyifWxsh-Q-v0Wegr7sqNzxqNazCww"], ["LIMIT", 1]]
  User Load (1.7ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  SessionActivation Load (2.5ms)  SELECT  "session_activations".* FROM "session_activations" WHERE "session_activations"."session_id" = $1 LIMIT $2  [["session_id", "378e5b94629516862b0b93d6ab8f900f"], ["LIMIT", 1]]
  Account Load (2.3ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  Notification Load (2.0ms)  SELECT  "notifications"."id", "notifications"."updated_at", "notifications"."activity_type", "notifications"."activity_id" FROM "notifications" INNER JOIN "accounts" ON "accounts"."id" = "notifications"."from_account_id" WHERE "notifications"."account_id" = $1 AND "accounts"."suspended_at" IS NULL AND "notifications"."type" IN ($2, $3, $4, $5, $6, $7) ORDER BY "notifications"."id" DESC LIMIT $8  [["account_id", 1], ["type", "mention"], ["type", "status"], ["type", "reblog"], ["type", "follow"], ["type", "favourite"], ["type", "poll"], ["LIMIT", 15]]
  Notification Load (2.0ms)  SELECT "notifications".* FROM "notifications" WHERE "notifications"."id" IN ($1, $2, $3, $4, $5, $6, $7)  [["id", 7], ["id", 6], ["id", 5], ["id", 4], ["id", 3], ["id", 2], ["id", 1]]
  Account Load (2.2ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 3]]
  Status Load (2.3ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND "statuses"."id" IN ($1, $2, $3, $4, $5) ORDER BY "statuses"."id" DESC  [["id", 1], ["id", 105633831934347478], ["id", 2], ["id", 105633832073943742], ["id", 3]]
  CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 3]]
  MediaAttachment Load (2.0ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN ($1, $2) ORDER BY "media_attachments"."id" ASC  [["status_id", 105633832073943742], ["status_id", 105633831934347478]]
  HABTM_Tags Load (1.6ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN ($1, $2)  [["status_id", 105633832073943742], ["status_id", 105633831934347478]]
  Mention Load (1.6ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."silent" = $1 AND "mentions"."status_id" IN ($2, $3)  [["silent", false], ["status_id", 105633832073943742], ["status_id", 105633831934347478]]
  Status Load (1.8ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND "statuses"."id" IN ($1, $2) ORDER BY "statuses"."id" DESC  [["id", 105508139787263284], ["id", 105605752787288430]]
  Account Load (1.6ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 1]]
  Doorkeeper::Application Load (1.8ms)  SELECT "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1  [["id", 1]]
  MediaAttachment Load (1.6ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN ($1, $2) ORDER BY "media_attachments"."id" ASC  [["status_id", 105605752787288430], ["status_id", 105508139787263284]]
  HABTM_Tags Load (1.9ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN ($1, $2)  [["status_id", 105605752787288430], ["status_id", 105508139787263284]]
  Tag Load (1.8ms)  SELECT "tags".* FROM "tags" WHERE "tags"."id" = $1  [["id", 1]]
  Mention Load (1.8ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."silent" = $1 AND "mentions"."status_id" IN ($2, $3)  [["silent", false], ["status_id", 105605752787288430], ["status_id", 105508139787263284]]
  Mention Load (2.4ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."id" IN ($1, $2, $3, $4, $5)  [["id", 1], ["id", 105633831934347478], ["id", 2], ["id", 105633832073943742], ["id", 3]]
  Status Load (2.5ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND "statuses"."id" = $1 ORDER BY "statuses"."id" DESC  [["id", 105633832456495666]]
  CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 3]]
  CACHE Doorkeeper::Application Load (0.0ms)  SELECT "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1  [["id", 1]]
  MediaAttachment Load (1.8ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" = $1 ORDER BY "media_attachments"."id" ASC  [["status_id", 105633832456495666]]
  HABTM_Tags Load (1.9ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" = $1  [["status_id", 105633832456495666]]
  Mention Load (1.8ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."silent" = $1 AND "mentions"."status_id" = $2  [["silent", false], ["status_id", 105633832456495666]]
  CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 1]]
  Favourite Load (1.8ms)  SELECT "favourites".* FROM "favourites" WHERE "favourites"."id" IN ($1, $2, $3, $4, $5)  [["id", 1], ["id", 105633831934347478], ["id", 2], ["id", 105633832073943742], ["id", 3]]
  CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 3]]
  Status Load (1.7ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND "statuses"."id" IN ($1, $2, $3) ORDER BY "statuses"."id" DESC  [["id", 105605752787288430], ["id", 105605750742241758], ["id", 105508138911264929]]
  CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 1]]
  CACHE Doorkeeper::Application Load (0.0ms)  SELECT "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1  [["id", 1]]
  MediaAttachment Load (1.8ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN ($1, $2, $3) ORDER BY "media_attachments"."id" ASC  [["status_id", 105605752787288430], ["status_id", 105605750742241758], ["status_id", 105508138911264929]]
  HABTM_Tags Load (1.7ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN ($1, $2, $3)  [["status_id", 105605752787288430], ["status_id", 105605750742241758], ["status_id", 105508138911264929]]
  Mention Load (2.5ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."silent" = $1 AND "mentions"."status_id" IN ($2, $3, $4)  [["silent", false], ["status_id", 105605752787288430], ["status_id", 105605750742241758], ["status_id", 105508138911264929]]
  Follow Load (2.2ms)  SELECT "follows".* FROM "follows" WHERE "follows"."id" IN ($1, $2, $3, $4, $5)  [["id", 1], ["id", 105633831934347478], ["id", 2], ["id", 105633832073943742], ["id", 3]]
  CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 3]]
  FollowRequest Load (1.7ms)  SELECT "follow_requests".* FROM "follow_requests" WHERE "follow_requests"."id" IN ($1, $2, $3, $4, $5)  [["id", 1], ["id", 105633831934347478], ["id", 2], ["id", 105633832073943742], ["id", 3]]
  Poll Load (1.6ms)  SELECT "polls".* FROM "polls" WHERE "polls"."id" IN ($1, $2, $3, $4, $5)  [["id", 1], ["id", 105633831934347478], ["id", 2], ["id", 105633832073943742], ["id", 3]]
  Status Load (1.7ms)  SELECT "statuses"."reblog_of_id" FROM "statuses" WHERE "statuses"."reblog_of_id" IN ($1, $2, $3, $4, $5) AND "statuses"."account_id" = $6  [["reblog_of_id", 105633832456495666], ["reblog_of_id", 105508138911264929], ["reblog_of_id", 105508139787263284], ["reblog_of_id", 105605750742241758], ["reblog_of_id", 105605752787288430], ["account_id", 1]]
  Favourite Load (1.8ms)  SELECT "favourites"."status_id" FROM "favourites" WHERE "favourites"."status_id" IN ($1, $2, $3, $4, $5) AND "favourites"."account_id" = $6  [["status_id", 105633832456495666], ["status_id", 105508138911264929], ["status_id", 105508139787263284], ["status_id", 105605750742241758], ["status_id", 105605752787288430], ["account_id", 1]]
  Bookmark Load (1.7ms)  SELECT "bookmarks"."status_id" FROM "bookmarks" WHERE "bookmarks"."status_id" IN ($1, $2, $3, $4, $5) AND "bookmarks"."account_id" = $6  [["status_id", 105633832456495666], ["status_id", 105508138911264929], ["status_id", 105508139787263284], ["status_id", 105605750742241758], ["status_id", 105605752787288430], ["account_id", 1]]
  ConversationMute Load (1.4ms)  SELECT "conversation_mutes"."conversation_id" FROM "conversation_mutes" WHERE "conversation_mutes"."conversation_id" IN ($1, $2, $3, $4) AND "conversation_mutes"."account_id" = $5  [["conversation_id", 1], ["conversation_id", 2], ["conversation_id", 3], ["conversation_id", 4], ["account_id", 1]]
  StatusPin Load (1.8ms)  SELECT "status_pins"."status_id" FROM "status_pins" WHERE "status_pins"."status_id" IN ($1, $2, $3, $4, $5) AND "status_pins"."account_id" = $6  [["status_id", 105508138911264929], ["status_id", 105508139787263284], ["status_id", 105605750742241758], ["status_id", 105605752787288430], ["status_id", 105605752787288430], ["account_id", 1]]
[active_model_serializers]   AccountStat Load (1.8ms)  SELECT  "account_stats".* FROM "account_stats" WHERE "account_stats"."account_id" = $1 LIMIT $2  [["account_id", 3], ["LIMIT", 1]]
[active_model_serializers]   StatusStat Load (1.7ms)  SELECT  "status_stats".* FROM "status_stats" WHERE "status_stats"."status_id" = $1 LIMIT $2  [["status_id", 105633832456495666], ["LIMIT", 1]]
[active_model_serializers]   User Load (1.9ms)  SELECT  "users".* FROM "users" WHERE "users"."account_id" = $1 LIMIT $2  [["account_id", 3], ["LIMIT", 1]]
[active_model_serializers]   Setting Load (1.5ms)  SELECT  "settings".* FROM "settings" WHERE "settings"."thing_type" = $1 AND "settings"."thing_id" = $2 AND "settings"."var" = $3 LIMIT $4  [["thing_type", "User"], ["thing_id", 3], ["var", "show_application"], ["LIMIT", 1]]
[active_model_serializers]   Setting Load (1.9ms)  SELECT  "settings".* FROM "settings" WHERE (thing_type is NULL and thing_id is NULL) AND "settings"."var" = $1 ORDER BY "settings"."id" ASC LIMIT $2  [["var", "theme"], ["LIMIT", 1]]
[active_model_serializers]   Setting Load (1.5ms)  SELECT  "settings".* FROM "settings" WHERE (thing_type is NULL and thing_id is NULL) AND "settings"."var" = $1 ORDER BY "settings"."id" ASC LIMIT $2  [["var", "noindex"], ["LIMIT", 1]]
[active_model_serializers]   CACHE AccountStat Load (0.0ms)  SELECT  "account_stats".* FROM "account_stats" WHERE "account_stats"."account_id" = $1 LIMIT $2  [["account_id", 3], ["LIMIT", 1]]
[active_model_serializers]   PreviewCard Load (2.1ms)  SELECT  "preview_cards".* FROM "preview_cards" INNER JOIN "preview_cards_statuses" ON "preview_cards"."id" = "preview_cards_statuses"."preview_card_id" WHERE "preview_cards_statuses"."status_id" = $1 ORDER BY "preview_cards"."id" ASC LIMIT $2  [["status_id", 105633832456495666], ["LIMIT", 1]]
[active_model_serializers]   StatusStat Load (2.2ms)  SELECT  "status_stats".* FROM "status_stats" WHERE "status_stats"."status_id" = $1 LIMIT $2  [["status_id", 105508138911264929], ["LIMIT", 1]]
[active_model_serializers]   User Load (2.6ms)  SELECT  "users".* FROM "users" WHERE "users"."account_id" = $1 LIMIT $2  [["account_id", 1], ["LIMIT", 1]]
[active_model_serializers]   Setting Load (1.6ms)  SELECT  "settings".* FROM "settings" WHERE "settings"."thing_type" = $1 AND "settings"."thing_id" = $2 AND "settings"."var" = $3 LIMIT $4  [["thing_type", "User"], ["thing_id", 1], ["var", "show_application"], ["LIMIT", 1]]
[active_model_serializers]   AccountStat Load (1.7ms)  SELECT  "account_stats".* FROM "account_stats" WHERE "account_stats"."account_id" = $1 LIMIT $2  [["account_id", 1], ["LIMIT", 1]]
[active_model_serializers]   PreviewCard Load (1.7ms)  SELECT  "preview_cards".* FROM "preview_cards" INNER JOIN "preview_cards_statuses" ON "preview_cards"."id" = "preview_cards_statuses"."preview_card_id" WHERE "preview_cards_statuses"."status_id" = $1 ORDER BY "preview_cards"."id" ASC LIMIT $2  [["status_id", 105508138911264929], ["LIMIT", 1]]
[active_model_serializers]   StatusStat Load (1.7ms)  SELECT  "status_stats".* FROM "status_stats" WHERE "status_stats"."status_id" = $1 LIMIT $2  [["status_id", 105508139787263284], ["LIMIT", 1]]
[active_model_serializers]   CACHE User Load (0.0ms)  SELECT  "users".* FROM "users" WHERE "users"."account_id" = $1 LIMIT $2  [["account_id", 1], ["LIMIT", 1]]
[active_model_serializers]   CACHE AccountStat Load (0.0ms)  SELECT  "account_stats".* FROM "account_stats" WHERE "account_stats"."account_id" = $1 LIMIT $2  [["account_id", 1], ["LIMIT", 1]]
[active_model_serializers]   PreviewCard Load (2.4ms)  SELECT  "preview_cards".* FROM "preview_cards" INNER JOIN "preview_cards_statuses" ON "preview_cards"."id" = "preview_cards_statuses"."preview_card_id" WHERE "preview_cards_statuses"."status_id" = $1 ORDER BY "preview_cards"."id" ASC LIMIT $2  [["status_id", 105508139787263284], ["LIMIT", 1]]
[active_model_serializers]   StatusStat Load (2.0ms)  SELECT  "status_stats".* FROM "status_stats" WHERE "status_stats"."status_id" = $1 LIMIT $2  [["status_id", 105605750742241758], ["LIMIT", 1]]
[active_model_serializers]   PreviewCard Load (1.7ms)  SELECT  "preview_cards".* FROM "preview_cards" INNER JOIN "preview_cards_statuses" ON "preview_cards"."id" = "preview_cards_statuses"."preview_card_id" WHERE "preview_cards_statuses"."status_id" = $1 ORDER BY "preview_cards"."id" ASC LIMIT $2  [["status_id", 105605750742241758], ["LIMIT", 1]]
[active_model_serializers]   StatusStat Load (1.9ms)  SELECT  "status_stats".* FROM "status_stats" WHERE "status_stats"."status_id" = $1 LIMIT $2  [["status_id", 105605752787288430], ["LIMIT", 1]]
[active_model_serializers]   PreviewCard Load (1.5ms)  SELECT  "preview_cards".* FROM "preview_cards" INNER JOIN "preview_cards_statuses" ON "preview_cards"."id" = "preview_cards_statuses"."preview_card_id" WHERE "preview_cards_statuses"."status_id" = $1 ORDER BY "preview_cards"."id" ASC LIMIT $2  [["status_id", 105605752787288430], ["LIMIT", 1]]
[active_model_serializers]   CACHE StatusStat Load (0.0ms)  SELECT  "status_stats".* FROM "status_stats" WHERE "status_stats"."status_id" = $1 LIMIT $2  [["status_id", 105605752787288430], ["LIMIT", 1]]
[active_model_serializers]   CACHE PreviewCard Load (0.0ms)  SELECT  "preview_cards".* FROM "preview_cards" INNER JOIN "preview_cards_statuses" ON "preview_cards"."id" = "preview_cards_statuses"."preview_card_id" WHERE "preview_cards_statuses"."status_id" = $1 ORDER BY "preview_cards"."id" ASC LIMIT $2  [["status_id", 105605752787288430], ["LIMIT", 1]]
Completed 200 OK in 256ms (Views: 98.1ms | ActiveRecord: 101.3ms)
```

### after
query count: 40

```
Started GET "/api/v1/notifications?exclude_types[]=follow_request" for 127.0.0.1 at 2021-01-30 00:41:30 +0900
Processing by Api::V1::NotificationsController#index as HTML
  Parameters: {"exclude_types"=>["follow_request"]}
  Doorkeeper::AccessToken Load (2.6ms)  SELECT  "oauth_access_tokens".* FROM "oauth_access_tokens" WHERE "oauth_access_tokens"."token" = $1 LIMIT $2  [["token", "rS5uip_bRAIyzLyifWxsh-Q-v0Wegr7sqNzxqNazCww"], ["LIMIT", 1]]
  User Load (1.6ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  SessionActivation Load (1.3ms)  SELECT  "session_activations".* FROM "session_activations" WHERE "session_activations"."session_id" = $1 LIMIT $2  [["session_id", "378e5b94629516862b0b93d6ab8f900f"], ["LIMIT", 1]]
  Account Load (1.8ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  Notification Load (3.0ms)  SELECT  "notifications".* FROM "notifications" INNER JOIN "accounts" ON "accounts"."id" = "notifications"."from_account_id" WHERE "notifications"."account_id" = $1 AND "accounts"."suspended_at" IS NULL AND "notifications"."type" IN ($2, $3, $4, $5, $6, $7) ORDER BY "notifications"."id" DESC LIMIT $8  [["account_id", 1], ["type", "mention"], ["type", "status"], ["type", "reblog"], ["type", "follow"], ["type", "favourite"], ["type", "poll"], ["LIMIT", 15]]
  Account Load (1.2ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 3]]
  AccountStat Load (1.2ms)  SELECT "account_stats".* FROM "account_stats" WHERE "account_stats"."account_id" = $1  [["account_id", 3]]
  Mention Load (1.3ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."id" = $1  [["id", 1]]
  Status Load (1.2ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND "statuses"."id" = $1 ORDER BY "statuses"."id" DESC  [["id", 105633832456495666]]
  Favourite Load (1.4ms)  SELECT "favourites".* FROM "favourites" WHERE "favourites"."id" IN ($1, $2, $3)  [["id", 3], ["id", 2], ["id", 1]]
  Status Load (1.9ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND "statuses"."id" IN ($1, $2, $3) ORDER BY "statuses"."id" DESC  [["id", 105605752787288430], ["id", 105605750742241758], ["id", 105508138911264929]]
  Status Load (1.5ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND "statuses"."id" IN ($1, $2) ORDER BY "statuses"."id" DESC  [["id", 105633832073943742], ["id", 105633831934347478]]
  Status Load (1.4ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND "statuses"."id" IN ($1, $2) ORDER BY "statuses"."id" DESC  [["id", 105508139787263284], ["id", 105605752787288430]]
  Status Load (1.5ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND "statuses"."id" IN ($1, $2, $3, $4, $5) ORDER BY "statuses"."id" DESC  [["id", 105633832456495666], ["id", 105508138911264929], ["id", 105508139787263284], ["id", 105605750742241758], ["id", 105605752787288430]]
  Doorkeeper::Application Load (1.3ms)  SELECT "oauth_applications".* FROM "oauth_applications" WHERE "oauth_applications"."id" = $1  [["id", 1]]
  MediaAttachment Load (1.5ms)  SELECT "media_attachments".* FROM "media_attachments" WHERE "media_attachments"."status_id" IN ($1, $2, $3, $4, $5) ORDER BY "media_attachments"."id" ASC  [["status_id", 105633832456495666], ["status_id", 105605752787288430], ["status_id", 105605750742241758], ["status_id", 105508139787263284], ["status_id", 105508138911264929]]
  Conversation Load (1.5ms)  SELECT "conversations".* FROM "conversations" WHERE "conversations"."id" IN ($1, $2, $3, $4)  [["id", 1], ["id", 4], ["id", 3], ["id", 2]]
  StatusStat Load (2.1ms)  SELECT "status_stats".* FROM "status_stats" WHERE "status_stats"."status_id" IN ($1, $2, $3, $4, $5)  [["status_id", 105633832456495666], ["status_id", 105605752787288430], ["status_id", 105605750742241758], ["status_id", 105508139787263284], ["status_id", 105508138911264929]]
  HABTM_Tags Load (1.8ms)  SELECT "statuses_tags".* FROM "statuses_tags" WHERE "statuses_tags"."status_id" IN ($1, $2, $3, $4, $5)  [["status_id", 105633832456495666], ["status_id", 105605752787288430], ["status_id", 105605750742241758], ["status_id", 105508139787263284], ["status_id", 105508138911264929]]
  Tag Load (3.3ms)  SELECT "tags".* FROM "tags" WHERE "tags"."id" = $1  [["id", 1]]
  HABTM_PreviewCards Load (2.1ms)  SELECT "preview_cards_statuses".* FROM "preview_cards_statuses" WHERE "preview_cards_statuses"."status_id" IN ($1, $2, $3, $4, $5)  [["status_id", 105633832456495666], ["status_id", 105605752787288430], ["status_id", 105605750742241758], ["status_id", 105508139787263284], ["status_id", 105508138911264929]]
  Account Load (1.8ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" IN ($1, $2)  [["id", 3], ["id", 1]]
  AccountStat Load (1.4ms)  SELECT "account_stats".* FROM "account_stats" WHERE "account_stats"."account_id" IN ($1, $2)  [["account_id", 1], ["account_id", 3]]
  Mention Load (1.4ms)  SELECT "mentions".* FROM "mentions" WHERE "mentions"."silent" = $1 AND "mentions"."status_id" IN ($2, $3, $4, $5, $6)  [["silent", false], ["status_id", 105633832456495666], ["status_id", 105605752787288430], ["status_id", 105605750742241758], ["status_id", 105508139787263284], ["status_id", 105508138911264929]]
  Account Load (1.2ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 1]]
  AccountStat Load (1.1ms)  SELECT "account_stats".* FROM "account_stats" WHERE "account_stats"."account_id" = $1  [["account_id", 1]]
  Status Load (1.3ms)  SELECT "statuses".* FROM "statuses" WHERE "statuses"."deleted_at" IS NULL AND "statuses"."id" = $1 ORDER BY "statuses"."id" DESC  [["id", 105508138911264929]]
  CACHE Account Load (0.0ms)  SELECT "accounts".* FROM "accounts" WHERE "accounts"."id" = $1  [["id", 1]]
  CACHE AccountStat Load (0.0ms)  SELECT "account_stats".* FROM "account_stats" WHERE "account_stats"."account_id" = $1  [["account_id", 1]]
  Status Load (1.9ms)  SELECT "statuses"."reblog_of_id" FROM "statuses" WHERE "statuses"."reblog_of_id" IN ($1, $2, $3, $4, $5) AND "statuses"."account_id" = $6  [["reblog_of_id", 105633832456495666], ["reblog_of_id", 105508138911264929], ["reblog_of_id", 105508139787263284], ["reblog_of_id", 105605750742241758], ["reblog_of_id", 105605752787288430], ["account_id", 1]]
  Favourite Load (1.6ms)  SELECT "favourites"."status_id" FROM "favourites" WHERE "favourites"."status_id" IN ($1, $2, $3, $4, $5) AND "favourites"."account_id" = $6  [["status_id", 105633832456495666], ["status_id", 105508138911264929], ["status_id", 105508139787263284], ["status_id", 105605750742241758], ["status_id", 105605752787288430], ["account_id", 1]]
  Bookmark Load (1.7ms)  SELECT "bookmarks"."status_id" FROM "bookmarks" WHERE "bookmarks"."status_id" IN ($1, $2, $3, $4, $5) AND "bookmarks"."account_id" = $6  [["status_id", 105633832456495666], ["status_id", 105508138911264929], ["status_id", 105508139787263284], ["status_id", 105605750742241758], ["status_id", 105605752787288430], ["account_id", 1]]
  ConversationMute Load (2.6ms)  SELECT "conversation_mutes"."conversation_id" FROM "conversation_mutes" WHERE "conversation_mutes"."conversation_id" IN ($1, $2, $3, $4) AND "conversation_mutes"."account_id" = $5  [["conversation_id", 1], ["conversation_id", 2], ["conversation_id", 3], ["conversation_id", 4], ["account_id", 1]]
  StatusPin Load (1.6ms)  SELECT "status_pins"."status_id" FROM "status_pins" WHERE "status_pins"."status_id" IN ($1, $2, $3, $4, $5) AND "status_pins"."account_id" = $6  [["status_id", 105508138911264929], ["status_id", 105508139787263284], ["status_id", 105605750742241758], ["status_id", 105605752787288430], ["status_id", 105605752787288430], ["account_id", 1]]
[active_model_serializers]   User Load (2.4ms)  SELECT  "users".* FROM "users" WHERE "users"."account_id" = $1 LIMIT $2  [["account_id", 3], ["LIMIT", 1]]
[active_model_serializers]   Setting Load (2.2ms)  SELECT  "settings".* FROM "settings" WHERE "settings"."thing_type" = $1 AND "settings"."thing_id" = $2 AND "settings"."var" = $3 LIMIT $4  [["thing_type", "User"], ["thing_id", 3], ["var", "show_application"], ["LIMIT", 1]]
[active_model_serializers]   Setting Load (1.6ms)  SELECT  "settings".* FROM "settings" WHERE (thing_type is NULL and thing_id is NULL) AND "settings"."var" = $1 ORDER BY "settings"."id" ASC LIMIT $2  [["var", "theme"], ["LIMIT", 1]]
[active_model_serializers]   Setting Load (1.5ms)  SELECT  "settings".* FROM "settings" WHERE (thing_type is NULL and thing_id is NULL) AND "settings"."var" = $1 ORDER BY "settings"."id" ASC LIMIT $2  [["var", "noindex"], ["LIMIT", 1]]
[active_model_serializers]   User Load (3.0ms)  SELECT  "users".* FROM "users" WHERE "users"."account_id" = $1 LIMIT $2  [["account_id", 1], ["LIMIT", 1]]
[active_model_serializers]   Setting Load (1.5ms)  SELECT  "settings".* FROM "settings" WHERE "settings"."thing_type" = $1 AND "settings"."thing_id" = $2 AND "settings"."var" = $3 LIMIT $4  [["thing_type", "User"], ["thing_id", 1], ["var", "show_application"], ["LIMIT", 1]]
Completed 200 OK in 183ms (Views: 67.5ms | ActiveRecord: 66.2ms)
```
