### PR TITLE
Make the 'Trending now' header a link to Explore

### DIFF
--- a/app/javascript/mastodon/features/getting_started/components/trends.js
+++ b/app/javascript/mastodon/features/getting_started/components/trends.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
 import { FormattedMessage } from 'react-intl';
+import { Link } from 'react-router-dom';
 
 export default class Trends extends ImmutablePureComponent {
 
@@ -36,7 +37,11 @@ export default class Trends extends ImmutablePureComponent {
 
     return (
       <div className='getting-started__trends'>
-        <h4><FormattedMessage id='trends.trending_now' defaultMessage='Trending now' /></h4>
+        <h4>
+          <Link to={'/explore/tags'}>
+            <FormattedMessage id='trends.trending_now' defaultMessage='Trending now' />
+          </Link>
+        </h4>
 
         {trends.take(3).map(hashtag => <Hashtag key={hashtag.get('name')} hashtag={hashtag} />)}
       </div>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3139,12 +3139,16 @@ $ui-header-height: 55px;
     margin-top: 10px;
 
     h4 {
+      border-bottom: 1px solid lighten($ui-base-color, 8%);
+      padding: 10px;
       font-size: 12px;
       text-transform: uppercase;
-      color: $darker-text-color;
-      padding: 10px;
       font-weight: 500;
-      border-bottom: 1px solid lighten($ui-base-color, 8%);
+
+      a {
+        color: $darker-text-color;
+        text-decoration: none;
+      }
     }
 
     @media screen and (max-height: 810px) {


### PR DESCRIPTION
This keeps the same design that exists currently, but makes "Trending now" into a link to the Hashtags section of "Explore".

Resolves #21758.

And the design of the element itself is unchanged:

<img width="329" alt="Screen Shot 2022-11-27 at 3 42 20 PM" src="https://user-images.githubusercontent.com/2977353/204163643-b7b6f802-91f7-4e93-b305-98b841ee6b8f.png">
