### PR TITLE
Fix a typo in user role priority

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -102,7 +102,7 @@ en:
         highlighted: This makes the role publicly visible
         name: Public name of the role, if role is set to be displayed as a badge
         permissions_as_keys: Users with this role will have access to...
-        position: Higher role decides conflict resolution in certain situations. Certain actions can only be performed on roles with alower priority
+        position: Higher role decides conflict resolution in certain situations. Certain actions can only be performed on roles with a lower priority
       webhook:
         events: Select events to send
         url: Where events will be sent to


### PR DESCRIPTION
"alower priority" -> "a lower priority"