### PR TITLE
Add support for editing labelling of one's own role

### DIFF
--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -90,6 +90,7 @@ class UserRole < ApplicationRecord
   validate :validate_permissions_elevation
   validate :validate_position_elevation
   validate :validate_dangerous_permissions
+  validate :validate_own_role_edition
 
   before_validation :set_position
 
@@ -163,6 +164,12 @@ class UserRole < ApplicationRecord
 
   def set_position
     self.position = -1 if everyone?
+  end
+
+  def validate_own_role_edition
+    return unless defined?(@current_account) && @current_account.user_role.id == id
+    errors.add(:permissions_as_keys, :own_role) if permissions_changed?
+    errors.add(:position, :own_role) if position_changed?
   end
 
   def validate_permissions_elevation

--- a/app/policies/user_role_policy.rb
+++ b/app/policies/user_role_policy.rb
@@ -10,7 +10,7 @@ class UserRolePolicy < ApplicationPolicy
   end
 
   def update?
-    role.can?(:manage_roles) && role.overrides?(record)
+    role.can?(:manage_roles) && (role.overrides?(record) || role.id == record.id)
   end
 
   def destroy?

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -8,8 +8,9 @@
     .fields-group
       = f.input :name, wrapper: :with_label
 
-    .fields-group
-      = f.input :position, wrapper: :with_label, input_html: { max: current_user.role.position - 1 }
+    - unless current_user.role.id == @role.id
+      .fields-group
+        = f.input :position, wrapper: :with_label, input_html: { max: current_user.role.position - 1 }
 
     .fields-group
       = f.input :color, wrapper: :with_label, input_html: { placeholder: '#000000' }
@@ -21,17 +22,19 @@
 
     %hr.spacer/
 
-  .field-group
-    .input.with_block_label
-      %label= t('simple_form.labels.user_role.permissions_as_keys')
-      %span.hint= t('simple_form.hints.user_role.permissions_as_keys')
+  - unless current_user.role.id == @role.id
 
-    - (@role.everyone? ? UserRole::Flags::CATEGORIES.slice(:invites) : UserRole::Flags::CATEGORIES).each do |category, permissions|
-      %h4= t(category, scope: 'admin.roles.categories')
+    .field-group
+      .input.with_block_label
+        %label= t('simple_form.labels.user_role.permissions_as_keys')
+        %span.hint= t('simple_form.hints.user_role.permissions_as_keys')
 
-      = f.input :permissions_as_keys, collection: permissions, wrapper: :with_block_label, include_blank: false, label_method: lambda { |privilege| safe_join([t("admin.roles.privileges.#{privilege}"), content_tag(:span, t("admin.roles.privileges.#{privilege}_description"), class: 'hint')]) }, required: false, as: :check_boxes, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', label: false, hint: false, disabled: permissions.filter { |privilege| UserRole::FLAGS[privilege] & current_user.role.computed_permissions == 0 }
+      - (@role.everyone? ? UserRole::Flags::CATEGORIES.slice(:invites) : UserRole::Flags::CATEGORIES).each do |category, permissions|
+        %h4= t(category, scope: 'admin.roles.categories')
 
-  %hr.spacer/
+        = f.input :permissions_as_keys, collection: permissions, wrapper: :with_block_label, include_blank: false, label_method: lambda { |privilege| safe_join([t("admin.roles.privileges.#{privilege}"), content_tag(:span, t("admin.roles.privileges.#{privilege}_description"), class: 'hint')]) }, required: false, as: :check_boxes, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li', label: false, hint: false, disabled: permissions.filter { |privilege| UserRole::FLAGS[privilege] & current_user.role.computed_permissions == 0 }
+
+    %hr.spacer/
 
   .actions
     = f.button :button, @role.new_record? ? t('admin.roles.add_new') : t('generic.save_changes'), type: :submit

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -45,5 +45,7 @@ en:
             permissions_as_keys:
               dangerous: include permissions that are not safe for the base role
               elevated: cannot include permissions your current role does not possess
+              own_role: cannot be changed with your current role
             position:
               elevated: cannot be higher than your current role
+              own_role: cannot be changed with your current role


### PR DESCRIPTION
Still disallow edition of rank or permissions, and still requires the proper permission