### PR TITLE
Fix hidden overflow on interaction modal

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7969,7 +7969,7 @@ noscript {
   width: 600px;
   background: $ui-base-color;
   border-radius: 8px;
-  overflow: hidden;
+  overflow: auto;
   position: relative;
   display: block;
   padding: 20px;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7969,7 +7969,8 @@ noscript {
   width: 600px;
   background: $ui-base-color;
   border-radius: 8px;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   position: relative;
   display: block;
   padding: 20px;


### PR DESCRIPTION
Allow the interaction modal to overflow if needed.
Fixes this issue: https://github.com/mastodon/mastodon/issues/21622

#### Mobile
[overflow.webm](https://user-images.githubusercontent.com/1364447/204165703-41a42735-ba84-4fb0-86d9-98f1288a2aa1.webm)

#### Desktop (no changes)
![large](https://user-images.githubusercontent.com/1364447/204165747-e42a8039-13d5-45fe-b0cf-8a2984036c8f.png)

