### PR TITLE
Add mention of the translation provider when translating a post

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -208,7 +208,7 @@ class StatusContent extends React.PureComponent {
 
     const translateButton = (
       <button className='status__content__read-more-button' onClick={this.handleTranslate}>
-        {status.get('translation') ? <span><FormattedMessage id='status.translated_from' defaultMessage='Translated from {lang}' values={{ lang: languageName }} /> · <FormattedMessage id='status.show_original' defaultMessage='Show original' /></span> : <FormattedMessage id='status.translate' defaultMessage='Translate' />}
+        {status.get('translation') ? <span><FormattedMessage id='status.translated_from_with' defaultMessage='Translated from {lang} using {provider}' values={{ lang: languageName, provider: status.getIn(['translation', 'provider']) }} /> · <FormattedMessage id='status.show_original' defaultMessage='Show original' /></span> : <FormattedMessage id='status.translate' defaultMessage='Translate' />}
       </button>
     );
 

--- a/app/lib/translation_service/deepl.rb
+++ b/app/lib/translation_service/deepl.rb
@@ -46,7 +46,7 @@ class TranslationService::DeepL < TranslationService
 
     raise UnexpectedResponseError unless json.is_a?(Hash)
 
-    Translation.new(text: json.dig('translations', 0, 'text'), detected_source_language: json.dig('translations', 0, 'detected_source_language')&.downcase)
+    Translation.new(text: json.dig('translations', 0, 'text'), detected_source_language: json.dig('translations', 0, 'detected_source_language')&.downcase, provider: 'DeepL.com')
   rescue Oj::ParseError
     raise UnexpectedResponseError
   end

--- a/app/lib/translation_service/libre_translate.rb
+++ b/app/lib/translation_service/libre_translate.rb
@@ -37,7 +37,7 @@ class TranslationService::LibreTranslate < TranslationService
 
     raise UnexpectedResponseError unless json.is_a?(Hash)
 
-    Translation.new(text: json['translatedText'], detected_source_language: source_language)
+    Translation.new(text: json['translatedText'], detected_source_language: source_language, provider: 'LibreTranslate')
   rescue Oj::ParseError
     raise UnexpectedResponseError
   end

--- a/app/lib/translation_service/translation.rb
+++ b/app/lib/translation_service/translation.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class TranslationService::Translation < ActiveModelSerializers::Model
-  attributes :text, :detected_source_language
+  attributes :text, :detected_source_language, :provider
 end

--- a/app/serializers/rest/translation_serializer.rb
+++ b/app/serializers/rest/translation_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::TranslationSerializer < ActiveModel::Serializer
-  attributes :content, :detected_source_language
+  attributes :content, :detected_source_language, :provider
 
   def content
     object.text


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/384364/197514384-10355418-2336-496d-a51f-9bdca6c1e904.png)

I chose to change the translation string name to force the information to be taken into account even with stale translations, but maybe that wasn't the best way to do it.