### PR TITLE
Add “services” and “metadata” to NodeInfo

### DIFF
--- a/app/serializers/nodeinfo/serializer.rb
+++ b/app/serializers/nodeinfo/serializer.rb
@@ -38,7 +38,7 @@ class NodeInfo::Serializer < ActiveModel::Serializer
   end
 
   def metadata
-    Array([])
+    []
   end
 
   private

--- a/app/serializers/nodeinfo/serializer.rb
+++ b/app/serializers/nodeinfo/serializer.rb
@@ -38,7 +38,7 @@ class NodeInfo::Serializer < ActiveModel::Serializer
   end
   
   def metadata
-    { [] }
+    { Array([]) }
   end
 
   private

--- a/app/serializers/nodeinfo/serializer.rb
+++ b/app/serializers/nodeinfo/serializer.rb
@@ -3,7 +3,7 @@
 class NodeInfo::Serializer < ActiveModel::Serializer
   include RoutingHelper
 
-  attributes :version, :software, :protocols, :usage, :open_registrations
+  attributes :version, :software, :protocols, :services, :usage, :open_registrations
 
   def version
     '2.0'

--- a/app/serializers/nodeinfo/serializer.rb
+++ b/app/serializers/nodeinfo/serializer.rb
@@ -36,7 +36,7 @@ class NodeInfo::Serializer < ActiveModel::Serializer
   def open_registrations
     Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode
   end
-  
+
   def metadata
     Array([])
   end

--- a/app/serializers/nodeinfo/serializer.rb
+++ b/app/serializers/nodeinfo/serializer.rb
@@ -38,7 +38,7 @@ class NodeInfo::Serializer < ActiveModel::Serializer
   end
   
   def metadata
-    { Array([]) }
+    Array([])
   end
 
   private

--- a/app/serializers/nodeinfo/serializer.rb
+++ b/app/serializers/nodeinfo/serializer.rb
@@ -3,7 +3,7 @@
 class NodeInfo::Serializer < ActiveModel::Serializer
   include RoutingHelper
 
-  attributes :version, :software, :protocols, :services, :usage, :open_registrations
+  attributes :version, :software, :protocols, :services, :usage, :open_registrations, :metadata
 
   def version
     '2.0'
@@ -35,6 +35,10 @@ class NodeInfo::Serializer < ActiveModel::Serializer
 
   def open_registrations
     Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode
+  end
+  
+  def metadata
+    { [] }
   end
 
   private


### PR DESCRIPTION
“services” and “metadata” are both required by the [NodeInfo schema version 2.0](http://nodeinfo.diaspora.software/ns/schema/2.0).