### PR TITLE
Update spec failure when running on forks

### DIFF
--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -89,8 +89,8 @@ describe InstancePresenter do
   end
 
   describe '#source_url' do
-    it 'returns "https://github.com/mastodon/mastodon"' do
-      expect(instance_presenter.source_url).to eq('https://github.com/mastodon/mastodon')
+    it 'returns the repo address' do
+      expect(instance_presenter.source_url).to eq("https://github.com/#{ENV.fetch('GITHUB_REPOSITORY')}")
     end
   end
 


### PR DESCRIPTION
Not sure this is the best fix, but it was annoying that this test would always fail when pushing to my fork. Seemed a little better than just commenting it out, but maybe @mjankowski has a better idea