### PR TITLE
Vagrant: Use curl to download Ruby signing keys from rvm.io instead of keys.gnupg.net

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,16 +45,8 @@ sudo apt-get install \
 # Install rvm
 read RUBY_VERSION < .ruby-version
 
-gpg_command="gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
-$($gpg_command)
-if [ $? -ne 0 ];then
-  echo "GPG command failed, This prevented RVM from installing."
-  echo "Retrying once..." && $($gpg_command)
-  if [ $? -ne 0 ];then
-    echo "GPG failed for the second time, please ensure network connectivity."
-    echo "Exiting..." && exit 1
-  fi
-fi
+curl -sSL https://rvm.io/mpapis.asc | gpg --import
+curl -sSL https://rvm.io/pkuczynski.asc | gpg --import
 
 curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer | bash -s stable --ruby=$RUBY_VERSION
 source /home/vagrant/.rvm/scripts/rvm


### PR DESCRIPTION
keys.gnupg.net is unreliable so replacing it with direct download of keys from rvm.io as suggested in the second answer here: https://stackoverflow.com/questions/66217436/gpg-keyserver-receive-failed-no-name. Tested it and the commands succeeded.

Removed instead of modified retry logic since it is only necessary for keys.gnupg.net.

Fixes #16567