### PR TITLE
Disable ElasticSearch for AccountSearchService spec to make tests pass locally

### DIFF
--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
-describe AccountSearchService, type: :service do
-  around :each do |example|
-    old_setting = Chewy.settings[:enabled]
-    Chewy.settings[:enabled] = false
-    example.run
-    Chewy.settings[:enabled] = old_setting
-  end
+describe AccountSearchService, type: :service, disable_chewy: true do
 
   describe '#call' do
     context 'with a query to ignore' do

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 describe AccountSearchService, type: :service do
+  around :each do |example|
+    old_setting = Chewy.settings[:enabled]
+    Chewy.settings[:enabled] = false
+    example.run
+    Chewy.settings[:enabled] = old_setting
+  end
+
   describe '#call' do
     context 'with a query to ignore' do
       it 'returns empty array for missing query' do

--- a/spec/support/helpers/chewy_spec_helpers.rb
+++ b/spec/support/helpers/chewy_spec_helpers.rb
@@ -1,0 +1,22 @@
+module ChewySpecHelpers
+  def with_chewy_disabled(&block)
+    with_chewy_settings(enabled: false, &block)
+  end
+  def with_chewy_settings(new_settings)
+    old_settings = Chewy.settings
+    merged_settings = old_settings.merge(new_settings)
+    Chewy.settings  = merged_settings
+    yield
+  ensure
+    Chewy.settings = old_settings
+  end
+end
+
+RSpec.configure do |config|
+  config.include ChewySpecHelpers, type: :service
+  config.around :each, type: :service, disable_chewy: true do |example|
+    with_chewy_disabled do 
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
Out of the box, if ElasticSearch is available, the AccountSearchService spec will try to use it, and some of the examples will fail. This change explicitly disables Chewy in a localized way.

I'm not sure this is the RIGHT way to do it. I don't think any of the specs rely on ES, so it might make more sense to globally disable Chewy in the spec helper?