### PR TITLE
Change public statuses pages to mount the web UI

### DIFF
--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module WebAppControllerConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_body_classes
+    before_action :set_referrer_policy_header
+  end
+
+  def set_body_classes
+    @body_classes = 'app-body'
+  end
+
+  def set_referrer_policy_header
+    response.headers['Referrer-Policy'] = 'origin'
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
+  include WebAppControllerConcern
+
   before_action :redirect_unauthenticated_to_permalinks!
-  before_action :set_referrer_policy_header
   before_action :set_instance_presenter
 
-  def index
-    @body_classes = 'app-body'
-  end
+  def index; end
 
   private
 
@@ -17,10 +16,6 @@ class HomeController < ApplicationController
     redirect_path = PermalinkRedirector.new(request.path).redirect_path
 
     redirect_to(redirect_path) if redirect_path.present?
-  end
-
-  def set_referrer_policy_header
-    response.headers['Referrer-Policy'] = 'origin'
   end
 
   def set_instance_presenter

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -5,17 +5,15 @@ class StatusesController < ApplicationController
   include SignatureAuthentication
   include Authorization
   include AccountOwnedConcern
-
-  layout 'public'
+  include WebAppControllerConcern
 
   before_action :require_account_signature!, only: [:show, :activity], if: -> { request.format == :json && authorized_fetch_mode? }
   before_action :set_status
   before_action :set_instance_presenter
   before_action :set_link_headers
   before_action :redirect_to_original, only: :show
-  before_action :set_referrer_policy_header, only: :show
   before_action :set_cache_headers
-  before_action :set_body_classes
+  before_action :set_body_classes, only: :embed
 
   skip_around_action :set_locale, if: -> { request.format == :json }
   skip_before_action :require_functional!, only: [:show, :embed], unless: :whitelist_mode?
@@ -28,8 +26,6 @@ class StatusesController < ApplicationController
     respond_to do |format|
       format.html do
         expires_in 10.seconds, public: true if current_account.nil?
-        set_ancestors
-        set_descendants
       end
 
       format.json do
@@ -76,9 +72,5 @@ class StatusesController < ApplicationController
 
   def redirect_to_original
     redirect_to ActivityPub::TagManager.instance.url_for(@status.reblog) if @status.reblog?
-  end
-
-  def set_referrer_policy_header
-    response.headers['Referrer-Policy'] = 'origin' unless @status.distributable?
   end
 end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,20 +1,4 @@
 - content_for :header_tags do
-  - if user_signed_in?
-    = preload_pack_asset 'features/getting_started.js', crossorigin: 'anonymous'
-    = preload_pack_asset 'features/compose.js', crossorigin: 'anonymous'
-    = preload_pack_asset 'features/home_timeline.js', crossorigin: 'anonymous'
-    = preload_pack_asset 'features/notifications.js', crossorigin: 'anonymous'
-
   = render partial: 'shared/og'
 
-  %meta{name: 'applicationServerKey', content: Rails.configuration.x.vapid_public_key}
-
-  = render_initial_state
-  = javascript_pack_tag 'application', crossorigin: 'anonymous'
-
-.notranslate.app-holder#mastodon{ data: { props: Oj.dump(default_props) } }
-  %noscript
-    = image_pack_tag 'logo.svg', alt: 'Mastodon'
-
-    %div
-      = t('errors.noscript_html', apps_path: 'https://joinmastodon.org/apps')
+= render 'shared/web_app'

