### PR TITLE
Change first profile metadata placeholder to pronouns example

### DIFF
--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -42,8 +42,8 @@
 
         = f.simple_fields_for :fields do |fields_f|
           .row
-            = fields_f.input :name, placeholder: t('simple_form.labels.account.fields.name'), input_html: { maxlength: 255 }
-            = fields_f.input :value, placeholder: t('simple_form.labels.account.fields.value'), input_html: { maxlength: 255 }
+            = fields_f.input :name, placeholder: fields_f.index.zero? ? t('simple_form.labels.account.fields.pronouns.name') : t('simple_form.labels.account.fields.name'), input_html: { maxlength: 255 }
+            = fields_f.input :value, placeholder: fields_f.index.zero? ? t('simple_form.labels.account.fields.pronouns.value') : t('simple_form.labels.account.fields.value'), input_html: { maxlength: 255 }
 
     .fields-row__column.fields-group.fields-row__column-6
       %h6= t('verification.verification')

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -93,6 +93,9 @@ en:
       account:
         fields:
           name: Label
+          pronouns:
+            name: Pronouns
+            value: she/her, they/them, …
           value: Content
       account_alias:
         acct: Handle of the old account


### PR DESCRIPTION
Change first profile metadata field placeholder to provide an example of what profile metadata fields are for, and to encourage people writing how they want to be referred to.

![image](https://user-images.githubusercontent.com/384364/146809885-0c0b160b-d485-43ae-9fbe-76ea8facd660.png)