### PR TITLE
Add tootctl command to mark remote media for redownload

### DIFF
--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -627,16 +627,6 @@ module Mastodon
       ActiveRecord::Base.connection.select_all("SELECT string_agg(id::text, ',') AS ids FROM accounts GROUP BY lower(username), COALESCE(lower(domain), '') HAVING count(*) > 1")
     end
 
-    desc 'mark-media-missing', 'Clears references to locally-stored remote media.'
-    long_desc <<~LONG_DESC
-      Clears references to file and thumbnails stored locally that originated remotely.
-
-      This is useful if you are restoring a backup without the cache and need Mastodon to fetch remote media again.
-    LONG_DESC
-    def mark_media_missing
-     MediaAttachment.cached.where.not(remote_url: '').each { |f| f.file.destroy; f.thumbnail.destroy; f.save }
-    end
-
     def remove_index_if_exists!(table, name)
       ActiveRecord::Base.connection.remove_index(table, name: name)
     rescue ArgumentError

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -627,6 +627,16 @@ module Mastodon
       ActiveRecord::Base.connection.select_all("SELECT string_agg(id::text, ',') AS ids FROM accounts GROUP BY lower(username), COALESCE(lower(domain), '') HAVING count(*) > 1")
     end
 
+    desc 'mark-media-missing', 'Clears references to locally-stored remote media.'
+    long_desc <<~LONG_DESC
+      Clears references to file and thumbnails stored locally that originated remotely.
+
+      This is useful if you are restoring a backup without the cache and need Mastodon to fetch remote media again.
+    LONG_DESC
+    def mark_media_missing
+     MediaAttachment.cached.where.not(remote_url: '').each { |f| f.file.destroy; f.thumbnail.destroy; f.save }
+    end
+
     def remove_index_if_exists!(table, name)
       ActiveRecord::Base.connection.remove_index(table, name: name)
     rescue ArgumentError

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -184,6 +184,16 @@ module Mastodon
       say("Removed #{removed} orphans (approx. #{number_to_human_size(reclaimed_bytes)})#{dry_run}", :green, true)
     end
 
+    desc 'mark-media-missing', 'Clears references to remote media which has been stored locally'
+    long_desc <<~DESC
+      Clears references to file and thumbnails stored locally that originated remotely.
+
+      This is useful if you are restoring a backup without the cache and need Mastodon to fetch remote media again.
+    DESC
+    def mark_media_missing
+     MediaAttachment.cached.where.not(remote_url: '').each { |f| f.file.destroy; f.thumbnail.destroy; f.save }
+    end
+
     option :account, type: :string
     option :domain, type: :string
     option :status, type: :numeric
@@ -328,16 +338,6 @@ module Mastodon
       preload_map.each_with_object({}) do |(model_name, record_ids), model_map|
         model_map[model_name] = model_name.constantize.where(id: record_ids).index_by(&:id)
       end
-    end
-
-    desc 'mark-media-missing', 'Clears references to remote media which has been stored locally'
-    long_desc <<~LONG_DESC
-      Clears references to file and thumbnails stored locally that originated remotely.
-
-      This is useful if you are restoring a backup without the cache and need Mastodon to fetch remote media again.
-    LONG_DESC
-    def mark_media_missing
-     MediaAttachment.cached.where.not(remote_url: '').each { |f| f.file.destroy; f.thumbnail.destroy; f.save }
     end
 
   end

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -191,7 +191,11 @@ module Mastodon
       This is useful if you are restoring a backup without the cache and need Mastodon to fetch remote media again.
     DESC
     def mark_media_missing
-     MediaAttachment.cached.where.not(remote_url: '').each { |f| f.file.destroy; f.thumbnail.destroy; f.save }
+      MediaAttachment.cached.where.not(remote_url: '').each do |attachment| 
+        attachment.file.destroy
+        attachment.thumbnail.destroy
+        attachment.save
+      end
     end
 
     option :account, type: :string

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -329,5 +329,16 @@ module Mastodon
         model_map[model_name] = model_name.constantize.where(id: record_ids).index_by(&:id)
       end
     end
+
+    desc 'mark-media-missing', 'Clears references to remote media which has been stored locally'
+    long_desc <<~LONG_DESC
+      Clears references to file and thumbnails stored locally that originated remotely.
+
+      This is useful if you are restoring a backup without the cache and need Mastodon to fetch remote media again.
+    LONG_DESC
+    def mark_media_missing
+     MediaAttachment.cached.where.not(remote_url: '').each { |f| f.file.destroy; f.thumbnail.destroy; f.save }
+    end
+
   end
 end

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -339,6 +339,5 @@ module Mastodon
         model_map[model_name] = model_name.constantize.where(id: record_ids).index_by(&:id)
       end
     end
-
   end
 end

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -191,7 +191,7 @@ module Mastodon
       This is useful if you are restoring a backup without the cache and need Mastodon to fetch remote media again.
     DESC
     def mark_media_missing
-      MediaAttachment.cached.where.not(remote_url: '').each do |attachment| 
+      MediaAttachment.cached.where.not(remote_url: '').each do |attachment|
         attachment.file.destroy
         attachment.thumbnail.destroy
         attachment.save


### PR DESCRIPTION
Makes excluding public/system/cache from backups more convenient, thereby allowing for smaller backups. After restore, running the command `mark-media-missing` will mark all remote media to be downloaded again from the source server.

Implemented @ClearlyClaire's suggestion from https://discourse.joinmastodon.org/t/can-the-cache-directory-be-removed-from-backups/3683/4 to fix #16456.

No errors occurred testing `RAILS_ENV=development bin/tootctl media mark-media-missing` on a relatively blank development instance. 