### PR TITLE
Fix missing commas in blurhash checks

### DIFF
--- a/app/lib/activitypub/parser/media_attachment_parser.rb
+++ b/app/lib/activitypub/parser/media_attachment_parser.rb
@@ -50,7 +50,7 @@ class ActivityPub::Parser::MediaAttachmentParser
     components = begin
       blurhash = @json['blurhash']
 
-      if blurhash.present? && /^[\w#$%*+-.:;=?@\[\]^{|}~]+$/.match?(blurhash)
+      if blurhash.present? && /^[\w#$%*+,-.:;=?@\[\]^{|}~]+$/.match?(blurhash)
         Blurhash.components(blurhash)
       end
     end


### PR DESCRIPTION
Related: https://github.com/mastodon/mastodon/pull/16583 , https://github.com/Gargron/blurhash/pull/16.