### PR TITLE
Fix checkmark symbol for sensitive media in compose form

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -423,7 +423,7 @@
 
       &.active {
         border-color: $highlight-text-color;
-        background: $highlight-text-color;
+        background: $highlight-text-color url("data:image/svg+xml;utf8,<svg width='18' height='18' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M4.5 8.5L8 12l6-6' stroke='white' stroke-width='1.5'/></svg>") center center no-repeat;
       }
     }
   }


### PR DESCRIPTION
This PR resolves #20721, where the checkbox for "Mark media as sensitive" in the compose form is not easy to distinguish between checked an unchecked states.

Before:

<img src="https://user-images.githubusercontent.com/726932/209690718-a1e52ca1-374f-4811-8f85-8129560d4317.png" width="279" height="114" alt="Before">

After:

<img src="https://user-images.githubusercontent.com/726932/209690743-614cc4a4-1bbb-4b11-819b-363fad1b1ad9.png" width="279" height="114" alt="After">