### PR TITLE
Fix DB connection pool settings in CLI

### DIFF
--- a/lib/mastodon/cli_helper.rb
+++ b/lib/mastodon/cli_helper.rb
@@ -25,7 +25,9 @@ module Mastodon
         exit(1)
       end
 
-      ActiveRecord::Base.configurations[Rails.env]['pool'] = options[:concurrency] + 1
+      db_config = ActiveRecord::Base.configurations[Rails.env].dup
+      db_config['pool'] = options[:concurrency] + 1
+      ActiveRecord::Base.establish_connection(db_config)
 
       progress  = create_progress_bar(scope.count)
       pool      = Concurrent::FixedThreadPool.new(options[:concurrency])


### PR DESCRIPTION
In Rails 6, some CLI commands did not work because `ActiveRecord::Base.configurations` returned a frozen Hash.

```
$ RAILS_ENV=production ./bin/tootctl media remove
WARNING: Sidekiq::Web.session_secret= is no longer relevant and will be removed in Sidekiq 7.0. /home/mastodon/live/ven
dor/bundle/ruby/2.7.0/gems/sidekiq-6.2.0/lib/sidekiq/web.rb:75:in `set'
WARNING: Sidekiq::Web.session_secret= is no longer relevant and will be removed in Sidekiq 7.0. /home/mastodon/live/ven
dor/bundle/ruby/2.7.0/gems/sidekiq-6.2.0/lib/sidekiq/web.rb:75:in `set'
Traceback (most recent call last):
        11: from ./bin/tootctl:8:in `<main>'
        10: from /home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
         9: from /home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
         8: from /home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_com
mand'
         7: from /home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
         6: from /home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor.rb:243:in `block in subcommand'
         5: from /home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:116:in `invoke'
         4: from /home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
         3: from /home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
         2: from /home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
         1: from /home/mastodon/live/lib/mastodon/media_cli.rb:31:in `remove'
/home/mastodon/live/lib/mastodon/cli_helper.rb:28:in `parallelize_with_progress': can't modify frozen Hash: {:adapter=>
"postgresql", :pool=>5, :timeout=>5000, :encoding=>"unicode", :sslmode=>"prefer", :database=>"mastodon_production", :us
ername=>"mastodon", :password=>nil, :host=>"/var/run/postgresql", :port=>5432, :prepared_statements=>true} (FrozenError
)
```

So I changed it to use ActiveRecord::Base.establish_connection to reconfigure the Hash instead of changing it directly.