### PR TITLE
Add 'Follow System Theme' Theme setting to preferences page

### DIFF
--- a/app/javascript/styles/system.scss
+++ b/app/javascript/styles/system.scss
@@ -1,0 +1,31 @@
+@media (prefers-color-scheme: light) {
+  @import 'mastodon-light/variables';
+  @import 'application';
+  @import 'mastodon-light/diff';
+}
+
+@media (prefers-color-scheme: dark) {
+  @import 'mastodon/mixins';
+  @import 'mastodon/variables';
+  @import 'fonts/roboto';
+  @import 'fonts/roboto-mono';
+  @import 'mastodon/reset';
+  @import 'mastodon/basics';
+  @import 'mastodon/branding';
+  @import 'mastodon/containers';
+  @import 'mastodon/lists';
+  @import 'mastodon/widgets';
+  @import 'mastodon/forms';
+  @import 'mastodon/accounts';
+  @import 'mastodon/statuses';
+  @import 'mastodon/boost';
+  @import 'mastodon/components';
+  @import 'mastodon/polls';
+  @import 'mastodon/modal';
+  @import 'mastodon/emoji_picker';
+  @import 'mastodon/about';
+  @import 'mastodon/tables';
+  @import 'mastodon/admin';
+  @import 'mastodon/dashboard';
+  @import 'mastodon/rtl';
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1553,6 +1553,7 @@ en:
     contrast: Mastodon (High contrast)
     default: Mastodon (Dark)
     mastodon-light: Mastodon (Light)
+    system: Follow System Theme
   time:
     formats:
       default: "%b %d, %Y, %H:%M"

--- a/config/themes.yml
+++ b/config/themes.yml
@@ -1,3 +1,4 @@
 default: styles/application.scss
 contrast: styles/contrast.scss
 mastodon-light: styles/mastodon-light.scss
+system: styles/system.scss


### PR DESCRIPTION
Taking a stab at #20867

---

I was wanting this as well so I kinda hacked together a solution.

This is a pretty small PR that contains a couple things:
1. I added a new Theme setting, `system`, which just imports ALL of the css and goes off of the browser's `prefers-color-scheme` function. It's basically ripped from the default and mastodon-light themes. 
2. Adds a locale entry for a prettified name in English, I should probably get my translator out and do the rest but running out of time today.  

*One caveat I did notice:*
Webpack will fail to compile if I included the accessibility stylesheet here: https://github.com/mastodon/mastodon/blob/69378eac99c013a0db7d2d5ff9a54dfcc287d9ce/app/javascript/styles/application.scss#L25

So if you have `system` enabled it won't apply those styles. 

---

Thanks in advance for any reviews!

----
Short video demo (I am switching my gtk theme in the background): 

https://user-images.githubusercontent.com/5856504/202930147-1f5e2291-6dbd-4af5-8b43-7a4f1d7205a6.mp4

Screenshot of settings page:
![image](https://user-images.githubusercontent.com/5856504/202930204-1846fd70-ded1-4f99-a802-c35752b5eee9.png)
