### PR TITLE
Fix JavaScript console error on Getting Started column

### DIFF
--- a/app/javascript/mastodon/components/column_header.js
+++ b/app/javascript/mastodon/components/column_header.js
@@ -57,9 +57,7 @@ class ColumnHeader extends React.PureComponent {
   }
 
   handleTitleClick = () => {
-    if (this.props.onClick) {
-      this.props.onClick();
-    }
+    this.props.onClick?.();
   }
 
   handleMoveLeft = () => {

--- a/app/javascript/mastodon/components/column_header.js
+++ b/app/javascript/mastodon/components/column_header.js
@@ -57,7 +57,9 @@ class ColumnHeader extends React.PureComponent {
   }
 
   handleTitleClick = () => {
-    this.props.onClick();
+    if (this.props.onClick) {
+      this.props.onClick();
+    }
   }
 
   handleMoveLeft = () => {


### PR DESCRIPTION
When clicking on the “Getting Started” column title:

<img width="363" alt="image" src="https://user-images.githubusercontent.com/132/200188471-639c3897-5e40-47b6-b1c0-86e07c7ebe8e.png">

This raises a JavaScript error:

<img width="947" alt="image" src="https://user-images.githubusercontent.com/132/200188419-6ea18bc3-ba40-439b-844b-9f63432105bb.png">
