### PR TITLE
Fix TagManager#local_url? erroring out on invalid URL

### DIFF
--- a/app/lib/tag_manager.rb
+++ b/app/lib/tag_manager.rb
@@ -24,8 +24,11 @@ class TagManager
 
   def local_url?(url)
     uri    = Addressable::URI.parse(url).normalize
+    return false unless uri.host
     domain = uri.host + (uri.port ? ":#{uri.port}" : '')
 
     TagManager.instance.web_domain?(domain)
+  rescue Addressable::URI::InvalidURIError
+    false
   end
 end


### PR DESCRIPTION
This can occur when searching for `https:// foo.bar` in the WebUI search bar for instance