### PR TITLE
Split up LowPriorityDeliveryWorker from pull queue

### DIFF
--- a/app/workers/activitypub/low_priority_delivery_worker.rb
+++ b/app/workers/activitypub/low_priority_delivery_worker.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ActivityPub::LowPriorityDeliveryWorker < ActivityPub::DeliveryWorker
-  sidekiq_options queue: 'pull', retry: 8, dead: false
+  sidekiq_options queue: 'low_delivery', retry: 8, dead: false
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,6 +6,7 @@
   - [ingress, 4]
   - [mailers, 2]
   - [pull]
+  - [low_delivery]
   - [scheduler]
 :scheduler:
   :listened_queues_only: true


### PR DESCRIPTION
Currently, `LowPriorityDeliveryWorker` using `pull` queue. This is grammatically incorrect. And causes high pull queue latency.
This PR split that worker into a new queue with lowest priority called `low_delivery` queue.

I tested on my server. And it works fine especially someone deleted their account (It causes timeline stop before)