### PR TITLE
Format API responses when viewed directly in a browser

### DIFF
--- a/lib/mastodon/rack_middleware.rb
+++ b/lib/mastodon/rack_middleware.rb
@@ -17,7 +17,7 @@ class Mastodon::RackMiddleware
 
   # If the request is expecting HTML but the response is JSON,
   # pretty-print the json so it can be more easily read
-  def format_json env, headers, response
+  def format_json(env, headers, response)
     if headers['Content-Type']&.include?('application/json') && env['HTTP_ACCEPT']&.include?('text/html')
       [JSON.pretty_generate(JSON.parse(response.body))]
     else

--- a/lib/mastodon/rack_middleware.rb
+++ b/lib/mastodon/rack_middleware.rb
@@ -6,12 +6,24 @@ class Mastodon::RackMiddleware
   end
 
   def call(env)
-    @app.call(env)
+    status, headers, response = @app.call(env)
+    response = format_json(env, headers, response)
+    [status, headers, response]
   ensure
     clean_up_sockets!
   end
 
   private
+
+  # If the request is expecting HTML but the response is JSON,
+  # pretty-print the json so it can be more easily read
+  def format_json env, headers, response
+    if headers['Content-Type']&.include?('application/json') && env['HTTP_ACCEPT']&.include?('text/html')
+      [JSON.pretty_generate(JSON.parse(response.body))]
+    else
+      response
+    end
+  end
 
   def clean_up_sockets!
     clean_up_redis_socket!


### PR DESCRIPTION
Previously, API responses when viewed in the browser showed up on one line. Chrome and Safari didn’t even word wrap it so you have to scroll horizontally (Firefox parses the JSON and renders an interactive viewer instead which is amazing!).

This PR uses `JSON.pretty_generate` to reformat a JSON response body, but only if the `Accept` header contains `text/html`. There doesn’t appear to be a significant performance impact (although I don’t know how caching works so my limited local testing could be invalid). If a program is mistakenly sending `Accept: text/html` it will still get valid JSON in the response, it will just have more whitespace than previously so nothing should break in that respect.