### PR TITLE
use relative path for `scope`

### DIFF
--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -48,7 +48,7 @@ class ManifestSerializer < ActiveModel::Serializer
   end
 
   def scope
-    root_url
+    '/'
   end
 
   def share_target


### PR DESCRIPTION
Use relative path for `scope` in web manifest to allow users use PWA correctly via alternate domains.