### PR TITLE
Fix/remove calling private method with send in model

### DIFF
--- a/app/lib/vacuum/feeds_vacuum.rb
+++ b/app/lib/vacuum/feeds_vacuum.rb
@@ -9,14 +9,14 @@ class Vacuum::FeedsVacuum
   private
 
   def vacuum_inactive_home_feeds!
-    inactive_users.select(:id, :account_id).find_in_batches do |users|
-      feed_manager.clean_feeds!(:home, users.map(&:account_id))
+    inactive_users.select(:id, :account_id).in_batches do |users|
+      feed_manager.clean_feeds!(:home, users.pluck(:account_id))
     end
   end
 
   def vacuum_inactive_list_feeds!
-    inactive_users_lists.select(:id).find_in_batches do |lists|
-      feed_manager.clean_feeds!(:list, lists.map(&:id))
+    inactive_users_lists.select(:id).in_batches do |lists|
+      feed_manager.clean_feeds!(:list, lists.ids)
     end
   end
 

--- a/app/lib/vacuum/statuses_vacuum.rb
+++ b/app/lib/vacuum/statuses_vacuum.rb
@@ -19,10 +19,7 @@ class Vacuum::StatusesVacuum
       # as the search index, must be handled first.
       statuses.direct_visibility
               .includes(mentions: :account)
-              .find_each do |status|
-        # TODO: replace temporary solution - call of private model method
-        status.send(:unlink_from_conversations)
-      end
+              .find_each(&:unlink_from_conversations!)
       remove_from_search_index(statuses.ids) if Chewy.enabled?
 
       # Foreign keys take care of most associated records for us.

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -19,9 +19,7 @@ class BatchedRemoveStatusService < BaseService
 
     ActiveRecord::Associations::Preloader.new.preload(statuses_with_account_conversations, [mentions: :account])
 
-    statuses_with_account_conversations.each do |status|
-      status.send(:unlink_from_conversations)
-    end
+    statuses_with_account_conversations.each(&:unlink_from_conversations!)
 
     # We do not batch all deletes into one to avoid having a long-running
     # transaction lock the database, but we use the delete method instead


### PR DESCRIPTION
[fix(status): remove send usage for private unlink_from_conversations](https://github.com/mastodon/mastodon/commit/4b73079c4476a1a8285f7fe2fc8d775f2cbd1533)

- make unlink_from_conversations public method
- rename unlink_from_conversations to unlink_from_conversations!
- fix send call on private method in statuses_vacuum and batched_remove_status_service

[fix(feeds_vacuum): replace find_in_batches with in_batches](https://github.com/mastodon/mastodon/commit/458fcbfa9dd47b47dfeee6d1ab1c5f407ab487b7)

because active record query results should be a little more efficient than
itterating with map and each. Postgres can grasp such lists of ids much quicker
than ruby can.
Will probably make allmost no difference, but cannot hurt either.