### PR TITLE
Remove meta tag for official iOS app

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,7 +23,6 @@
     %link{ rel: 'manifest', href: manifest_path(format: :json) }/
     %meta{ name: 'theme-color', content: '#191b22' }/
     %meta{ name: 'apple-mobile-web-app-capable', content: 'yes' }/
-    %meta{ name: 'apple-itunes-app', content: 'app-id=1571998974' }/
 
     %title= content_for?(:page_title) ? safe_join([yield(:page_title).chomp.html_safe, title], ' - ') : title
 


### PR DESCRIPTION
- fixes #19654 and also revert of #16599 

> I hope the banner will not appear in PWAs (when added to home screen) but I'm not sure, that is up to Safari. Since this is a system banner controlled by Safari I am hoping that it will not annoy anyone (I hate the custom banners that Reddit/Imgur/etc implement).

![IMG_5758](https://user-images.githubusercontent.com/29011440/199390838-81cc6a12-b69a-4b7e-8bc9-bb27d0ccdaa1.jpg)
It shows up on PWAs.

And also Banner is too big that it decreases user experience.