### PR TITLE
Fix double button to clear emoji search input

### DIFF
--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -132,6 +132,10 @@
     &:active {
       outline: 0 !important;
     }
+
+    &::-webkit-search-cancel-button {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
When using the emoji search using Google Chrome, there are two inputs to clear the search:

<img width="318" alt="Mastodon emoji search input with two clear buttons" src="https://user-images.githubusercontent.com/132/200186714-4793c439-54c6-4cf3-bd74-851c7595f28d.png">

This patch clears the browser’s default button using [the webkit-specific pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-cancel-button).

<img width="311" alt="Mastodon emoji search input with one clear button" src="https://user-images.githubusercontent.com/132/200186638-8d97a7ee-1bfc-47c8-b93b-cc379d6d512a.png">
