### PR TITLE
linting: RuboCop update, config fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 require:
   - rubocop-rails
+  - rubocop-rspec
+  - rubocop-performance
 
 AllCops:
   TargetRubyVersion: 2.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -313,3 +313,14 @@ Style/TrailingCommaInHashLiteral:
 
 Style/UnpackFirst:
   Enabled: false
+
+RSpec/ScatteredSetup:
+  Enabled: false
+RSpec/ImplicitExpect:
+  Enabled: false
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/DescribeClass:
+  Enabled: false
+RSpec/LetSetup:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   TargetRubyVersion: 2.7
   NewCops: disable
   Exclude:
-    - 'db/**/*'
+    - db/schema.rb
     - 'app/views/**/*'
     - 'config/**/*'
     - 'bin/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,6 @@ AllCops:
   TargetRubyVersion: 2.7
   NewCops: disable
   Exclude:
-    - 'spec/**/*'
     - 'db/**/*'
     - 'app/views/**/*'
     - 'config/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,12 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.7
-  NewCops: disable
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  ExtraDetails: true
+  UseCache: true
+  CacheRootDirectory: tmp
+  NewCops: enable
   Exclude:
     - db/schema.rb
     - 'app/views/**/*'
@@ -68,15 +73,57 @@ Lint/UselessAccessModifier:
     - class_methods
 
 Metrics/AbcSize:
-  Max: 115
+  Max: 34 # RuboCop default 17
   Exclude:
-    - 'lib/mastodon/*_cli.rb'
+    - 'lib/**/*cli*.rb'
+    - db/*migrate/**/*
+    - lib/paperclip/color_extractor.rb
+    - app/workers/scheduler/follow_recommendations_scheduler.rb
+    - app/services/activitypub/fetch*_service.rb
+    - lib/paperclip/**/*
+  CountRepeatedAttributes: false
+  AllowedMethods:
+    - update_media_attachments!
+    - account_link_to
+    - attempt_oembed
+    - build_crutches
+    - calculate_scores
+    - cc
+    - dump_actor!
+    - filter_from_home?
+    - hydrate
+    - import_bookmarks!
+    - import_relationships!
+    - initialize
+    - link_to_mention
+    - log_target
+    - matches_time_window?
+    - parse_metadata
+    - perform_statuses_search!
+    - privatize_media_attachments!
+    - process_update
+    - publish_media_attachments!
+    - remotable_attachment
+    - render_initial_state
+    - render_with_cache
+    - searchable_by
+    - self.cached_filters_for
+    - set_fetchable_attributes!
+    - signed_request_actor
+    - statuses_to_delete
+    - update_poll!
 
 Metrics/BlockLength:
   Max: 55
   Exclude:
-    - 'lib/tasks/**/*'
     - 'lib/mastodon/*_cli.rb'
+  CountComments: false
+  CountAsOne: [array, heredoc]
+  AllowedMethods:
+    - task
+    - namespace
+    - class_methods
+    - included
 
 Metrics/BlockNesting:
   Max: 3
@@ -86,34 +133,144 @@ Metrics/BlockNesting:
 Metrics/ClassLength:
   CountComments: false
   Max: 500
+  CountAsOne: [array, heredoc]
   Exclude:
     - 'lib/mastodon/*_cli.rb'
 
 Metrics/CyclomaticComplexity:
-  Max: 25
+  Max: 12
   Exclude:
-    - 'lib/mastodon/*_cli.rb'
+    - lib/mastodon/*cli*.rb
+    - db/*migrate/**/*
+  AllowedMethods:
+    - attempt_oembed
+    - blocked?
+    - build_crutches
+    - calculate_scores
+    - cc
+    - discover_endpoint!
+    - filter_from_home?
+    - hydrate
+    - klass
+    - link_to_mention
+    - log_target
+    - matches_time_window?
+    - patch_for_forwarding!
+    - preprocess_attributes!
+    - process_update
+    - remotable_attachment
+    - scan_text!
+    - self.cached_filters_for
+    - set_fetchable_attributes!
+    - setup_redis_env_url
+    - update_media_attachments!
 
 Layout/LineLength:
+  Max: 140 # RuboCop default 120
+  AllowHeredoc: true
   AllowURI: true
