### PR TITLE
Fix issue for selecting the mark media as sensitive checkbox via tab.

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -405,7 +405,7 @@
     }
 
     input[type="checkbox"] {
-      display: none;
+      opacity: 0;
     }
 
     .checkbox {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -405,7 +405,9 @@
     }
 
     input[type="checkbox"] {
-      opacity: 0;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
     }
 
     .checkbox {


### PR DESCRIPTION
User was unable to select the Mark as sensitive checkbox when posting using tab and toggle it via space.

https://user-images.githubusercontent.com/2009988/210124975-809e7a55-bb25-493b-a074-89990e05716c.mp4


This fixes #22842