### PR TITLE
nginx: optimize location blocks (part 2)

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -67,11 +67,11 @@ server {
 
   location / {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri @proxy;
+    try_files $uri @mastodon;
   }
 
   # If Docker is used for deployment and Rails serves static files,
-  # then needed must replace line `try_files $uri =404;` with `try_files $uri @proxy;`.
+  # then needed must replace line `try_files $uri =404;` with `try_files $uri @mastodon;`.
   location ^~ /assets/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
@@ -141,7 +141,7 @@ server {
     tcp_nodelay on;
   }
 
-  location @proxy {
+  location @mastodon {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -136,8 +136,6 @@ server {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
 
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-
     tcp_nodelay on;
   }
 

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -107,12 +107,6 @@ server {
     try_files $uri =404;
   }
 
-  location ^~ /shortcuts/ {
-    add_header Cache-Control "public, max-age=2419200, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
-  }
-
   location ^~ /sounds/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -71,47 +71,41 @@ server {
   }
 
   # If Docker is used for deployment and Rails serves static files,
-  # then needed must replace line `try_files $uri =404;` with `try_files $uri @mastodon;`.
+  # then needed uncomment line with `try_files $uri @mastodon;`.
   location ^~ /assets/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
+    # try_files $uri @mastodon;
   }
 
   location ^~ /avatars/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
   }
 
   location ^~ /emoji/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
   }
 
   location ^~ /headers/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
   }
 
   location ^~ /ocr/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
   }
 
   location ^~ /packs/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
   }
 
   location ^~ /sounds/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
   }
 
   location ^~ /system/ {
@@ -119,7 +113,6 @@ server {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     add_header X-Content-Type-Options nosniff;
     add_header Content-Security-Policy "default-src 'none'; form-action 'none'";
-    try_files $uri =404;
   }
 
   location ^~ /api/v1/streaming {

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -101,6 +101,12 @@ server {
     try_files $uri =404;
   }
 
+  location ^~ /ocr/ {
+    add_header Cache-Control "public, max-age=2419200, must-revalidate";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+    try_files $uri =404;
+  }
+
   location ^~ /packs/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -77,49 +77,49 @@ server {
     try_files $uri =404;
   }
 
-  location ~ ^/assets/ {
+  location ^~ /assets/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri =404;
   }
 
-  location ~ ^/avatars/ {
+  location ^~ /avatars/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri =404;
   }
 
-  location ~ ^/emoji/ {
+  location ^~ /emoji/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri =404;
   }
 
-  location ~ ^/headers/ {
+  location ^~ /headers/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri =404;
   }
 
-  location ~ ^/packs/ {
+  location ^~ /packs/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri =404;
   }
 
-  location ~ ^/shortcuts/ {
+  location ^~ /shortcuts/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri =404;
   }
 
-  location ~ ^/sounds/ {
+  location ^~ /sounds/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri =404;
   }
 
-  location ~ ^/system/ {
+  location ^~ /system/ {
     add_header Cache-Control "public, max-age=2419200, immutable";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     add_header X-Content-Type-Options nosniff;

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -66,17 +66,12 @@ server {
   gzip_static on;
 
   location / {
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
     try_files $uri @proxy;
   }
 
   # If Docker is used for deployment and Rails serves static files,
   # then needed must replace line `try_files $uri =404;` with `try_files $uri @proxy;`.
-  location = /sw.js {
-    add_header Cache-Control "public, max-age=604800, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
-  }
-
   location ^~ /assets/ {
     add_header Cache-Control "public, max-age=2419200, must-revalidate";
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";


### PR DESCRIPTION
Changes:
 - Remove regexp function from location block. In PR 19438, there was an error in way location blocks was handled.
 - Remove unused location block and add new location block.
 - Move processing of remaining static files to main location block.
 - Renaming `@proxy` block to `@mastodon`.
 - Remove unused header.
 - Remove try_files directive.

Headers for `sw.js.map` file before PR:
```
HTTP/2 200
server: nginx
date: Tue, 01 Nov 2022 16:47:36 GMT
content-type: application/octet-stream
content-length: 297410
etag: "9417r0hndwiqqq6vp5i9ql956bhypr0c"
strict-transport-security: max-age=63072000; includeSubDomains
accept-ranges: bytes
```
After PR:
```
HTTP/2 200
server: nginx
date: Tue, 01 Nov 2022 17:31:44 GMT
content-type: application/octet-stream
content-length: 297410
etag: "9417r0hndwiqqq6vp5i9ql956bhypr0c"
cache-control: public, max-age=604800, must-revalidate
strict-transport-security: max-age=63072000; includeSubDomains
accept-ranges: bytes
```