### PR TITLE
Allow connecting to heroku redis servers with self-signed certificates

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
-redis_connection = Redis.new(
+opts = {
   url: ENV['REDIS_URL'],
   driver: :hiredis
-)
+}
+
+if ENV['REDIS_TLS_NOVERIFY']
+  opts[:driver] = :ruby
+  opts[:ssl_params] = { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+end
+
+redis_connection = Redis.new(opts)
 
 namespace = ENV.fetch('REDIS_NAMESPACE') { nil }
 


### PR DESCRIPTION
Adds a new environment variable: `REDIS_TLS_NOVERIFY`.

When set, it configures the redis client to use `VERIFY_NONE`, as required by heroku when connecting to their redis addon offering.

See:

- https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance

- https://devcenter.heroku.com/articles/securing-heroku-redis#using-ruby