### PR TITLE
Show full footer on small screens

### DIFF
--- a/app/javascript/styles/mastodon/footer.scss
+++ b/app/javascript/styles/mastodon/footer.scss
@@ -84,26 +84,30 @@
       }
 
       @media screen and (max-width: $no-gap-breakpoint) {
-        .column-0,
-        .column-1,
-        .column-3,
-        .column-4 {
-          display: none;
+        grid-template-columns: 1fr;
+
+        > div {
+          text-align: center;
+
+          &.column-0 {
+            grid-row: 2;
+          }
+          &.column-1 {
+            grid-row: 3;
+          }
+          &.column-2 {
+            grid-row: 1;
+            grid-column: 1;
+          }
+          &.column-3 {
+            grid-row: 4;
+            grid-column: 1;
+          }
+          &.column-4 {
+            grid-row: 5;
+            grid-column: 1;
+          }
         }
-
-        .column-2 h4 {
-          display: none;
-        }
-      }
-    }
-
-    .legal-xs {
-      display: none;
-      text-align: center;
-      padding-top: 20px;
-
-      @media screen and (max-width: $no-gap-breakpoint) {
-        display: block;
       }
     }
 
@@ -119,8 +123,7 @@
       }
     }
 
-    ul a,
-    .legal-xs a {
+    ul a {
       text-decoration: none;
       color: lighten($ui-base-color, 34%);
 

--- a/app/views/layouts/public.html.haml
+++ b/app/views/layouts/public.html.haml
@@ -54,9 +54,5 @@
             %ul
               %li= link_to t('about.source_code'), Mastodon::Version.source_url
               %li= link_to t('about.apps'), 'https://joinmastodon.org/apps'
-        .legal-xs
-          = link_to "v#{Mastodon::Version.to_s}", Mastodon::Version.source_url
-          ·
-          = link_to t('about.privacy_policy'), terms_path
 
 = render template: 'layouts/application'


### PR DESCRIPTION
This PR replaces the two links added in bbd34744161fc46 with the full footer in a rearranged single-column grid.

This causes the links to mobile apps, docs, etc. to now also be visible on small screen sizes.

It looks okay even on very small screen sizes (please ignore custom theming):
<img width="263" alt="Screenshot of the full footer on a very small screen size." src="https://user-images.githubusercontent.com/5144843/154409724-222f7b99-c0cf-45f0-a043-48ab3024b6a8.png">

