### PR TITLE
Fix Mastodon not correctly processing HTTP Signatures with query strings

### DIFF
--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -91,14 +91,21 @@ module SignatureVerification
     raise SignatureVerificationError, "Public key not found for key #{signature_params['keyId']}" if actor.nil?
 
     signature             = Base64.decode64(signature_params['signature'])
-    compare_signed_string = build_signed_string
+    compare_signed_string = build_signed_string(request_target_quirk: true)
 
+    return actor unless verify_signature(actor, signature, compare_signed_string).nil?
+
+    compare_signed_string = build_signed_string(request_target_quirk: false)
     return actor unless verify_signature(actor, signature, compare_signed_string).nil?
 
     actor = stoplight_wrap_request { actor_refresh_key!(actor) }
 
     raise SignatureVerificationError, "Could not refresh public key #{signature_params['keyId']}" if actor.nil?
 
+    compare_signed_string = build_signed_string(request_target_quirk: true)
+    return actor unless verify_signature(actor, signature, compare_signed_string).nil?
+
+    compare_signed_string = build_signed_string(request_target_quirk: false)
     return actor unless verify_signature(actor, signature, compare_signed_string).nil?
 
     fail_with! "Verification failed for #{actor.to_log_human_identifier} #{actor.uri} using rsa-sha256 (RSASSA-PKCS1-v1_5 with SHA-256)", signed_string: compare_signed_string, signature: signature_params['signature']
@@ -180,11 +187,15 @@ module SignatureVerification
     nil
   end
 
-  def build_signed_string
+  def build_signed_string(request_target_quirk: true)
     signed_headers.map do |signed_header|
       case signed_header
       when Request::REQUEST_TARGET
-        "#{Request::REQUEST_TARGET}: #{request.method.downcase} #{request.path}"
+        if request_target_quirk
+          "#{Request::REQUEST_TARGET}: #{request.method.downcase} #{request.path}"
+        else
+          "#{Request::REQUEST_TARGET}: #{request.method.downcase} #{request.original_fullpath}"
+        end
       when '(created)'
         raise SignatureVerificationError, 'Invalid pseudo-header (created) for rsa-sha256' unless signature_algorithm == 'hs2019'
         raise SignatureVerificationError, 'Pseudo-header (created) used but corresponding argument missing' if signature_params['created'].blank?

--- a/app/controllers/concerns/signature_verification.rb
+++ b/app/controllers/concerns/signature_verification.rb
@@ -91,21 +91,21 @@ module SignatureVerification
     raise SignatureVerificationError, "Public key not found for key #{signature_params['keyId']}" if actor.nil?
 
     signature             = Base64.decode64(signature_params['signature'])
-    compare_signed_string = build_signed_string(request_target_quirk: true)
+    compare_signed_string = build_signed_string(request_target_quirk: false)
 
     return actor unless verify_signature(actor, signature, compare_signed_string).nil?
 
-    compare_signed_string = build_signed_string(request_target_quirk: false)
+    compare_signed_string = build_signed_string(request_target_quirk: true)
     return actor unless verify_signature(actor, signature, compare_signed_string).nil?
 
     actor = stoplight_wrap_request { actor_refresh_key!(actor) }
 
     raise SignatureVerificationError, "Could not refresh public key #{signature_params['keyId']}" if actor.nil?
 
-    compare_signed_string = build_signed_string(request_target_quirk: true)
+    compare_signed_string = build_signed_string(request_target_quirk: false)
     return actor unless verify_signature(actor, signature, compare_signed_string).nil?
 
-    compare_signed_string = build_signed_string(request_target_quirk: false)
+    compare_signed_string = build_signed_string(request_target_quirk: true)
     return actor unless verify_signature(actor, signature, compare_signed_string).nil?
 
     fail_with! "Verification failed for #{actor.to_log_human_identifier} #{actor.uri} using rsa-sha256 (RSASSA-PKCS1-v1_5 with SHA-256)", signed_string: compare_signed_string, signature: signature_params['signature']

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -77,6 +77,7 @@ class Request
     @url         = Addressable::URI.parse(url).normalize
     @http_client = options.delete(:http_client)
     @allow_local = options.delete(:allow_local)
+    @full_path   = options.delete(:with_query_string)
     @options     = options.merge(socket_class: use_proxy? || @allow_local ? ProxySocket : Socket)
     @options     = @options.merge(timeout_class: PerOperationWithDeadline, timeout_options: TIMEOUT)
     @options     = @options.merge(proxy_url) if use_proxy?
@@ -146,7 +147,7 @@ class Request
   private
 
   def set_common_headers!
-    @headers[REQUEST_TARGET]    = "#{@verb} #{@url.path}"
+    @headers[REQUEST_TARGET]    = request_target
     @headers['User-Agent']      = Mastodon::Version.user_agent
     @headers['Host']            = @url.host
     @headers['Date']            = Time.now.utc.httpdate
@@ -155,6 +156,14 @@ class Request
 
   def set_digest!
     @headers['Digest'] = "SHA-256=#{Digest::SHA256.base64digest(@options[:body])}"
+  end
+
+  def request_target
+    if @url.query.nil? || !@full_path
+      "#{@verb} #{@url.path}"
+    else
+      "#{@verb} #{@url.path}?#{@url.query}"
+    end
   end
 
   def signature


### PR DESCRIPTION
cf. https://honk.tedunangst.com/u/tedu/h/1mZMtCVQ1clC7MfBg9

When signing or verifying signatures for requests with query strings, Mastodon incorrectly builds the `request-target` pseudo-header. Indeed, it does not include the query string, while the HTTP Signatures draft states:

> If the header field name is `(request-target)` then generate the header field value by concatenating the lowercased :method, an ASCII space, and the :path pseudo-headers (as specified in [HTTP/2, Section 8.1.2.3](https://tools.ietf.org/html/rfc7540#section-8.1.2.3)). Note: For the avoidance of doubt, lowercasing only applies to the :method pseudo-header and not to the :path pseudo-header.

The `:path` pseudo-header is defined as:
> The ":path" pseudo-header field includes the path and query parts of the target URI (the "path-absolute" production and optionally a '?' character followed by the "query" production (see Sections [3.3](https://datatracker.ietf.org/doc/html/rfc7540#section-3.3) and 3.4 of [[RFC3986](https://datatracker.ietf.org/doc/html/rfc3986)]).  A request in asterisk form includes the  value '*' for the ":path" pseudo-header field.

Because this is the first time in years that I have seen someone raise this issue, I think we can assume other implementations got it wrong too (or did not bother reporting it and worked around it instead). Therefore, changing to the correct version of this draft will likely cause compatibility issues. That's why for the time being, this PR only handles *incoming* requests *in addition* to the previous broken signatures.

On a side note, the drafts we are currently implementing have been superseded by more recent drafts, which we should probably move to eventually. However, I would like #15605 to be merged before working on that.