### PR TITLE
Update Helm README and bump version

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/readme.md
+++ b/chart/readme.md
@@ -48,6 +48,24 @@ upgrading Mastodon versions, it may sometimes be necessary to manually delete
 the Rails and Sidekiq pods so that they are recreated against the latest
 migration.
 
+# Upgrades in 2.1.0
+
+## ingressClassName and tls-acme changes
+The annotations previously defaulting to nginx have been removed and support
+ for ingressClassName has been added.
+```yaml
+ingress:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+```
+
+To restore the old functionality simply add the above snippet to your `values.yaml`,
+but the recommendation is to replace these with `ingress.ingressClassName` and use
+cert-manager's issuer/cluster-issuer instead of tls-acme.
+If you're uncertain about your current setup leave `ingressClassName` empty and add
+`kubernetes.io/tls-acme` to `ingress.annotations` in your `values.yaml`.
+
 # Upgrades in 2.0.0
 
 ## Fixed labels

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -104,8 +104,11 @@ mastodon:
 ingress:
   enabled: true
   annotations:
-    #kubernetes.io/ingress.class: nginx
-    #kubernetes.io/tls-acme: "true"
+    # For choosing an ingress ingressClassName is preferred over annotations
+    # kubernetes.io/ingress.class: nginx
+    #
+    # To automatically request TLS certificates use one of the following
+    # kubernetes.io/tls-acme: "true"
     # cert-manager.io/cluster-issuer: "letsencrypt"
     #
     # ensure that NGINX's upload size matches Mastodon's


### PR DESCRIPTION
Updates the README with upgrading instructions and bumps next version to 2.2.0