### PR TITLE
flex advance mode columns to use available space

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2278,7 +2278,7 @@ $ui-header-height: 55px;
 }
 
 .column {
-  width: 350px;
+  min-width: 350px;
   position: relative;
   box-sizing: border-box;
   display: flex;
@@ -2331,7 +2331,7 @@ $ui-header-height: 55px;
 
   .column,
   .drawer {
-    flex: 0 0 auto;
+    flex: 0 0 100%;
     padding: 10px;
     padding-left: 5px;
     padding-right: 5px;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2278,7 +2278,8 @@ $ui-header-height: 55px;
 }
 
 .column {
-  min-width: 350px;
+  min-width: 300px;
+  max-width: 550px;
   position: relative;
   box-sizing: border-box;
   display: flex;
@@ -2300,7 +2301,8 @@ $ui-header-height: 55px;
 }
 
 .drawer {
-  width: 300px;
+  min-width: 300px;
+  max-width: 400px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
as discussed in #22009 this allows columns in advance mode to be a bit wider to fill the screen, they have a min-width of 350 so if there isn't enough screen they scroll as before