### PR TITLE
Autofix Rails/EagerEvaluationLogMessage

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -285,7 +285,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
 
     media_attachments
   rescue Addressable::URI::InvalidURIError => e
-    Rails.logger.debug "Invalid URL in attachment: #{e}"
+    Rails.logger.debug { "Invalid URL in attachment: #{e}" }
     media_attachments
   end
 

--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -248,7 +248,7 @@ class LinkDetailsExtractor
 
         structured_data
       rescue Oj::ParseError, EncodingError
-        Rails.logger.debug("Invalid JSON-LD in #{@original_url}")
+        Rails.logger.debug { "Invalid JSON-LD in #{@original_url}" }
         next
       end.first
     end

--- a/app/models/concerns/remotable.rb
+++ b/app/models/concerns/remotable.rb
@@ -27,11 +27,11 @@ module Remotable
             public_send("#{attachment_name}=", ResponseWithLimit.new(response, limit))
           end
         rescue Mastodon::UnexpectedResponseError, HTTP::TimeoutError, HTTP::ConnectionError, OpenSSL::SSL::SSLError => e
-          Rails.logger.debug "Error fetching remote #{attachment_name}: #{e}"
+          Rails.logger.debug { "Error fetching remote #{attachment_name}: #{e}" }
           public_send("#{attachment_name}=", nil) if public_send("#{attachment_name}_file_name").present?
           raise e unless suppress_errors
         rescue Paperclip::Errors::NotIdentifiedByImageMagickError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, Paperclip::Error, Mastodon::DimensionsValidationError, Mastodon::StreamValidationError => e
-          Rails.logger.debug "Error fetching remote #{attachment_name}: #{e}"
+          Rails.logger.debug { "Error fetching remote #{attachment_name}: #{e}" }
           public_send("#{attachment_name}=", nil) if public_send("#{attachment_name}_file_name").present?
         end
 

--- a/app/services/activitypub/fetch_featured_collection_service.rb
+++ b/app/services/activitypub/fetch_featured_collection_service.rb
@@ -53,7 +53,7 @@ class ActivityPub::FetchFeaturedCollectionService < BaseService
 
       status.id
     rescue ActiveRecord::RecordInvalid => e
-      Rails.logger.debug "Invalid pinned status #{uri}: #{e.message}"
+      Rails.logger.debug { "Invalid pinned status #{uri}: #{e.message}" }
       nil
     end
 

--- a/app/services/activitypub/fetch_remote_account_service.rb
+++ b/app/services/activitypub/fetch_remote_account_service.rb
@@ -6,7 +6,7 @@ class ActivityPub::FetchRemoteAccountService < ActivityPub::FetchRemoteActorServ
     actor = super
     return actor if actor.nil? || actor.is_a?(Account)
 
-    Rails.logger.debug "Fetching account #{uri} failed: Expected Account, got #{actor.class.name}"
+    Rails.logger.debug { "Fetching account #{uri} failed: Expected Account, got #{actor.class.name}" }
     raise Error, "Expected Account, got #{actor.class.name}" unless suppress_errors
   end
 end

--- a/app/services/activitypub/fetch_remote_actor_service.rb
+++ b/app/services/activitypub/fetch_remote_actor_service.rb
@@ -38,7 +38,7 @@ class ActivityPub::FetchRemoteActorService < BaseService
 
     ActivityPub::ProcessAccountService.new.call(@username, @domain, @json, only_key: only_key, verified_webfinger: !only_key, request_id: request_id)
   rescue Error => e
-    Rails.logger.debug "Fetching actor #{uri} failed: #{e.message}"
+    Rails.logger.debug { "Fetching actor #{uri} failed: #{e.message}" }
     raise unless suppress_errors
   end
 

--- a/app/services/activitypub/fetch_remote_key_service.rb
+++ b/app/services/activitypub/fetch_remote_key_service.rb
@@ -38,7 +38,7 @@ class ActivityPub::FetchRemoteKeyService < BaseService
 
     find_actor(owner_uri, @owner, suppress_errors)
   rescue Error => e
-    Rails.logger.debug "Fetching key #{uri} failed: #{e.message}"
+    Rails.logger.debug { "Fetching key #{uri} failed: #{e.message}" }
     raise unless suppress_errors
   end
 

--- a/app/services/activitypub/process_collection_service.rb
+++ b/app/services/activitypub/process_collection_service.rb
@@ -11,7 +11,7 @@ class ActivityPub::ProcessCollectionService < BaseService
     begin
       @json = compact(@json) if @json['signature'].is_a?(Hash)
     rescue JSON::LD::JsonLdError => e
-      Rails.logger.debug "Error when compacting JSON-LD document for #{value_or_id(@json['actor'])}: #{e.message}"
+      Rails.logger.debug { "Error when compacting JSON-LD document for #{value_or_id(@json['actor'])}: #{e.message}" }
       @json = original_json.without('signature')
     end
 
@@ -72,7 +72,7 @@ class ActivityPub::ProcessCollectionService < BaseService
     @account = nil unless @account.is_a?(Account)
     @account
   rescue JSON::LD::JsonLdError, RDF::WriterError => e
