### PR TITLE
Use custom mascot on static share page

### DIFF
--- a/app/helpers/mascot_helper.rb
+++ b/app/helpers/mascot_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module MascotHelper
+  def mascot_url
+    instance_presenter.mascot&.file&.url || helpers.asset_pack_path('media/images/elephant_ui_plane.svg')
+  end
+
+  private
+
+  def instance_presenter
+    @instance_presenter ||= InstancePresenter.new
+  end
+end

--- a/app/helpers/mascot_helper.rb
+++ b/app/helpers/mascot_helper.rb
@@ -2,7 +2,7 @@
 
 module MascotHelper
   def mascot_url
-    instance_presenter.mascot&.file&.url || helpers.asset_pack_path('media/images/elephant_ui_plane.svg')
+    full_asset_url(instance_presenter.mascot&.file&.url || asset_pack_path('media/images/elephant_ui_plane.svg'))
   end
 
   private

--- a/app/javascript/styles/mastodon/modal.scss
+++ b/app/javascript/styles/mastodon/modal.scss
@@ -12,10 +12,19 @@
   flex-direction: column;
   justify-content: flex-end;
 
-  > * {
+  > div {
     flex: 1;
     max-height: 235px;
-    background: url('../images/elephant_ui_plane.svg') no-repeat left bottom / contain;
+    position: relative;
+
+    img {
+      max-height: 100%;
+      max-width: 100%;
+      height: 100%;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+    }
   }
 }
 

--- a/app/views/layouts/modal.html.haml
+++ b/app/views/layouts/modal.html.haml
@@ -14,5 +14,6 @@
   .container-alt= yield
   .modal-layout__mastodon
     %div
+      %img{alt:'', draggable:'false', src:"#{mascot_url}"}
 
 = render template: 'layouts/application'


### PR DESCRIPTION
Use our customised mascot on `/share` page