### PR TITLE
Fix mastodon:setup not setting the admin's role properly

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -433,7 +433,8 @@ namespace :mastodon do
 
           password = SecureRandom.hex(16)
 
-          user = User.new(admin: true, email: email, password: password, confirmed_at: Time.now.utc, account_attributes: { username: username }, bypass_invite_request_check: true)
+          owner_role = UserRole.find_by(name: 'Owner')
+          user = User.new(email: email, password: password, confirmed_at: Time.now.utc, account_attributes: { username: username }, bypass_invite_request_check: true, role: owner_role)
           user.save(validate: false)
 
           prompt.ok "You can login with the password: #{password}"

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -437,6 +437,8 @@ namespace :mastodon do
           user = User.new(email: email, password: password, confirmed_at: Time.now.utc, account_attributes: { username: username }, bypass_invite_request_check: true, role: owner_role)
           user.save(validate: false)
 
+          Setting.site_contact_username = username
+
           prompt.ok "You can login with the password: #{password}"
           prompt.warn 'You can change your password once you login.'
         end


### PR DESCRIPTION
Also set `Setting.site_contact_username` accordingly.