### PR TITLE
Remove stackprof gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -146,8 +146,6 @@ group :development do
   gem 'capistrano-rails', '~> 1.6'
   gem 'capistrano-rbenv', '~> 2.2'
   gem 'capistrano-yarn', '~> 2.0'
-
-  gem 'stackprof'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -685,7 +685,6 @@ GEM
     sshkit (1.21.4)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    stackprof (0.2.23)
     statsd-ruby (1.5.0)
     stoplight (3.0.1)
       redlock (~> 1.0)
@@ -888,7 +887,6 @@ DEPENDENCIES
   simplecov (~> 0.22)
   sprockets (~> 3.7.2)
   sprockets-rails (~> 3.4)
-  stackprof
   stoplight (~> 3.0.1)
   strong_migrations (~> 0.7)
   thor (~> 1.2)


### PR DESCRIPTION
Looks like it was added in https://github.com/mastodon/mastodon/pull/7301
Might still be used as a CLI for benchmarking, but didn't see it wired directly into the code or rack