### PR TITLE
Fix data integrity of featured tags

### DIFF
--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -4,8 +4,8 @@
 # Table name: featured_tags
 #
 #  id             :bigint(8)        not null, primary key
-#  account_id     :bigint(8)
-#  tag_id         :bigint(8)
+#  account_id     :bigint(8)        not null
+#  tag_id         :bigint(8)        not null
 #  statuses_count :bigint(8)        default(0), not null
 #  last_status_at :datetime
 #  created_at     :datetime         not null

--- a/db/migrate/20220307094650_fix_featured_tags_constraints.rb
+++ b/db/migrate/20220307094650_fix_featured_tags_constraints.rb
@@ -1,0 +1,17 @@
+class FixFeaturedTagsConstraints < ActiveRecord::Migration[6.1]
+  def up
+    safety_assured do
+      execute 'DELETE FROM featured_tags WHERE tag_id IS NULL'
+      change_column_null :featured_tags, :tag_id, false
+      execute 'DELETE FROM featured_tags WHERE account_id IS NULL'
+      change_column_null :featured_tags, :account_id, false
+    end
+  end
+
+  def down
+    safety_assured do
+      change_column_null :featured_tags, :tag_id, true
+      change_column_null :featured_tags, :account_id, true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_04_195405) do
+ActiveRecord::Schema.define(version: 2022_03_07_094650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -420,8 +420,8 @@ ActiveRecord::Schema.define(version: 2022_03_04_195405) do
   end
 
   create_table "featured_tags", force: :cascade do |t|
-    t.bigint "account_id"
-    t.bigint "tag_id"
+    t.bigint "account_id", null: false
+    t.bigint "tag_id", null: false
     t.bigint "statuses_count", default: 0, null: false
     t.datetime "last_status_at"
     t.datetime "created_at", null: false


### PR DESCRIPTION
I am not sure why this was not enforced before. There is no use case I can think of where a featured tag should have no account or no tag it belongs to.