### PR TITLE
Fix translations not being formatted, other issues in web UI

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -6,7 +6,7 @@ import Permalink from './permalink';
 import classnames from 'classnames';
 import PollContainer from 'mastodon/containers/poll_container';
 import Icon from 'mastodon/components/icon';
-import { autoPlayGif } from 'mastodon/initial_state';
+import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_state';
 
 const MAX_HEIGHT = 642; // 20px * 32 (+ 2px padding at the top)
 
@@ -180,8 +180,9 @@ class StatusContent extends React.PureComponent {
     const hidden = this.props.onExpandedToggle ? !this.props.expanded : this.state.hidden;
     const renderReadMore = this.props.onClick && status.get('collapsed');
     const renderViewThread = this.props.showThread && status.get('in_reply_to_id') && status.get('in_reply_to_account_id') === status.getIn(['account', 'id']);
-    const renderTranslate = this.props.onTranslate && ['public', 'unlisted'].includes(status.get('visibility')) && intl.locale !== status.get('language');
-    const languageNames = new Intl.DisplayNames([intl.locale], { type: 'language' });
+    const renderTranslate = this.props.onTranslate && ['public', 'unlisted'].includes(status.get('visibility')) && status.get('contentHtml').length > 0 && intl.locale !== status.get('language');
+    const language = preloadedLanguages.find(lang => lang[0] === status.get('language'));
+    const languageName = language ? language[2] : status.get('language');
 
     const content = { __html: status.get('translation') ? status.getIn(['translation', 'content']) : status.get('contentHtml') };
     const spoilerContent = { __html: status.get('spoilerHtml') };
@@ -206,7 +207,7 @@ class StatusContent extends React.PureComponent {
 
     const translateButton = (
       <button className='status__content__read-more-button' onClick={this.handleTranslate}>
-        {status.get('translation') ? <span><FormattedMessage id='status.translated_from' defaultMessage='Translated from {lang}' values={{ lang: languageNames.of(status.get('language')) }} /> · <FormattedMessage id='status.show_original' defaultMessage='Show original' /></span> : <FormattedMessage id='status.translate' defaultMessage='Translate' />}
+        {status.get('translation') ? <span><FormattedMessage id='status.translated_from' defaultMessage='Translated from {lang}' values={{ lang: languageName }} /> · <FormattedMessage id='status.show_original' defaultMessage='Show original' /></span> : <FormattedMessage id='status.translate' defaultMessage='Translate' />}
       </button>
     );
 

--- a/app/services/translate_status_service.rb
+++ b/app/services/translate_status_service.rb
@@ -3,13 +3,16 @@
 class TranslateStatusService < BaseService
   CACHE_TTL = 1.day.freeze
 
+  include FormattingHelper
+
   def call(status, target_language)
     raise Mastodon::NotPermittedError unless status.public_visibility? || status.unlisted_visibility?
 
     @status = status
+    @content = status_content_format(@status)
     @target_language = target_language
 
-    Rails.cache.fetch("translations/#{@status.language}/#{@target_language}/#{content_hash}", expires_in: CACHE_TTL) { translation_backend.translate(@status.text, @status.language, @target_language) }
+    Rails.cache.fetch("translations/#{@status.language}/#{@target_language}/#{content_hash}", expires_in: CACHE_TTL) { translation_backend.translate(@content, @status.language, @target_language) }
   end
 
   private
@@ -19,6 +22,6 @@ class TranslateStatusService < BaseService
   end
 
   def content_hash
-    Digest::SHA256.base64digest(@status.text)
+    Digest::SHA256.base64digest(@content)
   end
 end


### PR DESCRIPTION
Fix #19237

`Intl.DisplayNames` is not yet supported in all browsers, and loading the polyfill is not straightforward. `react-intl` needs an upgrade to the latest version. Reverting to using our own list of languages.