### PR TITLE
Add `roles` attribute to Account entities in REST API

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -117,7 +117,7 @@ class Status < ApplicationRecord
                    :tags,
                    :preview_cards,
                    :preloadable_poll,
-                   account: [:account_stat, :user],
+                   account: [:account_stat, user: :role],
                    active_mentions: { account: :account_stat },
                    reblog: [
                      :application,
@@ -127,7 +127,7 @@ class Status < ApplicationRecord
                      :conversation,
                      :status_stat,
                      :preloadable_poll,
-                     account: [:account_stat, :user],
+                     account: [:account_stat, user: :role],
                      active_mentions: { account: :account_stat },
                    ],
                    thread: { account: :account_stat }

--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -26,6 +26,16 @@ class REST::AccountSerializer < ActiveModel::Serializer
     end
   end
 
+  class RoleSerializer < ActiveModel::Serializer
+    attributes :id, :name, :color
+
+    def id
+      object.id.to_s
+    end
+  end
+
+  has_many :roles, serializer: RoleSerializer, if: :local?
+
   class FieldSerializer < ActiveModel::Serializer
     include FormattingHelper
 
@@ -112,6 +122,14 @@ class REST::AccountSerializer < ActiveModel::Serializer
 
   def silenced
     object.silenced?
+  end
+
+  def roles
+    if object.suspended?
+      []
+    else
+      [object.user.role].compact.filter { |role| role.highlighted? }
+    end
   end
 
   def noindex

--- a/spec/fabricators/user_role_fabricator.rb
+++ b/spec/fabricators/user_role_fabricator.rb
@@ -1,5 +1,5 @@
 Fabricator(:user_role) do
   name        "MyString"
-  color       "MyString"
-  permissions ""
+  color       ""
+  permissions 0
 end


### PR DESCRIPTION
Split from #21393 so that the API change is not blocked by us not settling on the UI design.