### PR TITLE
Heroku fix

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,8 +1,8 @@
 ffmpeg
 libicu[0-9][0-9]
 libicu-dev
-libidn11
-libidn11-dev
+libidn12
+libidn-dev
 libpq-dev
 libxdamage1
 libxfixes3


### PR DESCRIPTION
Currently building on Heroku fails with a package error for libidn11. Since Mastodon uses idn-ruby 0.1.2 we should upgrade to libidn12