### PR TITLE
Change account deletion requests processing to spread out over time

### DIFF
--- a/app/workers/admin/account_deletion_worker.rb
+++ b/app/workers/admin/account_deletion_worker.rb
@@ -3,7 +3,7 @@
 class Admin::AccountDeletionWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull'
+  sidekiq_options queue: 'pull', lock: :until_executed
 
   def perform(account_id)
     DeleteAccountService.new.call(Account.find(account_id), reserve_username: true, reserve_email: true)

--- a/app/workers/scheduler/suspended_user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/suspended_user_cleanup_scheduler.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class Scheduler::SuspendedUserCleanupScheduler
+  include Sidekiq::Worker
+
+  # Each processed deletion request may enqueue an enormous
+  # amount of jobs in the `pull` queue, so only enqueue when
+  # the queue is empty or close to being so.
+  MAX_PULL_SIZE = 50
+
+  # Since account deletion is very expensive, we want to avoid
+  # overloading the server by queing too much at once.
+  # This job runs approximately once per 2 minutes, so with a
+  # value of `MAX_DELETIONS_PER_JOB` of 10, a server can
+  # handle the deletion of 7200 accounts per day, provided it
+  # has the capacity for it.
+  MAX_DELETIONS_PER_JOB = 10
+
+  sidekiq_options retry: 0
+
+  def perform
+    return if Sidekiq::Queue.new('pull').size > MAX_PULL_SIZE
+
+    clean_suspended_accounts!
+  end
+
+  private
+
+  def clean_suspended_accounts!
+    # This should be fine because we only process a small amount of deletion requests at once and
+    # `id` and `created_at` should follow the same order.
+    AccountDeletionRequest.reorder(id: :asc).take(MAX_DELETIONS_PER_JOB).each do |deletion_request|
+      next unless deletion_request.created_at < AccountDeletionRequest::DELAY_TO_DELETION.ago
+
+      Admin::AccountDeletionWorker.perform_async(deletion_request.account_id)
+    end
+  end
+end

--- a/app/workers/scheduler/user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/user_cleanup_scheduler.rb
@@ -7,7 +7,6 @@ class Scheduler::UserCleanupScheduler
 
   def perform
     clean_unconfirmed_accounts!
-    clean_suspended_accounts!
     clean_discarded_statuses!
   end
 
@@ -19,12 +18,6 @@ class Scheduler::UserCleanupScheduler
       AccountModerationNote.where(account_id: batch.map(&:account_id)).delete_all
       Account.where(id: batch.map(&:account_id)).delete_all
       User.where(id: batch.map(&:id)).delete_all
-    end
-  end
-
-  def clean_suspended_accounts!
-    AccountDeletionRequest.where('created_at <= ?', AccountDeletionRequest::DELAY_TO_DELETION.ago).reorder(nil).find_each do |deletion_request|
-      Admin::AccountDeletionWorker.perform_async(deletion_request.account_id)
     end
   end
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -53,3 +53,7 @@
     interval: 1 minute
     class: Scheduler::AccountsStatusesCleanupScheduler
     queue: scheduler
+  suspended_user_cleanup_scheduler:
+    interval: 1 minute
+    class: Scheduler::SuspendedUserCleanupScheduler
+    queue: scheduler


### PR DESCRIPTION
Currently, account deletion requests reaching their effective date are processed all at once once a day, but account deletions, especially local ones, are very expensive and will fill up sidekiq's really quickly. This can be especially bad for servers with a large amount of registrations, especially if accounts are banned in waves, or misconfigured servers who did not run the scheduler queue for a long while.

This PR does not reduce the overall amount of work to be done, but changes how it is distributed by queuing up to 15 deletions every 2 minutes, and only do that if the `pull` queue is empty or nearing so. This should spread out the load over time and not fill up the sidekiq queue with large amounts of jobs.