### PR TITLE
fix media uploads with ffmpeg 5

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -104,6 +104,7 @@ class MediaAttachment < ApplicationRecord
         'c:v' => 'h264',
         'maxrate' => '1300K',
         'bufsize' => '1300K',
+        'b:v' => '1300K',
         'frames:v' => 60 * 60 * 3,
         'crf' => 18,
         'map_metadata' => '-1',


### PR DESCRIPTION
Fixes #21154. This was tested by running the ffmpeg command manually in a docker container on Ubuntu 20.04 and Debian 11, and this Ruby change was tested on my Fedora 36 server's mastodon instance.