### PR TITLE
Add a setting to display large link previews

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -54,6 +54,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_use_pending_items,
       :setting_trends,
       :setting_crop_images,
+      :setting_display_large_previews,
       :setting_always_send_emails,
       notification_emails: %i(follow follow_request reblog favourite mention report pending_account trending_tag appeal),
       interactions: %i(must_be_follower must_be_following must_be_following_dm)

--- a/app/javascript/mastodon/features/status/components/card.js
+++ b/app/javascript/mastodon/features/status/components/card.js
@@ -6,7 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import punycode from 'punycode';
 import classnames from 'classnames';
 import Icon from 'mastodon/components/icon';
-import { useBlurhash } from 'mastodon/initial_state';
+import { displayLargePreviews, useBlurhash } from 'mastodon/initial_state';
 import Blurhash from 'mastodon/components/blurhash';
 import { debounce } from 'lodash';
 
@@ -194,7 +194,7 @@ export default class Card extends React.PureComponent {
     const provider    = card.get('provider_name').length === 0 ? decodeIDNA(getHostname(card.get('url'))) : card.get('provider_name');
     const horizontal  = (!compact && card.get('width') > card.get('height') && (card.get('width') + 100 >= width)) || card.get('type') !== 'link' || embedded;
     const interactive = card.get('type') !== 'link';
-    const className   = classnames('status-card', { horizontal, compact, interactive });
+    const className   = classnames('status-card', { horizontal, compact, interactive, large: displayLargePreviews });
     const title       = interactive ? <a className='status-card__title' href={card.get('url')} title={card.get('title')} rel='noopener noreferrer' target='_blank'><strong>{card.get('title')}</strong></a> : <strong className='status-card__title' title={card.get('title')}>{card.get('title')}</strong>;
     const ratio       = card.get('width') / card.get('height');
     const height      = (compact && !embedded) ? (width / (16 / 9)) : (width / ratio);

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -55,6 +55,7 @@
  * @property {boolean=} delete_modal
  * @property {boolean=} disable_swiping
  * @property {string=} disabled_account_id
+ * @property {boolean} display_large_previews
  * @property {boolean} display_media
  * @property {string} domain
  * @property {boolean=} expand_spoilers
@@ -107,6 +108,7 @@ export const cropImages = getMeta('crop_images');
 export const deleteModal = getMeta('delete_modal');
 export const disableSwiping = getMeta('disable_swiping');
 export const disabledAccountId = getMeta('disabled_account_id');
+export const displayLargePreviews = getMeta('display_large_previews');
 export const displayMedia = getMeta('display_media');
 export const domain = getMeta('domain');
 export const expandSpoilers = getMeta('expand_spoilers');

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3439,6 +3439,44 @@ a.status-card {
   }
 }
 
