### PR TITLE
Slightly reorder three dots menu on toots to make it more intuitive

### DIFF
--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -223,11 +223,11 @@ class StatusActionBar extends ImmutablePureComponent {
   render () {
     const { status, relationship, intl, withDismiss, scrollKey } = this.props;
 
-    const mutingConversation = status.get('muted');
     const anonymousAccess    = !me;
     const publicStatus       = ['public', 'unlisted'].includes(status.get('visibility'));
+    const mutingConversation = status.get('muted');
     const account            = status.get('account');
-    const writtenByMe        = status.getIn(['account', 'id']) === me
+    const writtenByMe        = status.getIn(['account', 'id']) === me;
 
     let menu = [];
 

--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -227,6 +227,7 @@ class StatusActionBar extends ImmutablePureComponent {
     const anonymousAccess    = !me;
     const publicStatus       = ['public', 'unlisted'].includes(status.get('visibility'));
     const account            = status.get('account');
+    const writtenByMe        = status.getIn(['account', 'id']) === me
 
     let menu = [];
 
@@ -237,19 +238,22 @@ class StatusActionBar extends ImmutablePureComponent {
       menu.push({ text: intl.formatMessage(messages.embed), action: this.handleEmbed });
     }
 
-    menu.push({ text: intl.formatMessage(status.get('bookmarked') ? messages.removeBookmark : messages.bookmark), action: this.handleBookmarkClick });
     menu.push(null);
 
-    if (status.getIn(['account', 'id']) === me || withDismiss) {
+    menu.push({ text: intl.formatMessage(status.get('bookmarked') ? messages.removeBookmark : messages.bookmark), action: this.handleBookmarkClick });
+
+    if (writtenByMe && publicStatus) {
+      menu.push({ text: intl.formatMessage(status.get('pinned') ? messages.unpin : messages.pin), action: this.handlePinClick });
+    }
+
+    menu.push(null);
+
+    if (writtenByMe || withDismiss) {
       menu.push({ text: intl.formatMessage(mutingConversation ? messages.unmuteConversation : messages.muteConversation), action: this.handleConversationMuteClick });
       menu.push(null);
     }
 
-    if (status.getIn(['account', 'id']) === me) {
-      if (publicStatus) {
-        menu.push({ text: intl.formatMessage(status.get('pinned') ? messages.unpin : messages.pin), action: this.handlePinClick });
-      }
-
+    if (writtenByMe) {
       menu.push({ text: intl.formatMessage(messages.delete), action: this.handleDeleteClick });
       menu.push({ text: intl.formatMessage(messages.redraft), action: this.handleRedraftClick });
     } else {

--- a/app/javascript/mastodon/features/status/components/action_bar.js
+++ b/app/javascript/mastodon/features/status/components/action_bar.js
@@ -202,9 +202,9 @@ class ActionBar extends React.PureComponent {
     if (me === status.getIn(['account', 'id'])) {
       if (publicStatus) {
         menu.push({ text: intl.formatMessage(status.get('pinned') ? messages.unpin : messages.pin), action: this.handlePinClick });
+        menu.push(null);
       }
 
-      menu.push(null);
       menu.push({ text: intl.formatMessage(mutingConversation ? messages.unmuteConversation : messages.muteConversation), action: this.handleConversationMuteClick });
       menu.push(null);
       menu.push({ text: intl.formatMessage(messages.delete), action: this.handleDeleteClick });

--- a/app/javascript/mastodon/features/status/components/action_bar.js
+++ b/app/javascript/mastodon/features/status/components/action_bar.js
@@ -187,9 +187,10 @@ class ActionBar extends React.PureComponent {
   render () {
     const { status, relationship, intl } = this.props;
 
-    const publicStatus = ['public', 'unlisted'].includes(status.get('visibility'));
+    const publicStatus       = ['public', 'unlisted'].includes(status.get('visibility'));
     const mutingConversation = status.get('muted');
     const account            = status.get('account');
+    const writtenByMe        = status.getIn(['account', 'id']) === me;
 
     let menu = [];
 
@@ -199,7 +200,7 @@ class ActionBar extends React.PureComponent {
       menu.push(null);
     }
 
-    if (me === status.getIn(['account', 'id'])) {
+    if (writtenByMe) {
       if (publicStatus) {
         menu.push({ text: intl.formatMessage(status.get('pinned') ? messages.unpin : messages.pin), action: this.handlePinClick });
         menu.push(null);


### PR DESCRIPTION
- Make “Pin to profile” always appear at the same place
- Add separator to group “Bookmark” and “Pin to profile”
- Fix separator being the first item in some cases

Before/after (on a non-expanded public toot written by me):
![bildo](https://user-images.githubusercontent.com/2446451/106396542-d28e7700-6408-11eb-8f67-6026ee50fb67.png) ![bildo](https://user-images.githubusercontent.com/2446451/106396638-8859c580-6409-11eb-8118-1710ca015c06.png)

Before/after (on a non-expanded DM written by me):
![bildo](https://user-images.githubusercontent.com/2446451/106396474-788db180-6408-11eb-9ad1-c7fa52994c1a.png) ![bildo](https://user-images.githubusercontent.com/2446451/106396505-a83cb980-6408-11eb-8150-94e38f393a2a.png)

Before/after (on an expanded DM written by me):
![bildo](https://user-images.githubusercontent.com/2446451/106396698-fa320f00-6409-11eb-8b22-4f92b1fe80e3.png) ![bildo](https://user-images.githubusercontent.com/2446451/106396716-09b15800-640a-11eb-96d4-af99ec8e48c1.png)

Before/after (on a toot in the notification column written by someone else):
![bildo](https://user-images.githubusercontent.com/2446451/106397104-0d45de80-640c-11eb-907c-b0618782ead8.png) ![bildo](https://user-images.githubusercontent.com/2446451/106397145-2e0e3400-640c-11eb-8f7e-f3ecba8e8f6f.png)