### PR TITLE
Add spec for the CLI `version` task

### DIFF
--- a/spec/lib/mastodon/cli_spec.rb
+++ b/spec/lib/mastodon/cli_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'cli'
+
+describe Mastodon::CLI do
+  describe 'version' do
+    it 'returns the Mastodon version' do
+      expect { described_class.new.invoke(:version) }.to output(
+        a_string_including(Mastodon::Version.to_s)
+      ).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
This causes all of the cli classes to be loaded, which is a big win in code coverage LOC in exchange for this trivial spec addition.

In my search for the lowest hanging fruit in spec coverage increase, I realized that the _cli classes are a big source of missed lines, even though they are a small number of files. I have a separate branch going to add more coverage to the CLI code, but its sort of slow going. I realized that just adding this one tiny spec actually gets about +600 LOC covered because the main CLI file requires the various subcommand files.

Assuming this is approved, I'd love feedback on a small refactor while I add coverage to the rest...

- Thoughts on moving all the CLI subcommands to sit under a common /cli/ module? (instead of all having _cli.rb file names)
- Thoughts on adding a Base class for the CLI commands which extends Thor, includes the CLI Helper file, defines the exit behavior, etc?


