### PR TITLE
3.0.5 version of cimg/ruby:3.0-node upgraded to node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,9 @@ jobs:
           cache-version: v1
           pkg-manager: yarn
       - run:
-          command: ./bin/rails assets:precompile
+          command: |
+            export NODE_OPTIONS=--openssl-legacy-provider
+            ./bin/rails assets:precompile
           name: Precompile assets
       - persist_to_workspace:
           paths:


### PR DESCRIPTION
Node 18 caused build to fail - 
Error: error:0308010C:digital envelope routines::unsupported