### PR TITLE
Fix announcement dates not being validated client-side

### DIFF
--- a/app/views/admin/announcements/edit.html.haml
+++ b/app/views/admin/announcements/edit.html.haml
@@ -4,7 +4,7 @@
 - content_for :header_tags do
   = javascript_pack_tag 'admin', async: true, crossorigin: 'anonymous'
 
-= simple_form_for @announcement, url: admin_announcement_path(@announcement) do |f|
+= simple_form_for @announcement, url: admin_announcement_path(@announcement), html: { novalidate: false } do |f|
   = render 'shared/error_messages', object: @announcement
 
   .fields-group

--- a/app/views/admin/announcements/new.html.haml
+++ b/app/views/admin/announcements/new.html.haml
@@ -4,7 +4,7 @@
 - content_for :header_tags do
   = javascript_pack_tag 'admin', async: true, crossorigin: 'anonymous'
 
-= simple_form_for @announcement, url: admin_announcements_path do |f|
+= simple_form_for @announcement, url: admin_announcements_path, html: { novalidate: false } do |f|
   = render 'shared/error_messages', object: @announcement
 
   .fields-group


### PR DESCRIPTION
Otherwise, it's easy for admins to overlook an incomplete date-time entry and get the announcement saved without that info.