### PR TITLE
Change text version of warning mail to mention appeals instead of mails

### DIFF
--- a/app/views/user_mailer/warning.text.erb
+++ b/app/views/user_mailer/warning.text.erb
@@ -32,4 +32,5 @@
 ---
 <% end %>
 
-<%= t 'user_mailer.warning.get_in_touch', instance: @instance %>
+<%= t 'user_mailer.warning.appeal_description', instance: @instance %>
+<%= disputes_strike_url(@warning) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1651,7 +1651,6 @@ en:
         sensitive: From now on, all your uploaded media files will be marked as sensitive and hidden behind a click-through warning.
         silence: You can still use your account but only people who are already following you will see your posts on this server, and you may be excluded from various discovery features. However, others may still manually follow you.
         suspend: You can no longer use your account, and your profile and other data are no longer accessible. You can still login to request a backup of your data until the data is fully removed in about 30 days, but we will retain some basic data to prevent you from evading the suspension.
-      get_in_touch: If you believe this is an error, you can reply to this e-mail to get in touch with the staff of %{instance}.
       reason: 'Reason:'
       statuses: 'Posts cited:'
       subject:


### PR DESCRIPTION
Also, the instruction to reply to e-mail would probably not work in many cases where the notifications e-mail address is not able to receive incoming emails or the mailbox is not actively monitored.

~~Also do not link to deleted statuses since it'll raise a not found error anyway.~~