### PR TITLE
Remove dependency on pluck_each gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -157,4 +157,3 @@ gem 'concurrent-ruby', require: false
 gem 'connection_pool', require: false
 
 gem 'xorcist', '~> 1.1'
-gem 'pluck_each', git: 'https://github.com/nsommer/pluck_each', ref: '73be0947c52fc54bf6d7085378db008358aac5eb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,15 +9,6 @@ GIT
       sidekiq (>= 3.5)
       statsd-ruby (~> 1.4, >= 1.4.0)
 
-GIT
-  remote: https://github.com/nsommer/pluck_each
-  revision: 73be0947c52fc54bf6d7085378db008358aac5eb
-  ref: 73be0947c52fc54bf6d7085378db008358aac5eb
-  specs:
-    pluck_each (0.1.3)
-      activerecord (>= 6.1.0)
-      activesupport (>= 6.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -771,7 +762,6 @@ DEPENDENCIES
   pg (~> 1.2)
   pghero (~> 2.8)
   pkg-config (~> 1.4)
-  pluck_each!
   posix-spawn
   premailer-rails
   private_address_check (~> 0.5)

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ require_relative '../lib/webpacker/helper_extensions'
 require_relative '../lib/action_dispatch/cookie_jar_extensions'
 require_relative '../lib/rails/engine_extensions'
 require_relative '../lib/active_record/database_tasks_extensions'
+require_relative '../lib/active_record/batches'
 
 Dotenv::Railtie.load
 

--- a/lib/active_record/batches.rb
+++ b/lib/active_record/batches.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Batches
+    def pluck_each(*column_names)
+      relation = self
+
+      options = column_names.extract_options!
+
+      flatten     = column_names.size == 1
+      batch_limit = options[:batch_limit] || 1_000
+      order       = options[:order] || :asc
+
+      column_names.unshift(primary_key)
+
+      relation = relation.reorder(batch_order(order)).limit(batch_limit)
+      relation.skip_query_cache!
+
+      batch_relation = relation
+
+      loop do
+        batch = batch_relation.pluck(*column_names)
+
+        break if batch.empty?
+
+        primary_key_offset = batch.last[0]
+
+        batch.each do |record|
+          if flatten
+            yield record[1]
+          else
+            yield record[1..-1]
+          end
+        end
+
+        break if batch.size < batch_limit
+
+        batch_relation = relation.where(
+          predicate_builder[primary_key, primary_key_offset, order == :desc ? :lt : :gt]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
I tried re-implementing the function based on `in_batches` code within Rails to avoid copying the gem code verbatim, though in the end there are still overlaps.