### PR TITLE
Remove unused InstancePresenter#sample_accounts method

### DIFF
--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -74,10 +74,6 @@ class InstancePresenter < ActiveModelSerializers::Model
     Rails.cache.fetch('distinct_domain_count') { Instance.count }
   end
 
-  def sample_accounts
-    Rails.cache.fetch('sample_accounts', expires_in: 12.hours) { Account.local.discoverable.popular.limit(3) }
-  end
-
   def version
     Mastodon::Version.to_s
   end


### PR DESCRIPTION
Was used only in about/show.html.haml.erb which was removed - https://github.com/mastodon/mastodon/commit/58d5b28cb00ffadfeb7a3e1e03f7ae0d3b0d8486#diff-db94067e44c20bcd85ce8bdb07d824216ac798cf7898cc3f146dd47564a45630