### PR TITLE
Fix typo in handler function call name

### DIFF
--- a/app/javascript/mastodon/features/ui/components/columns_area.js
+++ b/app/javascript/mastodon/features/ui/components/columns_area.js
@@ -97,7 +97,7 @@ export default class ColumnsArea extends ImmutablePureComponent {
       if (this.mediaQuery.removeEventListener) {
         this.mediaQuery.removeEventListener('change', this.handleLayoutChange);
       } else {
-        this.mediaQuery.removeListener(this.handleLayouteChange);
+        this.mediaQuery.removeListener(this.handleLayoutChange);
       }
     }
   }


### PR DESCRIPTION
Did a pass with cSpell to see if there was much. Mostly some minor things in comments/tests, but this was a functional issue, so I kept it separate from the other changes