### PR TITLE
Add tests to indicate inclusion of self replies in statuses endpoint

### DIFF
--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe Api::V1::Accounts::StatusesController do
@@ -15,7 +16,12 @@ describe Api::V1::Accounts::StatusesController do
     it 'returns http success' do
       get :index, params: { account_id: user.account.id, limit: 1 }
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns expected headers' do
+      get :index, params: { account_id: user.account.id, limit: 1 }
+
       expect(response.headers['Link'].links.size).to eq(2)
     end
 
@@ -23,28 +29,28 @@ describe Api::V1::Accounts::StatusesController do
       it 'returns http success' do
         get :index, params: { account_id: user.account.id, only_media: true }
 
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
     end
 
     context 'with exclude replies' do
       let!(:older_statuses) { user.account.statuses.destroy_all }
       let!(:status) { Fabricate(:status, account: user.account) }
-      let!(:status_reply) { Fabricate(:status, account: user.account, thread: Fabricate(:status)) }
       let!(:status_self_reply) { Fabricate(:status, account: user.account, thread: status) }
 
       before do
+        Fabricate(:status, account: user.account, thread: Fabricate(:status)) # Reply to another user
         get :index, params: { account_id: user.account.id, exclude_replies: true }
       end
 
       it 'returns http success' do
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
 
       it 'returns posts along with self replies' do
         json = body_as_json
         post_ids = json.map { |item| item[:id].to_i }.sort
-        
+
         expect(post_ids).to eq [status.id, status_self_reply.id]
       end
     end
@@ -57,7 +63,7 @@ describe Api::V1::Accounts::StatusesController do
       it 'returns http success' do
         get :index, params: { account_id: user.account.id, pinned: true }
 
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -65,12 +71,15 @@ describe Api::V1::Accounts::StatusesController do
       let(:account)        { Fabricate(:account, username: 'bob', domain: 'example.com') }
       let(:status)         { Fabricate(:status, account: account) }
       let(:private_status) { Fabricate(:status, account: account, visibility: :private) }
-      let!(:pin)           { Fabricate(:status_pin, account: account, status: status) }
-      let!(:private_pin)   { Fabricate(:status_pin, account: account, status: private_status) }
+
+      before do
+        Fabricate(:status_pin, account: account, status: status)
+        Fabricate(:status_pin, account: account, status: private_status)
+      end
 
       it 'returns http success' do
         get :index, params: { account_id: account.id, pinned: true }
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
 
       context 'when user does not follow account' do


### PR DESCRIPTION
Closes #22152 , as it is an unwanted behaviour change.

This PR is to explicitly specify the behaviour for the below endpoint.

**Endpoint**: `/api/v1/accounts/:account_id/statuses?exclude_replies=true`

**Behaviour**: The endpoint when called with query param **exclude_replies** set to true should include **self-replies** as well.



