### PR TITLE
Fix a type error in domain_block policies

### DIFF
--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -32,7 +32,7 @@ class DomainBlock < ApplicationRecord
 
   def policies
     if suspend?
-      :suspend
+      [:suspend]
     else
       [severity.to_sym, reject_media? ? :reject_media : nil, reject_reports? ? :reject_reports : nil].reject { |policy| policy == :noop || policy.nil? }
     end


### PR DESCRIPTION
Returns an array, since an array is expected