### PR TITLE
fixes ArgumentError when proxy is used

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -281,7 +281,7 @@ class Request
 
   class ProxySocket < Socket
     class << self
-      def check_private_address(_address,_host)
+      def check_private_address(_address, _host)
         # Accept connections to private addresses as HTTP proxies will usually
         # be on local addresses
         nil

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -281,7 +281,7 @@ class Request
 
   class ProxySocket < Socket
     class << self
-      def check_private_address(_address)
+      def check_private_address(_address,_host)
         # Accept connections to private addresses as HTTP proxies will usually
         # be on local addresses
         nil


### PR DESCRIPTION
I updated my instance to 4.0.0rc2 recently, but after upgrading, I encountered a lot of errors in the logs like this:
```
Nov 11 14:41:58 rpi4 puma[774251]: [e05b7a66-463a-4154-a838-5f857ef0718e] method=GET path=/authorize_interaction format=html controller=AuthorizeInteractionsController action=show status=500 error='ArgumentError: wrong number of arguments (given 2, expected 1) on ** duration=53.95 view=0.00 db=5.66
Nov 11 14:41:58 rpi4 puma[774251]: [e05b7a66-463a-4154-a838-5f857ef0718e]
Nov 11 14:41:58 rpi4 puma[774251]: [e05b7a66-463a-4154-a838-5f857ef0718e] ArgumentError (wrong number of arguments (given 2, expected 1) on *:
Nov 11 14:41:58 rpi4 puma[774251]: [e05b7a66-463a-4154-a838-5f857ef0718e]
Nov 11 14:41:58 rpi4 puma[774251]: [e05b7a66-463a-4154-a838-5f857ef0718e] app/lib/request.rb:277:in `check_private_address'
```

After looking into the code, I found in #15605, `check_private_address(address)` was changed to `check_private_address(address, host)`
https://github.com/mastodon/mastodon/blob/1145dbd327ae9b56357cc488801d723051f58e0b/app/lib/request.rb#L267

but `ProxySocket` has not been updated, and my instance has proxy enabled:
https://github.com/mastodon/mastodon/blob/1145dbd327ae9b56357cc488801d723051f58e0b/app/lib/request.rb#L281-L289

Adding the new argument will fix this problem.