### PR TITLE
Fix error resposes for `from` search prefix

### DIFF
--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -13,7 +13,7 @@ class Api::V2::SearchController < Api::BaseController
     render json: @search, serializer: REST::SearchSerializer
   rescue Mastodon::SyntaxError
     unprocessable_entity
-  rescue Mastodon::NotFound
+  rescue ActiveRecord::RecordNotFound
     not_found
   end
 

--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -11,6 +11,10 @@ class Api::V2::SearchController < Api::BaseController
   def index
     @search = Search.new(search_results)
     render json: @search, serializer: REST::SearchSerializer
+  rescue Mastodon::SyntaxError
+    unprocessable_entity
+  rescue Mastodon::NotFound
+    not_found
   end
 
   private

--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -89,11 +89,9 @@ class SearchQueryTransformer < Parslet::Transform
       when 'from'
         @filter = :account_id
 
-        username, domain = Account.validate_account_string(term)
-        raise Mastodon::SyntaxError if username.nil?
-
-        account = Account.find_local_or_remote(username, domain)
-        raise Mastodon::NotFound if account.nil?
+        username, domain = term.gsub(/\A@/, '').split('@')
+        domain           = nil if TagManager.instance.local_domain?(domain)
+        account          = Account.find_remote!(username, domain)
 
         @term = account.id
       else

--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -88,14 +88,16 @@ class SearchQueryTransformer < Parslet::Transform
       case prefix
       when 'from'
         @filter = :account_id
-        username, domain = term.split('@')
-        account = Account.find_remote(username, domain)
 
-        raise "Account not found: #{term}" unless account
+        username, domain = Account.validate_account_string(term)
+        raise Mastodon::SyntaxError if username.nil?
+
+        account = Account.find_local_or_remote(username, domain)
+        raise Mastodon::NotFound if account.nil?
 
         @term = account.id
       else
-        raise "Unknown prefix: #{prefix}"
+        raise Mastodon::SyntaxError
       end
     end
   end

--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -25,7 +25,20 @@ module AccountFinderConcern
     def find_remote(username, domain)
       AccountFinder.new(username, domain).account
     end
+
+    def find_local_or_remote(username, domain)
+      TagManager.instance.local_domain?(domain) ? find_local(username) : find_remote(username, domain)
+    end
+
+    def validate_account_string(account_string)
+      match = ACCOUNT_STRING_RE.match(account_string)
+
+      [match[:username], match[:domain]] if match
+    end
   end
+
+  # Placing this constant above the previous block breaks tests
+  ACCOUNT_STRING_RE = /^@?(?<username>#{Account::USERNAME_RE})(?:@(?<domain>[[:word:]\.\-]+))?$/i
 
   class AccountFinder
     attr_reader :username, :domain

--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -25,20 +25,7 @@ module AccountFinderConcern
     def find_remote(username, domain)
       AccountFinder.new(username, domain).account
     end
-
-    def find_local_or_remote(username, domain)
-      TagManager.instance.local_domain?(domain) ? find_local(username) : find_remote(username, domain)
-    end
-
-    def validate_account_string(account_string)
-      match = ACCOUNT_STRING_RE.match(account_string)
-
-      [match[:username], match[:domain]] if match
-    end
   end
-
-  # Placing this constant above the previous block breaks tests
-  ACCOUNT_STRING_RE = /^@?(?<username>#{Account::USERNAME_RE})(?:@(?<domain>[[:word:]\.\-]+))?$/i
 
   class AccountFinder
     attr_reader :username, :domain

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -10,7 +10,6 @@ module Mastodon
   class StreamValidationError < ValidationError; end
   class RaceConditionError < Error; end
   class RateLimitExceededError < Error; end
-  class NotFound < Error; end
   class SyntaxError < Error; end
 
   class UnexpectedResponseError < Error

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -10,6 +10,8 @@ module Mastodon
   class StreamValidationError < ValidationError; end
   class RaceConditionError < Error; end
   class RateLimitExceededError < Error; end
+  class NotFound < Error; end
+  class SyntaxError < Error; end
 
   class UnexpectedResponseError < Error
     attr_reader :response


### PR DESCRIPTION
Addresses #17941.

Using unsupported prefixes now reports a 422; searching for posts from an account the instance is not aware of reports a 404. I think the UI for this on the front end is only barely more helpful at actually communicating any problems to the user, but at least the semantics are reasonable.

In addition, this commit addresses two minor points. More importantly, `from:username@domain` succeeds when `domain` is the local domain. Less importantly, `from:@username(@domain)?` is now valid syntax.

For the record, a nealy identical version of this commit in https://github.com/kibicat/mastodon/commit/945c9b1342b7a000da05074e4572abe6ce7feb9c is running on https://glitch.cat.family, with no reported issues.