### PR TITLE
Fix edge case in migration helpers that caused crash because of PostgreSQL quirk

### DIFF
--- a/lib/mastodon/migration_helpers.rb
+++ b/lib/mastodon/migration_helpers.rb
@@ -295,7 +295,7 @@ module Mastodon
       table = Arel::Table.new(table_name)
 
       total = estimate_rows_in_table(table_name).to_i
-      if total == 0
+      if total < 1
         count_arel = table.project(Arel.star.count.as('count'))
         count_arel = yield table, count_arel if block_given?
 


### PR DESCRIPTION
For some reason, the estimate can be `-1` in some cases, at least on CI, which leads to a division somewhere in the migration helper code.

Fix this by considering `< 1` values as inaccurate instead of `0` values.