### PR TITLE
Add fallback redirection when getting a webfinger query `LOCAL_DOMAIN@LOCAL_DOMAIN`

### DIFF
--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -26,10 +26,6 @@ module WellKnown
           Account.find_local!(username)
         end
       end
-    rescue ActiveRecord::RecordNotFound
-      raise unless username == Rails.configuration.x.local_domain
-
-      @account = Account.representative
     end
 
     def username_from_resource

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -19,7 +19,13 @@ module WellKnown
 
     def set_account
       username = username_from_resource
-      @account = Account.find_local!(username)
+      @account = begin
+        if username == Rails.configuration.x.local_domain
+          Account.representative
+        else
+          Account.find_local!(username)
+        end
+      end
     rescue ActiveRecord::RecordNotFound
       raise unless username == Rails.configuration.x.local_domain
 

--- a/app/controllers/well_known/webfinger_controller.rb
+++ b/app/controllers/well_known/webfinger_controller.rb
@@ -18,7 +18,12 @@ module WellKnown
     private
 
     def set_account
-      @account = Account.find_local!(username_from_resource)
+      username = username_from_resource
+      @account = Account.find_local!(username)
+    rescue ActiveRecord::RecordNotFound
+      raise unless username == Rails.configuration.x.local_domain
+
+      @account = Account.representative
     end
 
     def username_from_resource

--- a/spec/controllers/well_known/webfinger_controller_spec.rb
+++ b/spec/controllers/well_known/webfinger_controller_spec.rb
@@ -6,7 +6,7 @@ describe WellKnown::WebfingerController, type: :controller do
   render_views
 
   describe 'GET #show' do
-    subject do
+    subject(:perform_show!) do
       get :show, params: { resource: resource }, format: :json
     end
 
@@ -45,7 +45,7 @@ describe WellKnown::WebfingerController, type: :controller do
       let(:resource) { alice.to_webfinger_s }
 
       before do
-        subject
+        perform_show!
       end
 
       it_behaves_like 'a successful response'
@@ -56,7 +56,7 @@ describe WellKnown::WebfingerController, type: :controller do
 
       before do
         alice.suspend!
-        subject
+        perform_show!
       end
 
       it_behaves_like 'a successful response'
@@ -68,7 +68,7 @@ describe WellKnown::WebfingerController, type: :controller do
       before do
         alice.suspend!
         alice.deletion_request.destroy
-        subject
+        perform_show!
       end
 
       it 'returns http gone' do
@@ -80,7 +80,7 @@ describe WellKnown::WebfingerController, type: :controller do
       let(:resource) { 'acct:not@existing.com' }
 
       before do
-        subject
+        perform_show!
       end
 
       it 'returns http not found' do
@@ -92,7 +92,7 @@ describe WellKnown::WebfingerController, type: :controller do
       let(:alternate_domains) { ['foo.org'] }
 
       before do
-        subject
+        perform_show!
       end
 
       context 'when an account exists' do
@@ -116,11 +116,39 @@ describe WellKnown::WebfingerController, type: :controller do
       end
     end
 
+    context 'when the old name scheme is used to query the instance actor' do
+      let(:resource) do
+        "#{Rails.configuration.x.local_domain}@#{Rails.configuration.x.local_domain}"
+      end
+
+      before do
+        perform_show!
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'does not set a Vary header' do
+        expect(response.headers['Vary']).to be_nil
+      end
+
+      it 'returns application/jrd+json' do
+        expect(response.media_type).to eq 'application/jrd+json'
+      end
+
+      it 'returns links for the internal account' do
+        json = body_as_json
+        expect(json[:subject]).to eq 'acct:mastodon.internal@cb6e6126.ngrok.io'
+        expect(json[:aliases]).to eq ['https://cb6e6126.ngrok.io/actor']
+      end
+    end
+
     context 'with no resource parameter' do
       let(:resource) { nil }
 
       before do
-        subject
+        perform_show!
       end
 
       it 'returns http bad request' do
@@ -132,7 +160,7 @@ describe WellKnown::WebfingerController, type: :controller do
       let(:resource) { 'df/:dfkj' }
 
       before do
-        subject
+        perform_show!
       end
 
       it 'returns http bad request' do


### PR DESCRIPTION
Since #22307, the name of the instance actor has changed to not depend on the `LOCAL_DOMAIN`.

This is in theory simpler and more robust, but in cases where the server existed already and gets re-created anew with a brand new database, this will cause the webfinger `acct` of the instance actor to change, as shown in #23594. Unfortunately, Mastodon is really bad at handling this and whenever receiving a signed query it can't verify, it will query the previously-known webfinger acct instead of the actual ActivityPub URI.

This PR adds a workaround that will make such queries redirect to the new webfinger `acct`, thus triggering the `ActivityPub::ProcessAccountService#process_duplicate_accounts!` code for handling changing accts as expected.