### PR TITLE
Properly resolve schema.org @context

### DIFF
--- a/app/helpers/context_helper.rb
+++ b/app/helpers/context_helper.rb
@@ -14,7 +14,7 @@ module ContextHelper
     also_known_as: { 'alsoKnownAs' => { '@id' => 'as:alsoKnownAs', '@type' => '@id' } },
     emoji: { 'toot' => 'http://joinmastodon.org/ns#', 'Emoji' => 'toot:Emoji' },
     featured: { 'toot' => 'http://joinmastodon.org/ns#', 'featured' => { '@id' => 'toot:featured', '@type' => '@id' }, 'featuredTags' => { '@id' => 'toot:featuredTags', '@type' => '@id' } },
-    property_value: { 'schema' => 'http://schema.org#', 'PropertyValue' => 'schema:PropertyValue', 'value' => 'schema:value' },
+    property_value: { 'schema' => 'http://schema.org/', 'PropertyValue' => 'schema:PropertyValue', 'value' => 'schema:value' },
     atom_uri: { 'ostatus' => 'http://ostatus.org#', 'atomUri' => 'ostatus:atomUri' },
     conversation: { 'ostatus' => 'http://ostatus.org#', 'inReplyToAtomUri' => 'ostatus:inReplyToAtomUri', 'conversation' => 'ostatus:conversation' },
     focal_point: { 'toot' => 'http://joinmastodon.org/ns#', 'focalPoint' => { '@container' => '@list', '@id' => 'toot:focalPoint' } },

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -192,7 +192,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
     attribute :context, key: :@context
 
     def context
-      {"name" => "schema:name"}
+      { 'name' => 'schema:name' }
     end
 
     def type

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -189,6 +189,11 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
     include FormattingHelper
 
     attributes :type, :name, :value
+    attribute :context, key: :@context
+
+    def context
+      {"name" => "schema:name"}
+    end
 
     def type
       'PropertyValue'


### PR DESCRIPTION
Fix #18361

If not importing the entire `https://schema.org` context, then the few cherry-picked definitions will not resolve correctly. The proper IRI is of the form `http://schema.org/propertyName`, so I changed the context map to use a `/` instead of a `#`, which causes JSON-LD expansion/compaction to consistently produce the correct IRI. Consequently, one would have to reserialize the JSON-LD representation with the provided context and then parse the document as normal JSON in order to maintain consistent definitions, which is an unnecessary step and also precludes parsing as JSON-LD (for zero ambiguity).

Simultaneously, I noticed that profile fields (`actor.attachment`) uses schema.org's PropertyValue type, and sub-properties `schema:name` and `schema:value` -- but only `schema:value` is defined in the context, so `name` does not resolve to `schema:name`. Instead, it resolves to `as:name`, which is semantically incorrect.

### Shortcomings

I don't know how to just define the `@context` once within the `attachment` property instead of once-per-field within each field, so the current state of the PR will cause some repetition (up to 4 times instead of 1 time only, since Mastodon currently allows a maximum of 4 profile fields by default). However, this repetition may be necessary, since the only other alternative I can think of is to use a different shorthand property name that is not `name`, and then define that shorthand in the main `@context` to be equal to `schema:name` -- although this would be more disruptive, since it would affect JSON-only parsers.

### Considerations

I would hope this doesn't break any compatibility, but if prior versions of Mastodon expect `as:name` instead of `schema:name`, then they will probably break.

### Behavior before

Context:
```
"schema": "http://schema.org#"
```

Serializer results:
```
 "attachment": [
    {
      "type": "PropertyValue",
      "name": "pronouns",
      "value": "they/them"
    },
    {
      "type": "PropertyValue",
      "name": "website",
      "value": "https://mastodon.local"
    }
  ],
```

Compacted results:
```
"https://www.w3.org/ns/activitystreams#attachment": [
    {
      "@type": "http://schema.org#PropertyValue",
      "http://schema.org#value": "they/them",
      "https://www.w3.org/ns/activitystreams#name": "pronouns"
    },
    {
      "@type": "http://schema.org#PropertyValue",
      "http://schema.org#value": "https://mastodon.local",
      "https://www.w3.org/ns/activitystreams#name": "website"
    }
  ],
```

### Behavior after

Context:
```
"schema": "http://schema.org/"
```

Serializer results:
```
 "attachment": [
    {
      "type": "PropertyValue",
      "name": "pronouns",
      "value": "they/them",
      "@context": {
        "name": "schema:name"
      }
    },
    {
      "type": "PropertyValue",
      "name": "website",
      "value": "https://mastodon.local",
      "@context": {
        "name": "schema:name"
      }
    }
  ],
```

Compacted results:
```
"https://www.w3.org/ns/activitystreams#attachment": [
    {
      "@type": "http://schema.org/PropertyValue",
      "http://schema.org/name": "pronouns",
      "http://schema.org/value": "they/them"
    },
    {
      "@type": "http://schema.org/PropertyValue",
      "http://schema.org/name": "website",
      "http://schema.org/value": "https://mastodon.local"
    }
  ],
```
