### PR TITLE
Add workaround for YouTube Shorts links

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -208,7 +208,7 @@ class LinkDetailsExtractor
   end
 
   def valid_url_or_nil(str, same_origin_only: false)
-    return if str.blank?
+    return if str.blank? || str == 'null'
 
     url = @original_url + Addressable::URI.parse(str)
 

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe LinkDetailsExtractor do
       let(:html) { '<!doctype html><link rel="canonical" href="null" />' }
 
       it 'ignores the canonical URLs' do
-        expect(subject.canonical_url).to eq 'https://foo.com/article'
+        expect(subject.canonical_url).to eq original_url
       end
     end
   end

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe LinkDetailsExtractor do
         expect(subject.canonical_url).to eq 'https://foo.com/article'
       end
     end
+
+    context 'when canonical URL is set to "null"' do
+      let(:html) { '<!doctype html><link rel="canonical" href="null" />' }
+
+      it 'ignores the canonical URLs' do
+        expect(subject.canonical_url).to eq 'https://foo.com/article'
+      end
+    end
   end
 
   context 'when structured data is present' do


### PR DESCRIPTION
For an unknown reason, YouTube Shorts advertises a `<link rel="canonical" href="null" />` on their pages. Together with missing OEmbed discovery links, this results in all YouTube shorts getting the same preview card (whichever one was first fetched and saved as `https://www.youtube.com/shorts/null` URL)