### PR TITLE
helm: Keep create admin job to retrieve initial password

### DIFF
--- a/chart/templates/job-create-admin.yaml
+++ b/chart/templates/job-create-admin.yaml
@@ -7,9 +7,9 @@ metadata:
     {{- include "mastodon.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-1"
 spec:
+  ttlSecondsAfterFinished: 3600
   template:
     metadata:
       name: {{ include "mastodon.fullname" . }}-create-admin


### PR DESCRIPTION
This may be a security issue so needs to be thought about thoroughly. It makes initial setup way easier in my opinion though and you can also immediately reset your password afterwards in the web interface.