### PR TITLE
Correct hashtag warning

### DIFF
--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -128,7 +128,7 @@
   "compose.language.search": "Search languages...",
   "compose_form.direct_message_warning_learn_more": "Learn more",
   "compose_form.encryption_warning": "Posts on Mastodon are not end-to-end encrypted. Do not share any sensitive information over Mastodon.",
-  "compose_form.hashtag_warning": "This post won't be listed under any hashtag as it is unlisted. Only public posts can be searched by hashtag.",
+  "compose_form.hashtag_warning": "This post won't be listed under any hashtag as it is not public. Only public posts can be searched by hashtag.",
   "compose_form.lock_disclaimer": "Your account is not {locked}. Anyone can follow you to view your follower-only posts.",
   "compose_form.lock_disclaimer.lock": "locked",
   "compose_form.placeholder": "What's on your mind?",


### PR DESCRIPTION
Posts with any visibility setting that is not 'Public' are prevented from being listed under any hashtag.

---

P.S. I did not update the string in other locales, e.g. `en-GB`, under the assumption that this would be done by the translators and because of similar pull requests by reputable contributors not containing such changes. Hope that's OK.