### PR TITLE
Add working nginx configuration for container deployments

### DIFF
--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -53,6 +53,54 @@ server {
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml image/x-icon;
 
   location / {
+
+    ### This section of the configuration attempts to read the static files
+    ### directly from the root directory configured above. If the static files
+    ### are not directly accessible, like in pure container deployments, but
+    ### must be served by Rails instead, comment this section out, and uncomment
+    ### the section below instead.
+
+    location = /sw.js {
+      add_header Cache-Control "public, max-age=604800, must-revalidate";
+      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+      try_files $uri =404;
+    }
+
+    location ~ ^/(assets|avatars|emoji|headers|packs|shortcuts|sounds)/ {
+      add_header Cache-Control "public, max-age=2419200, must-revalidate";
+      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+      try_files $uri =404;
+    }
+
+    location /system/ {
+      add_header Cache-Control "public, max-age=2419200, immutable";
+      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+      try_files $uri =404;
+    }
+
+    ### End of direct access configuration ###
+
+    ### Uncomment the following section for pure container deployments
+    ### without direct access to static files, and comment out the section
+    ### above.
+
+    # if ($uri = /sw.js) {
+    #   set $cachectrl "public, max-age=604800, must-revalidate";
+    # }
+
+    # if ($uri ~ ^/(assets|avatars|emoji|headers|packs|shortcuts|sounds)/) {
+    #   set $cachectrl "public, max-age=2419200, must-revalidate";
+    # }
+
+    # if ($uri ~ ^/system/) {
+    #   set $cachectrl "public, max-age=2419200, immutable";
+    # }
+
+    # add_header Cache-Control $cachectrl;
+    # proxy_force_ranges on; # for iOS clients
+
+    ### End of container configuration ###
+
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -74,62 +122,6 @@ server {
     add_header X-Cached $upstream_cache_status;
 
     tcp_nodelay on;
-  }
-
-  # If Docker is used for deployment and Rails serves static files,
-  # then needed must replace line `try_files $uri =404;` with `try_files $uri @proxy;`.
-  location = /sw.js {
-    add_header Cache-Control "public, max-age=604800, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
-  }
-
-  location ~ ^/assets/ {
-    add_header Cache-Control "public, max-age=2419200, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
-  }
-
-  location ~ ^/avatars/ {
-    add_header Cache-Control "public, max-age=2419200, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
-  }
-
-  location ~ ^/emoji/ {
-    add_header Cache-Control "public, max-age=2419200, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
-  }
-
-  location ~ ^/headers/ {
-    add_header Cache-Control "public, max-age=2419200, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
-  }
-
-  location ~ ^/packs/ {
-    add_header Cache-Control "public, max-age=2419200, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
-  }
-
-  location ~ ^/shortcuts/ {
-    add_header Cache-Control "public, max-age=2419200, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
-  }
-
-  location ~ ^/sounds/ {
-    add_header Cache-Control "public, max-age=2419200, must-revalidate";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
-  }
-
-  location ~ ^/system/ {
-    add_header Cache-Control "public, max-age=2419200, immutable";
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-    try_files $uri =404;
   }
 
   location ^~ /api/v1/streaming {

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -53,7 +53,27 @@ server {
   gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml image/x-icon;
 
   location / {
-    try_files $uri @proxy;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Proxy "";
+    proxy_pass_header Server;
+
+    proxy_pass http://backend;
+    proxy_buffering on;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    proxy_cache CACHE;
+    proxy_cache_valid 200 7d;
+    proxy_cache_valid 410 24h;
+    proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+    add_header X-Cached $upstream_cache_status;
+
+    tcp_nodelay on;
   }
 
   # If Docker is used for deployment and Rails serves static files,
@@ -127,30 +147,6 @@ server {
     proxy_set_header Connection $connection_upgrade;
 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
-
-    tcp_nodelay on;
-  }
-
-  location @proxy {
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header Proxy "";
-    proxy_pass_header Server;
-
-    proxy_pass http://backend;
-    proxy_buffering on;
-    proxy_redirect off;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $connection_upgrade;
-
-    proxy_cache CACHE;
-    proxy_cache_valid 200 7d;
-    proxy_cache_valid 410 24h;
-    proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-    add_header X-Cached $upstream_cache_status;
 
     tcp_nodelay on;
   }


### PR DESCRIPTION
The provided nginx configuration (even when changed as suggested in its comment) does not work well von pure container deployments:

1. iOS Apps can't play videos, if nginx does not serve the files directly but instead the reverse proxy cache is used, as it is common for containerized deployments. Addition of the `proxy_force_ranges` to the proxy cache configuration fixes this. (For background see below.)

2. The `add_header Cache-Control` and `add_header Strict-Transport-Security` lines have no effect, if the following `try_files` directive is changed to redirect to the named location `@proxy`, as it is currently suggested. Instead only the `add_header` directives of `@proxy` are effective.

This change simplifies the configuration and adds an alternative section that solves these two issues and can be used for pure container deployments.

**Background**
The iOS library _AppleCoreMedia_ - which is used by iOS Apps to play videos (and  probably also older Safaris) - uses and requires byte-range requests, as mentioned [here](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/CreatingVideoforSafarioniPhone/CreatingVideoforSafarioniPhone.html#//apple_ref/doc/uid/TP40006514-SW6). The cache of the reverse proxy of Nginx supports byte-range requests, but honours them _only_ if the "Accept-Ranges" is set by the ~~client, which  _AppleCoreMedia_ does not do~~ upstream server, which Rails does not do. Instead Nginx responds to these byte-range requests with 200 and the complete file, which is standard compliant, but this library ignores them and only accepts 206 responses with the requested range. This results in videos not playing. Fortunately there is an nginx configuration option [proxy_force_ranges](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_force_ranges) which makes nginx always respond with 206 if a range has been requested.

Related to #15872 