### PR TITLE
Add `POST /api/v1/emails/confirmations` to REST API

### DIFF
--- a/app/controllers/api/v1/emails/confirmations_controller.rb
+++ b/app/controllers/api/v1/emails/confirmations_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Api::V1::Emails::ConfirmationsController < Api::BaseController
+  before_action :doorkeeper_authorize!
+  before_action :require_user_owned_by_application!
+
+  def create
+    current_user.resend_confirmation_instructions if current_user.unconfirmed_email.present?
+    render_empty
+  end
+
+  private
+
+  def require_user_owned_by_application!
+    render json: { error: 'This method is only available to the application the user originally signed-up with' }, status: :forbidden unless current_user && current_user.created_by_application_id == doorkeeper_token.application_id
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -403,6 +403,10 @@ Rails.application.routes.draw do
 
       resources :apps, only: [:create]
 
+      namespace :emails do
+        resources :confirmations, only: [:create]
+      end
+
       resource :instance, only: [:show] do
         resources :peers, only: [:index], controller: 'instances/peers'
         resource :activity, only: [:show], controller: 'instances/activity'


### PR DESCRIPTION
Only available to the application the user originally signed-up with