### PR TITLE
Add ReadWritePaths directive to service files

### DIFF
--- a/dist/mastodon-sidekiq.service
+++ b/dist/mastodon-sidekiq.service
@@ -47,6 +47,7 @@ SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @mount @obsolete @privileg
 SystemCallFilter=@chown
 SystemCallFilter=pipe
 SystemCallFilter=pipe2
+ReadWritePaths=/home/mastodon/live
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-streaming.service
+++ b/dist/mastodon-streaming.service
@@ -45,6 +45,7 @@ SystemCallArchitectures=native
 SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @memlock @mount @obsolete @privileged @resources @setuid
 SystemCallFilter=pipe
 SystemCallFilter=pipe2
+ReadWritePaths=/home/mastodon/live
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-web.service
+++ b/dist/mastodon-web.service
@@ -47,6 +47,7 @@ SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @mount @obsolete @privileg
 SystemCallFilter=@chown
 SystemCallFilter=pipe
 SystemCallFilter=pipe2
+ReadWritePaths=/home/mastodon/live
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hi,

this PR adds the [`ReadWritePaths`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ReadWritePaths=) attribute to the systemd service files.

This attribute might not be required when following the default install path (`/home/mastodon/live`) but will prevent `Read Only File System` errors when Mastodon is not installed into the standard path. 

I think it would be a good idea to include this, since the Mastodon documentation advises to edit those files when not following the default paths and finding this on search engines by searching for the `Read only File System` errors is a rather disgusting path to take.