### PR TITLE
Fix stoplight not using REDIS_NAMESPACE

### DIFF
--- a/config/initializers/stoplight.rb
+++ b/config/initializers/stoplight.rb
@@ -1,4 +1,4 @@
 require 'stoplight'
 
-Stoplight::Light.default_data_store = Stoplight::DataStore::Redis.new(Redis.current)
+Stoplight::Light.default_data_store = Stoplight::DataStore::Redis.new(RedisConfiguration.new.connection)
 Stoplight::Light.default_notifiers  = [Stoplight::Notifier::Logger.new(Rails.logger)]


### PR DESCRIPTION
This remains a global redis client instance for the time being, but that can be improved later.