### PR TITLE
Increase the width of the unread notification border.

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7650,7 +7650,7 @@ noscript {
       left: 0;
       width: 100%;
       height: 100%;
-      border-left: 2px solid $highlight-text-color;
+      border-left: 4px solid $highlight-text-color;
       pointer-events: none;
     }
   }


### PR DESCRIPTION
The smaller border is difficult to see for some users, especially when the browser window was thinner, and so the unread border is at the very left edge of the window.

Before:
<img width="591" alt="Screen Shot 2022-11-26 at 12 44 56 PM" src="https://user-images.githubusercontent.com/2977353/204106675-b64dd866-3b88-4872-ad89-1c2855c11749.png">

After:
<img width="597" alt="Screen Shot 2022-11-26 at 12 44 28 PM" src="https://user-images.githubusercontent.com/2977353/204106682-2a73e4c1-bd37-4a27-a76d-b340a856571a.png">

