### PR TITLE
Remove “No description added” media warning in edit mode

### DIFF
--- a/app/javascript/mastodon/features/compose/components/upload.js
+++ b/app/javascript/mastodon/features/compose/components/upload.js
@@ -47,7 +47,7 @@ export default class Upload extends ImmutablePureComponent {
                 {!isEditingStatus && (<button type='button' className='icon-button' onClick={this.handleFocalPointClick}><Icon id='pencil' /> <FormattedMessage id='upload_form.edit' defaultMessage='Edit' /></button>)}
               </div>
 
-              {(media.get('description') || '').length === 0 && (
+              {(media.get('description') || '').length === 0 && !isEditingStatus && (
                 <div className='compose-form__upload__warning'>
                   <button type='button' className='icon-button' onClick={this.handleFocalPointClick}><Icon id='info-circle' /> <FormattedMessage id='upload_form.description_missing' defaultMessage='No description added' /></button>
                 </div>


### PR DESCRIPTION
Editing media metadata is not currently possible in edit mode, the button would open the modal but saving the changes would error out.

Edition of already-posted media metadata is still planned, but for after 4.0.