### PR TITLE
Fix streaming API regression that breaks some clients

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -112,7 +112,7 @@ server {
     try_files $uri =404;
   }
 
-  location ^~ /api/v1/streaming/ {
+  location ^~ /api/v1/streaming {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
https://github.com/mastodon/mastodon/pull/19438 made a slight change to the nginx routes, which breaks some clients' ability to stream content.

Issue is described in more detail here: https://github.com/mastodon/mastodon/issues/19872

This pull request fixes the streaming route so that the path that is advertised by the documentation can continue to be used by clients without issues.