### PR TITLE
Optimize archive export service and export zip files instead of gzipped tar files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -162,3 +162,4 @@ gem 'xorcist', '~> 1.1'
 gem 'cocoon', '~> 1.2'
 
 gem 'net-http', '~> 0.3.2'
+gem 'rubyzip', '~> 2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -636,6 +636,7 @@ GEM
       nokogiri (>= 1.10.5)
       rexml
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     rufus-scheduler (3.8.2)
       fugit (~> 1.1, >= 1.1.6)
     safety_net_attestation (0.4.0)
@@ -876,6 +877,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   ruby-progressbar (~> 1.13)
+  rubyzip (~> 2.3)
   sanitize (~> 6.0)
   scenic (~> 1.7)
   sidekiq (~> 6.5)

--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -22,9 +22,8 @@ class BackupService < BaseService
     skeleton[:@context] = full_context
     skeleton[:orderedItems] = ['!PLACEHOLDER!']
     skeleton = Oj.dump(skeleton)
-    prepend    = skeleton.gsub(/"!PLACEHOLDER!".*/, '')
-    append     = skeleton.gsub(/.*"!PLACEHOLDER!"/, '')
-    add_comma  = false
+    prepend, append = skeleton.split('"!PLACEHOLDER!"')
+    add_comma = false
 
     file.write(prepend)
 
@@ -38,7 +37,7 @@ class BackupService < BaseService
 
         unless item[:type] == 'Announce' || item[:object][:attachment].blank?
           item[:object][:attachment].each do |attachment|
