### PR TITLE
Remove duplicate HSTS headers from nginx.conf

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -52,21 +52,17 @@ server {
   gzip_http_version 1.1;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml image/x-icon;
 
-  add_header Strict-Transport-Security "max-age=31536000" always;
-
   location / {
     try_files $uri @proxy;
   }
 
   location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
     add_header Cache-Control "public, max-age=31536000, immutable";
-    add_header Strict-Transport-Security "max-age=31536000" always;
     try_files $uri @proxy;
   }
 
   location /sw.js {
     add_header Cache-Control "public, max-age=0";
-    add_header Strict-Transport-Security "max-age=31536000" always;
     try_files $uri @proxy;
   }
 
@@ -90,7 +86,6 @@ server {
     proxy_cache_valid 410 24h;
     proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
     add_header X-Cached $upstream_cache_status;
-    add_header Strict-Transport-Security "max-age=31536000" always;
 
     tcp_nodelay on;
   }

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -52,17 +52,21 @@ server {
   gzip_http_version 1.1;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml image/x-icon;
 
+  # add_header Strict-Transport-Security "max-age=31536000" always;
+
   location / {
     try_files $uri @proxy;
   }
 
   location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
     add_header Cache-Control "public, max-age=31536000, immutable";
+    # add_header Strict-Transport-Security "max-age=31536000" always;
     try_files $uri @proxy;
   }
 
   location /sw.js {
     add_header Cache-Control "public, max-age=0";
+    # add_header Strict-Transport-Security "max-age=31536000" always;
     try_files $uri @proxy;
   }
 
@@ -86,6 +90,7 @@ server {
     proxy_cache_valid 410 24h;
     proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
     add_header X-Cached $upstream_cache_status;
+    # add_header Strict-Transport-Security "max-age=31536000" always;
 
     tcp_nodelay on;
   }

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -52,21 +52,19 @@ server {
   gzip_http_version 1.1;
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml image/x-icon;
 
-  # add_header Strict-Transport-Security "max-age=31536000" always;
-
   location / {
     try_files $uri @proxy;
   }
 
   location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
     add_header Cache-Control "public, max-age=31536000, immutable";
-    # add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
   location /sw.js {
     add_header Cache-Control "public, max-age=0";
-    # add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
@@ -90,7 +88,6 @@ server {
     proxy_cache_valid 410 24h;
     proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
     add_header X-Cached $upstream_cache_status;
-    # add_header Strict-Transport-Security "max-age=31536000" always;
 
     tcp_nodelay on;
   }


### PR DESCRIPTION
Mastodevs: This PR is going to require action on behalf of the mastodon instance admins...

You'll need to inform them to remove the `strict-transport-security` header from their existing nginx setup, and then validate it's correct using `curl -I https://instance.com | grep -i 'strict-transport'`

```
(Less wrong) STS Survey
* 0 headers: 50 (1.5%)
* 1 headers: 967 (29.1%)
* 2 headers: 2184 (65.7%)
* 3 headers: 118 (3.5%)
* 4 headers: 1 (0.03%)

wrong: 70.9%
```

Fixes #17083

----

Noticed my STS was sent twice.
```
Strict-Transport-Security: max-age=31536000;
Strict-Transport-Security: max-age=63072000; includeSubDomains
```

This nukes it from the nginx config which leaves the default rails STS header alone.
