### PR TITLE
Coverage improvement round-out following up previous work

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -661,6 +661,7 @@ RSpec/ExpectInHook:
 RSpec/FilePath:
   Exclude:
     - 'spec/config/initializers/rack_attack_spec.rb'
+    - 'spec/controllers/activitypub/claims_controller_spec.rb'
     - 'spec/controllers/activitypub/collections_controller_spec.rb'
     - 'spec/controllers/activitypub/followers_synchronizations_controller_spec.rb'
     - 'spec/controllers/activitypub/inboxes_controller_spec.rb'

--- a/spec/controllers/activitypub/claims_controller_spec.rb
+++ b/spec/controllers/activitypub/claims_controller_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ActivityPub::ClaimsController do
+  let(:account) { Fabricate(:account) }
+
+  describe 'POST #create' do
+    context 'without signature' do
+      before do
+        post :create, params: { account_username: account.username }, body: '{}'
+      end
+
+      it 'returns http not authorized' do
+        expect(response).to have_http_status(401)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v2/instances_controller_spec.rb
+++ b/spec/controllers/api/v2/instances_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V2::InstancesController do
+  render_views
+
+  let(:user)  { Fabricate(:user) }
+  let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id) }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/api/v2/suggestions_controller_spec.rb
+++ b/spec/controllers/api/v2/suggestions_controller_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V2::SuggestionsController do
+  render_views
+
+  let(:user)  { Fabricate(:user) }
+  let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read') }
+
+  before do
+    allow(controller).to receive(:doorkeeper_token) { token }
+  end
+
+  describe 'GET #index' do
+    it 'returns http success' do
+      get :index
+
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/auth/setup_controller_spec.rb
+++ b/spec/controllers/auth/setup_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Auth::SetupController do
+  render_views
+
+  describe 'GET #show' do
+    context 'with a signed out request' do
+      it 'returns http redirect' do
+        get :show
+        expect(response).to be_redirect
+      end
+    end
+
+    context 'with an unconfirmed signed in user' do
+      before { sign_in Fabricate(:user, confirmed_at: nil) }
+
+      it 'returns http success' do
+        get :show
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end

--- a/spec/controllers/custom_css_controller_spec.rb
+++ b/spec/controllers/custom_css_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CustomCssController do
+  render_views
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/filters/statuses_controller_spec.rb
+++ b/spec/controllers/filters/statuses_controller_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Filters::StatusesController do
+  render_views
+
+  describe 'GET #index' do
+    let(:filter) { Fabricate(:custom_filter) }
+
+    context 'with signed out user' do
+      it 'redirects' do
+        get :index, params: { filter_id: filter }
+
+        expect(response).to be_redirect
+      end
+    end
+
+    context 'with a signed in user' do
+      context 'with the filter user signed in' do
+        before { sign_in(filter.account.user) }
+
+        it 'returns http success' do
+          get :index, params: { filter_id: filter }
+
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      context 'with another user signed in' do
+        before { sign_in(Fabricate(:user)) }
+
+        it 'returns http not found' do
+          get :index, params: { filter_id: filter }
+
+          expect(response).to have_http_status(404)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/filters_controller_spec.rb
+++ b/spec/controllers/filters_controller_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe FiltersController do
+  render_views
+
+  describe 'GET #index' do
+    context 'with signed out user' do
+      it 'redirects' do
+        get :index
+
+        expect(response).to be_redirect
+      end
+    end
+
+    context 'with a signed in user' do
+      before { sign_in(Fabricate(:user)) }
+
+      it 'returns http success' do
+        get :index
+
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+end

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HealthController do
+  render_views
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/privacy_controller_spec.rb
+++ b/spec/controllers/privacy_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PrivacyController do
+  render_views
+
+  describe 'GET #show' do
+    it 'returns http success' do
+      get :show
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/helpers/statuses_helper_spec.rb
+++ b/spec/helpers/statuses_helper_spec.rb
@@ -2,7 +2,33 @@
 
 require 'rails_helper'
 
