### PR TITLE
Exclude user's replies to their own posts when sending posts requested with exclude_replies flag

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -93,7 +93,7 @@ class Status < ApplicationRecord
   scope :remote, -> { where(local: false).where.not(uri: nil) }
   scope :local,  -> { where(local: true).or(where(uri: nil)) }
   scope :with_accounts, ->(ids) { where(id: ids).includes(:account) }
-  scope :without_replies, -> { where('statuses.reply = FALSE OR statuses.in_reply_to_account_id = statuses.account_id') }
+  scope :without_replies, -> { where('statuses.reply = FALSE') }
   scope :without_reblogs, -> { where('statuses.reblog_of_id IS NULL') }
   scope :with_public_visibility, -> { where(visibility: :public) }
   scope :tagged_with, ->(tag_ids) { joins(:statuses_tags).where(statuses_tags: { tag_id: tag_ids }) }

--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -29,13 +29,21 @@ describe Api::V1::Accounts::StatusesController do
 
     context 'with exclude replies' do
       before do
+        user.account.statuses.destroy_all
+        
+        Fabricate(:status, account: user.account)
         Fabricate(:status, account: user.account, thread: Fabricate(:status))
+
+        get :index, params: { account_id: user.account.id, exclude_replies: true }
       end
 
       it 'returns http success' do
-        get :index, params: { account_id: user.account.id, exclude_replies: true }
-
         expect(response).to have_http_status(200)
+      end
+
+      it 'returns only posts' do
+        json = body_as_json
+        expect(json.count).to eq 1
       end
     end
 


### PR DESCRIPTION
Fixes #22152

#### Context:
List Posts(Statuses) for a user requested with query param **exclude_replies** set to true

#### Previous Behaviour: 
Response used to include user's posts as well as their replies to their own posts.

#### Updated Behaviour:
Response contains user's posts only.


**Note:**  There are two separate sections on the profile page: one for posts, and one for posts along with replies.