### PR TITLE
Cleanup unused i18n strings

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check locale file normalization
         run: bundle exec i18n-tasks check-normalized
       - name: Check for unused strings
-        run: bundle exec i18n-tasks unused -l en
+        run: bundle exec i18n-tasks unused
       - name: Check for wrong string interpolations
         run: bundle exec i18n-tasks check-consistent-interpolations
       - name: Check that all required locale files exist

--- a/config/locales/af.yml
+++ b/config/locales/af.yml
@@ -96,9 +96,7 @@ af:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   exports:
     bookmarks: Boekmerke

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -232,9 +232,7 @@ bn:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   verification:
     verification: সত্যতা নির্ধারণ

--- a/config/locales/br.yml
+++ b/config/locales/br.yml
@@ -342,9 +342,7 @@ br:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   exports:
     archive_takeout:

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -6,7 +6,5 @@ bs:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/csb.yml
+++ b/config/locales/csb.yml
@@ -6,7 +6,5 @@ csb:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -190,9 +190,7 @@ en-GB:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   sessions:
     browsers:

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -369,9 +369,7 @@ ga:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   exports:
     archive_takeout:

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -435,6 +435,8 @@ ga:
     prev: Ceann roimhe seo
   preferences:
     other: Eile
+    posting_defaults: Posting defaults
+    public_timelines: Public timelines
   relationships:
     follow_selected_followers: Lean leantóirí roghnaithe
     followers: Leantóirí

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -6,7 +6,5 @@ hi:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -81,9 +81,7 @@ hr:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   exports:
     archive_takeout:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -539,7 +539,6 @@ hy:
     '404': Էջը, որը փնտրում ես գոյութիւն չունի։
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Չափազանց շատ հարցումներ
     '500':
       title: Էջը ճիշտ չէ

--- a/config/locales/ig.yml
+++ b/config/locales/ig.yml
@@ -6,7 +6,5 @@ ig:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -394,6 +394,8 @@ ka:
     prev: წინა
   preferences:
     other: სხვა
+    posting_defaults: Posting defaults
+    public_timelines: Public timelines
   remote_follow:
     missing_resource: საჭირო გადამისამართების ურლ თქვენი ანგარიშისთვის ვერ მოიძებნა
   sessions:

--- a/config/locales/kab.yml
+++ b/config/locales/kab.yml
@@ -508,7 +508,6 @@ kab:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
     '500':
       title: Asebter-ayi d arameγtu

--- a/config/locales/kab.yml
+++ b/config/locales/kab.yml
@@ -629,6 +629,8 @@ kab:
     prev: Win iɛeddan
   preferences:
     other: Wiyaḍ
+    posting_defaults: Posting defaults
+    public_timelines: Public timelines
   privacy_policy:
     title: Tasertit tabaḍnit
   relationships:

--- a/config/locales/kn.yml
+++ b/config/locales/kn.yml
@@ -6,7 +6,5 @@ kn:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/kw.yml
+++ b/config/locales/kw.yml
@@ -11,9 +11,7 @@ kw:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   settings:
     account: Akont

--- a/config/locales/la.yml
+++ b/config/locales/la.yml
@@ -6,7 +6,5 @@ la:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -426,6 +426,8 @@ lt:
     prev: Ankstesnis
   preferences:
     other: Kita
+    posting_defaults: Posting defaults
+    public_timelines: Public timelines
   remote_follow:
     missing_resource: Jūsų paskyros nukreipimo URL nerasta
   scheduled_statuses:

--- a/config/locales/mk.yml
+++ b/config/locales/mk.yml
@@ -6,7 +6,5 @@ mk:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/ml.yml
+++ b/config/locales/ml.yml
@@ -87,9 +87,7 @@ ml:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   filters:
     contexts:

--- a/config/locales/mr.yml
+++ b/config/locales/mr.yml
@@ -6,7 +6,5 @@ mr:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -827,7 +827,6 @@ ms:
     '422':
       title: Pengesahan keselamatan gagal
     '429': Terlalu banyak permintaan
-    '500': 
     '503': Halaman tidak dapat disampaikan kerana kegagalan pelayan sementara.
   exports:
     archive_takeout:

--- a/config/locales/my.yml
+++ b/config/locales/my.yml
@@ -6,7 +6,5 @@ my:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -6,7 +6,5 @@ pa:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/sa.yml
+++ b/config/locales/sa.yml
@@ -6,7 +6,5 @@ sa:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -288,6 +288,8 @@ sr-Latn:
     prev: Prethodni
   preferences:
     other: Ostali
+    posting_defaults: Posting defaults
+    public_timelines: Public timelines
   remote_follow:
     missing_resource: Ne mogu da nađem zahtevanu adresu preusmeravanja za Vaš nalog
   sessions:

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -209,7 +209,6 @@ sr-Latn:
     '404': Strana koju ste tražili ne postoji.
     '406': This page is not available in the requested format.
     '410': Strana koju ste tražili više ne postoji.
-    '422': 
     '429': Uspored
     '500':
       content: Izvinjavamo se, nešto je pošlo po zlu sa ove strane.

--- a/config/locales/szl.yml
+++ b/config/locales/szl.yml
@@ -6,7 +6,5 @@ szl:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -203,9 +203,7 @@ ta:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   filters:
     index:

--- a/config/locales/tai.yml
+++ b/config/locales/tai.yml
@@ -6,7 +6,5 @@ tai:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/te.yml
+++ b/config/locales/te.yml
@@ -76,7 +76,5 @@ te:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/tt.yml
+++ b/config/locales/tt.yml
@@ -136,9 +136,7 @@ tt:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   exports:
     archive_takeout:

--- a/config/locales/tt.yml
+++ b/config/locales/tt.yml
@@ -181,6 +181,8 @@ tt:
     truncate: "&hellip;"
   preferences:
     other: Башка
+    posting_defaults: Posting defaults
+    public_timelines: Public timelines
   relationships:
     following: Язылгансыз
   sessions:

--- a/config/locales/ug.yml
+++ b/config/locales/ug.yml
@@ -6,7 +6,5 @@ ug:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -6,7 +6,5 @@ ur:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -45,7 +45,5 @@ uz:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.

--- a/config/locales/zgh.yml
+++ b/config/locales/zgh.yml
@@ -89,9 +89,7 @@ zgh:
     '404': The page you are looking for isn't here.
     '406': This page is not available in the requested format.
     '410': The page you were looking for doesn't exist here anymore.
-    '422': 
     '429': Too many requests
-    '500': 
     '503': The page could not be served due to a temporary server failure.
   exports:
     archive_takeout:


### PR DESCRIPTION
Cleans up the results from `bundle exec i18n-tasks unused`.
- The 422/500 keys were flagged because they moved from a string to an object in the English
- The `preference.other` seems to complain without the siblings in this case
- Enable the CI checking for all locales going forward