### PR TITLE
style(vacuum): style fixes and minor code smell fixes (readability, convention)

### DIFF
--- a/app/lib/vacuum/access_tokens_vacuum.rb
+++ b/app/lib/vacuum/access_tokens_vacuum.rb
@@ -1,18 +1,24 @@
 # frozen_string_literal: true
 
-class Vacuum::AccessTokensVacuum
-  def perform
-    vacuum_revoked_access_tokens!
-    vacuum_revoked_access_grants!
-  end
+module Vacuum
+  class AccessTokensVacuum
+    def perform
+      vacuum_revoked_access_tokens!
+      vacuum_revoked_access_grants!
+    end
 
-  private
+    private
 
-  def vacuum_revoked_access_tokens!
-    Doorkeeper::AccessToken.where('revoked_at IS NOT NULL').where('revoked_at < NOW()').delete_all
-  end
+    def vacuum_revoked_access_tokens!
+      Doorkeeper::AccessToken.where.not(revoked_at: nil)
+                             .where('revoked_at < NOW()')
+                             .delete_all
+    end
 
-  def vacuum_revoked_access_grants!
-    Doorkeeper::AccessGrant.where('revoked_at IS NOT NULL').where('revoked_at < NOW()').delete_all
+    def vacuum_revoked_access_grants!
+      Doorkeeper::AccessGrant.where.not(revoked_at: nil)
+                             .where('revoked_at < NOW()')
+                             .delete_all
+    end
   end
 end

--- a/app/lib/vacuum/backups_vacuum.rb
+++ b/app/lib/vacuum/backups_vacuum.rb
@@ -1,25 +1,19 @@
 # frozen_string_literal: true
 
-class Vacuum::BackupsVacuum
-  def initialize(retention_period)
-    @retention_period = retention_period
-  end
+module Vacuum
+  class BackupsVacuum < Vacuum::RetentionPeriod
+    def perform
+      vacuum_expired_backups! if @retention_period.present?
+    end
 
-  def perform
-    vacuum_expired_backups! if retention_period?
-  end
+    private
 
-  private
+    def vacuum_expired_backups!
+      backups_past_retention_period.in_batches(&:destroy_all)
+    end
 
-  def vacuum_expired_backups!
-    backups_past_retention_period.in_batches.destroy_all
-  end
-
-  def backups_past_retention_period
-    Backup.unscoped.where(Backup.arel_table[:created_at].lt(@retention_period.ago))
-  end
-
-  def retention_period?
-    @retention_period.present?
+    def backups_past_retention_period
+      Backup.unscoped.where(created_at: ...@retention_period.ago)
+    end
   end
 end

--- a/app/lib/vacuum/feeds_vacuum.rb
+++ b/app/lib/vacuum/feeds_vacuum.rb
@@ -1,34 +1,32 @@
 # frozen_string_literal: true
 
-class Vacuum::FeedsVacuum
-  def perform
-    vacuum_inactive_home_feeds!
-    vacuum_inactive_list_feeds!
-  end
-
-  private
-
-  def vacuum_inactive_home_feeds!
-    inactive_users.select(:id, :account_id).find_in_batches do |users|
-      feed_manager.clean_feeds!(:home, users.map(&:account_id))
+module Vacuum
+  class FeedsVacuum
+    def perform
+      vacuum_inactive_home_feeds!
+      vacuum_inactive_list_feeds!
     end
-  end
 
-  def vacuum_inactive_list_feeds!
-    inactive_users_lists.select(:id).find_in_batches do |lists|
-      feed_manager.clean_feeds!(:list, lists.map(&:id))
+    private
+
+    def vacuum_inactive_home_feeds!
+      inactive_users.select(:id, :account_id).in_batches do |users|
+        FeedManager.instance.clean_feeds!(:home, users.pluck(:account_id))
+      end
     end
-  end
 
