### PR TITLE
Fix pgBouncer resetting application name on every transaction

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -5,6 +5,7 @@ default: &default
   connect_timeout: 15
   encoding: unicode
   sslmode: <%= ENV['DB_SSLMODE'] || "prefer" %>
+  application_name: ''
 
 development:
   <<: *default


### PR DESCRIPTION
18% of database CPU on mastodon.social is consumed by `SET application_name` calls. This is caused by pgBouncer in transaction mode. If we deliberately set `application_name` to an empty string, the call will not be made.

Ref: pgbouncer/pgbouncer#349

