### PR TITLE
Fix some actions being logged on idempotent calls

### DIFF
--- a/app/controllers/api/v1/admin/accounts_controller.rb
+++ b/app/controllers/api/v1/admin/accounts_controller.rb
@@ -46,8 +46,10 @@ class Api::V1::Admin::AccountsController < Api::BaseController
 
   def enable
     authorize @account.user, :enable?
-    @account.user.enable!
-    log_action :enable, @account.user
+    if @account.user.disabled
+      @account.user.enable!
+      log_action :enable, @account.user
+    end
     render json: @account, serializer: REST::Admin::AccountSerializer
   end
 
@@ -71,15 +73,19 @@ class Api::V1::Admin::AccountsController < Api::BaseController
 
   def unsensitive
     authorize @account, :unsensitive?
-    @account.unsensitize!
-    log_action :unsensitive, @account
+    if @account.sensitized?
+      @account.unsensitize!
+      log_action :unsensitive, @account
+    end
     render json: @account, serializer: REST::Admin::AccountSerializer
   end
 
   def unsilence
     authorize @account, :unsilence?
-    @account.unsilence!
-    log_action :unsilence, @account
+    if @account.silenced?
+      @account.unsilence!
+      log_action :unsilence, @account
+    end
     render json: @account, serializer: REST::Admin::AccountSerializer
   end
 

--- a/app/controllers/api/v1/admin/reports_controller.rb
+++ b/app/controllers/api/v1/admin/reports_controller.rb
@@ -40,29 +40,37 @@ class Api::V1::Admin::ReportsController < Api::BaseController
 
   def assign_to_self
     authorize @report, :update?
-    @report.update!(assigned_account_id: current_account.id)
-    log_action :assigned_to_self, @report
+    unless @report.assigned_account_id == current_account.id
+      @report.update!(assigned_account_id: current_account.id)
+      log_action :assigned_to_self, @report
+    end
     render json: @report, serializer: REST::Admin::ReportSerializer
   end
 
   def unassign
     authorize @report, :update?
-    @report.update!(assigned_account_id: nil)
-    log_action :unassigned, @report
+    if @report.assigned_account_id
+      @report.update!(assigned_account_id: nil)
+      log_action :unassigned, @report
+    end
     render json: @report, serializer: REST::Admin::ReportSerializer
   end
 
   def reopen
     authorize @report, :update?
-    @report.unresolve!
-    log_action :reopen, @report
+    unless @report.unresolved?
+      @report.unresolve!
+      log_action :reopen, @report
+    end
     render json: @report, serializer: REST::Admin::ReportSerializer
   end
 
   def resolve
     authorize @report, :update?
-    @report.resolve!(current_account)
-    log_action :resolve, @report
+    unless @report.action_taken?
+      @report.resolve!(current_account)
+      log_action :resolve, @report
+    end
     render json: @report, serializer: REST::Admin::ReportSerializer
   end
 


### PR DESCRIPTION
Related to #19149

Some calls are idempotent (see #19147) and this means that calling them multiple times will lead to nonsensical audit log entries that don't actually reflect changes in state.