### PR TITLE
[Dockerfile] [Security] Update NodeJS to V16 (LTS) on docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get update && \
 
 ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin"
 
-RUN npm install -g yarn && \
+RUN npm install -g npm && \
+  npm install -g yarn && \
 	gem install bundler && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends git libicu-dev libidn11-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:20.04 as build-dep
 SHELL ["/bin/bash", "-c"]
 
 # Install Node v14 (LTS)
-ENV NODE_VER="14.17.6"
+ENV NODE_VER="14.18.1"
 RUN ARCH= && \
     dpkgArch="$(dpkg --print-architecture)" && \
   case "${dpkgArch##*-}" in \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ RUN apt-get update && \
 
 ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin"
 
-RUN npm install -g npm && \
-  npm install -g yarn && \
+RUN npm install -g npm@latest && \
+	npm install -g yarn && \
 	gem install bundler && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends git libicu-dev libidn11-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:20.04 as build-dep
 # Use bash for the shell
 SHELL ["/bin/bash", "-c"]
 
-# Install Node v14 (LTS)
-ENV NODE_VER="14.18.1"
+# Install Node v16 (LTS)
+ENV NODE_VER="16.13.0"
 RUN ARCH= && \
     dpkgArch="$(dpkg --print-architecture)" && \
   case "${dpkgArch##*-}" in \


### PR DESCRIPTION
`This release marks the transition of Node.js 16.x into Long Term Support (LTS) with the codename 'Gallium'. The 16.x release line now moves into "Active LTS" and will remain so until October 2022.`

https://nodejs.org/en/blog/vulnerability/oct-2021-security-releases/