### PR TITLE
Add alt text badge to images and gifs with alt text, and display alt text when badge is clicked

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -162,6 +162,7 @@ class Item extends React.PureComponent {
 
     const altTextButton = (classes) => (
       <button
+        aria-hidden={true}
         className={`view-alt-text-button ${classes}`}
         onClick={this.handleAltText}
       >

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -34,6 +34,7 @@ class Item extends React.PureComponent {
 
   state = {
     loaded: false,
+    showAltText: false,
   };
 
   handleMouseEnter = (e) => {
@@ -70,6 +71,15 @@ class Item extends React.PureComponent {
       onClick(index);
     }
 
+    e.stopPropagation();
+  }
+
+  handleAltText = (e) => {
+    if (e.button === 0 && !(e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      this.setState({ showAltText: this.state.showAltText ? false : true });
+    }
+    
     e.stopPropagation();
   }
 
@@ -131,6 +141,34 @@ class Item extends React.PureComponent {
 
     let thumbnail = '';
 
+    const altText = attachment.get('description');
+    
+    const altTextModal = (mediaType) => (
+      <div className="alt-text-modal">
+        <p className="alt-text">
+          <b>
+            {"Alt text: "}
+          </b>
+          {altText}
+        </p>
+        <button
+          className="exit-alt-text-button"
+          onClick={this.handleAltText}
+        >
+          Return to {mediaType}
+        </button>
+      </div>
+    );
+
+    const altTextButton = (classes) => (
+      <button
+        className={`view-alt-text-button ${classes}`}
+        onClick={this.handleAltText}
+      >
+        ALT
+      </button>
+    );
+
     if (attachment.get('type') === 'unknown') {
       return (
         <div className={classNames('media-gallery__item', { standalone })} key={attachment.get('id')} style={{ left: left, top: top, right: right, bottom: bottom, width: `${width}%`, height: `${height}%` }}>
@@ -161,46 +199,52 @@ class Item extends React.PureComponent {
       const y      = ((focusY / -2) + .5) * 100;
 
       thumbnail = (
-        <a
-          className='media-gallery__item-thumbnail'
-          href={attachment.get('remote_url') || originalUrl}
-          onClick={this.handleClick}
-          target='_blank'
-          rel='noopener noreferrer'
-        >
-          <img
-            src={previewUrl}
-            srcSet={srcSet}
-            sizes={sizes}
-            alt={attachment.get('description')}
-            title={attachment.get('description')}
-            style={{ objectPosition: `${x}% ${y}%` }}
-            onLoad={this.handleImageLoad}
-          />
-        </a>
+        <>
+          {altText && altTextButton()}
+          <a
+            className='media-gallery__item-thumbnail'
+            href={attachment.get('remote_url') || originalUrl}
+            onClick={this.handleClick}
+            target='_blank'
+            rel='noopener noreferrer'
+          >
+            <img
+              src={previewUrl}
+              srcSet={srcSet}
+              sizes={sizes}
+              alt={altText}
+              title={altText}
+              style={{ objectPosition: `${x}% ${y}%` }}
+              onLoad={this.handleImageLoad}
+            />
+          </a>
+        </>
       );
     } else if (attachment.get('type') === 'gifv') {
       const autoPlay = this.getAutoPlay();
 
       thumbnail = (
-        <div className={classNames('media-gallery__gifv', { autoplay: autoPlay })}>
-          <video
-            className='media-gallery__item-gifv-thumbnail'
-            aria-label={attachment.get('description')}
-            title={attachment.get('description')}
-            role='application'
-            src={attachment.get('url')}
-            onClick={this.handleClick}
-            onMouseEnter={this.handleMouseEnter}
-            onMouseLeave={this.handleMouseLeave}
-            autoPlay={autoPlay}
-            playsInline
-            loop
-            muted
-          />
+        <>
+          {altText && altTextButton("gif")}
+          <div className={classNames('media-gallery__gifv', { autoplay: autoPlay })}>
+            <video
+              className='media-gallery__item-gifv-thumbnail'
+              aria-label={attachment.get('description')}
+              title={attachment.get('description')}
+              role='application'
+              src={attachment.get('url')}
+              onClick={this.handleClick}
+              onMouseEnter={this.handleMouseEnter}
+              onMouseLeave={this.handleMouseLeave}
+              autoPlay={autoPlay}
+              playsInline
+              loop
+              muted
+            />
 
-          <span className='media-gallery__gifv__label'>GIF</span>
-        </div>
+            <span className='media-gallery__gifv__label'>GIF</span>
+          </div>
+        </>
       );
     }
 
@@ -213,7 +257,8 @@ class Item extends React.PureComponent {
             'media-gallery__preview--hidden': visible && this.state.loaded,
           })}
         />
-        {visible && thumbnail}
+        {visible && !this.state.showAltText && thumbnail}
+        {this.state.showAltText && altTextModal(attachment.get('type') === 'gifv' ? "gif" : "image")}
       </div>
     );
   }

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -79,7 +79,7 @@ class Item extends React.PureComponent {
       e.preventDefault();
       this.setState({ showAltText: this.state.showAltText ? false : true });
     }
-    
+
     e.stopPropagation();
   }
 
@@ -142,17 +142,17 @@ class Item extends React.PureComponent {
     let thumbnail = '';
 
     const altText = attachment.get('description');
-    
+
     const altTextModal = (mediaType) => (
-      <div className="alt-text-modal">
-        <p className="alt-text">
+      <div className='alt-text-modal'>
+        <p className='alt-text'>
           <b>
-            {"Alt text: "}
+            {'Alt text: '}
           </b>
           {altText}
         </p>
         <button
-          className="exit-alt-text-button"
+          className='exit-alt-text-button'
           onClick={this.handleAltText}
         >
           Return to {mediaType}
@@ -225,7 +225,7 @@ class Item extends React.PureComponent {
 
       thumbnail = (
         <>
-          {altText && altTextButton("gif")}
+          {altText && altTextButton('gif')}
           <div className={classNames('media-gallery__gifv', { autoplay: autoPlay })}>
             <video
               className='media-gallery__item-gifv-thumbnail'
@@ -258,7 +258,7 @@ class Item extends React.PureComponent {
           })}
         />
         {visible && !this.state.showAltText && thumbnail}
-        {this.state.showAltText && altTextModal(attachment.get('type') === 'gifv' ? "gif" : "image")}
+        {this.state.showAltText && altTextModal(attachment.get('type') === 'gifv' ? 'gif' : 'image')}
       </div>
     );
   }

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -162,7 +162,7 @@ class Item extends React.PureComponent {
 
     const altTextButton = (classes) => (
       <button
-        aria-hidden={true}
+        aria-hidden
         className={`view-alt-text-button ${classes}`}
         onClick={this.handleAltText}
       >

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -617,6 +617,7 @@ body,
   display: block;
   margin: 0 auto;
   overflow-wrap: break-word;
+
   b {
     font-weight: 500;
   }
@@ -658,10 +659,11 @@ body,
   height: 20%;
   width: 100%;
   border: 0;
-  margin: 0px;
-  padding-bottom: 0px;
-  padding-top: 0px;
+  margin: 0;
+  padding-bottom: 0;
+  padding-top: 0;
   position: absolute;
+
   &:hover,
   &:focus,
   &:active {

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -597,6 +597,79 @@ body,
   }
 }
 
+.alt-text-modal {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+  z-index: 100; /* necessary to show in front of 'hide media' button */
+}
+
+.alt-text {
+  font-size: 15px;
+  background-color: $ui-base-color;
+  padding-left: 2%;
+  padding-right: 2%;
+  overflow: auto;
+  height: 80%;
+  display: block;
+  margin: 0 auto;
+  overflow-wrap: break-word;
+  b {
+    font-weight: 500;
+  }
+}
+
+.view-alt-text-button {
+  display: block;
+  position: absolute;
+  color: $primary-text-color;
+  background: rgba($base-overlay-background, 0.5);
+  bottom: 6px;
+  left: 6px;
+  padding: 2px 6px;
+  border: 0;
+  border-radius: 2px;
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0.9;
+  transition: opacity 0.1s ease;
+  line-height: 18px;
+  z-index: 2; /* necessary to be clickable in front of image expand clickable area */
+  &:hover,
+  &:focus,
+  &:active {
+    border: 4px solid $ui-highlight-color;
+    background-color: white;
+    color: black;
+  }
+}
+
+.view-alt-text-button.gif {
+  left: 40.727px;
+}
+
+.exit-alt-text-button {
+  background-color: $ui-highlight-color;
+  color: $primary-text-color;
+  font-weight: 500;
+  height: 20%;
+  width: 100%;
+  border: 0;
+  margin: 0px;
+  padding-bottom: 0px;
+  padding-top: 0px;
+  position: absolute;
+  &:hover,
+  &:focus,
+  &:active {
+    border: 4px solid $ui-highlight-color;
+    background-color: $ui-base-color;
+  }
+}
+
 .simple_form.new_report_note,
 .simple_form.new_account_moderation_note {
   max-width: 100%;


### PR DESCRIPTION
Twitter had success in promoting alt text use and awareness by adding the `ALT` badge to tweeted images and gifs that contain alt text (aka an image description).
https://help.twitter.com/en/using-twitter/how-to-use-alt-gif

This PR adds the feature to Mastodon, with some modifications that make it more seamlessly weaved into the existing UI (e.g. the alt text of individual images/gifs from the same post can be exposed one-by-one and shown inside the image frame with a back button to view the image, instead of the alt text taking up your whole screen as is the case on the Twitter app).

This simple feature will:
- encourage more folks to make their posts more accessible
- allow folks to view alt text without assistive technology or dev skills (a number of accounts write really good alt text that folks who are not blind or low-vision also enjoy being able to read)

### Demo part 1
https://user-images.githubusercontent.com/38192823/208328029-79d9a61e-7768-414f-9b32-756dba2ccdd3.mov

### Demo part 2
https://user-images.githubusercontent.com/38192823/208328258-68bbcfe3-522c-46eb-a4a1-38dc78763caa.mov

### Demo part 3
https://user-images.githubusercontent.com/38192823/208328528-f1e3d305-861e-430f-9c65-c72703012c09.mov

### Demo part 4
https://user-images.githubusercontent.com/38192823/208328659-afa7ac2b-2c8a-4ef5-9d16-9475cbe33c08.mov