### PR TITLE
Refactor and improve tests

### DIFF
--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe AccountsController, type: :controller do
   render_views
 
-  let(:account) { Fabricate(:user).account }
+  let(:account) { Fabricate(:account) }
 
   shared_examples 'cachable response' do
     it 'does not set cookies' do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Admin::AccountsController, type: :controller do
 
   describe 'GET #show' do
     let(:current_user) { Fabricate(:user, admin: true) }
-    let(:account) { Fabricate(:account, username: 'bob') }
+    let(:account) { Fabricate(:account) }
 
     it 'returns http success' do
       get :show, params: { id: account.id }
@@ -73,7 +73,7 @@ RSpec.describe Admin::AccountsController, type: :controller do
     subject { post :memorialize, params: { id: account.id } }
 
     let(:current_user) { Fabricate(:user, admin: current_user_admin) }
-    let(:account) { Fabricate(:account, user: user) }
+    let(:account) { user.account }
     let(:user) { Fabricate(:user, admin: target_user_admin) }
 
     context 'when user is admin' do
@@ -125,7 +125,7 @@ RSpec.describe Admin::AccountsController, type: :controller do
     subject { post :enable, params: { id: account.id } }
 
     let(:current_user) { Fabricate(:user, admin: admin) }
-    let(:account) { Fabricate(:account, user: user) }
+    let(:account) { user.account }
     let(:user) { Fabricate(:user, disabled: true) }
 
     context 'when user is admin' do

--- a/spec/controllers/admin/change_email_controller_spec.rb
+++ b/spec/controllers/admin/change_email_controller_spec.rb
@@ -11,10 +11,9 @@ RSpec.describe Admin::ChangeEmailsController, type: :controller do
 
   describe "GET #show" do
     it "returns http success" do
-      account = Fabricate(:account)
-      user = Fabricate(:user, account: account)
+      user = Fabricate(:user)
 
-      get :show, params: { account_id: account.id }
+      get :show, params: { account_id: user.account.id }
 
       expect(response).to have_http_status(200)
     end
@@ -26,12 +25,11 @@ RSpec.describe Admin::ChangeEmailsController, type: :controller do
     end
 
     it "returns http success" do
-      account = Fabricate(:account)
-      user = Fabricate(:user, account: account)
+      user = Fabricate(:user)
 
       previous_email = user.email
 
-      post :update, params: { account_id: account.id, user: { unconfirmed_email: 'test@example.com' } }
+      post :update, params: { account_id: user.account.id, user: { unconfirmed_email: 'test@example.com' } }
 
       user.reload
 
@@ -41,7 +39,7 @@ RSpec.describe Admin::ChangeEmailsController, type: :controller do
 
       expect(UserMailer).to have_received(:confirmation_instructions).with(user, user.confirmation_token, { to: 'test@example.com' })
 
-      expect(response).to redirect_to(admin_account_path(account.id))
+      expect(response).to redirect_to(admin_account_path(user.account.id))
     end
   end
 end

--- a/spec/controllers/admin/confirmations_controller_spec.rb
+++ b/spec/controllers/admin/confirmations_controller_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe Admin::ConfirmationsController, type: :controller do
 
   describe 'POST #create' do
     it 'confirms the user' do
-      account = Fabricate(:account)
-      user = Fabricate(:user, confirmed_at: false, account: account)
-      post :create, params: { account_id: account.id }
+      user = Fabricate(:user, confirmed_at: false)
+      post :create, params: { account_id: user.account.id }
 
       expect(response).to redirect_to(admin_accounts_path)
       expect(user.reload).to be_confirmed
@@ -32,10 +31,9 @@ RSpec.describe Admin::ConfirmationsController, type: :controller do
   end
 
   describe 'POST #resernd' do
-    subject { post :resend, params: { account_id: account.id } }
+    subject { post :resend, params: { account_id: user.account.id } }
 
-    let(:account) { Fabricate(:account) }
-    let!(:user) { Fabricate(:user, confirmed_at: confirmed_at, account: account) }
+    let!(:user) { Fabricate(:user, confirmed_at: confirmed_at) }
 
     before do
       allow(UserMailer).to receive(:confirmation_instructions) { double(:email, deliver_later: nil) }

--- a/spec/controllers/admin/resets_controller_spec.rb
+++ b/spec/controllers/admin/resets_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Admin::ResetsController do
   render_views
 
-  let(:account) { Fabricate(:account, user: Fabricate(:user)) }
+  let(:account) { Fabricate(:account) }
   before do
     sign_in Fabricate(:user, admin: true), scope: :user
   end

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -28,7 +28,7 @@ describe Api::BaseController do
   end
 
   describe 'non-functional accounts handling' do
-    let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+    let(:user)  { Fabricate(:user) }
     let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read') }
 
     controller do

--- a/spec/controllers/api/v1/accounts/credentials_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/credentials_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::Accounts::CredentialsController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
 
   context 'with an oauth token' do

--- a/spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::Accounts::FollowerAccountsController do
   render_views
 
