### PR TITLE
Change wording of “Content cache retention period” setting to highlight destructive implications

### DIFF
--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -269,10 +269,6 @@ code {
       margin-bottom: 15px;
     }
 
-    .hint + .warning-hint {
-      margin-top: -15px;
-    }
-
     ul {
       columns: 2;
     }

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -269,6 +269,10 @@ code {
       margin-bottom: 15px;
     }
 
+    .hint + .warning-hint {
+      margin-top: -15px;
+    }
+
     ul {
       columns: 2;
     }

--- a/app/views/admin/settings/content_retention/show.html.haml
+++ b/app/views/admin/settings/content_retention/show.html.haml
@@ -15,7 +15,7 @@
 
   .fields-group
     = f.input :media_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
-    = f.input :content_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
+    = f.input :content_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }, hint: t('simple_form.hints.form_admin_settings.content_cache_retention_period_html')
     = f.input :backups_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
 
   .actions

--- a/app/views/admin/settings/content_retention/show.html.haml
+++ b/app/views/admin/settings/content_retention/show.html.haml
@@ -15,7 +15,7 @@
 
   .fields-group
     = f.input :media_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
-    = f.input :content_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }, hint: t('simple_form.hints.form_admin_settings.content_cache_retention_period_html')
+    = f.input :content_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }, hint: t('simple_form.hints.form_admin_settings.content_cache_retention_period_html'), warning_hint: t('simple_form.hints.form_admin_settings.content_cache_retention_period_warning_html')
     = f.input :backups_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
 
   .actions

--- a/app/views/admin/settings/content_retention/show.html.haml
+++ b/app/views/admin/settings/content_retention/show.html.haml
@@ -15,7 +15,7 @@
 
   .fields-group
     = f.input :media_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
-    = f.input :content_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }, hint: t('simple_form.hints.form_admin_settings.content_cache_retention_period_html'), warning_hint: t('simple_form.hints.form_admin_settings.content_cache_retention_period_warning_html')
+    = f.input :content_cache_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }, hint: false, warning_hint: t('simple_form.hints.form_admin_settings.content_cache_retention_period')
     = f.input :backups_retention_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
 
   .actions

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -110,7 +110,7 @@ SimpleForm.setup do |config|
     b.use :html5
     b.use :label
     b.use :hint, wrap_with: { tag: :span, class: :hint }
-    b.use :warning_hint, wrap_with: { tag: :div, class: [:hint, 'warning-hint'] }
+    b.use :warning_hint, wrap_with: { tag: :span, class: [:hint, 'warning-hint'] }
     b.use :input, wrap_with: { tag: :div, class: :label_input }
     b.use :error, wrap_with: { tag: :span, class: :error }
   end

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -19,8 +19,17 @@ module RecommendedComponent
   end
 end
 
+module WarningHintComponent
+  def warning_hint(_wrapper_options = nil)
+    @warning_hint ||= begin
+      options[:warning_hint].to_s.html_safe if options[:warning_hint].present?
+    end
+  end
+end
+
 SimpleForm.include_component(AppendComponent)
 SimpleForm.include_component(RecommendedComponent)
+SimpleForm.include_component(WarningHintComponent)
 
 SimpleForm.setup do |config|
   # Wrappers are used by the form builder to generate a
@@ -101,6 +110,7 @@ SimpleForm.setup do |config|
     b.use :html5
     b.use :label
     b.use :hint, wrap_with: { tag: :span, class: :hint }
+    b.use :warning_hint, wrap_with: { tag: :div, class: [:hint, 'warning-hint'] }
     b.use :input, wrap_with: { tag: :div, class: :label_input }
     b.use :error, wrap_with: { tag: :span, class: :error }
   end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -78,8 +78,7 @@ en:
         backups_retention_period: Keep generated user archives for the specified number of days.
         bootstrap_timeline_accounts: These accounts will be pinned to the top of new users' follow recommendations.
         closed_registrations_message: Displayed when sign-ups are closed
-        content_cache_retention_period_html: "<strong>All</strong> posts and boosts from other servers will be deleted after the specified number of days."
-        content_cache_retention_period_warning_html: 'This will delete all remote posts, including those which have been interacted with. As a result: <ul><li>Boosts will be lost and impossible to undo</li><li>Favourites will be lost and impossible to undo</li><li>Bookmarks will be lost</li><li>Non-public posts may be permanently lost</li></ul>'
+        content_cache_retention_period: All posts and boosts from other servers will be deleted after the specified number of days. Some posts may not be recoverable. All related bookmarks, favourites and boosts will also be lost and impossible to undo.
         custom_css: You can apply custom styles on the web version of Mastodon.
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -78,7 +78,7 @@ en:
         backups_retention_period: Keep generated user archives for the specified number of days.
         bootstrap_timeline_accounts: These accounts will be pinned to the top of new users' follow recommendations.
         closed_registrations_message: Displayed when sign-ups are closed
-        content_cache_retention_period: Posts from other servers will be deleted after the specified number of days when set to a positive value. This may be irreversible.
+        content_cache_retention_period_html: "<strong>All</strong> posts and boosts from other servers will be deleted after the specified number of days, <strong>even if they have been interacted with or bookmarked</strong>. This may be <strong>irreversible</strong>, and favorites and bookmarks <strong>will be permanently lost</strong>."
         custom_css: You can apply custom styles on the web version of Mastodon.
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -78,7 +78,8 @@ en:
         backups_retention_period: Keep generated user archives for the specified number of days.
         bootstrap_timeline_accounts: These accounts will be pinned to the top of new users' follow recommendations.
         closed_registrations_message: Displayed when sign-ups are closed
-        content_cache_retention_period_html: "<strong>All</strong> posts and boosts from other servers will be deleted after the specified number of days, <strong>even if they have been interacted with or bookmarked</strong>. This may be <strong>irreversible</strong>, and favorites and bookmarks <strong>will be permanently lost</strong>."
+        content_cache_retention_period_html: "<strong>All</strong> posts and boosts from other servers will be deleted after the specified number of days."
+        content_cache_retention_period_warning_html: 'This will delete all remote posts, including those which have been interacted with. As a result: <ul><li>Boosts will be lost and impossible to undo</li><li>Favourites will be lost and impossible to undo</li><li>Bookmarks will be lost</li><li>Non-public posts may be permanently lost</li></ul>'
         custom_css: You can apply custom styles on the web version of Mastodon.
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.


### PR DESCRIPTION
The effects of the setting introduced by #19232 are surprising to many admins and not documented clearly enough, as evidenced by the PR's comments and issues such as https://github.com/mastodon/mastodon/issues/23206.

I am not sure the feature itself is useful to many admins in its current form, but implementing a useful version of it that doesn't end up being too inefficient is a complex task.

In the meantime, I think it is worth rewording the description to make the destructive implications of the setting much clearer.

## Before

> Posts from other servers will be deleted after the specified number of days when set to a positive value. This may be irreversible.

![image](https://user-images.githubusercontent.com/384364/214803168-c2be9ca3-53e8-4918-a186-3dfdc2f0f92c.png)

## After

> All posts and boosts from other servers will be deleted after the specified number of days. Some posts may not be recoverable. All related bookmarks, favourites and boosts will also be lost and impossible to undo.

![image](https://github.com/mastodon/mastodon/assets/384364/6b74afc2-de2b-4a40-90e7-e32d15553179)