### PR TITLE
Fix JavaScript console warning when loading notifications

### DIFF
--- a/app/javascript/mastodon/features/notifications/index.js
+++ b/app/javascript/mastodon/features/notifications/index.js
@@ -58,7 +58,7 @@ const getNotifications = createSelector([
 const mapStateToProps = state => ({
   showFilterBar: state.getIn(['settings', 'notifications', 'quickFilter', 'show']),
   notifications: getNotifications(state),
-  isLoading: state.getIn(['notifications', 'isLoading'], true),
+  isLoading: state.getIn(['notifications', 'isLoading'], 0) > 0,
   isUnread: state.getIn(['notifications', 'unread']) > 0 || state.getIn(['notifications', 'pendingItems']).size > 0,
   hasMore: state.getIn(['notifications', 'hasMore']),
   numPending: state.getIn(['notifications', 'pendingItems'], ImmutableList()).size,


### PR DESCRIPTION
When notifications are loading, the following JavaScript warning pops up:

<img width="1028" alt="Warning: Failed prop type: Invalid prop `showLoading` of type `number` supplied to `ScrollableList`, expected `boolean`." src="https://user-images.githubusercontent.com/132/200118013-d8dd34ca-d232-496c-ad25-3a6c5ffa441b.png">

The `isLoading` state is actually a number here since it can increment & decrement.