### PR TITLE
Add healthcheck for sidekiq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,9 @@ services:
       - internal_network
     volumes:
       - ./public/system:/mastodon/public/system
+    healthcheck:
+      test: ["CMD-SHELL", "ps aux | grep '[s]idekiq\ 6' || false"]
+
 ## Uncomment to enable federation with tor instances along with adding the following ENV variables
 ## http_proxy=http://privoxy:8118
 ## ALLOW_ACCESS_TO_HIDDEN_SERVICE=true


### PR DESCRIPTION
I found that in the docker-compose example of the repository, only `sidekiq` was missing a healthcheck, so I added it.