### PR TITLE
Enable Style/FrozenStringLiteralComment for specs

### DIFF
--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Rack::Attack do

--- a/spec/controllers/about_controller_spec.rb
+++ b/spec/controllers/about_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AboutController, type: :controller do

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AccountsController, type: :controller do

--- a/spec/controllers/activitypub/followers_synchronizations_controller_spec.rb
+++ b/spec/controllers/activitypub/followers_synchronizations_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::FollowersSynchronizationsController, type: :controller do

--- a/spec/controllers/activitypub/outboxes_controller_spec.rb
+++ b/spec/controllers/activitypub/outboxes_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::OutboxesController, type: :controller do

--- a/spec/controllers/admin/account_moderation_notes_controller_spec.rb
+++ b/spec/controllers/admin/account_moderation_notes_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::AccountModerationNotesController, type: :controller do

--- a/spec/controllers/admin/accounts_controller_spec.rb
+++ b/spec/controllers/admin/accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::AccountsController, type: :controller do

--- a/spec/controllers/admin/change_email_controller_spec.rb
+++ b/spec/controllers/admin/change_email_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::ChangeEmailsController, type: :controller do

--- a/spec/controllers/admin/confirmations_controller_spec.rb
+++ b/spec/controllers/admin/confirmations_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::ConfirmationsController, type: :controller do

--- a/spec/controllers/admin/custom_emojis_controller_spec.rb
+++ b/spec/controllers/admin/custom_emojis_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Admin::CustomEmojisController do

--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::Disputes::AppealsController, type: :controller do

--- a/spec/controllers/admin/domain_allows_controller_spec.rb
+++ b/spec/controllers/admin/domain_allows_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::DomainAllowsController, type: :controller do

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::DomainBlocksController, type: :controller do

--- a/spec/controllers/admin/export_domain_allows_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_allows_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::ExportDomainAllowsController, type: :controller do

--- a/spec/controllers/admin/export_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_blocks_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::ExportDomainBlocksController, type: :controller do

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::InstancesController, type: :controller do

--- a/spec/controllers/admin/report_notes_controller_spec.rb
+++ b/spec/controllers/admin/report_notes_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Admin::ReportNotesController do

--- a/spec/controllers/admin/reports/actions_controller_spec.rb
+++ b/spec/controllers/admin/reports/actions_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Admin::Reports::ActionsController do

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Admin::ReportsController do

--- a/spec/controllers/admin/resets_controller_spec.rb
+++ b/spec/controllers/admin/resets_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Admin::ResetsController do

--- a/spec/controllers/admin/roles_controller_spec.rb
+++ b/spec/controllers/admin/roles_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Admin::RolesController do

--- a/spec/controllers/admin/statuses_controller_spec.rb
+++ b/spec/controllers/admin/statuses_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Admin::StatusesController do

--- a/spec/controllers/admin/users/roles_controller.rb
+++ b/spec/controllers/admin/users/roles_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Admin::Users::RolesController do

--- a/spec/controllers/admin/users/two_factor_authentications_controller_spec.rb
+++ b/spec/controllers/admin/users/two_factor_authentications_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'webauthn/fake_client'
 

--- a/spec/controllers/api/oembed_controller_spec.rb
+++ b/spec/controllers/api/oembed_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::OEmbedController, type: :controller do

--- a/spec/controllers/api/v1/accounts/credentials_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/credentials_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Api::V1::Accounts::CredentialsController do

--- a/spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Api::V1::Accounts::FollowerAccountsController do

--- a/spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Api::V1::Accounts::FollowingAccountsController do

--- a/spec/controllers/api/v1/accounts/lists_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/lists_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Api::V1::Accounts::ListsController do

--- a/spec/controllers/api/v1/accounts/notes_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/notes_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Api::V1::Accounts::NotesController do

--- a/spec/controllers/api/v1/accounts/relationships_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/relationships_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Api::V1::Accounts::RelationshipsController do

--- a/spec/controllers/api/v1/accounts/search_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/search_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::Accounts::SearchController, type: :controller do

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::AccountsController, type: :controller do

--- a/spec/controllers/api/v1/admin/account_actions_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/account_actions_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::AccountActionsController, type: :controller do

--- a/spec/controllers/api/v1/admin/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::AccountsController, type: :controller do

--- a/spec/controllers/api/v1/admin/domain_allows_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/domain_allows_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::DomainAllowsController, type: :controller do

--- a/spec/controllers/api/v1/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/domain_blocks_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::DomainBlocksController, type: :controller do

--- a/spec/controllers/api/v1/admin/reports_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/reports_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::Admin::ReportsController, type: :controller do

--- a/spec/controllers/api/v1/apps/credentials_controller_spec.rb
+++ b/spec/controllers/api/v1/apps/credentials_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Api::V1::Apps::CredentialsController do

--- a/spec/controllers/api/v1/apps_controller_spec.rb
+++ b/spec/controllers/api/v1/apps_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::AppsController, type: :controller do

--- a/spec/controllers/api/v1/blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/blocks_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::BlocksController, type: :controller do

--- a/spec/controllers/api/v1/bookmarks_controller_spec.rb
+++ b/spec/controllers/api/v1/bookmarks_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::BookmarksController, type: :controller do

--- a/spec/controllers/api/v1/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/conversations_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::ConversationsController, type: :controller do

--- a/spec/controllers/api/v1/domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/domain_blocks_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::DomainBlocksController, type: :controller do

--- a/spec/controllers/api/v1/emails/confirmations_controller_spec.rb
+++ b/spec/controllers/api/v1/emails/confirmations_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::Emails::ConfirmationsController, type: :controller do

--- a/spec/controllers/api/v1/favourites_controller_spec.rb
+++ b/spec/controllers/api/v1/favourites_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::FavouritesController, type: :controller do

--- a/spec/controllers/api/v1/filters_controller_spec.rb
+++ b/spec/controllers/api/v1/filters_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::FiltersController, type: :controller do

--- a/spec/controllers/api/v1/follow_requests_controller_spec.rb
+++ b/spec/controllers/api/v1/follow_requests_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::FollowRequestsController, type: :controller do

--- a/spec/controllers/api/v1/followed_tags_controller_spec.rb
+++ b/spec/controllers/api/v1/followed_tags_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::FollowedTagsController, type: :controller do

