### PR TITLE
Remove title tag from mailer layout

### DIFF
--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -4,8 +4,6 @@
     %meta{ 'http-equiv' => 'Content-Type', 'content' => 'text/html; charset=utf-8' }/
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0, shrink-to-fit=no' }
 
-    %title/
-
     = stylesheet_pack_tag 'mailer'
   %body{ dir: locale_direction }
     %table.email-table{ cellspacing: 0, cellpadding: 0 }


### PR DESCRIPTION
[`<title/>` is invalid HTML.](https://stackoverflow.com/a/19400695) So is an empty title tag. By default, Premailer would convert the mail content into well-formed HTML, but things can still go wrong on configurations that are less widely used.

There are three ways to resolve this issue:
* Use an appropriate title for each email.
* Use a generic title like "Mastodon".
* Remove the element altogether. This is acceptable in email per [HTML standard, section 4.2.1](https://html.spec.whatwg.org/multipage/semantics.html#the-head-element).

This PR takes the third way as removing an (ill-formed) element results in no visible change.