### PR TITLE
db/migrate: adding index over url on preview_cards, fixing #21222

### DIFF
--- a/db/migrate/20221120142406_add_index_preview_cards_url_hash_idx_on_preview_cards.sql
+++ b/db/migrate/20221120142406_add_index_preview_cards_url_hash_idx_on_preview_cards.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY preview_cards_url_hash_idx ON preview_cards USING hash (url);


### PR DESCRIPTION
I didn’t understood how other migrations work, so I added it directly using SQL.