### PR TITLE
Be more lenient with OEmbed detection and validation

### DIFF
--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -28,7 +28,7 @@ class FetchOEmbedService
     page    = Nokogiri::HTML(html)
 
     if @format.nil? || @format == :json
-      @endpoint_url ||= page.at_xpath('//link[@type="application/json+oembed"]')&.attribute('href')&.value
+      @endpoint_url ||= page.at_xpath('//link[@type="application/json+oembed"]|//link[@type="text/json+oembed"]')&.attribute('href')&.value
       @format       ||= :json if @endpoint_url
     end
 
@@ -100,7 +100,7 @@ class FetchOEmbedService
   end
 
   def validate(oembed)
-    oembed if oembed[:version] == '1.0' && oembed[:type].present?
+    oembed if oembed[:version].to_s == '1.0' && oembed[:type].present?
   end
 
   def html


### PR DESCRIPTION
Fixes two conditions which currently stop some OEmbeds (SoundCloud being the known one) from being recognised.

Technically as far as I can tell, we're already fully compliant with the spec, and SoundCloud aren't. However, I doubt I can get SoundCloud to fix things, and this feels like a harmless improvement to make our support more lenient.