### PR TITLE
Ignore JSX files from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -69,6 +69,7 @@ app/javascript/styles/mastodon/reset.scss
 
 # Ignore Javascript pending https://github.com/mastodon/mastodon/pull/23631
 *.js
+*.jsx
 
 # Ignore HTML till cleaned and included in CI
 *.html


### PR DESCRIPTION
These might get opted back in as part of the PR in the comments, but right now, it causes noise running `yarn format` because they're not ignored after the file renames