### PR TITLE
Enable Rubocop RSpec/HooksBeforeExamples

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1349,12 +1349,6 @@ RSpec/HookArgument:
     - 'spec/services/import_service_spec.rb'
     - 'spec/spec_helper.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-RSpec/HooksBeforeExamples:
-  Exclude:
-    - 'spec/services/fetch_resource_service_spec.rb'
-
 # Offense count: 159
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.

--- a/spec/services/fetch_resource_service_spec.rb
+++ b/spec/services/fetch_resource_service_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe FetchResourceService, type: :service do
 
       before do
         stub_request(:get, url).to_return(status: 200, body: body, headers: headers)
+        stub_request(:get, 'http://example.com/foo').to_return(status: 200, body: json, headers: { 'Content-Type' => 'application/activity+json' })
       end
 
       it 'signs request' do
@@ -87,11 +88,6 @@ RSpec.describe FetchResourceService, type: :service do
         let(:body) { json }
 
         it { is_expected.to eq [1, { prefetched_body: body, id: true }] }
-      end
-
-      before do
-        stub_request(:get, url).to_return(status: 200, body: body, headers: headers)
-        stub_request(:get, 'http://example.com/foo').to_return(status: 200, body: json, headers: { 'Content-Type' => 'application/activity+json' })
       end
 
       context 'when link header is present' do


### PR DESCRIPTION
The autofix hoisted the second `before` beside the first, so merged them

https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspechooksbeforeexamples