### PR TITLE
Add Message-ID header to outgoing emails

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,7 +92,8 @@ Rails.application.configure do
   # E-mails
   config.action_mailer.default_options = {
     from: ENV.fetch('SMTP_FROM_ADDRESS', 'notifications@localhost'),
-    reply_to: ENV['SMTP_REPLY_TO']
+    reply_to: ENV['SMTP_REPLY_TO'],
+    'Message-ID': -> { "<#{Mail.random_tag}@#{Rails.configuration.x.web_domain}>" },
   }
 
   config.action_mailer.smtp_settings = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,16 +90,12 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # E-mails
-  outgoing_mail_domain = begin
-    Mail::Address.new(ENV['SMTP_FROM_ADDRESS']).domain
-  rescue
-    nil
-  end
-
+  outgoing_email_address = ENV.fetch('SMTP_FROM_ADDRESS', 'notifications@localhost')
+  outgoing_mail_domain   = Mail::Address.new(outgoing_email_address).domain
   config.action_mailer.default_options = {
-    from: ENV.fetch('SMTP_FROM_ADDRESS', 'notifications@localhost'),
+    from: outgoing_email_address,
     reply_to: ENV['SMTP_REPLY_TO'],
-    'Message-ID': -> { "<#{Mail.random_tag}@#{outgoing_mail_domain || Rails.configuration.x.web_domain}>" },
+    'Message-ID': -> { "<#{Mail.random_tag}@#{outgoing_mail_domain}>" },
   }
 
   config.action_mailer.smtp_settings = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,10 +90,16 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # E-mails
+  outgoing_mail_domain = begin
+    Mail::Address.new(ENV['SMTP_FROM_ADDRESS']).domain
+  rescue
+    nil
+  end
+
   config.action_mailer.default_options = {
     from: ENV.fetch('SMTP_FROM_ADDRESS', 'notifications@localhost'),
     reply_to: ENV['SMTP_REPLY_TO'],
-    'Message-ID': -> { "<#{Mail.random_tag}@#{Rails.configuration.x.web_domain}>" },
+    'Message-ID': -> { "<#{Mail.random_tag}@#{outgoing_mail_domain || Rails.configuration.x.web_domain}>" },
   }
 
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
Currently, we do not define any Message-ID, which means it gets generated by the `mail` gem as follows:

https://github.com/mikel/mail/blob/8fbb17d4d5364c77cc870769d451bc2739b3a8ce/lib/mail/utilities.rb#L325-L327

This PR changes that to specify our own `domain` part, by parsing `SMTP_FROM_ADDRESS`.