### PR TITLE
l10n: Better German localization if notifications are shortenend

### DIFF
--- a/app/javascript/mastodon/locales/de.json
+++ b/app/javascript/mastodon/locales/de.json
@@ -392,7 +392,7 @@
   "not_signed_in_indicator.not_signed_in": "Du musst dich anmelden, um auf diesen Inhalt zugreifen zu können.",
   "notification.admin.report": "{target} wurde von {name} gemeldet",
   "notification.admin.sign_up": "{name} registrierte sich",
-  "notification.favourite": "{name} hat deinen Beitrag favorisiert",
+  "notification.favourite": "{name} favorisierte deinen Beitrag",
   "notification.follow": "{name} folgt dir jetzt",
   "notification.follow_request": "{name} möchte dir folgen",
   "notification.mention": "{name} erwähnte dich",

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1290,7 +1290,7 @@ de:
         subject: "%{name} registrierte sich"
     favourite:
       body: 'Dein Beitrag wurde von %{name} favorisiert:'
-      subject: "%{name} hat deinen Beitrag favorisiert"
+      subject: "%{name} favorisierte deinen Beitrag"
       title: Neue Favorisierung
     follow:
       body: "%{name} folgt dir jetzt!"
@@ -1304,13 +1304,13 @@ de:
     mention:
       action: Antworten
       body: "%{name} hat dich erwähnt:"
-      subject: "%{name} hat dich erwähnt"
+      subject: "%{name} erwähnte dich"
       title: Neue Erwähnung
     poll:
       subject: Eine Umfrage von %{name} ist beendet
     reblog:
       body: 'Deinen Beitrag hat %{name} geteilt:'
-      subject: "%{name} hat deinen Beitrag geteilt"
+      subject: "%{name} teilte deinen Beitrag"
       title: Dein Beitrag wurde geteilt
     status:
       subject: "%{name} hat gerade etwas gepostet"


### PR DESCRIPTION
The title of notifications may be be shortened. Depending on the length of the username, the action may be truncated in the German localization:
![IMG_3642](https://user-images.githubusercontent.com/26421/208657275-b0f81252-f04c-4187-96c0-143f0f515d77.jpg)
![Bildschirm­foto 2022-12-20 um 12 42 02](https://user-images.githubusercontent.com/26421/208659277-e86e517d-fa62-410c-9f82-90d3b0569eb0.png)

"hat Deinen Beitrag … " may end with "geteilt" (boosted) or "favorisiert" (favored). A quick glimpse at the notification does not give me this information.

By changing the grammar slightly, it says correct and will more likely convey all the needed information at first glance, because the verb is now in front.

I am aware that this is the web version of mastodon, my assumption would be that the mobile app uses the same localization