### PR TITLE
Use FeaturedTag serializer for featured_tags/suggestions

### DIFF
--- a/app/controllers/api/v1/featured_tags/suggestions_controller.rb
+++ b/app/controllers/api/v1/featured_tags/suggestions_controller.rb
@@ -17,6 +17,6 @@ class Api::V1::FeaturedTags::SuggestionsController < Api::BaseController
       .recently_used(current_account)
       .where.not(id: current_account.featured_tags)
       .limit(10)
-      .collect { |tag| current_account.featured_tags.new(id: tag.id, name: tag.name) }
+      .map { |tag| current_account.featured_tags.new(id: tag.id, name: tag.name) }
   end
 end

--- a/app/controllers/api/v1/featured_tags/suggestions_controller.rb
+++ b/app/controllers/api/v1/featured_tags/suggestions_controller.rb
@@ -6,12 +6,16 @@ class Api::V1::FeaturedTags::SuggestionsController < Api::BaseController
   before_action :set_recently_used_tags, only: :index
 
   def index
-    render json: @recently_used_tags, each_serializer: REST::TagSerializer, relationships: TagRelationshipsPresenter.new(@recently_used_tags, current_user&.account_id)
+    render json: @recently_used_tags, each_serializer: REST::FeaturedTagSerializer
   end
 
   private
 
   def set_recently_used_tags
-    @recently_used_tags = Tag.recently_used(current_account).where.not(id: current_account.featured_tags).limit(10)
+    @recently_used_tags = Tag
+    	.recently_used(current_account)
+    	.where.not(id: current_account.featured_tags)
+    	.limit(10)
+    	.collect{ |tag| current_account.featured_tags.new(:id => tag.id, :name => tag.name) }
   end
 end

--- a/app/controllers/api/v1/featured_tags/suggestions_controller.rb
+++ b/app/controllers/api/v1/featured_tags/suggestions_controller.rb
@@ -12,10 +12,11 @@ class Api::V1::FeaturedTags::SuggestionsController < Api::BaseController
   private
 
   def set_recently_used_tags
-    @recently_used_tags = Tag
-    	.recently_used(current_account)
-    	.where.not(id: current_account.featured_tags)
-    	.limit(10)
-    	.collect{ |tag| current_account.featured_tags.new(:id => tag.id, :name => tag.name) }
+    @recently_used_tags =
+      Tag
+      .recently_used(current_account)
+      .where.not(id: current_account.featured_tags)
+      .limit(10)
+      .collect { |tag| current_account.featured_tags.new(id: tag.id, name: tag.name) }
   end
 end

--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -19,8 +19,8 @@ class FeaturedTag < ApplicationRecord
   validate :validate_tag_name, on: :create
   validate :validate_featured_tags_limit, on: :create
 
-  before_create :set_tag
-  before_create :reset_data
+  after_initialize :set_tag
+  after_initialize :reset_data
 
   delegate :display_name, to: :tag
 


### PR DESCRIPTION
This should be safe since the only relevant fields in a Tag (as far as suggestions for featuring a tag) would be the `name` and maybe the `url`. However, the inclusion of `history` is misleading as this represents the history of *everyone* using the tag, not just you. Also, it is completely irrelevant whether you are `following` the tag or not, since we are only considering your own posts (and your own posts are included in the home feed).

More generally, it makes way more sense to be working with FeaturedTags when asking for suggestions on which tags to feature. The `url` is localized to your own account, so you can easily view tagged posts from yourself only.

Note that the `id` used is from the Tag, as these are merely suggestions and no FeaturedTag has been created yet.