### PR TITLE
Fix AccountAlias.pretty_acct

### DIFF
--- a/app/models/account_alias.rb
+++ b/app/models/account_alias.rb
@@ -28,6 +28,11 @@ class AccountAlias < ApplicationRecord
     super(val.start_with?('@') ? val[1..-1] : val)
   end
 
+  def pretty_acct
+    username, domain = acct.split('@')
+    domain.nil? ? username : "#{username}@#{Addressable::IDNA.to_unicode(domain)}"
+  end
+
   private
 
   def set_uri


### PR DESCRIPTION
This fixes rendering bug on settings/alias page:

```
undefined method `pretty_acct' for #<AccountAlias id: 7, account_id: [redacted], acct: "[redacted]@[redacted]", uri: "https://[redacted]/users/[redacted]", created_at: "2022-04-09 16:12:39.380584000 +0000", updated_at: "2022-04-09 16:12:39.380584000 +0000">
Did you mean?  pretty_inspect
```

```
Crashed in non-app:
activemodel (6.1.5) lib/active_model/attribute_methods.rb in method_missing
app/views/settings/aliases/index.html.haml at line 32
app/views/settings/aliases/index.html.haml in each at line 30
app/views/settings/aliases/index.html.haml at line 30
Called from:
actionview (6.1.5) lib/action_view/base.rb in public_send
app/controllers/concerns/localized.rb in set_locale at line 11
Called from:
activesupport (6.1.5) lib/active_support/callbacks.rb in block in run_callbacks
```