### PR TITLE
Updated 'new post' compose box to suit dark theme

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -497,8 +497,8 @@
     box-sizing: border-box;
     width: 100%;
     margin: 0;
-    color: $inverted-text-color;
-    background: $simple-background-color;
+    color: $classic-secondary-color;
+    background: $classic-base-color;
     padding: 10px;
     font-family: inherit;
     font-size: 14px;
@@ -507,7 +507,7 @@
     outline: 0;
 
     &::placeholder {
-      color: $dark-text-color;
+      color: $classic-primary-color;
     }
 
     &:focus {
@@ -693,7 +693,7 @@
 
   .compose-form__buttons-wrapper {
     padding: 10px;
-    background: darken($simple-background-color, 8%);
+    background: lighten($ui-base-color, 8%);
     border-radius: 0 0 4px 4px;
     display: flex;
     justify-content: space-between;
@@ -2745,7 +2745,7 @@ $ui-header-height: 55px;
 
   .compose-form__autosuggest-wrapper {
     overflow-y: auto;
-    background-color: $white;
+    background-color: $classic-base-color;
     border-radius: 4px 4px 0 0;
     flex: 0 1 auto;
   }


### PR DESCRIPTION
Hi, I have made some slight tweaks to colours used for the 'New Post' compose box, see below:

![combined_01](https://user-images.githubusercontent.com/22441451/209492147-cefce602-7845-4d55-8123-0a0f0a93379a.png)

The changes made are not hard coded i.e. they use existing SCSS variables from `variables.scss` so as not to break compatibility.
