### PR TITLE
Change followed_by link to location=all if account is local on /admin/accounts/:id page

### DIFF
--- a/app/views/admin/accounts/show.html.haml
+++ b/app/views/admin/accounts/show.html.haml
@@ -37,7 +37,7 @@
       .dashboard__counters__num= number_to_human_size @account.media_attachments.sum('file_file_size')
       .dashboard__counters__label= t 'admin.accounts.media_attachments'
   %div
-    = link_to admin_account_relationships_path(@account.id, location: 'local', relationship: 'followed_by') do
+    = link_to admin_account_relationships_path(@account.id, location: @account.local? ? nil : 'local', relationship: 'followed_by') do
       .dashboard__counters__num= number_with_delimiter @account.local_followers_count
       .dashboard__counters__label= t 'admin.accounts.followers'
   %div


### PR DESCRIPTION
Previously, "followed_by" links to "local followers" page whether `@account` is remote or not.
But it is more meaningful "all followers" instead of "local followers" if `@account` is local (Still "local followers" is better when remote account)

![image](https://user-images.githubusercontent.com/5047683/217684799-610bc7b5-c999-4e1f-892a-d70a09cb1aef.png)
