### PR TITLE
Fix official docker images nto being compatible with some cloud providers

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
+          provenance: false
           builder: ${{ steps.buildx.outputs.name }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
See #23333 and https://github.com/docker/buildx/issues/1533

The new default `provenance` option outputs images in a format that is not compatible with several cloud providers, that is a breaking change though I am not sure how many admins actually use those services, if any.