### PR TITLE
Fix error when a MX is shared across blocked domains

### DIFF
--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -38,6 +38,8 @@ module Admin
           log_action :create, @email_domain_block
 
           (@email_domain_block.other_domains || []).uniq.each do |domain|
+            next if EmailDomainBlock.where(domain: domain).exists?
+
             other_email_domain_block = EmailDomainBlock.create!(domain: domain, parent: @email_domain_block)
             log_action :create, other_email_domain_block
           end


### PR DESCRIPTION
In some cases, a common MX server will be used to serve different domains. When blocking a domain, a moderator can't know whether a MX record is already covered by another email domain block. Instead of failing with a cryptic error when there is a duplicate, just ignore the MX record.

The drawback is that if the other domain is unblocked, the MX will be unblocked to, but we can't get around it with the current database schema.