### PR TITLE
Change “status” and “message” to “post” in WebUI

### DIFF
--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -24,7 +24,7 @@ en:
         status:
           attributes:
             reblog:
-              taken: of status already exists
+              taken: of post already exists
         user:
           attributes:
             email:

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -138,12 +138,12 @@ en:
       read:notifications: see your notifications
       read:reports: see your reports
       read:search: search on your behalf
-      read:statuses: see all statuses
+      read:statuses: see all posts
       write: modify all your account's data
       write:accounts: modify your profile
       write:blocks: block accounts and domains
-      write:bookmarks: bookmark statuses
-      write:favourites: favourite statuses
+      write:bookmarks: bookmark posts
+      write:favourites: favourite posts
       write:filters: create filters
       write:follows: follow people
       write:lists: create lists
@@ -151,4 +151,4 @@ en:
       write:mutes: mute people and conversations
       write:notifications: clear your notifications
       write:reports: report other people
-      write:statuses: publish statuses
+      write:statuses: publish posts

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1431,7 +1431,7 @@ en:
       edit_profile_step: You can customize your profile by uploading an avatar, header, changing your display name and more. If you’d like to review new followers before they’re allowed to follow you, you can lock your account.
       explanation: Here are some tips to get you started
       final_action: Start posting
-      final_step: 'Start posting! Even without followers your public messages may be seen by others, for example on the local timeline and in hashtags. You may want to introduce yourself on the #introductions hashtag.'
+      final_step: 'Start posting! Even without followers your public posts may be seen by others, for example on the local timeline and in hashtags. You may want to introduce yourself on the #introductions hashtag.'
       full_handle: Your full handle
       full_handle_hint: This is what you would tell your friends so they can message or follow you from another server.
       review_preferences_action: Change preferences

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -52,7 +52,7 @@ en:
         setting_display_media_hide_all: Always hide media
         setting_display_media_show_all: Always show media
         setting_hide_network: Who you follow and who follows you will be hidden on your profile
-        setting_noindex: Affects your public profile and status pages
+        setting_noindex: Affects your public profile and post pages
         setting_show_application: The application you use to post will be displayed in the detailed view of your posts
         setting_use_blurhash: Gradients are based on the colors of the hidden visuals but obfuscate any details
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
@@ -197,12 +197,12 @@ en:
         severity: Rule
       notification_emails:
         digest: Send digest e-mails
-        favourite: Someone favourited your status
+        favourite: Someone favourited your post
         follow: Someone followed you
         follow_request: Someone requested to follow you
         mention: Someone mentioned you
         pending_account: New account needs review
-        reblog: Someone boosted your status
+        reblog: Someone boosted your post
         report: New report is submitted
         trending_tag: An unreviewed hashtag is trending
       rule:


### PR DESCRIPTION
Follow-up of #16080 and #16089.
Fix #13193 for good (hopefully).

Edit: I didn’t change
https://github.com/tootsuite/mastodon/blob/4c7efdba402b6b8ee0363b6f1dc2c202303d7623/config/locales/en.yml#L1052

because I feel like the more personal sense of message (directory to the person) is intended.