### PR TITLE
Add ES6 compatibility to browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -4,6 +4,4 @@ not IE 11
 not dead
 
 [development]
-last 1 chrome version
-last 1 firefox version
-last 1 safari version
+supports es6-module


### PR DESCRIPTION
It seems that webpack v4 does not support static keywords. Therefore, I will add ES6 compatibility to the browserslist.