### PR TITLE
Fix background-color of emoji-mart selector

### DIFF
--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -176,8 +176,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    // background-color: rgba($ui-secondary-color, 0.7);
-    background-color: #f4f4f4;
+    background-color: rgba($ui-secondary-color, 0.7);
     border-radius: 100%;
   }
 }


### PR DESCRIPTION
Reverts part of #16907 to fix hardcoded color