### PR TITLE
Fix punycode encoding of the local domain

### DIFF
--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -16,7 +16,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       streaming_api_base_url: Rails.configuration.x.streaming_api_base_url,
       access_token: object.token,
       locale: I18n.locale,
-      domain: instance_presenter.domain,
+      domain: Addressable::IDNA.to_unicode(instance_presenter.domain),
       title: instance_presenter.title,
       admin: object.admin&.id&.to_s,
       search_enabled: Chewy.enabled?,


### PR DESCRIPTION
This adds a call to `punycode.toUnicode` to prettify the *local* domain, changing e.g.  `@matti@xn--lofll-1sat.is` to `@matti@loðfíll.is`.
This happens on the:
  + local user profile page
  + the footer
  + the about page
  + ..., everywhere {domain} is used directly.