### PR TITLE
Fix JavaScript console warning that appears when uploading a media

### DIFF
--- a/app/javascript/mastodon/features/compose/components/upload.js
+++ b/app/javascript/mastodon/features/compose/components/upload.js
@@ -17,7 +17,7 @@ export default class Upload extends ImmutablePureComponent {
     media: ImmutablePropTypes.map.isRequired,
     onUndo: PropTypes.func.isRequired,
     onOpenFocalPoint: PropTypes.func.isRequired,
-    isEditingStatus: PropTypes.func.isRequired,
+    isEditingStatus: PropTypes.bool.isRequired,
   };
 
   handleUndoClick = e => {


### PR DESCRIPTION
Fixes a warning when uploading files:

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/132/200114022-f2fb49bc-5775-4099-b27c-6d5b8a43583a.png">
