### PR TITLE
Remove HTML tags from RSS titles 

### DIFF
--- a/app/lib/rss/serializer.rb
+++ b/app/lib/rss/serializer.rb
@@ -21,11 +21,11 @@ class RSS::Serializer
   end
 
   def status_title(status)
-    preview = status.proper.spoiler_text.presence || status.proper.text
+    preview = status.proper.spoiler_text.presence || PlainTextFormatter.new(status.text, status.local?).to_s
 
-    if preview.length > 30 || preview[0, 30].include?("\n")
-      preview = preview[0, 30]
-      preview = preview[0, preview.index("\n").presence || 30] + '…'
+    if preview.length > 128 || preview[0, 128].include?("\n")
+      preview = preview[0, 128]
+      preview = preview[0, preview.index("\n").presence || 128] + '…'
     end
 
     preview = "#{status.proper.spoiler_text.present? ? 'CW ' : ''}“#{preview}”#{status.proper.sensitive? ? ' (sensitive)' : ''}"

--- a/spec/lib/rss/serializer_spec.rb
+++ b/spec/lib/rss/serializer_spec.rb
@@ -14,10 +14,11 @@ describe RSS::Serializer do
     subject { RSS::Serializer.new.send(:status_title, status) }
 
     context 'on a toot with long text' do
-      let(:text) { "This toot's text is longer than the allowed number of characters" }
+      let(:text) { "This toot's text is longer than the allowed number of characters and it should be truncated" +
+        " to a text up to 128 characters long!!"}
 
       it 'truncates toot text appropriately' do
-        expect(subject).to eq "#{account.acct}: “This toot's text is longer tha…”"
+        expect(subject).to eq "#{account.acct}: “This toot's text is longer than the allowed number of characters and it should be truncated to a text up to 128 characters long!…”"
       end
     end
 


### PR DESCRIPTION
Changes related to issue  #18256 

- Remove HTML from RSS items title
- Increased RSS item title to 128 characters max