### PR TITLE
Fix compression-webpack-plugin configuration

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -43,7 +43,7 @@ module.exports = merge(sharedConfig, {
 
   plugins: [
     new CompressionPlugin({
-      filename: '[path].gz[query]',
+      filename: '[path][base].gz[query]',
       cache: true,
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf|map)$/,
     }),


### PR DESCRIPTION
compression-webpack-plugin 6.0.0 has changed how filenames were generated, so from #14892 onward (Mastodon v3.3.0 and later), compressed files were output to a file named `.gz` instead of the correct filenames.