### PR TITLE
Fix typos in source documentation

### DIFF
--- a/app/workers/scheduler/suspended_user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/suspended_user_cleanup_scheduler.rb
@@ -9,7 +9,7 @@ class Scheduler::SuspendedUserCleanupScheduler
   MAX_PULL_SIZE = 50
 
   # Since account deletion is very expensive, we want to avoid
-  # overloading the server by queing too much at once.
+  # overloading the server by queuing too much at once.
   # This job runs approximately once per 2 minutes, so with a
   # value of `MAX_DELETIONS_PER_JOB` of 10, a server can
   # handle the deletion of 7200 accounts per day, provided it

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -159,7 +159,7 @@ Devise.setup do |config|
   # config.request_keys = []
 
   # Configure which authentication keys should be case-insensitive.
-  # These keys will be downcased upon creating or modifying a user and when used
+  # These keys will be lowercased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
   config.case_insensitive_keys = [:email]
 


### PR DESCRIPTION
Fixed 2 source comment/documentation typos