### PR TITLE
Extract appearances of Compose component to Presentation components

### DIFF
--- a/app/javascript/mastodon/features/compose/compose_presentation.jsx
+++ b/app/javascript/mastodon/features/compose/compose_presentation.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ComposeFormContainer from './containers/compose_form_container';
+import NavigationContainer from './containers/navigation_container';
+import PropTypes from 'prop-types';
+import Column from 'mastodon/components/column';
+import { Helmet } from 'react-helmet';
+
+const ComposePresentation = ({ onFocus, onBlur }) => {
+  return (
+    <Column onFocus={onFocus}>
+      <NavigationContainer onClose={onBlur} />
+      <ComposeFormContainer />
+
+      <Helmet>
+        <meta name='robots' content='noindex' />
+      </Helmet>
+    </Column>
+  );
+};
+
+ComposePresentation.propTypes = {
+  onFocus: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+};
+
+export default ComposePresentation;

--- a/app/javascript/mastodon/features/compose/compose_presentation_for_multi_column.jsx
+++ b/app/javascript/mastodon/features/compose/compose_presentation_for_multi_column.jsx
@@ -14,6 +14,8 @@ import { mascot } from '../../initial_state';
 import Icon from 'mastodon/components/icon';
 import { isMobile } from '../../is_mobile';
 
