### PR TITLE
Fix undefined variable for Auth::OmniauthCallbacksController

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -11,7 +11,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
       if @user.persisted?
         LoginActivity.create(
-          user: user,
+          user: @user,
           success: true,
           authentication_method: :omniauth,
           provider: provider,


### PR DESCRIPTION
The addition of authentication history broke the omniauth login with
the following error:

  method=GET path=/auth/auth/cas/callback format=html
  controller=Auth::OmniauthCallbacksController action=cas status=500
  error='NameError: undefined local variable or method `user' for
  #<Auth::OmniauthCallbacksController:0x00000000036290>
  Did you mean?  @user' duration=435.93 view=0.00 db=36.19

* app/controllers/auth/omniauth_callbacks_controller.rb: fix variable
  name to `@user`