### PR TITLE
Explicitly set userVerification to discoraged when getting the options for create/get

### DIFF
--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -45,7 +45,10 @@ class Auth::SessionsController < Devise::SessionsController
     user = find_user
 
     if user&.webauthn_enabled?
-      options_for_get = WebAuthn::Credential.options_for_get(allow: user.webauthn_credentials.pluck(:external_id))
+      options_for_get = WebAuthn::Credential.options_for_get(
+        allow: user.webauthn_credentials.pluck(:external_id),
+        user_verification: 'discouraged'
+      )
 
       session[:webauthn_challenge] = options_for_get.challenge
 

--- a/app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb
+++ b/app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb
@@ -21,7 +21,8 @@ module Settings
             display_name: current_user.account.username,
             id: current_user.webauthn_id,
           },
-          exclude: current_user.webauthn_credentials.pluck(:external_id)
+          exclude: current_user.webauthn_credentials.pluck(:external_id),
+          authenticator_selection: { user_verification: 'discouraged' }
         )
 
         session[:webauthn_challenge] = options_for_create.challenge


### PR DESCRIPTION
## Why

In #14466, we've introduced WebAuthn as an alternative 2FA method, allowing users who already have 2FA (OTP) to register WebAuthn security keys and login using WebAuthn as 2FA or fallback to OTP.

When getting options for add security keys or login using WebAuthn, currently user_verfication is not set, so the default value is "preferred" which will instruct the user-agent to acquire [user verification](https://www.w3.org/TR/webauthn/#user-verification) [“if possible”](https://www.w3.org/TR/webauthn/#dom-userverificationrequirement-preferred). On modern versions of Windows this is interpreted such that a user will be prompted to configure a PIN during credential creation on an authenticator that supports it, and such that a user will be prompted for a PIN if one is already set. On other platforms, Chrome will not direct the user to create a PIN if one is not already set, but will be prompt for a PIN if one is configured. This is quite different from the traditional user experience of security keys.

https://chromium.googlesource.com/chromium/src/+/refs/heads/main/content/browser/webauth/uv_preferred.md
> The traditional user experience is best replicated by setting userVerification to discouraged. This does not preclude the UV flag being set in a signature because some authenticators may always do user verification. (For example, a built-in fingerprint reader.) But it will prevent PIN prompts from appearing.


Same problem reported in #16007 https://github.com/duo-labs/webauthn.io/issues/13
>- Once a pin is set it, Windows seems to require it for all credential creation via the Webauthn API (but not U2F for some reason), even if userVerification is discouraged and the security key itself doesn't require the pin.
>- After setting a pin, all sites that don't explicitly set userVerification to discouraged suddenly require pin entry.
>- On YubiKeys, the pin can't be removed without a reset, so you're stuck with it after trying the demo.

So we should explicitly enabling or disabling user verification to avoid unintended or unexpected user interaction.

[Yubico](https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/User_Presence_vs_User_Verification.html) recommends disable user verification for 2FA:
> User verification is not recommended for 2FA because the user will have already entered a shared secret (password) sent to the server over the network
>
> User verification is appropriate for passwordless scenarios and multi-factor authentication (MFA) because the user enters a shared secret with the authenticator (PIN) that is not sent over the network.

## What

2984c6b Explicitly set userVerification to discoraged

## Other information
Addresses #15936