### PR TITLE
Add menu column of explore to getting-started

### DIFF
--- a/app/javascript/mastodon/features/getting_started/index.js
+++ b/app/javascript/mastodon/features/getting_started/index.js
@@ -21,6 +21,7 @@ const messages = defineMessages({
   public_timeline: { id: 'navigation_bar.public_timeline', defaultMessage: 'Federated timeline' },
   settings_subheading: { id: 'column_subheading.settings', defaultMessage: 'Settings' },
   community_timeline: { id: 'navigation_bar.community_timeline', defaultMessage: 'Local timeline' },
+  explore: { id: 'navigation_bar.explore', defaultMessage: 'Explore' },
   direct: { id: 'navigation_bar.direct', defaultMessage: 'Direct messages' },
   bookmarks: { id: 'navigation_bar.bookmarks', defaultMessage: 'Bookmarks' },
   preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
@@ -99,9 +100,10 @@ class GettingStarted extends ImmutablePureComponent {
         <ColumnSubheading key='header-discover' text={intl.formatMessage(messages.discover)} />,
         <ColumnLink key='community_timeline' icon='users' text={intl.formatMessage(messages.community_timeline)} to='/public/local' />,
         <ColumnLink key='public_timeline' icon='globe' text={intl.formatMessage(messages.public_timeline)} to='/public' />,
+        <ColumnLink key='explore' icon='globe' text={intl.formatMessage(messages.explore)} to='/explore' />,
       );
 
-      height += 34 + 48*2;
+      height += 34 + 48*3;
 
       navItems.push(
         <ColumnSubheading key='header-personal' text={intl.formatMessage(messages.personal)} />,

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -1957,6 +1957,10 @@
         "id": "navigation_bar.community_timeline"
       },
       {
+        "defaultMessage": "Explore",
+        "id": "navigation_bar.explore"
+      },
+      {
         "defaultMessage": "Direct messages",
         "id": "navigation_bar.direct"
       },

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -294,6 +294,7 @@
   "navigation_bar.discover": "Discover",
   "navigation_bar.domain_blocks": "Blocked domains",
   "navigation_bar.edit_profile": "Edit profile",
+  "navigation_bar.explore": "Explore",
   "navigation_bar.favourites": "Favourites",
   "navigation_bar.filters": "Muted words",
   "navigation_bar.follow_requests": "Follow requests",


### PR DESCRIPTION
"Explore" has been added but it is not visible in the "advanced web interface".
This adds that menu item.
<img width="345" alt="2022-03-13 11 36 46" src="https://user-images.githubusercontent.com/766076/158042545-b08be0e0-3462-4414-8b1c-8dc6c6db3134.png">

By the way, I'm thinking about what to do about the problem that the "Federated timeline" and "Explore" icons are the same.
