### PR TITLE
Remove LDSignature on actor Delete activities

### DIFF
--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -267,7 +267,7 @@ class DeleteAccountService < BaseService
   end
 
   def delete_actor_json
-    @delete_actor_json ||= Oj.dump(serialize_payload(@account, ActivityPub::DeleteActorSerializer, signer: @account, always_sign: true))
+    @delete_actor_json ||= Oj.dump(serialize_payload(@account, ActivityPub::DeleteActorSerializer))
   end
 
   def delivery_inboxes


### PR DESCRIPTION
Mastodon currently LD-signs `Delete` activities on actors, but I am not aware of those signatures being used for anything.

`Delete` activities on actor are only sent when an account is deleted, but when that happens, the same payload is enqueued countless times in redis and sent out to countless servers, so reducing the payload's size makes sense, and LDSignatures take on average more than half of the payload's size for such activities.

If we ever change how such activities are delivered and start relaying them, we can add signatures back, but for the time being, LDSignatures on such activities are wasteful.

Related: #19452