### PR TITLE
allow the oidc client secret to be set in an existing secret in helm chart

### DIFF
--- a/chart/templates/configmap-env.yaml
+++ b/chart/templates/configmap-env.yaml
@@ -101,7 +101,9 @@ data:
   OIDC_SCOPE: {{ .Values.externalAuth.oidc.scope | quote }}
   OIDC_UID_FIELD: {{ .Values.externalAuth.oidc.uid_field }}
   OIDC_CLIENT_ID: {{ .Values.externalAuth.oidc.client_id }}
+  {{- if not .Values.externalAuth.oidc.existingSecret }}
   OIDC_CLIENT_SECRET: {{ .Values.externalAuth.oidc.client_secret }}
+  {{- end }}
   OIDC_REDIRECT_URI: {{ .Values.externalAuth.oidc.redirect_uri }}
   OIDC_SECURITY_ASSUME_EMAIL_IS_VERIFIED: {{ .Values.externalAuth.oidc.assume_email_is_verified | quote }}
   {{- if .Values.externalAuth.oidc.client_auth_method }}

--- a/chart/templates/deployment-web.yaml
+++ b/chart/templates/deployment-web.yaml
@@ -76,6 +76,13 @@ spec:
                   key: redis-password
             - name: "PORT"
               value: {{ .Values.mastodon.web.port | quote }}
+            {{- if (and .Values.externalAuth.oidc.enabled .Values.externalAuth.oidc.existingSecret) }}
+            - name: "OIDC_CLIENT_SECRET"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalAuth.oidc.existingSecret }}
+                  key: OIDC_CLIENT_SECRET
+            {{- end }}
             {{- if (and .Values.mastodon.s3.enabled .Values.mastodon.s3.existingSecret) }}
             - name: "AWS_SECRET_ACCESS_KEY"
               valueFrom:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -190,6 +190,11 @@ externalAuth:
     # uid_field: uid
     # client_id: mastodon
     # client_secret: SECRETKEY
+    #
+    # you can also specify the name of an existing Secret
+    # with key OIDC_CLIENT_SECRET
+    # existingsecret: ""
+    #
     # redirect_uri: https://example.com/auth/auth/openid_connect/callback
     # assume_email_is_verified: true
     # client_auth_method:


### PR DESCRIPTION
Right now you need to hardcode the `OIDC_CLIENT_SECRET` into the values. Move it to an existing secret so its security is on par with the rest of the secure tokens.