### PR TITLE
Fix follow recommendation biased towards older accounts

### DIFF
--- a/app/workers/scheduler/follow_recommendations_scheduler.rb
+++ b/app/workers/scheduler/follow_recommendations_scheduler.rb
@@ -16,12 +16,12 @@ class Scheduler::FollowRecommendationsScheduler
     AccountSummary.refresh
     FollowRecommendation.refresh
 
-    fallback_recommendations = FollowRecommendation.limit(SET_SIZE).index_by(&:account_id)
+    fallback_recommendations = FollowRecommendation.order(rank: :desc).limit(SET_SIZE).index_by(&:account_id)
 
     I18n.available_locales.each do |locale|
       recommendations = begin
         if AccountSummary.safe.filtered.localized(locale).exists? # We can skip the work if no accounts with that language exist
-          FollowRecommendation.localized(locale).limit(SET_SIZE).index_by(&:account_id)
+          FollowRecommendation.localized(locale).order(rank: :desc).limit(SET_SIZE).index_by(&:account_id)
         else
           {}
         end

--- a/db/migrate/20211213040746_update_account_summaries_to_version_2.rb
+++ b/db/migrate/20211213040746_update_account_summaries_to_version_2.rb
@@ -1,0 +1,24 @@
+class UpdateAccountSummariesToVersion2 < ActiveRecord::Migration[6.1]
+  def up
+    reapplication_follow_recommendations_v2 do
+      drop_view :account_summaries, materialized: true
+      create_view :account_summaries, version: 2, materialized: { no_data: true }
+      safety_assured { add_index :account_summaries, :account_id, unique: true }
+    end
+  end
+
+  def down
+    reapplication_follow_recommendations_v2 do
+      drop_view :account_summaries, materialized: true
+      create_view :account_summaries, version: 1, materialized: { no_data: true }
+      safety_assured { add_index :account_summaries, :account_id, unique: true }
+    end
+  end
+
+  def reapplication_follow_recommendations_v2
+    drop_view :follow_recommendations, materialized: true
+    yield
+    create_view :follow_recommendations, version: 2, materialized: { no_data: true }
+    safety_assured { add_index :follow_recommendations, :account_id, unique: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_26_000907) do
+ActiveRecord::Schema.define(version: 2021_12_13_040746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1129,7 +1129,7 @@ ActiveRecord::Schema.define(version: 2021_11_26_000907) do
               statuses.language,
               statuses.sensitive
              FROM statuses
-            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL))
+            WHERE ((statuses.account_id = accounts.id) AND (statuses.deleted_at IS NULL) AND (statuses.reblog_of_id IS NULL))
             ORDER BY statuses.id DESC
            LIMIT 20) t0)
     WHERE ((accounts.suspended_at IS NULL) AND (accounts.silenced_at IS NULL) AND (accounts.moved_to_account_id IS NULL) AND (accounts.discoverable = true) AND (accounts.locked = false))

--- a/db/views/account_summaries_v02.sql
+++ b/db/views/account_summaries_v02.sql
@@ -1,0 +1,23 @@
+SELECT
+  accounts.id AS account_id,
+  mode() WITHIN GROUP (ORDER BY language ASC) AS language,
+  mode() WITHIN GROUP (ORDER BY sensitive ASC) AS sensitive
+FROM accounts
+CROSS JOIN LATERAL (
+  SELECT
+    statuses.account_id,
+    statuses.language,
+    statuses.sensitive
+  FROM statuses
+  WHERE statuses.account_id = accounts.id
+    AND statuses.deleted_at IS NULL
+    AND statuses.reblog_of_id IS NULL
+  ORDER BY statuses.id DESC
+  LIMIT 20
+) t0
+WHERE accounts.suspended_at IS NULL
+  AND accounts.silenced_at IS NULL
+  AND accounts.moved_to_account_id IS NULL
+  AND accounts.discoverable = 't'
+  AND accounts.locked = 'f'
+GROUP BY accounts.id


### PR DESCRIPTION
Currently, the follow recommendations do not show the newly recognized accounts by the server, as the wrong refinement will preferentially select the old account ID. Fix this.

Also, since the boost is included when detecting the language used by the account from the status, the language detection fails in rare cases. Fix this.

