### PR TITLE
blurhash_transcoder: prevent out-of-bound reads with <8bpp images

### DIFF
--- a/lib/paperclip/blurhash_transcoder.rb
+++ b/lib/paperclip/blurhash_transcoder.rb
@@ -5,7 +5,7 @@ module Paperclip
     def make
       return @file unless options[:style] == :small || options[:blurhash]
 
-      pixels   = convert(':source RGB:-', source: File.expand_path(@file.path)).unpack('C*')
+      pixels   = convert(':source -depth 8 RGB:-', source: File.expand_path(@file.path)).unpack('C*')
       geometry = options.fetch(:file_geometry_parser).from_file(@file)
 
       attachment.instance.blurhash = Blurhash.encode(geometry.width, geometry.height, pixels, **(options[:blurhash] || {}))


### PR DESCRIPTION
Note: untested. I could not find any relevant unit tests for this code, and I have not yet redeployed my own instance. I also lack the knowledge of how to exactly hit this code path.

---

The Blurhash library used by Mastodon requires an input encoded as 24 bits raw RGB data. The conversion to raw RGB using Imagemagick did not previously specify the desired bit depth. In some situations, this leads Imagemagick to output in a pixel format using less bpp than expected. This then manifested as segfaults of the Sidekiq process due to out-of-bounds read, or potentially a (highly noisy) memory infoleak.

Fixes #19235.