### PR TITLE
Local development setup using Docker and Makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ public/packs
 node_modules
 neo4j
 vendor/bundle
+vendor/cache
 .DS_Store
 *.swp
 *~
@@ -18,3 +19,5 @@ postgres
 redis
 elasticsearch
 chart
+.git
+.cache

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,9 @@
+LOCAL_DOMAIN=mastodon.local
+WEB_DOMAIN=localhost:3000
+
+DB_HOST=db
+DB_USER=mastodon
+DB_NAME=mastodon
+DB_PASS=mastodon
+
+REDIS_HOST=redis

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 # Ignore bundler config and downloaded libraries.
 /.bundle
 /vendor/bundle
+/vendor/cache
+
+# Ignore yarn config and downloaded libraries.
+/node_modules/
+/.cache/
+/.yarn/
 
 # Ignore the default SQLite database.
 /db/*.sqlite3
@@ -25,8 +31,8 @@
 .env
 .env.production
 .env.development
-/node_modules/
 /build/
+.docker-db-initialized
 
 # Ignore Vagrant files
 .vagrant/
@@ -42,7 +48,6 @@
 /postgres
 /redis
 /elasticsearch
-
 # ignore Helm dependency charts
 /chart/charts/*.tgz
 

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+# Yarn constantly fails on this causing long timeouts after successful installs
+disable-self-update-check true

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,47 +17,47 @@ RUN ARCH= && \
     *) echo "unsupported architecture"; exit 1 ;; \
   esac && \
     echo "Etc/UTC" > /etc/localtime && \
-	apt-get update && \
-	apt-get install -y --no-install-recommends ca-certificates wget python && \
-	cd ~ && \
-	wget -q https://nodejs.org/download/release/v$NODE_VER/node-v$NODE_VER-linux-$ARCH.tar.gz && \
-	tar xf node-v$NODE_VER-linux-$ARCH.tar.gz && \
-	rm node-v$NODE_VER-linux-$ARCH.tar.gz && \
-	mv node-v$NODE_VER-linux-$ARCH /opt/node
+  apt-get update && \
+  apt-get install -y --no-install-recommends ca-certificates wget python && \
+  cd ~ && \
+  wget -q https://nodejs.org/download/release/v$NODE_VER/node-v$NODE_VER-linux-$ARCH.tar.gz && \
+  tar xf node-v$NODE_VER-linux-$ARCH.tar.gz && \
+  rm node-v$NODE_VER-linux-$ARCH.tar.gz && \
+  mv node-v$NODE_VER-linux-$ARCH /opt/node
 
 # Install Ruby
 ENV RUBY_VER="2.7.2"
 RUN apt-get update && \
   apt-get install -y --no-install-recommends build-essential \
     bison libyaml-dev libgdbm-dev libreadline-dev libjemalloc-dev \
-		libncurses5-dev libffi-dev zlib1g-dev libssl-dev && \
-	cd ~ && \
-	wget https://cache.ruby-lang.org/pub/ruby/${RUBY_VER%.*}/ruby-$RUBY_VER.tar.gz && \
-	tar xf ruby-$RUBY_VER.tar.gz && \
-	cd ruby-$RUBY_VER && \
-	./configure --prefix=/opt/ruby \
-	  --with-jemalloc \
-	  --with-shared \
-	  --disable-install-doc && \
-	make -j"$(nproc)" > /dev/null && \
-	make install && \
-	rm -rf ../ruby-$RUBY_VER.tar.gz ../ruby-$RUBY_VER
+    libncurses5-dev libffi-dev zlib1g-dev libssl-dev && \
+  cd ~ && \
+  wget https://cache.ruby-lang.org/pub/ruby/${RUBY_VER%.*}/ruby-$RUBY_VER.tar.gz && \
+  tar xf ruby-$RUBY_VER.tar.gz && \
+  cd ruby-$RUBY_VER && \
+    ./configure --prefix=/opt/ruby \
+    --with-jemalloc \
+    --with-shared \
+    --disable-install-doc && \
+  make -j"$(nproc)" > /dev/null && \
+  make install && \
+  rm -rf ../ruby-$RUBY_VER.tar.gz ../ruby-$RUBY_VER
 
 ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin"
 
 RUN npm install -g yarn && \
-	gem install bundler && \
-	apt-get update && \
-	apt-get install -y --no-install-recommends git libicu-dev libidn11-dev \
-	libpq-dev libprotobuf-dev protobuf-compiler shared-mime-info
+  gem install bundler && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends git libicu-dev libidn11-dev \
+  libpq-dev libprotobuf-dev protobuf-compiler shared-mime-info
 
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
 RUN cd /opt/mastodon && \
   bundle config set deployment 'true' && \
   bundle config set without 'development test' && \
-	bundle install -j"$(nproc)" && \
-	yarn install --pure-lockfile
+  bundle install -j"$(nproc)" && \
+  yarn install --pure-lockfile
 
 FROM ubuntu:20.04
 
@@ -73,23 +73,23 @@ ARG UID=991
 ARG GID=991
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
-	echo "Etc/UTC" > /etc/localtime && \
-	apt-get install -y --no-install-recommends whois wget && \
-	addgroup --gid $GID mastodon && \
-	useradd -m -u $UID -g $GID -d /opt/mastodon mastodon && \
-	echo "mastodon:$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256)" | chpasswd && \
-	rm -rf /var/lib/apt/lists/*
+  echo "Etc/UTC" > /etc/localtime && \
+  apt-get install -y --no-install-recommends whois wget && \
+  addgroup --gid $GID mastodon && \
+  useradd -m -u $UID -g $GID -d /opt/mastodon mastodon && \
+  echo "mastodon:$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 24 | mkpasswd -s -m sha-256)" | chpasswd && \
+  rm -rf /var/lib/apt/lists/*
 
 # Install mastodon runtime deps
 RUN apt-get update && \
   apt-get -y --no-install-recommends install \
-	  libssl1.1 libpq5 imagemagick ffmpeg libjemalloc2 \
-	  libicu66 libprotobuf17 libidn11 libyaml-0-2 \
-	  file ca-certificates tzdata libreadline8 gcc tini && \
-	ln -s /opt/mastodon /mastodon && \
-	gem install bundler && \
-	rm -rf /var/cache && \
-	rm -rf /var/lib/apt/lists/*
+    libssl1.1 libpq5 imagemagick ffmpeg libjemalloc2 \
+    libicu66 libprotobuf17 libidn11 libyaml-0-2 \
+    file ca-certificates tzdata libreadline8 gcc tini && \
+  ln -s /opt/mastodon /mastodon && \
+  gem install bundler && \
+  rm -rf /var/cache && \
+  rm -rf /var/lib/apt/lists/*
 
 # Copy over mastodon source, and dependencies from building, and set permissions
 COPY --chown=mastodon:mastodon . /opt/mastodon
@@ -108,8 +108,8 @@ USER mastodon
 
 # Precompile assets
 RUN cd ~ && \
-	OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile && \
-	yarn cache clean
+  OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile && \
+  yarn cache clean
 
 # Set the work dir and the container entry point
 WORKDIR /opt/mastodon

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+DOCKER_IMAGE_DEV ?= "tootsuite/mastodon:development"
+DOCKER_IMAGE_PROD ?= "tootsuite/mastodon:production"
+DOCKER_PROJECT = $(shell basename "$$PWD")
+UNAME_S := $(shell uname -s)
+UID ?= "991"
+GID ?= "991"
+NPROC = 1
+
+# Hide the annoying docker snyk ad
+export DOCKER_SCAN_SUGGEST=false
+
+ifeq ($(UNAME_S),Linux)
+	NPROC = $(shell nproc)
+	UID=`id -u ${USER}`
+	GID=`id -g ${USER}`
+endif
+ifeq ($(UNAME_S),Darwin)
+	NPROC = $(shell sysctl -n hw.ncpu)
+endif
+
+up:
+ifeq (,$(wildcard .docker-db-initialized))
+	@echo "Database has not been initialized, running init script..."
+	make init
+else
+	make install
+endif
+	docker-compose -f docker-compose.local.yml up
+
+init: install
+	docker-compose -f docker-compose.local.yml run --rm sidekiq bash -c "\
+		bundle exec rails db:environment:set RAILS_ENV=development &&\
+		bundle exec rails db:setup RAILS_ENV=development &&\
+		bundle exec rails db:migrate RAILS_ENV=development"
+	docker-compose -f docker-compose.local.yml down
+	touch .docker-db-initialized
+	@echo "\nMastodon initialization finished! You can now start all containers using: $ make up"
+
+down:
+	docker-compose -f docker-compose.local.yml down
+
+clean:
+	docker-compose -f docker-compose.local.yml down
+	docker volume rm -f $(DOCKER_PROJECT)_db $(DOCKER_PROJECT)_redis
+	rm .docker-db-initialized
+
+
+install: build-development
+	docker-compose -f docker-compose.local.yml down
+	docker-compose -f docker-compose.local.yml up -d db
+	docker-compose -f docker-compose.local.yml run --rm webpack bash -c "\
+		bundle install -j$(NPROC) && \
+		yarn install --pure-lockfile"
+
+build-development:
+	DOCKER_BUILDKIT=1 \
+	docker build --target development \
+		--build-arg UID=$(UID) \
+		--build-arg GID=$(GID) \
+		--tag $(DOCKER_IMAGE_DEV) .
+
+build-production:
+	DOCKER_BUILDKIT=1 \
+	docker build --target production \
+		--tag $(DOCKER_IMAGE_PROD) .

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ The repository includes deployment configurations for **Docker and docker-compos
 
 A **Vagrant** configuration is included for development purposes.
 
+A **Docker** setup for local development is also included, start it using `make up`.
+
 ## Contributing
 
 Mastodon is **free, open-source software** licensed under **AGPLv3**.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -29,8 +29,10 @@ Rails.application.config.content_security_policy do |p|
 
   if Rails.env.development?
     webpacker_urls = %w(ws http).map { |protocol| "#{protocol}#{Webpacker.dev_server.https? ? 's' : ''}://#{Webpacker.dev_server.host_with_port}" }
+    # TODO: get these from webpack.yml config key: public
+    webpacker_public_urls = 'http://localhost:3035', 'ws://localhost:3035'
 
-    p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url, *webpacker_urls
+    p.connect_src :self, :data, :blob, assets_host, media_host, Rails.configuration.x.streaming_api_base_url, *webpacker_urls, *webpacker_public_urls
     p.script_src  :self, :unsafe_inline, :unsafe_eval, assets_host
     p.child_src   :self, :blob, assets_host
     p.worker_src  :self, :blob, assets_host

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -55,7 +55,7 @@ development:
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
     https: false
-    host: localhost
+    host: webpack # TODO this change will break vagrant!
     port: 3035
     public: localhost:3035
     hmr: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -177,7 +177,7 @@ ActiveRecord::Schema.define(version: 2021_05_26_193025) do
     t.integer "suspension_origin"
     t.datetime "sensitized_at"
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
-    t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
+    t.index "lower((username)::text), (COALESCE(lower((domain)::text), ''::text))", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["moved_to_account_id"], name: "index_accounts_on_moved_to_account_id"
     t.index ["uri"], name: "index_accounts_on_uri"
     t.index ["url"], name: "index_accounts_on_url"

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,95 @@
+version: '3.5'
+# This docker setup is for local development and NOT intended for production use!
+
+volumes:
+  db:
+  redis:
+
+services:
+
+  db:
+    restart: unless-stopped
+    image: postgres:9.6-alpine
+    shm_size: 256mb
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "mastodon"]
+    volumes:
+      - db:/var/lib/postgresql/data
+    environment:
+      # Disable authentication  https://www.postgresql.org/docs/current/auth-trust.html
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: mastodon
+      POSTGRES_PASSWORD: mastodon
+
+  redis:
+    restart: unless-stopped
+    image: redis:6.0-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+    volumes:
+      - redis:/data
+
+  web:
+    build:
+      context: .
+      target: development
+    image: tootsuite/mastodon:development
+    restart: unless-stopped
+    env_file: .env.local
+    command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -b 0.0.0.0 -p 3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider --proxy=off localhost:3000/health || exit 1"]
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on:
+      - db
+      - redis
+      - webpack
+#      - es
+    volumes:
+      - .:/mastodon:delegated
+
+  webpack:
+    build:
+      context: .
+      target: development
+    image: tootsuite/mastodon:development
+    restart: unless-stopped
+    env_file: .env.local
+    command: ./bin/webpack-dev-server --listen-host 0.0.0.0
+    ports:
+      - "127.0.0.1:3035:3035"
+    volumes:
+      - .:/mastodon:delegated
+
+  streaming:
+    build:
+      context: .
+      target: development
+    image: tootsuite/mastodon:development
+    restart: unless-stopped
+    env_file: .env.local
+    command: node ./streaming
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider --proxy=off localhost:4000/api/v1/streaming/health || exit 1"]
+    ports:
+      - "127.0.0.1:4000:4000"
+    depends_on:
+      - db
+      - redis
+    volumes:
+      - .:/mastodon:delegated
+
+  sidekiq:
+    build:
+      context: .
+      target: development
+    image: tootsuite/mastodon:development
+    restart: unless-stopped
+    env_file: .env.local
+    command: bundle exec sidekiq
+    depends_on:
+      - db
+      - redis
+    volumes:
+      - .:/mastodon:delegated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 version: '3'
+# This docker setup is an example file for production use
+
 services:
 
   db:


### PR DESCRIPTION
This adds a Docker setup to work locally for development. It now requires Docker version 18.09 or later that supports BuildKit and you also need the "make" tool for using the Makefile commands.

Changes summary:
- Adds stages to the Dockerfile for the development build while still keeping production the default
- Adds fancy Docker Buildkit cache mounts to the Dockerfile for speeding up apt installs
- Adds a docker-compose.local.yml file used for local dev environment
- Adds a Makefile for short and easy commands that initialize the database and start the local environment
- It should not interfere with the current docker-compose.yml used for production
- It should not interfere with the current vagrant setup used for local development

We are using this setup to work on Mastodon/Hometown in our small collective and see the following benefits:
- On Linux and Windows WSL hosts this is much much faster than the Vagrant VM based approach
- We are now using (almost) the same Docker image in both local, staging and production environments
- It is really fast to start and stop while checking out different commits to test and init a clean database when needed
- If this works well for everyone, then there is no need to maintain the separate Vagrant setup anymore

Any thoughts or feedback appreciated :relaxed: 

## Instructions

### Installation
1. Install make
  Mac: `brew install make`
  Ubuntu: `sudo apt install make`
  Windows: https://stackoverflow.com/questions/32127524/how-to-install-and-use-make-in-windows
2. Install Docker
  Ubuntu: https://docs.docker.com/engine/install/ubuntu/
  Mac/Windows: https://www.docker.com/products/docker-desktop
3. Make sure that docker is correctly set up in your environment. This command should print an empty list of containers that are running:
  `$ docker ps`
  If that command gives you an error, resolve that using standard Docker guides _before continuing_. The command should not require sudo, if it does, your setup is not working correctly.

### Usage
1. Initialize the project and start the containers
  `$ make up`
   The first time this build can take up to 30 minutes depending on your machine.
   Wait until all services has started and webpack says it has compiled all resources.
2. Then you can access Hometown on http://localhost:3000
3. Press CTRL-C to stop the services.
4. To start it again next time, run the same command. 
   Dependencies are updated and containers rebuilt as needed.
   `$ make up`
5. Want to start over with a clean dev environment? 
   Run 'clean' to stop everything and delete all databases.
   `$ make clean`


## TODO
Currently these changes will likely break webpack in the Vagrant setup cause I had to change the host in `config/webpacker.yml`. That should be possible to solve with a dynamic variable by someone more experienced with Ruby than me :)

- [ ] Make webpacker dev server work with both vagrant host and docker host https://github.com/tootsuite/mastodon/pull/16211/files#diff-46b7721b943217c3670f6818a10c2661ec1f9f72dfea66469fd9f026dc74c36a
- [ ] Load webpacker public URL dynamically https://github.com/tootsuite/mastodon/pull/16211/files#diff-c1c619ffb7b249550067cb696b8e7d6c29d1efe2ed4cf5b7a8bb6bed47b409d1