### PR TITLE
Fix console log error on column settings load

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/column_settings.js
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.js
@@ -21,7 +21,7 @@ export default class ColumnSettings extends React.PureComponent {
     onRequestNotificationPermission: PropTypes.func,
     alertsEnabled: PropTypes.bool,
     browserSupport: PropTypes.bool,
-    browserPermission: PropTypes.bool,
+    browserPermission: PropTypes.string,
   };
 
   onPushChange = (path, checked) => {


### PR DESCRIPTION
When clicking on the notifications dropdown:

<img width="346" alt="image" src="https://user-images.githubusercontent.com/132/200186150-bc6021a2-71f6-422b-8fa6-bada9ff7ad2d.png">

The following console warning appears:

<img width="750" alt="Warning: Failed prop type: Invalid prop `browserPermission` of type `string` supplied to `ColumnSettings`, expected `boolean`." src="https://user-images.githubusercontent.com/132/200186121-e3b76ca0-2f73-46f3-a603-45192de4418c.png">