### PR TITLE
Add Postgres 15 testing for migrations

### DIFF
--- a/.github/workflows/test-migrations-one-step.yml
+++ b/.github/workflows/test-migrations-one-step.yml
@@ -23,9 +23,17 @@ jobs:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        postgres:
+          - 14-alpine
+          - 15-alpine
+
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:${{ matrix.postgres}}
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres

--- a/.github/workflows/test-migrations-two-step.yml
+++ b/.github/workflows/test-migrations-two-step.yml
@@ -23,9 +23,17 @@ jobs:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        postgres:
+          - 14-alpine
+          - 15-alpine
+
     services:
       postgres:
-        image: postgres:14-alpine
+        image: postgres:${{ matrix.postgres}}
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres


### PR DESCRIPTION
Not sure if the `14.5` should be changed to the floating `14` to use the latest, but I used that during the conversion because that is what CircleCI is still using