### PR TITLE
Remove db:setup dependency on running Redis server

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -88,7 +88,7 @@ class Account < ApplicationRecord
 
   # Local user validations
   validates :username, format: { with: /\A[a-z0-9_]+\z/i }, length: { maximum: 30 }, if: -> { local? && will_save_change_to_username? && actor_type != 'Application' }
-  validates_with UnreservedUsernameValidator, if: -> { local? && will_save_change_to_username? }
+  validates_with UnreservedUsernameValidator, if: -> { local? && will_save_change_to_username? && actor_type != 'Application' }
   validates :display_name, length: { maximum: 30 }, if: -> { local? && will_save_change_to_display_name? }
   validates :note, note_length: { maximum: 500 }, if: -> { local? && will_save_change_to_note? }
   validates :fields, length: { maximum: 4 }, if: -> { local? && will_save_change_to_fields? }

--- a/lib/paperclip/attachment_extensions.rb
+++ b/lib/paperclip/attachment_extensions.rb
@@ -81,6 +81,9 @@ module Paperclip
     # to respond or don't respond at all and as such minimize the
     # impact of object storage outages on application throughput
     def save
+      # Don't go through Stoplight if we don't have anything object-storage-oriented to do
+      return super if @queued_for_delete.empty? && @queued_for_write.empty? && !dirty?
+
       Stoplight('object-storage') { super }.with_threshold(STOPLIGHT_THRESHOLD).with_cool_off_time(STOPLIGHT_COOLDOWN).with_error_handler do |error, handle|
         if error.is_a?(Seahorse::Client::NetworkingError)
           handle.call(error)


### PR DESCRIPTION
This makes the deployment procedure a little bit more flexible.