### PR TITLE
Point latest docker tag to most recent release

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -31,6 +31,7 @@ jobs:
           tags: |
             type=edge,branch=main
             type=match,pattern=v(\d.\d.\d)(?!rc),group=0
+            type=match,pattern=v(\d.\d.\d)(rc),group=1,value={{ tag }}
             type=ref,event=pr
       - uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,11 +17,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
-      - uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: github.event_name != 'pull_request'
       - uses: docker/metadata-action@v3
         id: meta
         with:
@@ -33,11 +28,3 @@ jobs:
             type=match,pattern=v(\d.\d.\d)(?!rc),group=0
             type=match,pattern=v(\d.\d.\d)(rc),group=1,value={{ tag }}
             type=ref,event=pr
-      - uses: docker/build-push-action@v2
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=registry,ref=tootsuite/mastodon:latest
-          cache-to: type=inline

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -30,7 +30,7 @@ jobs:
             latest=auto
           tags: |
             type=edge,branch=main
-            type=match,pattern=v(.*),group=0
+            type=match,pattern=v(\d.\d.\d)(?!rc),group=0
             type=ref,event=pr
       - uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Issue: #17884

'latest' docker hub tag was updated with release candidate commits.

Changes:
* Only non-release candidates with be tagged as 'latest' in dockerhub
* Release candidates will have their own release candidate tag