### PR TITLE
Avoid CSP error regarding the style-src-attr directive

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,6 +23,7 @@ Rails.application.config.content_security_policy do |p|
   p.font_src        :self, assets_host
   p.img_src         :self, :https, :data, :blob, assets_host
   p.style_src       :self, assets_host
+  p.style_src_attr  :unsafe_inline
   p.media_src       :self, :https, :data, assets_host
   p.frame_src       :self, :https
   p.manifest_src    :self, assets_host


### PR DESCRIPTION
Removing the following error in a browser inspector:

"Refused to apply a stylesheet because its hash, its nonce, or 'unsafe-inline' does not appear in the style-src directive of the Content Security Policy."

generated in:
mastodon.social:71
mastodon.social:88