### PR TITLE
Disable nginx ssl_session_tickets for better security

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -31,6 +31,7 @@ server {
   ssl_ciphers HIGH:!MEDIUM:!LOW:!aNULL:!NULL:!SHA;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
+  ssl_session_tickets off;
 
   # Uncomment these lines once you acquire a certificate:
   # ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;


### PR DESCRIPTION
It's default turned on, but it's better to turn it off for security reason.

Reference:
- https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets
- https://github.com/mozilla/server-side-tls/issues/135