### PR TITLE
chore: bump elasticsearch version in docker-compose.yml file; closes …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   # es:
   #   restart: always
-  #   image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+  #   image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.17.4
   #   environment:
   #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
   #     - "cluster.name=es-mastodon"


### PR DESCRIPTION
…#18189

Even if this is commented out code and not realy hurting anyone:
New Mastodon Admins might install an Elasticsearch version which includes security vulnerabilities.

Thanks for considering the change.