### PR TITLE
Add `email` param to `POST /api/v1/emails/confirmations`

### DIFF
--- a/app/controllers/api/v1/emails/confirmations_controller.rb
+++ b/app/controllers/api/v1/emails/confirmations_controller.rb
@@ -5,7 +5,11 @@ class Api::V1::Emails::ConfirmationsController < Api::BaseController
   before_action :require_user_owned_by_application!
 
   def create
-    current_user.resend_confirmation_instructions if current_user.unconfirmed_email.present?
+    if !current_user.confirmed? && current_user.unconfirmed_email.present?
+      current_user.update!(email: params[:email]) if params.key?(:email)
+      current_user.resend_confirmation_instructions
+    end
+
     render_empty
   end
 


### PR DESCRIPTION
Allow changing e-mail as long as the account is unconfirmed

I wonder if it would make sense to add an OAuth scope for managing e-mail and then having generic methods for retrieving and changing the e-mail in general. However, this way should be sufficient for the sign-up flow.