### PR TITLE
Fix devcontainer.json format

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,16 +4,22 @@
   "service": "app",
   "workspaceFolder": "/mastodon",
 
-  // Set *default* container specific settings.json values on container create.
-  "settings": {},
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {},
 
-  // Add the IDs of extensions you want installed when the container is created.
-  "extensions": [
-    "EditorConfig.EditorConfig",
-    "dbaeumer.vscode-eslint",
-    "rebornix.Ruby",
-    "webben.browserslist"
-  ],
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "dbaeumer.vscode-eslint",
+        "rebornix.Ruby",
+        "webben.browserslist"
+      ]
+    }
+  },
 
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {


### PR DESCRIPTION
The latest devcontainer.json requires the use of `customizations.vscode` for `settings` and `extensions`.