### PR TITLE
Fix owned account notes not being deleted when an account is deleted

### DIFF
--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -81,6 +81,9 @@ module AccountInteractions
     has_many :following, -> { order('follows.id desc') }, through: :active_relationships,  source: :target_account
     has_many :followers, -> { order('follows.id desc') }, through: :passive_relationships, source: :account
 
+    # Account notes
+    has_many :account_notes, dependent: :destroy
+
     # Block relationships
     has_many :block_relationships, class_name: 'Block', foreign_key: 'account_id', dependent: :destroy
     has_many :blocking, -> { order('blocks.id desc') }, through: :block_relationships, source: :target_account

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -4,6 +4,7 @@ class DeleteAccountService < BaseService
   include Payloadable
 
   ASSOCIATIONS_ON_SUSPEND = %w(
+    account_notes
     account_pins
     active_relationships
     aliases
@@ -34,6 +35,7 @@ class DeleteAccountService < BaseService
   # by foreign keys, making them safe to delete without loading
   # into memory
   ASSOCIATIONS_WITHOUT_SIDE_EFFECTS = %w(
+    account_notes
     account_pins
     aliases
     conversation_mutes

--- a/db/post_migrate/20210808071221_clear_orphaned_account_notes.rb
+++ b/db/post_migrate/20210808071221_clear_orphaned_account_notes.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ClearOrphanedAccountNotes < ActiveRecord::Migration[5.2]
+  class Account < ApplicationRecord
+    # Dummy class, to make migration possible across version changes
+  end
+
+  class AccountNote < ApplicationRecord
+    # Dummy class, to make migration possible across version changes
+    belongs_to :account
+    belongs_to :target_account, class_name: 'Account'
+  end
+
+  def up
+    AccountNote.where('NOT EXISTS (SELECT * FROM users u WHERE u.account_id = account_notes.account_id)').in_batches.delete_all
+  end
+
+  def down
+    # nothing to do
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_30_000137) do
+ActiveRecord::Schema.define(version: 2021_08_08_071221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/services/delete_account_service_spec.rb
+++ b/spec/services/delete_account_service_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe DeleteAccountService, type: :service do
     let!(:favourite_notification) { Fabricate(:notification, account: local_follower, activity: favourite, type: :favourite) }
     let!(:follow_notification) { Fabricate(:notification, account: local_follower, activity: active_relationship, type: :follow) }
 
+    let!(:account_note) { Fabricate(:account_note, account: account) }
+
     subject do
       -> { described_class.new.call(account) }
     end
@@ -35,8 +37,9 @@ RSpec.describe DeleteAccountService, type: :service do
           account.active_relationships,
           account.passive_relationships,
           account.polls,
+          account.account_notes,
         ].map(&:count)
-      }.from([2, 1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0, 0])
+      }.from([2, 1, 1, 1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0, 0, 0, 0])
     end
 
     it 'deletes associated target records' do


### PR DESCRIPTION
When an account is deleted while keeping its `account` record (which is the default when definitely suspending, or self-deleting a local account), account notes owned by this account are not deleted, unlike any other data owned by the deleted account.

In addition to keeping private data for longer than it should (possibly indefinitely), this also may be the root cause for the issue addressed in #16576.

This PR fixes `DeleteAccountService` to delete those account notes, and adds a migration script to automatically delete every already-orphaned account notes.