### PR TITLE
Determine the Date Equality by Unix time

### DIFF
--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -146,10 +146,10 @@ class ComposeForm extends ImmutablePureComponent {
     //     - Replying to zero or one users, places the cursor at the end of the textbox.
     //     - Replying to more than one user, selects any usernames past the first;
     //       this provides a convenient shortcut to drop everyone else from the conversation.
-    if (this.props.focusDate !== prevProps.focusDate) {
+    if (this.props.focusDate.getTime() !== prevProps.focusDate.getTime()) {
       let selectionEnd, selectionStart;
 
-      if (this.props.preselectDate !== prevProps.preselectDate) {
+      if (this.props.preselectDate.getTime() !== prevProps.preselectDate.getTime()) {
         selectionEnd   = this.props.text.length;
         selectionStart = this.props.text.search(/\s/) + 1;
       } else if (typeof this.props.caretPosition === 'number') {

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -146,10 +146,10 @@ class ComposeForm extends ImmutablePureComponent {
     //     - Replying to zero or one users, places the cursor at the end of the textbox.
     //     - Replying to more than one user, selects any usernames past the first;
     //       this provides a convenient shortcut to drop everyone else from the conversation.
-    if (this.props.focusDate.getTime() !== prevProps.focusDate.getTime()) {
+    if (this.props.focusDate?.getTime() !== prevProps.focusDate?.getTime()) {
       let selectionEnd, selectionStart;
 
-      if (this.props.preselectDate.getTime() !== prevProps.preselectDate.getTime()) {
+      if (this.props.preselectDate?.getTime() !== prevProps.preselectDate?.getTime()) {
         selectionEnd   = this.props.text.length;
         selectionStart = this.props.text.search(/\s/) + 1;
       } else if (typeof this.props.caretPosition === 'number') {


### PR DESCRIPTION
Date instances shouldn't be compared by a strict equal. Because they are object. This change can solve unintended focus issue. I don't think ``focusDate`` and ``preselectDate`` should be Date instance, and I think they should be number. But I cannot investigate the influence of the change, so I made small PR.