### PR TITLE
Add unlisted api call parameter for custom emojis

### DIFF
--- a/app/controllers/api/v1/custom_emojis_controller.rb
+++ b/app/controllers/api/v1/custom_emojis_controller.rb
@@ -5,6 +5,11 @@ class Api::V1::CustomEmojisController < Api::BaseController
 
   def index
     expires_in 3.minutes, public: true
-    render_with_cache(each_serializer: REST::CustomEmojiSerializer) { CustomEmoji.listed.includes(:category) }
+    emojis = if truthy_param?(:include_unlisted)
+               CustomEmoji.visible.includes(:category)
+             else
+               CustomEmoji.listed.includes(:category)
+             end
+    render_with_cache(each_serializer: REST::CustomEmojiSerializer) { emojis }
   end
 end

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -48,6 +48,7 @@ class CustomEmoji < ApplicationRecord
   scope :alphabetic, -> { order(domain: :asc, shortcode: :asc) }
   scope :by_domain_and_subdomains, ->(domain) { where(domain: domain).or(where(arel_table[:domain].matches('%.' + domain))) }
   scope :listed, -> { local.where(disabled: false).where(visible_in_picker: true) }
+  scope :visible, -> { local.where(visible_in_picker: true) }
 
   remotable_attachment :image, LIMIT
 


### PR DESCRIPTION
- added `include_unlisted` parameter to CustomEmoji api call
- added CustomEmoji scope for list listed and unlisted

Issue: #12447 