### PR TITLE
Change Direct Message warning to make admins' ability to access them clearer

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -48,7 +48,7 @@ const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning
   if (directMessageWarning) {
     const message = (
       <span>
-        <FormattedMessage id='compose_form.direct_message_warning' defaultMessage='This toot will only be sent to all the mentioned users.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a>
+        <FormattedMessage id='compose_form.direct_message_warning' defaultMessage='This post will only be sent to all the mentioned users, and may also be accessed by the operators of the involved servers.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a>
       </span>
     );
 

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -1508,7 +1508,7 @@
         "id": "compose_form.hashtag_warning"
       },
       {
-        "defaultMessage": "This toot will only be sent to all the mentioned users.",
+        "defaultMessage": "This post will only be sent to all the mentioned users, and may also be accessed by the operators of the involved servers.",
         "id": "compose_form.direct_message_warning"
       },
       {


### PR DESCRIPTION
Fixes #18079

The current English warning is apparently not enough to convey that server administrators are technically able to access Direct Messages, as users are still surprised after learning about it outside of Mastodon.

The message introduced in #7420 was more explicit about it, but was later changed in #7546. The concern at that point seems to have been that it may alarm users more than necessary.

However, the French translation remained as a loose translation of the message introduced in #7420, and I have never witnessed anyone being upset at this warning, so I think it is actually fine.