### PR TITLE
Add Dependabot ignores for stuck updates and those needing manual interventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,11 @@ updates:
       - dependency-name: 'history'
         versions:
           - '5.x'
+      # TODO: This requires code changes for migration
+      - dependency-name: 'tesseract.js'
+        versions:
+          - '3.x'
+          - '4.x'
 
   - package-ecosystem: bundler
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     open-pull-requests-limit: 99
     allow:
       - dependency-type: direct
+    ignore:
+      # This version needs to match Rails major version, so stick to 6.x only
+      - dependency-name: '@rails/ujs'
+        versions:
+          - '7.x'
 
   - package-ecosystem: bundler
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,10 @@ updates:
       - dependency-name: 'rails-i18n'
         versions:
           - '7.x'
+      # This version needs manual updates https://github.com/rails/sprockets/blob/master/UPGRADING.md#guide-to-upgrading-from-sprockets-3x-to-4x
+      - dependency-name: 'sprockets'
+        versions:
+          - '4.x'
 
   - package-ecosystem: github-actions
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
       - dependency-name: 'uuid'
         versions:
           - '9.x'
+      # TODO: This version got stuck in https://github.com/mastodon/mastodon/pull/14073 and this should be deleted to fix
+      - dependency-name: 'history'
+        versions:
+          - '5.x'
 
   - package-ecosystem: bundler
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,10 @@ updates:
         versions:
           - '3.x'
           - '4.x'
+      # TODO: This version needs manual updates for breaking changes
+      - dependency-name: 'react-hotkeys'
+        versions:
+          - '2.x'
 
   - package-ecosystem: bundler
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,10 @@ updates:
       - dependency-name: 'pg'
         versions:
           - '8.x'
+      # TODO: This was ignored in https://github.com/mastodon/mastodon/pull/19120
+      - dependency-name: 'uuid'
+        versions:
+          - '9.x'
 
   - package-ecosystem: bundler
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
       - dependency-name: '@rails/ujs'
         versions:
           - '7.x'
+      # TODO: This version got stuck in https://github.com/mastodon/mastodon/pull/14004 and this should be deleted to fix
+      - dependency-name: 'pg'
+        versions:
+          - '8.x'
 
   - package-ecosystem: bundler
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,10 @@ updates:
       - dependency-name: 'react-hotkeys'
         versions:
           - '2.x'
+      # TODO: This version got stuck in https://github.com/mastodon/mastodon/pull/15206 and this should be deleted to fix
+      - dependency-name: 'terser'
+        versions:
+          - '5.x'
 
   - package-ecosystem: bundler
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,11 @@ updates:
     open-pull-requests-limit: 99
     allow:
       - dependency-type: direct
+    ignore:
+      # This version needs to match Rails major version, so stick to 6.x only
+      - dependency-name: 'rails-i18n'
+        versions:
+          - '7.x'
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
This is already disabled through a comment on the previous PRs. That doesn't work for forks that have enabled Dependabot (not the default behaviour), and gives an indication when the ignore should be revisited.