### PR TITLE
[RFC] [WIP] Allow IP addresses to be added to the allowlist which skips the rate limit checks

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,6 +2,9 @@
 
 require 'doorkeeper/grape/authorization_decorator'
 
+WHITELISTED_IPS_ENV_VALUE = ENV.fetch('RATE_LIMIT_WHITELIST_IPS', '')
+WHITELISTED_IPS = WHITELISTED_IPS_ENV_VALUE.split(",")
+
 class Rack::Attack
   class Request
     def authenticated_token
@@ -56,6 +59,10 @@ class Rack::Attack
 
   Rack::Attack.safelist('allow from localhost') do |req|
     req.remote_ip == '127.0.0.1' || req.remote_ip == '::1'
+  end
+
+  Rack::Attack.safelist('allow from whitelisted ips') do |req|
+    WHITELISTED_IPS.include?(req.remote_ip)
   end
 
   Rack::Attack.blocklist('deny from blocklist') do |req|

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,8 +2,8 @@
 
 require 'doorkeeper/grape/authorization_decorator'
 
-WHITELISTED_IPS_ENV_VALUE = ENV.fetch('RATE_LIMIT_WHITELIST_IPS', '')
-WHITELISTED_IPS = WHITELISTED_IPS_ENV_VALUE.split(",")
+ALLOWLISTED_IPS_ENV_VALUE = ENV.fetch('RATE_LIMIT_ALLOWLIST_IPS', '')
+ALLOWLISTED_IPS = ALLOWLISTED_IPS_ENV_VALUE.split(",")
 
 class Rack::Attack
   class Request
@@ -61,8 +61,8 @@ class Rack::Attack
     req.remote_ip == '127.0.0.1' || req.remote_ip == '::1'
   end
 
-  Rack::Attack.safelist('allow from whitelisted ips') do |req|
-    WHITELISTED_IPS.include?(req.remote_ip)
+  Rack::Attack.safelist('allow from ips in the allowlist') do |req|
+    ALLOWLISTED_IPS.include?(req.remote_ip)
   end
 
   Rack::Attack.blocklist('deny from blocklist') do |req|


### PR DESCRIPTION
## Background, Context

I'm self hosting my own Mastodon instance and I encounter "Too many requests" / "Rate limit reached" errors very often even when just very lightly and casually browsing my timeline as an authenticated user using a web browser.

Possibly related issue - https://github.com/mastodon/mastodon/issues/13098

## Proposed Changes

In this PR, I introduce new ``RATE_LIMIT_ALLOWLIST_IPS`` environment variable with which instance administrator can specify which IP addresses should be allowlisted / excluded from the rate limits.

This change / approach works fine for me since I always access my instance over VPN using internal IP address.

Keep in mind that this PR is not final, it's just a quick draft to get the discussion going on the possible solutions and to see if the project is opening to accepting such change.

## TODO (once agreed on the approach, etc.)

- [ ] Any code changes / polishing
- [ ] Tests
- [ ] Docs