### PR TITLE
Prevent unauthenticated access to tag timelines if timeline_preview is disabled

### DIFF
--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Timelines::TagController < Api::BaseController
+  before_action :require_user!, only: [:show], if: :require_auth?
   before_action :load_tag
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 
@@ -10,6 +11,10 @@ class Api::V1::Timelines::TagController < Api::BaseController
   end
 
   private
+  
+  def require_auth?
+    !Setting.timeline_preview
+  end
 
   def load_tag
     @tag = Tag.find_normalized(params[:id])


### PR DESCRIPTION
Make this site setting correctly apply to tag timelines.

![image](https://user-images.githubusercontent.com/834880/208810216-628e94e8-b5a0-4691-9c8d-13bef910fcd2.png)
