### PR TITLE
Drop support for Ruby v2.5 and Node.js v12

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Mastodon acts as an OAuth2 provider, so 3rd party apps can use the REST and Stre
 
 - **PostgreSQL** 9.5+
 - **Redis** 4+
-- **Ruby** 2.5+
-- **Node.js** 12+
+- **Ruby** 2.6+
+- **Node.js** 14+
 
 The repository includes deployment configurations for **Docker and docker-compose** as well as specific platforms like **Heroku**, **Scalingo**, and **Nanobox**. The [**standalone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the documentation.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mastodon/mastodon",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "scripts": {
     "postversion": "git push --tags",


### PR DESCRIPTION
Node.js v12 is no longer supported with an end-of-life of 2022-04-30. Ruby v2.5 is also ending-of-life.