### PR TITLE
Fixed issue with .env.vagrant not setting RAILS_ENV variable

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -2,4 +2,3 @@ VAGRANT=true
 LOCAL_DOMAIN=mastodon.local
 BIND=0.0.0.0
 DB_HOST=/var/run/postgresql/
-RAILS_ENV=development

--- a/.env.vagrant
+++ b/.env.vagrant
@@ -2,3 +2,4 @@ VAGRANT=true
 LOCAL_DOMAIN=mastodon.local
 BIND=0.0.0.0
 DB_HOST=/var/run/postgresql/
+RAILS_ENV=development

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,10 +72,12 @@ bundle install
 yarn install
 
 # Build Mastodon
+export RAILS_ENV=development 
 export $(cat ".env.vagrant" | xargs)
 bundle exec rails db:setup
 
 # Configure automatic loading of environment variable
+echo 'export RAILS_ENV=development' >> ~/.bash_profile
 echo 'export $(cat "/vagrant/.env.vagrant" | xargs)' >> ~/.bash_profile
 
 SCRIPT


### PR DESCRIPTION
When setting up a dev environment with Vagrant came across an issue. Because the RAILS_ENV variable wasn't set in .env.vagrant the dev database wasn't being set up.