### PR TITLE
Hide subthreads by blocked users when looking at a post's descendants

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -397,7 +397,9 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
     return false if local_usernames.empty?
 
-    Account.local.exists?(username: local_usernames)
+    scope = Account.local.where(Account.arel_table[:username].lower.in(local_usernames.map(&:downcase)))
+    scope = scope.where.not('EXISTS (SELECT 1 FROM blocks WHERE account_id = accounts.id AND target_account_id = ?)', @account.id)
+    scope.exists?
   end
 
   def tombstone_exists?

--- a/app/models/concerns/status/threading_concern.rb
+++ b/app/models/concerns/status/threading_concern.rb
@@ -84,7 +84,11 @@ module Status::ThreadingConcern
       UNION ALL
 
         SELECT
-          statuses.id, path || statuses.id, authors || statuses.account_id
+          statuses.id, path || statuses.id, (CASE
+            WHEN array_length(authors, 1) >= 30 THEN authors
+            WHEN statuses.account_id = ANY(authors) THEN authors
+            ELSE authors || statuses.account_id
+          END)
         FROM
           search_tree
         JOIN

--- a/app/models/concerns/status/threading_concern.rb
+++ b/app/models/concerns/status/threading_concern.rb
@@ -73,15 +73,26 @@ module Status::ThreadingConcern
     limit += 1 if limit.present?
 
     descendants_with_self = Status.find_by_sql([<<-SQL.squish, id: id, limit: limit, depth: depth])
