### PR TITLE
Fix /users/:username/statuses/:id leading to a soft 404 in web app

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
   }
 
   get '/users/:username', to: redirect('/@%{username}'), constraints: lambda { |req| req.format.nil? || req.format.html? }
+  get '/users/:username/statuses/:id', to: redirect('/@%{username}/%{id}'), constraints: lambda { |req| req.format.nil? || req.format.html? }
   get '/authorize_follow', to: redirect { |_, request| "/authorize_interaction?#{request.params.to_query}" }
 
   resources :accounts, path: 'users', only: [:show], param: :username do


### PR DESCRIPTION
Since the logged-out UI redesign, `/users/:username/statuses/:id` (which is the canonical URI for activities, even though we also provide a better-suited URL property of `/@:username/:id`) renders the Web UI but the Web UI itself does not handle those URLs.

This PR fixes it so that the server redirects web browsers from `/users/:username/statuses/:id` to `/@:username/:id`, similar to how profiles themselves are handled.