### PR TITLE
Add Montenegrin (cnr)

### DIFF
--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -190,6 +190,7 @@ module LanguagesHelper
   ISO_639_3 = {
     ast: ['Asturian', 'Asturianu'].freeze,
     ckb: ['Sorani (Kurdish)', 'سۆرانی'].freeze,
+    cnr: ['Montenegrin', 'crnogorski'].freeze,
     jbo: ['Lojban', 'la .lojban.'].freeze,
     kab: ['Kabyle', 'Taqbaylit'].freeze,
     kmr: ['Kurmanji (Kurdish)', 'Kurmancî'].freeze,


### PR DESCRIPTION
Official language of Montenegro, the country is a bit polarised on what their language is called but around 136k Montenegrin citizens declared themselves to speak Montenegrin in 2011 and it's been on the up since then