### PR TITLE
Fix for #18637 - Migrate from elasticsearch-oss to elasticsearch basic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
 #     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4
 #     environment:
 #       - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"
+#       - "xpack.license.self_generated.type=basic"
 #       - "xpack.security.enabled=false"
 #       - "xpack.watcher.enabled=false"
 #       - "xpack.graph.enabled=false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,24 +23,35 @@ services:
     volumes:
       - ./redis:/data
 
-  # es:
-  #   restart: always
-  #   image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.17.4
-  #   environment:
-  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-  #     - "cluster.name=es-mastodon"
-  #     - "discovery.type=single-node"
-  #     - "bootstrap.memory_lock=true"
-  #   networks:
-  #      - internal_network
-  #   healthcheck:
-  #      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
-  #   volumes:
-  #      - ./elasticsearch:/usr/share/elasticsearch/data
-  #   ulimits:
-  #     memlock:
-  #       soft: -1
-  #       hard: -1
+#   es:
+#     restart: always
+#     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4
+#     environment:
+#       - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"
+#       - "xpack.security.enabled=false"
+#       - "xpack.watcher.enabled=false"
+#       - "xpack.graph.enabled=false"
+#       - "xpack.ml.enabled=false"
+#       - "bootstrap.memory_lock=true"
+#       - "cluster.name=es-mastodon"
+#       - "discovery.type=single-node"
+#       - "thread_pool.write.queue_size=1000"
+#     networks:
+#        - external_network
+#        - internal_network
+#     healthcheck:
+#        test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+#     volumes:
+#        - ./elasticsearch:/usr/share/elasticsearch/data
+#     ulimits:
+#       memlock:
+#         soft: -1
+#         hard: -1
+#       nofile:
+#         soft: 65536
+#         hard: 65536
+#     ports:
+#       - '127.0.0.1:9200:9200'
 
   web:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,36 +23,36 @@ services:
     volumes:
       - ./redis:/data
 
-#   es:
-#     restart: always
-#     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4
-#     environment:
-#       - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"
-#       - "xpack.license.self_generated.type=basic"
-#       - "xpack.security.enabled=false"
-#       - "xpack.watcher.enabled=false"
-#       - "xpack.graph.enabled=false"
-#       - "xpack.ml.enabled=false"
-#       - "bootstrap.memory_lock=true"
-#       - "cluster.name=es-mastodon"
-#       - "discovery.type=single-node"
-#       - "thread_pool.write.queue_size=1000"
-#     networks:
-#        - external_network
-#        - internal_network
-#     healthcheck:
-#        test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
-#     volumes:
-#        - ./elasticsearch:/usr/share/elasticsearch/data
-#     ulimits:
-#       memlock:
-#         soft: -1
-#         hard: -1
-#       nofile:
-#         soft: 65536
-#         hard: 65536
-#     ports:
-#       - '127.0.0.1:9200:9200'
+  # es:
+  #   restart: always
+  #   image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4
+  #   environment:
+  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"
+  #     - "xpack.license.self_generated.type=basic"
+  #     - "xpack.security.enabled=false"
+  #     - "xpack.watcher.enabled=false"
+  #     - "xpack.graph.enabled=false"
+  #     - "xpack.ml.enabled=false"
+  #     - "bootstrap.memory_lock=true"
+  #     - "cluster.name=es-mastodon"
+  #     - "discovery.type=single-node"
+  #     - "thread_pool.write.queue_size=1000"
+  #   networks:
+  #      - external_network
+  #      - internal_network
+  #   healthcheck:
+  #      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+  #   volumes:
+  #      - ./elasticsearch:/usr/share/elasticsearch/data
+  #   ulimits:
+  #     memlock:
+  #       soft: -1
+  #       hard: -1
+  #     nofile:
+  #       soft: 65536
+  #       hard: 65536
+  #   ports:
+  #     - '127.0.0.1:9200:9200'
 
   web:
     build: .


### PR DESCRIPTION
I'm testing this on aus.social production atm.

```
docker-compose stop es
docker-compose pull es
docker-compose up -d es

# Note: this next command might take multiple days! You need to make sure the shell will remain open for the whole time, or use tmux or similar to stash the shell.
docker-compose run --rm web bin/tootctl search deploy
```

FYI @Gargron 

https://www.elastic.co/pricing/faq/licensing 
`For Open Source projects, we are happy to support your project and provide redistribution rights free of charge. Please reach out to us at elastic_license@elastic.co and we will provide a license addendum providing the right to redistribute.`