### PR TITLE
Fix icons having an image role

### DIFF
--- a/app/javascript/mastodon/components/icon.js
+++ b/app/javascript/mastodon/components/icon.js
@@ -14,7 +14,7 @@ export default class Icon extends React.PureComponent {
     const { id, className, fixedWidth, ...other } = this.props;
 
     return (
-      <i role='img' className={classNames('fa', `fa-${id}`, className, { 'fa-fw': fixedWidth })} {...other} />
+      <i className={classNames('fa', `fa-${id}`, className, { 'fa-fw': fixedWidth })} {...other} />
     );
   }
 


### PR DESCRIPTION
Icons are mainly used within buttons that have their own text or labels. The icon is a decorative element and as such does not require this role or its own independent label.