### PR TITLE
Revert "Bump redis from 4.0.6 to 4.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "react-swipeable-views": "^0.14.0",
     "react-textarea-autosize": "^8.3.3",
     "react-toggle": "^4.1.2",
-    "redis": "^4.1.0",
+    "redis": "^4.0.6",
     "redux": "^4.2.0",
     "redux-immutable": "^4.0.0",
     "redux-thunk": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9436,7 +9436,7 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redis@^4.1.0:
+redis@^4.0.6:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/redis/-/redis-4.1.0.tgz#6e400e8edf219e39281afe95e66a3d5f7dcf7289"
   integrity sha512-5hvJ8wbzpCCiuN1ges6tx2SAh2XXCY0ayresBmu40/SGusWHFW86TAlIPpbimMX2DFHOX7RN34G2XlPA1Z43zg==


### PR DESCRIPTION
Restore compatibility with Node 12