### PR TITLE
Bump minimum Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 2.5.0', '< 3.1.0'
+ruby '>= 2.6.0', '< 3.1.0'
 
 gem 'pkg-config', '~> 1.4'
 gem 'rexml', '~> 3.2'


### PR DESCRIPTION
Mastodon has been incompatible with Ruby 2.5 for a few releases due to some dependencies, this just updates the Gemfile description to match that situation.

Some development dependencies actually require 2.7+, but I'm unsure how to express that.