### PR TITLE
Center the text itself in upload area

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4509,6 +4509,7 @@ a.status-card.compact:hover {
   display: flex;
   align-items: center;
   justify-content: center;
+  text-align: center;
   color: $secondary-text-color;
   font-size: 18px;
   font-weight: 500;


### PR DESCRIPTION
Trivial CSS fix for "Drag & drop to upload" area, where text may wrap and cause it to align to the left without explicitly aligning text to center.

Fixes #24028.