### PR TITLE
Remove broken link references to bug bounty program

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: GitHub Discussions
     url: https://github.com/mastodon/mastodon/discussions
     about: Please ask and answer questions here.
-  - name: Bug Bounty Program
-    url: https://app.intigriti.com/programs/mastodon/mastodonio/detail
-    about: Please report security vulnerabilities here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-If you believe you've identified a security vulnerability in Mastodon (a bug that allows something to happen that shouldn't be possible), you should submit the report through our [Bug Bounty Program][bug-bounty]. Alternatively, you can reach us at <hello@joinmastodon.org>.
+If you believe you've identified a security vulnerability in Mastodon (a bug that allows something to happen that shouldn't be possible), you can reach us at <hello@joinmastodon.org>.
 
 You should *not* report such issues on GitHub or in other public spaces to give us time to publish a fix for the issue without exposing Mastodon's users to increased risk.
 
@@ -16,5 +16,3 @@ A "vulnerability in Mastodon" is a vulnerability in the code distributed through
 | 3.4.x   | Yes                |
 | 3.3.x   | No                 |
 | < 3.3   | No                 |
-
-[bug-bounty]: https://app.intigriti.com/programs/mastodon/mastodonio/detail


### PR DESCRIPTION
The link https://app.intigriti.com/programs/mastodon/mastodonio/detail no longer works

* Closes #19491