-  let(:user)    { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:accounts') }
   let(:account) { Fabricate(:account) }
   let(:alice)   { Fabricate(:account) }
@@ -49,10 +49,10 @@ describe Api::V1::Accounts::FollowerAccountsController do
     end
 
     context 'when requesting user is the account owner' do
-      let(:user) { Fabricate(:user, account: account) }
+      let(:user) { account.user }
 
       it 'returns all accounts, including muted accounts' do
-        user.account.mute!(bob)
+        account.mute!(bob)
         get :index, params: { account_id: account.id, limit: 2 }
 
         expect(body_as_json.size).to eq 2

--- a/spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::Accounts::FollowingAccountsController do
   render_views
 
-  let(:user)    { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:accounts') }
   let(:account) { Fabricate(:account) }
   let(:alice)   { Fabricate(:account) }
@@ -49,10 +49,10 @@ describe Api::V1::Accounts::FollowingAccountsController do
     end
 
     context 'when requesting user is the account owner' do
-      let(:user) { Fabricate(:user, account: account) }
+      let(:user) { account.user }
 
       it 'returns all accounts, including muted accounts' do
-        user.account.mute!(bob)
+        account.mute!(bob)
         get :index, params: { account_id: account.id, limit: 2 }
 
         expect(body_as_json.size).to eq 2

--- a/spec/controllers/api/v1/accounts/lists_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/lists_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::Accounts::ListsController do
   render_views
 
-  let(:user)    { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:lists') }
   let(:account) { Fabricate(:account) }
   let(:list)    { Fabricate(:list, account: user.account) }

--- a/spec/controllers/api/v1/accounts/notes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/notes_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::Accounts::NotesController do
   render_views
 
-  let(:user)    { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)    { Fabricate(:user) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:accounts') }
   let(:account) { Fabricate(:account) }
   let(:comment) { 'foo' }

--- a/spec/controllers/api/v1/accounts/pins_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/pins_controller_spec.rb
@@ -3,8 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::Accounts::PinsController, type: :controller do
-  let(:john)  { Fabricate(:user, account: Fabricate(:account, username: 'john')) }
-  let(:kevin) { Fabricate(:user, account: Fabricate(:account, username: 'kevin')) }
+  let(:john)  { Fabricate(:user) }
+  let(:kevin) { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: john.id, scopes: 'write:accounts') }
 
   before do

--- a/spec/controllers/api/v1/accounts/relationships_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/relationships_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::Accounts::RelationshipsController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:follows') }
 
   before do
@@ -11,8 +11,8 @@ describe Api::V1::Accounts::RelationshipsController do
   end
 
   describe 'GET #index' do
-    let(:simon) { Fabricate(:user, email: 'simon@example.com', account: Fabricate(:account, username: 'simon')).account }
-    let(:lewis) { Fabricate(:user, email: 'lewis@example.com', account: Fabricate(:account, username: 'lewis')).account }
+    let(:simon) { Fabricate(:account) }
+    let(:lewis) { Fabricate(:account) }
 
     before do
       user.account.follow!(simon)

--- a/spec/controllers/api/v1/accounts/search_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/search_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::Accounts::SearchController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:accounts') }
 
   before do

--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::Accounts::StatusesController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:statuses') }
 
   before do

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::AccountsController, type: :controller do
   render_views
 
-  let(:user)   { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)   { Fabricate(:user) }
   let(:scopes) { '' }
   let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
 
@@ -69,7 +69,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
   describe 'POST #follow' do
     let(:scopes) { 'write:follows' }
-    let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', locked: locked)).account }
+    let(:other_account) { Fabricate(:account, username: 'bob', locked: locked) }
 
     context do
       before do
@@ -150,7 +150,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
   describe 'POST #unfollow' do
     let(:scopes) { 'write:follows' }
-    let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:other_account) { Fabricate(:account, username: 'bob') }
 
     before do
       user.account.follow!(other_account)
@@ -170,7 +170,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
   describe 'POST #remove_from_followers' do
     let(:scopes) { 'write:follows' }
-    let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:other_account) { Fabricate(:account, username: 'bob') }
 
     before do
       other_account.follow!(user.account)
@@ -190,7 +190,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
   describe 'POST #block' do
     let(:scopes) { 'write:blocks' }
-    let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:other_account) { Fabricate(:account, username: 'bob') }
 
     before do
       user.account.follow!(other_account)
@@ -214,7 +214,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
   describe 'POST #unblock' do
     let(:scopes) { 'write:blocks' }
-    let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:other_account) { Fabricate(:account, username: 'bob') }
 
     before do
       user.account.block!(other_account)
@@ -234,7 +234,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
   describe 'POST #mute' do
     let(:scopes) { 'write:mutes' }
-    let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:other_account) { Fabricate(:account, username: 'bob') }
 
     before do
       user.account.follow!(other_account)
@@ -262,7 +262,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
   describe 'POST #mute with notifications set to false' do
     let(:scopes) { 'write:mutes' }
-    let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:other_account) { Fabricate(:account, username: 'bob') }
 
     before do
       user.account.follow!(other_account)
@@ -290,7 +290,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
   describe 'POST #mute with nonzero duration set' do
     let(:scopes) { 'write:mutes' }
-    let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:other_account) { Fabricate(:account, username: 'bob') }
 
     before do
       user.account.follow!(other_account)
@@ -318,7 +318,7 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
   describe 'POST #unmute' do
     let(:scopes) { 'write:mutes' }
-    let(:other_account) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:other_account) { Fabricate(:account, username: 'bob') }
 
     before do
       user.account.mute!(other_account)

--- a/spec/controllers/api/v1/admin/account_actions_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/account_actions_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Api::V1::Admin::AccountActionsController, type: :controller do
   render_views
 
   let(:role)   { 'moderator' }
-  let(:user)   { Fabricate(:user, role: role, account: Fabricate(:account, username: 'alice')) }
+  let(:user)   { Fabricate(:user, role: role) }
   let(:scopes) { 'admin:read admin:write' }
   let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
-  let(:account) { Fabricate(:user).account }
+  let(:account) { Fabricate(:account) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }

--- a/spec/controllers/api/v1/admin/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/accounts_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Api::V1::Admin::AccountsController, type: :controller do
   render_views
 
   let(:role)   { 'moderator' }
-  let(:user)   { Fabricate(:user, role: role, account: Fabricate(:account, username: 'alice')) }
+  let(:user)   { Fabricate(:user, role: role) }
   let(:scopes) { 'admin:read admin:write' }
   let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
-  let(:account) { Fabricate(:user).account }
+  let(:account) { Fabricate(:account) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }

--- a/spec/controllers/api/v1/admin/reports_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/reports_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Api::V1::Admin::ReportsController, type: :controller do
   render_views
 
   let(:role)   { 'moderator' }
-  let(:user)   { Fabricate(:user, role: role, account: Fabricate(:account, username: 'alice')) }
+  let(:user)   { Fabricate(:user, role: role) }
   let(:scopes) { 'admin:read admin:write' }
   let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:report) { Fabricate(:report) }

--- a/spec/controllers/api/v1/blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/blocks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::BlocksController, type: :controller do
   render_views
 
-  let(:user)   { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)   { Fabricate(:user) }
   let(:scopes) { 'read:blocks' }
   let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
 

--- a/spec/controllers/api/v1/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/conversations_controller_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Api::V1::ConversationsController, type: :controller do
   render_views
 
