### PR TITLE
Remove Redundant HSTS Header Declarations (nginx)

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -60,13 +60,11 @@ server {
 
   location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
     add_header Cache-Control "public, max-age=31536000, immutable";
-    add_header Strict-Transport-Security "max-age=31536000" always;
     try_files $uri @proxy;
   }
 
   location /sw.js {
     add_header Cache-Control "public, max-age=0";
-    add_header Strict-Transport-Security "max-age=31536000" always;
     try_files $uri @proxy;
   }
 

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -52,7 +52,7 @@ server {
   gzip_http_version 1.1;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
-  add_header Strict-Transport-Security "max-age=31536000" always;
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
 
   location / {
     try_files $uri @proxy;
@@ -60,6 +60,7 @@ server {
 
   location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
     add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     try_files $uri @proxy;
   }
 
@@ -88,7 +89,6 @@ server {
     proxy_cache_valid 410 24h;
     proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
     add_header X-Cached $upstream_cache_status;
-    add_header Strict-Transport-Security "max-age=31536000" always;
 
     tcp_nodelay on;
   }


### PR DESCRIPTION


fix(#17083): remove redundant header declarations

only one add_header call is required for
`Strict-Transport-Security`