### PR TITLE
Do not leave Mastodon when clicking “Back”

### DIFF
--- a/app/javascript/mastodon/components/column_back_button.jsx
+++ b/app/javascript/mastodon/components/column_back_button.jsx
@@ -15,10 +15,10 @@ export default class ColumnBackButton extends React.PureComponent {
   };
 
   handleClick = () => {
-    if (window.history && window.history.length === 1) {
-      this.context.router.history.push('/');
-    } else {
+    if (window.history && window.history.state) {
       this.context.router.history.goBack();
+    } else {
+      this.context.router.history.push('/');
     }
   };
 

--- a/app/javascript/mastodon/components/column_header.jsx
+++ b/app/javascript/mastodon/components/column_header.jsx
@@ -43,14 +43,6 @@ class ColumnHeader extends React.PureComponent {
     animating: false,
   };
 
-  historyBack = () => {
-    if (window.history && window.history.length === 1) {
-      this.context.router.history.push('/');
-    } else {
-      this.context.router.history.goBack();
-    }
-  };
-
   handleToggleClick = (e) => {
     e.stopPropagation();
     this.setState({ collapsed: !this.state.collapsed, animating: true });
@@ -69,7 +61,11 @@ class ColumnHeader extends React.PureComponent {
   };
 
   handleBackClick = () => {
-    this.historyBack();
+    if (window.history && window.history.state) {
+      this.context.router.history.goBack();
+    } else {
+      this.context.router.history.push('/');
+    }
   };
 
   handleTransitionEnd = () => {

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -474,10 +474,10 @@ class UI extends React.PureComponent {
   };
 
   handleHotkeyBack = () => {
-    if (window.history && window.history.length === 1) {
-      this.context.router.history.push('/');
-    } else {
+    if (window.history && window.history.state) {
       this.context.router.history.goBack();
+    } else {
+      this.context.router.history.push('/');
     }
   };
 


### PR DESCRIPTION
Clicking “Back” takes you away from Mastodon, if you arrive to the page from an external URL. This is probably not what users expect.

This issue has been fixed in glitch-soc: https://github.com/glitch-soc/mastodon/pull/509

## Example 1
### Steps to reproduce
1. Click on this link: https://mastodon.social/tags/CatsOfMastodon.
2. Click the “Back” button in the column header.

### Expected result
Browser opens some page on mastodon.social, e.g. the Home timeline.

### Actual result
Browser returns to this GitHub page, leaving Mastodon.

## Example 2
### Steps to reproduce
1. Open a new empty browser tab.
2. Go to this URL by copy-pasting the URL into the browser's address field: https://mastodon.social/tags/CatsOfMastodon
3. Click the “Back” button in the column header.

### Expected result
Browser opens some page on mastodon.social, e.g. the Home timeline.

### Actual result
Browser returns to the empty tab.
