### PR TITLE
Fix `mailers` queue not being used for mailers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -163,6 +163,7 @@ module Mastodon
     # config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]
 
     config.active_job.queue_adapter = :sidekiq
+    config.action_mailer.deliver_later_queue_name = 'mailers'
 
     config.middleware.use Rack::Attack
     config.middleware.use Mastodon::RackMiddleware


### PR DESCRIPTION
Regression since Rails 6.1