-  let!(:user) { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let!(:user) { Fabricate(:user, account_attributes: { username: 'alice' }) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
-  let(:other) { Fabricate(:user, account: Fabricate(:account, username: 'bob')) }
+  let(:other) { Fabricate(:user) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }

--- a/spec/controllers/api/v1/domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/domain_blocks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::DomainBlocksController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
 
   before do

--- a/spec/controllers/api/v1/follow_requests_controller_spec.rb
+++ b/spec/controllers/api/v1/follow_requests_controller_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe Api::V1::FollowRequestsController, type: :controller do
   render_views
 
-  let(:user)     { Fabricate(:user, account: Fabricate(:account, username: 'alice', locked: true)) }
+  let(:user)     { Fabricate(:user, account_attributes: { locked: true }) }
   let(:token)    { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
-  let(:follower) { Fabricate(:account, username: 'bob') }
+  let(:follower) { Fabricate(:account) }
 
   before do
     FollowService.new.call(follower, user.account)

--- a/spec/controllers/api/v1/instances_controller_spec.rb
+++ b/spec/controllers/api/v1/instances_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::InstancesController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id) }
 
   before do

--- a/spec/controllers/api/v1/lists/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/lists/accounts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Api::V1::Lists::AccountsController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:list)  { Fabricate(:list, account: user.account) }
 

--- a/spec/controllers/api/v1/lists_controller_spec.rb
+++ b/spec/controllers/api/v1/lists_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::ListsController, type: :controller do
   render_views
 
-  let!(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let!(:user)  { Fabricate(:user) }
   let!(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let!(:list)  { Fabricate(:list, account: user.account) }
 

--- a/spec/controllers/api/v1/markers_controller_spec.rb
+++ b/spec/controllers/api/v1/markers_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::MarkersController, type: :controller do
   render_views
 
-  let!(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let!(:user)  { Fabricate(:user) }
   let!(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:statuses write:statuses') }
 
   before { allow(controller).to receive(:doorkeeper_token) { token } }

--- a/spec/controllers/api/v1/media_controller_spec.rb
+++ b/spec/controllers/api/v1/media_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::MediaController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:media') }
 
   before do

--- a/spec/controllers/api/v1/mutes_controller_spec.rb
+++ b/spec/controllers/api/v1/mutes_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::MutesController, type: :controller do
   render_views
 
-  let(:user)   { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)   { Fabricate(:user) }
   let(:scopes) { 'read:mutes' }
   let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
 

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe Api::V1::NotificationsController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user, account_attributes: { username: 'alice' }) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
-  let(:other) { Fabricate(:user, account: Fabricate(:account, username: 'bob')) }
-  let(:third) { Fabricate(:user, account: Fabricate(:account, username: 'carol')) }
+  let(:other) { Fabricate(:user) }
+  let(:third) { Fabricate(:user) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }

--- a/spec/controllers/api/v1/polls/votes_controller_spec.rb
+++ b/spec/controllers/api/v1/polls/votes_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::Polls::VotesController, type: :controller do
   render_views
 
-  let(:user)   { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)   { Fabricate(:user) }
   let(:scopes) { 'write:statuses' }
   let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
 

--- a/spec/controllers/api/v1/polls_controller_spec.rb
+++ b/spec/controllers/api/v1/polls_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::PollsController, type: :controller do
   render_views
 
-  let(:user)   { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)   { Fabricate(:user) }
   let(:scopes) { 'read:statuses' }
   let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
 

--- a/spec/controllers/api/v1/reports_controller_spec.rb
+++ b/spec/controllers/api/v1/reports_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::ReportsController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
 
   before do

--- a/spec/controllers/api/v1/statuses/bookmarks_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/bookmarks_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Statuses::BookmarksController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:bookmarks', application: app) }
 

--- a/spec/controllers/api/v1/statuses/favourited_by_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/favourited_by_accounts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::Statuses::FavouritedByAccountsController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: app, scopes: 'read:accounts') }
   let(:alice) { Fabricate(:account) }

--- a/spec/controllers/api/v1/statuses/favourites_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/favourites_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Statuses::FavouritesController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:favourites', application: app) }
 

--- a/spec/controllers/api/v1/statuses/histories_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/histories_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Statuses::HistoriesController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:statuses', application: app) }
 

--- a/spec/controllers/api/v1/statuses/mutes_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/mutes_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Statuses::MutesController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:mutes', application: app) }
 

--- a/spec/controllers/api/v1/statuses/pins_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/pins_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Statuses::PinsController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:accounts', application: app) }
 

--- a/spec/controllers/api/v1/statuses/reblogged_by_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reblogged_by_accounts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::Statuses::RebloggedByAccountsController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: app, scopes: 'read:accounts') }
   let(:alice) { Fabricate(:account) }

--- a/spec/controllers/api/v1/statuses/reblogs_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reblogs_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Statuses::ReblogsController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:statuses', application: app) }
 

--- a/spec/controllers/api/v1/statuses/sources_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/sources_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Statuses::SourcesController do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:statuses', application: app) }
 

--- a/spec/controllers/api/v1/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::StatusesController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, application: app, scopes: scopes) }
 

--- a/spec/controllers/api/v1/timelines/home_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/home_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Timelines::HomeController do
   render_views
 
-  let(:user) { Fabricate(:user, account: Fabricate(:account, username: 'alice'), current_sign_in_at: 1.day.ago) }
+  let(:user) { Fabricate(:user, current_sign_in_at: 1.day.ago) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }

--- a/spec/controllers/api/v1/timelines/list_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/list_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Timelines::ListController do
   render_views
 
-  let(:user) { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user) { Fabricate(:user) }
   let(:list) { Fabricate(:list, account: user.account) }
 
   before do
@@ -30,7 +30,7 @@ describe Api::V1::Timelines::ListController do
   end
 
   context 'with the wrong user context' do
-    let(:other_user) { Fabricate(:user, account: Fabricate(:account, username: 'bob')) }
+    let(:other_user) { Fabricate(:user) }
     let(:token)      { Fabricate(:accessible_access_token, resource_owner_id: other_user.id, scopes: 'read') }
 
     describe 'GET #show' do

--- a/spec/controllers/api/v1/timelines/public_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/public_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Timelines::PublicController do
   render_views
 
-  let(:user) { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user) { Fabricate(:user) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }

--- a/spec/controllers/api/v1/timelines/tag_controller_spec.rb
+++ b/spec/controllers/api/v1/timelines/tag_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::V1::Timelines::TagController do
   render_views
 
