### PR TITLE
Be clearer about who can see DMs

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -48,7 +48,7 @@ const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning
   if (directMessageWarning) {
     const message = (
       <span>
-        <FormattedMessage id='compose_form.encryption_warning' defaultMessage='Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a>
+        <FormattedMessage id='compose_form.encryption_warning' defaultMessage='Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a>
       </span>
     );
 

--- a/app/javascript/mastodon/features/direct_timeline/index.js
+++ b/app/javascript/mastodon/features/direct_timeline/index.js
@@ -92,7 +92,7 @@ class DirectTimeline extends React.PureComponent {
           scrollKey={`direct_timeline-${columnId}`}
           timelineId='direct'
           onLoadMore={this.handleLoadMore}
-          prepend={<div className='follow_requests-unlocked_explanation'><span><FormattedMessage id='compose_form.encryption_warning' defaultMessage='Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a></span></div>}
+          prepend={<div className='follow_requests-unlocked_explanation'><span><FormattedMessage id='compose_form.encryption_warning' defaultMessage='Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.' /> <a href='/terms' target='_blank'><FormattedMessage id='compose_form.direct_message_warning_learn_more' defaultMessage='Learn more' /></a></span></div>}
           emptyMessage={<FormattedMessage id='empty_column.direct' defaultMessage="You don't have any direct messages yet. When you send or receive one, it will show up here." />}
         />
 

--- a/app/javascript/mastodon/locales/ast.json
+++ b/app/javascript/mastodon/locales/ast.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Camudar la llingua",
   "compose.language.search": "Buscar llingües…",
   "compose_form.direct_message_warning_learn_more": "Saber más",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/bn.json
+++ b/app/javascript/mastodon/locales/bn.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "আরো জানুন",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "কোনো হ্যাশট্যাগের ভেতরে এই টুটটি থাকবেনা কারণ এটি তালিকাবহির্ভূত। শুধুমাত্র প্রকাশ্য ঠোটগুলো হ্যাশট্যাগের ভেতরে খুঁজে পাওয়া যাবে।",
   "compose_form.lock_disclaimer": "আপনার নিবন্ধনে তালা দেওয়া নেই, যে কেও আপনাকে অনুসরণ করতে পারবে এবং অনুশারকদের জন্য লেখা দেখতে পারবে।",
   "compose_form.lock_disclaimer.lock": "তালা দেওয়া",

--- a/app/javascript/mastodon/locales/ckb.json
+++ b/app/javascript/mastodon/locales/ckb.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "زیاتر فێربه",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "ئەم توتە لە ژێر هیچ هاشتاگییەک دا ناکرێت وەک ئەوەی لە لیستەکەدا نەریزراوە. تەنها توتی گشتی دەتوانرێت بە هاشتاگی بگەڕێت.",
   "compose_form.lock_disclaimer": "هەژمێرەکەی لە حاڵەتی {locked}. هەر کەسێک دەتوانێت شوێنت بکەوێت بۆ پیشاندانی بابەتەکانی تەنها دوایخۆی.",
   "compose_form.lock_disclaimer.lock": "قفڵ دراوە",

--- a/app/javascript/mastodon/locales/co.json
+++ b/app/javascript/mastodon/locales/co.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Amparà di più",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "Stu statutu ùn hè \"Micca listatu\" è ùn sarà micca listatu indè e circate da hashtag. Per esse vistu in quesse, u statutu deve esse \"Pubblicu\".",
   "compose_form.lock_disclaimer": "U vostru contu ùn hè micca {locked}. Tuttu u mondu pò seguitavi è vede i vostri statuti privati.",
   "compose_form.lock_disclaimer.lock": "privatu",

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -1776,7 +1776,7 @@
         "id": "compose_form.hashtag_warning"
       },
       {
-        "defaultMessage": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+        "defaultMessage": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
         "id": "compose_form.encryption_warning"
       },
       {
@@ -1888,7 +1888,7 @@
         "id": "column.direct"
       },
       {
-        "defaultMessage": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+        "defaultMessage": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
         "id": "compose_form.encryption_warning"
       },
       {

--- a/app/javascript/mastodon/locales/et.json
+++ b/app/javascript/mastodon/locales/et.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Vaata veel",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "Seda tuuti ei kuvata ühegi sildi all, sest see on kirjendamata. Ainult avalikud tuutid on sildi järgi otsitavad.",
   "compose_form.lock_disclaimer": "Teie konto ei ole {locked}. Igaüks saab Teid jälgida ja näha Teie ainult-jälgijatele postitusi.",
   "compose_form.lock_disclaimer.lock": "lukus",

--- a/app/javascript/mastodon/locales/fy.json
+++ b/app/javascript/mastodon/locales/fy.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Taal wizigje",
   "compose.language.search": "Talen sykje…",
   "compose_form.direct_message_warning_learn_more": "Mear ynfo",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "beskoattele",

--- a/app/javascript/mastodon/locales/ga.json
+++ b/app/javascript/mastodon/locales/ga.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Athraigh teanga",
   "compose.language.search": "Cuardaigh teangacha...",
   "compose_form.direct_message_warning_learn_more": "Tuilleadh eolais",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Níl an cuntas seo {locked}. Féadfaidh duine ar bith tú a leanúint agus na postálacha atá dírithe agat ar do lucht leanúna amháin a fheiceáil.",
   "compose_form.lock_disclaimer.lock": "faoi ghlas",

--- a/app/javascript/mastodon/locales/hr.json
+++ b/app/javascript/mastodon/locales/hr.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Saznajte više",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "Ovaj toot neće biti prikazan ni pod jednim hashtagom jer je postavljen kao neprikazan. Samo javni tootovi mogu biti pretraživani pomoći hashtagova.",
   "compose_form.lock_disclaimer": "Vaš račun nije {locked}. Svatko Vas može pratiti kako bi vidjeli objave namijenjene Vašim pratiteljima.",
   "compose_form.lock_disclaimer.lock": "zaključan",

--- a/app/javascript/mastodon/locales/hy.json
+++ b/app/javascript/mastodon/locales/hy.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Իմանալ աւելին",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "Այս գրառումը չի հաշուառուի որեւէ պիտակի տակ, քանզի այն ծածուկ է։ Միայն հրապարակային թթերը հնարաւոր է որոնել պիտակներով։",
   "compose_form.lock_disclaimer": "Քո հաշիւը {locked} չէ։ Իւրաքանչիւրութիւն ոք կարող է հետեւել քեզ եւ տեսնել միայն հետեւողների համար նախատեսուած գրառումները։",
   "compose_form.lock_disclaimer.lock": "փակ",

--- a/app/javascript/mastodon/locales/ig.json
+++ b/app/javascript/mastodon/locales/ig.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Gbanwee asụsụ",
   "compose.language.search": "Chọọ asụsụ...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/ka.json
+++ b/app/javascript/mastodon/locales/ka.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "გაიგე მეტი",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "ეს ტუტი არ მოექცევა ჰეშტეგების ქვეს, რამეთუ ის არაა მითითებული. მხოლოდ ღია ტუტები მოიძებნება ჰეშტეგით.",
   "compose_form.lock_disclaimer": "თქვენი ანგარიში არაა {locked}. ნებისმიერს შეიძლია გამოგყვეთ, რომ იხილოს თქვენი მიმდევრებზე გათვლილი პოსტები.",
   "compose_form.lock_disclaimer.lock": "ჩაკეტილი",

--- a/app/javascript/mastodon/locales/kab.json
+++ b/app/javascript/mastodon/locales/kab.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Beddel tutlayt",
   "compose.language.search": "Nadi tutlayin …",
   "compose_form.direct_message_warning_learn_more": "Issin ugar",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Amiḍan-ik ur yelli ara {locked}. Menwala yezmer ad k-yeḍfeṛ akken ad iẓer acu tbeṭṭuḍ akked yimeḍfaṛen-ik.",
   "compose_form.lock_disclaimer.lock": "yettwacekkel",

--- a/app/javascript/mastodon/locales/kk.json
+++ b/app/javascript/mastodon/locales/kk.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Көбірек білу",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "Бұл пост іздеуде хэштегпен шықпайды, өйткені ол бәріне ашық емес. Тек ашық жазбаларды ғана хэштег арқылы іздеп табуға болады.",
   "compose_form.lock_disclaimer": "Аккаунтыңыз {locked} емес. Кез келген адам жазылып, сізді оқи алады.",
   "compose_form.lock_disclaimer.lock": "жабық",

--- a/app/javascript/mastodon/locales/kn.json
+++ b/app/javascript/mastodon/locales/kn.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/kw.json
+++ b/app/javascript/mastodon/locales/kw.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Dyski moy",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "Ny vydh an post ma diskwedhys yn-dann vòlnos vyth awos y vos mes a rol. Ny yllir hwilas saw poblow postek dre vòlnos.",
   "compose_form.lock_disclaimer": "Nyns yw agas akont {locked}. Piwpynag a yll agas holya dhe weles agas postow holyoryon-hepken.",
   "compose_form.lock_disclaimer.lock": "Alhwedhys",

--- a/app/javascript/mastodon/locales/lt.json
+++ b/app/javascript/mastodon/locales/lt.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/mk.json
+++ b/app/javascript/mastodon/locales/mk.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Научи повеќе",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "заклучен",

--- a/app/javascript/mastodon/locales/ml.json
+++ b/app/javascript/mastodon/locales/ml.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "കൂടുതൽ പഠിക്കുക",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "ഈ ടൂട്ട് പട്ടികയിൽ ഇല്ലാത്തതിനാൽ ഒരു ചർച്ചാവിഷയത്തിന്റെ പട്ടികയിലും പെടുകയില്ല. പരസ്യമായ ടൂട്ടുകൾ മാത്രമേ ചർച്ചാവിഷയം അടിസ്ഥാനമാക്കി തിരയുവാൻ സാധിക്കുകയുള്ളു.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "ലോക്കുചെയ്തു",

--- a/app/javascript/mastodon/locales/mr.json
+++ b/app/javascript/mastodon/locales/mr.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "अधिक जाणून घ्या",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/ms.json
+++ b/app/javascript/mastodon/locales/ms.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Ketahui lebih lanjut",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "Hantaran ini tidak akan disenaraikan di bawah mana-mana tanda pagar kerana ia tidak tersenarai. Hanya hantaran awam sahaja boleh dicari menggunakan tanda pagar.",
   "compose_form.lock_disclaimer": "Akaun anda tidak {locked}. Sesiapa pun boleh mengikuti anda untuk melihat hantaran pengikut-sahaja anda.",
   "compose_form.lock_disclaimer.lock": "dikunci",

--- a/app/javascript/mastodon/locales/my.json
+++ b/app/javascript/mastodon/locales/my.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/pa.json
+++ b/app/javascript/mastodon/locales/pa.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/sa.json
+++ b/app/javascript/mastodon/locales/sa.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "अधिकं ज्ञायताम्",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "न कस्मिन्नपि प्रचलितवस्तुषु सूचितमिदं दौत्यम् । केवलं सार्वजनिकदौत्यानि प्रचलितवस्तुचिह्नेन अन्वेषयितुं शक्यते ।",
   "compose_form.lock_disclaimer": "तव लेखा न प्रवेष्टुमशक्या {locked} । कोऽप्यनुसर्ता ते केवलमनुसर्तृृणां कृते स्थितानि दौत्यानि द्रष्टुं शक्नोति ।",
   "compose_form.lock_disclaimer.lock": "अवरुद्धः",

--- a/app/javascript/mastodon/locales/sc.json
+++ b/app/javascript/mastodon/locales/sc.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Àteras informatziones",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "Custa publicatzione no at a èssere ammustrada in peruna eticheta, dae chi no est listada. Isceti is publicatziones pùblicas podent èssere chircadas cun etichetas.",
   "compose_form.lock_disclaimer": "Su contu tuo no est {locked}. Cale si siat persone ti podet sighire pro bìdere is messàgios tuos chi imbies a sa gente chi ti sighit.",
   "compose_form.lock_disclaimer.lock": "blocadu",

--- a/app/javascript/mastodon/locales/sk.json
+++ b/app/javascript/mastodon/locales/sk.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Zmeň jazyk",
   "compose.language.search": "Hľadaj medzi jazykmi...",
   "compose_form.direct_message_warning_learn_more": "Zisti viac",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "Tento toot nebude zobrazený pod žiadným haštagom lebo nieje listovaný. Iba verejné tooty môžu byť nájdené podľa haštagu.",
   "compose_form.lock_disclaimer": "Tvoj účet nie je {locked}. Ktokoľvek ťa môže nasledovať a vidieť tvoje správy pre sledujúcich.",
   "compose_form.lock_disclaimer.lock": "zamknutý",

--- a/app/javascript/mastodon/locales/sr-Latn.json
+++ b/app/javascript/mastodon/locales/sr-Latn.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Vaš nalog nije {locked}. Svako može da Vas zaprati i da vidi objave namenjene samo Vašim pratiocima.",
   "compose_form.lock_disclaimer.lock": "zaključan",

--- a/app/javascript/mastodon/locales/sr.json
+++ b/app/javascript/mastodon/locales/sr.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Сазнајте више",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "Ова труба неће бити излистана под било којом тарабом јер је сакривена. Само јавне трубе могу бити претражене тарабом.",
   "compose_form.lock_disclaimer": "Ваш налог није {locked}. Свако може да Вас запрати и да види објаве намењене само Вашим пратиоцима.",
   "compose_form.lock_disclaimer.lock": "закључан",

--- a/app/javascript/mastodon/locales/szl.json
+++ b/app/javascript/mastodon/locales/szl.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/tai.json
+++ b/app/javascript/mastodon/locales/tai.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/te.json
+++ b/app/javascript/mastodon/locales/te.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "మరింత తెలుసుకోండి",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "ఈ టూట్ అన్లిస్టెడ్ కాబట్టి ఏ హాష్ ట్యాగ్ క్రిందకూ రాదు. పబ్లిక్ టూట్ లను మాత్రమే హాష్ ట్యాగ్ ద్వారా శోధించవచ్చు.",
   "compose_form.lock_disclaimer": "మీ ఖాతా {locked} చేయబడలేదు. ఎవరైనా మిమ్మల్ని అనుసరించి మీ అనుచరులకు-మాత్రమే పోస్ట్లను వీక్షించవచ్చు.",
   "compose_form.lock_disclaimer.lock": "బిగించబడినది",

--- a/app/javascript/mastodon/locales/tt.json
+++ b/app/javascript/mastodon/locales/tt.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/ug.json
+++ b/app/javascript/mastodon/locales/ug.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",

--- a/app/javascript/mastodon/locales/ur.json
+++ b/app/javascript/mastodon/locales/ur.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "مزید جانیں",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "چونکہ یہ ٹوٹ غیر مندرجہ ہے لہذا یہ کسی بھی ہیش ٹیگ کے تحت درج نہیں کیا جائے گا. ہیش ٹیگ کے تحت صرف \nعمومی ٹوٹ تلاش کئے جا سکتے ہیں.",
   "compose_form.lock_disclaimer": "آپ کا اکاؤنٹ {locked} نہیں ہے. کوئی بھی آپ کے مخصوص برائے پیروکار ٹوٹ دیکھنے کی خاطر آپ کی پیروی کر سکتا ہے.",
   "compose_form.lock_disclaimer.lock": "مقفل",

--- a/app/javascript/mastodon/locales/zgh.json
+++ b/app/javascript/mastodon/locales/zgh.json
@@ -126,7 +126,7 @@
   "compose.language.change": "Change language",
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "ⵙⵙⵏ ⵓⴳⴳⴰⵔ",
-  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any dangerous information over Mastodon.",
+  "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted, and mentioned users can see these posts. Do not share private information over Mastodon.",
   "compose_form.hashtag_warning": "This toot won't be listed under any hashtag as it is unlisted. Only public toots can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "ⵉⵜⵜⵓⵔⴳⵍ",


### PR DESCRIPTION
You don't want to have people DMing their friends about some awful/embarassing thing that one of their mutuals did by using their mututal's Mastodon username, then be surprised when that mutual can see the DM.

Result looks like this:

![image](https://user-images.githubusercontent.com/1170909/201684651-155b8d9e-20fb-4c7f-bd30-54a56758c41f.png)