+.status-card.large {
+  background-color: #191b22;
+  border-radius: 10px;
+
+  flex-direction: column;
+
+  .status-card__image {
+    flex: unset;
+
+    .status-card__image-image {
+      border-radius: 0;
+    }
+  }
+
+  .status-card__content {
+    padding: 15px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .status-card__host, .status-card__description {
+    color: $lighter-text-color;
+  }
+
+  .status-card__title {
+    order: 2;
+    margin-bottom: 0;
+  }
+
+  .status-card__host {
+    order: 1;
+  }
+
+  .status-card__description {
+    order: 3;
+  }
+}
+
 a.status-card.compact:hover {
   background-color: lighten($ui-base-color, 4%);
 }

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -15,30 +15,31 @@ class UserSettingsDecorator
   private
 
   def process_update
-    user.settings['notification_emails'] = merged_notification_emails if change?('notification_emails')
-    user.settings['interactions']        = merged_interactions if change?('interactions')
-    user.settings['default_privacy']     = default_privacy_preference if change?('setting_default_privacy')
-    user.settings['default_sensitive']   = default_sensitive_preference if change?('setting_default_sensitive')
-    user.settings['default_language']    = default_language_preference if change?('setting_default_language')
-    user.settings['unfollow_modal']      = unfollow_modal_preference if change?('setting_unfollow_modal')
-    user.settings['boost_modal']         = boost_modal_preference if change?('setting_boost_modal')
-    user.settings['delete_modal']        = delete_modal_preference if change?('setting_delete_modal')
-    user.settings['auto_play_gif']       = auto_play_gif_preference if change?('setting_auto_play_gif')
-    user.settings['display_media']       = display_media_preference if change?('setting_display_media')
-    user.settings['expand_spoilers']     = expand_spoilers_preference if change?('setting_expand_spoilers')
-    user.settings['reduce_motion']       = reduce_motion_preference if change?('setting_reduce_motion')
-    user.settings['disable_swiping']     = disable_swiping_preference if change?('setting_disable_swiping')
-    user.settings['system_font_ui']      = system_font_ui_preference if change?('setting_system_font_ui')
-    user.settings['noindex']             = noindex_preference if change?('setting_noindex')
-    user.settings['theme']               = theme_preference if change?('setting_theme')
-    user.settings['aggregate_reblogs']   = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
-    user.settings['show_application']    = show_application_preference if change?('setting_show_application')
-    user.settings['advanced_layout']     = advanced_layout_preference if change?('setting_advanced_layout')
-    user.settings['use_blurhash']        = use_blurhash_preference if change?('setting_use_blurhash')
-    user.settings['use_pending_items']   = use_pending_items_preference if change?('setting_use_pending_items')
-    user.settings['trends']              = trends_preference if change?('setting_trends')
-    user.settings['crop_images']         = crop_images_preference if change?('setting_crop_images')
-    user.settings['always_send_emails']  = always_send_emails_preference if change?('setting_always_send_emails')
+    user.settings['notification_emails']    = merged_notification_emails if change?('notification_emails')
+    user.settings['interactions']           = merged_interactions if change?('interactions')
+    user.settings['default_privacy']        = default_privacy_preference if change?('setting_default_privacy')
+    user.settings['default_sensitive']      = default_sensitive_preference if change?('setting_default_sensitive')
+    user.settings['default_language']       = default_language_preference if change?('setting_default_language')
+    user.settings['unfollow_modal']         = unfollow_modal_preference if change?('setting_unfollow_modal')
+    user.settings['boost_modal']            = boost_modal_preference if change?('setting_boost_modal')
+    user.settings['delete_modal']           = delete_modal_preference if change?('setting_delete_modal')
+    user.settings['auto_play_gif']          = auto_play_gif_preference if change?('setting_auto_play_gif')
+    user.settings['display_media']          = display_media_preference if change?('setting_display_media')
+    user.settings['expand_spoilers']        = expand_spoilers_preference if change?('setting_expand_spoilers')
+    user.settings['reduce_motion']          = reduce_motion_preference if change?('setting_reduce_motion')
+    user.settings['disable_swiping']        = disable_swiping_preference if change?('setting_disable_swiping')
+    user.settings['system_font_ui']         = system_font_ui_preference if change?('setting_system_font_ui')
+    user.settings['noindex']                = noindex_preference if change?('setting_noindex')
+    user.settings['theme']                  = theme_preference if change?('setting_theme')
+    user.settings['aggregate_reblogs']      = aggregate_reblogs_preference if change?('setting_aggregate_reblogs')
+    user.settings['show_application']       = show_application_preference if change?('setting_show_application')
+    user.settings['advanced_layout']        = advanced_layout_preference if change?('setting_advanced_layout')
+    user.settings['use_blurhash']           = use_blurhash_preference if change?('setting_use_blurhash')
+    user.settings['use_pending_items']      = use_pending_items_preference if change?('setting_use_pending_items')
+    user.settings['trends']                 = trends_preference if change?('setting_trends')
+    user.settings['crop_images']            = crop_images_preference if change?('setting_crop_images')
+    user.settings['display_large_previews'] = display_large_previews_preference if change?('setting_display_large_previews')
+    user.settings['always_send_emails']     = always_send_emails_preference if change?('setting_always_send_emails')
   end
 
   def merged_notification_emails
@@ -131,6 +132,10 @@ class UserSettingsDecorator
 
   def crop_images_preference
     boolean_cast_setting 'setting_crop_images'
+  end
+
+  def display_large_previews_preference
+    boolean_cast_setting 'setting_display_large_previews'
   end
 
   def always_send_emails_preference

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,7 +135,7 @@ class User < ApplicationRecord
            :reduce_motion, :system_font_ui, :noindex, :theme, :display_media,
            :expand_spoilers, :default_language, :aggregate_reblogs, :show_application,
            :advanced_layout, :use_blurhash, :use_pending_items, :trends, :crop_images,
-           :disable_swiping, :always_send_emails,
+           :disable_swiping, :always_send_emails, :display_large_previews,
            to: :settings, prefix: :setting, allow_nil: false
 
   delegate :can?, to: :role

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -49,12 +49,14 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:use_pending_items] = object.current_account.user.setting_use_pending_items
       store[:trends]            = Setting.trends && object.current_account.user.setting_trends
       store[:crop_images]       = object.current_account.user.setting_crop_images
