### PR TITLE
docker-compose: Only build/compile an image once for web/streaming/sidekiq services.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,9 @@ services:
 #        hard: -1
 
   web:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
@@ -64,7 +66,6 @@ services:
       - ./public/system:/mastodon/public/system
 
   streaming:
-    build: .
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production
@@ -81,7 +82,6 @@ services:
       - redis
 
   sidekiq:
-    build: .
     image: tootsuite/mastodon
     restart: always
     env_file: .env.production


### PR DESCRIPTION
The `docker-compose build` currently completes the build process 3 times - This change triggers the build stage once.