### PR TITLE
Add word break to rule list text

### DIFF
--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -52,5 +52,9 @@ $fluid-breakpoint: $maximum-width + 20px;
     &:last-child {
       border-bottom: 0;
     }
+    
+    .rules-list__text {
+      word-break: break-word;
+    }
   }
 }

--- a/app/javascript/styles/mastodon/about.scss
+++ b/app/javascript/styles/mastodon/about.scss
@@ -52,7 +52,7 @@ $fluid-breakpoint: $maximum-width + 20px;
     &:last-child {
       border-bottom: 0;
     }
-    
+
     .rules-list__text {
       word-break: break-word;
     }


### PR DESCRIPTION
On a Mastodon instance I use, it would include a long URL in one of the listed rules. As there was no word wrap, this would go out of view, requiring the user to either select and drag the text or scroll horizontally.

This adjustment to the styling aims to wrap long "words" (text) such as the aforementioned so that it remains in view.

Note: more of the Mastodon UI could do with such specific enhancement. For example, most of the 'about' page. This is just one of those low-hanging quick styling adjustments.