### PR TITLE
Add maskable icon support for Android

### DIFF
--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -35,6 +35,7 @@ class ManifestSerializer < ActiveModel::Serializer
         src: full_pack_url("media/icons/android-chrome-#{size}x#{size}.png"),
         sizes: "#{size}x#{size}",
         type: 'image/png',
+        purpose: "maskable",
       }
     end
   end

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -35,7 +35,7 @@ class ManifestSerializer < ActiveModel::Serializer
         src: full_pack_url("media/icons/android-chrome-#{size}x#{size}.png"),
         sizes: "#{size}x#{size}",
         type: 'image/png',
-        purpose: "any maskable",
+        purpose: 'any maskable',
       }
     end
   end

--- a/app/serializers/manifest_serializer.rb
+++ b/app/serializers/manifest_serializer.rb
@@ -35,7 +35,7 @@ class ManifestSerializer < ActiveModel::Serializer
         src: full_pack_url("media/icons/android-chrome-#{size}x#{size}.png"),
         sizes: "#{size}x#{size}",
         type: 'image/png',
-        purpose: "maskable",
+        purpose: "any maskable",
       }
     end
   end


### PR DESCRIPTION
Updated the PWA manifest to support [maskable icons](https://web.dev/maskable-icon/) on Android devices.

Without maskable support the PWA icon currently looks like this on Android devices.

![image](https://user-images.githubusercontent.com/49479599/202301085-520a7f66-c212-4270-b1e0-12dced1cdbf9.png)

With maskable support the icon will be masked and shaped by the OS preferences. Examples below:

<img width="157" alt="image" src="https://user-images.githubusercontent.com/49479599/202301422-5c0d2d66-399c-4a97-af15-7d9d9124b4f4.png">

<img width="161" alt="image" src="https://user-images.githubusercontent.com/49479599/202301323-9423ffb5-492b-4e30-afba-fe87fd64d75f.png">

<img width="160" alt="image" src="https://user-images.githubusercontent.com/49479599/202301490-8a15caf3-ce0c-4755-91e4-efc8c63d31b5.png">

