### PR TITLE
User mailer spec coverage improvements

### DIFF
--- a/app/views/user_mailer/appeal_rejected.html.haml
+++ b/app/views/user_mailer/appeal_rejected.html.haml
@@ -17,7 +17,7 @@
                                 %tbody
                                   %tr
                                     %td
-                                      = image_tag full_pack_url('media/images/mailer/icon_warning.png'), alt: ''
+                                      = image_tag full_pack_url('media/images/mailer/icon_flag.png'), alt: ''
 
                               %h1= t 'user_mailer.appeal_rejected.title'
 

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -94,4 +94,17 @@ describe UserMailer, type: :mailer do
       expect(mail.body.encoded).to include strike.text
     end
   end
+
+  describe 'webauthn_credential_deleted' do
+    let(:credential) { Fabricate(:webauthn_credential, user_id: receiver.id) }
+    let(:mail) { UserMailer.webauthn_credential_deleted(receiver, credential) }
+
+    it 'renders webauthn credential deleted notification' do
+      receiver.update!(locale: nil)
+      expect(mail.body.encoded).to include I18n.t('devise.mailer.webauthn_credential.deleted.title')
+    end
+
+    include_examples 'localized subject',
+                     'devise.mailer.webauthn_credential.deleted.subject'
+  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -132,4 +132,14 @@ describe UserMailer, type: :mailer do
       expect(mail.body.encoded).to include I18n.t('user_mailer.appeal_approved.title')
     end
   end
+
+  describe 'appeal_rejected' do
+    let(:appeal) { Fabricate(:appeal, account: receiver.account, rejected_at: Time.now.utc) }
+    let(:mail) { UserMailer.appeal_rejected(receiver, appeal) }
+
+    it 'renders appeal_rejected notification' do
+      expect(mail.subject).to eq I18n.t('user_mailer.appeal_rejected.subject', date: I18n.l(appeal.created_at))
+      expect(mail.body.encoded).to include I18n.t('user_mailer.appeal_rejected.title')
+    end
+  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -122,4 +122,14 @@ describe UserMailer, type: :mailer do
     include_examples 'localized subject',
                      'user_mailer.suspicious_sign_in.subject'
   end
+
+  describe 'appeal_approved' do
+    let(:appeal) { Fabricate(:appeal, account: receiver.account, approved_at: Time.now.utc) }
+    let(:mail) { UserMailer.appeal_approved(receiver, appeal) }
+
+    it 'renders appeal_approved notification' do
+      expect(mail.subject).to eq I18n.t('user_mailer.appeal_approved.subject', date: I18n.l(appeal.created_at))
+      expect(mail.body.encoded).to include I18n.t('user_mailer.appeal_approved.title')
+    end
+  end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -107,4 +107,19 @@ describe UserMailer, type: :mailer do
     include_examples 'localized subject',
                      'devise.mailer.webauthn_credential.deleted.subject'
   end
+
+  describe 'suspicious_sign_in' do
+    let(:ip) { '192.168.0.1' }
+    let(:agent) { 'NCSA_Mosaic/2.0 (Windows 3.1)' }
+    let(:timestamp) { Time.now.utc }
+    let(:mail) { UserMailer.suspicious_sign_in(receiver, ip, agent, timestamp) }
+
+    it 'renders suspicious sign in notification' do
+      receiver.update!(locale: nil)
+      expect(mail.body.encoded).to include I18n.t('user_mailer.suspicious_sign_in.explanation')
+    end
+
+    include_examples 'localized subject',
+                     'user_mailer.suspicious_sign_in.subject'
+  end
 end


### PR DESCRIPTION
This adds coverage for the methods which did not have any C0 coverage via simplecov report in the UserMailer.

In order to get `appeal_rejected` passing I had to change a reference to an icon (the referenced icon_warning is missing since - https://github.com/mastodon/mastodon/commit/45aa5781ce611ea411e34e3b18358a9fe15f67ce) and decided to change it to use `flag` instead based on other change made in that same commit.