### PR TITLE
Add --password option (optional) to tootctl accounts create

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -53,6 +53,7 @@ module Mastodon
     end
 
     option :email, required: true
+    option :password
     option :confirmed, type: :boolean
     option :role
     option :reattach, type: :boolean
@@ -61,6 +62,8 @@ module Mastodon
     long_desc <<-LONG_DESC
       Create a new user account with a given USERNAME and an
       e-mail address provided with --email.
+
+      With the --password option, the password can be supplied.
 
       With the --confirmed option, the confirmation e-mail will
       be skipped and the account will be active straight away.
@@ -87,8 +90,13 @@ module Mastodon
         role_id = role.id
       end
 
+      if options[:password]
+        password = options[:password]
+      elsif
+        password = SecureRandom.hex
+      end
+
       account  = Account.new(username: username)
-      password = SecureRandom.hex
       user     = User.new(email: options[:email], password: password, agreement: true, approved: true, role_id: role_id, confirmed_at: options[:confirmed] ? Time.now.utc : nil, bypass_invite_request_check: true)
 
       if options[:reattach]


### PR DESCRIPTION
You can supply a password for the new user.