### PR TITLE
Helm: assign unique set of labels to k8s deployments

### DIFF
--- a/chart/templates/cronjob-media-remove.yaml
+++ b/chart/templates/cronjob-media-remove.yaml
@@ -27,7 +27,7 @@ spec:
               requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
                   matchExpressions:
-                    - key: component
+                    - key: app.kubernetes.io/part-of
                       operator: In
                       values:
                         - rails

--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -11,7 +11,8 @@ spec:
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" . | nindent 6 }}
-      component: rails
+      app.kubernetes.io/component: sidekiq
+      app.kubernetes.io/part-of: rails
   template:
     metadata:
     {{- with .Values.podAnnotations }}
@@ -22,7 +23,8 @@ spec:
     {{- end }}
       labels:
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
-        component: rails
+        app.kubernetes.io/component: sidekiq
+        app.kubernetes.io/part-of: rails
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -40,7 +42,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-                - key: component
+                - key: app.kubernetes.io/part-of
                   operator: In
                   values:
                     - rails

--- a/chart/templates/deployment-streaming.yaml
+++ b/chart/templates/deployment-streaming.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: streaming
   template:
     metadata:
     {{- with .Values.podAnnotations }}
@@ -19,6 +20,7 @@ spec:
     {{- end }}
       labels:
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: streaming
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -11,7 +11,8 @@ spec:
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" . | nindent 6 }}
-      component: rails
+      app.kubernetes.io/component: web
+      app.kubernetes.io/part-of: rails
   template:
     metadata:
     {{- with .Values.podAnnotations }}
@@ -22,7 +23,8 @@ spec:
     {{- end }}
       labels:
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
-        component: rails
+        app.kubernetes.io/component: web
+        app.kubernetes.io/part-of: rails
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/templates/job-assets-precompile.yaml
+++ b/chart/templates/job-assets-precompile.yaml
@@ -27,7 +27,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-                - key: component
+                - key: app.kubernetes.io/part-of
                   operator: In
                   values:
                     - rails

--- a/chart/templates/job-chewy-upgrade.yaml
+++ b/chart/templates/job-chewy-upgrade.yaml
@@ -28,7 +28,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-                - key: component
+                - key: app.kubernetes.io/part-of
                   operator: In
                   values:
                     - rails

--- a/chart/templates/job-create-admin.yaml
+++ b/chart/templates/job-create-admin.yaml
@@ -28,7 +28,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-                - key: component
+                - key: app.kubernetes.io/part-of
                   operator: In
                   values:
                     - rails

--- a/chart/templates/job-db-migrate.yaml
+++ b/chart/templates/job-db-migrate.yaml
@@ -27,7 +27,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-                - key: component
+                - key: app.kubernetes.io/part-of
                   operator: In
                   values:
                     - rails

--- a/chart/templates/service-streaming.yaml
+++ b/chart/templates/service-streaming.yaml
@@ -13,3 +13,4 @@ spec:
       name: streaming
   selector:
     {{- include "mastodon.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: streaming

--- a/chart/templates/service-web.yaml
+++ b/chart/templates/service-web.yaml
@@ -13,3 +13,4 @@ spec:
       name: http
   selector:
     {{- include "mastodon.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web


### PR DESCRIPTION
This fixes #19703 but is also a breaking change as Deployments have to be deleted or the upgrade forced as the fields are immutable

I don't know what the praxis regarding breaking changes is so it'd be great with an extra set of eyes here.