### PR TITLE
Add admin setting to disable trending links separately from trending hashtags

### DIFF
--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::Trends::LinksController < Api::BaseController
 
   def set_links
     @links = begin
-      if Setting.trends
+      if Setting.trending_links
         Trends.links.get(true, limit_param(10))
       else
         []

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -30,6 +30,7 @@ class Form::AdminSettings
     mascot
     trends
     trendable_by_default
+    trending_links
     show_domain_blocks
     show_domain_blocks_rationale
     noindex
@@ -47,6 +48,7 @@ class Form::AdminSettings
     profile_directory
     trends
     trendable_by_default
+    trending_links
     noindex
     require_invite_text
   ).freeze

--- a/app/models/trends.rb
+++ b/app/models/trends.rb
@@ -18,10 +18,7 @@ module Trends
   end
 
   def self.request_review!
-    [links, tags].each(&:request_review) if enabled?
-  end
-
-  def self.enabled?
-    Setting.trends
+    tags.request_review if Setting.trends
+    links.request_review if Setting.trending_links
   end
 end

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -87,6 +87,9 @@
       = f.input :trendable_by_default, as: :boolean, wrapper: :with_label, label: t('admin.settings.trendable_by_default.title'), hint: t('admin.settings.trendable_by_default.desc_html')
 
     .fields-group
+      = f.input :trending_links, as: :boolean, wrapper: :with_label, label: t('admin.settings.trending_links.title'), hint: t('admin.settings.trending_links.desc_html')
+
+    .fields-group
       = f.input :noindex, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_noindex.title'), hint: t('admin.settings.default_noindex.desc_html')
 
   %hr.spacer/

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -673,9 +673,12 @@ en:
       trendable_by_default:
         desc_html: Affects hashtags that have not been previously disallowed
         title: Allow hashtags to trend without prior review
+      trending_links:
+        desc_html: Publicly display links that are currently trending
+        title: Trending links
       trends:
-        desc_html: Publicly display previously reviewed content that is currently trending
-        title: Trends
+        desc_html: Publicly display previously reviewed hashtags that are currently trending
+        title: Trending hashtags
     site_uploads:
       delete: Delete uploaded file
       destroyed_msg: Site upload successfully deleted!

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,6 +37,7 @@ defaults: &defaults
   use_pending_items: false
   trends: true
   trendable_by_default: false
+  trending_links: false
   crop_images: true
   notification_emails:
     follow: false


### PR DESCRIPTION
I am still unconvinced that #16917—which has been merged without addressing the stated concerns nor with any clear approval from the community—is a good idea.

Thankfully, the way it is implemented means links will not actually be reported as trending to users without moderators taking action first. Unfortunately, it ties the feature to trending hashtags, so moderators who want trending hashtags but not trending links will still get spammed with review requests for the latter.

This PR adds a separate setting to enable trending links independently from trending hashtags.