### PR TITLE
Change accepting video resolution while preserve target resolution

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -43,6 +43,7 @@ class MediaAttachment < ApplicationRecord
   VIDEO_LIMIT = 40.megabytes
 
   MAX_VIDEO_MATRIX_LIMIT = 2_304_000 # 1920x1200px
+  MAX_VIDEO_INPUT_MATRIX_LIMIT = 8_294_400 # 3840x2160
   MAX_VIDEO_FRAME_RATE   = 60
 
   IMAGE_FILE_EXTENSIONS = %w(.jpg .jpeg .png .gif .webp .heic .heif .avif).freeze
@@ -100,7 +101,7 @@ class MediaAttachment < ApplicationRecord
         'loglevel' => 'fatal',
         'movflags' => 'faststart',
         'pix_fmt' => 'yuv420p',
-        'vf' => 'scale=\'trunc(iw/2)*2:trunc(ih/2)*2\'',
+        'vf' => "scale='trunc(min(#{MAX_VIDEO_MATRIX_LIMIT}, iw*ih) / ih / 2)*2:-2'",
         'vsync' => 'cfr',
         'c:v' => 'h264',
         'maxrate' => '1300K',
@@ -347,7 +348,7 @@ class MediaAttachment < ApplicationRecord
     return unless movie.valid?
 
     raise Mastodon::StreamValidationError, 'Video has no video stream' if movie.width.nil? || movie.frame_rate.nil?
-    raise Mastodon::DimensionsValidationError, "#{movie.width}x#{movie.height} videos are not supported" if movie.width * movie.height > MAX_VIDEO_MATRIX_LIMIT
+    raise Mastodon::DimensionsValidationError, "#{movie.width}x#{movie.height} videos are not supported" if movie.width * movie.height > MAX_VIDEO_INPUT_MATRIX_LIMIT
     raise Mastodon::DimensionsValidationError, "#{movie.frame_rate.floor}fps videos are not supported" if movie.frame_rate.floor > MAX_VIDEO_FRAME_RATE
   end
 


### PR DESCRIPTION
Increase uploadable/processable video resolution to 4k while target resolution is same.
This PR doesn't break old servers because the target resolution is same

Possible todos:
- [ ] Increase video upload file size
- [ ] Increase accepting FPS