### PR TITLE
Fix PG::AmbiguousColumn error on EmailScheduler

### DIFF
--- a/app/workers/scheduler/email_scheduler.rb
+++ b/app/workers/scheduler/email_scheduler.rb
@@ -19,7 +19,7 @@ class Scheduler::EmailScheduler
 
   def eligible_users
     User.emailable
-        .where('current_sign_in_at < ?', (FREQUENCY + SIGN_IN_OFFSET).ago)
-        .where('last_emailed_at IS NULL OR last_emailed_at < ?', FREQUENCY.ago)
+        .where('users.current_sign_in_at < ?', (FREQUENCY + SIGN_IN_OFFSET).ago)
+        .where('users.last_emailed_at IS NULL OR users.last_emailed_at < ?', FREQUENCY.ago)
   end
 end


### PR DESCRIPTION
EmailScheduler keep dying with this error:

```
ActiveRecord::StatementInvalid: PG::AmbiguousColumn: ERROR: column reference "current_sign_in_at" is ambiguous LINE 1: ...AND "accounts"."moved_to_account_id" IS NULL AND (current_si... ...
```