### PR TITLE
Support "http_hidden_proxy" ENV var for hidden service only proxy

### DIFF
--- a/config/initializers/http_client_proxy.rb
+++ b/config/initializers/http_client_proxy.rb
@@ -18,5 +18,22 @@ Rails.application.configure do
     }.compact
   end
 
+  if ENV['http_hidden_proxy'].present?
+    proxy = URI.parse(ENV['http_hidden_proxy'])
+
+    raise "Unsupported proxy type: #{proxy.scheme}" unless %w(http https).include? proxy.scheme
+    raise "No proxy host" unless proxy.host
+
+    host = proxy.host
+    host = host[1...-1] if host[0] == '[' # for IPv6 address
+
+    config.x.http_client_hidden_proxy[:proxy] = {
+      proxy_address: host,
+      proxy_port: proxy.port,
+      proxy_username: proxy.user,
+      proxy_password: proxy.password,
+    }.compact
+  end
+
   config.x.access_to_hidden_service = ENV['ALLOW_ACCESS_TO_HIDDEN_SERVICE'] == 'true'
 end


### PR DESCRIPTION
Currently, to support hidden service integration, must enable `http_proxy` and route via privoxy.
(Another option is using tor's transparent proxy. But it is hard to configure)

Privoxy is not maintained well and hangs 30 seconds to connect for certain sites. which causes timeout for worker.

This PR present new `http_hidden_proxy` environment variable to connect through proxy only when target host is onion or i2p.