### PR TITLE
Revert "Remove LDSignature on actor Delete activities (#21466)"

### DIFF
--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -267,7 +267,7 @@ class DeleteAccountService < BaseService
   end
 
   def delete_actor_json
-    @delete_actor_json ||= Oj.dump(serialize_payload(@account, ActivityPub::DeleteActorSerializer))
+    @delete_actor_json ||= Oj.dump(serialize_payload(@account, ActivityPub::DeleteActorSerializer, signer: @account, always_sign: true))
   end
 
   def delivery_inboxes


### PR DESCRIPTION
While significantly cutting down on traffic generated by account deletions, removing the signature prevents relays from relaying `Delete` activities, see https://github.com/mastodon/mastodon/pull/21466#issuecomment-1399151997

This reverts commit f4f2b062ec7827ed7749d85579aca2da2ec40593.