### PR TITLE
Add closed registrations modal

### DIFF
--- a/app/javascript/mastodon/features/closed_registrations_modal/index.js
+++ b/app/javascript/mastodon/features/closed_registrations_modal/index.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { FormattedMessage } from 'react-intl';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { domain } from 'mastodon/initial_state';
+import { fetchServer } from 'mastodon/actions/server';
+
+const mapStateToProps = state => ({
+  closed_registrations_message: state.getIn(['server', 'server', 'registrations', 'closed_registrations_message']),
+});
+
+export default @connect(mapStateToProps)
+class ClosedRegistrationsModal extends ImmutablePureComponent {
+
+  componentDidMount () {
+    const { dispatch } = this.props;
+    dispatch(fetchServer());
+  }
+
+  render () {
+    let closedRegistrationsMessage;
+
+    if (this.props.closed_registrations_message) {
+      closedRegistrationsMessage = (
+        <p
+          className='prose'
+          dangerouslySetInnerHTML={{ __html: this.props.closed_registrations_message }}
+        />
+      );
+    } else {
+      closedRegistrationsMessage = (
+        <p className='prose'>
+          <FormattedMessage
+            id='closed_registrations_modal.description'
+            defaultMessage='Creating an account on {domain} is currently not possible, but please keep in mind that you do not need an account specifically on {domain} to use Mastodon.'
+            values={{ domain: <strong>{domain}</strong> }}
+          />
+        </p>
+      );
+    }
+
+    return (
+      <div className='modal-root__modal interaction-modal'>
+        <div className='interaction-modal__lead'>
+          <h3><FormattedMessage id='closed_registrations_modal.title' defaultMessage='Signing up on Mastodon' /></h3>
+          <p>
+            <FormattedMessage
+              id='closed_registrations_modal.preamble'
+              defaultMessage='Mastodon is decentralized, so no matter where you create your account, you will be able to follow and interact with anyone on this server. You can even self-host it!'
+            />
+          </p>
+        </div>
+
+        <div className='interaction-modal__choices'>
+          <div className='interaction-modal__choices__choice'>
+            <h3><FormattedMessage id='interaction_modal.on_this_server' defaultMessage='On this server' /></h3>
+            {closedRegistrationsMessage}
+          </div>
+
+          <div className='interaction-modal__choices__choice'>
+            <h3><FormattedMessage id='interaction_modal.on_another_server' defaultMessage='On a different server' /></h3>
+            <p className='prose'>
+              <FormattedMessage
+                id='closed_registrations.other_server_instructions'
+                defaultMessage='Since Mastodon is decentralized, you can create an account on another server and still interact with this one.'
+              />
+            </p>
+            <a href='https://joinmastodon.org/servers' className='button button--block'><FormattedMessage id='closed_registrations_modal.find_another_server' defaultMessage='Find another server' /></a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+};

--- a/app/javascript/mastodon/features/interaction_modal/index.js
+++ b/app/javascript/mastodon/features/interaction_modal/index.js
@@ -5,9 +5,17 @@ import { registrationsOpen } from 'mastodon/initial_state';
 import { connect } from 'react-redux';
 import Icon from 'mastodon/components/icon';
 import classNames from 'classnames';
+import { openModal, closeModal } from 'mastodon/actions/modal';
 
 const mapStateToProps = (state, { accountId }) => ({
   displayNameHtml: state.getIn(['accounts', accountId, 'display_name_html']),
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  onSignupClick() {
+    dispatch(closeModal());
+    dispatch(openModal('CLOSED_REGISTRATIONS'));
+  },
 });
 
 class Copypaste extends React.PureComponent {
@@ -66,14 +74,19 @@ class Copypaste extends React.PureComponent {
 
 }
 
-export default @connect(mapStateToProps)
+export default @connect(mapStateToProps, mapDispatchToProps)
 class InteractionModal extends React.PureComponent {
 
   static propTypes = {
     displayNameHtml: PropTypes.string,
     url: PropTypes.string,
     type: PropTypes.oneOf(['reply', 'reblog', 'favourite', 'follow']),
+    onSignupClick: PropTypes.func.isRequired,
   };
+
+  handleSignupClick = () => {
+    this.props.onSignupClick();
+  }
 
   render () {
     const { url, type, displayNameHtml } = this.props;
@@ -105,6 +118,22 @@ class InteractionModal extends React.PureComponent {
       break;
     }
 
+    let signupButton;
+
+    if (registrationsOpen) {
+      signupButton = (
+        <a href='/auth/sign_up' className='button button--block button-tertiary'>
+          <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+        </a>
+      );
+    } else {
+      signupButton = (
+        <button className='button button--block button-tertiary' onClick={this.handleSignupClick}>
+          <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+        </button>
+      );
+    }
+
     return (
       <div className='modal-root__modal interaction-modal'>
         <div className='interaction-modal__lead'>
@@ -116,7 +145,7 @@ class InteractionModal extends React.PureComponent {
           <div className='interaction-modal__choices__choice'>
             <h3><FormattedMessage id='interaction_modal.on_this_server' defaultMessage='On this server' /></h3>
             <a href='/auth/sign_in' className='button button--block'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Sign in' /></a>
-            <a href={registrationsOpen ? '/auth/sign_up' : 'https://joinmastodon.org/servers'} className='button button--block button-tertiary'><FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' /></a>
+            {signupButton}
           </div>
 
           <div className='interaction-modal__choices__choice'>

--- a/app/javascript/mastodon/features/ui/components/modal_root.js
+++ b/app/javascript/mastodon/features/ui/components/modal_root.js
@@ -23,6 +23,7 @@ import {
   FilterModal,
   InteractionModal,
   SubscribedLanguagesModal,
+  ClosedRegistrationsModal,
 } from 'mastodon/features/ui/util/async-components';
 import { Helmet } from 'react-helmet';
 
@@ -44,6 +45,7 @@ const MODAL_COMPONENTS = {
   'FILTER': FilterModal,
   'SUBSCRIBED_LANGUAGES': SubscribedLanguagesModal,
   'INTERACTION': InteractionModal,
+  'CLOSED_REGISTRATIONS': ClosedRegistrationsModal,
 };
 
 export default class ModalRoot extends React.PureComponent {

--- a/app/javascript/mastodon/features/ui/components/sign_in_banner.js
+++ b/app/javascript/mastodon/features/ui/components/sign_in_banner.js
@@ -1,13 +1,40 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { useDispatch } from 'react-redux';
 import { registrationsOpen } from 'mastodon/initial_state';
+import { openModal } from 'mastodon/actions/modal';
 
-const SignInBanner = () => (
-  <div className='sign-in-banner'>
-    <p><FormattedMessage id='sign_in_banner.text' defaultMessage='Sign in to follow profiles or hashtags, favourite, share and reply to posts, or interact from your account on a different server.' /></p>
-    <a href='/auth/sign_in' className='button button--block'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Sign in' /></a>
-    <a href={registrationsOpen ? '/auth/sign_up' : 'https://joinmastodon.org/servers'} className='button button--block button-tertiary'><FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' /></a>
-  </div>
-);
+const SignInBanner = () => {
+  const dispatch = useDispatch();
+
+  const openClosedRegistrationsModal = useCallback(
+    () => dispatch(openModal('CLOSED_REGISTRATIONS')),
+    [dispatch],
+  );
+
+  let signupButton;
+
+  if (registrationsOpen) {
+    signupButton = (
+      <a href='/auth/sign_up' className='button button--block button-tertiary'>
+        <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+      </a>
+    );
+  } else {
+    signupButton = (
+      <button className='button button--block button-tertiary' onClick={openClosedRegistrationsModal}>
+        <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+      </button>
+    );
+  }
+
+  return (
+    <div className='sign-in-banner'>
+      <p><FormattedMessage id='sign_in_banner.text' defaultMessage='Sign in to follow profiles or hashtags, favourite, share and reply to posts, or interact from your account on a different server.' /></p>
+      <a href='/auth/sign_in' className='button button--block'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Sign in' /></a>
+      {signupButton}
+    </div>
+  );
+};
 
 export default SignInBanner;

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -174,6 +174,10 @@ export function SubscribedLanguagesModal () {
   return import(/*webpackChunkName: "modals/subscribed_languages_modal" */'../../subscribed_languages_modal');
 }
 
+export function ClosedRegistrationsModal () {
+  return import(/*webpackChunkName: "modals/closed_registrations_modal" */'../../closed_registrations_modal');
+}
+
 export function About () {
   return import(/*webpackChunkName: "features/about" */'../../about');
 }

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -81,8 +81,15 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   def registrations
     {
-      enabled: Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode,
+      enabled: registrations_enabled?,
       approval_required: Setting.registrations_mode == 'approved',
+      closed_registrations_message: registrations_enabled? ? nil : Setting.closed_registrations_message,
     }
+  end
+
+  private
+
+  def registrations_enabled?
+    Setting.registrations_mode != 'none' && !Rails.configuration.x.single_user_mode
   end
 end


### PR DESCRIPTION
Since the recent redesigns, clicking the “Create account” button on a server with closed registrations would send the user directly to https://joinmastodon.org/servers. Furthermore, the custom closed registrations message is nowhere to be seen.

This can be confusing, and make it harder for instances to communicate that their registrations are only temporarily closed, happen out-of-band (e.g. tied to patreon subscriptions, non-profit membership, …) or getting in relies on getting invited.

This PR introduces the following modal to address those issues:
![image](https://user-images.githubusercontent.com/384364/198092881-7d16cb1d-d9a6-4fbf-91c2-eb471f39899a.png)

A custom message can be set by the instance administrator:
![image](https://user-images.githubusercontent.com/384364/198088733-9f629aad-1bca-40bb-9596-7c88d6ab7caa.png)