### PR TITLE
Clarify steps for and limitations on verification

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1642,7 +1642,7 @@ en:
     seamless_external_login: You are logged in via an external service, so password and e-mail settings are not available.
     signed_in_as: 'Signed in as:'
   verification:
-    explanation_html: 'You can <strong>verify yourself as the owner of the links</strong> in your profile metadata. First, add the HTTPS URL for your Mastodon profile page, as an <a> or <link> tag, to any one of your site's static HTML pages. The link must contain a <code>rel="me"</code> attribute. Then add the HTTPS URL for your website to the profile metadata section on this page. If verification succeeds, the link to your website will turn green. Example:'
+    explanation_html: 'You can <strong>verify yourself as the owner of the links</strong> in your profile metadata. First, add the HTTPS URL for your Mastodon profile page, as an <a> or <link> tag, to a static HTML page served by your site. The link must contain a <code>rel="me"</code> attribute. Then add the HTTPS URL for your website to the profile metadata section on this page. If verification succeeds, the link to your website will turn green. Example:'
     verification: Verification
   webauthn_credentials:
     add: Add new security key

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1642,7 +1642,7 @@ en:
     seamless_external_login: You are logged in via an external service, so password and e-mail settings are not available.
     signed_in_as: 'Signed in as:'
   verification:
-    explanation_html: 'You can <strong>verify yourself as the owner of the links</strong> in your profile metadata. First, add the HTTPS URL for your Mastodon profile page, as an <a> or <link> tag, to a static HTML page served by your site. The link must contain a <code>rel="me"</code> attribute. Then add the HTTPS URL for your website to the profile metadata section on this page. If verification succeeds, the link to your website will turn green. Example:'
+    explanation_html: 'You can <strong>verify yourself as the owner of the links</strong> in your profile metadata. First, add the HTTPS URL for your Mastodon profile page, as an <a> or <link> tag, to a static HTML page served by your site. The link must contain a <code>rel="me"</code> attribute. Then add the HTTPS URL for that static HTML page on your website to the profile metadata section here. If verification succeeds, the link to your website will turn green. Example:'
     verification: Verification
   webauthn_credentials:
     add: Add new security key

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1642,7 +1642,7 @@ en:
     seamless_external_login: You are logged in via an external service, so password and e-mail settings are not available.
     signed_in_as: 'Signed in as:'
   verification:
-    explanation_html: 'You can <strong>verify yourself as the owner of the links</strong> in your profile metadata. 1) Add the HTTPS URL for your website to the profile metadata section on this page and 2) add the HTTPS URL for your Mastodon profile page to any one of your site's static HTML pages. This link must contain a <code>rel="me"</code> attribute. If verification succeeds, the link to your website will turn green. Example:'
+    explanation_html: 'You can <strong>verify yourself as the owner of the links</strong> in your profile metadata. First, add the HTTPS URL for your Mastodon profile page, as an <a> or <link> tag, to any one of your site's static HTML pages. The link must contain a <code>rel="me"</code> attribute. Then add the HTTPS URL for your website to the profile metadata section on this page. If verification succeeds, the link to your website will turn green. Example:'
     verification: Verification
   webauthn_credentials:
     add: Add new security key

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1642,7 +1642,7 @@ en:
     seamless_external_login: You are logged in via an external service, so password and e-mail settings are not available.
     signed_in_as: 'Signed in as:'
   verification:
-    explanation_html: 'You can <strong>verify yourself as the owner of the links in your profile metadata</strong>. For that, the linked website must contain a link back to your Mastodon profile. The link back <strong>must</strong> have a <code>rel="me"</code> attribute. The text content of the link does not matter. Here is an example:'
+    explanation_html: 'You can <strong>verify yourself as the owner of the links</strong> in your profile metadata. 1) Add the HTTPS URL for your website to the profile metadata section on this page and 2) add the HTTPS URL for your Mastodon profile page to any one of your site's static HTML pages. This link must contain a <code>rel="me"</code> attribute. If verification succeeds, the link to your website will turn green. Example:'
     verification: Verification
   webauthn_credentials:
     add: Add new security key


### PR DESCRIPTION
1) The docs indicate that the link to a personal website should be in HTTPS format. That's been added here. 2) Only if the website uses at least one page of static HTML will verification succeed, and the link to Mastodon has to be within that static HTML. That's been clarified. The docs will be enhanced to clarify the limitation with respect to CMS websites. 3) What you should expect to see if verification succeeds has been added.