### PR TITLE
Bump NODE_VER to 16.14.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-c"]
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Install Node v16 (LTS)
-ENV NODE_VER="16.13.2"
+ENV NODE_VER="16.14.2"
 RUN ARCH= && \
     dpkgArch="$(dpkg --print-architecture)" && \
   case "${dpkgArch##*-}" in \


### PR DESCRIPTION
See the announcement
https://nodejs.org/en/blog/vulnerability/mar-2022-security-releases/