### PR TITLE
Fix situations in which instance actor can be set to a Mastodon-incompatible name

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -84,8 +84,8 @@ class Account < ApplicationRecord
   validates :username, presence: true
   validates_with UniqueUsernameValidator, if: -> { will_save_change_to_username? }
 
-  # Remote user validations
-  validates :username, format: { with: USERNAME_ONLY_RE }, if: -> { !local? && will_save_change_to_username? }
+  # Remote user validations, also applies to internal actors
+  validates :username, format: { with: USERNAME_ONLY_RE }, if: -> { (!local? || actor_type == 'Application') && will_save_change_to_username? }
 
   # Local user validations
   validates :username, format: { with: /\A[a-z0-9_]+\z/i }, length: { maximum: 30 }, if: -> { local? && will_save_change_to_username? && actor_type != 'Application' }

--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -13,7 +13,9 @@ module AccountFinderConcern
     end
 
     def representative
-      Account.find(-99).tap(&:ensure_keys!)
+      actor = Account.find(-99).tap(&:ensure_keys!)
+      actor.update!(username: 'internal.actor') if actor.username.include?(':')
+      actor
     rescue ActiveRecord::RecordNotFound
       Account.create!(id: -99, actor_type: 'Application', locked: true, username: 'internal.actor')
     end

--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -15,7 +15,7 @@ module AccountFinderConcern
     def representative
       Account.find(-99).tap(&:ensure_keys!)
     rescue ActiveRecord::RecordNotFound
-      Account.create!(id: -99, actor_type: 'Application', locked: true, username: Rails.configuration.x.local_domain)
+      Account.create!(id: -99, actor_type: 'Application', locked: true, username: 'internal.actor')
     end
 
     def find_local(username)

--- a/app/models/concerns/account_finder_concern.rb
+++ b/app/models/concerns/account_finder_concern.rb
@@ -14,10 +14,10 @@ module AccountFinderConcern
 
     def representative
       actor = Account.find(-99).tap(&:ensure_keys!)
-      actor.update!(username: 'internal.actor') if actor.username.include?(':')
+      actor.update!(username: 'mastodon.internal') if actor.username.include?(':')
       actor
     rescue ActiveRecord::RecordNotFound
-      Account.create!(id: -99, actor_type: 'Application', locked: true, username: 'internal.actor')
+      Account.create!(id: -99, actor_type: 'Application', locked: true, username: 'mastodon.internal')
     end
 
     def find_local(username)

--- a/db/seeds/02_instance_actor.rb
+++ b/db/seeds/02_instance_actor.rb
@@ -1,1 +1,1 @@
-Account.create_with(actor_type: 'Application', locked: true, username: ENV['LOCAL_DOMAIN'] || Rails.configuration.x.local_domain).find_or_create_by(id: -99)
+Account.create_with(actor_type: 'Application', locked: true, username: 'internal.actor').find_or_create_by(id: -99)

--- a/db/seeds/02_instance_actor.rb
+++ b/db/seeds/02_instance_actor.rb
@@ -1,1 +1,1 @@
-Account.create_with(actor_type: 'Application', locked: true, username: 'internal.actor').find_or_create_by(id: -99)
+Account.create_with(actor_type: 'Application', locked: true, username: 'mastodon.internal').find_or_create_by(id: -99)


### PR DESCRIPTION
Fixes #20820

- instead of using `instance-name@instance-name`, use `internal.actor@instance-name` for the name of new instance actors, this still makes the instance actor use a name that can't be used by local user
- validate actor name to catch such issues
- automatically reset the instance actor name if it is found to include a `:`, as it would be incompatible with most of the existing fediverse