### PR TITLE
helm: update elasticsearch chart to v15.10.3

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 14.2.3
+  version: 15.10.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 8.10.14
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 10.9.0
-digest: sha256:9e3e7b987c6ffba9295a30b7fae2613fe680c2b1a1832ff5afb185414ce1898e
-generated: "2021-02-27T01:01:12.776919968Z"
+digest: sha256:f5c57108f7768fd16391c1a050991c7809f84a640cca308d7d24d87379d04000
+generated: "2021-08-05T08:01:01.457727804Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -24,7 +24,7 @@ appVersion: 3.3.0
 
 dependencies:
   - name: elasticsearch
-    version: 14.2.3
+    version: 15.10.3
     repository: https://charts.bitnami.com/bitnami
     condition: elasticsearch.enabled
   - name: postgresql


### PR DESCRIPTION
this is a backwards-compatible upgrade: https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#to-1500