### PR TITLE
Fix server status page URL being a required server setting

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -69,7 +69,7 @@ class Form::AdminSettings
   validates :show_domain_blocks_rationale, inclusion: { in: %w(disabled users all) }, if: -> { defined?(@show_domain_blocks_rationale) }
   validates :media_cache_retention_period, :content_cache_retention_period, :backups_retention_period, numericality: { only_integer: true }, allow_blank: true, if: -> { defined?(@media_cache_retention_period) || defined?(@content_cache_retention_period) || defined?(@backups_retention_period) }
   validates :site_short_description, length: { maximum: 200 }, if: -> { defined?(@site_short_description) }
-  validates :status_page_url, url: true
+  validates :status_page_url, url: true, allow_blank: true
   validate :validate_site_uploads
 
   KEYS.each do |key|


### PR DESCRIPTION
Leaving the setting introduced by #23390 blank would cause a confusing error when updating server settings:

![image](https://user-images.githubusercontent.com/384364/218047533-715cb276-c960-4949-af69-c11aa97b6d2c.png)

This PR makes the setting optional.