### PR TITLE
Helm document the major refactor

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 4.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/README.md
+++ b/chart/README.md
@@ -19,6 +19,23 @@ The variables that _must_ be configured are:
 
 - SMTP settings for your mailer in the `mastodon.smtp` group.
 
+If your PersistentVolumeClaim is `ReadWriteOnce` and you're unable to use a S3-compatible service or
+run a self-hosted compatible service like [Minio](https://min.io/docs/minio/kubernetes/upstream/index.html)
+then you need to set the pod affinity so the web and sidekiq pods are scheduled to the same node.
+
+Example configuration:
+```yaml
+podAffinity:
+  requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+          - key: app.kubernetes.io/part-of
+            operator: In
+            values:
+              - rails
+      topologyKey: kubernetes.io/hostname
+```
+
 # Administration
 
 You can run [admin CLI](https://docs.joinmastodon.org/admin/tootctl/) commands in the web deployment.

--- a/chart/templates/cronjob-media-remove.yaml
+++ b/chart/templates/cronjob-media-remove.yaml
@@ -67,6 +67,18 @@ spec:
                       key: redis-password
                 - name: "PORT"
                   value: {{ .Values.mastodon.web.port | quote }}
+                {{- if (and .Values.mastodon.s3.enabled .Values.mastodon.s3.existingSecret) }}
+                - name: "AWS_SECRET_ACCESS_KEY"
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.mastodon.s3.existingSecret }}
+                      key: AWS_SECRET_ACCESS_KEY
+                - name: "AWS_ACCESS_KEY_ID"
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.mastodon.s3.existingSecret }}
+                      key: AWS_ACCESS_KEY_ID
+                {{- end }}
               {{- if (not .Values.mastodon.s3.enabled) }}
               volumeMounts:
                 - name: assets

--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -10,10 +10,12 @@ metadata:
     app.kubernetes.io/component: sidekiq-{{ .name }}
     app.kubernetes.io/part-of: rails
 spec:
-  replicas: {{ .replicas }}
   {{- if (has "scheduler" .queues) }}
+  replicas: {{ min .replicas 1 }}
   strategy:
     type: Recreate
+  {{- else }}
+  replicas: {{ .replicas }}
   {{- end }}
   selector:
     matchLabels:

--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -99,7 +99,7 @@ spec:
             - name: "AWS_ACCESS_KEY_ID"
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.mastodon.s3.existingSecret }}
+                  name: {{ $context.Values.mastodon.s3.existingSecret }}
                   key: AWS_ACCESS_KEY_ID
             {{- end }}
             {{- if $context.Values.mastodon.smtp.existingSecret }}

--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -11,12 +11,13 @@ metadata:
     app.kubernetes.io/part-of: rails
 spec:
   {{- if (has "scheduler" .queues) }}
-  replicas: {{ min .replicas 1 }}
+    {{- if (gt (int .replicas) 1) }}
+      {{ fail "The scheduler queue should never have more than 1 replicas" }}
+    {{- end }}
   strategy:
     type: Recreate
-  {{- else }}
-  replicas: {{ .replicas }}
   {{- end }}
+  replicas: {{ .replicas }}
   selector:
     matchLabels:
       {{- include "mastodon.selectorLabels" $context | nindent 6 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -104,9 +104,10 @@ mastodon:
       # -- Sidekiq queues for Mastodon that are handled by this worker. See https://docs.joinmastodon.org/admin/scaling/#concurrency
       # See https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues for how to weight queues as argument
       queues:
-        - default
-        - push
-        - mailers
+        - default,8
+        - push,6
+        - ingress,4
+        - mailers,2
         - pull
         - scheduler # Make sure the scheduler queue only exists once and with a worker that has 1 replica.
     #- name: push-pull


### PR DESCRIPTION
Should be merged after #20733

- Adds the ingress queue to the default sidekiq deployment
- Adds queue weights to default sidekiq deployment matching `config/sidekiq.yml`
- Updates the chart version to 4.0.0
- Updates the README to document the changes in #20733
- Fixes S3 existing secret in CronJob (related to #21726)
- Fixes S3 existing secret error in deployment