### PR TITLE
Fix trends layout

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3022,13 +3022,13 @@ a.account__display-name {
     }
 
     @media screen and (max-height: 810px) {
-      .trends__item:nth-child(3) {
+      .trends__item:nth-of-type(3) {
         display: none;
       }
     }
 
     @media screen and (max-height: 720px) {
-      .trends__item:nth-child(2) {
+      .trends__item:nth-of-type(2) {
         display: none;
       }
     }


### PR DESCRIPTION
With #7700, trending tags are hidden one by one on small screen. But there are bug on CSS selector.
1st child is H4 header. It causes hiding 2nd, 1st item instead of 3rd, 2nd item. And also has problem shown below if there are 1 or 2 trending tags
![image](https://user-images.githubusercontent.com/5047683/128299434-ad5f6e4f-db62-460a-8bf5-ee0e627305ea.png)
