### PR TITLE
Fix "cb is not a function" error in streaming API server

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -1062,7 +1062,7 @@ const startWorker = (workerId) => {
       }
 
       ws.isAlive = false;
-      ws.ping('', false, true);
+      ws.ping('', false);
     });
   }, 30000);
 


### PR DESCRIPTION
Third argument of `ping` is the callback

Regression from #15932