### PR TITLE
Fix extra “zero” key in some plural translation strings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,7 +168,6 @@ en:
       previous_strikes_description_html:
         one: This account has <strong>one</strong> strike.
         other: This account has <strong>%{count}</strong> strikes.
-        zero: This account is <strong>in good standing</strong>.
       promote: Promote
       protocol: Protocol
       public: Public
@@ -530,7 +529,6 @@ en:
       known_accounts:
         one: "%{count} known account"
         other: "%{count} known accounts"
-        zero: No known account
       moderation:
         all: All
         limited: Limited
@@ -802,7 +800,6 @@ en:
         shared_by_over_week:
           one: Shared by one person over the last week
           other: Shared by %{count} people over the last week
-          zero: Shared by noone over the last week
         title: Trending links
         usage_comparison: Shared %{today} times today, compared to %{yesterday} yesterday
       pending_review: Pending review
@@ -845,7 +842,6 @@ en:
         used_by_over_week:
           one: Used by one person over the last week
           other: Used by %{count} people over the last week
-          zero: Used by noone over the last week
       title: Trends
     warning_presets:
       add_new: Add new


### PR DESCRIPTION
Most of those were erroneously added in #17576.

This was misguided, as the error it aimed to fix was lying with the translation, not with the source string itself (although hardcoding “1” likely mislead translators).

Using `zero` here is misguided, as it's not defined for English in the [CLDR plural rules](https://unicode-org.github.io/cldr-staging/charts/37/supplemental/language_plural_rules.html), ~~and is not used for English~~. EDIT: Rails does actually use the `zero` key for English if present, but that is not standard and I still believe this is what causes issues with Crowdin.

I also believe using `zero` was the reason Crowdin did not consider those strings as plural strings, which causes more issues down the line (see #17882).