### PR TITLE
Change “Only people I mention” to “Mentioned people only”

### DIFF
--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.js
@@ -16,7 +16,7 @@ const messages = defineMessages({
   unlisted_long: { id: 'privacy.unlisted.long', defaultMessage: 'Visible for all, but opted-out of discovery features' },
   private_short: { id: 'privacy.private.short', defaultMessage: 'Followers only' },
   private_long: { id: 'privacy.private.long', defaultMessage: 'Visible for followers only' },
-  direct_short: { id: 'privacy.direct.short', defaultMessage: 'Only people I mention' },
+  direct_short: { id: 'privacy.direct.short', defaultMessage: 'Mentioned people only' },
   direct_long: { id: 'privacy.direct.long', defaultMessage: 'Visible for mentioned users only' },
   change_privacy: { id: 'privacy.change', defaultMessage: 'Adjust status privacy' },
 });

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -1326,7 +1326,7 @@
         "id": "privacy.private.long"
       },
       {
-        "defaultMessage": "Only people I mention",
+        "defaultMessage": "Mentioned people only",
         "id": "privacy.direct.short"
       },
       {

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -366,7 +366,7 @@
   "poll_button.remove_poll": "Remove poll",
   "privacy.change": "Change post privacy",
   "privacy.direct.long": "Visible for mentioned users only",
-  "privacy.direct.short": "Only people I mention",
+  "privacy.direct.short": "Mentioned people only",
   "privacy.private.long": "Visible for followers only",
   "privacy.private.short": "Followers only",
   "privacy.public.long": "Visible for all",


### PR DESCRIPTION
#18146 changed the string `privacy.direct.short` from “Direct” to “Only people I mention”, but that change wasn't done in a consistent way (sorry I didn't catch that earlier), as in a place (`app/javascript/mastodon/components/status.js`, for tooltips), it has been changed to “Mentioned people only”.

It would be possible to use two different strings, but “Mentioned people only” works in both contexts, and none of the other dropdown options refer to the user in using the first person.