### PR TITLE
Remove unused ESLint disable directives

### DIFF
--- a/app/javascript/packs/public-path.js
+++ b/app/javascript/packs/public-path.js
@@ -17,5 +17,5 @@ function formatPublicPath(host = '', path = '') {
 
 const cdnHost = document.querySelector('meta[name=cdn-host]');
 
-// eslint-disable-next-line camelcase, no-undef, no-unused-vars
+// eslint-disable-next-line no-undef
 __webpack_public_path__ = formatPublicPath(cdnHost ? cdnHost.content : '', process.env.PUBLIC_OUTPUT_PATH);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "node ./streaming/index.js",
     "test": "${npm_execpath} run test:lint:js && ${npm_execpath} run test:jest",
     "test:lint": "${npm_execpath} run test:lint:js && ${npm_execpath} run test:lint:sass",
-    "test:lint:js": "eslint --ext=js . --cache",
+    "test:lint:js": "eslint --ext=js . --cache --report-unused-disable-directives",
     "test:lint:sass": "stylelint \"**/*.{css,scss}\"",
     "test:jest": "cross-env NODE_ENV=test jest",
     "format": "prettier --write \"**/*.{json,yml}\"",


### PR DESCRIPTION
The `--report-unused-disable-directives` flags any inline disabled directives that are no longer used.