### PR TITLE
Avoid vulnerabilities by auto upgrading base images in Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: '/'
+    directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
@@ -14,7 +14,7 @@ updates:
       - dependency-type: direct
 
   - package-ecosystem: bundler
-    directory: '/'
+    directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
@@ -22,7 +22,7 @@ updates:
       - dependency-type: direct
 
   - package-ecosystem: docker
-    directory: '/'
+    directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
@@ -32,10 +32,11 @@ updates:
       - dependency-name: "node"
         update-types: ["version-update:semver-major"]
       - dependency-name: "moritzheiber/ruby-jemalloc"
-        update-types: ["version-update:semver-major","version-update:semver-minor"]
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: github-actions
-    directory: '/'
+    directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
@@ -14,7 +14,7 @@ updates:
       - dependency-type: direct
 
   - package-ecosystem: bundler
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
@@ -22,21 +22,21 @@ updates:
       - dependency-type: direct
 
   - package-ecosystem: docker
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
     allow:
       - dependency-type: direct
     ignore:
-      - dependency-name: "node"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "moritzheiber/ruby-jemalloc"
+      - dependency-name: 'node'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'moritzheiber/ruby-jemalloc'
         update-types:
-          ["version-update:semver-major", "version-update:semver-minor"]
+          ['version-update:semver-major', 'version-update:semver-minor']
 
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,19 @@ updates:
     allow:
       - dependency-type: direct
 
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+    allow:
+      - dependency-type: direct
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "moritzheiber/ruby-jemalloc"
+        update-types: ["version-update:semver-major","version-update:semver-minor"]
+
   - package-ecosystem: github-actions
     directory: '/'
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # This needs to be bullseye-slim because the Ruby image is built on bullseye-slim
-ARG NODE_VERSION="16.18.1-bullseye-slim"
-
 FROM ghcr.io/moritzheiber/ruby-jemalloc:3.0.4-slim as ruby
-FROM node:${NODE_VERSION} as build
+FROM node:16.18.1-bullseye-slim as build
 
 COPY --link --from=ruby /opt/ruby /opt/ruby
 
@@ -39,7 +37,7 @@ RUN apt-get update && \
     bundle install -j"$(nproc)" && \
     yarn install --pure-lockfile --network-timeout 600000
 
-FROM node:${NODE_VERSION}
+FROM node:16.18.1-bullseye-slim
 
 ARG UID="991"
 ARG GID="991"


### PR DESCRIPTION
Most of system packages vulnerabilities could be easily fixed just by letting automation working.

This will only update patch/minor version of ruby/node.

Previous Dockerfile version (using ubuntu based images) was better because it would avoid require updating nodejs/ruby version to update all systèmes packages.