### PR TITLE
Fix HPA target name to match web deployment

### DIFF
--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -9,7 +9,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "mastodon.fullname" . }}
+    name: {{ include "mastodon.fullname" . }}-web
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
The HPA for the `web` deployment wasn't working because the target name was incorrect.

```
kind: Deployment
metadata:
  name: {{ include "mastodon.fullname" . }}-web
```

This PR updates the HPA to match the name.

Not sure on policy to version the chart - do I do that as part of the PR?