### PR TITLE
Change reblogs to not count towards hashtag trends anymore

### DIFF
--- a/app/models/trends/tags.rb
+++ b/app/models/trends/tags.rb
@@ -11,12 +11,9 @@ class Trends::Tags < Trends::Base
   }
 
   def register(status, at_time = Time.now.utc)
-    original_status = status.reblog? ? status.reblog : status
+    return unless !status.reblog? && status.public_visibility? && !status.account.silenced?
 
-    return unless original_status.public_visibility? && status.public_visibility? &&
-                  !original_status.account.silenced? && !status.account.silenced?
-
-    original_status.tags.each do |tag|
+    status.tags.each do |tag|
       add(tag, status.account_id, at_time) if tag.usable?
     end
   end


### PR DESCRIPTION
With #17431 there will be overlap between top trending hashtags and top trending posts. Returning to only counting by volume of original posts makes sense here.