### PR TITLE
Set up Docker compose for development with minimal changes

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,103 @@
+# syntax=docker/dockerfile:1.4
+
+# This file is referenced in docker-compose.dev.yml
+# Mostly same as Dockerfile which is meant for production
+# Only differences:
+# "development" group of gems is installed instead of "production"
+# And RAILS_ENV and NODE_ENV are set to "development" instead of "production"
+
+# This needs to be bullseye-slim because the Ruby image is built on bullseye-slim
+ARG NODE_VERSION="16.17.1-bullseye-slim"
+
+FROM ghcr.io/moritzheiber/ruby-jemalloc:3.0.4-slim as ruby
+FROM node:${NODE_VERSION} as build
+
+COPY --link --from=ruby /opt/ruby /opt/ruby
+
+ENV DEBIAN_FRONTEND="noninteractive" \
+    PATH="${PATH}:/opt/ruby/bin"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+WORKDIR /opt/mastodon
+COPY Gemfile* package.json yarn.lock /opt/mastodon/
+
+RUN apt update && \
+    apt-get install -y --no-install-recommends build-essential \
+        ca-certificates \
+        git \
+        libicu-dev \
+        libidn11-dev \
+        libpq-dev \
+        libjemalloc-dev \
+        zlib1g-dev \
+        libgdbm-dev \
+        libgmp-dev \
+        libssl-dev \
+        libyaml-0-2 \
+        ca-certificates \
+        libreadline8 \
+        python3 \
+        shared-mime-info && \
+    bundle config set --local deployment 'true' && \
+    bundle config set --local without 'production test' && \
+    bundle config set silence_root_warning true && \
+    bundle install -j"$(nproc)" && \
+    yarn install --pure-lockfile
+
+FROM node:${NODE_VERSION}
+
+ARG UID="991"
+ARG GID="991"
+
+COPY --link --from=ruby /opt/ruby /opt/ruby
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND="noninteractive" \
+    PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
+
+RUN apt-get update && \
+    echo "Etc/UTC" > /etc/localtime && \
+    groupadd -g "${GID}" mastodon && \
+    useradd -u "$UID" -g "${GID}" -m -d /opt/mastodon mastodon && \
+    apt-get -y --no-install-recommends install whois \
+        wget \
+        procps \
+        libssl1.1 \
+        libpq5 \
+        imagemagick \
+        ffmpeg \
+        libjemalloc2 \
+        libicu67 \
+        libidn11 \
+        libyaml-0-2 \
+        file \
+        ca-certificates \
+        tzdata \
+        libreadline8 \
+        tini && \
+    ln -s /opt/mastodon /mastodon
+
+# Note: no, cleaning here since Debian does this automatically
+# See the file /etc/apt/apt.conf.d/docker-clean within the Docker image's filesystem
+
+COPY --chown=mastodon:mastodon . /opt/mastodon
+COPY --chown=mastodon:mastodon --from=build /opt/mastodon /opt/mastodon
+
+ENV RAILS_ENV="development" \
+    NODE_ENV="development" \
+    RAILS_SERVE_STATIC_FILES="true" \
+    BIND="0.0.0.0"
+
+# Set the run user
+USER mastodon
+WORKDIR /opt/mastodon
+
+# Precompile assets
+RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile && \
+    yarn cache clean
+
+# Set the work dir and the container entry point
+ENTRYPOINT ["/usr/bin/tini", "--"]
+EXPOSE 3000 4000

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,138 @@
+version: '3'
+services:
+  db:
+    restart: always
+    image: postgres:14-alpine
+    shm_size: 256mb
+    networks:
+      - internal_network
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-U', 'mastodon', '-d', 'mastodon_development']
+    volumes:
+      - ./postgres14:/var/lib/postgresql/data
+    environment:
+      - 'POSTGRES_HOST_AUTH_METHOD=trust'
+      - 'POSTGRES_USER=mastodon'
+      - 'POSTGRES_PASSWORD=mysecretpassword'
+      - 'POSTGRES_DB=mastodon_development'
+  redis:
+    restart: always
+    image: redis:7-alpine
+    networks:
+      - internal_network
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+    volumes:
+      - ./redis:/data
+
+  # es:
+  #   restart: always
+  #   image: docker.elastic.co/elasticsearch/elasticsearch:7.17.4
+  #   environment:
+  #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Des.enforce.bootstrap.checks=true"
+  #     - "xpack.license.self_generated.type=basic"
+  #     - "xpack.security.enabled=false"
+  #     - "xpack.watcher.enabled=false"
+  #     - "xpack.graph.enabled=false"
+  #     - "xpack.ml.enabled=false"
+  #     - "bootstrap.memory_lock=true"
+  #     - "cluster.name=es-mastodon"
+  #     - "discovery.type=single-node"
+  #     - "thread_pool.write.queue_size=1000"
+  #   networks:
+  #      - external_network
+  #      - internal_network
+  #   healthcheck:
+  #      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+  #   volumes:
+  #      - ./elasticsearch:/usr/share/elasticsearch/data
+  #   ulimits:
+  #     memlock:
+  #       soft: -1
+  #       hard: -1
+  #     nofile:
+  #       soft: 65536
+  #       hard: 65536
+  #   ports:
+  #     - '127.0.0.1:9200:9200'
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    restart: always
+    env_file: .env.development
+    command: bash -c "rm -f /mastodon/tmp/pids/server.pid; bundle exec rails s -p 3000 -b 0.0.0.0"
+    networks:
+      - external_network
+      - internal_network
+    healthcheck:
+      # prettier-ignore
+      test: ['CMD-SHELL', 'wget -q --spider --proxy=off localhost:3000/health || exit 1']
+    ports:
+      - '127.0.0.1:3000:3000'
+    depends_on:
+      - db
+      - redis
+      # - es
+    volumes:
+      - ./public/system:/mastodon/public/system
+
+  streaming:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    restart: always
+    env_file: .env.development
+    command: node ./streaming
+    networks:
+      - external_network
+      - internal_network
+    healthcheck:
+      # prettier-ignore
+      test: ['CMD-SHELL', 'wget -q --spider --proxy=off localhost:4000/api/v1/streaming/health || exit 1']
+    ports:
+      - '127.0.0.1:4000:4000'
+    depends_on:
+      - db
+      - redis
+
+  sidekiq:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    restart: always
+    env_file: .env.development
+    command: bundle exec sidekiq
+    depends_on:
+      - db
+      - redis
+    networks:
+      - external_network
+      - internal_network
+    volumes:
+      - ./public/system:/mastodon/public/system
+    healthcheck:
+      test: ['CMD-SHELL', "ps aux | grep '[s]idekiq\ 6' || false"]
+
+  ## Uncomment to enable federation with tor instances along with adding the following ENV variables
+  ## http_proxy=http://privoxy:8118
+  ## ALLOW_ACCESS_TO_HIDDEN_SERVICE=true
+  # tor:
+  #   image: sirboops/tor
+  #   networks:
+  #      - external_network
+  #      - internal_network
+  #
+  # privoxy:
+  #   image: sirboops/privoxy
+  #   volumes:
+  #     - ./priv-config:/opt/config
+  #   networks:
+  #     - external_network
+  #     - internal_network
+
+networks:
+  external_network:
+  internal_network:
+    internal: true


