### PR TITLE
Preload libjemalloc.so for long-running Ruby

### DIFF
--- a/dist/mastodon-sidekiq.service
+++ b/dist/mastodon-sidekiq.service
@@ -9,6 +9,7 @@ WorkingDirectory=/home/mastodon/live
 Environment="RAILS_ENV=production"
 Environment="DB_POOL=25"
 Environment="MALLOC_ARENA_MAX=2"
+Environment="LD_PRELOAD=libjemalloc.so"
 ExecStart=/home/mastodon/.rbenv/shims/bundle exec sidekiq -c 25
 TimeoutSec=15
 Restart=always

--- a/dist/mastodon-web.service
+++ b/dist/mastodon-web.service
@@ -8,6 +8,7 @@ User=mastodon
 WorkingDirectory=/home/mastodon/live
 Environment="RAILS_ENV=production"
 Environment="PORT=3000"
+Environment="LD_PRELOAD=libjemalloc.so"
 ExecStart=/home/mastodon/.rbenv/shims/bundle exec puma -C config/puma.rb
 ExecReload=/bin/kill -SIGUSR1 $MAINPID
 TimeoutSec=15


### PR DESCRIPTION
Always mark jemalloc needed if jemalloc is enabled by akihikodaki · Pull Request #4627 · ruby/ruby
https://github.com/ruby/ruby/pull/4627
> Symbols exported by jemalloc is referred by the shared library but not by the executables when building Ruby as a shared library with jemalloc. It causes shared libraries such as the GNU C++ library occasionally rely on the memory allocator provided by the standard C library. Worse, the resolved symbols can later be replaced with jemalloc, and jemalloc may see pointers from the standard C library, which results in various failures. e.g. https://github.com/tootsuite/mastodon/issues/15751

As a workaround, do not rely on jemalloc enablement of Ruby, and preload `libjemalloc.so` instead.