### PR TITLE
templates/systemd/mastodon: update sandbox mode

### DIFF
--- a/dist/mastodon-sidekiq.service
+++ b/dist/mastodon-sidekiq.service
@@ -12,6 +12,9 @@ Environment="MALLOC_ARENA_MAX=2"
 ExecStart=/home/mastodon/.rbenv/shims/bundle exec sidekiq -c 25
 TimeoutSec=15
 Restart=always
+# Proc filesystem
+ProcSubset=pid
+ProtectProc=invisible
 # Capabilities
 CapabilityBoundingSet=
 # Security
@@ -34,6 +37,7 @@ RestrictNamespaces=true
 LockPersonality=true
 RestrictRealtime=true
 RestrictSUIDSGID=true
+RemoveIPC=true
 PrivateMounts=true
 ProtectClock=true
 # System Call Filtering

--- a/dist/mastodon-sidekiq.service
+++ b/dist/mastodon-sidekiq.service
@@ -42,7 +42,8 @@ PrivateMounts=true
 ProtectClock=true
 # System Call Filtering
 SystemCallArchitectures=native
-SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @raw-io @reboot @setuid @swap
+SystemCallFilter=~@cpu-emulation @debug @keyring @mount @obsolete @privileged @setuid
+SystemCallFilter=@chown
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-sidekiq.service
+++ b/dist/mastodon-sidekiq.service
@@ -42,8 +42,10 @@ PrivateMounts=true
 ProtectClock=true
 # System Call Filtering
 SystemCallArchitectures=native
-SystemCallFilter=~@cpu-emulation @debug @keyring @mount @obsolete @privileged @setuid
+SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @mount @obsolete @privileged @setuid
 SystemCallFilter=@chown
+SystemCallFilter=pipe
+SystemCallFilter=pipe2
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-streaming.service
+++ b/dist/mastodon-streaming.service
@@ -42,7 +42,7 @@ PrivateMounts=true
 ProtectClock=true
 # System Call Filtering
 SystemCallArchitectures=native
-SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @mount @obsolete @privileged @resources @setuid
+SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @memlock @mount @obsolete @privileged @resources @setuid
 SystemCallFilter=pipe
 SystemCallFilter=pipe2
 

--- a/dist/mastodon-streaming.service
+++ b/dist/mastodon-streaming.service
@@ -42,7 +42,9 @@ PrivateMounts=true
 ProtectClock=true
 # System Call Filtering
 SystemCallArchitectures=native
-SystemCallFilter=~@cpu-emulation @debug @keyring @mount @obsolete @privileged @resources @setuid
+SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @mount @obsolete @privileged @resources @setuid
+SystemCallFilter=pipe
+SystemCallFilter=pipe2
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-streaming.service
+++ b/dist/mastodon-streaming.service
@@ -42,7 +42,7 @@ PrivateMounts=true
 ProtectClock=true
 # System Call Filtering
 SystemCallArchitectures=native
-SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @privileged @raw-io @reboot @resources @setuid @swap
+SystemCallFilter=~@cpu-emulation @debug @keyring @mount @obsolete @privileged @resources @setuid
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-streaming.service
+++ b/dist/mastodon-streaming.service
@@ -12,6 +12,9 @@ Environment="STREAMING_CLUSTER_NUM=1"
 ExecStart=/usr/bin/node ./streaming
 TimeoutSec=15
 Restart=always
+# Proc filesystem
+ProcSubset=pid
+ProtectProc=invisible
 # Capabilities
 CapabilityBoundingSet=
 # Security
@@ -34,6 +37,7 @@ RestrictNamespaces=true
 LockPersonality=true
 RestrictRealtime=true
 RestrictSUIDSGID=true
+RemoveIPC=true
 PrivateMounts=true
 ProtectClock=true
 # System Call Filtering

--- a/dist/mastodon-web.service
+++ b/dist/mastodon-web.service
@@ -42,7 +42,8 @@ PrivateMounts=true
 ProtectClock=true
 # System Call Filtering
 SystemCallArchitectures=native
-SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @raw-io @reboot @resources @setuid @swap
+SystemCallFilter=~@cpu-emulation @debug @keyring @mount @obsolete @privileged @resources @setuid
+SystemCallFilter=@chown
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-web.service
+++ b/dist/mastodon-web.service
@@ -42,7 +42,7 @@ PrivateMounts=true
 ProtectClock=true
 # System Call Filtering
 SystemCallArchitectures=native
-SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @mount @obsolete @privileged @resources @setuid
+SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @mount @obsolete @privileged @setuid
 SystemCallFilter=@chown
 SystemCallFilter=pipe
 SystemCallFilter=pipe2

--- a/dist/mastodon-web.service
+++ b/dist/mastodon-web.service
@@ -12,6 +12,9 @@ ExecStart=/home/mastodon/.rbenv/shims/bundle exec puma -C config/puma.rb
 ExecReload=/bin/kill -SIGUSR1 $MAINPID
 TimeoutSec=15
 Restart=always
+# Proc filesystem
+ProcSubset=pid
+ProtectProc=invisible
 # Capabilities
 CapabilityBoundingSet=
 # Security
@@ -34,6 +37,7 @@ RestrictNamespaces=true
 LockPersonality=true
 RestrictRealtime=true
 RestrictSUIDSGID=true
+RemoveIPC=true
 PrivateMounts=true
 ProtectClock=true
 # System Call Filtering

--- a/dist/mastodon-web.service
+++ b/dist/mastodon-web.service
@@ -42,8 +42,10 @@ PrivateMounts=true
 ProtectClock=true
 # System Call Filtering
 SystemCallArchitectures=native
-SystemCallFilter=~@cpu-emulation @debug @keyring @mount @obsolete @privileged @resources @setuid
+SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @mount @obsolete @privileged @resources @setuid
 SystemCallFilter=@chown
+SystemCallFilter=pipe
+SystemCallFilter=pipe2
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added `ProcSubset`, `ProtectProc` and `RemoveIPC` options.
Remoded duplicates filters. Filter `@privileged`  includes the following filters - `@chown`, `@clock`, `@module`, `@raw-io`, `@reboot`, `@swap`.
```
systemd-analyze syscall-filter
...
@privileged
    # All system calls which need super-user capabilities
    @chown
    @clock
    @module
    @raw-io
    @reboot
    @swap
    _sysctl
    acct
    bpf
...
```
To `ruby` process allow only `@chown` system calls instead `@privileged`
To service `mastodon-streaming` deny `@memlock` system calls.
