### PR TITLE
Fix media media API limit

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -55,7 +55,7 @@ class Rack::Attack
   end
 
   throttle('throttle_api_media', limit: 30, period: 30.minutes) do |req|
-    req.authenticated_user_id if req.post? && req.path.start_with?('/api/v1/media')
+    req.authenticated_user_id if req.post? && req.path.match?('^/api/v\d+/media')
   end
 
   throttle('throttle_media_proxy', limit: 30, period: 10.minutes) do |req|


### PR DESCRIPTION
Previously, only v1 of media API was throttled.
As mastodon uses v2 API to upload media, It should also catch v2 usage