### PR TITLE
Tweak docker-compose.yml - Redis from 6.0.4 to 6.2.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   redis:
     restart: always
-    image: redis:6.0-alpine
+    image: redis:6-alpine
     networks:
       - internal_network
     healthcheck:


### PR DESCRIPTION
The hardcoded minor is not required.