-    Rails.logger.debug "Could not verify LD-Signature for #{value_or_id(@json['actor'])}: #{e.message}"
+    Rails.logger.debug { "Could not verify LD-Signature for #{value_or_id(@json['actor'])}: #{e.message}" }
     nil
   end
 end

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -94,7 +94,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
 
         @next_media_attachments << media_attachment
       rescue Addressable::URI::InvalidURIError => e
-        Rails.logger.debug "Invalid URL in attachment: #{e}"
+        Rails.logger.debug { "Invalid URL in attachment: #{e}" }
       end
     end
 

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -30,7 +30,7 @@ class FetchLinkCardService < BaseService
 
     attach_card if @card&.persisted?
   rescue HTTP::Error, OpenSSL::SSL::SSLError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError => e
-    Rails.logger.debug "Error fetching link #{@original_url}: #{e}"
+    Rails.logger.debug { "Error fetching link #{@original_url}: #{e}" }
     nil
   end
 

--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -12,7 +12,7 @@ class FetchResourceService < BaseService
 
     process(url)
   rescue HTTP::Error, OpenSSL::SSL::SSLError, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError => e
-    Rails.logger.debug "Error fetching resource #{@url}: #{e}"
+    Rails.logger.debug { "Error fetching resource #{@url}: #{e}" }
     nil
   end
 

--- a/app/services/keys/claim_service.rb
+++ b/app/services/keys/claim_service.rb
@@ -58,7 +58,7 @@ class Keys::ClaimService < BaseService
 
     @result = Result.new(@target_account, @device_id, key_id: json['id'], key: json['publicKeyBase64'], signature: json.dig('signature', 'signatureValue'))
   rescue HTTP::Error, OpenSSL::SSL::SSLError, Mastodon::Error => e
-    Rails.logger.debug "Claiming one-time key for #{@target_account.acct}:#{@device_id} failed: #{e}"
+    Rails.logger.debug { "Claiming one-time key for #{@target_account.acct}:#{@device_id} failed: #{e}" }
     nil
   end
 

--- a/app/services/keys/query_service.rb
+++ b/app/services/keys/query_service.rb
@@ -73,7 +73,7 @@ class Keys::QueryService < BaseService
       Device.new(device_id: device['id'], name: device['name'], identity_key: device.dig('identityKey', 'publicKeyBase64'), fingerprint_key: device.dig('fingerprintKey', 'publicKeyBase64'), claim_url: device['claim'])
     end
   rescue HTTP::Error, OpenSSL::SSL::SSLError, Mastodon::Error => e
-    Rails.logger.debug "Querying devices for #{@account.acct} failed: #{e}"
+    Rails.logger.debug { "Querying devices for #{@account.acct} failed: #{e}" }
     nil
   end
 end

--- a/app/services/resolve_account_service.rb
+++ b/app/services/resolve_account_service.rb
@@ -54,7 +54,7 @@ class ResolveAccountService < BaseService
 
     fetch_account!
   rescue Webfinger::Error => e
-    Rails.logger.debug "Webfinger query for #{@uri} failed: #{e}"
+    Rails.logger.debug { "Webfinger query for #{@uri} failed: #{e}" }
     raise unless @options[:suppress_errors]
   end
 

--- a/app/services/verify_link_service.rb
+++ b/app/services/verify_link_service.rb
@@ -11,7 +11,7 @@ class VerifyLinkService < BaseService
 
     field.mark_verified!
   rescue OpenSSL::SSL::SSLError, HTTP::Error, Addressable::URI::InvalidURIError, Mastodon::HostValidationError, Mastodon::LengthValidationError, IPAddr::AddressFamilyError => e
-    Rails.logger.debug "Error fetching link #{@url}: #{e}"
+    Rails.logger.debug { "Error fetching link #{@url}: #{e}" }
     nil
   end
 

--- a/app/workers/activitypub/processing_worker.rb
+++ b/app/workers/activitypub/processing_worker.rb
@@ -15,6 +15,6 @@ class ActivityPub::ProcessingWorker
 
     ActivityPub::ProcessCollectionService.new.call(body, actor, override_timestamps: true, delivered_to_account_id: delivered_to_account_id, delivery: true)
   rescue ActiveRecord::RecordInvalid => e
-    Rails.logger.debug "Error processing incoming ActivityPub object: #{e}"
+    Rails.logger.debug { "Error processing incoming ActivityPub object: #{e}" }
   end
 end

--- a/spec/models/concerns/remotable_spec.rb
+++ b/spec/models/concerns/remotable_spec.rb
@@ -194,7 +194,9 @@ RSpec.describe Remotable do
           let(:error_class) { error_class }
 
           it 'calls Rails.logger.debug' do
-            expect(Rails.logger).to receive(:debug).with(/^Error fetching remote #{hoge}: /)
+            expect(Rails.logger).to receive(:debug) do |&block|
+              expect(block.call).to match(/^Error fetching remote #{hoge}: /)
+            end
             foo.hoge_remote_url = url
           end
         end


### PR DESCRIPTION
Noticed this message on on of the other PRs, and read the https://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance.
Seems like a safe/performance related change, os I ran `bundle exec rubocop -a --only Rails/EagerEvaluationLogMessage` to just autofix the one issue