### PR TITLE
Fix attached media uploads not being cleared when replying to a post

### DIFF
--- a/app/javascript/mastodon/features/compose/components/upload.js
+++ b/app/javascript/mastodon/features/compose/components/upload.js
@@ -31,6 +31,11 @@ export default class Upload extends ImmutablePureComponent {
 
   render () {
     const { media } = this.props;
+
+    if (!media) {
+      return null;
+    }
+
     const focusX = media.getIn(['meta', 'focus', 'x']);
     const focusY = media.getIn(['meta', 'focus', 'y']);
     const x = ((focusX /  2) + .5) * 100;

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -330,6 +330,8 @@ export default function compose(state = initialState, action) {
       map.set('preselectDate', new Date());
       map.set('idempotencyKey', uuid());
 
+      map.update('media_attachments', list => list.filter(media => media.get('unattached')));
+
       if (action.status.get('language') && !action.status.has('translation')) {
         map.set('language', action.status.get('language'));
       } else {


### PR DESCRIPTION
Unlike attachments for unsent posts, media attachments already attached to a post can't be reused in another post.