### PR TITLE
Fix remote account in contact account setting not being used

### DIFF
--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -12,7 +12,9 @@ class InstancePresenter < ActiveModelSerializers::Model
     end
 
     def account
-      Account.find_local(Setting.site_contact_username.strip.gsub(/\A@/, ''))
+      username, domain = Setting.site_contact_username.strip.gsub(/\A@/, '').split('@', 2)
+      domain = nil if TagManager.instance.local_domain?(domain)
+      Account.find_remote(username, domain) if username.present?
     end
   end
 

--- a/app/validators/existing_username_validator.rb
+++ b/app/validators/existing_username_validator.rb
@@ -6,7 +6,7 @@ class ExistingUsernameValidator < ActiveModel::EachValidator
 
     usernames_and_domains = begin
       value.split(',').map do |str|
-        username, domain = str.strip.gsub(/\A@/, '').split('@')
+        username, domain = str.strip.gsub(/\A@/, '').split('@', 2)
         domain = nil if TagManager.instance.local_domain?(domain)
 
         next if username.blank?
@@ -21,8 +21,8 @@ class ExistingUsernameValidator < ActiveModel::EachValidator
 
     if options[:multiple]
       record.errors.add(attribute, I18n.t('existing_username_validator.not_found_multiple', usernames: usernames_with_no_accounts.join(', '))) if usernames_with_no_accounts.any?
-    else
-      record.errors.add(attribute, I18n.t('existing_username_validator.not_found')) if usernames_with_no_accounts.any? || usernames_and_domains.size > 1
+    elsif usernames_with_no_accounts.any? || usernames_and_domains.size > 1
+      record.errors.add(attribute, I18n.t('existing_username_validator.not_found'))
     end
   end
 end


### PR DESCRIPTION
It's possible to input a remote account into the contact account setting, but it would not be interpreted correctly.