### PR TITLE
Fix missing link style in warning and strike cards

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1665,6 +1665,15 @@ a.sparkline {
   box-sizing: border-box;
   min-height: 100%;
 
+  a {
+    text: &highlight-text-color;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
   p {
     margin-bottom: 20px;
     unicode-bidi: plaintext;


### PR DESCRIPTION
Originally discovered in https://github.com/glitch-soc/mastodon/pull/1999, but also exists upstream, so fix proposed here.

# Issue
If a warning is issued that contains a link, no style is applied to it, and the default link-blue is used, which is nigh-unreadable on the dark mastodon background.

