### PR TITLE
Change max. thumbnail dimensions to 640x360px (360p)

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -72,7 +72,7 @@ class MediaAttachment < ApplicationRecord
     }.freeze,
 
     small: {
-      pixels: 160_000, # 400x400px
+      pixels: 230_400, # 640x360px
       file_geometry_parser: FastGeometryParser,
       blurhash: BLURHASH_OPTIONS,
     }.freeze,

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -157,9 +157,9 @@ RSpec.describe MediaAttachment, type: :model do
       expect(media.file.meta["original"]["width"]).to eq 600
       expect(media.file.meta["original"]["height"]).to eq 400
       expect(media.file.meta["original"]["aspect"]).to eq 1.5
-      expect(media.file.meta["small"]["width"]).to eq 490
-      expect(media.file.meta["small"]["height"]).to eq 327
-      expect(media.file.meta["small"]["aspect"]).to eq 490.0 / 327
+      expect(media.file.meta["small"]["width"]).to eq 588
+      expect(media.file.meta["small"]["height"]).to eq 392
+      expect(media.file.meta["small"]["aspect"]).to eq 1.5
     end
 
     it 'gives the file a random name' do


### PR DESCRIPTION
In single-column layout on desktop, because the width of the container is around 600px, the `small` version of image attachments is not used in the `srcSet` as it is too small, leading to full images being loaded when browsing the timeline.