### PR TITLE
Enable Lint/RedundantCopDisableDirective

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3649,7 +3649,3 @@ Style/WordArray:
     - 'spec/services/activitypub/process_account_service_spec.rb'
     - 'spec/services/delete_account_service_spec.rb'
     - 'spec/workers/scheduler/accounts_statuses_cleanup_scheduler_spec.rb'
-
-# don't clean out the manual directives overridden by generated file
-Lint/RedundantCopDisableDirective:
-  Enabled: false

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -10,7 +10,6 @@ class InitialStateSerializer < ActiveModel::Serializer
   has_one :push_subscription, serializer: REST::WebPushSubscriptionSerializer
   has_one :role, serializer: REST::RoleSerializer
 
-  # rubocop:disable Metrics/AbcSize
   def meta
     store = {
       streaming_api_base_url: Rails.configuration.x.streaming_api_base_url,

--- a/lib/mastodon/migration_helpers.rb
+++ b/lib/mastodon/migration_helpers.rb
@@ -289,8 +289,6 @@ module Mastodon
     # determines this method to be too complex while there's no way to make it
     # less "complex" without introducing extra methods (which actually will
     # make things _more_ complex).
-    #
-    # rubocop: disable Metrics/AbcSize
     def update_column_in_batches(table_name, column, value)
       if transaction_open?
         raise 'update_column_in_batches can not be run inside a transaction, ' \
@@ -573,7 +571,7 @@ module Mastodon
             o.conname as name,
             o.confdeltype as on_delete
           from pg_constraint o
-          left join pg_class f on f.oid = o.confrelid 
+          left join pg_class f on f.oid = o.confrelid
           left join pg_class c on c.oid = o.conrelid
           left join pg_class m on m.oid = o.conrelid
           where o.contype = 'f'


### PR DESCRIPTION
I had manually added this one to the TODO file since some of the rules were only partially suppressed in the files. This cleans out the rest of the pragmas that are fully disabled in the TODO so they can be looked at when the rules are turned on again