### PR TITLE
Change compose form checkbox to native input with `appearance: none`

### DIFF
--- a/app/javascript/mastodon/features/compose/containers/sensitive_button_container.jsx
+++ b/app/javascript/mastodon/features/compose/containers/sensitive_button_container.jsx
@@ -54,8 +54,6 @@ class SensitiveButton extends React.PureComponent {
             disabled={disabled}
           />
 
-          <span className={classNames('checkbox', { active })} />
-
           <FormattedMessage
             id='compose_form.sensitive.hide'
             defaultMessage='{count, plural, one {Mark media as sensitive} other {Mark media as sensitive}}'

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -405,10 +405,7 @@ body > [data-popper-placement] {
     }
 
     input[type='checkbox'] {
-      display: none;
-    }
-
-    .checkbox {
+      appearance: none;
       display: inline-block;
       position: relative;
       border: 1px solid $ui-primary-color;
@@ -420,8 +417,9 @@ body > [data-popper-placement] {
       top: -1px;
       border-radius: 4px;
       vertical-align: middle;
+      cursor: inherit;
 
-      &.active {
+      &:checked {
         border-color: $highlight-text-color;
         background: $highlight-text-color
           url("data:image/svg+xml;utf8,<svg width='18' height='18' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M4.5 8.5L8 12l6-6' stroke='white' stroke-width='1.5'/></svg>")


### PR DESCRIPTION
Tested on Firefox 108.0, Chromium 108.0.5359.124, Microsoft Edge 108.0.1462.54, as well as Safari on iOS 9.3.5, 15.7.1 and 16.

This should be tested on more browsers, especially older ones.

Ideally, a custom focus style should also be defined, as it currently uses the browser's default one which may be a bit jarring. At least the button *can* be focused, which was not possible before this PR.