### PR TITLE
Add fy locale

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -93,6 +93,7 @@ module Mastodon
       :fa,
       :fi,
       :fr,
+      :fy,
       :ga,
       :gd,
       :gl,


### PR DESCRIPTION
Locale code on Crowdin needs to be fixed first, see my post in discussion https://crowdin.com/project/mastodon/discussions/138

`fy` is already listed in `app/helpers/languages_helper.rb`, so no change needed there.