### PR TITLE
Fix invalid CSS for links in warning and strike cards

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -1666,7 +1666,7 @@ a.sparkline {
   min-height: 100%;
 
   a {
-    text: &highlight-text-color;
+    color: $highlight-text-color;
     text-decoration: none;
 
     &:hover {


### PR DESCRIPTION
Follow-up to #22177, I'm not quite sure how I let that slip through, sorry.