### PR TITLE
fix: custom emoji shortcode case not respected

### DIFF
--- a/app/lib/entity_cache.rb
+++ b/app/lib/entity_cache.rb
@@ -19,22 +19,28 @@ class EntityCache
     shortcodes = Array(shortcodes)
     return [] if shortcodes.empty?
 
-    cached       = Rails.cache.read_multi(*shortcodes.map { |shortcode| to_key(:emoji, shortcode, domain) })
+    domain = domain.downcase if domain
+
+    cached       = Rails.cache.read_multi(*shortcodes.map { |shortcode| to_emoji(:emoji, shortcode, domain) })
     uncached_ids = []
 
     shortcodes.each do |shortcode|
-      uncached_ids << shortcode unless cached.key?(to_key(:emoji, shortcode, domain))
+      uncached_ids << shortcode unless cached.key?(to_emoji(:emoji, shortcode, domain))
     end
 
     unless uncached_ids.empty?
       uncached = CustomEmoji.enabled.where(shortcode: shortcodes, domain: domain).index_by(&:shortcode)
-      uncached.each_value { |item| Rails.cache.write(to_key(:emoji, item.shortcode, domain), item, expires_in: MAX_EXPIRATION) }
+      uncached.each_value { |item| Rails.cache.write(to_emoji(:emoji, item.shortcode, domain), item, expires_in: MAX_EXPIRATION) }
     end
 
-    shortcodes.filter_map { |shortcode| cached[to_key(:emoji, shortcode, domain)] || uncached[shortcode] }
+    shortcodes.filter_map { |shortcode| cached[to_emoji(:emoji, shortcode, domain)] || uncached[shortcode] }
   end
 
   def to_key(type, *ids)
     "#{type}:#{ids.compact.map(&:downcase).join(':')}"
+  end
+
+  def to_emoji(type, *ids)
+    "#{type}:#{ids.compact.join(':')}"
   end
 end

--- a/spec/lib/entity_cache_spec.rb
+++ b/spec/lib/entity_cache_spec.rb
@@ -18,4 +18,12 @@ RSpec.describe EntityCache do
       end
     end
   end
+
+  describe '#to_emoji' do
+    context 'when input shortcode has cases' do
+      it 'returns emoji with cases preserved' do
+        expect(described_class.instance.to_emoji(:emoji, 'FooBar', 'example.org')).to eq 'emoji:FooBar:example.org'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, custom emojis with different cases but same characters are allowed in the database, and are treated as different emojis, e.g., :blob: and :Blob: are different ones. However, these are not parsed by mastodon's backend services, which will cause one case of the emoji not parsed, as is in the following screenshot:
![image](https://user-images.githubusercontent.com/50446405/200883654-30767990-8997-4b1b-8412-cf364fe8ceae.png)
This patch will allow emojis with same chars but different cases be parsed correctly.