### PR TITLE
Add notice for locally logged-in users to public pages

### DIFF
--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -119,13 +119,18 @@
   box-shadow: 0 0 15px rgba($base-shadow-color, 0.2);
 }
 
-.placeholder-widget {
+.placeholder-widget,
+.info-widget {
   padding: 16px;
   border-radius: 4px;
   border: 2px dashed $dark-text-color;
   text-align: center;
   color: $darker-text-color;
   margin-bottom: 10px;
+}
+
+.info-widget {
+  border-style: solid;
 }
 
 .contact-widget {
@@ -589,7 +594,8 @@ $fluid-breakpoint: $maximum-width + 20px;
 }
 
 .notice-widget,
-.placeholder-widget {
+.placeholder-widget,
+.info-widget {
   a {
     text-decoration: none;
     font-weight: 500;

--- a/app/views/accounts/show.html.haml
+++ b/app/views/accounts/show.html.haml
@@ -19,6 +19,14 @@
 
 = render 'header', account: @account, with_bio: true
 
+- if user_signed_in?
+  .info-widget
+    = fa_icon 'info-circle fw'
+    = t('accounts.viewing_public')
+    = link_to web_url("@#{@account.acct}") do
+      = t('accounts.view_in_web')
+      = fa_icon 'chevron-right fw'
+
 .grid
   .column-0
     .h-feed

--- a/app/views/follower_accounts/index.html.haml
+++ b/app/views/follower_accounts/index.html.haml
@@ -7,6 +7,14 @@
 
 = render 'accounts/header', account: @account
 
+- if user_signed_in?
+  .info-widget
+    = fa_icon 'info-circle fw'
+    = t('accounts.viewing_public')
+    = link_to web_url("@#{@account.acct}/followers") do
+      = t('accounts.view_in_web')
+      = fa_icon 'chevron-right fw'
+
 - if @account.hide_collections?
   .nothing-here= t('accounts.network_hidden')
 - elsif user_signed_in? && @account.blocking?(current_account)

--- a/app/views/following_accounts/index.html.haml
+++ b/app/views/following_accounts/index.html.haml
@@ -7,6 +7,14 @@
 
 = render 'accounts/header', account: @account
 
+- if user_signed_in?
+  .info-widget
+    = fa_icon 'info-circle fw'
+    = t('accounts.viewing_public')
+    = link_to web_url("@#{@account.acct}/following") do
+      = t('accounts.view_in_web')
+      = fa_icon 'chevron-right fw'
+
 - if @account.hide_collections?
   .nothing-here= t('accounts.network_hidden')
 - elsif user_signed_in? && @account.blocking?(current_account)

--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -17,6 +17,14 @@
   = render 'og_description', activity: @status
   = render 'og_image', activity: @status, account: @account
 
+- if user_signed_in?
+  .info-widget
+    = fa_icon 'info-circle fw'
+    = t('statuses.viewing_public')
+    = link_to web_url("@#{@status.account.acct}/#{@status.id}") do
+      = t('statuses.view_in_web')
+      = fa_icon 'chevron-right fw'
+
 .grid
   .column-0
     .activity-stream.h-entry

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,8 @@ en:
       moderator: Mod
     unavailable: Profile unavailable
     unfollow: Unfollow
+    view_in_web: Open this profile in the Web app
+    viewing_public: You are viewing a public page. Want to return to the posting interface?
   admin:
     account_actions:
       action: Perform action
@@ -1473,6 +1475,8 @@ en:
     show_thread: Show thread
     sign_in_to_participate: Sign in to participate in the conversation
     title: '%{name}: "%{quote}"'
+    view_in_web: Open this post in the Web app
+    viewing_public: You are viewing a public page. Want to return to the posting interface?
     visibilities:
       direct: Direct
       private: Followers-only


### PR DESCRIPTION
One common source of confusion for new users is ending up on a server-side-rendered account/status page from their own server.

To help with that, this PR adds a notice when viewing such a public page on a server on which you are already logged in.

This doesn't address the confusion that can arise from visiting a page from another instance, though.

![image](https://user-images.githubusercontent.com/384364/167856693-672630bc-74a8-4711-a16a-7513071d5543.png)
![image](https://user-images.githubusercontent.com/384364/167856849-3d5f7079-1b0f-4ffb-bf5c-ce0e5664532a.png)