### PR TITLE
Fix links are not on trends without review

### DIFF
--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -75,10 +75,10 @@ class PreviewCard < ApplicationRecord
   end
 
   def trendable?
-    if attributes['trendable'].nil?
+    if attributes['trendable'].nil? && provider.present?
       provider&.trendable?
     else
-      attributes['trendable']
+      boolean_with_default('trendable', Setting.trendable_by_default)
     end
   end
 


### PR DESCRIPTION
Links were not on trends without review even if "Trends without prior review" settings on