### PR TITLE
Add explanation text to log-in page

### DIFF
--- a/app/views/auth/sessions/new.html.haml
+++ b/app/views/auth/sessions/new.html.haml
@@ -6,6 +6,8 @@
 
 - unless omniauth_only?
   = simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+    %h1.title= t('auth.sign_in.title', domain: site_hostname)
+    %p.lead= t('auth.sign_in.preamble_html', domain: site_hostname)
     .fields-group
       - if use_seamless_external_login?
         = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.username_or_email'), input_html: { 'aria-label': t('simple_form.labels.defaults.username_or_email') }, hint: false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -971,6 +971,9 @@ en:
       email_below_hint_html: If the below e-mail address is incorrect, you can change it here and receive a new confirmation e-mail.
       email_settings_hint_html: The confirmation e-mail was sent to %{email}. If that e-mail address is not correct, you can change it in account settings.
       title: Setup
+    sign_in:
+      preamble_html: Sign in with your <strong>%{domain}</strong> credentials. If your account is hosted on a different server, you will not be able to log in here.
+      title: Sign in to %{domain}
     sign_up:
       preamble: With an account on this Mastodon server, you'll be able to follow any other person on the network, regardless of where their account is hosted.
       title: Let's get you set up on %{domain}.


### PR DESCRIPTION
Users are sometimes confused and trying to log into the “wrong” server.

## Before

![image](https://user-images.githubusercontent.com/384364/202466635-6d72b4a7-658c-43f8-b6ff-c102d066076c.png)

## After

![image](https://user-images.githubusercontent.com/384364/202466946-b166082b-b72b-4349-9abd-89519f4508a6.png)