### PR TITLE
Change relays handling to not record boosts

### DIFF
--- a/app/lib/activitypub/activity/announce.rb
+++ b/app/lib/activitypub/activity/announce.rb
@@ -8,6 +8,7 @@ class ActivityPub::Activity::Announce < ActivityPub::Activity
       original_status = status_from_object
 
       return reject_payload! if original_status.nil? || !announceable?(original_status)
+      return if requested_through_relay?
 
       @status = Status.find_by(account: @account, reblog: original_status)
 


### PR DESCRIPTION
There is no real reason to record a reblog when we know it is coming from a relay. As long as the original status has been fetched, the purpose of the `Announce` has been served.

Not recording them would save a bit of database space, though I am not sure it is worth special-casing replay boosts.

TODO:
- [x] rewrite tests in a way that makes sense