### PR TITLE
Fix multiple accounts being unable to verify with the same website

### DIFF
--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -30,10 +30,11 @@ class VerifyLinkService < BaseService
 
     if links.any? { |link| link['href'].downcase == @link_back.downcase }
       true
+    elsif link.any? { |link| link_redirects_back?(link['href']) }
+      true
     elsif links.empty?
       false
     else
-      link_redirects_back?(links.first['href'])
     end
   end
 


### PR DESCRIPTION
This pull requests fixes #20259 - a bug that restricted only the first account linked on a website to being verified. 

Before, if you had multiple accounts and wanted to verify multiple ones with a website, Mastodon would only verify the first one. Now, if you have multiple accounts, Mastodon will check every link on the page to see if any of them link back to your profile.