### PR TITLE
Update rebase needed job settings

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           dirtyLabel: 'rebase needed :construction:'
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          commentOnClean: This pull request has resolved merge conflicts and is ready for review.
           commentOnDirty: This pull request has merge conflicts that must be resolved before it can be merged.
           retryMax: 10
           continueOnMissingPermissions: false

--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     types: [synchronize]
 
+permissions:
+  pull-requests: write
+
 jobs:
   label-rebase-needed:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -24,3 +24,4 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           commentOnDirty: This pull request has merge conflicts that must be resolved before it can be merged.
           retryMax: 10
+          continueOnMissingPermissions: false

--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -23,3 +23,4 @@ jobs:
           dirtyLabel: 'rebase needed :construction:'
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           commentOnDirty: This pull request has merge conflicts that must be resolved before it can be merged.
+          retryMax: 10


### PR DESCRIPTION
The job seems to be running a little long right now, so I was seeing if anything can be done to make sure it fully completes.
Increasing the retries might actually make this worse, but might actually get through the full repo.
Added a message to post after the PR becomes clean again, to signal it's ready to review again.
Limits the job's token permission to the minimal amount to write the PR status