### PR TITLE
Fix poll votes not being properly reset on poll change

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -83,6 +83,12 @@ class Poll < ApplicationRecord
     end
   end
 
+  def reset_votes!
+    self.cached_tallies = options.map { 0 }
+    self.votes_count = 0
+    votes.delete_all unless new_record?
+  end
+
   private
 
   def prepare_cached_tallies

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -95,10 +95,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
       # If for some reasons the options were changed, it invalidates all previous
       # votes, so we need to remove them
-      if poll_parser.significantly_changes?(poll)
-        @poll_changed = true
-        poll.reset_votes! unless poll.new_record?
-      end
+      @poll_changed = true if poll_parser.significantly_changes?(poll)
 
       poll.last_fetched_at = Time.now.utc
       poll.options         = poll_parser.options
@@ -106,6 +103,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
       poll.expires_at      = poll_parser.expires_at
       poll.voters_count    = poll_parser.voters_count
       poll.cached_tallies  = poll_parser.cached_tallies
+      poll.reset_votes! if @poll_changed
       poll.save!
 
       @status.poll_id = poll.id

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -97,7 +97,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
       # votes, so we need to remove them
       if poll_parser.significantly_changes?(poll)
         @poll_changed = true
-        poll.votes.delete_all unless poll.new_record?
+        poll.reset_votes! unless poll.new_record?
       end
 
       poll.last_fetched_at = Time.now.utc

--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -73,15 +73,13 @@ class UpdateStatusService < BaseService
 
       # If for some reasons the options were changed, it invalidates all previous
       # votes, so we need to remove them
-      if @options[:poll][:options] != poll.options || ActiveModel::Type::Boolean.new.cast(@options[:poll][:multiple]) != poll.multiple
-        @poll_changed = true
-        poll.reset_votes! unless poll.new_record?
-      end
+      @poll_changed = true if @options[:poll][:options] != poll.options || ActiveModel::Type::Boolean.new.cast(@options[:poll][:multiple]) != poll.multiple
 
       poll.options     = @options[:poll][:options]
       poll.hide_totals = @options[:poll][:hide_totals] || false
       poll.multiple    = @options[:poll][:multiple] || false
       poll.expires_in  = @options[:poll][:expires_in]
+      poll.reset_votes! if @poll_changed
       poll.save!
 
       @status.poll_id = poll.id

--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -75,7 +75,7 @@ class UpdateStatusService < BaseService
       # votes, so we need to remove them
       if @options[:poll][:options] != poll.options || ActiveModel::Type::Boolean.new.cast(@options[:poll][:multiple]) != poll.multiple
         @poll_changed = true
-        poll.votes.delete_all unless poll.new_record?
+        poll.reset_votes! unless poll.new_record?
       end
 
       poll.options     = @options[:poll][:options]


### PR DESCRIPTION
Only the recorded votes were cleared, not the actual tallies (which are in general not recomputed from the recorded votes).

Add tests and fix the existing ones which apparently did not properly attach the poll prior to the update, thus catching the “a poll was added” rather than the “a poll was changed” case.