### PR TITLE
Add `configuration` attribute to `GET /api/v1/instance`

### DIFF
--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -5,7 +5,8 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   attributes :uri, :title, :short_description, :description, :email,
              :version, :urls, :stats, :thumbnail,
-             :languages, :registrations, :approval_required, :invites_enabled
+             :languages, :registrations, :approval_required, :invites_enabled,
+             :configuration
 
   has_one :contact_account, serializer: REST::AccountSerializer
 
@@ -51,6 +52,32 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   def urls
     { streaming_api: Rails.configuration.x.streaming_api_base_url }
+  end
+
+  def configuration
+    {
+      statuses: {
+        max_characters: StatusLengthValidator::MAX_CHARS,
+        max_media_attachments: 4,
+        characters_reserved_per_url: StatusLengthValidator::URL_PLACEHOLDER_CHARS,
+      },
+
+      media_attachments: {
+        supported_mime_types: MediaAttachment::IMAGE_MIME_TYPES + MediaAttachment::VIDEO_MIME_TYPES + MediaAttachment::AUDIO_MIME_TYPES,
+        image_size_limit: MediaAttachment::IMAGE_LIMIT,
+        image_matrix_limit: Attachmentable::MAX_MATRIX_LIMIT,
+        video_size_limit: MediaAttachment::VIDEO_LIMIT,
+        video_frame_rate_limit: MediaAttachment::MAX_VIDEO_FRAME_RATE,
+        video_matrix_limit: MediaAttachment::MAX_VIDEO_MATRIX_LIMIT,
+      },
+
+      polls: {
+        max_options: PollValidator::MAX_OPTIONS,
+        max_characters_per_option: PollValidator::MAX_OPTION_CHARS,
+        min_expiration: PollValidator::MIN_EXPIRATION,
+        max_expiration: PollValidator::MAX_EXPIRATION,
+      },
+    }
   end
 
   def languages

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -2,7 +2,8 @@
 
 class StatusLengthValidator < ActiveModel::Validator
   MAX_CHARS = 500
-  URL_PLACEHOLDER = "\1#{'x' * 23}"
+  URL_PLACEHOLDER_CHARS = 23
+  URL_PLACEHOLDER = "\1#{'x' * URL_PLACEHOLDER_CHARS}"
 
   def validate(status)
     return unless status.local? && !status.reblog?


### PR DESCRIPTION
List various values like file size limits and supported mime types

Fix #4915

```json
{
  "statuses": {
    "max_characters": 500,
    "max_media_attachments": 4,
    "characters_reserved_per_url": 23
  },
  "media_attachments": {
    "supported_mime_types": [
      "image/jpeg",
      "image/png",
      "image/gif",
      "video/webm",
      "video/mp4",
      "video/quicktime",
      "video/ogg",
      "audio/wave",
      "audio/wav",
      "audio/x-wav",
      "audio/x-pn-wave",
      "audio/ogg",
      "audio/mpeg",
      "audio/mp3",
      "audio/webm",
      "audio/flac",
      "audio/aac",
      "audio/m4a",
      "audio/x-m4a",
      "audio/mp4",
      "audio/3gpp",
      "video/x-ms-asf"
    ],
    "image_size_limit": 10485760,
    "image_matrix_limit": 16777216,
    "video_size_limit": 41943040,
    "video_frame_rate_limit": 60,
    "video_matrix_limit": 2304000
  },
  "polls": {
    "max_options": 4,
    "max_characters_per_option": 50,
    "min_expiration": 300,
    "max_expiration": 2629746
  }
}
```