### PR TITLE
Mark job pods not to use Istio's envoy sidecar

### DIFF
--- a/chart/templates/cronjob-media-remove.yaml
+++ b/chart/templates/cronjob-media-remove.yaml
@@ -12,8 +12,10 @@ spec:
       template:
         metadata:
           name: {{ include "mastodon.fullname" . }}-media-remove
+        {{- with .Values.jobAnnotations }}
           annotations:
-            "sidecar.istio.io/inject": "false"
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
         spec:
           restartPolicy: OnFailure
           {{- if (not .Values.mastodon.s3.enabled) }}

--- a/chart/templates/cronjob-media-remove.yaml
+++ b/chart/templates/cronjob-media-remove.yaml
@@ -12,6 +12,8 @@ spec:
       template:
         metadata:
           name: {{ include "mastodon.fullname" . }}-media-remove
+          annotations:
+            "sidecar.istio.io/inject": "false"
         spec:
           restartPolicy: OnFailure
           {{- if (not .Values.mastodon.s3.enabled) }}

--- a/chart/templates/job-assets-precompile.yaml
+++ b/chart/templates/job-assets-precompile.yaml
@@ -12,6 +12,8 @@ spec:
   template:
     metadata:
       name: {{ include "mastodon.fullname" . }}-assets-precompile
+      annotations:
+        "sidecar.istio.io/inject": "false"
     spec:
       restartPolicy: Never
       {{- if (not .Values.mastodon.s3.enabled) }}

--- a/chart/templates/job-assets-precompile.yaml
+++ b/chart/templates/job-assets-precompile.yaml
@@ -12,8 +12,10 @@ spec:
   template:
     metadata:
       name: {{ include "mastodon.fullname" . }}-assets-precompile
+    {{- with .Values.jobAnnotations }}
       annotations:
-        "sidecar.istio.io/inject": "false"
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       restartPolicy: Never
       {{- if (not .Values.mastodon.s3.enabled) }}

--- a/chart/templates/job-chewy-upgrade.yaml
+++ b/chart/templates/job-chewy-upgrade.yaml
@@ -13,6 +13,8 @@ spec:
   template:
     metadata:
       name: {{ include "mastodon.fullname" . }}-chewy-upgrade
+      annotations:
+        "sidecar.istio.io/inject": "false"
     spec:
       restartPolicy: Never
       {{- if (not .Values.mastodon.s3.enabled) }}

--- a/chart/templates/job-chewy-upgrade.yaml
+++ b/chart/templates/job-chewy-upgrade.yaml
@@ -13,8 +13,10 @@ spec:
   template:
     metadata:
       name: {{ include "mastodon.fullname" . }}-chewy-upgrade
+    {{- with .Values.jobAnnotations }}
       annotations:
-        "sidecar.istio.io/inject": "false"
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       restartPolicy: Never
       {{- if (not .Values.mastodon.s3.enabled) }}

--- a/chart/templates/job-create-admin.yaml
+++ b/chart/templates/job-create-admin.yaml
@@ -13,6 +13,8 @@ spec:
   template:
     metadata:
       name: {{ include "mastodon.fullname" . }}-create-admin
+      annotations:
+        "sidecar.istio.io/inject": "false"
     spec:
       restartPolicy: Never
       {{- if (not .Values.mastodon.s3.enabled) }}

--- a/chart/templates/job-create-admin.yaml
+++ b/chart/templates/job-create-admin.yaml
@@ -13,8 +13,10 @@ spec:
   template:
     metadata:
       name: {{ include "mastodon.fullname" . }}-create-admin
+    {{- with .Values.jobAnnotations }}
       annotations:
-        "sidecar.istio.io/inject": "false"
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       restartPolicy: Never
       {{- if (not .Values.mastodon.s3.enabled) }}

--- a/chart/templates/job-db-migrate.yaml
+++ b/chart/templates/job-db-migrate.yaml
@@ -12,8 +12,10 @@ spec:
   template:
     metadata:
       name: {{ include "mastodon.fullname" . }}-db-migrate
+    {{- with .Values.jobAnnotations }}
       annotations:
-        "sidecar.istio.io/inject": "false"
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       restartPolicy: Never
       {{- if (not .Values.mastodon.s3.enabled) }}

--- a/chart/templates/job-db-migrate.yaml
+++ b/chart/templates/job-db-migrate.yaml
@@ -12,6 +12,8 @@ spec:
   template:
     metadata:
       name: {{ include "mastodon.fullname" . }}-db-migrate
+      annotations:
+        "sidecar.istio.io/inject": "false"
     spec:
       restartPolicy: Never
       {{- if (not .Values.mastodon.s3.enabled) }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -263,8 +263,12 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# Kubernetes manages pods for jobs and pods for deployments differently, so you might
+# need to apply different annotations to the two different sets of pods. The annotations
+# set with podAnnotations will be added to all deployment-managed pods.
 podAnnotations: {}
 
+# The annotations set with jobAnnotations will be added to all job pods.
 jobAnnotations: {}
 
 resources: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -265,6 +265,8 @@ serviceAccount:
 
 podAnnotations: {}
 
+jobAnnotations: {}
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Istio injects sidecars into pods to implement mTLS between pods. Jobs
usually don't know about this, so they don't signal the Envoy process
to stop when the job finishes. Since at least one process is running
in the pod, Kubernetes doesn't consider the job to be completed, so it
lingers.

By adding the `sidecar.istio.io/inject` annotation set to `"false"`,
we let Istio know that it should not inject the sidecar. If Istio is
not installed, then this has no impact.

Someone installing Mastodon with [Istio](https://istio.io/) will probably not enable the chart's ingress since Istio provides an ingress that integrates with the Istio mesh. If we want explicit support for Istio and Istio ingresses, I'm happy to put a PR together. Such support could also override the entrypoint in the images to signal job completion to Envoy for those users who want to run jobs with mTLS and Istio security enabled. But it's also easy enough to run Mastodon with this helm chart on Istio with these as the only changes in the chart.