### PR TITLE
Fix multiple `Scheduler::FollowRecommendationsScheduler` running at the same time if too slow

### DIFF
--- a/app/workers/scheduler/follow_recommendations_scheduler.rb
+++ b/app/workers/scheduler/follow_recommendations_scheduler.rb
@@ -4,7 +4,7 @@ class Scheduler::FollowRecommendationsScheduler
   include Sidekiq::Worker
   include Redisable
 
-  sidekiq_options retry: 0
+  sidekiq_options retry: 0, lock: :until_executed, lock_ttl: 2.weeks.to_i
 
   # The maximum number of accounts that can be requested in one page from the
   # API is 80, and the suggestions API does not allow pagination. This number


### PR DESCRIPTION
Partially addresses #23813