### PR TITLE
Fix focus rings and tab index so that keyboard navigation works as expected

### DIFF
--- a/app/javascript/mastodon/components/intersection_observer_article.js
+++ b/app/javascript/mastodon/components/intersection_observer_article.js
@@ -113,7 +113,6 @@ export default class IntersectionObserverArticle extends React.Component {
           aria-setsize={listLength}
           style={{ height: `${this.height || cachedHeight}px`, opacity: 0, overflow: 'hidden' }}
           data-id={id}
-          tabIndex='0'
         >
           {children && React.cloneElement(children, { hidden: true })}
         </article>
@@ -121,7 +120,7 @@ export default class IntersectionObserverArticle extends React.Component {
     }
 
     return (
-      <article ref={this.handleRef} aria-posinset={index + 1} aria-setsize={listLength} data-id={id} tabIndex='0'>
+      <article ref={this.handleRef} aria-posinset={index + 1} aria-setsize={listLength} data-id={id}>
         {children && React.cloneElement(children, { hidden: false })}
       </article>
     );

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -261,7 +261,7 @@ class StatusContent extends React.PureComponent {
       }
 
       return (
-        <div className={classNames} ref={this.setRef} tabIndex='0' onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+        <div className={classNames} ref={this.setRef} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
           <p style={{ marginBottom: hidden && status.get('mentions').isEmpty() ? '0px' : null }}>
             <span dangerouslySetInnerHTML={spoilerContent} className='translate' lang={lang} />
             {' '}
@@ -279,7 +279,7 @@ class StatusContent extends React.PureComponent {
     } else if (this.props.onClick) {
       return (
         <>
-          <div className={classNames} ref={this.setRef} tabIndex='0' onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} key='status-content' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+          <div className={classNames} ref={this.setRef} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} key='status-content' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
             <div className='status__content__text status__content__text--visible translate' lang={lang} dangerouslySetInnerHTML={content} />
 
             {poll}
@@ -291,7 +291,7 @@ class StatusContent extends React.PureComponent {
       );
     } else {
       return (
-        <div className={classNames} ref={this.setRef} tabIndex='0' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+        <div className={classNames} ref={this.setRef} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
           <div className='status__content__text status__content__text--visible translate' lang={lang} dangerouslySetInnerHTML={content} />
 
           {poll}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -74,6 +74,11 @@
     background-color: $ui-highlight-color;
   }
 
+  &:focus {
+    outline: 5px auto $ui-highlight-color;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
+
   &--destructive {
     &:active,
     &:focus,
@@ -237,6 +242,8 @@
 
   &:focus {
     background-color: rgba($action-button-color, 0.3);
+    outline: 5px auto $ui-highlight-color;
+    outline: 5px auto -webkit-focus-ring-color;
   }
 
   &.disabled {
@@ -294,8 +301,14 @@
     border-radius: 4px;
     padding: 2px;
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: rgba($base-overlay-background, 0.9);
+    }
+
+    &:focus {
+      outline: 5px auto $ui-highlight-color;
+      outline: 5px auto -webkit-focus-ring-color;
     }
   }
 
@@ -340,6 +353,8 @@
 
   &:focus {
     background-color: rgba($lighter-text-color, 0.3);
+    outline: 5px auto $ui-highlight-color;
+    outline: 5px auto -webkit-focus-ring-color;
   }
 
   &.disabled {
@@ -2935,8 +2950,14 @@ $ui-header-height: 55px;
   padding: 0 5px 0 0;
   z-index: 3;
 
-  &:hover {
+  &:hover,
+  &:focus {
     text-decoration: underline;
+  }
+
+  &:focus {
+    outline: 5px auto $ui-highlight-color;
+    outline: 5px auto -webkit-focus-ring-color;
   }
 
   &:last-child {
@@ -3083,10 +3104,6 @@ $ui-header-height: 55px;
   &:focus,
   &:active {
     background: lighten($ui-base-color, 11%);
-  }
-
-  &:focus {
-    outline: 0;
   }
 
   &--transparent {
@@ -3687,6 +3704,11 @@ a.status-card.compact:hover {
   cursor: pointer;
   font-size: 16px;
   padding: 0 15px;
+
+  &:focus {
+    outline: 5px auto $ui-highlight-color;
+    outline: 5px auto -webkit-focus-ring-color;
+  }
 
   &:hover {
     color: lighten($darker-text-color, 7%);


### PR DESCRIPTION
There were some inconsistencies with focus ring usage that made keyboard navigation unwieldly. This PR fixes `tabIndex` values to match expectations (namely items without onKey/button actions should not have `tabIndex="0"`) and also adds focus outlines back to some buttons and links that were missing them. For browsers that don't support `-webkit-focus-ring-color` I propose using the Mastodon UI color as a fallback for the focus rings.

### Before
https://user-images.githubusercontent.com/38192823/208843168-b9448fa2-c6f6-40dd-b501-d8a353b948c4.mov

### After
https://user-images.githubusercontent.com/38192823/208842661-31fa4ff6-5967-4591-8faa-18db0710a62a.mov
