### PR TITLE
Do not strip tags from `Setting.site_short_description`

### DIFF
--- a/app/views/application/_sidebar.html.haml
+++ b/app/views/application/_sidebar.html.haml
@@ -3,7 +3,7 @@
     = image_tag @instance_presenter.thumbnail&.file&.url(:'@1x') || asset_pack_path('media/images/preview.png'), alt: @instance_presenter.title
 
   .hero-widget__text
-    %p= @instance_presenter.description.html_safe.presence || t('about.about_mastodon_html')
+    %p= @instance_presenter.description.presence || t('about.about_mastodon_html')
 
 - if Setting.trends && !(user_signed_in? && !current_user.setting_trends)
   - trends = Trends.tags.query.allowed.limit(3)

--- a/app/views/shared/_og.html.haml
+++ b/app/views/shared/_og.html.haml
@@ -1,5 +1,5 @@
 - thumbnail     = @instance_presenter.thumbnail
-- description ||= strip_tags(@instance_presenter.description.presence || t('about.about_mastodon_html'))
+- description ||= @instance_presenter.description.presence || strip_tags(t('about.about_mastodon_html'))
 
 %meta{ name: 'description', content: description }/
 


### PR DESCRIPTION
`Setting.site_short_description` is plain text and should not be passed through `strip_tags`.

In addition to stripping HTML tags, `strip_tags` also escapes unescaped characters, so `strip_tags('gin & <i>tonic</i>')` returns `gin &amp; tonic`.

## Steps to reproduce
1. Go to /admin/settings/branding, enter `You & I ❤️ <html>` in the _Server description_ field and then save.
2. Open the front page in an incognito window. Notice the text `You & I ❤️ <html>` in the left sidebar.  
2. View HTML source.

### Expected result
HTML source should contain this:
```
<meta content="You &amp; me ❤️ &lt;html&gt;" property="og:description" />
```
i.e. the human-readable description is `You & I ❤️ <html>`, exactly as entered.

### Actual result
HTML source contains this:
```
<meta content="You &amp;amp; I ❤️ " property="og:description" />
```
i.e. the human-readable description is `You &amp; I ❤️ `.
