### PR TITLE
Implement pending specs for StatusesController

### DIFF
--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -719,65 +719,180 @@ describe StatusesController do
     end
 
     context 'when status is public' do
-      pending
+      before do
+        status.update(visibility: :public)
+        get :activity, params: { account_username: account.username, id: status.id }
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:success)
+      end
     end
 
     context 'when status is private' do
-      pending
+      before do
+        status.update(visibility: :private)
+        get :activity, params: { account_username: account.username, id: status.id }
+      end
+
+      it 'returns http not_found' do
+        expect(response).to have_http_status(404)
+      end
     end
 
     context 'when status is direct' do
-      pending
+      before do
+        status.update(visibility: :direct)
+        get :activity, params: { account_username: account.username, id: status.id }
+      end
+
+      it 'returns http not_found' do
+        expect(response).to have_http_status(404)
+      end
     end
 
     context 'when signed-in' do
+      let(:user) { Fabricate(:user) }
+
+      before do
+        sign_in(user)
+      end
+
       context 'when status is public' do
-        pending
+        before do
+          status.update(visibility: :public)
+          get :activity, params: { account_username: account.username, id: status.id }
+        end
+
+        it 'returns http success' do
+          expect(response).to have_http_status(:success)
+        end
       end
 
       context 'when status is private' do
+        before do
+          status.update(visibility: :private)
+        end
+
         context 'when user is authorized to see it' do
-          pending
+          before do
+            user.account.follow!(account)
+            get :activity, params: { account_username: account.username, id: status.id }
+          end
+
+          it 'returns http success' do
+            expect(response).to have_http_status(200)
+          end
         end
 
         context 'when user is not authorized to see it' do
-          pending
+          before do
+            get :activity, params: { account_username: account.username, id: status.id }
+          end
+
+          it 'returns http not_found' do
+            expect(response).to have_http_status(404)
+          end
         end
       end
 
       context 'when status is direct' do
+        before do
+          status.update(visibility: :direct)
+        end
+
         context 'when user is authorized to see it' do
-          pending
+          before do
+            Fabricate(:mention, account: user.account, status: status)
+            get :activity, params: { account_username: account.username, id: status.id }
+          end
+
+          it 'returns http success' do
+            expect(response).to have_http_status(200)
+          end
         end
 
         context 'when user is not authorized to see it' do
-          pending
+          before do
+            get :activity, params: { account_username: account.username, id: status.id }
+          end
+
+          it 'returns http not_found' do
+            expect(response).to have_http_status(404)
+          end
         end
       end
     end
 
     context 'with signature' do
+      let(:remote_account) { Fabricate(:account, domain: 'example.com') }
+
+      before do
+        allow(controller).to receive(:signed_request_actor).and_return(remote_account)
+      end
+
       context 'when status is public' do
-        pending
+        before do
+          status.update(visibility: :public)
+          get :activity, params: { account_username: account.username, id: status.id }
+        end
+
+        it 'returns http success' do
+          expect(response).to have_http_status(:success)
+        end
       end
 
       context 'when status is private' do
+        before do
+          status.update(visibility: :private)
+        end
+
         context 'when user is authorized to see it' do
-          pending
+          before do
+            remote_account.follow!(account)
+            get :activity, params: { account_username: account.username, id: status.id }
+          end
+
+          it 'returns http success' do
+            expect(response).to have_http_status(200)
+          end
         end
 
         context 'when user is not authorized to see it' do
-          pending
+          before do
+            get :activity, params: { account_username: account.username, id: status.id }
+          end
+
+          it 'returns http not_found' do
+            expect(response).to have_http_status(404)
+          end
         end
       end
 
       context 'when status is direct' do
+        before do
+          status.update(visibility: :direct)
+        end
+
         context 'when user is authorized to see it' do
-          pending
+          before do
+            Fabricate(:mention, account: remote_account, status: status)
+            get :activity, params: { account_username: account.username, id: status.id }
+          end
+
+          it 'returns http success' do
+            expect(response).to have_http_status(200)
+          end
         end
 
         context 'when user is not authorized to see it' do
-          pending
+          before do
+            get :activity, params: { account_username: account.username, id: status.id }
+          end
+
+          it 'returns http not_found' do
+            expect(response).to have_http_status(404)
+          end
         end
       end
     end


### PR DESCRIPTION
Updates a collection of specs for the `activity` action which were written and outlined but not implemented.

I have a question here before this is merged ... for the specs where the user is signed in and we have either a `private` or `direct` visibility status -- what are the actual conditions which lead to the user being authorized to see it or not, in the context of this controller action?

From a quick look at the code, there's a check for `status.distributable?` in place, but that in turn is just checking for public or unlisted visbility -- so it seems like we'd always return 404 when not in those states, regardless of which user was making the request.

It strikes me as possible that these specs were outlined and the behavior has changed since then so the descriptions are no longer relevant ... or that I'm missing something in how the code processes these different types of requests.

After I get clarity on this I'll edit this PR to update as relevant, and also add in the specs for the "signature" block in this spec which is still pending.