### PR TITLE
Add setting to explicitly consent to full-text search indexing of public posts

### DIFF
--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -59,6 +59,7 @@ class Api::V1::StatusesController < Api::BaseController
       sensitive: status_params[:sensitive],
       spoiler_text: status_params[:spoiler_text],
       visibility: status_params[:visibility],
+      indexable: status_params[:indexable],
       language: status_params[:language],
       scheduled_at: status_params[:scheduled_at],
       application: doorkeeper_token.application,
@@ -88,6 +89,7 @@ class Api::V1::StatusesController < Api::BaseController
       media_ids: status_params[:media_ids],
       media_attributes: status_params[:media_attributes],
       sensitive: status_params[:sensitive],
+      indexable: status_params[:indexable],
       language: status_params[:language],
       spoiler_text: status_params[:spoiler_text],
       poll: status_params[:poll]
@@ -133,6 +135,7 @@ class Api::V1::StatusesController < Api::BaseController
       :sensitive,
       :spoiler_text,
       :visibility,
+      :indexable,
       :language,
       :scheduled_at,
       allowed_mentions: [],

--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -55,6 +55,7 @@ class Settings::PreferencesController < Settings::BaseController
       :setting_trends,
       :setting_crop_images,
       :setting_always_send_emails,
+      :setting_default_indexable,
       notification_emails: %i(follow follow_request reblog favourite mention report pending_account trending_tag appeal),
       interactions: %i(must_be_follower must_be_following must_be_following_dm)
     )

--- a/app/helpers/context_helper.rb
+++ b/app/helpers/context_helper.rb
@@ -23,6 +23,7 @@ module ContextHelper
     voters_count: { 'toot' => 'http://joinmastodon.org/ns#', 'votersCount' => 'toot:votersCount' },
     olm: { 'toot' => 'http://joinmastodon.org/ns#', 'Device' => 'toot:Device', 'Ed25519Signature' => 'toot:Ed25519Signature', 'Ed25519Key' => 'toot:Ed25519Key', 'Curve25519Key' => 'toot:Curve25519Key', 'EncryptedMessage' => 'toot:EncryptedMessage', 'publicKeyBase64' => 'toot:publicKeyBase64', 'deviceId' => 'toot:deviceId', 'claim' => { '@type' => '@id', '@id' => 'toot:claim' }, 'fingerprintKey' => { '@type' => '@id', '@id' => 'toot:fingerprintKey' }, 'identityKey' => { '@type' => '@id', '@id' => 'toot:identityKey' }, 'devices' => { '@type' => '@id', '@id' => 'toot:devices' }, 'messageFranking' => 'toot:messageFranking', 'messageType' => 'toot:messageType', 'cipherText' => 'toot:cipherText' },
     suspended: { 'toot' => 'http://joinmastodon.org/ns#', 'suspended' => 'toot:suspended' },
+    indexable: { 'toot' => 'http://joinmastodon.org/ns#', 'indexable' => 'toot:indexable' },
   }.freeze
 
   def full_context

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -121,6 +121,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       reply: @status_parser.reply,
       sensitive: @account.sensitized? || @status_parser.sensitive || false,
       visibility: @status_parser.visibility,
+      indexable: @status_parser.indexable,
       thread: replied_to_status,
       conversation: conversation_from_uri(@object['conversation']),
       media_attachment_ids: process_attachments.take(4).map(&:id),

--- a/app/lib/activitypub/parser/status_parser.rb
+++ b/app/lib/activitypub/parser/status_parser.rb
@@ -84,6 +84,10 @@ class ActivityPub::Parser::StatusParser
     end
   end
 
+  def indexable
+    @object['indexable']
+  end
+
   def language
     if content_language_map?
       @object['contentMap'].keys.first

--- a/app/lib/user_settings_decorator.rb
+++ b/app/lib/user_settings_decorator.rb
@@ -39,6 +39,7 @@ class UserSettingsDecorator
     user.settings['trends']              = trends_preference if change?('setting_trends')
     user.settings['crop_images']         = crop_images_preference if change?('setting_crop_images')
     user.settings['always_send_emails']  = always_send_emails_preference if change?('setting_always_send_emails')
+    user.settings['default_indexable']   = default_indexable_preference if change?('setting_default_indexable')
   end
 
   def merged_notification_emails
@@ -135,6 +136,10 @@ class UserSettingsDecorator
 
   def always_send_emails_preference
     boolean_cast_setting 'setting_always_send_emails'
+  end
+
+  def default_indexable
+    boolean_cast_setting 'setting_default_indexable'
   end
 
   def boolean_cast_setting(key)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -27,6 +27,7 @@
 #  edited_at                    :datetime
 #  trendable                    :boolean
 #  ordered_media_attachment_ids :bigint(8)        is an Array
