### PR TITLE
Change max. video file size to 99 MB

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -151,7 +151,7 @@ class MediaAttachment < ApplicationRecord
   }.freeze
 
   IMAGE_LIMIT = 10.megabytes
-  VIDEO_LIMIT = 40.megabytes
+  VIDEO_LIMIT = 99.megabytes
 
   MAX_VIDEO_MATRIX_LIMIT = 2_304_000 # 1920x1200px
   MAX_VIDEO_FRAME_RATE   = 60


### PR DESCRIPTION
1 minute of video recorded with 1080p at 60 fps weighs 90 MB in the HEVC format (iOS). In the more common H264 format, it is 175 MB. Currently, 40 MB allows 1 minute of video with 720p at 30 fps, or less than a minute in H264.

For comparison, Twitter allows 512 MB, though they have a separate length limit of 140 seconds (or at least, used to).

Caveat: Our example nginx config limits the body size to 80 MB, so admins would need to update it. Also, we currently do not accept HEVC files, which we should do if ffmpeg supports it by default.