### PR TITLE
Fix image type not being set after conversion for convertible image types

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -82,6 +82,7 @@ class MediaAttachment < ApplicationRecord
   IMAGE_CONVERTED_STYLES = {
     original: {
       format: 'jpeg',
+      content_type: 'image/jpeg',
     }.merge(IMAGE_STYLES[:original]).freeze,
 
     small: {


### PR DESCRIPTION
E.g. media attachment was still recorded as being `image/heic` even after conversion to JPEG.