### PR TITLE
Add af, gd and si locales

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -2,6 +2,7 @@
 
 module SettingsHelper
   HUMAN_LOCALES = {
+    af: 'Afrikaans',
     ar: 'العربية',
     ast: 'Asturianu',
     bg: 'Български',
@@ -24,6 +25,7 @@ module SettingsHelper
     fi: 'Suomi',
     fr: 'Français',
     ga: 'Gaeilge',
+    gd: 'Gàidhlig',
     gl: 'Galego',
     he: 'עברית',
     hi: 'हिन्दी',
@@ -59,6 +61,7 @@ module SettingsHelper
     ru: 'Русский',
     sa: 'संस्कृतम्',
     sc: 'Sardu',
+    si: 'සිංහල',
     sk: 'Slovenčina',
     sl: 'Slovenščina',
     sq: 'Shqip',

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,7 @@ module Mastodon
     # All translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.available_locales = [
+      :af,
       :ar,
       :ast,
       :bg,
@@ -75,6 +76,7 @@ module Mastodon
       :fi,
       :fr,
       :ga,
+      :gd,
       :gl,
       :he,
       :hi,
@@ -109,6 +111,7 @@ module Mastodon
       :ru,
       :sa,
       :sc,
+      :si,
       :sk,
       :sl,
       :sq,


### PR DESCRIPTION
Add Afrikaans, Scottish Gaelic & Sinhala.

I did this by running `grep zh-HK * -r` to find the locations to edit. I hope I haven't missed anything.

I sourced the Sinhala native language name from the [CLDR](https://unicode-org.github.io/cldr-staging/charts/latest/summary/si.html#6b773b0f539e5dc6).

Please add the locales to Crowdin too (c.f. https://crowdin.com/project/mastodon/discussions/22)

Re https://github.com/tootsuite/mastodon/issues/15826
Re https://github.com/tootsuite/mastodon/issues/15799