### PR TITLE
Add alternate domains to helm chart

### DIFF
--- a/chart/templates/configmap-env.yaml
+++ b/chart/templates/configmap-env.yaml
@@ -25,6 +25,9 @@ data:
   {{- with .Values.mastodon.web_domain }}
   WEB_DOMAIN: {{ . }}
   {{- end }}
+  {{- with .Values.mastodon.alternate_domains}}
+  ALTERNATE_DOMAINS: {{ join "," . }}
+  {{- end }}
   {{- with .Values.mastodon.singleUserMode }}
   SINGLE_USER_MODE: "true"
   {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -34,6 +34,11 @@ mastodon:
   # You must redirect the path LOCAL_DOMAIN/.well-known/ to WEB_DOMAIN/.well-known/ as described
   # Example: mastodon.example.com
   web_domain: null
+  # If you have multiple domains pointed at your Mastodon server, this setting will allow Mastodon to recognize
+  # itself when users are addressed using those other domains.
+  # alternate_domains:
+  #   - foo.com
+  #   - bar.com
   # -- If set to true, the frontpage of your Mastodon server will always redirect to the first profile in the database and registrations will be disabled.
   singleUserMode: false
   # -- Enables "Secure Mode" for more details see: https://docs.joinmastodon.org/admin/config/#authorized_fetch


### PR DESCRIPTION
Implement `ALTERNATE_DOMAINS` environment variable as defined in [Configuring your environment](https://docs.joinmastodon.org/admin/config/#alternate_domains) into Helm chart and `values.yaml`.

This will need users of the chart to configure the extra hosts in the ingress (that seems pretty straight forward to me).