### PR TITLE
Fix Undo Announce sometimes inlining the originally Announced status

### DIFF
--- a/app/presenters/activitypub/activity_presenter.rb
+++ b/app/presenters/activitypub/activity_presenter.rb
@@ -4,7 +4,7 @@ class ActivityPub::ActivityPresenter < ActiveModelSerializers::Model
   attributes :id, :type, :actor, :published, :to, :cc, :virtual_object
 
   class << self
-    def from_status(status)
+    def from_status(status, allow_inlining: true)
       new.tap do |presenter|
         presenter.id        = ActivityPub::TagManager.instance.activity_uri_for(status)
         presenter.type      = status.reblog? ? 'Announce' : 'Create'
@@ -15,7 +15,7 @@ class ActivityPub::ActivityPresenter < ActiveModelSerializers::Model
 
         presenter.virtual_object = begin
           if status.reblog?
-            if status.account == status.proper.account && status.proper.private_visibility? && status.local?
+            if allow_inlining && status.account == status.proper.account && status.proper.private_visibility? && status.local?
               status.proper
             else
               ActivityPub::TagManager.instance.uri_for(status.proper)

--- a/app/serializers/activitypub/undo_announce_serializer.rb
+++ b/app/serializers/activitypub/undo_announce_serializer.rb
@@ -22,6 +22,6 @@ class ActivityPub::UndoAnnounceSerializer < ActivityPub::Serializer
   end
 
   def virtual_object
-    ActivityPub::ActivityPresenter.from_status(object)
+    ActivityPub::ActivityPresenter.from_status(object, allow_inlining: false)
   end
 end


### PR DESCRIPTION
The Undo Announce activity sent when unboosting a private self-post used to inline the original `Note` itself.

It would not be signed, nor sent to anyone that wasn't in your followers at the time of unboosting, but I think we're better safe than sorry by making sure it's never inlined, especially before merging stuff like #17484

This also adds tighter tests around the expected ActivityPub payloads sent for Delete/Undo Announce