### PR TITLE
Update Node to 16.17.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ SHELL ["/bin/bash", "-c"]
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Install Node v16 (LTS)
-ENV NODE_VER="16.16.0"
+ENV NODE_VER="16.17.1"
 RUN ARCH= && \
     dpkgArch="$(dpkg --print-architecture)" && \
   case "${dpkgArch##*-}" in \


### PR DESCRIPTION
See
https://nodejs.org/en/blog/vulnerability/september-2022-security-releases/ for the details.