### PR TITLE
fix(streaming): req.scopes can be null

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -430,7 +430,7 @@ const startWorker = (workerId) => {
       requiredScopes.push('read:statuses');
     }
 
-    if (requiredScopes.some(requiredScope => req.scopes.includes(requiredScope))) {
+    if (req.scopes && requiredScopes.some(requiredScope => req.scopes.includes(requiredScope))) {
       resolve();
       return;
     }


### PR DESCRIPTION
When checking for required OAuth scopes, an unexpected error could happen due to missing (null-y) `req.scopes`. This PR fixes that by checking if `req.scopes` are present before checking if any required scopes are present, otherwise it skips that straight to rejection.