### PR TITLE
Change migration to migrate admins to Owner role rather than Admin role

### DIFF
--- a/db/post_migrate/20220617202502_migrate_roles.rb
+++ b/db/post_migrate/20220617202502_migrate_roles.rb
@@ -9,18 +9,19 @@ class MigrateRoles < ActiveRecord::Migration[5.2]
   def up
     load Rails.root.join('db', 'seeds', '03_roles.rb')
 
-    admin_role     = UserRole.find_by(name: 'Admin')
+    owner_role     = UserRole.find_by(name: 'Owner')
     moderator_role = UserRole.find_by(name: 'Moderator')
 
-    User.where(admin: true).in_batches.update_all(role_id: admin_role.id)
+    User.where(admin: true).in_batches.update_all(role_id: owner_role.id)
     User.where(moderator: true).in_batches.update_all(role_id: moderator_role.id)
   end
 
   def down
     admin_role     = UserRole.find_by(name: 'Admin')
+    owner_role     = UserRole.find_by(name: 'Owner')
     moderator_role = UserRole.find_by(name: 'Moderator')
 
-    User.where(role_id: admin_role.id).in_batches.update_all(admin: true) if admin_role
+    User.where(role_id: [admin_role.id, owner_role.id]).in_batches.update_all(admin: true) if admin_role
     User.where(role_id: moderator_role.id).in_batches.update_all(moderator: true) if moderator_role
   end
 end


### PR DESCRIPTION
Relatively late in the PR that introduced that migration, it was [changed to use the `Admin` role rather than `Owner`](https://github.com/mastodon/mastodon/pull/18641#issuecomment-1173303208).

While the `Admin` role covers most of the permissions that were covered by the old admin flag, some are left out (most notably, access to the sidekiq web interface, and some sysadmin-related dashboard warnings).

No rationale has been given in that comment, but as far as I understand, the reasoning is that an `Owner` cannot be demoted without using the CLI, that the “real owner” can always use the CLI to promote themselves to `Owner`, and that the permissions provided by default by the `Admin` role are sufficient in most cases.

However, the “real owner” cannot demote fellow admins either without using the CLI if they are also `Admin`. So if they can promote themselves from the CLI, they can also demote other admins from the CLI too. I don't think this reason stands.

Migrating to `Admin` instead of `Owner` requires an additional manual step to recover all the functionality that was provided previously, and it makes it is likely to be a hassle for every Mastodon hosting services.