### PR TITLE
Remove set-cookie header on custom.css

### DIFF
--- a/app/controllers/custom_css_controller.rb
+++ b/app/controllers/custom_css_controller.rb
@@ -3,6 +3,10 @@
 class CustomCssController < ApplicationController
   skip_before_action :store_current_location
   skip_before_action :require_functional!
+  skip_before_action :update_user_sign_in
+  skip_before_action :set_session_activity
+
+  skip_around_action :set_locale
 
   before_action :set_cache_headers
 

--- a/app/controllers/custom_css_controller.rb
+++ b/app/controllers/custom_css_controller.rb
@@ -8,6 +8,7 @@ class CustomCssController < ApplicationController
 
   def show
     expires_in 3.minutes, public: true
+    request.session_options[:skip] = true
     render plain: Setting.custom_css || '', content_type: 'text/css'
   end
 end


### PR DESCRIPTION
`/custom.css` intended to be cached, But was not cached by nginx, cdn because it has `Set-Cookie` header.
This commit will fix that problem.