### PR TITLE
Fix leak of existence of otherwise inaccessible statuses in REST API

### DIFF
--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -92,8 +92,9 @@ class Api::V1::StatusesController < Api::BaseController
   end
 
   def set_thread
-    @thread = status_params[:in_reply_to_id].blank? ? nil : Status.find(status_params[:in_reply_to_id])
-  rescue ActiveRecord::RecordNotFound
+    @thread = Status.find(status_params[:in_reply_to_id]) if status_params[:in_reply_to_id].present?
+    authorize(@thread, :show?) if @thread.present?
+  rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     render json: { error: I18n.t('statuses.errors.in_reply_not_found') }, status: 404
   end
 


### PR DESCRIPTION
There is no practical application of this information, however.