### PR TITLE
Fix `tootctl accounts cull` not excluding domains on timeouts and certificate issues

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -299,7 +299,7 @@ module Mastodon
 
         begin
           code = Request.new(:head, account.uri).perform(&:code)
-        rescue HTTP::ConnectionError
+        rescue HTTP::TimeoutError, HTTP::ConnectionError, OpenSSL::SSL::SSLError
           skip_domains << account.domain
         end
 


### PR DESCRIPTION
Fixes #16410

This change makes sense to me, although I am not completely sure about the timeout change, which may skip domains a bit too easily.