### PR TITLE
Remove the sort as it is unnecessary overhead.

### DIFF
--- a/lib/rails/engine_extensions.rb
+++ b/lib/rails/engine_extensions.rb
@@ -3,7 +3,7 @@ module Rails
     # Rewrite task loading code to filter digitalocean.rake task
     def run_tasks_blocks(app)
       Railtie.instance_method(:run_tasks_blocks).bind(self).call(app)
-      paths["lib/tasks"].existent.reject { |ext| ext.end_with?('digitalocean.rake') }.sort.each { |ext| load(ext) }
+      paths["lib/tasks"].existent.reject { |ext| ext.end_with?('digitalocean.rake') }.each { |ext| load(ext) }
     end
   end
 end


### PR DESCRIPTION
All we are doing is selecting or rejecting files based on certain criteria. The order in which we do so does not matter. This commit should improve the efficiency of Mastodon.