### PR DESCRIPTION
This should fix #16747

Currently, docker-compose.yml is set up for production. And .env.production is NOT meant for Docker at all.

To get Docker-based development going without affecting either of the above settings, this PR adds a `docker-compose.dev.yml` file and a `Dockerfile.dev`. The corresponding config will have to go in `.env.development` which remains gitignored.

Here are the summary of changes:

- docker-compose.dev.yml
  - Postgres container is configured with explicit username, password and database name
  - Postgres healthcheck command is corrected
  - For `web`, `streaming`, and `sidekiq` services, build now refers to `Dockerfile.dev` and env_file refers to `.env.development`. References to pre-built images on Docker Hub are removed.
  - The web service is started with `-b 0.0.0.0`
- Dockerflie.dev
  - This is mostly similar to `Dockerfile` except that `RAILS_ENV` and `NODE_ENV` are set to "development"
  - "development" group of gems is installed instead of "production"

With this PR, you will need the following changes in your .env.development:

- LOCAL_DOMAIN=masto.local
- REDIS_HOST=redis
- DB_HOST=db
- DB_USER=mastodon
- DB_NAME=mastodon_development
- DB_PASS=mysecretpassword
- DB_PORT=5432
- ES_ENABLED=false
- S3_ENABLED=false

The steps to set up the development environment would be:

- Build the image with: `docker build -f Dockerfile.dev .`
- Clean the DB data with: `rm -rf ./postgres14/*`
- Start DB and Redis so that we can run Rails migrations: `docker compose -f docker-compose.dev.yml up -d db redis`
- Run Rails DB migrations: `docker compose -f docker-compose.dev.yml run --rm web bundle exec rake db:migrate`
- Now, all the services can be started with: `docker compose -f docker-compose.dev.yml up`
- Create an admin account and generate a random password with: `docker compose -f docker-compose.dev.yml run --rm web bundle exec bin/tootctl accounts create eshnil --email youremail@example.com --confirmed --role admin`
- Modify your `/etc/hosts` file so that `masto.local` points to 127.0.0.1
- Open http://masto.local:3000 and login with the above email/password
