### PR TITLE
caniuse-lite: add hash sum

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,7 +2943,7 @@ caniuse-api@^3.0.0:
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001271, caniuse-lite@^1.0.30001286:
   version "1.0.30001310"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001310.tgz"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001310.tgz#da02cd07432c9eece6992689d1b84ca18139eea8"
   integrity sha512-cb9xTV8k9HTIUA3GnPUJCk0meUnrHL5gy5QePfDjxHyNBcnzPzrHFv5GqfP7ue5b1ZyzZL0RJboD6hQlPXjhjg==
 
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:


### PR DESCRIPTION
Since PR #17493, the PR hash sum has been removed for the caniuse-lite package.
Because of this, the assembly of the Mastodon package in the NixoS OS error building.

Build log:
```
error: builder for '/nix/store/z7dsyn82193v86x73fqv9rg2y02yhl35-offline.drv' failed with exit code 1;
       last 10 log lines:
       > downloading https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz
       > downloading https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz
       > downloading https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz
       > downloading https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz
       > downloading https://registry.yarnpkg.com/charcodes/-/charcodes-0.2.0.tgz
       > Error: hash mismatch, expected undefined, got da02cd07432c9eece6992689d1b84ca18139eea8
       >     at IncomingMessage.<anonymous> (/nix/store/s85gqyx5v30jz96clchfn2gcr4g2fbpd-prefetch-yarn-deps/libexec/index.js:46:42)
       >     at IncomingMessage.emit (node:events:538:35)
       >     at endReadableNT (node:internal/streams/readable:1345:12)
       >     at processTicksAndRejections (node:internal/process/task_queues:83:21)
       For full logs, run 'nix log /nix/store/z7dsyn82193v86x73fqv9rg2y02yhl35-offline.drv'.
error: 1 dependencies of derivation '/nix/store/d1ih9w817y36jahnc3ndldibk26r4pf7-mastodon-3.5.0rc3.drv' failed to build

```﻿
