### PR TITLE
Add `GET /api/v1/accounts/lookup` REST API

### DIFF
--- a/app/controllers/api/v1/accounts/lookup_controller.rb
+++ b/app/controllers/api/v1/accounts/lookup_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Api::V1::Accounts::LookupController < Api::BaseController
+  before_action -> { authorize_if_got_token! :read, :'read:accounts' }
+  before_action :set_account
+
+  def show
+    render json: @account, serializer: REST::AccountSerializer
+  end
+
+  private
+
+  def set_account
+    @account = ResolveAccountService.new.call(params[:acct], skip_webfinger: true) || raise(ActiveRecord::RecordNotFound)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -431,6 +431,7 @@ Rails.application.routes.draw do
         get :verify_credentials, to: 'credentials#show'
         patch :update_credentials, to: 'credentials#update'
         resource :search, only: :show, controller: :search
+        resource :lookup, only: :show, controller: :lookup
         resources :relationships, only: :index
       end
 


### PR DESCRIPTION
Allows converting a `username@domain` into a local ID quickly (unlike search, it does not resolve anything, and as such, is available without an API token). Extracted this tiny part from #15509 