### PR TITLE
Fix empty “It violates server rules” report option

### DIFF
--- a/app/javascript/mastodon/features/report/category.js
+++ b/app/javascript/mastodon/features/report/category.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import Button from 'mastodon/components/button';
 import Option from './components/option';
@@ -17,11 +19,17 @@ const messages = defineMessages({
   account: { id: 'report.category.title_account', defaultMessage: 'profile' },
 });
 
-export default @injectIntl
+const mapStateToProps = state => ({
+  rules: state.get('rules'),
+});
+
+export default @connect(mapStateToProps)
+@injectIntl
 class Category extends React.PureComponent {
 
   static propTypes = {
     onNextStep: PropTypes.func.isRequired,
+    rules: ImmutablePropTypes.list,
     category: PropTypes.string,
     onChangeCategory: PropTypes.func.isRequired,
     startedFrom: PropTypes.oneOf(['status', 'account']),
@@ -53,12 +61,16 @@ class Category extends React.PureComponent {
   };
 
   render () {
-    const { category, startedFrom, intl } = this.props;
+    const { category, startedFrom, rules, intl } = this.props;
 
-    const options = [
+    const options = rules.size > 0 ? [
       'dislike',
       'spam',
       'violation',
+      'other',
+    ] : [
+      'dislike',
+      'spam',
       'other',
     ];
 

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -14,6 +14,7 @@ import { uploadCompose, resetCompose, changeComposeSpoilerness } from '../../act
 import { expandHomeTimeline } from '../../actions/timelines';
 import { expandNotifications } from '../../actions/notifications';
 import { fetchFilters } from '../../actions/filters';
+import { fetchRules } from '../../actions/rules';
 import { clearHeight } from '../../actions/height_cache';
 import { focusApp, unfocusApp, changeLayout } from 'mastodon/actions/app';
 import { synchronouslySubmitMarkers, submitMarkers, fetchMarkers } from 'mastodon/actions/markers';
@@ -368,6 +369,7 @@ class UI extends React.PureComponent {
     this.props.dispatch(expandHomeTimeline());
     this.props.dispatch(expandNotifications());
     setTimeout(() => this.props.dispatch(fetchFilters()), 500);
+    setTimeout(() => this.props.dispatch(fetchRules()), 3000);
 
     this.hotkeys.__mousetrap__.stopCallback = (e, element) => {
       return ['TEXTAREA', 'SELECT', 'INPUT'].includes(element.tagName);


### PR DESCRIPTION
When a server has not set any server rules, the “It violates server rules” option leads to a dialog with no option and no way to proceed.

This PR hides the option when no server rules are set.