### PR TITLE
Add warning for composing public posts on #FediBlock

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/warning_container.js
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.js
@@ -38,9 +38,9 @@ const buildProtectedTagRE = () => {
     return new RegExp(
       '(?:^|[^\\/\\)\\w])#(' +
       PROTECTED_TAGS.join('|') +
-      ')(?:$|' + 
+      ')(?:$|' +
       '[^' + WORD + HASHTAG_SEPARATORS + ']' +
-      ')', 'iu'
+      ')', 'iu',
     );
   } catch (error) {
     return new RegExp(`?:^|[^\/\)\w])#(${PROTECTED_TAGS.join('|')})(?:$|[^\w·])`, 'i');
@@ -56,7 +56,7 @@ const mapStateToProps = state => ({
   directMessageWarning: state.getIn(['compose', 'privacy']) === 'direct',
 });
 
-const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning }) => {
+const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning, protectedHashtagWarning }) => {
   if (needsLockWarning) {
     return <Warning message={<FormattedMessage id='compose_form.lock_disclaimer' defaultMessage='Your account is not {locked}. Anyone can follow you to view your follower-only posts.' values={{ locked: <a href='/settings/profile'><FormattedMessage id='compose_form.lock_disclaimer.lock' defaultMessage='locked' /></a> }} />} />;
   }
@@ -66,7 +66,7 @@ const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning
   }
 
   if (protectedHashtagWarning) {
-    return <Warning message={<FormattedMessage id='compose_form.protected_tag_warning' defaultMessage="One of these hashtags is conventionally reserved for a specific purpose. Make sure that you understand this purpose before posting publicly." />} />;
+    return <Warning message={<FormattedMessage id='compose_form.protected_tag_warning' defaultMessage='One of these hashtags is conventionally reserved for a specific purpose. Make sure that you understand this purpose before posting publicly.' />} />;
   }
 
   if (directMessageWarning) {
@@ -85,6 +85,7 @@ const WarningWrapper = ({ needsLockWarning, hashtagWarning, directMessageWarning
 WarningWrapper.propTypes = {
   needsLockWarning: PropTypes.bool,
   hashtagWarning: PropTypes.bool,
+  protectedHashtagWarning: PropTypes.bool,
   directMessageWarning: PropTypes.bool,
 };
 

--- a/app/javascript/mastodon/locales/en-GB.json
+++ b/app/javascript/mastodon/locales/en-GB.json
@@ -128,6 +128,7 @@
   "compose_form.direct_message_warning_learn_more": "Learn more",
   "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any sensitive information over Mastodon.",
   "compose_form.hashtag_warning": "This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag.",
+  "compose_form.protected_tag_warning": "One of these hashtags is conventionally reserved for a specific purpose. Make sure that you understand this purpose before posting publicly.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",
   "compose_form.placeholder": "What's on your mind?",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -128,6 +128,7 @@
   "compose_form.direct_message_warning_learn_more": "Learn more",
   "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any sensitive information over Mastodon.",
   "compose_form.hashtag_warning": "This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag.",
+  "compose_form.protected_tag_warning": "One of these hashtags is conventionally reserved for a specific purpose. Make sure that you understand this purpose before posting publicly.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",
   "compose_form.placeholder": "What's on your mind?",


### PR DESCRIPTION
Example code for #22195

The `#FediBlock` hashtag is well-established as an informal channel for discussing potential defederation choices with other admins. It is a feature that anyone can post to it, but it's easy for new folks to reference the tag for purposes other than its intended purpose.

In a similar vein to the existing warnings in the web UI that let users know they might be about to, say, post privately to hashtags, or post "privately" when unlocked, a soft warning indicating that they are posting to a functional hashtag feels (to me) like the appropriate level of gatekeeping.

While this is motivated by the `#FediBlock` tag, I've written this with the intention of potential future extension to other functional hashtags, as necessary.

I've not complete i18n steps as I wasn't sure if the core idea would be welcomed.

## The RegEx ##

I've tried to follow the existing standard, with the extension here that we mustn't match with hashtags that extend past the string we're looking for. Examples below:

**Should match:**

 #FediBlock 
 .#FediBlock
 #FediBlock-d

**Shouldn't match:**

#FediBlockMeta 
, #FediBlock_foo
#FediBlock1
My#FediBlock,
#_FediBlock 
#FediBlock·A
Check this out https://medium.com/@alice/some-article#FediBlock23
https://en.wikipedia.org/wiki/Ghostbusters_(song)#FediBlock

