### PR TITLE
Change IRC channel to LiberaChat in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Mastodon is **free, open-source software** licensed under **AGPLv3**.
 
 You can open issues for bugs you've found or features you think are missing. You can also submit pull requests to this repository, or submit translations using Crowdin. To get started, take a look at [CONTRIBUTING.md](CONTRIBUTING.md). If your contributions are accepted into Mastodon, you can request to be paid through [our OpenCollective](https://opencollective.com/mastodon).
 
-**IRC channel**: #mastodon on irc.freenode.net
+**IRC channel**: #mastodon on irc.libera.chat
 
 ## License
 


### PR DESCRIPTION
Hi Eugen and others,

Freenode was taken over by a different entity, and former Freenode staff created LiberaChat.
As the current OP of #mastodon @ freenode, I recommend we move the official channel there.

Short summary of the situation:

* https://blog.bofh.it/debian/id_461
* https://twitter.com/freenodestaff/status/1395046345145307140

With more details:

* https://gist.github.com/joepie91/df80d8d36cd9d1bde46ba018af497409
* https://gist.github.com/aaronmdjones/1a9a93ded5b7d162c3f58bdd66b8f491

I do not yet have control there. So @Gargron , before merging this PR, could you take ownership of the channel, by asking the LiberaChat staff, at #libera @ irc.libera.chat?

Alternatively, I am willing to handle the registration, if you confirm here that you want me to own the channel on behalf of Mastodon.

Thanks!