### PR TITLE
Change referrer-policy to no-referrer application-wide

### DIFF
--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -6,15 +6,10 @@ module WebAppControllerConcern
   included do
     prepend_before_action :redirect_unauthenticated_to_permalinks!
     before_action :set_app_body_class
-    before_action :set_referrer_policy_header
   end
 
   def set_app_body_class
     @body_classes = 'app-body'
-  end
-
-  def set_referrer_policy_header
-    response.headers['Referrer-Policy'] = 'origin'
   end
 
   def redirect_unauthenticated_to_permalinks!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -138,6 +138,7 @@ Rails.application.configure do
     'X-Content-Type-Options' => 'nosniff',
     'X-XSS-Protection'       => '0',
     'Permissions-Policy'     => 'interest-cohort=()',
+    'Referrer-Policy'        => 'no-referrer',
   }
 
   config.x.otp_secret = ENV.fetch('OTP_SECRET')


### PR DESCRIPTION
From https://github.com/mastodon/mastodon/issues/21795#issuecomment-1374680597:
> At the moment, I can't actually guarantee that no link in Mastodon allows the browser to send the referrer header. It could well be inconsistent.

This change should enforce it application-wide.