### PR TITLE
Support brotli compression in Rails by rack-brotli gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'rails', '~> 6.1.5'
 gem 'sprockets', '~> 3.7.2'
 gem 'thor', '~> 1.2'
 gem 'rack', '~> 2.2.3'
+gem 'rack-brotli', '~> 1.2.0'
 
 gem 'hamlit-rails', '~> 0.2'
 gem 'pg', '~> 1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -845,9 +845,3 @@ DEPENDENCIES
   webpacker (~> 5.4)
   webpush (~> 0.3)
   xorcist (~> 1.1)
-
-RUBY VERSION
-   ruby 3.0.3p157
-
-BUNDLED WITH
-   2.3.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     bootsnap (1.10.3)
       msgpack (~> 1.2)
     brakeman (5.2.1)
+    brotli (0.4.0)
     browser (4.2.0)
     brpoplpush-redis_script (0.1.2)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -468,6 +469,9 @@ GEM
     rack (2.2.3)
     rack-attack (6.6.0)
       rack (>= 1.0, < 3)
+    rack-brotli (1.2.0)
+      brotli (>= 0.1.7)
+      rack (>= 1.4)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-oauth2 (1.16.0)
@@ -801,6 +805,7 @@ DEPENDENCIES
   pundit (~> 2.2)
   rack (~> 2.2.3)
   rack-attack (~> 6.6)
+  rack-brotli (~> 1.2.0)
   rack-cors (~> 1.1)
   rails (~> 6.1.5)
   rails-controller-testing (~> 1.0)
@@ -840,3 +845,9 @@ DEPENDENCIES
   webpacker (~> 5.4)
   webpush (~> 0.3)
   xorcist (~> 1.1)
+
+RUBY VERSION
+   ruby 3.0.3p157
+
+BUNDLED WITH
+   2.3.10

--- a/config/application.rb
+++ b/config/application.rb
@@ -166,6 +166,7 @@ module Mastodon
 
     config.middleware.use Rack::Attack
     config.middleware.use Rack::Deflater
+    config.middleware.use Rack::Brotli
 
     config.to_prepare do
       Doorkeeper::AuthorizationsController.layout 'modal'


### PR DESCRIPTION
Currently, the only compression delivered by Rails is gzip. This PR is intended to reduce network payload more with brotli for supported browsers.