### PR TITLE
Allow MathML Core tags in post content

### DIFF
--- a/spec/lib/sanitize_config_spec.rb
+++ b/spec/lib/sanitize_config_spec.rb
@@ -41,5 +41,17 @@ describe Sanitize::Config do
     it 'keeps a with href' do
       expect(Sanitize.fragment('<a href="http://example.com">Test</a>', subject)).to eq '<a href="http://example.com" rel="nofollow noopener noreferrer" target="_blank">Test</a>'
     end
+
+    it 'keeps math' do
+      MATHML = '<math display="block"><mrow><mrow><munder><mo movablelimits="false">∑</mo><mrow><mi>a</mi><mo>∈</mo><mi>𝔄</mi></mrow></munder></mrow><mn>2</mn><mo>⁢</mo><mi>a</mi><mo>+</mo><mn>1</mn></mrow></math>'
+      expect(Sanitize.fragment(MATHML, subject)).to eq MATHML
+    end
+
+    it 'correctly sanitizes linethickness' do
+      expect(Sanitize.fragment('<math><mfrac linethickness="0"><mn>1</mn><mn>2</mn></mfrac></math>', subject)).to eq '<math><mfrac linethickness="0"><mn>1</mn><mn>2</mn></mfrac></math>'
+      expect(Sanitize.fragment('<math><mfrac linethickness="1"><mn>1</mn><mn>2</mn></mfrac></math>', subject)).to eq '<math><mfrac><mn>1</mn><mn>2</mn></mfrac></math>'
+    end
+
+    ''
   end
 end


### PR DESCRIPTION
See #19806 for more info.

Test Plan:
----------
```
$ RAILS_ENV=test bundle exec rspec spec/lib/sanitize_config_spec.rb

Randomized with seed 19230
 11/11 |========================================================================================== 100 ===========================================================================================>| Time: 00:00:00

Finished in 0.07389 seconds (files took 1.67 seconds to load)
11 examples, 0 failures

Randomized with seed 19230
Coverage report generated for RSpec to /home/pounce/programming/mastodon/coverage. 1343 / 35156 LOC (3.82%) covered.
```
observed 100% code coverage of lib/sanitize_ext/sanitize_config.rb.

closes #19806