### PR TITLE
Pending example models minimal coverage

### DIFF
--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -2,6 +2,37 @@
 
 require 'rails_helper'
 
-RSpec.describe Appeal, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Appeal do
+  describe 'scopes' do
+    describe 'approved' do
+      let(:approved_appeal) { Fabricate(:appeal, approved_at: 10.days.ago) }
+      let(:not_approved_appeal) { Fabricate(:appeal, approved_at: nil) }
+
+      it 'finds the correct records' do
+        results = described_class.approved
+        expect(results).to eq([approved_appeal])
+      end
+    end
+
+    describe 'rejected' do
+      let(:rejected_appeal) { Fabricate(:appeal, rejected_at: 10.days.ago) }
+      let(:not_rejected_appeal) { Fabricate(:appeal, rejected_at: nil) }
+
+      it 'finds the correct records' do
+        results = described_class.rejected
+        expect(results).to eq([rejected_appeal])
+      end
+    end
+
+    describe 'pending' do
+      let(:approved_appeal) { Fabricate(:appeal, approved_at: 10.days.ago) }
+      let(:rejected_appeal) { Fabricate(:appeal, rejected_at: 10.days.ago) }
+      let(:pending_appeal) { Fabricate(:appeal, rejected_at: nil, approved_at: nil) }
+
+      it 'finds the correct records' do
+        results = described_class.pending
+        expect(results).to eq([pending_appeal])
+      end
+    end
+  end
 end

--- a/spec/models/custom_emoji_category_spec.rb
+++ b/spec/models/custom_emoji_category_spec.rb
@@ -2,6 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe CustomEmojiCategory, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe CustomEmojiCategory do
+  describe 'validations' do
+    it 'validates name presence' do
+      record = described_class.new(name: nil)
+
+      expect(record).to_not be_valid
+      expect(record).to model_have_error_on_field(:name)
+    end
+  end
 end

--- a/spec/models/domain_allow_spec.rb
+++ b/spec/models/domain_allow_spec.rb
@@ -2,6 +2,17 @@
 
 require 'rails_helper'
 
-RSpec.describe DomainAllow, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe DomainAllow do
+  describe 'scopes' do
+    describe 'matches_domain' do
+      let(:domain) { Fabricate(:domain_allow, domain: 'example.com') }
+      let(:other_domain) { Fabricate(:domain_allow, domain: 'example.biz') }
+
+      it 'returns the correct records' do
+        results = described_class.matches_domain('example.com')
+
+        expect(results).to eq([domain])
+      end
+    end
+  end
 end

--- a/spec/models/ip_block_spec.rb
+++ b/spec/models/ip_block_spec.rb
@@ -2,6 +2,14 @@
 
 require 'rails_helper'
 
-RSpec.describe IpBlock, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe IpBlock do
+  describe 'to_log_human_identifier' do
+    let(:ip_block) { described_class.new(ip: '192.168.0.1') }
+
+    it 'combines the IP and prefix into a string' do
+      result = ip_block.to_log_human_identifier
+
+      expect(result).to eq('192.168.0.1/32')
+    end
+  end
 end

--- a/spec/models/marker_spec.rb
+++ b/spec/models/marker_spec.rb
@@ -2,6 +2,15 @@
 
 require 'rails_helper'
 
-RSpec.describe Marker, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Marker do
+  describe 'validations' do
+    describe 'timeline' do
+      it 'must be included in valid list' do
+        record = described_class.new(timeline: 'not real timeline')
+
+        expect(record).to_not be_valid
+        expect(record).to model_have_error_on_field(:timeline)
+      end
+    end
+  end
 end

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -2,6 +2,31 @@
 
 require 'rails_helper'
 
-RSpec.describe Poll, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Poll do
+  describe 'scopes' do
+    let(:status) { Fabricate(:status) }
+    let(:attached_poll) { Fabricate(:poll, status: status) }
+    let(:not_attached_poll) do
+      Fabricate(:poll).tap do |poll|
+        poll.status = nil
+        poll.save(validate: false)
+      end
+    end
+
+    describe 'attached' do
+      it 'finds the correct records' do
+        results = described_class.attached
+
+        expect(results).to eq([attached_poll])
+      end
+    end
+
+    describe 'unattached' do
+      it 'finds the correct records' do
+        results = described_class.unattached
+
+        expect(results).to eq([not_attached_poll])
+      end
+    end
+  end
 end

--- a/spec/models/rule_spec.rb
+++ b/spec/models/rule_spec.rb
@@ -2,6 +2,18 @@
 
 require 'rails_helper'
 
-RSpec.describe Rule, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Rule do
+  describe 'scopes' do
+    describe 'ordered' do
+      let(:deleted_rule) { Fabricate(:rule, deleted_at: 10.days.ago) }
+      let(:first_rule) { Fabricate(:rule, deleted_at: nil, priority: 1) }
+      let(:last_rule) { Fabricate(:rule, deleted_at: nil, priority: 10) }
+
+      it 'finds the correct records' do
+        results = described_class.ordered
+
+        expect(results).to eq([first_rule, last_rule])
+      end
+    end
+  end
 end

--- a/spec/models/status_edit_spec.rb
+++ b/spec/models/status_edit_spec.rb
@@ -2,6 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe StatusEdit, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe StatusEdit do
+  describe '#reblog?' do
+    it 'returns false' do
+      record = described_class.new
+
+      expect(record).to_not be_a_reblog
+    end
+  end
 end

--- a/spec/models/trends/tags_spec.rb
+++ b/spec/models/trends/tags_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe Trends::Tags do
   end
 
   describe '#query' do
-    pending
+    it 'returns a composable query scope' do
+      expect(subject.query).to be_a Trends::Query
+    end
   end
 
   describe '#refresh' do


### PR DESCRIPTION
Goal here was to get all of the "add some examples or delete" output out of the spec run. For all of those models I just added whatever the first thing I noticed from the model that was straightforward to add. Basically all of them could stand for more coverage to be added, but this first stab accomplishes the goal of getting rid of the "add or delete" output.

There are still a bunch of `pending` or `xit` instances left which I haven't addressed here but might separately in future PR.