### PR TITLE
Fix potentially missing statuses when reconnecting to websocket

### DIFF
--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -184,6 +184,7 @@ export function connectTimeline(timeline) {
   return {
     type: TIMELINE_CONNECT,
     timeline,
+    usePendingItems: preferPendingItems,
   };
 };
 

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -87,10 +87,19 @@ const expandNormalizedTimeline = (state, timeline, statuses, next, isPartial, is
           insertedIds = insertedIds.unshift(null);
         }
 
-        return oldIds.take(firstIndex).concat(
+        let result = oldIds.take(firstIndex).concat(
           insertedIds,
           oldIds.skip(lastIndex),
         );
+
+        // If we are disconnected, ensure there is a gap marker at the top, otherwise,
+        // re-connecting and receiving a status without first expanding the timeline
+        // may lead to missed statuses
+        if (result.size > 0 && result.first() !== null && !mMap.get('online')) {
+          result = result.unshift(null);
+        }
+
+        return result;
       });
     }
   }));


### PR DESCRIPTION
Currently, on disconnecting from websocket/EventSource, a gap marker is added to the top of the timeline.
However, that gap marker gets removed when the user fetches new timeline content from clicking on it.
After reconnecting to websocket/EventSource, if a new status is received, neither the WebUI nor the user know whether there's a gap of missing content.

This PR ensures that the gap marker stays as long as we're disconnected from websocket/EventSource.
The downside is the gap marker will appear to do nothing if the user clicks on it and there is no new content.