### PR TITLE
chart: allow to disable migrate job to fix a broken deployment

### DIFF
--- a/chart/templates/job-db-migrate.yaml
+++ b/chart/templates/job-db-migrate.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mastodon.migrate.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -75,3 +76,4 @@ spec:
             - name: system
               mountPath: /opt/mastodon/public/system
           {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -19,6 +19,11 @@ mastodon:
     enabled: false
     username: not_gargron
     email: not@example.com
+  # Run database migration before upgrade.
+  migrate:
+    # This should always be enabled, but can be turned off if you want to redeploy to fix a failing database. Otherwise,
+    # the pre-upgrade migrate job would never succeed, preventing the upgrade to be applied.
+    enabled: true
   cron:
     # run `tootctl media remove` every week
     removeMedia:


### PR DESCRIPTION
If you tweak the postgres subchart in a bad way and leave it in a broken state, the migrate job will prevent a subsequent upgrade from fixing the database, as the upgrade job will fail to connect to the existing broken one and prevent the update from applying anything.

This PR adds a simple flag that you can tweak to perform an emergency deployment without running the upgrade job.