### PR TITLE
Fix bad type for spellCheck attribute

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_input.js
+++ b/app/javascript/mastodon/components/autosuggest_input.js
@@ -51,7 +51,7 @@ export default class AutosuggestInput extends ImmutablePureComponent {
     searchTokens: PropTypes.arrayOf(PropTypes.string),
     maxLength: PropTypes.number,
     lang: PropTypes.string,
-    spellCheck: PropTypes.string,
+    spellCheck: PropTypes.bool,
   };
 
   static defaultProps = {


### PR DESCRIPTION
In #23395 I specified the wrong type for the `spellCheck` property for `AutosuggestInput`. Sorry :-)

This triggers the following warning in the browser console:
> Warning: Failed prop type: Invalid prop `spellCheck` of type `boolean` supplied to `AutosuggestInput`, expected `string`.
>    in AutosuggestInput (at compose_form.js:230)