### PR TITLE
Fix DevContainer post-create warnings

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,13 +3,15 @@
 set -e # Fail the whole script on first error
 
 # Fetch Ruby gem dependencies
-bundle install --path vendor/bundle --with='development test'
-
-# Fetch Javascript dependencies
-yarn install
+bundle config path 'vendor/bundle'
+bundle config with 'development test'
+bundle install
 
 # Make Gemfile.lock pristine again
 git checkout -- Gemfile.lock
+
+# Fetch Javascript dependencies
+yarn --frozen-lockfile
 
 # [re]create, migrate, and seed the test database
 RAILS_ENV=test ./bin/rails db:setup


### PR DESCRIPTION
As mentined in #21889 windows gives warnings about untrusted git repositories.
There were also warnings about the bundle config settings

Closes #21889