### PR TITLE
Only run latest for PR Rebase job

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   label-rebase-needed:
     runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
+
     steps:
       - name: Check for merge conflicts
         uses: eps1lon/actions-label-merge-conflict@releases/2.x


### PR DESCRIPTION
Noticing that the PR Needs Rebase job seems to be spinning out a little recently. Not sure if it's due to the number of PRs, but thought the same basic concurrency as used on the Docker build might make sense