### PR TITLE
Do not populate AccountSummaries and FollowRecommendation views on migration

### DIFF
--- a/db/migrate/20210322164601_create_account_summaries.rb
+++ b/db/migrate/20210322164601_create_account_summaries.rb
@@ -1,6 +1,6 @@
 class CreateAccountSummaries < ActiveRecord::Migration[5.2]
   def change
-    create_view :account_summaries, materialized: true
+    create_view :account_summaries, materialized: { no_data: true }
 
     # To be able to refresh the view concurrently,
     # at least one unique index is required

--- a/db/migrate/20210505174616_update_follow_recommendations_to_version_2.rb
+++ b/db/migrate/20210505174616_update_follow_recommendations_to_version_2.rb
@@ -4,7 +4,7 @@ class UpdateFollowRecommendationsToVersion2 < ActiveRecord::Migration[6.1]
 
   def up
     drop_view :follow_recommendations
-    create_view :follow_recommendations, version: 2, materialized: true
+    create_view :follow_recommendations, version: 2, materialized: { no_data: true }
 
     # To be able to refresh the view concurrently,
     # at least one unique index is required


### PR DESCRIPTION
Materializing those views can take a while, and they are currently refreshed anyway each time they are actually used, in the FollowRecommendationsScheduler.