### PR TITLE
Remove old duplicate index

### DIFF
--- a/db/migrate/20220105163928_remove_mentions_status_id_index.rb
+++ b/db/migrate/20220105163928_remove_mentions_status_id_index.rb
@@ -1,0 +1,9 @@
+class RemoveMentionsStatusIdIndex < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :mentions, name: :mentions_status_id_index if index_exists?(:mentions, :status_id, name: :mentions_status_id_index)
+  end
+
+  def down
+    # As this index should not exist and is a duplicate of another index, do not re-create it
+  end
+end


### PR DESCRIPTION
Some Mastodon versions (v1.1 and v1.2) had a duplicate index in `db/schema.rb` without any migration script creating it. #2224 (included in v1.3) removed the duplicate index from the file but did not provide a migration script to remove it.

This means that any instance that was installed from v1.1 or v1.2's source code has a duplicate index and a corresponding warning in PgHero. Instances set up using an earlier or later Mastodon version do not have this issue.

This PR removes the duplicate index if it is present.