### PR TITLE
Added .tool-versions to manage dependencies with asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+ruby 3.0.4
+nodejs 16.17.1
+postgres 14.6
+redis 7.0.5


### PR DESCRIPTION
[asdf](https://asdf-vm.com/) is a developer tool to manage multiple versions of multiple programming languages, databases and other dependencies. This PR adds a `.tool-versions` file that specifies all necessary dependencies for local development of Mastodon. Once merged, correct versions of Ruby, NodeJS, Postgres and Redis can be installed with `asdf install` in the root directory.

I have taken Ruby and NodeJS versions as they're specified in the existing `Dockerfile` and Postgres and Redis versions as they are specified in the existing `docker-compose.yml`. If different versions are supported, the `.tool-versions` file will need to be changed appropriately.

An additional convenience can be achieved by changing `Procfile.dev` to look like this:

```
pgsql: postgres
redis: redis-server
web: env PORT=3000 RAILS_ENV=development bundle exec puma -C config/puma.rb
sidekiq: env PORT=3000 RAILS_ENV=development bundle exec sidekiq
stream: env PORT=4000 yarn run start
webpack: ./bin/webpack-dev-server --listen-host 0.0.0.0
```

This will enable `foreman start` to enable not just Mastodon but also Postgresql and Redis in non-daemon mode and collect logs in the same terminal. Because this may not be the desirable workflow for all, the PR does not include this change.