### PR TITLE
Replace sidekiq-bulk usage with Sidekiq's `perform_bulk`

### DIFF
--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -41,7 +41,7 @@ class MoveWorker
     bypass_locked = @target_account.local?
 
     @source_account.followers.local.select(:id).find_in_batches do |accounts|
-      UnfollowFollowWorker.push_bulk(accounts.map(&:id)) { |follower_id| [follower_id, @source_account.id, @target_account.id, bypass_locked] }
+      UnfollowFollowWorker.perform_bulk(accounts.map { |follower| [follower.id, @source_account.id, @target_account.id, bypass_locked] })
     rescue => e
       @deferred_error = e
     end


### PR DESCRIPTION
We've been using `sidekiq-scheduler`'s `push_bulk` as a slightly higher-level interface around `Sidekiq::Client.push_bulk`. A very similar interface [has been introduced in Sidekiq 6.3](https://www.mikeperham.com/2021/11/07/whats-new-in-sidekiq-6.3/#bulk-perform) so we can move away from using `sidekiq-bulk` pretty easily.

Notable differences between `sidekiq-bulk` and Sidekiq's `perform_bulk`:
- the default batch size is 10,000 jobs in `sidekiq-bulk` and 1,000 jobs in Sidekiq's `perform_bulk`: this means more back-and-forth between redis and Rails, but less long-running Redis commands; ultimately this should not make a huge difference
- `sidekiq-bulk` accepts blocks, Sidekiq's `perform_bulk` does not: this may have negative implications regarding memory usage in the Rails side of things, especially when some job arguments are shared across jobs; will investigate the use of `Enumerator::Lazy`

In addition, this PR moves away from low-level tests I wrote for `push_bulk` when I did not know better, and use `rspec-sidekiq` instead.

---

Ref: MAS-102