### PR TITLE
Add Foreman to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,6 +131,7 @@ group :development do
   gem 'better_errors', '~> 2.9'
   gem 'binding_of_caller', '~> 1.0'
   gem 'bullet', '~> 7.0'
+  gem 'foreman'
   gem 'letter_opener', '~> 1.8'
   gem 'letter_opener_web', '~> 2.0'
   gem 'memory_profiler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ GEM
       fog-core (>= 1.45, <= 2.1.0)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
+    foreman (0.87.2)
     formatador (0.2.5)
     fugit (1.7.1)
       et-orbi (~> 1, >= 1.2.7)
@@ -769,6 +770,7 @@ DEPENDENCIES
   fastimage
   fog-core (<= 2.1.0)
   fog-openstack (~> 0.3)
+  foreman
   fuubar (~> 2.5)
   gitlab-omniauth-openid-connect (~> 0.10.0)
   hamlit-rails (~> 0.2)
@@ -855,3 +857,9 @@ DEPENDENCIES
   webpacker (~> 5.4)
   webpush!
   xorcist (~> 1.1)
+
+RUBY VERSION
+   ruby 3.0.4p208
+
+BUNDLED WITH
+   2.3.15


### PR DESCRIPTION
The [development documentation](https://docs.joinmastodon.org/dev/setup/) (which I am in the process of re-writing) recommends installing Foreman and using it to run the development servers specified in `Procfile.dev`.

Wouldn't it be easier to simply add Foreman as a dev dependency in the `Gemfile`?