### PR TITLE
chore(chart): Update appVersion in helm chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,7 +20,7 @@ version: 2.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.3.0
+appVersion: v3.5.3
 
 dependencies:
   - name: elasticsearch

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,7 +8,7 @@ image:
   # built from the most recent commit
   #
   # tag: latest
-  tag: v3.5.2
+  tag: ""
   # use `Always` when using `latest` tag
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This patch updates the helm chart appVersion to the current release and removes the additional definition in the image tag field, to reduce duplication.

Since the image will automatically default to the Charts' app version anyway and this is the more common place to specifiy application versions for helm charts, this patch switches the prefering this field.

The reason why to use the tag field for the chart itself, seems to be gone. Since renovatebot is no longer used.