### PR TITLE
Yarn cache cleanup right after install in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get update && \
     bundle config set --local without 'development test' && \
     bundle config set silence_root_warning true && \
     bundle install -j"$(nproc)" && \
-    yarn install --pure-lockfile --network-timeout 600000
+    yarn install --pure-lockfile --network-timeout 600000 && \
+    yarn cache clean
 
 FROM node:${NODE_VERSION}
 
@@ -91,8 +92,7 @@ USER mastodon
 WORKDIR /opt/mastodon
 
 # Precompile assets
-RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile && \
-    yarn cache clean
+RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile
 
 # Set the work dir and the container entry point
 ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION
This is likely a duplicate of several PRs that go much further their approach.
This does the bare change of removing the global cache at the layer it's used, so it doesn't carry over to the other layers only to be cleaned up at a later stage.