### PR TITLE
Remove dependency on parallel_tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,6 @@ gem 'nsa', '~> 0.2'
 gem 'oj', '~> 3.13'
 gem 'ox', '~> 2.14'
 gem 'parslet'
-gem 'parallel', '~> 1.21'
 gem 'posix-spawn'
 gem 'pundit', '~> 2.1'
 gem 'premailer-rails'
@@ -121,7 +120,6 @@ group :test do
   gem 'rspec-sidekiq', '~> 3.1'
   gem 'simplecov', '~> 0.21', require: false
   gem 'webmock', '~> 3.14'
-  gem 'parallel_tests', '~> 3.7'
   gem 'rspec_junit_formatter', '~> 0.4'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,8 +395,6 @@ GEM
     orm_adapter (0.5.0)
     ox (2.14.5)
     parallel (1.21.0)
-    parallel_tests (3.7.3)
-      parallel
     parser (3.0.2.0)
       ast (~> 2.4.1)
     parslet (2.0.0)
@@ -736,8 +734,6 @@ DEPENDENCIES
   omniauth-rails_csrf_protection (~> 0.1)
   omniauth-saml (~> 1.10)
   ox (~> 2.14)
-  parallel (~> 1.21)
-  parallel_tests (~> 3.7)
   parslet
   pg (~> 1.2)
   pghero (~> 2.8)


### PR DESCRIPTION
No dependency on paralell_tests since #13587. Remove it as a dependency to improve the speed of `bundle install`.