### PR TITLE
Fix sidekiq jobs not triggering Elasticsearch index updates

### DIFF
--- a/bin/tootctl
+++ b/bin/tootctl
@@ -5,7 +5,9 @@ require_relative '../config/boot'
 require_relative '../lib/cli'
 
 begin
-  Mastodon::CLI.start(ARGV)
+  Chewy.strategy(:mastodon) do
+    Mastodon::CLI.start(ARGV)
+  end
 rescue Interrupt
   exit(130)
 end

--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -19,7 +19,6 @@ Chewy.settings = {
 # cycle, which takes care of checking if Elasticsearch is enabled
 # or not. However, mind that for the Rails console, the :urgent
 # strategy is set automatically with no way to override it.
-Chewy.root_strategy              = :mastodon
 Chewy.request_strategy           = :mastodon
 Chewy.use_after_commit_callbacks = false
 

--- a/lib/mastodon/sidekiq_middleware.rb
+++ b/lib/mastodon/sidekiq_middleware.rb
@@ -3,8 +3,8 @@
 class Mastodon::SidekiqMiddleware
   BACKTRACE_LIMIT = 3
 
-  def call(*)
-    yield
+  def call(*, &block)
+    Chewy.strategy(:mastodon, &block)
   rescue Mastodon::HostValidationError
     # Do not retry
   rescue => e


### PR DESCRIPTION
Saving and updating models from Sidekiq workers is currently broken.

This is because our custom `:mastodon` strategy only schedules the stashed updates when it is popped (`Chewy::Strategy::Mastodon#leave`), but the root strategy cannot be popped.

It works in puma because Chewy sets a middleware that wraps controller actions with the `request_strategy` (in our case, `:mastodon`), leading to a stack of `[:mastodon, :mastodon]`, with the second one popped as expected.

This PR wraps Sidekiq jobs with a `:mastodon` strategy to mirror the puma situation.

It also unsets the `root_strategy` so that we get errors instead of Elasticsearch updates being silently dropped, but we may want to revisit that decision.