### PR TITLE
Fix error when trying to revoke OAuth token without supplying a token

### DIFF
--- a/app/controllers/oauth/tokens_controller.rb
+++ b/app/controllers/oauth/tokens_controller.rb
@@ -2,7 +2,8 @@
 
 class Oauth::TokensController < Doorkeeper::TokensController
   def revoke
-    unsubscribe_for_token if authorized? && token.accessible?
+    unsubscribe_for_token if token.present? && authorized? && token.accessible?
+
     super
   end
 


### PR DESCRIPTION
Original controller checks `token.blank?` before calling `authorized?`, but we didn't