### PR TITLE
Fix unnecessary query on status creation

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -443,7 +443,7 @@ class Status < ApplicationRecord
   end
 
   def set_poll_id
-    update_column(:poll_id, poll.id) unless poll.nil?
+    update_column(:poll_id, poll.id) if association(:poll).loaded? && poll.present?
   end
 
   def set_visibility


### PR DESCRIPTION
When creating a status with no poll, `poll.nil?` would perform an unnecessary database query.