### PR TITLE
Enable brotli compression for static files

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -34,6 +34,12 @@ module.exports = merge(sharedConfig, {
       cache: true,
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf|map)$/,
     }),
+    new CompressionPlugin({
+      filename: '[path][base].br[query]',
+      algorithm: 'brotliCompress',
+      cache: true,
+      test: /\.(js|css|html|json|ico|svg|eot|otf|ttf|map)$/,
+    }),
     new BundleAnalyzerPlugin({ // generates report.html
       analyzerMode: 'static',
       openAnalyzer: false,


### PR DESCRIPTION
If add support for brotli format to nginx, then static files compressed in gzip format are used by default.

Before PR:
```
curl --head -H "Accept-Encoding: gzip, br" https://_my_domayn_/packs/js/common-86f946cd0c43ba4e6b20.js 2>&1 | grep content-encoding
content-encoding: gzip
```

After PR:
```
curl --head -H "Accept-Encoding: gzip, br" https://_my_domayn_/packs/js/common-86f946cd0c43ba4e6b20.js 2>&1 | grep content-encoding
content-encoding: br
```
сс @ClearlyClaire 