### PR TITLE
Add remove from followers api

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::AccountsController < Api::BaseController
-  before_action -> { authorize_if_got_token! :read, :'read:accounts' }, except: [:create, :follow, :unfollow, :block, :unblock, :mute, :unmute]
-  before_action -> { doorkeeper_authorize! :follow, :'write:follows' }, only: [:follow, :unfollow]
+  before_action -> { authorize_if_got_token! :read, :'read:accounts' }, except: [:create, :follow, :unfollow, :remove_from_followers, :block, :unblock, :mute, :unmute]
+  before_action -> { doorkeeper_authorize! :follow, :'write:follows' }, only: [:follow, :unfollow, :remove_from_followers]
   before_action -> { doorkeeper_authorize! :follow, :'write:mutes' }, only: [:mute, :unmute]
   before_action -> { doorkeeper_authorize! :follow, :'write:blocks' }, only: [:block, :unblock]
   before_action -> { doorkeeper_authorize! :write, :'write:accounts' }, only: [:create]
@@ -50,6 +50,11 @@ class Api::V1::AccountsController < Api::BaseController
 
   def unfollow
     UnfollowService.new.call(current_user.account, @account)
+    render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships
+  end
+
+  def remove_from_followers
+    RemoveFromFollowersService.new.call(current_user.account, @account)
     render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships
   end
 

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -195,6 +195,10 @@ module AccountInteractions
     !following_anyone?
   end
 
+  def followed_by?(other_account)
+    other_account.following?(self)
+  end
+
   def blocking?(other_account)
     block_relationships.where(target_account: other_account).exists?
   end

--- a/app/models/form/account_batch.rb
+++ b/app/models/form/account_batch.rb
@@ -43,9 +43,7 @@ class Form::AccountBatch
   end
 
   def remove_from_followers!
-    current_account.passive_relationships.where(account_id: account_ids).find_each do |follow|
-      reject_follow!(follow)
-    end
+    RemoveFromFollowersService.new.call(current_account, account_ids)
   end
 
   def block_domains!
@@ -60,14 +58,6 @@ class Form::AccountBatch
 
   def accounts
     Account.where(id: account_ids)
-  end
-
-  def reject_follow!(follow)
-    follow.destroy
-
-    return unless follow.account.activitypub?
-
-    ActivityPub::DeliveryWorker.perform_async(Oj.dump(serialize_payload(follow, ActivityPub::RejectFollowSerializer)), current_account.id, follow.account.inbox_url)
   end
 
   def approve!

--- a/app/services/remove_from_followers_service.rb
+++ b/app/services/remove_from_followers_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class RemoveFromFollowersService < BaseService
+  include Payloadable
+
+  def call(source_account, target_accounts)
+    source_account.passive_relationships.where(account_id: target_accounts).find_each do |follow|
+      follow.destroy
+
+      if source_account.local? && !follow.account.local? && follow.account.activitypub?
+        create_notification(follow)
+      end
+    end
+  end
+
+  private
+
+  def create_notification(follow)
+    ActivityPub::DeliveryWorker.perform_async(build_json(follow), follow.target_account_id, follow.account.inbox_url)
+  end
+
+  def build_json(follow)
+    Oj.dump(serialize_payload(follow, ActivityPub::RejectFollowSerializer))
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -459,6 +459,7 @@ Rails.application.routes.draw do
         member do
           post :follow
           post :unfollow
+          post :remove_from_followers
           post :block
           post :unblock
           post :mute

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -168,6 +168,26 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
     it_behaves_like 'forbidden for wrong scope', 'read:accounts'
   end
 
+  describe 'POST #remove_from_followers' do
+    let(:scopes) { 'write:follows' }
+    let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+
+    before do
+      other_account.follow!(user.account)
+      post :remove_from_followers, params: { id: other_account.id }
+    end
+
+    it 'returns http success' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'removes the followed relation between user and target user' do
+      expect(user.account.followed_by?(other_account)).to be false
+    end
+
+    it_behaves_like 'forbidden for wrong scope', 'read:accounts'
+  end
+
   describe 'POST #block' do
     let(:scopes) { 'write:blocks' }
     let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }

--- a/spec/models/concerns/account_interactions_spec.rb
+++ b/spec/models/concerns/account_interactions_spec.rb
@@ -360,6 +360,23 @@ describe AccountInteractions do
     end
   end
 
+  describe '#followed_by?' do
+    subject { account.followed_by?(target_account) }
+
+    context 'followed by target_account' do
+      it 'returns true' do
+        account.passive_relationships.create(account: target_account)
+        is_expected.to be true
+      end
+    end
+
+    context 'not followed by target_account' do
+      it 'returns false' do
+        is_expected.to be false
+      end
+    end
+  end
+
   describe '#blocking?' do
     subject { account.blocking?(target_account) }
 

--- a/spec/services/remove_from_follwers_service_spec.rb
+++ b/spec/services/remove_from_follwers_service_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe RemoveFromFollowersService, type: :service do
+  let(:bob) { Fabricate(:account, username: 'bob') }
+
+  subject { RemoveFromFollowersService.new }
+
+  describe 'local' do
+    let(:sender) { Fabricate(:account, username: 'alice') }
+ 
+    before do
+      Follow.create(account: sender, target_account: bob)
+      subject.call(bob, sender)
+    end
+
+    it 'does not create follow relation' do
+      expect(bob.followed_by?(sender)).to be false
+    end
+  end
+
+  describe 'remote ActivityPub' do
+    let(:sender) { Fabricate(:account, username: 'alice', domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
+
+    before do
+      Follow.create(account: sender, target_account: bob)
+      stub_request(:post, sender.inbox_url).to_return(status: 200)
+      subject.call(bob, sender)
+    end
+
+    it 'does not create follow relation' do
+      expect(bob.followed_by?(sender)).to be false
+    end
+
+    it 'sends a reject activity' do
+      expect(a_request(:post, sender.inbox_url)).to have_been_made.once
+    end
+  end
+end


### PR DESCRIPTION
Add an API to remove from followers. Same as "remove from followers" provided on the relationships page.

POST `https://mastodon.example/api/v1/accounts/:id/remove_from_followers`

Returns etc. are the same as unfollow.