### PR TITLE
Fix rss view on hashtag

### DIFF
--- a/app/views/tags/show.rss.ruby
+++ b/app/views/tags/show.rss.ruby
@@ -3,7 +3,6 @@ RSS::Builder.build do |doc|
   doc.description(I18n.t('rss.descriptions.tag', hashtag: @tag.name))
   doc.link(tag_url(@tag))
   doc.last_build_date(@statuses.first.created_at) if @statuses.any?
-  doc.icon(full_asset_url(@account.avatar.url(:original)))
   doc.logo(full_pack_url('media/images/logo_transparent_white.svg'))
   doc.generator("Mastodon v#{Mastodon::Version.to_s}")
 


### PR DESCRIPTION
After #18356, hashtag's rss feed was broken.
This PR fixes that