### PR TITLE
Remove needlessly specific Ruby/Bundler versions from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -877,9 +877,3 @@ DEPENDENCIES
   webpacker (~> 5.4)
   webpush!
   xorcist (~> 1.1)
-
-RUBY VERSION
-   ruby 3.0.4p208
-
-BUNDLED WITH
-   2.2.33


### PR DESCRIPTION
This has caused issues in the past.