### PR TITLE
New env variable: CAS_SECURITY_ASSUME_EMAIL_IS_VERIFIED

### DIFF
--- a/.env.nanobox
+++ b/.env.nanobox
@@ -228,6 +228,7 @@ SMTP_FROM_ADDRESS=notifications@${APP_NAME}.nanoapp.io
 # CAS_LOCATION_KEY='location'
 # CAS_IMAGE_KEY='image'
 # CAS_PHONE_KEY='phone'
+# CAS_SECURITY_ASSUME_EMAIL_IS_VERIFIED=true
 
 # Optional SAML authentication (cf. omniauth-saml)
 # SAML_ENABLED=true

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -30,6 +30,8 @@ Devise.setup do |config|
     cas_options[:location_key] = ENV['CAS_LOCATION_KEY'] || 'location'
     cas_options[:image_key] = ENV['CAS_IMAGE_KEY'] || 'image'
     cas_options[:phone_key] = ENV['CAS_PHONE_KEY'] || 'phone'
+    cas_options[:security] = {}
+    cas_options[:security][:assume_email_is_verified] = ENV['CAS_SECURITY_ASSUME_EMAIL_IS_VERIFIED'] == 'true'
     config.omniauth :cas, cas_options
   end
 


### PR DESCRIPTION
When using a CAS server, the users only have a temporary email
`change@me-foo-cas.com` which can't be changed but by an
administrator.

We need a new environment variable like for SAML to assume the email
from CAS is verified.

* config/initializers/omniauth.rb: define CAS option for assuming
  email are always verified.
* .env.nanobox: add new variable as an example.