### PR TITLE
Fix invalid blurhash handling in Create activity

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -446,8 +446,12 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   end
 
   def supported_blurhash?(blurhash)
-    components = blurhash.blank? ? nil : Blurhash.components(blurhash)
+    components = blurhash.blank? || !blurhash_valid_chars?(blurhash) ? nil : Blurhash.components(blurhash)
     components.present? && components.none? { |comp| comp > 5 }
+  end
+
+  def blurhash_valid_chars?(blurhash)
+    /^[\w#$%*+-.:;=?@\[\]^{|}~]+$/.match?(blurhash)
   end
 
   def skip_download?


### PR DESCRIPTION
Check if blurhash is valid because it may fail to get status due to invalid blurhash.

An example of invalid blurhash is like this.

> "blurhash": "/bin/sh: /usr/local/pleroma/_build/prod/lib/eblurhash/priv/blurhash: Exec format error",

It is better to modify the blurhash gem.
Due to an invalid blurhash string, find_index fails and nil cannot be added, resulting in an error.
https://github.com/Gargron/blurhash/blob/cb529b4c65ad07d5663d8431a8f7746b3641c7ed/lib/blurhash.rb#L47-L48