### PR TITLE
rake mastodon:setup: Restore Redis config prior to creating an admin user

### DIFF
--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -470,6 +470,15 @@ namespace :mastodon do
           require_relative '../../config/environment'
           disable_log_stdout!
 
+          # With the environment now reloaded, update Sidekiq to use the Redis config that was provided earlier interactively, in case it differs from the default localhost:6379.
+          # When the admin user is created, User dispatches an 'account.created' event to Sidekiq, which connects to Redis.
+          Sidekiq.configure_client do |config|
+            new_params = REDIS_SIDEKIQ_PARAMS.dup
+            new_params['url'] = "redis://:#{env['REDIS_PASSWORD']}@#{env['REDIS_HOST']}:#{env['REDIS_PORT']}/0"
+            new_params.freeze
+            config.redis = new_params
+          end
+          
           username = prompt.ask('Username:') do |q|
             q.required true
             q.default 'admin'


### PR DESCRIPTION
`RAILS_ENV=production bundle exec rake mastodon:setup` with a non-localhost Redis server.

When creating an admin user - towards the end of the interactive setup - the environment is reloaded, and the Redis config reverts to localhost:6379, instead of to the host:port typed by the user earlier in the setup.

For setups with a non-localhost Redis server, this causes the creation of the admin user to fail with the error:
`Redis::CannotConnectError: Error connecting to Redis on localhost:6379 (Errno::ECONNREFUSED)`

The issue is solved by configuring the Sidekiq client to use the Redis vars provided earlier in the interactive setup (after the environment is reloaded) so that when the new admin User is created, Sidekiq is able to connect to Redis and the 'account.created' event is dispatched successfully.