### PR TITLE
Disable transpile to older iOS versions

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,9 @@
+[production]
+defaults
+not IE 11
+not dead
+
+[development]
+last 1 chrome version
+last 1 firefox version
+last 1 safari version

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
   "extensions": [
     "EditorConfig.EditorConfig",
     "dbaeumer.vscode-eslint",
-    "rebornix.Ruby"
+    "rebornix.Ruby",
+    "webben.browserslist"
   ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/package.json
+++ b/package.json
@@ -22,12 +22,6 @@
     "type": "git",
     "url": "https://github.com/mastodon/mastodon.git"
   },
-  "browserslist": [
-    "last 2 versions",
-    "not IE 11",
-    "iOS >= 9",
-    "not dead"
-  ],
   "private": true,
   "dependencies": {
     "@babel/core": "^7.17.12",


### PR DESCRIPTION
Currently, "iOS >= 9" was specified as a fixed value, so more than necessary was being transpiled. By specifying `.browserslistrc` with `defaults`, web browsers with a market share of more than 0.5% will be addressed and transpiled.

| Before                                                                                                                                                                                                                                    | After                                                                                                                                                                                                           |
| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [![Screenshot on browserslist.dev](https://user-images.githubusercontent.com/12539/169381837-163ddf45-912e-4134-9f29-a6589bc4bac3.png)](https://browserslist.dev/?q=bGFzdCAyIHZlcnNpb25zLCBub3QgSUUgMTEsIGlPUyA%2BPSA5LCAgbm90IGRlYWQ%3D) | [![Screenshot on browserslist.dev](https://user-images.githubusercontent.com/12539/169381737-fc251ec7-b251-4c98-9f66-ac4ee39bc0aa.png)](https://browserslist.dev/?q=ZGVmYXVsdHMsIG5vdCBJRSAxMSwgbm90IGRlYWQ%3D) |

```diff
--- before.txt	2022-05-19 19:33:08.427281436 +0000
+++ after.txt	2022-05-19 19:33:28.751436540 +0000
@@ -3,50 +3,32 @@
 Using targets:
 {
   "android": "100",
-  "chrome": "100",
-  "edge": "100",
-  "firefox": "98",
-  "ios": "9",
+  "chrome": "97",
+  "edge": "98",
+  "firefox": "91",
+  "ios": "12.2",
   "opera": "85",
-  "safari": "15.2",
+  "safari": "14.1",
   "samsung": "15"
 }
 
 Using modules transform: false
 
 Using plugins:
-  proposal-class-static-block { ios, safari, samsung }
-  proposal-private-property-in-object { ios < 15, samsung }
+  proposal-class-static-block { firefox < 93, ios, safari, samsung }
+  proposal-private-property-in-object { ios < 15, safari < 15, samsung }
   proposal-class-properties { ios < 15 }
-  proposal-private-methods { ios < 15 }
+  proposal-private-methods { ios < 15, safari < 15 }
   proposal-numeric-separator { ios < 13 }
   proposal-logical-assignment-operators { ios < 14 }
   proposal-nullish-coalescing-operator { ios < 13.4 }
   proposal-optional-chaining { ios < 13.4, samsung }
-  proposal-json-strings { ios < 12 }
-  proposal-optional-catch-binding { ios < 11.3 }
+  syntax-json-strings
+  syntax-optional-catch-binding
   transform-parameters { ios, safari }
-  proposal-async-generator-functions { ios < 12 }
-  proposal-object-rest-spread { ios < 11.3 }
-  transform-dotall-regex { ios < 11.3 }
-  proposal-unicode-property-regex { ios < 11.3 }
-  transform-named-capturing-groups-regex { ios < 11.3 }
-  transform-async-to-generator { ios < 11 }
-  transform-exponentiation-operator { ios < 10.3 }
+  syntax-async-generators
+  syntax-object-rest-spread
   transform-template-literals { ios < 13 }
-  transform-function-name { ios < 10 }
-  transform-arrow-functions { ios < 10 }
-  transform-block-scoped-functions { ios < 10 }
-  transform-classes { ios < 10 }
-  transform-object-super { ios < 10 }
-  transform-for-of { ios < 10 }
-  transform-sticky-regex { ios < 10 }
-  transform-unicode-regex { ios < 12 }
-  transform-spread { ios < 10 }
-  transform-destructuring { ios < 10 }
-  transform-block-scoping { ios < 11 }
-  transform-new-target { ios < 10 }
-  transform-regenerator { ios < 10 }
   proposal-export-namespace-from { ios, safari }
   syntax-dynamic-import
   syntax-top-level-await
```