### PR TITLE
Fix breaking change about format of accounts.created_at

### DIFF
--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -56,7 +56,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def created_at
-    object.created_at.midnight.iso8601
+    object.created_at.midnight.as_json
   end
 
   def last_status_at


### PR DESCRIPTION
> I think we should use `.as_json` instead of `.iso8601` because `.iso8601` breaks some implementations that parse created_at as `YYYY-MM-DD'T'HH:mm:ss.SSSZZZZZZ` (from @noellabo 's report https://fedibird.com/@noellabo/106197433762056061)
> related: https://github.com/imas/mastodon/pull/200

from my comment: https://github.com/tootsuite/mastodon/pull/16169#issuecomment-835050958