### PR TITLE
Fix floating action button obscuring last element

### DIFF
--- a/app/javascript/mastodon/features/ui/components/columns_area.js
+++ b/app/javascript/mastodon/features/ui/components/columns_area.js
@@ -234,7 +234,7 @@ class ColumnsArea extends ImmutablePureComponent {
             </div>
           </div>
 
-          <div className='columns-area__panels__main'>
+          <div className={`columns-area__panels__main ${floatingActionButton && 'with-fab'}`}>
             <TabsBar key='tabs' />
             {content}
           </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2469,6 +2469,10 @@ a.account__display-name {
   .columns-area__panels__pane--compositional {
     display: none;
   }
+
+  .with-fab .scrollable .item-list:last-child {
+    padding-bottom: 5.25rem;
+  }
 }
 
 @media screen and (min-width: 600px + (285px * 1) + (10px * 1)) {


### PR DESCRIPTION
Fixes #18331

Add some padding below the last element of scrollable lists when the FAB is shown in order for users to always be able to fully see the last element.


https://user-images.githubusercontent.com/384364/167144315-fe6b4d82-e90d-4684-b556-c74b89014207.mp4