### PR TITLE
[Docker-Compose] Upgrade ElasticSearch-OSS 6.8.10 to 7.10.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
 #  es:
 #    restart: always
-#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.15.1
+#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.15.2
 #    environment:
 #      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 #      - "cluster.name=es-mastodon"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
 #  es:
 #    restart: always
-#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.15.2
+#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 #    environment:
 #      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 #      - "cluster.name=es-mastodon"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
 #  es:
 #    restart: always
-#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.10
+#    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.15.1
 #    environment:
 #      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 #      - "cluster.name=es-mastodon"


### PR DESCRIPTION
Figure this can be paired with #16915

I need to investigate if the 6.8.10 can be migrated to 7.10.2 automatically with a rolling upgrade. I believe there is no human interaction required on these versions.

https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html
https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html
