### PR TITLE
Fix tag rendering error in hashtag column settings

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.js
@@ -33,8 +33,8 @@ class ColumnSettings extends React.PureComponent {
   tags (mode) {
     let tags = this.props.settings.getIn(['tags', mode]) || [];
 
-    if (tags.toArray) {
-      return tags.toArray().map(tag => tag.toJSON());
+    if (tags.toJS) {
+      return tags.toJS();
     } else {
       return tags;
     }

--- a/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.js
@@ -33,8 +33,8 @@ class ColumnSettings extends React.PureComponent {
   tags (mode) {
     let tags = this.props.settings.getIn(['tags', mode]) || [];
 
-    if (tags.toJSON) {
-      return tags.toJSON();
+    if (tags.toArray) {
+      return tags.toArray().map(tag => tag.toJSON());
     } else {
       return tags;
     }


### PR DESCRIPTION
When additional tags are added to a hashtag column, the tags initially appear correct but turn into empty blocks once the page is refreshed. This is caused by an attempt to convert the configuration's internal representation (i.e. a stack object) to JSON, which does not produce the expected label values. To fix this, the stack is first flattened to a regular array, which is then converted to JSON.

Fixes #17089 