### PR TITLE
hide mobile ui header width overflow

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2526,6 +2526,7 @@ $ui-header-height: 55px;
     display: flex;
     background: $ui-base-color;
     border-bottom: 1px solid lighten($ui-base-color, 8%);
+    overflow: hidden;
   }
 
   .column-header,


### PR DESCRIPTION
tested with Vagrant build

ui tested that setting overflow hidden on this class does not negatively impact other viewport widths

fixes https://github.com/mastodon/mastodon/issues/21996