### PR TITLE
Check items is present on FetchFeaturedCollectionService

### DIFF
--- a/app/services/activitypub/fetch_featured_collection_service.rb
+++ b/app/services/activitypub/fetch_featured_collection_service.rb
@@ -22,7 +22,7 @@ class ActivityPub::FetchFeaturedCollectionService < BaseService
   private
 
   def process_items(items)
-    status_ids = items.filter_map do |item|
+    status_ids = items&.filter_map do |item|
       uri = value_or_id(item)
       next if ActivityPub::TagManager.instance.local_uri?(uri)
 


### PR DESCRIPTION
This pr fixes this error from FetchFeaturedColelctionService (when fetching non-mastodon user)
```NoMethodError: undefined method `filter_map` for nil:NilClass```