### PR TITLE
Add cold start follow recommendations

### DIFF
--- a/app/controllers/admin/follow_recommendations_controller.rb
+++ b/app/controllers/admin/follow_recommendations_controller.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Admin
+  class FollowRecommendationsController < BaseController
+    before_action :set_language
+
+    def show
+      authorize :follow_recommendation, :show?
+
+      @form     = Form::AccountBatch.new
+      @accounts = filtered_follow_recommendations
+    end
+
+    def update
+      @form = Form::AccountBatch.new(form_account_batch_params.merge(current_account: current_account, action: action_from_button))
+      @form.save
+    rescue ActionController::ParameterMissing
+      # Do nothing
+    ensure
+      redirect_to admin_follow_recommendations_path(filter_params)
+    end
+
+    private
+
+    def set_language
+      @language = follow_recommendation_filter.language
+    end
+
+    def filtered_follow_recommendations
+      follow_recommendation_filter.results
+    end
+
+    def follow_recommendation_filter
+      @follow_recommendation_filter ||= FollowRecommendationFilter.new(filter_params)
+    end
+
+    def form_account_batch_params
+      params.require(:form_account_batch).permit(:action, account_ids: [])
+    end
+
+    def filter_params
+      params.slice(*FollowRecommendationFilter::KEYS).permit(*FollowRecommendationFilter::KEYS)
+    end
+
+    def action_from_button
+      if params[:suppress]
+        'suppress_follow_recommendation'
+      elsif params[:unsuppress]
+        'unsuppress_follow_recommendation'
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/suggestions_controller.rb
+++ b/app/controllers/api/v1/suggestions_controller.rb
@@ -19,6 +19,6 @@ class Api::V1::SuggestionsController < Api::BaseController
   private
 
   def set_accounts
-    @accounts = PotentialFriendshipTracker.get(current_account.id, limit: limit_param(DEFAULT_ACCOUNTS_LIMIT))
+    @accounts = PotentialFriendshipTracker.get(current_account, limit_param(DEFAULT_ACCOUNTS_LIMIT))
   end
 end

--- a/app/controllers/api/v2/suggestions_controller.rb
+++ b/app/controllers/api/v2/suggestions_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Api::V2::SuggestionsController < Api::BaseController
+  include Authorization
+
+  before_action -> { doorkeeper_authorize! :read }
+  before_action :require_user!
+  before_action :set_suggestions
+
+  def index
+    render json: @suggestions, each_serializer: REST::SuggestionSerializer
+  end
+
+  private
+
+  def set_suggestions
+    @suggestions = AccountSuggestions.get(current_account, limit_param(DEFAULT_ACCOUNTS_LIMIT))
+  end
+end

