### PR TITLE
Fix audit log message "%{user} removed post by (deleted post)"

### DIFF
--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -52,7 +52,7 @@ module Admin::ActionLogsHelper
       if tmp_status.account
         link_to tmp_status.account&.acct || "##{tmp_status.account_id}", admin_account_path(tmp_status.account_id)
       else
-        I18n.t('admin.action_logs.deleted_status')
+        I18n.t('admin.action_logs.deleted_account')
       end
     when 'Announcement'
       truncate(attributes['text'].is_a?(Array) ? attributes['text'].last : attributes['text'])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,7 +332,7 @@ en:
         update_custom_emoji_html: "%{name} updated emoji %{target}"
         update_domain_block_html: "%{name} updated domain block for %{target}"
         update_status_html: "%{name} updated post by %{target}"
-      deleted_status: "(deleted post)"
+      deleted_account: "(deleted account)"
       empty: No logs found.
       filter_by_action: Filter by action
       filter_by_user: Filter by user

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -205,7 +205,7 @@ en_GB:
         unsuspend_account: "%{name} unsuspended %{target}'s account"
         update_custom_emoji: "%{name} updated emoji %{target}"
         update_status: "%{name} updated status by %{target}"
-      deleted_status: "(deleted status)"
+      deleted_account: "(deleted account)"
       title: Audit log
     custom_emojis:
       by_domain: Domain

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -327,7 +327,7 @@ ko:
         update_custom_emoji_html: "%{name} 님이 에모지 %{target}를 업데이트 했습니다"
         update_domain_block_html: "%{name} 님이 %{target}에 대한 도메인 차단을 갱신했습니다"
         update_status_html: "%{name} 님이 %{target}의 게시물을 업데이트 했습니다"
-      deleted_status: "(삭제된 게시물)"
+      deleted_account: "(삭제된 계정)"
       empty: 로그를 찾을 수 없습니다
       filter_by_action: 행동으로 거르기
       filter_by_user: 사용자로 거르기


### PR DESCRIPTION
This is wrong message
![image](https://user-images.githubusercontent.com/5047683/179554324-80875023-7a43-4dd6-b5e6-5dff5b6e2f75.png)

It caused because incorrectly changing "status" → "post" on #16080