### PR TITLE
make the admin creation job use Owner role

### DIFF
--- a/chart/templates/job-create-admin.yaml
+++ b/chart/templates/job-create-admin.yaml
@@ -55,7 +55,7 @@ spec:
             - {{ .Values.mastodon.createAdmin.email }}
             - --confirmed
             - --role
-            - admin
+            - Owner
           envFrom:
             - configMapRef:
                 name: {{ include "mastodon.fullname" . }}-env


### PR DESCRIPTION
The helm chart can be made to create an admin user, however that role name has recently changed from `admin` to `Owner`.  The helm chart was not updated.  This PR updates the role of the admin user being created to `Owner` so the job succeeds.