### PR TITLE
Fix GitHub form label type

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: If something isn't working as expected
-labels: bug
+labels: [bug]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2.feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: I have a suggestion
-labels: suggestion
+labels: [suggestion]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Schema validator in VSCode was complaining about these because they're an array type, rather than a string