### PR TITLE
Separate ESLint CI from Superlinter

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -1,0 +1,40 @@
+name: JavaScript Linting
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    paths:
+      - 'package.json'
+      - 'yarn.lock'
+      - '.prettier*'
+      - '.eslint*'
+      - '**/*.js'
+      - '.github/workflows/lint-js.yml'
+
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'yarn.lock'
+      - '.prettier*'
+      - '.eslint*'
+      - '**/*.js'
+      - '.github/workflows/lint-js.yml'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+
+      - name: Install all yarn packages
+        run: yarn --frozen-lockfile
+
+      - name: ESLint
+        run: yarn test:lint:js

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -74,10 +74,8 @@ jobs:
           DEFAULT_BRANCH: main
           NO_COLOR: 1 # https://github.com/xt0rted/stylelint-problem-matcher/issues/360
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JAVASCRIPT_ES_CONFIG_FILE: .eslintrc.js
           LINTER_RULES_PATH: .
           RUBY_CONFIG_FILE: .rubocop.yml
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CSS: true
-          VALIDATE_JAVASCRIPT_ES: true
           VALIDATE_RUBY: true

--- a/app/javascript/mastodon/actions/tags.js
+++ b/app/javascript/mastodon/actions/tags.js
@@ -60,7 +60,7 @@ export function fetchFollowedHashtagsRequest() {
   return {
     type: FOLLOWED_HASHTAGS_FETCH_REQUEST,
   };
-};
+}
 
 export function fetchFollowedHashtagsSuccess(followed_tags, next) {
   return {
@@ -68,14 +68,14 @@ export function fetchFollowedHashtagsSuccess(followed_tags, next) {
     followed_tags,
     next,
   };
-};
+}
 
 export function fetchFollowedHashtagsFail(error) {
   return {
     type: FOLLOWED_HASHTAGS_FETCH_FAIL,
     error,
   };
-};
+}
 
 export function expandFollowedHashtags() {
   return (dispatch, getState) => {
@@ -94,13 +94,13 @@ export function expandFollowedHashtags() {
       dispatch(expandFollowedHashtagsFail(error));
     });
   };
-};
+}
 
 export function expandFollowedHashtagsRequest() {
   return {
     type: FOLLOWED_HASHTAGS_EXPAND_REQUEST,
   };
-};
+}
 
 export function expandFollowedHashtagsSuccess(followed_tags, next) {
   return {
@@ -108,14 +108,14 @@ export function expandFollowedHashtagsSuccess(followed_tags, next) {
     followed_tags,
     next,
   };
-};
+}
 
 export function expandFollowedHashtagsFail(error) {
   return {
     type: FOLLOWED_HASHTAGS_EXPAND_FAIL,
     error,
   };
-};
+}
 
 export const followHashtag = name => (dispatch, getState) => {
   dispatch(followHashtagRequest(name));

--- a/app/javascript/mastodon/features/account/components/header.js
+++ b/app/javascript/mastodon/features/account/components/header.js
@@ -296,9 +296,9 @@ class Header extends ImmutablePureComponent {
       if ((permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS) {
         menu.push({ text: intl.formatMessage(messages.admin_account, { name: account.get('username') }), href: `/admin/accounts/${account.get('id')}` });
       }
-        if (isRemote && (permissions & PERMISSION_MANAGE_FEDERATION) === PERMISSION_MANAGE_FEDERATION) {
-          menu.push({ text: intl.formatMessage(messages.admin_domain, { domain: remoteDomain }), href: `/admin/instances/${remoteDomain}` });
-        }
+      if (isRemote && (permissions & PERMISSION_MANAGE_FEDERATION) === PERMISSION_MANAGE_FEDERATION) {
+        menu.push({ text: intl.formatMessage(messages.admin_domain, { domain: remoteDomain }), href: `/admin/instances/${remoteDomain}` });
+      }
     }
 
     const content         = { __html: account.get('note_emojified') };

--- a/app/javascript/mastodon/features/followed_tags/index.js
+++ b/app/javascript/mastodon/features/followed_tags/index.js
@@ -38,7 +38,7 @@ class FollowedTags extends ImmutablePureComponent {
 
   componentDidMount() {
     this.props.dispatch(fetchFollowedHashtags());
-  };
+  }
 
   handleLoadMore = debounce(() => {
     this.props.dispatch(expandFollowedHashtags());

--- a/app/javascript/mastodon/reducers/followed_tags.js
+++ b/app/javascript/mastodon/reducers/followed_tags.js
@@ -39,4 +39,4 @@ export default function followed_tags(state = initialState, action) {
   default:
     return state;
   }
-};
+}


### PR DESCRIPTION
Will run the full ESLint check each time any JS or related config change is made. This will properly test the entire codebase when rules are changed, or when dependencies are update, but not when only things like ruby files are touched