### PR TITLE
Fix contact email overflow (#14723)

### DIFF
--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -152,7 +152,7 @@
   }
 
   & > a {
-    display: inline-block;
+    display: block;
     padding: 10px;
     padding-top: 0;
     color: $darker-text-color;


### PR DESCRIPTION
Hi there!
I made a tiny CSS change to fix the contact-email address from overflowing on small screen-sizes on the `/about/more` page.
This should fix the overflow and horizontal scroll issue on the mentioned page and thus issue #14723.