### PR TITLE
Fix upgrade path from 3.4.0

### DIFF
--- a/app/models/account_stat.rb
+++ b/app/models/account_stat.rb
@@ -15,6 +15,7 @@
 
 class AccountStat < ApplicationRecord
   self.locking_column = nil
+  self.ignored_columns = %w(lock_version)
 
   belongs_to :account, inverse_of: :account_stat
 


### PR DESCRIPTION
3.4.1 dropped account_stats.lock_version, but in a way breaking the usual upgrade path by requiring services to be reloaded after the post-migrations.

Indeed, `self.locking_column = nil` was not enough for Rails to ignore the `lock_version` column when preparing statements on application load, resulting in some ActiveRecord queries (typically those involving `includes(:account_stat)`) erroring out with:

> ActiveRecord::StatementInvalid (PG::UndefinedColumn: ERROR:  column account_stats.lock_version does not exist