### PR TITLE
Visually shorten gemini urls in account bio header fields

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -288,7 +288,7 @@ class Formatter
 
   def link_html(url)
     url    = Addressable::URI.parse(url).to_s
-    prefix = url.match(/\A(https?:\/\/(www\.)?|xmpp:)/).to_s
+    prefix = url.match(/\A(https?:\/\/(www\.)?|xmpp:|gemini:\/\/)/).to_s
     text   = url[prefix.length, 30]
     suffix = url[prefix.length + 30..-1]
     cutoff = url[prefix.length..-1].length > 30

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -251,6 +251,14 @@ RSpec.describe Formatter do
       end
     end
 
+    context 'given a stand-alone gemini URI' do
+      let(:text) { 'gemini://gemini.circumlunar.space' }
+
+      it 'matches the full URI' do
+        is_expected.to include 'href="gemini://gemini.circumlunar.space"'
+      end
+    end
+
     context 'given a stand-alone xmpp: URI' do
       let(:text) { 'xmpp:user@instance.com' }
 


### PR DESCRIPTION
This pull request updates the `link_html` method in the `Formatter` to match Gemini urls.

Closes #15990