### PR TITLE
Add card with who invited you to join when displaying rules on sign-up

### DIFF
--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -3,11 +3,8 @@
     display: block;
     text-decoration: none;
     color: inherit;
-    box-shadow: 0 0 15px rgba($base-shadow-color, 0.2);
-
-    @media screen and (max-width: $no-gap-breakpoint) {
-      box-shadow: none;
-    }
+    overflow: hidden;
+    border-radius: 4px;
 
     &:hover,
     &:active,
@@ -22,7 +19,6 @@
     height: 130px;
     position: relative;
     background: darken($ui-base-color, 12%);
-    border-radius: 4px 4px 0 0;
 
     img {
       display: block;
@@ -30,7 +26,6 @@
       height: 100%;
       margin: 0;
       object-fit: cover;
-      border-radius: 4px 4px 0 0;
     }
 
     @media screen and (width <= 600px) {
@@ -45,11 +40,6 @@
     justify-content: flex-start;
     align-items: center;
     background: lighten($ui-base-color, 4%);
-    border-radius: 0 0 4px 4px;
-
-    @media screen and (max-width: $no-gap-breakpoint) {
-      border-radius: 0;
-    }
 
     .avatar {
       flex: 0 0 auto;

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -137,6 +137,10 @@ code {
     color: $secondary-text-color;
     margin-bottom: 30px;
 
+    &.invited-by {
+      margin-bottom: 15px;
+    }
+
     a {
       color: $highlight-text-color;
     }

--- a/app/views/application/_card.html.haml
+++ b/app/views/application/_card.html.haml
@@ -1,9 +1,11 @@
 - account_url = local_assigns[:admin] ? admin_account_path(account.id) : ActivityPub::TagManager.instance.url_for(account)
+- compact ||= false
 
 .card.h-card
   = link_to account_url, target: '_blank', rel: 'noopener noreferrer' do
-    .card__img
-      = image_tag account.header.url, alt: ''
+    - unless compact
+      .card__img
+        = image_tag account.header.url, alt: ''
     .card__bar
       .avatar
         = image_tag account.avatar.url, alt: '', width: 48, height: 48, class: 'u-photo'

--- a/app/views/auth/registrations/rules.html.haml
+++ b/app/views/auth/registrations/rules.html.haml
@@ -9,7 +9,7 @@
 
   - if @invite.present? && @invite.autofollow?
     %h1.title= t('auth.rules.title_invited')
-    %p.lead= t('auth.rules.invited_by', domain: site_hostname)
+    %p.lead.invited-by= t('auth.rules.invited_by', domain: site_hostname)
     = render 'application/card', account: @invite.user.account, compact: true
     %p.lead= t('auth.rules.preamble_invited', domain: site_hostname)
   - else

--- a/app/views/auth/registrations/rules.html.haml
+++ b/app/views/auth/registrations/rules.html.haml
@@ -7,8 +7,14 @@
 .simple_form
   = render 'auth/shared/progress', stage: 'rules'
 
-  %h1.title= t('auth.rules.title')
-  %p.lead= t('auth.rules.preamble', domain: site_hostname)
+  - if @invite.present? && @invite.autofollow?
+    %h1.title= t('auth.rules.title_invited')
+    %p.lead= t('auth.rules.invited_by', domain: site_hostname)
+    = render 'application/card', account: @invite.user.account, compact: true
+    %p.lead= t('auth.rules.preamble_invited', domain: site_hostname)
+  - else
+    %h1.title= t('auth.rules.title')
+    %p.lead= t('auth.rules.preamble', domain: site_hostname)
 
   %ol.rules-list
     - @rules.each do |rule|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1031,8 +1031,11 @@ en:
     rules:
       accept: Accept
       back: Back
+      invited_by: 'You can join %{domain} thanks to the invitation you have received from:'
       preamble: These are set and enforced by the %{domain} moderators.
+      preamble_invited: Before you proceed, please consider the ground rules set by the moderators of %{domain}.
       title: Some ground rules.
+      title_invited: You've been invited.
     security: Security
     set_new_password: Set new password
     setup:


### PR DESCRIPTION
Sometimes, users post invite links to point at their account, but this presents server rules with no context. This is also confusing to anyone who already has an account on a different server.

This PR adds a compact version of the invite card to provide some context on who invited you:
![image](https://github.com/mastodon/mastodon/assets/384364/dd0adb0e-63dc-4b62-9bc3-1c23cfbd5cdf)