### PR TITLE
Add an env var to set a status page link

### DIFF
--- a/app/javascript/mastodon/features/ui/components/link_footer.js
+++ b/app/javascript/mastodon/features/ui/components/link_footer.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { domain, version, source_url, profile_directory as profileDirectory } from 'mastodon/initial_state';
+import { domain, version, source_url, profile_directory as profileDirectory, statusPageUrl } from 'mastodon/initial_state';
 import { logOut } from 'mastodon/utils/log_out';
 import { openModal } from 'mastodon/actions/modal';
 import { PERMISSION_INVITE_USERS } from 'mastodon/permissions';
@@ -74,6 +74,12 @@ class LinkFooter extends React.PureComponent {
           )}
           {DividingCircle}
           <Link key='privacy-policy' to='/privacy-policy'><FormattedMessage id='footer.privacy_policy' defaultMessage='Privacy policy' /></Link>
+          {statusPageUrl && (
+            <>
+              {DividingCircle}
+              <Link href={statusPageUrl} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.status' defaultMessage='Status' /></Link>
+            </>
+          )}
         </p>
 
         <p>

--- a/app/javascript/mastodon/features/ui/components/link_footer.js
+++ b/app/javascript/mastodon/features/ui/components/link_footer.js
@@ -77,7 +77,7 @@ class LinkFooter extends React.PureComponent {
           {statusPageUrl && (
             <>
               {DividingCircle}
-              <Link href={statusPageUrl} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.status' defaultMessage='Status' /></Link>
+              <a href={statusPageUrl} rel='noopener noreferrer' target='_blank'><FormattedMessage id='footer.status' defaultMessage='Status' /></a>
             </>
           )}
         </p>

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -81,6 +81,7 @@
  * @property {boolean=} use_pending_items
  * @property {string} version
  * @property {boolean} translation_enabled
+ * @property {string} status_page_url
  */
 
 /**
@@ -133,6 +134,7 @@ export const useBlurhash = getMeta('use_blurhash');
 export const usePendingItems = getMeta('use_pending_items');
 export const version = getMeta('version');
 export const translationEnabled = getMeta('translation_enabled');
+export const statusPageUrl = getMeta('status_page_url');
 export const languages = initialState?.languages;
 
 export default initialState;

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -33,6 +33,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       single_user_mode: Rails.configuration.x.single_user_mode,
       translation_enabled: TranslationService.configured?,
       trends_as_landing_page: Setting.trends_as_landing_page,
+      status_page_url: ENV.fetch('STATUS_PAGE_URL', nil),
     }
 
     if object.current_account


### PR DESCRIPTION
As discussed on mastodon's discord, this PR adds a way to link to a status page for the server

Sorry if this is not the right way to do it, i'm not familiar with ruby nor the code base