### PR TITLE
Add null check on application in dispute viewer

### DIFF
--- a/app/views/disputes/strikes/show.html.haml
+++ b/app/views/disputes/strikes/show.html.haml
@@ -59,8 +59,9 @@
                         = media_attachment.file_file_name
                 .strike-card__statuses-list__item__meta
                   %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
-                  ·
-                  = status.application.name
+                  - unless status.application.nil?
+                    ·
+                    = status.application.name
               - else
                 .one-liner= t('disputes.strikes.status', id: status_id)
                 .strike-card__statuses-list__item__meta


### PR DESCRIPTION
Fixes the following error:

```
ActionView::Template::Error (undefined method `name' for nil:NilClass):
    61:                   %time.formatted{ datetime: status.created_at.iso8601, title: l(status.created_at) }= l(status.created_at)
    62:                   - if (status = status_map[status_id.to_i])
    63:                     ·
    64:                     = status.application.name
    65:               - else
    66:                 .one-liner= t('disputes.strikes.status', id: status_id)
    67:                 .strike-card__statuses-list__item__meta
Nov 06 11:46:27 kalos bundle[2967470]: [af6cb5d4-60ce-437d-9180-f3a0e8888f23]
app/views/disputes/strikes/show.html.haml:64
app/views/disputes/strikes/show.html.haml:49:in `each'
app/views/disputes/strikes/show.html.haml:49
app/controllers/concerns/localized.rb:11:in `set_locale'
lib/mastodon/rack_middleware.rb:9:in `call'
```

that can occur whenever a reported post does not have an application assigned to it.