### PR TITLE
Fix spurious edits and require incoming edits to be explicitly marked as such

### DIFF
--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -19,9 +19,6 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
     last_edit_date = status.edited_at.presence || status.created_at
 
-    # Since we rely on tracking of previous changes, ensure clean slate
-    status.clear_changes_information
-
     # Only allow processing one create/update per status at a time
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?

--- a/spec/services/activitypub/fetch_remote_status_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_status_service_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService, type: :service do
       let(:existing_status) { Fabricate(:status, account: sender, text: 'Foo', uri: note[:id]) }
 
       context 'with a Note object' do
-        let(:object) { note }
+        let(:object) { note.merge(updated: '2021-09-08T22:39:25Z') }
 
         it 'updates status' do
           existing_status.reload
@@ -211,7 +211,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService, type: :service do
             id: "https://#{valid_domain}/@foo/1234/create",
             type: 'Create',
             actor: ActivityPub::TagManager.instance.uri_for(sender),
-            object: note,
+            object: note.merge(updated: '2021-09-08T22:39:25Z'),
           }
         end
 


### PR DESCRIPTION
Partially fixes #17910

Require edited activities to explicitly feature an `updated` attribute to avoid spurious edits.

Also, do not consider a text change to be significant if it's identical after reformatting (which currently overrides the `rel` attribute of links, thus avoiding one of the identified causes of spurious changes). Indeed, the way Mastodon serialized toots changed slightly over time. One such change is the `rel` attribute of links. Since Mastodon stores the raw incoming HTML (for good reasons), changes to how a toot is rendered are considered changes to the toot's text. But not all such changes are significant.

Keep a path to update poll tallies without explicit post edits.