### PR TITLE
Add image tags to docker-compose.yml for dockerhub prebuilt images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   web:
     build: .
-    image: tootsuite/mastodon
+    image: tootsuite/mastodon:v3.4.4
     restart: always
     env_file: .env.production
     command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000"
@@ -65,7 +65,7 @@ services:
 
   streaming:
     build: .
-    image: tootsuite/mastodon
+    image: tootsuite/mastodon:v3.4.4
     restart: always
     env_file: .env.production
     command: node ./streaming
@@ -82,7 +82,7 @@ services:
 
   sidekiq:
     build: .
-    image: tootsuite/mastodon
+    image: tootsuite/mastodon:v3.4.4
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq


### PR DESCRIPTION
We need to debate if these are required.

Because mastodevs are building branch hotfix builds. They'll need to make sure they tag those builds with the correct version tags.

They'll need to make sure these image tags are updated on every release - not a huge problem but just another thing to add to the check list on releases.