### PR TITLE
Fix LetterOpennerWeb CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -60,4 +60,20 @@ Rails.application.reloader.to_prepare do
   PgHero::HomeController.after_action do
     request.content_security_policy_nonce_generator = nil
   end
+
+  if Rails.env.development?
+    LetterOpenerWeb::LettersController.content_security_policy do |p|
+      p.child_src       :self
+      p.connect_src     :none
+      p.frame_ancestors :self
+      p.frame_src       :self
+      p.script_src      :unsafe_inline
+      p.style_src       :unsafe_inline
+      p.worker_src      :none
+    end
+
+    LetterOpenerWeb::LettersController.after_action do |p|
+      request.content_security_policy_nonce_directives = %w(script-src)
+    end
+  end
 end


### PR DESCRIPTION
Fix `/letter_opener` was not reflecting style sheets and scripts.