### PR TITLE
Fix breaking change in admin account API

### DIFF
--- a/app/serializers/rest/admin/account_serializer.rb
+++ b/app/serializers/rest/admin/account_serializer.rb
@@ -77,6 +77,6 @@ class REST::Admin::AccountSerializer < ActiveModel::Serializer
   end
 
   def ip
-    ips&.first.ip
+    ips&.first&.ip
   end
 end

--- a/app/serializers/rest/admin/account_serializer.rb
+++ b/app/serializers/rest/admin/account_serializer.rb
@@ -77,6 +77,6 @@ class REST::Admin::AccountSerializer < ActiveModel::Serializer
   end
 
   def ip
-    ips&.first
+    ips&.first.ip
   end
 end


### PR DESCRIPTION
Ensure that `ip` is a String value and not returning a raw database entry

### Rationale

#16409 included a change to add `ips` as a property that returns an array of serialized entities containing the IP address and the timestamp it was last used at. For compatibility, `ip` was changed to return the first item in the `ips` array. However, this was done incorrectly, and instead of returning the string value, the API would instead return the raw database entry with all columns, including a `user_id` column that is otherwise not used even in the Admin::IpSerializer.

This PR fixes the broken behavior by ensuring that the string `ip` value is returned for the `ip` property.