### PR TITLE
Add a11y tags to the modal

### DIFF
--- a/app/views/layouts/modal.html.haml
+++ b/app/views/layouts/modal.html.haml
@@ -8,7 +8,7 @@
       .name
         = t 'users.signed_in_as'
         %span.username @#{current_account.local_username_and_domain}
-      = link_to destroy_user_session_path(continue: true), method: :delete, class: 'logout-link icon-button' do
+      = link_to destroy_user_session_path(continue: true), method: :delete, class: 'logout-link icon-button', title: t('applications.logout'), 'aria-label': t('applications.logout') do
         = fa_icon 'sign-out'
 
   .container-alt= yield


### PR DESCRIPTION
This PR closes #22547 by adding the `title` and `aria-label` attributes to the "Sign out" button in the modal (as seen on the /share endpoint, for example)