### PR TITLE
config/locales: Note app always disclosed to author

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -206,7 +206,7 @@ en:
         setting_hide_network: Hide your social graph
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
-        setting_show_application: Disclose application used to send posts
+        setting_show_application: Disclose application used to send posts. The author of the post can always see what app was used, to detect app misuse
         setting_system_font_ui: Use system's default font
         setting_theme: Site theme
         setting_trends: Show today's trends


### PR DESCRIPTION
Context:

![image](https://user-images.githubusercontent.com/1130872/206549702-b155ff2a-c8d7-4d31-b4d5-aedc4bbfa33d.png)

I thought that perhaps there was an issue when I had this box unchecked but still saw the app used. I then saw in https://github.com/mastodon/mastodon/issues/13091 where @Gargron noted that an author can always see what app was used to detect misuse.

This PR adds that note as a string for additional clarification in case helpful.