### PR TITLE
Fix GET /api/v1/admin/ip_blocks/:id

### DIFF
--- a/app/policies/ip_block_policy.rb
+++ b/app/policies/ip_block_policy.rb
@@ -5,6 +5,10 @@ class IpBlockPolicy < ApplicationPolicy
     role.can?(:manage_blocks)
   end
 
+  def show?
+    role.can?(:manage_blocks)
+  end
+
   def create?
     role.can?(:manage_blocks)
   end


### PR DESCRIPTION
A missing authorization check method meant that `GET /api/v1/admin/ip_blocks/:id` was actually broken and would return a 500 error with HTML response