### PR TITLE
Fix duplicate featured tags

### DIFF
--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -60,6 +60,6 @@ class FeaturedTag < ApplicationRecord
   def validate_tag_name
     errors.add(:name, :blank) if @name.blank?
     errors.add(:name, :invalid) unless @name.match?(/\A(#{Tag::HASHTAG_NAME_RE})\z/i)
-    errors.add(:name, I18n.t('featured_tags.errors.duplicate_hashtag')) if FeaturedTag.by_name(@name).where(account_id: account_id).exists?
+    errors.add(:name, :taken) if FeaturedTag.by_name(@name).where(account_id: account_id).exists?
   end
 end

--- a/app/models/featured_tag.rb
+++ b/app/models/featured_tag.rb
@@ -22,6 +22,8 @@ class FeaturedTag < ApplicationRecord
   before_create :set_tag
   before_create :reset_data
 
+  scope :by_name, ->(name) { joins(:tag).where(tag: { name: HashtagNormalizer.new.normalize(name) }) }
+
   delegate :display_name, to: :tag
 
   attr_writer :name
@@ -58,5 +60,6 @@ class FeaturedTag < ApplicationRecord
   def validate_tag_name
     errors.add(:name, :blank) if @name.blank?
     errors.add(:name, :invalid) unless @name.match?(/\A(#{Tag::HASHTAG_NAME_RE})\z/i)
+    errors.add(:name, I18n.t('featured_tags.errors.duplicate_hashtag')) if FeaturedTag.by_name(@name).where(account_id: account_id).exists?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1110,7 +1110,6 @@ en:
   featured_tags:
     add_new: Add new
     errors:
-      duplicate_hashtag: Hashtag already registered
       limit: You have already featured the maximum amount of hashtags
     hint_html: "<strong>What are featured hashtags?</strong> They are displayed prominently on your public profile and allow people to browse your public posts specifically under those hashtags. They are a great tool for keeping track of creative works or long-term projects."
   filters:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1110,6 +1110,7 @@ en:
   featured_tags:
     add_new: Add new
     errors:
+      duplicate_hashtag: Hashtag already registered
       limit: You have already featured the maximum amount of hashtags
     hint_html: "<strong>What are featured hashtags?</strong> They are displayed prominently on your public profile and allow people to browse your public posts specifically under those hashtags. They are a great tool for keeping track of creative works or long-term projects."
   filters:

--- a/db/migrate/20221021055441_add_index_featured_tags_on_account_id_and_tag_id.rb
+++ b/db/migrate/20221021055441_add_index_featured_tags_on_account_id_and_tag_id.rb
@@ -1,0 +1,19 @@
+class AddIndexFeaturedTagsOnAccountIdAndTagId < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    duplicates = FeaturedTag.connection.select_all('SELECT string_agg(id::text, \',\') AS ids FROM featured_tags GROUP BY account_id, tag_id HAVING count(*) > 1').to_ary
+
+    duplicates.each do |row|
+      FeaturedTag.where(id: row['ids'].split(',')[0...-1]).destroy_all
+    end
+
+    add_index :featured_tags, [:account_id, :tag_id], unique: true, algorithm: :concurrently
+    remove_index :featured_tags, [:account_id], algorithm: :concurrently
+  end
+
+  def down
+    add_index :featured_tags, [:account_id], algorithm: :concurrently
+    remove_index :featured_tags, [:account_id, :tag_id], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_12_181003) do
+ActiveRecord::Schema.define(version: 2022_10_21_055441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -442,7 +442,7 @@ ActiveRecord::Schema.define(version: 2022_10_12_181003) do
     t.datetime "last_status_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["account_id"], name: "index_featured_tags_on_account_id"
+    t.index ["account_id", "tag_id"], name: "index_featured_tags_on_account_id_and_tag_id", unique: true
     t.index ["tag_id"], name: "index_featured_tags_on_tag_id"
   end
 


### PR DESCRIPTION
There was a bug that allowed featured tags with the same tag to be created because the unique constraint was not set. Fix this.