### PR TITLE
Allow keeping only 1 boosts/favs on auto deleting posts

### DIFF
--- a/app/models/account_statuses_cleanup_policy.rb
+++ b/app/models/account_statuses_cleanup_policy.rb
@@ -164,8 +164,8 @@ class AccountStatusesCleanupPolicy < ApplicationRecord
 
   def without_popular_scope
     scope = Status.left_joins(:status_stat)
-    scope = scope.where('COALESCE(status_stats.reblogs_count, 0) <= ?', min_reblogs) unless min_reblogs.nil?
-    scope = scope.where('COALESCE(status_stats.favourites_count, 0) <= ?', min_favs) unless min_favs.nil?
+    scope = scope.where('COALESCE(status_stats.reblogs_count, 0) < ?', min_reblogs) unless min_reblogs.nil?
+    scope = scope.where('COALESCE(status_stats.favourites_count, 0) < ?', min_favs) unless min_favs.nil?
     scope
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1336,10 +1336,10 @@ en:
       '63113904': 2 years
       '7889238': 3 months
     min_age_label: Age threshold
-    min_favs: Keep posts favourited more than
-    min_favs_hint: Doesn't delete any of your posts that has received more than this amount of favourites. Leave blank to delete posts regardless of their number of favourites
-    min_reblogs: Keep posts boosted more than
-    min_reblogs_hint: Doesn't delete any of your posts that has been boosted more than this number of times. Leave blank to delete posts regardless of their number of boosts
+    min_favs: Keep posts favourited at least
+    min_favs_hint: Doesn't delete any of your posts that has received at least this amount of favourites. Leave blank to delete posts regardless of their number of favourites
+    min_reblogs: Keep posts boosted at least
+    min_reblogs_hint: Doesn't delete any of your posts that has been boosted at least this number of times. Leave blank to delete posts regardless of their number of boosts
   stream_entries:
     pinned: Pinned post
     reblogged: boosted

--- a/spec/models/account_statuses_cleanup_policy_spec.rb
+++ b/spec/models/account_statuses_cleanup_policy_spec.rb
@@ -499,9 +499,9 @@ RSpec.describe AccountStatusesCleanupPolicy, type: :model do
       end
     end
 
-    context 'when policy is to keep statuses with more than 4 boosts' do
+    context 'when policy is to keep statuses with at least 5 boosts' do
       before do
-        account_statuses_cleanup_policy.min_reblogs = 4
+        account_statuses_cleanup_policy.min_reblogs = 5
       end
 
       it 'does not return the recent toot' do
@@ -521,9 +521,9 @@ RSpec.describe AccountStatusesCleanupPolicy, type: :model do
       end
     end
 
-    context 'when policy is to keep statuses with more than 4 favs' do
+    context 'when policy is to keep statuses with at least 5 favs' do
       before do
-        account_statuses_cleanup_policy.min_favs = 4
+        account_statuses_cleanup_policy.min_favs = 5
       end
 
       it 'does not return the recent toot' do


### PR DESCRIPTION
Some people want to keep posts that are boosted or favourited even if there are only one person engaged.

Related: #16529 