### PR TITLE
Fix alias page not loading if you have an alias set

### DIFF
--- a/app/views/settings/aliases/index.html.haml
+++ b/app/views/settings/aliases/index.html.haml
@@ -29,5 +29,5 @@
       - else
         - @aliases.each do |account_alias|
           %tr
-            %td= account_alias.pretty_acct
+            %td= account_alias.acct
             %td= table_link_to 'trash', t('aliases.remove'), settings_alias_path(account_alias), data: { method: :delete }


### PR DESCRIPTION
Fix alias page render error due to function not existing when an alias is set

Fixes: https://github.com/mastodon/mastodon/issues/18114

Cause: https://github.com/mastodon/mastodon/commit/392b367835c3c25e37be7c45e8cd130422de10aa

This simply reverts the alias display to acct instead of pretty_acct. Page now renders

![image](https://user-images.githubusercontent.com/9691551/165410444-f1a2fb4b-e70f-49fd-837a-c1fd1f390aa3.png)
