### PR TITLE
Add peers API endpoint toggle to Server Settings

### DIFF
--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -29,6 +29,11 @@
   .fields-group
     = f.input :noindex, as: :boolean, wrapper: :with_label, label: t('admin.settings.default_noindex.title'), hint: t('admin.settings.default_noindex.desc_html')
 
+  %h4= t('admin.settings.discovery.publish_discovered_servers')
+
+  .fields-group
+    = f.input :peers_api_enabled, as: :boolean, wrapper: :with_label, recommended: :recommended
+
   %h4= t('admin.settings.discovery.follow_recommendations')
 
   .fields-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -713,6 +713,7 @@ en:
         preamble: Surfacing interesting content is instrumental in onboarding new users who may not know anyone Mastodon. Control how various discovery features work on your server.
         profile_directory: Profile directory
         public_timelines: Public timelines
+        publish_discovered_servers: Publish discovered servers
         title: Discovery
         trends: Trends
       domain_blocks:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -237,8 +237,8 @@ en:
         custom_css: Custom CSS
         mascot: Custom mascot (legacy)
         media_cache_retention_period: Media cache retention period
-        profile_directory: Enable profile directory
         peers_api_enabled: Publish list of discovered servers in the API
+        profile_directory: Enable profile directory
         registrations_mode: Who can sign-up
         require_invite_text: Require a reason to join
         show_domain_blocks: Show domain blocks

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -81,6 +81,7 @@ en:
         custom_css: You can apply custom styles on the web version of Mastodon.
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.
+        peers_api_enabled: A list of domain names this server has encountered in the fediverse. No data is included here about whether you federate with a given server, just that your server knows about it. This is used by services that collect statistics on federation in a general sense.
         profile_directory: The profile directory lists all users who have opted-in to be discoverable.
         require_invite_text: When sign-ups require manual approval, make the “Why do you want to join?” text input mandatory rather than optional
         site_contact_email: How people can reach you for legal or support inquiries.
@@ -237,6 +238,7 @@ en:
         mascot: Custom mascot (legacy)
         media_cache_retention_period: Media cache retention period
         profile_directory: Enable profile directory
+        peers_api_enabled: Publish list of discovered servers in the API
         registrations_mode: Who can sign-up
         require_invite_text: Require a reason to join
         show_domain_blocks: Show domain blocks


### PR DESCRIPTION
This PR adds back the admin panel toggle for the `api/v1/instance/peers` endpoint, which was removed in #19407. It lives under Administration -> Site Settings -> Discovery.

![image](https://user-images.githubusercontent.com/266454/209871754-1bc65222-ca26-4615-b10f-4b9544b09970.png)

This also expands the hint text to explain further what the endpoint is used for. Added a "Recommended" tag since it was recommended in v3 before it was removed.

Fixes #22222 