### PR TITLE
Add git config command to devcontainer.json postCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
   "forwardPorts": [3000, 4000],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "bundle install --path vendor/bundle && yarn install && git checkout -- Gemfile.lock && ./bin/rails db:setup",
+  "postCreateCommand": "git config --global --add safe.directory /workspaces/mastodon && bundle install --path vendor/bundle && yarn install && git checkout -- Gemfile.lock && ./bin/rails db:setup",
 
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode"


### PR DESCRIPTION
Using the `devcontainer.json` file with VSCode was failing while running the `postCreateCommand` with an error regarding uncertain ownership of the `/workspace/mastodon` folder. I added `git config --global --add safe.directory /workspaces/mastodon && ` to the beginning of the `postCreateCommand` as recommend by the git generated error, this resolves the issue.

Not sure if this is something that occurs on all Operating Systems but I was having this problem on a Windows 10 Pro (10.0.19045). I don't think adding this command will cause any issues for other OS'es even if they aren't having the issue.