### PR TITLE
Change follow recommendations to be limited to 20 instead of 40 in web UI

### DIFF
--- a/app/javascript/mastodon/actions/suggestions.js
+++ b/app/javascript/mastodon/actions/suggestions.js
@@ -12,7 +12,7 @@ export function fetchSuggestions(withRelationships = false) {
   return (dispatch, getState) => {
     dispatch(fetchSuggestionsRequest());
 
-    api(getState).get('/api/v2/suggestions').then(response => {
+    api(getState).get('/api/v2/suggestions', { params: { limit: 20 } }).then(response => {
       dispatch(importFetchedAccounts(response.data.map(x => x.account)));
       dispatch(fetchSuggestionsSuccess(response.data));
 


### PR DESCRIPTION
I'm not sure about this... @ClearlyClaire said 40 might be overwhelming, but what if none of the 20 are interesting to the user?