### PR TITLE
Allow VerifyLinkService to accept backlinks with differing case

### DIFF
--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -28,7 +28,7 @@ class VerifyLinkService < BaseService
 
     links = Nokogiri::HTML(@body).xpath('//a[contains(concat(" ", normalize-space(@rel), " "), " me ")]|//link[contains(concat(" ", normalize-space(@rel), " "), " me ")]')
 
-    if links.any? { |link| link['href'] == @link_back }
+    if links.any? { |link| link['href'].downcase == @link_back.downcase }
       true
     elsif links.empty?
       false


### PR DESCRIPTION
As I understand it, ActivityPub identifiers are actually case-sensitive, but within Mastodon instances, guards exist to prevent two identifiers which are case-insensitively equal from being created, and browsing to a url with a case modified identifier will resolve the correct identity.

Given that, it seems we can safely allow the VerifyLinkService to match on case-insensitive equivalent URIs.

Apologies if my assumptions there are incorrect.