### PR TITLE
Fix possible crash when a post references an invalid media attachment

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -254,7 +254,7 @@ class Status < ApplicationRecord
       media_attachments
     else
       map = media_attachments.index_by(&:id)
-      ordered_media_attachment_ids.map { |media_attachment_id| map[media_attachment_id] }
+      ordered_media_attachment_ids.filter_map { |media_attachment_id| map[media_attachment_id] }
     end
   end
 


### PR DESCRIPTION
This is a partial fix to #18209 which is caused by two statuses referencing the same media attachment due to a race condition on status creation.

This fix would avoid the crash but not the duplicate status creation. However this would be a rare occurrence and a much more minor issue than a crash.