### PR TITLE
Fix inconsistency in error handling when removing a status

### DIFF
--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -17,10 +17,10 @@ class RemoveStatusService < BaseService
     @account  = status.account
     @options  = options
 
-    @status.discard
-
     RedisLock.acquire(lock_options) do |lock|
       if lock.acquired?
+        @status.discard
+
         remove_from_self if @account.local?
         remove_from_followers
         remove_from_lists


### PR DESCRIPTION
Not completely sure this could actually have any ill effect, but if `RemoveStatusService` fails to acquire a lock in an `ActivityPub::ProcessingWorker` job processing a `Delete`, the status is currently discarded and causes a job failure but the next time the job is attempted, it will skip deleting the status due to it being discarded.

This commit makes the behavior of `RemoveStatusService` a bit more consistent in case of failure to acquire the lock.