### PR TITLE
Change two-column grid static pages to stack

### DIFF
--- a/app/javascript/styles/mastodon/containers.scss
+++ b/app/javascript/styles/mastodon/containers.scss
@@ -410,6 +410,7 @@
         grid-row: 2;
         grid-column: 1;
       }
+
       .column-1 {
         grid-row: 1;
         grid-column: 1;

--- a/app/javascript/styles/mastodon/containers.scss
+++ b/app/javascript/styles/mastodon/containers.scss
@@ -406,8 +406,13 @@
       grid-template-columns: 100%;
       grid-gap: 0;
 
+      .column-0 {
+        grid-row: 2;
+        grid-column: 1;
+      }
       .column-1 {
-        display: none;
+        grid-row: 1;
+        grid-column: 1;
       }
     }
   }


### PR DESCRIPTION
Fixes #16097.

Tweaks the media query so that column-1 stacks above column-0 on mobile layouts. This layout affects the user page, terms page, and the about the instance page, and the other layouts seem unaffected by this.

Open question: Will this play nice with a profile page that has a decked out column 1? (Eg. tons of "user picks", a moved banner, etc.?) If not I might need to add some `display: none`s for those widgets on mobile.

<img width="398" alt="image" src="https://user-images.githubusercontent.com/20846414/131028323-80d3b736-42c3-445f-840a-997e8462d4af.png">

cc @ClearlyClaire 
