### PR TITLE
Remove pinned rexml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 ruby '>= 2.7.0', '< 3.3.0'
 
 gem 'pkg-config', '~> 1.5'
-gem 'rexml', '~> 3.2'
 
 gem 'puma', '~> 6.1'
 gem 'rails', '~> 6.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -855,7 +855,6 @@ DEPENDENCIES
   redcarpet (~> 3.6)
   redis (~> 4.5)
   redis-namespace (~> 1.10)
-  rexml (~> 3.2)
   rqrcode (~> 2.1)
   rspec-rails (~> 6.0)
   rspec-sidekiq (~> 3.1)


### PR DESCRIPTION
Was added in https://github.com/mastodon/mastodon/pull/16982 to make CircleCI happy, but it has a transient depenedncy on the same version. Opening as a Draft to see if the CircleCI issue still exists