### PR TITLE
Fix spurious errors when receiving an Add activity for a private post

### DIFF
--- a/app/lib/activitypub/activity/add.rb
+++ b/app/lib/activitypub/activity/add.rb
@@ -7,7 +7,7 @@ class ActivityPub::Activity::Add < ActivityPub::Activity
     status   = status_from_uri(object_uri)
     status ||= fetch_remote_original_status
 
-    return unless !status.nil? && status.account_id == @account.id && !@account.pinned?(status)
+    return unless !status.nil? && status.account_id == @account.id && !@account.pinned?(status) && status.distributable?
 
     StatusPin.create!(account: @account, status: status)
   end


### PR DESCRIPTION
Mastodon `main` has added support for private pinned posts, but current Mastodon releases will error out when processing the resulting `Add`, causing unneeded fetches and retries (but functionally breaking nothing).

Merging this PR in stable releases would fix the unneeded errors and retries by just ignoring such `Add` activities.