-      WITH RECURSIVE search_tree(id, path) AS (
-        SELECT id, ARRAY[id]
-        FROM statuses
-        WHERE id = :id
+      WITH RECURSIVE search_tree(id, path, authors) AS (
+        SELECT
+          id, ARRAY[id], ARRAY[account_id]
+        FROM
+          statuses
+        WHERE
+          id = :id
+
       UNION ALL
-        SELECT statuses.id, path || statuses.id
-        FROM search_tree
-        JOIN statuses ON statuses.in_reply_to_id = search_tree.id
-        WHERE COALESCE(array_length(path, 1) < :depth, TRUE) AND NOT statuses.id = ANY(path)
+
+        SELECT
+          statuses.id, path || statuses.id, authors || statuses.account_id
+        FROM
+          search_tree
+        JOIN
+          statuses ON statuses.in_reply_to_id = search_tree.id
+        WHERE
+          COALESCE(array_length(path, 1) < :depth, TRUE) AND NOT statuses.id = ANY(path)
+          AND NOT EXISTS (SELECT 1 FROM blocks WHERE target_account_id = statuses.account_id AND account_id = any(authors))
+          AND NOT EXISTS (SELECT 1 FROM account_domain_blocks b JOIN accounts a ON a.domain = b.domain WHERE a.id = statuses.account_id AND b.account_id = any(authors))
       )
       SELECT id
       FROM search_tree

--- a/spec/controllers/activitypub/replies_controller_spec.rb
+++ b/spec/controllers/activitypub/replies_controller_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe ActivityPub::RepliesController do
   let(:remote_reply_id) { 'https://foobar.com/statuses/1234' }
   let(:remote_querier) { nil }
 
+  let!(:reply1) { Fabricate(:status, thread: status, visibility: :public) }
+  let!(:reply2) { Fabricate(:status, thread: status, visibility: :public) }
+  let!(:reply3) { Fabricate(:status, thread: status, visibility: :private) }
+  let!(:reply4) { Fabricate(:status, account: status.account, thread: status, visibility: :public) }
+  let!(:reply5) { Fabricate(:status, account: status.account, thread: status, visibility: :private) }
+  let!(:reply6) { Fabricate(:status, account: remote_account, thread: status, visibility: :public, uri: remote_reply_id) }
+
   shared_examples 'common behavior' do
     context 'when status is private' do
       let(:parent_visibility) { :private }
@@ -177,14 +184,6 @@ RSpec.describe ActivityPub::RepliesController do
   before do
     stub_const 'ActivityPub::RepliesController::DESCENDANTS_LIMIT', 5
     allow(controller).to receive(:signed_request_actor).and_return(remote_querier)
-
-    Fabricate(:status, thread: status, visibility: :public)
-    Fabricate(:status, thread: status, visibility: :public)
-    Fabricate(:status, thread: status, visibility: :private)
-    Fabricate(:status, account: status.account, thread: status, visibility: :public)
-    Fabricate(:status, account: status.account, thread: status, visibility: :private)
-
-    Fabricate(:status, account: remote_account, thread: status, visibility: :public, uri: remote_reply_id)
   end
 
   describe 'GET #index' do

--- a/spec/controllers/activitypub/replies_controller_spec.rb
+++ b/spec/controllers/activitypub/replies_controller_spec.rb
@@ -130,6 +130,17 @@ RSpec.describe ActivityPub::RepliesController do
       context 'with only_other_accounts' do
         let(:only_other_accounts) { 'true' }
 
+        context 'when blocking some of the repliers' do
+          before do
+            status.account.block!(reply1.account)
+            status.account.block!(reply6.account)
+          end
+
+          it "does not list the blocked user's replies" do
+            expect(page_json[:items].map { |item| item.is_a?(String) ? item : item[:id] }).to match_array([ActivityPub::TagManager.instance.uri_for(reply2)])
+          end
+        end
+
         it 'returns items with other public or unlisted replies' do
           expect(response.parsed_body)
             .to include(

--- a/spec/models/concerns/status/threading_concern_spec.rb
+++ b/spec/models/concerns/status/threading_concern_spec.rb
@@ -82,10 +82,13 @@ RSpec.describe Status::ThreadingConcern do
     let!(:alice)  { Fabricate(:account, username: 'alice') }
     let!(:bob)    { Fabricate(:account, username: 'bob', domain: 'example.com') }
     let!(:jeff)   { Fabricate(:account, username: 'jeff') }
+    let!(:jack)   { Fabricate(:account, username: 'jack') }
     let!(:status) { Fabricate(:status, account: alice) }
     let!(:reply_to_status_from_alice) { Fabricate(:status, thread: status, account: alice) }
     let!(:reply_to_status_from_bob) { Fabricate(:status, thread: status, account: bob) }
     let!(:reply_to_alice_reply_from_jeff) { Fabricate(:status, thread: reply_to_status_from_alice, account: jeff) }
+    let!(:reply_to_alice_from_jack) { Fabricate(:status, thread: status, account: jack) }
+    let!(:reply_to_jack_from_bob) { Fabricate(:status, thread: reply_to_alice_from_jack, account: bob) }
     let!(:viewer) { Fabricate(:account, username: 'viewer') }
 
     it 'returns replies' do
@@ -102,6 +105,12 @@ RSpec.describe Status::ThreadingConcern do
     it 'does not return replies from users blocked by the viewer' do
       viewer.block!(jeff)
       expect(status.descendants(4, viewer)).to_not include(reply_to_alice_reply_from_jeff)
+    end
+
+    it 'does not return subthreads from users blocked by the author' do
+      alice.block!(jack)
+      expect(status.descendants(50, viewer)).to_not include(reply_to_alice_from_jack)
+      expect(status.descendants(50, viewer)).to_not include(reply_to_jack_from_bob)
     end
 
     it 'does not return replies from users muted by the viewer' do

--- a/spec/models/concerns/status/threading_concern_spec.rb
+++ b/spec/models/concerns/status/threading_concern_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Status::ThreadingConcern do
       expect(reply_to_second_reply.ancestors(4, viewer)).to_not include(reply_to_status, status)
     end
 
-    it 'does not return conversation history from blocked users' do
+    it 'does not return conversation history from users blocked by the viewer' do
       viewer.block!(jeff)
       expect(reply_to_second_reply.ancestors(4, viewer)).to_not include(reply_to_status)
     end
 
-    it 'does not return conversation history from muted users' do
+    it 'does not return conversation history from users muted by the viewer' do
       viewer.mute!(jeff)
       expect(reply_to_second_reply.ancestors(4, viewer)).to_not include(reply_to_status)
     end
@@ -39,7 +39,7 @@ RSpec.describe Status::ThreadingConcern do
       expect(reply_to_second_reply.ancestors(4, viewer)).to_not include(reply_to_status)
     end
 
-    it 'does not return conversation history from blocked domains' do
+    it 'does not return conversation history from domains blocked by the viewer' do
       viewer.block_domain!('example.com')
       expect(reply_to_second_reply.ancestors(4, viewer)).to_not include(reply_to_first_reply)
     end
@@ -99,12 +99,12 @@ RSpec.describe Status::ThreadingConcern do
       expect(status.descendants(4, viewer)).to_not include(reply_to_status_from_alice, reply_to_alice_reply_from_jeff)
     end
 
-    it 'does not return replies from blocked users' do
+    it 'does not return replies from users blocked by the viewer' do
       viewer.block!(jeff)
       expect(status.descendants(4, viewer)).to_not include(reply_to_alice_reply_from_jeff)
     end
 
-    it 'does not return replies from muted users' do
+    it 'does not return replies from users muted by the viewer' do
       viewer.mute!(jeff)
       expect(status.descendants(4, viewer)).to_not include(reply_to_alice_reply_from_jeff)
     end
@@ -114,7 +114,7 @@ RSpec.describe Status::ThreadingConcern do
       expect(status.descendants(4, viewer)).to_not include(reply_to_alice_reply_from_jeff)
     end
 
-    it 'does not return replies from blocked domains' do
+    it 'does not return replies from domains blocked by the viewer' do
       viewer.block_domain!('example.com')
       expect(status.descendants(4, viewer)).to_not include(reply_to_status_from_bob)
     end


### PR DESCRIPTION
This is about the server not returning known subthreads started by people blocked by the **post's author**, not the viewer.

e.g., if we have `A → B → C → D → E`, where `a → b` means “b replies to a”, and `B` has blocked `D`, querying the descendants for `A` will return `A → B → C`

This affects both the public pages and the API response for the “context” call.

Additionally, do not forward incoming replies when the person being replied to has blocked the person replying, and skip processing incoming posts altogether if the only reason they would have been processed is because they mentioned a local user and that user is blocking the author.