### PR TITLE
Automatically Choose `.ruby-version` Version for Bundler Platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Fix wrong color on mentions hidden behind content warning in web UI ([Gargron](https://github.com/mastodon/mastodon/pull/20724))
 - Fix filters from other users being used in the streaming service ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/20719))
 - Fix `unsafe-eval` being used when `wasm-unsafe-eval` is enough in Content Security Policy ([Gargron](https://github.com/mastodon/mastodon/pull/20729), [prplecake](https://github.com/mastodon/mastodon/pull/20606))
+- Fix use `.ruby-version` as Bundler's chosen Ruby version ([HamptonMakes])
 
 ## [4.0.1] - 2022-11-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ All notable changes to this project will be documented in this file.
 - Fix wrong color on mentions hidden behind content warning in web UI ([Gargron](https://github.com/mastodon/mastodon/pull/20724))
 - Fix filters from other users being used in the streaming service ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/20719))
 - Fix `unsafe-eval` being used when `wasm-unsafe-eval` is enough in Content Security Policy ([Gargron](https://github.com/mastodon/mastodon/pull/20729), [prplecake](https://github.com/mastodon/mastodon/pull/20606))
-- Fix use `.ruby-version` as Bundler's chosen Ruby version ([HamptonMakes](https://github.com/mastodon/mastodon/pull/21742))
 
 ## [4.0.1] - 2022-11-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Fix wrong color on mentions hidden behind content warning in web UI ([Gargron](https://github.com/mastodon/mastodon/pull/20724))
 - Fix filters from other users being used in the streaming service ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/20719))
 - Fix `unsafe-eval` being used when `wasm-unsafe-eval` is enough in Content Security Policy ([Gargron](https://github.com/mastodon/mastodon/pull/20729), [prplecake](https://github.com/mastodon/mastodon/pull/20606))
-- Fix use `.ruby-version` as Bundler's chosen Ruby version ([HamptonMakes])
+- Fix use `.ruby-version` as Bundler's chosen Ruby version ([HamptonMakes](https://github.com/mastodon/mastodon/pull/21742))
 
 ## [4.0.1] - 2022-11-14
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 2.7.0', '< 3.1.0'
+ruby File.read(File.join(__dir__, '.ruby-version')).strip
 
 gem 'pkg-config', '~> 1.4'
 gem 'rexml', '~> 3.2'


### PR DESCRIPTION
This change means that `bundle platform --ruby` will return our actual suggested Ruby version which is kept in the `.ruby-version` file.