### PR TITLE
Change IP retention to 31 days and include the question in the setup

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -73,5 +73,5 @@ S3_ALIAS_HOST=files.example.com
 # Make sure to modify the scheduling of ip_cleanup_scheduler in config/sidekiq.yml
 # to be less than daily if you lower IP_RETENTION_PERIOD below two days (172800).
 # -----------------------
-IP_RETENTION_PERIOD=31556952
+IP_RETENTION_PERIOD=2678400
 SESSION_RETENTION_PERIOD=31556952

--- a/app/workers/scheduler/ip_cleanup_scheduler.rb
+++ b/app/workers/scheduler/ip_cleanup_scheduler.rb
@@ -3,7 +3,7 @@
 class Scheduler::IpCleanupScheduler
   include Sidekiq::Worker
 
-  IP_RETENTION_PERIOD = ENV.fetch('IP_RETENTION_PERIOD', 1.year).to_i.seconds.freeze
+  IP_RETENTION_PERIOD = ENV.fetch('IP_RETENTION_PERIOD', 31.days).to_i.seconds.freeze
   SESSION_RETENTION_PERIOD = ENV.fetch('SESSION_RETENTION_PERIOD', 1.year).to_i.seconds.freeze
 
   sidekiq_options retry: 0

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -40,6 +40,16 @@ namespace :mastodon do
       env['VAPID_PUBLIC_KEY']  = vapid_key.public_key
 
       prompt.say "\n"
+      
+      ip_retention_period_days = prompt.ask('How long should we store IP addresses in the database? (in days)') do |q|
+        q.required true
+        q.default 31
+        q.convert :int
+      end
+      
+      env['IP_RETENTION_PERIOD'] = (ip_retention_period_days * 86400)
+      
+      prompt.say "\n"
 
       using_docker        = prompt.yes?('Are you using Docker to run Mastodon?')
       db_connection_works = false


### PR DESCRIPTION
This is a PR in response to https://github.com/mastodon/mastodon/pull/22393

Personally I think the suggested 2 days by @eobrain changes too much to the moderation process of Mastodon, however I do also understand the privacy concerns of storing IPs by default for 1 year.

**This change does the following:**

- Changes the IP_RETENTION_PERIOD in .env.production.sample to 31 days
- Changes the IP_RETENTION_PERIOD's default to 31 days in the sidekiq worker file
- Asks the user in the setup process for how many days they would wish to store IP addresses, with a default option of 31 days.

This in my honest opinion would be the best combination of enhanced privacy, with giving the administrator of an instance the option to easily lower or increase the retention in the setup process. 

**Things to keep in mind:**

As IP_RETENTION_PERIOD is not defined by default in .env.production, this update will affect already configured instances once they update. 

Administrators should take note this might permanently remove IP addresses from their database as the default will change from 1 year to 31 days. 

Any questions let me know. 