### PR TITLE
Downgrade Node.js requirement to 14+

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Mastodon acts as an OAuth2 provider, so 3rd party apps can use the REST and Stre
 - **PostgreSQL** 9.5+
 - **Redis** 4+
 - **Ruby** 2.7+
-- **Node.js** 16+
+- **Node.js** 14+
 
 The repository includes deployment configurations for **Docker and docker-compose** as well as specific platforms like **Heroku**, **Scalingo**, and **Nanobox**. The [**standalone** installation guide](https://docs.joinmastodon.org/admin/install/) is available in the documentation.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mastodon/mastodon",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "scripts": {
     "postversion": "git push --tags",


### PR DESCRIPTION
I don't think there was anything warranting bumping the minimum required version just yet.