### PR TITLE
Delete conversation if empty after deleting status

### DIFF
--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -59,6 +59,11 @@ class Api::V1::StatusesController < Api::BaseController
     RemovalWorker.perform_async(@status.id, redraft: true)
     @status.account.statuses_count = @status.account.statuses_count - 1
 
+    status_conversation = Conversation.find(@status.conversation_id)
+    if status_conversation.status_ids.empty?
+      status_conversation.destroy
+    end
+
     render json: @status, serializer: REST::StatusSerializer, source_requested: true
   end
 


### PR DESCRIPTION
This makes sure that when a status is deleted and the conversation it belongs to no longer contains any statuses as a result, the conversation is cleaned up as well. The current situation is that empty conversations are left behind in the database when statuses are deleted.

Fixes #16629 