### PR TITLE
helm: upgrade elasticsearch to 7.x

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -110,10 +110,8 @@ elasticsearch:
   # RAILS_ENV=production bundle exec rake chewy:sync
   # (https://docs.joinmastodon.org/admin/optional/elasticsearch/)
   enabled: true
-  # may be removed once https://github.com/tootsuite/mastodon/pull/13828 is part
-  # of a tagged release
   image:
-    tag: 6
+    tag: 7
 
 # https://github.com/bitnami/charts/tree/master/bitnami/postgresql#parameters
 postgresql:


### PR DESCRIPTION
see https://github.com/mastodon/mastodon/issues/17070

I was able to upgrade the ES on my instance in-place from 6 to 7, so I don't think we need a major version bump on the chart.