### PR TITLE
Advanced interface: ensure home column's width can grow for larger screens

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2342,6 +2342,11 @@ $ui-header-height: 55px;
       padding-left: 10px;
     }
 
+    &[aria-label="Home"] {
+      flex-grow: 1;
+      max-width: 600px;
+    }
+
     &:last-child {
       padding-right: 10px;
     }


### PR DESCRIPTION
## Description

Fixes #11413. With the [advanced web interface](https://docs.joinmastodon.org/user/preferences/#layout) enabled on a large screen the drawers do not take up all the available space. Now the home column is able to grow to take up extra space.
