### PR TITLE
Create new media queue, move all ffmpeg/imagemagick tasks onto it

### DIFF
--- a/app/workers/post_process_media_worker.rb
+++ b/app/workers/post_process_media_worker.rb
@@ -3,7 +3,7 @@
 class PostProcessMediaWorker
   include Sidekiq::Worker
 
-  sidekiq_options retry: 1, dead: false
+  sidekiq_options queue: 'highcpu', retry: 1, dead: false
 
   sidekiq_retries_exhausted do |msg|
     media_attachment_id = msg['args'].first

--- a/app/workers/post_process_media_worker.rb
+++ b/app/workers/post_process_media_worker.rb
@@ -3,7 +3,7 @@
 class PostProcessMediaWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'highcpu', retry: 1, dead: false
+  sidekiq_options queue: 'media', retry: 1, dead: false
 
   sidekiq_retries_exhausted do |msg|
     media_attachment_id = msg['args'].first

--- a/app/workers/redownload_media_worker.rb
+++ b/app/workers/redownload_media_worker.rb
@@ -5,7 +5,7 @@ class RedownloadMediaWorker
   include ExponentialBackoff
   include JsonLdHelper
 
-  sidekiq_options queue: 'pull', retry: 3
+  sidekiq_options queue: 'highcpu', retry: 3
 
   def perform(id)
     media_attachment = MediaAttachment.find(id)

--- a/app/workers/redownload_media_worker.rb
+++ b/app/workers/redownload_media_worker.rb
@@ -5,7 +5,7 @@ class RedownloadMediaWorker
   include ExponentialBackoff
   include JsonLdHelper
 
-  sidekiq_options queue: 'highcpu', retry: 3
+  sidekiq_options queue: 'media', retry: 3
 
   def perform(id)
     media_attachment = MediaAttachment.find(id)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,6 +5,7 @@
   - [push, 6]
   - [ingress, 4]
   - [mailers, 2]
+  - [highcpu, 2]
   - [pull]
   - [scheduler]
 :scheduler:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,7 +5,7 @@
   - [push, 6]
   - [ingress, 4]
   - [mailers, 2]
-  - [highcpu, 2]
+  - [media, 2]
   - [pull]
   - [scheduler]
 :scheduler:


### PR DESCRIPTION
Move two tasks that are known to spawn really CPU-intensive processes onto their own queue. This allows admins to provision dedicated workers with much lower thread:core ratio and/or separately control concurrency.

When running those CPU-intensive tasks next to IO-bound tasks in the same queue on the same machines, it is fundamentally impossible to pick an optimal thread:core ratio. IO-bound tasks should get a high thread:core ratio (high value for `-c`) in order to get the most throughput from their process that has the rails app loaded, while those media tasks cannot really share a core with each other and therefore need lower `-c`.
