### PR TITLE
Add guard against DNS rebinding attacks

### DIFF
--- a/config/initializers/1_hosts.rb
+++ b/config/initializers/1_hosts.rb
@@ -26,4 +26,8 @@ Rails.application.configure do
       "ws://#{ENV['REMOTE_DEV'] == 'true' ? host.split(':').first : 'localhost'}:4000"
     end
   end
+
+  config.hosts << host if host.present?
+  config.hosts << web_host if web_host.present?
+  config.hosts << alternate_domains if alternate_domains.present?
 end

--- a/config/initializers/1_hosts.rb
+++ b/config/initializers/1_hosts.rb
@@ -27,7 +27,9 @@ Rails.application.configure do
     end
   end
 
-  config.hosts << host if host.present?
-  config.hosts << web_host if web_host.present?
-  config.hosts << alternate_domains if alternate_domains.present?
+  unless Rails.env.test?
+    config.hosts << host if host.present?
+    config.hosts << web_host if web_host.present?
+    config.hosts << alternate_domains if alternate_domains.present?
+  end
 end


### PR DESCRIPTION
Add a guard against DNS rebinding attacks (by the middleware ActionDispatch::HostAuthorization added from Rails 6).
https://github.com/rails/rails/pull/33145

In the development environment, access by host name is now prohibited unless the host is whitelisted after updating to Rails 6. I was inconvenienced by this, so I created this PR.