### PR TITLE
Fix replying from modal

### DIFF
--- a/app/javascript/mastodon/components/modal_root.js
+++ b/app/javascript/mastodon/components/modal_root.js
@@ -6,6 +6,10 @@ import { multiply } from 'color-blend';
 
 export default class ModalRoot extends React.PureComponent {
 
+  static contextTypes = {
+    router: PropTypes.object,
+  };
+
   static propTypes = {
     children: PropTypes.node,
     onClose: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixes #16515

Not using a router object somehow made `this.history` lag behind the real browser history whenever pushing a new history item in `replyCompose`.

Not using the context-provided router in this case was an oversight made when porting glitch-soc changes in #16499.