### PR TITLE
Support STREAMING_API_BASE_URL in Helm Chart

### DIFF
--- a/chart/templates/configmap-env.yaml
+++ b/chart/templates/configmap-env.yaml
@@ -83,6 +83,9 @@ data:
   SMTP_TLS: {{ .Values.mastodon.smtp.tls | quote }}
   {{- end }}
   STREAMING_CLUSTER_NUM: {{ .Values.mastodon.streaming.workers | quote }}
+  {{- if .Values.mastodon.streaming.base_url }}
+  STREAMING_API_BASE_URL: {{ .Values.mastodon.streaming.base_url | quote }}
+  {{- end }}
   {{- if .Values.externalAuth.oidc.enabled }}
   OIDC_ENABLED: {{ .Values.externalAuth.oidc.enabled | quote }}
   OIDC_DISPLAY_NAME: {{ .Values.externalAuth.oidc.display_name }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -83,6 +83,9 @@ mastodon:
     # the node running the pod, which is unrelated to the resources allocated to
     # the pod by k8s
     workers: 1
+    # The base url for streaming can be set if the streaming API is deployed to
+    # a different domain/subdomain.
+    # base_url: wws://streaming.example.com
   web:
     port: 3000
 


### PR DESCRIPTION
This adds a mastodon.streaming.base_url setting in the Helm chart values file to allow setting the STREAMING_API_BASE_URL in the Mastodon environment config map.