### PR TITLE
Fix follower and other counters being able to go negative

### DIFF
--- a/app/models/account_stat.rb
+++ b/app/models/account_stat.rb
@@ -20,4 +20,16 @@ class AccountStat < ApplicationRecord
   belongs_to :account, inverse_of: :account_stat
 
   update_index('accounts', :account)
+
+  def following_count
+    [attributes['following_count'], 0].max
+  end
+
+  def followers_count
+    [attributes['followers_count'], 0].max
+  end
+
+  def statuses_count
+    [attributes['statuses_count'], 0].max
+  end
 end

--- a/app/models/status_stat.rb
+++ b/app/models/status_stat.rb
@@ -17,6 +17,18 @@ class StatusStat < ApplicationRecord
 
   after_commit :reset_parent_cache
 
+  def replies_count
+    [attributes['replies_count'], 0].max
+  end
+
+  def reblogs_count
+    [attributes['reblogs_count'], 0].max
+  end
+
+  def favourites_count
+    [attributes['favourites_count'], 0].max
+  end
+
   private
 
   def reset_parent_cache


### PR DESCRIPTION
Among other things, since #18463, negative follower counts can break search queries by producing NaN values in score functions