### PR TITLE
Handle links with no href in VerifyLinkService

### DIFF
--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -28,7 +28,7 @@ class VerifyLinkService < BaseService
 
     links = Nokogiri::HTML(@body).xpath('//a[contains(concat(" ", normalize-space(@rel), " "), " me ")]|//link[contains(concat(" ", normalize-space(@rel), " "), " me ")]')
 
-    if links.any? { |link| link['href'].downcase == @link_back.downcase }
+    if links.any? { |link| link['href']&.downcase == @link_back.downcase }
       true
     elsif links.empty?
       false
@@ -38,6 +38,8 @@ class VerifyLinkService < BaseService
   end
 
   def link_redirects_back?(test_url)
+    return false if test_url.blank?
+
     redirect_to_url = Request.new(:head, test_url, follow: false).perform do |res|
       res.headers['Location']
     end

--- a/spec/services/verify_link_service_spec.rb
+++ b/spec/services/verify_link_service_spec.rb
@@ -76,7 +76,25 @@ RSpec.describe VerifyLinkService, type: :service do
     context 'when a link does not contain a link back' do
       let(:html) { '' }
 
-      it 'marks the field as verified' do
+      it 'does not mark the field as verified' do
+        expect(field.verified?).to be false
+      end
+    end
+
+    context 'when link has no `href` attribute' do
+      let(:html) do
+        <<-HTML
+          <!doctype html>
+          <head>
+            <link type="text/html" rel="me" />
+          </head>
+          <body>
+            <a rel="me" target="_blank">Follow me on Mastodon</a>
+          </body>
+        HTML
+      end
+
+      it 'does not mark the field as verified' do
         expect(field.verified?).to be false
       end
     end


### PR DESCRIPTION
Before this change, the following error would cause the `VerifyAccountLinksWorker` job to fail:

```
NoMethodError: undefined method `downcase' for nil:NilClass
  [PROJECT_ROOT]/app/services/verify_link_service.rb:31 :in `block in link_back_present?`
```

See [here](https://app.honeybadger.io/fault/105544/0ffa28355350e2805a5a4dcd532c5959) for details. I think this may also fix [this error](https://app.honeybadger.io/fault/105544/6e1395b296ff3d25929c60d900d49d32) (see the guard I added to `#link_redirects_back?`).