### PR TITLE
Fix dangling language-specific trends

### DIFF
--- a/app/models/trends/base.rb
+++ b/app/models/trends/base.rb
@@ -65,8 +65,8 @@ class Trends::Base
   end
 
   def trim_older_items
-    redis.zremrangebyscore("#{key_prefix}:all", '-inf', '(1')
-    redis.zremrangebyscore("#{key_prefix}:allowed", '-inf', '(1')
+    redis.zremrangebyscore("#{key_prefix}:all", '-inf', '(0.3')
+    redis.zremrangebyscore("#{key_prefix}:allowed", '-inf', '(0.3')
   end
 
   def score_at_rank(rank)

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -6,7 +6,7 @@ class Trends::Statuses < Trends::Base
   self.default_options = {
     threshold: 5,
     review_threshold: 3,
-    score_halflife: 2.hours.freeze,
+    score_halflife: 6.hours.freeze,
   }
 
   class Query < Trends::Query
@@ -48,7 +48,6 @@ class Trends::Statuses < Trends::Base
   def refresh(at_time = Time.now.utc)
     statuses = Status.where(id: (recently_used_ids(at_time) + currently_trending_ids(false, -1)).uniq).includes(:account, :media_attachments)
     calculate_scores(statuses, at_time)
-    trim_older_items
   end
 
   def request_review
@@ -111,13 +110,15 @@ class Trends::Statuses < Trends::Base
         })
       end
 
+      trim_older_items
+
       # Clean up localized sets by calculating the intersection with the main
       # set. We do this instead of just deleting the localized sets to avoid
       # having moments where the API returns empty results
 
       Trends.available_locales.each do |locale|
         redis.zinterstore("#{key_prefix}:all:#{locale}", ["#{key_prefix}:all:#{locale}", "#{key_prefix}:all"], aggregate: 'max')
-        redis.zinterstore("#{key_prefix}:allowed:#{locale}", ["#{key_prefix}:allowed:#{locale}", "#{key_prefix}:all"], aggregate: 'max')
+        redis.zinterstore("#{key_prefix}:allowed:#{locale}", ["#{key_prefix}:allowed:#{locale}", "#{key_prefix}:allowed"], aggregate: 'max')
       end
     end
   end


### PR DESCRIPTION
- Change score half-life for trending statuses from 2 to 6 hours
- Change score threshold for trimming old items from 1 to 0.3