-  def inactive_users
-    User.confirmed.inactive
-  end
+    def vacuum_inactive_list_feeds!
+      inactive_users_lists.select(:id).in_batches do |lists|
+        FeedManager.instance.clean_feeds!(:list, lists.ids)
+      end
+    end
 
-  def inactive_users_lists
-    List.where(account_id: inactive_users.select(:account_id))
-  end
+    def inactive_users
+      User.confirmed.inactive
+    end
 
-  def feed_manager
-    FeedManager.instance
+    def inactive_users_lists
+      List.where(account_id: inactive_users.select(:account_id))
+    end
   end
 end

--- a/app/lib/vacuum/media_attachments_vacuum.rb
+++ b/app/lib/vacuum/media_attachments_vacuum.rb
@@ -1,40 +1,24 @@
 # frozen_string_literal: true
 
-class Vacuum::MediaAttachmentsVacuum
-  TTL = 1.day.freeze
+module Vacuum
+  class MediaAttachmentsVacuum < Vacuum::RetentionPeriod
+    TTL = 1.day.freeze
 
-  def initialize(retention_period)
-    @retention_period = retention_period
-  end
-
-  def perform
-    vacuum_orphaned_records!
-    vacuum_cached_files! if retention_period?
-  end
-
-  private
-
-  def vacuum_cached_files!
-    media_attachments_past_retention_period.find_each do |media_attachment|
-      media_attachment.file.destroy
-      media_attachment.thumbnail.destroy
-      media_attachment.save
+    def perform
+      vacuum_orphaned_records!
+      vacuum_cached_files! if @retention_period.present?
     end
-  end
 
-  def vacuum_orphaned_records!
-    orphaned_media_attachments.in_batches.destroy_all
-  end
+    private
 
-  def media_attachments_past_retention_period
-    MediaAttachment.unscoped.remote.cached.where(MediaAttachment.arel_table[:created_at].lt(@retention_period.ago)).where(MediaAttachment.arel_table[:updated_at].lt(@retention_period.ago))
-  end
+    def vacuum_cached_files!
+      MediaAttachment.unscoped
+                     .past_retention(@retention_period.ago)
+                     .find_each(&:destroy_file_and_thumbnail!)
+    end
 
-  def orphaned_media_attachments
-    MediaAttachment.unscoped.unattached.where(MediaAttachment.arel_table[:created_at].lt(TTL.ago))
-  end
-
-  def retention_period?
-    @retention_period.present?
+    def vacuum_orphaned_records!
+      MediaAttachment.unscoped.orphaned(TTL.ago).in_batches(&:destroy_all)
+    end
   end
 end

--- a/app/lib/vacuum/retention_period.rb
+++ b/app/lib/vacuum/retention_period.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Vacuum
+  # Vacuumer initialized with retention period duration
+  class RetentionPeriod
+    # @param retention_period [ActiveSupport::Duration] the retention duration
+    def initialize(retention_period)
+      @retention_period = retention_period
+    end
+
+    def perform
+      raise "Tried to run perform on base klass: #{self.class.name}"
+    end
+  end
+end

--- a/app/lib/vacuum/statuses_vacuum.rb
+++ b/app/lib/vacuum/statuses_vacuum.rb
@@ -1,47 +1,42 @@
 # frozen_string_literal: true
 
-class Vacuum::StatusesVacuum
-  include Redisable
+module Vacuum
+  class StatusesVacuum < Vacuum::RetentionPeriod
+    include Redisable
 
-  def initialize(retention_period)
-    @retention_period = retention_period
-  end
-
-  def perform
-    vacuum_statuses! if @retention_period.present?
-  end
-
-  private
-
-  def vacuum_statuses!
-    statuses_scope.in_batches do |statuses|
-      # Side-effects not covered by foreign keys, such
-      # as the search index, must be handled first.
-      statuses.direct_visibility
-              .includes(mentions: :account)
-              .find_each do |status|
-        # TODO: replace temporary solution - call of private model method
-        status.send(:unlink_from_conversations)
-      end
-      remove_from_search_index(statuses.ids) if Chewy.enabled?
-
-      # Foreign keys take care of most associated records for us.
-      # Media attachments will be orphaned.
-      statuses.delete_all
+    def perform
+      vacuum_statuses! if @retention_period.present?
     end
