### PR TITLE
Change batch account suspension to create a strike

### DIFF
--- a/app/models/form/account_batch.rb
+++ b/app/models/form/account_batch.rb
@@ -115,6 +115,10 @@ class Form::AccountBatch
     authorize(account, :suspend?)
     log_action(:suspend, account)
     account.suspend!(origin: :local)
+    account.strikes.create!(
+      account: current_account,
+      action: :suspend
+    )
     Admin::SuspensionWorker.perform_async(account.id)
   end
 


### PR DESCRIPTION
So that users banned in error can file an appeal. Still does not send an email, as most of the banned accounts would likely be spammers not worth emailing.