### PR TITLE
[Dependashlee] Bump color-blend from 3.0.1 to 4.0.0 (JS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "blurhash": "^2.0.5",
     "classnames": "^2.3.2",
     "cocoon-js-vanilla": "^1.3.0",
-    "color-blend": "^3.0.1",
+    "color-blend": "^4.0.0",
     "compression-webpack-plugin": "^6.1.1",
     "cross-env": "^7.0.3",
     "css-loader": "^5.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3373,10 +3373,10 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-blend@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/color-blend/-/color-blend-3.0.1.tgz#3882ed1190ca18760ffe11570d8537960171172b"
-  integrity sha512-KueDvNiKHAvVeApic0SxHZLyy4x3NELfTLzMHRpRRLi+9e2kWhpeWvtuH3Sjb92mOJYEUhRjb8z7lr4OqDv17Q==
+color-blend@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/color-blend/-/color-blend-4.0.0.tgz#e9950e9fa5d6e552ff8bb107c39f7e83a0c1a3bb"
+  integrity sha512-fYODTHhI/NG+B5GnzvuL3kiFrK/UnkUezWFTgEPBTY5V+kpyfAn95Vn9sJeeCX6omrCOdxnqCL3CvH+6sXtIbw==
 
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"


### PR DESCRIPTION
Dependabot has been ignoring this package. Hopefully this kicks it back into action.

----
This release "soft drops Node 12 and below". We're 14+, so no issues.