### PR TITLE
Save avatar or header correctly even if other one fails

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -341,9 +341,15 @@ class Account < ApplicationRecord
 
   def save_with_optional_media!
     save!
-  rescue ActiveRecord::RecordInvalid
-    self.avatar = nil
-    self.header = nil
+  rescue ActiveRecord::RecordInvalid => e
+    errors = e.record.errors.errors
+    errors.each do |err|
+      if err.attribute == :avatar
+        self.avatar = nil
+      elsif err.attribute == :header
+        self.header = nil
+      end
+    end
 
     save!
   end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Account, type: :model do
         expect(account.avatar_remote_url).to eq 'https://remote.test/invalid_avatar'
         expect(account.header_remote_url).to eq expectation.header_remote_url
         expect(account.avatar_file_name).to  eq nil
-        expect(account.header_file_name).to  eq nil
+        expect(account.header_file_name).to  eq expectation.header_file_name
       end
     end
   end


### PR DESCRIPTION
Some users from remote(misskey or pleroma) may has webp header and png avatar at the same time (or vice versa).
Currently, Mastodon will reject both if one fails, Resulting their profile picture is not shown
This PR fixes that problem. 