--- a/app/javascript/mastodon/actions/suggestions.js
+++ b/app/javascript/mastodon/actions/suggestions.js
@@ -11,8 +11,8 @@ export function fetchSuggestions() {
   return (dispatch, getState) => {
     dispatch(fetchSuggestionsRequest());
 
-    api(getState).get('/api/v1/suggestions').then(response => {
-      dispatch(importFetchedAccounts(response.data));
+    api(getState).get('/api/v2/suggestions').then(response => {
+      dispatch(importFetchedAccounts(response.data.map(x => x.account)));
       dispatch(fetchSuggestionsSuccess(response.data));
     }).catch(error => dispatch(fetchSuggestionsFail(error)));
   };
@@ -25,10 +25,10 @@ export function fetchSuggestionsRequest() {
   };
 };
 
-export function fetchSuggestionsSuccess(accounts) {
+export function fetchSuggestionsSuccess(suggestions) {
   return {
     type: SUGGESTIONS_FETCH_SUCCESS,
-    accounts,
+    suggestions,
     skipLoading: true,
   };
 };

--- a/app/javascript/mastodon/features/compose/components/search_results.js
+++ b/app/javascript/mastodon/features/compose/components/search_results.js
@@ -51,13 +51,13 @@ class SearchResults extends ImmutablePureComponent {
               <FormattedMessage id='suggestions.header' defaultMessage='You might be interested in…' />
             </div>
 
-            {suggestions && suggestions.map(accountId => (
+            {suggestions && suggestions.map(suggestion => (
               <AccountContainer
-                key={accountId}
-                id={accountId}
-                actionIcon='times'
-                actionTitle={intl.formatMessage(messages.dismissSuggestion)}
-                onActionClick={dismissSuggestion}
+                key={suggestion.get('account')}
+                id={suggestion.get('account')}
+                actionIcon={suggestion.get('source') === 'past_interaction' && 'times'}
+                actionTitle={suggestion.get('source') === 'past_interaction' && intl.formatMessage(messages.dismissSuggestion)}
+                onActionClick={suggestion.get('source') === 'past_interaction' && dismissSuggestion}
               />
             ))}
           </div>

--- a/app/javascript/mastodon/reducers/suggestions.js
+++ b/app/javascript/mastodon/reducers/suggestions.js
@@ -19,18 +19,18 @@ export default function suggestionsReducer(state = initialState, action) {
     return state.set('isLoading', true);
   case SUGGESTIONS_FETCH_SUCCESS:
     return state.withMutations(map => {
-      map.set('items', fromJS(action.accounts.map(x => x.id)));
+      map.set('items', fromJS(action.suggestions.map(x => ({ ...x, account: x.account.id }))));
       map.set('isLoading', false);
     });
   case SUGGESTIONS_FETCH_FAIL:
     return state.set('isLoading', false);
   case SUGGESTIONS_DISMISS:
-    return state.update('items', list => list.filterNot(id => id === action.id));
+    return state.update('items', list => list.filterNot(x => x.account === action.id));
   case ACCOUNT_BLOCK_SUCCESS:
   case ACCOUNT_MUTE_SUCCESS:
-    return state.update('items', list => list.filterNot(id => id === action.relationship.id));
+    return state.update('items', list => list.filterNot(x => x.account === action.relationship.id));
   case DOMAIN_BLOCK_SUCCESS:
-    return state.update('items', list => list.filterNot(id => action.accounts.includes(id)));
+    return state.update('items', list => list.filterNot(x => action.accounts.includes(x.account)));
   default:
     return state;
   }

--- a/app/lib/potential_friendship_tracker.rb
+++ b/app/lib/potential_friendship_tracker.rb
@@ -28,10 +28,14 @@ class PotentialFriendshipTracker
       redis.zrem("interactions:#{account_id}", target_account_id)
     end
 
-    def get(account_id, limit: 20, offset: 0)
-      account_ids = redis.zrevrange("interactions:#{account_id}", offset, limit)
-      return [] if account_ids.empty?
-      Account.searchable.where(id: account_ids)
+    def get(account, limit)
+      account_ids = redis.zrevrange("interactions:#{account.id}", 0, limit)
+
+      return [] if account_ids.empty? || limit < 1
+
+      accounts = Account.searchable.where(id: account_ids).index_by(&:id)
+
+      account_ids.map { |id| accounts[id.to_i] }.compact
     end
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -110,6 +110,7 @@ class Account < ApplicationRecord
   scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
   scope :searchable, -> { without_suspended.where(moved_to_account_id: nil) }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).left_outer_joins(:account_stat) }
+  scope :followable_by, ->(account) { joins(arel_table.join(Follow.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:id].eq(Follow.arel_table[:target_account_id]).and(Follow.arel_table[:account_id].eq(account.id))).join_sources).where(Follow.arel_table[:id].eq(nil)).joins(arel_table.join(FollowRequest.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:id].eq(FollowRequest.arel_table[:target_account_id]).and(FollowRequest.arel_table[:account_id].eq(account.id))).join_sources).where(FollowRequest.arel_table[:id].eq(nil)) }
   scope :tagged_with, ->(tag) { joins(:accounts_tags).where(accounts_tags: { tag_id: tag }) }
   scope :by_recent_status, -> { order(Arel.sql('(case when account_stats.last_status_at is null then 1 else 0 end) asc, account_stats.last_status_at desc, accounts.id desc')) }
   scope :by_recent_sign_in, -> { order(Arel.sql('(case when users.current_sign_in_at is null then 1 else 0 end) asc, users.current_sign_in_at desc, accounts.id desc')) }
@@ -363,7 +364,7 @@ class Account < ApplicationRecord
   end
 
   def excluded_from_timeline_account_ids
-    Rails.cache.fetch("exclude_account_ids_for:#{id}") { blocking.pluck(:target_account_id) + blocked_by.pluck(:account_id) + muting.pluck(:target_account_id) }
+    Rails.cache.fetch("exclude_account_ids_for:#{id}") { block_relationships.pluck(:target_account_id) + blocked_by_relationships.pluck(:account_id) + mute_relationships.pluck(:target_account_id) }
   end
 
   def excluded_from_timeline_domains

--- a/app/models/account_suggestions.rb
+++ b/app/models/account_suggestions.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AccountSuggestions
+  class Suggestion < ActiveModelSerializers::Model
+    attributes :account, :source
+  end
+
+  def self.get(account, limit)
+    suggestions = PotentialFriendshipTracker.get(account, limit).map { |target_account| Suggestion.new(account: target_account, source: :past_interaction) }
+    suggestions.concat(FollowRecommendation.get(account, limit - suggestions.size, suggestions.map { |suggestion| suggestion.account.id }).map { |target_account| Suggestion.new(account: target_account, source: :global) }) if suggestions.size < limit
+    suggestions
+  end
+
+  def self.remove(account, target_account_id)
+    PotentialFriendshipTracker.remove(account.id, target_account_id)
+  end
+end

--- a/app/models/account_summary.rb
+++ b/app/models/account_summary.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: account_summaries
+#
+#  account_id :bigint(8)        primary key
+#  language   :string
+#  sensitive  :boolean
+#
+
+class AccountSummary < ApplicationRecord
+  self.primary_key = :account_id
+
+  scope :safe, -> { where(sensitive: false) }
+  scope :localized, ->(locale) { where(language: locale) }
+  scope :filtered, -> { joins(arel_table.join(FollowRecommendationSuppression.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:account_id].eq(FollowRecommendationSuppression.arel_table[:account_id])).join_sources).where(FollowRecommendationSuppression.arel_table[:id].eq(nil)) }
+
+  def self.refresh
+    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
+  end
+
+  def readonly?
+    true
+  end
+end

--- a/app/models/concerns/account_associations.rb
+++ b/app/models/concerns/account_associations.rb
@@ -63,5 +63,8 @@ module AccountAssociations
 
     # Account deletion requests
     has_one :deletion_request, class_name: 'AccountDeletionRequest', inverse_of: :account, dependent: :destroy
+
+    # Follow recommendations
+    has_one :follow_recommendation_suppression, inverse_of: :account, dependent: :destroy
   end
 end

--- a/app/models/follow_recommendation.rb
+++ b/app/models/follow_recommendation.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: follow_recommendations
+#
+#  account_id :bigint(8)        primary key
+#  rank       :decimal(, )
+#  reason     :text             is an Array
+#
+
+class FollowRecommendation < ApplicationRecord
+  self.primary_key = :account_id
+
+  belongs_to :account_summary, foreign_key: :account_id
+  belongs_to :account, foreign_key: :account_id
+
+  scope :safe, -> { joins(:account_summary).merge(AccountSummary.safe) }
+  scope :localized, ->(locale) { joins(:account_summary).merge(AccountSummary.localized(locale)) }
+  scope :filtered, -> { joins(:account_summary).merge(AccountSummary.filtered) }
+
+  def readonly?
+    true
+  end
+
+  def self.get(account, limit, exclude_account_ids = [])
+    account_ids = Redis.current.zrevrange("follow_recommendations:#{account.user_locale}", 0, -1).map(&:to_i) - exclude_account_ids - [account.id]
+
+    return [] if account_ids.empty? || limit < 1
+
+    accounts = Account.followable_by(account)
+                      .not_excluded_by_account(account)
+                      .not_domain_blocked_by_account(account)
+                      .where(id: account_ids)
+                      .limit(limit)
+                      .index_by(&:id)
+
+    account_ids.map { |id| accounts[id] }.compact
+  end
+end

--- a/app/models/follow_recommendation_filter.rb
+++ b/app/models/follow_recommendation_filter.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class FollowRecommendationFilter
+  KEYS = %i(
+    language
+    status
+  ).freeze
+
+  attr_reader :params, :language
+
+  def initialize(params)
+    @language = params.delete('language') || I18n.locale
+    @params   = params
+  end
+
+  def results
+    if params['status'] == 'suppressed'
+      Account.joins(:follow_recommendation_suppression).order(FollowRecommendationSuppression.arel_table[:id].desc).to_a
+    else
+      account_ids = Redis.current.zrevrange("follow_recommendations:#{@language}", 0, -1).map(&:to_i)
+      accounts    = Account.where(id: account_ids).index_by(&:id)
+
+      account_ids.map { |id| accounts[id] }.compact
+    end
+  end
+end

--- a/app/models/follow_recommendation_suppression.rb
+++ b/app/models/follow_recommendation_suppression.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+# == Schema Information
+#
+# Table name: follow_recommendation_suppressions
+#
+#  id         :bigint(8)        not null, primary key
+#  account_id :bigint(8)        not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class FollowRecommendationSuppression < ApplicationRecord
+  include Redisable
+
+  belongs_to :account
+
+  after_commit :remove_follow_recommendations, on: :create
+
+  private
+
+  def remove_follow_recommendations
+    redis.pipelined do
+      I18n.available_locales.each do |locale|
+        redis.zrem("follow_recommendations:#{locale}", account_id)
+      end
+    end
+  end
+end

--- a/app/models/form/account_batch.rb
+++ b/app/models/form/account_batch.rb
@@ -21,6 +21,10 @@ class Form::AccountBatch
       approve!
     when 'reject'
       reject!
+    when 'suppress_follow_recommendation'
+      suppress_follow_recommendation!
+    when 'unsuppress_follow_recommendation'
+      unsuppress_follow_recommendation!
     end
   end
 
@@ -78,5 +82,19 @@ class Form::AccountBatch
 
     records.each { |account| authorize(account.user, :reject?) }
            .each { |account| DeleteAccountService.new.call(account, reserve_email: false, reserve_username: false) }
+  end
+
+  def suppress_follow_recommendation!
+    authorize(:follow_recommendation, :suppress?)
+
+    accounts.each do |account|
+      FollowRecommendationSuppression.create(account: account)
+    end
+  end
+
+  def unsuppress_follow_recommendation!
+    authorize(:follow_recommendation, :unsuppress?)
+
+    FollowRecommendationSuppression.where(account_id: account_ids).destroy_all
   end
 end

--- a/app/policies/follow_recommendation_policy.rb
+++ b/app/policies/follow_recommendation_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class FollowRecommendationPolicy < ApplicationPolicy
+  def show?
+    staff?
+  end
+
+  def suppress?
+    staff?
+  end
+
+  def unsuppress?
+    staff?
+  end
+end

--- a/app/serializers/rest/suggestion_serializer.rb
+++ b/app/serializers/rest/suggestion_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class REST::SuggestionSerializer < ActiveModel::Serializer
+  attributes :source
+
+  has_one :account, serializer: REST::AccountSerializer
+end

--- a/app/views/admin/follow_recommendations/_account.html.haml
+++ b/app/views/admin/follow_recommendations/_account.html.haml
@@ -1,0 +1,20 @@
+.batch-table__row
+  %label.batch-table__row__select.batch-table__row__select--aligned.batch-checkbox
+    = f.check_box :account_ids, { multiple: true, include_hidden: false }, account.id
+  .batch-table__row__content.batch-table__row__content--unpadded
+    %table.accounts-table
+      %tbody
+        %tr
+          %td= account_link_to account
+          %td.accounts-table__count.optional
+            = number_to_human account.statuses_count, strip_insignificant_zeros: true
+            %small= t('accounts.posts', count: account.statuses_count).downcase
+          %td.accounts-table__count.optional
+            = number_to_human account.followers_count, strip_insignificant_zeros: true
+            %small= t('accounts.followers', count: account.followers_count).downcase
+          %td.accounts-table__count
+            - if account.last_status_at.present?
+              %time.time-ago{ datetime: account.last_status_at.to_date.iso8601, title: l(account.last_status_at.to_date) }= l account.last_status_at
+            - else
+              \-
+            %small= t('accounts.last_active')

--- a/app/views/admin/follow_recommendations/show.html.haml
+++ b/app/views/admin/follow_recommendations/show.html.haml
@@ -1,0 +1,42 @@
+- content_for :page_title do
+  = t('admin.follow_recommendations.title')
+
+- content_for :header_tags do
+  = javascript_pack_tag 'admin', async: true, crossorigin: 'anonymous'
+
+.simple_form
+  %p.hint= t('admin.follow_recommendations.description_html')
+
+%hr.spacer/
+
+= form_tag admin_follow_recommendations_path, method: 'GET', class: 'simple_form' do
+  .filters
+    .filter-subset.filter-subset--with-select
+      %strong= t('admin.follow_recommendations.language')
+      .input.select.optional
+        = select_tag :language, options_for_select(I18n.available_locales.map { |key| [human_locale(key), key]}, @language)
+
+    .filter-subset
+      %strong= t('admin.follow_recommendations.status')
+      %ul
+        %li= filter_link_to t('admin.accounts.moderation.active'), status: nil
+        %li= filter_link_to t('admin.follow_recommendations.suppressed'), status: 'suppressed'
+
+= form_for(@form, url: admin_follow_recommendations_path, method: :patch) do |f|
+  - RelationshipFilter::KEYS.each do |key|
+    = hidden_field_tag key, params[key] if params[key].present?
+
+  .batch-table
+    .batch-table__toolbar
+      %label.batch-table__toolbar__select.batch-checkbox-all
+        = check_box_tag :batch_checkbox_all, nil, false
+      .batch-table__toolbar__actions
+        - if params[:status].blank? && can?(:suppress, :follow_recommendation)
+          = f.button safe_join([fa_icon('times'), t('admin.follow_recommendations.suppress')]), name: :suppress, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
+        - if params[:status] == 'suppressed' && can?(:unsuppress, :follow_recommendation)
+          = f.button safe_join([fa_icon('plus'), t('admin.follow_recommendations.unsuppress')]), name: :unsuppress, class: 'table-action-link', type: :submit
+    .batch-table__body
+      - if @accounts.empty?
+        = nothing_here 'nothing-here--under-tabs'
+      - else
+        = render partial: 'account', collection: @accounts, locals: { f: f }

--- a/app/workers/scheduler/follow_recommendations_scheduler.rb
+++ b/app/workers/scheduler/follow_recommendations_scheduler.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class Scheduler::FollowRecommendationsScheduler
+  include Sidekiq::Worker
+  include Redisable
+
+  sidekiq_options retry: 0
+
+  # The maximum number of accounts that can be requested in one page from the
+  # API is 80, and the suggestions API does not allow pagination. This number
+  # leaves some room for accounts being filtered during live access
+  SET_SIZE = 100
+
+  def perform
+    # Maintaining a materialized view speeds-up subsequent queries significantly
+    AccountSummary.refresh
+
+    fallback_recommendations = FollowRecommendation.safe.filtered.limit(SET_SIZE).index_by(&:account_id)
+
+    I18n.available_locales.each do |locale|
+      recommendations = begin
+        if AccountSummary.safe.filtered.localized(locale).exists? # We can skip the work if no accounts with that language exist
+          FollowRecommendation.safe.filtered.localized(locale).limit(SET_SIZE).index_by(&:account_id)
+        else
+          {}
+        end
+      end
+
+      # Use language-agnostic results if there are not enough language-specific ones
+      missing = SET_SIZE - recommendations.keys.size
+
+      if missing.positive?
+        added = 0
+
+        # Avoid duplicate results
+        fallback_recommendations.each_value do |recommendation|
+          next if recommendations.key?(recommendation.account_id)
+
+          recommendations[recommendation.account_id] = recommendation
+          added += 1
+
+          break if added >= missing
+        end
+      end
+
+      redis.pipelined do
+        redis.del(key(locale))
+
+        recommendations.each_value do |recommendation|
+          redis.zadd(key(locale), recommendation.rank, recommendation.account_id)
+        end
+      end
+    end
+  end
+
+  private
+
+  def key(locale)
+    "follow_recommendations:#{locale}"
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -441,6 +441,14 @@ en:
         create: Add domain
         title: Block new e-mail domain
       title: Blocked e-mail domains
+    follow_recommendations:
+      description_html: "<strong>Follow recommendations help new users quickly find interesting content</strong>. When a user has not interacted with others enough to form personalized follow recommendations, these accounts are recommended instead. They are re-calculated on a daily basis from a mix of accounts with the highest recent engagements and highest local follower counts for a given language."
+      language: For language
+      status: Status
+      suppress: Suppress follow recommendation
+      suppressed: Suppressed
+      title: Follow recommendations
+      unsuppress: Restore follow recommendation
     instances:
       by_domain: Domain
       delivery_available: Delivery is available

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -39,6 +39,7 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :accounts, safe_join([fa_icon('users fw'), t('admin.accounts.title')]), admin_accounts_url, highlights_on: %r{/admin/accounts|/admin/pending_accounts}
       s.item :invites, safe_join([fa_icon('user-plus fw'), t('admin.invites.title')]), admin_invites_path
       s.item :tags, safe_join([fa_icon('hashtag fw'), t('admin.tags.title')]), admin_tags_path, highlights_on: %r{/admin/tags}
+      s.item :follow_recommendations, safe_join([fa_icon('user-plus fw'), t('admin.follow_recommendations.title')]), admin_follow_recommendations_path, highlights_on: %r{/admin/follow_recommendations}
       s.item :instances, safe_join([fa_icon('cloud fw'), t('admin.instances.title')]), admin_instances_url(limited: whitelist_mode? ? nil : '1'), highlights_on: %r{/admin/instances|/admin/domain_blocks|/admin/domain_allows}, if: -> { current_user.admin? }
       s.item :email_domain_blocks, safe_join([fa_icon('envelope fw'), t('admin.email_domain_blocks.title')]), admin_email_domain_blocks_url, highlights_on: %r{/admin/email_domain_blocks}, if: -> { current_user.admin? }
       s.item :ip_blocks, safe_join([fa_icon('ban fw'), t('admin.ip_blocks.title')]), admin_ip_blocks_url, highlights_on: %r{/admin/ip_blocks}, if: -> { current_user.admin? }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -292,6 +292,7 @@ Rails.application.routes.draw do
     end
 
     resources :account_moderation_notes, only: [:create, :destroy]
+    resource :follow_recommendations, only: [:show, :update]
 
     resources :tags, only: [:index, :show, :update] do
       collection do
@@ -507,6 +508,7 @@ Rails.application.routes.draw do
     namespace :v2 do
       resources :media, only: [:create]
       get '/search', to: 'search#index', as: :search
+      resources :suggestions, only: [:index]
     end
 
     namespace :web do

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -25,6 +25,10 @@
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(0..2) %> * * *'
     class: Scheduler::FeedCleanupScheduler
     queue: scheduler
+  follow_recommendations_scheduler:
+    cron: '<%= Random.rand(0..59) %> <%= Random.rand(6..9) %> * * *'
+    class: Scheduler::FollowRecommendationsScheduler
+    queue: scheduler
   doorkeeper_cleanup_scheduler:
     cron: '<%= Random.rand(0..59) %> <%= Random.rand(0..2) %> * * 0'
     class: Scheduler::DoorkeeperCleanupScheduler

--- a/db/migrate/20210322164601_create_account_summaries.rb
+++ b/db/migrate/20210322164601_create_account_summaries.rb
@@ -1,0 +1,9 @@
+class CreateAccountSummaries < ActiveRecord::Migration[5.2]
+  def change
+    create_view :account_summaries, materialized: true
+
+    # To be able to refresh the view concurrently,
+    # at least one unique index is required
+    safety_assured { add_index :account_summaries, :account_id, unique: true }
+  end
+end

--- a/db/migrate/20210323114347_create_follow_recommendations.rb
+++ b/db/migrate/20210323114347_create_follow_recommendations.rb
@@ -1,0 +1,5 @@
+class CreateFollowRecommendations < ActiveRecord::Migration[5.2]
+  def change
+    create_view :follow_recommendations
+  end
+end

--- a/db/migrate/20210324171613_create_follow_recommendation_suppressions.rb
+++ b/db/migrate/20210324171613_create_follow_recommendation_suppressions.rb
@@ -1,0 +1,9 @@
+class CreateFollowRecommendationSuppressions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :follow_recommendation_suppressions do |t|
+      t.references :account, null: false, foreign_key: { on_delete: :cascade }, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_08_133107) do
+ActiveRecord::Schema.define(version: 2021_03_24_171613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -404,6 +404,13 @@ ActiveRecord::Schema.define(version: 2021_03_08_133107) do
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_featured_tags_on_account_id"
     t.index ["tag_id"], name: "index_featured_tags_on_tag_id"
+  end
+
+  create_table "follow_recommendation_suppressions", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["account_id"], name: "index_follow_recommendation_suppressions_on_account_id", unique: true
   end
 
   create_table "follow_requests", force: :cascade do |t|
@@ -996,6 +1003,7 @@ ActiveRecord::Schema.define(version: 2021_03_08_133107) do
   add_foreign_key "favourites", "statuses", name: "fk_b0e856845e", on_delete: :cascade
   add_foreign_key "featured_tags", "accounts", on_delete: :cascade
   add_foreign_key "featured_tags", "tags", on_delete: :cascade
+  add_foreign_key "follow_recommendation_suppressions", "accounts", on_delete: :cascade
   add_foreign_key "follow_requests", "accounts", column: "target_account_id", name: "fk_9291ec025d", on_delete: :cascade
   add_foreign_key "follow_requests", "accounts", name: "fk_76d644b0e7", on_delete: :cascade
   add_foreign_key "follows", "accounts", column: "target_account_id", name: "fk_745ca29eac", on_delete: :cascade
@@ -1079,4 +1087,47 @@ ActiveRecord::Schema.define(version: 2021_03_08_133107) do
   SQL
   add_index "instances", ["domain"], name: "index_instances_on_domain", unique: true
 
+  create_view "account_summaries", materialized: true, sql_definition: <<-SQL
+      SELECT accounts.id AS account_id,
+      mode() WITHIN GROUP (ORDER BY t0.language) AS language,
+      mode() WITHIN GROUP (ORDER BY t0.sensitive) AS sensitive
+     FROM (accounts
+       CROSS JOIN LATERAL ( SELECT statuses.account_id,
+              statuses.language,
+              statuses.sensitive
+             FROM statuses
+            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL))
+            ORDER BY statuses.id DESC
+           LIMIT 20) t0)
+    WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))
+    GROUP BY accounts.id;
+  SQL
+  add_index "account_summaries", ["account_id"], name: "index_account_summaries_on_account_id", unique: true
+
+  create_view "follow_recommendations", sql_definition: <<-SQL
+      SELECT t0.account_id,
+      sum(t0.rank) AS rank,
+      array_agg(t0.reason) AS reason
+     FROM ( SELECT accounts.id AS account_id,
+              ((count(follows.id))::numeric / (1.0 + (count(follows.id))::numeric)) AS rank,
+              'most_followed'::text AS reason
+             FROM ((follows
+               JOIN accounts ON ((accounts.id = follows.target_account_id)))
+               JOIN users ON ((users.account_id = follows.account_id)))
+            WHERE ((users.current_sign_in_at >= (now() - 'P30D'::interval)) AND (accounts.suspended_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.locked = false) AND (accounts.discoverable = true))
+            GROUP BY accounts.id
+           HAVING (count(follows.id) >= 5)
+          UNION ALL
+           SELECT accounts.id AS account_id,
+              (sum((status_stats.reblogs_count + status_stats.favourites_count)) / (1.0 + sum((status_stats.reblogs_count + status_stats.favourites_count)))) AS rank,
+              'most_interactions'::text AS reason
+             FROM ((status_stats
+               JOIN statuses ON ((statuses.id = status_stats.status_id)))
+               JOIN accounts ON ((accounts.id = statuses.account_id)))
+            WHERE ((statuses.id >= (((date_part('epoch'::text, (now() - 'P30D'::interval)) * (1000)::double precision))::bigint << 16)) AND (accounts.suspended_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.locked = false) AND (accounts.discoverable = true))
+            GROUP BY accounts.id
+           HAVING (sum((status_stats.reblogs_count + status_stats.favourites_count)) >= (5)::numeric)) t0
+    GROUP BY t0.account_id
+    ORDER BY (sum(t0.rank)) DESC;
+  SQL
 end

