### PR TITLE
Fix incorrectly formatted datetime in account moderation note timestamp

### DIFF
--- a/app/views/admin/report_notes/_report_note.html.haml
+++ b/app/views/admin/report_notes/_report_note.html.haml
@@ -4,7 +4,7 @@
   .report-notes__item__header
     %span.username
       = link_to report_note.account.username, admin_account_path(report_note.account_id)
-    %time.relative-formatted{ datetime: report_note.created_at }
+    %time.relative-formatted{ datetime: report_note.created_at.iso8601 }
       = t('admin.report_notes.created_at')
 
   .report-notes__item__content

--- a/app/views/admin/report_notes/_report_note.html.haml
+++ b/app/views/admin/report_notes/_report_note.html.haml
@@ -5,7 +5,7 @@
     %span.username
       = link_to report_note.account.username, admin_account_path(report_note.account_id)
     %time.relative-formatted{ datetime: report_note.created_at.iso8601 }
-      = t('admin.report_notes.created_at')
+      = l report_note.created_at.to_date
 
   .report-notes__item__content
     = simple_format(h(report_note.content))

--- a/app/views/admin/reports/show.html.haml
+++ b/app/views/admin/reports/show.html.haml
@@ -145,7 +145,7 @@
           - else
             = link_to @report.account.domain, admin_instance_path(@report.account.domain)
         %time.relative-formatted{ datetime: @report.created_at.iso8601 }
-          = t('admin.report_notes.created_at')
+          = l @report.created_at.to_date
 
       .report-notes__item__content
         = simple_format(h(@report.comment))

--- a/app/views/disputes/strikes/show.html.haml
+++ b/app/views/disputes/strikes/show.html.haml
@@ -111,7 +111,7 @@
         %span.username
           = link_to @appeal.account.username, can?(:show, @appeal.account) ? admin_account_path(@appeal.account_id) : short_account_url(@appeal.account)
         %time.relative-formatted{ datetime: @appeal.created_at.iso8601 }
-          = t('admin.report_notes.created_at')
+          = l @appeal.created_at.to_date
 
       .report-notes__item__content
         = simple_format(h(@appeal.text))


### PR DESCRIPTION
Fixes an oversight from #21878

Also fixes HTML-rendered code using a translation string that does not exist.