### PR TITLE
Fix 404 error when filtering admin action logs by non-existent target account

### DIFF
--- a/app/models/admin/action_log_filter.rb
+++ b/app/models/admin/action_log_filter.rb
@@ -76,7 +76,7 @@ class Admin::ActionLogFilter
     when 'account_id'
       Admin::ActionLog.where(account_id: value)
     when 'target_account_id'
-      account = Account.find(value)
+      account = Account.find_or_initialize_by(id: value)
       Admin::ActionLog.where(target: [account, account.user].compact)
     else
       raise "Unknown filter: #{key}"


### PR DESCRIPTION
Currently, there is no way for an admin to delete an account record.
However, should that happen in the future, or should an admin mistype an account id, `/admin/action_logs?target_account_id=<non-existent-account-id>` currently returns a 404 instead of an empty list.

With this commit, the aforementioned page returns a correct list instead (potentially non-empty if the account has been manually deleted)