### PR TITLE
docs: add first draft of design contribution guidelines

### DIFF
--- a/.design/README.md
+++ b/.design/README.md
@@ -1,0 +1,126 @@
+<h1><picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./lib/assets/wordmark.dark.png?raw=true">
+  <source media="(prefers-color-scheme: light)" srcset="./lib/assets/wordmark.light.png?raw=true">
+  <img alt="Mastodon" src="./lib/assets/wordmark.light.png?raw=true" height="34">
+</picture></h1>
+
+A collection of design contribution guidelines and resources for Mastodon.
+
+> **These guides are very early stage – all participating designers are highly encouraged to shape and evolve these guidelines!**
+
+## 👋 Welcome
+
+We're thrilled you'd like to contribute design efforts towards Mastodon and would love to give you a brief guide on how to do so and where to find relevant resources.
+
+Mastodon is a free, open-source social network server where users can follow friends and discover new ones. On Mastodon, users can publish anything they want: links, pictures, text, video. 
+
+## 📖 Table of contents
+
+- [👋 Welcome](#-welcome)
+- [📖 Table of contents](#-table-of-contents)
+- [🚢 How to contribute design](#-how-to-contribute-design)
+- [🚀 Mastodon web](#-mastodon-web)
+  - [Target audience](#target-audience)
+  - [Design materials](#design-materials)
+  - [Fonts](#fonts)
+  - [Colors](#colors)
+- [📱 Mastodon mobile](#-mastodon-mobile)
+  - [Target audience](#target-audience-1)
+  - [Design materials](#design-materials-1)
+  - [Fonts](#fonts-1)
+  - [Colors](#colors-1)
+- [💅 Design relevant materials](#-design-relevant-materials)
+  - [Logos and Branding](#logos-and-branding)
+- [🎓 License](#-license)
+
+## 🚢 How to contribute design
+
+1. Check out open [issues](https://github.com/mastodon/mastodon/issues) here on GitHub (we label them with `design: required`)
+2. Feel free to open an issue on your own if you find something you would like to contribute to the project and use the `design: idea` label for it.
+3. Clone the public Figma/Penpot files (available below) or create new ones and make sure to **share them publicly**.
+4. Add your contributions to an issue and we promise we will review your contribution carefully and foster discussions
+
+## 🚀 Mastodon web
+
+Our web version can be found over here: https://joinmastodon.org
+You can create an account for free on a server of your choice, login and discover it on your own.
+
+The web version is a responsive, progressive WebApp – which you should keep in mind whenever you design for it.
+
+
+### Target audience
+
+> TBC
+
+### Design materials
+
+There are currently multiple efforts to replicate the current design and flows in Figma and Penpot. 
+We will update these documents while those resources evolve.
+
+### Fonts
+
+> TBC
+
+For now it seems we're using a custom font on the web which is mapped to Roboto 
+
+Roboto is available on Google Fonts:
+https://fonts.google.com/specimen/Roboto
+
+### Colors
+
+> TBC
+
+We'll provide a dedicated color palette for our themes very shortly... In the mean time please refer to our code, linked below.
+
+You can find a subset of our basic color tokens over here:
+https://github.com/mastodon/mastodon/blob/main/app/javascript/styles/contrast/variables.scss
+
+
+## 📱 Mastodon mobile
+
+We have two different native apps one for [iOS](https://apps.apple.com/us/app/mastodon-for-iphone/id1571998974) and one for [Android](https://play.google.com/store/apps/details?id=org.joinmastodon.android)
+
+Both of them have a separate home on GitHub (and therefor separate issues, userflows and designs)
+
+* [iOS](https://github.com/mastodon/mastodon-ios)
+* [Android](https://github.com/mastodon/mastodon-android)
+
+### Target audience
+
+> TBC
+
+### Design materials
+
+There are currently multiple efforts to replicate the current design and flows in Figma and Penpot. 
+We will update these documents while those resources evolve.
+
+### Fonts
+
+> TBC
+
+
+### Colors
+
+> TBC
+
+We'll provide a dedicated color palette for our themes very shortly... 
+
+In the mean time feel free to browse through our iOS and Android codebase for the colors.
+
+
+## 💅 Design relevant materials
+
+Here is a list of design relevant information and materials for Mastodon:
+
+### Logos and Branding
+
+You can find our Brand kit here:
+https://joinmastodon.org/branding
+
+
+## 🎓 License
+
+All design work is licensed under the
+[AGPL-3.0 license](https://github.com/mastodon/mastodon/blob/main/LICENSE)
+
+[(Back to top)](#-table-of-contents)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Code Climate](https://img.shields.io/codeclimate/maintainability/mastodon/mastodon.svg)][code_climate]
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/mastodon/localized.svg)][crowdin]
 [![Docker Pulls](https://img.shields.io/docker/pulls/tootsuite/mastodon.svg)][docker]
+[![contribute.design](https://contribute.design/api/shield/mastodon/mastodon)](https://contribute.design/mastodon/mastodon)
 
 [releases]: https://github.com/mastodon/mastodon/releases
 [circleci]: https://circleci.com/gh/mastodon/mastodon


### PR DESCRIPTION
A lot of discussions in [this repo](https://github.com/mastodon/mastodon/discussions/21967) but also all across Mastodon start to pop up - where loads of designers are eager to contribute to the design of Mastodon.

There are also quite some initiatives out there where multiple designers start to replicate the app(s) in Figma/Penpot to have a better starting point.

Since everyone is very clueless where to start or how to contribute I thought having a first set of contribution guidelines which are publicly accessible would be a great idea.

I tried to nail some specifics as good as possible and proposed a "process" which used to work pretty well in other Open Source projects which allow for design contributions. 

I'd love to have these guidelines in place, improve and extend them (heavily) as things evolve and allow the sheer immense influx of designers to participate in shaping an exceptional product :) 