### PR TITLE
helm: set default SMTP_CA_FILE

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -60,7 +60,7 @@ mastodon:
     concurrency: 25
   smtp:
     auth_method: plain
-    ca_file:
+    ca_file: /etc/ssl/certs/ca-certificates.crt
     delivery_method: smtp
     domain:
     enable_starttls_auto: true


### PR DESCRIPTION
see https://github.com/mastodon/mastodon/pull/10857; this avoids https://github.com/mastodon/mastodon/issues/10853 on helm deployments