### PR TITLE
Fix spacing warning from ESLint

### DIFF
--- a/app/javascript/mastodon/reducers/user_lists.js
+++ b/app/javascript/mastodon/reducers/user_lists.js
@@ -22,7 +22,7 @@ import {
   FOLLOW_REQUESTS_EXPAND_FAIL,
   FOLLOW_REQUEST_AUTHORIZE_SUCCESS,
   FOLLOW_REQUEST_REJECT_SUCCESS,
-  } from '../actions/accounts';
+} from '../actions/accounts';
 import {
   REBLOGS_FETCH_SUCCESS,
   FAVOURITES_FETCH_SUCCESS,


### PR DESCRIPTION
Ran `yarn test:lint:js --fix` to cleanup a minor spacing warning that shows up on all the PRs from the linter