### PR TITLE
Fix remote reports with comments revealing remote reporter

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1367,16 +1367,20 @@ a.sparkline {
       line-height: 20px;
       margin-bottom: 4px;
 
-      .username a {
+      .username {
         color: $primary-text-color;
         font-weight: 500;
-        text-decoration: none;
         margin-right: 5px;
 
-        &:hover,
-        &:focus,
-        &:active {
-          text-decoration: underline;
+        a {
+          color: inherit;
+          text-decoration: none;
+
+          &:hover,
+          &:focus,
+          &:active {
+            text-decoration: underline;
+          }
         }
       }
 

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -130,7 +130,7 @@
 
       .report-notes__item__header
         %span.username
-          = link_to display_name(@report.account), admin_account_path(@report.account_id)
+          = link_to @report.account.username, admin_account_path(@report.account_id)
         %time{ datetime: @report.created_at.iso8601, title: l(@report.created_at) }
           - if @report.created_at.today?
             = t('admin.report_notes.today_at', time: l(@report.created_at, format: :time))

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -127,7 +127,7 @@
   - elsif @report.account.local?
     %p= t('admin.reports.comment_description_html', name: content_tag(:strong, @report.account.username, class: 'username'))
   - else
-    %p= t('admin.reports.comment_description_html', name: t('admin.reports.remote_user_placeholder'))
+    %p= t('admin.reports.comment_description_html', name: t('admin.reports.remote_user_placeholder', instance: @report.account.domain))
 
   .report-notes
     .report-notes__item

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -143,7 +143,7 @@
           - elsif @report.account.local?
             = link_to @report.account.username, admin_account_path(@report.account_id)
           - else
-            = @report.account.domain
+            = link_to @report.account.domain, admin_instance_path(@report.account.domain)
         %time{ datetime: @report.created_at.iso8601, title: l(@report.created_at) }
           - if @report.created_at.today?
             = t('admin.report_notes.today_at', time: l(@report.created_at, format: :time))

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -122,15 +122,28 @@
 = react_admin_component :report_reason_selector, id: @report.id, category: @report.category, rule_ids: @report.rule_ids&.map(&:to_s), disabled: @report.action_taken?
 
 - if @report.comment.present?
-  %p= t('admin.reports.comment_description_html', name: content_tag(:strong, @report.account.username, class: 'username'))
+  - if @report.account.instance_actor?
+    %p= t('admin.reports.comment_description_html', name: content_tag(:strong, site_hostname, class: 'username'))
+  - elsif @report.account.local?
+    %p= t('admin.reports.comment_description_html', name: content_tag(:strong, @report.account.username, class: 'username'))
+  - else
+    %p= t('admin.reports.comment_description_html', name: t('admin.reports.remote_user_placeholder'))
 
   .report-notes
     .report-notes__item
-      = image_tag @report.account.avatar.url, class: 'report-notes__item__avatar'
+      - if @report.account.local? && !@report.account.instance_actor?
+        = image_tag @report.account.avatar.url, class: 'report-notes__item__avatar'
+      - else
+        = image_tag(full_asset_url('avatars/original/missing.png', skip_pipeline: true), class: 'report-notes__item__avatar')
 
       .report-notes__item__header
         %span.username
-          = link_to @report.account.username, admin_account_path(@report.account_id)
+          - if @report.account.instance_actor?
+            = site_hostname
+          - elsif @report.account.local?
+            = link_to @report.account.username, admin_account_path(@report.account_id)
+          - else
+            = @report.account.domain
         %time{ datetime: @report.created_at.iso8601, title: l(@report.created_at) }
           - if @report.created_at.today?
             = t('admin.report_notes.today_at', time: l(@report.created_at, format: :time))

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -623,7 +623,7 @@ en:
       reported_by: Reported by
       resolved: Resolved
       resolved_msg: Report successfully resolved!
-      remote_user_placeholder: the remote user
+      remote_user_placeholder: the remote user from %{instance}
       skip_to_actions: Skip to actions
       status: Status
       statuses: Reported content

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -623,6 +623,7 @@ en:
       reported_by: Reported by
       resolved: Resolved
       resolved_msg: Report successfully resolved!
+      remote_user_placeholder: the remote user
       skip_to_actions: Skip to actions
       status: Status
       statuses: Reported content

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -617,13 +617,13 @@ en:
         title: Notes
       notes_description_html: View and leave notes to other moderators and your future self
       quick_actions_description_html: 'Take a quick action or scroll down to see reported content:'
+      remote_user_placeholder: the remote user from %{instance}
       reopen: Reopen report
       report: 'Report #%{id}'
       reported_account: Reported account
       reported_by: Reported by
       resolved: Resolved
       resolved_msg: Report successfully resolved!
-      remote_user_placeholder: the remote user from %{instance}
       skip_to_actions: Skip to actions
       status: Status
       statuses: Reported content


### PR DESCRIPTION
Fix an oversight when a remote report contains a comment.

Also change that comment section to use the username rather than the display name, for consistency with report comments.

## Before

![image](https://user-images.githubusercontent.com/384364/155857130-a594ee2e-3c35-4b98-b755-a2b797f19dbd.png)

## After

![image](https://user-images.githubusercontent.com/384364/155857393-086bf361-8e3e-4eca-9c21-ed1579b9a0f3.png)