### PR TITLE
templates/systemd/mastodon: enable sandbox mode

### DIFF
--- a/dist/mastodon-sidekiq.service
+++ b/dist/mastodon-sidekiq.service
@@ -12,6 +12,33 @@ Environment="MALLOC_ARENA_MAX=2"
 ExecStart=/home/mastodon/.rbenv/shims/bundle exec sidekiq -c 25
 TimeoutSec=15
 Restart=always
+# Capabilities
+CapabilityBoundingSet=
+# Security
+NoNewPrivileges=true
+# Sandboxing
+ProtectSystem=strict
+PrivateTmp=true
+PrivateDevices=true
+PrivateUsers=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET
+RestrictAddressFamilies=AF_INET6
+RestrictAddressFamilies=AF_NETLINK
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+PrivateMounts=true
+ProtectClock=true
+# System Call Filtering
+SystemCallArchitectures=native
+SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @reboot @resources @setuid @swap
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-streaming.service
+++ b/dist/mastodon-streaming.service
@@ -12,6 +12,33 @@ Environment="STREAMING_CLUSTER_NUM=1"
 ExecStart=/usr/bin/node ./streaming
 TimeoutSec=15
 Restart=always
+# Capabilities
+CapabilityBoundingSet=
+# Security
+NoNewPrivileges=true
+# Sandboxing
+ProtectSystem=strict
+PrivateTmp=true
+PrivateDevices=true
+PrivateUsers=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET
+RestrictAddressFamilies=AF_INET6
+RestrictAddressFamilies=AF_NETLINK
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+PrivateMounts=true
+ProtectClock=true
+# System Call Filtering
+SystemCallArchitectures=native
+SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @reboot @resources @setuid @swap
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-web.service
+++ b/dist/mastodon-web.service
@@ -12,6 +12,33 @@ ExecStart=/home/mastodon/.rbenv/shims/bundle exec puma -C config/puma.rb
 ExecReload=/bin/kill -SIGUSR1 $MAINPID
 TimeoutSec=15
 Restart=always
+# Capabilities
+CapabilityBoundingSet=
+# Security
+NoNewPrivileges=true
+# Sandboxing
+ProtectSystem=strict
+PrivateTmp=true
+PrivateDevices=true
+PrivateUsers=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET
+RestrictAddressFamilies=AF_INET6
+RestrictAddressFamilies=AF_NETLINK
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+PrivateMounts=true
+ProtectClock=true
+# System Call Filtering
+SystemCallArchitectures=native
+SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @reboot @resources @setuid @swap
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added options to enable sandbox mode in systemd services.

These options are checked on a personal node running on OS NixOS.
PR on OS NixOS - https://github.com/NixOS/nixpkgs/pull/113190

