### PR TITLE
Add setting to notify mentions email only for dm

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -56,7 +56,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_crop_images,
       :setting_always_send_emails,
       notification_emails: %i(follow follow_request reblog favourite mention report pending_account trending_tag appeal),
-      interactions: %i(must_be_follower must_be_following must_be_following_dm)
+      interactions: %i(must_be_follower must_be_following must_be_following_dm must_be_dm_to_send_email)
     )
   end
 end

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -42,6 +42,10 @@ class NotifyService < BaseService
     @recipient.user.settings.interactions['must_be_following'] && !following_sender?
   end
 
+  def optional_non_direct_message?
+    message? && @recipient.user.settings.interactions['must_be_dm_to_send_email'] && !@notification.target_status.direct_visibility?
+  end
+
   def message?
     @notification.type == :mention
   end
@@ -154,6 +158,8 @@ class NotifyService < BaseService
   end
 
   def send_email!
+    return if optional_non_direct_message?
+
     NotificationMailer.public_send(@notification.type, @recipient, @notification).deliver_later(wait: 2.minutes) if NotificationMailer.respond_to?(@notification.type)
   end
 

--- a/app/views/settings/preferences/notifications/show.html.haml
+++ b/app/views/settings/preferences/notifications/show.html.haml
@@ -33,3 +33,4 @@
       = ff.input :must_be_follower, as: :boolean, wrapper: :with_label
       = ff.input :must_be_following, as: :boolean, wrapper: :with_label
       = ff.input :must_be_following_dm, as: :boolean, wrapper: :with_label
+      = ff.input :must_be_dm_to_send_email, as: :boolean, wrapper: :with_label

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -208,6 +208,7 @@ en:
           hide: Hide completely
           warn: Hide with a warning
       interactions:
+        must_be_dm_to_send_email: Block e-mail notifications from mentions to you other than direct messages
         must_be_follower: Block notifications from non-followers
         must_be_following: Block notifications from people you don't follow
         must_be_following_dm: Block direct messages from people you don't follow

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,6 +50,7 @@ defaults: &defaults
     appeal: true
   always_send_emails: false
   interactions:
+    must_be_dm_to_send_email: false
     must_be_follower: false
     must_be_following: false
     must_be_following_dm: false


### PR DESCRIPTION
Add a function to limit the notification type :mention to direct messages when notifying by e-mail.