### PR TITLE
Fix parsing `TRUSTED_PROXY_IP`

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Allow to specify public IP of reverse proxy if it's needed
-  config.action_dispatch.trusted_proxies = ENV['TRUSTED_PROXY_IP'].split.map { |item| IPAddr.new(item) } if ENV['TRUSTED_PROXY_IP'].present?
+  config.action_dispatch.trusted_proxies = ENV['TRUSTED_PROXY_IP'].split(/(?:\s*,\s*|\s+)/).map { |item| IPAddr.new(item) } if ENV['TRUSTED_PROXY_IP'].present?
 
   config.force_ssl = true
   config.ssl_options = {

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -146,7 +146,7 @@ const startWorker = async (workerId) => {
 
   const app = express();
 
-  app.set('trusted proxy', process.env.TRUSTED_PROXY_IP || 'loopback,uniquelocal');
+  app.set('trust proxy', process.env.TRUSTED_PROXY_IP ? process.env.TRUSTED_PROXY_IP.split(/(?:\s*,\s*|\s+)/) : 'loopback,uniquelocal');
 
   const pgPool = new pg.Pool(Object.assign(pgConfigs[env], dbUrlToConfig(process.env.DATABASE_URL)));
   const server = http.createServer(app);


### PR DESCRIPTION
The `TRUSTED_PROXY_IP` requires a space delimiter (e.g. `130.211.0.0/22 35.191.0.0/16`) in the Rails App, while the streaming server requires a comma delimiter (e.g. `130.211.0.0/22,35.191.0.0/16`) is requested. This is confusing and should be corrected so that both can use both space and comma delimiters.

Closes #13288