-  end
 
-  def statuses_scope
-    Status.unscoped.kept
-          .joins(:account).merge(Account.remote)
-          .where('statuses.id < ?', retention_period_as_id)
-  end
+    private
 
-  def retention_period_as_id
-    Mastodon::Snowflake.id_at(@retention_period.ago, with_random: false)
-  end
+    def vacuum_statuses!
+      statuses_scope.in_batches do |statuses|
+        # Side-effects not covered by foreign keys, such
+        # as the search index, must be handled first.
+        statuses.direct_visibility
+                .includes(mentions: :account)
+                .find_each(&:unlink_from_conversations!)
+        remove_from_search_index(statuses.ids) if Chewy.enabled?
 
-  def remove_from_search_index(status_ids)
-    with_redis { |redis| redis.sadd('chewy:queue:StatusesIndex', status_ids) }
+        # Foreign keys take care of most associated records for us.
+        # Media attachments will be orphaned.
+        statuses.delete_all
+      end
+    end
+
+    def statuses_scope
+      Status.unscoped.kept
+            .joins(:account).merge(Account.remote)
+            .where(statuses: { id: ...retention_period_as_id })
+    end
+
+    def retention_period_as_id
+      Mastodon::Snowflake.id_at(@retention_period.ago, with_random: false)
+    end
+
+    def remove_from_search_index(status_ids)
+      with_redis { |redis| redis.sadd('chewy:queue:StatusesIndex', status_ids) }
+    end
   end
 end

--- a/app/lib/vacuum/system_keys_vacuum.rb
+++ b/app/lib/vacuum/system_keys_vacuum.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-class Vacuum::SystemKeysVacuum
-  def perform
-    vacuum_expired_system_keys!
-  end
+module Vacuum
+  class SystemKeysVacuum
+    def perform
+      vacuum_expired_system_keys!
+    end
 
-  private
+    private
 
-  def vacuum_expired_system_keys!
-    SystemKey.expired.delete_all
+    def vacuum_expired_system_keys!
+      SystemKey.expired.in_batches(&:delete_all)
+    end
   end
 end

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -132,6 +132,11 @@ class PreviewCard < ApplicationRecord
     end
   end
 
+  def destroy_image!
+    image.destroy
+    save
+  end
+
   private
 
   def extract_dimensions

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -29,7 +29,7 @@
 #
 
 class Status < ApplicationRecord
-  before_destroy :unlink_from_conversations
+  before_destroy :unlink_from_conversations!
 
   include Discard::Model
   include Paginable
@@ -447,6 +447,17 @@ class Status < ApplicationRecord
     update_attribute(:deleted_at, discard_time)
   end
 
+  def unlink_from_conversations!
+    return unless direct_visibility?
+
+    inbox_owners = mentioned_accounts.local
+    inbox_owners += [account] if account.local?
+
+    inbox_owners.each do |inbox_owner|
+      AccountConversation.remove_status(inbox_owner, self)
+    end
+  end
+
   private
 
   def update_status_stat!(attrs)
@@ -523,16 +534,5 @@ class Status < ApplicationRecord
     account&.decrement_count!(:statuses_count)
     reblog&.decrement_count!(:reblogs_count) if reblog?
     thread&.decrement_count!(:replies_count) if in_reply_to_id.present? && distributable?
-  end
-
-  def unlink_from_conversations
-    return unless direct_visibility?
-
-    inbox_owners = mentioned_accounts.local
-    inbox_owners += [account] if account.local?
-
-    inbox_owners.each do |inbox_owner|
-      AccountConversation.remove_status(inbox_owner, self)
-    end
   end
 end

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -19,9 +19,7 @@ class BatchedRemoveStatusService < BaseService
 
     ActiveRecord::Associations::Preloader.new.preload(statuses_with_account_conversations, [mentions: :account])
 
