### PR TITLE
Remove broken “share” option on account profile dropdown

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -32,7 +32,6 @@ const messages = defineMessages({
   block: { id: 'account.block', defaultMessage: 'Block @{name}' },
   mute: { id: 'account.mute', defaultMessage: 'Mute @{name}' },
   report: { id: 'account.report', defaultMessage: 'Report @{name}' },
-  share: { id: 'account.share', defaultMessage: 'Share @{name}\'s profile' },
   media: { id: 'account.media', defaultMessage: 'Media' },
   blockDomain: { id: 'account.block_domain', defaultMessage: 'Block domain {domain}' },
   unblockDomain: { id: 'account.unblock_domain', defaultMessage: 'Unblock domain {domain}' },
@@ -213,11 +212,6 @@ class Header extends ImmutablePureComponent {
 
     if (isRemote) {
       menu.push({ text: intl.formatMessage(messages.openOriginalPage), href: account.get('url') });
-      menu.push(null);
-    }
-
-    if ('share' in navigator) {
-      menu.push({ text: intl.formatMessage(messages.share, { name: account.get('username') }), action: this.handleShare });
       menu.push(null);
     }
 

--- a/app/javascript/mastodon/locales/af.json
+++ b/app/javascript/mastodon/locales/af.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots and replies",
   "account.report": "Rapporteer @{name}",
   "account.requested": "Awaiting approval",
-  "account.share": "Deel @{name} se profiel",
   "account.show_reblogs": "Wys hupstote vanaf @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Ontblok @{name}",

--- a/app/javascript/mastodon/locales/an.json
+++ b/app/javascript/mastodon/locales/an.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Posts and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval. Click to cancel follow request",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Post} other {{counter} Posts}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/ar.json
+++ b/app/javascript/mastodon/locales/ar.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "المنشورات والرُدود",
   "account.report": "الإبلاغ عن @{name}",
   "account.requested": "في انتظار القبول. اضغط لإلغاء طلب المُتابعة",
-  "account.share": "شارِك الملف التعريفي لـ @{name}",
   "account.show_reblogs": "عرض مشاركات @{name}",
   "account.statuses_counter": "{count, plural, zero {لَا منشورات} one {منشور واحد} two {منشوران إثنان} few {{counter} منشورات} many {{counter} منشورًا} other {{counter} منشور}}",
   "account.unblock": "إلغاء الحَظر عن @{name}",

--- a/app/javascript/mastodon/locales/ast.json
+++ b/app/javascript/mastodon/locales/ast.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Artículos y rempuestes",
   "account.report": "Informar de @{name}",
   "account.requested": "Esperando pola aprobación. Calca pa encaboxar la solicitú de siguimientu",
-  "account.share": "Compartir el perfil de @{name}",
   "account.show_reblogs": "Amosar les comparticiones de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} artículu} other {{counter} artículos}}",
   "account.unblock": "Desbloquiar a @{name}",

--- a/app/javascript/mastodon/locales/bg.json
+++ b/app/javascript/mastodon/locales/bg.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Публикации и отговори",
   "account.report": "Докладване на @{name}",
   "account.requested": "Чака се одобрение. Щракнете за отмяна на заявката за последване",
-  "account.share": "Споделяне на профила на @{name}",
   "account.show_reblogs": "Показване на споделяния от @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} публикация} other {{counter} публикации}}",
   "account.unblock": "Отблокиране на @{name}",

--- a/app/javascript/mastodon/locales/bn.json
+++ b/app/javascript/mastodon/locales/bn.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "টুট এবং মতামত",
   "account.report": "@{name} কে রিপোর্ট করুন",
   "account.requested": "অনুমতির অপেক্ষা। অনুসরণ করার অনুরোধ বাতিল করতে এখানে ক্লিক করুন",
-  "account.share": "@{name} র প্রোফাইল অন্যদের দেখান",
   "account.show_reblogs": "@{name} র সমর্থনগুলো দেখান",
   "account.statuses_counter": "{count, plural,one {{counter} টুট} other {{counter} টুট}}",
   "account.unblock": "@{name} র কার্যকলাপ দেখুন",

--- a/app/javascript/mastodon/locales/br.json
+++ b/app/javascript/mastodon/locales/br.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toudoù ha respontoù",
   "account.report": "Disklêriañ @{name}",
   "account.requested": "O c'hortoz an asant. Klikit evit nullañ ar goulenn heuliañ",
-  "account.share": "Skignañ profil @{name}",
   "account.show_reblogs": "Diskouez skignadennoù @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toud} two {{counter} Doud} other {{counter} a Doudoù}}",
   "account.unblock": "Diverzañ @{name}",

--- a/app/javascript/mastodon/locales/bs.json
+++ b/app/javascript/mastodon/locales/bs.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Posts and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval. Click to cancel follow request",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Post} other {{counter} Posts}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/ca.json
+++ b/app/javascript/mastodon/locales/ca.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Tuts i respostes",
   "account.report": "Informa quant a @{name}",
   "account.requested": "S'està esperant l'aprovació. Feu clic per a cancel·lar la petició de seguiment",
-  "account.share": "Comparteix el perfil de @{name}",
   "account.show_reblogs": "Mostra els impulsos de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Tut} other {{counter} Tuts}}",
   "account.unblock": "Desbloca @{name}",

--- a/app/javascript/mastodon/locales/ckb.json
+++ b/app/javascript/mastodon/locales/ckb.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "توتس و وەڵامەکان",
   "account.report": "گوزارشت @{name}",
   "account.requested": "چاوەڕێی ڕەزامەندین. کرتە بکە بۆ هەڵوەشاندنەوەی داواکاری شوێنکەوتن",
-  "account.share": "پرۆفایلی @{name} هاوبەش بکە",
   "account.show_reblogs": "پیشاندانی بەرزکردنەوەکان لە @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Following} other {{counter} Following}}",
   "account.unblock": "@{name} لاببە",

--- a/app/javascript/mastodon/locales/co.json
+++ b/app/javascript/mastodon/locales/co.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Statuti è risposte",
   "account.report": "Palisà @{name}",
   "account.requested": "In attesa d'apprubazione. Cliccate per annullà a dumanda",
-  "account.share": "Sparte u prufile di @{name}",
   "account.show_reblogs": "Vede spartere da @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Statutu} other {{counter} Statuti}}",
   "account.unblock": "Sbluccà @{name}",

--- a/app/javascript/mastodon/locales/cs.json
+++ b/app/javascript/mastodon/locales/cs.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Příspěvky a odpovědi",
   "account.report": "Nahlásit @{name}",
   "account.requested": "Čeká na schválení. Kliknutím žádost o sledování zrušíte",
-  "account.share": "Sdílet profil uživatele @{name}",
   "account.show_reblogs": "Zobrazit boosty od @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Příspěvek} few {{counter} Příspěvky} many {{counter} Příspěvků} other {{counter} Příspěvků}}",
   "account.unblock": "Odblokovat @{name}",

--- a/app/javascript/mastodon/locales/cy.json
+++ b/app/javascript/mastodon/locales/cy.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Postiadau ac atebion",
   "account.report": "Adrodd @{name}",
   "account.requested": "Aros am gymeradwyaeth. Cliciwch er mwyn canslo cais dilyn",
-  "account.share": "Rhannwch broffil @{name}",
   "account.show_reblogs": "Dangos bwstiau o @{name}",
   "account.statuses_counter": "{count, plural, one {Tŵtiau: {counter}} other {Tŵtiau: {counter}}}",
   "account.unblock": "Dadflocio @{name}",

--- a/app/javascript/mastodon/locales/da.json
+++ b/app/javascript/mastodon/locales/da.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Indlæg og svar",
   "account.report": "Anmeld @{name}",
   "account.requested": "Afventer godkendelse. Tryk for at annullere følgeanmodning",
-  "account.share": "Del @{name}s profil",
   "account.show_reblogs": "Vis fremhævelser fra @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Indlæg} other {{counter} Indlæg}}",
   "account.unblock": "Afblokér @{name}",

--- a/app/javascript/mastodon/locales/de.json
+++ b/app/javascript/mastodon/locales/de.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Beiträge und Antworten",
   "account.report": "@{name} melden",
   "account.requested": "Warte auf Genehmigung. Klicke hier, um die Anfrage zum Folgen abzubrechen",
-  "account.share": "Profil von @{name} teilen",
   "account.show_reblogs": "Geteilte Beiträge von @{name} wieder anzeigen",
   "account.statuses_counter": "{count, plural, one {{counter} Beitrag} other {{counter} Beiträge}}",
   "account.unblock": "@{name} entblocken",

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -1100,10 +1100,6 @@
         "id": "account.report"
       },
       {
-        "defaultMessage": "Share @{name}'s profile",
-        "id": "account.share"
-      },
-      {
         "defaultMessage": "Media",
         "id": "account.media"
       },

--- a/app/javascript/mastodon/locales/el.json
+++ b/app/javascript/mastodon/locales/el.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Τουτ και απαντήσεις",
   "account.report": "Κατάγγειλε @{name}",
   "account.requested": "Εκκρεμεί έγκριση. Κάνε κλικ για να ακυρώσεις το αίτημα παρακολούθησης",
-  "account.share": "Μοίρασμα του προφίλ @{name}",
   "account.show_reblogs": "Εμφάνιση προωθήσεων από @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Τουτ} other {{counter} Τουτ}}",
   "account.unblock": "Ξεμπλόκαρε @{name}",

--- a/app/javascript/mastodon/locales/en-GB.json
+++ b/app/javascript/mastodon/locales/en-GB.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Posts and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval. Click to cancel follow request",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Post} other {{counter} Posts}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Posts and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval. Click to cancel follow request",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Post} other {{counter} Posts}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/eo.json
+++ b/app/javascript/mastodon/locales/eo.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Mesaĝoj kaj respondoj",
   "account.report": "Raporti @{name}",
   "account.requested": "Atendo de aprobo. Alklaku por nuligi peton de sekvado",
-  "account.share": "Diskonigi la profilon de @{name}",
   "account.show_reblogs": "Montri diskonigojn de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Afiŝo} other {{counter} Afiŝoj}}",
   "account.unblock": "Malbloki @{name}",

--- a/app/javascript/mastodon/locales/es-AR.json
+++ b/app/javascript/mastodon/locales/es-AR.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Mnsjs y resp. públicas",
   "account.report": "Denunciar a @{name}",
   "account.requested": "Esperando aprobación. Hacé clic para cancelar la solicitud de seguimiento",
-  "account.share": "Compartir el perfil de @{name}",
   "account.show_reblogs": "Mostrar adhesiones de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Mensaje} other {{counter} Mensajes}}",
   "account.unblock": "Desbloquear a @{name}",

--- a/app/javascript/mastodon/locales/es-MX.json
+++ b/app/javascript/mastodon/locales/es-MX.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Publicaciones y respuestas",
   "account.report": "Reportar a @{name}",
   "account.requested": "Esperando aprobación. Haga clic para cancelar la solicitud de seguimiento",
-  "account.share": "Compartir el perfil de @{name}",
   "account.show_reblogs": "Mostrar retoots de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Desbloquear a @{name}",

--- a/app/javascript/mastodon/locales/es.json
+++ b/app/javascript/mastodon/locales/es.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Publicaciones y respuestas",
   "account.report": "Reportar a @{name}",
   "account.requested": "Esperando aprobación",
-  "account.share": "Compartir el perfil de @{name}",
   "account.show_reblogs": "Mostrar retoots de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Publicación} other {{counter} Publicaciones}}",
   "account.unblock": "Desbloquear a @{name}",

--- a/app/javascript/mastodon/locales/et.json
+++ b/app/javascript/mastodon/locales/et.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Postitused ja vastused",
   "account.report": "Raporteeri @{name}",
   "account.requested": "Ootab kinnitust. Klõpsa jälgimise soovi tühistamiseks",
-  "account.share": "Jaga @{name} profiili",
   "account.show_reblogs": "Näita kasutaja @{name} upitusi",
   "account.statuses_counter": "{count, plural, one {{counter} postitus} other {{counter} postitust}}",
   "account.unblock": "Eemalda blokeering @{name}",

--- a/app/javascript/mastodon/locales/eu.json
+++ b/app/javascript/mastodon/locales/eu.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Bidalketak eta erantzunak",
   "account.report": "Salatu @{name}",
   "account.requested": "Onarpenaren zain. Klikatu jarraitzeko eskaera ezeztatzeko",
-  "account.share": "@{name}(e)ren profila elkarbanatu",
   "account.show_reblogs": "Erakutsi @{name}(r)en bultzadak",
   "account.statuses_counter": "{count, plural, one {Bidalketa {counter}} other {{counter} bidalketa}}",
   "account.unblock": "Desblokeatu @{name}",

--- a/app/javascript/mastodon/locales/fa.json
+++ b/app/javascript/mastodon/locales/fa.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "فرسته‌ها و پاسخ‌ها",
   "account.report": "گزارش ‎@{name}",
   "account.requested": "منتظر پذیرش است. برای لغو درخواست پی‌گیری کلیک کنید",
-  "account.share": "هم‌رسانی نمایهٔ ‎@{name}",
   "account.show_reblogs": "نمایش تقویت‌های ‎@{name}",
   "account.statuses_counter": "{count, plural, one {{counter} فرسته} other {{counter} فرسته}}",
   "account.unblock": "رفع مسدودیت ‎@{name}",

--- a/app/javascript/mastodon/locales/fi.json
+++ b/app/javascript/mastodon/locales/fi.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Viestit ja vastaukset",
   "account.report": "Raportoi @{name}",
   "account.requested": "Odottaa hyväksyntää. Peruuta seuraamispyyntö klikkaamalla",
-  "account.share": "Jaa käyttäjän @{name} profiili",
   "account.show_reblogs": "Näytä buustaukset käyttäjältä @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Salli @{name}",

--- a/app/javascript/mastodon/locales/fo.json
+++ b/app/javascript/mastodon/locales/fo.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Uppsløg og svar",
   "account.report": "Melda @{name}",
   "account.requested": "Bíðar eftir góðkenning. Trýst fyri at angra umbønina",
-  "account.share": "Deil vanga @{name}'s",
   "account.show_reblogs": "Vís lyft frá @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} postur} other {{counter} postar}}",
   "account.unblock": "Banna ikki @{name}",

--- a/app/javascript/mastodon/locales/fr-QC.json
+++ b/app/javascript/mastodon/locales/fr-QC.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Messages et réponses",
   "account.report": "Signaler @{name}",
   "account.requested": "En attente d’approbation. Cliquez pour annuler la demande",
-  "account.share": "Partager le profil de @{name}",
   "account.show_reblogs": "Afficher les partages de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Message} other {{counter} Messages}}",
   "account.unblock": "Débloquer @{name}",

--- a/app/javascript/mastodon/locales/fr.json
+++ b/app/javascript/mastodon/locales/fr.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Messages et réponses",
   "account.report": "Signaler @{name}",
   "account.requested": "En attente d’approbation. Cliquez pour annuler la demande",
-  "account.share": "Partager le profil de @{name}",
   "account.show_reblogs": "Afficher les partages de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Message} other {{counter} Messages}}",
   "account.unblock": "Débloquer @{name}",

--- a/app/javascript/mastodon/locales/fy.json
+++ b/app/javascript/mastodon/locales/fy.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Berjochten en reaksjes",
   "account.report": "@{name} rapportearje",
   "account.requested": "Wacht op goedkarring. Klik om it folchfersyk te annulearjen",
-  "account.share": "Profyl fan @{name} diele",
   "account.show_reblogs": "Boosts fan @{name} toane",
   "account.statuses_counter": "{count, plural, one {{counter} berjocht} other {{counter} berjochten}}",
   "account.unblock": "@{name} deblokkearje",

--- a/app/javascript/mastodon/locales/ga.json
+++ b/app/javascript/mastodon/locales/ga.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Postálacha agus freagraí",
   "account.report": "Tuairiscigh @{name}",
   "account.requested": "Ag fanacht le ceadú. Cliceáil chun an iarratas leanúnaí a chealú",
-  "account.share": "Roinn próifíl @{name}",
   "account.show_reblogs": "Taispeáin moltaí ó @{name}",
   "account.statuses_counter": "{count, plural, one {Postáil amháin} other {{counter} Postáil}}",
   "account.unblock": "Bain bac de @{name}",

--- a/app/javascript/mastodon/locales/gd.json
+++ b/app/javascript/mastodon/locales/gd.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Postaichean ’s freagairtean",
   "account.report": "Dèan gearan mu @{name}",
   "account.requested": "A’ feitheamh air aontachadh. Briog airson sgur dhen iarrtas leantainn",
-  "account.share": "Co-roinn a’ phròifil aig @{name}",
   "account.show_reblogs": "Seall na brosnachaidhean o @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} phost} two {{counter} phost} few {{counter} postaichean} other {{counter} post}}",
   "account.unblock": "Dì-bhac @{name}",

--- a/app/javascript/mastodon/locales/gl.json
+++ b/app/javascript/mastodon/locales/gl.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Publicacións e respostas",
   "account.report": "Informar sobre @{name}",
   "account.requested": "Agardando aprobación. Preme para desbotar a solicitude",
-  "account.share": "Compartir o perfil de @{name}",
   "account.show_reblogs": "Amosar compartidos de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Publicación} other {{counter} Publicacións}}",
   "account.unblock": "Desbloquear @{name}",

--- a/app/javascript/mastodon/locales/he.json
+++ b/app/javascript/mastodon/locales/he.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "הודעות ותגובות",
   "account.report": "דווח על @{name}",
   "account.requested": "בהמתנה לאישור. לחצי כדי לבטל בקשת מעקב",
-  "account.share": "שתף את הפרופיל של @{name}",
   "account.show_reblogs": "הצג הדהודים מאת @{name}",
   "account.statuses_counter": "{count, plural, one {הודעה} two {הודעותיים} many {{count} הודעות} other {{count} הודעות}}",
   "account.unblock": "הסר את החסימה של @{name}",

--- a/app/javascript/mastodon/locales/hi.json
+++ b/app/javascript/mastodon/locales/hi.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "टूट्स एवं जवाब",
   "account.report": "रिपोर्ट @{name}",
   "account.requested": "मंजूरी का इंतजार। फॉलो रिक्वेस्ट को रद्द करने के लिए क्लिक करें",
-  "account.share": "@{name} की प्रोफाइल शेयर करे",
   "account.show_reblogs": "@{name} के बूस्ट दिखाए",
   "account.statuses_counter": "{count, plural, one {{counter} भोंपू} other {{counter} भोंपू}}",
   "account.unblock": "@{name} को अनब्लॉक करें",

--- a/app/javascript/mastodon/locales/hr.json
+++ b/app/javascript/mastodon/locales/hr.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Tootovi i odgovori",
   "account.report": "Prijavi @{name}",
   "account.requested": "Čekanje na potvrdu. Kliknite za otkazivanje zahtjeva za praćenje",
-  "account.share": "Podijeli profil @{name}",
   "account.show_reblogs": "Prikaži boostove od @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} toot} other {{counter} toota}}",
   "account.unblock": "Deblokiraj @{name}",

--- a/app/javascript/mastodon/locales/hu.json
+++ b/app/javascript/mastodon/locales/hu.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Bejegyzések és válaszok",
   "account.report": "@{name} jelentése",
   "account.requested": "Engedélyre vár. Kattints a követési kérés visszavonásához",
-  "account.share": "@{name} profiljának megosztása",
   "account.show_reblogs": "@{name} megtolásainak mutatása",
   "account.statuses_counter": "{count, plural, one {{counter} Bejegyzés} other {{counter} Bejegyzés}}",
   "account.unblock": "@{name} letiltásának feloldása",

--- a/app/javascript/mastodon/locales/hy.json
+++ b/app/javascript/mastodon/locales/hy.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Գրառումներ եւ պատասխաններ",
   "account.report": "Բողոքել @{name}֊ի մասին",
   "account.requested": "Հաստատման կարիք ունի։ Սեղմիր՝ հետեւելու հայցը չեղարկելու համար։",
-  "account.share": "Կիսուել @{name}֊ի էջով",
   "account.show_reblogs": "Ցուցադրել @{name}֊ի տարածածները",
   "account.statuses_counter": "{count, plural, one {{counter} Գրառում} other {{counter} Գրառումներ}}",
   "account.unblock": "Ապաարգելափակել @{name}֊ին",

--- a/app/javascript/mastodon/locales/id.json
+++ b/app/javascript/mastodon/locales/id.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Kiriman dan balasan",
   "account.report": "Laporkan @{name}",
   "account.requested": "Menunggu persetujuan. Klik untuk membatalkan permintaan",
-  "account.share": "Bagikan profil @{name}",
   "account.show_reblogs": "Tampilkan boost dari @{name}",
   "account.statuses_counter": "{count, plural, other {{counter} Kiriman}}",
   "account.unblock": "Hapus blokir @{name}",

--- a/app/javascript/mastodon/locales/ig.json
+++ b/app/javascript/mastodon/locales/ig.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Posts and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval. Click to cancel follow request",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Post} other {{counter} Posts}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/io.json
+++ b/app/javascript/mastodon/locales/io.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Posti e respondi",
   "account.report": "Denuncar @{name}",
   "account.requested": "Vartante aprobo",
-  "account.share": "Partigez profilo di @{name}",
   "account.show_reblogs": "Montrez busti de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Posto} other {{counter} Posti}}",
   "account.unblock": "Desblokusar @{name}",

--- a/app/javascript/mastodon/locales/is.json
+++ b/app/javascript/mastodon/locales/is.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Færslur og svör",
   "account.report": "Kæra @{name}",
   "account.requested": "Bíður eftir samþykki. Smelltu til að hætta við beiðni um að fylgjast með",
-  "account.share": "Deila notandasniði fyrir @{name}",
   "account.show_reblogs": "Sýna endurbirtingar frá @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} færsla} other {{counter} færslur}}",
   "account.unblock": "Aflétta útilokun af @{name}",

--- a/app/javascript/mastodon/locales/it.json
+++ b/app/javascript/mastodon/locales/it.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Post e risposte",
   "account.report": "Segnala @{name}",
   "account.requested": "In attesa d'approvazione. Clicca per annullare la richiesta di seguire",
-  "account.share": "Condividi il profilo di @{name}",
   "account.show_reblogs": "Mostra potenziamenti da @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Post} other {{counter} Post}}",
   "account.unblock": "Sblocca @{name}",

--- a/app/javascript/mastodon/locales/ja.json
+++ b/app/javascript/mastodon/locales/ja.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "投稿と返信",
   "account.report": "@{name}さんを通報",
   "account.requested": "フォロー承認待ちです。クリックしてキャンセル",
-  "account.share": "@{name}さんのプロフィールを共有する",
   "account.show_reblogs": "@{name}さんからのブーストを表示",
   "account.statuses_counter": "{counter} 投稿",
   "account.unblock": "@{name}さんのブロックを解除",

--- a/app/javascript/mastodon/locales/ka.json
+++ b/app/javascript/mastodon/locales/ka.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "ტუტები და პასუხები",
   "account.report": "დაარეპორტე @{name}",
   "account.requested": "დამტკიცების მოლოდინში. დააწკაპუნეთ რომ უარყოთ დადევნების მოთხონვა",
-  "account.share": "გააზიარე @{name}-ის პროფილი",
   "account.show_reblogs": "აჩვენე ბუსტები @{name}-სგან",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "განბლოკე @{name}",

--- a/app/javascript/mastodon/locales/kab.json
+++ b/app/javascript/mastodon/locales/kab.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Tisuffaɣ d tririyin",
   "account.report": "Cetki ɣef @{name}",
   "account.requested": "Di laɛḍil ad yettwaqbel. Ssit i wakken ad yefsex usuter n uḍfar",
-  "account.share": "Bḍu amaɣnu n @{name}",
   "account.show_reblogs": "Ssken-d inebḍa n @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} n tsuffeɣt} other {{counter} n tsuffaɣ}}",
   "account.unblock": "Serreḥ i @{name}",

--- a/app/javascript/mastodon/locales/kk.json
+++ b/app/javascript/mastodon/locales/kk.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Жазбалар мен жауаптар",
   "account.report": "Шағымдану @{name}",
   "account.requested": "Растауын күтіңіз. Жазылудан бас тарту үшін басыңыз",
-  "account.share": "@{name} профилін бөлісу\"",
   "account.show_reblogs": "@{name} бөліскендерін көрсету",
   "account.statuses_counter": "{count, plural, one {{counter} Пост} other {{counter} Пост}}",
   "account.unblock": "Бұғаттан шығару @{name}",

--- a/app/javascript/mastodon/locales/kn.json
+++ b/app/javascript/mastodon/locales/kn.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/ko.json
+++ b/app/javascript/mastodon/locales/ko.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "게시물과 답장",
   "account.report": "@{name} 신고",
   "account.requested": "승인 대기 중. 클릭해서 취소하기",
-  "account.share": "@{name}의 프로필 공유",
   "account.show_reblogs": "@{name}의 부스트 보기",
   "account.statuses_counter": "{counter} 게시물",
   "account.unblock": "차단 해제",

--- a/app/javascript/mastodon/locales/ku.json
+++ b/app/javascript/mastodon/locales/ku.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Şandî û bersiv",
   "account.report": "@{name} ragihîne",
   "account.requested": "Li benda erêkirinê ye. Ji bo betal kirina daxwazê pêl bikin",
-  "account.share": "Profîla @{name} parve bike",
   "account.show_reblogs": "Bilindkirinên ji @{name} nîşan bike",
   "account.statuses_counter": "{count, plural,one {{counter} Şandî}other {{counter} Şandî}}",
   "account.unblock": "Astengê li ser @{name} rake",

--- a/app/javascript/mastodon/locales/kw.json
+++ b/app/javascript/mastodon/locales/kw.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Postow ha gorthebow",
   "account.report": "Reportya @{name}",
   "account.requested": "Ow kortos komendyans. Klyckyewgh dhe hedhi govyn holya",
-  "account.share": "Kevrenna profil @{name}",
   "account.show_reblogs": "Diskwedhes kenerthow a @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Tout} other {{counter} Tout}}",
   "account.unblock": "Anlettya @{name}",

--- a/app/javascript/mastodon/locales/lt.json
+++ b/app/javascript/mastodon/locales/lt.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/lv.json
+++ b/app/javascript/mastodon/locales/lv.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Ziņas un atbildes",
   "account.report": "Ziņot par lietotāju @{name}",
   "account.requested": "Gaidām apstiprinājumu. Nospied lai atceltu sekošanas pieparasījumu",
-  "account.share": "Dalīties ar @{name} profilu",
   "account.show_reblogs": "Parādīt @{name} pastiprinātos ierakstus",
   "account.statuses_counter": "{count, plural, one {{counter} ziņa} other {{counter} ziņas}}",
   "account.unblock": "Atbloķēt lietotāju @{name}",

--- a/app/javascript/mastodon/locales/mk.json
+++ b/app/javascript/mastodon/locales/mk.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Тутови и реплики",
   "account.report": "Пријави @{name}",
   "account.requested": "Се чека одобрување. Кликни за да одкажиш барање за следење",
-  "account.share": "Сподели @{name} профил",
   "account.show_reblogs": "Прикажи бустови од @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Одблокирај @{name}",

--- a/app/javascript/mastodon/locales/ml.json
+++ b/app/javascript/mastodon/locales/ml.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "പോസ്റ്റുകളും മറുപടികളും",
   "account.report": "റിപ്പോർട്ട് ചെയ്യുക @{name}",
   "account.requested": "അനുവാദത്തിനായി കാത്തിരിക്കുന്നു. പിന്തുടരാനുള്ള അപേക്ഷ റദ്ദാക്കുവാൻ ഞെക്കുക",
-  "account.share": "@{name} ന്റെ പ്രൊഫൈൽ പങ്കിടുക",
   "account.show_reblogs": "@{name} ൽ നിന്നുള്ള ബൂസ്റ്റുകൾ കാണിക്കുക",
   "account.statuses_counter": "{count, plural, one {{counter} ടൂട്ട്} other {{counter} ടൂട്ടുകൾ}}",
   "account.unblock": "@{name} തടഞ്ഞത് മാറ്റുക",

--- a/app/javascript/mastodon/locales/mr.json
+++ b/app/javascript/mastodon/locales/mr.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "{name}चे सर्व बुस्ट्स दाखवा",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "@{name} ला ब्लॉक करा",

--- a/app/javascript/mastodon/locales/ms.json
+++ b/app/javascript/mastodon/locales/ms.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Hantaran dan balasan",
   "account.report": "Laporkan @{name}",
   "account.requested": "Menunggu kelulusan. Klik untuk batalkan permintaan ikutan",
-  "account.share": "Kongsi profil @{name}",
   "account.show_reblogs": "Tunjukkan galakan daripada @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Hantaran} other {{counter} Hantaran}}",
   "account.unblock": "Nyahsekat @{name}",

--- a/app/javascript/mastodon/locales/my.json
+++ b/app/javascript/mastodon/locales/my.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Posts and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval. Click to cancel follow request",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Post} other {{counter} Posts}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/nl.json
+++ b/app/javascript/mastodon/locales/nl.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Berichten en reacties",
   "account.report": "@{name} rapporteren",
   "account.requested": "Wachten op goedkeuring. Klik om het volgverzoek te annuleren",
-  "account.share": "Profiel van @{name} delen",
   "account.show_reblogs": "Boosts van @{name} tonen",
   "account.statuses_counter": "{count, plural, one {{counter} bericht} other {{counter} berichten}}",
   "account.unblock": "@{name} deblokkeren",

--- a/app/javascript/mastodon/locales/nn.json
+++ b/app/javascript/mastodon/locales/nn.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Tut og svar",
   "account.report": "Rapporter @{name}",
   "account.requested": "Ventar på aksept. Klikk for å avbryta fylgjeførespurnaden",
-  "account.share": "Del @{name} sin profil",
   "account.show_reblogs": "Vis framhevingar frå @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} tut} other {{counter} tut}}",
   "account.unblock": "Stopp blokkering av @{name}",

--- a/app/javascript/mastodon/locales/no.json
+++ b/app/javascript/mastodon/locales/no.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Innlegg med svar",
   "account.report": "Rapportér @{name}",
   "account.requested": "Venter på godkjennelse. Klikk for å avbryte forespørselen",
-  "account.share": "Del @{name}s profil",
   "account.show_reblogs": "Vis boosts fra @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} innlegg} other {{counter} innlegg}}",
   "account.unblock": "Opphev blokkering av @{name}",

--- a/app/javascript/mastodon/locales/oc.json
+++ b/app/javascript/mastodon/locales/oc.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Tuts e responsas",
   "account.report": "Senhalar @{name}",
   "account.requested": "Invitacion mandada. Clicatz per anullar",
-  "account.share": "Partejar lo perfil a @{name}",
   "account.show_reblogs": "Mostrar los partatges de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Tut} other {{counter} Tuts}}",
   "account.unblock": "Desblocar @{name}",

--- a/app/javascript/mastodon/locales/pa.json
+++ b/app/javascript/mastodon/locales/pa.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/pl.json
+++ b/app/javascript/mastodon/locales/pl.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Wpisy i odpowiedzi",
   "account.report": "Zgłoś @{name}",
   "account.requested": "Oczekująca prośba, kliknij aby anulować",
-  "account.share": "Udostępnij profil @{name}",
   "account.show_reblogs": "Pokazuj podbicia od @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} wpis} few {{counter} wpisy} many {{counter} wpisów} other {{counter} wpisów}}",
   "account.unblock": "Odblokuj @{name}",

--- a/app/javascript/mastodon/locales/pt-BR.json
+++ b/app/javascript/mastodon/locales/pt-BR.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Com respostas",
   "account.report": "Denunciar @{name}",
   "account.requested": "Aguardando aprovação. Clique para cancelar a solicitação",
-  "account.share": "Compartilhar perfil de @{name}",
   "account.show_reblogs": "Mostrar boosts de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Desbloquear @{name}",

--- a/app/javascript/mastodon/locales/pt-PT.json
+++ b/app/javascript/mastodon/locales/pt-PT.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Publicações e respostas",
   "account.report": "Denunciar @{name}",
   "account.requested": "A aguardar aprovação. Clique para cancelar o pedido de seguidor",
-  "account.share": "Partilhar o perfil @{name}",
   "account.show_reblogs": "Mostrar partilhas de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Desbloquear @{name}",

--- a/app/javascript/mastodon/locales/ro.json
+++ b/app/javascript/mastodon/locales/ro.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Postări și răspunsuri",
   "account.report": "Raportează pe @{name}",
   "account.requested": "Se așteaptă aprobarea. Apasă pentru a anula cererea de urmărire",
-  "account.share": "Distribuie profilul lui @{name}",
   "account.show_reblogs": "Arată impulsurile de la @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Deblochează pe @{name}",

--- a/app/javascript/mastodon/locales/ru.json
+++ b/app/javascript/mastodon/locales/ru.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Посты и ответы",
   "account.report": "Пожаловаться на @{name}",
   "account.requested": "Ожидает подтверждения. Нажмите для отмены запроса",
-  "account.share": "Поделиться профилем @{name}",
   "account.show_reblogs": "Показывать продвижения от @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} пост} many {{counter} постов} other {{counter} поста}}",
   "account.unblock": "Разблокировать @{name}",

--- a/app/javascript/mastodon/locales/sa.json
+++ b/app/javascript/mastodon/locales/sa.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "दौत्यानि प्रत्युत्तराणि च",
   "account.report": "आविद्यताम् @{name}",
   "account.requested": "स्वीकृतिः प्रतीक्ष्यते । नश्यतामित्यस्मिन्नुद्यतां निराकर्तुम् ।",
-  "account.share": "@{name} मित्रस्य विवरणं विभाज्यताम्",
   "account.show_reblogs": "@{name} मित्रस्य प्रकाशनानि दृश्यन्ताम्",
   "account.statuses_counter": "{count, plural, one {{counter} दौत्यम्} two {{counter} दौत्ये} other {{counter} दौत्यानि}}",
   "account.unblock": "निषेधता नश्यताम् @{name}",

--- a/app/javascript/mastodon/locales/sc.json
+++ b/app/javascript/mastodon/locales/sc.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Publicatziones e rispostas",
   "account.report": "Signala @{name}",
   "account.requested": "Abetende s'aprovatzione. Incarca pro annullare sa rechesta de sighidura",
-  "account.share": "Cumpartzi su profilu de @{name}",
   "account.show_reblogs": "Ammustra is cumpartziduras de @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} publicatzione} other {{counter} publicatziones}}",
   "account.unblock": "Isbloca a @{name}",

--- a/app/javascript/mastodon/locales/sco.json
+++ b/app/javascript/mastodon/locales/sco.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Posts and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval. Click to cancel follow request",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Post} other {{counter} Posts}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/si.json
+++ b/app/javascript/mastodon/locales/si.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "ටූට්ස් සහ පිළිතුරු",
   "account.report": "@{name} වාර්තා කරන්න",
   "account.requested": "අනුමැතිය බලාපොරොත්තුවෙන්",
-  "account.share": "@{name} ගේ පැතිකඩ බෙදාගන්න",
   "account.show_reblogs": "@{name}සිට බූස්ට් පෙන්වන්න",
   "account.statuses_counter": "{count, plural, one {{counter} ටූට්} other {{counter} ටූට්ස්}}",
   "account.unblock": "@{name} අනවහිර කරන්න",

--- a/app/javascript/mastodon/locales/sk.json
+++ b/app/javascript/mastodon/locales/sk.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Príspevky a odpovede",
   "account.report": "Nahlás @{name}",
   "account.requested": "Čaká na schválenie. Klikni pre zrušenie žiadosti",
-  "account.share": "Zdieľaj @{name} profil",
   "account.show_reblogs": "Ukáž vyzdvihnutia od @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Odblokuj @{name}",

--- a/app/javascript/mastodon/locales/sl.json
+++ b/app/javascript/mastodon/locales/sl.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Objave in odgovori",
   "account.report": "Prijavi @{name}",
   "account.requested": "Čakanje na odobritev. Kliknite, da prekličete prošnjo za sledenje",
-  "account.share": "Deli profil osebe @{name}",
   "account.show_reblogs": "Pokaži izpostavitve osebe @{name}",
   "account.statuses_counter": "{count, plural, one {{count} tut} two {{count} tuta} few {{count} tuti} other {{count} tutov}}",
   "account.unblock": "Odblokiraj @{name}",

--- a/app/javascript/mastodon/locales/sq.json
+++ b/app/javascript/mastodon/locales/sq.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Mesazhe dhe përgjigje",
   "account.report": "Raportojeni @{name}",
   "account.requested": "Në pritje të miratimit. Që të anuloni kërkesën për ndjekje, klikojeni",
-  "account.share": "Ndajeni profilin e @{name} me të tjerët",
   "account.show_reblogs": "Shfaq përforcime nga @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Mesazh} other {{counter} Mesazhe}}",
   "account.unblock": "Zhbllokoje @{name}",

--- a/app/javascript/mastodon/locales/sr-Latn.json
+++ b/app/javascript/mastodon/locales/sr-Latn.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots with replies",
   "account.report": "Prijavi @{name}",
   "account.requested": "Čekam odobrenje. Kliknite da poništite zahtev za praćenje",
-  "account.share": "Podeli profil korisnika @{name}",
   "account.show_reblogs": "Prikaži podrške od korisnika @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Odblokiraj korisnika @{name}",

--- a/app/javascript/mastodon/locales/sr.json
+++ b/app/javascript/mastodon/locales/sr.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Трубе и одговори",
   "account.report": "Пријави @{name}",
   "account.requested": "Чекам одобрење. Кликните да поништите захтев за праћење",
-  "account.share": "Подели налог корисника @{name}",
   "account.show_reblogs": "Прикажи подршке од корисника @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} објава} few {{counter} објаве} other {{counter} објава}}",
   "account.unblock": "Одблокирај корисника @{name}",

--- a/app/javascript/mastodon/locales/sv.json
+++ b/app/javascript/mastodon/locales/sv.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Inlägg och svar",
   "account.report": "Rapportera @{name}",
   "account.requested": "Inväntar godkännande. Klicka för att ta tillbaka din begäran om att få följa",
-  "account.share": "Dela @{name}s profil",
   "account.show_reblogs": "Visa boostar från @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Inlägg} other {{counter} Inlägg}}",
   "account.unblock": "Avblockera @{name}",

--- a/app/javascript/mastodon/locales/szl.json
+++ b/app/javascript/mastodon/locales/szl.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/ta.json
+++ b/app/javascript/mastodon/locales/ta.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots மற்றும் பதில்கள்",
   "account.report": "@{name} -ஐப் புகாரளி",
   "account.requested": "ஒப்புதலுக்காகக் காத்திருக்கிறது. பின்தொடரும் கோரிக்கையை நீக்க அழுத்தவும்",
-  "account.share": "@{name} உடைய விவரத்தை பகிர்",
   "account.show_reblogs": "காட்டு boosts இருந்து @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} டூட்} other {{counter} டூட்டுகள்}}",
   "account.unblock": "@{name} மீது தடை நீக்குக",

--- a/app/javascript/mastodon/locales/tai.json
+++ b/app/javascript/mastodon/locales/tai.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/te.json
+++ b/app/javascript/mastodon/locales/te.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "టూట్లు మరియు ప్రత్యుత్తరములు",
   "account.report": "@{name}పై ఫిర్యాదుచేయు",
   "account.requested": "ఆమోదం కోసం వేచి ఉంది. అభ్యర్థనను రద్దు చేయడానికి క్లిక్ చేయండి",
-  "account.share": "@{name} యొక్క ప్రొఫైల్ను పంచుకోండి",
   "account.show_reblogs": "@{name}నుంచి బూస్ట్ లను చూపించు",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "@{name}పై బ్లాక్ ను తొలగించు",

--- a/app/javascript/mastodon/locales/th.json
+++ b/app/javascript/mastodon/locales/th.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "โพสต์และการตอบกลับ",
   "account.report": "รายงาน @{name}",
   "account.requested": "กำลังรอการอนุมัติ คลิกเพื่อยกเลิกคำขอติดตาม",
-  "account.share": "แบ่งปันโปรไฟล์ของ @{name}",
   "account.show_reblogs": "แสดงการดันจาก @{name}",
   "account.statuses_counter": "{count, plural, other {{counter} โพสต์}}",
   "account.unblock": "เลิกปิดกั้น @{name}",

--- a/app/javascript/mastodon/locales/tr.json
+++ b/app/javascript/mastodon/locales/tr.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Gönderiler ve yanıtlar",
   "account.report": "@{name}'i şikayet et",
   "account.requested": "Onay bekleniyor. Takip isteğini iptal etmek için tıklayın",
-  "account.share": "@{name}'in profilini paylaş",
   "account.show_reblogs": "@{name} kişisinin boostlarını göster",
   "account.statuses_counter": "{count, plural, one {{counter} Gönderi} other {{counter} Gönderi}}",
   "account.unblock": "@{name}'in engelini kaldır",

--- a/app/javascript/mastodon/locales/tt.json
+++ b/app/javascript/mastodon/locales/tt.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/ug.json
+++ b/app/javascript/mastodon/locales/ug.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval",
-  "account.share": "Share @{name}'s profile",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/uk.json
+++ b/app/javascript/mastodon/locales/uk.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Дописи й відповіді",
   "account.report": "Поскаржитися на @{name}",
   "account.requested": "Очікує підтвердження. Натисніть, щоб скасувати запит на підписку",
-  "account.share": "Поділитися профілем @{name}",
   "account.show_reblogs": "Показати поширення від @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} допис} few {{counter} дописи} many {{counter} дописів} other {{counter} дописи}}",
   "account.unblock": "Розблокувати @{name}",

--- a/app/javascript/mastodon/locales/ur.json
+++ b/app/javascript/mastodon/locales/ur.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "ٹوٹ اور جوابات",
   "account.report": "@{name} اطلاع کریں",
   "account.requested": "منظوری کا منتظر۔ درخواستِ پیروی منسوخ کرنے کیلئے کلک کریں",
-  "account.share": "@{name} کے مشخص کو بانٹیں",
   "account.show_reblogs": "@{name} کی افزائشات کو دکھائیں",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "@{name} کو بحال کریں",

--- a/app/javascript/mastodon/locales/vi.json
+++ b/app/javascript/mastodon/locales/vi.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Trả lời",
   "account.report": "Báo cáo @{name}",
   "account.requested": "Đang chờ chấp thuận. Nhấp vào đây để hủy yêu cầu theo dõi",
-  "account.share": "Chia sẻ trang @{name}",
   "account.show_reblogs": "Hiện tút do @{name} đăng lại",
   "account.statuses_counter": "{count, plural, one {{counter} Tút} other {{counter} Tút}}",
   "account.unblock": "Bỏ chặn @{name}",

--- a/app/javascript/mastodon/locales/zgh.json
+++ b/app/javascript/mastodon/locales/zgh.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "Toots and replies",
   "account.report": "Report @{name}",
   "account.requested": "Awaiting approval",
-  "account.share": "ⴱⴹⵓ ⵉⴼⵔⵙ ⵏ @{name}",
   "account.show_reblogs": "Show boosts from @{name}",
   "account.statuses_counter": "{count, plural, one {{counter} Toot} other {{counter} Toots}}",
   "account.unblock": "Unblock @{name}",

--- a/app/javascript/mastodon/locales/zh-CN.json
+++ b/app/javascript/mastodon/locales/zh-CN.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "嘟文和回复",
   "account.report": "举报 @{name}",
   "account.requested": "正在等待对方同意。点击可以取消发送关注请求",
-  "account.share": "分享@{name}的个人资料",
   "account.show_reblogs": "显示来自 @{name} 的转嘟",
   "account.statuses_counter": "{counter} 条嘟文",
   "account.unblock": "取消屏蔽 @{name}",

--- a/app/javascript/mastodon/locales/zh-HK.json
+++ b/app/javascript/mastodon/locales/zh-HK.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "包含回覆的文章",
   "account.report": "舉報 @{name}",
   "account.requested": "正在等待核准。按一下以取消追蹤請求",
-  "account.share": "分享 @{name} 的個人資料",
   "account.show_reblogs": "顯示 @{name} 的推文",
   "account.statuses_counter": "{count, plural,one {{counter} 篇}other {{counter} 篇}}文章",
   "account.unblock": "解除對 @{name} 的封鎖",

--- a/app/javascript/mastodon/locales/zh-TW.json
+++ b/app/javascript/mastodon/locales/zh-TW.json
@@ -54,7 +54,6 @@
   "account.posts_with_replies": "嘟文與回覆",
   "account.report": "檢舉 @{name}",
   "account.requested": "正在等待核准。按一下以取消跟隨請求",
-  "account.share": "分享 @{name} 的個人檔案",
   "account.show_reblogs": "顯示來自 @{name} 的嘟文",
   "account.statuses_counter": "{count, plural,one {{counter} 則}other {{counter} 則}}嘟文",
   "account.unblock": "取消封鎖 @{name}",


### PR DESCRIPTION
Fixes #20931

As pointed out of #20931, it's been broken ever since it was first introduced, over 3 years ago, so it should be either fixed (#21490) or dropped. Considering that I have seen nobody complain about it before now, it is unlikely many people even tried to use it, so removing it seems sensible.