### PR TITLE
Change how strikes are counted

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -271,7 +271,7 @@ class Account < ApplicationRecord
   end
 
   def previous_strikes_count
-    strikes.where(overruled_at: nil).count
+    strikes.where(overruled_at: nil).select(:report_id).distinct.count
   end
 
   def keypair

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,8 +164,8 @@ en:
       perform_full_suspension: Suspend
       previous_strikes: Previous strikes
       previous_strikes_description_html:
-        one: This account has <strong>one</strong> strike.
-        other: This account has <strong>%{count}</strong> strikes.
+        one: This account has received strikes for <strong>one</strong> report.
+        other: This account has received strikes for <strong>%{count}</strong> different reports.
         zero: This account is <strong>in good standing</strong>.
       promote: Promote
       protocol: Protocol


### PR DESCRIPTION
Group strikes per report, so that multiple actions taken on a single report do not count as multiple strikes.