### PR TITLE
Fix sign in token and warning emails failed to send in some cases

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -169,7 +169,7 @@ class UserMailer < Devise::Mailer
     I18n.with_locale(@resource.locale || I18n.default_locale) do
       mail to: @resource.email,
            subject: I18n.t("user_mailer.warning.subject.#{@warning.action}", acct: "@#{user.account.local_username_and_domain}"),
-           reply_to: Setting.site_contact_email
+           reply_to: ENV['SMTP_REPLY_TO']
     end
   end
 
@@ -206,7 +206,7 @@ class UserMailer < Devise::Mailer
     I18n.with_locale(@resource.locale || I18n.default_locale) do
       mail to: @resource.email,
            subject: I18n.t('user_mailer.sign_in_token.subject'),
-           reply_to: Setting.site_contact_email
+           reply_to: ENV['SMTP_REPLY_TO']
     end
   end
 end


### PR DESCRIPTION
When `Setting.site_contact_email` was incorrectly set with an invalid value such as `-` it could cause sign in token email failed to send with some SMTP providers such as Amazon SES because of invalid `Reply-To`. This also affect warning email on the same `app/mailers/user_mailer.rb` file.

**Example error in Sidekiq Jobs**
```
UserMailer#sign_in_token
Net::SMTPFatalError: 554 Transaction failed: Missing final '@domain'
```

Generally `Setting.site_contact_email` value should not have any effects on the ability to send sign in token or warning emails (`UserMailer.sign_in_token` and `UserMailer.warning` functions). Therefore `reply_to` field should use the global `SMTP_REPLY_TO` variable (https://github.com/mastodon/mastodon/pull/11718) instead based on `config/environments/production.rb`.