### PR TITLE
Add a Redis environment variable for sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 
-namespace    = ENV.fetch('REDIS_NAMESPACE') { nil }
-redis_params = { url: ENV['REDIS_URL'], driver: :hiredis }
-
-if namespace
-  redis_params[:namespace] = namespace
-end
-
 Sidekiq.configure_server do |config|
-  config.redis = redis_params
+  config.redis = REDIS_SIDEKIQ_PARAMS
 
   config.server_middleware do |chain|
     chain.add SidekiqErrorHandler
@@ -26,7 +19,7 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = redis_params
+  config.redis = REDIS_SIDEKIQ_PARAMS
 
   config.client_middleware do |chain|
     chain.add SidekiqUniqueJobs::Middleware::Client

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -22,13 +22,21 @@ end
 
 setup_redis_env_url
 setup_redis_env_url(:cache, false)
+setup_redis_env_url(:sidekiq, false)
 
-namespace       = ENV.fetch('REDIS_NAMESPACE', nil)
-cache_namespace = namespace ? namespace + '_cache' : 'cache'
+namespace         = ENV.fetch('REDIS_NAMESPACE', nil)
+cache_namespace   = namespace ? namespace + '_cache' : 'cache'
+sidekiq_namespace = namespace
 
 REDIS_CACHE_PARAMS = {
   driver: :hiredis,
   url: ENV['CACHE_REDIS_URL'],
   expires_in: 10.minutes,
   namespace: cache_namespace,
+}.freeze
+
+REDIS_SIDEKIQ_PARAMS = {
+  driver: :hiredis,
+  url: ENV['SIDEKIQ_REDIS_URL'],
+  namespace: sidekiq_namespace,
 }.freeze


### PR DESCRIPTION
Add an environment variable to configure a Redis server dedicated to Sidekiq.

- SIDEKIQ_REDIS_HOST
- SIDEKIQ_REDIS_PORT
- SIDEKIQ_REDIS_DB
- SIDEKIQ_REDIS_PASSWORD

or

- SIDEKIQ_REDIS_URL

If you want to separate Redis on a server that is already in operation, you need to migrate the key for Sidekiq to a new Redis. It includes, but is not limited to, the following keys:

```
dead
processes
queues
queue:*
retry
schedule
schedules
schedules_changed
sidekiq-scheduler:*
stat:*
uniquejobs:*
```

Alternatively, you can use the brand new Redis without migrating if you don't have to worry about past statistics or jobs being retried. Even so, it's a good idea to remove the key from your old Redis.