### PR TITLE
Improve error handling in mastodon:setup task

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -17,6 +17,8 @@ namespace :mastodon do
     ENV.delete('SIDEKIQ_REDIS_URL')
 
     begin
+      errors = false
+
       prompt.say('Your instance is identified by its domain name. Changing it afterward will break things.')
       env['LOCAL_DOMAIN'] = prompt.ask('Domain name:') do |q|
         q.required true
@@ -95,7 +97,11 @@ namespace :mastodon do
         rescue StandardError => e
           prompt.error 'Database connection could not be established with this configuration, try again.'
           prompt.error e.message
-          break unless prompt.yes?('Try again?')
+          unless prompt.yes?('Try again?')
+            return prompt.warn 'Nothing saved. Bye!' unless prompt.yes?('Continue anyway?')
+            errors = true
+            break
+          end
         end
       end
 
@@ -135,7 +141,11 @@ namespace :mastodon do
         rescue StandardError => e
           prompt.error 'Redis connection could not be established with this configuration, try again.'
           prompt.error e.message
-          break unless prompt.yes?('Try again?')
+          unless prompt.yes?('Try again?')
+            return prompt.warn 'Nothing saved. Bye!' unless prompt.yes?('Continue anyway?')
+            errors = true
+            break
+          end
         end
       end
 
@@ -420,7 +430,11 @@ namespace :mastodon do
         rescue StandardError => e
           prompt.error 'E-mail could not be sent with this configuration, try again.'
           prompt.error e.message
-          break unless prompt.yes?('Try again?')
+          unless prompt.yes?('Try again?')
+            return prompt.warn 'Nothing saved. Bye!' unless prompt.yes?('Continue anyway?')
+            errors = true
+            break
+          end
         end
       end
 
@@ -467,6 +481,7 @@ namespace :mastodon do
             prompt.ok 'Done!'
           else
             prompt.error 'That failed! Perhaps your configuration is not right'
+            errors = true
           end
         end
 
@@ -483,12 +498,17 @@ namespace :mastodon do
               prompt.say 'Done!'
             else
               prompt.error 'That failed! Maybe you need swap space?'
+              errors = true
             end
           end
         end
 
         prompt.say "\n"
-        prompt.ok 'All done! You can now power on the Mastodon server 🐘'
+        if errors
+          prompt.warn 'Your Mastodon server is set up, but there were some errors along the way, you may have to fix them.'
+        else
+          prompt.ok 'All done! You can now power on the Mastodon server 🐘'
+        end
         prompt.say "\n"
 
         if db_connection_works && prompt.yes?('Do you want to create an admin user straight away?')


### PR DESCRIPTION
- propose aborting setup on failure to connect to postgres or redis
- at the end of the process, print a warning if errors were encountered, instead of displaying “All done! You can now power on the Mastodon server 🐘” in green