### PR TITLE
Move Ruby code linting back to Codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -29,6 +29,7 @@ plugins:
     enabled: false
   rubocop:
     enabled: true
+    channel: rubocop-1-9-1
   sass-lint:
     enabled: false
 exclude_patterns:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,7 +28,7 @@ plugins:
   eslint:
     enabled: false
   rubocop:
-    enabled: false
+    enabled: true
   sass-lint:
     enabled: false
 exclude_patterns:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -29,7 +29,7 @@ plugins:
     enabled: false
   rubocop:
     enabled: true
-    channel: rubocop-1-9-1
+    channel: rubocop-1-39-0
   sass-lint:
     enabled: false
 exclude_patterns:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -80,4 +80,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CSS: true
           VALIDATE_JAVASCRIPT_ES: true
-          VALIDATE_RUBY: true
+          VALIDATE_RUBY: false  # handled by codeclimate

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -80,4 +80,3 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CSS: true
           VALIDATE_JAVASCRIPT_ES: true
-          VALIDATE_RUBY: false  # handled by codeclimate


### PR DESCRIPTION
Switching to super-linter reveals too many linting errors in files I
touch in PRs.

It seems that the PR that did this: https://github.com/mastodon/mastodon/pull/18587 -- is largely frontend-motivated, and that backend was better off with codeclimate.

Since both codeclimate and superlinter is configured in principle
anyway, we might as well have codeclimate for the backend and
superlinter for the frontend.
