### PR TITLE
Check media attachment size limit on client side before uploading

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -232,9 +232,16 @@ export function uploadCompose(files) {
     const media  = getState().getIn(['compose', 'media_attachments']);
     const pending  = getState().getIn(['compose', 'pending_media_attachments']);
     const progress = new Array(files.length).fill(0);
-    let total = Array.from(files).reduce((a, v) => a + v.size, 0);
+    const filesArray = Array.from(files);
+    const imageSizeLimit = 1024 * 1024 * 10;
+    const videoSizeLimit = 1024 * 1024 * 40;
+    let total = filesArray.reduce((a, v) => a + v.size, 0);
 
-    if (files.length + media.size + pending > uploadLimit) {
+    if (
+      filesArray.some(file =>
+        (file.type.match(/video\/.*/) && file.size > videoSizeLimit)
+        || (file.type.match(/image\/.*/) && file.size > imageSizeLimit))
+      || (files.length + media.size + pending > uploadLimit)) {
       dispatch(showAlert(undefined, messages.uploadErrorLimit));
       return;
     }


### PR DESCRIPTION
The user is informed whether a media attachment is too large after it has already been uploaded, which is inconvenient for the user as the faulty upload may take a long time before an error is returned. This adds the size limits from the backend (40MB for videos, 10MB for images) to the frontend as well, giving the user immediate feedback.

This might be an overly granular way of specifying whether or not an attachment is too large, but I wasn't quite sure yet.

Fixes #16718