### PR TITLE
use Notification::TYPES for api push subscription alerts

### DIFF
--- a/app/controllers/api/v1/push/subscriptions_controller.rb
+++ b/app/controllers/api/v1/push/subscriptions_controller.rb
@@ -52,6 +52,6 @@ class Api::V1::Push::SubscriptionsController < Api::BaseController
   def data_params
     return {} if params[:data].blank?
 
-    params.require(:data).permit(:policy, alerts: [:follow, :follow_request, :favourite, :reblog, :mention, :poll, :status])
+    params.require(:data).permit(:policy, alerts: Notification::TYPES)
   end
 end


### PR DESCRIPTION
change push alerts types definition to refer Notification::TYPES.

it's similar to app/controllers/api/web/push_subscriptions_controller.rb .
https://github.com/mastodon/mastodon/blob/7b816eb5aeeed61fa1e3a7c95cbb5bb7978f7fa5/app/controllers/api/web/push_subscriptions_controller.rb#L55
