### PR TITLE
Add basic coverage for some worker jobs

### DIFF
--- a/spec/workers/admin/account_deletion_worker_spec.rb
+++ b/spec/workers/admin/account_deletion_worker_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::AccountDeletionWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    let(:account) { Fabricate(:account) }
+    let(:service) { instance_double(DeleteAccountService, call: true) }
+
+    it 'calls delete account service' do
+      allow(DeleteAccountService).to receive(:new).and_return(service)
+      worker.perform(account.id)
+
+      expect(service).to have_received(:call).with(account, { reserve_email: true, reserve_username: true })
+    end
+  end
+end

--- a/spec/workers/cache_buster_worker_spec.rb
+++ b/spec/workers/cache_buster_worker_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CacheBusterWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    let(:path) { 'https://example.com' }
+    let(:service) { instance_double(CacheBuster, bust: true) }
+
+    it 'calls the cache buster' do
+      allow(CacheBuster).to receive(:new).and_return(service)
+      worker.perform(path)
+
+      expect(service).to have_received(:bust).with(path)
+    end
+  end
+end

--- a/spec/workers/poll_expiration_notify_worker_spec.rb
+++ b/spec/workers/poll_expiration_notify_worker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PollExpirationNotifyWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      expect { worker.perform(nil) }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/post_process_media_worker_spec.rb
+++ b/spec/workers/post_process_media_worker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PostProcessMediaWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      expect { worker.perform(nil) }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/push_conversation_worker_spec.rb
+++ b/spec/workers/push_conversation_worker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PushConversationWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      expect { worker.perform(nil) }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/push_encrypted_message_worker_spec.rb
+++ b/spec/workers/push_encrypted_message_worker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PushEncryptedMessageWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      expect { worker.perform(nil) }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/push_update_worker_spec.rb
+++ b/spec/workers/push_update_worker_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PushUpdateWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      account_id = nil
+      status_id = nil
+
+      expect { worker.perform(account_id, status_id) }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/redownload_avatar_worker_spec.rb
+++ b/spec/workers/redownload_avatar_worker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RedownloadAvatarWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      expect { worker.perform(nil) }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/redownload_header_worker_spec.rb
+++ b/spec/workers/redownload_header_worker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RedownloadHeaderWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      expect { worker.perform(nil) }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/remove_featured_tag_worker_spec.rb
+++ b/spec/workers/remove_featured_tag_worker_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RemoveFeaturedTagWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      account_id = nil
+      featured_tag_id = nil
+      expect { worker.perform(account_id, featured_tag_id) }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/resolve_account_worker_spec.rb
+++ b/spec/workers/resolve_account_worker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ResolveAccountWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      expect { worker.perform(nil) }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/scheduler/indexing_scheduler_spec.rb
+++ b/spec/workers/scheduler/indexing_scheduler_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Scheduler::IndexingScheduler do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error' do
+      expect { worker.perform }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/scheduler/instance_refresh_scheduler_spec.rb
+++ b/spec/workers/scheduler/instance_refresh_scheduler_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Scheduler::InstanceRefreshScheduler do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error' do
+      expect { worker.perform }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/scheduler/ip_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/ip_cleanup_scheduler_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Scheduler::IpCleanupScheduler do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error' do
+      expect { worker.perform }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/scheduler/pghero_scheduler_spec.rb
+++ b/spec/workers/scheduler/pghero_scheduler_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Scheduler::PgheroScheduler do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error' do
+      expect { worker.perform }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/scheduler/scheduled_statuses_scheduler_spec.rb
+++ b/spec/workers/scheduler/scheduled_statuses_scheduler_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Scheduler::ScheduledStatusesScheduler do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error' do
+      expect { worker.perform }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/scheduler/suspended_user_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/suspended_user_cleanup_scheduler_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Scheduler::SuspendedUserCleanupScheduler do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error' do
+      expect { worker.perform }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/scheduler/trends/refresh_scheduler_spec.rb
+++ b/spec/workers/scheduler/trends/refresh_scheduler_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Scheduler::Trends::RefreshScheduler do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error' do
+      expect { worker.perform }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/scheduler/trends/review_notifications_scheduler_spec.rb
+++ b/spec/workers/scheduler/trends/review_notifications_scheduler_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Scheduler::Trends::ReviewNotificationsScheduler do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error' do
+      expect { worker.perform }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/scheduler/vacuum_scheduler_spec.rb
+++ b/spec/workers/scheduler/vacuum_scheduler_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Scheduler::VacuumScheduler do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error' do
+      expect { worker.perform }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/unpublish_announcement_worker_spec.rb
+++ b/spec/workers/unpublish_announcement_worker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UnpublishAnnouncementWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      expect { worker.perform(nil) }.to_not raise_error
+    end
+  end
+end

--- a/spec/workers/webhooks/delivery_worker_spec.rb
+++ b/spec/workers/webhooks/delivery_worker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Webhooks::DeliveryWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error' do
+      expect { worker.perform(nil, nil) }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
In line with last few PRs -- adding some specs to workers which were at 0% coverage.

Some of these actually specify something useful about the worker, others are just hitting a "doesn't error on bad input" check to bump the coverage number up. Like the other PRs, further iteration needed here.