### PR TITLE
Fix margin for search field on medium window size

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2474,8 +2474,7 @@ $ui-header-height: 55px;
     height: calc(100% - 10px) !important;
   }
 
-  .getting-started__wrapper,
-  .search {
+  .getting-started__wrapper {
     margin-bottom: 10px;
   }
 
@@ -4671,6 +4670,7 @@ a.status-card.compact:hover {
 }
 
 .search {
+  margin-bottom: 10px;
   position: relative;
 }
 


### PR DESCRIPTION
It fixes margin-bottom of search field on `@media screen and (min-width: 631px) and (max-width: $no-gap-breakpoint)`.

### Before

<img width="307" alt="스크린샷 2022-11-25 20 13 45" src="https://user-images.githubusercontent.com/2531397/203973859-f71c1efc-ad95-4655-840a-627a0e40ebbe.png">


### After

<img width="305" alt="스크린샷 2022-11-25 20 13 18" src="https://user-images.githubusercontent.com/2531397/203973880-6e9b11b6-91a8-4f04-8dbf-bc006534d9bc.png">
