### PR TITLE
Change image matrix size limit from 1920×1080px to 4096×4096px

### DIFF
--- a/app/javascript/mastodon/utils/resize_image.js
+++ b/app/javascript/mastodon/utils/resize_image.js
@@ -1,6 +1,6 @@
 import EXIF from 'exif-js';
 
-const MAX_IMAGE_PIXELS = 2073600; // 1920x1080px
+const MAX_IMAGE_PIXELS = 16777216; // 4096x4096px
 
 const _browser_quirks = {};
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -68,7 +68,7 @@ class MediaAttachment < ApplicationRecord
 
   IMAGE_STYLES = {
     original: {
-      pixels: 2_073_600, # 1920x1080px
+      pixels: 16_777_216, # 4096x4096px
       file_geometry_parser: FastGeometryParser,
     }.freeze,
 


### PR DESCRIPTION
Mastodon currently uses ImageMagick on every user-uploaded picture, accepting images up to 4096×4096px and resizing them to 1920×1080px or less if needed.

This change would have the following effects:
- **Storage cost:** increased for uploads above 1920×1080px, but still limited to 10MB per picture
- **RAM usage:** kept about the same, as the already-high cost (~300MB of RAM for processing a single picture) of processing 4096×4096px input images with ImageMagick does not increase with the size of the output image (as long as it's 4096×4096 or below)
- **CPU usage:** actually lowered for pictures above the 1920×1080px matrix size limit since ImageMagick does not have to do expensive resizing work anymore
- **User ability to upload larger-sized images:** this change does not allow going above the 4096×4096px limit but keeps anything below that to its intended size