### PR TITLE
Calculate max_id without random vector on "tootctl statuses remove"

### DIFF
--- a/lib/mastodon/statuses_cli.rb
+++ b/lib/mastodon/statuses_cli.rb
@@ -54,7 +54,7 @@ module Mastodon
 
       ActiveRecord::Base.connection.add_index(:media_attachments, :remote_url, name: :index_media_attachments_remote_url, where: 'remote_url is not null', algorithm: :concurrently, if_not_exists: true)
 
-      max_id   = Mastodon::Snowflake.id_at(options[:days].days.ago)
+      max_id   = Mastodon::Snowflake.id_at(options[:days].days.ago, with_random: false)
       start_at = Time.now.to_f
 
       unless options[:continue] && ActiveRecord::Base.connection.table_exists?('statuses_to_be_deleted')


### PR DESCRIPTION
Everywhere else using snowflake to get max/min id of statuses are using `with_random: false` But was not this.