### PR TITLE
Add 'private' to Cache-Control, match Rails expectations

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -129,7 +129,7 @@ class Api::BaseController < ApplicationController
   end
 
   def set_cache_headers
-    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Cache-Control'] = 'private, no-store'
   end
 
   def disallow_unauthenticated_api_access?

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -154,6 +154,6 @@ class Auth::RegistrationsController < Devise::RegistrationsController
   end
 
   def set_cache_headers
-    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Cache-Control'] = 'private, no-store'
   end
 end

--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -30,6 +30,6 @@ class Oauth::AuthorizationsController < Doorkeeper::AuthorizationsController
   end
 
   def set_cache_headers
-    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Cache-Control'] = 'private, no-store'
   end
 end

--- a/app/controllers/settings/base_controller.rb
+++ b/app/controllers/settings/base_controller.rb
@@ -14,7 +14,7 @@ class Settings::BaseController < ApplicationController
   end
 
   def set_cache_headers
-    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Cache-Control'] = 'private, no-store'
   end
 
   def require_not_suspended!


### PR DESCRIPTION
Several controlers set quite intricate Cache-Control headers in order to hopefully not be cached by any intermediate proxies or local caches. Unfortunately, these headers are processed by ActionDispatch::HTTP::Cache in a way that squashes and discards any values set alongside no-store other than private: https://github.com/rails/rails/blob/8015c2c2cf5c8718449677570f372ceb01318a32/actionpack/lib/action_dispatch/http/cache.rb#L207-L209

We want to preserve no-store on these responses, but we might as well remove parts that are going to be dropped anyway. As many of the endpoints in these controllers are private to a particular user, we should also add "private", which will be preserved alongside no-store.