### PR TITLE
Fix language dropdown sometimes not appearing in web UI

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -282,7 +282,7 @@ class User < ApplicationRecord
   end
 
   def preferred_posting_language
-    valid_locale_cascade(settings.default_language, locale)
+    valid_locale_cascade(settings.default_language, locale, I18n.locale)
   end
 
   def setting_default_privacy


### PR DESCRIPTION
When user has no locale preference saved (such as never changing it from the default), the preferred posting language is nil, and the dropdown is not visible