### PR TITLE
Fix crash in Vacuum:StatusesVacuum when deleting expired direct messages

### DIFF
--- a/app/lib/vacuum/statuses_vacuum.rb
+++ b/app/lib/vacuum/statuses_vacuum.rb
@@ -41,7 +41,9 @@ class Vacuum::StatusesVacuum
   end
 
   def remove_from_account_conversations(statuses)
-    Status.where(id: statuses.select(&:direct_visibility?).map(&:id)).includes(:account, mentions: :account).each(&:unlink_from_conversations)
+    Status.where(id: statuses.select(&:direct_visibility?).map(&:id)).includes(:account, mentions: :account).each do |status|
+      status.send(:unlink_from_conversations)
+    end
   end
 
   def remove_from_search_index(statuses)


### PR DESCRIPTION
Fixes #21210

Note that I am still **very** uncomfortable with that setting deleting unrecoverable posts (such as direct messages) mentioning local users.