### PR TITLE
[Dependashlee] Bump fuzzysort from 1.9.0 to 2.0.4 (JS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "express": "^4.18.2",
     "file-loader": "^6.2.0",
     "font-awesome": "^4.7.0",
-    "fuzzysort": "^1.9.0",
+    "fuzzysort": "^2.0.4",
     "glob": "^8.1.0",
     "history": "^4.10.1",
     "http-link-header": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5263,10 +5263,10 @@ functions-have-names@^1.2.2:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-fuzzysort@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/fuzzysort/-/fuzzysort-1.9.0.tgz#d36d27949eae22340bb6f7ba30ea6751b92a181c"
-  integrity sha512-MOxCT0qLTwLqmEwc7UtU045RKef7mc8Qz8eR4r2bLNEq9dy/c3ZKMEFp6IEst69otkQdFZ4FfgH2dmZD+ddX1g==
+fuzzysort@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/fuzzysort/-/fuzzysort-2.0.4.tgz#a21d1ce8947eaf2797dc3b7c28c36db9d1165f84"
+  integrity sha512-Api1mJL+Ad7W7vnDZnWq5pGaXJjyencT+iKGia2PlHUcSsSzWwIQ3S1isiMpwpavjYtGd2FzhUIhnnhOULZgDw==
 
 gauge@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Dependabot has been ignoring this package. Hopefully this kicks it back into action.

----

### Changelog

#### v2.0.0
- Added new behavior when your search contains spaces!
- Added fuzzysort.min.js
- Now depends on ES6 features
- Removed `result.indexes` & Added `fuzzysort.indexes` (improved GC performance)
- Completely Removed `options.allowTypo`
- Completely Removed `fuzzysort.goAsync`
- Completely Removed `fuzzysort.new`
- Rewrote the demo
