### PR TITLE
Fix follow request count to dynamically update

### DIFF
--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -1,6 +1,6 @@
 import api, { getLinks } from '../api';
 import IntlMessageFormat from 'intl-messageformat';
-import { fetchRelationships } from './accounts';
+import { fetchFollowRequests, fetchRelationships } from './accounts';
 import {
   importFetchedAccount,
   importFetchedAccounts,
@@ -76,6 +76,10 @@ export function updateNotifications(notification, intlMessages, intlLocale) {
       }
 
       filtered = regex && regex.test(searchIndex);
+    }
+
+    if (['follow_request'].includes(notification.type)) {
+      dispatch(fetchFollowRequests());
     }
 
     dispatch(submitMarkers());


### PR DESCRIPTION
When we get an incoming follow request, we get notified for it over the streaming API, but we don't actually update state. This means that the follow requests button is static — it requires a refresh to show the updated count. Since many people leave their session open for long periods, this results in a less-than-ideal user experience. This patches the notification dispatch to grab the follow request count when we get a new request notification, updating state and UI.

Fixes #16178