### PR TITLE
Helm: fix sidekiq S3 existing secret

### DIFF
--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -82,6 +82,18 @@ spec:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.secretName" . }}
                   key: redis-password
+            {{- if (and .Values.mastodon.s3.enabled .Values.mastodon.s3.existingSecret) }}
+            - name: "AWS_SECRET_ACCESS_KEY"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mastodon.s3.existingSecret }}
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: "AWS_ACCESS_KEY_ID"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mastodon.s3.existingSecret }}
+                  key: AWS_ACCESS_KEY_ID
+            {{- end -}}
             {{- if .Values.mastodon.smtp.existingSecret }}
             - name: "SMTP_LOGIN"
               valueFrom:


### PR DESCRIPTION
In the current chart the S3 existing secret is missing for sidekiq