### PR TITLE
Fix UI header overflow on mobile

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2217,6 +2217,7 @@ $ui-header-height: 55px;
   z-index: 2;
   justify-content: space-between;
   align-items: center;
+  overflow: hidden;
 
   &__logo {
     display: inline-flex;
@@ -2233,9 +2234,14 @@ $ui-header-height: 55px;
     align-items: center;
     gap: 10px;
     padding: 0 10px;
+    overflow: hidden;
 
     .button {
       flex: 0 0 auto;
+    }
+
+    .button-tertiary {
+      flex-shrink: 1;
     }
   }
 }


### PR DESCRIPTION
With some languages, font sizes and screen sizes, the header UI would overflow the screen width, causing the document width to overflow and mess up modal position.

## Before

![Capture d’écran 2022-11-28 à 10 51 59](https://user-images.githubusercontent.com/384364/204249612-2e3b4116-5ca7-4dca-a0fd-284838b9446b.png)

## After (without reduced padding)

![Capture d’écran 2022-11-28 à 10 59 45](https://user-images.githubusercontent.com/384364/204249628-13a56d22-24d7-4d88-a955-2836dab2dbe2.png)

## After (reduced padding)

Reducing the horizontal button padding can also make the issue less likely to happen. It makes sense to reduce the padding considering the UI header is only displayed in width-constrained situations (or at least it should be, see #20943)

![Capture d’écran 2022-11-28 à 11 04 34](https://user-images.githubusercontent.com/384364/204250155-06acb6eb-cc73-40bd-aaa3-5bd6fa8fcc77.png)
