### PR TITLE
Fix and improve LDAP configuration in the Helm Chart

### DIFF
--- a/chart/templates/configmap-env.yaml
+++ b/chart/templates/configmap-env.yaml
@@ -281,13 +281,16 @@ data:
   {{- if .Values.externalAuth.ldap.enabled }}
   LDAP_ENABLED: {{ .Values.externalAuth.ldap.enabled | quote }}
   LDAP_HOST: {{ .Values.externalAuth.ldap.host }}
-  LDAP_PORT: {{ .Values.externalAuth.ldap.port }}
+  LDAP_PORT: {{ .Values.externalAuth.ldap.port | quote }}
   LDAP_METHOD: {{ .Values.externalAuth.ldap.method }}
+  {{- if .Values.externalAuth.ldap.tls_no_verify }}
+  LDAP_TLS_NO_VERIFY: {{ .Values.externalAuth.ldap.tls_no_verify | quote }}
+  {{- end }}
   {{- if .Values.externalAuth.ldap.base }}
   LDAP_BASE: {{ .Values.externalAuth.ldap.base }}
   {{- end }}
-  {{- if .Values.externalAuth.ldap.bind_on }}
-  LDAP_BIND_ON: {{ .Values.externalAuth.ldap.bind_on }}
+  {{- if .Values.externalAuth.ldap.bind_dn }}
+  LDAP_BIND_DN: {{ .Values.externalAuth.ldap.bind_dn }}
   {{- end }}
   {{- if .Values.externalAuth.ldap.password }}
   LDAP_PASSWORD: {{ .Values.externalAuth.ldap.password }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -265,10 +265,11 @@ externalAuth:
   ldap:
     enabled: false
     # host: myservice.namespace.svc
-    # port: 389
+    # port: 636
     # method: simple_tls
+    # tls_no_verify: true
     # base:
-    # bind_on:
+    # bind_dn:
     # password:
     # uid: cn
     # mail: mail


### PR DESCRIPTION
The bind DN option was wrongly named, the port is a number - so therefore needs to be quoted in the configmap, the simple_tls method uses the SSL port (636) and not the unencrypted/start_tls port (389), and lots of places don't actually use globally verifiable TLS certificates for their LDAP connection - so being able to skip verification is *very* helpful.