### PR TITLE
Add postgresql password settings hint in Helm chart

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -144,6 +144,8 @@ postgresql:
     # be rotated on each upgrade:
     # https://github.com/bitnami/charts/tree/master/bitnami/postgresql#upgrade
     password: ""
+    # Set same value as above
+    postgresPassword: ""
     # you can also specify the name of an existing Secret
     # with a key of postgres-password set to the password you want
     existingSecret: ""


### PR DESCRIPTION
I tried to my first mastodon cluster with helm chart 1 weeks ago.
But, It contained postgresql password problem.

helm install command ran few minutes and finally showed following error.

```
❯ helm install --namespace mastodon --create-namespace my-mastodon ./
Error: INSTALLATION FAILED: failed post-install: job failed: BackoffLimitExceeded
```

I found db-migrate job fails.
![Screenshot from 2022-09-04 08-14-19](https://user-images.githubusercontent.com/826646/188290300-ba9814ab-abe0-44db-9e51-d5636200e666.png)

This is log of job pod.

```
rake aborted!
ActiveRecord::ConnectionNotEstablished: FATAL:  password authentication failed for user "postgres"
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/postgresql_adapter.rb:83:in `rescue in new_client'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/postgresql_adapter.rb:77:in `new_client'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/postgresql_adapter.rb:37:in `postgresql_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:882:in `public_send'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:882:in `new_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:926:in `checkout_new_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:905:in `try_to_checkout_new_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:866:in `acquire_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:588:in `checkout'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:428:in `connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:1128:in `retrieve_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_handling.rb:327:in `retrieve_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_handling.rb:283:in `connection'
/opt/mastodon/lib/tasks/db.rake:21:in `block (2 levels) in <top (required)>'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/opt/ruby/bin/bundle:23:in `load'
/opt/ruby/bin/bundle:23:in `<main>'
Caused by:
PG::ConnectionBad: FATAL:  password authentication failed for user "postgres"
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/pg-1.3.5/lib/pg/connection.rb:637:in `async_connect_or_reset'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/pg-1.3.5/lib/pg/connection.rb:707:in `new'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/pg-1.3.5/lib/pg.rb:69:in `connect'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/postgresql_adapter.rb:78:in `new_client'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/postgresql_adapter.rb:37:in `postgresql_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:882:in `public_send'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:882:in `new_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:926:in `checkout_new_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:905:in `try_to_checkout_new_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:866:in `acquire_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:588:in `checkout'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:428:in `connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:1128:in `retrieve_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_handling.rb:327:in `retrieve_connection'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.5.1/lib/active_record/connection_handling.rb:283:in `connection'
/opt/mastodon/lib/tasks/db.rake:21:in `block (2 levels) in <top (required)>'
/opt/mastodon/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/opt/ruby/bin/bundle:23:in `load'
/opt/ruby/bin/bundle:23:in `<main>'
Tasks: TOP => db:migrate => db:pre_migration_check
(See full trace by running task with --trace)
```

Postgresql pod log is here:

```
postgresql 23:11:50.90 
postgresql 23:11:50.90 Welcome to the Bitnami postgresql container
postgresql 23:11:50.90 Subscribe to project updates by watching https://github.com/bitnami/bitnami-docker-postgresql
postgresql 23:11:50.90 Submit issues and feature requests at https://github.com/bitnami/bitnami-docker-postgresql/issues
postgresql 23:11:50.90 
postgresql 23:11:50.91 INFO  ==> ** Starting PostgreSQL setup **
postgresql 23:11:50.93 INFO  ==> Validating settings in POSTGRESQL_* env vars..
postgresql 23:11:50.93 INFO  ==> Loading custom pre-init scripts...
postgresql 23:11:50.93 INFO  ==> Initializing PostgreSQL database...
postgresql 23:11:50.94 INFO  ==> pg_hba.conf file not detected. Generating it...
postgresql 23:11:50.94 INFO  ==> Generating local authentication configuration
postgresql 23:11:51.77 INFO  ==> Starting PostgreSQL in background...
postgresql 23:11:51.94 INFO  ==> Changing password of postgres
postgresql 23:11:51.95 INFO  ==> Configuring replication parameters
postgresql 23:11:51.97 INFO  ==> Configuring synchronous_replication
postgresql 23:11:51.97 INFO  ==> Configuring fsync
postgresql 23:11:51.99 INFO  ==> Loading custom scripts...
postgresql 23:11:51.99 INFO  ==> Enabling remote connections
postgresql 23:11:52.00 INFO  ==> Stopping PostgreSQL...
waiting for server to shut down.... done
server stopped
postgresql 23:11:52.10 INFO  ==> ** PostgreSQL setup finished! **
postgresql 23:11:52.12 INFO  ==> ** Starting PostgreSQL **
2022-09-03 23:11:52.146 GMT [1] LOG:  pgaudit extension initialized
2022-09-03 23:11:52.149 GMT [1] LOG:  starting PostgreSQL 14.2 on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
2022-09-03 23:11:52.149 GMT [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2022-09-03 23:11:52.149 GMT [1] LOG:  listening on IPv6 address "::", port 5432
2022-09-03 23:11:52.151 GMT [1] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
2022-09-03 23:11:52.154 GMT [135] LOG:  database system was shut down at 2022-09-03 23:11:52 GMT
2022-09-03 23:11:52.157 GMT [1] LOG:  database system is ready to accept connections
2022-09-03 23:12:10.252 GMT [149] FATAL:  password authentication failed for user "postgres"
2022-09-03 23:12:10.252 GMT [149] DETAIL:  Connection matched pg_hba.conf line 1: "host     all             all             0.0.0.0/0               md5"
2022-09-03 23:12:21.009 GMT [158] FATAL:  password authentication failed for user "postgres"
2022-09-03 23:12:21.009 GMT [158] DETAIL:  Connection matched pg_hba.conf line 1: "host     all             all             0.0.0.0/0               md5"
2022-09-03 23:12:26.709 GMT [173] FATAL:  password authentication failed for user "postgres"
2022-09-03 23:12:26.709 GMT [173] DETAIL:  Connection matched pg_hba.conf line 1: "host     all             all             0.0.0.0/0               md5"
2022-09-03 23:12:32.899 GMT [174] FATAL:  password authentication failed for user "postgres"
2022-09-03 23:12:32.899 GMT [174] DETAIL:  Connection matched pg_hba.conf line 1: "host     all             all             0.0.0.0/0               md5"
2022-09-03 23:12:40.588 GMT [188] FATAL:  password authentication failed for user "postgres"
2022-09-03 23:12:40.588 GMT [188] DETAIL:  Connection matched pg_hba.conf line 1: "host     all             all             0.0.0.0/0               md5"
2022-09-03 23:12:46.869 GMT [203] FATAL:  password authentication failed for user "postgres"
2022-09-03 23:12:46.869 GMT [203] DETAIL:  Connection matched pg_hba.conf line 1: "host     all             all             0.0.0.0/0               md5"
2022-09-03 23:12:53.807 GMT [219] FATAL:  password authentication failed for user "postgres"
2022-09-03 23:12:53.807 GMT [219] DETAIL:  Connection matched pg_hba.conf line 1: "host     all             all             0.0.0.0/0               md5"
2022-09-03 23:13:25.397 GMT [262] FATAL:  password authentication failed for user "postgres"
2022-09-03 23:13:25.397 GMT [262] DETAIL:  Connection matched pg_hba.conf line 1: "host     all             all             0.0.0.0/0               md5"
2022-09-03 23:13:30.243 GMT [263] FATAL:  password authentication failed for user "postgres"
2022-09-03 23:13:30.243 GMT [263] DETAIL:  Connection matched pg_hba.conf line 1: "host     all             all             0.0.0.0/0               md5"
```

Finally, I found difference of password environment.

![Screenshot from 2022-09-04 08-19-38](https://user-images.githubusercontent.com/826646/188290370-9417e8d1-ce72-4fff-820d-050bbe19eb4c.png)
![Screenshot from 2022-09-04 08-19-21](https://user-images.githubusercontent.com/826646/188290371-999961c6-0287-4573-a7cd-0fb6f3748539.png)

Postgresql part of values.yaml is:

```yaml
postgresql:
  # disable if you want to use an existing db; in which case the values below
  # must match those of that external postgres instance
  enabled: true
  # postgresqlHostname: preexisting-postgresql
  auth:
    database: mastodon_production
    username: postgres
    # you must set a password; the password generated by the postgresql chart will
    # be rotated on each upgrade:
    # https://github.com/bitnami/charts/tree/master/bitnami/postgresql#upgrade
    password: "ThisIsSample18"
    # you can also specify the name of an existing Secret
    # with a key of postgres-password set to the password you want
    existingSecret: ""
```

Mastodon chart refers postgresql.auth.password but postgresql chart refers (postgresql.)auth.postgrePassword.
https://github.com/mastodon/mastodon/blob/95a149d7c12666d15257ac88687b3193a74179c1/chart/values.yaml#L135-L149 contains only the former.

I appended postgresql.auth.postgresPassword like

```yaml
# https://github.com/bitnami/charts/tree/master/bitnami/postgresql#parameters
postgresql:
  # disable if you want to use an existing db; in which case the values below
  # must match those of that external postgres instance
  enabled: true
  # postgresqlHostname: preexisting-postgresql
  auth:
    database: mastodon_production
    username: postgres
    # you must set a password; the password generated by the postgresql chart will
    # be rotated on each upgrade:
    # https://github.com/bitnami/charts/tree/master/bitnami/postgresql#upgrade
    password: "ThisIsSample18"
    # you can also specify the name of an existing Secret
    # with a key of postgres-password set to the password you want
    existingSecret: ""
    # Appended by me
    postgresPassword: "ThisIsSample18"
```

and succeeded.

```
❯ helm install --namespace mastodon --create-namespace my-mastodon ./
NAME: my-mastodon
LAST DEPLOYED: Sun Sep  4 08:53:07 2022
NAMESPACE: mastodon
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:
  https://mastodon.local/
```

### IMO

This problem may have been caused by a recent commit. https://github.com/mastodon/mastodon/commits/main/chart
If there is better fix, please tell me or create another PR. After it, I will close this PR.