### PR TITLE
Fix datatypes from integers to bigint

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -3,7 +3,6 @@
 #
 # Table name: accounts
 #
-#  id                            :bigint(8)        not null, primary key
 #  username                      :string           default(""), not null
 #  domain                        :string
 #  private_key                   :text
@@ -16,11 +15,11 @@
 #  url                           :string
 #  avatar_file_name              :string
 #  avatar_content_type           :string
-#  avatar_file_size              :integer
+#  avatar_file_size              :bigint(8)
 #  avatar_updated_at             :datetime
 #  header_file_name              :string
 #  header_content_type           :string
-#  header_file_size              :integer
+#  header_file_size              :bigint(8)
 #  header_updated_at             :datetime
 #  avatar_remote_url             :string
 #  locked                        :boolean          default(FALSE), not null
@@ -31,6 +30,7 @@
 #  shared_inbox_url              :string           default(""), not null
 #  followers_url                 :string           default(""), not null
 #  protocol                      :integer          default("ostatus"), not null
+#  id                            :bigint(8)        not null, primary key
 #  memorial                      :boolean          default(FALSE), not null
 #  moved_to_account_id           :bigint(8)
 #  featured_collection_url       :string
@@ -44,8 +44,8 @@
 #  avatar_storage_schema_version :integer
 #  header_storage_schema_version :integer
 #  devices_url                   :string
-#  suspension_origin             :integer
 #  sensitized_at                 :datetime
+#  suspension_origin             :integer
 #  trendable                     :boolean
 #  reviewed_at                   :datetime
 #  requested_review_at           :datetime

--- a/app/models/custom_emoji.rb
+++ b/app/models/custom_emoji.rb
@@ -8,7 +8,7 @@
 #  domain                       :string
 #  image_file_name              :string
 #  image_content_type           :string
-#  image_file_size              :integer
+#  image_file_size              :bigint(8)
 #  image_updated_at             :datetime
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -3,16 +3,16 @@
 #
 # Table name: imports
 #
-#  id                :bigint(8)        not null, primary key
 #  type              :integer          not null
 #  approved          :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  data_file_name    :string
 #  data_content_type :string
-#  data_file_size    :integer
+#  data_file_size    :bigint(8)
 #  data_updated_at   :datetime
 #  account_id        :bigint(8)        not null
+#  id                :bigint(8)        not null, primary key
 #  overwrite         :boolean          default(FALSE), not null
 #
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -3,11 +3,10 @@
 #
 # Table name: media_attachments
 #
-#  id                          :bigint(8)        not null, primary key
 #  status_id                   :bigint(8)
 #  file_file_name              :string
 #  file_content_type           :string
-#  file_file_size              :integer
+#  file_file_size              :bigint(8)
 #  file_updated_at             :datetime
 #  remote_url                  :string           default(""), not null
 #  created_at                  :datetime         not null
@@ -16,6 +15,7 @@
 #  type                        :integer          default("image"), not null
 #  file_meta                   :json
 #  account_id                  :bigint(8)
+#  id                          :bigint(8)        not null, primary key
 #  description                 :text
 #  scheduled_status_id         :bigint(8)
 #  blurhash                    :string
@@ -23,7 +23,7 @@
 #  file_storage_schema_version :integer
 #  thumbnail_file_name         :string
 #  thumbnail_content_type      :string
-#  thumbnail_file_size         :integer
+#  thumbnail_file_size         :bigint(8)
 #  thumbnail_updated_at        :datetime
 #  thumbnail_remote_url        :string
 #

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -9,7 +9,7 @@
 #  description                  :string           default(""), not null
 #  image_file_name              :string
 #  image_content_type           :string
-#  image_file_size              :integer
+#  image_file_size              :bigint(8)
 #  image_updated_at             :datetime
 #  type                         :integer          default("link"), not null
 #  html                         :text             default(""), not null

--- a/app/models/site_upload.rb
+++ b/app/models/site_upload.rb
@@ -7,7 +7,7 @@
 #  var               :string           default(""), not null
 #  file_file_name    :string
 #  file_content_type :string
