### PR TITLE
Fix an error with 'multiple mentions with same username'

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -276,7 +276,7 @@ class Formatter
 
     linkable_accounts.each do |item|
       same_username = item.username.casecmp(username).zero?
-      same_domain   = item.domain.nil? ? domain.nil? : item.domain.casecmp(domain).zero?
+      same_domain   = item.domain.nil? ? domain.nil? : item.domain.casecmp(domain)&.zero?
 
       if same_username && !same_domain
         same_username_hits += 1


### PR DESCRIPTION
Fix https://github.com/tootsuite/mastodon/pull/15718

I get a `.zero?` method execution error when comparing acct with no domain part and mentioning and posting users with remote accounts.

This is because `casecmp (nil)` returns nil.