### PR TITLE
Change confirm prompt for relationships management

### DIFF
--- a/app/views/relationships/show.html.haml
+++ b/app/views/relationships/show.html.haml
@@ -42,11 +42,11 @@
       %label.batch-table__toolbar__select.batch-checkbox-all
         = check_box_tag :batch_checkbox_all, nil, false
       .batch-table__toolbar__actions
-        = f.button safe_join([fa_icon('user-plus'), t('relationships.follow_selected_followers')]), name: :follow, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') } if followed_by_relationship? && !mutual_relationship?
+        = f.button safe_join([fa_icon('user-plus'), t('relationships.follow_selected_followers')]), name: :follow, class: 'table-action-link', type: :submit, data: { confirm: t('relationships.confirm_follow_selected_followers') } if followed_by_relationship? && !mutual_relationship?
 
-        = f.button safe_join([fa_icon('user-times'), t('relationships.remove_selected_follows')]), name: :unfollow, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') } unless followed_by_relationship?
+        = f.button safe_join([fa_icon('user-times'), t('relationships.remove_selected_follows')]), name: :unfollow, class: 'table-action-link', type: :submit, data: { confirm: t('relationships.confirm_remove_selected_follows') } unless followed_by_relationship?
 
-        = f.button safe_join([fa_icon('trash'), t('relationships.remove_selected_followers')]), name: :remove_from_followers, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') } unless following_relationship?
+        = f.button safe_join([fa_icon('trash'), t('relationships.remove_selected_followers')]), name: :remove_from_followers, class: 'table-action-link', type: :submit, data: { confirm: t('relationships.confirm_remove_selected_followers') } unless following_relationship?
 
         = f.button safe_join([fa_icon('trash'), t('relationships.remove_selected_domains')]), name: :block_domains, class: 'table-action-link', type: :submit, data: { confirm: t('admin.reports.are_you_sure') } if followed_by_relationship?
     .batch-table__body

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1371,6 +1371,9 @@ en:
       unrecognized_emoji: is not a recognized emoji
   relationships:
     activity: Account activity
+    confirm_follow_selected_followers: Are you sure to follow selected followers?
+    confirm_remove_selected_followers: Are you sure to remove selected followers?
+    confirm_remove_selected_follows: Are you sure to remove selected follows?
     dormant: Dormant
     follow_selected_followers: Follow selected followers
     followers: Followers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1371,9 +1371,9 @@ en:
       unrecognized_emoji: is not a recognized emoji
   relationships:
     activity: Account activity
-    confirm_follow_selected_followers: Are you sure to follow selected followers?
-    confirm_remove_selected_followers: Are you sure to remove selected followers?
-    confirm_remove_selected_follows: Are you sure to remove selected follows?
+    confirm_follow_selected_followers: Are you sure you want to follow selected followers?
+    confirm_remove_selected_followers: Are you sure you want to remove selected followers?
+    confirm_remove_selected_follows: Are you sure you want to remove selected follows?
     dormant: Dormant
     follow_selected_followers: Follow selected followers
     followers: Followers

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1343,6 +1343,9 @@ ko:
       unrecognized_emoji: 인식 되지 않은 에모지입니다
   relationships:
     activity: 계정 활동
+    confirm_follow_selected_followers: 정말로 선택된 팔로워들을 팔로우 하시겠습니까?
+    confirm_remove_selected_followers: 정말로 선택된 팔로워들을 삭제하시겠습니까?
+    confirm_remove_selected_follows: 정말로 선택된 팔로우를 끊으시겠습니까?
     dormant: 휴면
     follow_selected_followers: 선택한 팔로워들을 팔로우
     followers: 팔로워


### PR DESCRIPTION
On relationships manager, Just asking same "Are you sure?" for destructive action is not good.
Especially, for mobile interface, User cannot know if they touched different action

It maybe better if "Are you sure to ~~(action) for X users?", But it is fine with confirming with action like "Are you sure to follow selected followers?"