### PR TITLE
Use dynamically linked ruby to reduce disk footprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN apt-get update && \
 	cd ruby-$RUBY_VER && \
 	./configure --prefix=/opt/ruby \
 	  --with-jemalloc \
-	  --with-shared \
+	  --enable-shared \
+	  --disable-install-static-library \
 	  --disable-install-doc && \
 	make -j"$(nproc)" > /dev/null && \
 	make install && \


### PR DESCRIPTION
* Before:

```
root@211e2cd27106:~# du -ms /opt/ruby
174	/opt/ruby
```

```
root@d0e6c838b9f8:/# du -ms /opt/ruby/*
35	/opt/ruby/bin
3	/opt/ruby/include
137	/opt/ruby/lib
1	/opt/ruby/share
```

Two biggest offenders:

```
root@d0e6c838b9f8:/# du -ms /opt/ruby/bin/ruby /opt/ruby/lib/libruby-static.a
35	/opt/ruby/bin/ruby
98	/opt/ruby/lib/libruby-static.a
```

* After:

```
root@87e594fb0e8f:/# du -ms /opt/ruby
54	/opt/ruby
```

```
root@87e594fb0e8f:/# du -ms /opt/ruby/*
1	/opt/ruby/bin
3	/opt/ruby/include
51	/opt/ruby/lib
1	/opt/ruby/share
```

The overall image size change:

```
tootsuite/mastodon         v4.0.2-ivan-1    387e821a7a6d   About a minute ago   1.66GB
tootsuite/mastodon         v4.0.2           869933ac26fa   21 hours ago         1.79GB
```