### PR TITLE
Remove Style/Copyright Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,10 +94,6 @@ Rails/Exit:
     - 'lib/mastodon/cli_helper.rb'
     - 'lib/cli.rb'
 
-Style/Copyright:
-  Enabled: false
-  AutocorrectNotice:
-
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
 


### PR DESCRIPTION
This was required when EnableAllRules was turned on to silent a bunch of warnings in the logs. Since that rule didn't land with the .rubocop-todo.yml generation, this can just be removed till that other rule is looked at