### PR TITLE
Add policies and serializers groups to simplecov output

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,10 @@ GC.disable
 if ENV['DISABLE_SIMPLECOV'] != 'true'
   require 'simplecov'
   SimpleCov.start 'rails' do
-    add_group 'Services', 'app/services'
+    add_group 'Policies', 'app/policies'
     add_group 'Presenters', 'app/presenters'
+    add_group 'Serializers', 'app/serializers'
+    add_group 'Services', 'app/services'
     add_group 'Validators', 'app/validators'
   end
 end


### PR DESCRIPTION
These two make up the bulk of "ungrouped" currently.