### PR TITLE
Fix weird hash when updating account fields

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -312,7 +312,6 @@ class Account < ApplicationRecord
         next if attr[:name].blank?
         fields << persist_verified_at(attr, old_fields)
       end
-      self[:fields] = fields
     elsif attributes.is_a?(Array)
       attributes.each do |attr|
         next if attr[:name].blank?

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -304,11 +304,9 @@ class Account < ApplicationRecord
 
   def fields_attributes=(attributes)
     fields     = []
-    old_fields = self[:fields] || []
-    old_fields = [] if old_fields.is_a?(Hash)
-
-    if attributes.is_a?(Hash)
-      attributes.each_value do |attr|
+    old_fields = self[:fields]
+    if attributes.is_a?(Array)
+      attributes.each do |attr|
         next if attr[:name].blank?
 
         previous = old_fields.find { |item| item['value'] == attr[:value] }
@@ -320,7 +318,7 @@ class Account < ApplicationRecord
         fields << attr
       end
     end
-
+        
     self[:fields] = fields
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -325,7 +325,7 @@ class Account < ApplicationRecord
   def persist_verified_at(attr, old_fields)
     previous = old_fields.find { |item| item['value'] == attr[:value] }
 
-    if previous['verified_at']&.present?
+    if previous && previous['verified_at'].present?
       attr[:verified_at] = previous['verified_at']
     end
 


### PR DESCRIPTION
After seeing #22174 and #22146 if find it weird to pass fields_attributes in this format since we are not using the integer index
```
{
  "fields_attributes": {
    "0": {
      "name": "Website",
      "value": "https://trwnh.com"
    },
    "1": {
      "name": "Sponsor",
      "value": "https://liberapay.com/at"
    },
    // ...
  }
}
```
I refactored the code to use this format 

```
{
  "fields_attributes": [
    {
      "name": "Website",
      "value": "https://trwnh.com"
    },
    {
      "name": "Sponsor",
      "value": "https://liberapay.com/at"
    },
    // ...
  ]
}
```