### PR TITLE
Make word-break: keep-all for dismissable banner

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8317,6 +8317,7 @@ noscript {
     font-size: 14px;
     line-height: 18px;
     color: $primary-text-color;
+    word-break: keep-all;
   }
 
   &__action {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5047683/199906852-de9e7677-c6a8-4020-89b3-6ae568fbffea.png)
After:
![image](https://user-images.githubusercontent.com/5047683/199906881-15b6da48-6f3f-4cad-bdb7-557f8e218db1.png)
