### PR TITLE
Fix performance of query for allowed trending statuses

### DIFF
--- a/db/migrate/20221109211236_update_status_trends_index.rb
+++ b/db/migrate/20221109211236_update_status_trends_index.rb
@@ -1,0 +1,15 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class UpdateStatusTrendsIndex < ActiveRecord::Migration[6.1]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    safety_assured { update_index :status_trends, 'index_status_trends_on_account_id', [:account_id, :allowed] }
+  end
+
+  def down
+    safety_assured { update_index :status_trends, 'index_status_trends_on_account_id', [:account_id] }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_04_133904) do
+ActiveRecord::Schema.define(version: 2022_11_09_211236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -913,7 +913,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.integer "rank", default: 0, null: false
     t.boolean "allowed", default: false, null: false
     t.string "language"
-    t.index ["account_id"], name: "index_status_trends_on_account_id"
+    t.index ["account_id", "allowed"], name: "index_status_trends_on_account_id"
     t.index ["status_id"], name: "index_status_trends_on_status_id", unique: true
   end
 


### PR DESCRIPTION
This index saves on a costly filter operation. Brings down query time from ~70ms to ~13ms.