### PR TITLE
Fix "from:" search term working properly

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -92,7 +92,7 @@ class SearchService < BaseService
   def full_text_searchable?
     return false unless Chewy.enabled?
 
-    statuses_search? && !@account.nil? && !(@query.include?('@') && !@query.include?(' '))
+    statuses_search? && !@account.nil? && !(@query.include?('@') && !@query.include?(' ') && !@query.include?(':'))
   end
 
   def account_searchable?


### PR DESCRIPTION
This pr fixes search term like `from:username@remote.host`

This pr also fixes #18791