### PR TITLE
Remove support for OAUTH_REDIRECT_AT_SIGN_IN

### DIFF
--- a/.env.nanobox
+++ b/.env.nanobox
@@ -202,10 +202,6 @@ SMTP_FROM_ADDRESS=notifications@${APP_NAME}.nanoapp.io
 # Name of the pam service used for checking if an user can register (pam "account" section is evaluated) (nil (disabled) by default)
 # PAM_CONTROLLED_SERVICE=rpam
 
-# Global OAuth settings (optional) :
-# If you have only one strategy, you may want to enable this
-# OAUTH_REDIRECT_AT_SIGN_IN=true
-
 # Optional CAS authentication (cf. omniauth-cas) :
 # CAS_ENABLED=true
 # CAS_URL=https://sso.myserver.com/

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -13,14 +13,6 @@ class Auth::SessionsController < Devise::SessionsController
   before_action :set_instance_presenter, only: [:new]
   before_action :set_body_classes
 
-  def new
-    Devise.omniauth_configs.each do |provider, config|
-      return redirect_to(omniauth_authorize_path(resource_name, provider)) if config.strategy.redirect_at_sign_in
-    end
-
-    super
-  end
-
   def create
     super do |resource|
       # We only need to call this if this hasn't already been
@@ -85,14 +77,6 @@ class Auth::SessionsController < Devise::SessionsController
     else
       last_url || root_path
     end
-  end
-
-  def after_sign_out_path_for(_resource_or_scope)
-    Devise.omniauth_configs.each_value do |config|
-      return root_path if config.strategy.redirect_at_sign_in
-    end
-
-    super
   end
 
   def require_no_authentication

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -5,7 +5,6 @@ end
 Devise.setup do |config|
   # Devise omniauth strategies
   options = {}
-  options[:redirect_at_sign_in] = ENV['OAUTH_REDIRECT_AT_SIGN_IN'] == 'true'
 
   # CAS strategy
   if ENV['CAS_ENABLED'] == 'true'


### PR DESCRIPTION
Fixes #15959

Introduced in #6540, `OAUTH_REDIRECT_AT_SIGN_IN` allowed skipping the log-in form to instead redirect to the external OmniAuth login provider.

However, it did not prevent the log-in form on /about introduced by #10232 from appearing, and completely broke with the introduction of #15228.

As I restoring that previous log-in flow without introducing a security vulnerability may require extensive care and knowledge of how OmniAuth works, this PR removes support for `OAUTH_REDIRECT_AT_SIGN_IN` instead for the time being.

Ideally, a similar option should be created to avoid displaying the log-in form and instead only display the external provider buttons, both on `/about` and `/auth/sign_in`, and, if possible, do not require that extra click, but for the time being, I think it is better having a clunky login flow than one that does not work at all.