### PR TITLE
Fixed french typo

### DIFF
--- a/app/javascript/mastodon/locales/fr.json
+++ b/app/javascript/mastodon/locales/fr.json
@@ -408,7 +408,7 @@
   "notifications.column_settings.follow": "Nouveaux·elles abonné·e·s :",
   "notifications.column_settings.follow_request": "Nouvelles demandes d’abonnement :",
   "notifications.column_settings.mention": "Mentions :",
-  "notifications.column_settings.poll": "Résultats des sondage :",
+  "notifications.column_settings.poll": "Résultats des sondages :",
   "notifications.column_settings.push": "Notifications push",
   "notifications.column_settings.reblog": "Partages :",
   "notifications.column_settings.show": "Afficher dans la colonne",


### PR DESCRIPTION
Just fixed a typo in the french :fr: translation of mastodon. 

Thank you for this software. 