### PR TITLE
Use the Font Awesome id as Icon alt text unless decorative

### DIFF
--- a/app/javascript/mastodon/components/icon.js
+++ b/app/javascript/mastodon/components/icon.js
@@ -8,13 +8,14 @@ export default class Icon extends React.PureComponent {
     id: PropTypes.string.isRequired,
     className: PropTypes.string,
     fixedWidth: PropTypes.bool,
+    decorative: PropTypes.bool,
   };
 
   render () {
-    const { id, className, fixedWidth, ...other } = this.props;
+    const { id, className, fixedWidth, decorative, ...other } = this.props;
 
     return (
-      <i role='img' className={classNames('fa', `fa-${id}`, className, { 'fa-fw': fixedWidth })} {...other} />
+      <i role={decorative ? undefined : 'img'} className={classNames('fa', `fa-${id}`, className, { 'fa-fw': fixedWidth })} alt={decorative ? undefined : id} {...other} />
     );
   }
 

--- a/app/javascript/mastodon/components/icon_button.js
+++ b/app/javascript/mastodon/components/icon_button.js
@@ -125,7 +125,7 @@ export default class IconButton extends React.PureComponent {
 
     let contents = (
       <React.Fragment>
-        <Icon id={icon} fixedWidth aria-hidden='true' /> {typeof counter !== 'undefined' && <span className='icon-button__counter'><AnimatedNumber value={counter} obfuscate={obfuscateCount} /></span>}
+        <Icon id={icon} fixedWidth decorative /> {typeof counter !== 'undefined' && <span className='icon-button__counter'><AnimatedNumber value={counter} obfuscate={obfuscateCount} /></span>}
       </React.Fragment>
     );
 


### PR DESCRIPTION
Screen readers identify and announce images without labels as "image" or similar, which conveys very little meaning without any alt text.

Font Awesome icons are identified by a label that usually (always?) describes their appearance, so using that label as the default `alt` feels sensible. We then provide an escape hatch to treat the icon as decorative only by not setting the role.

Relates to #20445

I've not done a thorough review of `Icon` usage to know the full impact of this, but it seems like a sensible default to me. I'm very happy to be challenged on that.