### PR TITLE
Add form element on compose area

### DIFF
--- a/app/javascript/mastodon/components/button.js
+++ b/app/javascript/mastodon/components/button.js
@@ -6,6 +6,7 @@ export default class Button extends React.PureComponent {
 
   static propTypes = {
     text: PropTypes.node,
+    type: PropTypes.string,
     onClick: PropTypes.func,
     disabled: PropTypes.bool,
     block: PropTypes.bool,
@@ -42,6 +43,7 @@ export default class Button extends React.PureComponent {
         onClick={this.handleClick}
         ref={this.setRef}
         title={this.props.title}
+        type={this.props.type}
       >
         {this.props.text || this.props.children}
       </button>

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -217,7 +217,7 @@ class ComposeForm extends ImmutablePureComponent {
     }
 
     return (
-      <div className='compose-form'>
+      <form className='compose-form'>
         <WarningContainer />
 
         <ReplyIndicatorContainer />
@@ -279,10 +279,16 @@ class ComposeForm extends ImmutablePureComponent {
 
         <div className='compose-form__publish'>
           <div className='compose-form__publish-button-wrapper'>
-            <Button text={publishText} onClick={this.handleSubmit} disabled={!this.canSubmit()} block />
+            <Button
+              type="submit"
+              text={publishText}
+              onClick={this.handleSubmit}
+              disabled={!this.canSubmit()}
+              block
+            />
           </div>
         </div>
-      </div>
+      </form>
     );
   }
 


### PR DESCRIPTION
To increase the accessibility of the compose area, use the semantic `<form>` tag and the `type="submit"` attribute for browsers and assistive technologies.