### PR TITLE
Improve the contrast of the chart in “poll has ended” notifications

### DIFF
--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -279,10 +279,10 @@
   color: $dark-text-color;
 
   &__chart {
-    background: rgba(darken($ui-primary-color, 14%), 0.2);
+    background: rgba(darken($ui-primary-color, 14%), 0.5);
 
     &.leading {
-      background: rgba($ui-highlight-color, 0.2);
+      background: rgba($ui-highlight-color, 0.5);
     }
   }
 }

--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -279,7 +279,7 @@
   color: $dark-text-color;
 
   &__chart {
-    background: rgba(darken($ui-primary-color, 14%), 0.5);
+    background: rgba(darken($ui-primary-color, 14%), 0.7);
 
     &.leading {
       background: rgba($ui-highlight-color, 0.5);


### PR DESCRIPTION
Fixes #21552, fixes #20836. I’ve bumped the opacity from 0.2 to 0.5 but I think it might be better to go higher? Not sure.

Before/After:

<details><summary>Dark Mode</summary>

<img src=https://user-images.githubusercontent.com/25517624/208751529-0713890f-12e3-43bc-bade-3b3826e50c82.png width=400><img src=https://user-images.githubusercontent.com/25517624/208751522-e63cd060-dcf9-43f2-abeb-b86bf155797a.png width=400>
</details>

<details open><summary>Light Mode</summary>

<img src=https://user-images.githubusercontent.com/25517624/208751765-dadc61e1-4e8f-4068-b544-8c817095c141.png width=400><img src=https://user-images.githubusercontent.com/25517624/208751769-06c98ed5-f511-450b-a767-c793e2197632.png width=400>
</details>