-    statuses_with_account_conversations.each do |status|
-      status.send(:unlink_from_conversations)
-    end
+    statuses_with_account_conversations.each(&:unlink_from_conversations!)
 
     # We do not batch all deletes into one to avoid having a long-running
     # transaction lock the database, but we use the delete method instead


### PR DESCRIPTION
[refactor(vacuum): statuses](https://github.com/mastodon/mastodon/commit/99bdace6766c06decb778b9ba9e1a3fe9abf6218)

- fix [namespace definition](https://github.com/rubocop/ruby-style-guide#namespace-definition)
- inherit retention_period initialize from Vacuum::RetentionPeriod
- make Status#unlink_from_conversations public and rename to
  Status#unlink_from_conversations!
  - method! naming following naming conventions
  - make method public instead of hacky access with send in
    two places

[refactor(vacuum): preview card](https://github.com/mastodon/mastodon/commit/a418dbcc7ad5c4e20f84f2d4b830909769d8ca60)

- fix [namespace definition](https://github.com/rubocop/ruby-style-guide#namespace-definition)
- inherit retention_period initialize from Vacuum::RetentionPeriod
- more explicit query (no arel_table use)
- add PreviewCard#destroy_image! method - nicer and explicit piperclip
  handling with method doing paperclip.destroy and save in one

[refactor(vacuum): system keys](https://github.com/mastodon/mastodon/commit/c3570b8b60f407620b632050a628098fef7ed1e8)

- fix [namespace definition](https://github.com/rubocop/ruby-style-guide#namespace-definition)
- in_batches(&:delete_all) instead of in_batches.delete_all,
  to ensure in_batches scope is not unwrapped - delete_all realy
  runs in multiple batches, as expected - more explicit

[refactor(vacuum): feeds](https://github.com/mastodon/mastodon/commit/f50cf93566902c6fcc05088c729745f5edc3e2c6)

- fix [namespace definition](https://github.com/rubocop/ruby-style-guide#namespace-definition)
- in_batches instead of find_in_batches - because it's users and lists
  items can just as well use the relition instead of maping the values
  from array
- simplify methods - more explicit FeedManager.instance call in place -
  less obfuscation with no benefit

[refactor(vacuum): access_tokens](https://github.com/mastodon/mastodon/commit/c6c818172af8ee69ff8dc3e92ef42391494a91e2)

- fix [namespace definition](https://github.com/rubocop/ruby-style-guide#namespace-definition)
- more readable scopes

[refactor(vacuum): backups](https://github.com/mastodon/mastodon/commit/130bb4e43d7dbcfe5dd5e26a19e5acc316ca9bf6)

- fix [namespace definition](https://github.com/rubocop/ruby-style-guide#namespace-definition)
- inherit retention_period initialize from Vacuum::RetentionPeriod
- vacuum_expired_backups!
  - in_batches(&:destroy_all) instead of in_batches.destroy_all,
    to ensure in_batches scope is not unwrapped - destroy_all realy
    runs in multiple batches, as expected

[refactor(vacuum): media_attachment](https://github.com/mastodon/mastodon/commit/c2b97bfa57858b93bac24c57b761e0aa6bee1977)

- fix [namespace definition](https://github.com/rubocop/ruby-style-guide#namespace-definition)
- inherit retention_period initialize from Vacuum::RetentionPeriod
- vacuum_cached_files!
  - move complicated scope to model
  - handle file and thumbnail destroy in explicit ! model
    method
- vacuum_orphaned_records!
  - move complicated scope to model
  - in_batches(&:destroy_all) instead of in_batches.destroy_all,
    to ensure in_batches scope is not unwrapped - destroy_all realy
    runs in multiple batches, as expected