### PR TITLE
Test the native_locale_name of a non-standard locale

### DIFF
--- a/spec/helpers/languages_helper_spec.rb
+++ b/spec/helpers/languages_helper_spec.rb
@@ -11,7 +11,7 @@ describe LanguagesHelper do
 
   describe 'native_locale_name' do
     it 'finds the human readable native name from a key' do
-      expect(helper.native_locale_name(:en)).to eq('English')
+      expect(helper.native_locale_name(:de)).to eq('Deutsch')
     end
   end
 


### PR DESCRIPTION
`:en` is English for both `standard_locale_name` and `native_locale_name`, and so makes for a poor test candidate for differentiating between them.