### PR TITLE
reduce docker container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,8 @@ ENV RAILS_ENV="production" \
 COPY --from=build --link /usr/local/bin/node /usr/local/bin/node
 COPY --from=ruby           --link /opt/ruby           /opt/ruby
 
+# Ignoreing these here since we don't want to pin any versions and the Debian image removes apt-get content after use
+# hadolint ignore=DL3008
 RUN apt-get update && \
     echo "Etc/UTC" > /etc/localtime && \
     groupadd -g "${GID}" mastodon && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ ENV RAILS_ENV="production" \
     PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
 
 COPY --from=build --link /usr/local/bin/node /usr/local/bin/node
-COPY --from=ruby           --link /opt/ruby           /opt/ruby
+COPY --from=ruby --link /opt/ruby /opt/ruby
 
 # Ignoreing these here since we don't want to pin any versions and the Debian image removes apt-get content after use
 # hadolint ignore=DL3008

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ ENV RAILS_ENV="production" \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 WORKDIR /opt/mastodon
-COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
@@ -37,6 +36,8 @@ RUN apt-get update && \
         shared-mime-info  \
     && \
     rm -rf /var/lib/apt/lists/*
+
+COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
 RUN set -eux && \
     bundle config set --local deployment 'true' && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,6 @@ ARG NODE_VERSION="16.18.1-bullseye-slim"
 FROM ghcr.io/moritzheiber/ruby-jemalloc:3.0.4-slim as ruby
 FROM node:${NODE_VERSION} as build
 
-COPY --link --from=ruby /opt/ruby /opt/ruby
-
-ENV RAILS_ENV="production" \
-    NODE_ENV="production" \
-    PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
-
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -34,6 +28,12 @@ RUN apt-get update && \
         shared-mime-info  \
     && \
     rm -rf /var/lib/apt/lists/*
+
+COPY --link --from=ruby /opt/ruby /opt/ruby
+
+ENV RAILS_ENV="production" \
+    NODE_ENV="production" \
+    PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
 
 WORKDIR /opt/mastodon
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ ENV RAILS_ENV="production" \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-WORKDIR /opt/mastodon
-
 # hadolint ignore=DL3008
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends  \
@@ -36,6 +34,8 @@ RUN apt-get update && \
         shared-mime-info  \
     && \
     rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/mastodon
 
 COPY Gemfile* package.json yarn.lock /opt/mastodon/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ COPY --link --from=ruby /opt/ruby /opt/ruby
 
 ENV RAILS_ENV="production" \
     NODE_ENV="production" \
-    DEBIAN_FRONTEND="noninteractive" \
     PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -18,7 +17,8 @@ WORKDIR /opt/mastodon
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends  \
+        build-essential \
         ca-certificates \
         git \
         libicu-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN apt-get update && \
 USER mastodon
 WORKDIR /opt/mastodon
 
-COPY --chown=mastodon:mastodon --from=build --link /opt/mastodon /opt/mastodon
+COPY --chown=${UID}:${GID} --from=build --link /opt/mastodon /opt/mastodon
 
 # Set the work dir and the container entry point
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux && \
     bundle install -j"$(nproc)" && \
     yarn install --pure-lockfile --network-timeout 600000
 
-COPY --chown=mastodon:mastodon . /opt/mastodon
+COPY . /opt/mastodon
 
 # Precompile assets
 RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile && \


### PR DESCRIPTION
This pull request reduce the final size of the container of 370MB at the cost of the build speed, but with cache it should not be an issue

![image](https://user-images.githubusercontent.com/7402764/213776204-bb4e2891-f417-4d26-9c66-9faec04a4c01.png)

## Build size : 

### Before : 
![image](https://user-images.githubusercontent.com/7402764/213780612-875b4eed-b015-4cfc-8271-3a6cd3187ade.png)


### After : 
![image](https://user-images.githubusercontent.com/7402764/213780541-134ac2a6-a783-49f9-beeb-3eb1aba3ee46.png)

## Build Time : 

Tested on a AMD Ryzen 9 5950X machine with a 2.5Gbps fiber

### Before : 
```
docker build . -t mastodon:main --pull --no-cache  0.64s user 0.25s system 0% cpu 2:30.60 total
```

### After : 
```
docker build . -t mastodon:improve-docker-build --no-cache --pull  0.58s user 0.27s system 0% cpu 2:39.49 total
```