### PR TITLE
local-development: improvements and fixes for dotenv

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,31 @@
+# See https://docs.joinmastodon.org/admin/config/ on documentation regarding the ENV variables
+#
+# These are the default .env values given for the development environment.
+# You don't need to change this file, in order to adapt the values for your particular needs.
+# Instead create a .env.development.local (ignored by git), where you can overrwrite the values
+# set in here, or define others you need in your development env.
+
+# Node.js
+NODE_ENV=development
+
+# PostgreSQL
+# ----------
+# adapt this to your needs in .env.development.local
+# e.g. your using a local postgres, that trusts your user with no password
+# DB_HOST=localhost
+# DB_USER=myusername
+# DB_PASS=''
+# DB_PORT=5432
+# DB_NAME=mastodon_development
+# DATABASE_URL=postgresql://$DB_USER@$DB_HOST:$DB_PORT/$DB_NAME
+DB_HOST=localhost
+DB_USER=mastodon
+DB_PASS=mastodon
+DB_NAME=mastodon_development
+DB_PORT=5432
+DATABASE_URL=postgresql://$DB_USER:$DB_PASS@$DB_HOST:$DB_PORT/$DB_NAME
+
+# Redis
+# -----
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,21 @@
+# See https://docs.joinmastodon.org/admin/config/ on documentation regarding the ENV variables
+#
+# You can adapt the env variables given here in your own .env.test.local file
+# Which is ignored by git
+
 # Node.js
 NODE_ENV=tests
 # Federation
 LOCAL_DOMAIN=cb6e6126.ngrok.io
 LOCAL_HTTPS=true
+
+# PostgreSQL
+# ----------
+# adapt this to your needs in .env.test.local
+# e.g. your using a local postgres, that trusts your user with no password
+# DB_HOST=localhost
+# DB_USER=myusername
+# DB_PASS=''
+# DB_PORT=5432
+# DB_NAME=mastodon_test
+# DATABASE_URL=postgresql://$DB_USER@$DB_HOST:$DB_PORT/$DB_NAME

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@
 /public/packs-test
 .env
 .env.production
-.env.development
+.env*.local
 /node_modules/
 /build/
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,9 @@
 unless ENV.key?('RAILS_ENV')
+  # Load RAILS_ENV from '.env', when file present.
+  require 'dotenv/load'
+end
+
+unless ENV.key?('RAILS_ENV')
   STDERR.puts 'ERROR: Missing RAILS_ENV environment variable, please set it to "production", "development", or "test".'
   exit 1
 end


### PR DESCRIPTION
# dot env fixes

- config/boot.rb tries to load possible RAILS_ENV in `.env` file before testing RAILS_ENV is present
- add .env.development file, with explaining comments on how to use .env.development.local
- add comments on how to use .env.test.local to .env.test
