### PR TITLE
Fix account activation being triggered before email confirmation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,10 +195,16 @@ class User < ApplicationRecord
 
     super
 
-    if new_user && approved?
-      prepare_new_user!
-    elsif new_user
-      notify_staff_about_pending_account!
+    if new_user
+      # Avoid extremely unlikely race condition when approving and confirming
+      # the user at the same time
+      reload unless approved?
+
+      if approved?
+        prepare_new_user!
+      else
+        notify_staff_about_pending_account!
+      end
     end
   end
 
@@ -209,7 +215,13 @@ class User < ApplicationRecord
     skip_confirmation!
     save!
 
-    prepare_new_user! if new_user && approved?
+    if new_user
+      # Avoid extremely unlikely race condition when approving and confirming
+      # the user at the same time
+      reload unless approved?
+
+      prepare_new_user! if approved?
+    end
   end
 
   def update_sign_in!(new_sign_in: false)
@@ -260,7 +272,11 @@ class User < ApplicationRecord
     return if approved?
 
     update!(approved: true)
-    prepare_new_user!
+
+    # Avoid extremely unlikely race condition when approving and confirming
+    # the user at the same time
+    reload unless confirmed?
+    prepare_new_user! if confirmed?
   end
 
   def otp_enabled?


### PR DESCRIPTION
Fixes #23098

When registrations are open and not subject to approval, accounts are activated (`User#prepare_new_user!` is called, the welcome email is sent, the staff is notified, the `account.approved` Web Hook is triggered, and if the user was invited, the inviting user is followed) the moment the user confirms their email.

However, when approvals are required, this happens when a moderator approves the user, even if they have not confirmed their email, and should they confirm their email after being approved, their account will be activated twice.

Therefore, this PR changes it so the account is only activated when both confirmed and approved.