### PR TITLE
Remove posts count and last posts from ActivityPub representation of hashtag collections

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -11,7 +11,7 @@ class TagsController < ApplicationController
   before_action :authenticate_user!, if: :whitelist_mode?
   before_action :set_local
   before_action :set_tag
-  before_action :set_statuses
+  before_action :set_statuses, if: -> { request.format == :rss }
   before_action :set_instance_presenter
 
   skip_before_action :require_functional!, unless: :whitelist_mode?
@@ -44,12 +44,7 @@ class TagsController < ApplicationController
   end
 
   def set_statuses
-    case request.format&.to_sym
-    when :json
-      @statuses = cache_collection(TagFeed.new(@tag, current_account, local: @local).get(PAGE_SIZE, params[:max_id], params[:since_id], params[:min_id]), Status)
-    when :rss
-      @statuses = cache_collection(TagFeed.new(@tag, nil, local: @local).get(limit_param), Status)
-    end
+    @statuses = cache_collection(TagFeed.new(@tag, nil, local: @local).get(limit_param), Status)
   end
 
   def set_instance_presenter
@@ -64,8 +59,6 @@ class TagsController < ApplicationController
     ActivityPub::CollectionPresenter.new(
       id: tag_url(@tag),
       type: :ordered,
-      size: @tag.statuses.count,
-      items: @statuses.map { |status| ActivityPub::TagManager.instance.uri_for(status) }
     )
   end
 end


### PR DESCRIPTION
We don't use them for anything and it's somewhat expensive for little value, as there was no paging.