### PR TITLE
Fixed WebUI crash when a status opened in the media modal is deleted

### DIFF
--- a/app/javascript/mastodon/features/picture_in_picture/components/footer.js
+++ b/app/javascript/mastodon/features/picture_in_picture/components/footer.js
@@ -121,6 +121,13 @@ class Footer extends ImmutablePureComponent {
   render () {
     const { status, intl, withOpenButton } = this.props;
 
+    if (status == null) {
+      return (
+        <div className='picture-in-picture__footer'>
+        </div>
+      );
+    }
+
     const publicStatus  = ['public', 'unlisted'].includes(status.get('visibility'));
     const reblogPrivate = status.getIn(['account', 'id']) === me && status.get('visibility') === 'private';
 

--- a/app/javascript/mastodon/features/picture_in_picture/components/footer.js
+++ b/app/javascript/mastodon/features/picture_in_picture/components/footer.js
@@ -121,13 +121,6 @@ class Footer extends ImmutablePureComponent {
   render () {
     const { status, intl, withOpenButton } = this.props;
 
-    if (status == null) {
-      return (
-        <div className='picture-in-picture__footer'>
-        </div>
-      );
-    }
-
     const publicStatus  = ['public', 'unlisted'].includes(status.get('visibility'));
     const reblogPrivate = status.getIn(['account', 'id']) === me && status.get('visibility') === 'private';
 

--- a/app/javascript/mastodon/reducers/modal.js
+++ b/app/javascript/mastodon/reducers/modal.js
@@ -1,4 +1,5 @@
 import { MODAL_OPEN, MODAL_CLOSE } from '../actions/modal';
+import { TIMELINE_DELETE } from '../actions/timelines';
 
 const initialState = {
   modalType: null,
@@ -11,6 +12,10 @@ export default function modal(state = initialState, action) {
     return { modalType: action.modalType, modalProps: action.modalProps };
   case MODAL_CLOSE:
     return (action.modalType === undefined || action.modalType === state.modalType) ? initialState : state;
+  case TIMELINE_DELETE:
+    if (state.modalProps.statusId === action.id) {
+      return (action.modalType === undefined || action.modalType === state.modalType) ? initialState : state;
+    }
   default:
     return state;
   }

--- a/app/javascript/mastodon/reducers/modal.js
+++ b/app/javascript/mastodon/reducers/modal.js
@@ -13,11 +13,7 @@ export default function modal(state = initialState, action) {
   case MODAL_CLOSE:
     return (action.modalType === undefined || action.modalType === state.modalType) ? initialState : state;
   case TIMELINE_DELETE:
-    if (state.modalProps.statusId === action.id) {
-      return (action.modalType === undefined || action.modalType === state.modalType) ? initialState : state;
-    } else {
-      return state;
-    }
+    return (state.modalProps.statusId === action.id) ? initialState : state;
   default:
     return state;
   }

--- a/app/javascript/mastodon/reducers/modal.js
+++ b/app/javascript/mastodon/reducers/modal.js
@@ -15,6 +15,8 @@ export default function modal(state = initialState, action) {
   case TIMELINE_DELETE:
     if (state.modalProps.statusId === action.id) {
       return (action.modalType === undefined || action.modalType === state.modalType) ? initialState : state;
+    } else {
+      return state;
     }
   default:
     return state;


### PR DESCRIPTION
Fixed a problem that a compatibility error occurs when the status is deleted while the status image etc. is selected and displayed.