### PR TITLE
Fix #19631 make status clickable instead of only status__content

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -510,7 +510,7 @@ class Status extends ImmutablePureComponent {
         <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), unread, focusable: !this.props.muted })} tabIndex={this.props.muted ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader(intl, status, rebloggedByText)} ref={this.handleRef}>
           {prepend}
 
-          <div onClick={this.handleClick} className={classNames('status', `status-${status.get('visibility')}`, { 'status-reply': !!status.get('in_reply_to_id'), muted: this.props.muted })} data-id={status.get('id')}>
+          <div onClick={this.handleClick} className={classNames('status', 'status--with-action', `status-${status.get('visibility')}`, { 'status-reply': !!status.get('in_reply_to_id'), muted: this.props.muted })} data-id={status.get('id')}>
             <div className='status__info'>
               <a href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} className='status__relative-time' target='_blank' rel='noopener noreferrer'>
                 <span className='status__visibility-icon'><Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></span>

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -138,7 +138,7 @@ class Status extends ImmutablePureComponent {
   };
 
   handleClick = e => {
-    if (e && (e.button !== 0 || e.ctrlKey || e.metaKey)) {
+    if (e && (e.button !== 0 || e.ctrlKey || e.metaKey || e.defaultPrevented)) {
       return;
     }
 
@@ -510,8 +510,8 @@ class Status extends ImmutablePureComponent {
         <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), unread, focusable: !this.props.muted })} tabIndex={this.props.muted ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader(intl, status, rebloggedByText)} ref={this.handleRef}>
           {prepend}
 
