### PR TITLE
Increase contrast of upload progress background

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -258,6 +258,10 @@ html {
   border-color: $ui-base-color;
 }
 
+.upload-progress__backdrop {
+  background: $ui-base-color;
+}
+
 // Change the background colors of statuses
 .focusable:focus {
   background: $ui-base-color;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4543,7 +4543,7 @@ a.status-card.compact:hover {
   width: 100%;
   height: 6px;
   border-radius: 6px;
-  background: $ui-base-lighter-color;
+  background: darken($simple-background-color, 8%);
   position: relative;
   margin-top: 5px;
 }


### PR DESCRIPTION
Hi there! This is my first contribution, so please let me know if there's anything you'd like changed / adjusted 👋🏼

When using either of the dark themes, it is very difficult to see the progress of a file upload due to the low contrast between the blue bar and the background color.

This PR updates the background color (using the compose dialog as reference) so you can now more clearly see the progress of your file upload.

| Theme | Before | After |
| - | - | - |
| Dark | <img width="461" alt="before-dark" src="https://user-images.githubusercontent.com/153/220861915-60b8187e-a4ef-48fa-8eab-5d0879615c28.png"> | <img width="461" alt="after-dark" src="https://user-images.githubusercontent.com/153/220861989-7c215297-6b49-4c54-af82-4663a9f822c3.png"> |
| High Contrast | <img width="461" alt="before-dark-high-contrast" src="https://user-images.githubusercontent.com/153/220862047-06e43738-cc52-4501-b3a0-cb166811ce9d.png"> | <img width="461" alt="after-dark-high-contrast" src="https://user-images.githubusercontent.com/153/220862090-a4c5558f-7341-4919-b850-c76f4b084793.png"> |
| Light | <img width="461" alt="before-light" src="https://user-images.githubusercontent.com/153/220862139-93cf513c-f802-4856-9de5-4a661049721c.png"> | <img width="461" alt="after-light" src="https://user-images.githubusercontent.com/153/220862201-2aaf040c-2dc3-4d07-b0e3-d8ef90b955f2.png"> |