--- a/spec/controllers/api/v1/lists/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/lists/accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Api::V1::Lists::AccountsController do

--- a/spec/controllers/api/v1/lists_controller_spec.rb
+++ b/spec/controllers/api/v1/lists_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::ListsController, type: :controller do

--- a/spec/controllers/api/v1/markers_controller_spec.rb
+++ b/spec/controllers/api/v1/markers_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::MarkersController, type: :controller do

--- a/spec/controllers/api/v1/media_controller_spec.rb
+++ b/spec/controllers/api/v1/media_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::MediaController, type: :controller do

--- a/spec/controllers/api/v1/mutes_controller_spec.rb
+++ b/spec/controllers/api/v1/mutes_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::MutesController, type: :controller do

--- a/spec/controllers/api/v1/notifications_controller_spec.rb
+++ b/spec/controllers/api/v1/notifications_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::NotificationsController, type: :controller do

--- a/spec/controllers/api/v1/polls/votes_controller_spec.rb
+++ b/spec/controllers/api/v1/polls/votes_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::Polls::VotesController, type: :controller do

--- a/spec/controllers/api/v1/polls_controller_spec.rb
+++ b/spec/controllers/api/v1/polls_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::PollsController, type: :controller do

--- a/spec/controllers/api/v1/statuses/favourited_by_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/favourited_by_accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::Statuses::FavouritedByAccountsController, type: :controller do

--- a/spec/controllers/api/v1/statuses/reblogged_by_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reblogged_by_accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::Statuses::RebloggedByAccountsController, type: :controller do

--- a/spec/controllers/api/v1/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::StatusesController, type: :controller do

--- a/spec/controllers/api/v1/suggestions_controller_spec.rb
+++ b/spec/controllers/api/v1/suggestions_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::SuggestionsController, type: :controller do

--- a/spec/controllers/api/v1/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/tags_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V1::TagsController, type: :controller do

--- a/spec/controllers/api/v2/admin/accounts_controller_spec.rb
+++ b/spec/controllers/api/v2/admin/accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V2::Admin::AccountsController, type: :controller do

--- a/spec/controllers/api/v2/filters/keywords_controller_spec.rb
+++ b/spec/controllers/api/v2/filters/keywords_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V2::Filters::KeywordsController, type: :controller do

--- a/spec/controllers/api/v2/filters/statuses_controller_spec.rb
+++ b/spec/controllers/api/v2/filters/statuses_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V2::Filters::StatusesController, type: :controller do

--- a/spec/controllers/api/v2/filters_controller_spec.rb
+++ b/spec/controllers/api/v2/filters_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Api::V2::FiltersController, type: :controller do

--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Auth::RegistrationsController, type: :controller do

--- a/spec/controllers/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/disputes/appeals_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Disputes::AppealsController, type: :controller do

--- a/spec/controllers/disputes/strikes_controller_spec.rb
+++ b/spec/controllers/disputes/strikes_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Disputes::StrikesController, type: :controller do

--- a/spec/controllers/emojis_controller_spec.rb
+++ b/spec/controllers/emojis_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe EmojisController do

--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe FollowerAccountsController do

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe FollowingAccountsController do

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe HomeController, type: :controller do

--- a/spec/controllers/instance_actors_controller_spec.rb
+++ b/spec/controllers/instance_actors_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe InstanceActorsController, type: :controller do

--- a/spec/controllers/intents_controller_spec.rb
+++ b/spec/controllers/intents_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IntentsController, type: :controller do

--- a/spec/controllers/invites_controller_spec.rb
+++ b/spec/controllers/invites_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe InvitesController do

--- a/spec/controllers/manifests_controller_spec.rb
+++ b/spec/controllers/manifests_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ManifestsController do

--- a/spec/controllers/relationships_controller_spec.rb
+++ b/spec/controllers/relationships_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe RelationshipsController do

--- a/spec/controllers/settings/applications_controller_spec.rb
+++ b/spec/controllers/settings/applications_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::ApplicationsController do

--- a/spec/controllers/settings/deletes_controller_spec.rb
+++ b/spec/controllers/settings/deletes_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::DeletesController do

--- a/spec/controllers/settings/exports/blocked_accounts_controller_spec.rb
+++ b/spec/controllers/settings/exports/blocked_accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::Exports::BlockedAccountsController do

--- a/spec/controllers/settings/exports/bookmarks_controller_spec.rb
+++ b/spec/controllers/settings/exports/bookmarks_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::Exports::BookmarksController do

--- a/spec/controllers/settings/exports/following_accounts_controller_spec.rb
+++ b/spec/controllers/settings/exports/following_accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::Exports::FollowingAccountsController do

--- a/spec/controllers/settings/exports/muted_accounts_controller_spec.rb
+++ b/spec/controllers/settings/exports/muted_accounts_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::Exports::MutedAccountsController do

--- a/spec/controllers/settings/featured_tags_controller_spec.rb
+++ b/spec/controllers/settings/featured_tags_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::FeaturedTagsController do

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Settings::ImportsController, type: :controller do

--- a/spec/controllers/settings/migrations_controller_spec.rb
+++ b/spec/controllers/settings/migrations_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::MigrationsController do

--- a/spec/controllers/settings/preferences/notifications_controller_spec.rb
+++ b/spec/controllers/settings/preferences/notifications_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::Preferences::NotificationsController do

--- a/spec/controllers/settings/preferences/other_controller_spec.rb
+++ b/spec/controllers/settings/preferences/other_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::Preferences::OtherController do

--- a/spec/controllers/settings/profiles_controller_spec.rb
+++ b/spec/controllers/settings/profiles_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Settings::ProfilesController, type: :controller do

--- a/spec/controllers/settings/sessions_controller_spec.rb
+++ b/spec/controllers/settings/sessions_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Settings::SessionsController do

--- a/spec/controllers/shares_controller_spec.rb
+++ b/spec/controllers/shares_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe SharesController do

--- a/spec/controllers/statuses_cleanup_controller_spec.rb
+++ b/spec/controllers/statuses_cleanup_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe StatusesCleanupController, type: :controller do

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe TagsController, type: :controller do

--- a/spec/controllers/well_known/host_meta_controller_spec.rb
+++ b/spec/controllers/well_known/host_meta_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe WellKnown::HostMetaController, type: :controller do

