### PR TITLE
Add `legal` as report category

### DIFF
--- a/app/javascript/mastodon/features/report/category.jsx
+++ b/app/javascript/mastodon/features/report/category.jsx
@@ -16,6 +16,8 @@ const messages = defineMessages({
   dislike_description: { id: 'report.reasons.dislike_description', defaultMessage: 'It is not something you want to see' },
   spam: { id: 'report.reasons.spam', defaultMessage: 'It\'s spam' },
   spam_description: { id: 'report.reasons.spam_description', defaultMessage: 'Malicious links, fake engagement, or repetitive replies' },
+  legal: { id: 'report.reasons.legal', defaultMessage: 'It\'s illegal' },
+  legal_description: { id: 'report.reasons.legal_description', defaultMessage: 'You believe it violates the law of your or the server\'s country' },
   violation: { id: 'report.reasons.violation', defaultMessage: 'It violates server rules' },
   violation_description: { id: 'report.reasons.violation_description', defaultMessage: 'You are aware that it breaks specific rules' },
   other: { id: 'report.reasons.other', defaultMessage: 'It\'s something else' },
@@ -69,11 +71,13 @@ class Category extends PureComponent {
     const options = rules.size > 0 ? [
       'dislike',
       'spam',
+      'legal',
       'violation',
       'other',
     ] : [
       'dislike',
       'spam',
+      'legal',
       'other',
     ];
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -530,6 +530,8 @@
   "report.placeholder": "Additional comments",
   "report.reasons.dislike": "I don't like it",
   "report.reasons.dislike_description": "It is not something you want to see",
+  "report.reasons.legal": "It's illegal",
+  "report.reasons.legal_description": "You believe it violates the law of your or the server's country",
   "report.reasons.other": "It's something else",
   "report.reasons.other_description": "The issue does not fit into other categories",
   "report.reasons.spam": "It's spam",

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -51,6 +51,7 @@ class Report < ApplicationRecord
   enum category: {
     other: 0,
     spam: 1_000,
+    legal: 1_500,
     violation: 2_000,
   }
 


### PR DESCRIPTION
It doesn't make sense to have all server operators have a custom "Don't break the law" rule when it's really universal.

![Screenshot 2023-06-03 at 15-51-03 Localhost](https://github.com/mastodon/mastodon/assets/184731/72c848b6-bff7-42c7-b144-21595bcadf06)

___

Fixes MAS-71