### PR TITLE
Run prettier on full repo with ignored extensions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -51,15 +51,8 @@
 *~
 *.swp
 
-# Ignore npm debug log
-npm-debug.log
-
-# Ignore yarn log files
-yarn-error.log
-yarn-debug.log
-
-# Ignore vagrant log files
-*-cloudimg-console.log
+# Ignore log files
+*.log
 
 # Ignore Docker option files
 docker-compose.override.yml
@@ -73,3 +66,12 @@ docker-compose.override.yml
 
 # Ignore vendored CSS reset
 app/javascript/styles/mastodon/reset.scss
+
+# Ignore Javascript till ESLint Prettier is implimented
+*.js
+
+# Ignore Markdownlint pending https://github.com/mastodon/mastodon/pull/21972
+*.md
+
+# Ignore HTML till cleaned and included in CI
+*.html

--- a/.prettierignore
+++ b/.prettierignore
@@ -67,7 +67,7 @@ docker-compose.override.yml
 # Ignore vendored CSS reset
 app/javascript/styles/mastodon/reset.scss
 
-# Ignore Javascript till ESLint Prettier is implimented
+# Ignore Javascript pending https://github.com/mastodon/mastodon/pull/23631
 *.js
 
 # Ignore Markdownlint pending https://github.com/mastodon/mastodon/pull/21972

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "test:lint:js": "eslint --ext=js . --cache --report-unused-disable-directives",
     "test:lint:sass": "stylelint \"**/*.{css,scss}\" && prettier --check \"**/*.{css,scss}\"",
     "test:jest": "cross-env NODE_ENV=test jest",
-    "format": "prettier --write \"**/*.{json,yml}\"",
-    "format-check": "prettier --check \"**/*.{json,yml}\""
+    "format": "prettier --write .",
+    "format-check": "prettier --check ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Instead of opting in specific formats, this defaults to everything. Specific formats can be opted back in when they are covered by CI like in https://github.com/mastodon/mastodon/pull/21972