### PR TITLE
Add RAILS_LOG_LEVEL=warn to .env.production.sample

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -10,6 +10,9 @@
 # including surrounding quotes.
 # See: https://github.com/mastodon/mastodon/issues/16895
 
+# Logging
+RAILS_LOG_LEVEL=warn
+
 # Federation
 # ----------
 # This identifies your server and cannot be changed safely later

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -11,6 +11,7 @@
 # See: https://github.com/mastodon/mastodon/issues/16895
 
 # Logging
+# Options: debug, info, warn, error, fatal
 RAILS_LOG_LEVEL=warn
 
 # Federation


### PR DESCRIPTION
The default is info. On a functional production server, successful logging is less important.

Allows people to increase as required for troubleshooting.