### PR TITLE
Change following and followers API to be accessible without being logged in

### DIFF
--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
-  before_action -> { doorkeeper_authorize! :read, :'read:accounts' }
+  before_action -> { authorize_if_got_token! :read, :'read:accounts' }
   before_action :set_account
   after_action :insert_pagination_headers
 

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
-  before_action -> { doorkeeper_authorize! :read, :'read:accounts' }
+  before_action -> { authorize_if_got_token! :read, :'read:accounts' }
   before_action :set_account
   after_action :insert_pagination_headers
 


### PR DESCRIPTION
The HTML and ActivityPub methods of obtaining this information are publicly accessible, so this could be too. Primary purpose is to make the web app work as much as possible without being logged in.