### PR TITLE
Fix URI of repeat follow requests not being recorded

### DIFF
--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -6,7 +6,14 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
   def perform
     target_account = account_from_uri(object_uri)
 
-    return if target_account.nil? || !target_account.local? || delete_arrived_first?(@json['id']) || @account.requested?(target_account)
+    return if target_account.nil? || !target_account.local? || delete_arrived_first?(@json['id'])
+
+    # Update id of already-existing follow requests
+    existing_follow_request = ::FollowRequest.find_by(account: @account, target_account: target_account)
+    unless existing_follow_request.nil?
+      existing_follow_request.update!(uri: @json['id'])
+      return
+    end
 
     if target_account.blocking?(@account) || target_account.domain_blocking?(@account.domain) || target_account.moved? || target_account.instance_actor?
       reject_follow_request!(target_account)
@@ -14,7 +21,9 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
     end
 
     # Fast-forward repeat follow requests
-    if @account.following?(target_account)
+    existing_follow = ::Follow.find_by(account: @account, target_account: target_account)
+    unless existing_follow.nil?
+      existing_follow.update!(uri: @json['id'])
       AuthorizeFollowService.new.call(@account, target_account, skip_follow_request: true, follow_request_uri: @json['id'])
       return
     end


### PR DESCRIPTION
In case we receive a “repeat” or “duplicate” follow request, we automatically fast-forward the accept with the latest received Activity `id`, but we don't record it. This PR aims to fix that.

Indeed, in general, a “repeat” or “duplicate” follow request may happen if for some reason (e.g. inconsistent handling of Block or Undo Accept activities, an instance being brought back up from the dead, etc.) the local instance thought the remote actor were following them while the remote actor thought otherwise.

In those cases, the remote instance does not know about the older Follow activity `id`, so keeping that record serves no purpose, but knowing the most recent one is useful if the remote implementation at some point refers to it by `id` without inlining it.