### PR TITLE
Add CORS headers for statuses

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -22,11 +22,11 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       methods: [:get],
       credentials: false
     resource '/@:username/:id',
-      headers: :any,
+      headers: [],
       methods: [:get],
       credentials: false
     resource '/users/:username/statuses/:id',
-      headers: :any,
+      headers: [],
       methods: [:get],
       credentials: false
     resource '/api/*',

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -21,6 +21,14 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       headers: :any,
       methods: [:get],
       credentials: false
+    resource '/@:username/:id',
+      headers: :any,
+      methods: [:get],
+      credentials: false
+    resource '/users/:username/statuses/:id',
+      headers: :any,
+      methods: [:get],
+      credentials: false
     resource '/api/*',
       headers: :any,
       methods: [:post, :put, :delete, :get, :patch, :options],


### PR DESCRIPTION
So that they can be fetched by browser-based AP implementations.

Note that the `Signature` header is not allowed in such browser-issued requests. The rationale for disallowing the `Signature` header is that if a browser-based client can sign a fetch request, the end-user has the signing key, and can issue `Create` or other activities without them being screened by the domain holding their actor.

Its fine for single-user instances, but our security model assumes an actor can create any object identifier within the same domain, and therefore that the remote instance is responsible for not allowing its actors to spoof other actor's object ids. Therefore we cannot safely support multi-user instances which give the signing keys to the end-users.

This has the unwelcome effect of making the CORS header unsufficient for private posts and instances with authorized fetch mode, though.