### PR TITLE
Pre-create and chown system volume in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,10 @@ RUN apt-get update && \
 COPY --chown=mastodon:mastodon . /opt/mastodon
 COPY --chown=mastodon:mastodon --from=build /opt/mastodon /opt/mastodon
 
+RUN mkdir -p /opt/mastodon/public/system && \
+    chown mastodon:mastodon /opt/mastodon/public/system
+VOLUME /opt/mastodon/public/system
+
 ENV RAILS_ENV="production" \
     NODE_ENV="production" \
     RAILS_SERVE_STATIC_FILES="true" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - redis
       # - es
     volumes:
-      - ./public/system:/mastodon/public/system
+      - ./public/system:/opt/mastodon/public/system
 
   streaming:
     build: .
@@ -106,7 +106,7 @@ services:
       - external_network
       - internal_network
     volumes:
-      - ./public/system:/mastodon/public/system
+      - ./public/system:/opt/mastodon/public/system
     healthcheck:
       test: ['CMD-SHELL', "ps aux | grep '[s]idekiq\ 6' || false"]
 


### PR DESCRIPTION
Without explicitly doing this, the owner of the volume when using the provided compose file will very likely be wrong, resulting in permission issues involving writes to that directory.