### PR TITLE
Add `id` attribute to REST::TagSerializer.

### DIFF
--- a/app/serializers/rest/tag_serializer.rb
+++ b/app/serializers/rest/tag_serializer.rb
@@ -3,9 +3,13 @@
 class REST::TagSerializer < ActiveModel::Serializer
   include RoutingHelper
 
-  attributes :name, :url, :history
+  attributes :id, :name, :url, :history
 
   attribute :following, if: :current_user?
+
+  def id
+    object.id.to_s
+  end
 
   def url
     tag_url(object)


### PR DESCRIPTION
This serializer was missing the `id` attribute, and is used in the `api/v1/admin/trends/tags` endpoint (`app/controllers/api/v1/trends/tags_controller.rb`), where it's necessary for app devs to implement admin functionality.

The controller should maybe be updated to use the Admin-specific TagSerializer, but that'd be a breaking change so I'm just doing this for now.