### PR TITLE
chart: store smtp login and password on a secret

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -99,6 +99,17 @@ Get the mastodon secret.
 {{- end -}}
 
 {{/*
+Get the smtp secret.
+*/}}
+{{- define "mastodon.smtp.secretName" -}}
+{{- if .Values.mastodon.smtp.existingSecret }}
+    {{- printf "%s" (tpl .Values.mastodon.smtp.existingSecret $) -}}
+{{- else -}}
+    {{- printf "%s-smtp" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get the postgresql secret.
 */}}
 {{- define "mastodon.postgresql.secretName" -}}

--- a/chart/templates/configmap-env.yaml
+++ b/chart/templates/configmap-env.yaml
@@ -71,14 +71,8 @@ data:
   {{- with .Values.mastodon.smtp.from_address }}
   SMTP_FROM_ADDRESS: {{ . }}
   {{- end }}
-  {{- with .Values.mastodon.smtp.login }}
-  SMTP_LOGIN: {{ . }}
-  {{- end }}
   {{- with .Values.mastodon.smtp.openssl_verify_mode }}
   SMTP_OPENSSL_VERIFY_MODE: {{ . }}
-  {{- end }}
-  {{- with .Values.mastodon.smtp.password }}
-  SMTP_PASSWORD: {{ . }}
   {{- end }}
   {{- with .Values.mastodon.smtp.port }}
   SMTP_PORT: {{ . | quote }}

--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -87,6 +87,17 @@ spec:
                 secretKeyRef:
                   name: {{ template "mastodon.redis.secretName" $context }}
                   key: redis-password
+            - name: "SMTP_LOGIN"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mastodon.smtp.secretName" $context }}
+                  key: login
+                  optional: true
+            - name: "SMTP_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mastodon.smtp.secretName" $context }}
+                  key: password
             {{- if (and $context.Values.mastodon.s3.enabled $context.Values.mastodon.s3.existingSecret) }}
             - name: "AWS_SECRET_ACCESS_KEY"
               valueFrom:
@@ -98,19 +109,6 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.mastodon.s3.existingSecret }}
                   key: AWS_ACCESS_KEY_ID
-            {{- end }}
-            {{- if $context.Values.mastodon.smtp.existingSecret }}
-            - name: "SMTP_LOGIN"
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $context.Values.mastodon.smtp.existingSecret }}
-                  key: login
-                  optional: true
-            - name: "SMTP_PASSWORD"
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $context.Values.mastodon.smtp.existingSecret }}
-                  key: password
             {{- end }}
           {{- if (not $context.Values.mastodon.s3.enabled) }}
           volumeMounts:

--- a/chart/templates/secret-smtp.yaml
+++ b/chart/templates/secret-smtp.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.mastodon.smtp.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-smtp" (include "common.names.fullname" .) }}
+  labels:
+    {{- include "mastodon.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- with .Values.mastodon.smtp.login }}
+  login: {{ . | b64enc }}
+  {{- end }}
+  {{- with .Values.mastodon.smtp.password }}
+  password: {{ . | b64enc }}
+  {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -140,8 +140,8 @@ mastodon:
     tls: false
     login:
     password:
-    # -- you can also specify the name of an existing Secret
-    # with the keys login and password
+    # -- Instead of defining login/password above, you can specify the name of an existing secret here. Login and
+    # password must be located in keys named `login` and `password` respectively.
     existingSecret:
   streaming:
     port: 4000


### PR DESCRIPTION
Sensitive data such as login credentials should not be rendered in a `ConfigMap`, as cluster operators are often more lenient granting applications read permissions for them.

This PR moves `SMTP_LOGIN` and `SMTP_PASSWORD` env vars to a new secret `secret-smtp.yaml`, unless `.Values.mastodon.smtp.existingSecret` is defined. In this case, no secret is created and sidekiq will source the `login` and `password` variables from `.Values.mastodon.smtp.existingSecret`.

This change is backwards-compatible.
