### PR TITLE
Fix link in new hashtag notification email

### DIFF
--- a/app/views/admin_mailer/new_trending_tags.text.erb
+++ b/app/views/admin_mailer/new_trending_tags.text.erb
@@ -13,4 +13,4 @@
 <%= t('admin_mailer.new_trending_tags.no_approved_tags') %>
 <% end %>
 
-<%= raw t('application_mailer.view')%> <%= admin_trends_tags_url(pending_review: '1') %>
+<%= raw t('application_mailer.view')%> <%= admin_trends_tags_url(status: 'pending_review') %>


### PR DESCRIPTION
It's currently https://example.org/admin/trends/tags?pending_review=1 but should be https://example.org/admin/trends/tags?status=pending_review