### PR TITLE
Fix double render error when authorizing interaction

### DIFF
--- a/app/controllers/authorize_interactions_controller.rb
+++ b/app/controllers/authorize_interactions_controller.rb
@@ -13,7 +13,7 @@ class AuthorizeInteractionsController < ApplicationController
     if @resource.is_a?(Account)
       render :show
     elsif @resource.is_a?(Status)
-      redirect_to web_url("statuses/#{@resource.id}")
+      redirect_to web_url("@#{@resource.account.pretty_acct}/#{@resource.id}")
     else
       render :error
     end
@@ -25,15 +25,17 @@ class AuthorizeInteractionsController < ApplicationController
     else
       render :error
     end
-  rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
+  rescue ActiveRecord::RecordNotFound
     render :error
   end
 
   private
 
   def set_resource
-    @resource = located_resource || render(:error)
+    @resource = located_resource
     authorize(@resource, :show?) if @resource.is_a?(Status)
+  rescue Mastodon::NotPermittedError
+    not_found
   end
 
   def located_resource

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -21,7 +21,10 @@ class FollowingAccountsController < ApplicationController
       end
 
       format.json do
-        raise Mastodon::NotPermittedError if page_requested? && @account.hide_collections?
+        if page_requested? && @account.hide_collections?
+          forbidden
+          next
+        end
 
         expires_in(page_requested? ? 0 : 3.minutes, public: public_fetch_mode?)
 


### PR DESCRIPTION
`AbstractController::DoubleRenderError` caused by calling `render` from a `before_action` but *not* returning it (I think)