### PR TITLE
Fix upload of remote media with OpenStack Swift sometimes failing

### DIFF
--- a/lib/paperclip/response_with_limit_adapter.rb
+++ b/lib/paperclip/response_with_limit_adapter.rb
@@ -17,9 +17,9 @@ module Paperclip
 
     def cache_current_values
       @original_filename = filename_from_content_disposition.presence || filename_from_path.presence || 'data'
-      @size = @target.response.content_length
       @tempfile = copy_to_tempfile(@target)
       @content_type = ContentTypeDetector.new(@tempfile.path).detect
+      @size = File.size(@tempfile)
     end
 
     def copy_to_tempfile(source)


### PR DESCRIPTION
Under certain conditions, files fetched from remotes trigger an error when being uploaded using OpenStack Swift. This is because in some cases, the remote server will not return a content-length, so our `ResponseWithLimitAdapter` will hold a `nil` value for `#size`, which will lead to an invalid value for the `Content-Length` header of the Swift API call.

This commit fixes that by taking the size from the actually-downloaded file size rather than the upstream-provided `Content-Length` header value.