### PR TITLE
Fix unconfirmed accounts being registered as active users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -512,6 +512,8 @@ class User < ApplicationRecord
   end
 
   def prepare_returning_user!
+    return unless confirmed?
+
     ActivityTracker.record('activity:logins', id)
     regenerate_feed! if needs_feed_update?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -507,6 +507,7 @@ class User < ApplicationRecord
   def prepare_new_user!
     BootstrapTimelineWorker.perform_async(account_id)
     ActivityTracker.increment('activity:accounts:local')
+    ActivityTracker.record('activity:logins', id)
     UserMailer.welcome(self).deliver_later
     TriggerWebhookWorker.perform_async('account.approved', 'Account', account_id)
   end


### PR DESCRIPTION
The total user count is the total of users who have confirmed their email address, but the active user count also includes users who have not.

Note that confirmed but not-approved users remain part of the total user count and may be considered as active as well. Maybe we should change that too.