### PR TITLE
Add the possibility to set PREPARED_STATEMENTS environment variable

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/configmap-env.yaml
+++ b/chart/templates/configmap-env.yaml
@@ -15,6 +15,9 @@ data:
   DB_NAME: {{ .Values.postgresql.auth.database }}
   DB_POOL: {{ .Values.mastodon.sidekiq.concurrency | quote }}
   DB_USER: {{ .Values.postgresql.auth.username }}
+  {{- if .Values.mastodon.preparedStatements }}
+  PREPARED_STATEMENTS: {{ .Values.mastodon.preparedStatements | quote }}
+  {{- end }}
   DEFAULT_LOCALE: {{ .Values.mastodon.locale }}
   {{- if .Values.elasticsearch.enabled }}
   ES_ENABLED: "true"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -106,6 +106,10 @@ mastodon:
       # Enable statsd publishing via STATSD_ADDR environment variable
       address: ""
 
+  # Uncomment and set if there is a need to set the PREPARED_STATEMENTS
+  # environment variable for your postgresql hosting situation
+  # preparedStatements: false
+
 ingress:
   enabled: true
   annotations:


### PR DESCRIPTION
This can be useful in situations where prepared statements don't work as expected. Once such case can be pgbouncer as provided by DigitalOcean for connection pooling.