### PR TITLE
Prevent future translations from going out of sync on Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,19 +2,13 @@ commit_message: '[ci skip]'
 files:
   - source: /app/javascript/mastodon/locales/en.json
     translation: /app/javascript/mastodon/locales/%two_letters_code%.json
-    update_option: update_as_unapproved
   - source: /config/locales/en.yml
     translation: /config/locales/%two_letters_code%.yml
-    update_option: update_as_unapproved
   - source: /config/locales/simple_form.en.yml
     translation: /config/locales/simple_form.%two_letters_code%.yml
-    update_option: update_as_unapproved
   - source: /config/locales/activerecord.en.yml
     translation: /config/locales/activerecord.%two_letters_code%.yml
-    update_option: update_as_unapproved
   - source: /config/locales/devise.en.yml
     translation: /config/locales/devise.%two_letters_code%.yml
-    update_option: update_as_unapproved
   - source: /config/locales/doorkeeper.en.yml
     translation: /config/locales/doorkeeper.%two_letters_code%.yml
-    update_option: update_as_unapproved


### PR DESCRIPTION
Prevent translations from accidentally becoming completely different from source strings on Crowdin without translators noticing when the source string changes.

c.f. discussion on Crowdin: https://crowdin.com/project/mastodon/discussions/34

Motivation for this change:

1. Translators don't expect translations to remain valid when a source string changes, and a wrong translation is worse than no translation
2. Translators have to remember that Mastodon has this special workflow and remember to manually check the activity stream on Crowdin. I tend to forget, because nobody else does it this way.
3. Translators need to manually track the last datetime that they checked the activity stream on Crowdin for Mastodon
4. Translators would need to be trained that they have to keep checking the activity stream, which is not feasible
5. Manually going through the updated strings takes extra time and effort

Personally, I forgot to track the last datetime, so now I have to go through 6 months of changes to ensure that I haven't missed anything

@ariasuni 