### PR TITLE
Fix external authentication not running onboarding code for new users

### DIFF
--- a/app/models/concerns/omniauthable.rb
+++ b/app/models/concerns/omniauthable.rb
@@ -63,7 +63,7 @@ module Omniauthable
         user.account.avatar_remote_url = nil
       end
 
-      user.skip_confirmation! if email_is_verified
+      user.confirm! if email_is_verified
       user.save!
       user
     end


### PR DESCRIPTION
When not using external authentication, `User#prepare_new_user!` is called for new users whenever they have confirmed their email address and are approved (when needing approval). This code performs the following actions:
1. make them follow the user who invited them, if they were invited and the invitation had this option enabled
2. send a notification to server admins
3. bump the stats for local users
4. send a welcome e-mail
5. trigger the `account.approved` WebHook

This code is currently not called when the user was created through OmniAuth (external log-in such as OIDC or SAML) in such a way that the email is automatically considered valid.

The PR changes it to trigger that flow if needed, though I am not sure all of those steps are relevant for such settings.