### PR TITLE
Fix schema.org context while preserving compatibility with older Mastodon versions

### DIFF
--- a/app/helpers/context_helper.rb
+++ b/app/helpers/context_helper.rb
@@ -14,7 +14,7 @@ module ContextHelper
     also_known_as: { 'alsoKnownAs' => { '@id' => 'as:alsoKnownAs', '@type' => '@id' } },
     emoji: { 'toot' => 'http://joinmastodon.org/ns#', 'Emoji' => 'toot:Emoji' },
     featured: { 'toot' => 'http://joinmastodon.org/ns#', 'featured' => { '@id' => 'toot:featured', '@type' => '@id' }, 'featuredTags' => { '@id' => 'toot:featuredTags', '@type' => '@id' } },
-    property_value: { 'schema' => 'http://schema.org#', 'PropertyValue' => 'schema:PropertyValue', 'value' => 'schema:value' },
+    property_value: { 'schema' => 'http://schema.org/', 'PropertyValue' => 'schema:PropertyValue', 'value' => 'schema:value' },
     atom_uri: { 'ostatus' => 'http://ostatus.org#', 'atomUri' => 'ostatus:atomUri' },
     conversation: { 'ostatus' => 'http://ostatus.org#', 'inReplyToAtomUri' => 'ostatus:inReplyToAtomUri', 'conversation' => 'ostatus:conversation' },
     focal_point: { 'toot' => 'http://joinmastodon.org/ns#', 'focalPoint' => { '@container' => '@list', '@id' => 'toot:focalPoint' } },

--- a/app/helpers/jsonld_helper.rb
+++ b/app/helpers/jsonld_helper.rb
@@ -73,8 +73,7 @@ module JsonLdHelper
   end
 
   def canonicalize(json)
-    # The deep_dup call below is required until https://github.com/ruby-rdf/json-ld/issues/54 is fixed
-    graph = RDF::Graph.new << JSON::LD::API.toRdf(json.deep_dup, documentLoader: method(:load_jsonld_context))
+    graph = RDF::Graph.new << JSON::LD::API.toRdf(json, documentLoader: method(:load_jsonld_context))
     graph.dump(:normalize)
   end
 

--- a/app/helpers/jsonld_helper.rb
+++ b/app/helpers/jsonld_helper.rb
@@ -73,7 +73,8 @@ module JsonLdHelper
   end
 
   def canonicalize(json)
-    graph = RDF::Graph.new << JSON::LD::API.toRdf(json, documentLoader: method(:load_jsonld_context))
+    # The deep_dup call below is required until https://github.com/ruby-rdf/json-ld/issues/54 is fixed
+    graph = RDF::Graph.new << JSON::LD::API.toRdf(json.deep_dup, documentLoader: method(:load_jsonld_context))
     graph.dump(:normalize)
   end
 

--- a/app/lib/activitypub/case_transform.rb
+++ b/app/lib/activitypub/case_transform.rb
@@ -14,6 +14,8 @@ module ActivityPub::CaseTransform
       when String
         camel_lower_cache[value] ||= if value.start_with?('_:')
                                        "_:#{value.gsub(/\A_:/, '').underscore.camelize(:lower)}"
+                                     elsif value.start_with?('http://', 'https://')
+                                       value
                                      else
                                        value.underscore.camelize(:lower)
                                      end

--- a/spec/lib/activitypub/linked_data_signature_spec.rb
+++ b/spec/lib/activitypub/linked_data_signature_spec.rb
@@ -77,6 +77,24 @@ RSpec.describe ActivityPub::LinkedDataSignature do
     it 'can be verified again' do
       expect(described_class.new(subject).verify_actor!).to eq sender
     end
+
+    context 'with attribute fields' do
+      let(:sender) { Fabricate(:account, fields: [{ 'name' => 'foo', 'value' => 'bar' }]) }
+      let(:raw_json) { ActiveModelSerializers::SerializableResource.new(sender, serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter).as_json }
+
+      it 'returns a hash' do
+        expect(subject).to be_a Hash
+      end
+
+      it 'contains signature' do
+        expect(subject['signature']).to be_a Hash
+        expect(subject['signature']['signatureValue']).to be_present
+      end
+
+      it 'can be verified again' do
+        expect(described_class.new(subject).verify_actor!).to eq sender
+      end
+    end
   end
 
   def sign(from_actor, options, document)

