### PR TITLE
Fix email regex validation

### DIFF
--- a/app/views/about/_login.html.haml
+++ b/app/views/about/_login.html.haml
@@ -4,7 +4,7 @@
       - if use_seamless_external_login?
         = f.input :email, placeholder: t('simple_form.labels.defaults.username_or_email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.username_or_email') }, hint: false
       - else
-        = f.input :email, placeholder: t('simple_form.labels.defaults.email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.email') }, hint: false
+        = f.input :email, placeholder: t('simple_form.labels.defaults.email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), pattern: '^[a-z0-9]+@[a-z]+\.[a-z]+$' }, hint: false
 
       = f.input :password, placeholder: t('simple_form.labels.defaults.password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.password') }, hint: false
 

--- a/app/views/about/_registration.html.haml
+++ b/app/views/about/_registration.html.haml
@@ -9,7 +9,7 @@
       = f.simple_fields_for :account do |account_fields|
         = account_fields.input :username, wrapper: :with_label, label: false, required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.username'), :autocomplete => 'off', placeholder: t('simple_form.labels.defaults.username'), pattern: '[a-zA-Z0-9_]+', maxlength: 30 }, append: "@#{site_hostname}", hint: false, disabled: disabled
 
-      = f.input :email, placeholder: t('simple_form.labels.defaults.email'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), :autocomplete => 'off' }, hint: false, disabled: disabled
+      = f.input :email, placeholder: t('simple_form.labels.defaults.email'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), :autocomplete => 'off', pattern: '^[a-z0-9]+@[a-z]+\.[a-z]+$' }, hint: false, disabled: disabled
       = f.input :password, placeholder: t('simple_form.labels.defaults.password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.password'), :autocomplete => 'new-password', :minlength => User.password_length.first, :maxlength => User.password_length.last }, hint: false, disabled: disabled
       = f.input :password_confirmation, placeholder: t('simple_form.labels.defaults.confirm_password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.confirm_password'), :autocomplete => 'new-password' }, hint: false, disabled: disabled
 

--- a/app/views/auth/confirmations/new.html.haml
+++ b/app/views/auth/confirmations/new.html.haml
@@ -5,7 +5,7 @@
   = render 'shared/error_messages', object: resource
 
   .fields-group
-    = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.email') }, hint: false
+    = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), pattern: '^[a-z0-9]+@[a-z]+\.[a-z]+$' }, hint: false
 
   .actions
     = f.button :button, t('auth.resend_confirmation'), type: :submit

--- a/app/views/auth/passwords/new.html.haml
+++ b/app/views/auth/passwords/new.html.haml
@@ -5,7 +5,7 @@
   = render 'shared/error_messages', object: resource
 
   .fields-group
-    = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.email') }, hint: false
+    = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), pattern: '^[a-z0-9]+@[a-z]+\.[a-z]+$' }, hint: false
 
   .actions
     = f.button :button, t('auth.reset_password'), type: :submit

--- a/app/views/auth/registrations/edit.html.haml
+++ b/app/views/auth/registrations/edit.html.haml
@@ -11,7 +11,7 @@
   - if !use_seamless_external_login? || resource.encrypted_password.present?
     .fields-row
       .fields-row__column.fields-group.fields-row__column-6
-        = f.input :email, wrapper: :with_label, input_html: { 'aria-label' => t('simple_form.labels.defaults.email') }, required: true, disabled: current_account.suspended?
+        = f.input :email, wrapper: :with_label, input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), pattern: '^[a-z0-9]+@[a-z]+\.[a-z]+$' }, required: true, disabled: current_account.suspended?
       .fields-row__column.fields-group.fields-row__column-6
         = f.input :current_password, wrapper: :with_label, input_html: { 'aria-label' => t('simple_form.labels.defaults.current_password'), :autocomplete => 'off' }, required: true, disabled: current_account.suspended?, hint: false
 

--- a/app/views/auth/registrations/new.html.haml
+++ b/app/views/auth/registrations/new.html.haml
@@ -17,7 +17,7 @@
       = ff.input :username, wrapper: :with_label, autofocus: true, label: t('simple_form.labels.defaults.username'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.username'), :autocomplete => 'off', pattern: '[a-zA-Z0-9_]+', maxlength: 30 }, append: "@#{site_hostname}", hint: t('simple_form.hints.defaults.username', domain: site_hostname)
 
   .fields-group
-    = f.input :email, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), :autocomplete => 'off' }
+    = f.input :email, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), :autocomplete => 'off', pattern: '^[a-z0-9]+@[a-z]+\.[a-z]+$' }
 
   .fields-group
     = f.input :password, wrapper: :with_label, label: t('simple_form.labels.defaults.password'), required: true, input_html: { 'aria-label' => t('simple_form.labels.defaults.password'), :autocomplete => 'off', :minlength => User.password_length.first, :maxlength => User.password_length.last }

--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -8,9 +8,9 @@
   = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
     .fields-group
       - if use_seamless_external_login?
-        = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.username_or_email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.username_or_email') }, hint: false
+        = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.username_or_email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.username_or_email'), pattern: '^[a-z0-9]+@[a-z]+\.[a-z]+$' }, hint: false
       - else
-        = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.email') }, hint: false
+        = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), pattern: '^[a-z0-9]+@[a-z]+\.[a-z]+$' }, hint: false
     .fields-group
       = f.input :password, wrapper: :with_label, label: t('simple_form.labels.defaults.password'), input_html: { 'aria-label' => t('simple_form.labels.defaults.password'), :autocomplete => 'off' }, hint: false
 

--- a/app/views/auth/setup/show.html.haml
+++ b/app/views/auth/setup/show.html.haml
@@ -9,7 +9,7 @@
       %p.hint= t('auth.setup.email_below_hint_html')
 
     .fields-group
-      = f.input :email, required: true, hint: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), :autocomplete => 'off' }
+      = f.input :email, required: true, hint: false, input_html: { 'aria-label' => t('simple_form.labels.defaults.email'), :autocomplete => 'off', pattern: '^[a-z0-9]+@[a-z]+\.[a-z]+$' }
 
     .actions
       = f.submit t('admin.accounts.change_email.label'), class: 'button'


### PR DESCRIPTION
Hi people,
I think I found a bug in the email fields. I'm creating this pull request to contribute to the project. 😉

### Description
Email Regex was passing invalid emails (it was not properly validating the provider).

### Type of change
Bug fix (non-breaking change which fixes an issue).

### What was changed?
It was added the prop: `pattern: '^[a-z0-9]+@[a-z]+\.[a-z]+$'` in emails input created using `simple_form_for`.

### Evidences
The old regex allowed the email below:
![image](https://user-images.githubusercontent.com/39440032/176990407-cf212a42-8ad9-47e6-a2a7-7b55aff2d1b9.png)

The new regex going to validate correctly now:
![image](https://user-images.githubusercontent.com/39440032/176990427-46cec7d3-c4ce-479a-9b59-ce27c5040cee.png)
![image](https://user-images.githubusercontent.com/39440032/176990445-47eaaff4-fbef-4655-92d8-8cd84ca725b0.png)

#### I think we can isolate this regex, any suggestions? (I thought about creating a helper)