### PR TITLE
Fix cache redis not being used

### DIFF
--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -28,7 +28,7 @@ cache_namespace = namespace ? namespace + '_cache' : 'cache'
 
 REDIS_CACHE_PARAMS = {
   driver: :hiredis,
-  url: ENV['REDIS_URL'],
+  url: ENV['CACHE_REDIS_URL'],
   expires_in: 10.minutes,
   namespace: cache_namespace,
 }.freeze


### PR DESCRIPTION
Fix https://github.com/tootsuite/mastodon/pull/15911

Even though redis for caching was specified, it wasn't enabled.

----

Note: If you are using cache-only redis and you are running the main branch, it is recommended that you clear the cache from the main redis with tootctl as below after applying this change.

```
CACHE_REDIS_PORT=6379 RAILS_ENV=production bin/tootctl cache clear
```

This example assumes that REDIS_PORT is 6379 and CACHE_REDIS_PORT is different. Temporarily set CACHE_REDIS_ * to the same as REDIS_ * to clear the cache.