--- a/db/views/account_summaries_v01.sql
+++ b/db/views/account_summaries_v01.sql
@@ -1,0 +1,22 @@
+SELECT
+  accounts.id AS account_id,
+  mode() WITHIN GROUP (ORDER BY language ASC) AS language,
+  mode() WITHIN GROUP (ORDER BY sensitive ASC) AS sensitive
+FROM accounts
+CROSS JOIN LATERAL (
+  SELECT
+    statuses.account_id,
+    statuses.language,
+    statuses.sensitive
+  FROM statuses
+  WHERE statuses.account_id = accounts.id
+    AND statuses.deleted_at IS NULL
+  ORDER BY statuses.id DESC
+  LIMIT 20
+) t0
+WHERE accounts.suspended_at IS NULL
+  AND accounts.silenced_at IS NULL
+  AND accounts.moved_to_account_id IS NULL
+  AND accounts.discoverable = 't'
+  AND accounts.locked = 'f'
+GROUP BY accounts.id

--- a/db/views/follow_recommendations_v01.sql
+++ b/db/views/follow_recommendations_v01.sql
@@ -1,0 +1,38 @@
+SELECT
+  account_id,
+  sum(rank) AS rank,
+  array_agg(reason) AS reason
+FROM (
+  SELECT
+    accounts.id AS account_id,
+    count(follows.id) / (1.0 + count(follows.id)) AS rank,
+    'most_followed' AS reason
+  FROM follows
+  INNER JOIN accounts ON accounts.id = follows.target_account_id
+  INNER JOIN users ON users.account_id = follows.account_id
+  WHERE users.current_sign_in_at >= (now() - interval '30 days')
+    AND accounts.suspended_at IS NULL
+    AND accounts.moved_to_account_id IS NULL
+    AND accounts.silenced_at IS NULL
+    AND accounts.locked = 'f'
+    AND accounts.discoverable = 't'
+  GROUP BY accounts.id
+  HAVING count(follows.id) >= 5
+  UNION ALL
+  SELECT accounts.id AS account_id,
+         sum(reblogs_count + favourites_count) / (1.0 + sum(reblogs_count + favourites_count)) AS rank,
+         'most_interactions' AS reason
+  FROM status_stats
+  INNER JOIN statuses ON statuses.id = status_stats.status_id
+  INNER JOIN accounts ON accounts.id = statuses.account_id
+  WHERE statuses.id >= ((date_part('epoch', now() - interval '30 days') * 1000)::bigint << 16)
+    AND accounts.suspended_at IS NULL
+    AND accounts.moved_to_account_id IS NULL
+    AND accounts.silenced_at IS NULL
+    AND accounts.locked = 'f'
+    AND accounts.discoverable = 't'
+  GROUP BY accounts.id
+  HAVING sum(reblogs_count + favourites_count) >= 5
+) t0
+GROUP BY account_id
+ORDER BY rank DESC

