### PR TITLE
Fix CDN_HOST not affected on full_asset_url

### DIFF
--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -20,7 +20,7 @@ module RoutingHelper
   end
 
   def asset_host
-    Rails.configuration.action_controler.asset_host || root_url
+    Rails.configuration.action_controller.asset_host || root_url
   end
 
   def full_pack_url(source, **options)

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -16,7 +16,11 @@ module RoutingHelper
   def full_asset_url(source, **options)
     source = ActionController::Base.helpers.asset_url(source, **options) unless use_storage?
 
-    URI.join(root_url, source).to_s
+    URI.join(asset_host, source).to_s
+  end
+
+  def asset_host
+    Rails.configuration.action_controler.asset_host || root_url
   end
 
   def full_pack_url(source, **options)


### PR DESCRIPTION
`CDN_HOST` env var is for packs assets. But it was not respected on `full_asset_url` function