### PR TITLE
Ensure exact match is the first result in hashtag searches

### DIFF
--- a/app/services/tag_search_service.rb
+++ b/app/services/tag_search_service.rb
@@ -76,9 +76,25 @@ class TagSearchService < BaseService
     definition = TagsIndex.query(query)
     definition = definition.filter(filter) if @options[:exclude_unreviewed]
 
-    definition.limit(@limit).offset(@offset).objects.compact
+    ensure_exact_match(definition.limit(@limit).offset(@offset).objects.compact)
   rescue Faraday::ConnectionFailed, Parslet::ParseFailed
     nil
+  end
+
+  # Since the ElasticSearch Query doesn't guarantee the exact match will be the
+  # first result or that it will even be returned, patch the results accordingly
+  def ensure_exact_match(results)
+    return results unless @offset.nil? || @offset.zero?
+
+    normalized_query = Tag.normalize(@query)
+    exact_match = results.find { |tag| tag.name.downcase == normalized_query }
+    exact_match ||= Tag.find_normalized(normalized_query)
+    unless exact_match.nil?
+      results.delete(exact_match)
+      results = [exact_match] + results
+    end
+
+    results
   end
 
   def from_database


### PR DESCRIPTION
Fixes #17494

Note that I'm not familiar with ElasticSearch and it is not currently installed in my development environment, so I could not test it.