### PR TITLE
replace all instances of "ends_with?" with "end_with?"

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -135,15 +135,15 @@ class AccountsController < ApplicationController
   end
 
   def media_requested?
-    request.path.split('.').first.ends_with?('/media') && !tag_requested?
+    request.path.split('.').first.end_with?('/media') && !tag_requested?
   end
 
   def replies_requested?
-    request.path.split('.').first.ends_with?('/with_replies') && !tag_requested?
+    request.path.split('.').first.end_with?('/with_replies') && !tag_requested?
   end
 
   def tag_requested?
-    request.path.split('.').first.ends_with?(Addressable::URI.parse("/tagged/#{params[:tag]}").normalize)
+    request.path.split('.').first.end_with?(Addressable::URI.parse("/tagged/#{params[:tag]}").normalize)
   end
 
   def cached_filtered_status_page

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,7 +43,7 @@ class ApplicationController < ActionController::Base
   private
 
   def https_enabled?
-    Rails.env.production? && !request.path.start_with?('/health') && !request.headers["Host"].ends_with?(".onion")
+    Rails.env.production? && !request.path.start_with?('/health') && !request.headers["Host"].end_with?(".onion")
   end
 
   def authorized_fetch_mode?

--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -37,7 +37,7 @@ class MediaProxyController < ApplicationController
   end
 
   def version
-    if request.path.ends_with?('/small')
+    if request.path.end_with?('/small')
       :small
     else
       :original

--- a/app/lib/webfinger.rb
+++ b/app/lib/webfinger.rb
@@ -88,7 +88,7 @@ class Webfinger
   end
 
   def standard_url
-    if @domain.ends_with? ".onion"
+    if @domain.end_with? ".onion"
       "http://#{@domain}/.well-known/webfinger?resource=#{@uri}"
     else
       "https://#{@domain}/.well-known/webfinger?resource=#{@uri}"
@@ -96,7 +96,7 @@ class Webfinger
   end
 
   def host_meta_url
-    if @domain.ends_with? ".onion"
+    if @domain.end_with? ".onion"
       "http://#{@domain}/.well-known/host-meta"
     else
       "https://#{@domain}/.well-known/host-meta"

--- a/lib/action_dispatch/cookie_jar_extensions.rb
+++ b/lib/action_dispatch/cookie_jar_extensions.rb
@@ -7,7 +7,7 @@ module ActionDispatch
     # Monkey-patch ActionDispatch to serve secure cookies to Tor Hidden Service
     # users. Otherwise, ActionDispatch would drop the cookie over HTTP.
     def write_cookie?(*)
-      request.host.ends_with?('.onion') || super
+      request.host.end_with?('.onion') || super
     end
   end
 end
@@ -17,7 +17,7 @@ ActionDispatch::Cookies::CookieJar.prepend(ActionDispatch::CookieJarExtensions)
 module Rack
   module SessionPersistedExtensions
     def security_matches?(request, options)
-      request.host.ends_with?('.onion') || super
+      request.host.end_with?('.onion') || super
     end
   end
 end


### PR DESCRIPTION
The `ends_with?` method is [just a Rails alias](https://github.com/rails/rails/blob/fe912cb1a7fb502617792c8c61eaecf4a638da8b/activesupport/lib/active_support/core_ext/symbol/starts_ends_with.rb#L5) of Ruby's [`end_with?`](https://docs.ruby-lang.org/en/2.7.0/String.html#method-i-end_with-3F) method. Using the latter makes the code less brittle.

This is a follow up to #15741 (and #15739), since I don't think the Rack monkey patch should work with `ends_with?`? I haven't tested this PR either, but it should be pretty safe, given the above links.
Edit to add: To be clear, I have tested that `ends_with?` and `end_with?` do the same thing in the rails app and tests I have lying around, I just haven't tested Mastodon specifically.