### PR TITLE
Create instance actor if it hasn't been properly seeded

### DIFF
--- a/app/controllers/instance_actors_controller.rb
+++ b/app/controllers/instance_actors_controller.rb
@@ -13,7 +13,7 @@ class InstanceActorsController < ApplicationController
   private
 
   def set_account
-    @account = Account.find(-99)
+    @account = Account.representative
   end
 
   def restrict_fields_to

--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -14,6 +14,8 @@ module AccountFinderConcern
 
     def representative
       Account.find(-99)
+    rescue ActiveRecord::RecordNotFound
+      Account.create!(id: -99, actor_type: 'Application', locked: true, username: Rails.configuration.x.local_domain)
     end
 
     def find_local(username)


### PR DESCRIPTION
An uncommon but somewhat difficult to digagnose issue is dealing with improperly-seeded databases. In such cases, instance-signed fetches will fail with a ActiveRecord::RecordNotFound error, usually caught and handled as generic 404, leading people to think the remote resource itself has not been found, while it's the local instance actor that does not exist.

This commit changes the code so that failure to find the instance actor automatically creates a new one, so that improperly-seeded databases do not cause any issue.

I initially thought about raising a new, specific error in case the instance actor did not exist, but figured it would be just as easy to create it on the spot instead.