### PR TITLE
Fix link_to_login argument handling when a block is passed

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,6 +64,8 @@ module ApplicationHelper
   def link_to_login(name = nil, html_options = nil, &block)
     target = new_user_session_path
 
+    html_options = name if block_given?
+
     if omniauth_only? && Devise.mappings[:user].omniauthable? && User.omniauth_providers.size == 1
       target = omniauth_authorize_path(:user, User.omniauth_providers[0])
       html_options ||= {}


### PR DESCRIPTION
Fixes regression from #17288

`html_options` were not correctly passed to the underlying `link_to` call when passing a block, losing passed attributes such as `class` in the process, resulting in:
![image](https://user-images.githubusercontent.com/384364/150700719-cd56a380-d161-4e72-b3b6-edb0525e289e.png)