### PR TITLE
Fix PeerTube videos appearing with an erroneous “Edited at” marker

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -117,7 +117,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         language: @status_parser.language,
         spoiler_text: converted_object_type? ? '' : (@status_parser.spoiler_text || ''),
         created_at: @status_parser.created_at,
-        edited_at: @status_parser.edited_at,
+        edited_at: (@status_parser.edited_at && @status_parser.edited_at != @status_parser.created_at) ? @status_parser.edited_at : nil,
         override_timestamps: @options[:override_timestamps],
         reply: @status_parser.reply,
         sensitive: @account.sensitized? || @status_parser.sensitive || false,

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -117,7 +117,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
         language: @status_parser.language,
         spoiler_text: converted_object_type? ? '' : (@status_parser.spoiler_text || ''),
         created_at: @status_parser.created_at,
-        edited_at: (@status_parser.edited_at && @status_parser.edited_at != @status_parser.created_at) ? @status_parser.edited_at : nil,
+        edited_at: @status_parser.edited_at && @status_parser.edited_at != @status_parser.created_at ? @status_parser.edited_at : nil,
         override_timestamps: @options[:override_timestamps],
         reply: @status_parser.reply,
         sensitive: @account.sensitized? || @status_parser.sensitive || false,

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -29,6 +29,58 @@ RSpec.describe ActivityPub::Activity::Create do
         subject.perform
       end
 
+      context 'object has been edited' do
+        let(:object_json) do
+          {
+            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+            type: 'Note',
+            content: 'Lorem ipsum',
+            published: '2022-01-22T15:00:00Z',
+            updated: '2022-01-22T16:00:00Z',
+          }
+        end
+
+        it 'creates status' do
+          status = sender.statuses.first
+
+          expect(status).to_not be_nil
+          expect(status.text).to eq 'Lorem ipsum'
+        end
+
+        it 'marks status as edited' do
+          status = sender.statuses.first
+
+          expect(status).to_not be_nil
+          expect(status.edited?).to eq true
+        end
+      end
+
+      context 'object has update date equal to creation date' do
+        let(:object_json) do
+          {
+            id: [ActivityPub::TagManager.instance.uri_for(sender), '#bar'].join,
+            type: 'Note',
+            content: 'Lorem ipsum',
+            published: '2022-01-22T15:00:00Z',
+            updated: '2022-01-22T15:00:00Z',
+          }
+        end
+
+        it 'creates status' do
+          status = sender.statuses.first
+
+          expect(status).to_not be_nil
+          expect(status.text).to eq 'Lorem ipsum'
+        end
+
+        it 'does not mark status as edited' do
+          status = sender.statuses.first
+
+          expect(status).to_not be_nil
+          expect(status.edited?).to eq false
+        end
+      end
+
       context 'unknown object type' do
         let(:object_json) do
           {


### PR DESCRIPTION
PeerTube videos have an `updated` field equal to `published`.
When processing an incoming activity that has the same value for `updated` and `published`, assume this doesn't represent an actual edit.