### PR TITLE
Change automatic post deletion configuration to be accessible to redirected users

### DIFF
--- a/app/controllers/statuses_cleanup_controller.rb
+++ b/app/controllers/statuses_cleanup_controller.rb
@@ -19,6 +19,10 @@ class StatusesCleanupController < ApplicationController
     # Do nothing
   end
 
+  def require_functional!
+    redirect_to edit_user_registration_path unless current_user.functional_or_moved?
+  end
+
   private
 
   def set_policy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,7 +237,11 @@ class User < ApplicationRecord
   end
 
   def functional?
-    confirmed? && approved? && !disabled? && !account.suspended? && !account.memorial? && account.moved_to_account_id.nil?
+    functional_or_moved? && account.moved_to_account_id.nil?
+  end
+
+  def functional_or_moved?
+    confirmed? && approved? && !disabled? && !account.suspended? && !account.memorial?
   end
 
   def unconfirmed?

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -17,7 +17,7 @@ SimpleNavigation::Configuration.run do |navigation|
 
     n.item :relationships, safe_join([fa_icon('users fw'), t('settings.relationships')]), relationships_path, if: -> { current_user.functional? }
     n.item :filters, safe_join([fa_icon('filter fw'), t('filters.index.title')]), filters_path, highlights_on: %r{/filters}, if: -> { current_user.functional? }
-    n.item :statuses_cleanup, safe_join([fa_icon('history fw'), t('settings.statuses_cleanup')]), statuses_cleanup_path, if: -> { current_user.functional? }
+    n.item :statuses_cleanup, safe_join([fa_icon('history fw'), t('settings.statuses_cleanup')]), statuses_cleanup_path, if: -> { current_user.functional_or_moved? }
 
     n.item :security, safe_join([fa_icon('lock fw'), t('settings.account')]), edit_user_registration_path do |s|
       s.item :password, safe_join([fa_icon('lock fw'), t('settings.account_settings')]), edit_user_registration_path, highlights_on: %r{/auth/edit|/settings/delete|/settings/migration|/settings/aliases|/settings/login_activities|^/disputes}


### PR DESCRIPTION
Fixes #20550

Though I am wondering if it could make sense to also present the feature to:
- non-approved users (probably not)
- non-confirmed users (probably not)
- disabled users
- suspended users
- users whose account has been turned a memorial