### PR TITLE
Fix helm chart use of Postgres Password

### DIFF
--- a/chart/templates/cronjob-media-remove.yaml
+++ b/chart/templates/cronjob-media-remove.yaml
@@ -59,7 +59,7 @@ spec:
                   valueFrom:
                     secretKeyRef:
                       name: {{ template "mastodon.postgresql.secretName" . }}
-                      key: postgresql-password
+                      key: postgres-password
                 - name: "REDIS_PASSWORD"
                   valueFrom:
                     secretKeyRef:

--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -76,7 +76,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.postgresql.secretName" . }}
-                  key: postgresql-password
+                  key: postgres-password
             - name: "REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/deployment-streaming.yaml
+++ b/chart/templates/deployment-streaming.yaml
@@ -44,7 +44,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.postgresql.secretName" . }}
-                  key: postgresql-password
+                  key: postgres-password
             - name: "REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -62,7 +62,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.postgresql.secretName" . }}
-                  key: postgresql-password
+                  key: postgres-password
             - name: "REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/job-assets-precompile.yaml
+++ b/chart/templates/job-assets-precompile.yaml
@@ -60,7 +60,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.postgresql.secretName" . }}
-                  key: postgresql-password
+                  key: postgres-password
             - name: "REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/job-chewy-upgrade.yaml
+++ b/chart/templates/job-chewy-upgrade.yaml
@@ -61,7 +61,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.postgresql.secretName" . }}
-                  key: postgresql-password
+                  key: postgres-password
             - name: "REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/job-create-admin.yaml
+++ b/chart/templates/job-create-admin.yaml
@@ -66,7 +66,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.postgresql.secretName" . }}
-                  key: postgresql-password
+                  key: postgres-password
             - name: "REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/job-db-migrate.yaml
+++ b/chart/templates/job-db-migrate.yaml
@@ -60,7 +60,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "mastodon.postgresql.secretName" . }}
-                  key: postgresql-password
+                  key: postgres-password
             - name: "REDIS_PASSWORD"
               valueFrom:
                 secretKeyRef:

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -37,7 +37,7 @@ data:
   {{- end }}
   {{- if not .Values.postgresql.enabled }}
   {{- if not .Values.postgresql.auth.existingSecret }}
-  postgresql-password: "{{ .Values.postgresql.auth.password | b64enc }}"
+  postgres-password: "{{ .Values.postgresql.auth.password | b64enc }}"
   {{- end }}
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
Changed all references to `postgresql-password` to `postgres-password` so they match the ones generated by the PostgreSQL helm chart dependency.

Fixes #19536