### PR TITLE
[Feature] add a stand-alone smtp mail service for sending emails in docker-compose

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -45,11 +45,18 @@ VAPID_PUBLIC_KEY=
 
 # Sending mail
 # ------------
-SMTP_SERVER=smtp.mailgun.org
-SMTP_PORT=587
+SMTP_SERVER=postfix
+SMTP_PORT=25
 SMTP_LOGIN=
 SMTP_PASSWORD=
 SMTP_FROM_ADDRESS=notificatons@example.com
+
+# Postfix mail server configurations
+# ------------
+POSTFIX_myhostname=example.com
+OPENDKIM_DOMAINS=example.com
+# see https://github.com/wader/postfix-relay/pull/18
+OPENDKIM_RequireSafeKeys=no
 
 # File storage (optional)
 # -----------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,16 @@ services:
 #      - external_network
 #      - internal_network
 
+  postfix:
+    image: mwader/postfix-relay
+    env_file: .env.production
+    networks:
+      - external_network
+      - internal_network
+    volumes:
+      - ./docker-volume/opendkim/keys:/etc/opendkim/keys
+    restart: "always"
+
 networks:
   external_network:
   internal_network:


### PR DESCRIPTION
Instead of depending on third party services for sending mail, add a stand-alone smtp mail service for sending emails using https://hub.docker.com/r/mwader/postfix-relay/

The above container is chosen by referring   [docker-compose file](https://github.com/Chocobozzz/PeerTube/blob/e2464d22a5f19168022e72c77e82019726216542/support/docker/production/docker-compose.yml#L84) of "Peertube" project

This way, users can easily spin up a fully functional  Maston instances without depending on third-party  services