### PR TITLE
Make visible change for new post notification setting icon

### DIFF
--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -192,7 +192,7 @@ class Header extends ImmutablePureComponent {
     }
 
     if (account.getIn(['relationship', 'requested']) || account.getIn(['relationship', 'following'])) {
-      bellBtn = <IconButton icon='bell-o' size={24} active={account.getIn(['relationship', 'notifying'])} title={intl.formatMessage(account.getIn(['relationship', 'notifying']) ? messages.disableNotifications : messages.enableNotifications, { name: account.get('username') })} onClick={this.props.onNotifyToggle} />;
+      bellBtn = <IconButton icon={account.getIn(['relationship', 'notifying']) ? 'bell' : 'bell-o'} size={24} active={account.getIn(['relationship', 'notifying'])} title={intl.formatMessage(account.getIn(['relationship', 'notifying']) ? messages.disableNotifications : messages.enableNotifications, { name: account.get('username') })} onClick={this.props.onNotifyToggle} />;
     }
 
     if (me !== account.get('id')) {


### PR DESCRIPTION
To make more visible change, use bell-o as inactive(original) and bell as active.
It is also good for colorblinds

disabled:
![image](https://user-images.githubusercontent.com/5047683/208633582-76182a93-b630-41c1-a784-74f422e7d34e.png)
after:
![image](https://user-images.githubusercontent.com/5047683/208633612-96517561-0c40-47db-b4d0-803bdb8fc190.png)
before:
![image](https://user-images.githubusercontent.com/5047683/208633674-2d1dc021-cc80-4ec0-beaf-8de259b63856.png)
