### PR TITLE
Upgrade bootsnap for Ruby 3.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'blurhash', '~> 0.1'
 
 gem 'active_model_serializers', '~> 0.10'
 gem 'addressable', '~> 2.8'
-gem 'bootsnap', '~> 1.9.1', require: false
+gem 'bootsnap', '~> 1.9.2', require: false
 gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
 gem 'iso-639'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       debug_inspector (>= 0.0.1)
     blurhash (0.1.5)
       ffi (~> 1.14)
-    bootsnap (1.9.1)
+    bootsnap (1.9.3)
       msgpack (~> 1.0)
     brakeman (5.1.2)
     browser (4.2.0)
@@ -689,7 +689,7 @@ DEPENDENCIES
   better_errors (~> 2.9)
   binding_of_caller (~> 1.0)
   blurhash (~> 0.1)
-  bootsnap (~> 1.9.1)
+  bootsnap (~> 1.9.2)
   brakeman (~> 5.1)
   browser
   bullet (~> 6.1)


### PR DESCRIPTION
https://github.com/Shopify/bootsnap/blob/v1.9.3/CHANGELOG.md#193

bootsnap 1.9.2:

> Disable compile cache if [Ruby 3.0.3's ISeq cache bug](https://bugs.ruby-lang.org/issues/18250) is detected.

and 1.9.3:

> Only disable the compile cache for source files impacted by [Ruby 3.0.3 [Bug 18250]](https://bugs.ruby-lang.org/issues/18250).
