### PR TITLE
Helm: roll pods to pick up db migrations even if podAnnotations is empty

### DIFF
--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -14,12 +14,12 @@ spec:
       component: rails
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
         # roll the pods to pick up any db migrations
         rollme: {{ randAlphaNum 5 | quote }}
-    {{- end }}
       labels:
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
         component: rails

--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -14,12 +14,12 @@ spec:
       component: rails
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
         # roll the pods to pick up any db migrations
         rollme: {{ randAlphaNum 5 | quote }}
-    {{- end }}
       labels:
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
         component: rails


### PR DESCRIPTION
Currently if `podAnnotations` is empty in `values.yaml` (which is the default) pods will not be restarted automatically as intended with the `rollme` annotation.

This moves it outside the `with` so that db migrations and configuration changes are automatically picked up.