### PR TITLE
Fix crash on receiving requests with missing Digest header

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -133,6 +133,7 @@ module SignatureVerification
 
   def verify_body_digest!
     return unless signed_headers.include?('digest')
+    raise SignatureVerificationError, 'Digest header missing.' unless request.headers.key?('Digest')
 
     digests = request.headers['Digest'].split(',').map { |digest| digest.split('=', 2) }.map { |key, value| [key.downcase, value] }
     sha256  = digests.assoc('sha-256')

--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -133,7 +133,7 @@ module SignatureVerification
 
   def verify_body_digest!
     return unless signed_headers.include?('digest')
-    raise SignatureVerificationError, 'Digest header missing.' unless request.headers.key?('Digest')
+    raise SignatureVerificationError, 'Digest header missing' unless request.headers.key?('Digest')
 
     digests = request.headers['Digest'].split(',').map { |digest| digest.split('=', 2) }.map { |key, value| [key.downcase, value] }
     sha256  = digests.assoc('sha-256')


### PR DESCRIPTION
Return an error pointing out that Digest is missing, instead of crashing.

Fixes #15743