### PR TITLE
Update browser gem to version 5.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     brakeman (5.4.0)
-    browser (4.2.0)
+    browser (5.3.1)
     brpoplpush-redis_script (0.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       redis (>= 1.0, < 6)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1448,6 +1448,7 @@ en:
       electron: Electron
       firefox: Firefox
       generic: Unknown browser
+      huawei_browser: Huawei Browser
       ie: Internet Explorer
       micro_messenger: MicroMessenger
       nokia: Nokia S40 Ovi Browser
@@ -1457,6 +1458,7 @@ en:
       qq: QQ Browser
       safari: Safari
       uc_browser: UC Browser
+      unknown_browser: Unknown Browser
       weibo: Weibo
     current_session: Current session
     description: "%{browser} on %{platform}"
@@ -1469,9 +1471,10 @@ en:
       chrome_os: ChromeOS
       firefox_os: Firefox OS
       ios: iOS
+      kai_os: KaiOS
       linux: Linux
       mac: macOS
-      other: unknown platform
+      unknown_platform: Unknown Platform
       windows: Windows
       windows_mobile: Windows Mobile
       windows_phone: Windows Phone


### PR DESCRIPTION
I think this is safe -- looks like the breaking change from 4.x to 5.x was a rename of a method not used in Mastodon as far as I can tell.