### PR TITLE
Make sure nginx always send HSTS header

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -52,7 +52,7 @@ server {
   gzip_http_version 1.1;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
-  add_header Strict-Transport-Security "max-age=31536000";
+  add_header Strict-Transport-Security "max-age=31536000" always;
 
   location / {
     try_files $uri @proxy;
@@ -60,13 +60,13 @@ server {
 
   location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
     add_header Cache-Control "public, max-age=31536000, immutable";
-    add_header Strict-Transport-Security "max-age=31536000";
+    add_header Strict-Transport-Security "max-age=31536000" always;
     try_files $uri @proxy;
   }
 
   location /sw.js {
     add_header Cache-Control "public, max-age=0";
-    add_header Strict-Transport-Security "max-age=31536000";
+    add_header Strict-Transport-Security "max-age=31536000" always;
     try_files $uri @proxy;
   }
 
@@ -90,7 +90,7 @@ server {
     proxy_cache_valid 410 24h;
     proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
     add_header X-Cached $upstream_cache_status;
-    add_header Strict-Transport-Security "max-age=31536000";
+    add_header Strict-Transport-Security "max-age=31536000" always;
 
     tcp_nodelay on;
   }


### PR DESCRIPTION
By default, it'll only send those headers when the response code is one of the following:
- 200, 201, 204, 206, 301, 302, 303, 304, 307 & 308

As all the traffics should be https, the http protocol only exists to do 301 redirect,
and always send the HSTS header is almost one of the best practices, we should set
nginx to do so.

Reference:
- https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
- https://ssl-config.mozilla.org/