### PR TITLE
Change the "punitive action email" text in English to mention account locality

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -576,7 +576,7 @@ en:
         resolve_description_html: No action will be taken against the reported account, no strike recorded, and the report will be closed.
         silence_description_html: The profile will be visible only to those who already follow it or manually look it up, severely limiting its reach. Can always be reverted.
         suspend_description_html: The profile and all its contents will become inaccessible until it is eventually deleted. Interacting with the account will be impossible. Reversible within 30 days.
-      actions_description_html: Decide which action to take to resolve this report. If you are taking punitive action against a reported account from this instance, an e-mail notification will be sent to them, except when the <strong>Spam</strong> category is selected.
+      actions_description_html: Decide which action to take to resolve this report. If you are taking punitive action against a reported account from this server, an e-mail notification will be sent to them, except when the <strong>Spam</strong> category is selected.
       add_to_report: Add more to report
       are_you_sure: Are you sure?
       assign_to_self: Assign to me

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -576,7 +576,7 @@ en:
         resolve_description_html: No action will be taken against the reported account, no strike recorded, and the report will be closed.
         silence_description_html: The profile will be visible only to those who already follow it or manually look it up, severely limiting its reach. Can always be reverted.
         suspend_description_html: The profile and all its contents will become inaccessible until it is eventually deleted. Interacting with the account will be impossible. Reversible within 30 days.
-      actions_description_html: Decide which action to take to resolve this report. If you take a punitive action against the reported account, an e-mail notification will be sent to them, except when the <strong>Spam</strong> category is selected.
+      actions_description_html: Decide which action to take to resolve this report. If you are taking punitive action against a reported account from this instance, an e-mail notification will be sent to them, except when the <strong>Spam</strong> category is selected.
       add_to_report: Add more to report
       are_you_sure: Are you sure?
       assign_to_self: Assign to me


### PR DESCRIPTION
The current text may mislead admins to think that emails are sent to remote reported accounts. This change clarifies that emails will only be sent to local reported accounts.