+      store[:display_large_previews]       = object.current_account.user.setting_display_large_previews
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media
       store[:reduce_motion] = Setting.reduce_motion
       store[:use_blurhash]  = Setting.use_blurhash
       store[:crop_images]   = Setting.crop_images
+      store[:display_large_previews]   = Setting.display_large_previews
     end
 
     store[:disabled_account_id] = object.disabled_account.id.to_s if object.disabled_account

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -37,6 +37,7 @@
 
   .fields-group
     = f.input :setting_crop_images, as: :boolean, wrapper: :with_label
+    = f.input :setting_display_large_previews, as: :boolean, wrapper: :with_label
 
   %h4= t 'appearance.discovery'
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -193,6 +193,7 @@ en:
         setting_auto_play_gif: Auto-play animated GIFs
         setting_boost_modal: Show confirmation dialog before boosting
         setting_crop_images: Crop images in non-expanded posts to 16x9
+        setting_display_large_previews: Display large link previews
         setting_default_language: Posting language
         setting_default_privacy: Posting privacy
         setting_default_sensitive: Always mark media as sensitive

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,6 +37,7 @@ defaults: &defaults
   trends: true
   trendable_by_default: false
   crop_images: true
+  display_large_previews: true
   notification_emails:
     follow: true
     reblog: false


### PR DESCRIPTION
Use-case and arguments for this can be found in #21874

This works similarly to the 16x9 setting for images.

<img width="370" alt="image" src="https://user-images.githubusercontent.com/42070/204924362-9242859c-9e3e-4f8d-bca4-acaa2afa1b4f.png">

The setting is currently enabled by default (I really like it better) but I can change it if you disagree.

When enabled, link previews will be a bigger card with a full-width media (styled inspired by @innosflew's [work here](https://github.com/mastodon/mastodon/issues/21874#issuecomment-1332556018)).

<img width="628" alt="image" src="https://user-images.githubusercontent.com/42070/204924630-2943a476-c941-4e70-a796-7bd54199586d.png">

<img width="1661" alt="image" src="https://user-images.githubusercontent.com/42070/204926701-2c515476-1551-4adb-8a94-b885fca7624a.png">

I chose to keep the host part immediately below the media as this image is much bigger and I feel giving the source of the link near the big clickable area it is a good idea. The text hierarchy works great like this as well.

This may need some adjustments, for example forcing an `aspect-ratio` on the preview (+ `object-fit: cover`), depending on feedback on more content. I will run with this for a few days on my own instance to see how it goes.

Preview image size might need to be made a little bigger as well, to 600px width maybe?

<details>
<summary>
If you want to test the styling part on your own instance, you can use this custom CSS
</summary>

```css
.status-card {
  background-color: #191b22;
  border-radius: 10px;
  flex-direction: column;
}
.status-card .status-card .status-card__image {
  flex: unset;
}
.status-card .status-card .status-card__image .status-card .status-card__image-image {
  border-radius: 0;
}
.status-card .status-card__content {
  padding: 15px;
  display: flex;
  flex-direction: column;
}
.status-card .status-card__host, .status-card .status-card__description {
  color: #606984;
}
.status-card .status-card__title {
  order: 2;
  margin-bottom: 0;
}
.status-card .status-card__host {
  order: 1;
}
.status-card .status-card__description {
  order: 3;
}
```

</detail>