### PR TITLE
Add joined date to profiles in web UI

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -326,6 +326,8 @@ class Header extends ImmutablePureComponent {
               {account.get('id') !== me && !suspended && <AccountNoteContainer account={account} />}
 
               {account.get('note').length > 0 && account.get('note') !== '<p></p>' && <div className='account__header__content translate' dangerouslySetInnerHTML={content} />}
+
+              <div className='account__header__joined'><FormattedMessage id='account.joined' defaultMessage='Joined {date}' values={{ date: intl.formatDate(account.get('created_at'), { year: 'numeric', month: 'short', day: '2-digit' }) }} /></div>
             </div>
 
             {!suspended && (

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -909,6 +909,10 @@
       {
         "defaultMessage": "Group",
         "id": "account.badges.group"
+      },
+      {
+        "defaultMessage": "Joined {date}",
+        "id": "account.joined"
       }
     ],
     "path": "app/javascript/mastodon/features/account/components/header.json"
@@ -1919,12 +1923,12 @@
         "id": "home.hide_announcements"
       },
       {
-        "defaultMessage": "Your home timeline is empty! Visit {public} or use search to get started and meet other users.",
+        "defaultMessage": "Your home timeline is empty! Follow more people to fill it up. {suggestions}",
         "id": "empty_column.home"
       },
       {
-        "defaultMessage": "the public timeline",
-        "id": "empty_column.home.public_timeline"
+        "defaultMessage": "See some suggestions",
+        "id": "empty_column.home.suggestions"
       }
     ],
     "path": "app/javascript/mastodon/features/home_timeline/index.json"
@@ -2417,7 +2421,7 @@
         "id": "notifications.mark_as_read"
       },
       {
-        "defaultMessage": "You don't have any notifications yet. Interact with others to start the conversation.",
+        "defaultMessage": "You don't have any notifications yet. When other people interact with you, you will see it here.",
         "id": "empty_column.notifications"
       }
     ],

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6753,6 +6753,17 @@ noscript {
       }
     }
 
+    .account__header__joined {
+      font-size: 14px;
+      padding: 5px 15px;
+      color: $darker-text-color;
+
+      .columns-area--mobile & {
+        padding-left: 20px;
+        padding-right: 20px;
+      }
+    }
+
     .account__header__fields {
       margin: 0;
       border-top: 1px solid lighten($ui-base-color, 12%);

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -13,7 +13,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
              :inbox, :outbox, :featured, :featured_tags,
              :preferred_username, :name, :summary,
              :url, :manually_approves_followers,
-             :discoverable
+             :discoverable, :published
 
   has_one :public_key, serializer: ActivityPub::PublicKeySerializer
 
@@ -156,6 +156,10 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
 
   def also_known_as?
     !object.suspended? && !object.also_known_as.empty?
+  end
+
+  def published
+    object.created_at.midnight.iso8601
   end
 
   class CustomEmojiSerializer < ActivityPub::EmojiSerializer

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -55,6 +55,10 @@ class REST::AccountSerializer < ActiveModel::Serializer
     full_asset_url(object.suspended? ? object.header.default_url : object.header_static_url)
   end
 
+  def created_at
+    object.created_at.midnight.iso8601
+  end
+
   def last_status_at
     object.last_status_at&.to_date&.iso8601
   end

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -87,6 +87,7 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.url                     = url || @uri
     @account.uri                     = @uri
     @account.actor_type              = actor_type
+    @account.created_at              = @json['published'] if @json['published'].present?
   end
 
   def set_immediate_attributes!
@@ -101,7 +102,7 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def set_fetchable_key!
-    @account.public_key        = public_key || ''
+    @account.public_key = public_key || ''
   end
 
   def set_fetchable_attributes!

--- a/spec/lib/activitypub/activity/update_spec.rb
+++ b/spec/lib/activitypub/activity/update_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ActivityPub::Activity::Update do
   end
 
   let(:modified_sender) do
-    sender.dup.tap do |modified_sender|
+    sender.tap do |modified_sender|
       modified_sender.display_name = 'Totally modified now'
     end
   end


### PR DESCRIPTION
- Federate the date (not time) of sign-up through `published` property in ActivityPub
- Fix REST API revealing the exact time of a local user's sign-up (date only)