### PR TITLE
Change title of retention chart

### DIFF
--- a/app/javascript/mastodon/components/admin/Retention.js
+++ b/app/javascript/mastodon/components/admin/Retention.js
@@ -42,6 +42,7 @@ export default class Retention extends React.PureComponent {
 
   render () {
     const { loading, data } = this.state;
+    const { frequency } = this.props;
 
     let content;
 
@@ -129,9 +130,18 @@ export default class Retention extends React.PureComponent {
       );
     }
 
+    let title = null;
+    switch(frequency) {
+    case 'day':
+      title = <FormattedMessage id='admin.dashboard.daily_retention' defaultMessage='User retention rate by day after sign-up' />;
+      break;
+    default:
+      title = <FormattedMessage id='admin.dashboard.monthly_retention' defaultMessage='User retention rate by month after sign-up' />;
+    };
+
     return (
       <div className='retention'>
-        <h4><FormattedMessage id='admin.dashboard.retention' defaultMessage='Retention' /></h4>
+        <h4>{title}</h4>
 
         {content}
       </div>


### PR DESCRIPTION
Changes from “Retention” to “User retention rate by month after sign-up”.

This should make it much clearer to people not familiar with retention charts what it actually means.

## Before

![image](https://user-images.githubusercontent.com/384364/138869851-599b238b-20c4-41da-b694-94c0bed66c06.png)

## After

![image](https://user-images.githubusercontent.com/384364/138869686-b461cda6-222c-4b92-bd21-f6f9b77f6550.png)