### PR TITLE
Add listing of followed hashtags

### DIFF
--- a/app/javascript/mastodon/actions/tags.js
+++ b/app/javascript/mastodon/actions/tags.js
@@ -1,4 +1,4 @@
-import api from '../api';
+import api, { getLinks } from '../api';
 
 export const HASHTAG_FETCH_REQUEST = 'HASHTAG_FETCH_REQUEST';
 export const HASHTAG_FETCH_SUCCESS = 'HASHTAG_FETCH_SUCCESS';
@@ -7,6 +7,10 @@ export const HASHTAG_FETCH_FAIL    = 'HASHTAG_FETCH_FAIL';
 export const FOLLOWED_HASHTAGS_FETCH_REQUEST = 'FOLLOWED_HASHTAGS_FETCH_REQUEST';
 export const FOLLOWED_HASHTAGS_FETCH_SUCCESS = 'FOLLOWED_HASHTAGS_FETCH_SUCCESS';
 export const FOLLOWED_HASHTAGS_FETCH_FAIL    = 'FOLLOWED_HASHTAGS_FETCH_FAIL';
+
+export const FOLLOWED_HASHTAGS_EXPAND_REQUEST = 'FOLLOWED_HASHTAGS_EXPAND_REQUEST';
+export const FOLLOWED_HASHTAGS_EXPAND_SUCCESS = 'FOLLOWED_HASHTAGS_EXPAND_SUCCESS';
+export const FOLLOWED_HASHTAGS_EXPAND_FAIL    = 'FOLLOWED_HASHTAGS_EXPAND_FAIL';
 
 export const HASHTAG_FOLLOW_REQUEST = 'HASHTAG_FOLLOW_REQUEST';
 export const HASHTAG_FOLLOW_SUCCESS = 'HASHTAG_FOLLOW_SUCCESS';
