### PR TITLE
Fix inefficiency when searching accounts per username in admin interface

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -108,7 +108,7 @@ class Account < ApplicationRecord
   scope :bots, -> { where(actor_type: %w(Application Service)) }
   scope :groups, -> { where(actor_type: 'Group') }
   scope :alphabetic, -> { order(domain: :asc, username: :asc) }
-  scope :matches_username, ->(value) { where(arel_table[:username].matches("#{value}%")) }
+  scope :matches_username, ->(value) { where('lower((username)::text) LIKE lower(?)', "#{value}%") }
   scope :matches_display_name, ->(value) { where(arel_table[:display_name].matches("#{value}%")) }
   scope :matches_domain, ->(value) { where(arel_table[:domain].matches("%#{value}%")) }
   scope :without_unapproved, -> { left_outer_joins(:user).remote.or(left_outer_joins(:user).merge(User.approved.confirmed)) }


### PR DESCRIPTION
The query did a seq scan on the accounts table, it should now use the existing index correctly, performing a much faster index scan.

I used SQL strings rather than Arel because I believe it to be more readable and easier to check that it does indeed match the index definition.