### PR TITLE
Fix moved account chains not being resolved (up to 5 moves)

### DIFF
--- a/app/services/activitypub/fetch_remote_account_service.rb
+++ b/app/services/activitypub/fetch_remote_account_service.rb
@@ -2,7 +2,7 @@
 
 class ActivityPub::FetchRemoteAccountService < ActivityPub::FetchRemoteActorService
   # Does a WebFinger roundtrip on each call, unless `only_key` is true
-  def call(uri, id: true, prefetched_body: nil, break_on_redirect: false, only_key: false, suppress_errors: true, request_id: nil)
+  def call(uri, **options)
     actor = super
     return actor if actor.nil? || actor.is_a?(Account)
 

--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -277,7 +277,7 @@ class ActivityPub::ProcessAccountService < BaseService
 
   def moved_account
     account   = ActivityPub::TagManager.instance.uri_to_resource(@json['movedTo'], Account)
-    account ||= ActivityPub::FetchRemoteAccountService.new.call(@json['movedTo'], id: true, break_on_redirect: true, request_id: @options[:request_id])
+    account ||= ActivityPub::FetchRemoteAccountService.new.call(@json['movedTo'], id: true, redirect_depth: @options.fetch(:redirect_depth, 0) + 1, request_id: @options[:request_id])
     account
   end
 


### PR DESCRIPTION
When an account is moved to an account that is itself moved to another account, Mastodon currently aborts fetching the second account and considers the account as not having moved.

Instead of breaking on the second redirect, break after 5 redirects.

The initial `break_on_redirect` behavior has been introduced to fix an infinite loop (#8051). This occurred because the account was not saved to database before fetching the moved-to account, so a loop was possible, but it has since changed.

Removing `break_on_redirect` altogether would have been “safe”, since the 400 accounts discovery limit set in #22025 would have kicked in, but 400 recursive discoveries would have been too much for synchronous queries, so arbitrary limit to 5 instead. Another possibility would be to synchronously request the first few redirects and defer the remaining to a background job.