--- a/spec/controllers/well_known/nodeinfo_controller_spec.rb
+++ b/spec/controllers/well_known/nodeinfo_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe WellKnown::NodeInfoController, type: :controller do

--- a/spec/controllers/well_known/webfinger_controller_spec.rb
+++ b/spec/controllers/well_known/webfinger_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe WellKnown::WebfingerController, type: :controller do

--- a/spec/fabricators/access_grant_fabricator.rb
+++ b/spec/fabricators/access_grant_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator :access_grant, from: 'Doorkeeper::AccessGrant' do
   application
   resource_owner_id { Fabricate(:user).id }

--- a/spec/fabricators/access_token_fabricator.rb
+++ b/spec/fabricators/access_token_fabricator.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 Fabricator :access_token, from: 'Doorkeeper::AccessToken' do
 end

--- a/spec/fabricators/accessible_access_token_fabricator.rb
+++ b/spec/fabricators/accessible_access_token_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator :accessible_access_token, from: :access_token do
   expires_in { nil }
   revoked_at { nil }

--- a/spec/fabricators/account_alias_fabricator.rb
+++ b/spec/fabricators/account_alias_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_alias) do
   account
   acct 'test@example.com'

--- a/spec/fabricators/account_deletion_request_fabricator.rb
+++ b/spec/fabricators/account_deletion_request_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_deletion_request) do
   account
 end

--- a/spec/fabricators/account_domain_block_fabricator.rb
+++ b/spec/fabricators/account_domain_block_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_domain_block) do
   account
   domain 'example.com'

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 keypair     = OpenSSL::PKey::RSA.new(2048)
 public_key  = keypair.public_key.to_pem
 private_key = keypair.to_pem

--- a/spec/fabricators/account_migration_fabricator.rb
+++ b/spec/fabricators/account_migration_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_migration) do
   account
   target_account { |attrs| Fabricate(:account, also_known_as: [ActivityPub::TagManager.instance.uri_for(attrs[:account])]) }

--- a/spec/fabricators/account_moderation_note_fabricator.rb
+++ b/spec/fabricators/account_moderation_note_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_moderation_note) do
   content 'MyText'
   account nil

--- a/spec/fabricators/account_note_fabricator.rb
+++ b/spec/fabricators/account_note_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_note) do
   account
   target_account { Fabricate(:account) }

--- a/spec/fabricators/account_pin_fabricator.rb
+++ b/spec/fabricators/account_pin_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_pin) do
   account        nil
   target_account nil

--- a/spec/fabricators/account_stat_fabricator.rb
+++ b/spec/fabricators/account_stat_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_stat) do
   account         nil
   statuses_count  ''

--- a/spec/fabricators/account_statuses_cleanup_policy_fabricator.rb
+++ b/spec/fabricators/account_statuses_cleanup_policy_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_statuses_cleanup_policy) do
   account
 end

--- a/spec/fabricators/account_tag_stat_fabricator.rb
+++ b/spec/fabricators/account_tag_stat_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_tag_stat) do
   accounts_count ''
 end

--- a/spec/fabricators/account_warning_fabricator.rb
+++ b/spec/fabricators/account_warning_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_warning) do
   account
   target_account(fabricator: :account)

--- a/spec/fabricators/account_warning_preset_fabricator.rb
+++ b/spec/fabricators/account_warning_preset_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:account_warning_preset) do
   text 'MyText'
 end

--- a/spec/fabricators/admin_action_log_fabricator.rb
+++ b/spec/fabricators/admin_action_log_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator('Admin::ActionLog') do
   account nil
   action  'MyString'

--- a/spec/fabricators/announcement_fabricator.rb
+++ b/spec/fabricators/announcement_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:announcement) do
   text      { Faker::Lorem.paragraph(sentence_count: 2) }
   published true

--- a/spec/fabricators/announcement_mute_fabricator.rb
+++ b/spec/fabricators/announcement_mute_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:announcement_mute) do
   account
   announcement

--- a/spec/fabricators/announcement_reaction_fabricator.rb
+++ b/spec/fabricators/announcement_reaction_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:announcement_reaction) do
   account
   announcement

--- a/spec/fabricators/appeal_fabricator.rb
+++ b/spec/fabricators/appeal_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:appeal) do
   strike(fabricator: :account_warning)
   account { |attrs| attrs[:strike].target_account }

--- a/spec/fabricators/application_fabricator.rb
+++ b/spec/fabricators/application_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:application, from: Doorkeeper::Application) do
   name         'Example'
   website      'http://example.com'

--- a/spec/fabricators/backup_fabricator.rb
+++ b/spec/fabricators/backup_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:backup) do
   user
 end

--- a/spec/fabricators/block_fabricator.rb
+++ b/spec/fabricators/block_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:block) do
   account
   target_account { Fabricate(:account) }

--- a/spec/fabricators/bookmark_fabricator.rb
+++ b/spec/fabricators/bookmark_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:bookmark) do
   account
   status

--- a/spec/fabricators/canonical_email_block_fabricator.rb
+++ b/spec/fabricators/canonical_email_block_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:canonical_email_block) do
   email 'test@example.com'
   reference_account { Fabricate(:account) }

--- a/spec/fabricators/conversation_account_fabricator.rb
+++ b/spec/fabricators/conversation_account_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:conversation_account) do
   account                 nil
   conversation            nil

--- a/spec/fabricators/conversation_fabricator.rb
+++ b/spec/fabricators/conversation_fabricator.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 Fabricator(:conversation) do
 end

--- a/spec/fabricators/conversation_mute_fabricator.rb
+++ b/spec/fabricators/conversation_mute_fabricator.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 Fabricator(:conversation_mute) do
 end

--- a/spec/fabricators/custom_emoji_category_fabricator.rb
+++ b/spec/fabricators/custom_emoji_category_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:custom_emoji_category) do
   name 'MyString'
 end

--- a/spec/fabricators/custom_emoji_fabricator.rb
+++ b/spec/fabricators/custom_emoji_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:custom_emoji) do
   shortcode 'coolcat'
   domain    nil

--- a/spec/fabricators/custom_filter_fabricator.rb
+++ b/spec/fabricators/custom_filter_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:custom_filter) do
   account
   expires_at nil

--- a/spec/fabricators/custom_filter_keyword_fabricator.rb
+++ b/spec/fabricators/custom_filter_keyword_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:custom_filter_keyword) do
   custom_filter
   keyword 'discourse'

