### PR TITLE
Improve performance by avoiding method cache busts

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -62,8 +62,6 @@ class Request
     end
 
     begin
-      response = response.extend(ClientLimit)
-
       # If we are using a persistent connection, we have to
       # read every response to be able to move forward at all.
       # However, simply calling #to_s or #flush may not be safe,
@@ -178,6 +176,14 @@ class Request
       end
 
       contents
+    end
+  end
+
+  if ::HTTP::Response.methods.include?(:body_with_limit) && !Rails.env.production?
+    abort 'HTTP::Response#body_with_limit is already defined, the monkey patch will not be applied'
+  else
+    class ::HTTP::Response
+      include Request::ClientLimit
     end
   end
 


### PR DESCRIPTION
Switch to monkey-patching http.rb rather than a runtime extend of each response, so as to avoid busting the global method cache. A guard is included that will provide developer feedback in development and test environments should the monkey patch ever collide.