### PR TITLE
helm: Give the web container time to start

### DIFF
--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -94,13 +94,18 @@ spec:
               containerPort: {{ .Values.mastodon.web.port }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /health
+            tcpSocket:
               port: http
           readinessProbe:
             httpGet:
               path: /health
               port: http
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
This adds a [startupProbe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes) to prevent restart loops in case the `web` container takes a while to start up.

It also changes the `livenessProbe` to a [TCP probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-tcp-liveness-probe) so the container isn't killed for failing health checks, which can happen if the workers are busy. It's not fun when containers start getting killed just because of high load.

