### PR TITLE
Destroy follow requests on exhausted delivery attempts

### DIFF
--- a/app/services/follow_service.rb
+++ b/app/services/follow_service.rb
@@ -71,7 +71,7 @@ class FollowService < BaseService
     if @target_account.local?
       LocalNotificationWorker.perform_async(@target_account.id, follow_request.id, follow_request.class.name, 'follow_request')
     elsif @target_account.activitypub?
-      ActivityPub::DeliveryWorker.perform_async(build_json(follow_request), @source_account.id, @target_account.inbox_url)
+      ActivityPub::DeliveryWorker.perform_async(build_json(follow_request), @source_account.id, @target_account.inbox_url, { 'destroy_on_failure' => { 'class' => 'FollowRequest', 'id' => follow_request.id.to_s } })
     end
 
     follow_request


### PR DESCRIPTION
In rare cases, it is possible a follow request never reaches the server of the person that one is trying to follow.

Currently, that failure case is indistinguishable from other failure cases as far as the end-user is concerned, but that failure case can be detected by Mastodon.

In such a case, it might be more useful to delete the follow request than show it as pending, although I am not quite sure how this could be perceived by the user attempting to follow. Ideally, the error should be recorded and displayed to the user, but that requires changes to the API, storage and clients.

Also related: #21956, #21957