### PR TITLE
feat(Account): Allow Users to Unfollow Suspended Accounts

### DIFF
--- a/app/controllers/api/v1/accounts/relationships_controller.rb
+++ b/app/controllers/api/v1/accounts/relationships_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Accounts::RelationshipsController < Api::BaseController
   before_action :require_user!
 
   def index
-    accounts = Account.without_suspended.where(id: account_ids).select('id')
+    accounts = load_accounts
     # .where doesn't guarantee that our results are in the same order
     # we requested them, so return the "right" order to the requestor.
     @accounts = accounts.index_by(&:id).values_at(*account_ids).compact
@@ -13,6 +13,21 @@ class Api::V1::Accounts::RelationshipsController < Api::BaseController
   end
 
   private
+
+  def all_accounts
+    Account.where(id: account_ids).select('id')
+  end
+
+  def unsuspended_accounts
+    Account.without_suspended.where(id: account_ids).select('id')
+  end
+
+  def load_accounts
+    if current_user.account.show_suspended?
+      return all_accounts
+    end
+    unsuspended_accounts
+  end
 
   def relationships
     AccountRelationshipsPresenter.new(@accounts, current_user.account_id)

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -20,7 +20,7 @@ class Settings::ProfilesController < Settings::BaseController
   private
 
   def account_params
-    params.require(:account).permit(:display_name, :note, :avatar, :header, :locked, :bot, :discoverable, :hide_collections, fields_attributes: [:name, :value])
+    params.require(:account).permit(:display_name, :note, :avatar, :header, :locked, :bot, :discoverable, :hide_collections, :show_suspended, fields_attributes: [:name, :value])
   end
 
   def set_account

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -49,6 +49,7 @@
 #  trendable                     :boolean
 #  reviewed_at                   :datetime
 #  requested_review_at           :datetime
+#  show_suspended                :boolean
 #
 
 class Account < ApplicationRecord

--- a/app/views/settings/profiles/show.html.haml
+++ b/app/views/settings/profiles/show.html.haml
@@ -35,6 +35,9 @@
   .fields-group
     = f.input :hide_collections, as: :boolean, wrapper: :with_label, label: t('simple_form.labels.defaults.setting_hide_network'), hint: t('simple_form.hints.defaults.setting_hide_network')
 
+  .fields-group
+    = f.input :show_suspended, as: :boolean, wrapper: :with_label, label: t('simple_form.labels.defaults.setting_show_suspended'), hint: t('simple_form.hints.defaults.setting_show_suspended')
+  
   %hr.spacer/
 
   .fields-row

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -57,6 +57,7 @@ en:
         setting_hide_network: Who you follow and who follows you will be hidden on your profile
         setting_noindex: Affects your public profile and post pages
         setting_show_application: The application you use to post will be displayed in the detailed view of your posts
+        setting_show_suspended: Show suspended accounts you follow, muted, or blocked
         setting_use_blurhash: Gradients are based on the colors of the hidden visuals but obfuscate any details
         setting_use_pending_items: Hide timeline updates behind a click instead of automatically scrolling the feed
         username: Your username will be unique on %{domain}
@@ -211,6 +212,7 @@ en:
         setting_noindex: Opt-out of search engine indexing
         setting_reduce_motion: Reduce motion in animations
         setting_show_application: Disclose application used to send posts
+        setting_show_suspended: Show suspended accounts
         setting_system_font_ui: Use system's default font
         setting_theme: Site theme
         setting_trends: Show today's trends

--- a/db/migrate/20230206233953_add_show_suspended_to_accounts.rb
+++ b/db/migrate/20230206233953_add_show_suspended_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddShowSuspendedToAccounts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :accounts, :show_suspended, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_06_114142) do
+ActiveRecord::Schema.define(version: 2023_02_06_233953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -186,6 +186,7 @@ ActiveRecord::Schema.define(version: 2022_12_06_114142) do
     t.boolean "trendable"
     t.datetime "reviewed_at"
     t.datetime "requested_review_at"
+    t.boolean "show_suspended"
     t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
     t.index "lower((username)::text), COALESCE(lower((domain)::text), ''::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
     t.index ["moved_to_account_id"], name: "index_accounts_on_moved_to_account_id", where: "(moved_to_account_id IS NOT NULL)"

--- a/spec/controllers/api/v1/mutes_controller_spec.rb
+++ b/spec/controllers/api/v1/mutes_controller_spec.rb
@@ -3,13 +3,76 @@ require 'rails_helper'
 RSpec.describe Api::V1::MutesController, type: :controller do
   render_views
 
-  let(:user)   { Fabricate(:user) }
+  let(:user) { Fabricate(:user) }
+  let(:target_user) { Fabricate(:user) }
+  let(:account) { user.account }
+  let(:target_account) { target_user.account }
   let(:scopes) { 'read:mutes' }
   let(:token)  { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
 
   before { allow(controller).to receive(:doorkeeper_token) { token } }
 
   describe 'GET #index' do
+    context 'when a target account is suspended' do
+      before do
+        target_account.suspend!
+      end
+
+      context 'and the user has show_suspended enabled' do
+        before do
+          account.update(show_suspended: true)
+        end
+
+        it 'returns all of the the mutes' do
+          Fabricate(:mute, account: account, target_account: target_account)
+          Fabricate(:mute, account: account)
+          get :index, params: { limit: 2 }
+          expect(body_as_json.size).to eq 2
+        end
+      end
+
+      context 'and the user has show_suspended disabled' do
+        before do
+          account.update(show_suspended: false)
+        end
+
+        it 'returns the mutes from non-suspended accounts' do
+          Fabricate(:mute, account: account, target_account: target_account)
+          Fabricate(:mute, account: account)
+          get :index, params: { limit: 10 }
+          expect(body_as_json.size).to eq 1
+        end
+      end
+    end
+
+    context 'when a target account is not suspended' do
+      context 'and the user has show_suspended enabled' do
+        before do
+          account.update(show_suspended: true)
+        end
+
+        it 'returns all of the the mutes' do
+          Fabricate(:mute, account: account, target_account: target_account)
+          Fabricate(:mute, account: account)
+          get :index, params: { limit: 2 }
+          expect(body_as_json.size).to eq 2
+        end
+      end
+
+      context 'and the user has show_suspended disabled' do
+        before do
+          account.update(show_suspended: false)
+        end
+
+        it 'returns all of the the mutes' do
+          Fabricate(:mute, account: account, target_account: target_account)
+          Fabricate(:mute, account: account)
+          get :index, params: { limit: 2 }
+          expect(body_as_json.size).to eq 2
+        end
+      end
+    end
+
     it 'limits according to limit parameter' do
       2.times.map { Fabricate(:mute, account: user.account) }
       get :index, params: { limit: 1 }


### PR DESCRIPTION
This PR brings [back](https://github.com/mastodon/mastodon/pull/14765/files) the ability to see suspended accounts that a user follows, blocked, or muted via a `show_suspended` setting. It keeps the default behavior of suppressing suspended accounts while allowing users to toggle the setting on or off, so they have the option of unfollowing suspended accounts. 