### PR TITLE
"X-Accel-Mapping header missing" errors due to default nginx configuration.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Allow to specify public IP of reverse proxy if it's needed
   config.action_dispatch.trusted_proxies = ENV['TRUSTED_PROXY_IP'].split(/(?:\s*,\s*|\s+)/).map { |item| IPAddr.new(item) } if ENV['TRUSTED_PROXY_IP'].present?


### PR DESCRIPTION
On main
![image](https://user-images.githubusercontent.com/17537000/166096600-74db1714-f0f8-4427-999d-24dd1fe6e7aa.png)


The X-Accel is not configured in the default nginx and this results in a lot of errors in the logs.

Related to #3221 #3389 #8306 #15056