### PR TITLE
Fix sidebar cut-off on small screens in admin UI

### DIFF
--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -384,7 +384,7 @@ $content-width: 840px;
           position: fixed;
           z-index: 10;
           width: 100%;
-          height: calc(100vh - 56px);
+          height: calc(100% - 56px);
           left: 0;
           bottom: 0;
           overflow-y: auto;


### PR DESCRIPTION
Currently, version 4.1.0 doesn't show the sidebar on the admin UI correctly for small screens.

For example, on Google Pixel 4 XL Chrome, it shows like this (logo and close button are missing): [Android Screenshot](https://imgur.com/a/bDEQLG6)

On iPhone 14 iOS 16.2, it shows like this (buttons are cut-off): [iOS Screenshot](https://imgur.com/a/oQ4z4fF)

This fix makes sure the sidebar can be displayed correctly on such screens, like this: [Fixed Screenshot](https://imgur.com/a/Cu0N8rf)

P.S. ideally we should use `100dvh` here, but for the old browsers' compatibility let me use the old way instead : )

Fix #21279