### PR TITLE
Remove unnecessary sections from welcome e-mail

### DIFF
--- a/app/views/user_mailer/welcome.html.haml
+++ b/app/views/user_mailer/welcome.html.haml
@@ -76,26 +76,7 @@
                                     %td.button-primary
                                       = link_to settings_profile_url do
                                         %span= t 'user_mailer.welcome.edit_profile_action'
-              %tr
-                %td.content-cell
-                  .email-row
-                    .col-4
-                      %table.column{ cellspacing: 0, cellpadding: 0 }
-                        %tbody
-                          %tr
-                            %td.column-cell.padded
-                              = t 'user_mailer.welcome.review_preferences_step'
-                    .col-2
-                      %table.column{ cellspacing: 0, cellpadding: 0 }
-                        %tbody
-                          %tr
-                            %td.column-cell.padded
-                              %table.button.button-small{ align: 'left', cellspacing: 0, cellpadding: 0 }
-                                %tbody
-                                  %tr
-                                    %td.button-primary
-                                      = link_to settings_preferences_url do
-                                        %span= t 'user_mailer.welcome.review_preferences_action'
+
               %tr
                 %td.content-cell.padded-bottom
                   .email-row
@@ -116,29 +97,3 @@
                                     %td.button-primary
                                       = link_to web_url do
                                         %span= t 'user_mailer.welcome.final_action'
-
-%table.email-table{ cellspacing: 0, cellpadding: 0 }
-  %tbody
-    %tr
-      %td.email-body
-        .email-container
-          %table.content-section{ cellspacing: 0, cellpadding: 0 }
-            %tbody
-              %tr
-                %td.content-cell.border-top
-                  .email-row
-                    .col-6
-                      %table.column{ cellspacing: 0, cellpadding: 0 }
-                        %tbody
-                          %tr
-                            %td.column-cell.padded
-                              %h5= t 'user_mailer.welcome.tips'
-                              %ul
-                                %li
-                                  %span= t 'user_mailer.welcome.tip_mobile_webapp'
-                                %li
-                                  %span= t 'user_mailer.welcome.tip_following'
-                                %li
-                                  %span= t 'user_mailer.welcome.tip_local_timeline', instance: @instance
-                                %li
-                                  %span= t 'user_mailer.welcome.tip_federated_timeline'

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -11,19 +11,6 @@
 
 => <%= settings_profile_url %>
 
-<%= t 'user_mailer.welcome.review_preferences_step' %>
-
-=> <%= settings_preferences_url %>
-
 <%= t 'user_mailer.welcome.final_step' %>
 
 => <%= web_url %>
-
----
-
-<%= t 'user_mailer.welcome.tips' %>
-
-* <%= t 'user_mailer.welcome.tip_mobile_webapp' %>
-* <%= t 'user_mailer.welcome.tip_following' %>
-* <%= t 'user_mailer.welcome.tip_local_timeline', instance: @instance %>
-* <%= t 'user_mailer.welcome.tip_federated_timeline' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1792,20 +1792,13 @@ en:
         suspend: Account suspended
     welcome:
       edit_profile_action: Setup profile
-      edit_profile_step: You can customize your profile by uploading an avatar, header, changing your display name and more. If you’d like to review new followers before they’re allowed to follow you, you can lock your account.
+      edit_profile_step: You can customize your profile by uploading a profile picture, changing your display name and more. You can opt-in to review new followers before they’re allowed to follow you.
       explanation: Here are some tips to get you started
       final_action: Start posting
-      final_step: 'Start posting! Even without followers your public posts may be seen by others, for example on the local timeline and in hashtags. You may want to introduce yourself on the #introductions hashtag.'
+      final_step: 'Start posting! Even without followers, your public posts may be seen by others, for example on the local timeline or in hashtags. You may want to introduce yourself on the #introductions hashtag.'
       full_handle: Your full handle
       full_handle_hint: This is what you would tell your friends so they can message or follow you from another server.
-      review_preferences_action: Change preferences
-      review_preferences_step: Make sure to set your preferences, such as which emails you'd like to receive, or what privacy level you’d like your posts to default to. If you don’t have motion sickness, you could choose to enable GIF autoplay.
       subject: Welcome to Mastodon
-      tip_federated_timeline: The federated timeline is a firehose view of the Mastodon network. But it only includes people your neighbours are subscribed to, so it's not complete.
-      tip_following: You follow your server's admin(s) by default. To find more interesting people, check the local and federated timelines.
-      tip_local_timeline: The local timeline is a firehose view of people on %{instance}. These are your immediate neighbours!
-      tip_mobile_webapp: If your mobile browser offers you to add Mastodon to your homescreen, you can receive push notifications. It acts like a native app in many ways!
-      tips: Tips
       title: Welcome aboard, %{name}!
   users:
     follow_limit_reached: You cannot follow more than %{limit} people


### PR DESCRIPTION
- After we changed when notification e-mails are sent, we no longer need to push people towards adjusting the preferences
- The tips are a mix of outdated (autofollows) and no longer best practice (public timelines)