### PR TITLE
Change `AUTHORIZED_FETCH` to not block unauthenticated REST API access

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -133,7 +133,7 @@ class Api::BaseController < ApplicationController
   end
 
   def disallow_unauthenticated_api_access?
-    authorized_fetch_mode?
+    ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] == 'true' || Rails.configuration.x.whitelist_mode
   end
 
   private


### PR DESCRIPTION
New environment variable `DISALLOW_UNAUTHENTICATED_API_ACCESS`

Fix #19623