### PR TITLE
Fix empty batch statuses selection causing a 500 error

### DIFF
--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -29,8 +29,9 @@ module Admin
     end
 
     def after_create_redirect_path
-      if @status_batch_action.report_id.present?
-        admin_report_path(@status_batch_action.report_id)
+      report_id = @status_batch_action&.report_id || params[:report_id]
+      if report_id.present?
+        admin_report_path(report_id)
       else
         admin_account_statuses_path(params[:account_id], current_params)
       end
@@ -46,6 +47,15 @@ module Admin
 
     def filter_params
       params.slice(*Admin::StatusFilter::KEYS).permit(*Admin::StatusFilter::KEYS)
+    end
+
+    def current_params
+      page = (params[:page] || 1).to_i
+
+      {
+        media: params[:media],
+        page: page > 1 && page,
+      }.select { |_, value| value.present? }
     end
 
     def action_from_button

--- a/app/controllers/admin/statuses_controller.rb
+++ b/app/controllers/admin/statuses_controller.rb
@@ -50,12 +50,7 @@ module Admin
     end
 
     def current_params
-      page = (params[:page] || 1).to_i
-
-      {
-        media: params[:media],
-        page: page > 1 && page,
-      }.select { |_, value| value.present? }
+      params.slice(:media, :page).permit(:media, :page)
     end
 
     def action_from_button


### PR DESCRIPTION
Ideally, this should be caught client-side too, but this would be slightly more work than just using `rails-ujs`