### PR TITLE
Fix button to dismiss suggestions not showing up in search results

### DIFF
--- a/app/javascript/mastodon/features/compose/components/search_results.js
+++ b/app/javascript/mastodon/features/compose/components/search_results.js
@@ -61,8 +61,8 @@ class SearchResults extends ImmutablePureComponent {
               <AccountContainer
                 key={suggestion.get('account')}
                 id={suggestion.get('account')}
-                actionIcon={suggestion.get('source') === 'past_interaction' ? 'times' : null}
-                actionTitle={suggestion.get('source') === 'past_interaction' ? intl.formatMessage(messages.dismissSuggestion) : null}
+                actionIcon={suggestion.get('source') === 'past_interactions' ? 'times' : null}
+                actionTitle={suggestion.get('source') === 'past_interactions' ? intl.formatMessage(messages.dismissSuggestion) : null}
                 onActionClick={dismissSuggestion}
               />
             ))}


### PR DESCRIPTION
Fix a typo. The scope of this fix is pretty minor as that view only ever shows up in one corner case, now.