### PR TITLE
Spell check input fields

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_input.js
+++ b/app/javascript/mastodon/components/autosuggest_input.js
@@ -51,6 +51,7 @@ export default class AutosuggestInput extends ImmutablePureComponent {
     searchTokens: PropTypes.arrayOf(PropTypes.string),
     maxLength: PropTypes.number,
     lang: PropTypes.string,
+    spellCheck: PropTypes.string,
   };
 
   static defaultProps = {
@@ -186,7 +187,7 @@ export default class AutosuggestInput extends ImmutablePureComponent {
   };
 
   render () {
-    const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus, className, id, maxLength, lang } = this.props;
+    const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus, className, id, maxLength, lang, spellCheck } = this.props;
     const { suggestionsHidden } = this.state;
 
     return (
@@ -212,6 +213,7 @@ export default class AutosuggestInput extends ImmutablePureComponent {
             className={className}
             maxLength={maxLength}
             lang={lang}
+            spellCheck={spellCheck}
           />
         </label>
 

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -242,6 +242,7 @@ class ComposeForm extends ImmutablePureComponent {
             id='cw-spoiler-input'
             className='spoiler-input__input'
             lang={this.props.lang}
+            spellCheck
           />
         </div>
 

--- a/app/javascript/mastodon/features/compose/components/poll_form.js
+++ b/app/javascript/mastodon/features/compose/components/poll_form.js
@@ -93,6 +93,7 @@ class Option extends React.PureComponent {
             maxLength={50}
             value={title}
             lang={lang}
+            spellCheck
             onChange={this.handleOptionTitleChange}
             suggestions={this.props.suggestions}
             onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}


### PR DESCRIPTION
By default, browsers does spell checking in `<textarea>` elements but not in `<input>` elements (AFAICT this [very old overview](https://blog.whatwg.org/the-road-to-html-5-spellchecking#compatibility) is still true for Firefox and Chrome – Edge and Safari work like Chrome). 

This PR enables spell checking for the CW and poll option fields by adding `spellcheck="true"`.

In Firefox, the spell checker language is defined by the `lang` attribute (added in #23293 and #23240). Chrome, Safari and Edge ignore the `lang` attribute and use all installed dictionaries (marked as [wontfix](https://bugs.chromium.org/p/chromium/issues/detail?id=389498)).