### PR TITLE
Fix extremely rare race condition when deleting a toot or account

### DIFF
--- a/app/controllers/api/v1/admin/accounts_controller.rb
+++ b/app/controllers/api/v1/admin/accounts_controller.rb
@@ -65,8 +65,9 @@ class Api::V1::Admin::AccountsController < Api::BaseController
 
   def destroy
     authorize @account, :destroy?
+    json = render_to_body json: @account, serializer: REST::Admin::AccountSerializer
     Admin::AccountDeletionWorker.perform_async(@account.id)
-    render json: @account, serializer: REST::Admin::AccountSerializer
+    render json: json
   end
 
   def unsensitive

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -77,10 +77,12 @@ class Api::V1::StatusesController < Api::BaseController
     authorize @status, :destroy?
 
     @status.discard
-    RemovalWorker.perform_async(@status.id, { 'redraft' => true })
     @status.account.statuses_count = @status.account.statuses_count - 1
+    json = render_to_body json: @status, serializer: REST::StatusSerializer, source_requested: true
 
-    render json: @status, serializer: REST::StatusSerializer, source_requested: true
+    RemovalWorker.perform_async(@status.id, { 'redraft' => true })
+
+    render json: json
   end
 
   private


### PR DESCRIPTION
Incredibly unlikely to happen, but I have been reported a 500 error when deleting a status.

This is caused by the sidekiq job somehow being executed before rendering the query's result, thus causing the rendering to fail at loading some associations (e.g. media attachments).