### PR TITLE
Enable importing GIF emojis through CLI

### DIFF
--- a/lib/mastodon/emoji_cli.rb
+++ b/lib/mastodon/emoji_cli.rb
@@ -41,7 +41,7 @@ module Mastodon
 
       Gem::Package::TarReader.new(Zlib::GzipReader.open(path)) do |tar|
         tar.each do |entry|
-          next unless entry.file? && entry.full_name.end_with?('.png')
+          next unless entry.file? && entry.full_name.end_with?('.png', '.gif')
 
           filename = File.basename(entry.full_name, '.*')
 


### PR DESCRIPTION
While creating GIF emojis via the web interface works as expected, this was not yet enabled in the CLI. The filter has been expanded from allowing files with PNG extensions to files with either PNG or GIF extensions.

Fixes #17303 