### PR TITLE
Add user profile OG tag on status page

### DIFF
--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -13,6 +13,7 @@
   = opengraph 'og:title', "#{display_name(@account)} (#{acct(@account)})"
   = opengraph 'og:url', short_account_status_url(@account, @status)
   = opengraph 'og:published_time', @status.created_at.iso8601
+  = opengraph 'profile:username', acct(@account)[1..-1]
 
   = render 'og_description', activity: @status
   = render 'og_image', activity: @status, account: @account


### PR DESCRIPTION
This PR adds the `profile:username` opengraph tag to status pages, in addition to it already being shown on account profile pages. This allows for easier automation to detect which profile published a toot.

Without this addition, automations need to rely on regular expressions in order to extract the username from the `og:title` meta tag which contains the username as its set to `#{display_name(@account)} (#{acct(@account)})`.