### PR TITLE
Add logging for Rails cache timeouts

### DIFF
--- a/config/initializers/cache_logging.rb
+++ b/config/initializers/cache_logging.rb
@@ -1,0 +1,3 @@
+# Log cache errors with Rail's logger
+# This used to be the default in old Rails versions: https://github.com/rails/rails/commit/7fcf8590e788cef8b64cc266f75931c418902ca9#diff-f0748f0be8a653eea13369ebb1cadabcad71ede7cfaf20282447e64329817befL86
+Rails.cache.logger = Rails.logger

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -37,6 +37,7 @@ REDIS_CACHE_PARAMS = {
   namespace: cache_namespace,
   pool_size: Sidekiq.server? ? Sidekiq.options[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
   pool_timeout: 5,
+  connect_timeout: 5,
 }.freeze
 
 REDIS_SIDEKIQ_PARAMS = {


### PR DESCRIPTION
Currently, Rails cache connection to Redis times out after 20 seconds (for instance because of a firewall misconfiguration), and fails silently. This may cause some Redis-related issues to be difficult to diagnose.

This PR lowers the 20 seconds default to 5 seconds, as 5 seconds is the (default) value we use for other Redis uses, and it changes Rails cache to log errors to the standard Rails logger.

This will likely make the logs very noisy when Redis is timing out:
```
Nov 26 10:12:03 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: write_entry failed, returned false: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:08 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: read_entry failed, returned nil: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:13 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: write_entry failed, returned false: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:18 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: read_entry failed, returned nil: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:23 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: write_entry failed, returned false: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:28 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: read_entry failed, returned nil: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:33 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: write_entry failed, returned false: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:38 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: read_entry failed, returned nil: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:43 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: write_entry failed, returned false: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:48 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: read_entry failed, returned nil: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:53 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] [active_model_serializers] RedisCacheStore: write_entry failed, returned false: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:12:58 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] RedisCacheStore: read_entry failed, returned nil: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:13:03 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] RedisCacheStore: write_entry failed, returned false: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
Nov 26 10:13:08 mastodev bundle[1347]: [ba4ea586-c8f9-41db-84a7-e174ffa473c5] RedisCacheStore: read_entry failed, returned nil: Redis::CannotConnectError: Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
```

But it should not increase logs when Redis is running fine and reachable.