### PR TITLE
use host instead of headers to make Rack happy

### DIFF
--- a/lib/action_dispatch/cookie_jar_extensions.rb
+++ b/lib/action_dispatch/cookie_jar_extensions.rb
@@ -7,7 +7,7 @@ module ActionDispatch
     # Monkey-patch ActionDispatch to serve secure cookies to Tor Hidden Service
     # users. Otherwise, ActionDispatch would drop the cookie over HTTP.
     def write_cookie?(*)
-      request.headers['Host'].ends_with?('.onion') || super
+      request.host.ends_with?('.onion') || super
     end
   end
 end
@@ -17,7 +17,7 @@ ActionDispatch::Cookies::CookieJar.prepend(ActionDispatch::CookieJarExtensions)
 module Rack
   module SessionPersistedExtensions
     def security_matches?(request, options)
-      request.headers['Host'].ends_with?('.onion') || super
+      request.host.ends_with?('.onion') || super
     end
   end
 end


### PR DESCRIPTION
Hopefully fixes #15739.

It looks like `headers` is provided by [Rails' extension to the request class](https://github.com/rails/rails/blob/0f09dfca363410f51f6f60787a0e497ee66cdd13/actionpack/lib/action_dispatch/http/request.rb#L213), and doesn't appear [in Rack's](https://github.com/rack/rack/blob/master/lib/rack/request.rb).

I'm going to [submit a patch to Rails](https://github.com/rails/rails/issues/41426) (hopefully in the next 24 hours) that uses [`host`](https://github.com/rack/rack/blob/a05f8d56f9ac4da14dddb8f312a3b43644f73397/lib/rack/request.rb#L296) instead. I've already confirmed it works for that, I just need to get around to writing tests, then I'll file a PR for Rails and eventually try to upstream it to Rack as well. But **I have not tested this patch** for Mastodon, and the patches are slightly different.

@cohosh: Can you see if this works? I don't have a working masto instance right now.