### PR TITLE
Add moved note for newly followed via migration

### DIFF
--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -125,7 +125,7 @@ class MoveWorker
 
   def carry_follows_over!
     @source_account.followers.local.find_each do |follower|
-      add_account_note_if_needed!(follower.account, 'move_handler.carry_follows_over_text')
+      add_account_note_if_needed!(follower, 'move_handler.carry_follows_over_text')
     rescue => e
       @deferred_error = e
     end

--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -124,7 +124,7 @@ class MoveWorker
   end
 
   def carry_follows_over!
-    @source_account.followers.local.find_each do |follower|
+    @source_account.followers.local.reorder(nil).find_each do |follower|
       add_account_note_if_needed!(follower, 'move_handler.carry_follows_over_text')
     rescue => e
       @deferred_error = e

--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -20,6 +20,7 @@ class MoveWorker
     copy_account_notes!
     carry_blocks_over!
     carry_mutes_over!
+    carry_follows_over!
 
     raise @deferred_error unless @deferred_error.nil?
   rescue ActiveRecord::RecordNotFound
@@ -117,6 +118,14 @@ class MoveWorker
     @source_account.muted_by_relationships.where(account: Account.local).find_each do |mute|
       MuteService.new.call(mute.account, @target_account, notifications: mute.hide_notifications) unless mute.account.muting?(@target_account) || mute.account.following?(@target_account)
       add_account_note_if_needed!(mute.account, 'move_handler.carry_mutes_over_text')
+    rescue => e
+      @deferred_error = e
+    end
+  end
+
+  def carry_follows_over!
+    @source_account.followers.local.find_each do |follower|
+      add_account_note_if_needed!(follower.account, 'move_handler.carry_follows_over_text')
     rescue => e
       @deferred_error = e
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1458,8 +1458,8 @@ en:
     title: Moderation
   move_handler:
     carry_blocks_over_text: This user moved from %{acct}, which you had blocked.
-    carry_mutes_over_text: This user moved from %{acct}, which you had muted.
     carry_follows_over_text: This user moved from %{acct}, which you had followed.
+    carry_mutes_over_text: This user moved from %{acct}, which you had muted.
     copy_account_note_text: 'This user moved from %{acct}, here were your previous notes about them:'
   navigation:
     toggle_menu: Toggle menu

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1459,6 +1459,7 @@ en:
   move_handler:
     carry_blocks_over_text: This user moved from %{acct}, which you had blocked.
     carry_mutes_over_text: This user moved from %{acct}, which you had muted.
+    carry_follows_over_text: This user moved from %{acct}, which you had followed.
     copy_account_note_text: 'This user moved from %{acct}, here were your previous notes about them:'
   navigation:
     toggle_menu: Toggle menu


### PR DESCRIPTION
Sometimes auto-following migrated followee is very confusing.
People can curious "Why I am following this unknown person and I don't remember I followed"

Like carrying mute,block notes, It would be nice to have "This account is moved from your follower %{acct}" note