-  Enabled: false
+  IgnoreCopDirectives: true
+  AllowedPatterns:
+    # Allow comments to be long lines
+    - !ruby/regexp / \# .*$/
+    - !ruby/regexp /^\# .*$/
+  Exclude:
+    - lib/**/*cli*.rb
+    - db/*migrate/**/*
+    - db/seeds/**/*
 
 Metrics/MethodLength:
   CountComments: false
-  Max: 65
+  CountAsOne: [array, heredoc]
+  Max: 25 # RuboCop default 10
   Exclude:
     - 'lib/mastodon/*_cli.rb'
+  AllowedMethods:
+    - account_link_to
+    - attempt_oembed
+    - body_with_limit
+    - build_crutches
+    - cached_filters_for
+    - calculate_scores
+    - check_webfinger!
+    - clean_feeds!
+    - collection_items
+    - collection_presenter
+    - copy_account_notes!
+    - deduplicate_accounts!
+    - deduplicate_conversations!
+    - deduplicate_local_accounts!
+    - deduplicate_statuses!
+    - deduplicate_tags!
+    - deduplicate_users!
+    - discover_endpoint!
+    - extract_extra_uris_with_indices
+    - extract_hashtags_with_indices
+    - extract_mentions_or_lists_with_indices
+    - filter_from_home?
+    - from_elasticsearch
+    - handle_explicit_update!
+    - handle_mark_as_sensitive!
+    - hsl_to_rgb
+    - import_bookmarks!
+    - import_domain_blocks!
+    - import_relationships!
+    - ldap_options
+    - matches_time_window?
+    - outbox_presenter
+    - pam_get_user
+    - parallelize_with_progress
+    - parse_and_transform
+    - patch_for_forwarding!
+    - populate_home
+    - post_process_style
+    - preload_cache_collection_target_statuses
+    - privatize_media_attachments!
+    - provides_callback_for
+    - publish_media_attachments!
+    - relevant_account_timestamp
+    - remotable_attachment
+    - rgb_to_hsl
+    - rss_status_content_format
+    - set_fetchable_attributes!
+    - setup_redis_env_url
+    - signed_request_actor
+    - to_preview_card_attributes
+    - upgrade_storage_filesystem
+    - upgrade_storage_s3
+    - user_settings_params
+    - hydrate
+    - cc
+    - self_destruct
 
 Metrics/ModuleLength:
   CountComments: false
   Max: 200
+  CountAsOne: [array, heredoc]
 
 Metrics/ParameterLists:
-  Max: 5
-  CountKeywordArgs: true
+  Max: 5 # RuboCop default 5
+  CountKeywordArgs: true  # RuboCop default true
+  MaxOptionalParameters: 3 # RuboCop default 3
+  Exclude:
+    - app/models/concerns/account_interactions.rb
+    - app/services/activitypub/fetch_remote_account_service.rb
+    - app/services/activitypub/fetch_remote_actor_service.rb
 
 Metrics/PerceivedComplexity:
-  Max: 25
+  Max: 16 # RuboCop default 8
+  AllowedMethods:
+    - attempt_oembed
+    - build_crutches
+    - calculate_scores
+    - deduplicate_users!
+    - discover_endpoint!
+    - filter_from_home?
+    - hydrate
+    - patch_for_forwarding!
+    - process_update
+    - remove_orphans
+    - update_media_attachments!
 
 Naming/MemoizedInstanceVariableName:
   Enabled: false
@@ -268,9 +425,6 @@ Style/PercentLiteralDelimiters:
 Style/PerlBackrefs:
   AutoCorrect: false
 
-Style/RedundantAssignment:
-  Enabled: false
-
 Style/RedundantFetchBlock:
   Enabled: true
 
@@ -293,7 +447,7 @@ Style/RegexpLiteral:
   Enabled: false
 
 Style/RescueStandardError:
-  Enabled: false
+  Enabled: true
 
 Style/SignalException:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,10 @@ group :development, :test do
   gem 'pry-byebug', '~> 3.10'
   gem 'pry-rails', '~> 0.3'
   gem 'rspec-rails', '~> 5.1'
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
+  gem 'rubocop', require: false
 end
 
 group :production, :test do
@@ -134,8 +138,6 @@ group :development do
   gem 'letter_opener', '~> 1.8'
   gem 'letter_opener_web', '~> 2.0'
   gem 'memory_profiler'
