### PR TITLE
tootctl emoji import: case insensitive duplicate check

### DIFF
--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -49,7 +49,7 @@ module Mastodon
           next if filename.start_with?('._')
 
           shortcode    = [options[:prefix], filename, options[:suffix]].compact.join
-          custom_emoji = CustomEmoji.local.find_by(shortcode: shortcode)
+          custom_emoji = CustomEmoji.local.find_by("LOWER(shortcode) = ?", shortcode.downcase)
 
           if custom_emoji && !options[:overwrite]
             skipped += 1


### PR DESCRIPTION
I added a few hundreds of emojis to one of my instances using `tootctl emoji import` and `tar.gz` files. 

Some of them had duplicates with different case, like this:

<img width="884" alt="screenshot_2021-02-15_19-47-31" src="https://user-images.githubusercontent.com/11699655/107984061-59298380-6fc7-11eb-8226-e9b0484406a1.png">

They are displayed correctly in the admin and don't cause any issue during import.

However they don't display correctly:

<img width="330" alt="screenshot_2021-02-15_19-52-25" src="https://user-images.githubusercontent.com/11699655/107984102-74948e80-6fc7-11eb-945a-855d7077b9dd.png">

So I ended up removing the duplicates and reuploading the ones that had the same shortcode with a different case but a different image.

As explained by someone on discord (not sure if they want their name to be quoted)

> the db schema for custom emoji is case sensitive, but  CustomEmoji .search uses SQL's ILIKE operator it's not case sensitive.
> this means you can add emojis as case sensitive, but it can't be used as case sensitive.

To a least fix the batch import, I have come up with the fix attached to this PR which check of existing emojis regardless of the case.

That fixed the issue for me, for example if I have the `LoL` emoji, importing a tarball containing `lol.png` worked, but with the PR it would skip it.