### PR TITLE
Make a test more deterministic

### DIFF
--- a/spec/validators/disallowed_hashtags_validator_spec.rb
+++ b/spec/validators/disallowed_hashtags_validator_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe DisallowedHashtagsValidator, type: :validator do
 
         it 'adds an error' do
           expect(errors).to have_received(:add)
-            .with(:text, I18n.t('statuses.disallowed_hashtags', tags: disallowed_tags.join(', '), count: disallowed_tags.size))
+            .with(:text, I18n.t('statuses.disallowed_hashtags', tags: disallowed_tags.sort.join(', '), count: disallowed_tags.size))
         end
       end
     end


### PR DESCRIPTION
Avoid rspec failing with:

```
DisallowedHashtagsValidator#validate for a local original status when contains disallowed hashtags adds an error
  :
Diff:
@@ -1 +1 @@
-[:text, "contained the disallowed hashtags: a, b, c"]
+[:text, "contained the disallowed hashtags: b, c, a"]
```

at spec/validators/disallowed_hashtags_validator_spec.rb:42