### PR TITLE
Remove protobuf dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
           name: Install system dependencies
           command: |
             sudo apt-get update
-            sudo apt-get install -y libicu-dev libidn11-dev libprotobuf-dev protobuf-compiler
+            sudo apt-get install -y libicu-dev libidn11-dev
   install-ruby-dependencies:
     parameters:
       ruby-version:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -6,6 +6,10 @@ on:
       - "main"
     tags:
       - "*"
+  pull_request:
+    paths:
+      - .github/workflows/build-image.yml
+      - Dockerfile
 jobs:
   build-image:
     runs-on: ubuntu-latest
@@ -30,7 +34,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=tootsuite/mastodon:latest
           cache-to: type=inline

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libicu-dev libidn11-dev libprotobuf-dev protobuf-compiler
+        sudo apt-get install -y libicu-dev libidn11-dev
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/Aptfile
+++ b/Aptfile
@@ -4,10 +4,8 @@ libicu-dev
 libidn11
 libidn11-dev
 libpq-dev
-libprotobuf-dev
 libxdamage1
 libxfixes3
-protobuf-compiler
 zlib1g-dev
 libcairo2
 libcroco3

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN npm install -g npm@latest && \
 	gem install bundler && \
 	apt-get update && \
 	apt-get install -y --no-install-recommends git libicu-dev libidn11-dev \
-	libpq-dev libprotobuf-dev protobuf-compiler shared-mime-info
+	libpq-dev shared-mime-info
 
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
@@ -88,7 +88,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 RUN apt-get update && \
   apt-get -y --no-install-recommends install \
 	  libssl1.1 libpq5 imagemagick ffmpeg libjemalloc2 \
-	  libicu66 libprotobuf17 libidn11 libyaml-0-2 \
+	  libicu66 libidn11 libyaml-0-2 \
 	  file ca-certificates tzdata libreadline8 gcc tini apt-utils && \
 	ln -s /opt/mastodon /mastodon && \
 	gem install bundler && \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,11 +33,9 @@ sudo apt-get install \
   redis-tools \
   postgresql \
   postgresql-contrib \
-  protobuf-compiler \
   yarn \
   libicu-dev \
   libidn11-dev \
-  libprotobuf-dev \
   libreadline-dev \
   libpam0g-dev \
   -y


### PR DESCRIPTION
The `protobuf` that `cld3` depended on in `cld3` removed from dependencies (#17478) is no longer needed.