### PR TITLE
Redirect non-logged-in user to owner statuses on single user mode

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -211,6 +211,10 @@ module ApplicationHelper
       state_params[:admin]             = Account.find_local(Setting.site_contact_username.strip.gsub(/\A@/, ''))
     end
 
+    if single_user_mode?
+      state_params[:owner] = Account.local.without_suspended.where('id > 0').first
+    end
+
     json = ActiveModelSerializers::SerializableResource.new(InitialStatePresenter.new(state_params), serializer: InitialStateSerializer).to_json
     # rubocop:disable Rails/OutputSafety
     content_tag(:script, json_escape(json).html_safe, id: 'initial-state', type: 'application/json')

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -54,7 +54,7 @@ import {
   About,
   PrivacyPolicy,
 } from './util/async-components';
-import { me } from '../../initial_state';
+import initialState, { me, owner, singleUserMode } from '../../initial_state';
 import { closeOnboarding, INTRODUCTION_VERSION } from 'mastodon/actions/onboarding';
 import Header from './components/header';
 
@@ -161,6 +161,8 @@ class SwitchingColumnsArea extends React.PureComponent {
       } else {
         redirect = <Redirect from='/' to='/getting-started' exact />;
       }
+    } else if (singleUserMode && owner && initialState?.accounts[owner]) {
+      redirect = <Redirect from='/' to={`/@${initialState.accounts[owner].username}`} exact />;
     } else {
       redirect = <Redirect from='/' to='/explore' exact />;
     }

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -1,6 +1,45 @@
 // @ts-check
 
 /**
+ * @typedef Emoji
+ * @property {string} shortcode
+ * @property {string} static_url
+ * @property {string} url
+ */
+
+/**
+ * @typedef AccountField
+ * @property {string} name
+ * @property {string} value
+ * @property {string} verified_at
+ */
+
+/**
+ * @typedef Account
+ * @property {string} acct
+ * @property {string} avatar
+ * @property {string} avatar_static
+ * @property {boolean} bot
+ * @property {string} created_at
+ * @property {boolean=} discoverable
+ * @property {string} display_name
+ * @property {Emoji[]} emojis
+ * @property {AccountField[]} fields
+ * @property {number} followers_count
+ * @property {number} following_count
+ * @property {boolean} group
+ * @property {string} header
+ * @property {string} header_static
+ * @property {string} id
+ * @property {string=} last_status_at
+ * @property {boolean} locked
+ * @property {string} note
+ * @property {number} statuses_count
+ * @property {string} url
+ * @property {string} username
+ */
+
+/**
  * @typedef {[code: string, name: string, localName: string]} InitialStateLanguage
  */
 
@@ -22,11 +61,13 @@
  * @property {string} locale
  * @property {string | null} mascot
  * @property {string=} me
+ * @property {string=} owner
  * @property {boolean} profile_directory
  * @property {boolean} registrations_open
  * @property {boolean} reduce_motion
  * @property {string} repository
  * @property {boolean} search_enabled
+ * @property {boolean} single_user_mode
  * @property {string} source_url
  * @property {string} streaming_api_base_url
  * @property {boolean} timeline_preview
@@ -40,13 +81,14 @@
 
 /**
  * @typedef InitialState
+ * @property {Record<string, Account>} accounts
  * @property {InitialStateLanguage[]} languages
  * @property {InitialStateMeta} meta
  */
 
 const element = document.getElementById('initial-state');
 /** @type {InitialState | undefined} */
-const initialState = element && JSON.parse(element.textContent);
+const initialState = element?.textContent && JSON.parse(element.textContent);
 
 /**
  * @template {keyof InitialStateMeta} K
@@ -55,32 +97,34 @@ const initialState = element && JSON.parse(element.textContent);
  */
 const getMeta = (prop) => initialState?.meta && initialState.meta[prop];
 
-export const domain = getMeta('domain');
-export const reduceMotion = getMeta('reduce_motion');
+export const activityApiEnabled = getMeta('activity_api_enabled');
 export const autoPlayGif = getMeta('auto_play_gif');
-export const displayMedia = getMeta('display_media');
-export const expandSpoilers = getMeta('expand_spoilers');
-export const unfollowModal = getMeta('unfollow_modal');
 export const boostModal = getMeta('boost_modal');
