### PR TITLE
Update redis_config.rb with shared defaults

### DIFF
--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -38,7 +38,10 @@ REDIS_CACHE_PARAMS = {
   pool_size: Sidekiq.server? ? Sidekiq.options[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
   pool_timeout: 5,
   connect_timeout: 5,
+  read_timeout: 1
+  write_timeout: 1,
   reconnect_attempts: 1,  # Defaults to 0
+  reconnect_delay: 0.1,
 }.freeze
 
 REDIS_SIDEKIQ_PARAMS = {
@@ -48,7 +51,10 @@ REDIS_SIDEKIQ_PARAMS = {
   pool_size: Sidekiq.server? ? Sidekiq.options[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
   pool_timeout: 5,
   connect_timeout: 5,
+  read_timeout: 1
+  write_timeout: 1,
   reconnect_attempts: 1,  # Defaults to 0
+  reconnect_delay: 0.1,
 }.freeze
 
 if Rails.env.test?

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -38,12 +38,17 @@ REDIS_CACHE_PARAMS = {
   pool_size: Sidekiq.server? ? Sidekiq.options[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
   pool_timeout: 5,
   connect_timeout: 5,
+  reconnect_attempts: 1,  # Defaults to 0
 }.freeze
 
 REDIS_SIDEKIQ_PARAMS = {
   driver: :hiredis,
   url: ENV['SIDEKIQ_REDIS_URL'],
   namespace: sidekiq_namespace,
+  pool_size: Sidekiq.server? ? Sidekiq.options[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
+  pool_timeout: 5,
+  connect_timeout: 5,
+  reconnect_attempts: 1,  # Defaults to 0
 }.freeze
 
 if Rails.env.test?

--- a/lib/mastodon/redis_config.rb
+++ b/lib/mastodon/redis_config.rb
@@ -38,7 +38,7 @@ REDIS_CACHE_PARAMS = {
   pool_size: Sidekiq.server? ? Sidekiq.options[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
   pool_timeout: 5,
   connect_timeout: 5,
-  read_timeout: 1
+  read_timeout: 1,
   write_timeout: 1,
   reconnect_attempts: 1,  # Defaults to 0
   reconnect_delay: 0.1,
@@ -51,7 +51,7 @@ REDIS_SIDEKIQ_PARAMS = {
   pool_size: Sidekiq.server? ? Sidekiq.options[:concurrency] : Integer(ENV['MAX_THREADS'] || 5),
   pool_timeout: 5,
   connect_timeout: 5,
-  read_timeout: 1
+  read_timeout: 1,
   write_timeout: 1,
   reconnect_attempts: 1,  # Defaults to 0
   reconnect_delay: 0.1,


### PR DESCRIPTION
RedisCacheStore: read_entry failed, returned nil: Redis::ConnectionError: Connection lost (ECONNRESET)
RedisCacheStore: delete_entry failed, returned false: Redis::ConnectionError: Connection lost (ECONNRESET)

I've been getting a few of these errors on and off. `reconnect_attempts: 1` might help resolve them. (I'm testing)

and I've also looked into the other redis variables
```
read_timeout: 1
write_timeout: 1
```
I've seen these timeouts as low as `0.2` but this can be validated and lowered if required.