### PR TITLE
fix(chart): Fix gitops-incompatible random rolling

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -52,6 +52,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Rolling pod annotations
+*/}}
+{{- define "mastodon.rollingPodAnnotations" -}}
+rollme: {{ .Release.Revision | quote }}
+checksum/config-secrets: {{ include ( print $.Template.BasePath "/secrets.yaml" ) . | sha256sum | quote }}
+checksum/config-configmap: {{ include ( print $.Template.BasePath "/configmap-env.yaml" ) . | sha256sum | quote }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "mastodon.serviceAccountName" -}}

--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -16,11 +16,11 @@ spec:
   template:
     metadata:
       annotations:
-      {{- with .Values.podAnnotations }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-        # roll the pods to pick up any db migrations
-        rollme: {{ randAlphaNum 5 | quote }}
+        {{- end }}
+        # roll the pods to pick up any db migrations or other changes
+        {{- include "mastodon.rollingPodAnnotations" . | nindent 8 }}
       labels:
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: sidekiq

--- a/chart/templates/deployment-streaming.yaml
+++ b/chart/templates/deployment-streaming.yaml
@@ -14,10 +14,12 @@ spec:
       app.kubernetes.io/component: streaming
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+        {{- end }}
+        # roll the pods to pick up any db migrations or other changes
+        {{- include "mastodon.rollingPodAnnotations" . | nindent 8 }}
       labels:
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: streaming

--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -19,8 +19,8 @@ spec:
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
-        # roll the pods to pick up any db migrations
-        rollme: {{ randAlphaNum 5 | quote }}
+        # roll the pods to pick up any db migrations or other changes
+        {{- include "mastodon.rollingPodAnnotations" . | nindent 8 }}
       labels:
         {{- include "mastodon.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: web


### PR DESCRIPTION
This patch reworks the Pod rolling mechanism, which is supposed to update Pods
with each migration run, but since the it generates a new random value on each
helm execution, this will constantly roll all pods in a GitOps driven deployment,
which reconciles the helm release.

This is resolved by fixing the upgrade to the `.Release.Revision`, which should
stay identical, unless config or helm release version have been changed. Further
it introduces automatic rolls based on adjustments to the environment variables
and secrets.

The implementation uses a helper template, following the 1-2-N rule, and omitting
code duplication.

References:
https://helm.sh/docs/chart_template_guide/builtin_objects/
https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments