### PR TITLE
Add warning when replying to people you have no follow relationship with

### DIFF
--- a/app/javascript/mastodon/features/compose/components/warning.js
+++ b/app/javascript/mastodon/features/compose/components/warning.js
@@ -2,20 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Motion from '../../ui/util/optional_motion';
 import spring from 'react-motion/lib/spring';
+import classNames from 'classnames';
 
 export default class Warning extends React.PureComponent {
 
   static propTypes = {
     message: PropTypes.node.isRequired,
+    highlighted: PropTypes.bool,
   };
 
   render () {
-    const { message } = this.props;
+    const { message, highlighted } = this.props;
 
     return (
       <Motion defaultStyle={{ opacity: 0, scaleX: 0.85, scaleY: 0.75 }} style={{ opacity: spring(1, { damping: 35, stiffness: 400 }), scaleX: spring(1, { damping: 35, stiffness: 400 }), scaleY: spring(1, { damping: 35, stiffness: 400 }) }}>
         {({ opacity, scaleX, scaleY }) => (
-          <div className='compose-form__warning' style={{ opacity: opacity, transform: `scale(${scaleX}, ${scaleY})` }}>
+          <div className={classNames('compose-form__warning', { highlighted })} style={{ opacity: opacity, transform: `scale(${scaleX}, ${scaleY})` }}>
             {message}
           </div>
         )}

--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 import Warning from '../components/warning';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import ImmutablePureComponent from 'react-immutable-pure-component';
 import { me } from '../../../initial_state';
 
 const buildHashtagRE = () => {
@@ -30,38 +32,119 @@ const buildHashtagRE = () => {
 
 const APPROX_HASHTAG_RE = buildHashtagRE();
 
-const mapStateToProps = state => ({
-  needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),
-  hashtagWarning: state.getIn(['compose', 'privacy']) !== 'public' && APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])),
-  directMessageWarning: state.getIn(['compose', 'privacy']) === 'direct',
-});
+const mapStateToProps = state => {
+  const inReplyToStatusId = state.getIn(['compose', 'in_reply_to']);
+  const inReplyToAccount = state.getIn(['accounts', state.getIn(['statuses', inReplyToStatusId, 'account'])]);
+  const relationship = state.getIn(['relationships', inReplyToAccount?.get('id')]);
 
-const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning }) => {
-  if (needsLockWarning) {
-    return <Warning message={<FormattedMessage id='compose_form.lock_disclaimer' defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.' values={{ locked: <a href='/settings/profile'><FormattedMessage id='compose_form.lock_disclaimer.lock' defaultMessage='locked' /></a> }} />} />;
-  }
-
-  if (hashtagWarning) {
-    return <Warning message={<FormattedMessage id='compose_form.hashtag_warning' defaultMessage="This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag." />} />;
-  }
-
-  if (directMessageWarning) {
-    const message = (
-      <span>
-        <FormattedMessage id='compose_form.direct_message_warning' defaultMessage='This toot will only be sent to all the mentioned users.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a>
-      </span>
-    );
-
-    return <Warning message={message} />;
-  }
-
-  return null;
+  return ({
+    inReplyToAccount,
+    firstInteractionWarning:
+      (inReplyToAccount && me !== inReplyToAccount.get('id')
+       && !relationship?.get('followed_by') && !relationship?.get('following')
+       && !relationship?.get('requested')
+       && (inReplyToAccount.get('note') || inReplyToAccount.get('fields'))),
+    needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),
+    hashtagWarning: state.getIn(['compose', 'privacy']) !== 'public' && APPROX_HASHTAG_RE.test(state.getIn(['compose', 'text'])),
+    directMessageWarning: state.getIn(['compose', 'privacy']) === 'direct',
+  });
 };
 
-WarningWrapper.propTypes = {
-  needsLockWarning: PropTypes.bool,
-  hashtagWarning: PropTypes.bool,
-  directMessageWarning: PropTypes.bool,
+class WarningWrapper extends ImmutablePureComponent {
+
+  static propTypes = {
+    inReplyToAccount: ImmutablePropTypes.map,
+    needsFirstInteractionWarning: PropTypes.bool,
+    needsLockWarning: PropTypes.bool,
+    hashtagWarning: PropTypes.bool,
+    directMessageWarning: PropTypes.bool,
+  };
+
+  static contextTypes = {
+    router: PropTypes.object,
+  };
+
+  handleAccountClick = (e) => {
+    if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      this.context.router.history.push(`/@${this.props.inReplyToAccount.getIn(['acct'])}`);
+    }
+  }
+
+  render () {
+    const { inReplyToAccount, firstInteractionWarning, needsLockWarning, hashtagWarning, directMessageWarning } = this.props;
+
+    const warnings = [];
+
+    if (firstInteractionWarning) {
+      warnings.push(
+        <Warning
+          key='first-interaction-warning'
+          highlighted
+          message={
+            <FormattedMessage
+              id='compose_form.first_interaction_warning'
+              defaultMessage='Before sending your reply, please consider {reading_profile}!'
+              values={{ reading_profile: (
+                <a href={inReplyToAccount.get('url')} onClick={this.handleAccountClick}>
+                  <FormattedMessage
+                    id='compose_form.first_interaction_warning.reading_profile'
+                    defaultMessage="reading @{acct}'s profile"
+                    values={{ acct: inReplyToAccount.get('acct') }}
+                  />
+                </a>
+              ) }}
+            />
+          }
+        />,
+      );
+    }
+
+    if (needsLockWarning) {
+      warnings.push(
+        <Warning
+          key='lock-warning'
+          message={
+            <FormattedMessage
+              id='compose_form.lock_disclaimer'
+              defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.'
+              values={{ locked: <a href='/settings/profile'><FormattedMessage id='compose_form.lock_disclaimer.lock' defaultMessage='locked' /></a> }}
+            />
+          }
+        />,
+      );
+      return warnings;
+    }
+
+    if (hashtagWarning) {
+      warnings.push(
+        <Warning
+          key='hashtag-warning'
+          message={
+            <FormattedMessage
+              id='compose_form.hashtag_warning'
+              defaultMessage="This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag."
+            />
+          }
+        />,
+      );
+      return warnings;
+    }
+
+    if (directMessageWarning) {
+      const message = (
+        <span>
+          <FormattedMessage id='compose_form.direct_message_warning' defaultMessage='This toot will only be sent to all the mentioned users.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a>
+        </span>
+      );
+
+      warnings.push(<Warning key='direct-message-warning' message={message} />);
+      return warnings;
+    }
+
+    return warnings;
+  }
+
 };
 
 export default connect(mapStateToProps)(WarningWrapper);

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -413,6 +413,15 @@
         text-decoration: none;
       }
     }
+
+    &.highlighted {
+      color: $primary-text-color;
+      background: $gold-star;
+
+      a {
+        color: $primary-text-color;
+      }
+    }
   }
 
   .emoji-picker-dropdown {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/384364/146804340-1d7c8978-e0eb-4a66-a877-9ea5902c3d4e.png)

People's profiles may include information regarding how they want to be referred to, what kind of interactions they seek to avoid, etc.

This PR aims to encourage people to actually look at the profile of unknown people they attempt to reply to.

The warning will be shown if none of the following conditions is met:
- there is a follow relationship between accounts
- you have sent a follow request to the account you are replying to
- the profile is empty