--- a/spec/serializers/activitypub/actor_serializer_spec.rb
+++ b/spec/serializers/activitypub/actor_serializer_spec.rb
@@ -7,7 +7,7 @@ describe ActivityPub::ActorSerializer do
     JSON.parse(ActiveModelSerializers::SerializableResource.new(account, serializer: described_class, adapter: ActivityPub::Adapter).to_json)
   end
 
-  subject(:compacted) { JSON::LD::API.compact(json.deep_dup, nil) }
+  subject(:compacted) { JSON::LD::API.compact(json, nil) }
 
   let(:account) { Fabricate(:account, fields: [{ name: 'foo', value: 'bar' }]) }
 

--- a/spec/serializers/activitypub/actor_serializer_spec.rb
+++ b/spec/serializers/activitypub/actor_serializer_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ActivityPub::ActorSerializer do
+  subject(:json) do
+    JSON.parse(ActiveModelSerializers::SerializableResource.new(account, serializer: described_class, adapter: ActivityPub::Adapter).to_json)
+  end
+
+  subject(:compacted) { JSON::LD::API.compact(json.deep_dup, nil) }
+
+  let(:account) { Fabricate(:account, fields: [{ name: 'foo', value: 'bar' }]) }
+
+  it 'has a Person type' do
+    expect(json['type']).to eql('Person')
+  end
+
+  it 'has the correct actor URI set' do
+    expect(json['id']).to eql(ActivityPub::TagManager.instance.uri_for(account))
+  end
+
+  it 'outputs profile fields in a way readable in JSON' do
+    expect(json['attachment'].filter_map do |attachment|
+      [attachment['name'], attachment['value']] if attachment['type'] == 'PropertyValue'
+    end).to eq [['foo', 'bar']]
+  end
+
+  it 'outputs profile fields in a way that is correct JSON-LD' do
+    expect(compacted['https://www.w3.org/ns/activitystreams#attachment'].filter_map do |attachment|
+      [attachment['http://schema.org/name'], attachment['http://schema.org/value']] if attachment['@type'] == 'http://schema.org/PropertyValue'
+    end).to eq [['foo', 'bar']]
+  end
+
+  it 'outputs profile fields in a way that older Mastodon versions support' do
+    expect(compacted['https://www.w3.org/ns/activitystreams#attachment'].filter_map do |attachment|
+      [attachment['https://www.w3.org/ns/activitystreams#name'], attachment['http://schema.org#value']] if attachment['@type'] == 'http://schema.org#PropertyValue'
+    end).to eq [['foo', 'bar']]
+  end
+end

--- a/spec/services/activitypub/process_collection_service_spec.rb
+++ b/spec/services/activitypub/process_collection_service_spec.rb
@@ -66,6 +66,322 @@ RSpec.describe ActivityPub::ProcessCollectionService, type: :service do
       end
     end
 
