### PR TITLE
Fix nodeinfo metadata attribute being an array instead of an object

### DIFF
--- a/app/serializers/nodeinfo/serializer.rb
+++ b/app/serializers/nodeinfo/serializer.rb
@@ -38,7 +38,7 @@ class NodeInfo::Serializer < ActiveModel::Serializer
   end
 
   def metadata
-    []
+    {}
   end
 
   private


### PR DESCRIPTION
Fixes #20111