### PR TITLE
Fix docker service host names

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -12,12 +12,12 @@ LOCAL_DOMAIN=example.com
 
 # Redis
 # -----
-REDIS_HOST=localhost
+REDIS_HOST=redis
 REDIS_PORT=6379
 
 # PostgreSQL
 # ----------
-DB_HOST=/var/run/postgresql
+DB_HOST=db
 DB_USER=mastodon
 DB_NAME=mastodon_production
 DB_PASS=
@@ -26,7 +26,7 @@ DB_PORT=5432
 # ElasticSearch (optional)
 # ------------------------
 ES_ENABLED=true
-ES_HOST=localhost
+ES_HOST=es
 ES_PORT=9200
 
 # Secrets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     networks:
       - internal_network
     healthcheck:
-      test: ["CMD", "bash", "-c", "pg_isready -U $$DB_USER $$DB_NAME"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
     volumes:
       - ./postgres:/var/lib/postgresql/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,15 @@ services:
     restart: always
     image: postgres:9.6-alpine
     shm_size: 256mb
+    env_file: .env.production
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_HOST_AUTH_METHOD: trust
     networks:
       - internal_network
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "postgres"]
+      test: ["CMD", "pg_isready", "-U", "${DB_NAME}"]
     volumes:
       - ./postgres:/var/lib/postgresql/data
 
@@ -46,7 +51,7 @@ services:
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
-    command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000"
+    command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails db:migrate ; bundle exec rails db:seed; bundle exec rails s -p 3000"
     networks:
       - external_network
       - internal_network
@@ -92,6 +97,7 @@ services:
       - internal_network
     volumes:
       - ./public/system:/mastodon/public/system
+
 ## Uncomment to enable federation with tor instances along with adding the following ENV variables
 ## http_proxy=http://privoxy:8118
 ## ALLOW_ACCESS_TO_HIDDEN_SERVICE=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,18 @@ services:
     image: postgres:9.6-alpine
     shm_size: 256mb
     env_file: .env.production
+    command: ["postgres"]
+    entrypoint:
+      - bash
+      - -c
+      - "POSTGRES_USER=$$DB_USER POSTGRES_DB=$$DB_NAME docker-entrypoint.sh $$@"
+      - "--"
     environment:
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_DB: ${DB_NAME}
       POSTGRES_HOST_AUTH_METHOD: trust
     networks:
       - internal_network
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${DB_NAME}"]
+      test: ["CMD", "bash", "-c", "pg_isready -U $$DB_USER $$DB_NAME"]
     volumes:
       - ./postgres:/var/lib/postgresql/data
 


### PR DESCRIPTION
This PR fixes some small bugs in the docker-compose file . Its details are given below.

1. Current docker-compose file doesn't use correct Hostnames for various services including database, Redis & Elasticsearch. This PR fixes this issue.
2. The database service in current docker file does not respect  `$DB_USER` and `$DB_NAME` variables defined in the `env` file. This issue is fixed by re-exporting the correct variable by taking value from existing variables.
3. Current docker-compose file doesn't automate the process of database migration while starting the services. This PR fixes that too


All the above changes are tested and I verified its working in a server environment. 

Fixes #16135 , #15724 , #14670