### PR TITLE
Added support for specifying S3 storage classes in environment

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -90,6 +90,12 @@ if ENV['S3_ENABLED'] == 'true'
     )
   end
 
+  if ENV.has_key?('S3_STORAGE_CLASS')
+    Paperclip::Attachment.default_options[:s3_headers].merge!(
+      'X-Amz-Storage-Class' => ENV['S3_STORAGE_CLASS']
+    )
+  end
+
   # Some S3-compatible providers might not actually be compatible with some APIs
   # used by kt-paperclip, see https://github.com/mastodon/mastodon/issues/16822
   if ENV['S3_FORCE_SINGLE_REQUEST'] == 'true'


### PR DESCRIPTION
This PR adds support for AWS [storage classes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html). This will allow server operators to use classes such as [Intelligent-Tiering](https://aws.amazon.com/s3/storage-classes/intelligent-tiering/), which will automatically move data to more effective cost tiers. This could be particularly useful for cached content.

To set the storage class, set the `S3_STORAGE_CLASS` environment variable to one of the following:

`DEEP_ARCHIVE | GLACIER | GLACIER_IR | INTELLIGENT_TIERING | ONEZONE_IA | STANDARD_IA`

A list of available storage classes: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig-rule-transition.html