### PR TITLE
Fix Ruby 2.5 incompatibility

### DIFF
--- a/app/workers/scheduler/accounts_statuses_cleanup_scheduler.rb
+++ b/app/workers/scheduler/accounts_statuses_cleanup_scheduler.rb
@@ -66,7 +66,7 @@ class Scheduler::AccountsStatusesCleanupScheduler
   end
 
   def compute_budget
-    threads = Sidekiq::ProcessSet.new.filter { |x| x['queues'].include?('push') }.map { |x| x['concurrency'] }.sum
+    threads = Sidekiq::ProcessSet.new.select { |x| x['queues'].include?('push') }.map { |x| x['concurrency'] }.sum
     [PER_THREAD_BUDGET * threads, MAX_BUDGET].min
   end
 


### PR DESCRIPTION
(oldest supported ubuntu LTS ships Ruby 2.5)

EDIT: note that I haven't actually tried running Mastodon on Ruby 2.5, there might be other incompatibilities, but for now we're advertising support from 2.5 onward