### PR TITLE
Improve account name and handle legibility

### DIFF
--- a/app/javascript/styles/mastodon/containers.scss
+++ b/app/javascript/styles/mastodon/containers.scss
@@ -445,7 +445,7 @@
         position: absolute;
         width: 100%;
         height: 100%;
-        box-shadow: inset 0 -1px 1px 1px rgba($base-shadow-color, 0.15);
+        box-shadow: inset 0 -120px 60px -60px rgba($base-shadow-color, 0.65);
         top: 0;
         left: 0;
       }


### PR DESCRIPTION
This PR adjusts CSS to draw a gradient that improves contrast between account name and header image, see images in spoiler for before/after comparison.

<details>
  <summary>Screenshots</summary>

Before:

![mastodon cloud_kinday_pre](https://user-images.githubusercontent.com/1751980/194576507-20fe9435-3388-4236-a237-247ada25548b.png)

After:

![mastodon cloud_kinday_post](https://user-images.githubusercontent.com/1751980/194576514-efa50631-f4e4-4350-bc41-5c4d616da99a.png)

</details>