### PR TITLE
Force links to be rendered without taking any RTLO into account

### DIFF
--- a/app/lib/text_formatter.rb
+++ b/app/lib/text_formatter.rb
@@ -78,8 +78,10 @@ class TextFormatter
     suffix      = url[prefix.length + 30..-1]
     cutoff      = url[prefix.length..-1].length > 30
 
+    # dir="auto" avoids RTLO attacks, nearby text outside the span may contain
+    # an RTLO, this makes the browser render the URL ignoring it
     <<~HTML.squish
-      <a href="#{h(url)}" target="_blank" rel="#{rel.join(' ')}"><span class="invisible">#{h(prefix)}</span><span class="#{cutoff ? 'ellipsis' : ''}">#{h(display_url)}</span><span class="invisible">#{h(suffix)}</span></a>
+      <a href="#{h(url)}" target="_blank" rel="#{rel.join(' ')}"><span class="invisible">#{h(prefix)}</span><span class="#{cutoff ? 'ellipsis' : ''}" dir="auto">#{h(display_url)}</span><span class="invisible">#{h(suffix)}</span></a>
     HTML
   rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
     h(entity[:url])

--- a/spec/lib/text_formatter_spec.rb
+++ b/spec/lib/text_formatter_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe TextFormatter do
       end
 
       it 'has display URL' do
-        is_expected.to include '<span class="">nic.みんな/</span>'
+        is_expected.to include '<span class="" dir="auto">nic.みんな/</span>'
       end
     end
 


### PR DESCRIPTION
Avoids an attack where profile URLs can be constructed that trick the user into thinking they have a different target. This forces the browser to render the link itself, ignoring any nearby RTLO characters. This cannot be used to fake verification (as the whole field has to be only a URL, so the RTLO character stops verification), but it can be used to have confusing profile links.

After this change it is still possible to have text with RTLO characters in some cases, but the text won't be linkified, i.e. the user will have to copy and paste a link to be tricked, rather than simply clicking a link.