-  gem 'rubocop', '~> 1.30', require: false
-  gem 'rubocop-rails', '~> 2.15', require: false
   gem 'brakeman', '~> 5.4', require: false
   gem 'bundler-audit', '~> 0.9', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,21 +578,27 @@ GEM
     rspec-support (3.11.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.30.1)
+    rubocop (1.39.0)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.18.0, < 2.0)
+      rubocop-ast (>= 1.23.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.18.0)
+    rubocop-ast (1.23.0)
       parser (>= 3.1.1.0)
-    rubocop-rails (2.15.0)
+    rubocop-performance (1.15.1)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.17.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
-      rubocop (>= 1.7.0, < 2.0)
+      rubocop (>= 1.33.0, < 2.0)
+    rubocop-rspec (2.15.0)
+      rubocop (~> 1.33)
     ruby-progressbar (1.11.0)
     ruby-saml (1.13.0)
       nokogiri (>= 1.10.5)
@@ -725,7 +731,7 @@ GEM
     xorcist (1.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby
@@ -829,8 +835,10 @@ DEPENDENCIES
   rspec-rails (~> 5.1)
   rspec-sidekiq (~> 3.1)
   rspec_junit_formatter (~> 0.6)
-  rubocop (~> 1.30)
-  rubocop-rails (~> 2.15)
+  rubocop
+  rubocop-performance
+  rubocop-rails
+  rubocop-rspec
   ruby-progressbar (~> 1.11)
   sanitize (~> 6.0)
   scenic (~> 1.6)
@@ -855,3 +863,9 @@ DEPENDENCIES
   webpacker (~> 5.4)
   webpush!
   xorcist (~> 1.1)
+
+RUBY VERSION
+   ruby 3.0.4p208
+
+BUNDLED WITH
+   2.2.33


### PR DESCRIPTION
# RuboCop update and gem group

- update rubocop and rubocop-rails gems
- add rubocop-rspec and rubocop-performance gems
- move all rubocop gems to the `:development, :test` gem group – because only then RuboCop could run in a pipeline that runs with RAILS_ENV=test

# fix RuboCop config and excludes

[fix(rubocop): tune rules configs](https://github.com/mastodon/mastodon/pull/20574/commits/12d511abaf4d145259ef029059e374898ed1f21c) 

Bunch of commits squashed:

fix(rubocop): enable Layout/LineLength cop

Because this project has code with line lenghts > 500 chars.
This is not good practice at all, so I strongly suggest to
change the practice in the future.

But allow heredoc, URI and comments to still be long lines
and make the default Max: 120 explicit, by repeating it in the
config. To me this max length seems reasonable. Perhaps
a bit more could be ok for some. But > 500 chars in one line
Seems to be way too long IMHO.

fix(rubocop): Metrics/CyclomaticComplexity Max to 12

The default is 7, perhaps quite strict. But 25 is too loose,
the rule becomes pointless like that.

fix(rubocop): AllCops ruby version, cacheing and more info

- fix the target ruby version from 2.5 to 3.0
- have the cop error messages to be more informative and helpful
- enable cacheing in /tmp

fix(rubocop): Metrics/AbcSize to 34 from 115

Rubocops default is 17. If the rule is at 115 is becomes
pointless.

fix(rubocop): Metrics/BlockLength improvements

- instead of ignoring tasks completely, ignore only the
  long blocks that are specific to tasks (task, namespace)
- ignore also concern specific block methods (included, class_methods)

fix(rubocop): Metrics/ClassLength count heredoc array as one line

fix(rubocop): Metrics/MethodLength Max to 25

- the default is 10, but 65 is too loose, so perhaps 25?

fix(rubocop): Metrics/ModuleLength array and heredoc count as one

fix(rubocop): Metrics/PerceivedComplexity to 16 from 25

Rubocops default is 8, so how about only doubling that, instead
of > than tripple it?

fix(rubocop): enable Style/RedundantAssignment

Because I think that this rule would never really hurt,
but improve code quality and readability.

fix(rubocop): enable Style/RescueStandardError

I think everyone that ever had to debug what this can bring
will hopefully agree that this rule totally makes sense.
In the super rare exeptions where this is totally needed,
it can be excluded by disabling comment in that place.

fix(rubocop): Metrics/ParameterLists add explicit defaults and some excludes