### PR TITLE
Clear voter count when poll is reset

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -85,6 +85,7 @@ class Poll < ApplicationRecord
   def reset_votes!
     self.cached_tallies = options.map { 0 }
     self.votes_count = 0
+    self.voters_count = 0
     votes.delete_all unless new_record?
   end
 


### PR DESCRIPTION
When a poll is edited, we reset the poll and remove all previous votes. However, prior to this commit, the voter count on the poll was not reset. This leads to incorrect percentages being shown in poll results.

Fixes #21696