### PR TITLE
Don't crash on unobtainable avatars (omniauth-openid-connect)

### DIFF
--- a/app/models/concerns/omniauthable.rb
+++ b/app/models/concerns/omniauthable.rb
@@ -55,7 +55,14 @@ module Omniauthable
 
       user = User.new(user_params_from_auth(email, auth))
 
-      user.account.avatar_remote_url = auth.info.image if /\A#{URI::DEFAULT_PARSER.make_regexp(%w(http https))}\z/.match?(auth.info.image)
+      begin
+        if /\A#{URI::DEFAULT_PARSER.make_regexp(%w(http https))}\z/.match?(auth.info.image)
+          user.account.avatar_remote_url = auth.info.image
+        end
+      rescue Mastodon::UnexpectedResponseError
+        user.account.avatar_remote_url = nil
+      end
+
       user.skip_confirmation! if email_is_verified
       user.save!
       user


### PR DESCRIPTION
`create_for_oauth()` crashes with an `Mastodon::UnexpectedResponseError` when an avatar URI is specified by OIDC but unobtainable in some way. Typical example is Microsoft's Azure Active Directory, which provides all OIDC responses with a generic avatar URI of `https://graph.microsoft.com/v1.0/me/photo/$value` but this in turn requires authorisation at dereference time (which in turn involves additional permissions granted to the caller in advance to retrieve this).

Example crash below:

```
Dec 17 21:43:51 dev bundle[6348]: [2d61ef77-5fa4-4199-915b-dbf3a8040501] method=GET path=/auth/auth/openid_connect/callback format=html controller=Auth::OmniauthCallbacksController action=openid_connect status=500 error='Mastodon::UnexpectedResponseError: https://graph.microsoft.com/v1.0/me/photo/$value returned code 401' duration=46.19 view=0.00 db=9.07
Dec 17 21:43:51 dev bundle[6348]: [2d61ef77-5fa4-4199-915b-dbf3a8040501]
Dec 17 21:43:51 dev bundle[6348]: [2d61ef77-5fa4-4199-915b-dbf3a8040501] Mastodon::UnexpectedResponseError (https://graph.microsoft.com/v1.0/me/photo/$value returned code 401):
Dec 17 21:43:51 dev bundle[6348]: [2d61ef77-5fa4-4199-915b-dbf3a8040501]
Dec 17 21:43:51 dev bundle[6348]: [2d61ef77-5fa4-4199-915b-dbf3a8040501] app/models/concerns/remotable.rb:25:in `block (2 levels) in remotable_attachment'
```