### PR TITLE
Fix REST API serializer for Account not including `moved` when the moved account has itself moved

### DIFF
--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -16,6 +16,16 @@ class REST::AccountSerializer < ActiveModel::Serializer
   attribute :silenced, key: :limited, if: :silenced?
   attribute :noindex, if: :local?
 
+  class AccountDecorator < SimpleDelegator
+    def self.model_name
+      Account.model_name
+    end
+
+    def moved?
+      false
+    end
+  end
+
   class FieldSerializer < ActiveModel::Serializer
     include FormattingHelper
 
@@ -85,7 +95,7 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def moved_to_account
-    object.suspended? ? nil : object.moved_to_account
+    object.suspended? ? nil : AccountDecorator.new(object.moved_to_account)
   end
 
   def emojis
@@ -111,6 +121,6 @@ class REST::AccountSerializer < ActiveModel::Serializer
   delegate :suspended?, :silenced?, :local?, to: :object
 
   def moved_and_not_nested?
-    object.moved? && object.moved_to_account.moved_to_account_id.nil?
+    object.moved?
   end
 end


### PR DESCRIPTION
Fixes #22483
Related: #22131

Instead of cutting immediately, cut after one recursion.

This fixes clients (including the Web UI) showing accounts that have moved to accounts that have themselves moved as not having moved at all.

Despite the moved to account's `moved` not itself being rendered, this fixes the WebUI's behavior entirely, as visiting a profile triggers an API call. I am not sure how various clients handle that.