### PR TITLE
Fix `nofollow` rel being removed in web UI

### DIFF
--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -61,9 +61,6 @@ class StatusContent extends React.PureComponent {
         link.setAttribute('title', link.href);
         link.classList.add('unhandled-link');
       }
-
-      link.setAttribute('target', '_blank');
-      link.setAttribute('rel', 'noopener noreferrer');
     }
 
     if (this.props.status.get('collapsed', null) === null) {


### PR DESCRIPTION
Our formatter and sanitizer add the correct `rel` and `target` attributes on the server-side. The JS was replacing them.