### PR TITLE
Inform user when hashtag limit for a pinned hashtags filter has been reached

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
@@ -2,6 +2,12 @@ import { connect } from 'react-redux';
 import ColumnSettings from '../components/column_settings';
 import { changeColumnParams } from '../../../actions/columns';
 import api from '../../../api';
+import { showAlert } from '../../../actions/alerts';
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+  tooManyHashtags: { id: 'column_settings.too_many_hashtags', defaultMessage: 'A maximum of 4 hashtags can be added to a filter.' },
+});
 
 const mapStateToProps = (state, { columnId }) => {
   const columns = state.getIn(['settings', 'columns']);
@@ -25,7 +31,11 @@ const mapStateToProps = (state, { columnId }) => {
 
 const mapDispatchToProps = (dispatch, { columnId }) => ({
   onChange (key, value) {
-    dispatch(changeColumnParams(columnId, key, value));
+    if (value.length > 4) {
+      dispatch(showAlert(undefined, messages.tooManyHashtags));
+    } else {
+      dispatch(changeColumnParams(columnId, key, value));
+    }
   },
 });
 


### PR DESCRIPTION
While a limit on the number of applied hashtags in a filter is already in place, any hashtag beyond the fourth will be silently ignored. This adds an explicit error message if the user tries adding more than 4 tags.

Fixes #15194 