### PR TITLE
Debounce compose form

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -204,6 +204,7 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
 
             <DebounceInput
               element={Textarea}
+              debounceTimeout={1}
               inputRef={this.setTextarea}
               className='autosuggest-textarea__textarea'
               disabled={disabled}

--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import Textarea from 'react-textarea-autosize';
 import classNames from 'classnames';
+import DebounceInput from 'react-debounce-input';
 
 const textAtCursorMatchesToken = (str, caretPosition) => {
   let word;
@@ -201,8 +202,10 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
           <label>
             <span style={{ display: 'none' }}>{placeholder}</span>
 
-            <Textarea
-              ref={this.setTextarea}
+            <DebounceInput
+              element={Textarea}
+              debounceTimeout={300}
+              inputRef={this.setTextarea}
               className='autosuggest-textarea__textarea'
               disabled={disabled}
               placeholder={placeholder}

--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -204,7 +204,6 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
 
             <DebounceInput
               element={Textarea}
-              debounceTimeout={300}
               inputRef={this.setTextarea}
               className='autosuggest-textarea__textarea'
               disabled={disabled}

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "prop-types": "^15.8.1",
     "punycode": "^2.1.0",
     "react": "^16.14.0",
+    "react-debounce-input": "^3.2.5",
     "react-dom": "^16.14.0",
     "react-hotkeys": "^1.1.4",
     "react-immutable-proptypes": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6950,7 +6950,7 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.debounce@^4.0.8:
+lodash.debounce@^4, lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
@@ -8798,6 +8798,14 @@ raw-body@2.4.2:
     http-errors "1.8.1"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+react-debounce-input@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/react-debounce-input/-/react-debounce-input-3.2.5.tgz#3a29682c4b9dcd62694d6e03f85d7bfa96cec433"
+  integrity sha512-WDc9nvZ8E/cT4nW1RlD/r+Nsc5Z5+Jmj2v9HT9RzsPtxkwRTQUBCKJvdt1fCYy5ME/nQPoqVYmWUWSv7whGmig==
+  dependencies:
+    lodash.debounce "^4"
+    prop-types "^15.7.2"
 
 react-dom@^16.14.0:
   version "16.14.0"


### PR DESCRIPTION
Compose form's textarea was in a hell of re-rendering. Especially in CJK IME
It causes **missing characters on low powered machines** (even on my brand-new laptop), And it happened a lot and user experience was terrible as a Korean user.

As an example, I typed `가나다` (3 letters but 6 types)
```
ㄱ
가
간
가나
가낟
가나다
```

## Before
![image](https://user-images.githubusercontent.com/5047683/151713487-af696016-f0b6-420b-92ba-be2b54e68617.png)
```
render 가
render 가나
render 가낟
render 가
render 가나
render 가나다
render 가나
render 가나다
```

I don't know why they re-render more than 6 times (Maybe multiple hooks are used for onChange, onKeyup, onKeydown).

## After

![image](https://user-images.githubusercontent.com/5047683/151754022-89205108-a84c-44be-a7af-58ef5e9cd62a.png)

```
render ㄱ
render 가
render 간
render 가나
render 가낟
render 가나다
render 가나다 
render 가나다 @
render 가나다 @a
render 가나다 @ad
render 가나다 @ad
render 가나다 @admin
```

I set timeout to 1ms. It is enough to remove struggling effects, And also auto suggestions (mention, emoji, hashtag) are fine