### PR TITLE
Fix rubocop warning

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -46,7 +46,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     return reject_payload! if unsupported_object_type? || invalid_origin?(object_uri) || tombstone_exists? || !related_to_local_activity?
 
     lock_or_fail("create:#{object_uri}") do
-      return if delete_arrived_first?(object_uri) || poll_vote? # rubocop:disable Lint/NonLocalExitFromIterator
+      return if delete_arrived_first?(object_uri) || poll_vote?
 
       @status = find_existing_status
 


### PR DESCRIPTION
With the rubocop update, this disabling comment is no longer necessary.

```bash
$ bundle exec rubocop --fail-level W --display-only-fail-level-offenses --parallel
Inspecting 764 files
..............................................................................................................................................................................................................................................W.............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Offenses:

app/lib/activitypub/activity/create.rb:49:65: W: [Correctable] Lint/RedundantCopDisableDirective: Unnecessary disabling of Lint/NonLocalExitFromIterator.
      return if delete_arrived_first?(object_uri) || poll_vote? # rubocop:disable Lint/NonLocalExitFromIterator
                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

764 files inspected, 1 offense detected, 1 offense auto-correctable
```
