### PR TITLE
helm: upgrade elasticsearch chart to 14

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 12.8.2
+  version: 14.2.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 8.10.14
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 10.9.0
-digest: sha256:9e423aa9a7a46f49e44f0411d61afd685eedf4475752a2b1a24a86a83b0752d0
-generated: "2021-02-16T17:10:49.594247-08:00"
+digest: sha256:9e3e7b987c6ffba9295a30b7fae2613fe680c2b1a1832ff5afb185414ce1898e
+generated: "2021-02-27T01:01:12.776919968Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,7 +24,7 @@ appVersion: 3.3.0
 
 dependencies:
   - name: elasticsearch
-    version: 12.8.2
+    version: 14.2.3
     repository: https://charts.bitnami.com/bitnami
     condition: elasticsearch.enabled
   - name: postgresql


### PR DESCRIPTION
successfully upgraded in-place from the 12.x; the breaking changes aren't relevant here (we've never claimed to support Helm 2): https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#upgrading