### PR TITLE
Fix minor visual issue with the top border of verified account fields

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7138,10 +7138,12 @@ noscript {
 
       .verified {
         border: 1px solid rgba($valid-value-color, 0.5);
+        margin-top: -1px;
 
         &:first-child {
           border-top-left-radius: 4px;
           border-top-right-radius: 4px;
+          margin-top: 0;
         }
 
         &:last-child {


### PR DESCRIPTION
[tested in the browser console on mastodon.social]:

before:
<img width="555" alt="Screenshot_2022-12-03 14 46 42" src="https://user-images.githubusercontent.com/25517624/205459108-c7b7516d-1a85-4c90-a865-2c1d72bd3e2f.png">

after: the green border is pulled up by 1px to prevent double borders
<img width="557" alt="Screenshot_2022-12-03 14 47 28" src="https://user-images.githubusercontent.com/25517624/205459130-00d17db7-1bf5-42ea-9426-97802739c455.png">
