### PR TITLE
Fix webfinger_update_due to run WebFinger on stale activitypub-account

### DIFF
--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -122,7 +122,7 @@ class ResolveAccountService < BaseService
     return false if @options[:check_delivery_availability] && !DeliveryFailureTracker.available?(@domain)
     return false if @options[:skip_webfinger]
 
-    @account.nil? || (@account.ostatus? && @account.possibly_stale?)
+    @account.nil? || @account.possibly_stale?
   end
 
   def activitypub_ready?


### PR DESCRIPTION
Fix https://github.com/tootsuite/mastodon/pull/9220

Other than ostatus-account, there was a problem that WebFinger of the existing account was not executed forever.

Please point out if you have any special intentions about ostatus-account.