### PR TITLE
Fix crashes with Microsoft Translate on Microsoft Edge

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -309,8 +309,8 @@ class Status extends ImmutablePureComponent {
       return (
         <HotKeys handlers={handlers}>
           <div ref={this.handleRef} className={classNames('status__wrapper', { focusable: !this.props.muted })} tabIndex='0'>
-            {status.getIn(['account', 'display_name']) || status.getIn(['account', 'username'])}
-            {status.get('content')}
+            <span>{status.getIn(['account', 'display_name']) || status.getIn(['account', 'username'])}</span>
+            <span>{status.get('content')}</span>
           </div>
         </HotKeys>
       );


### PR DESCRIPTION
Fixes #16509

Microsoft Edge with translation enabled rewrites the DOM in ways that confuse react and prevent it from working properly. Wrapping the offending parts in a span avoids this issue.

https://github.com/facebook/react/issues/11538#issuecomment-417504600 has been helpful in identifying which elements caused issues