### PR TITLE
Bump ruby-jwt and json-jwt to support OpenSSL 3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ GEM
     jmespath (1.6.2)
     json (2.6.2)
     json-canonicalization (0.3.0)
-    json-jwt (1.13.0)
+    json-jwt (1.14.0)
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
@@ -347,7 +347,7 @@ GEM
     json-schema (3.0.0)
       addressable (>= 2.8)
     jsonapi-renderer (0.2.2)
-    jwt (2.4.1)
+    jwt (2.5.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)


### PR DESCRIPTION
Bump ruby-jwt and json-jwt to support OmniAuth OIDC w/ OpenSSL 3.0 

* https://github.com/jwt/ruby-jwt/issues/495
* https://github.com/nov/json-jwt/issues/100