### PR TITLE
fix: returns nil instead of empty URL on status.application.website

### DIFF
--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -137,6 +137,10 @@ class REST::StatusSerializer < ActiveModel::Serializer
 
   class ApplicationSerializer < ActiveModel::Serializer
     attributes :name, :website
+
+    def website
+      object.website.presence
+    end
   end
 
   class MentionSerializer < ActiveModel::Serializer


### PR DESCRIPTION
sometimes Mastodon returns empty string on `status.application.website`, and it will create useless link on WebUI.

so I fixed it.

related: https://github.com/mastodon/mastodon/pull/5259