### PR TITLE
Disable webpack compression plugin on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ USER mastodon
 WORKDIR /opt/mastodon
 
 # Precompile assets
-RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder IS_DOCKER=true rails assets:precompile
+RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder ENABLE_ASSET_BUILD_TIME_COMPRESSION=false rails assets:precompile
 
 # Set the work dir and the container entry point
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ USER mastodon
 WORKDIR /opt/mastodon
 
 # Precompile assets
-RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile
+RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder IS_DOCKER=true rails assets:precompile
 
 # Set the work dir and the container entry point
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -29,7 +29,7 @@ module.exports = merge(sharedConfig, {
   },
 
   plugins: [
-    ...(process.env.IS_DOCKER ? [new CompressionPlugin({
+    ...(process.env.ENABLE_ASSET_BUILD_TIME_COMPRESSION !== 'false' ? [new CompressionPlugin({
       filename: '[path][base].gz[query]',
       cache: true,
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf|map)$/,

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -29,7 +29,7 @@ module.exports = merge(sharedConfig, {
   },
 
   plugins: [
-    new CompressionPlugin({
+    ...(process.env.IS_DOCKER ? [new CompressionPlugin({
       filename: '[path][base].gz[query]',
       cache: true,
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf|map)$/,
@@ -40,6 +40,7 @@ module.exports = merge(sharedConfig, {
       cache: true,
       test: /\.(js|css|html|json|ico|svg|eot|otf|ttf|map)$/,
     }),
+    ] : []),
     new BundleAnalyzerPlugin({ // generates report.html
       analyzerMode: 'static',
       openAnalyzer: false,


### PR DESCRIPTION
As nginx serves static files through reverse proxying rails on docker deployment, These files are not used and uselessly increases build time