--- a/spec/fabricators/custom_filter_status_fabricator.rb
+++ b/spec/fabricators/custom_filter_status_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:custom_filter_status) do
   custom_filter
   status

--- a/spec/fabricators/device_fabricator.rb
+++ b/spec/fabricators/device_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:device) do
   access_token
   account

--- a/spec/fabricators/domain_allow_fabricator.rb
+++ b/spec/fabricators/domain_allow_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:domain_allow) do
   domain 'MyString'
 end

--- a/spec/fabricators/domain_block_fabricator.rb
+++ b/spec/fabricators/domain_block_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:domain_block) do
   domain { sequence(:domain) { |i| "#{i}#{Faker::Internet.domain_name}" } }
 end

--- a/spec/fabricators/email_domain_block_fabricator.rb
+++ b/spec/fabricators/email_domain_block_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:email_domain_block) do
   domain { sequence(:domain) { |i| "#{i}#{Faker::Internet.domain_name}" } }
 end

--- a/spec/fabricators/encrypted_message_fabricator.rb
+++ b/spec/fabricators/encrypted_message_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:encrypted_message) do
   device
   from_account

--- a/spec/fabricators/favourite_fabricator.rb
+++ b/spec/fabricators/favourite_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:favourite) do
   account
   status

--- a/spec/fabricators/featured_tag_fabricator.rb
+++ b/spec/fabricators/featured_tag_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:featured_tag) do
   account
   tag

--- a/spec/fabricators/follow_fabricator.rb
+++ b/spec/fabricators/follow_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:follow) do
   account
   target_account { Fabricate(:account) }

--- a/spec/fabricators/follow_recommendation_suppression_fabricator.rb
+++ b/spec/fabricators/follow_recommendation_suppression_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:follow_recommendation_suppression) do
   account
 end

--- a/spec/fabricators/follow_request_fabricator.rb
+++ b/spec/fabricators/follow_request_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:follow_request) do
   account
   target_account { Fabricate(:account, locked: true) }

--- a/spec/fabricators/identity_fabricator.rb
+++ b/spec/fabricators/identity_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:identity) do
   user     nil
   provider 'MyString'

--- a/spec/fabricators/import_fabricator.rb
+++ b/spec/fabricators/import_fabricator.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 Fabricator(:import) do
 end

--- a/spec/fabricators/invite_fabricator.rb
+++ b/spec/fabricators/invite_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:invite) do
   user
   expires_at nil

--- a/spec/fabricators/ip_block_fabricator.rb
+++ b/spec/fabricators/ip_block_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:ip_block) do
   ip         ''
   severity   ''

--- a/spec/fabricators/list_account_fabricator.rb
+++ b/spec/fabricators/list_account_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:list_account) do
   list    nil
   account nil

--- a/spec/fabricators/list_fabricator.rb
+++ b/spec/fabricators/list_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:list) do
   account
   title 'MyString'

--- a/spec/fabricators/login_activity_fabricator.rb
+++ b/spec/fabricators/login_activity_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:login_activity) do
   user
   authentication_method 'password'

--- a/spec/fabricators/marker_fabricator.rb
+++ b/spec/fabricators/marker_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:marker) do
   user
   timeline     'home'

--- a/spec/fabricators/media_attachment_fabricator.rb
+++ b/spec/fabricators/media_attachment_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:media_attachment) do
   account
 

--- a/spec/fabricators/mention_fabricator.rb
+++ b/spec/fabricators/mention_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:mention) do
   account
   status

--- a/spec/fabricators/mute_fabricator.rb
+++ b/spec/fabricators/mute_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:mute) do
   account
   target_account { Fabricate(:account) }

--- a/spec/fabricators/notification_fabricator.rb
+++ b/spec/fabricators/notification_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:notification) do
   activity fabricator: [:mention, :status, :follow, :follow_request, :favourite].sample
   account

--- a/spec/fabricators/one_time_key_fabricator.rb
+++ b/spec/fabricators/one_time_key_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:one_time_key) do
   device
   key_id { Faker::Alphanumeric.alphanumeric(number: 10) }

--- a/spec/fabricators/poll_fabricator.rb
+++ b/spec/fabricators/poll_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:poll) do
   account
   status

--- a/spec/fabricators/poll_vote_fabricator.rb
+++ b/spec/fabricators/poll_vote_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:poll_vote) do
   account
   poll

--- a/spec/fabricators/preview_card_fabricator.rb
+++ b/spec/fabricators/preview_card_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:preview_card) do
   url { Faker::Internet.url }
   title { Faker::Lorem.sentence }

--- a/spec/fabricators/relay_fabricator.rb
+++ b/spec/fabricators/relay_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:relay) do
   inbox_url 'https://example.com/inbox'
   state :idle

--- a/spec/fabricators/report_fabricator.rb
+++ b/spec/fabricators/report_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:report) do
   account
   target_account  { Fabricate(:account) }

--- a/spec/fabricators/report_note_fabricator.rb
+++ b/spec/fabricators/report_note_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:report_note) do
   report
   account { Fabricate(:account) }

--- a/spec/fabricators/rule_fabricator.rb
+++ b/spec/fabricators/rule_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:rule) do
   priority   0
   deleted_at nil

--- a/spec/fabricators/scheduled_status_fabricator.rb
+++ b/spec/fabricators/scheduled_status_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:scheduled_status) do
   account
   scheduled_at { 20.hours.from_now }

--- a/spec/fabricators/session_activation_fabricator.rb
+++ b/spec/fabricators/session_activation_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:session_activation) do
   user
   session_id 'MyString'

--- a/spec/fabricators/site_upload_fabricator.rb
+++ b/spec/fabricators/site_upload_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:site_upload) do
   file { File.open(File.join(Rails.root, 'spec', 'fabricators', 'assets', 'utah_teapot.png')) }
 end

--- a/spec/fabricators/status_edit_fabricator.rb
+++ b/spec/fabricators/status_edit_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:status_edit) do
   status                    nil
   account                   nil

--- a/spec/fabricators/status_fabricator.rb
+++ b/spec/fabricators/status_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:status) do
   account
   text 'Lorem ipsum dolor sit amet'

--- a/spec/fabricators/status_pin_fabricator.rb
+++ b/spec/fabricators/status_pin_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:status_pin) do
   account
   status { |attrs| Fabricate(:status, account: attrs[:account], visibility: :public) }

