### PR TITLE
Remove word-break:keep-all from Dismissable banner message

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8331,7 +8331,6 @@ noscript {
     font-size: 14px;
     line-height: 18px;
     color: $primary-text-color;
-    word-break: keep-all;
   }
 
   &__action {


### PR DESCRIPTION
`.dismissable-banner__message` now has `word-break: keep-all;`. [If I understand correctly](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break), this is the style to force CJK languages to not break lines.
With this applied, in CJK languages the text pushes out the frame of the action.

I don't think this is the intended behavior. In fact, this property is not used anywhere else.

![image](https://user-images.githubusercontent.com/3516343/200138361-eae2b82c-5cd5-4edf-aa20-7bfc35104962.png)

Removing this property fixes the problem with CJK languages.

![image](https://user-images.githubusercontent.com/3516343/200138370-0620c623-dde6-4958-849d-ed8a18200844.png)



