### PR TITLE
Change rate limit for media proxy

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -74,7 +74,7 @@ class Rack::Attack
     req.authenticated_user_id if req.post? && req.path.match?(/\A\/api\/v\d+\/media\z/i)
   end
 
-  throttle('throttle_media_proxy', limit: 30, period: 10.minutes) do |req|
+  throttle('throttle_media_proxy', limit: 300, period: 5.minutes) do |req|
     req.throttleable_remote_ip if req.path.start_with?('/media_proxy')
   end
 


### PR DESCRIPTION
With 30 per 10 minutes, the limit is reached too quickly when user follow some account with relatively large number of pictures.
When I was testing some accounts that posted a relatively large number of pictures at a slightly faster speed, the browser could initiate media proxy requests more than 200 times per minute.

I am not familiar with the mastodon platform, so this PR is only an attempt to increase the limit to 300 times in 5 minutes to make the platform relatively usable.
Whether the limit can be further increased requires further discussion and decision-making by the development team and the community.

Associated PR #10490 #11814