### PR TITLE
Remove microformats gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,6 @@ group :test do
   gem 'climate_control', '~> 0.2'
   gem 'faker', '~> 3.1'
   gem 'json-schema', '~> 3.0'
-  gem 'microformats', '~> 4.4'
   gem 'rack-test', '~> 2.0'  
   gem 'rails-controller-testing', '~> 1.0'
   gem 'rspec_junit_formatter', '~> 0.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,9 +397,6 @@ GEM
     matrix (0.4.2)
     memory_profiler (1.0.1)
     method_source (1.0.0)
-    microformats (4.4.1)
-      json (~> 2.2)
-      nokogiri (~> 1.10)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
@@ -809,7 +806,6 @@ DEPENDENCIES
   makara (~> 0.5)
   mario-redis-lock (~> 1.2)
   memory_profiler
-  microformats (~> 4.4)
   mime-types (~> 3.4.1)
   net-ldap (~> 0.17)
   nokogiri (~> 1.13)


### PR DESCRIPTION
Looks like this gem was introduced as a dependency in 89707ad0ac for testing Miroformat output.  The last test using the Microformats gem was removed in 62782babd08bc2385a604e275bf88af925d137c1, so I think it is safe to remove this dependency.

For context, you [can't install the microformats gem with Ruby 3.2](https://github.com/microformats/microformats-ruby/pull/131), so we can't currently bundle Mastodon with Ruby 3.2.  But since we don't really need this gem, we can just remove it and unblock Ruby 3.2