### PR TITLE
Replace admin header button flex styling with sensible layout rules

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -254,10 +254,8 @@ $content-width: 840px;
 
       &__actions {
         display: inline-flex;
-
-        & > :not(:first-child) {
-          margin-left: 5px;
-        }
+        flex-flow: wrap;
+        gap: 5px;
       }
 
       h2 small {


### PR DESCRIPTION
The old styling would cause multiple admin header buttons in a flex container to overflow the page on mobile:

![image](https://user-images.githubusercontent.com/266454/209739451-5e0102e7-7111-4a6c-891b-2aa6c5a8e403.png)

This new styling uses `flex-flow: wrap` along with a gap, which gets rid of the awkward `:not(:first-child)` pseudoselector and makes multiple buttons in a row flow nicely:

![image](https://user-images.githubusercontent.com/266454/209739468-5572f6cc-2c55-4002-9f7d-7530e2fa7c2c.png)

I tested this on every admin panel view in 4.0.2 in desktop and mobile and didn't notice any regressions.
