### PR TITLE
Change wording of the OAuth scopes descriptions

### DIFF
--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -122,14 +122,14 @@ en:
         admin/accounts: Administration of accounts
         admin/all: All administrative functions
         admin/reports: Administration of reports
-        all: Everything
+        all: Full access to your Mastodon account
         blocks: Blocks
         bookmarks: Bookmarks
         conversations: Conversations
         crypto: End-to-end encryption
         favourites: Favourites
         filters: Filters
-        follow: Relationships
+        follow: Follows, Mutes and Blocks
         follows: Follows
         lists: Lists
         media: Media attachments


### PR DESCRIPTION
- change `all` from “Everything” to “Full access to your Mastodon account”
- change `follow` from “Relationships” to “Follows, Mutes and Blocks”