### PR TITLE
Bump nodejs version requirement to node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tootsuite/mastodon",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=10.13"
+    "node": ">=12"
   },
   "scripts": {
     "postversion": "git push --tags",


### PR DESCRIPTION
One of our dependencies, yarg, now requires node 12 or later