### PR TITLE
Fix characters being emojified even when using Variation Selector 15 (text)

### DIFF
--- a/app/javascript/mastodon/features/emoji/__tests__/emoji-test.js
+++ b/app/javascript/mastodon/features/emoji/__tests__/emoji-test.js
@@ -74,9 +74,9 @@ describe('emoji', () => {
         .toEqual('<span class="invisible">😄<br>😴</span><img draggable="false" class="emojione" alt="😇" title=":innocent:" src="/emoji/1f607.svg">');
     });
 
-    it('skips the textual presentation VS15 character', () => {
+    it('does not emojify emojis with textual presentation VS15 character', () => {
       expect(emojify('✴︎')) // This is U+2734 EIGHT POINTED BLACK STAR then U+FE0E VARIATION SELECTOR-15
-        .toEqual('<img draggable="false" class="emojione" alt="✴" title=":eight_pointed_black_star:" src="/emoji/2734_border.svg">');
+        .toEqual('✴︎');
     });
 
     it('does an simple emoji properly', () => {

--- a/app/javascript/mastodon/features/emoji/emoji.js
+++ b/app/javascript/mastodon/features/emoji/emoji.js
@@ -23,9 +23,10 @@ const emojifyTextNode = (node, customEmojis) => {
   let str = node.textContent;
 
   const fragment = new DocumentFragment();
+  let i = 0;
 
   for (;;) {
-    let match, i = 0;
+    let match;
 
     if (customEmojis === null) {
       while (i < str.length && !(match = trie.search(str.slice(i)))) {
@@ -41,26 +42,26 @@ const emojifyTextNode = (node, customEmojis) => {
     if (i === str.length) {
       break;
     } else if (str[i] === ':') {
-      if (!(() => {
-        rend = str.indexOf(':', i + 1) + 1;
-        if (!rend) return false; // no pair of ':'
-        const shortname = str.slice(i, rend);
-        // now got a replacee as ':shortname:'
-        // if you want additional emoji handler, add statements below which set replacement and return true.
-        if (shortname in customEmojis) {
-          const filename = autoPlayGif ? customEmojis[shortname].url : customEmojis[shortname].static_url;
-          replacement = document.createElement('img');
-          replacement.setAttribute('draggable', 'false');
-          replacement.setAttribute('class', 'emojione custom-emoji');
-          replacement.setAttribute('alt', shortname);
-          replacement.setAttribute('title', shortname);
-          replacement.setAttribute('src', filename);
-          replacement.setAttribute('data-original', customEmojis[shortname].url);
-          replacement.setAttribute('data-static', customEmojis[shortname].static_url);
-          return true;
-        }
-        return false;
-      })()) rend = ++i;
+      rend = str.indexOf(':', i + 1) + 1;
+      if (!rend) {
+        continue; // no pair of ':'
+      }
+      const shortname = str.slice(i, rend);
+      // now got a replacee as ':shortname:'
+      // if you want additional emoji handler, add statements below which set replacement and return true.
+      if (shortname in customEmojis) {
+        const filename = autoPlayGif ? customEmojis[shortname].url : customEmojis[shortname].static_url;
+        replacement = document.createElement('img');
+        replacement.setAttribute('draggable', 'false');
+        replacement.setAttribute('class', 'emojione custom-emoji');
+        replacement.setAttribute('alt', shortname);
+        replacement.setAttribute('title', shortname);
+        replacement.setAttribute('src', filename);
+        replacement.setAttribute('data-original', customEmojis[shortname].url);
+        replacement.setAttribute('data-static', customEmojis[shortname].static_url);
+      } else {
+        continue;
+      }
     } else { // matched to unicode emoji
       const { filename, shortCode } = unicodeMapping[match];
       const title = shortCode ? `:${shortCode}:` : '';
@@ -82,6 +83,7 @@ const emojifyTextNode = (node, customEmojis) => {
       fragment.append(replacement);
     }
     str = str.slice(rend);
+    i = 0;
   }
 
   fragment.append(document.createTextNode(str));

--- a/app/javascript/mastodon/features/emoji/emoji.js
+++ b/app/javascript/mastodon/features/emoji/emoji.js
@@ -65,17 +65,18 @@ const emojifyTextNode = (node, customEmojis) => {
     } else { // matched to unicode emoji
       const { filename, shortCode } = unicodeMapping[match];
       const title = shortCode ? `:${shortCode}:` : '';
+      rend = i + match.length;
+      // If the matched character was followed by VS15 (for selecting text presentation), skip it.
+      if (str.codePointAt(rend - 1) !== 0xFE0F && str.codePointAt(rend) === 0xFE0E) {
+        i = rend + 1;
+        continue;
+      }
       replacement = document.createElement('img');
       replacement.setAttribute('draggable', 'false');
       replacement.setAttribute('class', 'emojione');
       replacement.setAttribute('alt', match);
       replacement.setAttribute('title', title);
       replacement.setAttribute('src', `${assetHost}/emoji/${emojiFilename(filename)}.svg`);
-      rend = i + match.length;
-      // If the matched character was followed by VS15 (for selecting text presentation), skip it.
-      if (str.codePointAt(rend) === 65038) {
-        rend += 1;
-      }
     }
 
     fragment.append(document.createTextNode(str.slice(0, i)));


### PR DESCRIPTION
Unicode Variation Selector 15 (text) requests that the preceding character should be displayed as text even if it has an emoji representation.

Also some refactoring and possibly small performance improvements.

Some characters (which are supposed to default to text form) could even benefit from not being eagerly represented as emojis, but I have found no way to do that. Furthermore, the behavior implemented in this PR is consistent with that of e.g. Twitter (which eagerly emojify but respects VS-15) as far as I can tell.