### PR TITLE
Check for missing i18n strings in CI

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -18,20 +18,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libicu-dev libidn11-dev
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+
       - name: Check locale file normalization
         run: bundle exec i18n-tasks check-normalized
+
       - name: Check for unused strings
         run: bundle exec i18n-tasks unused
+
+      - name: Check for missing strings in English
+        run: |
+          bundle exec i18n-tasks add-missing -l en
+          git diff --exit-code
+
       - name: Check for wrong string interpolations
         run: bundle exec i18n-tasks check-consistent-interpolations
+
       - name: Check that all required locale files exist
         run: bundle exec rake repo:check_locales_files

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,7 +476,7 @@ en:
       content_policies:
         comment: Internal note
         description_html: You can define content policies that will be applied to all accounts from this domain and any of its subdomains.
-        limited_federation_mode_description_html: You are chose whether to allow federation with this domain.
+        limited_federation_mode_description_html: You can chose whether to allow federation with this domain.
         policies:
           reject_media: Reject media
           reject_reports: Reject reports

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,7 +476,7 @@ en:
       content_policies:
         comment: Internal note
         description_html: You can define content policies that will be applied to all accounts from this domain and any of its subdomains.
-        limited_federation_mode_description_html: Limited federation mode description html
+        limited_federation_mode_description_html: You are chose whether to allow federation with this domain.
         policies:
           reject_media: Reject media
           reject_reports: Reject reports

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,7 @@ en:
       moderation:
         active: Active
         all: All
+        disabled: Disabled
         pending: Pending
         silenced: Limited
         suspended: Suspended
@@ -133,6 +134,7 @@ en:
       search: Search
       search_same_email_domain: Other users with the same e-mail domain
       search_same_ip: Other users with the same IP
+      security: Security
       security_measures:
         only_password: Only password
         password_and_2fa: Password and 2FA
@@ -427,6 +429,7 @@ en:
         resolve: Resolve domain
         title: Block new e-mail domain
       no_email_domain_block_selected: No e-mail domain blocks were changed as none were selected
+      not_permitted: Not permitted
       resolved_dns_records_hint_html: The domain name resolves to the following MX domains, which are ultimately responsible for accepting e-mail. Blocking an MX domain will block sign-ups from any e-mail address which uses the same MX domain, even if the visible domain name is different. <strong>Be careful not to block major e-mail providers.</strong>
       resolved_through_html: Resolved through %{domain}
       title: Blocked e-mail domains
@@ -473,6 +476,7 @@ en:
       content_policies:
         comment: Internal note
         description_html: You can define content policies that will be applied to all accounts from this domain and any of its subdomains.
+        limited_federation_mode_description_html: Limited federation mode description html
         policies:
           reject_media: Reject media
           reject_reports: Reject reports
@@ -585,11 +589,13 @@ en:
       assign_to_self: Assign to me
       assigned: Assigned moderator
       by_target_domain: Domain of reported account
+      cancel: Cancel
       category: Category
       category_description_html: The reason this account and/or content was reported will be cited in communication with the reported account
       comment:
         none: None
       comment_description_html: 'To provide more information, %{name} wrote:'
+      confirm: Confirm
       confirm_action: Confirm moderation action against @%{acct}
       created_at: Reported
       delete_and_resolve: Delete posts
@@ -792,6 +798,7 @@ en:
         suspend: "%{name} suspended %{target}'s account"
       appeal_approved: Appealed
       appeal_pending: Appeal pending
+      appeal_rejected: Appeal rejected
     system_checks:
       database_schema_check:
         message_html: There are pending database migrations. Please run them to ensure the application behaves as expected
@@ -827,6 +834,7 @@ en:
           other: Shared by %{count} people over the last week
         title: Trending links
         usage_comparison: Shared %{today} times today, compared to %{yesterday} yesterday
+      not_allowed_to_trend: Not allowed to trend
       only_allowed: Only allowed
       pending_review: Pending review
       preview_card_providers:
@@ -958,6 +966,7 @@ en:
   applications:
     created: Application successfully created
     destroyed: Application successfully deleted
+    logout: Logout
     regenerate_token: Regenerate access token
     token_regenerated: Access token successfully regenerated
     warning: Be very careful with this data. Never share it with anyone!
@@ -994,6 +1003,8 @@ en:
     resend_confirmation: Resend confirmation instructions
     reset_password: Reset password
     rules:
+      accept: Accept
+      back: Back
       preamble: These are set and enforced by the %{domain} moderators.
       title: Some ground rules.
     security: Security


### PR DESCRIPTION
Had a separate PR to do a large sync with the `add-missing`. This just checks the `en` locale and fails if that sync creates a diff.
Pushing the CI as first commit, then will add the en-only fixup in a following commit to confirm it goes red->green