### PR TITLE
Add i2p addresses alongside onion address for changed HTTPs handling

### DIFF
--- a/app/lib/webfinger.rb
+++ b/app/lib/webfinger.rb
@@ -90,7 +90,7 @@ class Webfinger
   end
 
   def standard_url
-    if @domain.end_with? ".onion"
+    if @domain.end_with?(".onion", ".i2p")
       "http://#{@domain}/.well-known/webfinger?resource=#{@uri}"
     else
       "https://#{@domain}/.well-known/webfinger?resource=#{@uri}"
@@ -98,7 +98,7 @@ class Webfinger
   end
 
   def host_meta_url
-    if @domain.end_with? ".onion"
+    if @domain.end_with?(".onion","i2p")
       "http://#{@domain}/.well-known/host-meta"
     else
       "https://#{@domain}/.well-known/host-meta"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = {
     redirect: {
-      exclude: -> request { request.path.start_with?('/health') || request.headers["Host"].end_with?('.onion') }
+      exclude: -> request { request.path.start_with?('/health') || request.headers["Host"].end_with?('.onion', 'i2p') }
     }
   }
 

--- a/lib/action_dispatch/cookie_jar_extensions.rb
+++ b/lib/action_dispatch/cookie_jar_extensions.rb
@@ -7,7 +7,7 @@ module ActionDispatch
     # Monkey-patch ActionDispatch to serve secure cookies to Tor Hidden Service
     # users. Otherwise, ActionDispatch would drop the cookie over HTTP.
     def write_cookie?(*)
-      request.host.end_with?('.onion') || super
+      request.host.end_with?('.onion', '.i2p') || super
     end
   end
 end
@@ -17,7 +17,7 @@ ActionDispatch::Cookies::CookieJar.prepend(ActionDispatch::CookieJarExtensions)
 module Rack
   module SessionPersistedExtensions
     def security_matches?(request, options)
-      request.host.end_with?('.onion') || super
+      request.host.end_with?('.onion', '.i2p') || super
     end
   end
 end


### PR DESCRIPTION
We could probably expand this list to include all the other hidden service TLDs but I'll leave that to the next person.