### PR TITLE
Fix styling of featured tags in light theme

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -551,25 +551,6 @@ html {
   }
 }
 
-.directory__tag.active > a,
-.directory__tag.active > div {
-  border-color: $ui-highlight-color;
-
-  &,
-  h4,
-  h4 small,
-  .fa,
-  .trends__item__current {
-    color: $white;
-  }
-
-  &:hover,
-  &:active,
-  &:focus {
-    background: $ui-highlight-color;
-  }
-}
-
 .batch-table {
   &__toolbar,
   &__row,

--- a/app/views/settings/featured_tags/index.html.haml
+++ b/app/views/settings/featured_tags/index.html.haml
@@ -17,7 +17,7 @@
 %hr.spacer/
 
 - @featured_tags.each do |featured_tag|
-  .directory__tag{ class: params[:tag] == featured_tag.name ? 'active' : nil }
+  .directory__tag
     %div
       %h4
         = fa_icon 'hashtag'


### PR DESCRIPTION
Fixes #23251

Also removes the use of a `active` class in the first place, it was never used and would highlight tags that had no casing override.