### PR TITLE
Fix I2P HTTPS redirect

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = {
     redirect: {
-      exclude: -> request { request.path.start_with?('/health') || request.headers["Host"].end_with?('.onion') }
+      exclude: -> request { request.path.start_with?('/health') || request.headers["Host"].end_with?('.onion') || request.headers["Host"].end_with?('.i2p') }
     }
   }
 


### PR DESCRIPTION
This PR fixes https redirect for i2p... 
Currently, when a user accesses the mastodon instance with a domain on .onion, it does not enforce https redirect since onion usually doesnt use https..
This patch makes it have the same behaviour for I2P, a project similar to tor..
This patch has been tested and has been working for over a week on fedi.vern.cc...

(Note this patch was not made by me, but @cobra@fedi.vern.cc.. I am just uploading this patch for her since she doesn't use GitHub)