### PR TITLE
Add server-side mention tag rewriting

### DIFF
--- a/app/lib/html_aware_formatter.rb
+++ b/app/lib/html_aware_formatter.rb
@@ -32,7 +32,16 @@ class HtmlAwareFormatter
     config = Sanitize::Config::MASTODON_STRICT
 
     if @options[:preloaded_accounts]
-      config = config.merge(mentions_map: @options[:preloaded_accounts].index_by { |account| ActivityPub::TagManager.instance.url_for(account) })
+      mentions_map = @options[:preloaded_accounts].index_by { |account| ActivityPub::TagManager.instance.url_for(account) }
+      mentions_map.merge!(@options[:preloaded_accounts].index_by(&:uri))
+      mentions_map.transform_values! do |account|
+        [
+          ActivityPub::TagManager.instance.url_for(account),
+          "@<span>#{ERB::Util.h(account.username)}</span>",
+        ]
+      end
+
+      config = config.merge(mentions_map: mentions_map)
     end
 
     Sanitize.fragment(text, config)

--- a/app/lib/html_aware_formatter.rb
+++ b/app/lib/html_aware_formatter.rb
@@ -29,7 +29,13 @@ class HtmlAwareFormatter
   private
 
   def reformat
-    Sanitize.fragment(text, Sanitize::Config::MASTODON_STRICT)
+    config = Sanitize::Config::MASTODON_STRICT
+
+    if @options[:preloaded_accounts]
+      config = config.merge(mentions_map: @options[:preloaded_accounts].index_by { |account| ActivityPub::TagManager.instance.url_for(account) })
+    end
+
+    Sanitize.fragment(text, config)
   end
 
   def linkify

--- a/app/lib/html_aware_formatter.rb
+++ b/app/lib/html_aware_formatter.rb
@@ -30,6 +30,7 @@ class HtmlAwareFormatter
 
   def reformat
     config = Sanitize::Config::MASTODON_STRICT
+    html = text
 
     if @options[:preloaded_accounts]
       mentions_map = @options[:preloaded_accounts].index_by { |account| ActivityPub::TagManager.instance.url_for(account) }
@@ -42,9 +43,13 @@ class HtmlAwareFormatter
       end
 
       config = config.merge(mentions_map: mentions_map)
+
+      # Hubzilla-specific rewriting
+      url_re = Regexp.union(mentions_map.keys.compact)
+      html = html.gsub(/@<a class="zrl" href="(#{url_re})"/, '<a class="mention" href="\1"')
     end
 
-    Sanitize.fragment(text, config)
+    Sanitize.fragment(html, config)
   end
 
   def linkify

--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -74,7 +74,7 @@ class Sanitize
       return unless env[:node_name] == 'a' && env[:config][:mentions_map].present?
 
       node = env[:node]
-      return unless node['class'] && node['class'].split(/[\t\n\f\r ]/).include?('mention')
+      return unless node['class']&.split(/[\t\n\f\r ]/)&.include?('mention')
 
       href = node['href']
       account = env[:config][:mentions_map][href]

--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -77,14 +77,13 @@ class Sanitize
       return unless node['class']&.split(/[\t\n\f\r ]/)&.include?('mention')
 
       href = node['href']
-      account = env[:config][:mentions_map][href]
-      return if account.nil?
+      url, text = env[:config][:mentions_map][node['href']]
+      return if url.nil?
 
       # Replace contents altogether
       node.children.remove
