### PR TITLE
Fix remotely-suspended accounts' toots being merged back into timelines

### DIFF
--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -142,6 +142,7 @@ class ResolveAccountService < BaseService
   end
 
   def queue_deletion!
+    @account.suspend!(origin: :remote)
     AccountDeletionWorker.perform_async(@account.id, reserve_username: false, skip_activitypub: true)
   end
 

--- a/app/services/unsuspend_account_service.rb
+++ b/app/services/unsuspend_account_service.rb
@@ -7,7 +7,7 @@ class UnsuspendAccountService < BaseService
     unsuspend!
     refresh_remote_account!
 
-    return if @account.nil?
+    return if @account.nil? || @account.suspended?
 
     merge_into_home_timelines!
     merge_into_list_timelines!


### PR DESCRIPTION
When a local admin has locally suspended a remote user and then unsuspends it, local followers get their existing toots back into their timelines.

However, this occurs even if the account is remotely suspended, which is not the expected behavior. This PR fixes this issue.

This PR also marks remotely-deleted accounts as remotely-deleted, pending their eventual deletion. This fixes possible inconsistencies between the time a remotely-deleted account is locally unsuspended and the time the deletion is processed (that is, showing an old profile containing offending material for the time needed for the server to process the deletion).