### PR TITLE
fix(helm-chart): resolve template rendering error in sidekiq deployment

### DIFF
--- a/chart/templates/deployment-sidekiq.yaml
+++ b/chart/templates/deployment-sidekiq.yaml
@@ -96,7 +96,7 @@ spec:
             - name: "AWS_ACCESS_KEY_ID"
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.mastodon.s3.existingSecret }}
+                  name: {{ $context.Values.mastodon.s3.existingSecret }}
                   key: AWS_ACCESS_KEY_ID
             {{- end }}
             {{- if $context.Values.mastodon.smtp.existingSecret }}


### PR DESCRIPTION
Without this, Helm fails to render the chart when using S3 along with the `existingSecret` option.