### PR TITLE
Fix confirmation redirect to app without `Location` header

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -40,7 +40,7 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
 
   def after_confirmation_path_for(_resource_name, user)
     if user.created_by_application && truthy_param?(:redirect_to_app)
-      user.created_by_application.redirect_uri
+      user.created_by_application.confirmation_redirect_uri
     else
       super
     end

--- a/app/lib/application_extension.rb
+++ b/app/lib/application_extension.rb
@@ -12,4 +12,8 @@ module ApplicationExtension
   def most_recently_used_access_token
     @most_recently_used_access_token ||= access_tokens.where.not(last_used_at: nil).order(last_used_at: :desc).first
   end
+
+  def confirmation_redirect_uri
+    redirect_uri.lines.first.strip
+  end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -128,6 +128,13 @@ Doorkeeper.configure do
   #
   force_ssl_in_redirect_uri false
 
+  # Specify what redirect URI's you want to block during Application creation.
+  # Any redirect URI is whitelisted by default.
+  #
+  # You can use this option in order to forbid URI's with 'javascript' scheme
+  # for example.
+  forbid_redirect_uri { |uri| %w[data vbscript javascript].include?(uri.scheme.to_s.downcase) }
+
   # Specify what grant flows are enabled in array of Strings. The valid
   # strings and the flows they enable are:
   #


### PR DESCRIPTION
MASTODON-M7EOHJWQ