### PR TITLE
Nicer sparkline scaling for comparing hashtags

### DIFF
--- a/app/javascript/mastodon/components/hashtag.jsx
+++ b/app/javascript/mastodon/components/hashtag.jsx
@@ -86,7 +86,7 @@ const Hashtag = ({ name, to, people, uses, history, className, description, with
     {withGraph && (
       <div className='trends__item__sparkline'>
         <SilentErrorBoundary>
-          <Sparklines width={50} height={28} data={history ? history : Array.from(Array(7)).map(() => 0)}>
+          <Sparklines width={50} height={28} data={history ? history : Array.from(Array(7)).map(() => 0)} min={0} max={history ? Math.max(...history) + 10 : 10}>
             <SparklinesCurve style={{ fill: 'none' }} />
           </Sparklines>
         </SilentErrorBoundary>


### PR DESCRIPTION
This will plot empty hashtags as a line at the bottom of the graph, instead of in the middle.

It will also scale small hashtags, so that e.g. something with 1 tag will only use ~10% of the available graph height, where something with 10 tags will use ~50% of the height, and something with 100 tags will use ~90% of the height, etc.

I haven't had time to set up a dev environment, so this is untested, but I'm 99% sure it should work as advertised, following the [react-sparkline docs](https://www.npmjs.com/package/react-sparklines).