### PR TITLE
Fix account deletion sometimes failing because of optimistic locks

### DIFF
--- a/app/models/account_stat.rb
+++ b/app/models/account_stat.rb
@@ -11,10 +11,11 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  last_status_at  :datetime
-#  lock_version    :integer          default(0), not null
 #
 
 class AccountStat < ApplicationRecord
+  self.locking_column = nil
+
   belongs_to :account, inverse_of: :account_stat
 
   update_index('accounts#account', :account)

--- a/app/models/concerns/account_counters.rb
+++ b/app/models/concerns/account_counters.rb
@@ -49,7 +49,6 @@ module AccountCounters
               ON CONFLICT (account_id) DO UPDATE
               SET #{key} = account_stats.#{key} + :value,
                   last_status_at = now(),
-                  lock_version = account_stats.lock_version + 1,
                   updated_at = now()
               RETURNING id;
             SQL
@@ -59,7 +58,6 @@ module AccountCounters
                 VALUES (:account_id, :default_value, now(), now())
               ON CONFLICT (account_id) DO UPDATE
               SET #{key} = account_stats.#{key} + :value,
-                  lock_version = account_stats.lock_version + 1,
                   updated_at = now()
               RETURNING id;
             SQL

--- a/db/post_migrate/20210526193025_remove_lock_version_from_account_stats.rb
+++ b/db/post_migrate/20210526193025_remove_lock_version_from_account_stats.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveLockVersionFromAccountStats < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      remove_column :account_stats, :lock_version, :integer, null: false, default: 0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_07_001928) do
+ActiveRecord::Schema.define(version: 2021_05_26_193025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,7 +111,6 @@ ActiveRecord::Schema.define(version: 2021_05_07_001928) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "last_status_at"
-    t.integer "lock_version", default: 0, null: false
     t.index ["account_id"], name: "index_account_stats_on_account_id", unique: true
   end
 

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -14,7 +14,7 @@ module Mastodon
     end
 
     MIN_SUPPORTED_VERSION = 2019_10_01_213028
-    MAX_SUPPORTED_VERSION = 2021_05_07_001928
+    MAX_SUPPORTED_VERSION = 2021_05_26_193025
 
     # Stubs to enjoy ActiveRecord queries while not depending on a particular
     # version of the code/database


### PR DESCRIPTION
In some [rare occasions](https://discourse.joinmastodon.org/t/account-cant-be-deleted/3602), deleting accounts would fail with a `StaleObjectError` exception.

Indeed, account deletion manually sets the `AccountStat` values without handling cases where the optimistic locking on `AccountStat` would fail.

To my knowledge, with the rewrite of account counters in #15913, the `DeleteAccountService` is now the only place that changes the counters in a way that is not atomic.

Since in this specific case, we do not care about the previous values of the account counters, it appears we don't need locking at all for this table anymore.