### PR TITLE
Replace leftover `envelope` icons with `at` icons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -132,7 +132,7 @@ module ApplicationHelper
     elsif status.private_visibility? || status.limited_visibility?
       fa_icon('lock', title: I18n.t('statuses.visibilities.private'))
     elsif status.direct_visibility?
-      fa_icon('envelope', title: I18n.t('statuses.visibilities.direct'))
+      fa_icon('at', title: I18n.t('statuses.visibilities.direct'))
     end
   end
 

--- a/app/helpers/statuses_helper.rb
+++ b/app/helpers/statuses_helper.rb
@@ -101,7 +101,7 @@ module StatusesHelper
     when 'private'
       fa_icon 'lock fw'
     when 'direct'
-      fa_icon 'envelope fw'
+      fa_icon 'at fw'
     end
   end
 

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -468,7 +468,7 @@ class Status extends ImmutablePureComponent {
       'public': { icon: 'globe', text: intl.formatMessage(messages.public_short) },
       'unlisted': { icon: 'unlock', text: intl.formatMessage(messages.unlisted_short) },
       'private': { icon: 'lock', text: intl.formatMessage(messages.private_short) },
-      'direct': { icon: 'envelope', text: intl.formatMessage(messages.direct_short) },
+      'direct': { icon: 'at', text: intl.formatMessage(messages.direct_short) },
     };
 
     const visibilityIcon = visibilityIconInfo[status.get('visibility')];

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -185,7 +185,7 @@ class DetailedStatus extends ImmutablePureComponent {
       'public': { icon: 'globe', text: intl.formatMessage(messages.public_short) },
       'unlisted': { icon: 'unlock', text: intl.formatMessage(messages.unlisted_short) },
       'private': { icon: 'lock', text: intl.formatMessage(messages.private_short) },
-      'direct': { icon: 'envelope', text: intl.formatMessage(messages.direct_short) },
+      'direct': { icon: 'at', text: intl.formatMessage(messages.direct_short) },
     };
 
     const visibilityIcon = visibilityIconInfo[status.get('visibility')];

--- a/app/javascript/mastodon/features/ui/components/boost_modal.js
+++ b/app/javascript/mastodon/features/ui/components/boost_modal.js
@@ -88,7 +88,7 @@ class BoostModal extends ImmutablePureComponent {
       'public': { icon: 'globe', text: intl.formatMessage(messages.public_short) },
       'unlisted': { icon: 'unlock', text: intl.formatMessage(messages.unlisted_short) },
       'private': { icon: 'lock', text: intl.formatMessage(messages.private_short) },
-      'direct': { icon: 'envelope', text: intl.formatMessage(messages.direct_short) },
+      'direct': { icon: 'at', text: intl.formatMessage(messages.direct_short) },
     };
 
     const visibilityIcon = visibilityIconInfo[status.get('visibility')];

--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -65,6 +65,6 @@
       - elsif status.private_visibility? || status.limited_visibility?
         = fa_icon 'lock fw'
       - else
-        = fa_icon 'envelope fw'
+        = fa_icon 'at fw'
     = link_to remote_interaction_path(status, type: :favourite), class: 'status__action-bar-button icon-button modal-button' do
       = fa_icon 'star fw'


### PR DESCRIPTION
The icon was first changed in the following commit: https://github.com/mastodon/mastodon/commit/be0bc9acbffe2d6126f382b946be0469d756048c

This patch replaces the `envelope` icons which persist in some parts of the UI with the new `at` icon.

![Before, envelope icon in the post details](https://user-images.githubusercontent.com/1540885/166713980-3f380195-92d9-42d1-90c9-b20f434bc762.png)

![After, at icon in the post details](https://user-images.githubusercontent.com/1540885/166714134-4fe5a938-3b84-4a7a-82d1-2c12e065956f.png)

