### PR TITLE
Add error message for when following own account

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -38,6 +38,9 @@ class Api::V1::AccountsController < Api::BaseController
     options = @account.locked? || current_user.account.silenced? ? {} : { following_map: { @account.id => { reblogs: follow.show_reblogs?, notify: follow.notify?, languages: follow.languages } }, requested_map: { @account.id => false } }
 
     render json: @account, serializer: REST::RelationshipSerializer, relationships: relationships(**options)
+
+  rescue FollowService::SelfFollowError
+    render json: { error: 'Follow your own account is not allowed' }, status: 403
   end
 
   def block

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -117,6 +117,27 @@ RSpec.describe Api::V1::AccountsController, type: :controller do
 
         it_behaves_like 'forbidden for wrong scope', 'read:accounts'
       end
+
+      context 'following own account' do
+        let(:locked) { false }
+        let(:other_account) { user.account }
+
+        it 'returns http forbidden' do
+          expect(response).to have_http_status(403)
+        end
+
+        it 'returns JSON with an error message' do
+          json = body_as_json
+          
+          expect(json[:error]).to eq 'Follow your own account is not allowed'
+        end
+
+        it 'dont creates a following relation between user and target user' do
+          expect(user.account.following?(other_account)).to be false
+        end
+
+        it_behaves_like 'forbidden for wrong scope', 'read:accounts'
+      end
     end
 
     context 'modifying follow options' do

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -134,6 +134,15 @@ RSpec.describe FollowService, type: :service do
         expect(Follow.find_by(account: sender, target_account: bob)&.languages).to match_array %w(en es)
       end
     end
+
+    describe "following own account" do
+      it "raises a SelfFollowError exception and don't creates a following relation" do
+        expect { subject.call(sender, sender) }
+          .to raise_error(FollowService::SelfFollowError)
+          .and not_change { sender.following?(sender) }
+
+        expect(sender.following?(sender)).to be false
+      end
   end
 
   context 'remote ActivityPub account' do


### PR DESCRIPTION
* Add a specific error message for when attempting to follow your own account via the API

It would handle the attempt to follow your own account as if the account record didn't exist.

* Add tests

fixes  #22690