### PR TITLE
Add meta tag for official iOS app

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,6 +18,7 @@
     %meta{ name: 'msapplication-config', content: '/browserconfig.xml' }/
     %meta{ name: 'theme-color', content: '#282c37' }/
     %meta{ name: 'apple-mobile-web-app-capable', content: 'yes' }/
+    %meta{ name: 'apple-itunes-app', content: 'app-id=1571998974' }/
 
     %title= content_for?(:page_title) ? safe_join([yield(:page_title).chomp.html_safe, title], ' - ') : title
 


### PR DESCRIPTION
Ref: https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners

We can pass navigational context for account/post pages so that the right screen opens in the app, but support for this has to be added on the app's side first. A far more seamless experience would be with [Universal Links](https://developer.apple.com/ios/universal-links/) however unfortunately Apple does not support Universal Links with arbitrary domains.

I hope the banner will not appear in PWAs (when added to home screen) but I'm not sure, that is up to Safari. Since this is a system banner controlled by Safari I am hoping that it will not annoy anyone (I hate the custom banners that Reddit/Imgur/etc implement).

I guess that this would need to be tested in production and reverted if necessary.