### PR TITLE
Micro-optimization: use `if`/`else` instead of `array.compact.min`

### DIFF
--- a/app/models/account_statuses_cleanup_policy.rb
+++ b/app/models/account_statuses_cleanup_policy.rb
@@ -139,7 +139,12 @@ class AccountStatusesCleanupPolicy < ApplicationRecord
     # Filtering on `id` rather than `min_status_age` ago will treat
     # non-snowflake statuses as older than they really are, but Mastodon
     # has switched to snowflake IDs significantly over 2 years ago anyway.
-    max_id = [max_id, Mastodon::Snowflake.id_at(min_status_age.seconds.ago, with_random: false)].compact.min
+    snowflake_id = Mastodon::Snowflake.id_at(min_status_age.seconds.ago, with_random: false)
+
+    if max_id.nil? || snowflake_id < max_id
+      max_id = snowflake_id
+    end
+
     Status.where(Status.arel_table[:id].lteq(max_id))
   end
 


### PR DESCRIPTION
Technically `if`/`else` is faster than using `Array#compact` and `Array#min` which creates two Array instances which must be later garbage collected.

```ruby
#!/usr/bin/env ruby
require 'benchmark'

Benchmark.bm do |b|
  n = 1_000_000

  value1 = nil
  value2 = 42

  b.report('Array#compact') do
    n.times do
      [value1, value2].compact.min
    end
  end

  b.report('if/else') do
    n.times do
      if value1.nil? || (value2 < value1)
        value2
      end
    end
  end
end
```

```
       user     system      total        real             
Array#compact  0.220198   0.000643   0.220841 (  0.222516)
if/else  0.057644   0.000000   0.057644 (  0.057988)      
```