### PR TITLE
Fix temporary network/remote server error prevent from interactions with remote accounts

### DIFF
--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -30,6 +30,11 @@ class ResolveURLService < BaseService
   end
 
   def process_url_from_db
+    if [500, 502, 503, 504, nil].include?(fetch_resource_service.response_code)
+      account = Account.find_by(uri: @url)
+      return account unless account.nil?
+    end
+
     return unless @on_behalf_of.present? && [401, 403, 404].include?(fetch_resource_service.response_code)
 
     # It may happen that the resource is a private toot, and thus not fetchable,

--- a/spec/services/resolve_url_service_spec.rb
+++ b/spec/services/resolve_url_service_spec.rb
@@ -7,13 +7,27 @@ describe ResolveURLService, type: :service do
 
   describe '#call' do
     it 'returns nil when there is no resource url' do
-      url     = 'http://example.com/missing-resource'
+      url           = 'http://example.com/missing-resource'
+      known_account = Fabricate(:account, uri: url)
       service = double
 
       allow(FetchResourceService).to receive(:new).and_return service
+      allow(service).to receive(:response_code).and_return(404)
       allow(service).to receive(:call).with(url).and_return(nil)
 
       expect(subject.call(url)).to be_nil
+    end
+
+    it 'returns known account on temporary error' do
+      url           = 'http://example.com/missing-resource'
+      known_account = Fabricate(:account, uri: url)
+      service = double
+
+      allow(FetchResourceService).to receive(:new).and_return service
+      allow(service).to receive(:response_code).and_return(500)
+      allow(service).to receive(:call).with(url).and_return(nil)
+
+      expect(subject.call(url)).to eq known_account
     end
 
     context 'searching for a remote private status' do


### PR DESCRIPTION
Untested. Should just makes things like the authorized_interaction flow a little bit more resilient.