+    context 'when receiving an Update Account activity with profile fields' do
+      context 'when received from a correct context with backward compat hack' do
+        let!(:payload) do
+          {
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              'https://w3id.org/security/v1',
+              {
+                manuallyApprovesFollowers: 'as:manuallyApprovesFollowers',
+                toot: 'http://joinmastodon.org/ns#',
+                featured: { '@id': 'toot:featured', '@type': '@id' },
+                featuredTags: { '@id': 'toot:featuredTags', '@type': '@id' },
+                alsoKnownAs: { '@id': 'as:alsoKnownAs', '@type': '@id' },
+                movedTo: { '@id': 'as:movedTo', '@type': '@id'},
+                schema: 'http://schema.org/',
+                PropertyValue: 'schema:PropertyValue',
+                value: 'schema:value',
+                discoverable: 'toot:discoverable',
+                Device: 'toot:Device',
+                Ed25519Signature: 'toot:Ed25519Signature',
+                Ed25519Key: 'toot:Ed25519Key',
+                Curve25519Key: 'toot:Curve25519Key',
+                EncryptedMessage: 'toot:EncryptedMessage',
+                publicKeyBase64: 'toot:publicKeyBase64',
+                deviceId: 'toot:deviceId',
+                claim: { '@type': '@id', '@id': 'toot:claim' },
+                fingerprintKey: { '@type': '@id', '@id': 'toot:fingerprintKey' },
+                identityKey: { '@type': '@id', '@id': 'toot:identityKey' },
+                devices: { '@type': '@id', '@id': 'toot:devices' },
+                messageFranking: 'toot:messageFranking',
+                messageType: 'toot:messageType',
+                cipherText: 'toot:cipherText',
+                suspended: 'toot:suspended'
+              }
+            ],
+            id: 'https://example.com/users/mark_mann21#updates/1652213426',
+            type: 'Update',
+            actor: 'https://example.com/users/mark_mann21',
+            to: ['https://www.w3.org/ns/activitystreams#Public'],
+            object: {
+              id: 'https://example.com/users/mark_mann21',
+              type: 'Person',
+              following: 'https://example.com/users/mark_mann21/following',
+              followers: 'https://example.com/users/mark_mann21/followers',
+              inbox: 'https://example.com/users/mark_mann21/inbox',
+              outbox: 'https://example.com/users/mark_mann21/outbox',
+              featured: 'https://example.com/users/mark_mann21/collections/featured',
+              featuredTags: 'https://example.com/users/mark_mann21/collections/tags',
+              preferredUsername: 'mark_mann21',
+              name: '',
+              summary: '',
+              url: 'https://example.com/@mark_mann21',
+              manuallyApprovesFollowers: false,
+              discoverable: false,
+              published: '2022-05-10T00:00:00Z',
+              devices: 'https://example.com/users/mark_mann21/collections/devices',
+              publicKey: {
+                id: 'https://example.com/users/mark_mann21#main-key',
+                owner: 'https://example.com/users/mark_mann21',
+                publicKeyPem: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA06TxtptmSLw3Pyxx/Lez\nPaF6/0wQnlsNEH1XMLKi0OcQw3YWsjNU5BiiIf4LjiPHM+w5ZZDlgSzW2d7irVpn\naUSQk4ovr02gddgH9zzjQY7IwiYbMCslVpmLw08+JuCJYTCtzpn4W18DF3xGDIqq\nlBOrXkmFSuMnDxvJ/HFGxyN7HFS36k78ylyrv2O7hnotFeJMiC9PblLlEdkmKh94\nkRqPZwH2eX0o3VOSFnUOWXXO0uNKqB1cERIFcSphiu45xvyCBtj/1vsxCdwOO3PP\nrNhLtIiId0p+zwebSac3CwdCR6rY12ejJpTK+HRJ73CkyzpGwxrkbmBTIM1jZadv\nUwIDAQAB\n-----END PUBLIC KEY-----\n"
+              },
+              tag: [],
+              attachment: [
+                { type: 'PropertyValue', name: 'foo', value: 'bar', '@context': { name: 'schema:name' }},
+                { type: 'PropertyValue', name: 'new', value: 'field', '@context': { name: 'schema:name' }}
+              ],
+              endpoints: {
+                sharedInbox: 'https://example.com/inbox'
+              },
+              'https://www.w3.org/ns/activitystreams#attachment': [
+                { type: 'http://schema.org#PropertyValue', name: 'foo', 'http://schema.org#value': 'bar' },
+                { type: 'http://schema.org#PropertyValue', name: 'new', 'http://schema.org#value': 'field' }
+              ]
+            },
+            signature: {
+              type: 'RsaSignature2017',
+              creator: 'https://example.com/users/mark_mann21#main-key',
+              created: '2022-05-10T20:10:26Z',
+              signatureValue: 'FFNrhKgjQsqUuuaEM9RbJHCQjN9y7VYg23x7OA5AgzQqYhDslefDbtAdbDUcgcQd55J8ul8KWlzNgHzoApWEMi7aghyvZrxAAeeDkDutk8tgdCEzN87NjBcU7pTkwYtnYZjjg3P3xEk2osWRF9b5mZB2UE0Gz1vnAKmgYbkkVKYeT2L7KGdOTRQVazopZzYsNphuiS6CCTJ0HtXNDQuovqg58XGp6BX1GCfpEU31Y5SfK8NsBs0oSham/Gcfb/s4Nhvati+5movD/nwt9zRszm71CQ9PA5Zi+JH9HkTCBuWw6Lm1KsKx6fAyOD1eMjuc37iokYQ5JqggaxD1uBExIw=='
+            }
+          }
+        end
+
+        let(:actor) {
+          Fabricate(:account,
+            username: payload[:object][:preferredUsername],
+            public_key: payload[:object][:publicKey][:publicKeyPem],
+            private_key: nil,
+            domain: 'example.com',
+            uri: payload[:object][:id],
+          )
+        }
+
+        before do
+          stub_request(:get, payload[:object][:outbox]).to_return status: 200, body: '{}'
+          stub_request(:get, payload[:object][:featured]).to_return status: 200, body: '{}'
+          stub_request(:get, payload[:object][:featuredTags]).to_return status: 200, body: '{}'
+          stub_request(:get, payload[:object][:following]).to_return status: 403
+          stub_request(:get, payload[:object][:followers]).to_return status: 403
+        end
+
+        it 'processes the payload' do
+          expect(actor.reload.fields).to eq []
+          subject.call(json, actor)
+          expect(actor.reload.fields.map { |f| [f.name, f.value] }).to eq([['foo', 'bar'], ['new', 'field']])
+        end
+      end
+
+      context 'when received from a correct context without backward compat hack' do
+        let!(:payload) do
+          {
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              'https://w3id.org/security/v1',
+              {
+                manuallyApprovesFollowers: 'as:manuallyApprovesFollowers',
+                toot: 'http://joinmastodon.org/ns#',
+                featured: { '@id': 'toot:featured', '@type': '@id' },
+                featuredTags: { '@id': 'toot:featuredTags', '@type': '@id' },
+                alsoKnownAs: { '@id': 'as:alsoKnownAs', '@type': '@id' },
+                movedTo: { '@id': 'as:movedTo', '@type': '@id'},
+                schema: 'http://schema.org/',
+                PropertyValue: 'schema:PropertyValue',
+                value: 'schema:value',
+                discoverable: 'toot:discoverable',
+                Device: 'toot:Device',
+                Ed25519Signature: 'toot:Ed25519Signature',
+                Ed25519Key: 'toot:Ed25519Key',
+                Curve25519Key: 'toot:Curve25519Key',
+                EncryptedMessage: 'toot:EncryptedMessage',
+                publicKeyBase64: 'toot:publicKeyBase64',
+                deviceId: 'toot:deviceId',
+                claim: { '@type': '@id', '@id': 'toot:claim' },
+                fingerprintKey: { '@type': '@id', '@id': 'toot:fingerprintKey' },
+                identityKey: { '@type': '@id', '@id': 'toot:identityKey' },
+                devices: { '@type': '@id', '@id': 'toot:devices' },
+                messageFranking: 'toot:messageFranking',
+                messageType: 'toot:messageType',
+                cipherText: 'toot:cipherText',
+                suspended: 'toot:suspended'
+              }
+            ],
+            id: 'https://example.com/users/moises14#updates/1652214021',
+            type: 'Update',
+            actor: 'https://example.com/users/moises14',
+            to: ['https://www.w3.org/ns/activitystreams#Public'],
+            object: {
+              id: 'https://example.com/users/moises14',
+              type: 'Person',
+              following: 'https://example.com/users/moises14/following',
+              followers: 'https://example.com/users/moises14/followers',
+              inbox: 'https://example.com/users/moises14/inbox',
+              outbox: 'https://example.com/users/moises14/outbox',
+              featured: 'https://example.com/users/moises14/collections/featured',
+              featuredTags: 'https://example.com/users/moises14/collections/tags',
+              preferredUsername: 'moises14',
+              name: '',
+              summary: '',
+              url: 'https://example.com/@moises14',
+              manuallyApprovesFollowers: false,
+              discoverable: false,
+              published: '2022-05-10T00:00:00Z',
+              devices: 'https://example.com/users/moises14/collections/devices',
+              publicKey: {
+                id: 'https://example.com/users/moises14#main-key',
+                owner: 'https://example.com/users/moises14',
+                publicKeyPem: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmurtQUOg7sa0uuqq0dUk\nWgQ4mJAWl7gTdFyVECYlnval0qe2X72/iRkYkv6st0qWDzKW0c0AIxt/qk9uRy8y\nVKw6xhBJI4uiE27EkEfz6tvJe2TfPKyBoNQDA3mV4FbwTYhOlncUSuLdOErLTGAc\nKmV18CD3WQTjKAOEmos0SgAzdfjJVRIVpb6iv1XzuffytOhGkd1OKO8HgZm2ZKTh\nR0ZZrHLu2xAnI3TxcaD1gCWmo2ON5HsPhf9DvUtEdaI/TlDcmlaSdqhNIKxK1fKz\nt3Lc7fvEeCyTwmw+d+DPCD/YNeGq4yUx4o3R0TQAVnAjQm90n1OSK4aWduTWYDPA\nXwIDAQAB\n-----END PUBLIC KEY-----\n"
+              },
+              tag: [],
+              attachment: [
+                { type: 'PropertyValue', name: 'foo', value: 'bar', '@context': { name: 'schema:name' }},
+                { type: 'PropertyValue', name: 'new', value: 'field', '@context': { name: 'schema:name' }}
+              ],
+              endpoints: {
+                sharedInbox: 'https://example.com/inbox'
+              }
+            },
+            signature: {
+              type: 'RsaSignature2017',
+              creator: 'https://example.com/users/moises14#main-key',
+              created: '2022-05-10T20:20:21Z',
+              signatureValue: 'RPSlfIKsUDPO8gnR6AabX5q+tyZh0t44U0dTvmOxbr4cqD9SEkuBmzdhmfiaII73xaFRfLkXcQnKTFfiwOMEgiFwmx9hoInvmzoRPzd/2Mu/TcoCj+ewQ3CvOyJJS5060fze/Ubb9qKv+8cFtcs3m5Qg5HoJt/BKaSV2Rm9QqWMX8AOjW7bbxIfURGVEFW6UEMnmMEhVQAxHAfavSBN53HKfEhBAVEDDXeUot5SfyYeHGdHpZJCpLmKJNv3/EaczaFJdQfT867J2GHLJeZCI02vD2UODc7Bu1m7GdUG0m1OzHQVUyfrjXUajoNivPKoO6kIDw2m6gkzJ6b/OgpcTvQ=='
+            }
+          }
+        end
+
+        let(:actor) {
+          Fabricate(:account,
+            username: payload[:object][:preferredUsername],
+            public_key: payload[:object][:publicKey][:publicKeyPem],
+            private_key: nil,
+            domain: 'example.com',
+            uri: payload[:object][:id],
+          )
+        }
+
+        before do
+          stub_request(:get, payload[:object][:outbox]).to_return status: 200, body: '{}'
+          stub_request(:get, payload[:object][:featured]).to_return status: 200, body: '{}'
+          stub_request(:get, payload[:object][:featuredTags]).to_return status: 200, body: '{}'
+          stub_request(:get, payload[:object][:following]).to_return status: 403
+          stub_request(:get, payload[:object][:followers]).to_return status: 403
+        end
+
+        it 'processes the payload' do
+          expect(actor.reload.fields).to eq []
+          subject.call(json, actor)
+          expect(actor.reload.fields.map { |f| [f.name, f.value] }).to eq([['foo', 'bar'], ['new', 'field']])
+        end
+      end
+
+      # Old versions of Mastodon use incorrect properties for fields
+      context 'when received from an older version with buggy context' do
+        let!(:payload) do
+          {
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              'https://w3id.org/security/v1',
+              {
+                manuallyApprovesFollowers: 'as:manuallyApprovesFollowers',
+                toot: 'http://joinmastodon.org/ns#',
+                featured: { '@id': 'toot:featured', '@type': '@id' },
+                featuredTags: { '@id': 'toot:featuredTags', '@type': '@id' },
+                alsoKnownAs: { '@id': 'as:alsoKnownAs', '@type': '@id' },
+                movedTo: { '@id': 'as:movedTo', '@type': '@id'},
+                schema: 'http://schema.org#', # This is one of the issues
+                PropertyValue: 'schema:PropertyValue',
+                value: 'schema:value',
+                discoverable: 'toot:discoverable',
+                Device: 'toot:Device',
+                Ed25519Signature: 'toot:Ed25519Signature',
+                Ed25519Key: 'toot:Ed25519Key',
+                Curve25519Key: 'toot:Curve25519Key',
+                EncryptedMessage: 'toot:EncryptedMessage',
+                publicKeyBase64: 'toot:publicKeyBase64',
+                deviceId: 'toot:deviceId',
+                claim: { '@type': '@id', '@id': 'toot:claim' },
+                fingerprintKey: { '@type': '@id', '@id': 'toot:fingerprintKey' },
+                identityKey: { '@type': '@id', '@id': 'toot:identityKey' },
+                devices: { '@type': '@id', '@id': 'toot:devices' },
+                messageFranking: 'toot:messageFranking',
+                messageType: 'toot:messageType',
+                cipherText: 'toot:cipherText',
+                suspended: 'toot:suspended'
+              }
+            ],
+            id: 'https://example.com/users/herlinda_hickle21#updates/1652202800',
+            type: 'Update',
+            actor: 'https://example.com/users/herlinda_hickle21',
+            to: ['https://www.w3.org/ns/activitystreams#Public'],
+            object: {
+              id: 'https://example.com/users/herlinda_hickle21',
+              type: 'Person',
+              following: 'https://example.com/users/herlinda_hickle21/following',
+              followers: 'https://example.com/users/herlinda_hickle21/followers',
+              inbox: 'https://example.com/users/herlinda_hickle21/inbox',
+              outbox: 'https://example.com/users/herlinda_hickle21/outbox',
+              featured: 'https://example.com/users/herlinda_hickle21/collections/featured',
+              featuredTags: 'https://example.com/users/herlinda_hickle21/collections/tags',
+              preferredUsername: 'herlinda_hickle21',
+              name: '',
+              summary: '',
+              url: 'https://example.com/@herlinda_hickle21',
+              manuallyApprovesFollowers: false,
+              discoverable: false,
+              published: '2022-05-10T00:00:00Z',
+              devices: 'https://example.com/users/herlinda_hickle21/collections/devices',
+              publicKey: {
+                id: 'https://example.com/users/herlinda_hickle21#main-key',
+                owner: 'https://example.com/users/herlinda_hickle21',
+                publicKeyPem: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqLDKPIy/vmUUaA60F/A+\nN2jcKWYhPeL7JFCFPI85W7tr7IyKhu07Gl1U9VwG9zJyYHHEFIeis0m4aDbS5S69\nFxIi5rL/Bkn7rQrnTwR4WSbs6MVOsAlPOzyP2l+jOrs2s6/ci7qeBgo9AjM6vq7H\nhrYYAm6ASYPxYo6DVJ33TnKn87XEXTks4HSwQBEgCeSV7iUe2/oIrRHml4STtGnQ\nFjAycKNbPlzWcKzyWtbisH425VjnIxnOQyxemb1ZV9rKrgNQtCzYg3cAACwRqvF3\nNHEwcig+xkH6GcsocL2w+hTwdWOUKhHyUdiTBI5lJ3aZthNwzTcsA4bhix0zIXEC\nfwIDAQAB\n-----END PUBLIC KEY-----\n"
+              },
+              tag: [],
+              attachment: [
+                { type: 'PropertyValue', name: 'foo', value: 'bar' }, # This is the other part of the issue, `name` here is `as:Name`
+                { type: 'PropertyValue', name: 'new', value: 'field' }
+              ],
+              endpoints: {
+                sharedInbox: 'https://example.com/inbox'
+              }
+            },
+            signature: {
+              type: 'RsaSignature2017',
+              creator: 'https://example.com/users/herlinda_hickle21#main-key',
+              created: '2022-05-10T17:13:20Z',
+              signatureValue: 'd/eg2m40yQ5fmeMSYNCOind7oiC/q/+ca4V5ccF+6pnX9nM2JgwqL9FesVcPJsudI0lJyB6DAAN7OAIvXPtGPpT9ZxyF3T347j+MvOokYfULsoPSd4JgRz+ZE1UgO8u6eSGVOczIetr9e8dUK25YtBp4Qps8sfdpkdXv5VYR5FyG9QalmAlwYadpXAnOVXMn7KlgydY5saftVtwCiH8AEx9qOWp5BnwHCr9FMIH6qDrruvyXRRbmHPPQnEOZCcLhSxabH55feKNjQVlxrb15v9Cx7fG0GrXERGPJUDBRoX3BOqz8SToxgGBVaTelVaGbKRSDxbMLQ3mmcjzAYaYRyw=='
+            }
+          }
+        end
+
+        let(:actor) {
+          Fabricate(:account,
+            username: payload[:object][:preferredUsername],
+            public_key: payload[:object][:publicKey][:publicKeyPem],
+            private_key: nil,
+            domain: 'example.com',
+            uri: payload[:object][:id],
+          )
+        }
+
+        before do
+          stub_request(:get, payload[:object][:outbox]).to_return status: 200, body: '{}'
+          stub_request(:get, payload[:object][:featured]).to_return status: 200, body: '{}'
+          stub_request(:get, payload[:object][:featuredTags]).to_return status: 200, body: '{}'
+          stub_request(:get, payload[:object][:following]).to_return status: 403
+          stub_request(:get, payload[:object][:followers]).to_return status: 403
+        end
+
+        it 'processes the payload' do
+          expect(actor.reload.fields).to eq []
+          subject.call(json, actor)
+          expect(actor.reload.fields.map { |f| [f.name, f.value] }).to eq([['foo', 'bar'], ['new', 'field']])
+        end
+      end
+    end
+
     context 'when actor differs from sender' do
       let(:forwarder) { Fabricate(:account, domain: 'example.com', uri: 'http://example.com/other_account') }
 


