### PR TITLE
Add warning icon on media that lacks descriptive text

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -170,7 +170,7 @@ class Item extends React.PureComponent {
           target='_blank'
           rel='noopener noreferrer'
         >
-          { !attachment.get('description') && <IconButton className='media-gallery__item-no-description media__no-description-icon' title={this.props.noDescriptionTitle} icon='exclamation-triangle' overlay /> }
+          { !attachment.get('description') && <IconButton className='media-gallery__item-no-description media__no-description-icon' title={this.props.noDescriptionTitle} icon='exclamation-triangle' style={{ right: `calc(4px + ${(left === 'auto' ? '0px' : left)})`, bottom: `calc(4px + ${(top === 'auto' ? '0px' : top)})` }} overlay /> }
           <img
             src={previewUrl}
             srcSet={srcSet}

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -170,7 +170,7 @@ class Item extends React.PureComponent {
           target='_blank'
           rel='noopener noreferrer'
         >
-          { !attachment.get('description') && <IconButton className='media-gallery__item-no-alt' title={this.props.noDescriptionTitle} icon='exclamation-triangle' overlay /> }
+          { !attachment.get('description') && <IconButton className='media-gallery__item-no-description media__no-description-icon' title={this.props.noDescriptionTitle} icon='exclamation-triangle' overlay /> }
           <img
             src={previewUrl}
             srcSet={srcSet}

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -25,7 +25,7 @@ class Item extends React.PureComponent {
     displayWidth: PropTypes.number,
     visible: PropTypes.bool.isRequired,
     autoplay: PropTypes.bool,
-    noDescriptionTitle: PropTypes.object,
+    noDescriptionTitle: PropTypes.string,
   };
 
   static defaultProps = {

--- a/app/javascript/mastodon/components/media_gallery.js
+++ b/app/javascript/mastodon/components/media_gallery.js
@@ -11,6 +11,7 @@ import Blurhash from 'mastodon/components/blurhash';
 
 const messages = defineMessages({
   toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: '{number, plural, one {Hide image} other {Hide images}}' },
+  no_descriptive_text: { id: 'media.no_descriptive_text', defaultMessage: 'No descriptive text was provided for this media.' },
 });
 
 class Item extends React.PureComponent {
@@ -24,6 +25,7 @@ class Item extends React.PureComponent {
     displayWidth: PropTypes.number,
     visible: PropTypes.bool.isRequired,
     autoplay: PropTypes.bool,
+    noDescriptionTitle: PropTypes.object,
   };
 
   static defaultProps = {
@@ -134,7 +136,7 @@ class Item extends React.PureComponent {
     if (attachment.get('type') === 'unknown') {
       return (
         <div className={classNames('media-gallery__item', { standalone })} key={attachment.get('id')} style={{ left: left, top: top, right: right, bottom: bottom, width: `${width}%`, height: `${height}%` }}>
-          <a className='media-gallery__item-thumbnail' href={attachment.get('remote_url') || attachment.get('url')} style={{ cursor: 'pointer' }} title={attachment.get('description')} target='_blank' rel='noopener noreferrer'>
+          <a className={`media-gallery__item-thumbnail ${!attachment.get('description') && 'media-missing-description'}`} href={attachment.get('remote_url') || attachment.get('url')} style={{ cursor: 'pointer' }} title={attachment.get('description')} target='_blank' rel='noopener noreferrer'>
             <Blurhash
               hash={attachment.get('blurhash')}
               className='media-gallery__preview'
@@ -162,12 +164,13 @@ class Item extends React.PureComponent {
 
       thumbnail = (
         <a
-          className='media-gallery__item-thumbnail'
+          className={`media-gallery__item-thumbnail ${!attachment.get('description') && 'media-missing-description'}`}
           href={attachment.get('remote_url') || originalUrl}
           onClick={this.handleClick}
           target='_blank'
           rel='noopener noreferrer'
         >
+          { !attachment.get('description') && <IconButton className='media-gallery__item-no-alt' title={this.props.noDescriptionTitle} icon='exclamation-triangle' overlay /> }
           <img
             src={previewUrl}
             srcSet={srcSet}
@@ -185,7 +188,7 @@ class Item extends React.PureComponent {
       thumbnail = (
         <div className={classNames('media-gallery__gifv', { autoplay: autoPlay })}>
           <video
-            className='media-gallery__item-gifv-thumbnail'
+            className={`media-gallery__item-gifv-thumbnail ${!attachment.get('description') && 'media-missing-description'}`}
             aria-label={attachment.get('description')}
             title={attachment.get('description')}
             role='application'
@@ -199,7 +202,10 @@ class Item extends React.PureComponent {
             muted
           />
 
-          <span className='media-gallery__gifv__label'>GIF</span>
+          <div className='media-gallery__gifv__label__container'>
+            <span className='media-gallery__gifv__label'>GIF</span>
+            { !attachment.get('description') && <span className='media-gallery__gifv__label__no-description'><IconButton title={this.props.noDescriptionTitle} icon='exclamation-triangle' overlay /></span> }
+          </div>
         </div>
       );
     }
@@ -329,13 +335,14 @@ class MediaGallery extends React.PureComponent {
       style.height = height;
     }
 
-    const size     = media.take(4).size;
-    const uncached = media.every(attachment => attachment.get('type') === 'unknown');
+    const size       = media.take(4).size;
+    const uncached   = media.every(attachment => attachment.get('type') === 'unknown');
+    const noDescriptionTitle = intl.formatMessage(messages.no_descriptive_text);
 
     if (standalone && this.isFullSizeEligible()) {
-      children = <Item standalone autoplay={autoplay} onClick={this.handleClick} attachment={media.get(0)} displayWidth={width} visible={visible} />;
+      children = <Item standalone autoplay={autoplay} onClick={this.handleClick} attachment={media.get(0)} displayWidth={width} visible={visible} noDescriptionTitle={noDescriptionTitle} />;
     } else {
-      children = media.take(4).map((attachment, i) => <Item key={attachment.get('id')} autoplay={autoplay} onClick={this.handleClick} attachment={attachment} index={i} size={size} displayWidth={width} visible={visible || uncached} />);
+      children = media.take(4).map((attachment, i) => <Item key={attachment.get('id')} autoplay={autoplay} onClick={this.handleClick} attachment={attachment} index={i} size={size} displayWidth={width} visible={visible || uncached} noDescriptionTitle={noDescriptionTitle} />);
     }
 
     if (uncached) {

--- a/app/javascript/mastodon/features/audio/index.js
+++ b/app/javascript/mastodon/features/audio/index.js
@@ -19,6 +19,7 @@ const messages = defineMessages({
   unmute: { id: 'video.unmute', defaultMessage: 'Unmute sound' },
   download: { id: 'video.download', defaultMessage: 'Download file' },
   hide: { id: 'audio.hide', defaultMessage: 'Hide audio' },
+  no_descriptive_text: { id: 'media.no_descriptive_text', defaultMessage: 'No descriptive text was provided for this media.' },
 });
 
 const TICK_SIZE = 10;
@@ -470,7 +471,7 @@ class Audio extends React.PureComponent {
     }
 
     return (
-      <div className={classNames('audio-player', { editable, inactive: !revealed })} ref={this.setPlayerRef} style={{ backgroundColor: this._getBackgroundColor(), color: this._getForegroundColor(), width: '100%', height: this.props.fullscreen ? '100%' : (this.state.height || this.props.height) }} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} tabIndex='0' onKeyDown={this.handleKeyDown}>
+      <div className={classNames('audio-player', { editable, inactive: !revealed, 'media-missing-description': !alt })} ref={this.setPlayerRef} style={{ backgroundColor: this._getBackgroundColor(), color: this._getForegroundColor(), width: '100%', height: this.props.fullscreen ? '100%' : (this.state.height || this.props.height) }} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} tabIndex='0' onKeyDown={this.handleKeyDown}>
 
         <Blurhash
           hash={blurhash}
@@ -555,6 +556,7 @@ class Audio extends React.PureComponent {
             </div>
 
             <div className='video-player__buttons right'>
+              {!alt && <button type='button' title={intl.formatMessage(messages.no_descriptive_text)} aria-label={intl.formatMessage(messages.no_descriptive_text)} className='player-button no-action' ><Icon id='exclamation-triangle' fixedWidth /></button>}
               {!editable && <button type='button' title={intl.formatMessage(messages.hide)} aria-label={intl.formatMessage(messages.hide)} className='player-button' onClick={this.toggleReveal}><Icon id='eye-slash' fixedWidth /></button>}
               <a title={intl.formatMessage(messages.download)} aria-label={intl.formatMessage(messages.download)} className='video-player__download__icon player-button' href={this.props.src} download>
                 <Icon id={'download'} fixedWidth />

--- a/app/javascript/mastodon/features/audio/index.js
+++ b/app/javascript/mastodon/features/audio/index.js
@@ -556,7 +556,7 @@ class Audio extends React.PureComponent {
             </div>
 
             <div className='video-player__buttons right'>
-              {!alt && <button type='button' title={intl.formatMessage(messages.no_descriptive_text)} aria-label={intl.formatMessage(messages.no_descriptive_text)} className='player-button no-action' ><Icon id='exclamation-triangle' fixedWidth /></button>}
+              {!alt && <button type='button' title={intl.formatMessage(messages.no_descriptive_text)} aria-label={intl.formatMessage(messages.no_descriptive_text)} className='player-button no-action media__no-description-icon' ><Icon id='exclamation-triangle' fixedWidth /></button>}
               {!editable && <button type='button' title={intl.formatMessage(messages.hide)} aria-label={intl.formatMessage(messages.hide)} className='player-button' onClick={this.toggleReveal}><Icon id='eye-slash' fixedWidth /></button>}
               <a title={intl.formatMessage(messages.download)} aria-label={intl.formatMessage(messages.download)} className='video-player__download__icon player-button' href={this.props.src} download>
                 <Icon id={'download'} fixedWidth />

--- a/app/javascript/mastodon/features/video/index.js
+++ b/app/javascript/mastodon/features/video/index.js
@@ -641,7 +641,7 @@ class Video extends React.PureComponent {
             </div>
 
             <div className='video-player__buttons right'>
-              {!alt && <button type='button' title={intl.formatMessage(messages.no_descriptive_text)} aria-label={intl.formatMessage(messages.no_descriptive_text)} className='player-button no-action' ><Icon id='exclamation-triangle' fixedWidth /></button>}
+              {!alt && <button type='button' title={intl.formatMessage(messages.no_descriptive_text)} aria-label={intl.formatMessage(messages.no_descriptive_text)} className='player-button no-action media__no-description-icon' ><Icon id='exclamation-triangle' fixedWidth /></button>}
               {(!onCloseVideo && !editable && !fullscreen && !this.props.alwaysVisible) && <button type='button' title={intl.formatMessage(messages.hide)} aria-label={intl.formatMessage(messages.hide)} className='player-button' onClick={this.toggleReveal}><Icon id='eye-slash' fixedWidth /></button>}
               {(!fullscreen && onOpenVideo) && <button type='button' title={intl.formatMessage(messages.expand)} aria-label={intl.formatMessage(messages.expand)} className='player-button' onClick={this.handleOpenVideo}><Icon id='expand' fixedWidth /></button>}
               {onCloseVideo && <button type='button' title={intl.formatMessage(messages.close)} aria-label={intl.formatMessage(messages.close)} className='player-button' onClick={this.handleCloseVideo}><Icon id='compress' fixedWidth /></button>}

--- a/app/javascript/mastodon/features/video/index.js
+++ b/app/javascript/mastodon/features/video/index.js
@@ -19,6 +19,7 @@ const messages = defineMessages({
   close: { id: 'video.close', defaultMessage: 'Close video' },
   fullscreen: { id: 'video.fullscreen', defaultMessage: 'Full screen' },
   exit_fullscreen: { id: 'video.exit_fullscreen', defaultMessage: 'Exit full screen' },
+  no_descriptive_text: { id: 'media.no_descriptive_text', defaultMessage: 'No descriptive text was provided for this media.' },
 });
 
 export const formatTime = secondsNum => {
@@ -558,7 +559,7 @@ class Video extends React.PureComponent {
     return (
       <div
         role='menuitem'
-        className={classNames('video-player', { inactive: !revealed, detailed, inline: inline && !fullscreen, fullscreen, editable })}
+        className={classNames('video-player', { inactive: !revealed, detailed, inline: inline && !fullscreen, fullscreen, editable, 'media-missing-description': !alt })}
         style={playerStyle}
         ref={this.setPlayerRef}
         onMouseEnter={this.handleMouseEnter}
@@ -640,6 +641,7 @@ class Video extends React.PureComponent {
             </div>
 
             <div className='video-player__buttons right'>
+              {!alt && <button type='button' title={intl.formatMessage(messages.no_descriptive_text)} aria-label={intl.formatMessage(messages.no_descriptive_text)} className='player-button no-action' ><Icon id='exclamation-triangle' fixedWidth /></button>}
               {(!onCloseVideo && !editable && !fullscreen && !this.props.alwaysVisible) && <button type='button' title={intl.formatMessage(messages.hide)} aria-label={intl.formatMessage(messages.hide)} className='player-button' onClick={this.toggleReveal}><Icon id='eye-slash' fixedWidth /></button>}
               {(!fullscreen && onOpenVideo) && <button type='button' title={intl.formatMessage(messages.expand)} aria-label={intl.formatMessage(messages.expand)} className='player-button' onClick={this.handleOpenVideo}><Icon id='expand' fixedWidth /></button>}
               {onCloseVideo && <button type='button' title={intl.formatMessage(messages.close)} aria-label={intl.formatMessage(messages.close)} className='player-button' onClick={this.handleCloseVideo}><Icon id='compress' fixedWidth /></button>}

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -360,6 +360,7 @@
   "load_pending": "{count, plural, one {# new item} other {# new items}}",
   "loading_indicator.label": "Loading...",
   "media_gallery.toggle_visible": "{number, plural, one {Hide image} other {Hide images}}",
+  "media.no_descriptive_text": "No descriptive text was provided for this media.",
   "missing_indicator.label": "Not found",
   "missing_indicator.sublabel": "This resource could not be found",
   "moved_to_account_banner.text": "Your account {disabledAccount} is currently disabled because you moved to {movedToAccount}.",

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5936,7 +5936,7 @@ a.status-card.compact:hover {
   }
 }
 
-.media-gallery__item-no-alt {
+.media-gallery__item-no-description {
   position: absolute;
   bottom: 4px;
   left: 4px;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5938,8 +5938,6 @@ a.status-card.compact:hover {
 
 .media-gallery__item-no-description {
   position: absolute;
-  bottom: 4px;
-  left: 4px;
 }
 
 .media-gallery__item-thumbnail {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5801,22 +5801,40 @@ a.status-card.compact:hover {
   z-index: 9999;
 }
 
-.media-gallery__gifv__label {
+.media-gallery__gifv__label__container {
   display: block;
   position: absolute;
+  bottom: 4px;
+  left: 4px;
+  z-index: 1;
+  cursor: default;
+}
+
+.media-gallery__gifv__label {
   color: $primary-text-color;
   background: rgba($base-overlay-background, 0.5);
-  bottom: 6px;
-  left: 6px;
-  padding: 2px 6px;
   border-radius: 2px;
+  padding: 3px 6px;
   font-size: 11px;
   font-weight: 600;
-  z-index: 1;
   pointer-events: none;
   opacity: 0.9;
   transition: opacity 0.1s ease;
-  line-height: 18px;
+}
+
+.media-gallery__gifv__label__no-description {
+  color: $primary-text-color;
+  border-radius: 2px;
+  padding: 2px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  z-index: 1;
+  opacity: 0.9;
+  transition: opacity 0.1s ease;
+
+  button {
+    cursor: default;
+  }
 }
 
 .media-gallery__gifv {
@@ -5916,6 +5934,12 @@ a.status-card.compact:hover {
       top: 0;
     }
   }
+}
+
+.media-gallery__item-no-alt {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
 }
 
 .media-gallery__item-thumbnail {
@@ -6204,6 +6228,10 @@ a.status-card.compact:hover {
       &:focus {
         color: $white;
       }
+    }
+
+    .no-action {
+      cursor: default;
     }
   }
 


### PR DESCRIPTION
This PR adds a warning icon to media that appears in user timelines without descriptive text. This is a signal to people who do not want to boost media that lacks descriptive text. It also is a signal to people who post media -- they will see it in their own timeline with the warning icon, which prompts them to add descriptive text if they have forgotten to do so.

What follows is examples of how it renders for each media type, and then a description of a custom CSS feature, and then a list of known issues and concerns related to this PR.

### Images

Gallery:

![image](https://user-images.githubusercontent.com/266454/209991671-e4c3e665-6285-4e03-9e45-812cca3e4582.png)

Single image:

![image](https://user-images.githubusercontent.com/266454/209991707-6fd54151-a0b2-4145-b6a3-530023a12347.png)

Gallery in mobile view:

![image](https://user-images.githubusercontent.com/266454/209994979-d8e1f481-6227-4c16-b7a8-e5c49b418aa3.png)

### gifv

![image](https://user-images.githubusercontent.com/266454/209991748-12e68a9a-0ca1-4d3d-b823-9e6465a2be1e.png)

### Audio

![image](https://user-images.githubusercontent.com/266454/209991784-4616edc2-003f-40eb-8311-afa5a4e7b443.png)

### Video

![image](https://user-images.githubusercontent.com/266454/209991824-b1304be0-4203-42cd-aa02-dea3f0b0ab39.png)

### Cursor behavior

The cursor, when it floats over the icon, remains as `cursor: default` to indicate that it is not an actionable button, and the tooltip text says in English, "No descriptive text was provided for this media."

### Custom CSS

Also, for admins who want to add custom CSS rules via the admin panel to media that is missing descriptions, there is now a `.media-missing-description` class that wraps all the above media types, so admins can further customize the behavior. Example:

```css
.media-missing-description: {
  border: 2px dashed red;
  box-styling: border-box;
}
```

The icon itself may also be customized via `.media__no-description-icon`.

![image](https://user-images.githubusercontent.com/266454/209992025-f78cf08c-e149-4235-a80d-f3f96915c31c.png)

### Known issues

~There is an alignment issue in a gallery where the left two icons appear 4px from the left but the right two icons appear 6px from the left. I think this is due to the gap between images factoring in to the right two icons, but I haven't been able to fix it yet:~

__Fixed in 0864a9526a__

### Concerns

There may be some wish for all icons on a media item to be the same size. For example, the "GIF" icon on a gifv is a different size from the warning icon. It was already a non-standard size but it's more evident when it is next to another icon.

~Also, I think it's unfortunate that the icon lives on the lower right in video/audio but on the lower left in image/gifv. Maybe it makes sense to move the icon to the lower right? For whatever reason though, seeing the "eye-slash" icon in the upper left and the "warning" icon in the lower right on an image looks weirder to me than having them both left-justified:~

__Update, I have moved the icons to the lower right for images and gifv__:

![image](https://user-images.githubusercontent.com/266454/210055405-9e992467-4513-4943-b3ec-59a1f4e35283.png)

Finally, I predict some users wanting to turn this off. I did not provide an off switch for this in Hometown on the user level, though admins can provide custom CSS to turn the icons off:

```css
.media__no-description-icon {
  display: none;
}
```

I strongly believe that this is a good feature for a healthy network, which is why I do not provide user opt-out here. But if someone on the Mastodon project wants to add it, of course I can't stop you -- but I won't do that work.