### PR TITLE
Fix bookmark import stopping at the first failure

### DIFF
--- a/app/services/import_service.rb
+++ b/app/services/import_service.rb
@@ -112,6 +112,11 @@ class ImportService < BaseService
       next if status.nil? && ActivityPub::TagManager.instance.local_uri?(uri)
 
       status || ActivityPub::FetchRemoteStatusService.new.call(uri)
+    rescue HTTP::Error, OpenSSL::SSL::SSLError, Mastodon::UnexpectedResponseError
+      nil
+    rescue StandardError => e
+      Rails.logger.warn "Unexpected error when importing bookmark: #{e}"
+      nil
     end
 
     account_ids         = statuses.map(&:account_id)


### PR DESCRIPTION
Fixes #19389

Ideally I think we should rework the data import/export feature to:
- reduce the possibility of accidentally importing a list in the wrong import type
- listing ongoing imports
- listing recently-finished imports, together with how many entries could not be imported, if any

But for now, I just made bookmark import more robust.