### PR TITLE
Add remove orphans to tootctl statuses remove

### DIFF
--- a/lib/mastodon/statuses_cli.rb
+++ b/lib/mastodon/statuses_cli.rb
@@ -19,7 +19,7 @@ module Mastodon
     option :skip_status_remove, type: :boolean, default: false, desc: 'Skip status remove (run only cleanup tasks)'
     option :skip_remove_orphans, type: :boolean, default: false, desc: 'Skip remove orphans that have lost their association with status'
     option :skip_media_remove, type: :boolean, default: false, desc: 'Skip remove orphaned media attachments'
-    option :vacuum, type: :boolean, default: false, desc: 'Reduce the file size and update the statistics. This option locks the table for a long time, so run it offline'
+    option :compression_database, type: :boolean, default: false, desc: 'Compression database and update the statistics. This option locks the table for a long time, so run it offline'
     desc 'remove', 'Remove unreferenced statuses'
     long_desc <<~LONG_DESC
       Remove statuses that are not referenced by local user activity, such as
@@ -147,9 +147,10 @@ module Mastodon
     end
 
     def vacuum_and_analyze_statuses
-      if options[:vacuum]
-        say('Run VACUUM and ANALYZE to statuses...')
+      if options[:compression_database]
+        say('Run VACUUM FULL ANALYZE and REINDEX to statuses...')
         ActiveRecord::Base.connection.execute('VACUUM FULL ANALYZE statuses')
+        ActiveRecord::Base.connection.execute('REINDEX TABLE statuses')
       else
         say('Run ANALYZE to statuses...')
         ActiveRecord::Base.connection.execute('ANALYZE statuses')
@@ -157,9 +158,10 @@ module Mastodon
     end
 
     def vacuum_and_analyze_conversations
-      if options[:vacuum]
-        say('Run VACUUM and ANALYZE to conversations...')
+      if options[:compression_database]
+        say('Run VACUUM FULL ANALYZE and REINDEX to conversations...')
         ActiveRecord::Base.connection.execute('VACUUM FULL ANALYZE conversations')
+        ActiveRecord::Base.connection.execute('REINDEX TABLE conversations')
       else
         say('Run ANALYZE to conversations...')
         ActiveRecord::Base.connection.execute('ANALYZE conversations')

--- a/lib/mastodon/statuses_cli.rb
+++ b/lib/mastodon/statuses_cli.rb
@@ -20,7 +20,7 @@ module Mastodon
     option :skip_status_remove, type: :boolean, default: false, desc: 'Skip status remove (run only cleanup tasks)'
     option :skip_remove_orphans, type: :boolean, default: false, desc: 'Skip remove orphans that have lost their association with status'
     option :skip_media_remove, type: :boolean, default: false, desc: 'Skip remove orphaned media attachments'
-    option :compression_database, type: :boolean, default: false, desc: 'Compression database and update the statistics. This option locks the table for a long time, so run it offline'
+    option :compress_database, type: :boolean, default: false, desc: 'Compress database and update the statistics. This option locks the table for a long time, so run it offline'
     desc 'remove', 'Remove unreferenced statuses'
     long_desc <<~LONG_DESC
       Remove statuses that are not referenced by local user activity, such as
@@ -204,7 +204,7 @@ module Mastodon
     end
 
     def vacuum_and_analyze_statuses
-      if options[:compression_database]
+      if options[:compress_database]
         say('Run VACUUM FULL ANALYZE to statuses...')
         ActiveRecord::Base.connection.execute('VACUUM FULL ANALYZE statuses')
         say('Run REINDEX to statuses...')
@@ -216,7 +216,7 @@ module Mastodon
     end
 
     def vacuum_and_analyze_conversations
-      if options[:compression_database]
+      if options[:compress_database]
         say('Run VACUUM FULL ANALYZE to conversations...')
         ActiveRecord::Base.connection.execute('VACUUM FULL ANALYZE conversations')
         say('Run REINDEX to conversations...')


### PR DESCRIPTION
Second take, https://github.com/mastodon/mastodon/pull/17053

We will add and integrate the function to remove orphan records (mainly conversations) to `tootctl status remove`, and provide the option to execute each function independently.

```
Usage:
  tootctl statuses remove

Options:
      [--days=N]                                         
                                                         # Default: 90
  b, [--batch-size=N]                                    # Number of records in each batch
                                                         # Default: 1000
      [--continue], [--no-continue]                      # If remove is not completed, execute from the previous continuation
      [--clean-followed], [--no-clean-followed]          # Include the status of remote accounts that are followed by local accounts as candidates for remove
      [--skip-status-remove], [--no-skip-status-remove]  # Skip status remove (run only cleanup tasks)
      [--skip-media-remove], [--no-skip-media-remove]    # Skip remove orphaned media attachments
      [--compress-database], [--no-compress-database]    # Compress database and update the statistics. This option locks the table for a long time, so run it offline

Description:
  Remove statuses that are not referenced by local user activity, such as ones that came from relays, or belonging to users that were once followed by someone locally but no longer are.

  It also removes orphaned records and performs additional cleanup tasks such as updating statistics and recovering disk space.

  This is a computationally heavy procedure that creates extra database indices before commencing, and removes them afterward.
```

## How to use

### Remove unreferenced remote posts

```
bin/tootctl statuses remove
```

- Remove unreferenced remote posts
- Remove orphaned records (conversations, and others)
- Remove orphaned attachments
- Recalculate statistical information with ANALYZE

### Do only cleanup tasks

```
bin/tootctl statuses remove --skip-status-remove
```

- Skip remove of post
- Remove orphaned records (conversations, and others)
- Remove orphaned attachments
- Recalculate statistical information with ANALYZE

### Recover disk space

```
bin/tootctl statuses remove --skip-status-remove --compress-database
```

- Complete the execution of remove in advance and use `--skip-status-remove`
- Run `VACUUM FULL ANALYZE` and `REINDEX TABLE` to recover database disk space (Warning: Run offline as the service will stop due to a long table lock)

There is an alternative called pg_repack, so consider that if possible.

### Faster execution (tuning) on ​​a small server

```
bin/tootctl statuses remove --batch-size=100
```

Depending on the size of the database and the performance of the PostgreSQL server, the normal batch size may be too large. By reducing the default of 1,000, you may be able to shorten the total execution time and lock time.

### Aggressive removal

```
bin/tootctl statuses remove --days=30 --clean-followed --compress-database
```

A way to keep the database size small to keep a small server. Specifies to actively remove if you haven't favorited, bookmarked, replied, or boosted, including posts from people you follow.

The first time you run it, it's likely to be very expensive and time consuming, so it's a good idea to announce that you're going into maintenance for a while and then run it all at once offline.

If you want to execute it regularly, execute it without specifying compress-database, and execute pg_repack during off-peak hours to recover the disk space.
