### PR TITLE
Move Jest tests to filtered GitHub Action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,11 +217,3 @@ workflows:
       - test-two-step-migrations:
           requires:
             - build
-      - node/run:
-          cache-version: v1
-          name: test-webui
-          pkg-manager: yarn
-          requires:
-            - build
-          version: '16.19'
-          yarn-run: test:jest

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -1,0 +1,41 @@
+name: JavaScript Testing
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+    paths:
+      - 'package.json'
+      - 'yarn.lock'
+      - '.nvmrc'
+      - '**/*.js'
+      - '**/*.snap'
+      - '.github/workflows/test-js.yml'
+
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'yarn.lock'
+      - '.nvmrc'
+      - '**/*.js'
+      - '**/*.snap'
+      - '.github/workflows/test-js.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version-file: '.nvmrc'
+
+      - name: Install all yarn packages
+        run: yarn --frozen-lockfile
+
+      - name: Jest testing
+        run: yarn test:jest --reporters github-actions summary

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,7 @@
-module.exports = {
-  'testEnvironment': 'jsdom',
-  'projects': [
-    '<rootDir>/app/javascript/mastodon',
-  ],
-  'testPathIgnorePatterns': [
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/vendor/',
     '<rootDir>/config/',
@@ -11,22 +9,17 @@ module.exports = {
     '<rootDir>/public/',
     '<rootDir>/tmp/',
   ],
-  'setupFiles': [
-    'raf/polyfill',
-  ],
-  'setupFilesAfterEnv': [
-    '<rootDir>/app/javascript/mastodon/test_setup.js',
-  ],
-  'collectCoverageFrom': [
+  setupFiles: ['raf/polyfill'],
+  setupFilesAfterEnv: ['<rootDir>/app/javascript/mastodon/test_setup.js'],
+  collectCoverageFrom: [
     'app/javascript/mastodon/**/*.js',
     '!app/javascript/mastodon/features/emoji/emoji_compressed.js',
     '!app/javascript/mastodon/locales/locale-data/*.js',
     '!app/javascript/mastodon/service_worker/entry.js',
     '!app/javascript/mastodon/test_setup.js',
   ],
-  'coverageDirectory': '<rootDir>/coverage',
-  'moduleDirectories': [
-    '<rootDir>/node_modules',
-    '<rootDir>/app/javascript',
-  ],
+  coverageDirectory: '<rootDir>/coverage',
+  moduleDirectories: ['<rootDir>/node_modules', '<rootDir>/app/javascript'],
 };
+
+module.exports = config;


### PR DESCRIPTION
Also included in #23608, but this could probably land even if the rest of that doesn't go forward.
The filter will run it on any JS change, but the current testing is only in the JS compontents folders right now.