### PR TITLE
[Dependashlee] Bump @github/webauthn-json from 0.5.7 to 2.1.1 (js)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@babel/preset-react": "^7.18.6",
     "@babel/runtime": "^7.21.0",
     "@gamestdio/websocket": "^0.3.2",
-    "@github/webauthn-json": "^0.5.7",
+    "@github/webauthn-json": "^2.1.1",
     "@rails/ujs": "^6.1.7",
     "abortcontroller-polyfill": "^1.7.5",
     "array-includes": "^3.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,10 +1245,10 @@
   resolved "https://registry.yarnpkg.com/@gamestdio/websocket/-/websocket-0.3.2.tgz#321ba0976ee30fd14e51dbf8faa85ce7b325f76a"
   integrity sha512-J3n5SKim+ZoLbe44hRGI/VYAwSMCeIJuBy+FfP6EZaujEpNchPRFcIsVQLWAwpU1bP2Ji63rC+rEUOd1vjUB6Q==
 
-"@github/webauthn-json@^0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@github/webauthn-json/-/webauthn-json-0.5.7.tgz#143bc67f6e0f75f8d188e565741507bb08c31214"
-  integrity sha512-SUYsttDxFSvWvvJssJpwzjmRCqYfdfqC9VCmAHQYfdKCVelyJteCHo9/lK1CB72mx/jrl6cFNY08aua4J2jIyg==
+"@github/webauthn-json@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@github/webauthn-json/-/webauthn-json-2.1.1.tgz#648e63fc28050917d2882cc2b27817a88cb420fc"
+  integrity sha512-XrftRn4z75SnaJOmZQbt7Mk+IIjqVHw+glDGOxuHwXkZBZh/MBoRS7MHjSZMDaLhT4RjN2VqiEU7EOYleuJWSQ==
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"


### PR DESCRIPTION
Dependabot has been ignoring this package. Hopefully this kicks it back into action.