### PR TITLE
Temporarily workaround asset compilation crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
     "yargs": "^17.7.0"
   },
   "resolutions": {
-    "kind-of": "^6.0.3"
+    "kind-of": "^6.0.3",
+    "babel-plugin-lodash/@babel/types": "~7.20.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.7",


### PR DESCRIPTION
Taken from https://github.com/lodash/babel-plugin-lodash/issues/259

Not sure if this is the right workaround or if it's needed in upstream