### PR TITLE
Add Scots to the supported locales

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -195,6 +195,7 @@ module LanguagesHelper
     kmr: ['Kurmanji (Kurdish)', 'Kurmancî'].freeze,
     ldn: ['Láadan', 'Láadan'].freeze,
     lfn: ['Lingua Franca Nova', 'lingua franca nova'].freeze,
+    sco: ['Scots', 'Scots'].freeze,
     tok: ['Toki Pona', 'toki pona'].freeze,
     zba: ['Balaibalan', 'باليبلن'].freeze,
     zgh: ['Standard Moroccan Tamazight', 'ⵜⴰⵎⴰⵣⵉⵖⵜ'].freeze,


### PR DESCRIPTION
Fixes #20249

To quote @AlistairDavidson on that issue:

> It's uncomfortable, when writing in Scots, to have it labelled as English. Also it is an official language in Northern Ireland and a recognised minority language in Scotland, with 1.5 million people reporting they could speak it in the 2011 census. https://en.wikipedia.org/wiki/Scots_language

This is my first contribution, so please let me know if I've missed anything.