### PR TITLE
Clean up GitHub sourced gem entry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'
 gem 'tzinfo-data', '~> 1.2022'
 gem 'webpacker', '~> 5.4'
-gem 'webpush', git: 'https://github.com/ClearlyClaire/webpush.git', ref: 'f14a4d52e201128b1b00245d11b6de80d6cfdcd9'
+gem 'webpush', github: 'ClearlyClaire/webpush', ref: 'f14a4d52e201128b1b00245d11b6de80d6cfdcd9'
 gem 'webauthn', '~> 2.5'
 
 gem 'json-ld'


### PR DESCRIPTION
Super quick cleanup to use the GitHub `Gemfile` shorthand syntax.

> If you are getting your gems from a public GitHub repository, you can use the shorthand
> 
> `gem 'rack', github: 'rack/rack'`
> 
> https://bundler.io/guides/git.html