### PR TITLE
Change old moderation strikes to be displayed in a separate page

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -127,7 +127,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   end
 
   def set_strikes
-    @strikes = current_account.strikes.active.latest
+    @strikes = current_account.strikes.recent.latest
   end
 
   def require_not_suspended!

--- a/app/controllers/disputes/strikes_controller.rb
+++ b/app/controllers/disputes/strikes_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class Disputes::StrikesController < Disputes::BaseController
-  before_action :set_strike
+  before_action :set_strike, only: [:show]
+
+  def index
+    @strikes = current_account.strikes.latest
+  end
 
   def show
     authorize @strike, :show?

--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -33,7 +33,7 @@ class AccountWarning < ApplicationRecord
 
   scope :latest, -> { order(id: :desc) }
   scope :custom, -> { where.not(text: '') }
-  scope :active, -> { where(overruled_at: nil).or(where('account_warnings.overruled_at >= ?', 30.days.ago)) }
+  scope :recent, -> { where('account_warnings.created_at >= ?', 3.months.ago) }
 
   def statuses
     Status.with_discarded.where(id: status_ids || [])

--- a/app/views/auth/registrations/_status.html.haml
+++ b/app/views/auth/registrations/_status.html.haml
@@ -14,4 +14,7 @@
 
 = render partial: 'account_warning', collection: @strikes
 
+- if @user.account.strikes.exists?
+  = link_to t('auth.status.view_strikes'), disputes_strikes_path
+
 %hr.spacer/

--- a/app/views/auth/registrations/_status.html.haml
+++ b/app/views/auth/registrations/_status.html.haml
@@ -12,6 +12,16 @@
 
 %h3= t('auth.status.account_status')
 
+%p.hint
+  - if @user.account.suspended?
+    %span.negative-hint= t('user_mailer.warning.explanation.suspend')
+  - elsif @user.disabled?
+    %span.negative-hint= t('user_mailer.warning.explanation.disable')
+  - elsif @user.account.silenced?
+    %span.warning-hint= t('user_mailer.warning.explanation.silence')
+  - else
+    %span.positive-hint= t('auth.status.functional')
+
 = render partial: 'account_warning', collection: @strikes
 
 - if @user.account.strikes.exists?

--- a/app/views/auth/registrations/_status.html.haml
+++ b/app/views/auth/registrations/_status.html.haml
@@ -15,6 +15,9 @@
 = render partial: 'account_warning', collection: @strikes
 
 - if @user.account.strikes.exists?
-  = link_to t('auth.status.view_strikes'), disputes_strikes_path
+  %hr.spacer/
+
+  %p.muted-hint
+    = link_to t('auth.status.view_strikes'), disputes_strikes_path
 
 %hr.spacer/

--- a/app/views/disputes/strikes/index.html.haml
+++ b/app/views/disputes/strikes/index.html.haml
@@ -1,0 +1,4 @@
+- content_for :page_title do
+  = t('settings.strikes')
+
+= render partial: 'auth/registrations/account_warning', collection: @strikes

--- a/app/views/disputes/strikes/index.html.haml
+++ b/app/views/disputes/strikes/index.html.haml
@@ -1,4 +1,6 @@
 - content_for :page_title do
   = t('settings.strikes')
 
+%p= t('disputes.strikes.description_html', instance: Rails.configuration.x.local_domain)
+
 = render partial: 'auth/registrations/account_warning', collection: @strikes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -984,6 +984,7 @@ en:
         submit: Submit appeal
       associated_report: Associated report
       created_at: Dated
+      description_html: "These are actions taken against your account and warnings that have been sent to you by the staff of %{instance}."
       recipient: Addressed to
       status: 'Post #%{id}'
       status_removed: Post already removed from system

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -909,6 +909,7 @@ en:
       confirming: Waiting for e-mail confirmation to be completed.
       pending: Your application is pending review by our staff. This may take some time. You will receive an e-mail if your application is approved.
       redirecting_to: Your account is inactive because it is currently redirecting to %{acct}.
+      view_strikes: View past strikes against your account
     too_fast: Form submitted too fast, try again.
     trouble_logging_in: Trouble logging in?
     use_security_key: Use security key

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -907,6 +907,7 @@ en:
     status:
       account_status: Account status
       confirming: Waiting for e-mail confirmation to be completed.
+      functional: Your account is fully operational.
       pending: Your application is pending review by our staff. This may take some time. You will receive an e-mail if your application is approved.
       redirecting_to: Your account is inactive because it is currently redirecting to %{acct}.
       view_strikes: View past strikes against your account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1362,6 +1362,7 @@ en:
     profile: Profile
     relationships: Follows and followers
     statuses_cleanup: Automated post deletion
+    strikes: Moderation strikes
     two_factor_authentication: Two-factor Auth
     webauthn_authentication: Security keys
   statuses:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -985,7 +985,7 @@ en:
         submit: Submit appeal
       associated_report: Associated report
       created_at: Dated