-          <div className={classNames('status', `status-${status.get('visibility')}`, { 'status-reply': !!status.get('in_reply_to_id'), muted: this.props.muted })} data-id={status.get('id')}>
-            <div onClick={this.handleClick} className='status__info'>
+          <div onClick={this.handleClick} className={classNames('status', `status-${status.get('visibility')}`, { 'status-reply': !!status.get('in_reply_to_id'), muted: this.props.muted })} data-id={status.get('id')}>
+            <div className='status__info'>
               <a href={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}`} className='status__relative-time' target='_blank' rel='noopener noreferrer'>
                 <span className='status__visibility-icon'><Icon id={visibilityIcon.icon} title={visibilityIcon.text} /></span>
                 <RelativeTimestamp timestamp={status.get('created_at')} />{status.get('edited_at') && <abbr title={intl.formatMessage(messages.edited, { date: intl.formatDate(status.get('edited_at'), { hour12: false, year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }) })}> *</abbr>}
@@ -528,7 +528,6 @@ class Status extends ImmutablePureComponent {
 
             <StatusContent
               status={status}
-              onClick={this.handleClick}
               expanded={!status.get('hidden')}
               onExpandedToggle={this.handleExpandedToggle}
               onTranslate={this.handleTranslate}

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -528,6 +528,7 @@ class Status extends ImmutablePureComponent {
 
             <StatusContent
               status={status}
+              onClick={this.handleClick}
               expanded={!status.get('hidden')}
               onExpandedToggle={this.handleExpandedToggle}
               onTranslate={this.handleTranslate}

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -198,7 +198,7 @@ class StatusContent extends React.PureComponent {
 
   handleClick = (e) => {
     e.preventDefault();
-  }
+  };
 
   handleSpoilerClick = (e) => {
     e.preventDefault();

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -264,7 +264,7 @@ class StatusContent extends React.PureComponent {
       }
 
       return (
-        <div className={classNames} ref={this.setRef} tabIndex='0' onClick={this.handleClick} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+        <div className={classNames} ref={this.setRef} onClick={this.handleClick} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
           <p style={{ marginBottom: hidden && status.get('mentions').isEmpty() ? '0px' : null }}>
             <span dangerouslySetInnerHTML={spoilerContent} className='translate' lang={lang} />
             {' '}
@@ -282,7 +282,7 @@ class StatusContent extends React.PureComponent {
     } else {
       return (
         <>
-          <div className={classNames} ref={this.setRef} tabIndex='0' onClick={this.handleClick} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} key='status-content' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+          <div className={classNames} ref={this.setRef} onClick={this.handleClick} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} key='status-content' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
             <div className='status__content__text status__content__text--visible translate' lang={lang} dangerouslySetInnerHTML={content} />
 
             {poll}

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -230,7 +230,6 @@ class StatusContent extends React.PureComponent {
     const spoilerContent = { __html: status.get('spoilerHtml') };
     const lang = status.get('translation') ? intl.locale : status.get('language');
     const classNames = classnames('status__content', {
-      'status__content--with-action': this.props.onClick && this.context.router,
       'status__content--with-spoiler': status.get('spoiler_text').length > 0,
       'status__content--collapsed': renderReadMore,
     });

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -196,6 +196,10 @@ class StatusContent extends React.PureComponent {
     this.startXY = null;
   };
 
+  handleClick = (e) => {
+    e.preventDefault();
+  }
+
   handleSpoilerClick = (e) => {
     e.preventDefault();
 
@@ -261,7 +265,7 @@ class StatusContent extends React.PureComponent {
       }
 
       return (
-        <div className={classNames} ref={this.setRef} tabIndex='0' onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+        <div className={classNames} ref={this.setRef} tabIndex='0' onClick={this.handleClick} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
           <p style={{ marginBottom: hidden && status.get('mentions').isEmpty() ? '0px' : null }}>
             <span dangerouslySetInnerHTML={spoilerContent} className='translate' lang={lang} />
             {' '}
@@ -276,10 +280,10 @@ class StatusContent extends React.PureComponent {
           {!hidden && translateButton}
         </div>
       );
-    } else if (this.props.onClick) {
+    } else {
       return (
         <>
-          <div className={classNames} ref={this.setRef} tabIndex='0' onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} key='status-content' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
+          <div className={classNames} ref={this.setRef} tabIndex='0' onClick={this.handleClick} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} key='status-content' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
             <div className='status__content__text status__content__text--visible translate' lang={lang} dangerouslySetInnerHTML={content} />
 
             {poll}
@@ -288,15 +292,6 @@ class StatusContent extends React.PureComponent {
 
           {readMoreButton}
         </>
-      );
-    } else {
-      return (
-        <div className={classNames} ref={this.setRef} tabIndex='0' onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave}>
-          <div className='status__content__text status__content__text--visible translate' lang={lang} dangerouslySetInnerHTML={content} />
-
-          {poll}
-          {translateButton}
-        </div>
       );
     }
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -845,10 +845,6 @@ body > [data-popper-placement] {
   margin-right: 5px;
 }
 
-.status__content--with-action {
-  cursor: pointer;
-}
-
 .status__content {
   clear: both;
 }
@@ -887,6 +883,8 @@ body > [data-popper-placement] {
     margin-bottom: 20px;
     white-space: pre-wrap;
     unicode-bidi: plaintext;
+    cursor: text;
+    width: fit-content;//so the text cursor only shows up where expected
 
     &:last-child {
       margin-bottom: 0;
@@ -927,6 +925,7 @@ body > [data-popper-placement] {
 
   .status__content__spoiler-link {
     background: $action-button-color;
+    cursor: pointer;
 
     &:hover,
     &:focus {
@@ -1107,6 +1106,10 @@ body > [data-popper-placement] {
   .audio-player,
   .attachment-list {
     margin-top: 16px;
+  }
+
+  &--with-action {
+    cursor: pointer;
   }
 
   &.light {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -884,7 +884,7 @@ body > [data-popper-placement] {
     white-space: pre-wrap;
     unicode-bidi: plaintext;
     cursor: text;
-    width: fit-content;// so the text cursor only shows up where expected
+    width: fit-content; // so the text cursor only shows up where expected
 
     &:last-child {
       margin-bottom: 0;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -884,7 +884,7 @@ body > [data-popper-placement] {
     white-space: pre-wrap;
     unicode-bidi: plaintext;
     cursor: text;
-    width: fit-content;//so the text cursor only shows up where expected
+    width: fit-content;// so the text cursor only shows up where expected
 
     &:last-child {
       margin-bottom: 0;


### PR DESCRIPTION
TODO:
- [x] Do the thing (I did the thing)
- [x] fix body text selections causing the post to open, which is quite annoying
  this isn't straightforward because I found code which interferes with my ability to detect drag events in the text content box. I suspect it's dead code, because what it does doesn't make sense considering the rest of the code
- [x] find out why the hell the pointer cursor doesn't show up despite it being clickable 🤔 
  edit: it seems react doesn't just automatically set cursors depending on clickability of components. I need to adjust the CSS.
  also maybe remove the --active class for status content since it seems to be required by behaviour that isn't there anymore
- [x] more testing for side-effects, not sure how this interacts with emojis and the various kinds of buttons…
- waiting for maintainers to tell me the way I used preventDefault to check if the event has been handled is okay and there isn't a way better solution for this which I'm not aware of
- [x] stuff with tabs (see warnings in CI)
- [x] also maybe think of a better title for the PR. This isn't really clear and doesn't match mastodon terminology either.

fixes #19631 (github didn't notice that I put it in the title)

[video of it working as intended, because why not](https://user-images.githubusercontent.com/57227431/210825400-d9c19e9a-cbb5-409b-b5c1-5ef9efa61f5f.mp4) (video is not corrupt, no idea why it says that)

also note these related issues I found, but which are out-of-scope for this PR I decided:
 - tabbing in general is pretty fucked. The timestamp and article both get keyboard focus when tabbing through.
 - posts that are already open don't gain focus when status__content is clicked.