### PR TITLE
Add “missing mentions” to the end of remote posts

### DIFF
--- a/app/helpers/formatting_helper.rb
+++ b/app/helpers/formatting_helper.rb
@@ -15,7 +15,27 @@ module FormattingHelper
   module_function :extract_status_plain_text
 
   def status_content_format(status)
-    html_aware_format(status.text, status.local?, preloaded_accounts: [status.account] + (status.respond_to?(:active_mentions) ? status.active_mentions.map(&:account) : []))
+    preloaded_accounts = [status.account] + (status.respond_to?(:active_mentions) ? status.active_mentions.map(&:account) : [])
+    output = html_aware_format(status.text, status.local?, preloaded_accounts: preloaded_accounts)
+
+    if status.respond_to?(:active_mentions)
+      unmatched_mentions = (status.active_mentions.map(&:account).to_a - [status.account]).index_by { |account| ActivityPub::TagManager.instance.url_for(account) }
+      Nokogiri::HTML5.fragment(output).css('a.mention').each do |a|
+        unmatched_mentions.delete(a['href'])
+      end
+
+      unless unmatched_mentions.empty?
+        extra_mentions = unmatched_mentions.values.sort_by(&:username).map do |account|
+          url = ActivityPub::TagManager.instance.url_for(account)
+          <<~HTML.squish
+            <span class="h-card"><a href="#{ERB::Util.h(url)}" class="u-url mention">@<span>#{ERB::Util.h(account.username)}</span></a></span>
+          HTML
+        end.join(' ')
+        output = [output, "\n<p>", extra_mentions, '</p>'].join('').html_safe # rubocop:disable Rails/OutputSafety
+      end
+    end
+
+    output
   end
 
   def rss_status_content_format(status)

--- a/app/lib/html_aware_formatter.rb
+++ b/app/lib/html_aware_formatter.rb
@@ -29,7 +29,13 @@ class HtmlAwareFormatter
   private
 
   def reformat
-    Sanitize.fragment(text, Sanitize::Config::MASTODON_STRICT)
+    config = Sanitize::Config::MASTODON_STRICT
+
+    if @options[:preloaded_accounts]
+      config = config.merge(mentions_map: @options[:preloaded_accounts].index_by { |account| ActivityPub::TagManager.instance.url_for(account) })
+    end
+
+    Sanitize.fragment(text, config)
   end
 
   def linkify

--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -74,7 +74,7 @@ class Sanitize
       return unless env[:node_name] == 'a' && env[:config][:mentions_map].present?
 
       node = env[:node]
-      return unless node['class'] && node['class'].split(/[\t\n\f\r ]/).include?('mention')
+      return unless node['class']&.split(/[\t\n\f\r ]/)&.include?('mention')
 
       href = node['href']
       account = env[:config][:mentions_map][href]


### PR DESCRIPTION
Short-term fix for #18708 that doesn't require client-side changes

Follow-up to #18711

The code is a bit rough, is lacking tests, and I'm not sure this is the best way to handle “missing mentions”.

The example post (https://friends.grishka.me/posts/136572) would look like:
![image](https://user-images.githubusercontent.com/384364/175293766-61bc1956-28b8-478a-93ad-4dc32c76aa3d.png)