### PR TITLE
fix: allow verification when page size exceeds 1MB (using HTML5 parser)

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -154,9 +154,7 @@ class Request
   end
 
   module ClientLimit
-    def body_with_limit(limit = 1.megabyte)
-      raise Mastodon::LengthValidationError if content_length.present? && content_length > limit
-
+    def truncated_body(limit = 1.megabyte)
       if charset.nil?
         encoding = Encoding::BINARY
       else
@@ -173,9 +171,17 @@ class Request
         contents << chunk
         chunk.clear
 
-        raise Mastodon::LengthValidationError if contents.bytesize > limit
+        break if contents.bytesize > limit
       end
 
+      contents
+    end
+
+    def body_with_limit(limit = 1.megabyte)
+      raise Mastodon::LengthValidationError if content_length.present? && content_length > limit
+
+      contents = truncated_body(limit)
+      raise Mastodon::LengthValidationError if contents.bytesize > limit
       contents
     end
   end

--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class VerifyLinkService < BaseService
+  LINK_BACK_XPATH =
+    '//a[contains(concat(" ", normalize-space(@rel), " "), " me ")]' \
+    '|//link[contains(concat(" ", normalize-space(@rel), " "), " me ")]'
+
   def call(field)
     @link_back = ActivityPub::TagManager.instance.url_for(field.account)
     @url       = field.value_for_verification
@@ -10,8 +14,9 @@ class VerifyLinkService < BaseService
     return unless link_back_present?
 
     field.mark_verified!
-  rescue OpenSSL::SSL::SSLError, HTTP::Error, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError => e
-    Rails.logger.debug "Error fetching link #{@url}: #{e}"
+  rescue OpenSSL::SSL::SSLError, HTTP::Error, Addressable::URI::InvalidURIError, Mastodon::HostValidationError,
+         Mastodon::LengthValidationError => e
+    Rails.logger.debug { "Error fetching link #{@url}: #{e}" }
     nil
   end
 
@@ -23,16 +28,12 @@ class VerifyLinkService < BaseService
     end
   end
 
-  def possibly_truncated_link?(test_url)
-    @body.end_with?(test_url)
-  end
-
   def link_back_present?
     return false if @body.blank?
 
-    links = Nokogiri::HTML(@body).xpath('//a[contains(concat(" ", normalize-space(@rel), " "), " me ")]|//link[contains(concat(" ", normalize-space(@rel), " "), " me ")]')
+    links = Nokogiri::HTML5(@body).xpath(LINK_BACK_XPATH)
 
-    if links.any? { |link| link['href']&.downcase == @link_back.downcase && !possibly_truncated_link?(link['href']) }
+    if links.any? { |link| link['href']&.downcase == @link_back.downcase }
       true
     elsif links.empty?
       false
@@ -42,7 +43,7 @@ class VerifyLinkService < BaseService
   end
 
   def link_redirects_back?(test_url)
-    return false if test_url.blank? || possibly_truncated_link?(test_url)
+    return false if test_url.blank?
 
     redirect_to_url = Request.new(:head, test_url, follow: false).perform do |res|
       res.headers['Location']

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -120,6 +120,11 @@ describe Request do
       expect { subject.perform { |response| response.body_with_limit } }.to raise_error Mastodon::LengthValidationError
     end
 
+    it 'truncates large monolithic body' do
+      stub_request(:any, 'http://example.com').to_return(body: SecureRandom.random_bytes(2.megabytes), headers: { 'Content-Length' => 2.megabytes })
+      expect(subject.perform { |response| response.truncated_body.bytesize }).to be < 2.megabytes
+    end
+
     it 'uses binary encoding if Content-Type does not tell encoding' do
       stub_request(:any, 'http://example.com').to_return(body: '', headers: { 'Content-Type' => 'text/html' })
       expect(subject.perform { |response| response.body_with_limit.encoding }).to eq Encoding::BINARY

--- a/spec/services/verify_link_service_spec.rb
+++ b/spec/services/verify_link_service_spec.rb
@@ -73,6 +73,33 @@ RSpec.describe VerifyLinkService, type: :service do
       end
     end
 
+    context 'when a document is truncated but the link back is valid' do
+      let(:html) do
+        "
+          <!doctype html>
+          <body>
+            <a rel=\"me\" href=\"#{ActivityPub::TagManager.instance.url_for(account)}\"
+        "
+      end
+
+      it 'marks the field as verified' do
+        expect(field.verified?).to be true
+      end
+    end
+
+    context 'when a link back might be truncated' do
+      let(:html) do
+        "
+          <!doctype html>
+          <body>
+            <a rel=\"me\" href=\"#{ActivityPub::TagManager.instance.url_for(account)}"
+      end
+
+      it 'does not mark the field as verified' do
+        expect(field.verified?).to be false
+      end
+    end
+
     context 'when a link does not contain a link back' do
       let(:html) { '' }
 

--- a/spec/services/verify_link_service_spec.rb
+++ b/spec/services/verify_link_service_spec.rb
@@ -1,16 +1,14 @@
-# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe VerifyLinkService, type: :service do
   subject { described_class.new }
 
-  context 'with a local account' do
+  context 'given a local account' do
     let(:account) { Fabricate(:account, username: 'alice') }
     let(:field)   { Account::Field.new(account, 'name' => 'Website', 'value' => 'http://example.com') }
 
     before do
-      stub_request(:head, 'https://redirect.me/abc').to_return(status: 301,
-                                                               headers: { 'Location' => ActivityPub::TagManager.instance.url_for(account) })
+      stub_request(:head, 'https://redirect.me/abc').to_return(status: 301, headers: { 'Location' => ActivityPub::TagManager.instance.url_for(account) })
       stub_request(:get, 'http://example.com').to_return(status: 200, body: html)
       subject.call(field)
     end
@@ -129,19 +127,9 @@ RSpec.describe VerifyLinkService, type: :service do
     end
   end
 
-  context 'with a remote account' do
+  context 'given a remote account' do
     let(:account) { Fabricate(:account, username: 'alice', domain: 'example.com', url: 'https://profile.example.com/alice') }
-    let(:field)   do
-      Account::Field.new(
-        account,
-        'name' => 'Website',
-        'value' =>
-          '<a href="http://example.com" rel="me">' \
-          '<span class="invisible">http://</span>' \
-          '<span class="">example.com</span>' \
-          '<span class="invisible"></span></a>'
-      )
-    end
+    let(:field)   { Account::Field.new(account, 'name' => 'Website', 'value' => '<a href="http://example.com" rel="me"><span class="invisible">http://</span><span class="">example.com</span><span class="invisible"></span></a>') }
 
     before do
       stub_request(:get, 'http://example.com').to_return(status: 200, body: html)


### PR DESCRIPTION
Truncates the page after 1MB instead, and switches to nokogiri HTML5 parser to handle some edgecases.

Alternative to #22703, handles one edgecase differently, `<a href="https://google.com/` is not considered as valid. I think this won't matter that much.

~~Also fixes some rubocop lints in the touched files because that's what CI demands of us at the moment.~~

Closes #15316