### PR TITLE
fix mastodon sidekiq process crash with Too many open files errors

### DIFF
--- a/dist/mastodon-sidekiq.service
+++ b/dist/mastodon-sidekiq.service
@@ -13,6 +13,7 @@ Environment="LD_PRELOAD=libjemalloc.so"
 ExecStart=/home/mastodon/.rbenv/shims/bundle exec sidekiq -c 25
 TimeoutSec=15
 Restart=always
+LimitNOFILE=65536
 # Proc filesystem
 ProcSubset=pid
 ProtectProc=invisible


### PR DESCRIPTION
fix mastodon sidekiq process crash with ``Too many open files`` errors
fix #18063