### PR TITLE
Add a hashtag public link to the trending hashtag page

### DIFF
--- a/app/javascript/mastodon/components/admin/Counter.js
+++ b/app/javascript/mastodon/components/admin/Counter.js
@@ -33,6 +33,7 @@ export default class Counter extends React.PureComponent {
     label: PropTypes.string.isRequired,
     href: PropTypes.string,
     params: PropTypes.object,
+    target: PropTypes.string,
   };
 
   state = {
@@ -54,7 +55,7 @@ export default class Counter extends React.PureComponent {
   }
 
   render () {
-    const { label, href } = this.props;
+    const { label, href, target } = this.props;
     const { loading, data } = this.state;
 
     let content;
@@ -99,11 +100,19 @@ export default class Counter extends React.PureComponent {
     );
 
     if (href) {
-      return (
-        <a href={href} className='sparkline'>
-          {inner}
-        </a>
-      );
+      if (target) {
+        return (
+          <a href={href} className='sparkline' target={target}>
+            {inner}
+          </a>
+        );
+      } else {
+        return (
+          <a href={href} className='sparkline'>
+            {inner}
+          </a>
+        );
+      }
     } else {
       return (
         <div className='sparkline'>

--- a/app/javascript/mastodon/components/admin/Counter.js
+++ b/app/javascript/mastodon/components/admin/Counter.js
@@ -100,19 +100,11 @@ export default class Counter extends React.PureComponent {
     );
 
     if (href) {
-      if (target) {
-        return (
-          <a href={href} className='sparkline' target={target}>
-            {inner}
-          </a>
-        );
-      } else {
-        return (
-          <a href={href} className='sparkline'>
-            {inner}
-          </a>
-        );
-      }
+      return (
+        <a href={href} className='sparkline' target={target}>
+          {inner}
+        </a>
+      );
     } else {
       return (
         <div className='sparkline'>

--- a/app/views/admin/tags/show.html.haml
+++ b/app/views/admin/tags/show.html.haml
@@ -11,7 +11,7 @@
 
 .dashboard
   .dashboard__item
-    = react_admin_component :counter, measure: 'tag_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_accounts_measure')
+    = react_admin_component :counter, measure: 'tag_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_accounts_measure'), href: tag_url(@tag), target: '_blank', rel: 'noopener noreferrer'
   .dashboard__item
     = react_admin_component :counter, measure: 'tag_uses', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_uses_measure')
   .dashboard__item

--- a/app/views/admin/tags/show.html.haml
+++ b/app/views/admin/tags/show.html.haml
@@ -11,7 +11,7 @@
 
 .dashboard
   .dashboard__item
-    = react_admin_component :counter, measure: 'tag_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_accounts_measure'), href: tag_url(@tag), target: '_blank', rel: 'noopener noreferrer'
+    = react_admin_component :counter, measure: 'tag_accounts', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_accounts_measure'), href: tag_url(@tag), target: '_blank'
   .dashboard__item
     = react_admin_component :counter, measure: 'tag_uses', start_at: @time_period.first, end_at: @time_period.last, params: { id: @tag.id }, label: t('admin.trends.tags.dashboard.tag_uses_measure')
   .dashboard__item


### PR DESCRIPTION
This PR will add a public link for the hashtag in the UNIQUE USES field.

It was on the previous trending hashtags page. And this helps moderate hashtags.
I don't think it's best to add a link in this field, but I think it's easy to understand.

![20211216_admin_hashtag](https://user-images.githubusercontent.com/766076/146321614-70b118a1-a475-47ee-a462-1a876a156f1f.png)
