### PR TITLE
Change index_accounts_on_uri to text_pattern_opts to improve queries

### DIFF
--- a/db/migrate/20210913190457_change_account_uri_index_to_btree.rb
+++ b/db/migrate/20210913190457_change_account_uri_index_to_btree.rb
@@ -1,0 +1,15 @@
+class ChangeAccountUriIndexToBtree < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :accounts, :uri, name: :index_accounts_on_uri_btree, opclass: :text_pattern_ops, algorithm: :concurrently
+    remove_index :accounts, :uri, name: :index_accounts_on_uri
+    rename_index :accounts, :index_accounts_on_uri_btree, :index_accounts_on_uri
+  end
+
+  def down
+    rename_index :accounts, :index_accounts_on_uri, :index_accounts_on_uri_btree
+    add_index :accounts, :uri, name: :index_accounts_on_uri_btree, algorithm: :concurrently
+    remove_index :accounts, :index_accounts_on_uri_btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_08_071221) do
+ActiveRecord::Schema.define(version: 2021_09_13_190457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -196,7 +196,7 @@ ActiveRecord::Schema.define(version: 2021_08_08_071221) do
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["moved_to_account_id"], name: "index_accounts_on_moved_to_account_id"
-    t.index ["uri"], name: "index_accounts_on_uri"
+    t.index ["uri"], name: "index_accounts_on_uri", opclass: :text_pattern_ops
     t.index ["url"], name: "index_accounts_on_url"
   end
 

--- a/lib/mastodon/maintenance_cli.rb
+++ b/lib/mastodon/maintenance_cli.rb
@@ -14,7 +14,7 @@ module Mastodon
     end
 
     MIN_SUPPORTED_VERSION = 2019_10_01_213028
-    MAX_SUPPORTED_VERSION = 2021_05_26_193025
+    MAX_SUPPORTED_VERSION = 2021_09_13_190457
 
     # Stubs to enjoy ActiveRecord queries while not depending on a particular
     # version of the code/database


### PR DESCRIPTION
`accounts` are searched for exact `uri` match as well as prefix matches (in `remote_followers_hash`). Switching to `text_pattern_opts` will not change anything to the former, but will make the index usable for the latter.

The speedup should only matter to accounts with large amounts of remote followers, though.