### PR TITLE
Change postgres connection timeout

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,7 @@ default: &default
   adapter: postgresql
   pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>
   timeout: 5000
+  connect_timeout: 15
   encoding: unicode
   sslmode: <%= ENV['DB_SSLMODE'] || "prefer" %>
 


### PR DESCRIPTION
By default, Rails currently waits 2 whole minutes before timing out when connecting to PostgreSQL. Reduce that timeout to 15 seconds to make firewall/connection issues easier to debug.