### PR TITLE
templates/systemd/mastodon: optimize SystemCallFilters

### DIFF
--- a/dist/mastodon-sidekiq.service
+++ b/dist/mastodon-sidekiq.service
@@ -38,7 +38,7 @@ PrivateMounts=true
 ProtectClock=true
 # System Call Filtering
 SystemCallArchitectures=native
-SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @privileged @raw-io @reboot @resources @setuid @swap
+SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @raw-io @reboot @setuid @swap
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-web.service
+++ b/dist/mastodon-web.service
@@ -38,7 +38,7 @@ PrivateMounts=true
 ProtectClock=true
 # System Call Filtering
 SystemCallArchitectures=native
-SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @privileged @raw-io @reboot @resources @setuid @swap
+SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @raw-io @reboot @resources @setuid @swap
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixed this errors:
```
web puma[116123]: [f966c281-c627-4bc2-8a59-289829acc152] method=POST path=/api/v1/markers format=html controller=Api::V1::MarkersController action=create status=200 duration=9.13 view=0.25 db=2.13
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] [paperclip] Trying to link /tmp/90c72744f60c48b76cef68748133c82520210427-116123-1qzk5ix.png to /tmp/1154bf3e2a76e55de7c1d06a8acd9a3e20210427-116123-1t055p7.png
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] Command :: file -b --mime '/tmp/1154bf3e2a76e55de7c1d06a8acd9a3e20210427-116123-1t055p7.png'
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] Command :: identify -format %m '/tmp/90c72744f60c48b76cef68748133c82520210427-116123-1qzk5ix.png[0]'
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] Command :: convert '/tmp/90c72744f60c48b76cef68748133c82520210427-116123-1qzk5ix.png[0]' -auto-orient -resize "313x" -crop "313x313+0+0" +repage -strip '/tmp/f06d269acc36b64cd5b571dc3c42e5a320210427-116123-uabp4z'
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] [paperclip] Trying to link /tmp/f06d269acc36b64cd5b571dc3c42e5a320210427-116123-uabp4z to /tmp/0b28ae97464f6cb7c7864c4e6f2fa32120210427-116123-sva4f9
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] [paperclip] Trying to link /tmp/b7398790ee7034568508adc9f02425da20210427-116123-1ci7bpu.png to /tmp/04bf2ad3e285ca44de8100db0204f56120210427-116123-yp5zmo.png
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] Command :: file -b --mime '/tmp/04bf2ad3e285ca44de8100db0204f56120210427-116123-yp5zmo.png'
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] [paperclip] Trying to link /tmp/b7398790ee7034568508adc9f02425da20210427-116123-1ci7bpu.png to /tmp/9b5cd50e7e4ebbd7eb264fde99c98c7f20210427-116123-113qglj.png
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] [paperclip] Trying to link /tmp/0b28ae97464f6cb7c7864c4e6f2fa32120210427-116123-sva4f9 to /tmp/dc8cd0a57c927980a652cb95b6efa1d820210427-116123-87ykpe.png
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] Command :: file -b --mime '/tmp/dc8cd0a57c927980a652cb95b6efa1d820210427-116123-87ykpe.png'
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] [paperclip] Trying to link /tmp/9b5cd50e7e4ebbd7eb264fde99c98c7f20210427-116123-113qglj.png to /tmp/04bf2ad3e285ca44de8100db0204f56120210427-116123-1b4175m.png
web puma[116123]: [9c2bcc18-526a-45d1-b191-09d2e4bcd47d] Command :: file -b --mime '/tmp/04bf2ad3e285ca44de8100db0204f56120210427-116123-1b4175m.png'
web systemd-coredump[113402]: [🡕] Process 116123 (puma) of user 997 dumped core.
```

