### PR TITLE
Allow importing exported lists

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -24,7 +24,7 @@ class Import < ApplicationRecord
 
   belongs_to :account
 
-  enum type: [:following, :blocking, :muting, :domain_blocking, :bookmarks]
+  enum type: [:following, :blocking, :muting, :domain_blocking, :bookmarks, :lists]
 
   validates :type, presence: true
   validates_with ImportValidator, on: :create

--- a/app/services/import_service.rb
+++ b/app/services/import_service.rb
@@ -128,10 +128,8 @@ class ImportService < BaseService
 
   def import_lists!
     parse_import_data!(['List name', 'Account address'])
-    items = @data.take(ROWS_PROCESSING_LIMIT).map { |row|
-      [row['List name'], row['Account address']]
-    }
-    list_titles = items.map {|row| row[0]}.uniq
+    items = @data.take(ROWS_PROCESSING_LIMIT).map { |row| [row['List name'], row['Account address']] }
+    list_titles = items.map { |row| row[0] }.uniq
 
     if @import.overwrite?
       List.where(title: list_titles, account: @account).destroy_all

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1143,8 +1143,8 @@ en:
       bookmarks: Bookmarks
       domain_blocking: Domain blocking list
       following: Following list
-      muting: Muting list
       lists: Lists
+      muting: Muting list
     upload: Upload
   in_memoriam_html: In Memoriam.
   invites:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1144,6 +1144,7 @@ en:
       domain_blocking: Domain blocking list
       following: Following list
       muting: Muting list
+      lists: Lists
     upload: Upload
   in_memoriam_html: In Memoriam.
   invites:


### PR DESCRIPTION
An option to export your lists as a CSV file is already present, but unlike other data types that can be exported, there is no option yet to import those same lists. This adds Lists as a selectable data type to make the available import/export operations symmetrical.

Fixes #10408