### PR TITLE
Remove dependency for @babel/plugin-proposal-class-properties

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -18,7 +18,6 @@ module.exports = (api) => {
     ],
     plugins: [
       ['@babel/proposal-decorators', { legacy: true }],
-      '@babel/proposal-class-properties',
       ['react-intl', { messagesDir: './build/messages' }],
       'preval',
     ],

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   "private": true,
   "dependencies": {
     "@babel/core": "^7.14.0",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-decorators": "^7.13.15",
     "@babel/plugin-transform-react-inline-elements": "^7.12.13",
     "@babel/plugin-transform-runtime": "^7.13.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -347,7 +347,7 @@
     "@babel/helper-remap-async-to-generator" "^7.13.0"
     "@babel/plugin-syntax-async-generators" "^7.8.4"
 
-"@babel/plugin-proposal-class-properties@^7.13.0", "@babel/plugin-proposal-class-properties@^7.8.3":
+"@babel/plugin-proposal-class-properties@^7.13.0":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.13.0.tgz#146376000b94efd001e57a40a88a525afaab9f37"
   integrity sha512-KnTDjFNC1g+45ka0myZNvSBFLhNCLN+GeGYLDEA8Oq7MZ6yMgfLoIRh86GRT0FjtJhZw8JyUskP9uvj5pHM9Zg==


### PR DESCRIPTION
`@babel/preset-env` 7.14 includes `@babel/plugin-proposal-class-properties`. Removes direct dependencies from Mastodon.

ref https://babel.dev/blog/2021/04/29/7.14.0#new-class-features-enabled-by-default