### PR TITLE
Add webhook `account.approved`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -489,6 +489,7 @@ class User < ApplicationRecord
     BootstrapTimelineWorker.perform_async(account_id)
     ActivityTracker.increment('activity:accounts:local')
     UserMailer.welcome(self).deliver_later
+    TriggerWebhookWorker.perform_async('account.approved', 'Account', account_id)
   end
 
   def prepare_returning_user!

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -15,6 +15,7 @@
 
 class Webhook < ApplicationRecord
   EVENTS = %w(
+    account.approved
     account.created
     report.created
   ).freeze


### PR DESCRIPTION
Implement `account.approved` webhook event which fires when new user has confirmed email and been approved (by staff or automatically if registrations are open). It happens at same time when home timeline is constructed and welcoming email is sent.

Closes #19577, a follow-up to #18510