### PR TITLE
Fix moderator account leak in status edit history

### DIFF
--- a/app/models/admin/status_batch_action.rb
+++ b/app/models/admin/status_batch_action.rb
@@ -68,6 +68,8 @@ class Admin::StatusBatchAction
   end
 
   def handle_mark_as_sensitive!
+    representative_account = Account.representative
+
     # Can't use a transaction here because UpdateStatusService queues
     # Sidekiq jobs
     statuses.includes(:media_attachments, :preview_cards).find_each do |status|
@@ -76,7 +78,7 @@ class Admin::StatusBatchAction
       authorize(status, :update?)
 
       if target_account.local?
-        UpdateStatusService.new.call(status, current_account.id, sensitive: true)
+        UpdateStatusService.new.call(status, representative_account.id, sensitive: true)
       else
         status.update(sensitive: true)
       end


### PR DESCRIPTION
Status edit history shows the account that performed the edit. When a moderator marks statuses as sensitive, this is recorded as an edit. Use a representative account so as to not reveal which moderator performed the action.