### PR TITLE
Auto slow mode and trim pending items

### DIFF
--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -116,6 +116,7 @@ const updateTimeline = (state, timeline, status, usePendingItems) => {
       return state;
     }
 
+    // allow to grow a bit, then trim to TIMELINE_PENDING_ITEMS_TRIM, with a gap marker (null)
     return state.update(timeline, initialTimeline, map => map.update('pendingItems',
       list => (list.size >= TIMELINE_PENDING_ITEMS_CHECK ? list.take(TIMELINE_PENDING_ITEMS_TRIM).push(null) : list).unshift(status.get('id'))).update('unread', unread => unread + 1));
   }

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -189,8 +189,10 @@ const reconnectTimeline = (state, usePendingItems) => {
     return state;
   }
 
+  const havePendingItems = !state.get('pendingItems')?.isEmpty?.();
+
   return state.withMutations(mMap => {
-    mMap.update(usePendingItems ? 'pendingItems' : 'items', items => items.first() ? items.unshift(null) : items);
+    mMap.update(usePendingItems || havePendingItems ? 'pendingItems' : 'items', items => items.first() ? items.unshift(null) : items);
     mMap.set('online', true);
   });
 };

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -225,7 +225,7 @@ export default function timelines(state = initialState, action) {
     return state.update(
       action.timeline,
       initialTimeline,
-      map => map.set('online', false).update(action.usePendingItems ? 'pendingItems' : 'items', items => items.first() ? items.unshift(null) : items),
+      map => map.set('online', false).update(action.usePendingItems  || !map.get('pendingItems')?.isEmpty?.() ? 'pendingItems' : 'items', items => items.first() ? items.unshift(null) : items),
     );
   case TIMELINE_MARK_AS_PARTIAL:
     return state.update(

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -20,7 +20,7 @@ import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrde
 import compareId from '../compare_id';
 
 // Turn on slow mode when scrolled down and have at least this many "items"
-const TIMELINE_SCROLLED_DOWN_SLOW_MODE_ITEMS = 50;
+const TIMELINE_SCROLLED_DOWN_SLOW_MODE_ITEMS = 120;
 
 // Cap pendingItems at 30, check once we're at >= 50
 const TIMELINE_PENDING_ITEMS_CHECK = 50;


### PR DESCRIPTION
Attempt to fix https://github.com/mastodon/mastodon/issues/20019, #21486, #21677  and related memory issues.

Might also address https://github.com/mastodon/mastodon/issues/20552, similar to the idea in https://github.com/mastodon/mastodon/issues/20552#issuecomment-1317801912_.

The idea behind this PR is:
1. automatically turn on slow mode when scrolled down and have more than, say, 50 items.
2. In slow mode, trim "pendingItems" to 30, with a gap marker. Allow to grow to 50 before trimming to 30 (similar to the current logic for trimming "items" when scrolled to the top (`top`=true)).
3. Since we have gap markers, the user can still recover the trimmed posts. 

It would also be nice to actually unsubscribe from the streaming when idle, to save on CPU, network usage and remote server load, but that can be independent of this PR.

I've tested this in slow and non-slow modes on a fast Federated timeline. But this needs feedback and help with more testing, for example to ensure it doesn't break other types of timelines (lists, Home, etc.).


