### PR TITLE
Improve tag search query

### DIFF
--- a/db/migrate/20210421121431_add_case_insensitive_btree_index_to_tags.rb
+++ b/db/migrate/20210421121431_add_case_insensitive_btree_index_to_tags.rb
@@ -1,0 +1,13 @@
+class AddCaseInsensitiveBtreeIndexToTags < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured { execute 'CREATE UNIQUE INDEX CONCURRENTLY index_tags_on_name_lower_btree ON tags (lower(name) text_pattern_ops)' }
+    remove_index :tags, name: 'index_tags_on_name_lower'
+  end
+
+  def down
+    safety_assured { execute 'CREATE UNIQUE INDEX CONCURRENTLY index_tags_on_name_lower ON tags (lower(name))' }
+    remove_index :tags, name: 'index_tags_on_name_lower_btree'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_16_200740) do
+ActiveRecord::Schema.define(version: 2021_04_21_121431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -862,7 +862,7 @@ ActiveRecord::Schema.define(version: 2021_04_16_200740) do
     t.datetime "last_status_at"
     t.float "max_score"
     t.datetime "max_score_at"
-    t.index "lower((name)::text)", name: "index_tags_on_name_lower", unique: true
+    t.index "lower((name)::text) text_pattern_ops", name: "index_tags_on_name_lower_btree", unique: true
   end
 
   create_table "tombstones", force: :cascade do |t|

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -96,6 +96,20 @@ RSpec.describe Tag, type: :model do
     end
   end
 
+  describe '.matches_name' do
+    it 'returns tags for multibyte case-insensitive names' do
+      upcase_string   = 'abcABCａｂｃＡＢＣやゆよ'
+      downcase_string = 'abcabcａｂｃａｂｃやゆよ';
+
+      tag = Fabricate(:tag, name: downcase_string)
+      expect(Tag.matches_name(upcase_string)).to eq [tag]
+    end
+
+    it 'uses the LIKE operator' do
+      expect(Tag.matches_name('100%abc').to_sql).to eq %q[SELECT "tags".* FROM "tags" WHERE LOWER("tags"."name") LIKE LOWER('100\\%abc%')]
+    end
+  end
+
   describe '.matching_name' do
     it 'returns tags for multibyte case-insensitive names' do
       upcase_string   = 'abcABCａｂｃＡＢＣやゆよ'


### PR DESCRIPTION
Tag search queries do not use indexes, so queries are slow to execute on instances with many tags. By reverting to index with the text_pattern_ops operator class and avoiding the ILIKE operator, index will be used.

before:
```sql
SELECT 
  "tags".* 
FROM 
  "tags" 
WHERE 
  (
    "tags"."listable" = TRUE 
    OR "tags"."listable" IS NULL
  ) 
  AND LOWER("tags"."name") ILIKE 'ABC%' 
  AND (
    LOWER("tags"."name") = 'ABC' 
    OR "tags"."reviewed_at" IS NOT NULL
  ) 
ORDER BY 
  length(name) ASC, 
  name ASC 
LIMIT 
  4 OFFSET 0
```

```
Limit  (cost=65.07..65.08 rows=1 width=99) (actual time=2.032..2.032 rows=0 loops=1)
  ->  Sort  (cost=65.07..65.08 rows=1 width=99) (actual time=2.018..2.018 rows=0 loops=1)
        Sort Key: (length((name)::text)), name
        Sort Method: quicksort  Memory: 25kB
        ->  Seq Scan on tags  (cost=0.00..65.06 rows=1 width=99) (actual time=1.999..1.999 rows=0 loops=1)
              Filter: ((listable OR (listable IS NULL)) AND (lower((name)::text) ~~* 'ABC%'::text) AND ((lower((name)::text) = 'ABC'::text) OR (reviewed_at IS NOT NULL)))
              Rows Removed by Filter: 2003
Planning time: 0.442 ms
Execution time: 2.082 ms
```



after:
```sql
SELECT 
  "tags".* 
FROM 
  "tags" 
WHERE 
  (
    "tags"."listable" = TRUE 
    OR "tags"."listable" IS NULL
  ) 
  AND LOWER("tags"."name") LIKE LOWER('ABC%') 
  AND (
    LOWER("tags"."name") = LOWER('ABC') 
    OR "tags"."reviewed_at" IS NOT NULL
  ) 
ORDER BY 
  length(name) ASC, 
  name ASC 
LIMIT 
  4 OFFSET 0
```

```
Limit  (cost=8.32..8.32 rows=1 width=99) (actual time=0.094..0.094 rows=0 loops=1)
  ->  Sort  (cost=8.32..8.32 rows=1 width=99) (actual time=0.072..0.072 rows=0 loops=1)
        Sort Key: (length((name)::text)), name
        Sort Method: quicksort  Memory: 25kB
        ->  Index Scan using index_tags_on_name_lower_btree on tags  (cost=0.28..8.31 rows=1 width=99) (actual time=0.031..0.031 rows=0 loops=1)
              Index Cond: ((lower((name)::text) ~>=~ 'abc'::text) AND (lower((name)::text) ~<~ 'abd'::text))
              Filter: ((listable OR (listable IS NULL)) AND (lower((name)::text) ~~ 'abc%'::text) AND ((lower((name)::text) = 'abc'::text) OR (reviewed_at IS NOT NULL)))
              Rows Removed by Filter: 1
Planning time: 0.162 ms
Execution time: 0.153 ms
```