### PR TITLE
Bump NODE_VER to 16.13.2, to solve security issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-c"]
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Install Node v16 (LTS)
-ENV NODE_VER="16.13.0"
+ENV NODE_VER="16.13.2"
 RUN ARCH= && \
     dpkgArch="$(dpkg --print-architecture)" && \
   case "${dpkgArch##*-}" in \


### PR DESCRIPTION
Fixes CVE-2021-44532, CVE-2021-44533, and CVE-2022-21824.
See: https://nodejs.org/en/blog/vulnerability/jan-2022-security-releases/

I finally could test it now that #17384 is 'solved'