### PR TITLE
Fix nil error when trying to fetch key for signature verification

### DIFF
--- a/app/helpers/jsonld_helper.rb
+++ b/app/helpers/jsonld_helper.rb
@@ -54,7 +54,7 @@ module JsonLdHelper
   end
 
   def unsupported_uri_scheme?(uri)
-    !uri.start_with?('http://', 'https://')
+    uri.nil? || !uri.start_with?('http://', 'https://')
   end
 
   def invalid_origin?(url)


### PR DESCRIPTION
The method is called from `fetch_resource` on a possibly non-existent key.