### PR TITLE
Make Mastodon use its own gemset

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+mastodon


### PR DESCRIPTION
Generally, having a gem environment that's specific to the app you're writing is a good idea. If merged, this will implement that.