+const hasColumn = (columns, id) => columns.some(column => column.get('id') === id);
+
 const messages = defineMessages({
   start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
   home_timeline: { id: 'tabs_bar.home', defaultMessage: 'Home' },
@@ -30,16 +32,16 @@ const ComposePresentationForMultiColumn = ({ showSearch, intl, columns, onClickL
     <div className='drawer' role='region' aria-label={intl.formatMessage(messages.compose)}>
       <nav className='drawer__header'>
         <Link to='/getting-started' className='drawer__tab' title={intl.formatMessage(messages.start)} aria-label={intl.formatMessage(messages.start)}><Icon id='bars' fixedWidth /></Link>
-        {!columns.some(column => column.get('id') === 'HOME') && (
+        {!hasColumn(columns, 'HOME') && (
           <Link to='/home' className='drawer__tab' title={intl.formatMessage(messages.home_timeline)} aria-label={intl.formatMessage(messages.home_timeline)}><Icon id='home' fixedWidth /></Link>
         )}
-        {!columns.some(column => column.get('id') === 'NOTIFICATIONS') && (
+        {!hasColumn(columns, 'NOTIFICATIONS') && (
           <Link to='/notifications' className='drawer__tab' title={intl.formatMessage(messages.notifications)} aria-label={intl.formatMessage(messages.notifications)}><Icon id='bell' fixedWidth /></Link>
         )}
-        {!columns.some(column => column.get('id') === 'COMMUNITY') && (
+        {!hasColumn(columns, 'COMMUNITY') && (
           <Link to='/public/local' className='drawer__tab' title={intl.formatMessage(messages.community)} aria-label={intl.formatMessage(messages.community)}><Icon id='users' fixedWidth /></Link>
         )}
-        {!columns.some(column => column.get('id') === 'PUBLIC') && (
+        {!hasColumn(columns, 'PUBLIC') && (
           <Link to='/public' className='drawer__tab' title={intl.formatMessage(messages.public)} aria-label={intl.formatMessage(messages.public)}><Icon id='globe' fixedWidth /></Link>
         )}
         <a href='/settings/preferences' className='drawer__tab' title={intl.formatMessage(messages.preferences)} aria-label={intl.formatMessage(messages.preferences)}><Icon id='cog' fixedWidth /></a>

--- a/app/javascript/mastodon/features/compose/compose_presentation_for_multi_column.jsx
+++ b/app/javascript/mastodon/features/compose/compose_presentation_for_multi_column.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import ComposeFormContainer from './containers/compose_form_container';
+import NavigationContainer from './containers/navigation_container';
+import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { defineMessages } from 'react-intl';
+import { Link } from 'react-router-dom';
+import SearchContainer from './containers/search_container';
+import Motion from '../ui/util/optional_motion';
+import spring from 'react-motion/lib/spring';
+import SearchResultsContainer from './containers/search_results_container';
+import elephantUIPlane from '../../../images/elephant_ui_plane.svg';
+import { mascot } from '../../initial_state';
+import Icon from 'mastodon/components/icon';
+import { isMobile } from '../../is_mobile';
+
+const messages = defineMessages({
+  start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
+  home_timeline: { id: 'tabs_bar.home', defaultMessage: 'Home' },
+  notifications: { id: 'tabs_bar.notifications', defaultMessage: 'Notifications' },
+  public: { id: 'navigation_bar.public_timeline', defaultMessage: 'Federated timeline' },
+  community: { id: 'navigation_bar.community_timeline', defaultMessage: 'Local timeline' },
+  preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
+  logout: { id: 'navigation_bar.logout', defaultMessage: 'Logout' },
+  compose: { id: 'navigation_bar.compose', defaultMessage: 'Compose new post' },
+});
+
+const ComposePresentationForMultiColumn = ({ showSearch, intl, columns, onClickLogout, onFocus, onBlur }) => {
+  return (
+    <div className='drawer' role='region' aria-label={intl.formatMessage(messages.compose)}>
+      <nav className='drawer__header'>
+        <Link to='/getting-started' className='drawer__tab' title={intl.formatMessage(messages.start)} aria-label={intl.formatMessage(messages.start)}><Icon id='bars' fixedWidth /></Link>
+        {!columns.some(column => column.get('id') === 'HOME') && (
+          <Link to='/home' className='drawer__tab' title={intl.formatMessage(messages.home_timeline)} aria-label={intl.formatMessage(messages.home_timeline)}><Icon id='home' fixedWidth /></Link>
+        )}
+        {!columns.some(column => column.get('id') === 'NOTIFICATIONS') && (
+          <Link to='/notifications' className='drawer__tab' title={intl.formatMessage(messages.notifications)} aria-label={intl.formatMessage(messages.notifications)}><Icon id='bell' fixedWidth /></Link>
+        )}
+        {!columns.some(column => column.get('id') === 'COMMUNITY') && (
+          <Link to='/public/local' className='drawer__tab' title={intl.formatMessage(messages.community)} aria-label={intl.formatMessage(messages.community)}><Icon id='users' fixedWidth /></Link>
+        )}
+        {!columns.some(column => column.get('id') === 'PUBLIC') && (
+          <Link to='/public' className='drawer__tab' title={intl.formatMessage(messages.public)} aria-label={intl.formatMessage(messages.public)}><Icon id='globe' fixedWidth /></Link>
+        )}
+        <a href='/settings/preferences' className='drawer__tab' title={intl.formatMessage(messages.preferences)} aria-label={intl.formatMessage(messages.preferences)}><Icon id='cog' fixedWidth /></a>
+        <a href='/auth/sign_out' className='drawer__tab' title={intl.formatMessage(messages.logout)} aria-label={intl.formatMessage(messages.logout)} onClick={onClickLogout}><Icon id='sign-out' fixedWidth /></a>
+      </nav>
+
+      <SearchContainer />
+
+      <div className='drawer__pager'>
+        <div className='drawer__inner' onFocus={onFocus}>
+          <NavigationContainer onClose={onBlur} />
+          <ComposeFormContainer autoFocus={!isMobile(window.innerWidth)} />
+
+          <div className='drawer__inner__mastodon'>
+            <img alt='' draggable='false' src={mascot || elephantUIPlane} />
+          </div>
+        </div>
+
+        <Motion defaultStyle={{ x: -100 }} style={{ x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }) }}>
+          {({ x }) => (
+            <div className='drawer__inner darker' style={{ transform: `translateX(${x}%)`, visibility: x === -100 ? 'hidden' : 'visible' }}>
+              <SearchResultsContainer />
+            </div>
+          )}
+        </Motion>
+      </div>
+    </div>
+  );
+};
+
+ComposePresentationForMultiColumn.propTypes = {
+  onFocus: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+  onClickLogout: PropTypes.func.isRequired,
+  columns: ImmutablePropTypes.list.isRequired,
+  showSearch: PropTypes.bool,
+  intl: PropTypes.object.isRequired,
+};
+
+export default ComposePresentationForMultiColumn;

--- a/app/javascript/mastodon/features/compose/index.jsx
+++ b/app/javascript/mastodon/features/compose/index.jsx
@@ -16,9 +16,8 @@ import elephantUIPlane from '../../../images/elephant_ui_plane.svg';
 import { mascot } from '../../initial_state';
 import Icon from 'mastodon/components/icon';
 import { logOut } from 'mastodon/utils/log_out';
-import Column from 'mastodon/components/column';
-import { Helmet } from 'react-helmet';
 import { isMobile } from '../../is_mobile';
+import ComposePresentation from './compose_presentation';
 
 const messages = defineMessages({
   start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
@@ -85,10 +84,10 @@ class Compose extends React.PureComponent {
   };
 
   render () {
-    const { multiColumn, showSearch, intl } = this.props;
+    const { multiColumn } = this.props;
 
     if (multiColumn) {
-      const { columns } = this.props;
+      const { columns, showSearch, intl } = this.props;
 
       return (
         <div className='drawer' role='region' aria-label={intl.formatMessage(messages.compose)}>
@@ -136,14 +135,10 @@ class Compose extends React.PureComponent {
     }
 
     return (
-      <Column onFocus={this.onFocus}>
-        <NavigationContainer onClose={this.onBlur} />
-        <ComposeFormContainer />
-
-        <Helmet>
-          <meta name='robots' content='noindex' />
-        </Helmet>
-      </Column>
+      <ComposePresentation
+        onBlur={this.onBlur}
+        onFocus={this.onFocus}
+      />
     );
   }
 

--- a/app/javascript/mastodon/features/compose/index.jsx
+++ b/app/javascript/mastodon/features/compose/index.jsx
@@ -1,33 +1,15 @@
 import React from 'react';
-import ComposeFormContainer from './containers/compose_form_container';
-import NavigationContainer from './containers/navigation_container';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 import { changeComposing, mountCompose, unmountCompose } from '../../actions/compose';
-import { Link } from 'react-router-dom';
 import { injectIntl, defineMessages } from 'react-intl';
-import SearchContainer from './containers/search_container';
-import Motion from '../ui/util/optional_motion';
-import spring from 'react-motion/lib/spring';
-import SearchResultsContainer from './containers/search_results_container';
 import { openModal } from 'mastodon/actions/modal';
-import elephantUIPlane from '../../../images/elephant_ui_plane.svg';
-import { mascot } from '../../initial_state';
-import Icon from 'mastodon/components/icon';
 import { logOut } from 'mastodon/utils/log_out';
-import { isMobile } from '../../is_mobile';
 import ComposePresentation from './compose_presentation';
+import ComposePresentationForMultiColumn from './compose_presentation_for_multi_column';
 
 const messages = defineMessages({
-  start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },
-  home_timeline: { id: 'tabs_bar.home', defaultMessage: 'Home' },
-  notifications: { id: 'tabs_bar.notifications', defaultMessage: 'Notifications' },
-  public: { id: 'navigation_bar.public_timeline', defaultMessage: 'Federated timeline' },
-  community: { id: 'navigation_bar.community_timeline', defaultMessage: 'Local timeline' },
-  preferences: { id: 'navigation_bar.preferences', defaultMessage: 'Preferences' },
-  logout: { id: 'navigation_bar.logout', defaultMessage: 'Logout' },
-  compose: { id: 'navigation_bar.compose', defaultMessage: 'Compose new post' },
   logoutMessage: { id: 'confirmations.logout.message', defaultMessage: 'Are you sure you want to log out?' },
   logoutConfirm: { id: 'confirmations.logout.confirm', defaultMessage: 'Log out' },
 });
@@ -90,47 +72,14 @@ class Compose extends React.PureComponent {
       const { columns, showSearch, intl } = this.props;
 
       return (
-        <div className='drawer' role='region' aria-label={intl.formatMessage(messages.compose)}>
-          <nav className='drawer__header'>
-            <Link to='/getting-started' className='drawer__tab' title={intl.formatMessage(messages.start)} aria-label={intl.formatMessage(messages.start)}><Icon id='bars' fixedWidth /></Link>
-            {!columns.some(column => column.get('id') === 'HOME') && (
-              <Link to='/home' className='drawer__tab' title={intl.formatMessage(messages.home_timeline)} aria-label={intl.formatMessage(messages.home_timeline)}><Icon id='home' fixedWidth /></Link>
-            )}
-            {!columns.some(column => column.get('id') === 'NOTIFICATIONS') && (
-              <Link to='/notifications' className='drawer__tab' title={intl.formatMessage(messages.notifications)} aria-label={intl.formatMessage(messages.notifications)}><Icon id='bell' fixedWidth /></Link>
-            )}
-            {!columns.some(column => column.get('id') === 'COMMUNITY') && (
-              <Link to='/public/local' className='drawer__tab' title={intl.formatMessage(messages.community)} aria-label={intl.formatMessage(messages.community)}><Icon id='users' fixedWidth /></Link>
-            )}
-            {!columns.some(column => column.get('id') === 'PUBLIC') && (
-              <Link to='/public' className='drawer__tab' title={intl.formatMessage(messages.public)} aria-label={intl.formatMessage(messages.public)}><Icon id='globe' fixedWidth /></Link>
-            )}
-            <a href='/settings/preferences' className='drawer__tab' title={intl.formatMessage(messages.preferences)} aria-label={intl.formatMessage(messages.preferences)}><Icon id='cog' fixedWidth /></a>
-            <a href='/auth/sign_out' className='drawer__tab' title={intl.formatMessage(messages.logout)} aria-label={intl.formatMessage(messages.logout)} onClick={this.handleLogoutClick}><Icon id='sign-out' fixedWidth /></a>
-          </nav>
-
-          {multiColumn && <SearchContainer /> }
-
-          <div className='drawer__pager'>
-            <div className='drawer__inner' onFocus={this.onFocus}>
-              <NavigationContainer onClose={this.onBlur} />
-
-              <ComposeFormContainer autoFocus={!isMobile(window.innerWidth)} />
-
-              <div className='drawer__inner__mastodon'>
-                <img alt='' draggable='false' src={mascot || elephantUIPlane} />
-              </div>
-            </div>
-
-            <Motion defaultStyle={{ x: -100 }} style={{ x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }) }}>
-              {({ x }) => (
-                <div className='drawer__inner darker' style={{ transform: `translateX(${x}%)`, visibility: x === -100 ? 'hidden' : 'visible' }}>
-                  <SearchResultsContainer />
-                </div>
-              )}
-            </Motion>
-          </div>
-        </div>
+        <ComposePresentationForMultiColumn
+          onBlur={this.onBlur}
+          onFocus={this.onFocus}
+          onClickLogout={this.handleLogoutClick}
+          intl={intl}
+          columns={columns}
+          showSearch={showSearch}
+        />
       );
     }
 


### PR DESCRIPTION
This PR extracts appearances of Compose component to Presentation components.

## Why?
Compose components are very complex with a mixture of state and appearance.

## Why not container?
Compose components have two different appearances.
If we create a container component outside of a Compose component, encapsulation is not valid because it affects the use side.