### PR TITLE
Add maintenance script to fix remote_url when media server changes

### DIFF
--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -196,7 +196,7 @@ module Mastodon
       @force  = options[:force]
 
       @prompt.say "Start fixing the remote_url of #{@types.join ', '} on the remote server \"#{@domain}\" from \"#{@from}\" to \"#{@to}\"."
-      raise 'User canceled' unless @prompt.yes?('Continue?')
+      exit(1) unless @prompt.yes?('Continue?')
 
       fix_accounts_remote_url!
       fix_custom_emojis_remote_url!

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -196,7 +196,7 @@ module Mastodon
       @force  = options[:force]
 
       @prompt.say "Start fixing the remote_url of #{@types.join ', '} on the remote server \"#{@domain}\" from \"#{@from}\" to \"#{@to}\"."
-      exit(1) unless @prompt.yes?('Continue?')
+      exit(1) unless @prompt.yes?('Continue?') # skipcq: RB-RL1021
 
       fix_accounts_remote_url!
       fix_custom_emojis_remote_url!

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -216,9 +216,8 @@ module Mastodon
 
       unless @force
         accounts_avatar_remote_url = ::Account.where(domain: @domain).where('avatar_remote_url like ?', "#{@from}%").reorder(avatar_updated_at: :desc).first&.avatar_remote_url&.sub(/^#{@from}/, @to)
-
-        return @prompt.warn  'There is no corresponding remote avatar image, so skip it.'      unless accounts_avatar_remote_url
-        return @prompt.error 'The remote avatar image cannot be reached with the changed URL.' unless reachable_url?(accounts_avatar_remote_url)
+        return @prompt.warn  'Skipping because no corresponding remote avatar image could be found.' unless accounts_avatar_remote_url
+        return @prompt.error 'The remote avatar image cannot be reached with the changed URL.'       unless reachable_url?(accounts_avatar_remote_url)
       end
 
       fixed_avatars = ActiveRecord::Base.connection.exec_update(<<-SQL.squish, 'SQL', [[nil, @domain], [nil, @from], [nil, @to], [nil, "#{@from}%"]])
@@ -270,8 +269,8 @@ module Mastodon
       unless @force
         custom_emojis_image_remote_url = ::CustomEmoji.where(domain: @domain).where('image_remote_url like ?', "#{@from}%").reorder(image_updated_at: :desc).first&.image_remote_url&.sub(/^#{@from}/, @to)
 
-        return @prompt.warn  'There is no corresponding remote custom emoji, so skip it.'       unless custom_emojis_image_remote_url
-        return @prompt.error 'The remote custom emoji cannot be reached with the modified URL.' unless reachable_url?(custom_emojis_image_remote_url)
+        return @prompt.warn  'Skipping because no corresponding remote custom emoji could be found.' unless custom_emojis_image_remote_url
+        return @prompt.error 'The remote custom emoji cannot be reached with the modified URL.'      unless reachable_url?(custom_emojis_image_remote_url)
       end
 
       fixed_emojis = ActiveRecord::Base.connection.exec_update(<<-SQL.squish, 'SQL', [[nil, @domain], [nil, @from], [nil, @to], [nil, "#{@from}%"]])
@@ -304,8 +303,8 @@ module Mastodon
       unless @force
         attatchments_remote_url = ::MediaAttachment.joins(status: :account).where(statuses: { accounts: { domain: @domain } }).where('remote_url like ?', "#{@from}%").reorder(file_updated_at: :desc).first&.remote_url&.sub(/^#{@from}/, @to)
 
-        return @prompt.warn  'There is no corresponding remote media attachment, so skip it.'       unless attatchments_remote_url
-        return @prompt.error 'The remote media attachment cannot be reached with the modified URL.' unless reachable_url?(attatchments_remote_url)
+        return @prompt.warn  'Skipping because no corresponding remote media attachment could be found.' unless attatchments_remote_url
+        return @prompt.error 'The remote media attachment cannot be reached with the modified URL.'      unless reachable_url?(attatchments_remote_url)
       end
 
       fixed_attachments = ActiveRecord::Base.connection.exec_update(<<-SQL.squish, 'SQL', [[nil, @domain], [nil, @from], [nil, @to], [nil, "#{@from}%"]])

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -196,7 +196,7 @@ module Mastodon
       @force  = options[:force]
 
       @prompt.say "Start fixing the remote_url of #{@types.join ', '} on the remote server \"#{@domain}\" from \"#{@from}\" to \"#{@to}\"."
-      exit(1) unless @prompt.yes?('Continue?')
+      raise 'User canceled' unless @prompt.yes?('Continue?')
 
       fix_accounts_remote_url!
       fix_custom_emojis_remote_url!
@@ -217,8 +217,8 @@ module Mastodon
       unless @force
         accounts_avatar_remote_url = ::Account.where(domain: @domain).where('avatar_remote_url like ?', "#{@from}%").reorder(avatar_updated_at: :desc).first&.avatar_remote_url&.sub(/^#{@from}/, @to)
 
-        return @prompt.warn  "There is no corresponding remote avatar image, so skip it."      unless accounts_avatar_remote_url
-        return @prompt.error "The remote avatar image cannot be reached with the changed URL." unless reachable_url?(accounts_avatar_remote_url)
+        return @prompt.warn  'There is no corresponding remote avatar image, so skip it.'      unless accounts_avatar_remote_url
+        return @prompt.error 'The remote avatar image cannot be reached with the changed URL.' unless reachable_url?(accounts_avatar_remote_url)
       end
 
       fixed_avatars = ActiveRecord::Base.connection.exec_update(<<-SQL.squish, 'SQL', [[nil, @domain], [nil, @from], [nil, @to], [nil, "#{@from}%"]])
@@ -270,8 +270,8 @@ module Mastodon
       unless @force
         custom_emojis_image_remote_url = ::CustomEmoji.where(domain: @domain).where('image_remote_url like ?', "#{@from}%").reorder(image_updated_at: :desc).first&.image_remote_url&.sub(/^#{@from}/, @to)
 
-        return @prompt.warn  "There is no corresponding remote custom emoji, so skip it."       unless custom_emojis_image_remote_url
-        return @prompt.error "The remote custom emoji cannot be reached with the modified URL." unless reachable_url?(custom_emojis_image_remote_url)
+        return @prompt.warn  'There is no corresponding remote custom emoji, so skip it.'       unless custom_emojis_image_remote_url
+        return @prompt.error 'The remote custom emoji cannot be reached with the modified URL.' unless reachable_url?(custom_emojis_image_remote_url)
       end
 
       fixed_emojis = ActiveRecord::Base.connection.exec_update(<<-SQL.squish, 'SQL', [[nil, @domain], [nil, @from], [nil, @to], [nil, "#{@from}%"]])
@@ -304,8 +304,8 @@ module Mastodon
       unless @force
         attatchments_remote_url = ::MediaAttachment.joins(status: :account).where(statuses: { accounts: { domain: @domain } }).where('remote_url like ?', "#{@from}%").reorder(file_updated_at: :desc).first&.remote_url&.sub(/^#{@from}/, @to)
 
-        return @prompt.warn  "There is no corresponding remote media attachment, so skip it."       unless attatchments_remote_url
-        return @prompt.error "The remote media attachment cannot be reached with the modified URL." unless reachable_url?(attatchments_remote_url)
+        return @prompt.warn  'There is no corresponding remote media attachment, so skip it.'       unless attatchments_remote_url
+        return @prompt.error 'The remote media attachment cannot be reached with the modified URL.' unless reachable_url?(attatchments_remote_url)
       end
 
       fixed_attachments = ActiveRecord::Base.connection.exec_update(<<-SQL.squish, 'SQL', [[nil, @domain], [nil, @from], [nil, @to], [nil, "#{@from}%"]])


### PR DESCRIPTION
Object storage may be unavoidably changed on the remote server in operation. This will invalidate the link to the original media because the remote_url of the media already obtained will be that of the old server. Also, if you are purging the cache with tootctl media remove etc., you will not be able to reacquire the image.

Add `tootctl maintenance fix-remote-url` to solve this.

This script replaces account avatars and headers, custom emojis, and remote_urls in media attachments. It also checks if the new address is valid to prevent erroneous operation.

Usage:

```
RAILS_ENV=production bin/tootctl maintenance fix-remote-url https://example.com/system/ https://s3-ap-northeast-1.amazonaws.com/example.com/ --domain example.com
```
