### PR TITLE
Update Node 16.18.1 for latest security release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt update && \
     bundle config set --local without 'development test' && \
     bundle config set silence_root_warning true && \
     bundle install -j"$(nproc)" && \
-    yarn install --pure-lockfile
+    yarn install --pure-lockfile --network-timeout 600000
 
 FROM node:${NODE_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 # This needs to be bullseye-slim because the Ruby image is built on bullseye-slim
-ARG NODE_VERSION="16.17.1-bullseye-slim"
+ARG NODE_VERSION="16.18.1-bullseye-slim"
 
 FROM ghcr.io/moritzheiber/ruby-jemalloc:3.0.4-slim as ruby
 FROM node:${NODE_VERSION} as build


### PR DESCRIPTION
Pull latest Node 16 patch release for a few CVEs:
- https://nodejs.org/en/blog/release/v16.18.0/ 
- https://nodejs.org/en/blog/release/v16.18.1/