### PR TITLE
Fix SVG files not being correctly included in templates

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -39,5 +39,5 @@
     = content_for?(:content) ? yield(:content) : yield
 
     .logo-resources
-      = render file: Rails.root.join('app', 'javascript', 'images', 'logo_transparent.svg')
-      = render file: Rails.root.join('app', 'javascript', 'images', 'logo_full.svg')
+      = raw render file: Rails.root.join('app', 'javascript', 'images', 'logo_transparent.svg')
+      = raw render file: Rails.root.join('app', 'javascript', 'images', 'logo_full.svg')

--- a/app/views/layouts/embedded.html.haml
+++ b/app/views/layouts/embedded.html.haml
@@ -21,4 +21,4 @@
     = yield
 
     .logo-resources
-      = render file: Rails.root.join('app', 'javascript', 'images', 'logo_transparent.svg')
+      = raw render file: Rails.root.join('app', 'javascript', 'images', 'logo_transparent.svg')


### PR DESCRIPTION
In Rails 6.1, raw file inclusion in templates have to be explicitly marked as HTML-safe, otherwise it's rendered as text.