### PR TITLE
Fix state mismatch of sensitive checkbox in compose form

### DIFF
--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -337,6 +337,10 @@ export default function compose(state = initialState, action) {
       if (action.status.get('spoiler_text').length > 0) {
         map.set('spoiler', true);
         map.set('spoiler_text', action.status.get('spoiler_text'));
+
+        if (map.get('media_attachments').size >= 1) {
+          map.set('sensitive', true);
+        }
       } else {
         map.set('spoiler', false);
         map.set('spoiler_text', '');


### PR DESCRIPTION
When reply to the status with spoiler text with the image uploaded first. Spoiler text is applied, but the sensitive checks that should be enforced remain unchecked.

before:

https://user-images.githubusercontent.com/32974885/204128978-d0c708d0-5aa9-4467-99d3-d9f1e154ef3d.mp4

This PR fix it.

after:

https://user-images.githubusercontent.com/32974885/204129220-9a478e6b-2885-4775-805f-82c179d28651.mp4


