### PR TITLE
[draft] Add support for Twtxt protocol

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -33,6 +33,9 @@ class AccountsController < ApplicationController
         expires_in 3.minutes, public: !(authorized_fetch_mode? && signed_request_account.present?)
         render_with_cache json: @account, content_type: 'application/activity+json', serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter
       end
+
+      format.txt do
+      end
     end
   end
 

--- a/app/views/accounts/show.txt.erb
+++ b/app/views/accounts/show.txt.erb
@@ -1,3 +1,3 @@
 <% @account.statuses.each do |status| %>
-<%= status.created_at %>	<%= extract_status_plain_text status %>
+<%= status.created_at.rfc3339 %>	<%= extract_status_plain_text status %>
 <% end %>

--- a/app/views/accounts/show.txt.erb
+++ b/app/views/accounts/show.txt.erb
@@ -1,3 +1,3 @@
 <% @account.statuses.each do |status| %>
-<%= status.created_at.rfc3339 %>	<%= extract_status_plain_text status %>
+<%= status.created_at.rfc3339 %>	<%= extract_status_plain_text(status).gsub "\n", "\u2028" %>
 <% end %>

--- a/app/views/accounts/show.txt.erb
+++ b/app/views/accounts/show.txt.erb
@@ -1,0 +1,3 @@
+<% @account.statuses.each do |status| %>
+<%= status.created_at %>	<%= extract_status_plain_text status %>
+<% end %>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,4 @@
 
 Mime::Type.register 'application/json', :json, %w(text/x-json application/jsonrequest application/jrd+json application/activity+json application/ld+json)
 Mime::Type.register 'text/xml',         :xml,  %w(application/xml application/atom+xml application/xrd+xml)
+Mime::Type.register 'text/plain',       :txt,  %w(text/plain)


### PR DESCRIPTION
The [Twtxt protocol](https://twtxt.readthedocs.io/en/latest/) is a plain-text based microblogging protocol. This pull request adds a `/@<username>.txt` path that generates a Twtxt-compatible feed, so that users of Twtxt and [Yarn.social](https://yarn.social) can follow users on Mastodon.

@prologic

To-do:
- [x] Post dates and contents
- [ ] Username, bio, and avatar
- [ ] Profile links
- [ ] Follows
- [ ] Media (images, videos, &c.)