### PR TITLE
Autofix Rubocop Rails/DeprecatedActiveModelErrorsMethods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1503,12 +1503,6 @@ Rails/CreateTableWithTimestamps:
     - 'db/migrate/20220824233535_create_status_trends.rb'
     - 'db/migrate/20221006061337_create_preview_card_trends.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Severity.
-Rails/DeprecatedActiveModelErrorsMethods:
-  Exclude:
-    - 'lib/mastodon/accounts_cli.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Severity.
 Rails/DuplicateAssociation:

--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -115,10 +115,9 @@ module Mastodon
         say('OK', :green)
         say("New password: #{password}")
       else
-        user.errors.to_h.each do |key, error|
-          say('Failure/Error: ', :red)
-          say(key)
-          say("    #{error}", :red)
+        user.errors.each do |error|
+          say(error.attribute)
+          say("    #{error.type}", :red)
         end
 
         exit(1)
@@ -190,10 +189,9 @@ module Mastodon
         say('OK', :green)
         say("New password: #{password}") if options[:reset_password]
       else
-        user.errors.to_h.each do |key, error|
-          say('Failure/Error: ', :red)
-          say(key)
-          say("    #{error}", :red)
+        user.errors.each do |error|
+          say(error.attribute)
+          say("    #{error.type}", :red)
         end
 
         exit(1)


### PR DESCRIPTION
https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsdeprecatedactivemodelerrorsmethods

There are still warnings about `accounts_cli.rb` not sure if they should be inline-ignored or converted to something around using `.errors.messages`. 