### PR TITLE
Fix FollowRecommendationsScheduler failing because of unpopulated views

### DIFF
--- a/app/models/account_summary.rb
+++ b/app/models/account_summary.rb
@@ -16,7 +16,7 @@ class AccountSummary < ApplicationRecord
   scope :filtered, -> { joins(arel_table.join(FollowRecommendationSuppression.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:account_id].eq(FollowRecommendationSuppression.arel_table[:account_id])).join_sources).where(FollowRecommendationSuppression.arel_table[:id].eq(nil)) }
 
   def self.refresh
-    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
+    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
   end
 
   def readonly?

--- a/app/models/follow_recommendation.rb
+++ b/app/models/follow_recommendation.rb
@@ -17,7 +17,7 @@ class FollowRecommendation < ApplicationRecord
   scope :localized, ->(locale) { joins(:account_summary).merge(AccountSummary.localized(locale)) }
 
   def self.refresh
-    Scenic.database.refresh_materialized_view(table_name, concurrently: true, cascade: false)
+    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
   end
 
   def readonly?


### PR DESCRIPTION
Since #16173, `account_summaries` and `follow_recommendations` are not populated at creation time, which causes concurrent refresh to fail.

As we currently only use those materialized views right after explicitly refreshing them, this commit changes refreshes to not be performed concurrently. This will fix the issue and ensure the refresh completes faster while using less resources.