--- a/spec/fabricators/status_stat_fabricator.rb
+++ b/spec/fabricators/status_stat_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:status_stat) do
   status_id        nil
   replies_count    ''

--- a/spec/fabricators/system_key_fabricator.rb
+++ b/spec/fabricators/system_key_fabricator.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 Fabricator(:system_key) do
 end

--- a/spec/fabricators/tag_fabricator.rb
+++ b/spec/fabricators/tag_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:tag) do
   name { sequence(:hashtag) { |i| "#{Faker::Lorem.word}#{i}" } }
 end

--- a/spec/fabricators/tag_follow_fabricator.rb
+++ b/spec/fabricators/tag_follow_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:tag_follow) do
   tag
   account

--- a/spec/fabricators/unavailable_domain_fabricator.rb
+++ b/spec/fabricators/unavailable_domain_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:unavailable_domain) do
   domain { Faker::Internet.domain }
 end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:user) do
   account      { Fabricate.build(:account, user: nil) }
   email        { sequence(:email) { |i| "#{i}#{Faker::Internet.email}" } }

--- a/spec/fabricators/user_invite_request_fabricator.rb
+++ b/spec/fabricators/user_invite_request_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:user_invite_request) do
   user
   text { Faker::Lorem.sentence }

--- a/spec/fabricators/user_role_fabricator.rb
+++ b/spec/fabricators/user_role_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:user_role) do
   name        'MyString'
   color       ''

--- a/spec/fabricators/web_push_subscription_fabricator.rb
+++ b/spec/fabricators/web_push_subscription_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:web_push_subscription, from: Web::PushSubscription) do
   endpoint   Faker::Internet.url
   key_p256dh Faker::Internet.password

--- a/spec/fabricators/web_setting_fabricator.rb
+++ b/spec/fabricators/web_setting_fabricator.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 Fabricator(:web_setting, from: Web::Setting) do
 end

--- a/spec/fabricators/webauthn_credential_fabricator.rb
+++ b/spec/fabricators/webauthn_credential_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:webauthn_credential) do
   user_id { Fabricate(:user).id }
   external_id { Base64.urlsafe_encode64(SecureRandom.random_bytes(16)) }

--- a/spec/fabricators/webhook_fabricator.rb
+++ b/spec/fabricators/webhook_fabricator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Fabricator(:webhook) do
   url { Faker::Internet.url }
   secret { SecureRandom.hex }

--- a/spec/helpers/accounts_helper_spec.rb
+++ b/spec/helpers/accounts_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AccountsHelper, type: :helper do

--- a/spec/helpers/admin/filter_helper_spec.rb
+++ b/spec/helpers/admin/filter_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Admin::FilterHelper do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ApplicationHelper do

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe HomeHelper, type: :helper do

--- a/spec/helpers/statuses_helper_spec.rb
+++ b/spec/helpers/statuses_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe StatusesHelper, type: :helper do

--- a/spec/lib/activitypub/activity/accept_spec.rb
+++ b/spec/lib/activitypub/activity/accept_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Accept do

--- a/spec/lib/activitypub/activity/add_spec.rb
+++ b/spec/lib/activitypub/activity/add_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Add do

--- a/spec/lib/activitypub/activity/announce_spec.rb
+++ b/spec/lib/activitypub/activity/announce_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Announce do

--- a/spec/lib/activitypub/activity/block_spec.rb
+++ b/spec/lib/activitypub/activity/block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Block do

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Create do

--- a/spec/lib/activitypub/activity/delete_spec.rb
+++ b/spec/lib/activitypub/activity/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Delete do

--- a/spec/lib/activitypub/activity/flag_spec.rb
+++ b/spec/lib/activitypub/activity/flag_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Flag do

--- a/spec/lib/activitypub/activity/follow_spec.rb
+++ b/spec/lib/activitypub/activity/follow_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Follow do

--- a/spec/lib/activitypub/activity/like_spec.rb
+++ b/spec/lib/activitypub/activity/like_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Like do

--- a/spec/lib/activitypub/activity/move_spec.rb
+++ b/spec/lib/activitypub/activity/move_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Move do

--- a/spec/lib/activitypub/activity/reject_spec.rb
+++ b/spec/lib/activitypub/activity/reject_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Reject do

--- a/spec/lib/activitypub/activity/remove_spec.rb
+++ b/spec/lib/activitypub/activity/remove_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Remove do

--- a/spec/lib/activitypub/activity/undo_spec.rb
+++ b/spec/lib/activitypub/activity/undo_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Undo do

--- a/spec/lib/activitypub/activity/update_spec.rb
+++ b/spec/lib/activitypub/activity/update_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Activity::Update do

--- a/spec/lib/activitypub/adapter_spec.rb
+++ b/spec/lib/activitypub/adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Adapter do

--- a/spec/lib/activitypub/dereferencer_spec.rb
+++ b/spec/lib/activitypub/dereferencer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::Dereferencer do

--- a/spec/lib/activitypub/linked_data_signature_spec.rb
+++ b/spec/lib/activitypub/linked_data_signature_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::LinkedDataSignature do

--- a/spec/lib/activitypub/tag_manager_spec.rb
+++ b/spec/lib/activitypub/tag_manager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::TagManager do

--- a/spec/lib/emoji_formatter_spec.rb
+++ b/spec/lib/emoji_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe EmojiFormatter do

--- a/spec/lib/entity_cache_spec.rb
+++ b/spec/lib/entity_cache_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe EntityCache do

--- a/spec/lib/feed_manager_spec.rb
+++ b/spec/lib/feed_manager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FeedManager do

--- a/spec/lib/html_aware_formatter_spec.rb
+++ b/spec/lib/html_aware_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe HtmlAwareFormatter do

--- a/spec/lib/link_details_extractor_spec.rb
+++ b/spec/lib/link_details_extractor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe LinkDetailsExtractor do

--- a/spec/lib/plain_text_formatter_spec.rb
+++ b/spec/lib/plain_text_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe PlainTextFormatter do

--- a/spec/lib/suspicious_sign_in_detector_spec.rb
+++ b/spec/lib/suspicious_sign_in_detector_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe SuspiciousSignInDetector do

--- a/spec/lib/tag_manager_spec.rb
+++ b/spec/lib/tag_manager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe TagManager do

