### PR TITLE
Skip rebase-needed job for i10n branch

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches-ignore:
       - 'dependabot/**'
+      - 'l10n_main'
   pull_request_target:
     branches-ignore:
       - 'dependabot/**'
+      - 'l10n_main'
     types: [synchronize]
 
 permissions:


### PR DESCRIPTION
It seems like even with the `[ci skip]` it still gets run on the Crowdin branches for the `syncronize` step. This should still get the label if stuff lands on main, but maybe it won't clear the flag automatically