### PR TITLE
Upgrade Docker image - Redis 6 to 7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   redis:
     restart: always
-    image: redis:6-alpine
+    image: redis:7-alpine
     networks:
       - internal_network
     healthcheck:


### PR DESCRIPTION
I've been using Redis 7 for a month. No problems so far... but let's get some confirmation from others if possible

```
tootctl feeds clear
tootctl feeds build  --all
```

https://redis.com/blog/introducing-redis-7/
https://redis.com/blog/redis-7-generally-available/