### PR TITLE
Support authentication for ElasticSearch

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -28,6 +28,9 @@ DB_PORT=5432
 ES_ENABLED=true
 ES_HOST=localhost
 ES_PORT=9200
+# Authentication for ES (optional)
+ES_USER=elastic
+ES_PASS=password
 
 # Secrets
 # -------

--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -2,7 +2,7 @@ enabled         = ENV['ES_ENABLED'] == 'true'
 host            = ENV.fetch('ES_HOST') { 'localhost' }
 port            = ENV.fetch('ES_PORT') { 9200 }
 user            = ENV.fetch('ES_USER') { nil }
-pass            = ENV.fetch('ES_PASS') { nil }
+password        = ENV.fetch('ES_PASS') { nil }
 fallback_prefix = ENV.fetch('REDIS_NAMESPACE') { nil }
 prefix          = ENV.fetch('ES_PREFIX') { fallback_prefix }
 
@@ -12,7 +12,7 @@ Chewy.settings = {
   enabled: enabled,
   journal: false,
   user: user,
-  pass: pass,
+  password: password,
   sidekiq: { queue: 'pull' },
 }
 

--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -1,6 +1,8 @@
 enabled         = ENV['ES_ENABLED'] == 'true'
 host            = ENV.fetch('ES_HOST') { 'localhost' }
 port            = ENV.fetch('ES_PORT') { 9200 }
+user            = ENV.fetch('ES_USER') { nil }
+pass            = ENV.fetch('ES_PASS') { nil }
 fallback_prefix = ENV.fetch('REDIS_NAMESPACE') { nil }
 prefix          = ENV.fetch('ES_PREFIX') { fallback_prefix }
 
@@ -9,6 +11,8 @@ Chewy.settings = {
   prefix: prefix,
   enabled: enabled,
   journal: false,
+  user: user,
+  pass: pass,
   sidekiq: { queue: 'pull' },
 }
 


### PR DESCRIPTION
Starting from ES 6.8.0, ES 7.1.0, authentication feature is free.
And chewy supports it.

So Mastodon should support this.