### PR TITLE
Add form-action CSP directive

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -26,6 +26,7 @@ Rails.application.config.content_security_policy do |p|
   p.media_src       :self, :https, :data, assets_host
   p.frame_src       :self, :https
   p.manifest_src    :self, assets_host
+  p.form_action     :self
 
   if Rails.env.development?
     webpacker_urls = %w(ws http).map { |protocol| "#{protocol}#{Webpacker.dev_server.https? ? 's' : ''}://#{Webpacker.dev_server.host_with_port}" }


### PR DESCRIPTION
Hardening against potential attacks.

Most pages require to be able to submit forms in one way or another (e.g. log-out link), so this can't be set to `:none` in general.