### PR TITLE
Fix default searchTokens

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_input.js
+++ b/app/javascript/mastodon/components/autosuggest_input.js
@@ -6,7 +6,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import classNames from 'classnames';
-import { List as ImmutableList } from 'immutable';
 
 const textAtCursorMatchesToken = (str, caretPosition, searchTokens) => {
   let word;
@@ -55,7 +54,7 @@ export default class AutosuggestInput extends ImmutablePureComponent {
 
   static defaultProps = {
     autoFocus: true,
-    searchTokens: ImmutableList(['@', ':', '#']),
+    searchTokens: ['@', ':', '#'],
   };
 
   state = {


### PR DESCRIPTION
`searchTokens` expects an array of strings, but the default value is ImmutableList.