### PR TITLE
[Docker-Compose] [Breaking] Postgres 9.6 is EOL (11th Nov 2021) - Migrate to 14 Stable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   db:
     restart: always
-    image: postgres:14.0-alpine
+    image: postgres:14-alpine
     shm_size: 256mb
     networks:
       - internal_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
     volumes:
-      - ./postgres:/var/lib/postgresql/data
+      - ./postgres14:/var/lib/postgresql/data
 
   redis:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       test: ["CMD", "pg_isready", "-U", "postgres"]
     volumes:
       - ./postgres14:/var/lib/postgresql/data
+    environment:
+      - "POSTGRES_HOST_AUTH_METHOD=trust"
 
   redis:
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   db:
     restart: always
-    image: postgres:9.6-alpine
+    image: postgres:14.0-alpine
     shm_size: 256mb
     networks:
       - internal_network


### PR DESCRIPTION
# Upgrade path using docker-compose

For safety, Old PostgreSQL 9.6 data is kept in `./postgres/`, and new PostgreSQL 14 data is stored in `./postgres14/`.

Rollback: This PR will allow for a recovery path for those having problems migrating to PostgreSQL 14. They can quickly roll back the docker-compose.yml to PostgreSQL 9.6. - While also working with a backup file to cleanly migrate on a fresh directory so no changes are made to the original DB in case of emergency. (postgres14 can be deleted to restart the import process if required)

**Please keep the existing `postgres` folder incase you need to roll back - Delete it after the upgrade is completed.**



## Part 1 - Backup DB from PostgreSQL 9.6
```
# Shutdown app containers (keeping db online)
$ docker-compose stop web streaming sidekiq

# Create backup of mastodon db to local file
$ docker-compose exec db pg_dumpall -U postgres > 9.6.backup

# Shutdown db container
$ docker-compose down --remove-orphans
```


## Part 2 - Import DB to PostgreSQL 14.x
```
# Checkout for Mastodon 3.5.x
$ git fetch && git checkout v3.5.x

# Boot the new DB - PostgreSQL 14.0
$ docker-compose up -d db

# Import the backup
$ cat 9.6.backup | docker-compose exec -T db psql -U postgres
```

## Part 3 - Confirm import of DB has no serious errors
$ `docker-compose logs db`  and confirm there are not any errors in the import stage. Below is a list of known errors, and their resolution.

#### Error 1
> db_1               | `ERROR: invalid input syntax for type <something>`

These errors are bad and need to be investigated. 

Running `vacuumdb` has apparently resolved these issues. Please read the optional command as an alternative to step 1.

#### Error 2
> db_1               | `LOG:  checkpoints are occurring too frequently (20 seconds apart)`
> db_1               | `HINT:  Consider increasing the configuration parameter "max_wal_size".`

These errors can be ignored.

#### Error 3
> db_1               | `ERROR:  canceling autovacuum task`
> db_1               | `CONTEXT:  while scanning block 307315 of relation "public.statuses"`
> db_1               | `automatic vacuum of table "mastodon_production.public.statuses"`

These errors can be ignored. https://pganalyze.com/docs/log-insights/autovacuum/A60


## Part 4 - Upgrade Mastodon
* Follow standard Upgrade notes.


## Alternative Step 1 - Vacuum DB before backup
We recommend completing the vacuum on your 9.6 DB before dumping the backup file.

```
# Shutdown app containers (keeping db online)
$ docker-compose stop web streaming sidekiq

# Vacuum your db (untested command)
## Note: If you believe your 9.6 DB might be corrupted or experience errors with the importing stage, 
$ docker-compose exec db pg_dumpall -U postgres > 9.6.novacuum.backup
$ docker-compose exec db vacuumdb  -U postgres --all --full --analyze --verbose 
$ docker-compose exec db pg_dumpall -U postgres > 9.6.backup

# Shutdown db container
$ docker-compose down --remove-orphans
```

## UPDATE: 
We're become aware of a rare issue with the postgres backup dump causing segfaults when restoring. If you experience this issue... Please try this or similar  
```
docker exec db bash -c 'pg_dumpall -U postgres > 9.6.backup'
docker cp db:/9.6.backup 9.6.backup
docker exec db bash -c 'rm 9.6.backup'
```

Ref: https://stackoverflow.com/questions/63934856/why-is-pg-restore-segfaulting-in-docker