### PR TITLE
Add `tootctl domains purge` options to select subdomains and keep domain blocks

### DIFF
--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -93,7 +93,9 @@ module Mastodon
       say("Removed #{processed} accounts#{dry_run}", :green)
 
       if options[:purge_domain_blocks]
+        domain_block_count = domain_block_scope.count
         domain_block_scope.in_batches.destroy_all unless options[:dry_run]
+        say("Removed #{domain_block_count} domain blocks#{dry_run}", :green)
       end
 
       custom_emojis_count = emoji_scope.count

--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -42,57 +42,62 @@ module Mastodon
       When the --purge-domain-blocks option is given, also purge matching domain blocks.
     LONG_DESC
     def purge(*domains)
-      dry_run = options[:dry_run] ? ' (DRY RUN)' : ''
+      dry_run            = options[:dry_run] ? ' (DRY RUN)' : ''
+      domains            = domains.map { |domain| TagManager.instance.normalize_domain(domain) }
+      account_scope      = Account.none
+      domain_block_scope = DomainBlock.none
+      emoji_scope        = CustomEmoji.none
 
-      domains = domains.map { |domain| TagManager.instance.normalize_domain(domain) }
+      # Sanity check on command arguments
+      if options[:limited_federation_mode] && !domains.empty?
+        say('DOMAIN parameter not supported with --limited-federation-mode', :red)
+        exit(1)
+      elsif domains.empty? && !options[:limited_federation_mode]
+        say('No domain(s) given', :red)
+        exit(1)
+      end
 
-      # Handle wildcard subdomains
-      subdomain_patterns = domains.filter_map { |domain| "%.#{Account.sanitize_sql_like(domain[2..])}" if domain.start_with?('*.') }
-      domains = domains.filter { |domain| !domain.start_with?('*.') }
+      # Build scopes from command arguments
+      if options[:limited_federation_mode]
+        account_scope = Account.remote.where.not(domain: DomainAllow.select(:domain))
+        emoji_scope   = CustomEmoji.remote.where.not(domain: DomainAllow.select(:domain))
+      else
+        # Handle wildcard subdomains
+        subdomain_patterns = domains.filter_map { |domain| "%.#{Account.sanitize_sql_like(domain[2..])}" if domain.start_with?('*.') }
+        domains = domains.filter { |domain| !domain.start_with?('*.') }
+        # Handle --include-subdomains
+        subdomain_patterns += domains.map { |domain| "%.#{Account.sanitize_sql_like(domain)}" } if options[:include_subdomains]
+        uri_patterns = (domains.map { |domain| Account.sanitize_sql_like(domain) } + subdomain_patterns).map { |pattern| "https://#{pattern}/%" }
 
-      subdomain_patterns += domains.map { |domain| "%.#{Account.sanitize_sql_like(domain)}" } if options[:include_subdomains]
+        if options[:purge_domain_blocks]
+          domain_block_scope = DomainBlock.where(domain: domains)
+          domain_block_scope = domain_block_scope.or(DomainBlock.where(DomainBlock.arel_table[:domain].matches_any(subdomain_patterns))) unless subdomain_patterns.empty?
+        end
 
-      uri_patterns = (domains.map { |domain| Account.sanitize_sql_like(domain) } + subdomain_patterns).map { |pattern| "https://#{pattern}/%" }
-
-      scope = begin
-        if options[:limited_federation_mode]
-          Account.remote.where.not(domain: DomainAllow.pluck(:domain))
-        elsif domains.empty? && subdomain_patterns.empty?
-          say('No domain(s) given', :red)
-          exit(1)
+        if options[:by_uri]
+          account_scope = Account.remote.where(Account.arel_table[:uri].matches_any(uri_patterns, false, true))
+          emoji_scope   = CustomEmoji.remote.where(CustomEmoji.arel_table[:uri].matches_any(uri_patterns, false, true))
         else
-          if options[:by_uri]
-            Account.remote.where(Account.arel_table[:uri].matches_any(uri_patterns, false, true))
-          else
-            scope = Account.remote.where(domain: domains)
-            scope = scope.or(Account.remote.where(Account.arel_table[:domain].matches_any(subdomain_patterns))) unless subdomain_patterns.empty?
-            scope
-          end
+          account_scope = Account.remote.where(domain: domains)
+          account_scope = account_scope.or(Account.remote.where(Account.arel_table[:domain].matches_any(subdomain_patterns))) unless subdomain_patterns.empty?
+          emoji_scope   = CustomEmoji.where(domain: domains)
+          emoji_scope   = emoji_scope.or(CustomEmoji.remote.where(CustomEmoji.arel_table[:uri].matches_any(subdomain_patterns))) unless subdomain_patterns.empty?
         end
       end
 
-      processed, = parallelize_with_progress(scope) do |account|
+      # Actually perform the deletions
+      processed, = parallelize_with_progress(account_scope) do |account|
         DeleteAccountService.new.call(account, reserve_username: false, skip_side_effects: true) unless options[:dry_run]
       end
 
       say("Removed #{processed} accounts#{dry_run}", :green)
 
       if options[:purge_domain_blocks]
-        DomainBlock.where(domain: domains).destroy_all unless options[:dry_run]
-        DomainBlock.where(DomainBlock.arel_table[:domain].matches_any(subdomain_patterns)).destroy_all unless subdomain_patterns.empty?
+        domain_block_scope.in_batches.destroy_all unless options[:dry_run]
       end
 
-      custom_emojis = begin
-        if options[:by_uri]
-          CustomEmoji.remote.where(CustomEmoji.arel_table[:uri].matches_any(uri_patterns, false, true))
-        else
-          scope = CustomEmoji.where(domain: domains)
-          scope = scope.or(CustomEmoji.remote.where(CustomEmoji.arel_table[:uri].matches_any(subdomain_patterns))) unless subdomain_patterns.empty?
-          scope
-        end
-      end
-      custom_emojis_count = custom_emojis.count
-      custom_emojis.destroy_all unless options[:dry_run]
+      custom_emojis_count = emoji_scope.count
+      emoji_scope.in_batches.destroy_all unless options[:dry_run]
 
       Instance.refresh unless options[:dry_run]
 


### PR DESCRIPTION
Fixes #21984

- Add a `--include-subdomains` option to match both passed domains and their subdomains
- Add support for the `*.` subdomain wildcard pattern regardless of `--include-subdomains` as people will somewhat frequently use it
- Fix issues with custom emoji deletion
- Change `tootctl domains purge` to not remove domain blocks by default, and add a `--purge-domain-blocks` option to recover that behavior: in most cases, if a domain block exists, admins do not actually want to remove it.