### PR TITLE
fix(component): adjust style of counter button to fix overflow issue

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -279,11 +279,12 @@
     display: inline-flex;
     align-items: center;
     width: auto !important;
+    padding: 0 4px 0 2px;
   }
 
   &__counter {
     display: inline-block;
-    width: 14px;
+    width: auto;
     margin-left: 4px;
     font-size: 12px;
     font-weight: 500;


### PR DESCRIPTION
Found a style issue when hovering the counter buttons below posts where the number would overflow the background and also missed padding around the content, so I adjusted it to look neat.

Before: 
<img width="63" alt="image" src="https://user-images.githubusercontent.com/8169746/198566718-41b5c07c-f557-4865-9c4d-1b3c78178454.png">
<img width="59" alt="image" src="https://user-images.githubusercontent.com/8169746/198567336-8e35d3bb-0c25-45f9-b887-4a1066343d23.png">

After:
<img width="66" alt="image" src="https://user-images.githubusercontent.com/8169746/198566674-62d13d36-bb99-40c4-988e-757367fda798.png">
<img width="59" alt="image" src="https://user-images.githubusercontent.com/8169746/198567425-a2d1af8d-4698-4ad9-ae82-4d99afb243a7.png">
