### PR TITLE
Fix spoiler buttons css not rendering correct color in light theme

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -268,7 +268,7 @@ html {
 .status__content .status__content__spoiler-link {
   background: $ui-base-color;
 
-  &:hover, 
+  &:hover,
   &:focus {
     background: lighten($ui-base-color, 4%);
   }

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -266,10 +266,10 @@ html {
 // Change the background colors of status__content__spoiler-link
 .reply-indicator__content .status__content__spoiler-link,
 .status__content .status__content__spoiler-link {
-  background: $ui-base-color !important;
+  background: $ui-base-color;
 
-  &:hover {
-    background: lighten($ui-base-color, 4%) !important;
+  &:hover, &:focus {
+    background: lighten($ui-base-color, 4%);
   }
 }
 

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -268,7 +268,8 @@ html {
 .status__content .status__content__spoiler-link {
   background: $ui-base-color;
 
-  &:hover, &:focus {
+  &:hover, 
+  &:focus {
     background: lighten($ui-base-color, 4%);
   }
 }

--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -266,10 +266,10 @@ html {
 // Change the background colors of status__content__spoiler-link
 .reply-indicator__content .status__content__spoiler-link,
 .status__content .status__content__spoiler-link {
-  background: $ui-base-color;
+  background: $ui-base-color !important;
 
   &:hover {
-    background: lighten($ui-base-color, 4%);
+    background: lighten($ui-base-color, 4%) !important;
   }
 }
 


### PR DESCRIPTION
The "Show more" and "Show less" spoiler-link buttons render with the wrong background color in the mastodon-light theme.  The issue is described in #19930.

This pull request fixes the issue by adding `!important` to the css in the `diff.scss` file for the mastodon-light theme in order to ensure that the correct background color is rendered in all browsers. 