### PR TITLE
Refactor notifications to go through a separate stream in streaming API

### DIFF
--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -127,7 +127,7 @@ class NotifyService < BaseService
   def push_notification!
     return if @notification.activity.nil?
 
-    Redis.current.publish("timeline:#{@recipient.id}", Oj.dump(event: :notification, payload: InlineRenderer.render(@notification, @recipient, :notification)))
+    Redis.current.publish("timeline:#{@recipient.id}:notifications", Oj.dump(event: :notification, payload: InlineRenderer.render(@notification, @recipient, :notification)))
     send_push_notifications!
   end
 


### PR DESCRIPTION
Eliminate need to have custom notifications filtering logic in the streaming API code by publishing notifications into a separate stream and then simply using the multi-stream capability to subscribe to that stream when necessary.

The only caveat is that Sidekiq would need to be restarted as well as the streaming API for the changes to take effect smoothly, otherwise notifications will be missing from the user streams.