### PR TITLE
Make the button that expands the compose form differentiable from the button that publishes a post

### DIFF
--- a/app/javascript/mastodon/features/ui/components/header.js
+++ b/app/javascript/mastodon/features/ui/components/header.js
@@ -35,7 +35,7 @@ class Header extends React.PureComponent {
     if (signedIn) {
       content = (
         <>
-          {location.pathname !== '/publish' && <Link to='/publish' className='button'><FormattedMessage id='compose_form.publish' defaultMessage='Publish' /></Link>}
+          {location.pathname !== '/publish' && <Link to='/publish' className='button'><FormattedMessage id='compose_form.publish_form' defaultMessage='Publish' /></Link>}
           <Account />
         </>
       );

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -3989,7 +3989,7 @@
     "descriptors": [
       {
         "defaultMessage": "Publish",
-        "id": "compose_form.publish"
+        "id": "compose_form.publish_form"
       },
       {
         "defaultMessage": "Sign in",


### PR DESCRIPTION
When I migrated my instance, I wasn't sure what that button *did* at first - I actually thought it was a layout glitch and the rest of the compose form wasn't showing.

I haven't changed the default text yet. I can do so if anybody has opinions, I think my instinct would be "Compose"