### PR TITLE
Change unauthenticated search to not support pagination in REST API

### DIFF
--- a/app/controllers/api/v2/search_controller.rb
+++ b/app/controllers/api/v2/search_controller.rb
@@ -6,6 +6,7 @@ class Api::V2::SearchController < Api::BaseController
   RESULTS_LIMIT = 20
 
   before_action -> { authorize_if_got_token! :read, :'read:search' }
+  before_action :validate_search_params!
 
   def index
     @search = Search.new(search_results)
@@ -18,12 +19,22 @@ class Api::V2::SearchController < Api::BaseController
 
   private
 
+  def validate_search_params!
+    params.require(:q)
+
+    return if user_signed_in?
+
+    return render json: { error: 'Search queries pagination is not supported without authentication' }, status: 401 if params[:offset].present?
+
+    render json: { error: 'Search queries that resolve remote resources are not supported without authentication' }, status: 401 if truthy_param?(:resolve)
+  end
+
   def search_results
     SearchService.new.call(
       params[:q],
       current_account,
       limit_param(RESULTS_LIMIT),
-      search_params.merge(resolve: user_signed_in? ? truthy_param?(:resolve) : false, exclude_unreviewed: truthy_param?(:exclude_unreviewed))
+      search_params.merge(resolve: truthy_param?(:resolve), exclude_unreviewed: truthy_param?(:exclude_unreviewed))
     )
   end
 

--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -3,6 +3,9 @@
 class AccountSearchService < BaseService
   attr_reader :query, :limit, :offset, :options, :account
 
+  # Min. number of characters to look for non-exact matches
+  MIN_QUERY_LENGTH = 5
+
   def call(query, account = nil, options = {})
     @acct_hint = query&.start_with?('@')
     @query     = query&.strip&.gsub(/\A@/, '')
@@ -135,6 +138,8 @@ class AccountSearchService < BaseService
   end
 
   def limit_for_non_exact_results
+    return 0 if @account.nil? && query.size < MIN_QUERY_LENGTH
+
     if exact_match?
       limit - 1
     else


### PR DESCRIPTION
- Only support search queries with 5 or more characters
- Do not support queries with `offset` (pagination)
- Return HTTP 401 on truthy `resolve` instead of overriding to false