### PR TITLE
Change half-life of trending status scores from 6 hours to 2 hours

### DIFF
--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -6,7 +6,7 @@ class Trends::Statuses < Trends::Base
   self.default_options = {
     threshold: 5,
     review_threshold: 3,
-    score_halflife: 6.hours.freeze,
+    score_halflife: 2.hours.freeze,
   }
 
   class Query < Trends::Query


### PR DESCRIPTION
I know this one's a bit of a back and forth, but it was better before. I think the main thing I wanted to achieve was keep statuses in the set for longer, but with the bigger half-life, they stick to the top too long, whereas what I really needed to tweak was the decay threshold.