### PR TITLE
Check OpenSearch compatibility version instead of regular version

### DIFF
--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -13,7 +13,14 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
 
   def message
     if running_version.present?
-      Admin::SystemCheck::Message.new(:elasticsearch_version_check, I18n.t('admin.system_checks.elasticsearch_version_check.version_comparison', running_version: running_version, required_version: required_version))
+      Admin::SystemCheck::Message.new(
+        :elasticsearch_version_check,
+        I18n.t(
+          'admin.system_checks.elasticsearch_version_check.version_comparison',
+          running_version: running_version,
+          required_version: required_version
+        )
+      )
     else
       Admin::SystemCheck::Message.new(:elasticsearch_running_check)
     end
@@ -23,7 +30,8 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
 
   def running_version
     @running_version ||= begin
-      Chewy.client.info['version']['number']
+      Chewy.client.info['version']['minimum_wire_compatibility_version'] ||
+        Chewy.client.info['version']['number']
     rescue Faraday::ConnectionFailed
       nil
     end


### PR DESCRIPTION
OpenSearch clusters have a `version.number` field in their info which reflects the actual version of OpenSearch and a `version.minimum_wire_compatibility_version` that reflects the version of compatible Elasticsearch clients. We should be checking the latter when connecting to an OpenSearch cluster. (Regular ES clusters don't have it.) This gets rid of a spurious warning when using the currently shipping OpenSearch 2.4.0, which is compatible with the ES 7.x that Mastodon expects.

Fixes #18535.