### PR DESCRIPTION
Fixes #18361

Compatibility is achieved by issuing extra items as following:

```json
 "attachment": [
    {
      "type": "PropertyValue",
      "name": "pronouns",
      "value": "they/them",
      "@context": {
        "name": "schema:name"
      }
    },
    {
      "type": "PropertyValue",
      "name": "website",
      "value": "https://mastodon.local",
      "@context": {
        "name": "schema:name"
      }
    }
  ],
 "https://www.w3.org/ns/activitystreams#attachment": [
    {
      "type": "http://schema.org#PropertyValue",
      "name": "pronouns",
      "http://schema.org#value": "they/them",
    },
    {
      "type": "http://schema.org#PropertyValue",
      "name": "website",
      "http://schema.org#value": "https://mastodon.local",
    }
  ],
```

Compacted with the context from Mastodon ≤ 3.5.2, this gives:
```json
"attachment": [
    {
      "type": "http://schema.org/PropertyValue",
      "http://schema.org/name": "pronouns",
      "http://schema.org/value": "they/them",
    },
    {
      "type": "http://schema.org/PropertyValue",
      "http://schema.org/name": "website",
      "http://schema.org/value": "https://mastodon.local",
    }
    {
      "type": "PropertyValue",
      "name": "pronouns",
      "value": "they/them",
    },
    {
      "type": "PropertyValue",
      "name": "website",
      "value": "https://mastodon.local",
    }
  ],
```

Compacted with the context from this PR, this gives:
```json
"attachment": [
    {
      "type": "PropertyValue",
      "schema:name": "pronouns",
      "value": "they/them",
    },
    {
      "type": "PropertyValue",
      "schema:name": "website",
      "value": "https://mastodon.local",
    }
    {
      "type": "http://schema.org#PropertyValue",
      "name": "pronouns",
      "http://schema.org#value": "they/them",
    },
    {
      "type": "http://schema.org#PropertyValue",
      "name": "website",
      "http://schema.org#value": "https://mastodon.local",
    }
  ],
```

Therefore, old Mastodon instances, as well as JSON-LD-unaware implementations will consume the new activity without any issue.

As for reading activities from both newer and older Mastodon versions, this is done by first looking for `PropertyValue` with `value` and `name` (or `schema:name` because of the compacting), then, if none could be found, look for `http://schema.org#PropertyValue` with `name` and `http://schema.org#value`.