### PR TITLE
Stick batch table toolbar to the top (Fixes #20441)

### DIFF
--- a/app/javascript/styles/mastodon/tables.scss
+++ b/app/javascript/styles/mastodon/tables.scss
@@ -178,6 +178,9 @@ a.table-action-link {
   }
 
   &__toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 1;
     border: 1px solid darken($ui-base-color, 8%);
     background: $ui-base-color;
     border-radius: 4px 0 0;


### PR DESCRIPTION
When scrolling down, the header will stick to the top of the screen, allowing for a more pleasant moderation experience.

![image](https://user-images.githubusercontent.com/6217438/201428402-a62778a5-40aa-465e-9bb1-afa389803b7f.png)
