### PR TITLE
Fix getting started footer visibility in wide and short viewports

### DIFF
--- a/app/javascript/mastodon/features/ui/components/compose_panel.js
+++ b/app/javascript/mastodon/features/ui/components/compose_panel.js
@@ -25,9 +25,11 @@ class ComposePanel extends React.PureComponent {
   render() {
     return (
       <div className='compose-panel' onFocus={this.onFocus}>
-        <SearchContainer openInRoute />
-        <NavigationContainer onClose={this.onBlur} />
-        <ComposeFormContainer singleColumn />
+        <div className='compose-ui'>
+          <SearchContainer openInRoute />
+          <NavigationContainer onClose={this.onBlur} />
+          <ComposeFormContainer singleColumn />
+        </div>
         <LinkFooter withHotkeys />
       </div>
     );

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2554,7 +2554,7 @@ a.account__display-name {
   display: flex;
   flex-direction: column;
   height: calc(100% - 10px);
-  overflow-y: hidden;
+  justify-content: space-between;
 
   .navigation-bar {
     padding-top: 20px;
@@ -2572,9 +2572,7 @@ a.account__display-name {
     overflow-y: hidden;
     display: flex;
     flex-direction: column;
-    min-height: 310px;
-    padding-bottom: 71px;
-    margin-bottom: -71px;
+    min-height: 0;
   }
 
   .compose-form__autosuggest-wrapper {


### PR DESCRIPTION
Fixes #16006 

Removes some hard-coded height numbers and relies on flexbox `space-between` positioning two children: one, a wrapper for the left-hand panel UI, and two, the getting started footer.

![Aug-26-2021 15-35-55](https://user-images.githubusercontent.com/20846414/131025095-11c08ec7-ec54-4d69-a888-32a694e2a9aa.gif)
