### PR TITLE
Fix account serializer crash if account doesn't have a user

### DIFF
--- a/app/serializers/rest/account_serializer.rb
+++ b/app/serializers/rest/account_serializer.rb
@@ -125,10 +125,10 @@ class REST::AccountSerializer < ActiveModel::Serializer
   end
 
   def roles
-    if object.suspended?
+    if object.suspended? || object.user.nil?
       []
     else
-      [object.user.role].compact.filter { |role| role.highlighted? }
+      [object.user.role].compact.filter(&:highlighted?)
     end
   end
 


### PR DESCRIPTION
Previous code causing `NoMethodError: undefined method 'role' for nil:NilClass`