### PR TITLE
Tweak DB_POOL fallback

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter: postgresql
-  pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>
+  pool: <%= ENV["DB_POOL"] || 25 %>
   timeout: 5000
   encoding: unicode
   sslmode: <%= ENV['DB_SSLMODE'] || "prefer" %>


### PR DESCRIPTION
Detected lots of `ActiveRecord::ConnectionNotEstablished (FATAL:  sorry, too many clients already` errors in sidekiq on my instance.

The DB_POOL should be higher than the MAX_THREADS. MAX_THREADS is commonly 5, which creates overhead during higher load.

This is safe fallback value for test/prod.