### PR TITLE
nginx: optimize locations

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -56,13 +56,13 @@ server {
     try_files $uri @proxy;
   }
 
-  location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
+  location ~ ^/(assets|avatars|emoji|headers|packs|shortcuts|sounds|system) {
     add_header Cache-Control "public, max-age=31536000, immutable";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
-  location /sw.js {
+  location = sw.js {
     add_header Cache-Control "public, max-age=0";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
@@ -92,7 +92,7 @@ server {
     tcp_nodelay on;
   }
 
-  location /api/v1/streaming {
+  location ^~ /api/v1/streaming/ {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -56,7 +56,49 @@ server {
     try_files $uri @proxy;
   }
 
-  location ~ ^/(assets|avatars|emoji|headers|packs|shortcuts|sounds|system) {
+  location ~ ^/assets/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+    try_files $uri @proxy;
+  }
+
+  location ~ ^/avatars/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+    try_files $uri @proxy;
+  }
+
+  location ~ ^/emoji/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+    try_files $uri @proxy;
+  }
+
+  location ~ ^/headers/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+    try_files $uri @proxy;
+  }
+
+  location ~ ^/packs/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+    try_files $uri @proxy;
+  }
+
+  location ~ ^/shortcuts/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+    try_files $uri @proxy;
+  }
+
+  location ~ ^/sounds/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+    try_files $uri @proxy;
+  }
+
+  location ~ ^/system/ {
     add_header Cache-Control "public, max-age=31536000, immutable";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -58,6 +58,12 @@ server {
 
   # If Docker is used for deployment and Rails serves static files,
   # then needed must replace line `try_files $uri =404;` with `try_files $uri @proxy;`.
+  location = sw.js {
+    add_header Cache-Control "public, max-age=604800, must-revalidate";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+    try_files $uri =404;
+  }
+
   location ~ ^/assets/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
@@ -106,10 +112,21 @@ server {
     try_files $uri =404;
   }
 
-  location = sw.js {
-    add_header Cache-Control "public, max-age=604800, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
+  location ^~ /api/v1/streaming/ {
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Proxy "";
+
+    proxy_pass http://streaming;
+    proxy_buffering off;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    tcp_nodelay on;
   }
 
   location @proxy {
@@ -132,23 +149,6 @@ server {
     proxy_cache_valid 410 24h;
     proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
     add_header X-Cached $upstream_cache_status;
-
-    tcp_nodelay on;
-  }
-
-  location ^~ /api/v1/streaming/ {
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header Proxy "";
-
-    proxy_pass http://streaming;
-    proxy_buffering off;
-    proxy_redirect off;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
 
     tcp_nodelay on;
   }

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -56,58 +56,60 @@ server {
     try_files $uri @proxy;
   }
 
+  # If Docker is used for deployment and Rails serves static files,
+  # then needed must replace line `try_files $uri =404;` with `try_files $uri @proxy;`.
   location ~ ^/assets/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri @proxy;
+    try_files $uri =404;
   }
 
   location ~ ^/avatars/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri @proxy;
+    try_files $uri =404;
   }
 
   location ~ ^/emoji/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri @proxy;
+    try_files $uri =404;
   }
 
   location ~ ^/headers/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri @proxy;
+    try_files $uri =404;
   }
 
   location ~ ^/packs/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri @proxy;
+    try_files $uri =404;
   }
 
   location ~ ^/shortcuts/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri @proxy;
+    try_files $uri =404;
   }
 
   location ~ ^/sounds/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri @proxy;
+    try_files $uri =404;
   }
 
   location ~ ^/system/ {
     add_header Cache-Control "public, max-age=2419200, immutable";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri @proxy;
+    try_files $uri =404;
   }
 
   location = sw.js {
     add_header Cache-Control "public, max-age=604800, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri @proxy;
+    try_files $uri =404;
   }
 
   location @proxy {
@@ -151,5 +153,5 @@ server {
     tcp_nodelay on;
   }
 
-  error_page 500 501 502 503 504 /500.html;
+  error_page 404 500 501 502 503 504 /500.html;
 }

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -126,6 +126,8 @@ server {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
 
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+
     tcp_nodelay on;
   }
 

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -57,55 +57,55 @@ server {
   }
 
   location ~ ^/assets/ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
   location ~ ^/avatars/ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
   location ~ ^/emoji/ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
   location ~ ^/headers/ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
   location ~ ^/packs/ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
   location ~ ^/shortcuts/ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
   location ~ ^/sounds/ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
   location ~ ^/system/ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cache-Control "public, max-age=2419200, immutable";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
   location = sw.js {
-    add_header Cache-Control "public, max-age=0";
+    add_header Cache-Control "public, max-age=604800, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }


### PR DESCRIPTION
### Small optimize nginx locations.
Processing nginx location before PR:
```
location /api/v1/streaming/ {
```

```
*360 test location: "/"
*360 test location: "sw.js"
*360 test location: "api/v1/streaming/"
*360 test location: ~ "^/(emoji|packs|system/accounts/avatars|system/media_attachments/files)"
*360 using configuration "/api/v1/streaming/"
```

```
location /sw.js {
```
```
*365 test location: "/"
*365 test location: "sw.js"
*365 test location: ~ "^/(emoji|packs|system/accounts/avatars|system/media_attachments/files)"
*365 using configuration "/sw.js"
```
After PR:
```
location ^~ /api/v1/streaming/ {
```
```
*358 test location: "/"
*358 test location: "sw.js"
*358 test location: "api/v1/streaming/"
*358 using configuration "/api/v1/streaming/"
```
```
location = /sw.js 
```
```
*366 test location: "/"
*366 test location: "sw.js"
*366 using configuration "=/sw.js"
```

### Added caching for all static files.
Caching time reduced to 28 days. For files with a unique name and location, an `immutable` cache mode is used.
For other files added cache mode with change detection - `must-revalidate` cache mode. By default, file changes are also checked against with HTTP ETag. Adding caching to `sw.js` file shouldn't cause negative consequences.

### Changed handles 404 page.
Now nginx handles missing static files on its own and throws a 404 error, instead of redirecting to masodon backend.

### Disable regex in locations
More information provided in this report from nginx developer - https://highload.guide/blog/scalable-configuration-nginx.html and https://www.getpagespeed.com/server-setup/nginx-locations-performance-impact-and-optimizations