### PR TITLE
Fix reference to non-existing translation in the exports page

### DIFF
--- a/app/views/settings/exports/show.html.haml
+++ b/app/views/settings/exports/show.html.haml
@@ -39,7 +39,7 @@
       %tr
         %th= t('exports.bookmarks')
         %td= number_with_delimiter @export.total_bookmarks
-        %td= table_link_to 'download', t('bookmarks.csv'), settings_exports_bookmarks_path(format: :csv)
+        %td= table_link_to 'download', t('exports.csv'), settings_exports_bookmarks_path(format: :csv)
 
 %hr.spacer/
 


### PR DESCRIPTION
The exports page showed a different "CSV" capitalisation in the "Bookmarks" row ("Csv") compared to the other rows ("CSV").
This was due to a referece to a translation string that does not exist, `bookmarks.csv`, defaulting to the key's last segment in title case.

This issue was introduced in commit dcd86204 (PR #14956).

(h/t @meqif for helping with figuring out the bug)