### PR TITLE
Implement GitOps job annotations support in the Helm Chart.

### DIFF
--- a/chart/templates/job-assets-precompile.yaml
+++ b/chart/templates/job-assets-precompile.yaml
@@ -8,6 +8,9 @@ metadata:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-2"
+  {{- with .Values.mastodon.job.assetsPrecompile.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/chart/templates/job-chewy-upgrade.yaml
+++ b/chart/templates/job-chewy-upgrade.yaml
@@ -9,6 +9,9 @@ metadata:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-1"
+  {{- with .Values.mastodon.job.chewyUpgrade.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/chart/templates/job-create-admin.yaml
+++ b/chart/templates/job-create-admin.yaml
@@ -9,6 +9,9 @@ metadata:
     "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-1"
+  {{- with .Values.mastodon.job.createAdmin.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/chart/templates/job-db-migrate.yaml
+++ b/chart/templates/job-db-migrate.yaml
@@ -8,6 +8,9 @@ metadata:
     "helm.sh/hook": post-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-weight": "-2"
+  {{- with .Values.mastodon.job.dbMigrate.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -106,6 +106,40 @@ mastodon:
       # Enable statsd publishing via STATSD_ADDR environment variable
       address: ""
 
+  job:
+    dbMigrate:
+      # Allows for additional annotations for the db-migrate job, useful in GitOps scenarios like ArgoCD Helm deployments
+      # E.g.
+      # extraAnnotations:
+      #   "argocd.argoproj.io/hook": PostSync
+      #   "argocd.argoproj.io/sync-wave": "-2"
+      #   "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
+      extraAnnotations: {}
+    assetsPrecompile:
+      # Allows for additional annotations for the assets-precompile job, useful in GitOps scenarios like ArgoCD Helm deployments
+      # E.g.
+      # extraAnnotations:
+      #   "argocd.argoproj.io/hook": PostSync
+      #   "argocd.argoproj.io/sync-wave": "-2"
+      #   "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
+      extraAnnotations: {}
+    chewyUpgrade:
+      # Allows for additional annotations for the chewy-upgrade job, useful in GitOps scenarios like ArgoCD Helm deployments
+      # E.g.
+      # extraAnnotations:
+      #   "argocd.argoproj.io/hook": PostSync
+      #   "argocd.argoproj.io/sync-wave": "-1"
+      #   "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
+      extraAnnotations: {}
+    createAdmin:
+      # Allows for additional annotations for the create-admin job, useful in GitOps scenarios like ArgoCD Helm deployments
+      # E.g.
+      # extraAnnotations:
+      #   "argocd.argoproj.io/hook": PostSync
+      #   "argocd.argoproj.io/sync-wave": "-1"
+      #   "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
+      extraAnnotations: {}
+
 ingress:
   enabled: true
   annotations:


### PR DESCRIPTION
The helm hooks configured in the job manifests will break deployments in situations where GitOps tools like ArgoCD are used. To make sure the deployment works, you need to set the additional hook annotations in the `values.yaml` file. For ArgoCD, this means that the [resource hooks](https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#usage) need to be used, in this case, the `PostSync` hook, which according to the docs, executes after all `Sync` hooks were completed and were successful, an application is successful, and all resources are in a Healthy state. This allows the resources to be synchronized first, and then the original helm hooks will be respected. Without this, ArgoCD will run the `db-migrate` job without deploying its dependencies, like the persistent volume claim.

For example, you can set the following in the `values.yaml` configuration:

```yaml
mastodon:
  job:
    dbMigrate:
      extraAnnotations:
        "argocd.argoproj.io/hook": PostSync
        "argocd.argoproj.io/sync-wave": "-2"
        "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded

    assetsPrecompile:
      extraAnnotations:
        "argocd.argoproj.io/hook": PostSync
        "argocd.argoproj.io/sync-wave": "-2"
        "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded

    chewyUpgrade:
      extraAnnotations:
        "argocd.argoproj.io/hook": PostSync
        "argocd.argoproj.io/sync-wave": "-1"
        "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded

    createAdmin:
      extraAnnotations:
        "argocd.argoproj.io/hook": PostSync
        "argocd.argoproj.io/sync-wave": "-1"
        "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation,HookSucceeded
```