### PR TITLE
Disable host check on healthcheck path

### DIFF
--- a/config/initializers/1_hosts.rb
+++ b/config/initializers/1_hosts.rb
@@ -31,5 +31,6 @@ Rails.application.configure do
     config.hosts << host if host.present?
     config.hosts << web_host if web_host.present?
     config.hosts.concat(alternate_domains) if alternate_domains.present?
+    config.hosts_authorization = { exclude: ->(request) { request.path == '/health' } }
   end
 end


### PR DESCRIPTION
Related #16087
Disable host header check on `/health` route path to prevent docker healthcheck command fail