### PR TITLE
Spec coverage for HomeHelper

### DIFF
--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -57,14 +57,6 @@ module HomeHelper
     end
   end
 
-  def optional_link_to(condition, path, options = {}, &block)
-    if condition
-      link_to(path, options, &block)
-    else
-      content_tag(:div, &block)
-    end
-  end
-
   def sign_up_message
     if closed_registrations?
       t('auth.registration_closed', instance: site_hostname)

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -41,9 +41,9 @@ module HomeHelper
 
   def obscured_counter(count)
     if count <= 0
-      0
+      '0'
     elsif count == 1
-      1
+      '1'
     else
       '1+'
     end

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -8,4 +8,30 @@ RSpec.describe HomeHelper, type: :helper do
       expect(helper.default_props).to eq locale: I18n.locale
     end
   end
+
+  describe 'account_link_to' do
+    context 'with a missing account' do
+      let(:account) { nil }
+
+      it 'returns a button' do
+        result = helper.account_link_to(account)
+
+        expect(result).to match t('about.contact_missing')
+      end
+    end
+
+    context 'with a valid account' do
+      let(:account) { Fabricate(:account) }
+
+      it 'returns a link to the account' do
+        without_partial_double_verification do
+          allow(helper).to receive(:current_account).and_return(account)
+          allow(helper).to receive(:prefers_autoplay?).and_return(false)
+          result = helper.account_link_to(account)
+
+          expect(result).to match "@#{account.acct}"
+        end
+      end
+    end
+  end
 end

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -88,4 +88,36 @@ RSpec.describe HomeHelper, type: :helper do
       end
     end
   end
+
+  describe 'sign_up_messages' do
+    context 'with closed registrations' do
+      it 'returns correct sign up message' do
+        allow(helper).to receive(:closed_registrations?).and_return(true)
+        result = helper.sign_up_message
+
+        expect(result).to eq t('auth.registration_closed', instance: 'cb6e6126.ngrok.io')
+      end
+    end
+
+    context 'with open registrations' do
+      it 'returns correct sign up message' do
+        allow(helper).to receive(:closed_registrations?).and_return(false)
+        allow(helper).to receive(:open_registrations?).and_return(true)
+        result = helper.sign_up_message
+
+        expect(result).to eq t('auth.register')
+      end
+    end
+
+    context 'with approved registrations' do
+      it 'returns correct sign up message' do
+        allow(helper).to receive(:closed_registrations?).and_return(false)
+        allow(helper).to receive(:open_registrations?).and_return(false)
+        allow(helper).to receive(:approved_registrations?).and_return(true)
+        result = helper.sign_up_message
+
+        expect(result).to eq t('auth.apply_for_account')
+      end
+    end
+  end
 end

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -68,4 +68,24 @@ RSpec.describe HomeHelper, type: :helper do
       end
     end
   end
+
+  describe 'custom_field_classes' do
+    context 'with a verified field' do
+      let(:field) { instance_double(Account::Field, verified?: true) }
+
+      it 'returns verified string' do
+        result = helper.custom_field_classes(field)
+        expect(result).to eq 'verified'
+      end
+    end
+
+    context 'with a non-verified field' do
+      let(:field) { instance_double(Account::Field, verified?: false) }
+
+      it 'returns verified string' do
+        result = helper.custom_field_classes(field)
+        expect(result).to eq 'emojify'
+      end
+    end
+  end
 end

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -34,4 +34,38 @@ RSpec.describe HomeHelper, type: :helper do
       end
     end
   end
+
+  describe 'obscured_counter' do
+    context 'with a value of less than zero' do
+      let(:count) { -10 }
+
+      it 'returns the correct string' do
+        expect(helper.obscured_counter(count)).to eq '0'
+      end
+    end
+
+    context 'with a value of zero' do
+      let(:count) { 0 }
+
+      it 'returns the correct string' do
+        expect(helper.obscured_counter(count)).to eq '0'
+      end
+    end
+
+    context 'with a value of one' do
+      let(:count) { 1 }
+
+      it 'returns the correct string' do
+        expect(helper.obscured_counter(count)).to eq '1'
+      end
+    end
+
+    context 'with a value of more than one' do
+      let(:count) { 10 }
+
+      it 'returns the correct string' do
+        expect(helper.obscured_counter(count)).to eq '1+'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Additional specs to get C0 coverage on HomeHelper.

While in there:

- Changed `obscured_counter` (only used in one place, in a view) to return Strings
- Removed `optional_link_to` which is not in use 