### PR TITLE
Add `types` param to `GET /api/v1/notifications` in REST API

### DIFF
--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -35,13 +35,18 @@ class Api::V1::NotificationsController < Api::BaseController
       limit_param(DEFAULT_NOTIFICATIONS_LIMIT),
       params_slice(:max_id, :since_id, :min_id)
     )
+
     Notification.preload_cache_collection_target_statuses(notifications) do |target_statuses|
       cache_collection(target_statuses, Status)
     end
   end
 
   def browserable_account_notifications
-    current_account.notifications.without_suspended.browserable(exclude_types, from_account)
+    current_account.notifications.without_suspended.browserable(
+      types: Array(browserable_params[:types]),
+      exclude_types: Array(browserable_params[:exclude_types]),
+      from_account_id: browserable_params[:account_id]
+    )
   end
 
   def target_statuses_from_notifications
@@ -72,17 +77,11 @@ class Api::V1::NotificationsController < Api::BaseController
     @notifications.first.id
   end
 
-  def exclude_types
-    val = params.permit(exclude_types: [])[:exclude_types] || []
-    val = [val] unless val.is_a?(Enumerable)
-    val
-  end
-
-  def from_account
-    params[:account_id]
+  def browserable_params
+    params.permit(:account_id, types: [], exclude_types: [])
   end
 
   def pagination_params(core_params)
-    params.slice(:limit, :exclude_types).permit(:limit, exclude_types: []).merge(core_params)
+    params.slice(:limit, :account_id, :types, :exclude_types).permit(:limit, :account_id, types: [], exclude_types: []).merge(core_params)
   end
 end

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -70,19 +70,19 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       end
 
       it 'includes reblog' do
-        expect(assigns(:notifications).map(&:activity)).to include(@reblog_of_first_status)
+        expect(body_as_json.map { |x| x[:type] }).to include 'reblog'
       end
 
       it 'includes mention' do
-        expect(assigns(:notifications).map(&:activity)).to include(@mention_from_status)
+        expect(body_as_json.map { |x| x[:type] }).to include 'mention'
       end
 
       it 'includes favourite' do
-        expect(assigns(:notifications).map(&:activity)).to include(@favourite)
+        expect(body_as_json.map { |x| x[:type] }).to include 'favourite'
       end
 
       it 'includes follow' do
-        expect(assigns(:notifications).map(&:activity)).to include(@follow)
+        expect(body_as_json.map { |x| x[:type] }).to include 'follow'
       end
     end
 
@@ -96,7 +96,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       end
 
       it 'returns only notifications from specified user' do
-        expect(assigns(:notifications).map(&:from_account_id).uniq).to eq [third.account.id]
+        expect(body_as_json.map { |x| x[:account][:id] }.uniq).to eq [third.account.id.to_s]
       end
     end
 
@@ -110,7 +110,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       end
 
       it 'returns nothing' do
-        expect(assigns(:notifications)).to be_empty
+        expect(body_as_json.size).to eq 0
       end
     end
 
@@ -124,7 +124,8 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       end
 
       it 'returns everything but excluded type' do
-        expect(assigns(:notifications).map(&:type).uniq).to_not include(:mention)
+        expect(body_as_json.size).to_not eq 0
+        expect(body_as_json.map { |x| x[:type] }.uniq).to_not include 'mention'
       end
     end
 
@@ -138,7 +139,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       end
 
       it 'returns only requested type' do
-        expect(assigns(:notifications).map(&:type).uniq).to eq %i(mention)
+        expect(body_as_json.map { |x| x[:type] }.uniq).to eq ['mention']
       end
     end
   end

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
       end
     end
 
-    describe 'from specified user' do
+    describe 'with account_id param' do
       before do
         get :index, params: { account_id: third.account.id }
       end
@@ -95,28 +95,12 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
         expect(response).to have_http_status(200)
       end
 
-      it 'includes favourite' do
-        expect(assigns(:notifications).map(&:activity)).to include(@second_favourite)
-      end
-
-      it 'excludes favourite' do
-        expect(assigns(:notifications).map(&:activity)).to_not include(@favourite)
-      end
-
-      it 'excludes mention' do
-        expect(assigns(:notifications).map(&:activity)).to_not include(@mention_from_status)
-      end
-
-      it 'excludes reblog' do
-        expect(assigns(:notifications).map(&:activity)).to_not include(@reblog_of_first_status)
-      end
-
-      it 'excludes follow' do
-        expect(assigns(:notifications).map(&:activity)).to_not include(@follow)
+      it 'returns only notifications from specified user' do
+        expect(assigns(:notifications).map(&:from_account_id).uniq).to eq [third.account.id]
       end
     end
 
-    describe 'from nonexistent user' do
+    describe 'with invalid account_id param' do
       before do
         get :index, params: { account_id: 'foo' }
       end
@@ -125,54 +109,36 @@ RSpec.describe Api::V1::NotificationsController, type: :controller do
         expect(response).to have_http_status(200)
       end
 
-      it 'excludes favourite' do
-        expect(assigns(:notifications).map(&:activity)).to_not include(@favourite)
-      end
-
-      it 'excludes second favourite' do
-        expect(assigns(:notifications).map(&:activity)).to_not include(@second_favourite)
-      end
-
-      it 'excludes mention' do
-        expect(assigns(:notifications).map(&:activity)).to_not include(@mention_from_status)
-      end
-
-      it 'excludes reblog' do
-        expect(assigns(:notifications).map(&:activity)).to_not include(@reblog_of_first_status)
-      end
-
-      it 'excludes follow' do
-        expect(assigns(:notifications).map(&:activity)).to_not include(@follow)
+      it 'returns nothing' do
+        expect(assigns(:notifications)).to be_empty
       end
     end
 
-    describe 'with excluded mentions' do
+    describe 'with excluded_types param' do
       before do
-        get :index, params: { exclude_types: ['mention'] }
+        get :index, params: { exclude_types: %w(mention) }
       end
 
       it 'returns http success' do
         expect(response).to have_http_status(200)
       end
 
-      it 'includes reblog' do
-        expect(assigns(:notifications).map(&:activity)).to include(@reblog_of_first_status)
+      it 'returns everything but excluded type' do
+        expect(assigns(:notifications).map(&:type).uniq).to_not include(:mention)
+      end
+    end
+
+    describe 'with types param' do
+      before do
+        get :index, params: { types: %w(mention) }
       end
 
-      it 'excludes mention' do
-        expect(assigns(:notifications).map(&:activity)).to_not include(@mention_from_status)
+      it 'returns http success' do
+        expect(response).to have_http_status(200)
       end
 
-      it 'includes favourite' do
-        expect(assigns(:notifications).map(&:activity)).to include(@favourite)
-      end
-
-      it 'includes third favourite' do
-        expect(assigns(:notifications).map(&:activity)).to include(@second_favourite)
-      end
-
-      it 'includes follow' do
-        expect(assigns(:notifications).map(&:activity)).to include(@follow)
+      it 'returns only requested type' do
+        expect(assigns(:notifications).map(&:type).uniq).to eq %i(mention)
       end
     end
   end


### PR DESCRIPTION
Instead of specifying every known type to exclude, you can specify only the types you want.