### PR TITLE
Fix fedi/local timeline nav link always hide

### DIFF
--- a/app/javascript/mastodon/features/ui/components/navigation_panel.js
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.js
@@ -58,7 +58,7 @@ class NavigationPanel extends React.Component {
         )}
 
         <ColumnLink transparent to='/explore' icon='hashtag' text={intl.formatMessage(messages.explore)} />
-        {signedIn || timelinePreview && (
+        {(signedIn || timelinePreview) && (
           <>
             <ColumnLink transparent to='/public/local' icon='users' text={intl.formatMessage(messages.local)} />
             <ColumnLink transparent exact to='/public' icon='globe' text={intl.formatMessage(messages.federated)} />


### PR DESCRIPTION
Regression from #19320