### PR TITLE
fix: set s3_acl_enabled to false when s3_permission empty

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -69,6 +69,7 @@ if ENV['S3_ENABLED'] == 'true'
   )
 
   Paperclip::Attachment.default_options[:s3_permissions] = ->(*) { nil } if ENV['S3_PERMISSION'] == ''
+  Paperclip::Attachment.default_options[:s3_acl_enabled] = ->(*) { false } if ENV['S3_PERMISSION'] == ''
 
   if ENV.has_key?('S3_ENDPOINT')
     Paperclip::Attachment.default_options[:s3_options].merge!(


### PR DESCRIPTION
for: https://github.com/mastodon/mastodon/issues/17978

A `kt-paperclip` upgrade is also needed, e.g.  https://github.com/kreeti/kt-paperclip/pull/80