### PR TITLE
fix(web-push-notifications): fix favourite push notifications

### DIFF
--- a/app/javascript/mastodon/service_worker/web_push_notifications.js
+++ b/app/javascript/mastodon/service_worker/web_push_notifications.js
@@ -1,6 +1,6 @@
 import IntlMessageFormat from 'intl-messageformat';
-import locales from './web_push_locales';
 import { unescape } from 'lodash';
+import locales from './web_push_locales';
 
 const MAX_NOTIFICATIONS = 5;
 const GROUP_TAG = 'tag';
@@ -90,7 +90,13 @@ export const handlePush = (event) => {
       options.tag       = notification.id;
       options.badge     = '/badge.png';
       options.image     = notification.status && notification.status.media_attachments.length > 0 && notification.status.media_attachments[0].preview_url || undefined;
-      options.data      = { access_token, preferred_locale, id: notification.status ? notification.status.id : notification.account.id, url: notification.status ? `/@${notification.account.acct}/${notification.status.id}` : `/@${notification.account.acct}` };
+      options.data      = { access_token, preferred_locale, id: notification.status ? notification.status.id : notification.account.id };
+
+      if (notification.status) {
+        options.data.url = `/@${notification.status.account.acct}/${notification.status.id}`;
+      } else {
+        options.data.url = `/@${notification.account.acct}`;
+      }
 
       if (notification.status && notification.status.spoiler_text || notification.status.sensitive) {
         options.data.hiddenBody  = htmlToPlainText(notification.status.content);


### PR DESCRIPTION
Fix a bug where clicking in a favourite push notification would result in a 404 (not found) error, since we were redirecting the user to the wrong URL (we were redirecting to `/@<user who favourited>/<favourited status id>`, when it should be `/@<favourited status author>/<favourited status id>`)