### PR TITLE
Specs api v1 controllers

### DIFF
--- a/spec/controllers/api/v1/accounts/familiar_followers_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/familiar_followers_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Accounts::FamiliarFollowersController do
+  render_views
+
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:follows') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/accounts/featured_tags_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/featured_tags_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Accounts::FeaturedTagsController do
+  render_views
+
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:accounts') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/accounts/identity_proofs_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/identity_proofs_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Accounts::IdentityProofsController do
+  render_views
+
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:accounts') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/accounts/lookup_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/lookup_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Accounts::LookupController do
+  render_views
+
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:accounts') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show, params: { account_id: account.id, acct: account.acct }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Admin::CanonicalEmailBlocksController do
+  render_views
+
+  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'admin:read') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/admin/dimensions_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/dimensions_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Admin::DimensionsController do
+  render_views
+
+  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'admin:read') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'POST #create' do
+    it 'returns http success' do
+      post :create, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Admin::EmailDomainBlocksController do
+  render_views
+
+  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'admin:read') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/admin/ip_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/ip_blocks_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Admin::IpBlocksController do
+  render_views
+
+  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'admin:read') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/admin/measures_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/measures_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Admin::MeasuresController do
+  render_views
+
+  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'admin:read') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'POST #create' do
+    it 'returns http success' do
+      post :create, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/admin/retention_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/retention_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Admin::RetentionController do
+  render_views
+
+  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'admin:read') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'POST #create' do
+    it 'returns http success' do
+      post :create, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/admin/trends/links_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/links_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Admin::Trends::LinksController do
+  render_views
+
+  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'admin:read') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/admin/trends/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/statuses_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Admin::Trends::StatusesController do
+  render_views
+
+  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'admin:read') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/admin/trends/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/tags_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Admin::Trends::TagsController do
+  render_views
+
+  let(:user)    { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'admin:read') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/directories_controller_spec.rb
+++ b/spec/controllers/api/v1/directories_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::DirectoriesController do
+  render_views
+
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:follows') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/featured_tags/suggestions_controller_spec.rb
+++ b/spec/controllers/api/v1/featured_tags/suggestions_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::FeaturedTags::SuggestionsController do
+  render_views
+
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:accounts') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/featured_tags_controller_spec.rb
+++ b/spec/controllers/api/v1/featured_tags_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::FeaturedTagsController do
+  render_views
+
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:accounts') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index, params: { account_id: account.id, limit: 2 }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/instances/domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/instances/domain_blocks_controller_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Instances::DomainBlocksController do
+  render_views
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      Setting.show_domain_blocks = 'all'
+      get :index
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/instances/extended_descriptions_controller_spec.rb
+++ b/spec/controllers/api/v1/instances/extended_descriptions_controller_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Instances::ExtendedDescriptionsController do
+  render_views
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/instances/privacy_policies_controller_spec.rb
+++ b/spec/controllers/api/v1/instances/privacy_policies_controller_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Instances::PrivacyPoliciesController do
+  render_views
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/instances/rules_controller_spec.rb
+++ b/spec/controllers/api/v1/instances/rules_controller_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Instances::RulesController do
+  render_views
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/preferences_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::PreferencesController do
+  render_views
+
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:accounts') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/scheduled_statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/scheduled_statuses_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::ScheduledStatusesController do
+  render_views
+
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:statuses') }
+  let(:account) { Fabricate(:account) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/statuses/translations_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/translations_controller_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Statuses::TranslationsController do
+  render_views
+
+  let(:user)  { Fabricate(:user) }
+  let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
+  let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:statuses', application: app) }
+
+  context 'with an oauth token' do
+    before do
+      allow(controller).to receive(:doorkeeper_token) { token }
+    end
+
+    describe 'POST #create' do
+      let(:status) { Fabricate(:status, account: user.account) }
+
+      before do
+        translation = TranslationService::Translation.new(text: 'Hello')
+        service = instance_double(TranslationService::DeepL, translate: translation)
+        allow(TranslationService).to receive(:configured).and_return(service)
+        post :create, params: { status_id: status.id }
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v1/trends/links_controller_spec.rb
+++ b/spec/controllers/api/v1/trends/links_controller_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Trends::LinksController do
+  render_views
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v1/trends/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/trends/statuses_controller_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Trends::StatusesController do
+  render_views
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
Adds a bunch of coverage for the `api/v1` controllers, increasing overall controller coverage from ~67% to ~76%.

Still more to do here, but similar in spirit to last few PRs -- just trying to reduce the number of files with 0% coverage and see what (deprecation, error, etc) surfaces by doing so.

Only side note here is there's another `rewhere` merge collision in the directories controller when `Account.discoverable` and `Account.not_domain_blocked_by_account` interact. Deprecation noise can be addressed in future PR -- wasn't obvious to me without digging how to handle.