-  let(:user) { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user) { Fabricate(:user) }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }

--- a/spec/controllers/api/v2/search_controller_spec.rb
+++ b/spec/controllers/api/v2/search_controller_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Api::V2::SearchController, type: :controller do
   render_views
 
-  let(:user)  { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:user)  { Fabricate(:user) }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:search') }
 
   before do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -49,7 +49,7 @@ describe ApplicationController, type: :controller do
 
     it 'returns account if signed in' do
       account = Fabricate(:account)
-      sign_in(Fabricate(:user, account: account))
+      sign_in(account.user)
       expect(controller.view_context.current_account).to eq account
     end
   end
@@ -164,13 +164,13 @@ describe ApplicationController, type: :controller do
     end
 
     it 'does nothing if user who signed in is not suspended' do
-      sign_in(Fabricate(:user, account: Fabricate(:account, suspended: false)))
+      sign_in(Fabricate(:account, suspended: false).user)
       get 'success'
       expect(response).to have_http_status(200)
     end
 
     it 'redirects to account status page' do
-      sign_in(Fabricate(:user, account: Fabricate(:account, suspended: true)))
+      sign_in(Fabricate(:account, suspended: true).user)
       get 'success'
       expect(response).to redirect_to(edit_user_registration_path)
     end

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Auth::RegistrationsController, type: :controller do
     end
 
     it 'does nothing if user already exists' do
-      Fabricate(:user, account: Fabricate(:account, username: 'test'))
+      Fabricate(:account, username: 'test')
       subject
     end
 

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -37,8 +37,11 @@ RSpec.describe Auth::SessionsController, type: :controller do
     end
 
     context 'with a suspended user' do
+      before do
+        user.account.suspend!
+      end
+
       it 'redirects to home after sign out' do
-        Fabricate(:account, user: user, suspended: true)
         sign_in(user, scope: :user)
         delete :destroy
 
@@ -78,8 +81,8 @@ RSpec.describe Auth::SessionsController, type: :controller do
       end
 
       context 'using a valid email and existing user' do
-        let(:user) do
-          account = Fabricate.build(:account, username: 'pam_user1')
+        let!(:user) do
+          account = Fabricate.build(:account, username: 'pam_user1', user: nil)
           account.save!(validate: false)
           user = Fabricate(:user, email: 'pam@example.com', password: nil, account: account, external: true)
           user

--- a/spec/controllers/authorize_interactions_controller_spec.rb
+++ b/spec/controllers/authorize_interactions_controller_spec.rb
@@ -16,7 +16,6 @@ describe AuthorizeInteractionsController do
 
     describe 'when signed in' do
       let(:user) { Fabricate(:user) }
-      let(:account) { Fabricate(:account, user: user) }
 
       before do
         sign_in(user)
@@ -76,7 +75,7 @@ describe AuthorizeInteractionsController do
 
     describe 'when signed in' do
       let!(:user) { Fabricate(:user) }
-      let!(:account) { user.account }
+      let(:account) { user.account }
 
       before do
         sign_in(user)

--- a/spec/controllers/concerns/account_controller_concern_spec.rb
+++ b/spec/controllers/concerns/account_controller_concern_spec.rb
@@ -17,7 +17,7 @@ describe ApplicationController, type: :controller do
 
   context 'when account is suspended' do
     it 'returns http gone' do
-      account = Fabricate(:account, suspended: true, user: Fabricate(:user))
+      account = Fabricate(:account, suspended: true)
       get 'success', params: { account_username: account.username }
       expect(response).to have_http_status(410)
     end
@@ -33,19 +33,19 @@ describe ApplicationController, type: :controller do
 
   context 'when account is not suspended' do
     it 'assigns @account' do
-      account = Fabricate(:account, user: Fabricate(:user))
+      account = Fabricate(:account)
       get 'success', params: { account_username: account.username }
       expect(assigns(:account)).to eq account
     end
 
     it 'sets link headers' do
-      account = Fabricate(:account, username: 'username', user: Fabricate(:user))
+      account = Fabricate(:account, username: 'username')
       get 'success', params: { account_username: 'username' }
       expect(response.headers['Link'].to_s).to eq '<http://test.host/.well-known/webfinger?resource=acct%3Ausername%40cb6e6126.ngrok.io>; rel="lrdd"; type="application/jrd+json", <https://cb6e6126.ngrok.io/users/username>; rel="alternate"; type="application/activity+json"'
     end
 
     it 'returns http success' do
-      account = Fabricate(:account, user: Fabricate(:user))
+      account = Fabricate(:account)
       get 'success', params: { account_username: account.username }
       expect(response).to have_http_status(200)
     end

--- a/spec/controllers/concerns/accountable_concern_spec.rb
+++ b/spec/controllers/concerns/accountable_concern_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe AccountableConcern do
     end
   end
 
-  let(:user)   { Fabricate(:user, account: Fabricate(:account)) }
-  let(:target) { Fabricate(:user, account: Fabricate(:account)) }
-  let(:hoge)   { Hoge.new(user.account) }
+  let(:user)   { Fabricate(:account) }
+  let(:target) { Fabricate(:account) }
+  let(:hoge)   { Hoge.new(user) }
 
   describe '#log_action' do
     it 'creates Admin::ActionLog' do
       expect do
-        hoge.log_action(:create, target.account)
+        hoge.log_action(:create, target)
       end.to change { Admin::ActionLog.count }.by(1)
     end
   end

--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe FollowerAccountsController do
   render_views
 
-  let(:alice) { Fabricate(:user).account }
+  let(:alice) { Fabricate(:account) }
   let(:follower0) { Fabricate(:account) }
   let(:follower1) { Fabricate(:account) }
 

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe FollowingAccountsController do
   render_views
 
-  let(:alice) { Fabricate(:user).account }
+  let(:alice) { Fabricate(:account) }
   let(:followee0) { Fabricate(:account) }
   let(:followee1) { Fabricate(:account) }
 

--- a/spec/controllers/settings/deletes_controller_spec.rb
+++ b/spec/controllers/settings/deletes_controller_spec.rb
@@ -17,7 +17,7 @@ describe Settings::DeletesController do
       end
 
       context 'when suspended' do
