### PR TITLE
Fix inefficiencies in auto-linking code

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -214,39 +214,10 @@ class Formatter
     result.flatten.join
   end
 
-  UNICODE_ESCAPE_BLACKLIST_RE = /\p{Z}|\p{P}/
-
   def utf8_friendly_extractor(text, options = {})
-    old_to_new_index = [0]
-
-    escaped = text.chars.map do |c|
-      output = begin
-        if c.ord.to_s(16).length > 2 && !UNICODE_ESCAPE_BLACKLIST_RE.match?(c)
-          CGI.escape(c)
-        else
-          c
-        end
-      end
-
-      old_to_new_index << old_to_new_index.last + output.length
-
-      output
-    end.join
-
     # Note: I couldn't obtain list_slug with @user/list-name format
     # for mention so this requires additional check
-    special = Extractor.extract_urls_with_indices(escaped, options).map do |extract|
-      new_indices = [
-        old_to_new_index.find_index(extract[:indices].first),
-        old_to_new_index.find_index(extract[:indices].last),
-      ]
-
-      next extract.merge(
-        indices: new_indices,
-        url: text[new_indices.first..new_indices.last - 1]
-      )
-    end
-
+    special = Extractor.extract_urls_with_indices(text, options)
     standard = Extractor.extract_entities_with_indices(text, options)
     extra = Extractor.extract_extra_uris_with_indices(text, options)
 

--- a/config/initializers/twitter_regex.rb
+++ b/config/initializers/twitter_regex.rb
@@ -24,6 +24,10 @@ module Twitter::TwitterText
         )
       \)
     /iox
+    REGEXEN[:valid_iri_ucschar] = /[\u{A0}-\u{D7FF}\u{F900}-\u{FDCF}\u{FDF0}-\u{FFEF}\u{10000}-\u{1FFFD}\u{20000}-\u{2FFFD}\u{30000}-\u{3FFFD}\u{40000}-\u{4FFFD}\u{50000}-\u{5FFFD}\u{60000}-\u{6FFFD}\u{70000}-\u{7FFFD}\u{80000}-\u{8FFFD}\u{90000}-\u{9FFFD}\u{A0000}-\u{AFFFD}\u{B0000}-\u{BFFFD}\u{C0000}-\u{CFFFD}\u{D0000}-\u{DFFFD}\u{E1000}-\u{EFFFD}]/iou
+    REGEXEN[:valid_iri_iprivate] = /[\u{E000}-\u{F8FF}\u{F0000}-\u{FFFFD}\u{100000}-\u{10FFFD}]/iou
+    REGEXEN[:valid_url_query_chars] = /(?:#{REGEXEN[:valid_iri_ucschar]})|(?:#{REGEXEN[:valid_iri_iprivate]})|[a-z0-9!?\*'\(\);:&=\+\$\/%#\[\]\-_\.,~|@]/iou
+    REGEXEN[:valid_url_query_ending_chars] = /(?:#{REGEXEN[:valid_iri_ucschar]})|(?:#{REGEXEN[:valid_iri_iprivate]})|[a-z0-9_&=#\/\-]/iou
     REGEXEN[:valid_url_path] = /(?:
       (?:
         #{REGEXEN[:valid_general_url_path_chars]}*


### PR DESCRIPTION
The auto-linking code basically rewrote the whole string escaping non-ascii characters in an inefficient way, and building a full character offset map between the unescaped and escaped texts before sending the contents to TwitterText's extractor.

Instead of doing that, this commit changes the TwitterText regexps to include valid IRI characters in addition to valid URI characters.

## Performance yields

### Methodology

Performances were evaluated by timing the rendering of a sample toot 100000 times on my development machine. Memory impact was evaluated using `MemoryProfiler`.

<details>
<summary>Example on old code</summary>

```
[mastodon@mastodev live]$ bundle exec rails c
Chewy console strategy is `urgent`
Loading production environment (Rails 6.1.4)
irb(main):001:0> s = Status.first
=> 
#<Status:0x0000564fdf4273d8
...
irb(main):002:0> s.text
=> "This is a test toot with a few #hashtags, emojis 🤔  and links, some including non-ascii characters and others not:\n- https://joinmastodon.org/\n- https://github.com/mastodon/mastodon\n- https://nic.みんな/\n#mastodev"
irb(main):003:0> Formatter.instance.format(s)
=> "<p>This is a test toot with a few <a href=\"https://mastodev.sitedethib.com/tags/hashtags\" class=\"mention hashtag\" rel=\"tag\">#<span>hashtags</span></a>, emojis 🤔  and links, some including non-ascii characters and others not:<br />- <a href=\"https://joinmastodon.org/\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"\">joinmastodon.org/</span><span class=\"invisible\"></span></a><br />- <a href=\"https://github.com/mastodon/mastodon\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"\">github.com/mastodon/mastodon</span><span class=\"invisible\"></span></a><br />- <a href=\"https://nic.みんな/\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"\">nic.みんな/</span><span class=\"invisible\"></span></a><br /><a href=\"https://mastodev.sitedethib.com/tags/mastodev\" class=\"mention hashtag\" rel=\"tag\">#<span>mastodev</span></a></p>"
irb(main):004:0> puts Benchmark.measure { for i in 1..100000; Formatter.instance.format(s); end }
114.277594   0.005209 114.282803 (114.291816)
=> nil
irb(main):005:0> require 'memory_profiler'
=> true
irb(main):007:0> MemoryProfiler.report { Formatter.instance.format(s) }.pretty_print
Total allocated: 140218 bytes (1637 objects)
Total retained:  6011 bytes (14 objects)

allocated memory by gem
-----------------------------------
     70949  htmlentities-4.3.4
     21833  live/app
     14025  activesupport-6.1.4
     12703  addressable-2.8.0
     10693  twitter-text-3.1.0
      5984  actionpack-6.1.4
      2831  actionview-6.1.4
      1080  activemodel-6.1.4
       120  other
[…]
```
</details>

### Results

#### Timing

|     | user | system | total | (real) |
| -- | ------ | ---------- | ----- | -------- |
| old code | 114.277594s | 0.005209s | 114.282803s | 114.291816s |
| this PR | 103.606800s | 0.001257s | 103.608057s | 103.615692s |

#### Memory allocations

|    | total allocated | total retained |
| -- | ------------------ | ----------------- |
| old code | 140218 bytes (1637 objects) | 6011 bytes (14 objects) |
| this PR | 117140 bytes (1208 objects) | 5724 bytes (13 objects) |