### PR TITLE
Fix how to change connection pool for rails 6

### DIFF
--- a/lib/mastodon/search_cli.rb
+++ b/lib/mastodon/search_cli.rb
@@ -53,9 +53,9 @@ module Mastodon
         index.specification.lock!
       end
 
-      configurations = ActiveRecord::Base.configurations.to_h
-      configurations[Rails.env]['pool'] = options[:concurrency] + 1
-      ActiveRecord::Base.configurations = configurations
+      db_config = ActiveRecord::Base.configurations[Rails.env].dup
+      db_config['pool'] = options[:concurrency] + 1
+      ActiveRecord::Base.establish_connection(db_config)
 
       pool    = Concurrent::FixedThreadPool.new(options[:concurrency])
       added   = Concurrent::AtomicFixnum.new(0)

--- a/lib/mastodon/search_cli.rb
+++ b/lib/mastodon/search_cli.rb
@@ -53,7 +53,9 @@ module Mastodon
         index.specification.lock!
       end
 
-      ActiveRecord::Base.configurations[Rails.env]['pool'] = options[:concurrency] + 1
+      configurations = ActiveRecord::Base.configurations.to_h
+      configurations[Rails.env]['pool'] = options[:concurrency] + 1
+      ActiveRecord::Base.configurations = configurations
 
       pool    = Concurrent::FixedThreadPool.new(options[:concurrency])
       added   = Concurrent::AtomicFixnum.new(0)


### PR DESCRIPTION
`tootctl search deploy` will result in an error.

~In rails 6, configurations now return an object and you can no longer change the value directly. Change it to extract as a hash and assign it again.~

Modify it in the same way as https://github.com/tootsuite/mastodon/pull/15983