### PR TITLE
Fix server error when failing to follow back followers from `/relationships`

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -19,6 +19,8 @@ class RelationshipsController < ApplicationController
     @form.save
   rescue ActionController::ParameterMissing
     # Do nothing
+  rescue Mastodon::NotPermittedError, ActiveRecord::RecordNotFound
+    flash[:alert] = I18n.t('relationships.follow_failure') if action_from_button == 'follow'
   ensure
     redirect_to relationships_path(filter_params)
   end

--- a/app/models/form/account_batch.rb
+++ b/app/models/form/account_batch.rb
@@ -35,9 +35,15 @@ class Form::AccountBatch
   private
 
   def follow!
+    error = nil
+
     accounts.each do |target_account|
       FollowService.new.call(current_account, target_account)
+    rescue Mastodon::NotPermittedError, ActiveRecord::RecordNotFound => e
+      error ||= e
     end
+
+    raise error if error.present?
   end
 
   def unfollow!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1410,6 +1410,7 @@ en:
     confirm_remove_selected_followers: Are you sure you want to remove selected followers?
     confirm_remove_selected_follows: Are you sure you want to remove selected follows?
     dormant: Dormant
+    follow_failure: Could not follow some of the selected accounts.
     follow_selected_followers: Follow selected followers
     followers: Followers
     following: Following


### PR DESCRIPTION
Fixes #23784

This can occur when e.g. a follower has moved to another account and Mastodon refuses to follow the moved account.