### PR TITLE
Fix Account Strike causing PG not null validation error

### DIFF
--- a/app/models/account_warning.rb
+++ b/app/models/account_warning.rb
@@ -26,6 +26,8 @@ class AccountWarning < ApplicationRecord
     suspend:                    4_000,
   }, _suffix: :action
 
+  before_validation :before_validate
+
   belongs_to :account, inverse_of: :account_warnings
   belongs_to :target_account, class_name: 'Account', inverse_of: :strikes
   belongs_to :report, optional: true
@@ -46,5 +48,11 @@ class AccountWarning < ApplicationRecord
 
   def to_log_human_identifier
     target_account.acct
+  end
+
+  private
+
+  def before_validate
+    self.text = '' if text.blank?
   end
 end


### PR DESCRIPTION
After #22375, deleting remote user's post from report action is broken

This error happens because `text` is `nil` for this kind of action.
So Change nil into '' before validate/save

```PG::NotNullViolation: ERROR:  null value in column "text" of relation "account_warnings" violates not-null constraint
DETAIL:  Failing row contains (161, 14, 109711948753457845, 1500, null, 2023-01-21 01:26:53.558703, 2023-01-21 01:26:53.558703, 224, {109723462015306624,109723459684372322}, null).```