### PR TITLE
Add option to store images up to 5K resolution

### DIFF
--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -80,7 +80,7 @@
  * @property {boolean=} use_pending_items
  * @property {string} version
  * @property {boolean} translation_enabled
- * @property {boolean} store_5k_photos
+ * @property {boolean} store_5k_images
  */
 
 /**
@@ -133,6 +133,6 @@ export const usePendingItems = getMeta('use_pending_items');
 export const version = getMeta('version');
 export const translationEnabled = getMeta('translation_enabled');
 export const languages = initialState?.languages;
-export const store_5k_photos = getMeta('store_5k_photos');
+export const store_5k_images = getMeta('store_5k_images');
 
 export default initialState;

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -80,6 +80,7 @@
  * @property {boolean=} use_pending_items
  * @property {string} version
  * @property {boolean} translation_enabled
+ * @property {boolean} store_5k_photos
  */
 
 /**
@@ -132,5 +133,6 @@ export const usePendingItems = getMeta('use_pending_items');
 export const version = getMeta('version');
 export const translationEnabled = getMeta('translation_enabled');
 export const languages = initialState?.languages;
+export const store_5k_photos = getMeta('store_5k_photos');
 
 export default initialState;

--- a/app/javascript/mastodon/utils/resize_image.js
+++ b/app/javascript/mastodon/utils/resize_image.js
@@ -1,6 +1,6 @@
 import EXIF from 'exif-js';
 
-const MAX_IMAGE_PIXELS = 2073600; // 1920x1080px
+const MAX_IMAGE_PIXELS = 14745600; // 5K resolution 5120x2880
 
 const _browser_quirks = {};
 
@@ -177,7 +177,7 @@ export default inputFile => new Promise((resolve) => {
   }
 
   loadImage(inputFile).then(img => {
-    if (img.width * img.height < MAX_IMAGE_PIXELS) {
+    if (img.width * img.height <= MAX_IMAGE_PIXELS) {
       resolve(inputFile);
       return;
     }

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -31,7 +31,7 @@ class Form::AdminSettings
     media_cache_retention_period
     content_cache_retention_period
     backups_retention_period
-    store_5k_photos
+    store_5k_images
   ).freeze
 
   INTEGER_KEYS = %i(
@@ -50,7 +50,7 @@ class Form::AdminSettings
     trendable_by_default
     noindex
     require_invite_text
-    store_5k_photos
+    store_5k_images
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -31,6 +31,7 @@ class Form::AdminSettings
     media_cache_retention_period
     content_cache_retention_period
     backups_retention_period
+    store_5k_photos
   ).freeze
 
   INTEGER_KEYS = %i(
@@ -49,6 +50,7 @@ class Form::AdminSettings
     trendable_by_default
     noindex
     require_invite_text
+    store_5k_photos
   ).freeze
 
   UPLOAD_KEYS = %i(

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -67,7 +67,7 @@ class MediaAttachment < ApplicationRecord
     y_comp: 4,
   }.freeze
 
-  # Setting.store_5k_photos
+  # Setting.store_5k_images
   IMAGE_STYLES_HIGH = {
     original: {
       pixels: 14_745_600, # 5120x2880px 5K
@@ -317,9 +317,9 @@ class MediaAttachment < ApplicationRecord
       if attachment.instance.file_content_type == 'image/gif' || VIDEO_CONVERTIBLE_MIME_TYPES.include?(attachment.instance.file_content_type)
         VIDEO_CONVERTED_STYLES
       elsif IMAGE_CONVERTIBLE_MIME_TYPES.include?(attachment.instance.file_content_type) || (IMAGE_MIME_TYPES.include?(attachment.instance.file_content_type) && attachment.instance.file_file_size > NONJPEG_KEEP_LIMIT)
-        Setting.store_5k_photos ? IMAGE_CONVERTED_STYLES_HIGH : IMAGE_CONVERTED_STYLES_LOW
+        Setting.store_5k_images ? IMAGE_CONVERTED_STYLES_HIGH : IMAGE_CONVERTED_STYLES_LOW
       elsif IMAGE_MIME_TYPES.include?(attachment.instance.file_content_type)
-        Setting.store_5k_photos ? IMAGE_STYLES_HIGH : IMAGE_STYLES_LOW
+        Setting.store_5k_images ? IMAGE_STYLES_HIGH : IMAGE_STYLES_LOW
       elsif VIDEO_MIME_TYPES.include?(attachment.instance.file_content_type)
         VIDEO_STYLES
       else

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -75,15 +75,15 @@ class MediaAttachment < ApplicationRecord
     }.freeze,
 
     small: {
-      pixels: 921_600,  # 1280x720px HD
+      pixels: 921_600, # 1280x720px HD
       file_geometry_parser: FastGeometryParser,
       blurhash: BLURHASH_OPTIONS,
     }.freeze,
-  }.freeze 
+  }.freeze
 
   IMAGE_STYLES_LOW = {
     original: {
-      pixels: 2_073_600,  # 1920x1080px
+      pixels: 2_073_600, # 1920x1080px
       file_geometry_parser: FastGeometryParser,
     }.freeze,
 
@@ -92,7 +92,7 @@ class MediaAttachment < ApplicationRecord
       file_geometry_parser: FastGeometryParser,
       blurhash: BLURHASH_OPTIONS,
     }.freeze,
-  }.freeze 
+  }.freeze
 
   IMAGE_CONVERTED_STYLES_LOW = {
     original: {
@@ -160,7 +160,7 @@ class MediaAttachment < ApplicationRecord
       convert_options: {
         output: {
           'loglevel' => 'fatal',
-          vf: 'scale=\'min(400\, iw):min(400\, ih)\':force_original_aspect_ratio=decrease',
+          'vf' => 'scale=\'min(400\, iw):min(400\, ih)\':force_original_aspect_ratio=decrease',
         }.freeze,
       }.freeze,
       format: 'png',

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -32,6 +32,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       activity_api_enabled: Setting.activity_api_enabled,
       single_user_mode: Rails.configuration.x.single_user_mode,
       translation_enabled: TranslationService.configured?,
+      store_5k_photos: Setting.store_5k_photos,
     }
 
     if object.current_account

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -32,7 +32,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       activity_api_enabled: Setting.activity_api_enabled,
       single_user_mode: Rails.configuration.x.single_user_mode,
       translation_enabled: TranslationService.configured?,
-      store_5k_photos: Setting.store_5k_photos,
+      store_5k_images: Setting.store_5k_images,
     }
 
     if object.current_account

--- a/app/views/admin/settings/content_retention/show.html.haml
+++ b/app/views/admin/settings/content_retention/show.html.haml
@@ -17,7 +17,7 @@
     = f.input :media_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
     = f.input :content_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
     = f.input :backups_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
-    = f.input :store_5k_photos, as: :boolean, wrapper: :with_label
+    = f.input :store_5k_images, as: :boolean, wrapper: :with_label
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/settings/content_retention/show.html.haml
+++ b/app/views/admin/settings/content_retention/show.html.haml
@@ -17,6 +17,7 @@
     = f.input :media_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
     = f.input :content_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
     = f.input :backups_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
+    = f.input :store_5k_photos, as: :boolean, wrapper: :with_label
 
   .actions
     = f.button :button, t('generic.save_changes'), type: :submit

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -83,6 +83,7 @@ en:
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.
         profile_directory: The profile directory lists all users who have opted-in to be discoverable.
         require_invite_text: When sign-ups require manual approval, make the “Why do you want to join?” text input mandatory rather than optional
+        store_5k_photos: Store images up to 5K resolution - 5120*2880
         site_contact_email: How people can reach you for legal or support inquiries.
         site_contact_username: How people can reach you on Mastodon.
         site_extended_description: Any additional information that may be useful to visitors and your users. Can be structured with Markdown syntax.

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -83,13 +83,13 @@ en:
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.
         profile_directory: The profile directory lists all users who have opted-in to be discoverable.
         require_invite_text: When sign-ups require manual approval, make the “Why do you want to join?” text input mandatory rather than optional
-        store_5k_images: Store images up to 5K resolution - 5120*2880
         site_contact_email: How people can reach you for legal or support inquiries.
         site_contact_username: How people can reach you on Mastodon.
         site_extended_description: Any additional information that may be useful to visitors and your users. Can be structured with Markdown syntax.
         site_short_description: A short description to help uniquely identify your server. Who is running it, who is it for?
         site_terms: Use your own privacy policy or leave blank to use the default. Can be structured with Markdown syntax.
         site_title: How people may refer to your server besides its domain name.
+        store_5k_images: Store images up to 5K resolution - 5120*2880
         theme: Theme that logged out visitors and new users see.
         thumbnail: A roughly 2:1 image displayed alongside your server information.
         timeline_preview: Logged out visitors will be able to browse the most recent public posts available on the server.

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -83,7 +83,7 @@ en:
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.
         profile_directory: The profile directory lists all users who have opted-in to be discoverable.
         require_invite_text: When sign-ups require manual approval, make the “Why do you want to join?” text input mandatory rather than optional
-        store_5k_photos: Store images up to 5K resolution - 5120*2880
+        store_5k_images: Store images up to 5K resolution - 5120*2880
         site_contact_email: How people can reach you for legal or support inquiries.
         site_contact_username: How people can reach you on Mastodon.
         site_extended_description: Any additional information that may be useful to visitors and your users. Can be structured with Markdown syntax.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,7 +70,7 @@ defaults: &defaults
   show_domain_blocks_rationale: 'disabled'
   require_invite_text: false
   backups_retention_period: 7
-  store_5k_photos: false
+  store_5k_images: false
 
 development:
   <<: *defaults

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -70,6 +70,7 @@ defaults: &defaults
   show_domain_blocks_rationale: 'disabled'
   require_invite_text: false
   backups_retention_period: 7
+  store_5k_photos: false
 
 development:
   <<: *defaults


### PR DESCRIPTION
This PR is a result of the discussion from Issue https://github.com/mastodon/mastodon/issues/20255

Specifically, this address the issue that uploaded images are forced to scaled down too much (under 1920x1080) in the client side javascript.

How this is addressed:

1. Increase client side upload limit to 5K (5120x2880). 5K is chosen because it is just under the mastodon limit of 4096x4096 `MAX_MATRIX_LIMIT = 16_777_216 # 4096x4096px or approx. 16MB`
2. Make it an admin option that is off by default. The option is added to Administration->Server Settings->Content Retention
3. If an uploaded image is over 2MB (png or otherwise), it will be forced to convert to jpg to save storage
4. Server will based on the admin setting, scale the image as needed to 5120x2880 or 1920x1080 limit.

How this is tested:

1. Set store-5k, upload 1.6MB 5393x2766 PNG using python client => Image converted to 5362x2750
2. Unset store-5k, upload 1.6MB 5393x2766 PNG using python client => Image converted to 2010x1031
3. Set store-5k, upload 10MB 3984x1538 PNG using python client => Image converted to 3984x1538 JPEG
4. Unset store-5k, upload 10MB 3984x1538 PNG using python client => Image converted to 2318x895 JPEG
5. Set store-5k, upload 8MB 4542x2555 JPEG using python client => Image converted to 3.1MB 4542x2555 JPEG
6. Unset store-5k, upload 8MB 4542x2555 JPEG using python client => Image converted to 600k 1920x1080 JPEG
7. Unset store-5k, upload 8MB 10000x5252 PNG using web client => Image converted to 800k 1987x1044 JPEG
8. Set store-5k, upload 8MB 10000x5252 PNG using web client => Image converted to 3.4MB 5299x2783 JPEG
