### PR TITLE
Slightly increase column size to improve youtube useability. 

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2240,7 +2240,7 @@ a.account__display-name {
 }
 
 .column {
-  width: 350px;
+  width: 400px;
   position: relative;
   box-sizing: border-box;
   display: flex;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2240,7 +2240,7 @@ a.account__display-name {
 }
 
 .column {
-  width: 400px;
+  width: 390px;
   position: relative;
   box-sizing: border-box;
   display: flex;


### PR DESCRIPTION
Obviously depends if you're set on the column size being 350, this is not tenable... but it's small enough change for me

Before - Youtube is missing the volume
![image](https://user-images.githubusercontent.com/17537000/193499224-a8e2642a-70bb-4708-aea8-c09f14861525.png)

After - Youtube volume is shown (and closed captions)
![image](https://user-images.githubusercontent.com/17537000/193499691-cdcf4c3e-a73c-4c25-a376-2427f216b6f4.png)

Edit: I think this can be solved by making the media full sized. and using the wasted white space on the left.

![image](https://user-images.githubusercontent.com/17537000/193500335-efd702af-7cfc-495f-992c-dd7c04a85951.png)