--- a/spec/lib/text_formatter_spec.rb
+++ b/spec/lib/text_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe TextFormatter do

--- a/spec/lib/vacuum/access_tokens_vacuum_spec.rb
+++ b/spec/lib/vacuum/access_tokens_vacuum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Vacuum::AccessTokensVacuum do

--- a/spec/lib/vacuum/backups_vacuum_spec.rb
+++ b/spec/lib/vacuum/backups_vacuum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Vacuum::BackupsVacuum do

--- a/spec/lib/vacuum/feeds_vacuum_spec.rb
+++ b/spec/lib/vacuum/feeds_vacuum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Vacuum::FeedsVacuum do

--- a/spec/lib/vacuum/media_attachments_vacuum_spec.rb
+++ b/spec/lib/vacuum/media_attachments_vacuum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Vacuum::MediaAttachmentsVacuum do

--- a/spec/lib/vacuum/preview_cards_vacuum_spec.rb
+++ b/spec/lib/vacuum/preview_cards_vacuum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Vacuum::PreviewCardsVacuum do

--- a/spec/lib/vacuum/statuses_vacuum_spec.rb
+++ b/spec/lib/vacuum/statuses_vacuum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Vacuum::StatusesVacuum do

--- a/spec/lib/vacuum/system_keys_vacuum_spec.rb
+++ b/spec/lib/vacuum/system_keys_vacuum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Vacuum::SystemKeysVacuum do

--- a/spec/lib/webfinger_resource_spec.rb
+++ b/spec/lib/webfinger_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe WebfingerResource do

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe NotificationMailer, type: :mailer do

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Preview all emails at http://localhost:3000/rails/mailers/admin_mailer
 
 class AdminMailerPreview < ActionMailer::Preview

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Preview all emails at http://localhost:3000/rails/mailers/notification_mailer
 
 class NotificationMailerPreview < ActionMailer::Preview

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Preview all emails at http://localhost:3000/rails/mailers/user_mailer
 
 class UserMailerPreview < ActionMailer::Preview

--- a/spec/models/account/field_spec.rb
+++ b/spec/models/account/field_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Account::Field, type: :model do

--- a/spec/models/account_alias_spec.rb
+++ b/spec/models/account_alias_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AccountAlias, type: :model do

--- a/spec/models/account_conversation_spec.rb
+++ b/spec/models/account_conversation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AccountConversation, type: :model do

--- a/spec/models/account_deletion_request_spec.rb
+++ b/spec/models/account_deletion_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AccountDeletionRequest, type: :model do

--- a/spec/models/account_domain_block_spec.rb
+++ b/spec/models/account_domain_block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AccountDomainBlock, type: :model do

--- a/spec/models/account_filter_spec.rb
+++ b/spec/models/account_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe AccountFilter do

--- a/spec/models/account_migration_spec.rb
+++ b/spec/models/account_migration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AccountMigration, type: :model do

--- a/spec/models/account_moderation_note_spec.rb
+++ b/spec/models/account_moderation_note_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AccountModerationNote, type: :model do

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Account, type: :model do

--- a/spec/models/account_statuses_cleanup_policy_spec.rb
+++ b/spec/models/account_statuses_cleanup_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AccountStatusesCleanupPolicy, type: :model do

--- a/spec/models/admin/account_action_spec.rb
+++ b/spec/models/admin/account_action_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Admin::AccountAction, type: :model do

--- a/spec/models/announcement_mute_spec.rb
+++ b/spec/models/announcement_mute_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AnnouncementMute, type: :model do

--- a/spec/models/announcement_reaction_spec.rb
+++ b/spec/models/announcement_reaction_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AnnouncementReaction, type: :model do

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Announcement, type: :model do

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Appeal, type: :model do

--- a/spec/models/backup_spec.rb
+++ b/spec/models/backup_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Backup, type: :model do

--- a/spec/models/block_spec.rb
+++ b/spec/models/block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Block, type: :model do

--- a/spec/models/canonical_email_block_spec.rb
+++ b/spec/models/canonical_email_block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe CanonicalEmailBlock, type: :model do

--- a/spec/models/concerns/account_counters_spec.rb
+++ b/spec/models/concerns/account_counters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe AccountCounters do

--- a/spec/models/concerns/account_interactions_spec.rb
+++ b/spec/models/concerns/account_interactions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe AccountInteractions do

--- a/spec/models/conversation_mute_spec.rb
+++ b/spec/models/conversation_mute_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ConversationMute, type: :model do

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Conversation, type: :model do

--- a/spec/models/custom_emoji_category_spec.rb
+++ b/spec/models/custom_emoji_category_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe CustomEmojiCategory, type: :model do

--- a/spec/models/custom_emoji_spec.rb
+++ b/spec/models/custom_emoji_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe CustomEmoji, type: :model do

--- a/spec/models/custom_filter_keyword_spec.rb
+++ b/spec/models/custom_filter_keyword_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe CustomFilterKeyword, type: :model do

--- a/spec/models/custom_filter_spec.rb
+++ b/spec/models/custom_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe CustomFilter, type: :model do

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Device, type: :model do

--- a/spec/models/domain_allow_spec.rb
+++ b/spec/models/domain_allow_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DomainAllow, type: :model do

--- a/spec/models/domain_block_spec.rb
+++ b/spec/models/domain_block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DomainBlock, type: :model do

--- a/spec/models/email_domain_block_spec.rb
+++ b/spec/models/email_domain_block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe EmailDomainBlock, type: :model do

--- a/spec/models/encrypted_message_spec.rb
+++ b/spec/models/encrypted_message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe EncryptedMessage, type: :model do

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Export do

--- a/spec/models/favourite_spec.rb
+++ b/spec/models/favourite_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Favourite, type: :model do

--- a/spec/models/featured_tag_spec.rb
+++ b/spec/models/featured_tag_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FeaturedTag, type: :model do

--- a/spec/models/follow_recommendation_suppression_spec.rb
+++ b/spec/models/follow_recommendation_suppression_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FollowRecommendationSuppression, type: :model do

--- a/spec/models/follow_request_spec.rb
+++ b/spec/models/follow_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FollowRequest, type: :model do

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Follow, type: :model do

--- a/spec/models/home_feed_spec.rb
+++ b/spec/models/home_feed_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe HomeFeed, type: :model do

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Identity, type: :model do

