### PR TITLE
Change CSP directives on API to be tight and concise

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -16,6 +16,26 @@ class Api::BaseController < ApplicationController
 
   protect_from_forgery with: :null_session
 
+  content_security_policy do |p|
+    # Set every directive that does not have a fallback
+    p.default_src :none
+    p.frame_ancestors :none
+    p.form_action :none
+
+    # Disable every directive with a fallback to cut on response size
+    p.base_uri false
+    p.font_src false
+    p.img_src false
+    p.style_src false
+    p.media_src false
+    p.frame_src false
+    p.manifest_src false
+    p.connect_src false
+    p.script_src false
+    p.child_src false
+    p.worker_src false
+  end
+
   rescue_from ActiveRecord::RecordInvalid, Mastodon::ValidationError do |e|
     render json: { error: e.to_s }, status: 422
   end


### PR DESCRIPTION
The global CSP only really apply to HTML pages with JS, and was getting quite long.

We basically don't need to allow anything for API calls, so we can make the CSP tighter and more concise.