### PR TITLE
Fix Undo Announce activity is not sent, when not followed by the reblogged post author

### DIFF
--- a/app/lib/status_reach_finder.rb
+++ b/app/lib/status_reach_finder.rb
@@ -16,33 +16,28 @@ class StatusReachFinder
   private
 
   def reached_account_inboxes
+    Account.where(id: reached_account_ids).inboxes
+  end
+
+  def reached_account_ids
     # When the status is a reblog, there are no interactions with it
     # directly, we assume all interactions are with the original one
 
     if @status.reblog?
-      reblogged_status_account = @status.reblog.account
-      if !reblogged_status_account.local? && reblogged_status_account.activitypub? && !reblogged_status_account.following?(@status.account)
-        [reblogged_status_account.inbox_url]
-      else
-        []
-      end
+      [reblog_of_account_id]
     else
-      Account.where(id: reached_account_ids).inboxes
-    end
-  end
-
-  def reached_account_ids
-    [
-      replied_to_account_id,
-      reblog_of_account_id,
-      mentioned_account_ids,
-      reblogs_account_ids,
-      favourites_account_ids,
-      replies_account_ids,
-    ].tap do |arr|
-      arr.flatten!
-      arr.compact!
-      arr.uniq!
+      [
+        replied_to_account_id,
+        reblog_of_account_id,
+        mentioned_account_ids,
+        reblogs_account_ids,
+        favourites_account_ids,
+        replies_account_ids,
+      ].tap do |arr|
+        arr.flatten!
+        arr.compact!
+        arr.uniq!
+      end
     end
   end
 

--- a/app/lib/status_reach_finder.rb
+++ b/app/lib/status_reach_finder.rb
@@ -20,7 +20,12 @@ class StatusReachFinder
     # directly, we assume all interactions are with the original one
 
     if @status.reblog?
-      []
+      reblogged_status_account = @status.reblog.account
+      if !reblogged_status_account.local? && reblogged_status_account.activitypub? && !reblogged_status_account.following?(@status.account)
+        [reblogged_status_account.inbox_url]
+      else
+        []
+      end
     else
       Account.where(id: reached_account_ids).inboxes
     end

--- a/app/services/reblog_service.rb
+++ b/app/services/reblog_service.rb
@@ -45,8 +45,6 @@ class ReblogService < BaseService
 
     if reblogged_status.account.local?
       LocalNotificationWorker.perform_async(reblogged_status.account_id, reblog.id, reblog.class.name, 'reblog')
-    elsif reblogged_status.account.activitypub? && !reblogged_status.account.following?(reblog.account)
-      ActivityPub::DeliveryWorker.perform_async(build_json(reblog), reblog.account_id, reblogged_status.account.inbox_url)
     end
   end
 

--- a/app/services/reblog_service.rb
+++ b/app/services/reblog_service.rb
@@ -43,9 +43,7 @@ class ReblogService < BaseService
   def create_notification(reblog)
     reblogged_status = reblog.reblog
 
-    if reblogged_status.account.local?
-      LocalNotificationWorker.perform_async(reblogged_status.account_id, reblog.id, reblog.class.name, 'reblog')
-    end
+    LocalNotificationWorker.perform_async(reblogged_status.account_id, reblog.id, reblog.class.name, 'reblog') if reblogged_status.account.local?
   end
 
   def increment_statistics

--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -113,9 +113,9 @@ RSpec.describe ActivityPub::TagManager do
       expect(subject.cc(status)).to_not include(subject.uri_for(alice))
     end
 
-    it 'returns poster of reblogged post, if relobg' do
-      bob    = Fabricate(:account, username: 'bob', inbox_url: 'http://example.com/bob')
-      alice  = Fabricate(:account, username: 'alice', inbox_url: 'http://example.com/alice')
+    it 'returns poster of reblogged post, if reblog' do
+      bob    = Fabricate(:account, username: 'bob', domain: 'example.com', inbox_url: 'http://example.com/bob')
+      alice  = Fabricate(:account, username: 'alice')
       status = Fabricate(:status, visibility: :public, account: bob)
       reblog = Fabricate(:status, visibility: :public, account: alice, reblog: status)
       expect(subject.cc(reblog)).to include(subject.uri_for(bob))

--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -112,6 +112,14 @@ RSpec.describe ActivityPub::TagManager do
       expect(subject.cc(status)).to include(subject.uri_for(foo))
       expect(subject.cc(status)).to_not include(subject.uri_for(alice))
     end
+
+    it 'returns poster of reblogged post, if relobg' do
+      bob    = Fabricate(:account, username: 'bob', inbox_url: 'http://example.com/bob')
+      alice  = Fabricate(:account, username: 'alice', inbox_url: 'http://example.com/alice')
+      status = Fabricate(:status, visibility: :public, account: bob)
+      reblog = Fabricate(:status, visibility: :public, account: alice, reblog: status)
+      expect(subject.cc(reblog)).to include(subject.uri_for(bob))
+    end
   end
 
   describe '#local_uri?' do

--- a/spec/services/reblog_service_spec.rb
+++ b/spec/services/reblog_service_spec.rb
@@ -86,9 +86,5 @@ RSpec.describe ReblogService, type: :service do
     it 'distributes to followers' do
       expect(ActivityPub::DistributionWorker).to have_received(:perform_async)
     end
-
-    it 'sends an announce activity to the author', :sidekiq_inline do
-      expect(a_request(:post, bob.inbox_url)).to have_been_made.once
-    end
   end
 end


### PR DESCRIPTION
fix #18471