### PR TITLE
Misc coverage improvements for validators

### DIFF
--- a/app/validators/ed25519_key_validator.rb
+++ b/app/validators/ed25519_key_validator.rb
@@ -6,7 +6,7 @@ class Ed25519KeyValidator < ActiveModel::EachValidator
 
     key = Base64.decode64(value)
 
-    record.errors[attribute] << I18n.t('crypto.errors.invalid_key') unless verified?(key)
+    record.errors.add(attribute, I18n.t('crypto.errors.invalid_key')) unless verified?(key)
   end
 
   private

--- a/app/validators/ed25519_signature_validator.rb
+++ b/app/validators/ed25519_signature_validator.rb
@@ -8,7 +8,7 @@ class Ed25519SignatureValidator < ActiveModel::EachValidator
     signature  = Base64.decode64(value)
     message    = option_to_value(record, :message)
 
-    record.errors[attribute] << I18n.t('crypto.errors.invalid_signature') unless verified?(verify_key, signature, message)
+    record.errors.add(attribute, I18n.t('crypto.errors.invalid_signature')) unless verified?(verify_key, signature, message)
   end
 
   private

--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Import, type: :model do
       expect(import).to model_have_error_on_field(:data)
     end
 
+    it 'is invalid with malformed data' do
+      import = Import.create(account: account, type: type, data: StringIO.new('\"test'))
+      expect(import).to model_have_error_on_field(:data)
+    end
+
     it 'is invalid with too many rows in data' do
       import = Import.create(account: account, type: type, data: StringIO.new("foo@bar.com\n" * (ImportService::ROWS_PROCESSING_LIMIT + 10)))
       expect(import).to model_have_error_on_field(:data)

--- a/spec/models/one_time_key_spec.rb
+++ b/spec/models/one_time_key_spec.rb
@@ -11,5 +11,13 @@ describe OneTimeKey do
         expect(one_time_key).to_not be_valid
       end
     end
+
+    context 'with an invalid key' do
+      let(:one_time_key) { Fabricate.build(:one_time_key, key: 'wrong!') }
+
+      it 'is invalid' do
+        expect(one_time_key).to_not be_valid
+      end
+    end
   end
 end

--- a/spec/models/one_time_key_spec.rb
+++ b/spec/models/one_time_key_spec.rb
@@ -2,5 +2,14 @@
 
 require 'rails_helper'
 
-RSpec.describe OneTimeKey, type: :model do
+describe OneTimeKey do
+  describe 'validations' do
+    context 'with an invalid signature' do
+      let(:one_time_key) { Fabricate.build(:one_time_key, signature: 'wrong!') }
+
+      it 'is invalid' do
+        expect(one_time_key).to_not be_valid
+      end
+    end
+  end
 end

--- a/spec/validators/email_mx_validator_spec.rb
+++ b/spec/validators/email_mx_validator_spec.rb
@@ -41,12 +41,18 @@ describe EmailMxValidator do
       expect(user.errors).to_not have_received(:add)
     end
 
-    it 'adds an error if the domain resolves as blank' do
+    it 'adds an error if the TagManager fails to normalize domain' do
       double = instance_double(TagManager)
       allow(TagManager).to receive(:instance).and_return(double)
       allow(double).to receive(:normalize_domain).with('example.com').and_raise(Addressable::URI::InvalidURIError)
 
-      user = double(email: 'foo@example.com', sign_up_ip: '1.2.3.4', errors: double(add: nil))
+      user = double(email: 'foo@example.com', errors: double(add: nil))
+      subject.validate(user)
+      expect(user.errors).to have_received(:add)
+    end
+
+    it 'adds an error if the domain email portion is blank' do
+      user = double(email: 'foo@', errors: double(add: nil))
       subject.validate(user)
       expect(user.errors).to have_received(:add)
     end

--- a/spec/validators/email_mx_validator_spec.rb
+++ b/spec/validators/email_mx_validator_spec.rb
@@ -41,6 +41,16 @@ describe EmailMxValidator do
       expect(user.errors).to_not have_received(:add)
     end
 
+    it 'adds an error if the domain resolves as blank' do
+      double = instance_double(TagManager)
+      allow(TagManager).to receive(:instance).and_return(double)
+      allow(double).to receive(:normalize_domain).with('example.com').and_raise(Addressable::URI::InvalidURIError)
+
+      user = double(email: 'foo@example.com', sign_up_ip: '1.2.3.4', errors: double(add: nil))
+      subject.validate(user)
+      expect(user.errors).to have_received(:add)
+    end
+
     it 'adds an error if the email domain name contains empty labels' do
       resolver = double
 


### PR DESCRIPTION
Adds a few specs to increase coverage of some app/validators code.

With more code covered I saw two deprecation warnings (use `errors.add` instead of `<<`) and fixed those as well.