### PR TITLE
Fix missing cast of status and rule IDs to string (fix #19048)

### DIFF
--- a/app/serializers/rest/report_serializer.rb
+++ b/app/serializers/rest/report_serializer.rb
@@ -9,4 +9,12 @@ class REST::ReportSerializer < ActiveModel::Serializer
   def id
     object.id.to_s
   end
+
+  def status_ids
+    object&.status_ids&.map(&:to_s)
+  end
+
+  def rule_ids
+    object&.rule_ids&.map(&:to_s)
+  end
 end


### PR DESCRIPTION
Fix #19048

```
    "status_ids": [
        "109308029266383624"
    ],
    "rule_ids": [
        "1"
    ],
```