### PR TITLE
Fix AccountStatusesFilter's blocking check

### DIFF
--- a/app/models/account_statuses_filter.rb
+++ b/app/models/account_statuses_filter.rb
@@ -97,7 +97,7 @@ class AccountStatusesFilter
   end
 
   def blocked?
-    account.blocking?(current_account) || (current_account.domain.present? && account.domain_blocking?(current_account.domain))
+    account.blocking?(current_account) || (account.domain.present? && current_account.domain_blocking?(account.domain))
   end
 
   def follower?


### PR DESCRIPTION
`current_account` and `account` was reversed on domain block checking
`current_account.domain` always nil. So previous check was meaningless