### PR TITLE
Fix typo

### DIFF
--- a/config/locales/devise.zh-CN.yml
+++ b/config/locales/devise.zh-CN.yml
@@ -4,7 +4,7 @@ zh-CN:
     confirmations:
       confirmed: 已成功确认你的邮箱地址。
       send_instructions: 你将在几分钟内收到一封电子邮件，指导你如何验证电子邮箱地址。如果你没有收到这封邮件，请检查你的垃圾邮件文件夹。
-      send_paranoid_instructions: 如果你的电子邮箱地址存在于我们的数据库中，你将在几分钟内收到一封邮件，知道你如何验证电子邮箱地址。如果你没有收到这封邮件，请检查你的垃圾邮件文件夹。
+      send_paranoid_instructions: 如果你的电子邮箱地址存在于我们的数据库中，你将在几分钟内收到一封邮件，指导你如何验证电子邮箱地址。如果你没有收到这封邮件，请检查你的垃圾邮件文件夹。
     failure:
       already_authenticated: 你已登录。
       inactive: 你还没有激活帐户。


### PR DESCRIPTION
"instructions" means "指导"，“知道” is a Chinese pinyin typo.