### PR TITLE
Add noindex setting to Admin settings Discovery page

### DIFF
--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -26,6 +26,9 @@
   .fields-group
     = f.input :timeline_preview, as: :boolean, wrapper: :with_label
 
+  .fields-group
+    = f.input :noindex, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_noindex.title'), hint: t('admin.settings.default_noindex.desc_html')
+
   %h4= t('admin.settings.discovery.follow_recommendations')
 
   .fields-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -704,6 +704,9 @@ en:
       content_retention:
         preamble: Control how user-generated content is stored in Mastodon.
         title: Content retention
+      default_noindex:
+        desc_html: Affects all users who have not changed this setting themselves
+        title: Opt users out of search engine indexing by default
       discovery:
         follow_recommendations: Follow recommendations
         preamble: Surfacing interesting content is instrumental in onboarding new users who may not know anyone Mastodon. Control how various discovery features work on your server.


### PR DESCRIPTION
Fixes #22203, "Opt users out of search engine indexing by default" admin setting missing.

The setting itself was forgotten when the new admin pages were redesigned, and the `default_noindex` i18n was removed in October sometime.

This replaces the admin setting.