-        let(:user) { Fabricate(:user, account_attributes: { username: 'alice', suspended_at: Time.now.utc }) }
+        let(:user) { Fabricate(:user, account_attributes: { suspended_at: Time.now.utc }) }
 
         it 'returns http forbidden' do
           get :show
@@ -64,7 +64,7 @@ describe Settings::DeletesController do
         end
 
         context 'when suspended' do
-          let(:user) { Fabricate(:user, account_attributes: { username: 'alice', suspended_at: Time.now.utc }) }
+          let(:user) { Fabricate(:user, account_attributes: { suspended_at: Time.now.utc }) }
 
           it 'returns http forbidden' do
             expect(response).to have_http_status(403)

--- a/spec/controllers/settings/migrations_controller_spec.rb
+++ b/spec/controllers/settings/migrations_controller_spec.rb
@@ -19,8 +19,7 @@ describe Settings::MigrationsController do
     context 'when user is sign in' do
       subject { get :show }
 
-      let(:user) { Fabricate(:user, account: account) }
-      let(:account) { Fabricate(:account, moved_to_account: moved_to_account) }
+      let(:user) { Fabricate(:account, moved_to_account: moved_to_account).user }
 
       before { sign_in user, scope: :user }
 

--- a/spec/controllers/settings/profiles_controller_spec.rb
+++ b/spec/controllers/settings/profiles_controller_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.describe Settings::ProfilesController, type: :controller do
   render_views
 
+  let!(:user) { Fabricate(:user) }
+  let(:account) { user.account }
+
   before do
-    @user = Fabricate(:user)
-    sign_in @user, scope: :user
+    sign_in user, scope: :user
   end
 
   describe "GET #show" do
@@ -16,10 +18,12 @@ RSpec.describe Settings::ProfilesController, type: :controller do
   end
 
   describe 'PUT #update' do
+    before do
+      user.account.update(display_name: 'Old name')
+    end
+
     it 'updates the user profile' do
       allow(ActivityPub::UpdateDistributionWorker).to receive(:perform_async)
-      account = Fabricate(:account, user: @user, display_name: 'Old name')
-
       put :update, params: { account: { display_name: 'New name' } }
       expect(account.reload.display_name).to eq 'New name'
       expect(response).to redirect_to(settings_profile_path)
@@ -30,7 +34,6 @@ RSpec.describe Settings::ProfilesController, type: :controller do
   describe 'PUT #update with new profile image' do
     it 'updates profile image' do
       allow(ActivityPub::UpdateDistributionWorker).to receive(:perform_async)
-      account = Fabricate(:account, user: @user, display_name: 'AvatarTest')
       expect(account.avatar.instance.avatar_file_name).to be_nil
 
       put :update, params: { account: { avatar: fixture_file_upload('avatar.gif', 'image/gif') } }
@@ -43,7 +46,6 @@ RSpec.describe Settings::ProfilesController, type: :controller do
   describe 'PUT #update with oversized image' do
     it 'gives the user an error message' do
       allow(ActivityPub::UpdateDistributionWorker).to receive(:perform_async)
-      account = Fabricate(:account, user: @user, display_name: 'AvatarTest')
       put :update, params: { account: { avatar: fixture_file_upload('4096x4097.png', 'image/png') } }
       expect(response.body).to include('images are not supported')
     end

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -10,4 +10,5 @@ Fabricator(:account) do
   private_key         { private_key }
   suspended_at        { |attrs| attrs[:suspended] ? Time.now.utc : nil }
   silenced_at         { |attrs| attrs[:silenced] ? Time.now.utc : nil }
+  user                { |attrs| attrs[:domain].nil? ? Fabricate.build(:user, account: nil) : nil }
 end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -1,5 +1,5 @@
 Fabricator(:user) do
-  account
+  account      { Fabricate.build(:account, user: nil) }
   email        { sequence(:email) { |i| "#{i}#{Faker::Internet.email}" } }
   password     "123456789"
   confirmed_at { Time.zone.now }

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -4,10 +4,14 @@ require 'rails_helper'
 
 RSpec.describe AdminMailer, type: :mailer do
   describe '.new_report' do
-    let(:sender)    { Fabricate(:account, username: 'John', user: Fabricate(:user)) }
-    let(:recipient) { Fabricate(:account, username: 'Mike', user: Fabricate(:user, locale: :en)) }
+    let(:sender)    { Fabricate(:account, username: 'John') }
+    let(:recipient) { Fabricate(:account, username: 'Mike') }
     let(:report)    { Fabricate(:report, account: sender, target_account: recipient) }
     let(:mail)      { described_class.new_report(recipient, report) }
+
+    before do
+      recipient.user.update(locale: :en)
+    end
 
     it 'renders the headers' do
       expect(mail.subject).to eq("New report for cb6e6126.ngrok.io (##{report.id})")

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe NotificationMailer, type: :mailer do
-  let(:receiver)       { Fabricate(:user, account: Fabricate(:account, username: 'alice')) }
+  let(:receiver)       { Fabricate(:user) }
   let(:sender)         { Fabricate(:account, username: 'bob') }
   let(:foreign_status) { Fabricate(:status, account: sender, text: 'The body of the foreign status') }
   let(:own_status)     { Fabricate(:status, account: receiver.account, text: 'The body of the own status') }

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Account, type: :model do
       end
 
       context 'when the account is of a local user' do
-        let!(:subject) { Fabricate(:account, user: Fabricate(:user, email: 'foo+bar@domain.org')) }
+        let!(:subject) { Fabricate(:user, email: 'foo+bar@domain.org').account }
 
         it 'creates a canonical domain block' do
           subject.suspend!

--- a/spec/models/admin/account_action_spec.rb
+++ b/spec/models/admin/account_action_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Admin::AccountAction, type: :model do
 
   describe '#save!' do
     subject              { account_action.save! }
-    let(:account)        { Fabricate(:account, user: Fabricate(:user, admin: true)) }
-    let(:target_account) { Fabricate(:account, user: Fabricate(:user)) }
+    let(:account)        { Fabricate(:user, admin: true).account }
+    let(:target_account) { Fabricate(:account) }
     let(:type)           { 'disable' }
 
     before do

--- a/spec/models/public_feed_spec.rb
+++ b/spec/models/public_feed_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe PublicFeed, type: :model do
     end
 
     it 'filters out silenced accounts' do
