### PR TITLE
chart: allow to specify resouces and replicas per-deployment

### DIFF
--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "mastodon.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.mastodon.sidekiq.replicaCount | default .Values.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -118,8 +118,13 @@ spec:
             - name: system
               mountPath: /opt/mastodon/public/system
           {{- end }}
+          {{- if .Values.mastodon.sidekiq.resources }}
+          resources:
+            {{- toYaml .Values.mastodon.sidekiq.resources | nindent 12 }}
+          {{- else if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/deployment-streaming.yaml
+++ b/chart/templates/deployment-streaming.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "mastodon.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.mastodon.streaming.replicaCount | default .Values.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -72,9 +72,12 @@ spec:
             httpGet:
               path: /api/v1/streaming/health
               port: streaming
-          {{- with .Values.resources }}
+          {{- if .Values.mastodon.streaming.resources }}
           resources:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .Values.mastodon.streaming.resources | nindent 12 }}
+          {{- else if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "mastodon.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.mastodon.web.replicaCount | default .Values.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
@@ -112,9 +112,12 @@ spec:
               port: http
             failureThreshold: 30
             periodSeconds: 5
-          {{- with .Values.resources }}
+          {{- if .Values.mastodon.web.resources }}
           resources:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .Values.mastodon.web.resources | nindent 12 }}
+          {{- else if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
It is likely that different components have different scaling and/or resourcing needs. For example, as far as I understand, I probably want to scale and spec more aggressively my sidekiq pods than the web or streaming pods.

This PR allows the helm chart to look for `mastodon.$component.resources` and `mastodon.$component.replicaCount` and use those for `$component` (sidekiq, streaming, or web) instead of the general ones if they are defined. If they are not, which is the default, the general ones at the root of the values are used.