### PR TITLE
Add a query string with site settings version to custom.css

### DIFF
--- a/app/controllers/custom_css_controller.rb
+++ b/app/controllers/custom_css_controller.rb
@@ -7,7 +7,7 @@ class CustomCssController < ApplicationController
   before_action :set_cache_headers
 
   def show
-    expires_in 3.minutes, public: true
+    expires_in 7.days, public: true
     render plain: Setting.custom_css || '', content_type: 'text/css'
   end
 end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -92,6 +92,9 @@ class Form::AdminSettings
         setting.update(value: typecast_value(key, value))
       end
     end
+
+    setting = Setting.where(var: 'settings_version').first_or_initialize(var: 'settings_version')
+    setting.update(value: Time.now.to_i)
   end
 
   private

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -31,7 +31,7 @@
     = stylesheet_link_tag '/inert.css', skip_pipeline: true, media: 'all', id: 'inert-style'
 
     - if Setting.custom_css.present?
-      = stylesheet_link_tag custom_css_path, host: request.host, media: 'all'
+      = stylesheet_link_tag custom_css_path(v: Setting.settings_version), host: request.host, media: 'all'
 
     = yield :header_tags
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -71,6 +71,7 @@ defaults: &defaults
   show_domain_blocks: 'disabled'
   show_domain_blocks_rationale: 'disabled'
   require_invite_text: false
+  settings_version: 0
 
 development:
   <<: *defaults


### PR DESCRIPTION
This is a new take on #15465

This is used to bust custom.css cache whenever the site settings change.

Also increase the normal caching duration from 3 minutes to 7 days.