### PR TITLE
Autofix Rubocop Style/TrailingCommaInArrayLiteral

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -3405,18 +3405,6 @@ Style/SymbolProc:
   Exclude:
     - 'spec/lib/request_spec.rb'
 
-# Offense count: 10
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInArrayLiteral:
-  Exclude:
-    - 'spec/helpers/jsonld_helper_spec.rb'
-    - 'spec/lib/extractor_spec.rb'
-    - 'spec/services/activitypub/process_account_service_spec.rb'
-    - 'spec/services/activitypub/process_collection_service_spec.rb'
-    - 'spec/workers/activitypub/move_distribution_worker_spec.rb'
-
 # Offense count: 4
 # This cop supports safe autocorrection (--autocorrect).
 Style/UnpackFirst:

--- a/spec/helpers/jsonld_helper_spec.rb
+++ b/spec/helpers/jsonld_helper_spec.rb
@@ -113,7 +113,7 @@ describe JsonLdHelper do
             {
               'type' => 'Mention',
               'href' => ['foo'],
-            }
+            },
           ],
         },
         'signature' => {

--- a/spec/lib/extractor_spec.rb
+++ b/spec/lib/extractor_spec.rb
@@ -20,7 +20,7 @@ describe Extractor do
       text = '@screen_name'
       extracted = Extractor.extract_mentions_or_lists_with_indices(text)
       expect(extracted).to eq [
-        { screen_name: 'screen_name', indices: [0, 12] }
+        { screen_name: 'screen_name', indices: [0, 12] },
       ]
     end
 

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
               type: 'Mention',
               href: "https://foo.test/users/#{i + 1}",
               name: "@user#{i + 1}",
-            }
+            },
           ],
           to: ['as:Public', "https://foo.test/users/#{i + 1}"],
         }.with_indifferent_access

--- a/spec/services/activitypub/process_collection_service_spec.rb
+++ b/spec/services/activitypub/process_collection_service_spec.rb
@@ -107,17 +107,17 @@ RSpec.describe ActivityPub::ProcessCollectionService, type: :service do
             '@context': [
               'https://www.w3.org/ns/activitystreams',
               nil,
-              { object: 'https://www.w3.org/ns/activitystreams#object' }
+              { object: 'https://www.w3.org/ns/activitystreams#object' },
             ],
             id: 'https://example.com/users/bob/fake-status/activity',
             type: 'Create',
             actor: 'https://example.com/users/bob',
             published: '2022-01-22T15:00:00Z',
             to: [
-              'https://www.w3.org/ns/activitystreams#Public'
+              'https://www.w3.org/ns/activitystreams#Public',
             ],
             cc: [
-              'https://example.com/users/bob/followers'
+              'https://example.com/users/bob/followers',
             ],
             signature: {
               type: 'RsaSignature2017',
@@ -140,10 +140,10 @@ RSpec.describe ActivityPub::ProcessCollectionService, type: :service do
               url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=puck-was-here',
               attributedTo: 'https://example.com/users/bob',
               to: [
-                'https://www.w3.org/ns/activitystreams#Public'
+                'https://www.w3.org/ns/activitystreams#Public',
               ],
               cc: [
-                'https://example.com/users/bob/followers'
+                'https://example.com/users/bob/followers',
               ],
               sensitive: false,
               atomUri: 'https://example.com/users/bob/fake-status',
@@ -166,7 +166,7 @@ RSpec.describe ActivityPub::ProcessCollectionService, type: :service do
                 {
                   '@value': '<p>hello world</p>',
                   '@language': 'en',
-                }
+                },
               ],
               'https://www.w3.org/ns/activitystreams#published': {
                 '@type': 'http://www.w3.org/2001/XMLSchema#dateTime',

--- a/spec/workers/activitypub/move_distribution_worker_spec.rb
+++ b/spec/workers/activitypub/move_distribution_worker_spec.rb
@@ -16,7 +16,7 @@ describe ActivityPub::MoveDistributionWorker do
     it 'delivers to followers and known blockers' do
       expect_push_bulk_to_match(ActivityPub::DeliveryWorker, [
                                   [kind_of(String), migration.account.id, 'http://example.com'],
-                                  [kind_of(String), migration.account.id, 'http://example2.com']
+                                  [kind_of(String), migration.account.id, 'http://example2.com'],
                                 ])
       subject.perform(migration.id)
     end


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/cops_style.html#styletrailingcommainarrayliteral

Removing the `EnforcedStyleForMultiline: 'comma'` in the root `.rubocop.yml` would change around 50 files instead