### PR TITLE
Add option to block follows from domain

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -82,15 +82,15 @@ module Admin
     end
 
     def update_params
-      params.require(:domain_block).permit(:severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate)
+      params.require(:domain_block).permit(:severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate, :reject_follows)
     end
 
     def resource_params
-      params.require(:domain_block).permit(:domain, :severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate)
+      params.require(:domain_block).permit(:domain, :severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate, :reject_follows)
     end
 
     def form_domain_block_batch_params
-      params.require(:form_domain_block_batch).permit(domain_blocks_attributes: [:enabled, :domain, :severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate])
+      params.require(:form_domain_block_batch).permit(domain_blocks_attributes: [:enabled, :domain, :severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate, :reject_follows])
     end
 
     def action_from_button

--- a/app/controllers/admin/export_domain_blocks_controller.rb
+++ b/app/controllers/admin/export_domain_blocks_controller.rb
@@ -36,6 +36,7 @@ module Admin
                                        severity: row['#severity'].strip,
                                        reject_media: row['#reject_media'].strip,
                                        reject_reports: row['#reject_reports'].strip,
+                                       reject_follows: row['#reject_follows'].strip,
                                        private_comment: @global_private_comment,
                                        public_comment: row['#public_comment']&.strip,
                                        obfuscate: row['#obfuscate'].strip)
@@ -57,13 +58,13 @@ module Admin
     end
 
     def export_headers
