### PR TITLE
Fix eslint error

### DIFF
--- a/app/javascript/mastodon/actions/boosts.js
+++ b/app/javascript/mastodon/actions/boosts.js
@@ -11,7 +11,7 @@ export function initBoostModal(props) {
 
     dispatch({
       type: BOOSTS_INIT_MODAL,
-      privacy
+      privacy,
     });
 
     dispatch(openModal('BOOST', props));

--- a/app/javascript/mastodon/features/notifications/containers/notification_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/notification_container.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 import { makeGetNotification, makeGetStatus } from '../../../selectors';
 import Notification from '../components/notification';
 import { initBoostModal } from '../../../actions/boosts';
-import { openModal } from '../../../actions/modal';
 import { mentionCompose } from '../../../actions/compose';
 import {
   reblog,


### PR DESCRIPTION
```
$ eslint --ext=js . --cache

/__w/mastodon/mastodon/app/javascript/mastodon/actions/boosts.js
  14:14  error  Missing trailing comma  comma-dangle

/__w/mastodon/mastodon/app/javascript/mastodon/features/notifications/containers/notification_container.js
  5:10  error  'openModal' is defined but never used  no-unused-vars

✖ 2 problems (2 errors, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```