-      account = Fabricate(:account)
       silenced_account = Fabricate(:account, silenced: true)
       status = Fabricate(:status, account: account)
       silenced_status = Fabricate(:status, account: silenced_account)
@@ -176,8 +175,7 @@ RSpec.describe PublicFeed, type: :model do
 
       context 'with language preferences' do
         it 'excludes statuses in languages not allowed by the account user' do
-          user = Fabricate(:user, chosen_languages: [:en, :es])
-          @account.update(user: user)
+          @account.user.update(chosen_languages: [:en, :es])
           en_status = Fabricate(:status, language: 'en')
           es_status = Fabricate(:status, language: 'es')
           fr_status = Fabricate(:status, language: 'fr')
@@ -188,8 +186,7 @@ RSpec.describe PublicFeed, type: :model do
         end
 
         it 'includes all languages when user does not have a setting' do
-          user = Fabricate(:user, chosen_languages: nil)
-          @account.update(user: user)
+          @account.user.update(chosen_languages: nil)
 
           en_status = Fabricate(:status, language: 'en')
           es_status = Fabricate(:status, language: 'es')
@@ -199,7 +196,8 @@ RSpec.describe PublicFeed, type: :model do
         end
 
         it 'includes all languages when account does not have a user' do
-          expect(@account.user).to be_nil
+          @account.update(user: nil)
+
           en_status = Fabricate(:status, language: 'en')
           es_status = Fabricate(:status, language: 'es')
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -194,12 +194,12 @@ RSpec.describe User, type: :model do
     end
 
     it "returns 'private' if user has not configured default privacy setting and account is locked" do
-      user = Fabricate(:user, account: Fabricate(:account, locked: true))
+      user = Fabricate(:account, locked: true).user
       expect(user.setting_default_privacy).to eq 'private'
     end
 
     it "returns 'public' if user has not configured default privacy setting and account is not locked" do
-      user = Fabricate(:user, account: Fabricate(:account, locked: false))
+      user = Fabricate(:account, locked: false).user
       expect(user.setting_default_privacy).to eq 'public'
     end
   end
@@ -248,7 +248,7 @@ RSpec.describe User, type: :model do
 
   it_behaves_like 'Settings-extended' do
     def create!
-      User.create!(account: Fabricate(:account), email: 'foo@mastodon.space', password: 'abcd1234', agreement: true)
+      User.create!(account: Fabricate(:account, user: nil), email: 'foo@mastodon.space', password: 'abcd1234', agreement: true)
     end
 
     def fabricate

--- a/spec/policies/account_moderation_note_policy_spec.rb
+++ b/spec/policies/account_moderation_note_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe AccountModerationNotePolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :create? do
     context 'staff' do
@@ -42,7 +42,7 @@ RSpec.describe AccountModerationNotePolicy do
     end
 
     context 'neither admin nor owner' do
-      let(:kevin) { Fabricate(:user).account }
+      let(:kevin) { Fabricate(:account) }
 
       it 'denies to destroy' do
         expect(subject).to_not permit(kevin, account_moderation_note)

--- a/spec/policies/account_policy_spec.rb
+++ b/spec/policies/account_policy_spec.rb
@@ -6,8 +6,8 @@ require 'pundit/rspec'
 RSpec.describe AccountPolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
-  let(:alice)   { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
+  let(:alice)   { Fabricate(:account) }
 
   permissions :index? do
     context 'staff' do

--- a/spec/policies/backup_policy_spec.rb
+++ b/spec/policies/backup_policy_spec.rb
@@ -5,7 +5,7 @@ require 'pundit/rspec'
 
 RSpec.describe BackupPolicy do
   let(:subject) { described_class }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :create? do
     context 'not user_signed_in?' do

--- a/spec/policies/custom_emoji_policy_spec.rb
+++ b/spec/policies/custom_emoji_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe CustomEmojiPolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :index?, :enable?, :disable? do
     context 'staff' do

--- a/spec/policies/domain_block_policy_spec.rb
+++ b/spec/policies/domain_block_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe DomainBlockPolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :index?, :show?, :create?, :destroy? do
     context 'admin' do

--- a/spec/policies/email_domain_block_policy_spec.rb
+++ b/spec/policies/email_domain_block_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe EmailDomainBlockPolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :index?, :create?, :destroy? do
     context 'admin' do

--- a/spec/policies/instance_policy_spec.rb
+++ b/spec/policies/instance_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe InstancePolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :index?, :show?, :destroy? do
     context 'admin' do

--- a/spec/policies/invite_policy_spec.rb
+++ b/spec/policies/invite_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe InvitePolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :index? do
     context 'staff?' do

--- a/spec/policies/relay_policy_spec.rb
+++ b/spec/policies/relay_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe RelayPolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :update? do
     context 'admin?' do

--- a/spec/policies/report_note_policy_spec.rb
+++ b/spec/policies/report_note_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe ReportNotePolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :create? do
     context 'staff?' do

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe ReportPolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :update?, :index?, :show? do
     context 'staff?' do

--- a/spec/policies/settings_policy_spec.rb
+++ b/spec/policies/settings_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe SettingsPolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :update?, :show? do
     context 'admin?' do

--- a/spec/policies/tag_policy_spec.rb
+++ b/spec/policies/tag_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe TagPolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :index?, :show?, :update? do
     context 'staff?' do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -6,7 +6,7 @@ require 'pundit/rspec'
 RSpec.describe UserPolicy do
   let(:subject) { described_class }
   let(:admin)   { Fabricate(:user, admin: true).account }
-  let(:john)    { Fabricate(:user).account }
+  let(:john)    { Fabricate(:account) }
 
   permissions :reset_password?, :change_email? do
     context 'staff?' do

--- a/spec/services/authorize_follow_service_spec.rb
+++ b/spec/services/authorize_follow_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AuthorizeFollowService, type: :service do
   subject { AuthorizeFollowService.new }
 
   describe 'local' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:bob) { Fabricate(:account, username: 'bob') }
 
     before do
       FollowRequest.create(account: bob, target_account: sender)
@@ -23,7 +23,7 @@ RSpec.describe AuthorizeFollowService, type: :service do
   end
 
   describe 'remote ActivityPub' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox')).account }
