### PR TITLE
Add stop delivery link also for failing instance

### DIFF
--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -87,7 +87,8 @@
     - else
       %span.negative-hint
         = t('admin.instances.availability.failures_recorded', count: @instance.delivery_failure_tracker.days)
-        = link_to t('admin.instances.delivery.clear'), clear_delivery_errors_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post } unless @instance.exhausted_deliveries_days.empty?
+        %span= link_to t('admin.instances.delivery.clear'), clear_delivery_errors_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post } unless @instance.exhausted_deliveries_days.empty?
+        %span= link_to t('admin.instances.delivery.stop'), stop_delivery_admin_instance_path(@instance), data: { confirm: t('admin.accounts.are_you_sure'), method: :post }
 
 - if @instance.purgeable?
   %p= t('admin.instances.purge_description_html')


### PR DESCRIPTION
Currently on admin instance page, shows "stop delivery" button for normally available domain and "clear failing" button for failing domain.
But it is more reasonable to have "stop delivery" on failing domain. And there are enough space to have it both