### PR TITLE
Fix Updates being forwarded even when not processable or causing no change

### DIFF
--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -26,10 +26,6 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
 
     return if @status.nil?
 
-    forwarder.forward! if ActivityPub::ProcessStatusUpdateService.new.call(@status, @object) && forwarder.forwardable?
-  end
-
-  def forwarder
-    @forwarder ||= ActivityPub::Forwarder.new(@account, @json, @status)
+    ActivityPub::ProcessStatusUpdateService.new.call(@status, @object)
   end
 end

--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -26,6 +26,10 @@ class ActivityPub::Activity::Update < ActivityPub::Activity
 
     return if @status.nil?
 
-    ActivityPub::ProcessStatusUpdateService.new.call(@status, @object)
+    forwarder.forward! if ActivityPub::ProcessStatusUpdateService.new.call(@status, @object) && forwarder.forwardable?
+  end
+
+  def forwarder
+    @forwarder ||= ActivityPub::Forwarder.new(@account, @json, @status)
   end
 end

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -13,7 +13,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     @poll_changed              = false
 
     # Only native types can be updated at the moment
-    return if !expected_type? || already_updated_more_recently?
+    return false if !expected_type? || already_updated_more_recently?
 
     # Only allow processing one create/update per status at a time
     RedisLock.acquire(lock_options) do |lock|
@@ -37,6 +37,8 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
         raise Mastodon::RaceConditionError
       end
     end
+
+    significant_changes?
   end
 
   private


### PR DESCRIPTION
Before #17698, `Update` activities were forwarded as long as they were signed and targeted a known status, causing accidental back-and-forth forwarding between instances.

This PR reintroduces forwarding, but with those additional requirements:
- the `Update` must be processeable by Mastodon
- it must have resulted in a “significant change” (e.g., not be a poll vote update)
- it must have an edit date strictly newer than the last known edit, so that even if something is amiss with the previous condition, an activity will not be forwarded twice by the same instance