+    let(:bob) { Fabricate(:account, username: 'bob', domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
 
     before do
       FollowRequest.create(account: bob, target_account: sender)

--- a/spec/services/batched_remove_status_service_spec.rb
+++ b/spec/services/batched_remove_status_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BatchedRemoveStatusService, type: :service do
 
   let!(:alice)  { Fabricate(:account) }
   let!(:bob)    { Fabricate(:account, username: 'bob', domain: 'example.com') }
-  let!(:jeff)   { Fabricate(:user).account }
+  let!(:jeff)   { Fabricate(:account) }
   let!(:hank)   { Fabricate(:account, username: 'hank', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
 
   let(:status1) { PostStatusService.new.call(alice, text: 'Hello @bob@example.com') }

--- a/spec/services/block_service_spec.rb
+++ b/spec/services/block_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BlockService, type: :service do
   subject { BlockService.new }
 
   describe 'local' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:bob) { Fabricate(:account, username: 'bob') }
 
     before do
       subject.call(sender, bob)
@@ -18,7 +18,7 @@ RSpec.describe BlockService, type: :service do
   end
 
   describe 'remote ActivityPub' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox')).account }
+    let(:bob) { Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
 
     before do
       stub_request(:post, 'http://example.com/inbox').to_return(status: 200)

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe FanOutOnWriteService, type: :service do
   let(:last_active_at) { Time.now.utc }
 
-  let!(:alice) { Fabricate(:user, current_sign_in_at: last_active_at, account: Fabricate(:account, username: 'alice')).account }
-  let!(:bob)   { Fabricate(:user, current_sign_in_at: last_active_at, account: Fabricate(:account, username: 'bob')).account }
-  let!(:tom)   { Fabricate(:user, current_sign_in_at: last_active_at, account: Fabricate(:account, username: 'tom')).account }
+  let!(:alice) { Fabricate(:user, current_sign_in_at: last_active_at).account }
+  let!(:bob)   { Fabricate(:user, current_sign_in_at: last_active_at, account_attributes: { username: 'bob' }).account }
+  let!(:tom)   { Fabricate(:user, current_sign_in_at: last_active_at).account }
 
   subject { described_class.new }
 

--- a/spec/services/favourite_service_spec.rb
+++ b/spec/services/favourite_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FavouriteService, type: :service do
   subject { FavouriteService.new }
 
   describe 'local' do
-    let(:bob)    { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:bob)    { Fabricate(:account) }
     let(:status) { Fabricate(:status, account: bob) }
 
     before do
@@ -19,7 +19,7 @@ RSpec.describe FavouriteService, type: :service do
   end
 
   describe 'remote ActivityPub' do
-    let(:bob)    { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, protocol: :activitypub, username: 'bob', domain: 'example.com', inbox_url: 'http://example.com/inbox')).account }
+    let(:bob)    { Fabricate(:account, protocol: :activitypub, username: 'bob', domain: 'example.com', inbox_url: 'http://example.com/inbox') }
     let(:status) { Fabricate(:status, account: bob) }
 
     before do

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FollowService, type: :service do
 
   context 'local account' do
     describe 'locked account' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, locked: true, username: 'bob')).account }
+      let(:bob) { Fabricate(:account, locked: true, username: 'bob') }
 
       before do
         subject.call(sender, bob)
@@ -19,7 +19,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'locked account, no reblogs' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, locked: true, username: 'bob')).account }
+      let(:bob) { Fabricate(:account, locked: true, username: 'bob') }
 
       before do
         subject.call(sender, bob, reblogs: false)
@@ -31,7 +31,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'unlocked account, from silenced account' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:account, username: 'bob') }
 
       before do
         sender.touch(:silenced_at)
@@ -44,7 +44,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'unlocked account, from a muted account' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:account, username: 'bob') }
 
       before do
         bob.mute!(sender)
@@ -58,7 +58,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'unlocked account' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:account, username: 'bob') }
 
       before do
         subject.call(sender, bob)
@@ -71,7 +71,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'unlocked account, no reblogs' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:account, username: 'bob') }
 
       before do
         subject.call(sender, bob, reblogs: false)
@@ -84,7 +84,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'already followed account' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:account, username: 'bob') }
 
       before do
         sender.follow!(bob)
@@ -97,7 +97,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'already followed account, turning reblogs off' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:account, username: 'bob') }
 
       before do
         sender.follow!(bob, reblogs: true)
@@ -110,7 +110,7 @@ RSpec.describe FollowService, type: :service do
     end
 
     describe 'already followed account, turning reblogs on' do
-      let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+      let(:bob) { Fabricate(:account, username: 'bob') }
 
       before do
         sender.follow!(bob, reblogs: false)
@@ -124,7 +124,7 @@ RSpec.describe FollowService, type: :service do
   end
 
   context 'remote ActivityPub account' do
