### PR TITLE
Add missing procps package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     useradd -u "$UID" -g "${GID}" -m -d /opt/mastodon mastodon && \
     apt-get -y --no-install-recommends install whois \
         wget \
+        procps \
         libssl1.1 \
         libpq5 \
         imagemagick \


### PR DESCRIPTION
The new Debian-Base does not come with this by default, making the ps based health-check in the compose file fail