--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Import, type: :model do

--- a/spec/models/invite_spec.rb
+++ b/spec/models/invite_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Invite, type: :model do

--- a/spec/models/ip_block_spec.rb
+++ b/spec/models/ip_block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IpBlock, type: :model do

--- a/spec/models/list_account_spec.rb
+++ b/spec/models/list_account_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ListAccount, type: :model do

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe List, type: :model do

--- a/spec/models/login_activity_spec.rb
+++ b/spec/models/login_activity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe LoginActivity, type: :model do

--- a/spec/models/marker_spec.rb
+++ b/spec/models/marker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Marker, type: :model do

--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe MediaAttachment, type: :model do

--- a/spec/models/mention_spec.rb
+++ b/spec/models/mention_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Mention, type: :model do

--- a/spec/models/mute_spec.rb
+++ b/spec/models/mute_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Mute, type: :model do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Notification, type: :model do

--- a/spec/models/one_time_key_spec.rb
+++ b/spec/models/one_time_key_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe OneTimeKey, type: :model do

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Poll, type: :model do

--- a/spec/models/preview_card_spec.rb
+++ b/spec/models/preview_card_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe PreviewCard, type: :model do

--- a/spec/models/preview_card_trend_spec.rb
+++ b/spec/models/preview_card_trend_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe PreviewCardTrend, type: :model do

--- a/spec/models/public_feed_spec.rb
+++ b/spec/models/public_feed_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe PublicFeed, type: :model do

--- a/spec/models/relay_spec.rb
+++ b/spec/models/relay_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Relay, type: :model do

--- a/spec/models/report_filter_spec.rb
+++ b/spec/models/report_filter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ReportFilter do

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Report do

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Rule, type: :model do

--- a/spec/models/scheduled_status_spec.rb
+++ b/spec/models/scheduled_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ScheduledStatus, type: :model do

--- a/spec/models/status_edit_spec.rb
+++ b/spec/models/status_edit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe StatusEdit, type: :model do

--- a/spec/models/status_pin_spec.rb
+++ b/spec/models/status_pin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe StatusPin, type: :model do

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Status, type: :model do

--- a/spec/models/status_stat_spec.rb
+++ b/spec/models/status_stat_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe StatusStat, type: :model do

--- a/spec/models/status_trend_spec.rb
+++ b/spec/models/status_trend_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe StatusTrend, type: :model do

--- a/spec/models/system_key_spec.rb
+++ b/spec/models/system_key_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe SystemKey, type: :model do

--- a/spec/models/tag_feed_spec.rb
+++ b/spec/models/tag_feed_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe TagFeed, type: :service do

--- a/spec/models/tag_follow_spec.rb
+++ b/spec/models/tag_follow_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe TagFollow, type: :model do

--- a/spec/models/trends/statuses_spec.rb
+++ b/spec/models/trends/statuses_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Trends::Statuses do

--- a/spec/models/trends/tags_spec.rb
+++ b/spec/models/trends/tags_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Trends::Tags do

--- a/spec/models/unavailable_domain_spec.rb
+++ b/spec/models/unavailable_domain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UnavailableDomain, type: :model do

--- a/spec/models/user_invite_request_spec.rb
+++ b/spec/models/user_invite_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UserInviteRequest, type: :model do

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UserRole, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require 'devise_two_factor/spec_helpers'
 

--- a/spec/models/web/push_subscription_spec.rb
+++ b/spec/models/web/push_subscription_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Web::PushSubscription, type: :model do

--- a/spec/models/web/setting_spec.rb
+++ b/spec/models/web/setting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Web::Setting, type: :model do

--- a/spec/models/webauthn_credentials_spec.rb
+++ b/spec/models/webauthn_credentials_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe WebauthnCredential, type: :model do

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Webhook, type: :model do

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe InstancePresenter do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 

--- a/spec/requests/catch_all_route_request_spec.rb
+++ b/spec/requests/catch_all_route_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'The catch all route' do

--- a/spec/requests/host_meta_request_spec.rb
+++ b/spec/requests/host_meta_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'The host_meta route' do

--- a/spec/requests/webfinger_request_spec.rb
+++ b/spec/requests/webfinger_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'The webfinger route' do

--- a/spec/routing/accounts_routing_spec.rb
+++ b/spec/routing/accounts_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'Routes under accounts/' do

--- a/spec/routing/well_known_routes_spec.rb
+++ b/spec/routing/well_known_routes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'Well Known routes' do

--- a/spec/services/account_search_service_spec.rb
+++ b/spec/services/account_search_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe AccountSearchService, type: :service do

--- a/spec/services/account_statuses_cleanup_service_spec.rb
+++ b/spec/services/account_statuses_cleanup_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe AccountStatusesCleanupService, type: :service do

--- a/spec/services/activitypub/fetch_featured_collection_service_spec.rb
+++ b/spec/services/activitypub/fetch_featured_collection_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::FetchFeaturedCollectionService, type: :service do

--- a/spec/services/activitypub/fetch_featured_tags_collection_service_spec.rb
+++ b/spec/services/activitypub/fetch_featured_tags_collection_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::FetchFeaturedTagsCollectionService, type: :service do

--- a/spec/services/activitypub/fetch_remote_account_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_account_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::FetchRemoteAccountService, type: :service do

--- a/spec/services/activitypub/fetch_remote_actor_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_actor_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::FetchRemoteActorService, type: :service do

--- a/spec/services/activitypub/fetch_remote_key_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_key_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::FetchRemoteKeyService, type: :service do

--- a/spec/services/activitypub/fetch_remote_status_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_status_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::FetchRemoteStatusService, type: :service do

--- a/spec/services/activitypub/fetch_replies_service_spec.rb
+++ b/spec/services/activitypub/fetch_replies_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::FetchRepliesService, type: :service do

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::ProcessAccountService, type: :service do

--- a/spec/services/activitypub/process_collection_service_spec.rb
+++ b/spec/services/activitypub/process_collection_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::ProcessCollectionService, type: :service do

--- a/spec/services/activitypub/process_status_update_service_spec.rb
+++ b/spec/services/activitypub/process_status_update_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 def poll_option_json(name, votes)

--- a/spec/services/activitypub/synchronize_followers_service_spec.rb
+++ b/spec/services/activitypub/synchronize_followers_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ActivityPub::SynchronizeFollowersService, type: :service do

