### PR TITLE
Fix “edited at” in public pages not being properly localized

### DIFF
--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -29,7 +29,7 @@
         %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
       - if status.edited?
         ·
-        = t('statuses.edited_at', date: l(status.edited_at))
+        = t('statuses.edited_at_html', date: content_tag(:time, l(status.edited_at), datetime: status.edited_at.iso8601, title: l(status.edited_at), class: 'formatted'))
       - if status.discarded?
         ·
         %span.negative-hint= t('admin.statuses.deleted')

--- a/app/views/statuses/_detailed_status.html.haml
+++ b/app/views/statuses/_detailed_status.html.haml
@@ -44,7 +44,7 @@
       %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
     ·
     - if status.edited?
-      = t('statuses.edited_at', date: l(status.edited_at))
+      = t('statuses.edited_at_html', date: content_tag(:time, l(status.edited_at), datetime: status.edited_at.iso8601, title: l(status.edited_at), class: 'formatted'))
       ·
     %span.detailed-status__visibility-icon
       = visibility_icon status

--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -8,7 +8,7 @@
         = visibility_icon status
       %time.time-ago{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
       - if status.edited?
-        %abbr{ title: t('statuses.edited_at', date: l(status.edited_at.to_date)) }
+        %abbr{ title: t('statuses.edited_at_html', date: l(status.edited_at.to_date)) }
           *
     %data.dt-published{ value: status.created_at.to_time.iso8601 }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1438,7 +1438,7 @@ en:
     disallowed_hashtags:
       one: 'contained a disallowed hashtag: %{tags}'
       other: 'contained the disallowed hashtags: %{tags}'
-    edited_at: Edited %{date}
+    edited_at_html: Edited %{date}
     errors:
       in_reply_not_found: The post you are trying to reply to does not appear to exist.
     open_in_web: Open in web


### PR DESCRIPTION
Fixes #17804

I'm not super happy having `edited_at_html` used both for the actual HTML bit and the `title`, but I don't think this warrants two different strings either.