### PR TITLE
Gradually increase retry waiting time for media processing to avoid API limit

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -252,12 +252,15 @@ export function uploadCompose(files) {
           if (status === 200) {
             dispatch(uploadComposeSuccess(data, f));
           } else if (status === 202) {
+            let tryCount = 1;
             const poll = () => {
               api(getState).get(`/api/v1/media/${data.id}`).then(response => {
                 if (response.status === 200) {
                   dispatch(uploadComposeSuccess(response.data, f));
                 } else if (response.status === 206) {
-                  setTimeout(() => poll(), 1000);
+                  let retryAfter = (Math.log2(tryCount) || 1) * 1000;
+                  tryCount += 1;
+                  setTimeout(() => poll(), retryAfter);
                 }
               }).catch(error => dispatch(uploadComposeFail(error)));
             };


### PR DESCRIPTION
When upload some large video to low powered server, it keeps polling every 1 second to check if the media was processed or not.
And it could causing media API limit.
To avoid this, This PR changes that behaviour to gradually increase waiting time.

This uses log2 mathematical function.
Compare to `*= 1.5`, that causes exponentially increasing waiting time, log function shows gradually increasing curve