### PR TITLE
fix: remove SMTP_SERVER

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -54,7 +54,7 @@ VAPID_PUBLIC_KEY=
 
 # Sending mail
 # ------------
-SMTP_SERVER=smtp.mailgun.org
+SMTP_SERVER=
 SMTP_PORT=587
 SMTP_LOGIN=
 SMTP_PASSWORD=


### PR DESCRIPTION
Firstly, mailgun.com is now their domain. Secondly they are lots of providers to use; and sysadmins should be able to choose.