+export const cropImages = getMeta('crop_images');
 export const deleteModal = getMeta('delete_modal');
-export const me = getMeta('me');
-export const searchEnabled = getMeta('search_enabled');
+export const disableSwiping = getMeta('disable_swiping');
+export const displayMedia = getMeta('display_media');
+export const domain = getMeta('domain');
+export const expandSpoilers = getMeta('expand_spoilers');
+export const forceSingleColumn = !getMeta('advanced_layout');
 export const limitedFederationMode = getMeta('limited_federation_mode');
+export const mascot = getMeta('mascot');
+export const me = getMeta('me');
+export const owner = getMeta('owner');
+export const profile_directory = getMeta('profile_directory');
+export const reduceMotion = getMeta('reduce_motion');
 export const registrationsOpen = getMeta('registrations_open');
 export const repository = getMeta('repository');
+export const searchEnabled = getMeta('search_enabled');
+export const showTrends = getMeta('trends');
+export const singleUserMode = getMeta('single_user_mode');
 export const source_url = getMeta('source_url');
-export const version = getMeta('version');
-export const mascot = getMeta('mascot');
-export const profile_directory = getMeta('profile_directory');
-export const forceSingleColumn = !getMeta('advanced_layout');
+export const timelinePreview = getMeta('timeline_preview');
+export const title = getMeta('title');
+export const unfollowModal = getMeta('unfollow_modal');
 export const useBlurhash = getMeta('use_blurhash');
 export const usePendingItems = getMeta('use_pending_items');
-export const showTrends = getMeta('trends');
-export const title = getMeta('title');
-export const cropImages = getMeta('crop_images');
-export const disableSwiping = getMeta('disable_swiping');
-export const timelinePreview = getMeta('timeline_preview');
-export const activityApiEnabled = getMeta('activity_api_enabled');
+export const version = getMeta('version');
 export const languages = initialState?.languages;
 
 export default initialState;

--- a/app/presenters/initial_state_presenter.rb
+++ b/app/presenters/initial_state_presenter.rb
@@ -2,7 +2,7 @@
 
 class InitialStatePresenter < ActiveModelSerializers::Model
   attributes :settings, :push_subscription, :token,
-             :current_account, :admin, :text, :visibility
+             :current_account, :admin, :owner, :text, :visibility
 
   def role
     current_account&.user_role

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -30,6 +30,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       registrations_open: Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode,
       timeline_preview: Setting.timeline_preview,
       activity_api_enabled: Setting.activity_api_enabled,
+      single_user_mode: Rails.configuration.x.single_user_mode,
     }
 
     if object.current_account
@@ -55,6 +56,10 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:crop_images]   = Setting.crop_images
     end
 
+    if Rails.configuration.x.single_user_mode
+      store[:owner] = object.owner&.id&.to_s
+    end
+
     store
   end
   # rubocop:enable Metrics/AbcSize
@@ -78,6 +83,7 @@ class InitialStateSerializer < ActiveModel::Serializer
     store = {}
     store[object.current_account.id.to_s] = ActiveModelSerializers::SerializableResource.new(object.current_account, serializer: REST::AccountSerializer) if object.current_account
     store[object.admin.id.to_s]           = ActiveModelSerializers::SerializableResource.new(object.admin, serializer: REST::AccountSerializer) if object.admin
+    store[object.owner.id.to_s]           = ActiveModelSerializers::SerializableResource.new(object.owner, serializer: REST::AccountSerializer) if object.owner
     store
   end
 

--- a/spec/views/statuses/show.html.haml_spec.rb
+++ b/spec/views/statuses/show.html.haml_spec.rb
@@ -12,6 +12,7 @@ describe 'statuses/show.html.haml', without_verify_partial_doubles: true do
     allow(view).to receive(:local_time)
     allow(view).to receive(:local_time_ago)
     allow(view).to receive(:current_account).and_return(nil)
+    allow(view).to receive(:single_user_mode?).and_return(false)
     assign(:instance_presenter, InstancePresenter.new)
   end
 


### PR DESCRIPTION
In many cases, explore does not work well on single user mode servers. It should redirect to the owner statuses as in the previous behavior.