### PR TITLE
Add account media prune and fetch command

### DIFF
--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -67,7 +67,7 @@ module Mastodon
       aggressive = options[:aggressive]
 
       processed, aggregate = parallelize_with_progress(
-        Account.where(last_webfingered_at: ..time_ago)
+        Account.where(last_webfingered_at: Time.zone.at(0)..time_ago)
                .left_outer_joins(:user)
                .where(user: { id: nil })
         ) do |account|

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -72,8 +72,8 @@ module Mastodon
                .where(user: { id: nil })
         ) do |account|
         next if account.local?
-        next if (not account.avatar.present? and not account.header.present?)
-        next if not aggressive and Follow.where(account: account).or(Follow.where(target_account: account)).count > 0
+        next if (!account.avatar.present? && !account.header.present?)
+        next if !aggressive && Follow.where(account: account).or(Follow.where(target_account: account)).count > 0
         
         size = (account.avatar_file_size || 0) + (account.header_file_size || 0)
 
@@ -109,13 +109,13 @@ module Mastodon
 
         size = 0
         unless options[:dry_run]
-          unless account.avatar.present? or account.avatar_remote_url.blank?
+          unless account.avatar.present? || account.avatar_remote_url.blank?
             account.download_avatar!
             if account.avatar_file_size?
               size = size + account.avatar_file_size
             end
           end
-          unless account.header.present? or account.header_remote_url.blank?
+          unless account.header.present? || account.header_remote_url.blank?
             account.download_header!
             if account.header_file_size?
               size = size + account.header_file_size


### PR DESCRIPTION
This implements two new sub-commands for `tootctl media`:

- `prune-profile-media` to remove old avatar and header images
- `fetch-profile-media` to download missing avatar and header images basically undoing the prune command

I am new to Ruby and ActiveRecord, so please advise if something is wrong, I will fix the errors if needed.

This is a fix to #9567 