### PR TITLE
Add `from:` query operator to search syntax

### DIFF
--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -16,17 +16,6 @@ class Api::V2::SearchController < Api::BaseController
   private
 
   def search_results
-    unless params[:account_id]
-      by_regex = /\bby:(\w+)(?:@(\S+))?\b/
-      query = params[:q]
-
-      query.match(by_regex) do |m|
-        params[:q] = query.delete(m.to_s)
-        by = m.captures
-        params[:account_id] = Account.find_remote(by[0], by[1])&.id
-      end
-    end
-
     SearchService.new.call(
       params[:q],
       current_account,

--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -16,6 +16,17 @@ class Api::V2::SearchController < Api::BaseController
   private
 
   def search_results
+    unless params[:account_id]
+      by_regex = /\bby:(\w+)(?:@(\S+))?\b/
+      query = params[:q]
+
+      query.match(by_regex) do |m|
+        params[:q] = query.delete(m.to_s)
+        by = m.captures
+        params[:account_id] = Account.find_remote(by[0], by[1])&.id
+      end
+    end
+
     SearchService.new.call(
       params[:q],
       current_account,

--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -2,19 +2,21 @@
 
 class SearchQueryTransformer < Parslet::Transform
   class Query
-    attr_reader :should_clauses, :must_not_clauses, :must_clauses
+    attr_reader :should_clauses, :must_not_clauses, :must_clauses, :filter_clauses
 
     def initialize(clauses)
       grouped = clauses.chunk(&:operator).to_h
       @should_clauses = grouped.fetch(:should, [])
       @must_not_clauses = grouped.fetch(:must_not, [])
       @must_clauses = grouped.fetch(:must, [])
+      @filter_clauses = grouped.fetch(:filter, [])
     end
 
     def apply(search)
       should_clauses.each { |clause| search = search.query.should(clause_to_query(clause)) }
       must_clauses.each { |clause| search = search.query.must(clause_to_query(clause)) }
       must_not_clauses.each { |clause| search = search.query.must_not(clause_to_query(clause)) }
+      filter_clauses.each { |clause| search = search.filter(**clause_to_filter(clause)) }
       search.query.minimum_should_match(1)
     end
 
@@ -30,7 +32,17 @@ class SearchQueryTransformer < Parslet::Transform
         raise "Unexpected clause type: #{clause}"
       end
     end
+
+    def clause_to_filter(clause)
+      case clause
+      when PrefixClause
+        { term: { clause.filter => clause.term } }
+      else
+        raise "Unexpected clause type: #{clause}"
+      end
+    end
   end
+
 
   class Operator
     class << self
@@ -69,11 +81,33 @@ class SearchQueryTransformer < Parslet::Transform
     end
   end
 
+  class PrefixClause
+    attr_reader :filter, :operator, :term
+
+    def initialize(prefix, operator, term)
+      @operator = :filter
+      case prefix
+      when "by"
+        @filter = :account_id
+        username, domain = term.split('@')
+        account = Account.find_remote(username, domain)
+
+        raise "Account not found: #{term}" unless account
+
+        @term = account.id
+      else
+        raise "Unknown prefix: #{prefix}"
+      end
+    end
+  end
+
   rule(clause: subtree(:clause)) do
     prefix   = clause[:prefix][:term].to_s if clause[:prefix]
     operator = clause[:operator]&.to_s
 
-    if clause[:term]
+    if clause[:prefix]
+      PrefixClause.new(prefix, operator, clause[:term].to_s)
+    elsif clause[:term]
       TermClause.new(prefix, operator, clause[:term].to_s)
     elsif clause[:shortcode]
       TermClause.new(prefix, operator, ":#{clause[:term]}:")

--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -43,7 +43,6 @@ class SearchQueryTransformer < Parslet::Transform
     end
   end
 
-
   class Operator
     class << self
       def symbol(str)
@@ -84,10 +83,10 @@ class SearchQueryTransformer < Parslet::Transform
   class PrefixClause
     attr_reader :filter, :operator, :term
 
-    def initialize(prefix, operator, term)
+    def initialize(prefix, term)
       @operator = :filter
       case prefix
-      when "by"
+      when 'by'
         @filter = :account_id
         username, domain = term.split('@')
         account = Account.find_remote(username, domain)
@@ -106,7 +105,7 @@ class SearchQueryTransformer < Parslet::Transform
     operator = clause[:operator]&.to_s
 
     if clause[:prefix]
-      PrefixClause.new(prefix, operator, clause[:term].to_s)
+      PrefixClause.new(prefix, clause[:term].to_s)
     elsif clause[:term]
       TermClause.new(prefix, operator, clause[:term].to_s)
     elsif clause[:shortcode]

--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -86,7 +86,7 @@ class SearchQueryTransformer < Parslet::Transform
     def initialize(prefix, term)
       @operator = :filter
       case prefix
-      when 'by'
+      when 'from'
         @filter = :account_id
         username, domain = term.split('@')
         account = Account.find_remote(username, domain)


### PR DESCRIPTION
As #10091, `account_id` parameter is usable on `/api/v2/search` API.
However, account_id is not easily usable by human and Not even used on web interface.
In this PR, introduce `by:username@domain` like query for handy.

examples:
- `by:local_user some words`
- `by:remote_user@domain.tld some words`