### PR TITLE
Make enable_starttls configurable by envvars

### DIFF
--- a/app.json
+++ b/app.json
@@ -79,8 +79,13 @@
       "description": "SMTP server certificate verification mode. Defaults is 'peer'.",
       "required": false
     },
+    "SMTP_ENABLE_STARTTLS": {
+      "description": "Enable STARTTLS? Default is 'auto'.",
+      "value": "auto",
+      "required": false
+    },
     "SMTP_ENABLE_STARTTLS_AUTO": {
-      "description": "Enable STARTTLS if SMTP server supports it? Default is true.",
+      "description": "Enable STARTTLS if SMTP server supports it? Deprecated by SMTP_ENABLE_STARTTLS.",
       "required": false
     }
   },

--- a/chart/templates/configmap-env.yaml
+++ b/chart/templates/configmap-env.yaml
@@ -58,6 +58,9 @@ data:
   {{- if .Values.mastodon.smtp.domain }}
   SMTP_DOMAIN: {{ .Values.mastodon.smtp.domain }}
   {{- end }}
+  {{- if .Values.mastodon.smtp.enable_starttls }}
+  SMTP_ENABLE_STARTTLS: {{ .Values.mastodon.smtp.enable_starttls | quote }}
+  {{- end }}
   {{- if .Values.mastodon.smtp.enable_starttls_auto }}
   SMTP_ENABLE_STARTTLS_AUTO: {{ .Values.mastodon.smtp.enable_starttls_auto | quote }}
   {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -77,7 +77,7 @@ mastodon:
     ca_file: /etc/ssl/certs/ca-certificates.crt
     delivery_method: smtp
     domain:
-    enable_starttls_auto: true
+    enable_starttls: 'auto'
     from_address: notifications@example.com
     openssl_verify_mode: peer
     port: 587

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,6 +101,20 @@ Rails.application.configure do
   config.action_mailer.default_options[:reply_to]    = ENV['SMTP_REPLY_TO'] if ENV['SMTP_REPLY_TO'].present?
   config.action_mailer.default_options[:return_path] = ENV['SMTP_RETURN_PATH'] if ENV['SMTP_RETURN_PATH'].present?
 
+  enable_starttls = nil
+  enable_starttls_auto = nil
+
+  case env['SMTP_ENABLE_STARTTLS']
+  when 'always'
+    enable_starttls = true
+  when 'never'
+    enable_starttls = false
+  when 'auto'
+    enable_starttls_auto = true
+  else
+    enable_starttls_auto = ENV['SMTP_ENABLE_STARTTLS_AUTO'] != 'false'
+  end
+
   config.action_mailer.smtp_settings = {
     :port                 => ENV['SMTP_PORT'],
     :address              => ENV['SMTP_SERVER'],
@@ -110,7 +124,8 @@ Rails.application.configure do
     :authentication       => ENV['SMTP_AUTH_METHOD'] == 'none' ? nil : ENV['SMTP_AUTH_METHOD'] || :plain,
     :ca_file              => ENV['SMTP_CA_FILE'].presence || '/etc/ssl/certs/ca-certificates.crt',
     :openssl_verify_mode  => ENV['SMTP_OPENSSL_VERIFY_MODE'],
-    :enable_starttls_auto => ENV['SMTP_ENABLE_STARTTLS_AUTO'] != 'false',
+    :enable_starttls      => enable_starttls,
+    :enable_starttls_auto => enable_starttls_auto,
     :tls                  => ENV['SMTP_TLS'].presence && ENV['SMTP_TLS'] == 'true',
     :ssl                  => ENV['SMTP_SSL'].presence && ENV['SMTP_SSL'] == 'true',
   }

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -271,6 +271,7 @@ namespace :mastodon do
           env['SMTP_PORT'] = 25
           env['SMTP_AUTH_METHOD'] = 'none'
           env['SMTP_OPENSSL_VERIFY_MODE'] = 'none'
+          env['SMTP_ENABLE_STARTTLS'] = 'auto'
         else
           env['SMTP_SERVER'] = prompt.ask('SMTP server:') do |q|
             q.required true
@@ -299,6 +300,8 @@ namespace :mastodon do
           end
 
           env['SMTP_OPENSSL_VERIFY_MODE'] = prompt.select('SMTP OpenSSL verify mode:', %w(none peer client_once fail_if_no_peer_cert))
+
+          env['SMTP_ENABLE_STARTTLS'] = prompt.select('Enable STARTTLS:', %w(auto always never))
         end
 
         env['SMTP_FROM_ADDRESS'] = prompt.ask('E-mail address to send e-mails "from":') do |q|
@@ -312,6 +315,20 @@ namespace :mastodon do
         send_to = prompt.ask('Send test e-mail to:', required: true)
 
         begin
+          enable_starttls = nil
+          enable_starttls_auto = nil
+
+          case env['SMTP_ENABLE_STARTTLS']
+          when 'always'
+            enable_starttls = true
+          when 'never'
+            enable_starttls = false
+          when 'auto'
+            enable_starttls_auto = true
+          else
+            enable_starttls_auto = ENV['SMTP_ENABLE_STARTTLS_AUTO'] != 'false'
+          end
+
           ActionMailer::Base.smtp_settings = {
             port:                 env['SMTP_PORT'],
             address:              env['SMTP_SERVER'],
@@ -320,7 +337,8 @@ namespace :mastodon do
             domain:               env['LOCAL_DOMAIN'],
             authentication:       env['SMTP_AUTH_METHOD'] == 'none' ? nil : env['SMTP_AUTH_METHOD'] || :plain,
             openssl_verify_mode:  env['SMTP_OPENSSL_VERIFY_MODE'],
-            enable_starttls_auto: true,
+            enable_starttls:      enable_starttls,
+            enable_starttls_auto: enable_starttls_auto,
           }
 
           ActionMailer::Base.default_options = {

--- a/scalingo.json
+++ b/scalingo.json
@@ -74,8 +74,13 @@
       "description": "SMTP server certificate verification mode. Defaults is 'peer'.",
       "required": false
     },
+    "SMTP_ENABLE_STARTTLS": {
+      "description": "Enable STARTTLS? Default is 'auto'.",
+      "value": "auto",
+      "required": false
+    },
     "SMTP_ENABLE_STARTTLS_AUTO": {
-      "description": "Enable STARTTLS if SMTP server supports it? Default is true.",
+      "description": "Enable STARTTLS if SMTP server supports it? Deprecated by SMTP_ENABLE_STARTTLS.",
       "required": false
     },
     "BUILDPACK_URL": {


### PR DESCRIPTION
ENABLE_STARTTLS is designed to replace ENABLE_STARTTLS_AUTO by accepting three values: 'auto' (the default), 'always', and 'never'. If ENABLE_STARTTLS isn't provided, we fall back to ENABLE_STARTTLS_AUTO. In this way, this change should be fully backwards compatible.

Resolves #20311