### PR TITLE
Change custom emoji file size limit from 50 KB to 256 KB

### DIFF
--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -23,7 +23,7 @@
 class CustomEmoji < ApplicationRecord
   include Attachmentable
 
-  LIMIT = 50.kilobytes
+  LIMIT = 256.kilobytes
 
   SHORTCODE_RE_FRAGMENT = '[a-zA-Z0-9_]{2,}'
 


### PR DESCRIPTION
Fix #18452