### PR TITLE
Add `confirmed` parameter to the “Register an account” API to bypass the confirmation email

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -89,7 +89,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def account_params
-    params.permit(:username, :email, :password, :agreement, :locale, :reason)
+    params.permit(:username, :email, :password, :agreement, :locale, :reason, :confirmed)
   end
 
   def check_enabled_registrations

--- a/app/services/app_sign_up_service.rb
+++ b/app/services/app_sign_up_service.rb
@@ -20,8 +20,21 @@ class AppSignUpService < BaseService
 
   def create_user!
     @user = User.create!(
-      user_params.merge(created_by_application: @app, sign_up_ip: @remote_ip, password_confirmation: user_params[:password], account_attributes: account_params, invite_request_attributes: invite_request_params)
+      user_params.merge(
+        created_by_application: @app,
+        sign_up_ip: @remote_ip,
+        password_confirmation: user_params[:password],
+        account_attributes: account_params,
+        invite_request_attributes: invite_request_params,
+      )
     )
+
+    if @params[:confirmed]
+      @user.confirmed_at = nil
+      @user.confirm!
+    end
+
+    @user
   end
 
   def create_access_token!

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe AppSignUpService, type: :service do
       expect(user.confirmed?).to be false
     end
 
+    it 'creates a confirmed user when the confirmed param is true' do
+      access_token = subject.call(app, remote_ip, good_params.merge(confirmed: true))
+      expect(access_token).to_not be_nil
+      user = User.find_by(id: access_token.resource_owner_id)
+      expect(user).to_not be_nil
+      expect(user.confirmed?).to be true
+    end
+
     it 'creates access token with the app\'s scopes' do
       access_token = subject.call(app, remote_ip, good_params)
       expect(access_token).to_not be_nil


### PR DESCRIPTION
This PR adds a `confirmed` boolean parameter to the [“Register an account” API](https://docs.joinmastodon.org/methods/accounts/#create). When `confirmed` is `true`, the new user’s email will be considered confirmed and they will not receive a confirmation email. The new user’s account will be activated immediately. This is very similar to the [`tootctl accounts create` `--confirmed` flag](https://docs.joinmastodon.org/admin/tootctl/#accounts-create).

For more context, I’m a software engineer at Medium. We recently set up our own Mastodon instance at [me.dm](https://me.dm/). We’d like to allow Medium members to automatically create an account on me.dm without receiving a confirmation email given that we have already confirmed the email attached to their Medium account.

We thought other Mastodon app developers might also appreciate this feature and we’d prefer contributing to the project rather than forking our instance with a custom implementation. Please let me know if there’s anything I can do to help get this change merged. Thanks!

---

Some additional detail:

We considered using `tootctl accounts create` to create accounts rather than the “Register an account” API, but `tootctl` is quite slow (even calling `tootctl help` was taking me ~15 seconds). Additionally, we’d like to pre-populate some of the user’s account details after account creation, which I don’t believe would be possible when using `tootctl`.

As far as I can tell, the only way to update all account details through the API is using the [“Update account credentials” API](https://docs.joinmastodon.org/methods/accounts/#update_credentials), which requires a User token, but we wouldn’t get a User token if we created accounts through `tootctl`