-      node.add_child(<<~HTML.squish)
-        @<span>#{ERB::Util.h(account.username)}</span>
-      HTML
+      node['href'] = url
+      node.add_child(text)
     end
 
     MASTODON_STRICT ||= freeze_config(

--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -76,7 +76,6 @@ class Sanitize
       node = env[:node]
       return unless node['class']&.split(/[\t\n\f\r ]/)&.include?('mention')
 
-      href = node['href']
       url, text = env[:config][:mentions_map][node['href']]
       return if url.nil?
 

--- a/spec/lib/html_aware_formatter_spec.rb
+++ b/spec/lib/html_aware_formatter_spec.rb
@@ -34,27 +34,47 @@ RSpec.describe HtmlAwareFormatter do
       end
 
       context 'given mentions' do
-        let(:text) do
-          '<a href="https://remote.com/@foo" class="mention">@<span>Foo</span></a> <a href="https://remote.com/@bar" class="mention">Barsname</a> <a href="https://remote.com/users/baz" class="mention">?</a>'
-        end
-        let(:options) do
-          {
-            preloaded_accounts:
-              [
-                Fabricate(:account, domain: 'remote.com', username: 'foo', url: 'https://remote.com/@foo', uri: 'https://remote.com/users/foo'),
-                Fabricate(:account, domain: 'remote.com', username: 'bar', url: 'https://remote.com/@bar', uri: 'https://remote.com/users/bar', display_name: 'Barsname'),
-                Fabricate(:account, domain: 'remote.com', username: 'baz', url: 'https://remote.com/@baz', uri: 'https://remote.com/users/baz'),
-              ],
-          }
+        let(:account) { Fabricate(:account, domain: 'remote.com', username: 'foo', url: 'https://remote.com/@foo', uri: 'https://remote.com/users/foo', display_name: 'f. oo') }
+        let(:options) { { preloaded_accounts: [account] } }
+
+        context 'with Mastodon-style mentions' do
+          let(:text) { '<a href="https://remote.com/@foo" class="mention">@<span>foo</span></a>' }
+
+          it 'rewrites mentions' do
+            is_expected.to include '>@<span>foo</span></a>'
+            is_expected.to include 'href="https://remote.com/@foo"'
+          end
         end
 
-        it 'rewrites mentions' do
-          is_expected.to include '>@<span>foo</span></a>'
-          is_expected.to include 'https://remote.com/@foo'
-          is_expected.to include '>@<span>bar</span></a>'
-          is_expected.to include 'https://remote.com/@bar'
-          is_expected.to include '>@<span>baz</span></a>'
-          is_expected.to include 'https://remote.com/@baz'
+        context 'with Smithereen-style mentions' do
+          let(:text) { '<a href="https://remote.com/@foo" class="u-url mention">f. oo</a>' }
+
+          it 'rewrites mentions' do
+            is_expected.to include '>@<span>foo</span></a>'
+            is_expected.to include 'href="https://remote.com/@foo"'
+          end
+        end
+
+        context 'with Friendica-style mentions' do
+          let(:text) { '<a href="https://remote.com/users/foo" class="mention">@<span>foo</span></a>' }
+
+          it 'rewrites mentions' do
+            is_expected.to include '>@<span>foo</span></a>'
+            is_expected.to include 'href="https://remote.com/@foo"'
+          end
+        end
+
+        context 'with Hubzilla-style mentions' do
+          let(:text) { '@<a class="zrl" href="https://remote.com/users/foo" target="_blank"  rel="nofollow noopener">f. oo</a>' }
+
+          it 'rewrites mentions' do
+            is_expected.to include '>@<span>foo</span></a>'
+            is_expected.to include 'href="https://remote.com/@foo"'
+          end
+
+          it 'does not have a @ outside the link' do
+            is_expected.not_to include '@<a'
+          end
         end
       end
 

--- a/spec/lib/html_aware_formatter_spec.rb
+++ b/spec/lib/html_aware_formatter_spec.rb
@@ -34,20 +34,27 @@ RSpec.describe HtmlAwareFormatter do
       end
 
       context 'given mentions' do
-        let(:text) { '<a href="https://remote.com/@foo" class="mention">@<span>Foo</span></a> <a href="https://remote.com/@bar" class="mention">Barsname</a>' }
+        let(:text) do
+          '<a href="https://remote.com/@foo" class="mention">@<span>Foo</span></a> <a href="https://remote.com/@bar" class="mention">Barsname</a> <a href="https://remote.com/users/baz" class="mention">?</a>'
+        end
         let(:options) do
           {
             preloaded_accounts:
               [
                 Fabricate(:account, domain: 'remote.com', username: 'foo', url: 'https://remote.com/@foo', uri: 'https://remote.com/users/foo'),
                 Fabricate(:account, domain: 'remote.com', username: 'bar', url: 'https://remote.com/@bar', uri: 'https://remote.com/users/bar', display_name: 'Barsname'),
+                Fabricate(:account, domain: 'remote.com', username: 'baz', url: 'https://remote.com/@baz', uri: 'https://remote.com/users/baz'),
               ],
           }
         end
 
         it 'rewrites mentions' do
           is_expected.to include '>@<span>foo</span></a>'
+          is_expected.to include 'https://remote.com/@foo'
           is_expected.to include '>@<span>bar</span></a>'
+          is_expected.to include 'https://remote.com/@bar'
+          is_expected.to include '>@<span>baz</span></a>'
+          is_expected.to include 'https://remote.com/@baz'
         end
       end
 


### PR DESCRIPTION
Different server software output mentions with different markup, and sometimes with different text.

For instance, some software output `@username`, other `@username@domain`, some do `@display name`, and so on.

An example is https://friends.grishka.me/posts/136572 which renders as follows, where it is not clear at all for Mastodon users that `Eugen` here is an actual clickable mention:
![image](https://user-images.githubusercontent.com/384364/175277051-eb8a4fa6-5c2d-40ac-9744-9e0968a024bc.png)

This PR rewrites mentions so that they always have the same markup as if they were authored by Mastodon, and does so server-side so clients don't have to reimplement their own logic.

The above post would look like the following after rewriting, which is in line with Mastodon users' expectations:
![image](https://user-images.githubusercontent.com/384364/175277452-fe923600-c09e-45d7-b821-ccdd698c7d31.png)