### PR TITLE
Fix blocking someone not clearing up list feeds

### DIFF
--- a/app/lib/feed_manager.rb
+++ b/app/lib/feed_manager.rb
@@ -194,6 +194,36 @@ class FeedManager
     end
   end
 
+  # Clear all statuses from or mentioning target_account from a list feed
+  # @param [List] list
+  # @param [Account] target_account
+  # @return [void]
+  def clear_from_list(list, target_account)
+    timeline_key        = key(:list, list.id)
+    timeline_status_ids = redis.zrange(timeline_key, 0, -1)
+    statuses            = Status.where(id: timeline_status_ids).select(:id, :reblog_of_id, :account_id).to_a
+    reblogged_ids       = Status.where(id: statuses.map(&:reblog_of_id).compact, account: target_account).pluck(:id)
+    with_mentions_ids   = Mention.active.where(status_id: statuses.flat_map { |s| [s.id, s.reblog_of_id] }.compact, account: target_account).pluck(:status_id)
+
+    target_statuses = statuses.select do |status|
+      status.account_id == target_account.id || reblogged_ids.include?(status.reblog_of_id) || with_mentions_ids.include?(status.id) || with_mentions_ids.include?(status.reblog_of_id)
+    end
+
+    target_statuses.each do |status|
+      unpush_from_list(list, status)
+    end
+  end
+
+  # Clear all statuses from or mentioning target_account from an account's lists
+  # @param [Account] account
+  # @param [Account] target_account
+  # @return [void]
+  def clear_from_lists(account, target_account)
+    List.where(account: account).each do |list|
+      clear_from_list(list, target_account)
+    end
+  end
+
   # Populate home feed of account from scratch
   # @param [Account] account
   # @return [void]

--- a/app/services/after_block_service.rb
+++ b/app/services/after_block_service.rb
@@ -6,6 +6,7 @@ class AfterBlockService < BaseService
     @target_account = target_account
 
     clear_home_feed!
+    clear_list_feeds!
     clear_notifications!
     clear_conversations!
   end
@@ -14,6 +15,10 @@ class AfterBlockService < BaseService
 
   def clear_home_feed!
     FeedManager.instance.clear_from_home(@account, @target_account)
+  end
+
+  def clear_list_feeds!
+    FeedManager.instance.clear_from_lists(@account, @target_account)
   end
 
   def clear_conversations!

--- a/spec/services/after_block_service_spec.rb
+++ b/spec/services/after_block_service_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe AfterBlockService, type: :service do
     -> { described_class.new.call(account, target_account) }
   end
 
-  let(:account) { Fabricate(:account) }
-  let(:target_account) { Fabricate(:account) }
+  let(:account)              { Fabricate(:account) }
+  let(:target_account)       { Fabricate(:account) }
+  let(:status)               { Fabricate(:status, account: target_account) }
+  let(:other_status)         { Fabricate(:status, account: target_account) }
+  let(:other_account_status) { Fabricate(:status) }
+  let(:other_account_reblog) { Fabricate(:status, reblog_of_id: other_status.id) }
 
   describe 'home timeline' do
-    let(:status) { Fabricate(:status, account: target_account) }
-    let(:other_account_status) { Fabricate(:status) }
     let(:home_timeline_key) { FeedManager.instance.key(:home, account.id) }
 
     before do
@@ -20,10 +22,30 @@ RSpec.describe AfterBlockService, type: :service do
     it "clears account's statuses" do
       FeedManager.instance.push_to_home(account, status)
       FeedManager.instance.push_to_home(account, other_account_status)
+      FeedManager.instance.push_to_home(account, other_account_reblog)
 
       is_expected.to change {
         Redis.current.zrange(home_timeline_key, 0, -1)
-      }.from([status.id.to_s, other_account_status.id.to_s]).to([other_account_status.id.to_s])
+      }.from([status.id.to_s, other_account_status.id.to_s, other_account_reblog.id.to_s]).to([other_account_status.id.to_s])
+    end
+  end
+
+  describe 'lists' do
+    let(:list)              { Fabricate(:list, account: account) }
+    let(:list_timeline_key) { FeedManager.instance.key(:list, list.id) }
+
+    before do
+      Redis.current.del(list_timeline_key)
+    end
+
+    it "clears account's statuses" do
+      FeedManager.instance.push_to_list(list, status)
+      FeedManager.instance.push_to_list(list, other_account_status)
+      FeedManager.instance.push_to_list(list, other_account_reblog)
+
+      is_expected.to change {
+        Redis.current.zrange(list_timeline_key, 0, -1)
+      }.from([status.id.to_s, other_account_status.id.to_s, other_account_reblog.id.to_s]).to([other_account_status.id.to_s])
     end
   end
 end


### PR DESCRIPTION
Currently, blocking someone ensures their toots (boosted or otherwise) are retroactively removed from the Home timeline, but it does not clean up lists.

This PR fixes that, applying the same retroactive clean up to list timelines when blocking someone.