### PR TITLE
Fix searching for additional hashtags in hashtag column

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
@@ -11,20 +11,21 @@ const mapStateToProps = (state, { columnId }) => {
     return {};
   }
 
-  return { settings: columns.get(index).get('params') };
+  return {
+    settings: columns.get(index).get('params'),
+    onLoad (value) {
+      return api(() => state).get('/api/v2/search', { params: { q: value, type: 'hashtags' } }).then(response => {
+        return (response.data.hashtags || []).map((tag) => {
+          return { value: tag.name, label: `#${tag.name}` };
+        });
+      });
+    },
+  };
 };
 
 const mapDispatchToProps = (dispatch, { columnId }) => ({
   onChange (key, value) {
     dispatch(changeColumnParams(columnId, key, value));
-  },
-
-  onLoad (value) {
-    return api().get('/api/v2/search', { params: { q: value, type: 'hashtags' } }).then(response => {
-      return (response.data.hashtags || []).map((tag) => {
-        return { value: tag.name, label: `#${tag.name}` };
-      });
-    });
   },
 });
 


### PR DESCRIPTION
The search API requires a valid token with `read` or `read:search` scopes, but the code for hashtag searches does not pass down the authentication token to the API module.

This used to work before #16171 (so it still works in every release so far) because the API module would actually copy the `Authorization` header to the `csrfHeader` object on previous API calls.

This PR passes the state to the API module so it can use the proper token.

Note that I am not completely sure about the performance implications of passing the state this way, although I suspect they are minor as the `state` object should be shared across the whole application anyway.