### PR TITLE
Add lazy load to emoji-mart

### DIFF
--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -169,14 +169,15 @@
   }
 
   &:hover::before {
-    z-index: 0;
+    z-index: -1;
     content: "";
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba($ui-secondary-color, 0.7);
+    // background-color: rgba($ui-secondary-color, 0.7);
+    background-color: #f4f4f4;
     border-radius: 100%;
   }
 }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "cssnano": "^4.1.11",
     "detect-passive-events": "^2.0.3",
     "dotenv": "^10.0.0",
-    "emoji-mart": "^3.0.1",
+    "emoji-mart": "npm:emoji-mart-lazyload",
     "es6-symbol": "^3.1.3",
     "escape-html": "^1.0.3",
     "exif-js": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4038,12 +4038,13 @@ emittery@^0.8.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
   integrity sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==
 
-emoji-mart@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/emoji-mart/-/emoji-mart-3.0.1.tgz#9ce86706e02aea0506345f98464814a662ca54c6"
-  integrity sha512-sxpmMKxqLvcscu6mFn9ITHeZNkGzIvD0BSNFE/LJESPbCA8s1jM6bCDPjWbV31xHq7JXaxgpHxLB54RCbBZSlg==
+"emoji-mart@npm:emoji-mart-lazyload":
+  version "3.0.1-h"
+  resolved "https://registry.npmjs.org/emoji-mart-lazyload/-/emoji-mart-lazyload-3.0.1-h.tgz#ba740156bcb0b8d820ea5bf148af8e983ac3dd71"
+  integrity sha512-lgJyEq/Ht231+lVJbb3eS28nkMqR83Bq5ClxPwxEmaWjl/JlhFPDoFkqI1e56U+jzEzXTDQl0tfTo2wFv7FCkQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
+    intersection-observer "^0.12.0"
     prop-types "^15.6.0"
 
 emoji-regex@^7.0.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4039,9 +4039,9 @@ emittery@^0.8.1:
   integrity sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==
 
 "emoji-mart@npm:emoji-mart-lazyload":
-  version "3.0.1-h"
-  resolved "https://registry.npmjs.org/emoji-mart-lazyload/-/emoji-mart-lazyload-3.0.1-h.tgz#ba740156bcb0b8d820ea5bf148af8e983ac3dd71"
-  integrity sha512-lgJyEq/Ht231+lVJbb3eS28nkMqR83Bq5ClxPwxEmaWjl/JlhFPDoFkqI1e56U+jzEzXTDQl0tfTo2wFv7FCkQ==
+  version "3.0.1-j"
+  resolved "https://registry.npmjs.org/emoji-mart-lazyload/-/emoji-mart-lazyload-3.0.1-j.tgz#87a90d30b79d9145ece078d53e3e683c1a10ce9c"
+  integrity sha512-0wKF7MR0/iAeCIoiBLY+JjXCugycTgYRC2SL0y9/bjNSQlbeMdzILmPQJAufU/mgLFDUitOvjxLDhOZ9yxZ48g==
   dependencies:
     "@babel/runtime" "^7.0.0"
     intersection-observer "^0.12.0"


### PR DESCRIPTION
### Pitch: 
Emoji-mart will show and load all emojis at the moment open the picker, which leads to poor performance when there be too many custom emojis (many instances have hundreds of custom images).

### Solution: 
Lazy load emoji images using  [Intersection Observer (with polyfill)](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API), so it looks like this now: 

![IMG_20211025_183647](https://user-images.githubusercontent.com/16148054/138683061-a3e336de-000d-41ab-945e-638d153db43f.jpg)

### What does this PR do?
Switch NPM package from emoji-mart to [emoji-mart-lazy](https://www.npmjs.com/package/emoji-mart-lazyload), whose source code here: [mashirozx/emoji-mart](https://github.com/mashirozx/emoji-mart). We may switch back to the official NPM source once [this PR](https://github.com/missive/emoji-mart/pull/539)  been merged.

