### PR TITLE
Add command to remove avatar and header images of inactive remote accounts from the local database

### DIFF
--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -184,6 +184,58 @@ module Mastodon
       say("Removed #{removed} orphans (approx. #{number_to_human_size(reclaimed_bytes)})#{dry_run}", :green, true)
     end
 
+    option :days, type: :numeric, default: 60, aliases: [:d]
+    option :skip_avatars, type: :boolean, default: false
+    option :include_follows, type: :boolean, default: false
+    option :concurrency, type: :numeric, default: 5, aliases: [:c]
+    option :verbose, type: :boolean, default: false, aliases: [:v]
+    option :dry_run, type: :boolean, default: false
+    desc 'remove-profile-media', 'Remove profile media files (headers, avatars)'
+    long_desc <<-DESC
+      Removes locally cached copies of profile headers and avatars. By default,
+      only accounts that are not followed by or following anyone locally are
+      pruned.
+      The --days option specifies how old the last webfinger request and update
+      to the user has to be before they are pruned. It defaults to 60 days.
+      If --skip_avatars is specified, avatars are not removed.
+      If --include_follows is specified, all non-local accounts will be pruned
+      irrespective of follow status.
+    DESC
+    def remove_profile_media
+      time_ago        = options[:days].days.ago
+      dry_run         = options[:dry_run] ? ' (DRY RUN)' : ''
+      include_follows = options[:include_follows]
+
+      purged_accounts = Concurrent::Set[]
+      processed, aggregate = parallelize_with_progress(
+        Account.where({ last_webfingered_at: Time.zone.at(0)..time_ago,
+          updated_at: Time.zone.at(0)..time_ago }).left_outer_joins(:user).where(users: { id: nil })
+      ) do |account|
+        next if account.local?
+        next if account.avatar.blank? && account.header.blank?
+        next if !include_follows && Follow.where(account: account).or(Follow.where(target_account: account)).count.positive?
+
+        purged_accounts << account.url
+        size = (account.header_file_size || 0)
+        size += (account.avatar_file_size || 0) unless options[:skip_avatars]
+        unless options[:dry_run]
+          account.header.destroy
+          account.avatar.destroy unless options[:skip_avatars]
+          account.save!
+        end
+
+        size
+      end
+
+      if options[:verbose] && !purged_accounts.empty?
+        say('List of purged accounts:')
+        purged_accounts.each do |url|
+          say(url.to_s)
+        end
+      end
+      say("Visited #{processed} accounts, and removed profile media from #{purged_accounts.size} accounts totaling #{number_to_human_size(aggregate)}#{dry_run}", :green)
+    end
+
     option :account, type: :string
     option :domain, type: :string
     option :status, type: :numeric


### PR DESCRIPTION
This implements a new sub-command for `tootctl media` called `remove-profile-media` to remove avatar and header images of remote accounts that appear inactive from the local database.

Fixes https://github.com/mastodon/mastodon/issues/9567 : absence of method to remove avatar and header images, leading to excessive disk usage. 

This PR is just a slight modification of https://github.com/mastodon/mastodon/pull/21066 by @dunkelstern, which was withdrawn by the author since `last_webfingered_at` was not a satisfactory way to determine old accounts. While imperfect, the existing `tootctl accounts cull` uses `updated_at` and `last_webfingered_at`. Maybe it is the best one can do? 

I have also added an option which lets one keep avatars.

All credit to @dunkelstern , I am just desperate to clear my storage and it looks like there are others like me who could use this too!
