### PR TITLE
Fix rare race condition when rebloged status is deleted

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -303,6 +303,8 @@ class Status < ApplicationRecord
   after_create_commit :store_uri, if: :local?
   after_create_commit :update_statistics, if: :local?
 
+  after_create_commit :check_reblog, if: :reblog?
+
   around_create Mastodon::Snowflake::Callbacks
 
   before_validation :prepare_contents, if: :local?
@@ -465,5 +467,9 @@ class Status < ApplicationRecord
     inbox_owners.each do |inbox_owner|
       AccountConversation.remove_status(inbox_owner, self)
     end
+  end
+
+  def check_reblog
+    discard unless Status.where(id: reblog_of_id, deleted_at: nil).exists?
   end
 end


### PR DESCRIPTION
In some cases, it's possible for a reblog to be created and not marked as discarded while the underlying status is discarded, causing `status.reblog?` to be `true` yet `status.reblog` and `status.proper` to be `nil`.

Note that this does not retroactively fix such records nor does it fix the call sites that use `status.reblog` or `status.proper`.