### PR TITLE
fix component name

### DIFF
--- a/app/javascript/mastodon/components/regeneration_indicator.js
+++ b/app/javascript/mastodon/components/regeneration_indicator.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import illustration from 'mastodon/../images/elephant_ui_working.svg';
 
-const MissingIndicator = () => (
+const RegenerationIndicator = () => (
   <div className='regeneration-indicator'>
     <div className='regeneration-indicator__figure'>
       <img src={illustration} alt='' />
@@ -15,4 +15,4 @@ const MissingIndicator = () => (
   </div>
 );
 
-export default MissingIndicator;
+export default RegenerationIndicator;


### PR DESCRIPTION
It seems forget renaming when It copied from MissingIndicator.

This renaming is no effect to StatusList.
It imports from default export.
https://github.com/tootsuite/mastodon/blob/6fda3cbbebfdc7b050f4437b996b2ad36c1db64c/app/javascript/mastodon/components/status_list.js#L9