### PR TITLE
Redirect old /web links

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -56,6 +56,14 @@ server {
     try_files $uri @proxy;
   }
 
+  location /web {
+    return 301 /$is_args$args;
+  }
+
+  location ~ ^/web(\/.*) {
+    return 301 $1$is_args$args;
+  }
+
   # If Docker is used for deployment and Rails serves static files,
   # then needed must replace line `try_files $uri =404;` with `try_files $uri @proxy;`.
   location = sw.js {


### PR DESCRIPTION
Some folks used to copy post links from the address bar. All such links break when the path starts with `/web`.