### PR TITLE
Fix docker build failure with missing shared-mime-info installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN npm install -g yarn && \
 	gem install bundler && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends git libicu-dev libidn11-dev \
-	libpq-dev libprotobuf-dev protobuf-compiler
+	libpq-dev libprotobuf-dev protobuf-compiler shared-mime-info
 
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
 


### PR DESCRIPTION
close #15977