### PR TITLE
Fix GIF autoplay on iOS

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { is } from 'immutable';
 import IconButton from './icon_button';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { isIOS } from '../is_mobile';
 import classNames from 'classnames';
 import { autoPlayGif, cropImages, displayMedia, useBlurhash } from '../initial_state';
 import { debounce } from 'lodash';
@@ -181,7 +180,7 @@ class Item extends React.PureComponent {
         </a>
       );
     } else if (attachment.get('type') === 'gifv') {
-      const autoPlay = !isIOS() && this.getAutoPlay();
+      const autoPlay = this.getAutoPlay();
 
       thumbnail = (
         <div className={classNames('media-gallery__gifv', { autoplay: autoPlay })}>
@@ -195,6 +194,7 @@ class Item extends React.PureComponent {
             onMouseEnter={this.handleMouseEnter}
             onMouseLeave={this.handleMouseLeave}
             autoPlay={autoPlay}
+            playsInline
             loop
             muted
           />

--- a/app/javascript/mastodon/features/account_gallery/components/media_item.js
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.js
@@ -2,7 +2,6 @@ import Blurhash from 'mastodon/components/blurhash';
 import classNames from 'classnames';
 import Icon from 'mastodon/components/icon';
 import { autoPlayGif, displayMedia, useBlurhash } from 'mastodon/initial_state';
-import { isIOS } from 'mastodon/is_mobile';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
@@ -109,7 +108,8 @@ export default class MediaItem extends ImmutablePureComponent {
             src={attachment.get('url')}
             onMouseEnter={this.handleMouseEnter}
             onMouseLeave={this.handleMouseLeave}
-            autoPlay={!isIOS() && autoPlayGif}
+            autoPlay={autoPlayGif}
+            playsInline
             loop
             muted
           />


### PR DESCRIPTION
This gets autoplay working on my iPhone. It's pretty straightforward, and I'm not seeing any changes in behavior on desktop Chrome/Firefox: autoplay still works when enabled in settings, hovering causes it to play when autoplay is disabled, and clicking on the thumbnail still opens the full-screen media viewer and starts playing.

I see that autoplay on iOS was intentionally disabled by 47bf592db7, but I'm not finding an issue or PR explaining the rationale.

Fixes #6217