### PR TITLE
Change index corruption warning to be a little less scary

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -21,8 +21,8 @@ namespace :db do
     at_exit do
       unless %w(C POSIX).include?(ActiveRecord::Base.connection.select_one('SELECT datcollate FROM pg_database WHERE datname = current_database();')['datcollate'])
         warn <<~WARNING
-          Your database collation is susceptible to index corruption.
-            (This warning does not indicate that index corruption has occurred and can be ignored)
+          Your database collation may be susceptible to index corruption.
+            (This warning does not indicate that index corruption has occurred, and it can be ignored if you've previously checked for index corruption)
             (To learn more, visit: https://docs.joinmastodon.org/admin/troubleshooting/index-corruption/)
         WARNING
       end


### PR DESCRIPTION
Some people still read this warning as an indication that they actually have corrupted indexes, so change the wording slightly.