### PR TITLE
Further improve the media attached status query for accounts

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -77,7 +77,7 @@ class AccountsController < ApplicationController
   end
 
   def only_media_scope
-    Status.joins(:media_attachments).group(:id)
+    Status.joins(:media_attachments).merge(@account.media_attachments.reorder(nil)).group(:id)
   end
 
   def no_replies_scope

--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -14,7 +14,7 @@ module Admin
       @statuses = @account.statuses.where(visibility: [:public, :unlisted])
 
       if params[:media]
-        @statuses.merge!(Status.joins(:media_attachments).group(:id))
+        @statuses.merge!(Status.joins(:media_attachments).merge(@account.media_attachments.reorder(nil)).group(:id))
       end
 
       @statuses = @statuses.preload(:media_attachments, :mentions).page(params[:page]).per(PER_PAGE)

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   end
 
   def only_media_scope
-    Status.joins(:media_attachments).group(:id)
+    Status.joins(:media_attachments).merge(@account.media_attachments.reorder(nil)).group(:id)
   end
 
   def pinned_scope

--- a/db/migrate/20210425135952_add_index_on_media_attachments_account_id_status_id.rb
+++ b/db/migrate/20210425135952_add_index_on_media_attachments_account_id_status_id.rb
@@ -1,0 +1,13 @@
+class AddIndexOnMediaAttachmentsAccountIdStatusId < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    add_index :media_attachments, [:account_id, :status_id], order: { status_id: :desc }, algorithm: :concurrently
+    remove_index :media_attachments, :account_id, algorithm: :concurrently
+  end
+
+  def down
+    add_index :media_attachments, :account_id, algorithm: :concurrently
+    remove_index :media_attachments, [:account_id, :status_id], order: { status_id: :desc }, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_21_121431) do
+ActiveRecord::Schema.define(version: 2021_04_25_135952) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -541,7 +541,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_121431) do
     t.integer "thumbnail_file_size"
     t.datetime "thumbnail_updated_at"
     t.string "thumbnail_remote_url"
-    t.index ["account_id"], name: "index_media_attachments_on_account_id"
+    t.index ["account_id", "status_id"], name: "index_media_attachments_on_account_id_and_status_id", order: { status_id: :desc }
     t.index ["scheduled_status_id"], name: "index_media_attachments_on_scheduled_status_id"
     t.index ["shortcode"], name: "index_media_attachments_on_shortcode", unique: true
     t.index ["status_id"], name: "index_media_attachments_on_status_id"


### PR DESCRIPTION
I further improved on https://github.com/tootsuite/mastodon/pull/16105. Added a composite index for account_id and status_id to allow sorting using the index while keeping the condition to filter media_attachments by account. With this change, we can expect faster query execution even for users with fewer media_attachments.


From the EXPLAIN result, you can see that media_attachments is narrowed down first.

before: 
```sql
SELECT 
  "statuses"."id", 
  "statuses"."updated_at" 
FROM 
  "statuses" 
  INNER JOIN "media_attachments" ON "media_attachments"."status_id" = "statuses"."id" 
WHERE 
  "statuses"."account_id" = xxxxxxxx 
  AND "statuses"."visibility" IN (0, 1) 
  AND "statuses"."deleted_at" IS NULL 
  AND (
    statuses.reply = FALSE 
    OR statuses.in_reply_to_account_id = statuses.account_id
  ) 
GROUP BY 
  "statuses"."id" 
ORDER BY 
  "statuses"."id" DESC 
LIMIT 
  20
```

```
Limit  (cost=0.99..1773.50 rows=20 width=16) (actual time=0.035..0.179 rows=20 loops=1)
  ->  Group  (cost=0.99..357429.10 rows=4033 width=16) (actual time=0.035..0.177 rows=20 loops=1)
        Group Key: statuses.id
        ->  Nested Loop  (cost=0.99..357419.02 rows=4033 width=16) (actual time=0.032..0.169 rows=22 loops=1)
              ->  Index Scan using index_statuses_20190820 on statuses  (cost=0.56..168563.86 rows=47324 width=16) (actual time=0.021..0.064 rows=29 loops=1)
                    Index Cond: (account_id = xxxxxxxx)
                    Filter: ((visibility = ANY ('{0,1}'::integer[])) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))
              ->  Index Only Scan using index_media_attachments_on_status_id on media_attachments  (cost=0.43..3.97 rows=2 width=8) (actual time=0.003..0.003 rows=1 loops=29)
                    Index Cond: (status_id = statuses.id)
                    Heap Fetches: 22
Planning time: 0.518 ms
Execution time: 0.214 ms
```

after:
```sql
SELECT 
  "statuses"."id", 
  "statuses"."updated_at" 
FROM 
  "statuses" 
  INNER JOIN "media_attachments" ON "media_attachments"."status_id" = "statuses"."id" 
WHERE 
  "statuses"."account_id" = xxxxxxxx 
  AND "statuses"."visibility" IN (0, 1) 
  AND "media_attachments"."account_id" = xxxxxxxx 
  AND "statuses"."deleted_at" IS NULL 
  AND (
    statuses.reply = FALSE 
    OR statuses.in_reply_to_account_id = statuses.account_id
  ) 
GROUP BY 
  "statuses"."id" 
ORDER BY 
  "statuses"."id" DESC 
LIMIT 
  20
```
```
Limit  (cost=0.86..57937.92 rows=20 width=16) (actual time=0.031..0.147 rows=20 loops=1)
  ->  Group  (cost=0.86..127462.40 rows=44 width=16) (actual time=0.031..0.146 rows=20 loops=1)
        Group Key: statuses.id
        ->  Nested Loop  (cost=0.86..127462.29 rows=44 width=16) (actual time=0.030..0.140 rows=21 loops=1)
              ->  Index Only Scan using index_media_attachments_on_account_id_and_status_id on media_attachments  (cost=0.43..31251.58 rows=12193 width=8) (actual time=0.019..0.034 rows=21 loops=1)
                    Index Cond: (account_id = xxxxxxxx)
                    Heap Fetches: 21
              ->  Index Scan using statuses_pkey on statuses  (cost=0.43..7.88 rows=1 width=16) (actual time=0.004..0.004 rows=1 loops=21)
                    Index Cond: (id = media_attachments.status_id)
                    Filter: ((deleted_at IS NULL) AND (visibility = ANY ('{0,1}'::integer[])) AND ((NOT reply) OR (in_reply_to_account_id = account_id)) AND (account_id = xxxxxxxx))
Planning time: 0.377 ms
Execution time: 0.179 ms
```