### PR TITLE
fix: handle nil doc children in extract_url_from_html 

### DIFF
--- a/app/models/account/field.rb
+++ b/app/models/account/field.rb
@@ -76,8 +76,8 @@ class Account::Field < ActiveModelSerializers::Model
   def extract_url_from_html
     doc = Nokogiri::HTML(value).at_xpath('//body')
 
-    return if doc.nil?
-    return if doc.children.size > 1
+    # check that there is exactly one child
+    return if (doc&.children&.size || 0) != 1
 
     element = doc.children.first
 


### PR DESCRIPTION
Should fix #20450 , which has the following stack trace:


```
mastodon-web-1        | NoMethodError (undefined method `children' for nil:NilClass):
mastodon-web-1        |   
mastodon-web-1        | app/models/account/field.rb:79:in `extract_url_from_html'
mastodon-web-1        | app/models/account/field.rb:32:in `value_for_verification'
mastodon-web-1        | app/models/account/field.rb:38:in `verifiable?'
mastodon-web-1        | app/models/account/field.rb:55:in `requires_verification?'
mastodon-web-1        | app/services/activitypub/process_account_service.rb:43:in `any?'
mastodon-web-1        | app/services/activitypub/process_account_service.rb:43:in `call'
mastodon-web-1        | app/services/activitypub/fetch_remote_actor_service.rb:38:in `call'
mastodon-web-1        | app/services/resolve_url_service.rb:26:in `process_url'
mastodon-web-1        | app/services/resolve_url_service.rb:16:in `call'
mastodon-web-1        | app/services/search_service.rb:83:in `url_resource'
mastodon-web-1        | app/services/search_service.rb:16:in `block in call'
mastodon-web-1        | app/services/search_service.rb:12:in `call'
mastodon-web-1        | app/controllers/api/v2/search_controller.rb:33:in `search_results'
mastodon-web-1        | app/controllers/api/v2/search_controller.rb:12:in `index'
mastodon-web-1        | app/controllers/concerns/localized.rb:11:in `set_locale'
mastodon-web-1        | lib/mastodon/rack_middleware.rb:9:in `call'
```