### PR TITLE
Fix streaming notifications not using quick filter logic

### DIFF
--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -58,7 +58,8 @@ export const loadPending = () => ({
 
 export function updateNotifications(notification, intlMessages, intlLocale) {
   return (dispatch, getState) => {
-    const showInColumn = getState().getIn(['settings', 'notifications', 'shows', notification.type], true);
+    const activeFilter = getState().getIn(['settings', 'notifications', 'quickFilter', 'active']);
+    const showInColumn = activeFilter === 'all' ? getState().getIn(['settings', 'notifications', 'shows', notification.type], true) : activeFilter === notification.type;
     const showAlert    = getState().getIn(['settings', 'notifications', 'alerts', notification.type], true);
     const playSound    = getState().getIn(['settings', 'notifications', 'sounds', notification.type], true);
     const filters      = getFiltersRegex(getState(), { contextType: 'notifications' });


### PR DESCRIPTION
Fixes #18309

The quickFilter logic was used on display and to request new notification pages, but not for live updates. The main issue this caused is bump the unread notifications count regardless of the quickFilter setting.

Since notifications are re-fetched when changing quickFilter settings, it is safe to drop live notifications that do not match the selected filter.