### PR TITLE
Fix couple of words in es/es-MX

### DIFF
--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -161,7 +161,7 @@ es-MX:
       unsuspended_msg: Se quitó con éxito la suspensión de la cuenta de %{username}
       username: Nombre de usuario
       view_domain: Ver resumen del dominio
-      warn: Adevertir
+      warn: Advertir
       web: Web
       whitelisted: Añadido a la lista blanca
     action_logs:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -161,7 +161,7 @@ es:
       unsuspended_msg: Se quitó con éxito la suspensión de la cuenta de %{username}
       username: Nombre de usuario
       view_domain: Ver resumen del dominio
-      warn: Adevertir
+      warn: Advertir
       web: Web
       whitelisted: Añadido a la lista blanca
     action_logs:


### PR DESCRIPTION
Fixed "Adevertir" → "Advertir" in `es` and `es-MX`.