### PR TITLE
Skip Docker CI Login/Push on forks

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: github.event_name != 'pull_request'
+        if: github.repository == 'mastodon/mastodon' && github.event_name != 'pull_request'
 
       - name: Log in to the Github Container registry
         uses: docker/login-action@v2
@@ -41,7 +41,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: github.event_name != 'pull_request'
+        if: github.repository == 'mastodon/mastodon' && github.event_name != 'pull_request'
 
       - uses: docker/metadata-action@v4
         id: meta


### PR DESCRIPTION
Noticed when syncing my local main branch that it would fail on the push.
This filters the login and push parts of the CI so they don't run on forks, but will still build and lint