### PR TITLE
Fix Ruby 3.0 dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,8 +538,9 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
-    ruby-saml (1.11.0)
-      nokogiri (>= 1.5.10)
+    ruby-saml (1.13.0)
+      nokogiri (>= 1.10.5)
+      rexml
     ruby2_keywords (0.0.4)
     rufus-scheduler (3.7.0)
       fugit (~> 1.1, >= 1.1.6)


### PR DESCRIPTION
Fixes #16720

Starting from Ruby 3.0, the `rexml` gem is not a default gem anymore, which means it has to be explicitly declared as a dependency to be used.

One of our dependencies, `ruby-saml`, implicitly depends on `rexml`. This is fixed in newer versions of `rexml`.