### PR TITLE
Add the option to configure external postgresql port

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/configmap-env.yaml
+++ b/chart/templates/configmap-env.yaml
@@ -7,12 +7,13 @@ metadata:
 data:
   {{- if .Values.postgresql.enabled }}
   DB_HOST: {{ template "mastodon.postgresql.fullname" . }}
+  DB_PORT: "5432"
   {{- else }}
   DB_HOST: {{ .Values.postgresql.postgresqlHostname }}
+  DB_PORT: {{ .Values.postgresql.postgresqlPort | default "5432" | quote }}
   {{- end }}
   DB_NAME: {{ .Values.postgresql.auth.database }}
   DB_POOL: {{ .Values.mastodon.sidekiq.concurrency | quote }}
-  DB_PORT: "5432"
   DB_USER: {{ .Values.postgresql.auth.username }}
   DEFAULT_LOCALE: {{ .Values.mastodon.locale }}
   {{- if .Values.elasticsearch.enabled }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -144,6 +144,7 @@ postgresql:
   # must match those of that external postgres instance
   enabled: true
   # postgresqlHostname: preexisting-postgresql
+  # postgresqlPort: 5432
   auth:
     database: mastodon_production
     username: mastodon


### PR DESCRIPTION
While the normal assumption of port `5432` for a postgresql server is pretty reliable I found that DigitalOcean puts them on a somewhat random port. This adds the ability to specify the port in the helm chart.