### PR TITLE
Fix uncaught 500 error on invalid `replies_policy` (Fix #19097)

### DIFF
--- a/app/controllers/api/v1/lists_controller.rb
+++ b/app/controllers/api/v1/lists_controller.rb
@@ -7,6 +7,10 @@ class Api::V1::ListsController < Api::BaseController
   before_action :require_user!
   before_action :set_list, except: [:index, :create]
 
+  rescue_from ArgumentError do |e|
+    render json: { error: e.to_s }, status: 422
+  end
+
   def index
     @lists = List.where(account: current_account).all
     render json: @lists, each_serializer: REST::ListSerializer


### PR DESCRIPTION
Fix #19097

```json
{
    "error": "'some' is not a valid replies_policy"
}
```