### PR TITLE
Redesign /about when already logged in

### DIFF
--- a/app/views/about/_logged_in.html.haml
+++ b/app/views/about/_logged_in.html.haml
@@ -1,0 +1,10 @@
+.simple_form
+  %p.lead= t('about.logged_in_as_html', username: content_tag(:strong, current_account.username))
+
+  .actions
+    = link_to t('about.continue_to_web'), root_url, class: 'button button-primary'
+
+.form-footer
+  %ul.no-list
+    %li= link_to t('about.get_apps'), 'https://joinmastodon.org/apps', target: '_blank', rel: 'noopener noreferrer'
+    %li= link_to t('auth.logout'), destroy_user_session_path, data: { method: :delete }

--- a/app/views/about/_registration.html.haml
+++ b/app/views/about/_registration.html.haml
@@ -1,4 +1,4 @@
-- disabled = closed_registrations? || current_account.present?
+- disabled = closed_registrations? || omniauth_only? || current_account.present?
 - show_message = disabled && (current_user.present? || @instance_presenter.closed_registrations_message.present?)
 
 .simple_form__overlay-area{ class: show_message ? 'simple_form__overlay-area__blurred' : '' }

--- a/app/views/about/_registration.html.haml
+++ b/app/views/about/_registration.html.haml
@@ -1,17 +1,20 @@
-.simple_form__overlay-area{ class: (closed_registrations? && @instance_presenter.closed_registrations_message.present?) ? 'simple_form__overlay-area__blurred' : '' }
+- disabled = closed_registrations? || current_account.present?
+- show_message = disabled && (current_user.present? || @instance_presenter.closed_registrations_message.present?)
+
+.simple_form__overlay-area{ class: show_message ? 'simple_form__overlay-area__blurred' : '' }
   = simple_form_for(new_user, url: user_registration_path, namespace: 'registration', html: { novalidate: false }) do |f|
     %p.lead= t('about.federation_hint_html', instance: content_tag(:strong, site_hostname))
 
     .fields-group
       = f.simple_fields_for :account do |account_fields|
-        = account_fields.input :username, wrapper: :with_label, label: false, required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.username'), :autocomplete => 'off', placeholder: t('simple_form.labels.defaults.username'), pattern: '[a-zA-Z0-9_]+', maxlength: 30 }, append: "@#{site_hostname}", hint: false, disabled: closed_registrations?
+        = account_fields.input :username, wrapper: :with_label, label: false, required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.username'), :autocomplete => 'off', placeholder: t('simple_form.labels.defaults.username'), pattern: '[a-zA-Z0-9_]+', maxlength: 30 }, append: "@#{site_hostname}", hint: false, disabled: disabled
 
-      = f.input :email, placeholder: t('simple_form.labels.defaults.email'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
-      = f.input :password, placeholder: t('simple_form.labels.defaults.password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.password'), :autocomplete => 'off', :minlength => User.password_length.first, :maxlength => User.password_length.last }, hint: false, disabled: closed_registrations?
-      = f.input :password_confirmation, placeholder: t('simple_form.labels.defaults.confirm_password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_password'), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
+      = f.input :email, placeholder: t('simple_form.labels.defaults.email'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), :autocomplete => 'off' }, hint: false, disabled: disabled
+      = f.input :password, placeholder: t('simple_form.labels.defaults.password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.password'), :autocomplete => 'off', :minlength => User.password_length.first, :maxlength => User.password_length.last }, hint: false, disabled: disabled
+      = f.input :password_confirmation, placeholder: t('simple_form.labels.defaults.confirm_password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_password'), :autocomplete => 'off' }, hint: false, disabled: disabled
 
