### PR TITLE
Fix suspicious sign-in mails never being sent

### DIFF
--- a/spec/fabricators/login_activity_fabricator.rb
+++ b/spec/fabricators/login_activity_fabricator.rb
@@ -1,8 +1,8 @@
 Fabricator(:login_activity) do
   user
-  strategy       'password'
-  success        true
-  failure_reason nil
-  ip             { Faker::Internet.ip_v4_address }
-  user_agent     { Faker::Internet.user_agent }
+  authentication_method 'password'
+  success               true
+  failure_reason        nil
+  ip                    { Faker::Internet.ip_v4_address }
+  user_agent            { Faker::Internet.user_agent }
 end


### PR DESCRIPTION
#17970 has replaced sign-in token verification by warning emails.

However, the log-in activity record was created before checking for suspicious log-ins, so logins were never considered suspicious.

Additionally, a much trickier reason that logins where never considered suspicious is that log-in actually happens **before `Auth::SessionsController#create` is called**. This is caused by the `Localized` concern being included (through `Devise::FailureApp.send :include, Localized`) and using `current_user` in a `around_action` hook. This is why the suspicious login test is now performed in a prepended `before_action` hook.

The added tests account for both these reasons.