### PR TITLE
Turn off RuboCop extension suggestions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
 AllCops:
   TargetRubyVersion: 2.5
   NewCops: disable
+  SuggestExtensions: false
   Exclude:
     - 'spec/**/*'
     - 'db/**/*'


### PR DESCRIPTION
Simply turning off extension suggestions so we can stop seeing this message.

![image](https://user-images.githubusercontent.com/1557529/201511584-8a80ae5d-8e1b-4d25-a948-4f55093dd838.png)

Alternative to adding `rubocop-rpec`, see below.
- https://github.com/mastodon/mastodon/pull/20557