### PR TITLE
Fix N+1 queries in NotificationsController

### DIFF
--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::NotificationsController < Api::BaseController
   private
 
   def load_notifications
-    notifications = browserable_account_notifications.includes(from_account: :account_stat).to_a_paginated_by_id(
+    notifications = browserable_account_notifications.includes(from_account: [:account_stat, :user]).to_a_paginated_by_id(
       limit_param(DEFAULT_NOTIFICATIONS_LIMIT),
       params_slice(:max_id, :since_id, :min_id)
     )


### PR DESCRIPTION
In #19319, the `noindex` attribute is added to `AccountSerializer`. The field is defined in the User model instead of the Account model, so an extra query will occur if the User model is not preloaded. The notifications controller returns the account associated with a notification, but does not preload `from_account.user`. Therefore, N+1 queries happen when rendering notifications.

This PR fixes the issue by preloading `:user` in `NotificationsController#load_notifications`.