### PR TITLE
Use Rails tag API to build RSS feed for spoilers and polls

### DIFF
--- a/app/helpers/formatting_helper.rb
+++ b/app/helpers/formatting_helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module FormattingHelper
-  HTML_SAFE_BR = '<br />'.html_safe
-
   def html_aware_format(text, local, options = {})
     HtmlAwareFormatter.new(text, local, options).to_s
   end
@@ -41,7 +39,8 @@ module FormattingHelper
           safe_join(
             status.preloadable_poll.options.map do |o|
               tag.send(status.preloadable_poll.multiple? ? 'checkbox' : 'radio', o, disabled: true)
-            end, HTML_SAFE_BR
+            end,
+            tag.br
           )
         end
       end

--- a/app/helpers/formatting_helper.rb
+++ b/app/helpers/formatting_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module FormattingHelper
+  HTML_SAFE_BR = '<br />'.html_safe
+
   def html_aware_format(text, local, options = {})
     HtmlAwareFormatter.new(text, local, options).to_s
   end
@@ -23,19 +25,27 @@ module FormattingHelper
 
     before_html = begin
       if status.spoiler_text?
-        "<p><strong>#{I18n.t('rss.content_warning', locale: available_locale_or_nil(status.language) || I18n.default_locale)}</strong> #{h(status.spoiler_text)}</p><hr />"
-      else
-        ''
+        tag.p do
+          tag.strong do
+            I18n.t('rss.content_warning', locale: available_locale_or_nil(status.language) || I18n.default_locale)
+          end
+
+          status.spoiler_text
+        end + tag.hr
       end
-    end.html_safe # rubocop:disable Rails/OutputSafety
+    end
 
     after_html = begin
       if status.preloadable_poll
-        "<p>#{status.preloadable_poll.options.map { |o| "<input type=#{status.preloadable_poll.multiple? ? 'checkbox' : 'radio'} disabled /> #{h(o)}" }.join('<br />')}</p>"
-      else
-        ''
+        tag.p do
+          safe_join(
+            status.preloadable_poll.options.map do |o|
+              tag.send(status.preloadable_poll.multiple? ? 'checkbox' : 'radio', o, disabled: true)
+            end, HTML_SAFE_BR
+          )
+        end
       end
-    end.html_safe # rubocop:disable Rails/OutputSafety
+    end
 
     prerender_custom_emojis(
       safe_join([before_html, html, after_html]),

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -18,7 +18,7 @@ describe FormattingHelper, type: :helper do
     end
 
     it 'renders the poll' do
-      expect(html).to include('<radio disabled="disabled">Yes&lt;&gt;</radio><br />')
+      expect(html).to include('<radio disabled="disabled">Yes&lt;&gt;</radio><br>')
     end
   end
 end

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -6,13 +6,8 @@ describe FormattingHelper, type: :helper do
   include Devise::Test::ControllerHelpers
 
   describe '#rss_status_content_format' do
-    let(:status) { Fabricate(:status, text: 'Hello world<>', spoiler_text: 'This is a spoiler<>') }
-    let(:poll) { Fabricate(:poll, status: status, options: %w(Yes<> No)) }
+    let(:status) { Fabricate(:status, text: 'Hello world<>', spoiler_text: 'This is a spoiler<>', poll: Fabricate(:poll, options: %w(Yes<> No))) }
     let(:html) { helper.rss_status_content_format(status) }
-
-    before do
-      status.preloadable_poll = poll
-    end
 
     it 'renders the spoiler text' do
       expect(html).to include('<p>This is a spoiler&lt;&gt;</p><hr>')

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe FormattingHelper, type: :helper do
+  include Devise::Test::ControllerHelpers
+
+  describe '#rss_status_content_format' do
+    let(:status) { Fabricate(:status, text: 'Hello world<>', spoiler_text: 'This is a spoiler<>') }
+    let(:poll) { Fabricate(:poll, status: status, options: %w(Yes<> No)) }
+    let(:html) { helper.rss_status_content_format(status) }
+
+    before do
+      status.preloadable_poll = poll
+    end
+
+    it 'renders the spoiler text' do
+      expect(html).to include('<p>This is a spoiler&lt;&gt;</p><hr>')
+    end
+
+    it 'renders the status text' do
+      expect(html).to include('<p>Hello world&lt;&gt;</p>')
+    end
+
+    it 'renders the poll' do
+      expect(html).to include('<radio disabled="disabled">Yes&lt;&gt;</radio><br />')
+    end
+  end
+end


### PR DESCRIPTION
While the previous method did not contain a bug or a potential issue, the tag API can be very resilient against future problems and reduces the amount of manual management of the escape status of the content.

I've added tests to ensure that the formatting is broken and still escapes control characters correctly.