### PR TITLE
Install SSH server into devcontainer image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,12 @@
     "webben.browserslist"
   ],
 
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  },
+
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // This can be used to network with other containers or the host.
   "forwardPorts": [3000, 4000],


### PR DESCRIPTION
Currently, JetBrains Gateway fails to connect to GitHub Codespaces due to lack of sshd.

![image](https://user-images.githubusercontent.com/27999567/209282907-dca61911-4fad-4c9b-a969-32a5f644b0a2.png)

To use GitHub Codespaces with JetBrains Gateway, SSH connection to the container is required.
This PR makes SSH server to be installed after container creation.
