### PR TITLE
Add single splat to callback method definitions to avoid ArgumentError

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,7 +11,7 @@ class UserMailer < Devise::Mailer
 
   helper RoutingHelper
 
-  def confirmation_instructions(user, token, **)
+  def confirmation_instructions(user, token, *, **)
     @resource = user
     @token    = token
     @instance = Rails.configuration.x.local_domain
@@ -25,7 +25,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def reset_password_instructions(user, token, **)
+  def reset_password_instructions(user, token, *, **)
     @resource = user
     @token    = token
     @instance = Rails.configuration.x.local_domain
@@ -37,7 +37,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def password_change(user, **)
+  def password_change(user, *, **)
     @resource = user
     @instance = Rails.configuration.x.local_domain
 
@@ -48,7 +48,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def email_changed(user, **)
+  def email_changed(user, *, **)
     @resource = user
     @instance = Rails.configuration.x.local_domain
 
@@ -59,7 +59,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def two_factor_enabled(user, **)
+  def two_factor_enabled(user, *, **)
     @resource = user
     @instance = Rails.configuration.x.local_domain
 
@@ -70,7 +70,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def two_factor_disabled(user, **)
+  def two_factor_disabled(user, *, **)
     @resource = user
     @instance = Rails.configuration.x.local_domain
 
@@ -81,7 +81,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def two_factor_recovery_codes_changed(user, **)
+  def two_factor_recovery_codes_changed(user, *, **)
     @resource = user
     @instance = Rails.configuration.x.local_domain
 
@@ -92,7 +92,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def webauthn_enabled(user, **)
+  def webauthn_enabled(user, *, **)
     @resource = user
     @instance = Rails.configuration.x.local_domain
 
@@ -103,7 +103,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def webauthn_disabled(user, **)
+  def webauthn_disabled(user, *, **)
     @resource = user
     @instance = Rails.configuration.x.local_domain
 


### PR DESCRIPTION
It looks like a [bug](https://bugs.ruby-lang.org/issues/18633) around autosplat is [fixed](https://bugs.ruby-lang.org/projects/ruby-master/repository/git/revisions/fbaadd1cfe7fbfd1b904f193f99d7c845a6ed804) on ruby-3.2.0-rc1 and breaks a test (but not on ruby <= 3.1.3):

```
$ bundle exec rspec ./spec/controllers/api/v1/emails/confirmations_controller_spec.rb:41
  :
  1) Api::V1::Emails::ConfirmationsController#create with an oauth token from an app that created the account when the account is already confirmed but user changed e-mail and has not confirmed it returns http success
     Failure/Error:
         def email_changed(user, **)
           @resource = user
           @instance = Rails.configuration.x.local_domain

           return unless @resource.active_for_authentication?

           I18n.with_locale(locale) do
             mail to: @resource.email, subject: I18n.t('devise.mailer.email_changed.subject')
           end
         end

     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./app/mailers/user_mailer.rb:51:in `email_changed'
     # ./app/models/user.rb:444:in `render_and_send_devise_message'
     # ./app/models/user.rb:430:in `block in send_pending_devise_notifications'
     # ./app/models/user.rb:429:in `each'
     # ./app/models/user.rb:429:in `send_pending_devise_notifications'
     # ./spec/controllers/api/v1/emails/confirmations_controller_spec.rb:38:in `block (7 levels) in <top (required)>'
```