### PR TITLE
Micro-optimization: only split `acct` into two Strings

### DIFF
--- a/app/models/account_alias.rb
+++ b/app/models/account_alias.rb
@@ -29,7 +29,7 @@ class AccountAlias < ApplicationRecord
   end
 
   def pretty_acct
-    username, domain = acct.split('@')
+    username, domain = acct.split('@', 2)
     domain.nil? ? username : "#{username}@#{Addressable::IDNA.to_unicode(domain)}"
   end
 


### PR DESCRIPTION
Since `acct` is split by `@` and assigned to `username` and `domain`, we only need to split `acct` into two Strings.