### PR TITLE
Escape database passwords in config/database.yml

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ development:
   <<: *default
   database: <%= ENV['DB_NAME'] || 'mastodon_development' %>
   username: <%= ENV['DB_USER'] %>
-  password: "<%= ENV['DB_PASS'] %>"
+  password: <%= (ENV['DB_PASS'] || '').to_json %>
   host: <%= ENV['DB_HOST'] %>
   port: <%= ENV['DB_PORT'] %>
 
@@ -20,7 +20,7 @@ test:
   <<: *default
   database: <%= ENV['DB_NAME'] || 'mastodon' %>_test<%= ENV['TEST_ENV_NUMBER'] %>
   username: <%= ENV['DB_USER'] %>
-  password: "<%= ENV['DB_PASS'] %>"
+  password: <%= (ENV['DB_PASS'] || '').to_json %>
   host: <%= ENV['DB_HOST'] %>
   port: <%= ENV['DB_PORT'] %>
 
@@ -28,7 +28,7 @@ production:
   <<: *default
   database: <%= ENV['DB_NAME'] || 'mastodon_production' %>
   username: <%= ENV['DB_USER'] || 'mastodon' %>
-  password: "<%= ENV['DB_PASS'] || '' %>"
+  password: <%= (ENV['DB_PASS'] || '').to_json %>
   host: <%= ENV['DB_HOST'] || 'localhost' %>
   port: <%= ENV['DB_PORT'] || 5432 %>
   prepared_statements: <%= ENV['PREPARED_STATEMENTS'] || 'true' %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ development:
   <<: *default
   database: <%= ENV['DB_NAME'] || 'mastodon_development' %>
   username: <%= ENV['DB_USER'] %>
-  password: <%= ENV['DB_PASS'] %>
+  password: "<%= ENV['DB_PASS'] %>"
   host: <%= ENV['DB_HOST'] %>
   port: <%= ENV['DB_PORT'] %>
 
@@ -20,7 +20,7 @@ test:
   <<: *default
   database: <%= ENV['DB_NAME'] || 'mastodon' %>_test<%= ENV['TEST_ENV_NUMBER'] %>
   username: <%= ENV['DB_USER'] %>
-  password: <%= ENV['DB_PASS'] %>
+  password: "<%= ENV['DB_PASS'] %>"
   host: <%= ENV['DB_HOST'] %>
   port: <%= ENV['DB_PORT'] %>
 
@@ -28,7 +28,7 @@ production:
   <<: *default
   database: <%= ENV['DB_NAME'] || 'mastodon_production' %>
   username: <%= ENV['DB_USER'] || 'mastodon' %>
-  password: <%= ENV['DB_PASS'] || '' %>
+  password: "<%= ENV['DB_PASS'] || '' %>"
   host: <%= ENV['DB_HOST'] || 'localhost' %>
   port: <%= ENV['DB_PORT'] || 5432 %>
   prepared_statements: <%= ENV['PREPARED_STATEMENTS'] || 'true' %>


### PR DESCRIPTION
I run `RAILS_ENV=production bundle exec rake mastodon:setup`, and it failed with below messages:

```
Prepare the database now? Yes
Running `RAILS_ENV=production rails db:setup` ...


rails aborted!
Cannot load database configuration:
YAML syntax error occurred while parsing /home/mastodon/.rbenv/live/config/database.yml. Please note that YAML must be consistently indented using spaces. Tabs are not allowed. Error: (<unknown>): did not find expected node content while parsing a block node at line 12 column 13
```

The yaml file was broken because the database password started with a comma.
I add double quotes to `<%= ENV['DB_PASS'] %>`, and it worked.