### PR TITLE
Fix crash in elasticsearch_check.rb

### DIFF
--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -34,6 +34,7 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
   end
 
   def compatible_version?
+    return false if running_version.nil?
     Gem::Version.new(running_version) >= Gem::Version.new(required_version)
   end
 end


### PR DESCRIPTION
Nil unwrap causes the admin dashboard to crash/500 when the Chewy client info version number value is nil. This occurs when running another ES-compatible backend such as MeiliSearch. Obviously it would be good for chewy to recognise upstream but at least avoiding the crash would be fine.
Not much of a ruby coder so don't really know what would fit the style better but afaict we just need to avoid passing nil to `Gem::Version.new()`.