### PR TITLE
Fix casing and spacing of words

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -608,7 +608,7 @@ en:
         other: "%{count} users"
       categories:
         administration: Administration
-        devops: Devops
+        devops: DevOps
         invites: Invites
         moderation: Moderation
         special: Special
@@ -659,7 +659,7 @@ en:
         view_audit_log_description: Allows users to see a history of administrative actions on the server
         view_dashboard: View Dashboard
         view_dashboard_description: Allows users to access the dashboard and various metrics
-        view_devops: Devops
+        view_devops: DevOps
         view_devops_description: Allows users to access Sidekiq and pgHero dashboards
       title: Roles
     rules:
@@ -1374,7 +1374,7 @@ en:
     browser: Browser
     browsers:
       alipay: Alipay
-      blackberry: Blackberry
+      blackberry: BlackBerry
       chrome: Chrome
       edge: Microsoft Edge
       electron: Electron
@@ -1388,7 +1388,7 @@ en:
       phantom_js: PhantomJS
       qq: QQ Browser
       safari: Safari
-      uc_browser: UCBrowser
+      uc_browser: UC Browser
       weibo: Weibo
     current_session: Current session
     description: "%{browser} on %{platform}"
@@ -1397,8 +1397,8 @@ en:
     platforms:
       adobe_air: Adobe Air
       android: Android
-      blackberry: Blackberry
-      chrome_os: Chrome OS
+      blackberry: BlackBerry
+      chrome_os: ChromeOS
       firefox_os: Firefox OS
       ios: iOS
       linux: Linux


### PR DESCRIPTION
- `Blackberry` -> `BlackBerry`
- `Chrome OS` -> `ChromeOS`
- `Devops` -> `DevOps`
- `UCBrowser` -> `UC Browser`

References: [BlackBerry](https://www.blackberry.com), [ChromeOS](https://www.google.com/chromebook/chrome-os/), [DevOps](https://en.wikipedia.org/wiki/DevOps), [UC Browser](https://www.ucweb.com)