### PR TITLE
Avoid return within block

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -82,9 +82,13 @@ class Rack::Attack
   end
 
   throttle('throttle_sign_up_attempts/ip', limit: 25, period: 5.minutes) do |req|
-    return unless req.post? && req.path == '/auth'
-    return req.remote_ip.mask(64) if req.remote_ip.ipv6?
-    req.remote_ip
+    if req.post? && req.path == '/auth'
+      if req.remote_ip.ipv6?
+        req.remote_ip.mask(64)
+      else
+        req.remote_ip
+      end
+    end
   end
 
   throttle('throttle_password_resets/ip', limit: 25, period: 5.minutes) do |req|


### PR DESCRIPTION
This prevents the error: `LocalJumpError (unexpected return)` I observed on my server running with ruby-3.1.0 after applying #17588.