### PR TITLE
Change sidekiq-bulk's batch size from 10,000 to 1,000 jobs in one Redis call

### DIFF
--- a/app/lib/activitypub/forwarder.rb
+++ b/app/lib/activitypub/forwarder.rb
@@ -12,7 +12,7 @@ class ActivityPub::Forwarder
   end
 
   def forward!
-    ActivityPub::LowPriorityDeliveryWorker.push_bulk(inboxes) do |inbox_url|
+    ActivityPub::LowPriorityDeliveryWorker.push_bulk(inboxes, limit: 1_000) do |inbox_url|
       [payload, signature_account_id, inbox_url]
     end
   end

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -257,11 +257,11 @@ class DeleteAccountService < BaseService
   end
 
   def delete_actor!
-    ActivityPub::DeliveryWorker.push_bulk(delivery_inboxes) do |inbox_url|
+    ActivityPub::DeliveryWorker.push_bulk(delivery_inboxes, limit: 1_000) do |inbox_url|
       [delete_actor_json, @account.id, inbox_url]
     end
 
-    ActivityPub::LowPriorityDeliveryWorker.push_bulk(low_priority_delivery_inboxes) do |inbox_url|
+    ActivityPub::LowPriorityDeliveryWorker.push_bulk(low_priority_delivery_inboxes, limit: 1_000) do |inbox_url|
       [delete_actor_json, @account.id, inbox_url]
     end
   end

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -88,7 +88,7 @@ class RemoveStatusService < BaseService
 
     status_reach_finder = StatusReachFinder.new(@status, unsafe: true)
 
-    ActivityPub::DeliveryWorker.push_bulk(status_reach_finder.inboxes) do |inbox_url|
+    ActivityPub::DeliveryWorker.push_bulk(status_reach_finder.inboxes, limit: 1_000) do |inbox_url|
       [signed_activity_json, @account.id, inbox_url]
     end
   end

--- a/app/services/unsuspend_account_service.rb
+++ b/app/services/unsuspend_account_service.rb
@@ -41,7 +41,7 @@ class UnsuspendAccountService < BaseService
 
     account_reach_finder = AccountReachFinder.new(@account)
 
-    ActivityPub::DeliveryWorker.push_bulk(account_reach_finder.inboxes) do |inbox_url|
+    ActivityPub::DeliveryWorker.push_bulk(account_reach_finder.inboxes, limit: 1_000) do |inbox_url|
       [signed_activity_json, @account.id, inbox_url]
     end
   end

--- a/app/services/update_account_service.rb
+++ b/app/services/update_account_service.rb
@@ -22,7 +22,7 @@ class UpdateAccountService < BaseService
   def authorize_all_follow_requests(account)
     follow_requests = FollowRequest.where(target_account: account)
     follow_requests = follow_requests.preload(:account).select { |req| !req.account.silenced? }
-    AuthorizeFollowWorker.push_bulk(follow_requests) do |req|
+    AuthorizeFollowWorker.push_bulk(follow_requests, limit: 1_000) do |req|
       [req.account_id, req.target_account_id]
     end
   end

--- a/app/workers/activitypub/distribute_poll_update_worker.rb
+++ b/app/workers/activitypub/distribute_poll_update_worker.rb
@@ -12,7 +12,7 @@ class ActivityPub::DistributePollUpdateWorker
 
     return unless @status.preloadable_poll
 
-    ActivityPub::DeliveryWorker.push_bulk(inboxes) do |inbox_url|
+    ActivityPub::DeliveryWorker.push_bulk(inboxes, limit: 1_000) do |inbox_url|
       [payload, @account.id, inbox_url]
     end
 

--- a/app/workers/activitypub/move_distribution_worker.rb
+++ b/app/workers/activitypub/move_distribution_worker.rb
@@ -10,7 +10,7 @@ class ActivityPub::MoveDistributionWorker
     @migration = AccountMigration.find(migration_id)
     @account   = @migration.account
 
-    ActivityPub::DeliveryWorker.push_bulk(inboxes) do |inbox_url|
+    ActivityPub::DeliveryWorker.push_bulk(inboxes, limit: 1_000) do |inbox_url|
       [signed_payload, @account.id, inbox_url]
     end
 

--- a/app/workers/activitypub/raw_distribution_worker.rb
+++ b/app/workers/activitypub/raw_distribution_worker.rb
@@ -25,7 +25,7 @@ class ActivityPub::RawDistributionWorker
   def distribute!
     return if inboxes.empty?
 
-    ActivityPub::DeliveryWorker.push_bulk(inboxes) do |inbox_url|
+    ActivityPub::DeliveryWorker.push_bulk(inboxes, limit: 1_000) do |inbox_url|
       [payload, source_account_id, inbox_url, options]
     end
   end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -131,7 +131,7 @@ module Mastodon
         json = Oj.dump(ActivityPub::LinkedDataSignature.new(payload).sign!(account))
 
         unless options[:dry_run]
-          ActivityPub::DeliveryWorker.push_bulk(inboxes) do |inbox_url|
+          ActivityPub::DeliveryWorker.push_bulk(inboxes, limit: 1_000) do |inbox_url|
             [json, account.id, inbox_url]
           end
 


### PR DESCRIPTION
This is an alternative to #24033.

In order to keep the code changes small, I did not change all `push_bulk` calls but only those that were outside `find_in_batches` calls (that already batch records per 1,000 items) and did not work on lists guaranteed or expected to be small, but I can change the other calls as well if that's preferred.

___

Fixes MAS-102