@@ -44,9 +48,12 @@ export const fetchHashtagFail = error => ({
 export const fetchFollowedHashtags = () => (dispatch, getState) => {
   dispatch(fetchFollowedHashtagsRequest());
 
-  api(getState).get('/api/v1/followed_tags')
-    .then(({ data }) => dispatch(fetchFollowedHashtagsSuccess(data)))
-    .catch(err => dispatch(fetchFollowedHashtagsFail(err)));
+  api(getState).get('/api/v1/followed_tags').then(response => {
+    const next = getLinks(response).refs.find(link => link.rel === 'next');
+    dispatch(fetchFollowedHashtagsSuccess(response.data, next ? next.uri : null));
+  }).catch(err => {
+    dispatch(fetchFollowedHashtagsFail(err));
+  });
 };
 
 export function fetchFollowedHashtagsRequest() {
@@ -55,16 +62,57 @@ export function fetchFollowedHashtagsRequest() {
   };
 };
 
-export function fetchFollowedHashtagsSuccess(followed_tags) {
+export function fetchFollowedHashtagsSuccess(followed_tags, next) {
   return {
     type: FOLLOWED_HASHTAGS_FETCH_SUCCESS,
     followed_tags,
+    next,
   };
 };
 
 export function fetchFollowedHashtagsFail(error) {
   return {
     type: FOLLOWED_HASHTAGS_FETCH_FAIL,
+    error,
+  };
+};
+
+export function expandFollowedHashtags() {
+  return (dispatch, getState) => {
+    const url = getState().getIn(['followed_tags', 'next']);
+
+    if (url === null) {
+      return;
+    }
+
+    dispatch(expandFollowedHashtagsRequest());
+
+    api(getState).get(url).then(response => {
+      const next = getLinks(response).refs.find(link => link.rel === 'next');
+      dispatch(expandFollowedHashtagsSuccess(response.data, next ? next.uri : null));
+    }).catch(error => {
+      dispatch(expandFollowedHashtagsFail(error));
+    });
+  };
+};
+
+export function expandFollowedHashtagsRequest() {
+  return {
+    type: FOLLOWED_HASHTAGS_EXPAND_REQUEST,
+  };
+};
+
+export function expandFollowedHashtagsSuccess(followed_tags, next) {
+  return {
+    type: FOLLOWED_HASHTAGS_EXPAND_SUCCESS,
+    followed_tags,
+    next,
+  };
+};
+
+export function expandFollowedHashtagsFail(error) {
+  return {
+    type: FOLLOWED_HASHTAGS_EXPAND_FAIL,
     error,
   };
 };

--- a/app/javascript/mastodon/actions/tags.js
+++ b/app/javascript/mastodon/actions/tags.js
@@ -46,7 +46,7 @@ export const fetchFollowedHashtags = () => (dispatch, getState) => {
 
   api(getState).get(`/api/v1/followed_tags`)
     .then(({ data }) => dispatch(fetchFollowedHashtagsSuccess(data)))
-    .catch(err => dispatch(fetchFollowedHashtagsSuccess(err)));
+    .catch(err => dispatch(fetchFollowedHashtagsFail(err)));
 };
 
 export function fetchFollowedHashtagsRequest() {

--- a/app/javascript/mastodon/actions/tags.js
+++ b/app/javascript/mastodon/actions/tags.js
@@ -44,7 +44,7 @@ export const fetchHashtagFail = error => ({
 export const fetchFollowedHashtags = () => (dispatch, getState) => {
   dispatch(fetchFollowedHashtagsRequest());
 
-  api(getState).get(`/api/v1/followed_tags`)
+  api(getState).get('/api/v1/followed_tags')
     .then(({ data }) => dispatch(fetchFollowedHashtagsSuccess(data)))
     .catch(err => dispatch(fetchFollowedHashtagsFail(err)));
 };

--- a/app/javascript/mastodon/actions/tags.js
+++ b/app/javascript/mastodon/actions/tags.js
@@ -4,6 +4,10 @@ export const HASHTAG_FETCH_REQUEST = 'HASHTAG_FETCH_REQUEST';
 export const HASHTAG_FETCH_SUCCESS = 'HASHTAG_FETCH_SUCCESS';
 export const HASHTAG_FETCH_FAIL    = 'HASHTAG_FETCH_FAIL';
 
+export const FOLLOWED_HASHTAGS_FETCH_REQUEST = 'FOLLOWED_HASHTAGS_FETCH_REQUEST';
+export const FOLLOWED_HASHTAGS_FETCH_SUCCESS = 'FOLLOWED_HASHTAGS_FETCH_SUCCESS';
+export const FOLLOWED_HASHTAGS_FETCH_FAIL    = 'FOLLOWED_HASHTAGS_FETCH_FAIL';
+
 export const HASHTAG_FOLLOW_REQUEST = 'HASHTAG_FOLLOW_REQUEST';
 export const HASHTAG_FOLLOW_SUCCESS = 'HASHTAG_FOLLOW_SUCCESS';
 export const HASHTAG_FOLLOW_FAIL    = 'HASHTAG_FOLLOW_FAIL';
@@ -36,6 +40,35 @@ export const fetchHashtagFail = error => ({
   type: HASHTAG_FETCH_FAIL,
   error,
 });
+
+export const fetchFollowedHashtags = () => (dispatch, getState) => {
+  dispatch(fetchFollowedHashtagsRequest());
+
+  api(getState).get(`/api/v1/followed_tags`)
+    .then(({ data }) => dispatch(fetchFollowedHashtagsSuccess(data)))
+    .catch(err => dispatch(fetchFollowedHashtagsSuccess(err)));
+};
+
+export function fetchFollowedHashtagsRequest() {
+  return {
+    type: FOLLOWED_HASHTAGS_FETCH_REQUEST,
+  };
+};
+
+export function fetchFollowedHashtagsSuccess(hashtags, next) {
+  return {
+    type: FOLLOWED_HASHTAGS_FETCH_SUCCESS,
+    hashtags,
+    next,
+  };
+};
+
+export function fetchFollowedHashtagsFail(error) {
+  return {
+    type: FOLLOWED_HASHTAGS_FETCH_FAIL,
+    error,
+  };
+};
 
 export const followHashtag = name => (dispatch, getState) => {
   dispatch(followHashtagRequest(name));

--- a/app/javascript/mastodon/actions/tags.js
+++ b/app/javascript/mastodon/actions/tags.js
@@ -55,11 +55,10 @@ export function fetchFollowedHashtagsRequest() {
   };
 };
 
-export function fetchFollowedHashtagsSuccess(hashtags, next) {
+export function fetchFollowedHashtagsSuccess(followed_tags) {
   return {
     type: FOLLOWED_HASHTAGS_FETCH_SUCCESS,
-    hashtags,
-    next,
+    followed_tags,
   };
 };
 

--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -46,6 +46,7 @@ const messages = defineMessages({
   follow_requests: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
   favourites: { id: 'navigation_bar.favourites', defaultMessage: 'Favourites' },
   lists: { id: 'navigation_bar.lists', defaultMessage: 'Lists' },
+  followed_tags: { id: 'navigation_bar.followed_tags', defaultMessage: 'Followed hashtags' },
   blocks: { id: 'navigation_bar.blocks', defaultMessage: 'Blocked users' },
   domain_blocks: { id: 'navigation_bar.domain_blocks', defaultMessage: 'Blocked domains' },
   mutes: { id: 'navigation_bar.mutes', defaultMessage: 'Muted users' },
@@ -241,6 +242,7 @@ class Header extends ImmutablePureComponent {
       menu.push({ text: intl.formatMessage(messages.follow_requests), to: '/follow_requests' });
       menu.push({ text: intl.formatMessage(messages.favourites), to: '/favourites' });
       menu.push({ text: intl.formatMessage(messages.lists), to: '/lists' });
+      menu.push({ text: intl.formatMessage(messages.followed_tags), to: '/followed_tags' });
       menu.push(null);
       menu.push({ text: intl.formatMessage(messages.mutes), to: '/mutes' });
       menu.push({ text: intl.formatMessage(messages.blocks), to: '/blocks' });

--- a/app/javascript/mastodon/features/compose/components/action_bar.js
+++ b/app/javascript/mastodon/features/compose/components/action_bar.js
@@ -11,6 +11,7 @@ const messages = defineMessages({
   follow_requests: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
   favourites: { id: 'navigation_bar.favourites', defaultMessage: 'Favourites' },
   lists: { id: 'navigation_bar.lists', defaultMessage: 'Lists' },
+  followed_tags: { id: 'navigation_bar.followed_tags', defaultMessage: 'Followed hashtags' },
   blocks: { id: 'navigation_bar.blocks', defaultMessage: 'Blocked users' },
   domain_blocks: { id: 'navigation_bar.domain_blocks', defaultMessage: 'Hidden domains' },
   mutes: { id: 'navigation_bar.mutes', defaultMessage: 'Muted users' },
@@ -45,6 +46,7 @@ class ActionBar extends React.PureComponent {
     menu.push({ text: intl.formatMessage(messages.favourites), to: '/favourites' });
     menu.push({ text: intl.formatMessage(messages.bookmarks), to: '/bookmarks' });
     menu.push({ text: intl.formatMessage(messages.lists), to: '/lists' });
+    menu.push({ text: intl.formatMessage(messages.followed_tags), to: '/followed_tags' });
     menu.push(null);
     menu.push({ text: intl.formatMessage(messages.mutes), to: '/mutes' });
     menu.push({ text: intl.formatMessage(messages.blocks), to: '/blocks' });

--- a/app/javascript/mastodon/features/followed_tags/index.js
+++ b/app/javascript/mastodon/features/followed_tags/index.js
@@ -64,16 +64,17 @@ class FollowedTags extends ImmutablePureComponent {
           scrollKey='followed_tags'
           emptyMessage={emptyMessage}
         >
-          {hashtags.map(hashtag =>
-            <Hashtag key={hashtag.get('name')}
+          {hashtags.map((hashtag) => (
+            <Hashtag
+              key={hashtag.get('name')}
               name={hashtag.get('name')}
               to={`/tags/${hashtag.get('name')}`}
               withGraph={false}
               // Taken from ImmutableHashtag. Should maybe refactor ImmutableHashtag to accept more options?
               people={hashtag.getIn(['history', 0, 'accounts']) * 1 + hashtag.getIn(['history', 1, 'accounts']) * 1}
               history={hashtag.get('history').reverse().map((day) => day.get('uses')).toArray()}
-            />,
-          )}
+            />
+          ))}
         </ScrollableList>
 
         <Helmet>

--- a/app/javascript/mastodon/features/followed_tags/index.js
+++ b/app/javascript/mastodon/features/followed_tags/index.js
@@ -6,7 +6,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 import ColumnHeader from 'mastodon/components/column_header';
-import LoadingIndicator from 'mastodon/components/loading_indicator';
 import ScrollableList from 'mastodon/components/scrollable_list';
 import Column from 'mastodon/features/ui/components/column';
 import { Helmet } from 'react-helmet';
@@ -34,11 +33,10 @@ class FollowedTags extends ImmutablePureComponent {
     hashtags: ImmutablePropTypes.list,
     isLoading: PropTypes.bool,
     hasMore: PropTypes.bool,
+    multiColumn: PropTypes.bool,
   };
 
-  constructor(props) {
-    super(props);
-
+  componentDidMount() {
     this.props.dispatch(fetchFollowedHashtags());
   };
 
@@ -47,15 +45,7 @@ class FollowedTags extends ImmutablePureComponent {
   }, 300, { leading: true });
 
   render () {
-    const { intl, hashtags, isLoading, hasMore } = this.props;
-
-    if (isLoading) {
-      return (
-        <Column>
-          <LoadingIndicator />
-        </Column>
-      );
-    }
+    const { intl, hashtags, isLoading, hasMore, multiColumn } = this.props;
 
     const emptyMessage = <FormattedMessage id='empty_column.followed_tags' defaultMessage='You have not followed any hashtags yet. When you do, they will show up here.' />;
 

--- a/app/javascript/mastodon/features/followed_tags/index.js
+++ b/app/javascript/mastodon/features/followed_tags/index.js
@@ -33,7 +33,9 @@ class FollowedTags extends ImmutablePureComponent {
     isLoading: PropTypes.bool,
   };
 
-  componentWillMount () {
+  constructor(props) {
+    super(props);
+
     this.props.dispatch(fetchFollowedHashtags());
   }
 
@@ -63,7 +65,14 @@ class FollowedTags extends ImmutablePureComponent {
           emptyMessage={emptyMessage}
         >
           {hashtags.map(hashtag =>
-            <Hashtag key={hashtag.get('name')} hashtag={hashtag} withGraph={false} />,
+            <Hashtag key={hashtag.get('name')}
+              name={hashtag.get('name')}
+              to={`/tags/${hashtag.get('name')}`}
+              withGraph={false}
+              // Taken from ImmutableHashtag. Should maybe refactor ImmutableHashtag to accept more options?
+              people={hashtag.getIn(['history', 0, 'accounts']) * 1 + hashtag.getIn(['history', 1, 'accounts']) * 1}
+              history={hashtag.get('history').reverse().map((day) => day.get('uses')).toArray()}
+            />,
           )}
         </ScrollableList>
 

--- a/app/javascript/mastodon/features/followed_tags/index.js
+++ b/app/javascript/mastodon/features/followed_tags/index.js
@@ -14,7 +14,7 @@ import { fetchFollowedHashtags } from 'mastodon/actions/tags';
 import { List } from 'immutable';
 
 const messages = defineMessages({
-  heading: { id: 'followed_hashtags', defaultMessage: 'Followed Hashtags' },
+  heading: { id: 'followed_hashtags', defaultMessage: 'Followed hashtags' },
 });
 
 const mapStateToProps = (state, props) => ({
@@ -38,7 +38,7 @@ class FollowedTags extends ImmutablePureComponent {
   }
 
   render () {
-    const { intl, tagIds, multiColumn } = this.props;
+    const { intl, tagIds } = this.props;
 
     if (!tagIds) {
       return (
@@ -51,18 +51,16 @@ class FollowedTags extends ImmutablePureComponent {
     const emptyMessage = <FormattedMessage id='empty_column.followed_tags' defaultMessage='You have not followed any hashtags yet. When you do, they will show up here.' />;
 
     return (
-      <Column bindToDocument={!multiColumn}>
+      <Column>
         <ColumnHeader
           icon='hashtag'
           title={intl.formatMessage(messages.heading)}
           showBackButton
-          multiColumn={multiColumn}
         />
 
         <ScrollableList
           scrollKey='followed_tags'
           emptyMessage={emptyMessage}
-          bindToDocument={!multiColumn}
         >
           {tagIds.map(id =>
             <Hashtag key={id} id={id} />,

--- a/app/javascript/mastodon/features/followed_tags/index.js
+++ b/app/javascript/mastodon/features/followed_tags/index.js
@@ -60,18 +60,21 @@ class FollowedTags extends ImmutablePureComponent {
     const emptyMessage = <FormattedMessage id='empty_column.followed_tags' defaultMessage='You have not followed any hashtags yet. When you do, they will show up here.' />;
 
     return (
-      <Column>
+      <Column bindToDocument={!multiColumn}>
         <ColumnHeader
           icon='hashtag'
           title={intl.formatMessage(messages.heading)}
           showBackButton
+          multiColumn={multiColumn}
         />
 
         <ScrollableList
           scrollKey='followed_tags'
           emptyMessage={emptyMessage}
           hasMore={hasMore}
+          isLoading={isLoading}
           onLoadMore={this.handleLoadMore}
+          bindToDocument={!multiColumn}
         >
           {hashtags.map((hashtag) => (
             <Hashtag

--- a/app/javascript/mastodon/features/followed_tags/index.js
+++ b/app/javascript/mastodon/features/followed_tags/index.js
@@ -16,7 +16,7 @@ const messages = defineMessages({
   heading: { id: 'followed_tags', defaultMessage: 'Followed hashtags' },
 });
 
-const mapStateToProps = (state, props) => ({
+const mapStateToProps = state => ({
   hashtags: state.getIn(['followed_tags', 'items']),
   isLoading: state.getIn(['followed_tags', 'isLoading'], true),
 });

--- a/app/javascript/mastodon/features/followed_tags/index.js
+++ b/app/javascript/mastodon/features/followed_tags/index.js
@@ -11,15 +11,14 @@ import Column from 'mastodon/features/ui/components/column';
 import { Helmet } from 'react-helmet';
 import Hashtag from 'mastodon/components/hashtag';
 import { fetchFollowedHashtags } from 'mastodon/actions/tags';
-import { List } from 'immutable';
 
 const messages = defineMessages({
-  heading: { id: 'followed_hashtags', defaultMessage: 'Followed hashtags' },
+  heading: { id: 'followed_tags', defaultMessage: 'Followed hashtags' },
 });
 
 const mapStateToProps = (state, props) => ({
-  // TODO?
-  tagIds: List(),
+  hashtags: state.getIn(['followed_tags', 'items']),
+  isLoading: state.getIn(['followed_tags', 'isLoading'], true),
 });
 
 export default @connect(mapStateToProps)
@@ -29,8 +28,9 @@ class FollowedTags extends ImmutablePureComponent {
   static propTypes = {
     params: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
-    tagIds: ImmutablePropTypes.list,
     intl: PropTypes.object.isRequired,
+    hashtags: ImmutablePropTypes.list,
+    isLoading: PropTypes.bool,
   };
 
   componentWillMount () {
@@ -38,9 +38,9 @@ class FollowedTags extends ImmutablePureComponent {
   }
 
   render () {
-    const { intl, tagIds } = this.props;
+    const { intl, hashtags, isLoading } = this.props;
 
-    if (!tagIds) {
+    if (isLoading) {
       return (
         <Column>
           <LoadingIndicator />
@@ -62,8 +62,8 @@ class FollowedTags extends ImmutablePureComponent {
           scrollKey='followed_tags'
           emptyMessage={emptyMessage}
         >
-          {tagIds.map(id =>
-            <Hashtag key={id} id={id} />,
+          {hashtags.map(hashtag =>
+            <Hashtag key={hashtag.get('name')} hashtag={hashtag} withGraph={false} />,
           )}
         </ScrollableList>
 

--- a/app/javascript/mastodon/features/followed_tags/index.js
+++ b/app/javascript/mastodon/features/followed_tags/index.js
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import { connect } from 'react-redux';
+import ColumnHeader from 'mastodon/components/column_header';
+import LoadingIndicator from 'mastodon/components/loading_indicator';
+import ScrollableList from 'mastodon/components/scrollable_list';
+import Column from 'mastodon/features/ui/components/column';
+import { Helmet } from 'react-helmet';
+import Hashtag from 'mastodon/components/hashtag';
+import { fetchFollowedHashtags } from 'mastodon/actions/tags';
+import { List } from 'immutable';
+
+const messages = defineMessages({
+  heading: { id: 'followed_hashtags', defaultMessage: 'Followed Hashtags' },
+});
+
+const mapStateToProps = (state, props) => ({
+  // TODO?
+  tagIds: List(),
+});
+
+export default @connect(mapStateToProps)
+@injectIntl
+class FollowedTags extends ImmutablePureComponent {
+
+  static propTypes = {
+    params: PropTypes.object.isRequired,
+    dispatch: PropTypes.func.isRequired,
+    tagIds: ImmutablePropTypes.list,
+    intl: PropTypes.object.isRequired,
+  };
+
+  componentWillMount () {
+    this.props.dispatch(fetchFollowedHashtags());
+  }
+
+  render () {
+    const { intl, tagIds, multiColumn } = this.props;
+
+    if (!tagIds) {
+      return (
+        <Column>
+          <LoadingIndicator />
+        </Column>
+      );
+    }
+
+    const emptyMessage = <FormattedMessage id='empty_column.followed_tags' defaultMessage='You have not followed any hashtags yet. When you do, they will show up here.' />;
+
+    return (
+      <Column bindToDocument={!multiColumn}>
+        <ColumnHeader
+          icon='hashtag'
+          title={intl.formatMessage(messages.heading)}
+          showBackButton
+          multiColumn={multiColumn}
+        />
+
+        <ScrollableList
+          scrollKey='followed_tags'
+          emptyMessage={emptyMessage}
+          bindToDocument={!multiColumn}
+        >
+          {tagIds.map(id =>
+            <Hashtag key={id} id={id} />,
+          )}
+        </ScrollableList>
+
+        <Helmet>
+          <meta name='robots' content='noindex' />
+        </Helmet>
+      </Column>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -42,6 +42,7 @@ import {
   FollowRequests,
   FavouritedStatuses,
   BookmarkedStatuses,
+  FollowedTags,
   ListTimeline,
   Blocks,
   DomainBlocks,
@@ -216,6 +217,7 @@ class SwitchingColumnsArea extends React.PureComponent {
           <WrappedRoute path='/follow_requests' component={FollowRequests} content={children} />
           <WrappedRoute path='/blocks' component={Blocks} content={children} />
           <WrappedRoute path='/domain_blocks' component={DomainBlocks} content={children} />
+          <WrappedRoute path='/followed_tags' component={FollowedTags} content={children} />
           <WrappedRoute path='/mutes' component={Mutes} content={children} />
           <WrappedRoute path='/lists' component={Lists} content={children} />
 

--- a/app/javascript/mastodon/features/ui/util/async-components.js
+++ b/app/javascript/mastodon/features/ui/util/async-components.js
@@ -90,6 +90,10 @@ export function FavouritedStatuses () {
   return import(/* webpackChunkName: "features/favourited_statuses" */'../../favourited_statuses');
 }
 
+export function FollowedTags () {
+  return import(/* webpackChunkName: "features/followed_tags" */'../../followed_tags');
+}
+
 export function BookmarkedStatuses () {
   return import(/* webpackChunkName: "features/bookmarked_statuses" */'../../bookmarked_statuses');
 }

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -1384,6 +1384,10 @@
         "id": "navigation_bar.lists"
       },
       {
+        "defaultMessage": "Followed hashtags",
+        "id": "navigation_bar.followed_tags"
+      },
+      {
         "defaultMessage": "Blocked users",
         "id": "navigation_bar.blocks"
       },

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -379,6 +379,7 @@
   "navigation_bar.favourites": "Favourites",
   "navigation_bar.filters": "Muted words",
   "navigation_bar.follow_requests": "Follow requests",
+  "navigation_bar.followed_tags": "Followed hashtags",
   "navigation_bar.follows_and_followers": "Follows and followers",
   "navigation_bar.lists": "Lists",
   "navigation_bar.logout": "Logout",

--- a/app/javascript/mastodon/reducers/followed_tags.js
+++ b/app/javascript/mastodon/reducers/followed_tags.js
@@ -2,6 +2,9 @@ import {
   FOLLOWED_HASHTAGS_FETCH_REQUEST,
   FOLLOWED_HASHTAGS_FETCH_SUCCESS,
   FOLLOWED_HASHTAGS_FETCH_FAIL,
+  FOLLOWED_HASHTAGS_EXPAND_REQUEST,
+  FOLLOWED_HASHTAGS_EXPAND_SUCCESS,
+  FOLLOWED_HASHTAGS_EXPAND_FAIL,
 } from 'mastodon/actions/tags';
 import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 
@@ -9,6 +12,7 @@ const initialState = ImmutableMap({
   followed_tags: ImmutableMap({
     items: ImmutableList(),
     isLoading: false,
+    next: null
   }),
 });
 
@@ -20,8 +24,19 @@ export default function followed_tags(state = initialState, action) {
     return state.withMutations(map => {
       map.setIn(['items'], fromJS(action.followed_tags));
       map.setIn(['isLoading'], false);
+      map.setIn(['next'], action.next);
     });
   case FOLLOWED_HASHTAGS_FETCH_FAIL:
+    return state.setIn(['isLoading'], false);
+  case FOLLOWED_HASHTAGS_EXPAND_REQUEST:
+    return state.setIn(['isLoading'], true);
+  case FOLLOWED_HASHTAGS_EXPAND_SUCCESS:
+    return state.withMutations(map => {
+      map.updateIn(['items'], set => set.concat(fromJS(action.followed_tags)));
+      map.setIn(['isLoading'], false);
+      map.setIn(['next'], action.next);
+    });
+  case FOLLOWED_HASHTAGS_EXPAND_FAIL:
     return state.setIn(['isLoading'], false);
   default:
     return state;

--- a/app/javascript/mastodon/reducers/followed_tags.js
+++ b/app/javascript/mastodon/reducers/followed_tags.js
@@ -1,0 +1,29 @@
+import {
+  FOLLOWED_HASHTAGS_FETCH_REQUEST,
+  FOLLOWED_HASHTAGS_FETCH_SUCCESS,
+  FOLLOWED_HASHTAGS_FETCH_FAIL
+} from 'mastodon/actions/tags';
+import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
+
+const initialState = ImmutableMap({
+  followed_tags: ImmutableMap({
+    items: ImmutableList(),
+    isLoading: false,
+  }),
+});
+
+export default function followed_tags(state = initialState, action) {
+  switch(action.type) {
+  case FOLLOWED_HASHTAGS_FETCH_REQUEST:
+    return state.setIn(['followed_tags', 'isLoading'], true);
+  case FOLLOWED_HASHTAGS_FETCH_SUCCESS:
+    return state.withMutations(map => {
+      map.setIn(['followed_tags', 'items'], fromJS(action.followed_tags));
+      map.setIn(['followed_tags', 'isLoading'], false);
+    });
+  case FOLLOWED_HASHTAGS_FETCH_FAIL:
+    return state.setIn(['followed_tags', 'isLoading'], false);
+  default:
+    return state;
+  }
+};

--- a/app/javascript/mastodon/reducers/followed_tags.js
+++ b/app/javascript/mastodon/reducers/followed_tags.js
@@ -15,14 +15,14 @@ const initialState = ImmutableMap({
 export default function followed_tags(state = initialState, action) {
   switch(action.type) {
   case FOLLOWED_HASHTAGS_FETCH_REQUEST:
-    return state.setIn(['followed_tags', 'isLoading'], true);
+    return state.setIn(['isLoading'], true);
   case FOLLOWED_HASHTAGS_FETCH_SUCCESS:
     return state.withMutations(map => {
-      map.setIn(['followed_tags', 'items'], fromJS(action.followed_tags));
-      map.setIn(['followed_tags', 'isLoading'], false);
+      map.setIn(['items'], fromJS(action.followed_tags));
+      map.setIn(['isLoading'], false);
     });
   case FOLLOWED_HASHTAGS_FETCH_FAIL:
-    return state.setIn(['followed_tags', 'isLoading'], false);
+    return state.setIn(['isLoading'], false);
   default:
     return state;
   }

--- a/app/javascript/mastodon/reducers/followed_tags.js
+++ b/app/javascript/mastodon/reducers/followed_tags.js
@@ -17,25 +17,25 @@ const initialState = ImmutableMap({
 export default function followed_tags(state = initialState, action) {
   switch(action.type) {
   case FOLLOWED_HASHTAGS_FETCH_REQUEST:
-    return state.setIn(['isLoading'], true);
+    return state.set('isLoading', true);
   case FOLLOWED_HASHTAGS_FETCH_SUCCESS:
     return state.withMutations(map => {
-      map.setIn(['items'], fromJS(action.followed_tags));
-      map.setIn(['isLoading'], false);
-      map.setIn(['next'], action.next);
+      map.set('items', fromJS(action.followed_tags));
+      map.set('isLoading', false);
+      map.set('next', action.next);
     });
   case FOLLOWED_HASHTAGS_FETCH_FAIL:
-    return state.setIn(['isLoading'], false);
+    return state.set('isLoading', false);
   case FOLLOWED_HASHTAGS_EXPAND_REQUEST:
-    return state.setIn(['isLoading'], true);
+    return state.set('isLoading', true);
   case FOLLOWED_HASHTAGS_EXPAND_SUCCESS:
     return state.withMutations(map => {
-      map.updateIn(['items'], set => set.concat(fromJS(action.followed_tags)));
-      map.setIn(['isLoading'], false);
-      map.setIn(['next'], action.next);
+      map.update('items', set => set.concat(fromJS(action.followed_tags)));
+      map.set('isLoading', false);
+      map.set('next', action.next);
     });
   case FOLLOWED_HASHTAGS_EXPAND_FAIL:
-    return state.setIn(['isLoading'], false);
+    return state.set('isLoading', false);
   default:
     return state;
   }

--- a/app/javascript/mastodon/reducers/followed_tags.js
+++ b/app/javascript/mastodon/reducers/followed_tags.js
@@ -1,7 +1,7 @@
 import {
   FOLLOWED_HASHTAGS_FETCH_REQUEST,
   FOLLOWED_HASHTAGS_FETCH_SUCCESS,
-  FOLLOWED_HASHTAGS_FETCH_FAIL
+  FOLLOWED_HASHTAGS_FETCH_FAIL,
 } from 'mastodon/actions/tags';
 import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 

--- a/app/javascript/mastodon/reducers/followed_tags.js
+++ b/app/javascript/mastodon/reducers/followed_tags.js
@@ -12,7 +12,7 @@ const initialState = ImmutableMap({
   followed_tags: ImmutableMap({
     items: ImmutableList(),
     isLoading: false,
-    next: null
+    next: null,
   }),
 });
 

--- a/app/javascript/mastodon/reducers/followed_tags.js
+++ b/app/javascript/mastodon/reducers/followed_tags.js
@@ -9,11 +9,9 @@ import {
 import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 
 const initialState = ImmutableMap({
-  followed_tags: ImmutableMap({
-    items: ImmutableList(),
-    isLoading: false,
-    next: null,
-  }),
+  items: ImmutableList(),
+  isLoading: false,
+  next: null,
 });
 
 export default function followed_tags(state = initialState, action) {

--- a/app/javascript/mastodon/reducers/index.js
+++ b/app/javascript/mastodon/reducers/index.js
@@ -40,6 +40,7 @@ import picture_in_picture from './picture_in_picture';
 import accounts_map from './accounts_map';
 import history from './history';
 import tags from './tags';
+import followed_tags from './followed_tags';
 
 const reducers = {
   announcements,
@@ -83,6 +84,7 @@ const reducers = {
   picture_in_picture,
   history,
   tags,
+  followed_tags,
 };
 
 export default combineReducers(reducers);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     /blocks
     /domain_blocks
     /mutes
+    /followed_tags
     /statuses/(*any)
   ).freeze
 


### PR DESCRIPTION
Resolves #20763 and #20132. Follows up on the addition of hashtag following in #18862.

The ability to follow hashtags was added in v4.0, but there was no addition of functionality for listing the hashtags that the current user is following. This resolves that problem, so users can view and manage their followed hashtags more easily.

This PR doesn't let you follow/unfollow from the list view because I had enough trouble just getting this to work in the first place, and it didn't really seem necessary for an MVP of the list view. It should be relatively easy for someone to go in and add the follow/unfollow buttons to the Hashtag component, or maybe create a distinct component for that purpose.

In the sidebar dropdown:

<img width="345" alt="Screen Shot 2022-11-27 at 8 59 26 PM" src="https://user-images.githubusercontent.com/2977353/204191220-b41efd2f-0b06-4e57-9098-365414d639bd.png">

In the Profile page dropdown:

<img width="219" alt="Screen Shot 2022-11-27 at 8 59 53 PM" src="https://user-images.githubusercontent.com/2977353/204191249-2a17c1da-c057-4add-a69c-e8f7b1bb57cc.png">

"Followed hashtags" list view:

<img width="1224" alt="Screen Shot 2022-11-27 at 8 39 32 PM" src="https://user-images.githubusercontent.com/2977353/204190846-72c350eb-bf88-43e9-a0c6-5e57612bb7a4.png">

Empty state for the "Followed hashtags" list view:

<img width="1217" alt="Screen Shot 2022-11-27 at 9 00 28 PM" src="https://user-images.githubusercontent.com/2977353/204191295-e8bc9d83-2871-43aa-a1b3-a73e9b1696f7.png">