--- a/spec/services/after_block_domain_from_account_service_spec.rb
+++ b/spec/services/after_block_domain_from_account_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AfterBlockDomainFromAccountService, type: :service do

--- a/spec/services/after_block_service_spec.rb
+++ b/spec/services/after_block_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AfterBlockService, type: :service do

--- a/spec/services/app_sign_up_service_spec.rb
+++ b/spec/services/app_sign_up_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AppSignUpService, type: :service do

--- a/spec/services/authorize_follow_service_spec.rb
+++ b/spec/services/authorize_follow_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe AuthorizeFollowService, type: :service do

--- a/spec/services/batched_remove_status_service_spec.rb
+++ b/spec/services/batched_remove_status_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe BatchedRemoveStatusService, type: :service do

--- a/spec/services/block_domain_service_spec.rb
+++ b/spec/services/block_domain_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe BlockDomainService, type: :service do

--- a/spec/services/block_service_spec.rb
+++ b/spec/services/block_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe BlockService, type: :service do

--- a/spec/services/bootstrap_timeline_service_spec.rb
+++ b/spec/services/bootstrap_timeline_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe BootstrapTimelineService, type: :service do

--- a/spec/services/clear_domain_media_service_spec.rb
+++ b/spec/services/clear_domain_media_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ClearDomainMediaService, type: :service do

--- a/spec/services/delete_account_service_spec.rb
+++ b/spec/services/delete_account_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DeleteAccountService, type: :service do

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FanOutOnWriteService, type: :service do

--- a/spec/services/favourite_service_spec.rb
+++ b/spec/services/favourite_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FavouriteService, type: :service do

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FetchLinkCardService, type: :service do

--- a/spec/services/fetch_remote_status_service_spec.rb
+++ b/spec/services/fetch_remote_status_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FetchRemoteStatusService, type: :service do

--- a/spec/services/fetch_resource_service_spec.rb
+++ b/spec/services/fetch_resource_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FetchResourceService, type: :service do

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FollowService, type: :service do

--- a/spec/services/import_service_spec.rb
+++ b/spec/services/import_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ImportService, type: :service do

--- a/spec/services/mute_service_spec.rb
+++ b/spec/services/mute_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe MuteService, type: :service do

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe NotifyService, type: :service do

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe PostStatusService, type: :service do

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ProcessMentionsService, type: :service do

--- a/spec/services/purge_domain_service_spec.rb
+++ b/spec/services/purge_domain_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe PurgeDomainService, type: :service do

--- a/spec/services/reblog_service_spec.rb
+++ b/spec/services/reblog_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ReblogService, type: :service do

--- a/spec/services/reject_follow_service_spec.rb
+++ b/spec/services/reject_follow_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe RejectFollowService, type: :service do

--- a/spec/services/remove_from_follwers_service_spec.rb
+++ b/spec/services/remove_from_follwers_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe RemoveFromFollowersService, type: :service do

--- a/spec/services/remove_status_service_spec.rb
+++ b/spec/services/remove_status_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe RemoveStatusService, type: :service do

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ReportService, type: :service do

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ResolveAccountService, type: :service do

--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe SuspendAccountService, type: :service do

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UnallowDomainService, type: :service do

--- a/spec/services/unblock_service_spec.rb
+++ b/spec/services/unblock_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UnblockService, type: :service do

--- a/spec/services/unfollow_service_spec.rb
+++ b/spec/services/unfollow_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UnfollowService, type: :service do

--- a/spec/services/unmute_service_spec.rb
+++ b/spec/services/unmute_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UnmuteService, type: :service do

--- a/spec/services/unsuspend_account_service_spec.rb
+++ b/spec/services/unsuspend_account_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UnsuspendAccountService, type: :service do

--- a/spec/services/update_account_service_spec.rb
+++ b/spec/services/update_account_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UpdateAccountService, type: :service do

--- a/spec/services/update_status_service_spec.rb
+++ b/spec/services/update_status_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe UpdateStatusService, type: :service do

--- a/spec/services/verify_link_service_spec.rb
+++ b/spec/services/verify_link_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe VerifyLinkService, type: :service do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 GC.disable
 
 if ENV['DISABLE_SIMPLECOV'] != 'true'

--- a/spec/support/matchers/json/match_json_schema.rb
+++ b/spec/support/matchers/json/match_json_schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :match_json_schema do |schema|
   match do |input_json|
     schema_path = Rails.root.join('spec', 'support', 'schema', "#{schema}.json").to_s

--- a/spec/support/matchers/model/model_have_error_on_field.rb
+++ b/spec/support/matchers/model/model_have_error_on_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :model_have_error_on_field do |expected|
   match do |record|
     record.valid? if record.errors.empty?

--- a/spec/workers/activitypub/distribute_poll_update_worker_spec.rb
+++ b/spec/workers/activitypub/distribute_poll_update_worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ActivityPub::DistributePollUpdateWorker do

--- a/spec/workers/activitypub/distribution_worker_spec.rb
+++ b/spec/workers/activitypub/distribution_worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ActivityPub::DistributionWorker do

--- a/spec/workers/activitypub/move_distribution_worker_spec.rb
+++ b/spec/workers/activitypub/move_distribution_worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ActivityPub::MoveDistributionWorker do

--- a/spec/workers/activitypub/processing_worker_spec.rb
+++ b/spec/workers/activitypub/processing_worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ActivityPub::ProcessingWorker do

--- a/spec/workers/activitypub/status_update_distribution_worker_spec.rb
+++ b/spec/workers/activitypub/status_update_distribution_worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ActivityPub::StatusUpdateDistributionWorker do

--- a/spec/workers/activitypub/update_distribution_worker_spec.rb
+++ b/spec/workers/activitypub/update_distribution_worker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ActivityPub::UpdateDistributionWorker do

--- a/spec/workers/scheduler/accounts_statuses_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/accounts_statuses_cleanup_scheduler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Scheduler::AccountsStatusesCleanupScheduler do

--- a/spec/workers/scheduler/user_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/user_cleanup_scheduler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe Scheduler::UserCleanupScheduler do


### PR DESCRIPTION
Temporarily enabled the rule in in `.rubocop-todo.yml` and ran `bundle exec rubocop --server -A spec/`
Figured this should be "safe" if it passes, given it doesn't impact the production code.