### PR TITLE
Fix misleading wording about waitlists

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -914,7 +914,7 @@ en:
     warning: Be very careful with this data. Never share it with anyone!
     your_token: Your access token
   auth:
-    apply_for_account: Get on waitlist
+    apply_for_account: Request an account
     change_password: Password
     delete_account: Delete account
     delete_account_html: If you wish to delete your account, you can <a href="%{path}">proceed here</a>. You will be asked for confirmation.


### PR DESCRIPTION
The “Waitlist” wording introduced in #19289 is inaccurate and misleading. https://joinmastodon.org/servers itself has changed its “Waitlist” wording to “Apply for an account”.

This PR changes “Get on waitlist” to “Request an account”

## Before

![image](https://user-images.githubusercontent.com/384364/202121001-9d8b89ca-522b-4abd-a65d-3712aadb9bcd.png)

## After

![image](https://user-images.githubusercontent.com/384364/202121298-32f7da72-3452-4008-926c-35f6f773c4e1.png)