### PR TITLE
Expand Stylelint glob to include CSS files

### DIFF
--- a/lib/assets/wordmark.dark.css
+++ b/lib/assets/wordmark.dark.css
@@ -1,1 +1,1 @@
-// Not needed
+/* Not needed */

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "${npm_execpath} run test:lint:js && ${npm_execpath} run test:jest",
     "test:lint": "${npm_execpath} run test:lint:js && ${npm_execpath} run test:lint:sass",
     "test:lint:js": "eslint --ext=js . --cache",
-    "test:lint:sass": "stylelint '**/*.scss'",
+    "test:lint:sass": "stylelint \"**/*.{css,scss}\"",
     "test:jest": "cross-env NODE_ENV=test jest",
     "format": "prettier --write \"**/*.{json,yml}\"",
     "format-check": "prettier --check \"**/*.{json,yml}\""

--- a/public/inert.css
+++ b/public/inert.css
@@ -3,7 +3,8 @@
   cursor: default;
 }
 
-[inert], [inert] * {
+[inert],
+[inert] * {
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;


### PR DESCRIPTION
- Fix the globbing so it also includes CSS files.
- Correct the quoting for cross-platform compatibility
- Manually fix bad comment style in CSS file