### PR TITLE
Fix admin API unconditionally requiring CSRF token

### DIFF
--- a/app/controllers/api/v1/admin/account_actions_controller.rb
+++ b/app/controllers/api/v1/admin/account_actions_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::AccountActionsController < Api::BaseController
-  protect_from_forgery with: :exception
-
   before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:accounts' }
   before_action :require_staff!
   before_action :set_account

--- a/app/controllers/api/v1/admin/accounts_controller.rb
+++ b/app/controllers/api/v1/admin/accounts_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::AccountsController < Api::BaseController
-  protect_from_forgery with: :exception
-
   include Authorization
   include AccountableConcern
 

--- a/app/controllers/api/v1/admin/dimensions_controller.rb
+++ b/app/controllers/api/v1/admin/dimensions_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::DimensionsController < Api::BaseController
-  protect_from_forgery with: :exception
-
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :require_staff!
   before_action :set_dimensions

--- a/app/controllers/api/v1/admin/measures_controller.rb
+++ b/app/controllers/api/v1/admin/measures_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::MeasuresController < Api::BaseController
-  protect_from_forgery with: :exception
-
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :require_staff!
   before_action :set_measures

--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::ReportsController < Api::BaseController
-  protect_from_forgery with: :exception
-
   include Authorization
   include AccountableConcern
 

--- a/app/controllers/api/v1/admin/retention_controller.rb
+++ b/app/controllers/api/v1/admin/retention_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::RetentionController < Api::BaseController
-  protect_from_forgery with: :exception
-
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :require_staff!
   before_action :set_cohorts

--- a/app/controllers/api/v1/admin/trends/links_controller.rb
+++ b/app/controllers/api/v1/admin/trends/links_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::Trends::LinksController < Api::BaseController
-  protect_from_forgery with: :exception
-
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :require_staff!
   before_action :set_links

--- a/app/controllers/api/v1/admin/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/admin/trends/statuses_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::Trends::StatusesController < Api::BaseController
-  protect_from_forgery with: :exception
-
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :require_staff!
   before_action :set_statuses

--- a/app/controllers/api/v1/admin/trends/tags_controller.rb
+++ b/app/controllers/api/v1/admin/trends/tags_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V1::Admin::Trends::TagsController < Api::BaseController
-  protect_from_forgery with: :exception
-
   before_action -> { authorize_if_got_token! :'admin:read' }
   before_action :require_staff!
   before_action :set_tags


### PR DESCRIPTION
Fixes #17898

Since #17204, the admin API has only been available through the web application because of the unconditional requirement to provide a valid CSRF token.

This commit changes it back to `null_session`, which should make it work both with session-based authentication (provided a CSRF token) and with a bearer token.