### PR TITLE
Streaming : Add status endpoint with the number of connected clients

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -850,6 +850,13 @@ const startWorker = async (workerId) => {
     res.end('OK');
   });
 
+  app.get('/status', (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      'connected_clients' : wss.clients.size,
+    }));
+  });
+
   app.use(authenticationMiddleware);
   app.use(errorMiddleware);
 

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -853,7 +853,7 @@ const startWorker = async (workerId) => {
   app.get('/status', (req, res) => {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({
-      'connected_clients' : wss.clients.size,
+      'connected_clients': wss.clients.size,
     }));
   });
 


### PR DESCRIPTION
In a Kubernetes environment, I need to be able to autoscale the number of streaming pods.
This modification allows me to use [Keda's Prometheus trigger](https://keda.sh/docs/1.4/scalers/prometheus/) in combination with [prometheus json exporter](https://github.com/prometheus-community/json_exporter)

I used the `/status` path instead of `/api/v1/streaming/status` since this endpoint is not supposed to be public