### PR TITLE
Store integer settings as integer

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -33,6 +33,12 @@ class Form::AdminSettings
     backups_retention_period
   ).freeze
 
+  INTEGER_KEYS = %i(
+    media_cache_retention_period
+    content_cache_retention_period
+    backups_retention_period
+  ).freeze
+
   BOOLEAN_KEYS = %i(
     timeline_preview
     activity_api_enabled
@@ -104,6 +110,8 @@ class Form::AdminSettings
   def typecast_value(key, value)
     if BOOLEAN_KEYS.include?(key)
       value == '1'
+    elsif INTEGER_KEYS.include?(key)
+      value.blank? ? value : Integer(value)
     else
       value
     end


### PR DESCRIPTION
This change introduces `INTEGER_KEYS` for the settings with values to be stored as `Integer`.

Without typecasting the retention period settings to `Integer`, they are stored as `String`:

```
>  SELECT var,value FROM settings WHERE var LIKE '%retention_period';
              var               |  value
--------------------------------+----------
 media_cache_retention_period   | --- '14'+
                                |
 backups_retention_period       | --- '7' +
                                |
 content_cache_retention_period | --- ''  +
                                |
(3 rows)
```

This makes `app/models/content_retention_policy.rb` detect the settings as unset:

```
$ rails c
> Setting.media_cache_retention_period
=> "14"
> Setting.media_cache_retention_period.is_a?(Integer)
=> false
> ContentRetentionPolicy.current.media_cache_retention_period
=> nil
```

