### PR TITLE
Ensure border left of avatar in account header is visible

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7066,7 +7066,6 @@ noscript {
     margin-top: -55px;
     padding-top: 10px;
     gap: 8px;
-    overflow: hidden;
     margin-left: -2px; // aligns the pfp with content below
 
     &__buttons {


### PR DESCRIPTION
Heya,

I checked whether this was discussed in an issue or PR before but couldn't find anything, so I hope this is helpful. There's a small problem with the user interface where a part of the border around a user's avatar is cut off on their profile.

Here is a screenshot before the change:
![image](https://user-images.githubusercontent.com/525780/211678480-08d5d721-eee8-4038-b1e5-831d1b8ad181.png)

And after:
![image](https://user-images.githubusercontent.com/525780/211678586-b8317465-402a-4249-84ff-0db3804ab8de.png)

I'm not sure why the line was in there in the first place - I don't see any change on desktop or mobile except for the border:
![image](https://user-images.githubusercontent.com/525780/211679019-eab99a57-53cf-45e3-a851-0d516a1a08f9.png)

Let me know if I missed anything.