### PR TITLE
Add line about using vagrant-hostsupdater in the Vagrant short guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The repository includes deployment configurations for **Docker and docker-compos
 A **Vagrant** configuration is included for development purposes. To use it, complete following steps:
 
 - Install Vagrant and Virtualbox
+- Install the `vagrant-hostsupdater` plugin: `vagrant plugin install vagrant-hostsupdater`
 - Run `vagrant up`
 - Run `vagrant ssh -c "cd /vagrant && foreman start"`
 - Open `http://mastodon.local` in your browser


### PR DESCRIPTION
This is documented in the `Vagrantfile`, but not in the `README`. As far as I know, following the short guide without installing this plugin will not make the container accessible at mastodon.local, thus breaking the last step of the guide.