### PR TITLE
Restore missing fabricators

### DIFF
--- a/spec/fabricators/account_warning_preset_fabricator.rb
+++ b/spec/fabricators/account_warning_preset_fabricator.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Fabricator(:account_warning_preset) do
+  text { Faker::Lorem.paragraph }
+end

--- a/spec/fabricators/list_account_fabricator.rb
+++ b/spec/fabricators/list_account_fabricator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Fabricator(:list_account) do
+  list
+  account
+  before_create { |list_account, _| list_account.list.account.follow!(account) }
+end

--- a/spec/fabricators/one_time_key_fabricator.rb
+++ b/spec/fabricators/one_time_key_fabricator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Fabricator(:one_time_key) do
+  device
+  key_id { Faker::Alphanumeric.alphanumeric(number: 10) }
+  key { Base64.strict_encode64(Ed25519::SigningKey.generate.verify_key.to_bytes) }
+
+  signature do |attrs|
+    signing_key = Ed25519::SigningKey.generate
+    attrs[:device].update(fingerprint_key: Base64.strict_encode64(signing_key.verify_key.to_bytes))
+    Base64.strict_encode64(signing_key.sign(attrs[:key]))
+  end
+end


### PR DESCRIPTION
One of my recent PRs removed a bunch of unused fabricators ... but then on a separate branch I added some specs which did in fact use some of those fabricators! This restores the ones which wound up being used by the added specs.

I think there may be a separate failure present here in the merged-in stuff related to a different rebase. Will check that out separately.