### PR TITLE
Change `POST /settings/applications/:id` to regenerate token on scopes change

### DIFF
--- a/app/controllers/settings/applications_controller.rb
+++ b/app/controllers/settings/applications_controller.rb
@@ -29,7 +29,13 @@ class Settings::ApplicationsController < Settings::BaseController
 
   def update
     if @application.update(application_params)
-      redirect_to settings_applications_path, notice: I18n.t('generic.changes_saved_msg')
+      if @application.scopes_previously_changed?
+        @access_token = current_user.token_for_app(@application)
+        @access_token.destroy
+        redirect_to settings_application_path(@application), notice: I18n.t('applications.token_regenerated')
+      else
+        redirect_to settings_application_path(@application), notice: I18n.t('generic.changes_saved_msg')
+      end
     else
       render :show
     end

--- a/spec/controllers/settings/applications_controller_spec.rb
+++ b/spec/controllers/settings/applications_controller_spec.rb
@@ -132,7 +132,7 @@ describe Settings::ApplicationsController do
       end
 
       it 'redirects back to applications page' do
-        expect(call_update).to redirect_to(settings_applications_path)
+        expect(call_update).to redirect_to(settings_application_path(app))
       end
     end
 


### PR DESCRIPTION
Fixes #23096

Instead of returning to the address, it goes back to the same page, with a message that depends on the changes.

## When scopes have not been changed

![image](https://user-images.githubusercontent.com/384364/216074765-0296c958-1de1-4851-8ce8-7320b099dee0.png)

## When scopes have been changed

Regenerates the token and says as much

![image](https://user-images.githubusercontent.com/384364/216074993-9858f4e9-6a5e-434f-a747-4124c4a4a2f0.png)