### PR TITLE
Save bundle config as local on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ RUN npm install -g npm@latest && \
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
 RUN cd /opt/mastodon && \
-  bundle config set deployment 'true' && \
-  bundle config set without 'development test' && \
+  bundle config set --local deployment 'true' && \
+  bundle config set --local without 'development test' && \
   bundle config set silence_root_warning true && \
 	bundle install -j"$(nproc)" && \
 	yarn install --pure-lockfile


### PR DESCRIPTION
Some bundle options are saved as global user config and not project local.
Specially, `deployment` must be saved as local config to be run on copied environment