### PR TITLE
Fix possible race conditions when suspending/unsuspending accounts

### DIFF
--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -3,10 +3,13 @@
 class SuspendAccountService < BaseService
   include Payloadable
 
+  # Carry out the suspension of a recently-suspended account
+  # @param [Account] account Account to suspend
   def call(account)
+    return unless account.suspended?
+
     @account = account
 
-    suspend!
     reject_remote_follows!
     distribute_update_actor!
     unmerge_from_home_timelines!
@@ -15,10 +18,6 @@ class SuspendAccountService < BaseService
   end
 
   private
-
-  def suspend!
-    @account.suspend! unless @account.suspended?
-  end
 
   def reject_remote_follows!
     return if @account.local? || !@account.activitypub?

--- a/app/services/unsuspend_account_service.rb
+++ b/app/services/unsuspend_account_service.rb
@@ -2,10 +2,12 @@
 
 class UnsuspendAccountService < BaseService
   include Payloadable
+
+  # Restores a recently-unsuspended account
+  # @param [Account] account Account to restore
   def call(account)
     @account = account
 
-    unsuspend!
     refresh_remote_account!
 
     return if @account.nil? || @account.suspended?
@@ -17,10 +19,6 @@ class UnsuspendAccountService < BaseService
   end
 
   private
-
-  def unsuspend!
-    @account.unsuspend! if @account.suspended?
-  end
 
   def refresh_remote_account!
     return if @account.local?

--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe SuspendAccountService, type: :service do
 
       local_follower.follow!(account)
       list.accounts << account
+
+      account.suspend!
     end
 
     it "unmerges from local followers' feeds" do
@@ -21,8 +23,8 @@ RSpec.describe SuspendAccountService, type: :service do
       expect(FeedManager.instance).to have_received(:unmerge_from_list).with(account, list)
     end
 
-    it 'marks account as suspended' do
-      expect { subject }.to change { account.suspended? }.from(false).to(true)
+    it 'does not change the “suspended” flag' do
+      expect { subject }.to_not change { account.suspended? }
     end
   end
 

--- a/spec/services/unsuspend_account_service_spec.rb
+++ b/spec/services/unsuspend_account_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe UnsuspendAccountService, type: :service do
       local_follower.follow!(account)
       list.accounts << account
 
-      account.suspend!(origin: :local)
+      account.unsuspend!
     end
   end
 
@@ -30,8 +30,8 @@ RSpec.describe UnsuspendAccountService, type: :service do
       stub_request(:post, 'https://bob.com/inbox').to_return(status: 201)
     end
 
-    it 'marks account as unsuspended' do
-      expect { subject }.to change { account.suspended? }.from(true).to(false)
+    it 'does not change the “suspended” flag' do
+      expect { subject }.to_not change { account.suspended? }
     end
 
     include_examples 'common behavior' do
@@ -83,8 +83,8 @@ RSpec.describe UnsuspendAccountService, type: :service do
           expect(FeedManager.instance).to have_received(:merge_into_list).with(account, list)
         end
 
-        it 'marks account as unsuspended' do
-          expect { subject }.to change { account.suspended? }.from(true).to(false)
+        it 'does not change the “suspended” flag' do
+          expect { subject }.to_not change { account.suspended? }
         end
       end
 
@@ -107,8 +107,8 @@ RSpec.describe UnsuspendAccountService, type: :service do
           expect(FeedManager.instance).to_not have_received(:merge_into_list).with(account, list)
         end
 
-        it 'does not mark the account as unsuspended' do
-          expect { subject }.not_to change { account.suspended? }
+        it 'marks account as suspended' do
+          expect { subject }.to change { account.suspended? }.from(false).to(true)
         end
       end
 


### PR DESCRIPTION
Currently, when suspending or unsuspending an account, the `suspended_at` flag is immediately updated, and the heavy work is performed in a background job. However, the background job sets the flag again (losing suspension origin in the process!) if it isn't set, which can lead to surprising and unwanted results: if an account is unsuspended before the suspension worker runs:
- in the best case scenario, the account will be suspended then promptly unsuspended by the unsuspension worker, the long-time result is not an issue, but there will be extra work and a time window in which the account will be marked as suspended for no good reason
- in the case where the suspension and unsuspension worker are picked up by different processes at the same time, the result is undefined
- in cases where the suspension or unsuspension workers fail for some reason, they will re-set the flag at each attempt, causing a highly confusing behavior (account re-suspended even though admins unsuspended the account, multiple times)
- it can change a remote suspension flag into a local suspension flag, which is very confusing

Therefore, this PR changes the suspension/unsuspension worker logics to not set the suspension flag, but check it instead: the appropriate worker will only be scheduled after the flag has been set appropriately on the call site, so this should be safe.