### PR TITLE
Fix YouTube embeds failing due to YouTube serving wrong OEmbed URLs

### DIFF
--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -38,7 +38,17 @@ class FetchOEmbedService
 
     return if @endpoint_url.blank?
 
-    @endpoint_url = (Addressable::URI.parse(@url) + @endpoint_url).to_s
+    @endpoint_url = begin
+      base_url = Addressable::URI.parse(@url)
+
+      # If the OEmbed endpoint is given as http but the URL we opened
+      # was served over https, we can assume OEmbed will be available
+      # through https as well
+
+      (base_url + @endpoint_url).tap do |absolute_url|
+        absolute_url.scheme = base_url.scheme if base_url.scheme == 'https'
+      end.to_s
+    end
 
     cache_endpoint!
   rescue Addressable::URI::InvalidURIError


### PR DESCRIPTION
YouTube serves http URLs as OEmbed endpoints on its pages, however, it returns HTTP 403 when trying to access them, saying that https is required. I believe it is a safe assumption that if the URL of the page is served over https, we can override the scheme of the OEmbed endpoint to also be https, thereby fixing this issue.