### PR TITLE
Update webpush to openssl3-compatible fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'
 gem 'tzinfo-data', '~> 1.2022'
 gem 'webpacker', '~> 5.4'
-gem 'webpush', '~> 0.3'
+gem 'webpush', git: 'https://github.com/ClearlyClaire/webpush.git', ref: 'f14a4d52e201128b1b00245d11b6de80d6cfdcd9'
 gem 'webauthn', '~> 3.0.0.alpha1'
 
 gem 'json-ld'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/ClearlyClaire/webpush.git
+  revision: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+  ref: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+  specs:
+    webpush (0.3.8)
+      hkdf (~> 0.2)
+      jwt (~> 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -709,9 +718,6 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    webpush (0.3.8)
-      hkdf (~> 0.2)
-      jwt (~> 2.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -844,5 +850,5 @@ DEPENDENCIES
   webauthn (~> 3.0.0.alpha1)
   webmock (~> 3.14)
   webpacker (~> 5.4)
-  webpush (~> 0.3)
+  webpush!
   xorcist (~> 1.1)


### PR DESCRIPTION
The fork is based on 0.3.8 and does not include changes to the `Content-Encoding` (although I do think we need to move to 1.1.0 and `aes128gcm` eventually).