### PR TITLE
Settings controllers specs

### DIFF
--- a/spec/controllers/settings/aliases_controller_spec.rb
+++ b/spec/controllers/settings/aliases_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Settings::AliasesController do
+  render_views
+
+  let!(:user) { Fabricate(:user) }
+  let(:account) { user.account }
+
+  before do
+    sign_in user, scope: :user
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/settings/exports/blocked_domains_controller_spec.rb
+++ b/spec/controllers/settings/exports/blocked_domains_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Settings::Exports::BlockedDomainsController do
+  render_views
+
+  describe 'GET #index' do
+    it 'returns a csv of the domains' do
+      account = Fabricate(:account, domain: 'example.com')
+      user = Fabricate(:user, account: account)
+      Fabricate(:account_domain_block, domain: 'example.com', account: account)
+
+      sign_in user, scope: :user
+      get :index, format: :csv
+
+      expect(response.body).to eq "example.com\n"
+    end
+  end
+end

--- a/spec/controllers/settings/exports/lists_controller_spec.rb
+++ b/spec/controllers/settings/exports/lists_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Settings::Exports::ListsController do
+  render_views
+
+  describe 'GET #index' do
+    it 'returns a csv of the domains' do
+      account = Fabricate(:account)
+      user = Fabricate(:user, account: account)
+      list = Fabricate(:list, account: account, title: 'The List')
+      Fabricate(:list_account, list: list, account: account)
+
+      sign_in user, scope: :user
+      get :index, format: :csv
+
+      expect(response.body).to match 'The List'
+    end
+  end
+end

--- a/spec/controllers/settings/login_activities_controller_spec.rb
+++ b/spec/controllers/settings/login_activities_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Settings::LoginActivitiesController do
+  render_views
+
+  let!(:user) { Fabricate(:user) }
+
+  before do
+    sign_in user, scope: :user
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/settings/migration/redirects_controller_spec.rb
+++ b/spec/controllers/settings/migration/redirects_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Settings::Migration::RedirectsController do
+  render_views
+
+  let!(:user) { Fabricate(:user) }
+
+  before do
+    sign_in user, scope: :user
+  end
+
+  describe 'GET #new' do
+    it 'returns http success' do
+      get :new
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/settings/pictures_controller_spec.rb
+++ b/spec/controllers/settings/pictures_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Settings::PicturesController do
+  render_views
+
+  let!(:user) { Fabricate(:user) }
+
+  before do
+    sign_in user, scope: :user
+  end
+
+  describe 'DELETE #destroy' do
+    context 'with invalid picture id' do
+      it 'returns http bad request' do
+        delete :destroy, params: { id: 'invalid' }
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+end

--- a/spec/controllers/settings/preferences/appearance_controller_spec.rb
+++ b/spec/controllers/settings/preferences/appearance_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Settings::Preferences::AppearanceController do
+  render_views
+
+  let!(:user) { Fabricate(:user) }
+
+  before do
+    sign_in user, scope: :user
+  end
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
For each of the /settings/ controllers which previously had zero percent coverage in simplecov, add at least one spec so that they are no longer at zero.

Many of these are just doing a simple GET to an action that doesn't do much ... the idea here is to reduce the amount of code which is not encountered at all one piece at a time.