### PR TITLE
Change incoming activity processing to happen in `ingress` queue

### DIFF
--- a/app/lib/admin/system_check/sidekiq_process_check.rb
+++ b/app/lib/admin/system_check/sidekiq_process_check.rb
@@ -7,6 +7,7 @@ class Admin::SystemCheck::SidekiqProcessCheck < Admin::SystemCheck::BaseCheck
     mailers
     pull
     scheduler
+    ingress
   ).freeze
 
   def skip?

--- a/app/workers/activitypub/processing_worker.rb
+++ b/app/workers/activitypub/processing_worker.rb
@@ -3,7 +3,7 @@
 class ActivityPub::ProcessingWorker
   include Sidekiq::Worker
 
-  sidekiq_options backtrace: true, retry: 8
+  sidekiq_options queue: 'ingress', backtrace: true, retry: 8
 
   def perform(actor_id, body, delivered_to_account_id = nil, actor_type = 'Account')
     case actor_type

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,8 +1,9 @@
 ---
 :concurrency: 5
 :queues:
-  - [default, 6]
-  - [push, 4]
+  - [default, 8]
+  - [push, 6]
+  - [ingress, 4]
   - [mailers, 2]
   - [pull]
   - [scheduler]


### PR DESCRIPTION
Allows local activity to not be affected by heavy federation activity.