### PR TITLE
Change follow/unfollow hashtag icon to "message" instead of "user".

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/index.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.js
@@ -195,7 +195,7 @@ class HashtagTimeline extends React.PureComponent {
 
       followButton = (
         <button className={classNames('column-header__button')} onClick={this.handleFollow} disabled={!signedIn} title={intl.formatMessage(following ? messages.unfollowHashtag : messages.followHashtag)} aria-label={intl.formatMessage(following ? messages.unfollowHashtag : messages.followHashtag)}>
-          <Icon id={following ? 'user-times' : 'user-plus'} fixedWidth className='column-header__icon' />
+          <Icon id={following ? 'message-xmark' : 'message-plus'} fixedWidth className='column-header__icon' />
         </button>
       );
     }


### PR DESCRIPTION
To be specific, changing these two icons (follow and unfollow):

https://fontawesome.com/icons/user-plus?s=solid&f=classic

https://fontawesome.com/icons/user-xmark?s=solid&f=classic

... to these two icons:

https://fontawesome.com/icons/message-plus?s=solid&f=classic

https://fontawesome.com/icons/message-xmark?s=solid&f=classic

Feel more representative of what you're actually following?