### PR TITLE
Fix test failure in translations_controller_spec.rb

### DIFF
--- a/spec/controllers/api/v1/statuses/translations_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/translations_controller_spec.rb
@@ -20,8 +20,7 @@ describe Api::V1::Statuses::TranslationsController do
       before do
         translation = TranslationService::Translation.new(text: 'Hello')
         service = instance_double(TranslationService::DeepL, translate: translation)
-        allow(status).to receive(:translatable?).and_return(true)
-        allow(service).to receive(:supported?).and_return(true)
+        allow_any_instance_of(Status).to receive(:translatable?).and_return(true)
         allow(TranslationService).to receive(:configured).and_return(service)
         post :create, params: { status_id: status.id }
       end

--- a/spec/controllers/api/v1/statuses/translations_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/translations_controller_spec.rb
@@ -20,6 +20,7 @@ describe Api::V1::Statuses::TranslationsController do
       before do
         translation = TranslationService::Translation.new(text: 'Hello')
         service = instance_double(TranslationService::DeepL, translate: translation)
+        allow(status).to receive(:translatable?).and_return(true)
         allow(service).to receive(:supported?).and_return(true)
         allow(TranslationService).to receive(:configured).and_return(service)
         post :create, params: { status_id: status.id }

--- a/spec/controllers/api/v1/statuses/translations_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/translations_controller_spec.rb
@@ -20,6 +20,7 @@ describe Api::V1::Statuses::TranslationsController do
       before do
         translation = TranslationService::Translation.new(text: 'Hello')
         service = instance_double(TranslationService::DeepL, translate: translation)
+        allow(service).to receive(:supported?).and_return(true)
         allow(TranslationService).to receive(:configured).and_return(service)
         post :create, params: { status_id: status.id }
       end


### PR DESCRIPTION
Fix test failure caused by a “merge conflict” between #23879 and #23930.

#23879 introduced a new method, `TranslationService#supported?`, which was not mocked in #23930.