### PR TITLE
Fix tootctl self-destruct not sending Delete activities for recently-suspended accounts

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -94,11 +94,13 @@ module Mastodon
 
       exit(1) unless prompt.ask('Type in the domain of the server to confirm:', required: true) == Rails.configuration.x.local_domain
 
-      prompt.warn('This operation WILL NOT be reversible. It can also take a long time.')
-      prompt.warn('While the data won\'t be erased locally, the server will be in a BROKEN STATE afterwards.')
-      prompt.warn('A running Sidekiq process is required. Do not shut it down until queues clear.')
+      unless options[:dry_run]
+        prompt.warn('This operation WILL NOT be reversible. It can also take a long time.')
+        prompt.warn('While the data won\'t be erased locally, the server will be in a BROKEN STATE afterwards.')
+        prompt.warn('A running Sidekiq process is required. Do not shut it down until queues clear.')
 
-      exit(1) if prompt.no?('Are you sure you want to proceed?')
+        exit(1) if prompt.no?('Are you sure you want to proceed?')
+      end
 
       inboxes   = Account.inboxes
       processed = 0

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -107,6 +107,7 @@ module Mastodon
       Setting.registrations_mode = 'none' unless options[:dry_run]
 
       if inboxes.empty?
+        Account.local.without_suspended.in_batches.update_all(suspended_at: Time.now.utc, suspension_origin: :local) unless options[:dry_run]
         prompt.ok('It seems like your server has not federated with anything')
         prompt.ok('You can shut it down and delete it any time')
         return

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -112,7 +112,7 @@ module Mastodon
 
       prompt.warn('Do NOT interrupt this process...')
 
-      Setting.registrations_mode = 'none'
+      Setting.registrations_mode = 'none' unless options[:dry_run]
 
       Account.local.without_suspended.find_each do |account|
         payload = ActiveModelSerializers::SerializableResource.new(

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -128,7 +128,7 @@ module Mastodon
             [json, account.id, inbox_url]
           end
 
-          account.suspend!
+          account.suspend!(block_email: false)
         end
 
         processed += 1

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -104,6 +104,8 @@ module Mastodon
       processed = 0
       dry_run   = options[:dry_run] ? ' (DRY RUN)' : ''
 
+      Setting.registrations_mode = 'none' unless options[:dry_run]
+
       if inboxes.empty?
         prompt.ok('It seems like your server has not federated with anything')
         prompt.ok('You can shut it down and delete it any time')
@@ -111,8 +113,6 @@ module Mastodon
       end
 
       prompt.warn('Do NOT interrupt this process...')
-
-      Setting.registrations_mode = 'none' unless options[:dry_run]
 
       Account.local.without_suspended.find_each do |account|
         payload = ActiveModelSerializers::SerializableResource.new(


### PR DESCRIPTION
Also fixes a few minor issues:
- do not block existing users' emails on self-destruct
- do not close registrations when running with the `--dry-run` option
- do close registrations and suspend local users even if no remote account is known
- do not ask for confirmation if running with `--dry-run` (the message not mentioning dry-run is confusing and scary)