### PR TITLE
Fix /admin/tags/:id crashing since Rails 6.1 update

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -59,8 +59,8 @@ module Admin
                              .where(Status.arel_table[:id].gteq(Mastodon::Snowflake.id_at(Time.now.utc.beginning_of_day)))
                              .joins(:account)
                              .group('accounts.domain')
-                             .reorder('statuses_count desc')
-                             .pluck('accounts.domain, count(*) AS statuses_count')
+                             .reorder(statuses_count: :desc)
+                             .pluck(Arel.sql('accounts.domain, count(*) AS statuses_count'))
     end
 
     def set_counters

--- a/spec/controllers/admin/tags_controller_spec.rb
+++ b/spec/controllers/admin/tags_controller_spec.rb
@@ -20,4 +20,16 @@ RSpec.describe Admin::TagsController, type: :controller do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe 'GET #show' do
+    let!(:tag) { Fabricate(:tag) }
+
+    before do
+      get :show, params: { id: tag.id }
+    end
+
+    it 'returns status 200' do
+      expect(response).to have_http_status(200)
+    end
+  end
 end


### PR DESCRIPTION
Raw SQL passed to `pluck` now has to be explicitly marked as SQL via Arel.sql, see https://github.com/rails/rails/pull/27947