### PR TITLE
Fix localization of cold-start follow recommendations

### DIFF
--- a/app/models/account_suggestions/global_source.rb
+++ b/app/models/account_suggestions/global_source.rb
@@ -6,7 +6,7 @@ class AccountSuggestions::GlobalSource < AccountSuggestions::Source
   end
 
   def get(account, skip_account_ids: [], limit: 40)
-    account_ids = account_ids_for_locale(account.user_locale) - [account.id] - skip_account_ids
+    account_ids = account_ids_for_locale(I18n.locale.to_str.split(/[_-]/).first) - [account.id] - skip_account_ids
 
     as_ordered_suggestions(
       scope(account).where(id: account_ids),

--- a/app/views/admin/follow_recommendations/show.html.haml
+++ b/app/views/admin/follow_recommendations/show.html.haml
@@ -13,7 +13,7 @@
     .filter-subset.filter-subset--with-select
       %strong= t('admin.follow_recommendations.language')
       .input.select.optional
-        = select_tag :language, options_for_select(I18n.available_locales.map { |key| [human_locale(key), key]}, @language)
+        = select_tag :language, options_for_select(I18n.available_locales.map { |key| key.to_s.split(/[_-]/).first.to_sym }.uniq.map { |key| [human_locale(key), key]}, @language)
 
     .filter-subset
       %strong= t('admin.follow_recommendations.status')

--- a/app/workers/scheduler/follow_recommendations_scheduler.rb
+++ b/app/workers/scheduler/follow_recommendations_scheduler.rb
@@ -16,28 +16,33 @@ class Scheduler::FollowRecommendationsScheduler
     AccountSummary.refresh
     FollowRecommendation.refresh
 
-    fallback_recommendations = FollowRecommendation.order(rank: :desc).limit(SET_SIZE).index_by(&:account_id)
+    fallback_recommendations = FollowRecommendation.order(rank: :desc).limit(SET_SIZE)
 
-    I18n.available_locales.each do |locale|
+    I18n.available_locales.map { |locale| locale.to_s.split(/[_-]/).first }.uniq.each do |locale|
       recommendations = begin
         if AccountSummary.safe.filtered.localized(locale).exists? # We can skip the work if no accounts with that language exist
-          FollowRecommendation.localized(locale).order(rank: :desc).limit(SET_SIZE).index_by(&:account_id)
+          FollowRecommendation.localized(locale).order(rank: :desc).limit(SET_SIZE).map { |recommendation| [recommendation.account_id, recommendation.rank] }
         else
-          {}
+          []
         end
       end
 
       # Use language-agnostic results if there are not enough language-specific ones
-      missing = SET_SIZE - recommendations.keys.size
+      missing = SET_SIZE - recommendations.size
 
-      if missing.positive?
+      if missing.positive? && fallback_recommendations.size.positive?
+        max_fallback_rank = fallback_recommendations.first.rank || 0
+
+        # Language-specific results should be above language-agnostic ones,
+        # otherwise language-agnostic ones will always overshadow them
+        recommendations.map! { |(account_id, rank)| [account_id, rank + max_fallback_rank] }
+
         added = 0
 
-        # Avoid duplicate results
-        fallback_recommendations.each_value do |recommendation|
-          next if recommendations.key?(recommendation.account_id)
+        fallback_recommendations.each do |recommendation|
+          next if recommendations.any? { |(account_id, _)| account_id == recommendation.account_id }
 
-          recommendations[recommendation.account_id] = recommendation
+          recommendations << [recommendation.account_id, recommendation.rank]
           added += 1
 
           break if added >= missing
@@ -47,8 +52,8 @@ class Scheduler::FollowRecommendationsScheduler
       redis.pipelined do
         redis.del(key(locale))
 
-        recommendations.each_value do |recommendation|
-          redis.zadd(key(locale), recommendation.rank, recommendation.account_id)
+        recommendations.each do |(account_id, rank)|
+          redis.zadd(key(locale), rank, account_id)
         end
       end
     end


### PR DESCRIPTION
- Use current locale (allows customization with #17464) 
- Display language-specific results before global results, since otherwise global ones always overshadow
- Fix cold-start follow recommendations being generated for locales that will never get results due to regional locale codes