### PR TITLE
Fix assets failing to build with OpenSSL 3 because of deprecated hash algorithm

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -37,6 +37,7 @@ module.exports = {
     filename: 'js/[name]-[chunkhash].js',
     chunkFilename: 'js/[name]-[chunkhash].chunk.js',
     hotUpdateChunkFilename: 'js/[id]-[hash].hot-update.js',
+    hashFunction: 'sha256',
     path: output.path,
     publicPath: output.publicPath,
   },


### PR DESCRIPTION
Fixes #17924

Note that it will change hashes for all chunks, although I do not expect that to be a problem beyond invalidating the cache for that one change.

`sha256` is likely slower than `md4` but that does not seem to be significant.