### PR TITLE
fix #17601 change `:keys` to `:attribute_names`

### DIFF
--- a/spec/support/matchers/model/model_have_error_on_field.rb
+++ b/spec/support/matchers/model/model_have_error_on_field.rb
@@ -8,7 +8,7 @@ RSpec::Matchers.define :model_have_error_on_field do |expected|
   end
 
   failure_message do |record|
-    keys = record.errors.keys
+    keys = record.errors.attribute_names
 
     "expect record.errors(#{keys}) to include #{expected}"
   end


### PR DESCRIPTION
My bad  @ClearlyClaire, I thought I had already submitted one.

I let the `:has_keys?` method as it is not concerned by a depreciation warning.