### PR TITLE
Escape domain names before building regex string

### DIFF
--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -97,7 +97,7 @@ module Mastodon
       failed          = Concurrent::AtomicFixnum.new(0)
       start_at        = Time.now.to_f
       seed            = start ? [start] : Instance.pluck(:domain)
-      blocked_domains = Regexp.new('\\.?' + DomainBlock.where(severity: 1).pluck(:domain).join('|') + '$')
+      blocked_domains = Regexp.new('\\.?' + DomainBlock.where(severity: 1).pluck(:domain).map {|d| Regexp.escape(d)}.join('|') + '$')
       progress        = create_progress_bar
 
       pool = Concurrent::ThreadPoolExecutor.new(min_threads: 0, max_threads: options[:concurrency], idletime: 10, auto_terminate: true, max_queue: 0)

--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -97,7 +97,7 @@ module Mastodon
       failed          = Concurrent::AtomicFixnum.new(0)
       start_at        = Time.now.to_f
       seed            = start ? [start] : Instance.pluck(:domain)
-      blocked_domains = Regexp.new("\\.?#{ DomainBlock.where(severity: 1).pluck(:domain).map { |d| Regexp.escape(d) }.join('|') }$")
+      blocked_domains = Regexp.new("\\.?#{DomainBlock.where(severity: 1).pluck(:domain).map { |d| Regexp.escape(d) }.join('|')}$")
       progress        = create_progress_bar
 
       pool = Concurrent::ThreadPoolExecutor.new(min_threads: 0, max_threads: options[:concurrency], idletime: 10, auto_terminate: true, max_queue: 0)

--- a/lib/mastodon/domains_cli.rb
+++ b/lib/mastodon/domains_cli.rb
@@ -97,7 +97,7 @@ module Mastodon
       failed          = Concurrent::AtomicFixnum.new(0)
       start_at        = Time.now.to_f
       seed            = start ? [start] : Instance.pluck(:domain)
-      blocked_domains = Regexp.new('\\.?' + DomainBlock.where(severity: 1).pluck(:domain).map {|d| Regexp.escape(d)}.join('|') + '$')
+      blocked_domains = Regexp.new("\\.?#{ DomainBlock.where(severity: 1).pluck(:domain).map { |d| Regexp.escape(d) }.join('|') }$")
       progress        = create_progress_bar
 
       pool = Concurrent::ThreadPoolExecutor.new(min_threads: 0, max_threads: options[:concurrency], idletime: 10, auto_terminate: true, max_queue: 0)


### PR DESCRIPTION
Fixes: https://github.com/mastodon/mastodon/issues/22180 (tootctl domains crawl terminates with unhandled errors and no result)

Strings from the blocked domains list are concatenated into a regex string without escaping. If the domain entry is something like `"*.example.org"`, this leads to an invalid regex syntax like `...|Blabla.com|*example.org|...` and causes `tootctl domains crawl` to fail.

Escaping the domain strings with `Regexp.escape` prevents this issue.

It also fixes another problem: If a blocked domain is `"social.example.org"`, the `"."` characters would remain unescaped too, matching any character so a domain like `social-example.org` would incorrectly match.
