### PR TITLE
Fix: tags get stuck after set as not trendable

### DIFF
--- a/app/models/trending_tags.rb
+++ b/app/models/trending_tags.rb
@@ -29,7 +29,7 @@ class TrendingTags
 
     def update!(at_time = Time.now.utc)
       tag_ids = redis.smembers("#{KEY}:used:#{at_time.beginning_of_day.to_i}") + redis.zrange(KEY, 0, -1)
-      tags    = Tag.trendable.where(id: tag_ids.uniq)
+      tags    = Tag.where(id: tag_ids.uniq)
 
       # First pass to calculate scores and update the set
 


### PR DESCRIPTION
In `TrendingHashtags` model, the `update` function will only use the filtered list of tags to calculate new trending scores, thus if set as not trendable when a tag was trending, it won't disappear even it was no longer used. (Of course, it won't show up on public pages but it was still on the admin dashboard.) 

*This bug only occurs in 3.4.4 and versions prior to it. Not sure if it still persists in the new version as the new tags model seems to be unfinished*