### PR TITLE
fix(pghero): update because CVE-2023-22626

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'rack', '~> 2.2.6'
 gem 'hamlit-rails', '~> 0.2'
 gem 'pg', '~> 1.4'
 gem 'makara', '~> 0.5'
-gem 'pghero', '~> 2.8'
+gem 'pghero'
 gem 'dotenv-rails', '~> 2.8'
 
 gem 'aws-sdk-s3', '~> 1.117', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -468,8 +468,8 @@ GEM
     pastel (0.8.0)
       tty-color (~> 0.5)
     pg (1.4.5)
-    pghero (2.8.3)
-      activerecord (>= 5)
+    pghero (3.1.0)
+      activerecord (>= 6)
     pkg-config (1.5.1)
     posix-spawn (0.3.15)
     premailer (1.18.0)
@@ -830,7 +830,7 @@ DEPENDENCIES
   ox (~> 2.14)
   parslet
   pg (~> 1.4)
-  pghero (~> 2.8)
+  pghero
   pkg-config (~> 1.5)
   posix-spawn
   premailer-rails


### PR DESCRIPTION
There is a vulnerability
[CVE-2023-22626](https://github.com/advisories/GHSA-vf99-xw26-86g5)

```
Name: pghero
Version: 2.8.3
CVE: CVE-2023-22626
GHSA: GHSA-vf99-xw26-86g5
Criticality: High
URL: https://github.com/ankane/pghero/issues/439
Title: Information Disclosure Through EXPLAIN Feature
Solution: upgrade to '>= 3.1.0'
```