### PR TITLE
Fix `ColumnLink` labels not disappearing in mobile UI

### DIFF
--- a/app/javascript/mastodon/features/ui/components/column_link.js
+++ b/app/javascript/mastodon/features/ui/components/column_link.js
@@ -13,7 +13,7 @@ const ColumnLink = ({ icon, text, to, href, method, badge, transparent, ...other
     return (
       <a href={href} className={className} data-method={method} title={text} {...other}>
         {iconElement}
-        {text}
+        <span>{text}</span>
         {badgeElement}
       </a>
     );
@@ -21,7 +21,7 @@ const ColumnLink = ({ icon, text, to, href, method, badge, transparent, ...other
     return (
       <NavLink to={to} className={className} title={text} {...other}>
         {iconElement}
-        {text}
+        <span>{text}</span>
         {badgeElement}
       </NavLink>
     );


### PR DESCRIPTION
This was not working properly because the `span` elements previously added by `FormattedMesseage` had disappeared.