### PR TITLE
Fix to be able to redownload avatar and header

### DIFF
--- a/app/models/concerns/account_avatar.rb
+++ b/app/models/concerns/account_avatar.rb
@@ -21,7 +21,7 @@ module AccountAvatar
     has_attached_file :avatar, styles: ->(f) { avatar_styles(f) }, convert_options: { all: '-strip' }, processors: [:lazy_thumbnail]
     validates_attachment_content_type :avatar, content_type: IMAGE_MIME_TYPES
     validates_attachment_size :avatar, less_than: LIMIT
-    remotable_attachment :avatar, LIMIT
+    remotable_attachment :avatar, LIMIT, suppress_errors: false
   end
 
   def avatar_original_url

--- a/app/models/concerns/account_header.rb
+++ b/app/models/concerns/account_header.rb
@@ -22,7 +22,7 @@ module AccountHeader
     has_attached_file :header, styles: ->(f) { header_styles(f) }, convert_options: { all: '-strip' }, processors: [:lazy_thumbnail]
     validates_attachment_content_type :header, content_type: IMAGE_MIME_TYPES
     validates_attachment_size :header, less_than: LIMIT
-    remotable_attachment :header, LIMIT
+    remotable_attachment :header, LIMIT, suppress_errors: false
   end
 
   def header_original_url

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -28,9 +28,11 @@ module Remotable
           end
         rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, OpenSSL::SSL::SSLError => e
           Rails.logger.debug "Error fetching remote #{attachment_name}: #{e}"
+          public_send("#{attachment_name}=", nil) if public_send("#{attachment_name}_file_name").present?
           raise e unless suppress_errors
         rescue Paperclip::Errors::NotIdentifiedByImageMagickError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, Paperclip::Error, Mastodon::DimensionsValidationError, Mastodon::StreamValidationError => e
           Rails.logger.debug "Error fetching remote #{attachment_name}: #{e}"
+          public_send("#{attachment_name}=", nil) if public_send("#{attachment_name}_file_name").present?
         end
 
         nil

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -106,8 +106,16 @@ class ActivityPub::ProcessAccountService < BaseService
   end
 
   def set_fetchable_attributes!
-    @account.avatar_remote_url = image_url('icon')  || '' unless skip_download?
-    @account.header_remote_url = image_url('image') || '' unless skip_download?
+    begin
+      @account.avatar_remote_url = image_url('icon') || '' unless skip_download?
+    rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, OpenSSL::SSL::SSLError
+      RedownloadAvatarWorker.perform_in(rand(30..600).seconds, @account.id)
+    end
+    begin
+      @account.header_remote_url = image_url('image') || '' unless skip_download?
+    rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, OpenSSL::SSL::SSLError
+      RedownloadHeaderWorker.perform_in(rand(30..600).seconds, @account.id)
+    end
     @account.statuses_count    = outbox_total_items    if outbox_total_items.present?
     @account.following_count   = following_total_items if following_total_items.present?
     @account.followers_count   = followers_total_items if followers_total_items.present?

--- a/app/workers/redownload_avatar_worker.rb
+++ b/app/workers/redownload_avatar_worker.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RedownloadAvatarWorker
+  include Sidekiq::Worker
+  include ExponentialBackoff
+  include JsonLdHelper
+
+  sidekiq_options queue: 'pull', retry: 7
+
+  def perform(id)
+    account = Account.find(id)
+
+    return if account.suspended? || DomainBlock.rule_for(account.domain)&.reject_media?
+    return if account.avatar_remote_url.blank? || account.avatar_file_name.present?
+
+    account.reset_avatar!
+    account.save!
+  rescue ActiveRecord::RecordNotFound
+    # Do nothing
+  rescue Mastodon::UnexpectedResponseError => e
+    response = e.response
+
+    if response_error_unsalvageable?(response)
+      # Give up
+    else
+      raise e
+    end
+  end
+end

--- a/app/workers/redownload_header_worker.rb
+++ b/app/workers/redownload_header_worker.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RedownloadHeaderWorker
+  include Sidekiq::Worker
+  include ExponentialBackoff
+  include JsonLdHelper
+
+  sidekiq_options queue: 'pull', retry: 7
+
+  def perform(id)
+    account = Account.find(id)
+
+    return if account.suspended? || DomainBlock.rule_for(account.domain)&.reject_media?
+    return if account.header_remote_url.blank? || account.header_file_name.present?
+
+    account.reset_header!
+    account.save!
+  rescue ActiveRecord::RecordNotFound
+    # Do nothing
+  rescue Mastodon::UnexpectedResponseError => e
+    response = e.response
+
+    if response_error_unsalvageable?(response)
+      # Give up
+    else
+      raise e
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/tootsuite/mastodon/pull/15477 Take 2.

If the acquisition of avatar and header fails, the already acquired image will be discarded. This solves the problem that you can't update your avatar because you're holding the wrong image.

Perform RedownloadAvatarWorker and RedownloadHeaderWorker if you cannot get the avatar or header from the specified url due to a media server issue when updating your account information.

The Worker will retry 7 times. This is about a day. From the next day onward, when the account information is referenced, the old account information will be updated, so there will be a chance that the image will be updated again.