--- a/spec/fabricators/follow_recommendation_suppression_fabricator.rb
+++ b/spec/fabricators/follow_recommendation_suppression_fabricator.rb
@@ -1,0 +1,3 @@
+Fabricator(:follow_recommendation_suppression) do
+  account
+end

--- a/spec/models/follow_recommendation_suppression_spec.rb
+++ b/spec/models/follow_recommendation_suppression_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe FollowRecommendationSuppression, type: :model do
+end


### PR DESCRIPTION
Joining a new social network is a disorienting experience. Unlike other platforms, offering the user to find their old friends using something like a contact list upload is impossible. So we need to at least present the user with new content. The features that served this purpose so far were the public timelines, the profile directory, trending hashtags, and automatically following the admin user(s).

The public timelines worked while Mastodon was new and small, under the radar of spammers and marketers, and mostly concentrated in a few major languages. As of today, I do not believe anyone could say with a serious face that new users should browse the federated timeline to get accustomed to the platform. The noise to signal ratio is simply too small.

The profile directory is slightly better in this aspect but its egalitarian sorting method (recent activity) means it is just one step of abstraction from the federated timeline and not any more helpful for finding quality content. Previous attempt to at least make it categorized by using hashtags in people's bios proved unsuccessful, due to some fundamental flaws:

