### PR TITLE
replaced hamlit-rails by haml-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'sprockets', '~> 3.7.2'
 gem 'thor', '~> 1.2'
 gem 'rack', '~> 2.2.6'
 
-gem 'hamlit-rails', '~> 0.2'
+gem 'haml-rails'
 gem 'pg', '~> 1.4'
 gem 'makara', '~> 0.5'
 gem 'pghero'


### PR DESCRIPTION
Hamlit was integrated as the new Haml.

There are no more reason to stay on Hamlit as it's support will be limited from now on.

It's a no impact on current code but it will facilitate dependencies management.