### PR TITLE
Add safeguard for mentions in followers-only and direct posts in WebUI

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -178,10 +178,10 @@ function resolveMentions(state, text, expectedMentions, unresolvedMentions) {
       }
     }
   }
-};
+}
 
 function handleUnexpectedMentions(routerHistory, extraAccounts, expectedMentions, unresolvedMentions) {
-  return (dispatch, getState) => {
+  return (dispatch) => {
     // It is possible that some accounts failed to resolve due to case-sensitive comparison.
     // Check whether this may be the case
     for (const acct of unresolvedMentions) {
@@ -207,7 +207,7 @@ function handleUnexpectedMentions(routerHistory, extraAccounts, expectedMentions
       }));
     }
   };
-};
+}
 
 export function submitCompose(routerHistory, acceptExtraMentions = null) {
   return function (dispatch, getState) {

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -157,7 +157,60 @@ export function directCompose(account, routerHistory) {
   };
 }
 
-export function submitCompose(routerHistory) {
+function resolveMentions(state, text, expectedMentions, unresolvedMentions) {
+  const mentionReSource = '@([a-z0-9_]+(?:[a-z0-9_\\.-]+[a-z0-9_]+)?(?:@[\\p{L}\\p{N}_-]+\\.[\\p{L}\\p{N}]{2,})?)';
+  const mentionRe = new RegExp(mentionReSource, 'gui');
+  const matcherRe = new RegExp(`^((${mentionReSource})[^\\S\\r\\n]+)*(${mentionReSource})`, 'gui');
+  const leadingMentionsText = text.match(matcherRe);
+
+  if (leadingMentionsText) {
+    for (const match of leadingMentionsText[0].matchAll(mentionRe)) {
+      const acct = match[1];
+
+      let accountId = state.getIn(['accounts_map', acct]);
+
+      if (!accountId && !unresolvedMentions.includes(acct)) {
+        unresolvedMentions.push(acct);
+      }
+
+      if (accountId && !expectedMentions.includes(accountId)) {
+        expectedMentions.push(accountId);
+      }
+    }
+  }
+};
+
+function handleUnexpectedMentions(routerHistory, extraAccounts, expectedMentions, unresolvedMentions) {
+  return (dispatch, getState) => {
+    // It is possible that some accounts failed to resolve due to case-sensitive comparison.
+    // Check whether this may be the case
+    for (const acct of unresolvedMentions) {
+      const index = extraAccounts.findIndex((account) => {
+        //TODO: handle IDN
+        return (acct.toLowerCase() === account.acct.toLowerCase());
+      });
+
+      if (index >= 0) {
+        expectedMentions.push(extraAccounts[index].id);
+        extraAccounts.splice(index, 1);
+      }
+    }
+
+    if (extraAccounts.length === 0) {
+      dispatch(submitCompose(routerHistory, expectedMentions));
+    } else {
+      //TODO: rewrite and move elsewhere
+      dispatch(openModal('UNEXPECTED_MENTIONS', {
+        extraAccounts: extraAccounts,
+        onConfirm: () => {
+          dispatch(submitCompose(routerHistory, expectedMentions.concat(extraAccounts.map((account) => account.id))));
+        },
+      }));
+    }
+  };
+};
+
+export function submitCompose(routerHistory, acceptExtraMentions = null) {
   return function (dispatch, getState) {
     const status   = getState().getIn(['compose', 'text'], '');
     const media    = getState().getIn(['compose', 'media_attachments']);
@@ -165,6 +218,18 @@ export function submitCompose(routerHistory) {
 
     if ((!status || !status.length) && media.size === 0) {
       return;
+    }
+
+    // When writing a private or direct status, warn the user if they mention someone in the middle of the
+    // status.
+    let expectedMentions = acceptExtraMentions;
+    let unresolvedMentions = [];
+    if (statusId === null && ['private', 'direct'].includes(getState().getIn(['compose', 'privacy']))) {
+      if (!expectedMentions) {
+        expectedMentions = [];
+      }
+
+      resolveMentions(getState(), status, expectedMentions, unresolvedMentions);
     }
 
     dispatch(submitComposeRequest());
@@ -202,6 +267,7 @@ export function submitCompose(routerHistory) {
         visibility: getState().getIn(['compose', 'privacy']),
         poll: getState().getIn(['compose', 'poll'], null),
         language: getState().getIn(['compose', 'language']),
+        allowed_mentions: expectedMentions,
       },
       headers: {
         'Idempotency-Key': getState().getIn(['compose', 'idempotencyKey']),
@@ -238,7 +304,14 @@ export function submitCompose(routerHistory) {
         insertIfOnline(`account:${response.data.account.id}`);
       }
     }).catch(function (error) {
-      dispatch(submitComposeFail(error));
+      if (error.response && error.response.status === 422 && error.response.data.unexpected_accounts) {
+        let extraAccounts = error.response.data.unexpected_accounts;
+        dispatch(importFetchedAccounts(extraAccounts));
+        dispatch(submitComposeFail(error, true));
+        dispatch(handleUnexpectedMentions(routerHistory, extraAccounts, expectedMentions, unresolvedMentions));
+      } else {
+        dispatch(submitComposeFail(error));
+      }
     });
   };
 }
@@ -256,10 +329,11 @@ export function submitComposeSuccess(status) {
   };
 }
 
-export function submitComposeFail(error) {
+export function submitComposeFail(error, skipAlert = false) {
   return {
     type: COMPOSE_SUBMIT_FAIL,
     error: error,
+    skipAlert: skipAlert,
   };
 }
 

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -199,9 +199,8 @@ function handleUnexpectedMentions(routerHistory, extraAccounts, expectedMentions
     if (extraAccounts.length === 0) {
       dispatch(submitCompose(routerHistory, expectedMentions));
     } else {
-      //TODO: rewrite and move elsewhere
       dispatch(openModal('UNEXPECTED_MENTIONS', {
-        extraAccounts: extraAccounts,
+        extraAccountIds: extraAccounts.map((account) => account.id),
         onConfirm: () => {
           dispatch(submitCompose(routerHistory, expectedMentions.concat(extraAccounts.map((account) => account.id))));
         },

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -9,6 +9,7 @@ import { useEmoji } from './emojis';
 import { importFetchedAccounts, importFetchedStatus } from './importer';
 import { openModal } from './modal';
 import { updateTimeline } from './timelines';
+import { mentionModal } from 'mastodon/initial_state';
 
 /** @type {AbortController | undefined} */
 let fetchComposeSuggestionsAccountsController;
@@ -223,7 +224,7 @@ export function submitCompose(routerHistory, acceptExtraMentions = null) {
     // status.
     let expectedMentions = acceptExtraMentions;
     let unresolvedMentions = [];
-    if (statusId === null && ['private', 'direct'].includes(getState().getIn(['compose', 'privacy']))) {
+    if (mentionModal && statusId === null && ['private', 'direct'].includes(getState().getIn(['compose', 'privacy']))) {
       if (!expectedMentions) {
         expectedMentions = [];
       }

--- a/app/javascript/mastodon/components/account.jsx
+++ b/app/javascript/mastodon/components/account.jsx
@@ -43,10 +43,12 @@ class Account extends ImmutablePureComponent {
     actionTitle: PropTypes.string,
     defaultAction: PropTypes.string,
     onActionClick: PropTypes.func,
+    interactive: PropTypes.bool,
   };
 
   static defaultProps = {
     size: 46,
+    interactive: true,
   };
 
   handleFollow = () => {
@@ -74,7 +76,7 @@ class Account extends ImmutablePureComponent {
   };
 
   render () {
-    const { account, intl, hidden, onActionClick, actionIcon, actionTitle, defaultAction, size, minimal } = this.props;
+    const { account, intl, hidden, onActionClick, actionIcon, actionTitle, defaultAction, size, minimal, interactive } = this.props;
 
     if (!account) {
       return (
@@ -154,21 +156,33 @@ class Account extends ImmutablePureComponent {
       verification = <>· <VerifiedBadge link={firstVerifiedField.get('value')} verifiedAt={firstVerifiedField.get('verified_at')} /></>;
     }
 
+    const contents = (
+      <React.Fragment>
+        <div className='account__avatar-wrapper'>
+          <Avatar account={account} size={size} />
+        </div>
+
+        <div>
+          <DisplayName account={account} />
+          {!minimal && <><ShortNumber value={account.get('followers_count')} renderer={counterRenderer('followers')} /> {verification} {muteTimeRemaining}</>}
+        </div>
+      </React.Fragment>
+    );
+
     return (
       <div className={classNames('account', { 'account--minimal': minimal })}>
         <div className='account__wrapper'>
-          <Link key={account.get('id')} className='account__display-name' title={account.get('acct')} to={`/@${account.get('acct')}`}>
-            <div className='account__avatar-wrapper'>
-              <Avatar account={account} size={size} />
-            </div>
+          { interactive ? (
+            <Link key={account.get('id')} className='account__display-name' title={account.get('acct')} to={`/@${account.get('acct')}`}>
+              {contents}
+            </Link>
+          ) : (
+            <span key={account.get('id')} className='account__display-name' title={account.get('acct')}>
+              {contents}
+            </span>
+          )}
 
-            <div>
-              <DisplayName account={account} />
-              {!minimal && <><ShortNumber value={account.get('followers_count')} renderer={counterRenderer('followers')} /> {verification} {muteTimeRemaining}</>}
-            </div>
-          </Link>
-
-          {!minimal && (
+          {interactive && !minimal && (
             <div className='account__relationship'>
               {buttons}
             </div>

--- a/app/javascript/mastodon/features/ui/components/modal_root.jsx
+++ b/app/javascript/mastodon/features/ui/components/modal_root.jsx
@@ -13,6 +13,7 @@ import AudioModal from './audio_modal';
 import ConfirmationModal from './confirmation_modal';
 import FocalPointModal from './focal_point_modal';
 import ImageModal from './image_modal';
+import UnexpectedMentionsModal from './unexpected_mentions_modal';
 import {
   MuteModal,
   BlockModal,
@@ -48,6 +49,7 @@ const MODAL_COMPONENTS = {
   'SUBSCRIBED_LANGUAGES': SubscribedLanguagesModal,
   'INTERACTION': InteractionModal,
   'CLOSED_REGISTRATIONS': ClosedRegistrationsModal,
+  'UNEXPECTED_MENTIONS': () => Promise.resolve({ default: UnexpectedMentionsModal }),
 };
 
 export default class ModalRoot extends React.PureComponent {

--- a/app/javascript/mastodon/features/ui/components/unexpected_mentions_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/unexpected_mentions_modal.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import ConfirmationModal from './confirmation_modal';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+const messages = defineMessages({
+  sendConfirm: { id: 'confirmations.unexpected_mentions.confirm', defaultMessage: 'Send' },
+});
+
+class UnexpectedMentionsModal extends React.PureComponent {
+
+  static propTypes = {
+    extraAccounts: ImmutablePropTypes.list.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onConfirm: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+  };
+
+  render () {
+    const { onClose, onConfirm, extraAccounts, intl } = this.props;
+
+    const message = (
+      <>
+        <FormattedMessage
+          id='confirmations.unexpected_mentions.message'
+          defaultMessage='This message is about to be sent to all mentioned users, including the following ones:'
+        />
+
+       <ul className='item-list'>
+         { extraAccounts.map((account) => <li>{account.acct}</li>) }
+       </ul>
+      </>
+    );
+
+    return (
+      <ConfirmationModal
+        message={message}
+        confirm={intl.formatMessage(messages.sendConfirm)}
+        onClose={onClose}
+        onConfirm={onConfirm}
+      />
+    );
+  }
+
+}
+
+export default injectIntl(UnexpectedMentionsModal);

--- a/app/javascript/mastodon/features/ui/components/unexpected_mentions_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/unexpected_mentions_modal.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import ConfirmationModal from './confirmation_modal';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import AccountContainer from 'mastodon/containers/account_container';
 
 const messages = defineMessages({
   sendConfirm: { id: 'confirmations.unexpected_mentions.confirm', defaultMessage: 'Send' },
@@ -11,14 +12,14 @@ const messages = defineMessages({
 class UnexpectedMentionsModal extends React.PureComponent {
 
   static propTypes = {
-    extraAccounts: ImmutablePropTypes.list.isRequired,
+    extraAccountIds: ImmutablePropTypes.list.isRequired,
     onClose: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
   };
 
   render () {
-    const { onClose, onConfirm, extraAccounts, intl } = this.props;
+    const { onClose, onConfirm, extraAccountIds, intl } = this.props;
 
     const message = (
       <>
@@ -27,8 +28,8 @@ class UnexpectedMentionsModal extends React.PureComponent {
           defaultMessage='This message is about to be sent to all mentioned users, including the following ones:'
         />
 
-       <ul className='item-list'>
-         { extraAccounts.map((account) => <li>{account.acct}</li>) }
+       <ul className='item-list light'>
+         { extraAccountIds.map((accountId) => <li><AccountContainer id={accountId} interactive={false} /></li>) }
        </ul>
       </>
     );

--- a/app/javascript/mastodon/features/ui/components/unexpected_mentions_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/unexpected_mentions_modal.jsx
@@ -28,9 +28,9 @@ class UnexpectedMentionsModal extends React.PureComponent {
           defaultMessage='This message is about to be sent to all mentioned users, including the following ones:'
         />
 
-       <ul className='item-list light'>
-         { extraAccountIds.map((accountId) => <li><AccountContainer id={accountId} interactive={false} /></li>) }
-       </ul>
+        <ul className='item-list light'>
+          { extraAccountIds.map((accountId) => <li key={accountId}><AccountContainer id={accountId} interactive={false} /></li>) }
+        </ul>
       </>
     );
 

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -62,6 +62,7 @@
  * @property {string} locale
  * @property {string | null} mascot
  * @property {string=} me
+ * @property {boolean} mention_modal
  * @property {string=} moved_to_account_id
  * @property {string=} owner
  * @property {boolean} profile_directory
@@ -114,6 +115,7 @@ export const forceSingleColumn = !getMeta('advanced_layout');
 export const limitedFederationMode = getMeta('limited_federation_mode');
 export const mascot = getMeta('mascot');
 export const me = getMeta('me');
+export const mentionModal = getMeta('mention_modal');
 export const movedToAccountId = getMeta('moved_to_account_id');
 export const owner = getMeta('owner');
 export const profile_directory = getMeta('profile_directory');

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -4387,6 +4387,19 @@
   {
     "descriptors": [
       {
+        "defaultMessage": "Send",
+        "id": "confirmations.unexpected_mentions.confirm"
+      },
+      {
+        "defaultMessage": "This message is about to be sent to all mentioned users, including the following ones:",
+        "id": "confirmations.unexpected_mentions.message"
+      }
+    ],
+    "path": "app/javascript/mastodon/features/ui/components/unexpected_mentions_modal.json"
+  },
+  {
+    "descriptors": [
+      {
         "defaultMessage": "Drag & drop to upload",
         "id": "upload_area.title"
       }

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -174,6 +174,8 @@
   "confirmations.redraft.message": "Are you sure you want to delete this post and re-draft it? Favourites and boosts will be lost, and replies to the original post will be orphaned.",
   "confirmations.reply.confirm": "Reply",
   "confirmations.reply.message": "Replying now will overwrite the message you are currently composing. Are you sure you want to proceed?",
+  "confirmations.unexpected_mentions.confirm": "Send",
+  "confirmations.unexpected_mentions.message": "This message is about to be sent to all mentioned users, including the following ones:",
   "confirmations.unfollow.confirm": "Unfollow",
   "confirmations.unfollow.message": "Are you sure you want to unfollow {name}?",
   "conversation.delete": "Delete conversation",

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5748,8 +5748,25 @@ a.status-card.compact:hover {
 
   .item-list {
     text-align: start;
-    padding: 10px;
-    list-style: disc inside;
+    margin-top: 15px;
+    overflow-y: auto;
+
+    &.light {
+      .display-name {
+        color: $light-text-color;
+
+        strong {
+          color: $inverted-text-color;
+        }
+      }
+    }
+
+    .account {
+      border: 0;
+      padding: 0;
+      margin-top: 8px;
+    }
+
   }
 }
 
@@ -6253,6 +6270,12 @@ a.status-card.compact:hover {
 .confirmation-modal__container,
 .report-modal__target {
   text-align: center;
+}
+
+.confirmation-modal__container {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .block-modal,

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5745,6 +5745,12 @@ a.status-card.compact:hover {
   width: 480px;
   position: relative;
   flex-direction: column;
+
+  .item-list {
+    text-align: start;
+    padding: 10px;
+    list-style: disc inside;
+  }
 }
 
 .actions-modal {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5766,7 +5766,6 @@ a.status-card.compact:hover {
       padding: 0;
       margin-top: 8px;
     }
-
   }
 }
 

--- a/app/models/concerns/has_user_settings.rb
+++ b/app/models/concerns/has_user_settings.rb
@@ -39,6 +39,10 @@ module HasUserSettings
     settings['web.delete_modal']
   end
 
+  def setting_mention_modal
+    settings['web.mention_modal']
+  end
+
   def setting_reduce_motion
     settings['web.reduce_motion']
   end

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -27,6 +27,7 @@ class UserSettings
     setting :delete_modal, default: true
     setting :reblog_modal, default: false
     setting :unfollow_modal, default: true
+    setting :mention_modal, default: true
     setting :reduce_motion, default: false
     setting :expand_content_warnings, default: false
     setting :display_media, default: 'default', in: %w(default show_all hide_all)

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -39,6 +39,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:unfollow_modal]    = object.current_account.user.setting_unfollow_modal
       store[:boost_modal]       = object.current_account.user.setting_boost_modal
       store[:delete_modal]      = object.current_account.user.setting_delete_modal
+      store[:mention_modal]     = object.current_account.user.setting_mention_modal
       store[:auto_play_gif]     = object.current_account.user.setting_auto_play_gif
       store[:display_media]     = object.current_account.user.setting_display_media
       store[:expand_spoilers]   = object.current_account.user.setting_expand_spoilers

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -35,27 +35,9 @@ class InitialStateSerializer < ActiveModel::Serializer
     }
 
     if object.current_account
-      store[:me]                = object.current_account.id.to_s
-      store[:unfollow_modal]    = object.current_account.user.setting_unfollow_modal
-      store[:boost_modal]       = object.current_account.user.setting_boost_modal
-      store[:delete_modal]      = object.current_account.user.setting_delete_modal
-      store[:mention_modal]     = object.current_account.user.setting_mention_modal
-      store[:auto_play_gif]     = object.current_account.user.setting_auto_play_gif
-      store[:display_media]     = object.current_account.user.setting_display_media
-      store[:expand_spoilers]   = object.current_account.user.setting_expand_spoilers
-      store[:reduce_motion]     = object.current_account.user.setting_reduce_motion
-      store[:disable_swiping]   = object.current_account.user.setting_disable_swiping
-      store[:advanced_layout]   = object.current_account.user.setting_advanced_layout
-      store[:use_blurhash]      = object.current_account.user.setting_use_blurhash
-      store[:use_pending_items] = object.current_account.user.setting_use_pending_items
-      store[:trends]            = Setting.trends && object.current_account.user.setting_trends
-      store[:crop_images]       = object.current_account.user.setting_crop_images
+      fill_logged_in_meta(store)
     else
-      store[:auto_play_gif] = Setting.auto_play_gif
-      store[:display_media] = Setting.display_media
-      store[:reduce_motion] = Setting.reduce_motion
-      store[:use_blurhash]  = Setting.use_blurhash
-      store[:crop_images]   = Setting.crop_images
+      fill_anonymous_meta(store)
     end
 
     store[:disabled_account_id] = object.disabled_account.id.to_s if object.disabled_account
@@ -64,6 +46,32 @@ class InitialStateSerializer < ActiveModel::Serializer
     store[:owner] = object.owner&.id&.to_s if Rails.configuration.x.single_user_mode
 
     store
+  end
+
+  def fill_logged_in_meta(store)
+    store[:me]                = object.current_account.id.to_s
+    store[:unfollow_modal]    = object.current_account.user.setting_unfollow_modal
+    store[:boost_modal]       = object.current_account.user.setting_boost_modal
+    store[:delete_modal]      = object.current_account.user.setting_delete_modal
+    store[:mention_modal]     = object.current_account.user.setting_mention_modal
+    store[:auto_play_gif]     = object.current_account.user.setting_auto_play_gif
+    store[:display_media]     = object.current_account.user.setting_display_media
+    store[:expand_spoilers]   = object.current_account.user.setting_expand_spoilers
+    store[:reduce_motion]     = object.current_account.user.setting_reduce_motion
+    store[:disable_swiping]   = object.current_account.user.setting_disable_swiping
+    store[:advanced_layout]   = object.current_account.user.setting_advanced_layout
+    store[:use_blurhash]      = object.current_account.user.setting_use_blurhash
+    store[:use_pending_items] = object.current_account.user.setting_use_pending_items
+    store[:trends]            = Setting.trends && object.current_account.user.setting_trends
+    store[:crop_images]       = object.current_account.user.setting_crop_images
+  end
+
+  def fill_anonymous_meta(store)
+    store[:auto_play_gif] = Setting.auto_play_gif
+    store[:display_media] = Setting.display_media
+    store[:reduce_motion] = Setting.reduce_motion
+    store[:use_blurhash]  = Setting.use_blurhash
+    store[:crop_images]   = Setting.crop_images
   end
 
   def compose

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -50,6 +50,7 @@
       = ff.input :'web.unfollow_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_unfollow_modal')
       = ff.input :'web.reblog_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_boost_modal')
       = ff.input :'web.delete_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_delete_modal')
+      = ff.input :'web.mention_modal', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_mention_modal')
 
     %h4= t 'appearance.sensitive_content'
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -208,6 +208,7 @@ en:
         setting_display_media_show_all: Show all
         setting_expand_spoilers: Always expand posts marked with content warnings
         setting_hide_network: Hide your social graph
+        setting_mention_modal: Show confirmation dialog before sending private posts with mentions in the middle of the text
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send posts


### PR DESCRIPTION
Uses #18350 to implement a confirmation dialog in the WebUI when possibly unexpected mentions (mentions that are not at the start of the first line) in followers-only and direct messages.

This is to address newcomers sometimes accidentally mentioning users because they do not expect Mastodon to send a message to all mentioned users.

![image](https://user-images.githubusercontent.com/384364/167452842-85dd0d8e-e654-4609-847e-eb0d21dee9f9.png)

This works by using  regexps to detect a block of possible mentions separated by non-newline space characters at the start of the to-be-posted toot text, then locally-resolving those mentions in the WebUI, and using the `safeguard_mentions` API from #18350 to tell the server to reject the post if it ends up resolving any other account. If the server returns an error, import the newly-returned extra accounts, see if by chance they aren't part of one of possibly unresolved mentions from the block, transparently re-send if all extraneous mentions could be resolved, and otherwise present the user with this dialog.