### PR TITLE
Change email address input to be read-only for logged-in users when requesting a new confirmation e-mail

### DIFF
--- a/app/views/auth/confirmations/new.html.haml
+++ b/app/views/auth/confirmations/new.html.haml
@@ -5,7 +5,7 @@
   = render 'shared/error_messages', object: resource
 
   .fields-group
-    = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label': t('simple_form.labels.defaults.email') }, hint: false
+    = f.input :email, autofocus: true, wrapper: :with_label, label: t('simple_form.labels.defaults.email'), input_html: { 'aria-label': t('simple_form.labels.defaults.email') }, readonly: current_user.present?, hint: current_user.present? && t('auth.confirmations.wrong_email_hint')
 
   .actions
     = f.button :button, t('auth.resend_confirmation'), type: :submit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -965,6 +965,8 @@ en:
   auth:
     apply_for_account: Request an account
     change_password: Password
+    confirmations:
+      wrong_email_hint: If that e-mail address is not correct, you can change it in account settings.
     delete_account: Delete account
     delete_account_html: If you wish to delete your account, you can <a href="%{path}">proceed here</a>. You will be asked for confirmation.
     description:


### PR DESCRIPTION
Fixes #23093

If a user fails to receive their confirmation e-mail, they can request a new one through `/auth/confirmation/new`. In case they are logged in, which is the most likely, this will be pre-filled with their initial e-mail address. If they change the e-mail address, they would likely expect the e-mail to be sent to the new address instead, but this is not what this controller does: it sends an e-mail to that address if it corresponds to an existing user. When the user is not logged in, this is explained in a notice, but when the user is logged in, it redirects to `/auth/setup`, which has a different notice.

To reduce the confusion, this PR makes the input read-only and adds a hint in this case, instructing to go to Account settings to change the e-mail address:
![image](https://user-images.githubusercontent.com/384364/214343743-7f6147cb-c9ea-46f1-9cbf-7af6468042ad.png)