### PR TITLE
Fix /api/v1/tags/:id route constraints

### DIFF
--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -24,6 +24,7 @@ class Api::V1::TagsController < Api::BaseController
   private
 
   def set_or_create_tag
+    return not_found unless /\A(#{Tag::HASHTAG_NAME_RE})\z/.match?(params[:id])
     @tag = Tag.find_normalized(params[:id]) || Tag.new(name: Tag.normalize(params[:id]), display_name: params[:id])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -530,7 +530,7 @@ Rails.application.routes.draw do
         resource :note, only: :create, controller: 'accounts/notes'
       end
 
-      resources :tags, only: [:show], constraints: { id: /#{Tag::HASHTAG_NAME_RE}/ } do
+      resources :tags, only: [:show] do
         member do
           post :follow
           post :unfollow


### PR DESCRIPTION
The constraint was applied prior to decoding, and rejected anything containing the '%' character, which would be used for anything with non-ASCII unicode characters.