### PR TITLE
Fix UserCleanupScheduler crash when an unconfirmed account has a moderation note

### DIFF
--- a/app/workers/scheduler/user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/user_cleanup_scheduler.rb
@@ -15,6 +15,8 @@ class Scheduler::UserCleanupScheduler
 
   def clean_unconfirmed_accounts!
     User.where('confirmed_at is NULL AND confirmation_sent_at <= ?', 2.days.ago).reorder(nil).find_in_batches do |batch|
+      # We have to do it separately because of missing database constraints
+      AccountModerationNote.where(account_id: batch.map(&:account_id)).delete_all
       Account.where(id: batch.map(&:account_id)).delete_all
       User.where(id: batch.map(&:id)).delete_all
     end


### PR DESCRIPTION
Fixes #19109

Related to #19628, but I opted for a code change rather than a database change for now as the migration could be somewhat costly.