### PR TITLE
Remove leftover database columns from Devise::Models::Rememberable

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,6 @@
 #  encrypted_password        :string           default(""), not null
 #  reset_password_token      :string
 #  reset_password_sent_at    :datetime
-#  remember_created_at       :datetime
 #  sign_in_count             :integer          default(0), not null
 #  current_sign_in_at        :datetime
 #  last_sign_in_at           :datetime
@@ -32,7 +31,6 @@
 #  disabled                  :boolean          default(FALSE), not null
 #  moderator                 :boolean          default(FALSE), not null
 #  invite_id                 :bigint(8)
-#  remember_token            :string
 #  chosen_languages          :string           is an Array
 #  created_by_application_id :bigint(8)
 #  approved                  :boolean          default(TRUE), not null
@@ -44,6 +42,11 @@
 #
 
 class User < ApplicationRecord
+  self.ignored_columns = %w(
+    remember_created_at
+    remember_token
+  )
+
   include Settings::Extend
   include UserRoles
 
@@ -329,10 +332,9 @@ class User < ApplicationRecord
   end
 
   def reset_password!
-    # First, change password to something random, invalidate the remember-me token,
-    # and deactivate all sessions
+    # First, change password to something random and deactivate all sessions
     transaction do
-      update(remember_token: nil, remember_created_at: nil, password: SecureRandom.hex)
+      update(password: SecureRandom.hex)
       session_activations.destroy_all
     end
 

--- a/db/post_migrate/20220118183010_remove_index_users_on_remember_token.rb
+++ b/db/post_migrate/20220118183010_remove_index_users_on_remember_token.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveIndexUsersOnRememberToken < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :users, name: :index_users_on_remember_token
+  end
+
+  def down
+    add_index :users, :remember_token, algorithm: :concurrently, unique: true, name: :index_users_on_remember_token
+  end
+end

--- a/db/post_migrate/20220118183123_remove_rememberable_from_users.rb
+++ b/db/post_migrate/20220118183123_remove_rememberable_from_users.rb
@@ -1,0 +1,8 @@
+class RemoveRememberableFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      remove_column :users, :remember_token, :string, null: true, default: nil
+      remove_column :users, :remember_created_at, :datetime, null: true, default: nil
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_16_202951) do
+ActiveRecord::Schema.define(version: 2022_01_18_183123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -924,7 +924,6 @@ ActiveRecord::Schema.define(version: 2022_01_16_202951) do
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
@@ -946,7 +945,6 @@ ActiveRecord::Schema.define(version: 2022_01_16_202951) do
     t.boolean "disabled", default: false, null: false
     t.boolean "moderator", default: false, null: false
     t.bigint "invite_id"
-    t.string "remember_token"
     t.string "chosen_languages", array: true
     t.bigint "created_by_application_id"
     t.boolean "approved", default: true, null: false
@@ -959,7 +957,6 @@ ActiveRecord::Schema.define(version: 2022_01_16_202951) do
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_by_application_id"], name: "index_users_on_created_by_application_id"
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["remember_token"], name: "index_users_on_remember_token", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
Follow-up to #16943, which avoided changing the database schema so that the fix could be immediately deployable, but stopped using `Devise::Models::Rememberable` altogether, making `remember_created_at` and `remember_token` useless.

Those are post-deployment migrations that warrant a two-step update with `SKIP_POST_DEPLOYMENT_MIGRATIONS=true`.

Also update the `fix-duplicates` maintenance script to the latest version of the database schema, slightly improve warnings/errors and add a check to not run if sidekiq processes are detected.