### PR TITLE
Fix various rspec warnings in ReportService tests

### DIFF
--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -42,13 +42,13 @@ RSpec.describe ReportService, type: :service do
       end
 
       it 'creates a report' do
-        is_expected.to change { target_account.targeted_reports.count }.from(0).to(1)
+        expect { subject.call }.to change { target_account.targeted_reports.count }.from(0).to(1)
       end
     end
 
     context 'when it is not addressed to the reporter' do
       it 'errors out' do
-        is_expected.to raise_error
+        expect { subject.call }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end
@@ -67,7 +67,7 @@ RSpec.describe ReportService, type: :service do
     end
 
     it 'does not send an e-mail' do
-      is_expected.to_not change(ActionMailer::Base.deliveries, :count).from(0)
+      expect { subject.call }.to_not change(ActionMailer::Base.deliveries, :count).from(0)
     end
   end
 end

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -44,11 +44,42 @@ RSpec.describe ReportService, type: :service do
       it 'creates a report' do
         expect { subject.call }.to change { target_account.targeted_reports.count }.from(0).to(1)
       end
+
+      it 'attaches the DM to the report' do
+        subject.call
+        expect(target_account.targeted_reports.pluck(:status_ids)).to eq [[status.id]]
+      end
     end
 
     context 'when it is not addressed to the reporter' do
       it 'errors out' do
         expect { subject.call }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'when the reporter is remote' do
+      let(:source_account) { Fabricate(:account, domain: 'example.com', uri: 'https://example.com/users/1') }
+
+      context 'when it is addressed to the reporter' do
+        before do
+          status.mentions.create(account: source_account)
+        end
+
+        it 'creates a report' do
+          expect { subject.call }.to change { target_account.targeted_reports.count }.from(0).to(1)
+        end
+
+        it 'attaches the DM to the report' do
+          subject.call
+          expect(target_account.targeted_reports.pluck(:status_ids)).to eq [[status.id]]
+        end
+      end
+
+      context 'when it is not addressed to the reporter' do
+        it 'does not add the DM to the report' do
+          subject.call
+          expect(target_account.targeted_reports.pluck(:status_ids)).to eq [[]]
+        end
       end
     end
   end


### PR DESCRIPTION
Also add a few tests.

Found the tests were a bit lacking when adding logic around groups, so I split those tests from my in-progress groups PR.