### PR TITLE
Fix pop-in player display when poster has long username or handle

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7291,6 +7291,7 @@ noscript {
     &__account {
       display: flex;
       text-decoration: none;
+      overflow: hidden;
     }
 
     .account__avatar {


### PR DESCRIPTION
## Before

username/handle overflow the surrounding box and push the close button outside the window

![image](https://user-images.githubusercontent.com/384364/124490511-77dfb980-ddb2-11eb-97e2-06bcde87cb29.png)

## After

![image](https://user-images.githubusercontent.com/384364/124490607-98a80f00-ddb2-11eb-8bfe-8b9f7daca626.png)
