### PR TITLE
fix: allow verification when page size exceeds 1MB

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -154,9 +154,7 @@ class Request
   end
 
   module ClientLimit
-    def body_with_limit(limit = 1.megabyte)
-      raise Mastodon::LengthValidationError if content_length.present? && content_length > limit
-
+    def truncated_body(limit = 1.megabyte)
       if charset.nil?
         encoding = Encoding::BINARY
       else
@@ -173,9 +171,17 @@ class Request
         contents << chunk
         chunk.clear
 
-        raise Mastodon::LengthValidationError if contents.bytesize > limit
+        break if contents.bytesize > limit
       end
 
+      contents
+    end
+
+    def body_with_limit(limit = 1.megabyte)
+      raise Mastodon::LengthValidationError if content_length.present? && content_length > limit
+
+      contents = truncated_body(limit)
+      raise Mastodon::LengthValidationError if contents.bytesize > limit
       contents
     end
   end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -120,6 +120,11 @@ describe Request do
       expect { subject.perform { |response| response.body_with_limit } }.to raise_error Mastodon::LengthValidationError
     end
 
+    it 'truncates large monolithic body' do
+      stub_request(:any, 'http://example.com').to_return(body: SecureRandom.random_bytes(2.megabytes), headers: { 'Content-Length' => 2.megabytes })
+      expect(subject.perform { |response| response.truncated_body.bytesize }).to be < 2.megabytes
+    end
+
     it 'uses binary encoding if Content-Type does not tell encoding' do
       stub_request(:any, 'http://example.com').to_return(body: '', headers: { 'Content-Type' => 'text/html' })
       expect(subject.perform { |response| response.body_with_limit.encoding }).to eq Encoding::BINARY

--- a/spec/services/verify_link_service_spec.rb
+++ b/spec/services/verify_link_service_spec.rb
@@ -73,6 +73,33 @@ RSpec.describe VerifyLinkService, type: :service do
       end
     end
 
+    context 'when a document is truncated but the link back is valid' do
+      let(:html) do
+        "
+          <!doctype html>
+          <body>
+            <a rel=\"me\" href=\"#{ActivityPub::TagManager.instance.url_for(account)}\"
+        "
+      end
+
+      it 'marks the field as verified' do
+        expect(field.verified?).to be true
+      end
+    end
+
+    context 'when a link back might be truncated' do
+      let(:html) do
+        "
+          <!doctype html>
+          <body>
+            <a rel=\"me\" href=\"#{ActivityPub::TagManager.instance.url_for(account)}"
+      end
+
+      it 'does not mark the field as verified' do
+        expect(field.verified?).to be false
+      end
+    end
+
     context 'when a link does not contain a link back' do
       let(:html) { '' }
 


### PR DESCRIPTION
This PR addresses a failure to verify when the linked page is more than 1 megabyte by adding a `truncated_body` method to the `ClientLimit` class which gets monkey patched into requests. This then uses that when verifying Mastodon profiles.

The Washington Post ran into this limit while trying to verify its journalists using links on their [author pages](https://www.washingtonpost.com/people/drew-harwell/), which are sometimes larger than 1 MB. Instead of failing silently in that case, this looks for verification links in the first 1 MB of the response body.

This method could also be useful other places limited-size requests are used, e.g. metadata fetching, however, I wanted to proceed cautiously to address this one case and not change the functionality of the existing API.

In testing, Nokogiri seemed to work well with truncated documents, so this should work in most cases.

However, per a good point raised by @ClearlyClaire's about the dangers of verifying a possibly truncated user name, this also tests whether the link is at the very end of the body, in which case it might be truncated. For instance, 
```html
<a rel="me" href="https://example.com/@al
```
would be rejected since the full link might be
```html
<a rel="me" href="https://example.com/@alice">
```

This should be a rare occurrence, e.g. just those cases where the link happens to fall right at the 1MB boundary, but worth guarding against just the same.

Closes #15316