### PR TITLE
Update .env.production.sample

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -67,3 +67,14 @@ S3_BUCKET=files.example.com
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 S3_ALIAS_HOST=files.example.com
+
+# Puma (performance tweaking)
+# -----------------------
+DB_POOL=25
+WEB_CONCURRENCY=2
+MAX_THREADS=5
+PERSISTENT_TIMEOUT=20
+
+# Streaming (performance tweaking)
+# -----------------------
+#STREAMING_CLUSTER_NUM=5


### PR DESCRIPTION
Setting a safe default for production.
DB_POOL is defaulting to 5. Production servers really should be closer to 25.