### PR TITLE
Enable EditorConfig trailing whitespace trimming

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,4 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
Most of the language linters already flag trailing whitespace already. The only language used here that has special cases of trailing whitespace is Markdown, that can use it for a newline. That style doesn't appear to be used here though