### PR TITLE
Remove home marker updates

### DIFF
--- a/app/javascript/mastodon/actions/markers.ts
+++ b/app/javascript/mastodon/actions/markers.ts
@@ -1,5 +1,3 @@
-import { List as ImmutableList } from 'immutable';
-
 import { debounce } from 'lodash';
 
 import type { MarkerJSON } from 'mastodon/api_types/markers';
@@ -71,19 +69,6 @@ interface MarkerParam {
   last_read_id?: string;
 }
 
-function getLastHomeId(state: RootState): string | undefined {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return (
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    state
-      // @ts-expect-error state.timelines is not yet typed
-      .getIn(['timelines', 'home', 'items'], ImmutableList())
-      // @ts-expect-error state.timelines is not yet typed
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      .find((item) => item !== null)
-  );
-}
-
 function getLastNotificationId(state: RootState): string | undefined {
   // @ts-expect-error state.notifications is not yet typed
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
@@ -93,14 +78,7 @@ function getLastNotificationId(state: RootState): string | undefined {
 const buildPostMarkersParams = (state: RootState) => {
   const params = {} as { home?: MarkerParam; notifications?: MarkerParam };
 
-  const lastHomeId = getLastHomeId(state);
   const lastNotificationId = getLastNotificationId(state);
-
-  if (lastHomeId && compareId(lastHomeId, state.markers.home) > 0) {
-    params.home = {
-      last_read_id: lastHomeId,
-    };
-  }
 
   if (
     lastNotificationId &&


### PR DESCRIPTION
Currently the web client sets the home marker but it does not read it back from the api. Because the web client does not restore the user's last read location, it will typically set the marker to the newest post in the user's timeline, wiping out any value other clients have set. This causes issues with other clients because a user may open the web to post something, and when they return to another client, their current position in their timeline gets wiped out.

This has led client developers to abandon the marker api. See https://social.shadowfacts.net/objects/94a82c8f-db49-4caf-8b8a-3838b0329d01 and https://mastodon.social/@libei/109547043962905774.