### PR TITLE
Add option for EMAIL_DOMAIN_DENYLIST/EMAIL_DOMAIN_ALLOWLIST to apply after confirmation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,7 +93,7 @@ class User < ApplicationRecord
   validates :invite_request, presence: true, on: :create, if: :invite_text_required?
 
   validates :locale, inclusion: I18n.available_locales.map(&:to_s), if: :locale?
-  validates_with BlacklistedEmailValidator, if: -> { !confirmed? }
+  validates_with BlacklistedEmailValidator, if: -> { ENV['EMAIL_DOMAIN_LISTS_APPLY_AFTER_CONFIRMATION'] == 'true' || !confirmed? }
   validates_with EmailMxValidator, if: :validate_email_dns?
   validates :agreement, acceptance: { allow_nil: false, accept: [true, 'true', '1'] }, on: :create
 


### PR DESCRIPTION
Fixes #18620

Add `EMAIL_DOMAIN_LISTS_APPLY_AFTER_CONFIRMATION` that, if set to `true`, makes Mastodon perform email domain allow/deny check not only for initial confirmation but for any email change.