### PR TITLE
Add `sensitized` to Admin::Account serializer (fix #19148)

### DIFF
--- a/app/serializers/rest/admin/account_serializer.rb
+++ b/app/serializers/rest/admin/account_serializer.rb
@@ -31,7 +31,7 @@ class REST::Admin::AccountSerializer < ActiveModel::Serializer
   def silenced
     object.silenced?
   end
-  
+
   def sensitized
     object.sensitized?
   end

--- a/app/serializers/rest/admin/account_serializer.rb
+++ b/app/serializers/rest/admin/account_serializer.rb
@@ -3,7 +3,7 @@
 class REST::Admin::AccountSerializer < ActiveModel::Serializer
   attributes :id, :username, :domain, :created_at,
              :email, :ip, :role, :confirmed, :suspended,
-             :silenced, :disabled, :approved, :locale,
+             :silenced, :sensitized, :disabled, :approved, :locale,
              :invite_request
 
   attribute :created_by_application_id, if: :created_by_application?
@@ -30,6 +30,10 @@ class REST::Admin::AccountSerializer < ActiveModel::Serializer
 
   def silenced
     object.silenced?
+  end
+  
+  def sensitized
+    object.sensitized?
   end
 
   def confirmed


### PR DESCRIPTION
Fix #19148

`sensitized?` was already present on the Account model, just not added to the Admin::Account serializer.