### PR TITLE
Add `SMTP_RETURN_PATH` environment variable to set bounce domain

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,11 +91,13 @@ Rails.application.configure do
 
   # E-mails
   outgoing_email_address = ENV.fetch('SMTP_FROM_ADDRESS', 'notifications@localhost')
-  outgoing_mail_domain   = Mail::Address.new(outgoing_email_address).domain
+  outgoing_email_domain  = Mail::Address.new(outgoing_email_address).domain
+
   config.action_mailer.default_options = {
     from: outgoing_email_address,
     reply_to: ENV['SMTP_REPLY_TO'],
-    'Message-ID': -> { "<#{Mail.random_tag}@#{outgoing_mail_domain}>" },
+    return_path: ENV['SMTP_RETURN_PATH'],
+    message_id: -> { "<#{Mail.random_tag}@#{outgoing_email_domain}>" },
   }
 
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
Allow explicitly setting an address where bounce messages would get delivered.