### PR TITLE
Fix the positioning of the image and text in the follow button in the detailed status

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1560,6 +1560,7 @@ a.account__display-name {
 
 .detailed-status .button.logo-button {
   margin-bottom: 15px;
+  padding-top: 7px;
 }
 
 .detailed-status__display-name {


### PR DESCRIPTION
The image and the text in the follow button of the detailed status page aligns to the top of the button. This PR fixes this by adding top padding to vertically align the image and text the middle of the button.

Before:
![2021-03-28_17-07](https://user-images.githubusercontent.com/6839214/112763582-f8955980-8ffc-11eb-8a85-6a325e3a82f5.png)

After:
![2021-03-28_17-08](https://user-images.githubusercontent.com/6839214/112763591-021ec180-8ffd-11eb-8689-3fca6fa00fd2.png)
