### PR TITLE
nginx: hide duplicate headers

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -89,6 +89,10 @@ server {
     proxy_cache_valid 200 7d;
     proxy_cache_valid 410 24h;
     proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+
+    proxy_hide_header Vary;
+    proxy_hide_header Strict-Transport-Security;
+
     add_header X-Cached $upstream_cache_status;
     add_header Strict-Transport-Security "max-age=31536000" always;
 


### PR DESCRIPTION
Before update:
```
curl --head --http2 https://example.com/about 2> /dev/null | grep vary
vary: Accept-Encoding
vary: Accept,Accept-Encoding

curl --head --http2 https://example.com/about 2> /dev/null | grep strict-transport-security
strict-transport-security: max-age=63072000; includeSubDomains
strict-transport-security: max-age=31536000
```

After update:
```
curl --head --http2 https://example.com/about 2> /dev/null | grep vary
vary: Accept-Encoding

curl --head --http2 https://example.com/about 2> /dev/null | grep strict-transport-security
strict-transport-security: max-age=31536000

```