### PR TITLE
Don't delivery a reply to domains which are blocked by author

### DIFF
--- a/app/lib/status_reach_finder.rb
+++ b/app/lib/status_reach_finder.rb
@@ -70,7 +70,7 @@ class StatusReachFinder
 
   def followers_inboxes
     if @status.in_reply_to_local_account? && distributable?
-      @status.account.followers.or(@status.thread.account.followers).inboxes
+      @status.account.followers.or(@status.thread.account.followers.not_domain_blocked_by_account(@status.account)).inboxes
     elsif @status.direct_visibility? || @status.limited_visibility?
       []
     else


### PR DESCRIPTION
Reply to a local user is leaked to author's blocked domains

This patch is written by @ClearlyClaire 