### PR TITLE
Treat http 401 as not salvageable on AP delivery

### DIFF
--- a/app/helpers/jsonld_helper.rb
+++ b/app/helpers/jsonld_helper.rb
@@ -203,7 +203,7 @@ module JsonLdHelper
   end
 
   def response_error_unsalvageable?(response)
-    response.code == 501 || ((400...500).cover?(response.code) && ![401, 408, 429].include?(response.code))
+    response.code == 501 || ((400...500).cover?(response.code) && ![408, 429].include?(response.code))
   end
 
   def build_request(uri, on_behalf_of = nil)


### PR DESCRIPTION
On sidekiq log, DeliveryWorker was keep retrying on http 401 error.
But http 401 happens when remote target unfollowed/blocked/etc author. And it doesn't need to retry

It usually happens on this kind of situations
1. remote inbox down
2. DeliveryWorker fails with http 5xx or something and pushed into retry queue
3. remote inbox up again and they unfollow or block author
4. retry happens and getting http 401 again and again until it decays