### PR TITLE
Change Dockerfile to use distribution-provided Ruby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,31 +26,20 @@ RUN ARCH= && \
 	rm node-v$NODE_VER-linux-$ARCH.tar.gz && \
 	mv node-v$NODE_VER-linux-$ARCH /opt/node
 
-# Install Ruby 3.0
-ENV RUBY_VER="3.0.3"
+# Install Ruby
 RUN apt-get update && \
   apt-get install -y --no-install-recommends build-essential \
-    bison libyaml-dev libgdbm-dev libreadline-dev libjemalloc-dev \
-		libncurses5-dev libffi-dev zlib1g-dev libssl-dev && \
-	cd ~ && \
-	wget https://cache.ruby-lang.org/pub/ruby/${RUBY_VER%.*}/ruby-$RUBY_VER.tar.gz && \
-	tar xf ruby-$RUBY_VER.tar.gz && \
-	cd ruby-$RUBY_VER && \
-	./configure --prefix=/opt/ruby \
-	  --with-jemalloc \
-	  --with-shared \
-	  --disable-install-doc && \
-	make -j"$(nproc)" > /dev/null && \
-	make install && \
-	rm -rf ../ruby-$RUBY_VER.tar.gz ../ruby-$RUBY_VER
+    libyaml-dev libgdbm-dev libreadline-dev libjemalloc-dev \
+    libncurses5-dev libffi-dev zlib1g-dev libssl-dev \
+    ruby ruby-dev
 
-ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin"
+ENV PATH="${PATH}:/opt/node/bin"
 
 RUN npm install -g npm@latest && \
 	npm install -g yarn && \
 	gem install bundler && \
 	apt-get update && \
-	apt-get install -y --no-install-recommends git libicu-dev libidn12-dev \
+	apt-get install -y --no-install-recommends git libicu-dev libidn-dev \
 	libpq-dev shared-mime-info
 
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
@@ -66,7 +55,6 @@ FROM ubuntu:22.04
 
 # Copy over all the langs needed for runtime
 COPY --from=build-dep /opt/node /opt/node
-COPY --from=build-dep /opt/ruby /opt/ruby
 
 # Add more PATHs to the PATH
 ENV PATH="${PATH}:/opt/ruby/bin:/opt/node/bin:/opt/mastodon/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as build-dep
+FROM ubuntu:22.04 as build-dep
 
 # Use bash for the shell
 SHELL ["/bin/bash", "-c"]
@@ -19,7 +19,7 @@ RUN ARCH= && \
   esac && \
     echo "Etc/UTC" > /etc/localtime && \
 	apt-get update && \
-	apt-get install -y --no-install-recommends ca-certificates wget python apt-utils && \
+	apt-get install -y --no-install-recommends ca-certificates wget python-is-python3 apt-utils && \
 	cd ~ && \
 	wget -q https://nodejs.org/download/release/v$NODE_VER/node-v$NODE_VER-linux-$ARCH.tar.gz && \
 	tar xf node-v$NODE_VER-linux-$ARCH.tar.gz && \
@@ -50,7 +50,7 @@ RUN npm install -g npm@latest && \
 	npm install -g yarn && \
 	gem install bundler && \
 	apt-get update && \
-	apt-get install -y --no-install-recommends git libicu-dev libidn11-dev \
+	apt-get install -y --no-install-recommends git libicu-dev libidn12-dev \
 	libpq-dev shared-mime-info
 
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
@@ -62,7 +62,7 @@ RUN cd /opt/mastodon && \
 	bundle install -j"$(nproc)" && \
 	yarn install --pure-lockfile
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Copy over all the langs needed for runtime
 COPY --from=build-dep /opt/node /opt/node
@@ -87,8 +87,8 @@ RUN apt-get update && \
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt-get update && \
   apt-get -y --no-install-recommends install \
-	  libssl1.1 libpq5 imagemagick ffmpeg libjemalloc2 \
-	  libicu66 libidn11 libyaml-0-2 \
+	  libssl3 libpq5 imagemagick ffmpeg libjemalloc2 \
+	  libicu70 libidn12 libyaml-0-2 \
 	  file ca-certificates tzdata libreadline8 gcc tini apt-utils && \
 	ln -s /opt/mastodon /mastodon && \
 	gem install bundler && \


### PR DESCRIPTION
This switches to ubuntu 22.04 and use the distribution-provided ruby, which is Ruby 3.0.2. The main reason is to avoid having to compile Ruby, which takes forever when building arm64 images (they seem to be built using qemu…)

TODO:
- [ ] add back jemalloc somehow (probably using `LD_PRELOAD`)
- [ ] test