### PR TITLE
Remove unused rspec-sidekiq gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,6 @@ group :test do
   gem 'rack-test', '~> 2.0'
   gem 'rails-controller-testing', '~> 1.0'
   gem 'rspec_junit_formatter', '~> 0.6'
-  gem 'rspec-sidekiq', '~> 3.1'
   gem 'simplecov', '~> 0.22', require: false
   gem 'webmock', '~> 3.18'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -601,9 +601,6 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
-    rspec-sidekiq (3.1.0)
-      rspec-core (~> 3.0, >= 3.0.0)
-      sidekiq (>= 2.4.0)
     rspec-support (3.11.1)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -870,7 +867,6 @@ DEPENDENCIES
   rexml (~> 3.2)
   rqrcode (~> 2.1)
   rspec-rails (~> 5.1)
-  rspec-sidekiq (~> 3.1)
   rspec_junit_formatter (~> 0.6)
   rubocop
   rubocop-performance


### PR DESCRIPTION
Noticed that this doesn't appear to be used. Maybe it was/will be but may not be that actively maintained right now https://github.com/philostler/rspec-sidekiq