### PR TITLE
Add featured tags to featured collection

### DIFF
--- a/app/controllers/activitypub/collections_controller.rb
+++ b/app/controllers/activitypub/collections_controller.rb
@@ -22,6 +22,7 @@ class ActivityPub::CollectionsController < ActivityPub::BaseController
     when 'featured'
       @items = for_signed_account { cache_collection(@account.pinned_statuses, Status) }
       @items = @items.map { |item| item.distributable? ? item : ActivityPub::TagManager.instance.uri_for(item) }
+      @items.concat(for_signed_account { @account.featured_tags })
     when 'tags'
       @items = for_signed_account { @account.featured_tags }
     when 'devices'

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -10,7 +10,7 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
                      :moved_to, :property_value, :discoverable, :olm, :suspended
 
   attributes :id, :type, :following, :followers,
-             :inbox, :outbox, :featured, :featured_tags,
+             :inbox, :outbox, :featured,
              :preferred_username, :name, :summary,
              :url, :manually_approves_followers,
              :discoverable, :published
@@ -80,10 +80,6 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
 
   def featured
     account_collection_url(object, :featured)
-  end
-
-  def featured_tags
-    account_collection_url(object, :tags)
   end
 
   def endpoints


### PR DESCRIPTION
This pull request is provided for testing purposes.
Please do not apply it to production environments as it will break the federation with versions prior to Mastodon v3.5.1, or other ActivityPub implementations. 

Merge the featured tags collection currently exposed in `featuredTags` with the `featured` collection.
This will allow `featured` to contain both Note and Hashtag objects.
(In the future, this may include Actors with AccountPin / endorsement)

However, `featured` has been implemented assuming that only Note objects are included and will fail if a `Hashtag` object is included; since Mastodon v3.5.1, uninterpretable objects are ignored, so This problem does not occur.
This problem does not occur in Mastodon v3.5.1 and later, since Mastodon v3.5.1 ignores uninterpretable objects. 

I'll provide code to pre-test this for reference.