### PR TITLE
Change actions in reports to require only one click

### DIFF
--- a/app/controllers/admin/reports/actions_controller.rb
+++ b/app/controllers/admin/reports/actions_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class Admin::Reports::ActionsController < Admin::BaseController
+  before_action :set_report
+
+  def create
+    authorize @report, :show?
+
+    case action_from_button
+    when 'delete'
+      status_batch_action = Admin::StatusBatchAction.new(
+        type: action_from_button,
+        status_ids: @report.status_ids,
+        current_account: current_account,
+        report_id: @report.id,
+        send_email_notification: !@report.spam?
+      )
+
+      status_batch_action.save!
+    when 'silence', 'suspend'
+      account_action = Admin::AccountAction.new(
+        type: action_from_button,
+        report_id: @report.id,
+        target_account: @report.target_account,
+        current_account: current_account,
+        send_email_notification: !@report.spam?
+      )
+
+      account_action.save!
+    end
+
+    redirect_to admin_reports_path
+  end
+
+  private
+
+  def set_report
+    @report = Report.find(params[:report_id])
+  end
+
+  def action_from_button
+    if params[:delete]
+      'delete'
+    elsif params[:silence]
+      'silence'
+    elsif params[:suspend]
+      'suspend'
+    end
+  end
+end

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1394,8 +1394,9 @@ a.sparkline {
     }
 
     &__button {
+      box-sizing: border-box;
       flex: 0 0 auto;
-      width: 100px;
+      width: 200px;
       padding: 15px;
       padding-right: 0;
 
@@ -1409,6 +1410,40 @@ a.sparkline {
       padding: 15px;
       font-size: 14px;
       color: $dark-text-color;
+    }
+  }
+
+  @media screen and (max-width: 800px) {
+    border: 0;
+
+    &__item {
+      flex-direction: column;
+      border: 0;
+
+      &__button {
+        width: 100%;
+        padding: 15px 0;
+      }
+
+      &__description {
+        padding: 0;
+        padding-bottom: 15px;
+      }
+    }
+  }
+}
+
+.section-skip-link {
+  float: right;
+
+  a {
+    color: $ui-highlight-color;
+    text-decoration: none;
+
+    &:hover,
+    &:focus,
+    &:active {
+      text-decoration: underline;
     }
   }
 }

--- a/app/views/admin/reports/_actions.html.haml
+++ b/app/views/admin/reports/_actions.html.haml
@@ -1,0 +1,27 @@
+= form_tag admin_report_actions_path(@report), method: :post do
+  .report-actions
+    .report-actions__item
+      .report-actions__item__button
+        = link_to t('admin.reports.mark_as_resolved'), resolve_admin_report_path(@report), method: :post, class: 'button'
+      .report-actions__item__description
+        = t('admin.reports.actions.resolve_description_html')
+    .report-actions__item
+      .report-actions__item__button
+        = button_tag t('admin.reports.delete_and_resolve'), name: :delete, class: 'button button--destructive'
+      .report-actions__item__description
+        = t('admin.reports.actions.delete_description_html')
+    .report-actions__item
+      .report-actions__item__button
+        = button_tag t('admin.accounts.silence'), name: :silence, class: 'button button--destructive'
+      .report-actions__item__description
+        = t('admin.reports.actions.silence_description_html')
+    .report-actions__item
+      .report-actions__item__button
+        = button_tag t('admin.accounts.suspend'), name: :suspend, class: 'button button--destructive'
+      .report-actions__item__description
+        = t('admin.reports.actions.suspend_description_html')
+    .report-actions__item
+      .report-actions__item__button
+        = link_to t('admin.accounts.custom'), new_admin_account_action_path(@report.target_account_id, report_id: @report.id), class: 'button'
+      .report-actions__item__description
+        = t('admin.reports.actions.other_description_html')

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -124,24 +124,30 @@
 - if @report.comment.present?
   %p= t('admin.reports.comment_description_html', name: content_tag(:strong, @report.account.username, class: 'username'))
 
-  .report-notes__item
-    = image_tag @report.account.avatar.url, class: 'report-notes__item__avatar'
+  .report-notes
+    .report-notes__item
+      = image_tag @report.account.avatar.url, class: 'report-notes__item__avatar'
 
-    .report-notes__item__header
-      %span.username
-        = link_to display_name(@report.account), admin_account_path(@report.account_id)
-      %time{ datetime: @report.created_at.iso8601, title: l(@report.created_at) }
-        - if @report.created_at.today?
-          = t('admin.report_notes.today_at', time: l(@report.created_at, format: :time))
-        - else
-          = l @report.created_at.to_date
+      .report-notes__item__header
+        %span.username
+          = link_to display_name(@report.account), admin_account_path(@report.account_id)
+        %time{ datetime: @report.created_at.iso8601, title: l(@report.created_at) }
+          - if @report.created_at.today?
+            = t('admin.report_notes.today_at', time: l(@report.created_at, format: :time))
+          - else
+            = l @report.created_at.to_date
 
-    .report-notes__item__content
-      = simple_format(h(@report.comment))
+      .report-notes__item__content
+        = simple_format(h(@report.comment))
 
 %hr.spacer/
 
