### PR TITLE
Make S3's retry limit a ENV variable

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -64,7 +64,7 @@ if ENV['S3_ENABLED'] == 'true'
       http_open_timeout: ENV.fetch('S3_OPEN_TIMEOUT'){ '5' }.to_i,
       http_read_timeout: ENV.fetch('S3_READ_TIMEOUT'){ '5' }.to_i,
       http_idle_timeout: 5,
-      retry_limit: 0,
+      retry_limit: ENV.fetch('S3_RETRY_LIMIT'){ '0'}.to_i,
     }
   )
   

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -64,7 +64,7 @@ if ENV['S3_ENABLED'] == 'true'
       http_open_timeout: ENV.fetch('S3_OPEN_TIMEOUT'){ '5' }.to_i,
       http_read_timeout: ENV.fetch('S3_READ_TIMEOUT'){ '5' }.to_i,
       http_idle_timeout: 5,
-      retry_limit: ENV.fetch('S3_RETRY_LIMIT'){ '0'}.to_i,
+      retry_limit: ENV.fetch('S3_RETRY_LIMIT'){ '0' }.to_i,
     }
   )
   


### PR DESCRIPTION
In #12085 we've configured the S3 retry_limit to be 0, however on some slightly less stable S3 services this results in some posts from other instances to have missing images/videos.

This has been observed in the issues https://github.com/mastodon/mastodon/issues/13739 & https://github.com/mastodon/mastodon/issues/16520

I have been running my instance with the retry_limit set to 2 for a while now, and I think making this an environment variable would give administrators the option to deal with S3 services sometimes having issues. (In my case a request may rarely randomly fail, causing a S3 action to fail. A retry straight away resolves this)

