### PR TITLE
Remove reference to non-existent column in StatusEdit

### DIFF
--- a/app/models/status_edit.rb
+++ b/app/models/status_edit.rb
@@ -20,10 +20,6 @@
 class StatusEdit < ApplicationRecord
   include RateLimitable
 
-  self.ignored_columns = %w(
-    media_attachments_changed
-  )
-
   class PreservedMediaAttachment < ActiveModelSerializers::Model
     attributes :media_attachment, :description
 


### PR DESCRIPTION
Looks like the column was removed in a migration - https://github.com/mastodon/mastodon/blob/main/db/post_migrate/20220303203437_remove_media_attachments_changed_from_status_edits.rb - but this ignored_columns was left behind.