### PR TITLE
Fix fallback locale when somehow user's locale is an empty string

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -18,7 +18,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.unconfirmed_email.presence || @resource.email,
            subject: I18n.t(@resource.pending_reconfirmation? ? 'devise.mailer.reconfirmation_instructions.subject' : 'devise.mailer.confirmation_instructions.subject', instance: @instance),
            template_name: @resource.pending_reconfirmation? ? 'reconfirmation_instructions' : 'confirmation_instructions'
@@ -32,7 +32,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.reset_password_instructions.subject')
     end
   end
@@ -43,7 +43,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.password_change.subject')
     end
   end
@@ -54,7 +54,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.email_changed.subject')
     end
   end
@@ -65,7 +65,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.two_factor_enabled.subject')
     end
   end
@@ -76,7 +76,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.two_factor_disabled.subject')
     end
   end
@@ -87,7 +87,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.two_factor_recovery_codes_changed.subject')
     end
   end
@@ -98,7 +98,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.webauthn_enabled.subject')
     end
   end
@@ -109,7 +109,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.webauthn_disabled.subject')
     end
   end
@@ -121,7 +121,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.webauthn_credential.added.subject')
     end
   end
@@ -133,7 +133,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('devise.mailer.webauthn_credential.deleted.subject')
     end
   end
@@ -144,7 +144,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('user_mailer.welcome.subject')
     end
   end
@@ -156,7 +156,7 @@ class UserMailer < Devise::Mailer
 
     return unless @resource.active_for_authentication?
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('user_mailer.backup_ready.subject')
     end
   end
@@ -167,7 +167,7 @@ class UserMailer < Devise::Mailer
     @instance = Rails.configuration.x.local_domain
     @statuses = @warning.statuses.includes(:account, :preloadable_poll, :media_attachments, active_mentions: [:account])
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t("user_mailer.warning.subject.#{@warning.action}", acct: "@#{user.account.local_username_and_domain}")
     end
   end
@@ -177,7 +177,7 @@ class UserMailer < Devise::Mailer
     @instance = Rails.configuration.x.local_domain
     @appeal   = appeal
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('user_mailer.appeal_approved.subject', date: l(@appeal.created_at))
     end
   end
@@ -187,7 +187,7 @@ class UserMailer < Devise::Mailer
     @instance = Rails.configuration.x.local_domain
     @appeal   = appeal
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('user_mailer.appeal_rejected.subject', date: l(@appeal.created_at))
     end
   end
@@ -200,8 +200,14 @@ class UserMailer < Devise::Mailer
     @detection  = Browser.new(user_agent)
     @timestamp  = timestamp.to_time.utc
 
-    I18n.with_locale(@resource.locale || I18n.default_locale) do
+    I18n.with_locale(locale) do
       mail to: @resource.email, subject: I18n.t('user_mailer.suspicious_sign_in.subject')
     end
+  end
+
+  private
+
+  def locale
+    @resource.locale.presence || I18n.default_locale
   end
 end

--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -47,7 +47,7 @@ class MoveWorker
 
   def copy_account_notes!
     AccountNote.where(target_account: @source_account).find_each do |note|
-      text = I18n.with_locale(note.account.user&.locale || I18n.default_locale) do
+      text = I18n.with_locale(note.account.user&.locale.presence || I18n.default_locale) do
         I18n.t('move_handler.copy_account_note_text', acct: @source_account.acct)
       end
 
@@ -90,7 +90,7 @@ class MoveWorker
 
   def add_account_note_if_needed!(account, id)
     unless AccountNote.where(account: account, target_account: @target_account).exists?
-      text = I18n.with_locale(account.user&.locale || I18n.default_locale) do
+      text = I18n.with_locale(account.user&.locale.presence || I18n.default_locale) do
         I18n.t(id, acct: @source_account.acct)
       end
       AccountNote.create!(account: account, target_account: @target_account, comment: text)

--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -51,7 +51,7 @@ class Web::PushNotificationWorker
   private
 
   def push_notification_json
-    json = I18n.with_locale(@subscription.locale || I18n.default_locale) do
+    json = I18n.with_locale(@subscription.locale.presence || I18n.default_locale) do
       ActiveModelSerializers::SerializableResource.new(
         @notification,
         serializer: Web::NotificationSerializer,


### PR DESCRIPTION
Somehow user's locale could be an empty string, And empty string itself
are treated as true value.

This PR will handle that kind of situation.

I got this error on production:
```
I18n::InvalidLocale
"" is not a valid locale
```