### PR TITLE
Increase resolution of created_at and Actor.published to 1-minute level

### DIFF
--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -159,7 +159,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
   end
 
   def published
-    object.created_at.midnight.iso8601
+    object.created_at.beginning_of_minute.iso8601
   end
 
   class CustomEmojiSerializer < ActivityPub::EmojiSerializer

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -56,7 +56,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def created_at
-    object.created_at.midnight.as_json
+    object.created_at.beginning_of_minute.as_json
   end
 
   def last_status_at


### PR DESCRIPTION
@Gargron decreased created_at resolution to 1-day level for protect privacy in #16169 .

but this doesn't work for newer accounts (because newer accounts are using timestamp-based "snowflake" ID, so we can count backward to timestamp from ID), and older accounts also can estimate by created_at of first post. and 1-day level resolution has other issue e.g. time-zone related issues.

**Why did you choose 1-minute level?** because I think 1-second (or millisecond) level created_at is hard to estimate, but 1-minute level created_at is easier than 1-second level.

I also considered 10-minute level, but 10-minute level is hard to create UI. I think `Joined at 2021/05/12 10:2X` is not supported in many formatters.