### PR TITLE
Fix some performance issues with /admin/instances

### DIFF
--- a/app/controllers/admin/instances_controller.rb
+++ b/app/controllers/admin/instances_controller.rb
@@ -57,7 +57,7 @@ module Admin
     end
 
     def preload_delivery_failures!
-      warning_domains_map = DeliveryFailureTracker.warning_domains_map
+      warning_domains_map = DeliveryFailureTracker.warning_domains_map(@instances.map(&:domain))
 
       @instances.each do |instance|
         instance.failure_days = warning_domains_map[instance.domain]

--- a/app/lib/delivery_failure_tracker.rb
+++ b/app/lib/delivery_failure_tracker.rb
@@ -65,8 +65,13 @@ class DeliveryFailureTracker
       domains - UnavailableDomain.all.pluck(:domain)
     end
 
-    def warning_domains_map
-      warning_domains.index_with { |domain| redis.scard(exhausted_deliveries_key_by(domain)) }
+    def warning_domains_map(domains = nil)
+      if domains.nil?
+        warning_domains.index_with { |domain| redis.scard(exhausted_deliveries_key_by(domain)) }
+      else
+        domains -= UnavailableDomain.where(domain: domains).pluck(:domain)
+        domains.index_with { |domain| redis.scard(exhausted_deliveries_key_by(domain)) }.filter { |_, days| days.positive? }
+      end
     end
 
     private


### PR DESCRIPTION
Currently, each page view of `/admin/instances` pulls the entire set of domains with recent delivery failures just to display a delivery warning icon for up to 40 instances. In order to do so it:
- uses Redis' `KEYS` command to; while reasonably fast in most cases, the cost is dependent on the total amount of Redis keys, not only the ones related to failing instances; worse, this locks other queries out of Redis for the total duration of the query (on my single-user instance that has been around for years, it's 2486 out of 37983 keys)
- queries the full `unavailable_domains` table in one SQL query (on my single-user instance that's only 46 rows)
- uses Redis' `SCARD` command on each failing domain that is not marked as unavailable (on my single-user instance, that's currently 2472 queries)

On my single-user instance, the whole ordeal takes a little over half a second, and that can degrade quickly with degraded Redis performances.

This PR changes it so that:
- `KEYS` is not used
- `unavailable_domains` is only queried for the current page, so 40 domains at most
- `SCARD` is called for every domain in the page that is not present in `unavailable_domains`, so 40 queries at most

On my single-user instance, that brings the whole thing down to less than 0.05s.

`/admin/instances?availability=failing` remains wholly unefficient