-%h3= t 'admin.reports.statuses'
+%h3
+  = t 'admin.reports.statuses'
+  %small.section-skip-link
+    = link_to '#actions' do
+      = fa_icon 'angle-double-down'
+      = t('admin.reports.skip_to_actions')
 
 %p
   = t 'admin.reports.statuses_description_html'
@@ -156,8 +162,6 @@
       .batch-table__toolbar__actions
         - if !@statuses.empty? && @report.unresolved?
           = f.button safe_join([fa_icon('times'), t('admin.statuses.batch.remove_from_report')]), name: :remove_from_report, class: 'table-action-link', type: :submit
-          = f.button safe_join([fa_icon('trash'), t('admin.reports.delete_and_resolve')]), name: :delete, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') }
-        - else
     .batch-table__body
       - if @statuses.empty?
         = nothing_here 'nothing-here--under-tabs'
@@ -167,24 +171,9 @@
 - if @report.unresolved?
   %hr.spacer/
 
-  %p= t 'admin.reports.actions_description_html'
+  %p#actions= t 'admin.reports.actions_description_html'
 
-  .report-actions
-    .report-actions__item
-      .report-actions__item__button
-        = link_to t('admin.accounts.silence'), new_admin_account_action_path(@report.target_account_id, type: 'silence', report_id: @report.id), class: 'button button--destructive'
-      .report-actions__item__description
-        = t('admin.reports.actions.silence_description_html')
-    .report-actions__item
-      .report-actions__item__button
-        = link_to t('admin.accounts.perform_full_suspension'), new_admin_account_action_path(@report.target_account_id, report_id: @report.id, type: 'suspend'), class: 'button button--destructive'
-      .report-actions__item__description
-        = t('admin.reports.actions.suspend_description_html')
-    .report-actions__item
-      .report-actions__item__button
-        = link_to t('admin.accounts.custom'), new_admin_account_action_path(@report.target_account_id, report_id: @report.id), class: 'button'
-      .report-actions__item__description
-        = t('admin.reports.actions.other_description_html')
+  = render partial: 'admin/reports/actions'
 
 - unless @action_logs.empty?
   %hr.spacer/

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -206,6 +206,7 @@ en:
       statuses: Posts
       strikes: Previous strikes
       subscribe: Subscribe
+      suspend: Suspend
       suspended: Suspended
       suspension_irreversible: The data of this account has been irreversibly deleted. You can unsuspend the account to make it usable but it will not recover any data it previously had.
       suspension_reversible_hint_html: The account has been suspended, and the data will be fully removed on %{date}. Until then, the account can be restored without any ill effects. If you wish to remove all of the account's data immediately, you can do so below.
@@ -560,10 +561,12 @@ en:
       action_log: Audit log
       action_taken_by: Action taken by
       actions:
+        delete_description_html: The reported posts will be deleted and a strike will be recorded to help you escalate on future infractions by the same account.
         other_description_html: See more options for controlling the account's behaviour and customize communication to the reported account.
+        resolve_description_html: No action will be taken against the reported account, no strike recorded, and the report will be closed.
         silence_description_html: The profile will be visible only to those who already follow it or manually look it up, severely limiting its reach. Can always be reverted.
         suspend_description_html: The profile and all its contents will become inaccessible until it is eventually deleted. Interacting with the account will be impossible. Reversible within 30 days.
-      actions_description_html: 'If removing the offending content above is insufficient:'
+      actions_description_html: Decide which action to take to resolve this report. If you take a punitive action against the reported account, an e-mail notification will be sent to them, except when the <strong>Spam</strong> category is selected.
       add_to_report: Add more to report
       are_you_sure: Are you sure?
       assign_to_self: Assign to me
@@ -575,7 +578,7 @@ en:
         none: None
       comment_description_html: 'To provide more information, %{name} wrote:'
       created_at: Reported
-      delete_and_resolve: Delete and resolve
+      delete_and_resolve: Delete posts
       forwarded: Forwarded
       forwarded_to: Forwarded to %{domain}
       mark_as_resolved: Mark as resolved
@@ -589,12 +592,14 @@ en:
         placeholder: Describe what actions have been taken, or any other related updates...
         title: Notes
       notes_description_html: View and leave notes to other moderators and your future self
+      quick_actions_description_html: 'Take a quick action or scroll down to see reported content:'
       reopen: Reopen report
       report: 'Report #%{id}'
       reported_account: Reported account
       reported_by: Reported by
       resolved: Resolved
       resolved_msg: Report successfully resolved!
+      skip_to_actions: Skip to actions
       status: Status
       statuses: Reported content
       statuses_description_html: Offending content will be cited in communication with the reported account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,6 +225,8 @@ Rails.application.routes.draw do
     resources :rules
 
     resources :reports, only: [:index, :show] do
+      resources :actions, only: [:create], controller: 'reports/actions'
+
       member do
         post :assign_to_self
         post :unassign


### PR DESCRIPTION
- Move "delete posts" action from table header to list of actions
- Duplicate list of actions above and below the table
- Instead of sending user to account action form, buttons (except for "Custom") perform the action with one click
- If the spam category is selected, no e-mail notification is generated (unless through "Custom")
- Increase width of action buttons to accommodate other languages