Result:
```
systemd-analyze security mastodon-web
```
```
  NAME                                                        DESCRIPTION                                                                EXPOSURE
✗ PrivateNetwork=                                             Service has access to the host's network                                        0.5
✓ User=/DynamicUser=                                          Service runs under a static non-root user identity
✓ CapabilityBoundingSet=~CAP_SET(UID|GID|PCAP)                Service cannot change UID/GID identities/capabilities
✓ CapabilityBoundingSet=~CAP_SYS_ADMIN                        Service has no administrator privileges
✓ CapabilityBoundingSet=~CAP_SYS_PTRACE                       Service has no ptrace() debugging abilities
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                           0.3
✓ RestrictNamespaces=~CLONE_NEWUSER                           Service cannot create user namespaces
✓ RestrictAddressFamilies=~…                                  Service cannot allocate exotic sockets
✓ CapabilityBoundingSet=~CAP_(CHOWN|FSETID|SETFCAP)           Service cannot change file ownership/access mode/capabilities
✓ CapabilityBoundingSet=~CAP_(DAC_*|FOWNER|IPC_OWNER)         Service cannot override UNIX file/IPC permission checks
✓ CapabilityBoundingSet=~CAP_NET_ADMIN                        Service has no network configuration privileges
✓ CapabilityBoundingSet=~CAP_SYS_MODULE                       Service cannot load kernel modules
✓ CapabilityBoundingSet=~CAP_SYS_RAWIO                        Service has no raw I/O access
✓ CapabilityBoundingSet=~CAP_SYS_TIME                         Service processes cannot change the system clock
✗ DeviceAllow=                                                Service has a device ACL with some special devices                              0.1
✗ IPAddressDeny=                                              Service does not define an IP address allow list                                0.2
✓ KeyringMode=                                                Service doesn't share key material with other services
✓ NoNewPrivileges=                                            Service processes cannot acquire new privileges
✓ NotifyAccess=                                               Service child processes cannot alter service state
✓ PrivateDevices=                                             Service has no access to hardware devices
✓ PrivateMounts=                                              Service cannot install system mounts
✓ PrivateTmp=                                                 Service has no access to other software's temporary files
✓ PrivateUsers=                                               Service does not have access to other users
✓ ProtectClock=                                               Service cannot write to the hardware clock or system clock
✓ ProtectControlGroups=                                       Service cannot modify the control group file system
✗ ProtectHome=                                                Service has full access to home directories                                     0.2
✓ ProtectKernelLogs=                                          Service cannot read from or write to the kernel log ring buffer
✓ ProtectKernelModules=                                       Service cannot load or read kernel modules
✓ ProtectKernelTunables=                                      Service cannot alter kernel tunables (/proc/sys, …)
✓ ProtectSystem=                                              Service has strict read-only access to the OS file hierarchy
✓ RestrictAddressFamilies=~AF_PACKET                          Service cannot allocate packet sockets
✓ RestrictSUIDSGID=                                           SUID/SGID file creation by service is restricted
✓ SystemCallArchitectures=                                    Service may execute system calls only with native ABI
✓ SystemCallFilter=~@clock                                    System call deny list defined for service, and @clock is included
✓ SystemCallFilter=~@debug                                    System call deny list defined for service, and @debug is included
✓ SystemCallFilter=~@module                                   System call deny list defined for service, and @module is included
✓ SystemCallFilter=~@mount                                    System call deny list defined for service, and @mount is included
✗ SystemCallFilter=~@raw-io                                   System call deny list defined for service, and @raw-io is not included          0.2
✓ SystemCallFilter=~@reboot                                   System call deny list defined for service, and @reboot is included
✓ SystemCallFilter=~@swap                                     System call deny list defined for service, and @swap is included
✗ SystemCallFilter=~@privileged                               System call deny list defined for service, and @privileged is not included      0.2
✓ SystemCallFilter=~@resources                                System call deny list defined for service, and @resources is included
✓ AmbientCapabilities=                                        Service process does not receive ambient capabilities
✓ CapabilityBoundingSet=~CAP_AUDIT_*                          Service has no audit subsystem access
✓ CapabilityBoundingSet=~CAP_KILL                             Service cannot send UNIX signals to arbitrary processes
✓ CapabilityBoundingSet=~CAP_MKNOD                            Service cannot create device nodes
✓ CapabilityBoundingSet=~CAP_NET_(BIND_SERVICE|BROADCAST|RAW) Service has no elevated networking privileges
✓ CapabilityBoundingSet=~CAP_SYSLOG                           Service has no access to kernel logging
✓ CapabilityBoundingSet=~CAP_SYS_(NICE|RESOURCE)              Service has no privileges to change resource use parameters
✓ RestrictNamespaces=~CLONE_NEWCGROUP                         Service cannot create cgroup namespaces
✓ RestrictNamespaces=~CLONE_NEWIPC                            Service cannot create IPC namespaces
✓ RestrictNamespaces=~CLONE_NEWNET                            Service cannot create network namespaces
✓ RestrictNamespaces=~CLONE_NEWNS                             Service cannot create file system namespaces
✓ RestrictNamespaces=~CLONE_NEWPID                            Service cannot create process namespaces
✓ RestrictRealtime=                                           Service realtime scheduling access is restricted
✓ SystemCallFilter=~@cpu-emulation                            System call deny list defined for service, and @cpu-emulation is included
✓ SystemCallFilter=~@obsolete                                 System call deny list defined for service, and @obsolete is included
✗ RestrictAddressFamilies=~AF_NETLINK                         Service may allocate netlink sockets                                            0.1
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                   0.1
✓ SupplementaryGroups=                                        Service has no supplementary groups
✓ CapabilityBoundingSet=~CAP_MAC_*                            Service cannot adjust SMACK MAC
✓ CapabilityBoundingSet=~CAP_SYS_BOOT                         Service cannot issue reboot()
✓ Delegate=                                                   Service does not maintain its own delegated control group subtree
✓ LockPersonality=                                            Service cannot change ABI personality
✗ MemoryDenyWriteExecute=                                     Service may create writable executable memory mappings                          0.1
✗ RemoveIPC=                                                  Service user may leave SysV IPC objects around                                  0.1
✓ RestrictNamespaces=~CLONE_NEWUTS                            Service cannot create hostname namespaces
✗ UMask=                                                      Files created by service are world-readable by default                          0.1
✓ CapabilityBoundingSet=~CAP_LINUX_IMMUTABLE                  Service cannot mark files immutable
✓ CapabilityBoundingSet=~CAP_IPC_LOCK                         Service cannot lock memory into RAM
✓ CapabilityBoundingSet=~CAP_SYS_CHROOT                       Service cannot issue chroot()
✓ ProtectHostname=                                            Service cannot change system host/domainname
✓ CapabilityBoundingSet=~CAP_BLOCK_SUSPEND                    Service cannot establish wake locks
✓ CapabilityBoundingSet=~CAP_LEASE                            Service cannot create file leases
✓ CapabilityBoundingSet=~CAP_SYS_PACCT                        Service cannot use acct()
✓ CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG                   Service cannot issue vhangup()
✓ CapabilityBoundingSet=~CAP_WAKE_ALARM                       Service cannot program timers that wake up the system
✗ RestrictAddressFamilies=~AF_UNIX                            Service may allocate local sockets                                              0.1

→ Overall exposure level for mastodon-web.service: 1.7 OK 🙂

```