### PR TITLE
Add copy address button to account header

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -54,6 +54,7 @@ const messages = defineMessages({
   admin_account: { id: 'status.admin_account', defaultMessage: 'Open moderation interface for @{name}' },
   languages: { id: 'account.languages', defaultMessage: 'Change subscribed languages' },
   openOriginalPage: { id: 'account.open_original_page', defaultMessage: 'Open original page' },
+  copyAddress: { id: 'account.copy_address', defaultMessage: 'Copy address to clipboard' },
 });
 
 const titleFromAccount = account => {
@@ -160,6 +161,10 @@ class Header extends ImmutablePureComponent {
     });
   }
 
+  handleCopyAddress = (address) => {
+    return () => navigator.clipboard.writeText(address);
+  }
+
   render () {
     const { account, hidden, intl, domain } = this.props;
     const { signedIn } = this.context.identity;
@@ -177,6 +182,7 @@ class Header extends ImmutablePureComponent {
     let bellBtn     = '';
     let lockedIcon  = '';
     let menu        = [];
+    let copyAddressButton = () => '';
 
     if (me !== account.get('id') && account.getIn(['relationship', 'followed_by'])) {
       info.push(<span key='followed_by' className='relationship-tag'><FormattedMessage id='account.follows_you' defaultMessage='Follows you' /></span>);
@@ -214,6 +220,10 @@ class Header extends ImmutablePureComponent {
 
     if (account.get('locked')) {
       lockedIcon = <Icon id='lock' title={intl.formatMessage(messages.account_locked)} />;
+    }
+
+    if ('clipboard' in navigator) {
+      copyAddressButton = (address) => <IconButton icon='clone' size={14} title={intl.formatMessage(messages.copyAddress)} onClick={this.handleCopyAddress(address)} />;
     }
 
     if (signedIn && account.get('id') !== me) {
@@ -342,7 +352,7 @@ class Header extends ImmutablePureComponent {
           <div className='account__header__tabs__name'>
             <h1>
               <span dangerouslySetInnerHTML={displayNameHtml} /> {badge}
-              <small>@{acct} {lockedIcon}</small>
+              <small>@{acct} {lockedIcon} {copyAddressButton('@'+acct)}</small>
             </h1>
           </div>
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -19,6 +19,7 @@
   "account.block_domain": "Block domain {domain}",
   "account.blocked": "Blocked",
   "account.browse_more_on_origin_server": "Browse more on the original profile",
+  "account.copy_address": "Copy address to clipboard",
   "account.cancel_follow_request": "Withdraw follow request",
   "account.direct": "Direct message @{name}",
   "account.disable_notifications": "Stop notifying me when @{name} posts",

--- a/app/javascript/mastodon/locales/fi.json
+++ b/app/javascript/mastodon/locales/fi.json
@@ -19,6 +19,7 @@
   "account.block_domain": "Estä verkkotunnus {domain}",
   "account.blocked": "Estetty",
   "account.browse_more_on_origin_server": "Selaile lisää alkuperäisellä palvelimella",
+  "account.copy_address": "Kopioi osoite leikepöydälle",
   "account.cancel_follow_request": "Peruuta seurantapyyntö",
   "account.direct": "Yksityisviesti käyttäjälle @{name}",
   "account.disable_notifications": "Lopeta @{name}:n julkaisuista ilmoittaminen",


### PR DESCRIPTION
This PR adds a copy address button next to the address in the account header:

![1](https://user-images.githubusercontent.com/338659/204163847-a9878f78-f72e-4721-bfa4-0d7c57a62b70.png)

If the the account is locked the lock icon is listed first:

![2](https://user-images.githubusercontent.com/338659/204163850-a954eb2e-4b0b-4864-a438-fd4f7d4de0f1.png)

In case you wonder how it would look with the icons swapped:

![3](https://user-images.githubusercontent.com/338659/204163853-06748a5b-b0f2-410f-b6c3-18285b7a8791.png)
