### PR TITLE
Add "recommended" label to activity/peers API toggles in admin UI

### DIFF
--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -72,10 +72,10 @@
 
   - unless whitelist_mode?
     .fields-group
-      = f.input :activity_api_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.activity_api_enabled.title'), hint: t('admin.settings.activity_api_enabled.desc_html')
+      = f.input :activity_api_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.activity_api_enabled.title'), hint: t('admin.settings.activity_api_enabled.desc_html'), recommended: true
 
     .fields-group
-      = f.input :peers_api_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.peers_api_enabled.title'), hint: t('admin.settings.peers_api_enabled.desc_html')
+      = f.input :peers_api_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.peers_api_enabled.title'), hint: t('admin.settings.peers_api_enabled.desc_html'), recommended: true
 
     .fields-group
       = f.input :preview_sensitive_media, as: :boolean, wrapper: :with_label, label: t('admin.settings.preview_sensitive_media.title'), hint: t('admin.settings.preview_sensitive_media.desc_html')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -562,7 +562,7 @@ en:
     settings:
       activity_api_enabled:
         desc_html: Counts of locally posted statuses, active users, and new registrations in weekly buckets
-        title: Publish aggregate statistics about user activity
+        title: Publish aggregate statistics about user activity in the API
       bootstrap_timeline_accounts:
         desc_html: Separate multiple usernames by comma. Only local and unlocked accounts will work. Default when empty is all local admins.
         title: Default follows for new users
@@ -593,7 +593,7 @@ en:
         title: Mascot image
       peers_api_enabled:
         desc_html: Domain names this server has encountered in the fediverse
-        title: Publish list of discovered servers
+        title: Publish list of discovered servers in the API
       preview_sensitive_media:
         desc_html: Link previews on other websites will display a thumbnail even if the media is marked as sensitive
         title: Show sensitive media in OpenGraph previews


### PR DESCRIPTION
Due to the unclear phrasing of the toggles' descriptions some admins have been disabling them when there is no otherwise valid reason to. The word "publish" implies phoning home of some sort but it's actually about making-public, and by adding "in the API" hopefully this is more clear. Just to encourage people that yes, those settings are supposed to be enabled unless you have a good reason to hide how many people are active on your server, I have added the "Recommended" label to them.