-      %w(#domain #severity #reject_media #reject_reports #public_comment #obfuscate)
+      %w(#domain #severity #reject_media #reject_reports #public_comment #obfuscate #reject_follows)
     end
 
     def export_data
       CSV.generate(headers: export_headers, write_headers: true) do |content|
         DomainBlock.with_limitations.each do |instance|
-          content << [instance.domain, instance.severity, instance.reject_media, instance.reject_reports, instance.public_comment, instance.obfuscate]
+          content << [instance.domain, instance.severity, instance.reject_media, instance.reject_reports, instance.public_comment, instance.obfuscate, instance.reject_follows]
         end
       end
     end

--- a/app/controllers/api/v1/admin/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/domain_blocks_controller.rb
@@ -71,7 +71,7 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
   end
 
   def domain_block_params
-    params.permit(:severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate)
+    params.permit(:severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate, :reject_follows)
   end
 
   def insert_pagination_headers
@@ -103,6 +103,6 @@ class Api::V1::Admin::DomainBlocksController < Api::BaseController
   end
 
   def resource_params
-    params.permit(:domain, :severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate)
+    params.permit(:domain, :severity, :reject_media, :reject_reports, :private_comment, :public_comment, :obfuscate, :reject_follows)
   end
 end

--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -109,6 +109,7 @@ delegate(document, '.filter-subset--with-select select', 'change', ({ target }) 
 const onDomainBlockSeverityChange = (target) => {
   const rejectMediaDiv   = document.querySelector('.input.with_label.domain_block_reject_media');
   const rejectReportsDiv = document.querySelector('.input.with_label.domain_block_reject_reports');
+  const rejectFollowsDiv = document.querySelector('.input.with_label.domain_block_reject_follows');
 
   if (rejectMediaDiv) {
     rejectMediaDiv.style.display = (target.value === 'suspend') ? 'none' : 'block';
@@ -116,6 +117,10 @@ const onDomainBlockSeverityChange = (target) => {
 
   if (rejectReportsDiv) {
     rejectReportsDiv.style.display = (target.value === 'suspend') ? 'none' : 'block';
+  }
+
+  if (rejectFollowsDiv) {
+    rejectFollowsDiv.style.display = (target.value === 'suspend') ? 'none' : 'block';
   }
 };
 

--- a/app/lib/activitypub/activity/follow.rb
+++ b/app/lib/activitypub/activity/follow.rb
@@ -15,6 +15,11 @@ class ActivityPub::Activity::Follow < ActivityPub::Activity
       return
     end
 
+    if DomainBlock.reject_follows?(@account.domain) && !target_account.following?(@account)
+      reject_follow_request!(target_account)
+      return
+    end
+
     if target_account.blocking?(@account) || target_account.domain_blocking?(@account.domain) || target_account.moved? || target_account.instance_actor?
       reject_follow_request!(target_account)
       return

--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -13,6 +13,7 @@
 #  private_comment :text
 #  public_comment  :text
 #  obfuscate       :boolean          default(FALSE), not null
+#  reject_follows  :boolean          default(FALSE), not null
 #
 
 class DomainBlock < ApplicationRecord
@@ -40,7 +41,7 @@ class DomainBlock < ApplicationRecord
     if suspend?
       [:suspend]
     else
-      [severity.to_sym, reject_media? ? :reject_media : nil, reject_reports? ? :reject_reports : nil].reject { |policy| policy == :noop || policy.nil? }
+      [severity.to_sym, reject_media? ? :reject_media : nil, reject_reports? ? :reject_reports : nil, reject_follows? ? :reject_follows : nil].reject { |policy| policy == :noop || policy.nil? }
     end
   end
 
@@ -59,6 +60,10 @@ class DomainBlock < ApplicationRecord
 
     def reject_reports?(domain)
       !!rule_for(domain)&.reject_reports?
+    end
+
+    def reject_follows?(domain)
+      !!rule_for(domain)&.reject_follows?
     end
 
     alias blocked? suspend?
@@ -81,7 +86,7 @@ class DomainBlock < ApplicationRecord
     return false if other_block.suspend? && (silence? || noop?)
     return false if other_block.silence? && noop?
 
-    (reject_media || !other_block.reject_media) && (reject_reports || !other_block.reject_reports)
+    (reject_media || !other_block.reject_media) && (reject_reports || !other_block.reject_reports) && (reject_follows || !other_block.reject_follows)
   end
 
   def affected_accounts_count

--- a/app/serializers/rest/admin/domain_block_serializer.rb
+++ b/app/serializers/rest/admin/domain_block_serializer.rb
@@ -2,7 +2,7 @@
 
 class REST::Admin::DomainBlockSerializer < ActiveModel::Serializer
   attributes :id, :domain, :created_at, :severity,
-             :reject_media, :reject_reports,
+             :reject_media, :reject_reports, :reject_follows,
              :private_comment, :public_comment, :obfuscate
 
   def id

--- a/app/views/admin/domain_blocks/edit.html.haml
+++ b/app/views/admin/domain_blocks/edit.html.haml
@@ -21,6 +21,9 @@
     = f.input :reject_reports, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_blocks.reject_reports'), hint: I18n.t('admin.domain_blocks.reject_reports_hint')
 
   .fields-group
+    = f.input :reject_follows, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_blocks.reject_follows'), hint: I18n.t('admin.domain_blocks.reject_follows_hint')
+
+  .fields-group
     = f.input :obfuscate, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_blocks.obfuscate'), hint: I18n.t('admin.domain_blocks.obfuscate_hint')
 
   .field-group

--- a/app/views/admin/domain_blocks/new.html.haml
+++ b/app/views/admin/domain_blocks/new.html.haml
@@ -21,6 +21,9 @@
     = f.input :reject_reports, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_blocks.reject_reports'), hint: I18n.t('admin.domain_blocks.reject_reports_hint')
 
   .fields-group
+    = f.input :reject_follows, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_blocks.reject_follows'), hint: I18n.t('admin.domain_blocks.reject_follows_hint')
+
+  .fields-group
     = f.input :obfuscate, as: :boolean, wrapper: :with_label, label: I18n.t('admin.domain_blocks.obfuscate'), hint: I18n.t('admin.domain_blocks.obfuscate_hint')
 
   .field-group

--- a/app/views/admin/export_domain_blocks/_domain_block.html.haml
+++ b/app/views/admin/export_domain_blocks/_domain_block.html.haml
@@ -11,6 +11,7 @@
       = f.hidden_field :severity
       = f.hidden_field :reject_media
       = f.hidden_field :reject_reports
+      = f.hidden_field :reject_follows
       = f.hidden_field :obfuscate
       = f.hidden_field :private_comment
       = f.hidden_field :public_comment

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,6 +403,8 @@ en:
       private_comment_hint: Comment about this domain limitation for internal use by the moderators.
       public_comment: Public comment
       public_comment_hint: Comment about this domain limitation for the general public, if advertising the list of domain limitations is enabled.
+      reject_follows: Reject follows
+      reject_follows_hint: Ignore all follow requests coming from this domain unless the recipient already follows the requester. Irrelevant for suspensions
       reject_media: Reject media files
       reject_media_hint: Removes locally stored media files and refuses to download any in the future. Irrelevant for suspensions
       reject_reports: Reject reports
@@ -471,6 +473,7 @@ en:
         comment: Internal note
         description_html: You can define content policies that will be applied to all accounts from this domain and any of its subdomains.
         policies:
+          reject_follows: Reject follows
           reject_media: Reject media
           reject_reports: Reject reports
           silence: Limit

--- a/config/locales/en_GB.yml
+++ b/config/locales/en_GB.yml
@@ -267,6 +267,8 @@ en_GB:
           silence: Silence
           suspend: Suspend
         title: New domain block
+      reject_follows: Reject follows
+      reject_follows_hint: Ignore all follow requests coming from this domain unless the recipient already follows the requester. Irrelevant for suspensions
       reject_media: Reject media files
       reject_media_hint: Removes locally stored media files and refuses to download any in the future. Irrelevant for suspensions
       reject_reports: Reject reports

--- a/db/migrate/20221120170739_add_reject_follows_to_domain_blocks.rb
+++ b/db/migrate/20221120170739_add_reject_follows_to_domain_blocks.rb
@@ -1,0 +1,17 @@
+require Rails.root.join('lib', 'mastodon', 'migration_helpers')
+
+class AddRejectFollowsToDomainBlocks < ActiveRecord::Migration[6.1]
+  include Mastodon::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      add_column_with_default :domain_blocks, :reject_follows, :boolean, default: false, allow_null: false
+    end
+  end
+
+  def down
+    remove_column :domain_blocks, :reject_follows
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_04_133904) do
+ActiveRecord::Schema.define(version: 2022_11_20_170739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -400,6 +400,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_133904) do
     t.text "private_comment"
     t.text "public_comment"
     t.boolean "obfuscate", default: false, null: false
+    t.boolean "reject_follows", default: false, null: false
     t.index ["domain"], name: "index_domain_blocks_on_domain", unique: true
   end
 

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Admin::DomainBlocksController, type: :controller do
       Fabricate(:domain_block, domain: 'example.com', severity: 'silence')
       allow(DomainBlockWorker).to receive(:perform_async).and_return(true)
 
-      post :create, params: { domain_block: { domain: 'example.com', severity: 'silence', reject_media: true, reject_reports: true } }
+      post :create, params: { domain_block: { domain: 'example.com', severity: 'silence', reject_media: true, reject_reports: true, reject_follows: true } }
 
       expect(DomainBlockWorker).to have_received(:perform_async)
       expect(flash[:notice]).to eq I18n.t('admin.domain_blocks.created_msg')

--- a/spec/controllers/admin/export_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_blocks_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Admin::ExportDomainBlocksController, type: :controller do
       Fabricate(:domain_block, domain: 'bad.domain', severity: 'silence', public_comment: 'bad')
       Fabricate(:domain_block, domain: 'worse.domain', severity: 'suspend', reject_media: true, reject_reports: true, public_comment: 'worse', obfuscate: true)
       Fabricate(:domain_block, domain: 'reject.media', severity: 'noop', reject_media: true, public_comment: 'reject media')
+      Fabricate(:domain_block, domain: 'reject.follows', severity: 'silence', reject_follows: true, public_comment: 'reject follows')
       Fabricate(:domain_block, domain: 'no.op', severity: 'noop', public_comment: 'noop')
 
       get :export, params: { format: :csv }
@@ -24,7 +25,7 @@ RSpec.describe Admin::ExportDomainBlocksController, type: :controller do
     it 'blocks imported domains' do
       post :import, params: { admin_import: { data: fixture_file_upload('domain_blocks.csv') } }
 
-      expect(assigns(:domain_blocks).map(&:domain)).to match_array ['bad.domain', 'worse.domain', 'reject.media']
+      expect(assigns(:domain_blocks).map(&:domain)).to match_array ['bad.domain', 'worse.domain', 'reject.media', 'reject.follows']
     end
   end
 

--- a/spec/fixtures/files/domain_blocks.csv
+++ b/spec/fixtures/files/domain_blocks.csv
@@ -1,4 +1,5 @@
-#domain,#severity,#reject_media,#reject_reports,#public_comment,#obfuscate
-bad.domain,silence,false,false,bad,false
-worse.domain,suspend,true,true,worse,true
-reject.media,noop,true,false,reject media,false
+#domain,#severity,#reject_media,#reject_reports,#public_comment,#obfuscate,#reject_follows
+bad.domain,silence,false,false,bad,false,false
+worse.domain,suspend,true,true,worse,true,false
+reject.media,noop,true,false,reject media,false,false
+reject.follows,silence,false,false,reject follows,false,true

--- a/spec/models/domain_block_spec.rb
+++ b/spec/models/domain_block_spec.rb
@@ -93,5 +93,11 @@ RSpec.describe DomainBlock, type: :model do
       newer = DomainBlock.new(domain: 'domain', severity: :silence, reject_media: false)
       expect(newer.stricter_than?(older)).to be false
     end
+
+    it 'returns false if the new block is less strict regarding follows' do
+      older = DomainBlock.new(domain: 'domain', severity: :silence, reject_follows: true)
+      newer = DomainBlock.new(domain: 'domain', severity: :silence, reject_follows: false)
+      expect(newer.stricter_than?(older)).to be false
+    end
   end
 end


### PR DESCRIPTION
This feature, if enabled, will block all follows from the given domain unless the recipient of the follow already follows the sender back.

🗒️ This is my first contribution to Mastodon; thanks for a really neat project! Feedback on style/code layout/etc. is appreciated 😃 