### PR TITLE
Add CI job to label PRs with merge conflicts

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -1,0 +1,17 @@
+name: PR Needs Rebase
+
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  label-rebase-needed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: 'rebase needed :construction:'
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          commentOnDirty: This pull request has merge conflicts that must be resolved before it can be merged.


### PR DESCRIPTION
Found this was useful over on the MDN repos to let PR authors know when their PRs have merge conflicts and need to be rebased.
It can help let them fix the conflicts so PRs can merge once a review can look at them