### PR TITLE
Enable Rubocop for app/views

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,6 @@ AllCops:
   NewCops: enable
   Exclude:
     - db/schema.rb
-    - 'app/views/**/*'
     - 'config/**/*'
     - 'bin/*'
     - 'Rakefile'

--- a/app/views/accounts/show.rss.ruby
+++ b/app/views/accounts/show.rss.ruby
@@ -18,12 +18,12 @@ RSS::Builder.build do |doc|
         item.enclosure(full_asset_url(media.file.url(:original, false)), media.file.content_type, media.file.size)
       end
 
-      status.ordered_media_attachments.each do |media|
-        item.media_content(full_asset_url(media.file.url(:original, false)), media.file.content_type, media.file.size) do |media_content|
-          media_content.medium(media.gifv? ? 'image' : media.type.to_s)
+      status.ordered_media_attachments.each do |media_attachment|
+        item.media_content(full_asset_url(media_attachment.file.url(:original, false)), media_attachment.file.content_type, media_attachment.file.size) do |media_content|
+          media_content.medium(media_attachment.gifv? ? 'image' : media_attachment.type.to_s)
           media_content.rating(status.sensitive? ? 'adult' : 'nonadult')
-          media_content.description(media.description) if media.description.present?
-          media_content.thumbnail(media.thumbnail.url(:original, false)) if media.thumbnail?
+          media_content.description(media_attachment.description) if media_attachment.description.present?
+          media_content.thumbnail(media_attachment.thumbnail.url(:original, false)) if media_attachment.thumbnail?
         end
       end
 

--- a/app/views/accounts/show.rss.ruby
+++ b/app/views/accounts/show.rss.ruby
@@ -5,7 +5,7 @@ RSS::Builder.build do |doc|
   doc.image(full_asset_url(@account.avatar.url(:original)), display_name(@account), params[:tag].present? ? short_account_tag_url(@account, params[:tag]) : short_account_url(@account))
   doc.last_build_date(@statuses.first.created_at) if @statuses.any?
   doc.icon(full_asset_url(@account.avatar.url(:original)))
-  doc.generator("Mastodon v#{Mastodon::Version.to_s}")
+  doc.generator("Mastodon v#{Mastodon::Version}")
 
   @statuses.each do |status|
     doc.item do |item|

--- a/app/views/tags/show.rss.ruby
+++ b/app/views/tags/show.rss.ruby
@@ -16,12 +16,12 @@ RSS::Builder.build do |doc|
         item.enclosure(full_asset_url(media.file.url(:original, false)), media.file.content_type, media.file.size)
       end
 
-      status.ordered_media_attachments.each do |media|
-        item.media_content(full_asset_url(media.file.url(:original, false)), media.file.content_type, media.file.size) do |media_content|
-          media_content.medium(media.gifv? ? 'image' : media.type.to_s)
+      status.ordered_media_attachments.each do |media_attachment|
+        item.media_content(full_asset_url(media_attachment.file.url(:original, false)), media_attachment.file.content_type, media_attachment.file.size) do |media_content|
+          media_content.medium(media_attachment.gifv? ? 'image' : media_attachment.type.to_s)
           media_content.rating(status.sensitive? ? 'adult' : 'nonadult')
-          media_content.description(media.description) if media.description.present?
-          media_content.thumbnail(media.thumbnail.url(:original, false)) if media.thumbnail?
+          media_content.description(media_attachment.description) if media_attachment.description.present?
+          media_content.thumbnail(media_attachment.thumbnail.url(:original, false)) if media_attachment.thumbnail?
         end
       end
 

--- a/app/views/tags/show.rss.ruby
+++ b/app/views/tags/show.rss.ruby
@@ -3,7 +3,7 @@ RSS::Builder.build do |doc|
   doc.description(I18n.t('rss.descriptions.tag', hashtag: @tag.display_name))
   doc.link(tag_url(@tag))
   doc.last_build_date(@statuses.first.created_at) if @statuses.any?
-  doc.generator("Mastodon v#{Mastodon::Version.to_s}")
+  doc.generator("Mastodon v#{Mastodon::Version}")
 
   @statuses.each do |status|
     doc.item do |item|

--- a/app/views/well_known/host_meta/show.xml.ruby
+++ b/app/views/well_known/host_meta/show.xml.ruby
@@ -9,4 +9,4 @@ doc << Ox::Element.new('XRD').tap do |xrd|
   end
 end
 
-('<?xml version="1.0" encoding="UTF-8"?>' + Ox.dump(doc, effort: :tolerant)).force_encoding('UTF-8')
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>#{Ox.dump(doc, effort: :tolerant)}".force_encoding('UTF-8')


### PR DESCRIPTION
The haml files would be covered sepeartely by #23524, but this opts in the few ruby files in here (also named `.ruby` instead of `.rb`)