### PR TITLE
Change S2S POST/GET Content-Type to match ActivityPub spec

### DIFF
--- a/app/lib/activitypub/dereferencer.rb
+++ b/app/lib/activitypub/dereferencer.rb
@@ -44,7 +44,7 @@ class ActivityPub::Dereferencer
 
     req = Request.new(:get, uri)
 
-    req.add_headers('Accept' => 'application/activity+json, application/ld+json')
+    req.add_headers('Accept' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"')
     req.add_headers(headers) if headers
     req.on_behalf_of(@signature_actor) if @signature_actor
 

--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -3,7 +3,7 @@
 class FetchResourceService < BaseService
   include JsonLdHelper
 
-  ACCEPT_HEADER = 'application/activity+json, application/ld+json; profile="https://www.w3.org/ns/activitystreams", text/html;q=0.1'
+  ACCEPT_HEADER = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
 
   attr_reader :response_code
 

--- a/app/services/keys/claim_service.rb
+++ b/app/services/keys/claim_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Keys::ClaimService < BaseService
-  HEADERS = { 'Content-Type' => 'application/activity+json' }.freeze
+  HEADERS = { 'Content-Type' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' }.freeze
 
   class Result < ActiveModelSerializers::Model
     attributes :account, :device_id, :key_id,

--- a/app/workers/activitypub/delivery_worker.rb
+++ b/app/workers/activitypub/delivery_worker.rb
@@ -10,7 +10,7 @@ class ActivityPub::DeliveryWorker
 
   sidekiq_options queue: 'push', retry: 16, dead: false
 
-  HEADERS = { 'Content-Type' => 'application/activity+json' }.freeze
+  HEADERS = { 'Content-Type' => 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"' }.freeze
 
   def perform(json, source_account_id, inbox_url, options = {})
     return unless DeliveryFailureTracker.available?(inbox_url)


### PR DESCRIPTION
Fix #22720

- Request types changed to ld+json per ActivityPub requirement
- Response types kept as activity+json per ActivityStreams-Core description