### PR TITLE
Allow configuring rate limits via environment variables (#15832)

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -64,64 +64,64 @@ class Rack::Attack
 
   rate_limits = {
     authenticated_api: {
-      count: ENV.fetch('AUTHENTICATED_API_RATE_LIMIT', 300),
-      minutes: ENV.fetch('AUTHENTICATED_API_RATE_LIMIT_MINUTES', 5).minutes
+      count: ENV.fetch('AUTHENTICATED_API_RATE_LIMIT', 300).to_i,
+      minutes: ENV.fetch('AUTHENTICATED_API_RATE_LIMIT_MINUTES', 5).to_i.minutes
     },
     unauthenticated_api: {
-      count: ENV.fetch('UNAUTHENTICATED_API_RATE_LIMIT', 300),
-      minutes: ENV.fetch('UNAUTHENTICATED_API_RATE_LIMIT_MINUTES', 5).minutes,
+      count: ENV.fetch('UNAUTHENTICATED_API_RATE_LIMIT', 300).to_i,
+      minutes: ENV.fetch('UNAUTHENTICATED_API_RATE_LIMIT_MINUTES', 5).to_i.minutes,
     },
     api_media: {
-      count: ENV.fetch('API_MEDIA_RATE_LIMIT', 30),
-      minutes: ENV.fetch('API_MEDIA_RATE_LIMIT_MINUTES', 30).minutes,
+      count: ENV.fetch('API_MEDIA_RATE_LIMIT', 30).to_i,
+      minutes: ENV.fetch('API_MEDIA_RATE_LIMIT_MINUTES', 30).to_i.minutes,
     },
     media_proxy: {
-      count: ENV.fetch('MEDIA_PROXY_RATE_LIMIT', 30),
-      minutes: ENV.fetch('MEDIA_PROXY_RATE_LIMIT_MINUTES', 10).minutes,
+      count: ENV.fetch('MEDIA_PROXY_RATE_LIMIT', 30).to_i,
+      minutes: ENV.fetch('MEDIA_PROXY_RATE_LIMIT_MINUTES', 10).to_i.minutes,
     },
     api_sign_up: {
-      count: ENV.fetch('API_SIGN_UP_RATE_LIMIT', 5),
-      minutes: ENV.fetch('API_SIGN_UP_RATE_LIMIT_MINUTES', 30).minutes,
+      count: ENV.fetch('API_SIGN_UP_RATE_LIMIT', 5).to_i,
+      minutes: ENV.fetch('API_SIGN_UP_RATE_LIMIT_MINUTES', 30).to_i.minutes,
     },
     authenticated_paging: {
-      count: ENV.fetch('AUTHENTICATED_PAGING_RATE_LIMIT', 300),
-      minutes: ENV.fetch('AUTHENTICATED_PAGING_RATE_LIMIT_MINUTES', 15).minutes,
+      count: ENV.fetch('AUTHENTICATED_PAGING_RATE_LIMIT', 300).to_i,
+      minutes: ENV.fetch('AUTHENTICATED_PAGING_RATE_LIMIT_MINUTES', 15).to_i.minutes,
     },
     unauthenticated_paging: {
-      count: ENV.fetch('UNAUTHENTICATED_PAGING_RATE_LIMIT', 300),
-      minutes: ENV.fetch('UNAUTHENTICATED_PAGING_RATE_LIMIT_MINUTES', 15).minutes,
+      count: ENV.fetch('UNAUTHENTICATED_PAGING_RATE_LIMIT', 300).to_i,
+      minutes: ENV.fetch('UNAUTHENTICATED_PAGING_RATE_LIMIT_MINUTES', 15).to_i.minutes,
     },
     api_delete: {
-      count: ENV.fetch('API_DELETE_RATE_LIMIT', 30),
-      minutes: ENV.fetch('API_DELETE_RATE_LIMIT_MINUTES', 30).minutes,
+      count: ENV.fetch('API_DELETE_RATE_LIMIT', 30).to_i,
+      minutes: ENV.fetch('API_DELETE_RATE_LIMIT_MINUTES', 30).to_i.minutes,
     },
     sign_up_attempts_ip: {
-      count: ENV.fetch('SIGN_UP_ATTEMPTS_IP_RATE_LIMIT', 25),
-      minutes: ENV.fetch('SIGN_UP_ATTEMPTS_IP_RATE_LIMIT_MINUTES', 5).minutes,
+      count: ENV.fetch('SIGN_UP_ATTEMPTS_IP_RATE_LIMIT', 25).to_i,
+      minutes: ENV.fetch('SIGN_UP_ATTEMPTS_IP_RATE_LIMIT_MINUTES', 5).to_i.minutes,
     },
     password_resets_ip: {
-      count: ENV.fetch('PASSWORD_RESETS_IP_RATE_LIMIT', 25),
-      minutes: ENV.fetch('PASSWORD_RESETS_IP_RATE_LIMIT_MINUTES', 5).minutes,
+      count: ENV.fetch('PASSWORD_RESETS_IP_RATE_LIMIT', 25).to_i,
+      minutes: ENV.fetch('PASSWORD_RESETS_IP_RATE_LIMIT_MINUTES', 5).to_i.minutes,
     },
     password_resets_email: {
-      count: ENV.fetch('PASSWORD_RESETS_EMAIL_RATE_LIMIT', 5),
-      minutes: ENV.fetch('PASSWORD_RESETS_EMAIL_RATE_LIMIT_MINUTES', 30).minutes,
+      count: ENV.fetch('PASSWORD_RESETS_EMAIL_RATE_LIMIT', 5).to_i,
+      minutes: ENV.fetch('PASSWORD_RESETS_EMAIL_RATE_LIMIT_MINUTES', 30).to_i.minutes,
     },
     email_confirmations_ip: {
-      count: ENV.fetch('EMAIL_CONFIRMATIONS_IP_RATE_LIMIT', 25),
-      minutes: ENV.fetch('EMAIL_CONFIRMATIONS_IP_RATE_LIMIT_MINUTES', 5).minutes,
+      count: ENV.fetch('EMAIL_CONFIRMATIONS_IP_RATE_LIMIT', 25).to_i,
+      minutes: ENV.fetch('EMAIL_CONFIRMATIONS_IP_RATE_LIMIT_MINUTES', 5).to_i.minutes,
     },
     email_confirmations_email: {
-      count: ENV.fetch('EMAIL_CONFIRMATIONS_EMAIL_RATE_LIMIT', 5),
-      minutes: ENV.fetch('EMAIL_CONFIRMATIONS_EMAIL_RATE_LIMIT_MINUTES', 30).minutes,
+      count: ENV.fetch('EMAIL_CONFIRMATIONS_EMAIL_RATE_LIMIT', 5).to_i,
+      minutes: ENV.fetch('EMAIL_CONFIRMATIONS_EMAIL_RATE_LIMIT_MINUTES', 30).to_i.minutes,
     },
     login_attempts_ip: {
-      count: ENV.fetch('LOGIN_ATTEMPTS_IP_RATE_LIMIT', 25),
-      minutes: ENV.fetch('LOGIN_ATTEMPTS_IP_RATE_LIMIT_MINUTES', 5).minutes,
+      count: ENV.fetch('LOGIN_ATTEMPTS_IP_RATE_LIMIT', 25).to_i,
+      minutes: ENV.fetch('LOGIN_ATTEMPTS_IP_RATE_LIMIT_MINUTES', 5).to_i.minutes,
     },
     login_attempts_email: {
-      count: ENV.fetch('LOGIN_ATTEMPTS_EMAIL_RATE_LIMIT', 25),
-      minutes: ENV.fetch('LOGIN_ATTEMPTS_EMAIL_RATE_LIMIT_MINUTES', 60).minutes,
+      count: ENV.fetch('LOGIN_ATTEMPTS_EMAIL_RATE_LIMIT', 25).to_i,
+      minutes: ENV.fetch('LOGIN_ATTEMPTS_EMAIL_RATE_LIMIT_MINUTES', 60).to_i.minutes,
     },
   }
 


### PR DESCRIPTION
This commit introduces the ability to set all existing `Rack::Attack` parameters using environment variables so that they can be configured by administrators before the service starts up.

I chose environment variables because:

* It is the least possible thing that could work.
* It is easy to configure *before* starting up the service, making it harder to circumvent the limits while Rails is still initializing (though I don't believe this is a real concern).
* It is easy to configure in Docker, etc.

I have created the ability to configure *all* rate limits, above and beyond those which are read-only, in order to use a consistent pattern in the code, but I recognize that this makes it very slightly easier for administrators to create rogue, misconfigured instances which can swamp others. If we find the risk is too great, we can remove those environment variables.

Personally, I think there are a few different implementations that might be better, but I wanted to float the idea in the form of a pull request to start a conversation about what kind of implementation would be most acceptable. For this reason, I have not yet written new tests, nor updated any documentation. If we align on this (or some other) implementation, I can add those in a new commit.

See https://github.com/mastodon/mastodon/issues/15832.