### PR TITLE
Fix invalid/empty RSS feed link on account pages

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -17,6 +17,8 @@ class AccountsController < ApplicationController
     respond_to do |format|
       format.html do
         expires_in 0, public: true unless user_signed_in?
+
+        @rss_url = rss_url
       end
 
       format.rss do


### PR DESCRIPTION
Fixes #20770

That being said, this one-line fix may actually not be what we want, since the tag will remain if you navigate to something else within the Web UI. But I don't think we currently expose the information in a way that would allow us to output the tag client-side.