### PR TITLE
Fix filtering on context mismatch

### DIFF
--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -73,6 +73,7 @@ export const makeGetStatus = () => {
         if (filterResults.some((result) => filters.getIn([result.get('filter'), 'filter_action']) === 'hide')) {
           return null;
         }
+        filterResults = filterResults.filter(result => filters.has(result.get('filter')));
         if (!filterResults.isEmpty()) {
           filtered = filterResults.map(result => filters.getIn([result.get('filter'), 'title']));
         }


### PR DESCRIPTION
Since #18058, posts are filtered whenever a matching filter exists even if it's not matching the context under consideration, and in that situation, the filter title would not be displayed.

This PR fixes to not filter posts when no filter match the context under consideration.