### PR TITLE
Improve access logs when clients connect via CGN

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -13,10 +13,15 @@ upstream streaming {
 
 proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=CACHE:10m inactive=7d max_size=1g;
 
+log_format mastodon '[$remote_addr]:$remote_port - $remote_user [$time_local] '
+                    '"$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent"';
+
 server {
   listen 80;
   listen [::]:80;
   server_name example.com;
+  access_log /var/log/nginx/access.log mastodon;
   root /home/mastodon/live/public;
   location /.well-known/acme-challenge/ { allow all; }
   location / { return 301 https://$host$request_uri; }
@@ -39,6 +44,8 @@ server {
   keepalive_timeout    70;
   sendfile             on;
   client_max_body_size 80m;
+
+  access_log /var/log/nginx/access.log mastodon;
 
   root /home/mastodon/live/public;
 


### PR DESCRIPTION
Add $remote_port to log_format (combined).

Please refer to RFC6302 for reference information.
https://tools.ietf.org/html/rfc6302#section-2
