### PR TITLE
Add back titles to RSS feeds

### DIFF
--- a/app/views/accounts/show.rss.ruby
+++ b/app/views/accounts/show.rss.ruby
@@ -9,6 +9,7 @@ RSS::Builder.build do |doc|
 
   @statuses.each do |status|
     doc.item do |item|
+      item.title("New post#{" (CW: #{status.spoiler_text})" unless status.spoiler_text.empty?}")
       item.link(ActivityPub::TagManager.instance.url_for(status))
       item.pub_date(status.created_at)
       item.description(rss_status_content_format(status))

--- a/app/views/tags/show.rss.ruby
+++ b/app/views/tags/show.rss.ruby
@@ -7,6 +7,7 @@ RSS::Builder.build do |doc|
 
   @statuses.each do |status|
     doc.item do |item|
+      item.title("New post by #{status.account.pretty_acct}#{" (CW: #{status.spoiler_text})" unless status.spoiler_text.empty?}")
       item.link(ActivityPub::TagManager.instance.url_for(status))
       item.pub_date(status.created_at)
       item.description(rss_status_content_format(status))


### PR DESCRIPTION
Originally, RSS feed titles were removed in #18640, as they were simply the created date, which wasn't useful.
However, since empty title fields in RSS readers are even less useful (and some readers ignore any such posts entirely), I am making this PR.

Changes:

- Account RSS feed title now says "New post", plus any content warning appended, should it exist.
- Tag RSS feed will say "New post by \<user handle>", plus any content warning appended, should it exist.