### PR TITLE
Fix the setting page's logo that is not displayed on the smartphone

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -75,6 +75,13 @@ $content-width: 840px;
       height: 100px;
     }
 
+    .logo--wordmark {
+      display: inherit;
+      margin: inherit;
+      width: inherit;
+      height: 20px;
+    }
+
     @media screen and (max-width: $no-columns-breakpoint) {
       & > a:first-child {
         display: none;


### PR DESCRIPTION
In the current main branch, the logo is not displayed in the upper left when opening the setting page via smartphone browser.
<img width="460" alt="2022-06-23 15 15 26" src="https://user-images.githubusercontent.com/766076/175275112-4010d6cf-1484-4c4b-b7dd-20a4dba94a3f.png">
This PR will fix it.
<img width="462" alt="2022-06-23 15 05 02" src="https://user-images.githubusercontent.com/766076/175275222-91723534-2ccc-4b6e-8c4a-f56fbe864374.png">

