### PR TITLE
Fix rules with same priority being sorted non-deterministically

### DIFF
--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -18,5 +18,5 @@ class Rule < ApplicationRecord
 
   validates :text, presence: true, length: { maximum: 300 }
 
-  scope :ordered, -> { kept.order(priority: :asc) }
+  scope :ordered, -> { kept.order(priority: :asc, id: :asc) }
 end


### PR DESCRIPTION
Apparently there is a `priority` column I forgot to ever expose in the admin UI, so it's always 0, which means ordering by it was falling back to PostgreSQL internal order. It's too late to add a new form field now but at least we can make the rules not jump around when you edit them.