### PR TITLE
Only build latest commit on branch for image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,6 +16,11 @@ permissions:
 jobs:
   build-image:
     runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@v3.1.0


### PR DESCRIPTION
Since this job can be long running and ties up build resources, it can cancel all but the most recent runs for a push or PR https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run