### PR TITLE
Fix WebUI crashing when SVG support is disabled

### DIFF
--- a/app/javascript/mastodon/components/hashtag.js
+++ b/app/javascript/mastodon/components/hashtag.js
@@ -2,9 +2,34 @@
 import React from 'react';
 import { Sparklines, SparklinesCurve } from 'react-sparklines';
 import { FormattedMessage } from 'react-intl';
+import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Permalink from './permalink';
 import ShortNumber from 'mastodon/components/short_number';
+
+class SilentErrorBoundary extends React.Component {
+
+  static propTypes = {
+    children: PropTypes.node,
+  };
+
+  state = {
+    error: false,
+  };
+
+  componentDidCatch () {
+    this.setState({ error: true });
+  }
+
+  render () {
+    if (this.state.error) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+
+}
 
 /**
  * Used to render counter of how much people are talking about hashtag
@@ -51,17 +76,19 @@ const Hashtag = ({ hashtag }) => (
     </div>
 
     <div className='trends__item__sparkline'>
-      <Sparklines
-        width={50}
-        height={28}
-        data={hashtag
-          .get('history')
-          .reverse()
-          .map((day) => day.get('uses'))
-          .toArray()}
-      >
-        <SparklinesCurve style={{ fill: 'none' }} />
-      </Sparklines>
+      <SilentErrorBoundary>
+        <Sparklines
+          width={50}
+          height={28}
+          data={hashtag
+            .get('history')
+            .reverse()
+            .map((day) => day.get('uses'))
+            .toArray()}
+        >
+          <SparklinesCurve style={{ fill: 'none' }} />
+        </Sparklines>
+      </SilentErrorBoundary>
     </div>
   </div>
 );


### PR DESCRIPTION
Fixes #14910

Tor Browser's “Safest” security setting disables SVGs entirely (`svg.disabled` in `about:settings`), causing React DOM reconciliation to crash when trying to render a SVG object in `react-sparklines`. This PR adds an error boundary to avoid crashing the whole app if `react-sparklines` errors out.