### PR TITLE
Add ARM64 Docker Image Support

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:
@@ -28,6 +29,7 @@ jobs:
       - uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=tootsuite/mastodon:latest


### PR DESCRIPTION
I'm running Mastodon on Docker on the aarch64 platform, so it would be nice if you could build the arm64 Docker image.

I have already confirmed that it works in the aarch64 environment.

See: [docker/build-push-action: Multi-platform image](https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md)