### PR TITLE
Redirect users to SLO at the IdP after logging them out of Mastodon.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,7 +61,11 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(_resource_or_scope)
-    new_user_session_path
+    if ENV['OMNIAUTH_ONLY'] == 'true' && ENV['OIDC_ENABLED'] == 'true'
+      '/auth/auth/openid_connect/logout'
+    else
+      new_user_session_path
+    end
   end
 
   protected


### PR DESCRIPTION
Currently when using an OIDC IdP as the sole login option, it is impossible to logout as a user, because Mastodon does not perform and has no option to perform the Single Logout (SLO) procedure.[^1]

To trigger this procedure a user must be redirected to `/auth/auth/openid_connect/logout` after logging them out locally - at which point the Ominauth OpenID Connect library calls the `end_session_endpoint` of the IdP.[^2]

This PR performs such a redirect, but only if the `OMNIAUTH_ONLY` and `OIDC_ENABLED` environment variables are true. 
For all other configurations this PR changes nothing.

There has been discussion on whether SLO should be enabled through an environment variable of it's own and whether this should default to false [^1]. This PR does not implement such an environment variable, because for such a variable to exist further PRs would have to be submitted to enable SLO for the other SSO protocols that Mastodon supports.

I've tested this PR on a test server running Mastodon and Keycloak, where I found it necessary to patch the [Ominauth OpenID  Connect](https://github.com/omniauth/omniauth_openid_connect) to pass along a certain `id_token_hint` query parameter to the `end_session_endpoint`. This patch is currently awaiting review by the maintainers of Ominauth OpenID Connect and I'd advise against merging this PR before that one [^3].

[^1]: See #21572

[^2]: This path can be modified using the [`logout_path`](https://github.com/omniauth/omniauth_openid_connect#options-overview)  option, but it has to be relative to `/auth/auth/openid_connect`

[^3]: See "[Add id_token_hint to the post logout redirect uri](https://github.com/omniauth/omniauth_openid_connect/pull/149)"