### PR TITLE
Fix minor typos in comments and spec names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND="noninteractive" \
     PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
 
-# Ignoreing these here since we don't want to pin any versions and the Debian image removes apt-get content after use
+# Ignoring these here since we don't want to pin any versions and the Debian image removes apt-get content after use
 # hadolint ignore=DL3008,DL3009
 RUN apt-get update && \
     echo "Etc/UTC" > /etc/localtime && \

--- a/app/javascript/mastodon/utils/__tests__/html-test.js
+++ b/app/javascript/mastodon/utils/__tests__/html-test.js
@@ -1,7 +1,7 @@
 import * as html from '../html';
 
 describe('html', () => {
-  describe('unsecapeHTML', () => {
+  describe('unescapeHTML', () => {
     it('returns unescaped HTML', () => {
       const output = html.unescapeHTML('<p>lorem</p><p>ipsum</p><br>&lt;br&gt;');
       expect(output).toEqual('lorem\n\nipsum\n<br>');

--- a/app/workers/post_process_media_worker.rb
+++ b/app/workers/post_process_media_worker.rb
@@ -24,7 +24,7 @@ class PostProcessMediaWorker
     media_attachment.processing = :in_progress
     media_attachment.save
 
-    # Because paperclip-av-transcover overwrites this attribute
+    # Because paperclip-av-transcoder overwrites this attribute
     # we will save it here and restore it after reprocess is done
     previous_meta = media_attachment.file_meta
 

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -22,7 +22,7 @@ module Mastodon
     desc 'remove', 'Remove remote media files, headers or avatars'
     long_desc <<-DESC
       Removes locally cached copies of media attachments (and optionally profile
-      headers and avatars) from other servers. By default, only media attachements
+      headers and avatars) from other servers. By default, only media attachments
       are removed.
       The --days option specifies how old media attachments have to be before
       they are removed. In case of avatars and headers, it specifies how old

--- a/lib/tasks/tests.rake
+++ b/lib/tasks/tests.rake
@@ -25,7 +25,7 @@ namespace :tests do
       end
 
       if Account.where(domain: Rails.configuration.x.local_domain).exists?
-        puts 'Faux remote accounts not properly claned up'
+        puts 'Faux remote accounts not properly cleaned up'
         exit(1)
       end
 

--- a/spec/controllers/admin/confirmations_controller_spec.rb
+++ b/spec/controllers/admin/confirmations_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Admin::ConfirmationsController, type: :controller do
     end
   end
 
-  describe 'POST #resernd' do
+  describe 'POST #resend' do
     subject { post :resend, params: { account_id: user.account.id } }
 
     let!(:user) { Fabricate(:user, confirmed_at: confirmed_at) }

--- a/spec/controllers/concerns/signature_verification_spec.rb
+++ b/spec/controllers/concerns/signature_verification_spec.rb
@@ -127,7 +127,7 @@ describe ApplicationController, type: :controller do
       end
     end
 
-    context 'with request with unparseable Date header' do
+    context 'with request with unparsable Date header' do
       before do
         get :success
 

--- a/spec/models/account_migration_spec.rb
+++ b/spec/models/account_migration_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AccountMigration, type: :model do
       end
     end
 
-    context 'with unresolveable account' do
+    context 'with unresolvable account' do
       let(:target_acct) { 'target@remote' }
 
       before do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -698,7 +698,7 @@ RSpec.describe Account, type: :model do
       expect(subject.match('Check this out https://medium.com/@alice/some-article#.abcdef123')).to be_nil
     end
 
-    xit 'does not match URL querystring' do
+    xit 'does not match URL query string' do
       expect(subject.match('https://example.com/?x=@alice')).to be_nil
     end
   end

--- a/spec/models/user_settings/setting_spec.rb
+++ b/spec/models/user_settings/setting_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe UserSettings::Setting do
 
   describe '#key' do
     context 'when there is no namespace' do
-      it 'returnsn a symbol' do
+      it 'returns a symbol' do
         expect(subject.key).to eq :foo
       end
     end

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
           '@context': ['https://www.w3.org/ns/activitystreams'],
           id: "https://foo.test/users/#{i}/featured",
           type: 'OrderedCollection',
-          totelItems: 1,
+          totalItems: 1,
           orderedItems: [status_json],
         }.with_indifferent_access
         webfinger = {


### PR DESCRIPTION
A few typos in test code and comments that shouldn't have any functional affect. Split out from #21829 functional typo