### PR TITLE
Fix paths with url-encoded @ to redirect to the correct path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,8 @@ Rails.application.routes.draw do
 
   resource :inbox, only: [:create], module: :activitypub
 
+  get '/:encoded_at(*path)', to: redirect("/@%{path}"), constraints: { encoded_at: /%40/ }
+
   constraints(username: /[^@\/.]+/) do
     get '/@:username', to: 'accounts#show', as: :short_account
     get '/@:username/with_replies', to: 'accounts#show', as: :short_account_with_replies


### PR DESCRIPTION
Some web platforms insist to urlencode the `@` sign in URLs. Toots, profile urls etc. pasted in such a platform wil generate hyperlinks to Mastodon with the `@` encoded to `%40`, yielding a 404 on Mastodon.

In order to not break these links for users, redirect any incoming URLs where the `@` is encoded to the correct unencoded version, for further processing. We HTTP redirect so there remains a single canonical location for every resource.

Example: a profile url `https://test.social.edu.nl/@twijs` when used in Sharepoint, is encoded as `https://test.social.edu.nl/%40twijs`. Visiting `https://test.social.edu.nl/%40twijs` results in a 404. After this change, visiting `https://test.social.edu.nl/%40twijs`, the user will be HTTP redirected to `https://test.social.edu.nl/@twijs` and the correct content is shown.

Closes: #15153