### PR TITLE
[Dependashlee] Bump browser from 4.2.0 to 5.3.1 (Ruby)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     brakeman (5.4.0)
-    browser (4.2.0)
+    browser (5.3.1)
     brpoplpush-redis_script (0.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       redis (>= 1.0, < 6)


### PR DESCRIPTION
Dependabot has been ignoring this package. Hopefully this kicks it back into action.

----

Is this even required?