### PR TITLE
Fix confusing error when webfinger request returns empty document

### DIFF
--- a/app/lib/webfinger.rb
+++ b/app/lib/webfinger.rb
@@ -46,7 +46,9 @@ class Webfinger
   def body_from_webfinger(url = standard_url, use_fallback = true)
     webfinger_request(url).perform do |res|
       if res.code == 200
-        res.body_with_limit
+        body = res.body_with_limit
+        raise Webfinger::Error, "Request for #{@uri} returned empty response" if body.empty?
+        body
       elsif res.code == 404 && use_fallback
         body_from_host_meta
       elsif res.code == 410


### PR DESCRIPTION
For some reason, some misconfigured servers return an empty document when queried over webfinger.
Since an empty document does not lead to a parse error, the error is not caught properly and triggers uncaught exceptions later on.

This PR fixes that by immediately erroring out with `Webfinger::Error` on getting an empty response.