### PR TITLE
Change featured hashtag deletion to be done synchronously

### DIFF
--- a/app/controllers/settings/featured_tags_controller.rb
+++ b/app/controllers/settings/featured_tags_controller.rb
@@ -23,7 +23,7 @@ class Settings::FeaturedTagsController < Settings::BaseController
   end
 
   def destroy
-    RemoveFeaturedTagWorker.perform_async(current_account.id, @featured_tag.id)
+    RemoveFeaturedTagService.new.call(current_account, @featured_tag)
     redirect_to settings_featured_tags_path
   end
 


### PR DESCRIPTION
I'm not aware of any reason to defer that to a background task, as the background task itself already queues the expensive part to background tasks.

Doing it immediately should not increase load but instead provide less confusing user experience (by immediately deleting the featured hashtag rather than having it still appear after clicking the deletion link).