### PR TITLE
Add `Cache-Control` header to openstack-stored files

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -125,6 +125,8 @@ elsif ENV['SWIFT_ENABLED'] == 'true'
       openstack_region: ENV['SWIFT_REGION'],
       openstack_cache_ttl: ENV.fetch('SWIFT_CACHE_TTL') { 60 },
     },
+    
+    fog_file: { 'Cache-Control' => 'public, max-age=315576000, immutable' },
 
     fog_directory: ENV['SWIFT_CONTAINER'],
     fog_host: ENV['SWIFT_OBJECT_URL'],


### PR DESCRIPTION
When storing files in S3, paperclip is configured with a Cache-Control header indicating the file is immutable, however no such header was added when using OpenStack storage.

Luckily Paperclip's fog integration makes this trivial, with a simple `fog_file` `Cache-Control` default doing the trick.