### PR TITLE
fix name of Lao language

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -97,7 +97,7 @@ module LanguagesHelper
     lg: ['Ganda', 'Luganda'].freeze,
     li: ['Limburgish', 'Limburgs'].freeze,
     ln: ['Lingala', 'Lingála'].freeze,
-    lo: ['Lao', 'ພາສາ'].freeze,
+    lo: ['Lao', 'ລາວ'].freeze,
     lt: ['Lithuanian', 'lietuvių kalba'].freeze,
     lu: ['Luba-Katanga', 'Tshiluba'].freeze,
     lv: ['Latvian', 'latviešu valoda'].freeze,


### PR DESCRIPTION
It said ພາສາ or pha-sa, which means just "language" in Lao. "ພາສາລາວ", pha-sa lao, is the full name but the short "ລາວ" is commonly used.