### PR TITLE
Strip spaces around URL when adding a relay

### DIFF
--- a/app/models/relay.rb
+++ b/app/models/relay.rb
@@ -18,6 +18,7 @@ class Relay < ApplicationRecord
 
   scope :enabled, -> { accepted }
 
+  before_validation :strip_url
   before_destroy :ensure_disabled
 
   alias enabled? accepted?
@@ -73,5 +74,9 @@ class Relay < ApplicationRecord
 
   def ensure_disabled
     disable! if enabled?
+  end
+
+  def strip_url
+    inbox_url&.strip!
   end
 end

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -10,5 +10,7 @@ class URLValidator < ActiveModel::EachValidator
   def compliant?(url)
     parsed_url = Addressable::URI.parse(url)
     parsed_url && %w(http https).include?(parsed_url.scheme) && parsed_url.host
+  rescue Addressable::URI::InvalidURIError
+    false
   end
 end


### PR DESCRIPTION
Fixes #22650

Also fixes URL validator crashing on invalid URLs.