### PR TITLE
Add hint to Follows and Followers, for discovering user search

### DIFF
--- a/app/views/relationships/show.html.haml
+++ b/app/views/relationships/show.html.haml
@@ -56,3 +56,7 @@
         = render partial: 'account', collection: @accounts, locals: { f: f }
 
 = paginate @accounts
+
+%hr.spacer/
+
+.flash-message= t('relationships.find_users_to_follow_hint')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1512,6 +1512,7 @@ en:
     confirm_remove_selected_followers: Are you sure you want to remove selected followers?
     confirm_remove_selected_follows: Are you sure you want to remove selected follows?
     dormant: Dormant
+    find_users_to_follow_hint: You can use the main search box to find users to follow
     follow_failure: Could not follow some of the selected accounts.
     follow_selected_followers: Follow selected followers
     followers: Followers


### PR DESCRIPTION
Addressing:

* #19976

I've added a note on the **Follows and Followers** screen to make it easier to discover how to find users to follow. It looks like so:

![image](https://user-images.githubusercontent.com/30010/200332883-f217516f-f7ee-47bf-a3c8-7f068da54949.png)

I've translated the note to Swedish. According to the config, afaiu, it should fall back on English for the non-translated languages. However, on my dev server it doesn't do that, but instead shows the translation key capitalized. Don't know what to make of that...

I would want the hint to refer to the search box in some clearer way than ”the search feature”, but I don't know how to. Some ideas:

* ”the search box on the main screen”
* ”the Mastodon search box” (The back link on the preferences screen says ”Back to Mastodon”.)
* "the search box”

I don't see the search feature mentioned in the documentation, so couldn't find inspiration there.

I'll be happy to work some more on this PR, if you think it should be worked on. 