### PR TITLE
Ignore ESLint nested ternary in JSX

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -81,7 +81,6 @@ module.exports = {
       },
     ],
     'no-empty': 'off',
-    'no-nested-ternary': 'warn',
     'no-restricted-properties': [
       'error',
       { property: 'substring', message: 'Use .slice instead of .substring.' },


### PR DESCRIPTION
It doesn't appear that there is anyway to rewrite these in JSX without moving it to a separate function and it isn't part of the recommended ruleset right now https://github.com/eslint/eslint/blob/main/conf/eslint-recommended.js

Alternately, this could be moved to an error and just use inline ignore statements for the JSX warnings