### PR TITLE
disable legacy XSS filtering

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,7 +118,7 @@ Rails.application.configure do
     'Server'                 => 'Mastodon',
     'X-Frame-Options'        => 'DENY',
     'X-Content-Type-Options' => 'nosniff',
-    'X-XSS-Protection'       => '1; mode=block',
+    'X-XSS-Protection'       => '0',
     'Permissions-Policy'     => 'interest-cohort=()',
   }
 


### PR DESCRIPTION
`X-XSS-Protection` is a legacy response header that was intended to prevent pages from loading when cross-site scripting attacks were detected by the browser-implemented auditor/filter. It was superseded by the much more modern CSP supported by all modern browsers.

Browsers such as [Chromium](https://chromestatus.com/feature/5021976655560704) and [Edge](https://blogs.windows.com/windows-insider/2018/07/25/announcing-windows-10-insider-preview-build-17723-and-build-18204/) fully removed this legacy protection, which is also known to be easy to bypass and causing a multitude of issues in practice. Research has shown that block mode could be abused to exfiltrate information using a fake reflected XSS (known as [XS-Leak attacks](https://github.com/xsleaks/xsleaks/wiki/Links#annex-xss-filters-information-leaks)). I would be happy to elaborate if you think it deems necessary.

The ideal fix should be to set the value of the header to `0`, thus effectively disabling filter/auditor in old browsers, but also Safari and IE which are still using it for some reason. Note however that even XSS-Auditor has been recently [fully removed from Webkit](https://bugs.webkit.org/show_bug.cgi?id=230499) so this change will come to Safari soon enough.

In a few months/years it should be even safe to remove the header altogether, saving resources in the end as it would then be a totally useless header. Thanks for considering this PR. :)