### PR TITLE
Update fix-duplicates maintenance script to support latest migrations

### DIFF
--- a/app/models/concerns/account_merging.rb
+++ b/app/models/concerns/account_merging.rb
@@ -15,7 +15,7 @@ module AccountMerging
       Status, StatusPin, MediaAttachment, Poll, Report, Tombstone, Favourite,
       Follow, FollowRequest, Block, Mute, AccountIdentityProof,
       AccountModerationNote, AccountPin, AccountStat, ListAccount,
-      PollVote, Mention, AccountDeletionRequest, AccountNote
+      PollVote, Mention, AccountDeletionRequest, AccountNote, FollowRecommendationSuppression
     ]
 
     owned_classes.each do |klass|
@@ -41,6 +41,10 @@ module AccountMerging
           next
         end
       end
+    end
+
+    CanonicalEmailBlock.where(reference_account_id: other_account.id).find_each do |record|
+      record.update_attribute(:reference_account_id, id)
     end
 
     # Some follow relationships have moved, so the cache is stale

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -14,7 +14,7 @@ module Mastodon
     end
 
     MIN_SUPPORTED_VERSION = 2019_10_01_213028
-    MAX_SUPPORTED_VERSION = 2021_03_08_133107
+    MAX_SUPPORTED_VERSION = 2021_05_07_001928
 
     # Stubs to enjoy ActiveRecord queries while not depending on a particular
     # version of the code/database
@@ -42,6 +42,8 @@ module Mastodon
     class CustomEmojiCategory < ApplicationRecord; end
     class Bookmark < ApplicationRecord; end
     class WebauthnCredential < ApplicationRecord; end
+    class FollowRecommendationSuppression < ApplicationRecord; end
+    class CanonicalEmailBlock < ApplicationRecord; end
 
     class PreviewCard < ApplicationRecord
       self.inheritance_column = false
@@ -88,6 +90,7 @@ module Mastodon
         ]
         owned_classes << AccountDeletionRequest if ActiveRecord::Base.connection.table_exists?(:account_deletion_requests)
         owned_classes << AccountNote if ActiveRecord::Base.connection.table_exists?(:account_notes)
+        owned_classes << FollowRecommendationSuppression if ActiveRecord::Base.connection.table_exists?(:follow_recommendation_suppressions)
 
         owned_classes.each do |klass|
           klass.where(account_id: other_account.id).find_each do |record|
@@ -109,6 +112,12 @@ module Mastodon
             rescue ActiveRecord::RecordNotUnique
               next
             end
+          end
+        end
+
+        if ActiveRecord::Base.connection.table_exists?(:canonical_email_blocks)
+          CanonicalEmailBlock.where(reference_account_id: other_account.id).find_each do |record|
+            record.update_attribute(:reference_account_id, id)
           end
         end
       end
@@ -466,6 +475,11 @@ module Mastodon
 
       @prompt.say 'Restoring tags indexes…'
       ActiveRecord::Base.connection.add_index :tags, 'lower((name)::text)', name: 'index_tags_on_name_lower', unique: true
+
+      if ActiveRecord::Base.connection.indexes(:tags).any? { |i| i.name == 'index_tags_on_name_lower_btree' }
+        @prompt.say 'Reindexing textual indexes on tags…'
+        ActiveRecord::Base.connection.execute('REINDEX INDEX index_tags_on_name_lower_btree;')
+      end
     end
 
     def deduplicate_webauthn_credentials!


### PR DESCRIPTION
Update `tootctl maintenance fix-duplicates` to work on databases up to version 20210507001928 (latest schema version as of 3.4.0rc2).

Also update similar code in `Account#merge_with!`.