### PR TITLE
Change tag feeds to have no maximum tag limit

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.js
@@ -40,18 +40,6 @@ class ColumnSettings extends React.PureComponent {
     }
   };
 
-  onSelect = mode => value => {
-    const oldValue = this.tags(mode);
-
-    // Prevent changes that add more than 4 tags, but allow removing
-    // tags that were already added before
-    if ((value.length > 4) && !(value < oldValue)) {
-      return;
-    }
-
-    this.props.onChange(['tags', mode], value);
-  };
-
   onToggle = () => {
     if (this.state.open && this.hasTags()) {
       this.props.onChange('tags', {});

--- a/app/models/tag_feed.rb
+++ b/app/models/tag_feed.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class TagFeed < PublicFeed
-  LIMIT_PER_MODE = 4
-
   # @param [Tag] tag
   # @param [Account] account
   # @param [Hash] options
@@ -51,6 +49,6 @@ class TagFeed < PublicFeed
   end
 
   def tags_for(names)
-    Tag.matching_name(Array(names).take(LIMIT_PER_MODE)).pluck(:id) if names.present?
+    Tag.matching_name(Array(names)).pluck(:id) if names.present?
   end
 end


### PR DESCRIPTION
Originally introduced in [#14728](https://github.com/mastodon/mastodon/pull/14728), hashtag feeds are currently limited to a maximum of 4 additional hashtags per timeline to avoid slow queries. However, the side effect of this limit is that when users discover they cannot add additional tags to a timeline, they will instead create whole new timelines, which has a significantly greater performance impact than simply allowing additional tags in the query.

At first I considered increasing the limit to something larger (25 or maybe 100), but I found:
- there is no limit on the maximum number of `TagFeed`
- Calls to `TagFeed#get` already respect `DEFAULT_STATUSES_LIMIT` for paginating results