### PR TITLE
Fix wrong padding in RTL layout in web UI

### DIFF
--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -109,7 +109,7 @@
     box-sizing: border-box;
     width: 18px;
     height: 18px;
-    margin-right: 10px;
+    margin-inline-end: 10px;
     top: -1px;
     border-radius: 50%;
     vertical-align: middle;
@@ -204,7 +204,7 @@
   .button {
     height: 36px;
     padding: 0 16px;
-    margin-right: 10px;
+    margin-inline-end: 10px;
     font-size: 14px;
   }
 }
@@ -240,7 +240,7 @@
     line-height: inherit;
     color: $action-button-color;
     border-color: $action-button-color;
-    margin-right: 5px;
+    margin-inline-end: 5px;
   }
 
   li {
@@ -250,7 +250,7 @@
     .poll__option {
       flex: 0 0 auto;
       width: calc(100% - (23px + 6px));
-      margin-right: 6px;
+      margin-inline-end: 6px;
     }
   }
 

--- a/app/javascript/styles/mastodon/rtl.scss
+++ b/app/javascript/styles/mastodon/rtl.scss
@@ -132,43 +132,6 @@ body.rtl {
     margin-right: 8px;
   }
 
-  .status__avatar {
-    left: auto;
-    right: 10px;
-  }
-
-  .status,
-  .activity-stream .status.light {
-    padding-left: 10px;
-    padding-right: 68px;
-  }
-
-  .status__info .status__display-name,
-  .activity-stream .status.light .status__display-name {
-    padding-left: 25px;
-    padding-right: 0;
-  }
-
-  .activity-stream .pre-header {
-    padding-right: 68px;
-    padding-left: 0;
-  }
-
-  .status__prepend {
-    margin-left: 0;
-    margin-right: 68px;
-  }
-
-  .status__prepend-icon-wrapper {
-    left: auto;
-    right: -26px;
-  }
-
-  .activity-stream .pre-header .pre-header__icon {
-    left: auto;
-    right: 42px;
-  }
-
   .account__header__tabs__buttons > .icon-button {
     margin-right: 0;
     margin-left: 8px;
@@ -184,12 +147,6 @@ body.rtl {
     left: 0;
   }
 
-  .status__relative-time,
-  .status__visibility-icon,
-  .activity-stream .status.light .status__header .status__meta {
-    float: left;
-  }
-
   .status__action-bar {
     &__counter {
       margin-right: 0;
@@ -200,16 +157,6 @@ body.rtl {
         margin-left: 4px;
       }
     }
-  }
-
-  .status__action-bar-button {
-    float: right;
-    margin-right: 0;
-    margin-left: 18px;
-  }
-
-  .status__action-bar-dropdown {
-    float: right;
   }
 
   .privacy-dropdown__dropdown {
@@ -230,7 +177,6 @@ body.rtl {
   .detailed-status__display-avatar {
     margin-right: 0;
     margin-left: 10px;
-    float: right;
   }
 
   .picture-in-picture__header__account .account__avatar {


### PR DESCRIPTION
In the future, we need to switch to `margin-inline-start`/`margin-inline-end` instead of `margin-left`/`margin-right` and using `gap` whenever possible to reduce the amount of overrides needed for the RTL layout.

Fix #20862