### PR TITLE
Fix media modal footer's "external link" button

### DIFF
--- a/app/javascript/mastodon/components/icon_button.js
+++ b/app/javascript/mastodon/components/icon_button.js
@@ -131,17 +131,9 @@ export default class IconButton extends React.PureComponent {
       </React.Fragment>
     );
 
-    if (href) {
-      return (
-        <a
-          href={href}
-          aria-label={title}
-          title={title}
-          target='_blank'
-          rel='noopener noreferrer'
-          className={classes}
-          style={style}
-        >
+    if (href && !this.prop) {
+      contents = (
+        <a href={href} target='_blank' rel='noopener noreferrer'>
           {contents}
         </a>
       );


### PR DESCRIPTION
Fixes regression from #18697

As far as I understand, the code from #18697 changed `IconButton` but did not end up using it. The change in `IconButton` breaks the media modal footer's “external link” both in style (minor alignment issues) and functionality (always open in an external tab instead of opening within the Web UI).