### PR TITLE
Update JWT Dependencies for OpenSSL 3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,6 +334,8 @@ GEM
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
+      faraday (>= 2.0)
+      faraday-follow_redirects
     json-ld (3.2.3)
       htmlentities (~> 4.3)
       json-canonicalization (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ GEM
     jmespath (1.6.2)
     json (2.6.2)
     json-canonicalization (0.3.0)
-    json-jwt (1.13.0)
+    json-jwt (1.16.1)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
@@ -347,7 +347,7 @@ GEM
     json-schema (3.0.0)
       addressable (>= 2.8)
     jsonapi-renderer (0.2.2)
-    jwt (2.4.1)
+    jwt (2.5.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)


### PR DESCRIPTION
Update JWT Dependencies for OpenSSL 3.0 , in particular:

* bump jwt to 2.5.0 - https://github.com/jwt/ruby-jwt/issues/495
* bump json-jwt to 1.16.1 - https://github.com/nov/json-jwt/issues/100

This fixes issues with openid_connect via omniauth on OpenSSL 3.0 platforms