### PR TITLE
Fix missing Javascript in domain block import confirmation page

### DIFF
--- a/app/views/admin/export_domain_blocks/import.html.haml
+++ b/app/views/admin/export_domain_blocks/import.html.haml
@@ -1,6 +1,9 @@
 - content_for :page_title do
   = t('admin.export_domain_blocks.import.title')
 
+- content_for :header_tags do
+  = javascript_pack_tag 'admin', async: true, crossorigin: 'anonymous'
+
 %p= t('admin.export_domain_blocks.import.description_html')
 
 - if defined?(@global_private_comment) && @global_private_comment.present?


### PR DESCRIPTION
Follow-up to #20597

The original feature was ported from glitch-soc, which emits script tags differently, so the `admin` pack wasn't properly used, which made the batch selection feature not work.