### PR TITLE
Fix minor visual issue with padding in the "Authorization required" page

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -1064,8 +1064,15 @@ code {
 
     &:last-child {
       border-bottom: 0;
-      padding-bottom: 0;
     }
+  }
+}
+
+// Only remove padding when listing applications, to prevent styling issues on
+// the Authorization page.
+.applications-list {
+  .permissions-list__item:last-child {
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
This fixes a styling issue on the Authorization page, where the bottom-most permission listed here had no padding, making the page look a bit off.

Before:

<img width="502" alt="Screen Shot 2022-11-10 at 6 15 16 PM" src="https://user-images.githubusercontent.com/2977353/201239535-e9ae82a4-b860-4533-aed4-a19dcf11ca8d.png">

After:

<img width="527" alt="Screen Shot 2022-11-10 at 6 15 04 PM" src="https://user-images.githubusercontent.com/2977353/201239556-f26b0da4-5792-478d-875b-8297197fb400.png">

This initial issue was caused by the changes in #17686, and I tried to avoid messing with the applications list styling while still fixing this minor visual issue.
