### PR TITLE
Fix follow recommendations UI in advanced layout

### DIFF
--- a/app/javascript/mastodon/features/follow_recommendations/index.js
+++ b/app/javascript/mastodon/features/follow_recommendations/index.js
@@ -76,7 +76,7 @@ class FollowRecommendations extends ImmutablePureComponent {
 
     return (
       <Column>
-        <div className='scrollable'>
+        <div className='scrollable follow-recommendations-container'>
           <div className='column-title'>
             <Logo />
             <h3><FormattedMessage id='follow_recommendations.heading' defaultMessage="Follow people you'd like to see posts from! Here are some suggestions." /></h3>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2508,13 +2508,20 @@ a.account__display-name {
   }
 }
 
+.follow-recommendations-container {
+  display: flex;
+  flex-direction: column;
+}
+
 .column-actions {
   display: flex;
-  align-items: center;
+  align-items: start;
   justify-content: center;
   padding: 40px;
   padding-top: 40px;
   padding-bottom: 200px;
+  flex-grow: 1;
+  position: relative;
 
   &__background {
     position: absolute;


### PR DESCRIPTION
In the advanced layout, the mascot background in `/web/start` (accessible by going manually to `/web/start` or from the default empty TL message) initially appears at the bottom of the visible area of the column, obscuring its contents, and scrolls with it.

This PR tweaks the CSS to fix that issue.

## Before


https://user-images.githubusercontent.com/384364/117811646-17744600-b261-11eb-9b8c-aaa81aa973f9.mp4

## After


https://user-images.githubusercontent.com/384364/117811665-1e02bd80-b261-11eb-8dfa-72817c562a6e.mp4
