### PR TITLE
Allow unsetting x-amz-acl S3 Permission headers

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -67,6 +67,12 @@ if ENV['S3_ENABLED'] == 'true'
       retry_limit: 0,
     }
   )
+  
+  if ENV['S3_PERMISSION'] == ''
+    Paperclip::Attachment.default_options.merge!(
+      s3_permissions: ->(*) { nil }
+    )
+  end
 
   if ENV.has_key?('S3_ENDPOINT')
     Paperclip::Attachment.default_options[:s3_options].merge!(


### PR DESCRIPTION
Some "S3 Compatible" storage providers (Cloudflare R2 is one such example) don't support setting ACLs on individual uploads with the `x-amz-acl` header, and instead just have a visibility for the whole bucket. To support uploads to such providers without getting unsupported errors back, lets use a blank `S3_PERMISSION` env var to indicate that these headers shouldn't be sent.

This is tested as working with Cloudflare R2.