### PR TITLE
Monkey patch Rack::Session to send secure cookies to onions

### DIFF
--- a/lib/action_dispatch/cookie_jar_extensions.rb
+++ b/lib/action_dispatch/cookie_jar_extensions.rb
@@ -13,3 +13,13 @@ module ActionDispatch
 end
 
 ActionDispatch::Cookies::CookieJar.prepend(ActionDispatch::CookieJarExtensions)
+
+module Rack
+  module SessionPersistedExtensions
+    def security_matches?(request, options)
+      request.headers['Host'].ends_with?('.onion') || super
+    end
+  end
+end
+
+Rack::Session::Abstract::Persisted.prepend(Rack::SessionPersistedExtensions)


### PR DESCRIPTION
This fixes an issue where secure cookies are not sent to onion services.