### PR TITLE
Build container image by GitHub Actions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -20,8 +20,10 @@ jobs:
         id: meta
         with:
           images: ghcr.io/${{ github.repository_owner }}/mastodon
+          flavor: |
+            latest=true
           tags: |
-            type=raw,value=latest
+            type=edge,branch=main
             type=semver,pattern={{ raw }}
       - uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,7 +2,7 @@ name: Build container image
 on:
   push:
     branches:
-      - "*"
+      - "main"
     tags:
       - "*"
 jobs:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,32 @@
+name: Build container image
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v3
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/mastodon
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{ raw }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mastodon:latest
+          cache-to: type=inline


### PR DESCRIPTION
Mastodon docker image is not hosted on Docker Hub from v3.4.2. The latest hosted image is v3.4.1, this is released 5 months ago.
https://hub.docker.com/r/tootsuite/mastodon/tags

Gargron says
> Docker Hub changed their pricing plans and silently stopped automated builds that we had.

https://github.com/mastodon/mastodon/issues/16952#issuecomment-962650575

So, build docker image per merge to the main branch on GitHub Actions. The image is hosted on GitHub Container Registry. 

like this `ghcr.io/mastodon/mastodon`

See also, this is how build-and-push works my forked repo.
https://github.com/unasuke/mastodon/actions/workflows/build-image.yml

I wondering about the "edge" tag. Is this built by every commit? 
![image](https://user-images.githubusercontent.com/4487291/141142175-296a1065-9121-4fcb-92ba-f21bd1375222.png)

ref #16952