### PR TITLE
Replace metadata-action type to match

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -30,7 +30,7 @@ jobs:
             latest=auto
           tags: |
             type=edge,branch=main
-            type=semver,pattern={{ raw }}
+            type=match,pattern=v(.*),group=0
             type=ref,event=pr
       - uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Mastodon tags don't work with `type=semver` because it strictly contradicts semver. Replace with `type=match`.

see https://github.com/docker/metadata-action#typematch