-RSpec.describe StatusesHelper, type: :helper do
+describe StatusesHelper do
+  describe 'status_text_summary' do
+    context 'with blank text' do
+      let(:status) { Status.new(spoiler_text: '') }
+
+      it 'returns immediately with nil' do
+        result = helper.status_text_summary(status)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'with present text' do
+      let(:status) { Status.new(spoiler_text: 'SPOILERS!!!') }
+
+      it 'returns the content warning' do
+        result = helper.status_text_summary(status)
+        expect(result).to eq(I18n.t('statuses.content_warning', warning: 'SPOILERS!!!'))
+      end
+    end
+  end
+
+  def status_text_summary(status)
+    return if status.spoiler_text.blank?
+
+    I18n.t('statuses.content_warning', warning: status.spoiler_text)
+  end
+
   describe 'link_to_newer' do
     it 'returns a link to newer content' do
       url = 'https://example.com'

--- a/spec/lib/importer/base_importer_spec.rb
+++ b/spec/lib/importer/base_importer_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Importer::BaseImporter do
+  describe 'import!' do
+    let(:pool) { Concurrent::FixedThreadPool.new(5) }
+    let(:importer) { described_class.new(batch_size: 123, executor: pool) }
+
+    it 'raises an error' do
+      expect { importer.import! }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SearchQueryTransformer do
+  describe 'initialization' do
+    let(:parser) { SearchQueryParser.new.parse('query') }
+
+    it 'sets attributes' do
+      transformer = described_class.new.apply(parser)
+
+      expect(transformer.should_clauses.first).to be_a(SearchQueryTransformer::TermClause)
+      expect(transformer.must_clauses.first).to be_nil
+      expect(transformer.must_not_clauses.first).to be_nil
+      expect(transformer.filter_clauses.first).to be_nil
+    end
+  end
+end

--- a/spec/models/admin/appeal_filter_spec.rb
+++ b/spec/models/admin/appeal_filter_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::AppealFilter do
+  describe '#results' do
+    let(:approved_appeal) { Fabricate(:appeal, approved_at: 10.days.ago) }
+    let(:not_approved_appeal) { Fabricate(:appeal, approved_at: nil) }
+
+    it 'returns filtered appeals' do
+      filter = described_class.new(status: 'approved')
+
+      expect(filter.results).to eq([approved_appeal])
+    end
+  end
+end

--- a/spec/models/form/admin_settings_spec.rb
+++ b/spec/models/form/admin_settings_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Form::AdminSettings do
+  describe 'validations' do
+    describe 'site_contact_username' do
+      context 'with no accounts' do
+        it 'is not valid' do
+          setting = described_class.new(site_contact_username: 'Test')
+          setting.valid?
+
+          expect(setting).to model_have_error_on_field(:site_contact_username)
+        end
+      end
+
+      context 'with an account' do
+        before { Fabricate(:account, username: 'Glorp') }
+
+        it 'is not valid when account doesnt match' do
+          setting = described_class.new(site_contact_username: 'Test')
+          setting.valid?
+
+          expect(setting).to model_have_error_on_field(:site_contact_username)
+        end
+
+        it 'is valid when account matches' do
+          setting = described_class.new(site_contact_username: 'Glorp')
+          setting.valid?
+
+          expect(setting).to_not model_have_error_on_field(:site_contact_username)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/form/status_filter_batch_action_spec.rb
+++ b/spec/models/form/status_filter_batch_action_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Form::StatusFilterBatchAction do
+  describe '#save!' do
+    it 'does nothing if status_filter_ids is empty' do
+      batch_action = described_class.new(status_filter_ids: [])
+
+      expect(batch_action.save!).to be_nil
+    end
+  end
+end

--- a/spec/workers/verify_account_links_worker_spec.rb
+++ b/spec/workers/verify_account_links_worker_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe VerifyAccountLinksWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      expect { worker.perform(nil) }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
On the tail of last weeks per-area improvements, this is sort of a grab-bag of things left over in each area.

For the most part this continues in that same style -- a) try to put *something* in place for files currently at 0% coverage, b) round out unexecuted code paths in various places.

The only refactor question that came out of this batch: any thoughts on moving both the controllers and controller specs for `ActivityPub` module stuff from the `activitypub` dir to an `activity_pub` dir (and getting rid of rubocop exceptions for it) ... critically here: assuming this can be done WITHOUT modifying the public routes.

