### PR TITLE
Fix “Add new domain block” button using last submitted instead of current search value

### DIFF
--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -192,7 +192,7 @@ ready(() => {
   }
 
   document.querySelector('a#add-instance-button')?.addEventListener('click', (e) => {
-    const domain = document.getElementById('by_domain')?.value;
+    const domain = document.querySelector('input[type="text"]#by_domain')?.value;
 
     if (domain) {
       const url = new URL(event.target.href);


### PR DESCRIPTION
Fixes #22162

It was meant to do that, but Rails inserts a `type="hidden"` input with the same ID as default, so it erroneously picked that instead.