### PR TITLE
helm: use full version chart repository

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -25,12 +25,12 @@ appVersion: 3.3.0
 dependencies:
   - name: elasticsearch
     version: 15.10.3
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: elasticsearch.enabled
   - name: postgresql
     version: 8.10.14
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: postgresql.enabled
   - name: redis
     version: 10.9.0
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami


### PR DESCRIPTION
earlier this year bitnami changed the behavior of their default chart
repository, removing versions older than 6 months:
https://github.com/bitnami/charts/issues/10539

this PR switches to the alternate repository that includes all published
versions