### PR TITLE
Word break at any character for long domain names

### DIFF
--- a/app/javascript/mastodon/features/about/index.js
+++ b/app/javascript/mastodon/features/about/index.js
@@ -195,7 +195,7 @@ class About extends React.PureComponent {
                   <tbody>
                     {domainBlocks.get('items').map(block => (
                       <tr key={block.get('domain')}>
-                        <td><span title={`SHA-256: ${block.get('digest')}`}>{block.get('domain')}</span></td>
+                        <td className='about__domain-blocks__domain'><span title={`SHA-256: ${block.get('digest')}`}>{block.get('domain')}</span></td>
                         <td><span title={intl.formatMessage(severityMessages[block.get('severity')].explanation)}>{intl.formatMessage(severityMessages[block.get('severity')].title)}</span></td>
                         <td>{block.get('comment')}</td>
                       </tr>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8580,5 +8580,9 @@ noscript {
     td {
       padding: 8px;
     }
+
+    &__domain {
+      word-break: break-all;
+    }
   }
 }


### PR DESCRIPTION
Long domains can cause the blocked domains table to overflow the visible screen space. This fixes that by allowing the browser to wrap at any character break if a domain is causing such an overflow.

Fixes #20351