### PR TITLE
Fix filters matching case-sensitively when "whole word" is checked

### DIFF
--- a/app/models/custom_filter.rb
+++ b/app/models/custom_filter.rb
@@ -72,7 +72,7 @@ class CustomFilter < ApplicationRecord
             sb = /\A[[:word:]]/.match?(keyword.keyword) ? '\b' : ''
             eb = /[[:word:]]\z/.match?(keyword.keyword) ? '\b' : ''
 
-            /(?mix:#{sb}#{Regexp.escape(keyword.keyword)}#{eb})/
+            /(?mix:#{sb}#{Regexp.escape(keyword.keyword)}#{eb})/i
           else
             /#{Regexp.escape(keyword.keyword)}/i
           end


### PR DESCRIPTION
Partial-word filters are case-insensitive, but whole-word filters are case sensitive. This has caused confusion for some users, so this PR modifies whole-word filters to *also* be case-insensitive.

Currently, a partial-word filter "hello" will match "hello", "hELLo", and "HELLO". But if "whole word" is checked, then the filter will *only* match "hello". With this PR, toggling "whole word" will no longer change a filter's case-sensitivity.