### PR TITLE
Hide list panel from nav bar in mobile layout

### DIFF
--- a/app/javascript/mastodon/features/ui/components/list_panel.js
+++ b/app/javascript/mastodon/features/ui/components/list_panel.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { createSelector } from 'reselect';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { fetchLists } from 'mastodon/actions/lists';
 import { connect } from 'react-redux';
-import { createSelector } from 'reselect';
-import { NavLink, withRouter } from 'react-router-dom';
-import Icon from 'mastodon/components/icon';
+import { withRouter } from 'react-router-dom';
+import { fetchLists } from 'mastodon/actions/lists';
+import ColumnLink from './column_link';
 
 const getOrderedLists = createSelector([state => state.get('lists')], lists => {
   if (!lists) {
@@ -42,11 +42,11 @@ class ListPanel extends ImmutablePureComponent {
     }
 
     return (
-      <div>
+      <div className='list-panel'>
         <hr />
 
         {lists.map(list => (
-          <NavLink key={list.get('id')} className='column-link column-link--transparent' strict to={`/lists/${list.get('id')}`}><Icon className='column-link__icon' id='list-ul' fixedWidth />{list.get('title')}</NavLink>
+          <ColumnLink icon='list-ul' key={list.get('id')} strict text={list.get('title')} to={`/lists/${list.get('id')}`} transparent />
         ))}
       </div>
     );

--- a/app/javascript/mastodon/features/ui/components/navigation_panel.js
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.js
@@ -5,11 +5,11 @@ import { Link } from 'react-router-dom';
 import Logo from 'mastodon/components/logo';
 import TrendsContainer from 'mastodon/features/getting_started/containers/trends_container';
 import { showTrends, timelinePreview } from 'mastodon/initial_state';
+import ColumnLink from './column_link';
 import FollowRequestsColumnLink from './follow_requests_column_link';
 import ListPanel from './list_panel';
 import NotificationsCounterIcon from './notifications_counter_icon';
 import SignInBanner from './sign_in_banner';
-import ColumnLink from 'mastodon/features/ui/components/column_link';
 
 const messages = defineMessages({
   home: { id: 'tabs_bar.home', defaultMessage: 'Home' },

--- a/app/javascript/mastodon/is_mobile.js
+++ b/app/javascript/mastodon/is_mobile.js
@@ -1,10 +1,19 @@
+// @ts-check
+
 import { supportsPassiveEvents } from 'detect-passive-events';
 import { forceSingleColumn } from 'mastodon/initial_state';
 
 const LAYOUT_BREAKPOINT = 630;
 
+/**
+ * @param {number} width
+ * @returns {boolean}
+ */
 export const isMobile = width => width <= LAYOUT_BREAKPOINT;
 
+/**
+ * @returns {string}
+ */
 export const layoutFromWindow = () => {
   if (isMobile(window.innerWidth)) {
     return 'mobile';
@@ -17,11 +26,13 @@ export const layoutFromWindow = () => {
 
 const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 
+const listenerOptions = supportsPassiveEvents ? { passive: true } : false;
+
 let userTouching = false;
-let listenerOptions = supportsPassiveEvents ? { passive: true } : false;
 
 const touchListener = () => {
   userTouching = true;
+
   window.removeEventListener('touchstart', touchListener, listenerOptions);
 };
 

--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -163,8 +163,8 @@ $small-breakpoint: 960px;
     th,
     td {
       padding: 8px;
-      align-self: start;
-      align-items: start;
+      align-self: flex-start;
+      align-items: flex-start;
       word-break: break-all;
 
       &.nowrap {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2673,6 +2673,10 @@ $ui-header-height: 55px;
     .column-link span {
       display: none;
     }
+
+    .list-panel {
+      display: none;
+    }
   }
 }
 
@@ -2755,7 +2759,7 @@ $ui-header-height: 55px;
 
 .column-actions {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   justify-content: center;
   padding: 40px;
   padding-top: 40px;


### PR DESCRIPTION
The list panel is indistinguishable from the nav bar, which is lined with icons in the mobile UI. The list panel should be omitted from the nav bar since there is already a link that takes the user to the list page.