### PR TITLE
app/workers: add JitteredRetryIn, use in UnfollowFollowWorker

### DIFF
--- a/app/workers/concerns/jittered_retry_in.rb
+++ b/app/workers/concerns/jittered_retry_in.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module JitteredRetryIn
+  extend ActiveSupport::Concern
+
+  included do
+    sidekiq_retry_in do |count|
+      # This is the same as the default Sidekiq implementation of delay_for,
+      # but with a random 50% more jitter.
+      ((15 + count**4) * (1 + rand(0..0.5))).floor
+    end
+  end
+end

--- a/app/workers/unfollow_follow_worker.rb
+++ b/app/workers/unfollow_follow_worker.rb
@@ -2,6 +2,7 @@
 
 class UnfollowFollowWorker
   include Sidekiq::Worker
+  include JitteredRetryIn
 
   sidekiq_options queue: 'pull'
 


### PR DESCRIPTION
This adds the JitteredRetryIn concern, which adds a random amount of jitter to the retry time for a failed job. The implementation matches that of the default Sidekiq retry time, plus an additional jitter of up to 50% of the retry time.

We then use this in UnfollowFollowWorker to jitter retries; this should help with cases where users with many followers migrate to a smaller server. Without jitter, hundreds or thousands of jobs are scheduled at the same time, some number of them succeed or fail, and then the failed ones all retry at exactly the same time, DoS-ing the target server.

Feedback appreciated on whether this is the right approach!

