### PR TITLE
Fix wrong translation of status.replied_to in polish

### DIFF
--- a/app/javascript/mastodon/locales/pl.json
+++ b/app/javascript/mastodon/locales/pl.json
@@ -576,7 +576,7 @@
   "status.reblogs.empty": "Nikt nie podbił jeszcze tego wpisu. Gdy ktoś to zrobi, pojawi się tutaj.",
   "status.redraft": "Usuń i przeredaguj",
   "status.remove_bookmark": "Usuń zakładkę",
-  "status.replied_to": "Odpowiedziałeś/aś {name}",
+  "status.replied_to": "W odpowiedzi do {name}",
   "status.reply": "Odpowiedz",
   "status.replyAll": "Odpowiedz na wątek",
   "status.report": "Zgłoś @{name}",


### PR DESCRIPTION
Currently polish translation is misleading- `Odpowiedziałeś/aś {name}` would mean that I was the person that did respond and that is not the sense of original sentence. New translation would mean something more like `In response to {name}`