### PR TITLE
Fix some Rails frameworks being unnecessarily loaded

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,21 @@
 require_relative 'boot'
 
-require 'rails/all'
+require 'rails'
+
+require 'active_record/railtie'
+#require 'active_storage/engine'
+require 'action_controller/railtie'
+require 'action_view/railtie'
+require 'action_mailer/railtie'
+require 'active_job/railtie'
+#require 'action_cable/engine'
+#require 'action_mailbox/engine'
+#require 'action_text/engine'
+#require 'rails/test_unit/railtie'
+require 'sprockets/railtie'
+
+# Used to be implicitly required in action_mailbox/engine
+require 'mail'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
Saves up to 10MiB of memory usage at boot.