### PR TITLE
Fix profile avatar being slightly offset into left border

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7011,7 +7011,6 @@ noscript {
       display: block;
       flex: 0 0 auto;
       width: 94px;
-      margin-left: -2px;
 
       .account__avatar {
         background: darken($ui-base-color, 8%);


### PR DESCRIPTION
With 4.0 I noticed that the avatar slightly collapsed into the border, looking somewhat weird especially on the light theme.

Before:
<img width="575" alt="Screenshot 2022-11-18 at 15 14 01" src="https://user-images.githubusercontent.com/1774242/202724672-82c270f2-472f-4607-bc65-835db716f40f.png">

After:
<img width="575" alt="Screenshot 2022-11-18 at 15 14 35" src="https://user-images.githubusercontent.com/1774242/202724713-106a5fbb-5cbf-426a-a87b-f933e853a300.png">
