### PR TITLE
Fix the command to create the admin user

### DIFF
--- a/chart/templates/job-create-admin.yaml
+++ b/chart/templates/job-create-admin.yaml
@@ -55,7 +55,7 @@ spec:
             - {{ .Values.mastodon.createAdmin.email }}
             - --confirmed
             - --role
-            - admin
+            - Admin
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env

--- a/chart/templates/job-create-admin.yaml
+++ b/chart/templates/job-create-admin.yaml
@@ -55,7 +55,7 @@ spec:
             - {{ .Values.mastodon.createAdmin.email }}
             - --confirmed
             - --role
-            - Admin
+            - Owner
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env


### PR DESCRIPTION
When I helm install this, I noticed the admin user wasn't created.  That's because it seems to be expecting the role name to be "Admin" rather than "admin".  This simply corrects the chart.

```
mastodon@mastodon-web-b4b65c7c6-88sj9:~$ tootctl accounts create bocan --email=chris@redacted --confirmed --role admin
Cannot find user role with that name

mastodon@mastodon-web-b4b65c7c6-88sj9:~$ tootctl accounts create bocan --email=chris@redacted --confirmed --role Admin
OK
```

That said, shouldn't it be "Owner"?  And/Or should the backend be non-case-sensitive?