### PR TITLE
Fix migration script not being able to run if it fails midway

### DIFF
--- a/db/migrate/20190726175042_add_case_insensitive_index_to_tags.rb
+++ b/db/migrate/20190726175042_add_case_insensitive_index_to_tags.rb
@@ -15,7 +15,13 @@ class AddCaseInsensitiveIndexToTags < ActiveRecord::Migration[5.2]
       Tag.where(id: redundant_tag_ids).in_batches.delete_all
     end
 
-    safety_assured { execute 'CREATE UNIQUE INDEX CONCURRENTLY index_tags_on_name_lower ON tags (lower(name))' }
+    begin
+      safety_assured { execute 'CREATE UNIQUE INDEX CONCURRENTLY index_tags_on_name_lower ON tags (lower(name))' }
+    rescue ActiveRecord::StatementInvalid
+      remove_index :tags, name: 'index_tags_on_name_lower'
+      raise
+    end
+
     remove_index :tags, name: 'index_tags_on_name'
     remove_index :tags, name: 'hashtag_search_index'
   end

--- a/db/migrate/20200620164023_add_fixed_lowercase_index_to_accounts.rb
+++ b/db/migrate/20200620164023_add_fixed_lowercase_index_to_accounts.rb
@@ -1,15 +1,9 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
 class AddFixedLowercaseIndexToAccounts < ActiveRecord::Migration[5.2]
+  include Mastodon::MigrationHelpers
+
   disable_ddl_transaction!
-
-  class CorruptionError < StandardError
-    def cause
-      nil
-    end
-
-    def backtrace
-      []
-    end
-  end
 
   def up
     if index_name_exists?(:accounts, 'old_index_accounts_on_username_and_domain_lower') && index_name_exists?(:accounts, 'index_accounts_on_username_and_domain_lower')
@@ -22,7 +16,7 @@ class AddFixedLowercaseIndexToAccounts < ActiveRecord::Migration[5.2]
       add_index :accounts, "lower (username), COALESCE(lower(domain), '')", name: 'index_accounts_on_username_and_domain_lower', unique: true, algorithm: :concurrently
     rescue ActiveRecord::RecordNotUnique
       remove_index :accounts, name: 'index_accounts_on_username_and_domain_lower'
-      raise CorruptionError, 'Migration failed because of index corruption, see https://docs.joinmastodon.org/admin/troubleshooting/index-corruption/#fixing'
+      raise CorruptionError
     end
 
     remove_index :accounts, name: 'old_index_accounts_on_username_and_domain_lower' if index_name_exists?(:accounts, 'old_index_accounts_on_username_and_domain_lower')

--- a/db/migrate/20200620164023_add_fixed_lowercase_index_to_accounts.rb
+++ b/db/migrate/20200620164023_add_fixed_lowercase_index_to_accounts.rb
@@ -21,6 +21,7 @@ class AddFixedLowercaseIndexToAccounts < ActiveRecord::Migration[5.2]
     begin
       add_index :accounts, "lower (username), COALESCE(lower(domain), '')", name: 'index_accounts_on_username_and_domain_lower', unique: true, algorithm: :concurrently
     rescue ActiveRecord::RecordNotUnique
+      remove_index :accounts, name: 'index_accounts_on_username_and_domain_lower'
       raise CorruptionError, 'Migration failed because of index corruption, see https://docs.joinmastodon.org/admin/troubleshooting/index-corruption/#fixing'
     end
 

--- a/db/migrate/20210421121431_add_case_insensitive_btree_index_to_tags.rb
+++ b/db/migrate/20210421121431_add_case_insensitive_btree_index_to_tags.rb
@@ -1,8 +1,25 @@
 class AddCaseInsensitiveBtreeIndexToTags < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
+  class CorruptionError < StandardError
+    def cause
+      nil
+    end
+
+    def backtrace
+      []
+    end
+  end
+
   def up
-    safety_assured { execute 'CREATE UNIQUE INDEX CONCURRENTLY index_tags_on_name_lower_btree ON tags (lower(name) text_pattern_ops)' }
+    begin
+      safety_assured { execute 'CREATE UNIQUE INDEX CONCURRENTLY index_tags_on_name_lower_btree ON tags (lower(name) text_pattern_ops)' }
+    rescue ActiveRecord::StatementInvalid => e
+      remove_index :tags, name: 'index_tags_on_name_lower_btree'
+      e = CorruptionError.new('Migration failed because of index corruption, see https://docs.joinmastodon.org/admin/troubleshooting/index-corruption/#fixing') if e.is_a?(ActiveRecord::RecordNotUnique)
+      raise e
+    end
+
     remove_index :tags, name: 'index_tags_on_name_lower'
   end
 

--- a/lib/mastodon/migration_helpers.rb
+++ b/lib/mastodon/migration_helpers.rb
@@ -41,6 +41,20 @@
 
 module Mastodon
   module MigrationHelpers
+    class CorruptionError < StandardError
+      def initialize(message = nil)
+        super(message.presence || 'Migration failed because of index corruption, see https://docs.joinmastodon.org/admin/troubleshooting/index-corruption/#fixing')
+      end
+
+      def cause
+        nil
+      end
+
+      def backtrace
+        []
+      end
+    end
+
     # Model that can be used for querying permissions of a SQL user.
     class Grant < ActiveRecord::Base
       self.table_name = 'information_schema.role_table_grants'


### PR DESCRIPTION
Partially addresses #16273, similar to #15361

More generally, we should be more careful when writing migration scripts with `disable_ddl_transaction!`.