### PR TITLE
Add font-display attribute to display text before loading

### DIFF
--- a/app/javascript/styles/fonts/montserrat.scss
+++ b/app/javascript/styles/fonts/montserrat.scss
@@ -5,6 +5,7 @@
     url('../fonts/montserrat/Montserrat-Regular.woff') format('woff'),
     url('../fonts/montserrat/Montserrat-Regular.ttf') format('truetype');
   font-weight: 400;
+  font-display: swap;
   font-style: normal;
 }
 
@@ -13,5 +14,6 @@
   src: local('Montserrat Medium'),
     url('../fonts/montserrat/Montserrat-Medium.ttf') format('truetype');
   font-weight: 500;
+  font-display: swap;
   font-style: normal;
 }

--- a/app/javascript/styles/fonts/roboto-mono.scss
+++ b/app/javascript/styles/fonts/roboto-mono.scss
@@ -6,5 +6,6 @@
     url('../fonts/roboto-mono/robotomono-regular-webfont.ttf') format('truetype'),
     url('../fonts/roboto-mono/robotomono-regular-webfont.svg#roboto_monoregular') format('svg');
   font-weight: 400;
+  font-display: swap;
   font-style: normal;
 }

--- a/app/javascript/styles/fonts/roboto.scss
+++ b/app/javascript/styles/fonts/roboto.scss
@@ -6,6 +6,7 @@
     url('../fonts/roboto/roboto-italic-webfont.ttf') format('truetype'),
     url('../fonts/roboto/roboto-italic-webfont.svg#roboto-italic-webfont') format('svg');
   font-weight: normal;
+  font-display: swap;
   font-style: italic;
 }
 
@@ -17,6 +18,7 @@
     url('../fonts/roboto/roboto-bold-webfont.ttf') format('truetype'),
     url('../fonts/roboto/roboto-bold-webfont.svg#roboto-bold-webfont') format('svg');
   font-weight: bold;
+  font-display: swap;
   font-style: normal;
 }
 
@@ -28,6 +30,7 @@
     url('../fonts/roboto/roboto-medium-webfont.ttf') format('truetype'),
     url('../fonts/roboto/roboto-medium-webfont.svg#roboto-medium-webfont') format('svg');
   font-weight: 500;
+  font-display: swap;
   font-style: normal;
 }
 
@@ -39,5 +42,6 @@
     url('../fonts/roboto/roboto-regular-webfont.ttf') format('truetype'),
     url('../fonts/roboto/roboto-regular-webfont.svg#roboto-regular-webfont') format('svg');
   font-weight: normal;
+  font-display: swap;
   font-style: normal;
 }


### PR DESCRIPTION
Most browsers blocking to display texts before font loading, That is called FOIT(Flash of invisible text).
When apply `font-display: swap`, browser displays text using fallback font, and swap font after loading web font.

FYI: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display