### PR TITLE
Fix display of toots without text content

### DIFF
--- a/app/javascript/mastodon/actions/importer/normalizer.js
+++ b/app/javascript/mastodon/actions/importer/normalizer.js
@@ -62,6 +62,13 @@ export function normalizeStatus(status, normalOldStatus) {
     normalStatus.spoilerHtml = normalOldStatus.get('spoilerHtml');
     normalStatus.hidden = normalOldStatus.get('hidden');
   } else {
+    // If the status has a CW but no contents, treat the CW as if it were the
+    // status' contents, to avoid having a CW toggle with seemingly no effect.
+    if (normalStatus.spoiler_text && !normalStatus.content) {
+      normalStatus.content = normalStatus.spoiler_text;
+      normalStatus.spoiler_text = '';
+    }
+
     const spoilerText   = normalStatus.spoiler_text || '';
     const searchContent = ([spoilerText, status.content].concat((status.poll && status.poll.options) ? status.poll.options.map(option => option.title) : [])).join('\n\n').replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n');
     const emojiMap      = makeEmojiMap(normalStatus);

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -170,10 +170,6 @@ export default class StatusContent extends React.PureComponent {
   render () {
     const { status } = this.props;
 
-    if (status.get('content').length === 0) {
-      return null;
-    }
-
     const hidden = this.props.onExpandedToggle ? !this.props.expanded : this.state.hidden;
     const renderReadMore = this.props.onClick && status.get('collapsed');
     const renderViewThread = this.props.showThread && status.get('in_reply_to_id') && status.get('in_reply_to_account_id') === status.getIn(['account', 'id']);


### PR DESCRIPTION
Fixes #12343

- fixes CWs from other implementations not showing up if toot has no text contents (e.g., Pleroma allows sending a message with a CW, media attachments, but no text contents)
- fixes the “Read more” thread indicator not showing up on threaded toots with no text contents