### PR TITLE
Add some missing indexes on foreign keys

### DIFF
--- a/db/migrate/20220428112511_add_index_statuses_on_account_id.rb
+++ b/db/migrate/20220428112511_add_index_statuses_on_account_id.rb
@@ -1,0 +1,7 @@
+class AddIndexStatusesOnAccountId < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :statuses, [:account_id], name: :index_statuses_on_account_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20220428112727_add_index_statuses_pins_on_status_id.rb
+++ b/db/migrate/20220428112727_add_index_statuses_pins_on_status_id.rb
@@ -1,0 +1,7 @@
+class AddIndexStatusesPinsOnStatusId < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :status_pins, [:status_id], name: :index_status_pins_on_status_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20220428114454_add_index_reports_on_assigned_account_id.rb
+++ b/db/migrate/20220428114454_add_index_reports_on_assigned_account_id.rb
@@ -1,0 +1,7 @@
+class AddIndexReportsOnAssignedAccountId < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :reports, [:assigned_account_id], name: :index_reports_on_assigned_account_id, algorithm: :concurrently, where: 'assigned_account_id IS NOT NULL'
+  end
+end

--- a/db/migrate/20220428114902_add_index_reports_on_action_taken_by_account_id.rb
+++ b/db/migrate/20220428114902_add_index_reports_on_action_taken_by_account_id.rb
@@ -1,0 +1,7 @@
+class AddIndexReportsOnActionTakenByAccountId < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :reports, [:action_taken_by_account_id], name: :index_reports_on_action_taken_by_account_id, algorithm: :concurrently, where: 'action_taken_by_account_id IS NOT NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_16_233212) do
+ActiveRecord::Schema.define(version: 2022_04_28_114902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -784,6 +784,8 @@ ActiveRecord::Schema.define(version: 2022_03_16_233212) do
     t.datetime "action_taken_at"
     t.bigint "rule_ids", array: true
     t.index ["account_id"], name: "index_reports_on_account_id"
+    t.index ["action_taken_by_account_id"], name: "index_reports_on_action_taken_by_account_id", where: "(action_taken_by_account_id IS NOT NULL)"
+    t.index ["assigned_account_id"], name: "index_reports_on_assigned_account_id", where: "(assigned_account_id IS NOT NULL)"
     t.index ["target_account_id"], name: "index_reports_on_target_account_id"
   end
 
@@ -860,6 +862,7 @@ ActiveRecord::Schema.define(version: 2022_03_16_233212) do
     t.datetime "created_at", default: -> { "now()" }, null: false
     t.datetime "updated_at", default: -> { "now()" }, null: false
     t.index ["account_id", "status_id"], name: "index_status_pins_on_account_id_and_status_id", unique: true
+    t.index ["status_id"], name: "index_status_pins_on_status_id"
   end
 
   create_table "status_stats", force: :cascade do |t|
@@ -896,6 +899,7 @@ ActiveRecord::Schema.define(version: 2022_03_16_233212) do
     t.boolean "trendable"
     t.bigint "ordered_media_attachment_ids", array: true
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20190820", order: { id: :desc }, where: "(deleted_at IS NULL)"
+    t.index ["account_id"], name: "index_statuses_on_account_id"
     t.index ["deleted_at"], name: "index_statuses_on_deleted_at", where: "(deleted_at IS NOT NULL)"
     t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["id", "account_id"], name: "index_statuses_public_20200119", order: { id: :desc }, where: "((deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
@@ -1236,4 +1240,5 @@ ActiveRecord::Schema.define(version: 2022_03_16_233212) do
     ORDER BY (sum(t0.rank)) DESC;
   SQL
   add_index "follow_recommendations", ["account_id"], name: "index_follow_recommendations_on_account_id", unique: true
+
 end


### PR DESCRIPTION
One of the main causes of long-running tasks on mastodon.social is account deletions, but even *empty* account deletions have been reported to take very long while they should be almost immediate.

While looking into it, I found that a number of foreign keys referencing the `accounts` table had no appropriate indexes, so `DELETE`ing from `accounts` would require some inefficient sequential scans or index scans.

I could not evaluate the actual performance impact on a database anywhere near the size of mastodon.social's, but the main culprits seem to be (roughly in the order of the ones I suspect are the most impactful to the least impactful):
- `statuses` lacks a proper `index on account_id` as `index_statuses_20190820` isn't suitable for that because of the `deleted_at IS NULL` condition, so when deleting any account (even with 0 posts), I think PostgreSQL does index scan on `index_statuses_on_reblog_of_id_and_account_id`. On my modest single-user server, this is by several orders of magnitude the slowest operation when deleting empty accounts.
- `reports` lacks a proper index on `assigned_account_id` and `action_taken_by_account_id` so deleting an account performs a sequential scan on reports, which may be impactful on servers with lots of reports
- `follow_requests` doesn't have an index on `target_account_id`, so I believe it uses `index_follow_requests_on_account_id_and_target_account_id`, which is not noticeable on my server but I suspect may be another story on a bigger server

Additionally, `statuses_pins` lacks an index on `status_id`, and adding such an index halves the deletion query time on my single-user server.

Unfortunately, some indexes being added here are fairly large, but I'm not sure there is a way around adding them to efficiently process (even empty) account deletions.