-      description_html: "These are actions taken against your account and warnings that have been sent to you by the staff of %{instance}."
+      description_html: These are actions taken against your account and warnings that have been sent to you by the staff of %{instance}.
       recipient: Addressed to
       status: 'Post #%{id}'
       status_removed: Post already removed from system

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -20,7 +20,7 @@ SimpleNavigation::Configuration.run do |navigation|
     n.item :statuses_cleanup, safe_join([fa_icon('history fw'), t('settings.statuses_cleanup')]), statuses_cleanup_url, if: -> { current_user.functional? }
 
     n.item :security, safe_join([fa_icon('lock fw'), t('settings.account')]), edit_user_registration_url do |s|
-      s.item :password, safe_join([fa_icon('lock fw'), t('settings.account_settings')]), edit_user_registration_url, highlights_on: %r{/auth/edit|/settings/delete|/settings/migration|/settings/aliases|/settings/login_activities|/disputes}
+      s.item :password, safe_join([fa_icon('lock fw'), t('settings.account_settings')]), edit_user_registration_url, highlights_on: %r{/auth/edit|/settings/delete|/settings/migration|/settings/aliases|/settings/login_activities|^/disputes}
       s.item :two_factor_authentication, safe_join([fa_icon('mobile fw'), t('settings.two_factor_authentication')]), settings_two_factor_authentication_methods_url, highlights_on: %r{/settings/two_factor_authentication|/settings/otp_authentication|/settings/security_keys}
       s.item :authorized_apps, safe_join([fa_icon('list fw'), t('settings.authorized_apps')]), oauth_authorized_applications_url
     end

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -20,9 +20,10 @@ SimpleNavigation::Configuration.run do |navigation|
     n.item :statuses_cleanup, safe_join([fa_icon('history fw'), t('settings.statuses_cleanup')]), statuses_cleanup_url, if: -> { current_user.functional? }
 
     n.item :security, safe_join([fa_icon('lock fw'), t('settings.account')]), edit_user_registration_url do |s|
-      s.item :password, safe_join([fa_icon('lock fw'), t('settings.account_settings')]), edit_user_registration_url, highlights_on: %r{/auth/edit|/settings/delete|/settings/migration|/settings/aliases|/settings/login_activities|^/disputes}
+      s.item :password, safe_join([fa_icon('lock fw'), t('settings.account_settings')]), edit_user_registration_url, highlights_on: %r{/auth/edit|/settings/delete|/settings/migration|/settings/aliases|/settings/login_activities}
       s.item :two_factor_authentication, safe_join([fa_icon('mobile fw'), t('settings.two_factor_authentication')]), settings_two_factor_authentication_methods_url, highlights_on: %r{/settings/two_factor_authentication|/settings/otp_authentication|/settings/security_keys}
       s.item :authorized_apps, safe_join([fa_icon('list fw'), t('settings.authorized_apps')]), oauth_authorized_applications_url
+      s.item :strikes, safe_join([fa_icon('warning'), t('settings.strikes')]), disputes_strikes_url, if: -> { current_account.strikes.exists? }, highlights_on: %r{|^/disputes}
     end
 
     n.item :data, safe_join([fa_icon('cloud-download fw'), t('settings.import_and_export')]), settings_export_url do |s|

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -20,10 +20,9 @@ SimpleNavigation::Configuration.run do |navigation|
     n.item :statuses_cleanup, safe_join([fa_icon('history fw'), t('settings.statuses_cleanup')]), statuses_cleanup_url, if: -> { current_user.functional? }
 
     n.item :security, safe_join([fa_icon('lock fw'), t('settings.account')]), edit_user_registration_url do |s|
-      s.item :password, safe_join([fa_icon('lock fw'), t('settings.account_settings')]), edit_user_registration_url, highlights_on: %r{/auth/edit|/settings/delete|/settings/migration|/settings/aliases|/settings/login_activities}
+      s.item :password, safe_join([fa_icon('lock fw'), t('settings.account_settings')]), edit_user_registration_url, highlights_on: %r{/auth/edit|/settings/delete|/settings/migration|/settings/aliases|/settings/login_activities|/disputes}
       s.item :two_factor_authentication, safe_join([fa_icon('mobile fw'), t('settings.two_factor_authentication')]), settings_two_factor_authentication_methods_url, highlights_on: %r{/settings/two_factor_authentication|/settings/otp_authentication|/settings/security_keys}
       s.item :authorized_apps, safe_join([fa_icon('list fw'), t('settings.authorized_apps')]), oauth_authorized_applications_url
-      s.item :strikes, safe_join([fa_icon('warning'), t('settings.strikes')]), disputes_strikes_url, if: -> { current_account.strikes.exists? }, highlights_on: %r{|^/disputes}
     end
 
     n.item :data, safe_join([fa_icon('cloud-download fw'), t('settings.import_and_export')]), settings_export_url do |s|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,7 +165,7 @@ Rails.application.routes.draw do
   end
 
   namespace :disputes do
-    resources :strikes, only: [:show] do
+    resources :strikes, only: [:show, :index] do
       resource :appeal, only: [:create]
     end
   end


### PR DESCRIPTION
Fixes #17552

This changes the moderation strikes displayed on `/auth/edit` to be those from the past 3 months, and make all moderation strikes targeting the current user available in `/disputes`.

![image](https://user-images.githubusercontent.com/384364/154226916-bd60848b-c82b-4ebf-9d4d-52acbdd928ed.png)
