### PR TITLE
Add: REDIS ENV to .env.production.sample

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -20,6 +20,9 @@ LOCAL_DOMAIN=example.com
 # -----
 REDIS_HOST=localhost
 REDIS_PORT=6379
+REDIS_DB=
+REDIS_PASSWORD=
+REDIS_URL=
 
 # PostgreSQL
 # ----------


### PR DESCRIPTION
We can set `REDIS_DB` `REDIS_PASSWORD` `REDIS_URL` to `.env.production`.
However sample file doesn't contain them.
Adding value should help admins set up.