### PR TITLE
Remove unneded `ignore_columns`

### DIFF
--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -11,11 +11,6 @@
 #
 
 class EmailDomainBlock < ApplicationRecord
-  self.ignored_columns = %w(
-    ips
-    last_refresh_at
-  )
-
   include DomainNormalizable
   include Paginable
 

--- a/app/models/email_domain_block.rb
+++ b/app/models/email_domain_block.rb
@@ -58,7 +58,7 @@ class EmailDomainBlock < ApplicationRecord
 
         segments = uri.normalized_host.split('.')
 
-        segments.map.with_index { |_, i| segments[i..-1].join('.') }
+        segments.map.with_index { |_, i| segments[i..].join('.') }
       end
     end
 


### PR DESCRIPTION
Because these columns have been removed in https://github.com/mastodon/mastodon/pull/18190.