### PR TITLE
Add CodeCov to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@2.0.0
   node: circleci/node@5.0.3
+  codecov: codecov/codecov@3.2.2
 
 executors:
   default:
@@ -17,7 +18,7 @@ executors:
           CONTINUOUS_INTEGRATION: true
           DB_HOST: localhost
           DB_USER: root
-          DISABLE_SIMPLECOV: true
+          DISABLE_SIMPLECOV: false
           RAILS_ENV: test
       - image: cimg/postgres:14.5
         environment:
@@ -109,6 +110,7 @@ jobs:
           command: ./bin/rails db:create db:schema:load db:seed
           name: Load database schema
       - ruby/rspec-test
+      - codecov/upload
 
 workflows:
   version: 2

--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,7 @@ group :test do
   gem 'rspec_junit_formatter', '~> 0.6'
   gem 'rspec-sidekiq', '~> 3.1'
   gem 'simplecov', '~> 0.22', require: false
+  gem 'simplecov-lcov', '~> 0.8', require: false
   gem 'webmock', '~> 3.18'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -664,6 +664,7 @@ GEM
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
     sprockets (3.7.2)
@@ -874,6 +875,7 @@ DEPENDENCIES
   simple-navigation (~> 4.4)
   simple_form (~> 5.2)
   simplecov (~> 0.22)
+  simplecov-lcov (~> 0.8)
   sprockets (~> 3.7.2)
   sprockets-rails (~> 3.4)
   stackprof

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,9 @@ GC.disable
 
 if ENV['DISABLE_SIMPLECOV'] != 'true'
   require 'simplecov'
+  require 'simplecov-lcov'
+  SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+  SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
   SimpleCov.start 'rails' do
     add_group 'Policies', 'app/policies'
     add_group 'Presenters', 'app/presenters'


### PR DESCRIPTION
I was trying this out with the GitHub Actions branch here https://github.com/nschonni/mastodon/pull/90#issuecomment-1441236032
Thought it might be useful to test out on the current CircleCI setup, so followed the basic instructions from https://docs.codecov.com/docs/github-2-getting-a-codecov-account-and-uploading-coverage#circleci to try on the current CI setup.

There may be some required hooks setup if this goes forward, but I thought I'd use this as a starting point

Sample direct output from the GitHub Actions setup https://app.codecov.io/github/nschonni/mastodon/commit/3c63fb8fd6dd9370b75af4630b826553fc4b04a0/tree

I had looked at running it conditionally just on the `3.2` run, but the conditional syntax in CircleCI is not familiar to me