### PR TITLE
Add aria-hidden to content warning field when dimmed so that it is not confusing to screen reader users

### DIFF
--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -225,7 +225,7 @@ class ComposeForm extends ImmutablePureComponent {
 
         <ReplyIndicatorContainer />
 
-        <div className={`spoiler-input ${this.props.spoiler ? 'spoiler-input--visible' : ''}`} ref={this.setRef}>
+        <div className={`spoiler-input ${this.props.spoiler ? 'spoiler-input--visible' : ''}`} ref={this.setRef} aria-hidden={!this.props.spoiler}>
           <AutosuggestInput
             placeholder={intl.formatMessage(messages.spoiler_placeholder)}
             value={this.props.spoilerText}


### PR DESCRIPTION
When using a screen reader to author a post, the prompt for adding content warning text is read out even before someone chooses to add a content warning to a post. If someone starts typing at this point, it actually starts filling the post field and not the content warning field. It is confusing to screen reader users to have this field described when it is (a) not usable and (b) they have not yet toggled it on. To fix this, we add `aria-hidden` to the cw field's wrapping div as long as it is not visible.

### Before
https://user-images.githubusercontent.com/38192823/208738972-3f5d7af7-5220-427d-9b1c-1b43bd9cab57.mov

### After
https://user-images.githubusercontent.com/38192823/208738322-c78f6b05-52dd-4e5a-a221-736b8036ead6.mov