-    let(:bob) { Fabricate(:user, account: Fabricate(:account, username: 'bob', domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox')).account }
+    let(:bob) { Fabricate(:account, username: 'bob', domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
 
     before do
       stub_request(:post, "http://example.com/inbox").to_return(:status => 200, :body => "", :headers => {})

--- a/spec/services/reject_follow_service_spec.rb
+++ b/spec/services/reject_follow_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RejectFollowService, type: :service do
   subject { RejectFollowService.new }
 
   describe 'local' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:bob) { Fabricate(:account) }
 
     before do
       FollowRequest.create(account: bob, target_account: sender)
@@ -23,7 +23,7 @@ RSpec.describe RejectFollowService, type: :service do
   end
 
   describe 'remote ActivityPub' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox')).account }
+    let(:bob) { Fabricate(:account, username: 'bob', domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
 
     before do
       FollowRequest.create(account: bob, target_account: sender)

--- a/spec/services/remove_status_service_spec.rb
+++ b/spec/services/remove_status_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe RemoveStatusService, type: :service do
   subject { RemoveStatusService.new }
 
-  let!(:alice)  { Fabricate(:account, user: Fabricate(:user)) }
+  let!(:alice)  { Fabricate(:account) }
   let!(:bob)    { Fabricate(:account, username: 'bob', domain: 'example.com') }
   let!(:jeff)   { Fabricate(:account) }
   let!(:hank)   { Fabricate(:account, username: 'hank', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ReportService, type: :service do
   subject { described_class.new }
 
-  let(:source_account) { Fabricate(:user).account }
+  let(:source_account) { Fabricate(:account) }
 
   context 'for a remote account' do
     let(:remote_account) { Fabricate(:account, domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }

--- a/spec/services/unblock_service_spec.rb
+++ b/spec/services/unblock_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UnblockService, type: :service do
   subject { UnblockService.new }
 
   describe 'local' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:bob) { Fabricate(:account) }
 
     before do
       sender.block!(bob)
@@ -19,7 +19,7 @@ RSpec.describe UnblockService, type: :service do
   end
 
   describe 'remote ActivityPub' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox')).account }
+    let(:bob) { Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
 
     before do
       sender.block!(bob)

--- a/spec/services/unfollow_service_spec.rb
+++ b/spec/services/unfollow_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UnfollowService, type: :service do
   subject { UnfollowService.new }
 
   describe 'local' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+    let(:bob) { Fabricate(:account, username: 'bob') }
 
     before do
       sender.follow!(bob)
@@ -19,7 +19,7 @@ RSpec.describe UnfollowService, type: :service do
   end
 
   describe 'remote ActivityPub' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox')).account }
+    let(:bob) { Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
 
     before do
       sender.follow!(bob)
@@ -37,7 +37,7 @@ RSpec.describe UnfollowService, type: :service do
   end
 
   describe 'remote ActivityPub (reverse)' do
-    let(:bob) { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox')).account }
+    let(:bob) { Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
 
     before do
       bob.follow!(sender)

--- a/spec/services/update_account_service_spec.rb
+++ b/spec/services/update_account_service_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe UpdateAccountService, type: :service do
 
   describe 'switching form locked to unlocked accounts' do
     let(:account) { Fabricate(:account, locked: true) }
-    let(:alice)   { Fabricate(:user, email: 'alice@example.com', account: Fabricate(:account, username: 'alice')).account }
-    let(:bob)     { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
-    let(:eve)     { Fabricate(:user, email: 'eve@example.com', account: Fabricate(:account, username: 'eve')).account }
+    let(:alice)   { Fabricate(:account) }
+    let(:bob)     { Fabricate(:account) }
+    let(:eve)     { Fabricate(:account) }
 
     before do
       bob.touch(:silenced_at)

--- a/spec/workers/move_worker_spec.rb
+++ b/spec/workers/move_worker_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 describe MoveWorker do
-  let(:local_follower)   { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
-  let(:blocking_account) { Fabricate(:user, email: 'bar@example.com', account: Fabricate(:account, username: 'bar')).account }
-  let(:muting_account)   { Fabricate(:user, email: 'foo@example.com', account: Fabricate(:account, username: 'foo')).account }
+  let(:local_follower)   { Fabricate(:account) }
+  let(:blocking_account) { Fabricate(:account) }
+  let(:muting_account)   { Fabricate(:account) }
   let(:source_account)   { Fabricate(:account, protocol: :activitypub, domain: 'example.com') }
   let(:target_account)   { Fabricate(:account, protocol: :activitypub, domain: 'example.com') }
   let(:local_user)       { Fabricate(:user) }
@@ -88,7 +88,7 @@ describe MoveWorker do
   end
 
   context 'target account is local' do
-    let(:target_account) { Fabricate(:user, email: 'alice@example.com', account: Fabricate(:account, username: 'alice')).account }
+    let(:target_account) { Fabricate(:account) }
 
     describe 'perform' do
       it 'calls UnfollowFollowWorker' do
@@ -102,8 +102,8 @@ describe MoveWorker do
   end
 
   context 'both target and source accounts are local' do
-    let(:target_account) { Fabricate(:user, email: 'alice@example.com', account: Fabricate(:account, username: 'alice')).account }
-    let(:source_account) { Fabricate(:user, email: 'alice_@example.com', account: Fabricate(:account, username: 'alice_')).account }
+    let(:target_account) { Fabricate(:account) }
+    let(:source_account) { Fabricate(:account) }
 
     describe 'perform' do
       it 'calls makes local followers follow the target account' do
@@ -115,7 +115,7 @@ describe MoveWorker do
       include_examples 'block and mute handling'
 
       it 'does not fail when a local user is already following both accounts' do
-        double_follower = Fabricate(:user, email: 'eve@example.com', account: Fabricate(:account, username: 'eve')).account
+        double_follower = Fabricate(:account)
         double_follower.follow!(source_account)
         double_follower.follow!(target_account)
         subject.perform(source_account.id, target_account.id)

--- a/spec/workers/unfollow_follow_worker_spec.rb
+++ b/spec/workers/unfollow_follow_worker_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe UnfollowFollowWorker do
-  let(:local_follower)   { Fabricate(:user, email: 'bob@example.com', account: Fabricate(:account, username: 'bob')).account }
+  let(:local_follower)   { Fabricate(:account) }
   let(:source_account)   { Fabricate(:account) }
   let(:target_account)   { Fabricate(:account) }
   let(:show_reblogs)     { true }


### PR DESCRIPTION
Currently, our tests are a mess as far as `Account` and `User` models are `Fabricate`d, there's lots of boilerplate, a lot of cargo-cult, multiple ways of expressing stuff, as well as a lot of cases where local accounts have no associated records and some cases when remote accounts do, neither of which is representative of the state of objects in production.

To remedy this, this PR changes the `:account` and `:user` fabricators so that:
- `Fabricate(:account)` implicitly fabricates an associated `user` if no `domain` attribute is given (`user: nil` can be passed to avoid that).
- `Fabricate(:account, user: Fabricate(:user))` should still be possible but is discouraged.

Tests were then fixed:
- Fix the few tests failing because they were expecting a local account to have no associated user record
- Fix the few tests failing because they `Fabricate`d users and accounts in different steps (causing lingering records that were not expected)
- Fix the few tests that explicitly associated user records to remote accounts (this did not cause any error, but it was not representative of the production code)

And refactored:
- avoid passing unneeded attributes to `Fabricate(:user)` and `Fabricate(:account)` (this includes passing unneeded embedded calls to `Fabricate(:user)` and `Fabricate(:account)`)
- prefer `Fabricate(:user, account_attributes: …)` to `Fabricate(:user, account: Fabricate(:account, …)`
- avoid embedding `Fabricate(:user)` into a `Fabricate(:account)` or the other
- prefer `Fabricate(:account)` over `Fabricate(:user).account`