### PR TITLE
ip_cleanup_scheduler: Make IP and session retention configurable

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -67,3 +67,11 @@ S3_BUCKET=files.example.com
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 S3_ALIAS_HOST=files.example.com
+
+# IP and session retention
+# -----------------------
+# Make sure to modify the scheduling of ip_cleanup_scheduler in config/sidekiq.yml
+# to be less than daily if you lower IP_RETENTION_PERIOD below two days (172800).
+# -----------------------
+IP_RETENTION_PERIOD=31556952
+SESSION_RETENTION_PERIOD=31556952

--- a/app/workers/scheduler/ip_cleanup_scheduler.rb
+++ b/app/workers/scheduler/ip_cleanup_scheduler.rb
@@ -3,7 +3,8 @@
 class Scheduler::IpCleanupScheduler
   include Sidekiq::Worker
 
-  IP_RETENTION_PERIOD = 1.year.freeze
+  IP_RETENTION_PERIOD = ENV.fetch('IP_RETENTION_PERIOD', 1.year).to_i.seconds.freeze
+  SESSION_RETENTION_PERIOD = ENV.fetch('SESSION_RETENTION_PERIOD', 1.year).to_i.seconds.freeze
 
   sidekiq_options retry: 0
 
@@ -15,7 +16,8 @@ class Scheduler::IpCleanupScheduler
   private
 
   def clean_ip_columns!
-    SessionActivation.where('updated_at < ?', IP_RETENTION_PERIOD.ago).in_batches.destroy_all
+    SessionActivation.where('updated_at < ?', SESSION_RETENTION_PERIOD.ago).in_batches.destroy_all
+    SessionActivation.where('updated_at < ?', IP_RETENTION_PERIOD.ago).in_batches.update_all(ip: nil)
     User.where('current_sign_in_at < ?', IP_RETENTION_PERIOD.ago).in_batches.update_all(sign_up_ip: nil)
     LoginActivity.where('created_at < ?', IP_RETENTION_PERIOD.ago).in_batches.destroy_all
     Doorkeeper::AccessToken.where('last_used_at < ?', IP_RETENTION_PERIOD.ago).in_batches.update_all(last_used_ip: nil)


### PR DESCRIPTION
In #6474, there are mentions of IP addresses being stored for too long (1 year). While this pull request doesn't allow disabling the storage of IP addresses, it would allow instance admins to limit the duration for which IP addresses are stored. In my Catstodon fork, I have deployed and tested these changes already, with success (with an IP address retention of 24 hours, and the Sidekiq job set to run every hour).

This pull request may require the following changes, but I am unsure how to best do them:
- another env config variable for defining how often the `ip_cleanup_scheduler` sidekiq job should be run, instead of having to modify [sidekiq.yml](https://github.com/mastodon/mastodon/blob/a233a9bfb5f384e89bdaef6e519fa20db2a99ae5/config/sidekiq.yml#L48-L49) directly. Or perhaps deriving an optimal value it from `IP_RETENTION_PERIOD`.
- A split between handling ip cleanups, session cleanups/terminations and login activity cleanups/deletions, all based on time. Currently, `ip_cleanup_scheduler.rb` handles *all* of these.


If this pull request is merged, the docs over at [Configuring your environment](https://github.com/mastodon/documentation/blob/master/content/en/admin/config.md) will also need to be updated.