-#  file_file_size    :integer
+#  file_file_size    :bigint(8)
 #  file_updated_at   :datetime
 #  meta              :json
 #  created_at        :datetime         not null

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,11 +153,11 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.string "url"
     t.string "avatar_file_name"
     t.string "avatar_content_type"
-    t.integer "avatar_file_size"
+    t.bigint "avatar_file_size"
     t.datetime "avatar_updated_at"
     t.string "header_file_name"
     t.string "header_content_type"
-    t.integer "header_file_size"
+    t.bigint "header_file_size"
     t.datetime "header_updated_at"
     t.string "avatar_remote_url"
     t.boolean "locked", default: false, null: false
@@ -181,8 +181,8 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.integer "avatar_storage_schema_version"
     t.integer "header_storage_schema_version"
     t.string "devices_url"
-    t.integer "suspension_origin"
     t.datetime "sensitized_at"
+    t.integer "suspension_origin"
     t.boolean "trendable"
     t.datetime "reviewed_at"
     t.datetime "requested_review_at"
@@ -328,7 +328,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.string "domain"
     t.string "image_file_name"
     t.string "image_content_type"
-    t.integer "image_file_size"
+    t.bigint "image_file_size"
     t.datetime "image_updated_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -495,7 +495,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.datetime "updated_at", null: false
     t.string "data_file_name"
     t.string "data_content_type"
-    t.integer "data_file_size"
+    t.bigint "data_file_size"
     t.datetime "data_updated_at"
     t.bigint "account_id", null: false
     t.boolean "overwrite", default: false, null: false
@@ -516,12 +516,12 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
   end
 
   create_table "ip_blocks", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "expires_at"
     t.inet "ip", default: "0.0.0.0", null: false
     t.integer "severity", default: 0, null: false
+    t.datetime "expires_at"
     t.text "comment", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["ip"], name: "index_ip_blocks_on_ip", unique: true
   end
 
@@ -569,7 +569,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.bigint "status_id"
     t.string "file_file_name"
     t.string "file_content_type"
-    t.integer "file_file_size"
+    t.bigint "file_file_size"
     t.datetime "file_updated_at"
     t.string "remote_url", default: "", null: false
     t.datetime "created_at", null: false
@@ -585,7 +585,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.integer "file_storage_schema_version"
     t.string "thumbnail_file_name"
     t.string "thumbnail_content_type"
-    t.integer "thumbnail_file_size"
+    t.bigint "thumbnail_file_size"
     t.datetime "thumbnail_updated_at"
     t.string "thumbnail_remote_url"
     t.index ["account_id", "status_id"], name: "index_media_attachments_on_account_id_and_status_id", order: { status_id: :desc }
@@ -752,7 +752,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.string "description", default: "", null: false
     t.string "image_file_name"
     t.string "image_content_type"
-    t.integer "image_file_size"
+    t.bigint "image_file_size"
     t.datetime "image_updated_at"
     t.integer "type", default: 0, null: false
     t.text "html", default: "", null: false
@@ -863,7 +863,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.string "var", default: "", null: false
     t.string "file_file_name"
     t.string "file_content_type"
-    t.integer "file_file_size"
+    t.bigint "file_file_size"
     t.datetime "file_updated_at"
     t.json "meta"
     t.datetime "created_at", null: false
@@ -890,8 +890,8 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
   create_table "status_pins", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.bigint "status_id", null: false
-    t.datetime "created_at", default: -> { "now()" }, null: false
-    t.datetime "updated_at", default: -> { "now()" }, null: false
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["account_id", "status_id"], name: "index_status_pins_on_account_id_and_status_id", unique: true
     t.index ["status_id"], name: "index_status_pins_on_status_id"
   end


### PR DESCRIPTION
A clean migration with a fresh install. Changes the `integer` to `bigInt`. Is this intentional to keep some compatibility? If not then the schema needs to be updated.