+#  indexable                    :boolean
 #
 
 class Status < ApplicationRecord
@@ -313,6 +314,7 @@ class Status < ApplicationRecord
   before_validation :prepare_contents, if: :local?
   before_validation :set_reblog
   before_validation :set_visibility
+  before_validation :set_indexable
   before_validation :set_conversation
   before_validation :set_local
 
@@ -487,6 +489,10 @@ class Status < ApplicationRecord
     self.visibility = reblog.visibility if reblog? && visibility.nil?
     self.visibility = (account.locked? ? :private : :public) if visibility.nil?
     self.sensitive  = false if sensitive.nil?
+  end
+
+  def set_indexable
+    self.indexable = false unless distributable?
   end
 
   def set_conversation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -136,7 +136,7 @@ class User < ApplicationRecord
            :reduce_motion, :system_font_ui, :noindex, :theme, :display_media,
            :expand_spoilers, :default_language, :aggregate_reblogs, :show_application,
            :advanced_layout, :use_blurhash, :use_pending_items, :trends, :crop_images,
-           :disable_swiping, :always_send_emails,
+           :disable_swiping, :always_send_emails, :default_indexable,
            to: :settings, prefix: :setting, allow_nil: false
 
   delegate :can?, to: :role

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -3,13 +3,13 @@
 class ActivityPub::NoteSerializer < ActivityPub::Serializer
   include FormattingHelper
 
-  context_extensions :atom_uri, :conversation, :sensitive, :voters_count
+  context_extensions :atom_uri, :conversation, :sensitive, :voters_count, :indexable
 
   attributes :id, :type, :summary,
              :in_reply_to, :published, :url,
              :attributed_to, :to, :cc, :sensitive,
              :atom_uri, :in_reply_to_atom_uri,
-             :conversation
+             :conversation, :indexable
 
   attribute :content
   attribute :content_map, if: :language?
@@ -106,6 +106,10 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
 
   def sensitive
     object.account.sensitized? || object.sensitive
+  end
+
+  def indexable
+    object.indexable?
   end
 
   def virtual_attachments

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -6,7 +6,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attributes :id, :created_at, :in_reply_to_id, :in_reply_to_account_id,
              :sensitive, :spoiler_text, :visibility, :language,
              :uri, :url, :replies_count, :reblogs_count,
-             :favourites_count, :edited_at
+             :favourites_count, :edited_at, :indexable
 
   attribute :favourited, if: :current_user?
   attribute :reblogged, if: :current_user?

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -156,6 +156,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
     @status.spoiler_text = @status_parser.spoiler_text || ''
     @status.sensitive    = @account.sensitized? || @status_parser.sensitive || false
     @status.language     = @status_parser.language
+    @status.indexable    = @status_parser.indexable
 
     @significant_changes = text_significantly_changed? || @status.spoiler_text_changed? || @media_attachments_changed || @poll_changed
 

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -22,6 +22,7 @@ class PostStatusService < BaseService
   # @option [Status] :thread Optional status to reply to
   # @option [Boolean] :sensitive
   # @option [String] :visibility
+  # @option [Boolean] :indexable
   # @option [String] :spoiler_text
   # @option [String] :language
   # @option [String] :scheduled_at
@@ -66,6 +67,7 @@ class PostStatusService < BaseService
     @text         = @options.delete(:spoiler_text) if @text.blank? && @options[:spoiler_text].present?
     @visibility   = @options[:visibility] || @account.user&.setting_default_privacy
     @visibility   = :unlisted if @visibility&.to_sym == :public && @account.silenced?
+    @indexable    = @visibility&.to_sym == :public && (@options[:indexable] || @account.user&.setting_default_indexable)
     @scheduled_at = @options[:scheduled_at]&.to_datetime
     @scheduled_at = nil if scheduled_in_the_past?
   rescue ArgumentError
@@ -193,6 +195,7 @@ class PostStatusService < BaseService
       sensitive: @sensitive,
       spoiler_text: @options[:spoiler_text] || '',
       visibility: @visibility,
+      indexable: @indexable,
       language: valid_locale_cascade(@options[:language], @account.user&.preferred_posting_language, I18n.default_locale),
       application: @options[:application],
       rate_limit: @options[:with_rate_limit],

--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -15,6 +15,7 @@ class UpdateStatusService < BaseService
   # @option options [String] :text
   # @option options [String] :spoiler_text
   # @option options [Boolean] :sensitive
+  # @option options [Boolean] :indexable
   # @option options [String] :language
   def call(status, account_id, options = {})
     @status                    = status
