### PR TITLE
Move Prettier CI checks to filtered jobs

### DIFF
--- a/.github/workflows/lint-json.yml
+++ b/.github/workflows/lint-json.yml
@@ -1,0 +1,38 @@
+name: JSON Linting
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    paths:
+      - 'package.json'
+      - 'yarn.lock'
+      - '.prettier*'
+      - '**/*.json'
+      - '.github/workflows/lint-json.yml'
+
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'yarn.lock'
+      - '.prettier*'
+      - '**/*.json'
+      - '.github/workflows/lint-json.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+
+      - name: Install all yarn packages
+        run: yarn --frozen-lockfile
+
+      - name: Prettier
+        run: yarn prettier --check "**/*.json"

--- a/.github/workflows/lint-yml.yml
+++ b/.github/workflows/lint-yml.yml
@@ -1,0 +1,40 @@
+name: YML Linting
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    paths:
+      - 'package.json'
+      - 'yarn.lock'
+      - '.prettier*'
+      - '**/*.yaml'
+      - '**/*.yml'
+      - '.github/workflows/lint-yml.yml'
+
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'yarn.lock'
+      - '.prettier*'
+      - '**/*.yaml'
+      - '**/*.yml'
+      - '.github/workflows/lint-yml.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+
+      - name: Install all yarn packages
+        run: yarn --frozen-lockfile
+
+      - name: Prettier
+        run: yarn prettier --check "**/*.{yml,yaml}"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -57,8 +57,6 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      - name: Check prettier formatting
-        run: yarn format-check
       - name: Set-up RuboCop Problem Mathcher
         uses: r7kamura/rubocop-problem-matchers-action@v1
       - name: Set-up Stylelint Problem Matcher


### PR DESCRIPTION
Split this out of a larger PR to replace the Superlinter job. Thought this one might be easier to land, since this task causes some unrelated failures in other PRs. Now the job only runs if a related file type or config file is touched, so it shouldn't cause those issues next time