```
web sidekiq[114493]: 2021-04-27T17:23:45.747Z pid=114493 tid=4k01 class=ActivityPub::ProcessingWorker jid=ca14901525c999dbf64774cb INFO: start
web sidekiq[114493]: /nix/store/jpc0rgxmn6fq39w4fs0v7sxn05b50jyz-mastodon-gems-3.3.0/lib/ruby/gems/2.7.0/gems/cld3-3.3.0/lib/cld3.rb:91: warning: rb_safe_level will be removed in Ruby 3.0
web sidekiq[114493]: Command :: file -b --mime '/tmp/ebeee28f222b829fe30eeeb989825c1e20210427-114493-1s8jk1c.webm'
web sidekiq[114493]: [paperclip] Trying to link /tmp/ebeee28f222b829fe30eeeb989825c1e20210427-114493-1s8jk1c.webm to /tmp/ebc3d18825afa9c90394ae55ffd47c7620210427-114493-19j76g1.webm
web sidekiq[114493]: Command :: file -b --mime '/tmp/ebc3d18825afa9c90394ae55ffd47c7620210427-114493-19j76g1.webm'
web sidekiq[114493]: [AV] Running command: if command -v avprobe 2>/dev/null; then echo "true"; else echo "false"; fi
web sidekiq[114493]: [AV] Running command: if command -v ffmpeg 2>/dev/null; then echo "true"; else echo "false"; fi
web sidekiq[114493]: [AV] Found ["ffmpeg"], using: Ffmpeg
web sidekiq[114493]: [AV] Running command: if command -v avprobe 2>/dev/null; then echo "true"; else echo "false"; fi
web sidekiq[114493]: [AV] Running command: if command -v ffmpeg 2>/dev/null; then echo "true"; else echo "false"; fi
web sidekiq[114493]: [AV] Found ["ffmpeg"], using: Ffmpeg
web sidekiq[114493]: [AV] Running command: ffmpeg -i "/tmp/ebeee28f222b829fe30eeeb989825c1e20210427-114493-1s8jk1c.webm" 2>&1
web sidekiq[114493]: [paperclip] [transcoder] Transocding supported file /tmp/ebeee28f222b829fe30eeeb989825c1e20210427-114493-1s8jk1c.webm
web sidekiq[114493]: [AV] Adding output parameter ["acodec", "aac"]
web sidekiq[114493]: [AV] Adding output parameter ["strict", "experimental"]
web sidekiq[114493]: [AV] Adding output parameter ["loglevel", "fatal"]
web sidekiq[114493]: [AV] Adding output parameter ["movflags", "faststart"]
web sidekiq[114493]: [AV] Adding output parameter ["pix_fmt", "yuv420p"]
web sidekiq[114493]: [AV] Adding output parameter ["vf", "scale='trunc(iw/2)*2:trunc(ih/2)*2'"]
web sidekiq[114493]: [AV] Adding output parameter ["vsync", "cfr"]
web sidekiq[114493]: [AV] Adding output parameter ["c:v", "h264"]
web sidekiq[114493]: [AV] Adding output parameter ["maxrate", "1300K"]
web sidekiq[114493]: [AV] Adding output parameter ["bufsize", "1300K"]
web sidekiq[114493]: [AV] Adding output parameter ["frames:v", 10800]
web sidekiq[114493]: [AV] Adding output parameter ["crf", 18]
web sidekiq[114493]: [AV] Adding output parameter ["map_metadata", "-1"]
web sidekiq[114493]: [AV] Running command: ffmpeg -i "/tmp/ebeee28f222b829fe30eeeb989825c1e20210427-114493-1s8jk1c.webm" -acodec aac -strict experimental -loglevel fatal -movflags faststart -pix_fmt yuv420p -vf scale='trunc(iw/2)*2:trunc(ih/2)*2' -vsync cfr -c:v h264 -maxrate 1300K -bufsize 1300K -frames:v 10800 -crf 18 -map_metadata -1 -y "/tmp/ebeee28f222b829fe30eeeb989825c1e20210427-114493-1s8jk1c20210427-114493-lgxeha.mp4"
web systemd-coredump[118476]: [🡕] Process 118457 (ffmpeg) of user 997 dumped core.
```