@@ -111,6 +112,7 @@ class UpdateStatusService < BaseService
     @status.text         = @options[:text].presence || @options.delete(:spoiler_text) || '' if @options.key?(:text)
     @status.spoiler_text = @options[:spoiler_text] || '' if @options.key?(:spoiler_text)
     @status.sensitive    = @options[:sensitive] || @options[:spoiler_text].present? if @options.key?(:sensitive) || @options.key?(:spoiler_text)
+    @status.indexable    = @status.public_visibility? && @options[:indexable] if @options.key?(:indexable)
     @status.language     = valid_locale_cascade(@options[:language], @status.language, @status.account.user&.preferred_posting_language, I18n.default_locale)
 
     # We raise here to rollback the entire transaction

--- a/app/views/settings/preferences/other/show.html.haml
+++ b/app/views/settings/preferences/other/show.html.haml
@@ -23,6 +23,9 @@
       = f.input :setting_default_language, collection: [nil] + filterable_languages, wrapper: :with_label, label_method: lambda { |locale| locale.nil? ? I18n.t('statuses.default_language') : native_locale_name(locale) }, required: false, include_blank: false, hint: false
 
   .fields-group
+    = f.input :setting_default_indexable, as: :boolean, wrapper: :with_label
+
+  .fields-group
     = f.input :setting_default_sensitive, as: :boolean, wrapper: :with_label
 
   .fields-group

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -50,6 +50,7 @@ en:
         scopes: Which APIs the application will be allowed to access. If you select a top-level scope, you don't need to select individual ones.
         setting_aggregate_reblogs: Do not show new boosts for posts that have been recently boosted (only affects newly-received boosts)
         setting_always_send_emails: Normally e-mail notifications won't be sent when you are actively using Mastodon
+        setting_default_indexable: Allow Mastodon users to search for your new public posts by text even if they have not seen or interacted with them previously. Public posts remain searchable by tag regardless of this setting. This does not technically prevent your posts from being indexed by other tools.
         setting_default_sensitive: Sensitive media is hidden by default and can be revealed with a click
         setting_display_media_default: Hide media marked as sensitive
         setting_display_media_hide_all: Always hide media
@@ -197,6 +198,7 @@ en:
         setting_auto_play_gif: Auto-play animated GIFs
         setting_boost_modal: Show confirmation dialog before boosting
         setting_crop_images: Crop images in non-expanded posts to 16x9
+        setting_default_indexable: Allow new public posts to be searchable by text
         setting_default_language: Posting language
         setting_default_privacy: Posting privacy
         setting_default_sensitive: Always mark media as sensitive

--- a/db/migrate/20230222155222_add_indexable_to_statuses.rb
+++ b/db/migrate/20230222155222_add_indexable_to_statuses.rb
@@ -1,0 +1,5 @@
+class AddIndexableToStatuses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :statuses, :indexable, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_06_114142) do
+ActiveRecord::Schema.define(version: 2023_02_22_155222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -940,6 +940,7 @@ ActiveRecord::Schema.define(version: 2022_12_06_114142) do
     t.datetime "edited_at"
     t.boolean "trendable"
     t.bigint "ordered_media_attachment_ids", array: true
+    t.boolean "indexable"
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20190820", order: { id: :desc }, where: "(deleted_at IS NULL)"
     t.index ["account_id"], name: "index_statuses_on_account_id"
     t.index ["deleted_at"], name: "index_statuses_on_deleted_at", where: "(deleted_at IS NOT NULL)"


### PR DESCRIPTION
NOTE: This PR does not implement the search functionality itself, just a framework to express explicit consent for posts to be indexed

Mastodon has historically refused to provide full-text search functionality outside of interacted posts to avoid harassment, “reply guys” and other issues.

Since Mastodon users post in “public” under that assumption, a post being “public” cannot be understood as consent from the user for having their post indexed, and Mastodon currently lacks any framework for users to give their consent for a feature that would be useful and that some people are very adamant about.

This PR aims to add such an explicit consent option in the form of a new per-post `indexable` attribute on `Status` entities in the REST API and a `toot:indexable` (shortened as `indexable`) in the ActivityPub representation.

The API allows setting the information per-post, but the UI does not. Instead, the user is presented with the following option:
![image](https://user-images.githubusercontent.com/384364/220692909-7ee037cf-90dc-414a-b98a-dc9dda42eb9f.png)

The option tries to highlight that not giving consent does not prevent bad actors from indexing the posts anyway.

## TODO

- [ ] make it visible in the Web UI whether a post is indexable or not
- [ ] add tests
- [ ] figure out if we should switch `toot:indexable` for something else
- [ ] (optional) add the option to override indexability per-post in the WebUI