-            attachment[:url] = Addressable::URI.parse(attachment[:url]).path.gsub(/\A\/system\//, '')
+            attachment[:url] = Addressable::URI.parse(attachment[:url]).path.delete_prefix('/system/')
           end
         end
 

--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -22,7 +22,7 @@ class BackupService < BaseService
 
     account.statuses.with_includes.reorder(nil).find_in_batches do |statuses|
       statuses.each do |status|
-        item = serialize_payload(ActivityPub::ActivityPresenter.from_status(status), ActivityPub::ActivitySerializer, signer: @account)
+        item = serialize_payload(ActivityPub::ActivityPresenter.from_status(status), ActivityPub::ActivitySerializer)
         item.delete(:@context)
 
         unless item[:type] == 'Announce' || item[:object][:attachment].blank?

--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -73,9 +73,12 @@ class BackupService < BaseService
   def dump_media_attachments!(zipfile)
     MediaAttachment.attached.where(account: account).reorder(nil).find_in_batches do |media_attachments|
       media_attachments.each do |m|
-        next unless m.file&.path
+        path = m.file&.path
+        next unless path
 
-        download_to_zip(zipfile, m.file, m.file.path)
+        path = path.gsub(/\A.*\/system\//, '')
+        path = path.gsub(/\A\/+/, '')
+        download_to_zip(zipfile, m.file, path)
       end
 
       GC.start

--- a/spec/services/backup_service_spec.rb
+++ b/spec/services/backup_service_spec.rb
@@ -28,8 +28,10 @@ RSpec.describe BackupService, type: :service do
     service_call
 
     json = Oj.load(read_zip_file(backup, 'outbox.json'))
+    expect(json['@context']).to_not be_nil
     expect(json['type']).to eq 'OrderedCollection'
     expect(json['totalItems']).to eq 2
+    expect(json['orderedItems'][0]['@context']).to be_nil
     expect(json['orderedItems'][0]).to include({
       'type' => 'Create',
       'object' => include({

--- a/spec/services/backup_service_spec.rb
+++ b/spec/services/backup_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe BackupService, type: :service do
   let!(:status)         { Fabricate(:status, account: user.account, text: 'Hello', visibility: :public, media_attachments: [attachment]) }
   let!(:private_status) { Fabricate(:status, account: user.account, text: 'secret', visibility: :private) }
   let!(:favourite)      { Fabricate(:favourite, account: user.account) }
+  let!(:bookmark)       { Fabricate(:bookmark, account: user.account) }
   let!(:backup)         { Fabricate(:backup, user: user) }
 
   def read_zip_file(backup, filename)
@@ -53,7 +54,14 @@ RSpec.describe BackupService, type: :service do
 
     json = Oj.load(read_zip_file(backup, 'likes.json'))
     expect(json['type']).to eq 'OrderedCollection'
-    expect(json['totalItems']).to eq 1
     expect(json['orderedItems']).to eq [ActivityPub::TagManager.instance.uri_for(favourite.status)]
+  end
+
+  it 'exports bookmarks.json as expected' do
+    service_call
+
+    json = Oj.load(read_zip_file(backup, 'bookmarks.json'))
+    expect(json['type']).to eq 'OrderedCollection'
+    expect(json['orderedItems']).to eq [ActivityPub::TagManager.instance.uri_for(bookmark.status)]
   end
 end

--- a/spec/services/backup_service_spec.rb
+++ b/spec/services/backup_service_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BackupService, type: :service do
+  subject(:service_call) { described_class.new.call(backup) }
+
+  let!(:user)           { Fabricate(:user) }
+  let!(:attachment)     { Fabricate(:media_attachment, account: user.account) }
+  let!(:status)         { Fabricate(:status, account: user.account, text: 'Hello', visibility: :public, media_attachments: [attachment]) }
+  let!(:private_status) { Fabricate(:status, account: user.account, text: 'secret', visibility: :private) }
+  let!(:favourite)      { Fabricate(:favourite, account: user.account) }
+  let!(:backup)         { Fabricate(:backup, user: user) }
+
+  def read_tgz_file(backup, filename)
+    file = Paperclip.io_adapters.for(backup.dump)
+    Zlib::GzipReader.wrap(file) do |gz|
+      Gem::Package::TarReader.new(gz) do |tar|
+        tar.each do |entry|
+          next unless entry.full_name == filename
+          return entry.read
+        end
+      end
+    end
+  end
+
+  it 'marks the backup as processed' do
+    expect { service_call }.to change(backup, :processed).from(false).to(true)
+  end
+
+  it 'exports outbox.json as expected' do
+    service_call
+
+    json = Oj.load(read_tgz_file(backup, 'outbox.json'))
+    expect(json['type']).to eq 'OrderedCollection'
+    expect(json['totalItems']).to eq 2
+    expect(json['orderedItems'][0]).to include({
+      'type' => 'Create',
+      'object' => include({
+        'id' => ActivityPub::TagManager.instance.uri_for(status),
+        'content' => '<p>Hello</p>',
+      }),
+    })
+    expect(json['orderedItems'][1]).to include({
+      'type' => 'Create',
+      'object' => include({
+        'id' => ActivityPub::TagManager.instance.uri_for(private_status),
+        'content' => '<p>secret</p>',
+      }),
+    })
+  end
+
+  it 'exports likes.json as expected' do
+    service_call
+
+    json = Oj.load(read_tgz_file(backup, 'likes.json'))
+    expect(json['type']).to eq 'OrderedCollection'
+    expect(json['totalItems']).to eq 1
+    expect(json['orderedItems']).to eq [ActivityPub::TagManager.instance.uri_for(favourite.status)]
+  end
+end


### PR DESCRIPTION
This PR optimizes the archive export service in multiple ways, reducing archive generation time by about 40%, as well as limiting the total memory consumption.

## Breaking changes

- changed from a `.tar.gz` archive to a `.zip` archive
- dropped LDSignatures (which were, for the most part, already broken)
- dropped `@context` on individual posts (that was already intended but broken)
- dropped `totalItems` from the `bookmarks.json` and `likes.json` collections

## Optimizations

### Change format from .tar.gz to .zip

The underlying compression algorithms are similar, so this is not in itself an optimization, however it simplifies code and allows the next optimization.

### Stream `outbox.json` generation and compression

Currently, the contents of `outbox.json` are serialized in one pass from memory, which can be fairly expensive.
Instead, compress the output in the zip file as it being generated, never storing the whole thing in memory.
Using zip files instead of .tar.gz makes it much easier 

### Stream `likes.json` and `bookmarks.json` generation and compression

Works in a similar way to `outbox.json`. This required dropping `totalItems` though.

### Skip LDSignatures

Having LDSigned posts is potentially useful, except we mutate the post after it gets signed whenever there are media attachments, so most signatures are actually invalid.

Furthermore, JSON generation accounts to over 85% of the archive export time, and skipping signatures cuts down the JSON generation time by half.

Skipping LD Signatures speeds up the archive generation time by about 40% and reduces the archive's size a little.

### Remove `@context` from individual entries

Instead, output the full JSON-LD context at the root of the collection. It seems removing `@context` was already intended, but not actually done, because the `delete` call used a symbol key while the object used a string key. This duplication compresses well, so it does not change much overall, but it reduces the uncompressed `outbox.json`'s file size by over 10%.