### PR TITLE
Allow adding relays while secure mode & limited federation mode are enabled

### DIFF
--- a/app/controllers/admin/relays_controller.rb
+++ b/app/controllers/admin/relays_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class RelaysController < BaseController
     before_action :set_relay, except: [:index, :new, :create]
-    before_action :require_signatures_enabled!, only: [:new, :create, :enable]
+    before_action :warn_signatures_not_enabled!, only: [:new, :create, :enable]
 
     def index
       authorize :relay, :update?
@@ -56,8 +56,8 @@ module Admin
       params.require(:relay).permit(:inbox_url)
     end
 
-    def require_signatures_enabled!
-      redirect_to admin_relays_path, alert: I18n.t('admin.relays.signatures_not_enabled') if authorized_fetch_mode?
+    def warn_signatures_not_enabled!
+      flash.now[:error] = I18n.t('admin.relays.signatures_not_enabled') if authorized_fetch_mode?
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -555,7 +555,7 @@ en:
       pending: Waiting for relay's approval
       save_and_enable: Save and enable
       setup: Setup a relay connection
-      signatures_not_enabled: Relays will not work correctly while secure mode or limited federation mode is enabled
+      signatures_not_enabled: Relays may not work correctly while secure mode or limited federation mode is enabled
       status: Status
       title: Relays
     report_notes:


### PR DESCRIPTION
Most current fediverse relay software can convert Creates to Announces, meaning that LD Signatures are not required for relay operation.

This change allows Mastodon instances to add a relay while in secure mode or limited federation mode.