### PR TITLE
Remove 3.3.x from supported versions in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ A "vulnerability in Mastodon" is a vulnerability in the code distributed through
 | ------- | ------------------ |
 | 3.5.x   | Yes                |
 | 3.4.x   | Yes                |
-| 3.3.x   | Yes                |
+| 3.3.x   | No                 |
 | < 3.3   | No                 |
 
 [bug-bounty]: https://app.intigriti.com/programs/mastodon/mastodonio/detail


### PR DESCRIPTION
It's been 1.5 years since 3.3.0 was released and the code has changed sufficiently that porting fixes is becoming impractical