### PR TITLE
Fix “discoverable” account setting being tied to profile directory

### DIFF
--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -29,9 +29,8 @@
   .fields-group
     = f.input :bot, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.bot')
 
-  - if Setting.profile_directory
-    .fields-group
-      = f.input :discoverable, as: :boolean, wrapper: :with_label, hint: t('simple_form.hints.defaults.discoverable'), recommended: true
+  .fields-group
+    = f.input :discoverable, as: :boolean, wrapper: :with_label, hint: t(Setting.profile_directory ? 'simple_form.hints.defaults.discoverable' : 'simple_form.hints.defaults.discoverable_no_directory'), recommended: true
 
   %hr.spacer/
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -35,7 +35,8 @@ en:
         current_password: For security purposes please enter the password of the current account
         current_username: To confirm, please enter the username of the current account
         digest: Only sent after a long period of inactivity and only if you have received any personal messages in your absence
-        discoverable: Allow your account to be discovered by strangers through recommendations and other features
+        discoverable: Allow your account to be discovered by strangers through recommendations, profile directory and other features
+        discoverable_no_directory: Allow your account to be discovered by strangers through recommendations and other features
         email: You will be sent a confirmation e-mail
         fields: You can have up to 4 items displayed as a table on your profile
         header: PNG, GIF or JPG. At most %{size}. Will be downscaled to %{dimensions}px


### PR DESCRIPTION
The “discoverable” account setting (“Suggest account to others”) was originally only used for the profile directory.
However, this has since changed to be federated as a `discoverable` attribute, and used in follow recommendations without that feature being tied to the profile directory.
Furthermore, when the profile directory is disabled, users cannot change their “discoverable” property, but that does not mean it is necessarily disabled: if they enabled it before the instance disabled the profile directory, for instance, the property is set but cannot be unset by the user.

This PR fixes that by displaying the setting regardless of whether the profile directory is enabled, just slightly adapting the text if it is.