### PR TITLE
Add ability to set approval-based registration through tootctl

### DIFF
--- a/lib/mastodon/settings_cli.rb
+++ b/lib/mastodon/settings_cli.rb
@@ -16,6 +16,20 @@ module Mastodon
       say('OK', :green)
     end
 
+    desc 'approved', 'Open approval-based registrations'
+    option :require_reason, type: :boolean, aliases: [:require_invite_text]
+    long_desc <<~LONG_DESC
+      Set registrations to require review from staff.
+
+      With --require-reason, require users to enter a reason when registering,
+      otherwise this field is optional.
+    LONG_DESC
+    def approved
+      Setting.registrations_mode = 'approved'
+      Setting.require_invite_text = options[:require_reason] unless options[:require_reason].nil?
+      say('OK', :green)
+    end
+
     desc 'close', 'Close registrations'
     def close
       Setting.registrations_mode = 'none'


### PR DESCRIPTION
Fixes #18235

Add `tootctl settings registrations approved` with optional `--require-reason` switch.