### PR TITLE
Update Stylelint disable settings and ignores

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -2,9 +2,16 @@ module.exports = {
   extends: ['stylelint-config-standard-scss'],
   ignoreFiles: [
     'app/javascript/styles/mastodon/reset.scss',
+    'coverage/**/*',
     'node_modules/**/*',
+    'public/assets/**/*',
+    'public/packs/**/*',
+    'public/packs-test/**/*',
     'vendor/**/*',
   ],
+  reportDescriptionlessDisables: true,
+  reportInvalidScopeDisables: true,
+  reportNeedlessDisables: true,
   rules: {
     'at-rule-empty-line-before': null,
     'color-function-notation': null,


### PR DESCRIPTION
Was running locally to test some of the options to flag unneded disabled directives (that aren't really used right now), and came across a few other paths that contain CSS files as part of the precompile step.