### PR TITLE
Fix public/local timeline posts not being properly filtered

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -681,7 +681,7 @@ const startWorker = async (workerId) => {
           queries.push(client.query('SELECT 1 FROM account_domain_blocks WHERE account_id = $1 AND domain = $2', [req.accountId, accountDomain]));
         }
 
-        if (!unpackedPayload.filter_results && !req.cachedFilters) {
+        if (!unpackedPayload.filtered && !req.cachedFilters) {
           queries.push(client.query('SELECT filter.id AS id, filter.phrase AS title, filter.context AS context, filter.expires_at AS expires_at, filter.action AS filter_action, keyword.keyword AS keyword, keyword.whole_word AS whole_word FROM custom_filter_keywords keyword JOIN custom_filters filter ON keyword.custom_filter_id = filter.id WHERE filter.account_id = $1 AND filter.expires_at IS NULL OR filter.expires_at > NOW()', [req.accountId]));
         }
 
@@ -692,7 +692,7 @@ const startWorker = async (workerId) => {
             return;
           }
 
-          if (!unpackedPayload.filter_results && !req.cachedFilters) {
+          if (!unpackedPayload.filtered && !req.cachedFilters) {
             const filterRows = values[accountDomain ? 2 : 1].rows;
 
             req.cachedFilters = filterRows.reduce((cache, row) => {
@@ -735,18 +735,18 @@ const startWorker = async (workerId) => {
           }
 
           // Check filters
-          if (req.cachedFilters && !unpackedPayload.filter_results) {
+          if (req.cachedFilters && !unpackedPayload.filtered) {
             const status = unpackedPayload;
             const searchContent = ([status.spoiler_text || '', status.content].concat((status.poll && status.poll.options) ? status.poll.options.map(option => option.title) : [])).concat(status.media_attachments.map(att => att.description)).join('\n\n').replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n');
             const searchIndex = JSDOM.fragment(searchContent).textContent;
 
             const now = new Date();
-            payload.filter_results = [];
+            payload.filtered = [];
             Object.values(req.cachedFilters).forEach((cachedFilter) => {
               if ((cachedFilter.expires_at === null || cachedFilter.expires_at > now)) {
                 const keyword_matches = searchIndex.match(cachedFilter.regexp);
                 if (keyword_matches) {
-                  payload.filter_results.push({
+                  payload.filtered.push({
                     filter: cachedFilter.repr,
                     keyword_matches,
                   });

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -707,7 +707,7 @@ const startWorker = async (workerId) => {
                     title: row.title,
                     context: row.context,
                     expires_at: row.expires_at,
-                    filter_action: row.filter_action,
+                    filter_action: ['warn', 'hide'][row.filter_action],
                   },
                 };
               }


### PR DESCRIPTION
The streaming server was checking and setting an obsolete attribute name for filter results, so fixed that. It was also not properly representing some filter values.

This also fixes the streaming server redundantly applying filters for Home and List timelines.