### PR TITLE
Fix query on clean_discarded_statuses

### DIFF
--- a/app/workers/scheduler/user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/user_cleanup_scheduler.rb
@@ -27,7 +27,7 @@ class Scheduler::UserCleanupScheduler
   end
 
   def clean_discarded_statuses!
-    Status.discarded.where('deleted_at <= ?', 30.days.ago).find_in_batches do |statuses|
+    Status.unscoped.discarded.where('deleted_at <= ?', 30.days.ago).find_in_batches do |statuses|
       RemovalWorker.push_bulk(statuses) do |status|
         [status.id, { 'immediate' => true }]
       end


### PR DESCRIPTION
```irb
irb(main):001:0> Status.discarded.where('deleted_at <?', 30.days.ago).to_sql
=> "SELECT \"statuses\".* FROM \"statuses\" WHERE \"statuses\".\"deleted_at\" IS NULL AND \"statuses\".\"deleted_at\" IS NOT NULL AND (deleted_at <'2022-02-16 07:17:47.866763') ORDER BY \"statuses\".\"id\" DESC"
irb(main):002:0> Status.with_discarded.where('deleted_at < ?', 30.days.ago).to_sql
=> "SELECT \"statuses\".* FROM \"statuses\" WHERE (deleted_at < '2022-02-16 07:20:11.330404') ORDER BY \"statuses\".\"id\" DESC"
irb(main):020:0> Status.unscoped.discarded.to_sql
=> "SELECT \"statuses\".* FROM \"statuses\" WHERE \"statuses\".\"deleted_at\" IS NOT NULL"
```

Previous query contains `deleted is null and deleted is not null` which is completely impossible.