### PR TITLE
Change collation rules to avoid index corruption

### DIFF
--- a/db/migrate/20210913164325_add_fixed_uri_index_to_statuses.rb
+++ b/db/migrate/20210913164325_add_fixed_uri_index_to_statuses.rb
@@ -1,0 +1,24 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddFixedUriIndexToStatuses < ActiveRecord::Migration[5.2]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    begin
+      safety_assured { add_index :statuses, :uri, name: 'index_statuses_on_uri_btree', opclass: :text_pattern_ops, unique: true, algorithm: :concurrently }
+    rescue ActiveRecord::StatementInvalid => e
+      remove_index :statuses, name: 'index_statuses_on_uri_btree'
+      raise CorruptionError if e.is_a?(ActiveRecord::RecordNotUnique)
+      raise e
+    end
+
+    remove_index :statuses, name: 'index_statuses_on_uri'
+  end
+
+  def down
+    safety_assured { add_index :statuses, :uri, name: 'index_statuses_on_uri', unique: true, algorithm: :concurrently }
+    remove_index :statuses, name: 'index_statuses_on_uri_btree'
+  end
+end

--- a/db/migrate/20210913171005_add_fixed_uri_index_to_conversations.rb
+++ b/db/migrate/20210913171005_add_fixed_uri_index_to_conversations.rb
@@ -1,0 +1,24 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddFixedUriIndexToConversations < ActiveRecord::Migration[5.2]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    begin
+      safety_assured { add_index :conversations, :uri, name: 'index_conversations_on_uri_btree', opclass: :text_pattern_ops, unique: true, algorithm: :concurrently }
+    rescue ActiveRecord::StatementInvalid => e
+      remove_index :conversations, name: 'index_conversations_on_uri_btree'
+      raise CorruptionError if e.is_a?(ActiveRecord::RecordNotUnique)
+      raise e
+    end
+
+    remove_index :conversations, name: 'index_conversations_on_uri'
+  end
+
+  def down
+    safety_assured { add_index :conversations, :uri, name: 'index_conversations_on_uri', unique: true, algorithm: :concurrently }
+    remove_index :conversations, name: 'index_conversations_on_uri_btree'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_08_071221) do
+ActiveRecord::Schema.define(version: 2021_09_13_164325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -849,7 +849,7 @@ ActiveRecord::Schema.define(version: 2021_08_08_071221) do
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
     t.index ["reblog_of_id", "account_id"], name: "index_statuses_on_reblog_of_id_and_account_id"
-    t.index ["uri"], name: "index_statuses_on_uri", unique: true
+    t.index ["uri"], name: "index_statuses_on_uri_btree", unique: true, opclass: :text_pattern_ops
   end
 
   create_table "statuses_tags", id: false, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_13_164325) do
+ActiveRecord::Schema.define(version: 2021_09_13_171005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -302,7 +302,7 @@ ActiveRecord::Schema.define(version: 2021_09_13_164325) do
     t.string "uri"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["uri"], name: "index_conversations_on_uri", unique: true
+    t.index ["uri"], name: "index_conversations_on_uri_btree", unique: true, opclass: :text_pattern_ops
   end
 
   create_table "custom_emoji_categories", force: :cascade do |t|

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -14,7 +14,7 @@ module Mastodon
     end
 
     MIN_SUPPORTED_VERSION = 2019_10_01_213028
-    MAX_SUPPORTED_VERSION = 2021_08_08_071221
+    MAX_SUPPORTED_VERSION = 2021_09_13_164325
 
     # Stubs to enjoy ActiveRecord queries while not depending on a particular
     # version of the code/database
@@ -444,6 +444,7 @@ module Mastodon
     end
 
     def deduplicate_statuses!
+      return if ActiveRecord::Base.connection.index_exists?(:statuses, :uri, name: 'index_statuses_on_uri_btree')
       remove_index_if_exists!(:statuses, 'index_statuses_on_uri')
 
       @prompt.say 'Deduplicating statuses…'

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -14,7 +14,7 @@ module Mastodon
     end
 
     MIN_SUPPORTED_VERSION = 2019_10_01_213028
-    MAX_SUPPORTED_VERSION = 2021_09_13_164325
+    MAX_SUPPORTED_VERSION = 2021_09_13_171005
 
     # Stubs to enjoy ActiveRecord queries while not depending on a particular
     # version of the code/database
@@ -300,6 +300,7 @@ module Mastodon
     end
 
     def deduplicate_conversations!
+      return if ActiveRecord::Base.connection.index_exists?(:conversations, :uri, name: 'index_conversations_on_uri_btree')
       remove_index_if_exists!(:conversations, 'index_conversations_on_uri')
 
       @prompt.say 'Deduplicating conversations…'

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -14,7 +14,7 @@ module Mastodon
     end
 
     MIN_SUPPORTED_VERSION = 2019_10_01_213028
-    MAX_SUPPORTED_VERSION = 2021_05_26_193025
+    MAX_SUPPORTED_VERSION = 2021_08_08_071221
 
     # Stubs to enjoy ActiveRecord queries while not depending on a particular
     # version of the code/database

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -290,7 +290,7 @@ module Mastodon
 
       remove_index_if_exists!(:announcement_reactions, 'index_announcement_reactions_on_account_id_and_announcement_id')
 
-      @prompt.say 'Removing duplicate account identity proofs…'
+      @prompt.say 'Removing duplicate announcement reactions…'
       ActiveRecord::Base.connection.select_all("SELECT string_agg(id::text, ',') AS ids FROM announcement_reactions GROUP BY account_id, announcement_id, name HAVING count(*) > 1").each do |row|
         AnnouncementReaction.where(id: row['ids'].split(',')).sort_by(&:id).reverse.drop(1).each(&:destroy)
       end


### PR DESCRIPTION
Downsides:
- somewhat heavy migrations (rebuilding lots of indexes)

Upsides:
- if one of the affected unique index is badly corrupted, admins will know immediately and will be able to fix it before it gets worse
- if one of the affected index is moderately corrupted, the new one would be exempt of corruption
- no risk of the new index getting corrupted in the future
- if we do that with all indexes, we can eventually get rid of the maintenance script for good
- even if we do that partially, the maintenance script will take less time to run as it will have less to deal with

Notes:
- there is at least one index that would see performance benefits from this change (`index_accounts_on_uri`)
- this is not applicable to some indexes because of the operations we do on them, what to do with them?

TODO: go over **all** the text indexes