### PR TITLE
Guard against error extracting `body` from URL

### DIFF
--- a/app/models/account/field.rb
+++ b/app/models/account/field.rb
@@ -76,6 +76,7 @@ class Account::Field < ActiveModelSerializers::Model
   def extract_url_from_html
     doc = Nokogiri::HTML(value).at_xpath('//body')
 
+    return if doc.nil?
     return if doc.children.size > 1
 
     element = doc.children.first


### PR DESCRIPTION
If `Nokogiri::HTML(value).at_xpath('//body')` fails to find the `body` element, it will return `nil`. We can guard against that with an early return. Avoids calling `children` on `Nilclass` in those cases.