### PR TITLE
Fix instance actor not being dereferenceable

### DIFF
--- a/app/controllers/instance_actors_controller.rb
+++ b/app/controllers/instance_actors_controller.rb
@@ -3,6 +3,7 @@
 class InstanceActorsController < ApplicationController
   include AccountControllerConcern
 
+  skip_before_action :check_account_confirmation
   skip_around_action :set_locale
 
   def show

--- a/spec/controllers/instance_actors_controller_spec.rb
+++ b/spec/controllers/instance_actors_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe InstanceActorsController, type: :controller do
+  describe 'GET #show' do
+    context 'as JSON' do
+      let(:format) { 'json' }
+
+      shared_examples 'shared behavior' do
+        before do
+          get :show, params: { format: format }
+        end
+
+        it 'returns http success' do
+          expect(response).to have_http_status(200)
+        end
+
+        it 'returns application/activity+json' do
+          expect(response.media_type).to eq 'application/activity+json'
+        end
+
+        it 'does not set cookies' do
+          expect(response.cookies).to be_empty
+          expect(response.headers['Set-Cookies']).to be nil
+        end
+
+        it 'does not set sessions' do
+          expect(session).to be_empty
+        end
+
+        it 'returns public Cache-Control header' do
+          expect(response.headers['Cache-Control']).to include 'public'
+        end
+
+        it 'renders account' do
+          json = body_as_json
+          expect(json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary, :inbox, :outbox, :url)
+        end
+
+        context 'in authorized fetch mode' do
+          let(:authorized_fetch_mode) { true }
+
+          it 'returns http unauthorized' do
+            expect(response).to have_http_status(401)
+          end
+        end
+      end
+
+      before do
+        allow(controller).to receive(:authorized_fetch_mode?).and_return(authorized_fetch_mode)
+      end
+
+      context 'without authorized fetch mode' do
+        let(:authorized_fetch_mode) { false }
+        it_behaves_like 'shared behavior'
+      end
+
+      context 'with authorized fetch mode' do
+        let(:authorized_fetch_mode) { true }
+        it_behaves_like 'shared behavior'
+      end
+    end
+  end
+end

--- a/spec/controllers/instance_actors_controller_spec.rb
+++ b/spec/controllers/instance_actors_controller_spec.rb
@@ -35,14 +35,6 @@ RSpec.describe InstanceActorsController, type: :controller do
           json = body_as_json
           expect(json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :inbox, :outbox, :url)
         end
-
-        context 'in authorized fetch mode' do
-          let(:authorized_fetch_mode) { true }
-
-          it 'returns http unauthorized' do
-            expect(response).to have_http_status(401)
-          end
-        end
       end
 
       before do

--- a/spec/controllers/instance_actors_controller_spec.rb
+++ b/spec/controllers/instance_actors_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe InstanceActorsController, type: :controller do
 
         it 'renders account' do
           json = body_as_json
-          expect(json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary, :inbox, :outbox, :url)
+          expect(json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :inbox, :outbox, :url)
         end
 
         context 'in authorized fetch mode' do


### PR DESCRIPTION
Fixes a regression from #17385

Indeed, the instance actor has no associated confirmed local user but should be rendered regardless.