### PR TITLE
Throttle IPv6 signup for subnet

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -82,7 +82,9 @@ class Rack::Attack
   end
 
   throttle('throttle_sign_up_attempts/ip', limit: 25, period: 5.minutes) do |req|
-    req.remote_ip if req.post? && req.path == '/auth'
+    return unless req.post? && req.path == '/auth'
+    return req.remote_ip.mask(64) if req.remote_ip.ipv6?
+    req.remote_ip
   end
 
   throttle('throttle_password_resets/ip', limit: 25, period: 5.minutes) do |req|


### PR DESCRIPTION
Currently, Mastodon throttle signup 25/5min per specific IP
Unlike IPv4, IPv6 address is very different. For an example, Cloud VPS providers give entire /64 subnet to a single server.

So this PR raise the bar using 64 bit netmask. while it is narrow enough compare to IPv4(=32bit mask)