### PR TITLE
Fix newlines in accout notes added by the Move handler

### DIFF
--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -13,9 +13,13 @@ class MoveWorker
       queue_follow_unfollows!
     end
 
+    @deferred_error = nil
+
     copy_account_notes!
     carry_blocks_over!
     carry_mutes_over!
+
+    raise @deferred_error unless @deferred_error.nil?
   rescue ActiveRecord::RecordNotFound
     true
   end
@@ -36,6 +40,8 @@ class MoveWorker
 
     @source_account.followers.local.select(:id).find_in_batches do |accounts|
       UnfollowFollowWorker.push_bulk(accounts.map(&:id)) { |follower_id| [follower_id, @source_account.id, @target_account.id, bypass_locked] }
+    rescue => e
+      @deferred_error = e
     end
   end
 
@@ -51,6 +57,8 @@ class MoveWorker
       else
         new_note.update!(comment: [text, note.comment, "\n", new_note.comment].join("\n"))
       end
+    rescue => e
+      @deferred_error = e
     end
   end
 
@@ -60,6 +68,8 @@ class MoveWorker
         BlockService.new.call(block.account, @target_account)
         add_account_note_if_needed!(block.account, 'move_handler.carry_blocks_over_text')
       end
+    rescue => e
+      @deferred_error = e
     end
   end
 
@@ -67,6 +77,8 @@ class MoveWorker
     @source_account.muted_by_relationships.where(account: Account.local).find_each do |mute|
       MuteService.new.call(mute.account, @target_account, notifications: mute.hide_notifications) unless mute.account.muting?(@target_account) || mute.account.following?(@target_account)
       add_account_note_if_needed!(mute.account, 'move_handler.carry_mutes_over_text')
+    rescue => e
+      @deferred_error = e
     end
   end
 

--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -47,9 +47,9 @@ class MoveWorker
 
       new_note = AccountNote.find_by(account: note.account, target_account: @target_account)
       if new_note.nil?
-        AccountNote.create!(account: note.account, target_account: @target_account, comment: [text, note.comment].join('\n'))
+        AccountNote.create!(account: note.account, target_account: @target_account, comment: [text, note.comment].join("\n"))
       else
-        new_note.update!(comment: [text, note.comment, '\n', new_note.comment].join('\n'))
+        new_note.update!(comment: [text, note.comment, "\n", new_note.comment].join("\n"))
       end
     end
   end


### PR DESCRIPTION
There's also some defensive programming stuff to avoid an error affecting one account from affecting other accounts.

Indeed, I have had a report about some behavior that I can only explain by the `Move` worker failing midway in either `copy_account_notes!` or `carry_blocks_over!`, but I have not had access to that server's logs yet, so I don't know what happened exactly. This change would not have fixed the underlying cause, but it would have made it so it didn't prevent the block from carrying over.