### PR TITLE
Improve nginx ssl configuration

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -4,11 +4,11 @@ map $http_upgrade $connection_upgrade {
 }
 
 upstream backend {
-    server 127.0.0.1:3000 fail_timeout=0;
+  server 127.0.0.1:3000 fail_timeout=0;
 }
 
 upstream streaming {
-    server 127.0.0.1:4000 fail_timeout=0;
+  server 127.0.0.1:4000 fail_timeout=0;
 }
 
 proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=CACHE:10m inactive=7d max_size=1g;

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -27,15 +27,27 @@ server {
   listen [::]:443 ssl http2;
   server_name example.com;
 
+  proxy_intercept_errors on;
+
   ssl_protocols TLSv1.2 TLSv1.3;
-  ssl_ciphers HIGH:!MEDIUM:!LOW:!aNULL:!NULL:!SHA;
+  ssl_ciphers EECDH+AESGCM;
+  ssl_ecdh_curve secp384r1;
   ssl_prefer_server_ciphers on;
   ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 1d;
+  ssl_stapling on;
+  ssl_stapling_verify on;
   ssl_session_tickets off;
 
   # Uncomment these lines once you acquire a certificate:
   # ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
   # ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+  add_header Feature-Policy "geolocation=(), midi=(), notifications(self 'https://soziale.cloud'), push=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker(self 'https://soziale.cloud'), vibrate=(), fullscreen=(self 'https://soziale.cloud'), payment=()";
+  add_header X-Frame-Options DENY;
+  add_header X-Content-Type-Options nosniff;
+  add_header X-XSS-Protection "1; mode=block";
 
   keepalive_timeout    70;
   sendfile             on;

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -43,8 +43,6 @@ server {
   # ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
   # ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
 
-  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-  add_header Feature-Policy "geolocation=(), midi=(), notifications(self 'https://soziale.cloud'), push=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker(self 'https://soziale.cloud'), vibrate=(), fullscreen=(self 'https://soziale.cloud'), payment=()";
   add_header X-Frame-Options DENY;
   add_header X-Content-Type-Options nosniff;
   add_header X-XSS-Protection "1; mode=block";


### PR DESCRIPTION
Hey 👋

the current stable version of Mastodons nginx configuration is fairly open in terms of ciphers being used.

This change results in the the following overall ssllabs rating - I've been cross checking `mastodon.social` as I expected that this repos configuration file (or at least close to it) is in use. I thus may be wrong:

new: 
![image](https://user-images.githubusercontent.com/6549061/201711985-760009f8-3576-41c6-96cd-6a6afb000eb5.png)

old:
![image](https://user-images.githubusercontent.com/6549061/201712029-0b8deffe-00d8-410d-a0cf-5aea27c2d758.png)

<!--
    Hey vendor editing this post 👋
    Here's above used ssllabs links for your better understanding:

    new: https://www.ssllabs.com/ssltest/analyze.html?d=soziale.cloud&s=109.123.250.83&hideResults=on&ignoreMismatch=on
    old: https://www.ssllabs.com/ssltest/analyze.html?d=mastodon.social&hideResults=on
-->


I intentionally left out the informational banners of the summary below ...

---

Client support:
*(For your convenience the list is sorted by no longer supported & asc)*

| OS | supported on old configuration | supported on new configuration |
| -- | ------------------------------------ | ------------------------------------ |
| IE 11 Win 7 | Yes | **NO** |
| IE 11 Win 8.1 | Yes | **NO** |
| IE 11 Win Phone 8.1 | Yes | **NO** |
| IE Win Phone 8.1 Update | Yes | **NO** |
| Safari 6 iOS 6.0.1 | Yes | **NO** |
| Safari 7 iOS 7.1 | Yes | **NO** |
| Safari 7 OS X 10.9 | Yes | **NO** |
| Safari 8 iOS 8.4 | Yes | **NO** |
| Safari 8 OS X 10.10 | Yes | **NO** |
| Android 4.4.2 | Yes | Yes |
| Android 5.0 | Yes | Yes |
| Android 6.0 | Yes | Yes |
| Android 7.0 | Yes | Yes |
| Android 8.0 | Yes | Yes |
| Android 8.1 | Yes | Yes |
| Android 9.0 | Yes | Yes |
| BingPreview Jan '15 | Yes | Yes |
| Chrome 49 XP SP3 | Yes | Yes |
| Chrome 69 Win 7 | Yes | Yes |
| Chrome 70 Win 10 | Yes | Yes |
| Chrome 80 Win 10 | Yes | Yes |
| Firefox 31.3.0 ESR Win 7 | Yes | Yes |
| Firefox 47 Win 7 | Yes | Yes |
| Firefox 49 XP SP3 | Yes | Yes |
| Firefox 62 Win 7 | Yes | Yes |
| Firefox 73 Win 10 | Yes | Yes |
| Googlebot Feb '18 | Yes | Yes |
| IE 11 Win 10 | Yes | Yes |
| Edge 15 Win 10 | Yes | Yes |
| Edge 16 Win 10 | Yes | Yes |
| Edge 18 Win 10 | Yes | Yes |
| Edge 13 Win Phone 10 | Yes | Yes |
| Java 8u161 | Yes | Yes |
| Java 11.0.0.3 | Yes | Yes |
| Java 12.0.1 | Yes | Yes |
| OpenSSL 1.0.1l | Yes | Yes |
| OpenSSL 1.0.2s | Yes | Yes |
| OpenSSL 1.1.0k | Yes | Yes |
| OpenSSL 1.1.1c | Yes | Yes |
| Safari 9 iOS 9 | Yes | Yes |
| Safari 9 OS X 10.11 | Yes | Yes |
| Safari 10 iOS 10 | Yes | Yes |
| Safari 10 OS X 10.12 | Yes | Yes |
| Safari 12.1.2 MacOS 10.14.6 Beta | Yes | Yes |
| Safari 12.1.1 iOS 12.3.1 | Yes | Yes |
| Apple ATS 9 iOS 9 | Yes | Yes |
| Yahoo Slurp Jan '15 | Yes | Yes |
| YandexBot Jan '15 | Yes | Yes |

Above no longer supported Browsers and OSes practically are at least 2 years end of life.
I believe, with all love to backwards compatibility, security wise these devices should be dropped.

If you believe that this security update is too much but still like the possible option for admins to choose, I can also gladly convert my changes to an optional set which by default is commented out.