### PR TITLE
Fix error when encountering invalid pinned posts

### DIFF
--- a/app/services/activitypub/fetch_featured_collection_service.rb
+++ b/app/services/activitypub/fetch_featured_collection_service.rb
@@ -22,9 +22,19 @@ class ActivityPub::FetchFeaturedCollectionService < BaseService
   private
 
   def process_items(items)
-    status_ids = items.map { |item| value_or_id(item) }
-                      .filter_map { |uri| ActivityPub::FetchRemoteStatusService.new.call(uri, on_behalf_of: local_follower) unless ActivityPub::TagManager.instance.local_uri?(uri) }
-                      .filter_map { |status| status.id if status.account_id == @account.id }
+    status_ids = items.filter_map do |item|
+      uri = value_or_id(item)
+      next if ActivityPub::TagManager.instance.local_uri?(uri)
+
+      status = ActivityPub::FetchRemoteStatusService.new.call(uri, on_behalf_of: local_follower)
+      next unless status.account_id == @account.id
+
+      status.id
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.debug "Invalid pinned status #{uri}: #{e.message}"
+      nil
+    end
+
     to_remove = []
     to_add    = status_ids
 


### PR DESCRIPTION
In rare cases, remote users may have pinned posts that Mastodon considers invalid.

In those cases, Mastodon will abort processing the pinned posts, and will have the job queued for retry, although reprocessing it will end up in the same issue.

This PR simply changes it so that invalid posts are ignored.