### PR TITLE
chart: fix double-unwrap of `.Values.mastodon.s3.alias_host`

### DIFF
--- a/chart/templates/configmap-env.yaml
+++ b/chart/templates/configmap-env.yaml
@@ -47,7 +47,7 @@ data:
   S3_REGION: {{ . }}
   {{- end }}
   {{- with .Values.mastodon.s3.alias_host }}
-  S3_ALIAS_HOST: {{ .Values.mastodon.s3.alias_host}}
+  S3_ALIAS_HOST: {{ . }}
   {{- end }}
   {{- end }}
   {{- with .Values.mastodon.smtp.auth_method }}


### PR DESCRIPTION
Most likely a typo 😉 

(This time I checked it is not being fixed already in #21501)