### PR TITLE
Enable Depependabot on Docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,18 @@ updates:
     open-pull-requests-limit: 99
     allow:
       - dependency-type: direct
+
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+    ignore:
+      - dependency-name: 'moritzheiber/ruby-jemalloc'
+        update-types:
+          # only suggest patch releases for ruby and needs to sync with .ruby-version
+          - 'version-update:semver-minor'
+      - dependency-name: 'node'
+        update-types:
+          # only node minor releases allowed unless .nvmrc major is changed
+          - 'version-update:semver-major'


### PR DESCRIPTION
This will create PRs to bump the ruby version of the container as patch ruby versions are released. There will still be a manual step to update the `.ruby-version` file.
The node version won't update currently pending https://github.com/dependabot/dependabot-core/issues/2057, unless the `ARG` value is inlined so it can be directly read as a `FROM` value