### PR TITLE
Fix featured tag display name in setting

### DIFF
--- a/app/views/settings/featured_tags/index.html.haml
+++ b/app/views/settings/featured_tags/index.html.haml
@@ -21,7 +21,7 @@
     %div
       %h4
         = fa_icon 'hashtag'
-        = featured_tag.name
+        = featured_tag.display_name
         %small
           - if featured_tag.last_status_at.nil?
             = t('accounts.nothing_here')


### PR DESCRIPTION
Fixed that the featured tag was not displayed as a display name in the setting page.