### PR TITLE
Make the reply indicator's header position relative to avoid possible z-ordering issues

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -811,6 +811,7 @@ body > [data-popper-placement] {
 }
 
 .reply-indicator__header {
+  position: relative;
   margin-bottom: 5px;
   overflow: hidden;
 }


### PR DESCRIPTION
**Problem:** The `.reply-indicator__header` class, unlike the `.reply-indicator__content` class, lacks `position: relative`, which may cause z-ordering in certain user-styles, where the reply indicator's header and the `.drawer__inner__mastodon` banner may overlap, especially in the advanced web interface.

**Solution:** Set the `position` attribute of `.reply-indicator__header` to be `relative`. This fixes the inconsistency. 