--- a/app/views/shared/_web_app.html.haml
+++ b/app/views/shared/_web_app.html.haml
@@ -1,0 +1,17 @@
+- content_for :header_tags do
+  - if user_signed_in?
+    = preload_pack_asset 'features/compose.js', crossorigin: 'anonymous'
+    = preload_pack_asset 'features/home_timeline.js', crossorigin: 'anonymous'
+    = preload_pack_asset 'features/notifications.js', crossorigin: 'anonymous'
+
+  %meta{ name: 'applicationServerKey', content: Rails.configuration.x.vapid_public_key }
+
+  = render_initial_state
+  = javascript_pack_tag 'application', crossorigin: 'anonymous'
+
+.notranslate.app-holder#mastodon{ data: { props: Oj.dump(default_props) } }
+  %noscript
+    = image_pack_tag 'logo.svg', alt: 'Mastodon'
+
+    %div
+      = t('errors.noscript_html', apps_path: 'https://joinmastodon.org/apps')

--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -17,9 +17,4 @@
   = render 'og_description', activity: @status
   = render 'og_image', activity: @status, account: @account
 
-.grid
-  .column-0
-    .activity-stream.h-entry
-      = render partial: 'status', locals: { status: @status, include_threads: true }
-  .column-1
-    = render 'application/sidebar'
+= render 'shared/web_app'

--- a/spec/views/statuses/show.html.haml_spec.rb
+++ b/spec/views/statuses/show.html.haml_spec.rb
@@ -15,54 +15,6 @@ describe 'statuses/show.html.haml', without_verify_partial_doubles: true do
     assign(:instance_presenter, InstancePresenter.new)
   end
 
-  it 'has valid author h-card and basic data for a detailed_status' do
-    alice  = Fabricate(:account, username: 'alice', display_name: 'Alice')
-    bob    = Fabricate(:account, username: 'bob', display_name: 'Bob')
-    status = Fabricate(:status, account: alice, text: 'Hello World')
-    media  = Fabricate(:media_attachment, account: alice, status: status, type: :video)
-    reply  = Fabricate(:status, account: bob, thread: status, text: 'Hello Alice')
-
-    assign(:status, status)
-    assign(:account, alice)
-    assign(:descendant_threads, [])
-
-    render
-
-    mf2 = Microformats.parse(rendered)
-
-    expect(mf2.entry.url.to_s).not_to be_empty
-    expect(mf2.entry.author.name.to_s).to eq alice.display_name
-    expect(mf2.entry.author.url.to_s).not_to be_empty
-  end
-
-  it 'has valid h-cites for p-in-reply-to and p-comment' do
-    alice   = Fabricate(:account, username: 'alice', display_name: 'Alice')
-    bob     = Fabricate(:account, username: 'bob', display_name: 'Bob')
-    carl    = Fabricate(:account, username: 'carl', display_name: 'Carl')
-    status  = Fabricate(:status, account: alice, text: 'Hello World')
-    media   = Fabricate(:media_attachment, account: alice, status: status, type: :video)
-    reply   = Fabricate(:status, account: bob, thread: status, text: 'Hello Alice')
-    comment = Fabricate(:status, account: carl, thread: reply, text: 'Hello Bob')
-
-    assign(:status, reply)
-    assign(:account, alice)
-    assign(:ancestors, reply.ancestors(1, bob))
-    assign(:descendant_threads, [{ statuses: reply.descendants(1) }])
-
-    render
-
-    mf2 = Microformats.parse(rendered)
-
-    expect(mf2.entry.url.to_s).not_to be_empty
-    expect(mf2.entry.comment.url.to_s).not_to be_empty
-    expect(mf2.entry.comment.author.name.to_s).to eq carl.display_name
-    expect(mf2.entry.comment.author.url.to_s).not_to be_empty
-
-    expect(mf2.entry.in_reply_to.url.to_s).not_to be_empty
-    expect(mf2.entry.in_reply_to.author.name.to_s).to eq alice.display_name
-    expect(mf2.entry.in_reply_to.author.url.to_s).not_to be_empty
-  end
-
   it 'has valid opengraph tags' do
     alice  = Fabricate(:account, username: 'alice', display_name: 'Alice')
     status = Fabricate(:status, account: alice, text: 'Hello World')


### PR DESCRIPTION
Partial progress towards not having a separate public UI. The view still renders the OpenGraph tags, so this should have no effect on linking to posts.