### PR TITLE
Add "disabled" user filter for admin/accounts UI

### DIFF
--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -81,7 +81,7 @@ class AccountFilter
     when 'suspended'
       Account.suspended
     when 'disabled'
-      accounts_with_users.merge(User.disabled)
+      accounts_with_users.merge(User.disabled).without_suspended
     when 'silenced'
       Account.silenced
     when 'sensitized'

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -13,7 +13,7 @@
     .filter-subset.filter-subset--with-select
       %strong= t('admin.accounts.moderation.title')
       .input.select.optional
-        = select_tag :status, options_for_select([[t('admin.accounts.moderation.active'), 'active'], [t('admin.accounts.moderation.silenced'), 'silenced'], [t('admin.accounts.moderation.suspended'), 'suspended'], [safe_join([t('admin.accounts.moderation.pending'), "(#{number_with_delimiter(User.pending.count)})"], ' '), 'pending']], params[:status]), prompt: I18n.t('generic.all')
+        = select_tag :status, options_for_select([[t('admin.accounts.moderation.active'), 'active'], [t('admin.accounts.moderation.silenced'), 'silenced'], [t('admin.accounts.moderation.disabled'), 'disabled'], [t('admin.accounts.moderation.suspended'), 'suspended'], [safe_join([t('admin.accounts.moderation.pending'), "(#{number_with_delimiter(User.pending.count)})"], ' '), 'pending']], params[:status]), prompt: I18n.t('generic.all')
     .filter-subset.filter-subset--with-select
       %strong= t('admin.accounts.role')
       .input.select.optional


### PR DESCRIPTION
* Add `disabled` filter for admin/accounts view
* Make `disabled` filter only show login disabled users, not including suspended

It is useful for moderation decision like this situation:
"We disabled user account for now for legal reason. After resolving this, your account will be opened or suspended"
