### PR TITLE
Fix local distribution of edited statuses

### DIFF
--- a/app/services/fan_out_on_write_service.rb
+++ b/app/services/fan_out_on_write_service.rb
@@ -119,7 +119,7 @@ class FanOutOnWriteService < BaseService
   end
 
   def update?
-    @is_update
+    @options[:update]
   end
 
   def broadcastable?


### PR DESCRIPTION
Because `FanOutOnWriteService#update?` was broken, edits were considered as new toots and a regular `update` payload was sent.