### PR TITLE
Fix tests with regards to upcoming immutable PKeys in OpenSSL 3

### DIFF
--- a/spec/fabricators/webauthn_credential_fabricator.rb
+++ b/spec/fabricators/webauthn_credential_fabricator.rb
@@ -1,7 +1,7 @@
 Fabricator(:webauthn_credential) do
   user_id { Fabricate(:user).id }
   external_id { Base64.urlsafe_encode64(SecureRandom.random_bytes(16)) }
-  public_key { OpenSSL::PKey::EC.new("prime256v1").generate_key.public_key }
+  public_key { OpenSSL::PKey::EC.generate('prime256v1').public_key }
   nickname 'USB key'
   sign_count 0
 end


### PR DESCRIPTION
Split off from #18449, this can be safely applied without updating the `openssl` or any other gem.