### PR TITLE
Add missing request specs for `/api/v1/tags` endpoint

### DIFF
--- a/spec/requests/api/v1/tags_spec.rb
+++ b/spec/requests/api/v1/tags_spec.rb
@@ -1,0 +1,272 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe '/api/v1/tags' do
+  let!(:tag) { Fabricate(:tag) }
+
+  describe 'GET /api/v1/tags/:id' do
+    context 'when not authenticated' do
+      it 'returns the expected JSON' do
+        get "/api/v1/tags/#{tag.name}"
+
+        expect(response.body).to match_json_schema('tag')
+      end
+
+      it 'omits the `following` flag in the JSON body' do
+        get "/api/v1/tags/#{tag.name}"
+
+        json = JSON.parse(response.body).deep_symbolize_keys
+        expect(json).not_to have_key(:following)
+      end
+
+      it 'returns not found error JSON when the tag is invalid' do
+        get '/api/v1/tags/invalid-tag'
+
+        expect(response.body).to eq '{"error":"Not Found"}'
+      end
+    end
+
+    context 'when authenticated' do
+      let!(:user) { Fabricate(:user) }
+      let!(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+      authorized_scopes = %w[follow read read:follows write:follows]
+      unauthorized_scopes = Doorkeeper.configuration.scopes.all - authorized_scopes
+
+      unauthorized_scopes.each do |scope|
+        context "when unauthorized with #{scope}" do
+          let!(:scopes) { scope }
+
+          before do
+            Fabricate(:tag_follow, tag: tag, account: user.account)
+          end
+
+          it 'returns the expected JSON' do
+            get "/api/v1/tags/#{tag.name}", headers: { authorization: "Bearer #{token.token}" }
+
+            expect(response.body).to match_json_schema('tag')
+          end
+
+          it 'omits the `following` flag in the JSON body' do
+            get "/api/v1/tags/#{tag.name}", headers: { authorization: "Bearer #{token.token}" }
+
+            json = JSON.parse(response.body).deep_symbolize_keys
+            expect(json).not_to have_key(:following)
+          end
+        end
+      end
+
+      authorized_scopes.each do |scope|
+        context "when authorized with #{scope} " do
+          let!(:scopes) { :read }
+
+          context 'when not following the tag' do
+            it 'includes `following` flag with value `false`' do
+              get "/api/v1/tags/#{tag.name}", headers: { authorization: "Bearer #{token.token}" }
+
+              json = JSON.parse(response.body).deep_symbolize_keys
+              expect(json[:following]).to be false
+            end
+          end
+
+          context 'when following the tag' do
+            before do
+              Fabricate(:tag_follow, tag: tag, account: user.account)
+            end
+
+            it 'includes `following` flag with value `true`' do
+              get "/api/v1/tags/#{tag.name}", headers: { authorization: "Bearer #{token.token}" }
+
+              json = JSON.parse(response.body).deep_symbolize_keys
+              expect(json[:following]).to be true
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe 'POST /api/v1/tags/:id/follow' do
+    context 'when not authenticated' do
+      it 'returns token invalid error JSON' do
+        post "/api/v1/tags/#{tag.name}/follow"
+
+        expect(response.body).to eq '{"error":"The access token is invalid"}'
+      end
+
+      it 'returns unauthorized status' do
+        post "/api/v1/tags/#{tag.name}/follow"
+
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when authenticated' do
+      let!(:user)   { Fabricate(:user) }
+      let!(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+      authorized_scopes = %w[follow write write:follows]
+      unauthorized_scopes = Doorkeeper.configuration.scopes.all - authorized_scopes
+
+      unauthorized_scopes.each do |scope|
+        context "when unauthorized with #{scope}" do
+          let(:scopes) { scope }
+
+          it 'returns forbidden status' do
+            post "/api/v1/tags/#{tag.name}/follow", headers: { authorization: "Bearer #{token.token}" }
+
+            expect(response).to have_http_status :forbidden
+          end
+
+          it 'returns authorization error JSON' do
+            post "/api/v1/tags/#{tag.name}/follow", headers: { authorization: "Bearer #{token.token}" }
+
+            expect(response.body).to eq '{"error":"This action is outside the authorized scopes"}'
+          end
+        end
+      end
+
+      authorized_scopes.each do |scope|
+        context "when authorized with #{scope}" do
+          let(:scopes) { scope }
+
+          it 'returns ok status' do
+            post "/api/v1/tags/#{tag.name}/follow", headers: { authorization: "Bearer #{token.token}" }
+
+            expect(response).to have_http_status :ok
+          end
+
+          it 'returns the expected JSON' do
+            post "/api/v1/tags/#{tag.name}/follow", headers: { authorization: "Bearer #{token.token}" }
+
+            expect(response.body).to match_json_schema('tag')
+          end
+
+          it 'includes the `following` flag with value `true`' do
+            post "/api/v1/tags/#{tag.name}/follow", headers: { authorization: "Bearer #{token.token}" }
+
+            json = JSON.parse(response.body).deep_symbolize_keys
+            expect(json[:following]).to be true
+          end
+
+          context 'when the tag is already followed' do
+            before do
+              Fabricate(:tag_follow, tag: tag, account: user.account)
+            end
+
+            it 'returns ok status' do
+              post "/api/v1/tags/#{tag.name}/follow", headers: { authorization: "Bearer #{token.token}" }
+
+              expect(response).to have_http_status :ok
+            end
+
+            it 'returns the expected JSON' do
+              post "/api/v1/tags/#{tag.name}/follow", headers: { authorization: "Bearer #{token.token}" }
+
+              expect(response.body).to match_json_schema('tag')
+            end
+
+            it 'includes the `following` flag with value `true`' do
+              post "/api/v1/tags/#{tag.name}/follow", headers: { authorization: "Bearer #{token.token}" }
+
+              json = JSON.parse(response.body).deep_symbolize_keys
+              expect(json[:following]).to be true
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe 'POST /api/v1/tags/:id/unfollow' do
+    context 'when not authenticated' do
+      it 'returns token invalid error JSON' do
+        post "/api/v1/tags/#{tag.name}/unfollow"
+
+        expect(response.body).to eq '{"error":"The access token is invalid"}'
+      end
+
+      it 'returns unauthorized status' do
+        post "/api/v1/tags/#{tag.name}/unfollow"
+
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'when authenticated' do
+      let!(:user)   { Fabricate(:user) }
+      let!(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+      authorized_scopes = %w[follow write write:follows]
+      unauthorized_scopes = Doorkeeper.configuration.scopes.all - authorized_scopes
+
+      unauthorized_scopes.each do |scope|
+        context "when unauthorized with #{scope}" do
+          let(:scopes) { scope }
+
+          it 'returns forbidden status' do
+            post "/api/v1/tags/#{tag.name}/unfollow", headers: { authorization: "Bearer #{token.token}" }
+
+            expect(response).to have_http_status :forbidden
+          end
+
+          it 'returns authorization error JSON' do
+            post "/api/v1/tags/#{tag.name}/unfollow", headers: { authorization: "Bearer #{token.token}" }
+
+            expect(response.body).to eq '{"error":"This action is outside the authorized scopes"}'
+          end
+        end
+      end
+
+      authorized_scopes.each do |scope|
+        context "when authorized with #{scope}" do
+          let(:scopes) { scope }
+
+          context 'when the tag is followed' do
+            before do
+              Fabricate(:tag_follow, tag: tag, account: user.account)
+            end
+
+            it 'returns ok status' do
+              post "/api/v1/tags/#{tag.name}/unfollow", headers: { authorization: "Bearer #{token.token}" }
+
+              expect(response).to have_http_status :ok
+            end
+
+            it 'returns the expected JSON' do
+              post "/api/v1/tags/#{tag.name}/unfollow", headers: { authorization: "Bearer #{token.token}" }
+
+              expect(response.body).to match_json_schema('tag')
+            end
+
+            it 'includes the `following` flag with value `false`' do
+              post "/api/v1/tags/#{tag.name}/unfollow", headers: { authorization: "Bearer #{token.token}" }
+
+              json = JSON.parse(response.body).deep_symbolize_keys
+              expect(json[:following]).to be false
+            end
+          end
+
+          context 'when the tag is not followed' do
+            it 'returns ok status' do
+              post "/api/v1/tags/#{tag.name}/unfollow", headers: { authorization: "Bearer #{token.token}" }
+
+              expect(response).to have_http_status :ok
+            end
+
+            it 'returns the expected JSON' do
+              post "/api/v1/tags/#{tag.name}/unfollow", headers: { authorization: "Bearer #{token.token}" }
+
+              expect(response.body).to match_json_schema('tag')
+            end
+
+            it 'includes the `following` flag with value `false`' do
+              post "/api/v1/tags/#{tag.name}/unfollow", headers: { authorization: "Bearer #{token.token}" }
+
+              json = JSON.parse(response.body).deep_symbolize_keys
+              expect(json[:following]).to be false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/schema/tag.json
+++ b/spec/support/schema/tag.json
@@ -1,0 +1,32 @@
+{
+  "id": "tag.json#",
+  "type": "object",
+  "required": [
+    "name",
+    "url",
+    "history"
+  ],
+  "properties": {
+    "name": {
+      "description": "The value of the hashtag after the # sign.",
+      "type": "string"
+    },
+    "url": {
+      "description": "A link to the hashtag on the instance. Parse string as URL.",
+      "type": "string"
+    },
+    "history": {
+      "description": "Usage statistics for given days (typically the past week).",
+      "example": [{"day":"1671062400", "accounts":"11", "uses":"16"}],
+      "type": "array",
+      "items": {
+        "$ref": "trend_history.json#"
+      },
+      "uniqueItems": true
+    },
+    "following": {
+      "description": "Whether the current token’s authorized user is following this tag.",
+      "type": "boolean"
+    }
+  }
+}

--- a/spec/support/schema/trend_history.json
+++ b/spec/support/schema/trend_history.json
@@ -1,0 +1,26 @@
+{
+  "id": "trend_history.json#",
+  "type": "object",
+  "required": [
+    "day",
+    "accounts",
+    "uses"
+  ],
+  "properties": {
+    "day": {
+      "description": "UNIX timestamp on midnight of the given day. Number cast as string.",
+      "type": "string",
+      "pattern": "\\d+"
+    },
+    "accounts": {
+      "description": "The total of accounts using the tag within that day. Number cast as string.",
+      "type": "string",
+      "pattern": "\\d+"
+    },
+    "uses": {
+      "description": "The counted usage of the tag within that day. Number cast as string.",
+      "type": "string",
+      "pattern": "\\d+"
+    }
+  }
+}


### PR DESCRIPTION
For discussion.

This relates to both #20572 and https://github.com/mastodon/mastodon/issues/22378#issuecomment-1356868858. I was kicking the tires on swapping out JSON serializers to improve API responsiveness, and was somewhat surprised to discover that there were no API request specs. The API is tested in some controller specs, but those specs are not exhaustive. So, I decided to pick a small endpoint and completely cover the behavior of it.

Given the number of connected clients and the API contract, I believe it's important to have request specs as a source of truth: it proves behavior, documents how the API responds in various circumstances, and prevents accidental breakage (critical in the case of testing out different serialization strategies). This is the tip of the iceberg - I believe the entire API should be covered in these kids of specs.

This PR adds a [JSON-Schema](https://json-schema.org) specification for [Tag](https://docs.joinmastodon.org/entities/Tag/) and the nested history object that I've called `TrendHistory`, and validates that the API responses match the schema.

This PR also introduces some failing tests worth additional discussion. When fleshing the specs out, I expected that the `following` flag in the JSON body would be associated with the `read:follows` scope, but that is apparently not the case. The `/api/v1/tags` endpoint always returns hashtag following information whenever there is an authenticated user, regardless of what scope the user has. I have a separate PR to tackle this, but I'm not sure that my expectations are indeed the actual expected behavior or not. I did raise this issue privately, and was given the green light to publicly discuss the behavior of it.

So, a few questions to help spark discussion:

 * Is this the right path to do down for adding API request specs? Perhaps these should be done via the [rswag](https://github.com/rswag/rswag) gem instead?
 * What should be done, if anything, about the `following` flag? Should it move behind an oauth scope? If so, should it re-use `read:follows`, or should a new one be made, such as `read:tag_follows`? I do have a PR I can submit that omits the flag from the response unless the user has `read:follows` scope granted, but I'm not sure that's desirable.