### PR TITLE
Skip double building on Dependabot branches

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -2,7 +2,11 @@ name: PR Needs Rebase
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request_target:
+    branches-ignore:
+      - 'dependabot/**'
     types: [synchronize]
 
 permissions:

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -2,6 +2,8 @@ name: Ruby Testing
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
 
 env:


### PR DESCRIPTION
Dependabot changes are all submitted through PRs, so CI resources can be freed up by not building on their pushes.
Realized that Dependabot also handles their own rebasing needs so the `rebase-needed` jobs can be skiped for those branches