### PR TITLE
Improve compose form's colors on dark mode

### DIFF
--- a/app/javascript/styles/contrast/diff.scss
+++ b/app/javascript/styles/contrast/diff.scss
@@ -76,7 +76,8 @@
   border-bottom: 4px solid $ui-highlight-color;
 }
 
-.compose-form .autosuggest-textarea__textarea::placeholder,
-.compose-form .spoiler-input__input::placeholder {
-  color: $inverted-text-color;
+.icon-button.inverted,
+.text-icon-button,
+.character-counter {
+  color: $ui-secondary-color;
 }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -419,6 +419,10 @@
     width: 100%;
   }
 
+  .autosuggest-textarea {
+    background: darken($ui-base-color, 7%);
+  }
+
   .spoiler-input {
     height: 0;
     transform-origin: bottom;
@@ -437,8 +441,8 @@
     box-sizing: border-box;
     width: 100%;
     margin: 0;
-    color: $inverted-text-color;
-    background: $simple-background-color;
+    background: $ui-base-color;
+    color: $darker-text-color;
     padding: 10px;
     font-family: inherit;
     font-size: 14px;
@@ -568,7 +572,7 @@
     color: $inverted-text-color;
     font-family: inherit;
     font-size: 14px;
-    background: $simple-background-color;
+    background: $ui-base-color;
 
     .compose-form__upload-wrapper {
       overflow: hidden;
@@ -633,7 +637,7 @@
 
   .compose-form__buttons-wrapper {
     padding: 10px;
-    background: darken($simple-background-color, 8%);
+    background: lighten($ui-base-color, 3%);
     border-radius: 0 0 4px 4px;
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
- Currently the compose form is light themed when you have selected dark mode/high contrast as Mastodon theme. This unexpected and actually should be, like all other components be dark themed. This patch fixes that by making the compose form dark-themed.
- Feel free to improve/suggest/ask questions about this patch (fair warning, first time digging around the codebase).
- Resolves #13258 (partially, I have left out the changes for emoji for now).

Screenshots:

Dark Mode:
![image](https://user-images.githubusercontent.com/25481501/191258881-fd43d6b8-c1f1-44db-90f0-24ef49ad4e05.png)

Light Mode (unaffected):
![image](https://user-images.githubusercontent.com/25481501/191258997-3609014a-17c6-4429-bf8b-38403199ca3d.png)

High contrast:
![image](https://user-images.githubusercontent.com/25481501/191259099-c4c7222a-87b0-4dce-9114-9a9253acfe13.png)

