### PR TITLE
Fix not to show follow button in global suggestion

### DIFF
--- a/app/javascript/mastodon/components/account.js
+++ b/app/javascript/mastodon/components/account.js
@@ -78,8 +78,10 @@ class Account extends ImmutablePureComponent {
 
     let buttons;
 
-    if (onActionClick && actionIcon) {
-      buttons = <IconButton icon={actionIcon} title={actionTitle} onClick={this.handleAction} />;
+    if (actionIcon) {
+      if (onActionClick) {
+        buttons = <IconButton icon={actionIcon} title={actionTitle} onClick={this.handleAction} />;
+      }
     } else if (account.get('id') !== me && account.get('relationship', null) !== null) {
       const following = account.getIn(['relationship', 'following']);
       const requested = account.getIn(['relationship', 'requested']);

--- a/app/javascript/mastodon/features/compose/components/search_results.js
+++ b/app/javascript/mastodon/features/compose/components/search_results.js
@@ -55,9 +55,9 @@ class SearchResults extends ImmutablePureComponent {
               <AccountContainer
                 key={suggestion.get('account')}
                 id={suggestion.get('account')}
-                actionIcon={suggestion.get('source') === 'past_interaction' && 'times'}
-                actionTitle={suggestion.get('source') === 'past_interaction' && intl.formatMessage(messages.dismissSuggestion)}
-                onActionClick={suggestion.get('source') === 'past_interaction' && dismissSuggestion}
+                actionIcon={suggestion.get('source') === 'past_interaction' ? 'times' : null }
+                actionTitle={suggestion.get('source') === 'past_interaction' ? intl.formatMessage(messages.dismissSuggestion) : null }
+                onActionClick={dismissSuggestion}
               />
             ))}
           </div>

--- a/app/javascript/mastodon/features/compose/components/search_results.js
+++ b/app/javascript/mastodon/features/compose/components/search_results.js
@@ -55,8 +55,8 @@ class SearchResults extends ImmutablePureComponent {
               <AccountContainer
                 key={suggestion.get('account')}
                 id={suggestion.get('account')}
-                actionIcon={suggestion.get('source') === 'past_interaction' ? 'times' : null }
-                actionTitle={suggestion.get('source') === 'past_interaction' ? intl.formatMessage(messages.dismissSuggestion) : null }
+                actionIcon={suggestion.get('source') === 'past_interaction' ? 'times' : null}
+                actionTitle={suggestion.get('source') === 'past_interaction' ? intl.formatMessage(messages.dismissSuggestion) : null}
                 onActionClick={dismissSuggestion}
               />
             ))}


### PR DESCRIPTION
If the suggestion is global, the dismiss button will be hidden, but if the relationship has been acquired, the follow button will be displayed.

This is an inconsistent behavior, so I fixed the icon to be hidden in the global suggestion.

It also fixes an issue that would pass a boolean to Props.