-      = f.input :confirm_password, as: :string, placeholder: t('simple_form.labels.defaults.honeypot', label: t('simple_form.labels.defaults.password')), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot', label: t('simple_form.labels.defaults.password')), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
-      = f.input :website, as: :url, placeholder: t('simple_form.labels.defaults.honeypot', label: 'Website'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot', label: 'Website'), :autocomplete => 'off' }, hint: false, disabled: closed_registrations?
+      = f.input :confirm_password, as: :string, placeholder: t('simple_form.labels.defaults.honeypot', label: t('simple_form.labels.defaults.password')), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot', label: t('simple_form.labels.defaults.password')), :autocomplete => 'off' }, hint: false, disabled: disabled
+      = f.input :website, as: :url, placeholder: t('simple_form.labels.defaults.honeypot', label: 'Website'), required: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.honeypot', label: 'Website'), :autocomplete => 'off' }, hint: false, disabled: disabled
 
     - if approved_registrations?
       .fields-group
@@ -19,13 +22,16 @@
           = invite_request_fields.input :text, as: :text, wrapper: :with_block_label, required: Setting.require_invite_text
 
     .fields-group
-      = f.input :agreement, as: :boolean, wrapper: :with_label, label: t('auth.checkbox_agreement_html', rules_path: about_more_path, terms_path: terms_path), required: true, disabled: closed_registrations?
+      = f.input :agreement, as: :boolean, wrapper: :with_label, label: t('auth.checkbox_agreement_html', rules_path: about_more_path, terms_path: terms_path), required: true, disabled: disabled
 
     .actions
-      = f.button :button, sign_up_message, type: :submit, class: 'button button-primary', disabled: closed_registrations?
+      = f.button :button, sign_up_message, type: :submit, class: 'button button-primary', disabled: disabled
 
-  - if closed_registrations? && @instance_presenter.closed_registrations_message.present?
+  - if show_message
     .simple_form__overlay-area__overlay
       .simple_form__overlay-area__overlay__content.rich-formatting
         .block-icon= fa_icon 'warning'
-        = @instance_presenter.closed_registrations_message.html_safe
+        - if current_account.present?
+          = t('about.logout_before_registering')
+        - else
+          = @instance_presenter.closed_registrations_message.html_safe

--- a/app/views/about/show.html.haml
+++ b/app/views/about/show.html.haml
@@ -46,7 +46,10 @@
 
     .landing__grid__column.landing__grid__column-login
       .box-widget
-        = render 'login'
+        - if current_user.present?
+          = render 'logged_in'
+        - else
+          = render 'login'
 
       .hero-widget
         .hero-widget__img

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
     contact: Contact
     contact_missing: Not set
     contact_unavailable: N/A
+    continue_to_web: Continue to the Web interface
     discover_users: Discover users
     documentation: Documentation
     federation_hint_html: With an account on %{instance} you'll be able to follow people on any Mastodon server and beyond.
@@ -25,6 +26,8 @@ en:
       This account is a virtual actor used to represent the server itself and not any individual user.
       It is used for federation purposes and should not be blocked unless you want to block the whole instance, in which case you should use a domain block.
     learn_more: Learn more
+    logged_in_as_html: You are currently logged in as %{username}.
+    logout_before_registering: You are already logged in.
     privacy_policy: Privacy policy
     rules: Server rules
     rules_html: 'Below is a summary of rules you need to follow if you want to have an account on this server of Mastodon:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
     contact: Contact
     contact_missing: Not set
     contact_unavailable: N/A
-    continue_to_web: Continue to the Web interface
+    continue_to_web: Continue to web app
     discover_users: Discover users
     documentation: Documentation
     federation_hint_html: With an account on %{instance} you'll be able to follow people on any Mastodon server and beyond.

--- a/spec/views/about/show.html.haml_spec.rb
+++ b/spec/views/about/show.html.haml_spec.rb
@@ -8,6 +8,7 @@ describe 'about/show.html.haml', without_verify_partial_doubles: true do
     allow(view).to receive(:site_title).and_return('example site')
     allow(view).to receive(:new_user).and_return(User.new)
     allow(view).to receive(:use_seamless_external_login?).and_return(false)
+    allow(view).to receive(:current_account).and_return(nil)
   end
 
   it 'has valid open graph tags' do


### PR DESCRIPTION
## Before

Upon visiting `/about`, one would not know they are already logged in, and will instead be presented with the registration and log-in form. If using any of them, they will just silently go to `/web`, without the registration or log-in action performed.

![Screenshot 2022-01-24 at 18-37-54 Mastodon Glitch Edition](https://user-images.githubusercontent.com/384364/150835179-1d971161-7f90-4dfe-8081-3b296afde103.png)

## After

Visiting `/about` when already logged in disables the registration form and replaces the log-in one by a button to go to the web interface.

![Screenshot 2022-01-24 at 18-33-52 Mastodon Glitch Edition](https://user-images.githubusercontent.com/384364/150835193-799c700b-7cc4-458a-b037-5c6b4f0c8d8f.png)