### PR TITLE
Change confirmations controller to redirect to / for approved users

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -17,7 +17,9 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
   private
 
   def require_unconfirmed!
-    redirect_to edit_user_registration_path if user_signed_in? && current_user.confirmed? && current_user.unconfirmed_email.blank?
+    if user_signed_in? && current_user.confirmed? && current_user.unconfirmed_email.blank?
+      redirect_to(current_user.approved? ? root_path : edit_user_registration_path)
+    end
   end
 
   def set_body_classes


### PR DESCRIPTION
Clicking the confirmation link multiple times currently leads to entering account settings, which can be confusing.

This commit changes that so that it redirects to the root path, so it behaves the same way as clicking only once in most cases.