### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - .github/workflows/build-image.yml
       - Dockerfile
+permissions:
+  contents: read
+
 jobs:
   build-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -9,6 +9,9 @@ on:
 env:
   RAILS_ENV: test
 
+permissions:
+  contents: read
+
 jobs:
   check-i18n:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflow runs:
https://github.com/mastodon/mastodon/runs/8126736236?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- build-image.yml
- check-i18n.yml	

The following workflow file already has the least privileged token permission set:

- nix.linter.yml

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>