1. People do not use hashtags in bios enough and
2. Hashtags in bios are not always an honest representation of someone's posting behaviour

Trending hashtags are useful, but not very prominent. Auto-following admin user(s) is probably *the* feature that has been carrying new user onboarding for years, but it too is flawed. It requires admins to consistently act as curators and boost interesting content from different users. It leaves people wondering why they are already following someone they don't know, and does not always translate into new users following other people.

Regardless of what you think about popularity contests or "clout", the reality is that a new user must be presented with something interesting quickly after signing up, or they will bounce and never return, and that means that popularity *must* play into the new user experience (that is, unless you have some AI oracle mechanism that can tell you when something is interesting before showing it to real people).

This feature will provide new users "who to follow" recommendations. This is an enhancement of the existing "who to follow" feature which so far has been essentially a reminder to follow people you often engage with (which is useless for new users who have not had anyone to engage with yet).

The results will be a shuffled mix of two parts:

1. Users who had the highest engagement (reblogs and favourites) in the past 30 days and
2. Users who have the most local followers (followers who were active in the past 30 days)

Where only users with unlocked, not-limited, active accounts who have opted-into the profile directory feature (though this might warrant a rename of the checkbox label; internally the setting is called "discoverable" and this no longer has anything to do with the profile directory specifically) are considered.

Furthermore, we can localize the results for whichever language the new user's interface is in, by looking at which language is most common among each user's most recent 10 posts.

While 2. highlights accounts that may have high significance or recognizability (like the EFF or Tutanota, or Mastodon itself), 1. promotes accounts that create content that resonates with the community.

The admin UI provides an overview of these recommendations with the ability to moderate them.