### PR TITLE
Autofix Rubocop RSpec/MatchArray

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -789,29 +789,6 @@ RSpec/LetSetup:
     - 'spec/workers/scheduler/accounts_statuses_cleanup_scheduler_spec.rb'
     - 'spec/workers/scheduler/user_cleanup_scheduler_spec.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-RSpec/MatchArray:
-  Exclude:
-    - 'spec/controllers/activitypub/followers_synchronizations_controller_spec.rb'
-    - 'spec/controllers/admin/export_domain_blocks_controller_spec.rb'
-    - 'spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb'
-    - 'spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb'
-    - 'spec/controllers/api/v1/accounts/statuses_controller_spec.rb'
-    - 'spec/controllers/api/v1/bookmarks_controller_spec.rb'
-    - 'spec/controllers/api/v1/favourites_controller_spec.rb'
-    - 'spec/controllers/api/v1/reports_controller_spec.rb'
-    - 'spec/controllers/api/v1/statuses/favourited_by_accounts_controller_spec.rb'
-    - 'spec/controllers/api/v1/statuses/reblogged_by_accounts_controller_spec.rb'
-    - 'spec/models/account_filter_spec.rb'
-    - 'spec/models/account_spec.rb'
-    - 'spec/models/account_statuses_cleanup_policy_spec.rb'
-    - 'spec/models/custom_emoji_filter_spec.rb'
-    - 'spec/models/status_spec.rb'
-    - 'spec/models/user_spec.rb'
-    - 'spec/presenters/familiar_followers_presenter_spec.rb'
-    - 'spec/services/activitypub/fetch_featured_collection_service_spec.rb'
-    - 'spec/services/update_status_service_spec.rb'
-
 RSpec/MessageChain:
   Exclude:
     - 'spec/controllers/api/v1/media_controller_spec.rb'

--- a/spec/controllers/activitypub/followers_synchronizations_controller_spec.rb
+++ b/spec/controllers/activitypub/followers_synchronizations_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ActivityPub::FollowersSynchronizationsController, type: :controll
 
       it 'returns orderedItems with followers from example.com' do
         expect(body[:orderedItems]).to be_an Array
-        expect(body[:orderedItems]).to match_array([follower_4.uri, follower_1.uri, follower_2.uri])
+        expect(body[:orderedItems]).to contain_exactly(follower_4.uri, follower_1.uri, follower_2.uri)
       end
 
       it 'returns private Cache-Control header' do

--- a/spec/controllers/admin/export_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_blocks_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Admin::ExportDomainBlocksController, type: :controller do
       end
 
       it 'renders page with expected domain blocks' do
-        expect(assigns(:domain_blocks).map { |block| [block.domain, block.severity.to_sym] }).to match_array [['bad.domain', :silence], ['worse.domain', :suspend], ['reject.media', :noop]]
+        expect(assigns(:domain_blocks).map { |block| [block.domain, block.severity.to_sym] }).to contain_exactly(['bad.domain', :silence], ['worse.domain', :suspend], ['reject.media', :noop])
       end
 
       it 'returns http success' do
@@ -43,7 +43,7 @@ RSpec.describe Admin::ExportDomainBlocksController, type: :controller do
       end
 
       it 'renders page with expected domain blocks' do
-        expect(assigns(:domain_blocks).map { |block| [block.domain, block.severity.to_sym] }).to match_array [['bad.domain', :suspend], ['worse.domain', :suspend], ['reject.media', :suspend]]
+        expect(assigns(:domain_blocks).map { |block| [block.domain, block.severity.to_sym] }).to contain_exactly(['bad.domain', :suspend], ['worse.domain', :suspend], ['reject.media', :suspend])
       end
 
       it 'returns http success' do

--- a/spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/follower_accounts_controller_spec.rb
@@ -28,7 +28,7 @@ describe Api::V1::Accounts::FollowerAccountsController do
       get :index, params: { account_id: account.id, limit: 2 }
 
       expect(body_as_json.size).to eq 2
-      expect([body_as_json[0][:id], body_as_json[1][:id]]).to match_array([alice.id.to_s, bob.id.to_s])
+      expect([body_as_json[0][:id], body_as_json[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
     end
 
     it 'does not return blocked users' do
@@ -58,7 +58,7 @@ describe Api::V1::Accounts::FollowerAccountsController do
         get :index, params: { account_id: account.id, limit: 2 }
 
         expect(body_as_json.size).to eq 2
-        expect([body_as_json[0][:id], body_as_json[1][:id]]).to match_array([alice.id.to_s, bob.id.to_s])
+        expect([body_as_json[0][:id], body_as_json[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
       end
     end
   end

--- a/spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/following_accounts_controller_spec.rb
@@ -28,7 +28,7 @@ describe Api::V1::Accounts::FollowingAccountsController do
       get :index, params: { account_id: account.id, limit: 2 }
 
       expect(body_as_json.size).to eq 2
-      expect([body_as_json[0][:id], body_as_json[1][:id]]).to match_array([alice.id.to_s, bob.id.to_s])
+      expect([body_as_json[0][:id], body_as_json[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
     end
 
     it 'does not return blocked users' do
@@ -58,7 +58,7 @@ describe Api::V1::Accounts::FollowingAccountsController do
         get :index, params: { account_id: account.id, limit: 2 }
 
         expect(body_as_json.size).to eq 2
-        expect([body_as_json[0][:id], body_as_json[1][:id]]).to match_array([alice.id.to_s, bob.id.to_s])
+        expect([body_as_json[0][:id], body_as_json[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
       end
     end
   end

--- a/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts/statuses_controller_spec.rb
@@ -99,7 +99,7 @@ describe Api::V1::Accounts::StatusesController do
         it 'lists both the public and the private statuses' do
           get :index, params: { account_id: account.id, pinned: true }
           json = body_as_json
-          expect(json.map { |item| item[:id].to_i }).to match_array([status.id, private_status.id])
+          expect(json.map { |item| item[:id].to_i }).to contain_exactly(status.id, private_status.id)
         end
       end
     end

--- a/spec/controllers/api/v1/bookmarks_controller_spec.rb
+++ b/spec/controllers/api/v1/bookmarks_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Api::V1::BookmarksController, type: :controller do
 
           get :index
 
-          expect(assigns(:statuses)).to match_array [bookmarked_by_user.status]
+          expect(assigns(:statuses)).to contain_exactly(bookmarked_by_user.status)
         end
 
         it 'adds pagination headers if necessary' do

--- a/spec/controllers/api/v1/favourites_controller_spec.rb
+++ b/spec/controllers/api/v1/favourites_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Api::V1::FavouritesController, type: :controller do
 
           get :index
 
-          expect(assigns(:statuses)).to match_array [favourite_by_user.status]
+          expect(assigns(:statuses)).to contain_exactly(favourite_by_user.status)
         end
 
         it 'adds pagination headers if necessary' do

--- a/spec/controllers/api/v1/reports_controller_spec.rb
+++ b/spec/controllers/api/v1/reports_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Api::V1::ReportsController, type: :controller do
       end
 
       it 'saves rule_ids' do
-        expect(target_account.targeted_reports.first.rule_ids).to match_array([rule.id])
+        expect(target_account.targeted_reports.first.rule_ids).to contain_exactly(rule.id)
       end
     end
   end

--- a/spec/controllers/api/v1/statuses/favourited_by_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/favourited_by_accounts_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::V1::Statuses::FavouritedByAccountsController, type: :control
       it 'returns accounts who favorited the status' do
         get :index, params: { status_id: status.id, limit: 2 }
         expect(body_as_json.size).to eq 2
-        expect([body_as_json[0][:id], body_as_json[1][:id]]).to match_array([alice.id.to_s, bob.id.to_s])
+        expect([body_as_json[0][:id], body_as_json[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
       end
 
       it 'does not return blocked users' do

--- a/spec/controllers/api/v1/statuses/reblogged_by_accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reblogged_by_accounts_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Api::V1::Statuses::RebloggedByAccountsController, type: :controll
       it 'returns accounts who reblogged the status' do
         get :index, params: { status_id: status.id, limit: 2 }
         expect(body_as_json.size).to eq 2
-        expect([body_as_json[0][:id], body_as_json[1][:id]]).to match_array([alice.id.to_s, bob.id.to_s])
+        expect([body_as_json[0][:id], body_as_json[1][:id]]).to contain_exactly(alice.id.to_s, bob.id.to_s)
       end
 
       it 'does not return blocked users' do

--- a/spec/models/account_filter_spec.rb
+++ b/spec/models/account_filter_spec.rb
@@ -26,22 +26,22 @@ describe AccountFilter do
 
     it 'works with domain first and origin remote' do
       filter = described_class.new(by_domain: 'example.org', origin: 'remote')
-      expect(filter.results).to match_array [remote_account_one]
+      expect(filter.results).to contain_exactly(remote_account_one)
     end
 
     it 'works with domain last and origin remote' do
       filter = described_class.new(origin: 'remote', by_domain: 'example.org')
-      expect(filter.results).to match_array [remote_account_one]
+      expect(filter.results).to contain_exactly(remote_account_one)
     end
 
     it 'works with domain first and origin local' do
       filter = described_class.new(by_domain: 'example.org', origin: 'local')
-      expect(filter.results).to match_array [local_account]
+      expect(filter.results).to contain_exactly(local_account)
     end
 
     it 'works with domain last and origin local' do
       filter = described_class.new(origin: 'local', by_domain: 'example.org')
-      expect(filter.results).to match_array [remote_account_one]
+      expect(filter.results).to contain_exactly(remote_account_one)
     end
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe Account, type: :model do
     it 'returns the domains blocked by the account' do
       account = Fabricate(:account)
       account.block_domain!('domain')
-      expect(account.excluded_from_timeline_domains).to match_array ['domain']
+      expect(account.excluded_from_timeline_domains).to contain_exactly('domain')
     end
   end
 
@@ -877,7 +877,7 @@ RSpec.describe Account, type: :model do
       it 'returns an array of accounts who have a domain' do
         account_1 = Fabricate(:account, domain: nil)
         account_2 = Fabricate(:account, domain: 'example.com')
-        expect(Account.remote).to match_array([account_2])
+        expect(Account.remote).to contain_exactly(account_2)
       end
     end
 
@@ -885,7 +885,7 @@ RSpec.describe Account, type: :model do
       it 'returns an array of accounts who do not have a domain' do
         account_1 = Fabricate(:account, domain: nil)
         account_2 = Fabricate(:account, domain: 'example.com')
-        expect(Account.where('id > 0').local).to match_array([account_1])
+        expect(Account.where('id > 0').local).to contain_exactly(account_1)
       end
     end
 
@@ -911,7 +911,7 @@ RSpec.describe Account, type: :model do
       it 'returns an array of accounts who are silenced' do
         account_1 = Fabricate(:account, silenced: true)
         account_2 = Fabricate(:account, silenced: false)
-        expect(Account.silenced).to match_array([account_1])
+        expect(Account.silenced).to contain_exactly(account_1)
       end
     end
 
@@ -919,7 +919,7 @@ RSpec.describe Account, type: :model do
       it 'returns an array of accounts who are suspended' do
         account_1 = Fabricate(:account, suspended: true)
         account_2 = Fabricate(:account, suspended: false)
-        expect(Account.suspended).to match_array([account_1])
+        expect(Account.suspended).to contain_exactly(account_1)
       end
     end
 
@@ -941,11 +941,11 @@ RSpec.describe Account, type: :model do
       end
 
       it 'returns every usable non-suspended account' do
-        expect(Account.searchable).to match_array([silenced_local, silenced_remote, local_account, remote_account])
+        expect(Account.searchable).to contain_exactly(silenced_local, silenced_remote, local_account, remote_account)
       end
 
       it 'does not mess with previously-applied scopes' do
-        expect(Account.where.not(id: remote_account.id).searchable).to match_array([silenced_local, silenced_remote, local_account])
+        expect(Account.where.not(id: remote_account.id).searchable).to contain_exactly(silenced_local, silenced_remote, local_account)
       end
     end
   end

--- a/spec/models/account_statuses_cleanup_policy_spec.rb
+++ b/spec/models/account_statuses_cleanup_policy_spec.rb
@@ -496,7 +496,7 @@ RSpec.describe AccountStatusesCleanupPolicy, type: :model do
       end
 
       it 'returns only normal statuses for deletion' do
-        expect(subject.pluck(:id)).to match_array([very_old_status.id, faved4.id, faved5.id, reblogged4.id, reblogged5.id])
+        expect(subject.pluck(:id)).to contain_exactly(very_old_status.id, faved4.id, faved5.id, reblogged4.id, reblogged5.id)
       end
     end
 

--- a/spec/models/custom_emoji_filter_spec.rb
+++ b/spec/models/custom_emoji_filter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CustomEmojiFilter do
 
         it 'returns ActiveRecord::Relation' do
           expect(subject).to be_a(ActiveRecord::Relation)
-          expect(subject).to match_array([custom_emoji_2])
+          expect(subject).to contain_exactly(custom_emoji_2)
         end
       end
 
@@ -25,7 +25,7 @@ RSpec.describe CustomEmojiFilter do
 
         it 'returns ActiveRecord::Relation' do
           expect(subject).to be_a(ActiveRecord::Relation)
-          expect(subject).to match_array([custom_emoji_0, custom_emoji_1])
+          expect(subject).to contain_exactly(custom_emoji_0, custom_emoji_1)
         end
       end
 
@@ -34,7 +34,7 @@ RSpec.describe CustomEmojiFilter do
 
         it 'returns ActiveRecord::Relation' do
           expect(subject).to be_a(ActiveRecord::Relation)
-          expect(subject).to match_array([custom_emoji_0])
+          expect(subject).to contain_exactly(custom_emoji_0)
         end
       end
 
@@ -43,7 +43,7 @@ RSpec.describe CustomEmojiFilter do
 
         it 'returns ActiveRecord::Relation' do
           expect(subject).to be_a(ActiveRecord::Relation)
-          expect(subject).to match_array([custom_emoji_2])
+          expect(subject).to contain_exactly(custom_emoji_2)
         end
       end
 
@@ -63,7 +63,7 @@ RSpec.describe CustomEmojiFilter do
 
       it 'returns ActiveRecord::Relation' do
         expect(subject).to be_a(ActiveRecord::Relation)
-        expect(subject).to match_array([custom_emoji_0, custom_emoji_1, custom_emoji_2])
+        expect(subject).to contain_exactly(custom_emoji_0, custom_emoji_1, custom_emoji_2)
       end
     end
   end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -265,17 +265,17 @@ RSpec.describe Status, type: :model do
 
     context 'when given one tag' do
       it 'returns the expected statuses' do
-        expect(Status.tagged_with([tag1.id]).reorder(:id).pluck(:id).uniq).to match_array([status1.id, status5.id])
-        expect(Status.tagged_with([tag2.id]).reorder(:id).pluck(:id).uniq).to match_array([status2.id, status5.id])
-        expect(Status.tagged_with([tag3.id]).reorder(:id).pluck(:id).uniq).to match_array([status3.id, status5.id])
+        expect(Status.tagged_with([tag1.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status1.id, status5.id)
+        expect(Status.tagged_with([tag2.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status2.id, status5.id)
+        expect(Status.tagged_with([tag3.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status3.id, status5.id)
       end
     end
 
     context 'when given multiple tags' do
       it 'returns the expected statuses' do
-        expect(Status.tagged_with([tag1.id, tag2.id]).reorder(:id).pluck(:id).uniq).to match_array([status1.id, status2.id, status5.id])
-        expect(Status.tagged_with([tag1.id, tag3.id]).reorder(:id).pluck(:id).uniq).to match_array([status1.id, status3.id, status5.id])
-        expect(Status.tagged_with([tag2.id, tag3.id]).reorder(:id).pluck(:id).uniq).to match_array([status2.id, status3.id, status5.id])
+        expect(Status.tagged_with([tag1.id, tag2.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status1.id, status2.id, status5.id)
+        expect(Status.tagged_with([tag1.id, tag3.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status1.id, status3.id, status5.id)
+        expect(Status.tagged_with([tag2.id, tag3.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status2.id, status3.id, status5.id)
       end
     end
   end
@@ -292,15 +292,15 @@ RSpec.describe Status, type: :model do
 
     context 'when given one tag' do
       it 'returns the expected statuses' do
-        expect(Status.tagged_with_all([tag1.id]).reorder(:id).pluck(:id).uniq).to match_array([status1.id, status5.id])
-        expect(Status.tagged_with_all([tag2.id]).reorder(:id).pluck(:id).uniq).to match_array([status2.id, status5.id])
-        expect(Status.tagged_with_all([tag3.id]).reorder(:id).pluck(:id).uniq).to match_array([status3.id])
+        expect(Status.tagged_with_all([tag1.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status1.id, status5.id)
+        expect(Status.tagged_with_all([tag2.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status2.id, status5.id)
+        expect(Status.tagged_with_all([tag3.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status3.id)
       end
     end
 
     context 'when given multiple tags' do
       it 'returns the expected statuses' do
-        expect(Status.tagged_with_all([tag1.id, tag2.id]).reorder(:id).pluck(:id).uniq).to match_array([status5.id])
+        expect(Status.tagged_with_all([tag1.id, tag2.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status5.id)
         expect(Status.tagged_with_all([tag1.id, tag3.id]).reorder(:id).pluck(:id).uniq).to eq []
         expect(Status.tagged_with_all([tag2.id, tag3.id]).reorder(:id).pluck(:id).uniq).to eq []
       end
@@ -319,17 +319,17 @@ RSpec.describe Status, type: :model do
 
     context 'when given one tag' do
       it 'returns the expected statuses' do
-        expect(Status.tagged_with_none([tag1.id]).reorder(:id).pluck(:id).uniq).to match_array([status2.id, status3.id, status4.id])
-        expect(Status.tagged_with_none([tag2.id]).reorder(:id).pluck(:id).uniq).to match_array([status1.id, status3.id, status4.id])
-        expect(Status.tagged_with_none([tag3.id]).reorder(:id).pluck(:id).uniq).to match_array([status1.id, status2.id, status4.id])
+        expect(Status.tagged_with_none([tag1.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status2.id, status3.id, status4.id)
+        expect(Status.tagged_with_none([tag2.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status1.id, status3.id, status4.id)
+        expect(Status.tagged_with_none([tag3.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status1.id, status2.id, status4.id)
       end
     end
 
     context 'when given multiple tags' do
       it 'returns the expected statuses' do
-        expect(Status.tagged_with_none([tag1.id, tag2.id]).reorder(:id).pluck(:id).uniq).to match_array([status3.id, status4.id])
-        expect(Status.tagged_with_none([tag1.id, tag3.id]).reorder(:id).pluck(:id).uniq).to match_array([status2.id, status4.id])
-        expect(Status.tagged_with_none([tag2.id, tag3.id]).reorder(:id).pluck(:id).uniq).to match_array([status1.id, status4.id])
+        expect(Status.tagged_with_none([tag1.id, tag2.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status3.id, status4.id)
+        expect(Status.tagged_with_none([tag1.id, tag3.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status2.id, status4.id)
+        expect(Status.tagged_with_none([tag2.id, tag3.id]).reorder(:id).pluck(:id).uniq).to contain_exactly(status1.id, status4.id)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe User, type: :model do
       it 'returns an array of users who are confirmed' do
         user_1 = Fabricate(:user, confirmed_at: nil)
         user_2 = Fabricate(:user, confirmed_at: Time.zone.now)
-        expect(User.confirmed).to match_array([user_2])
+        expect(User.confirmed).to contain_exactly(user_2)
       end
     end
 
@@ -74,7 +74,7 @@ RSpec.describe User, type: :model do
         specified = Fabricate(:user, current_sign_in_at: 15.days.ago)
         Fabricate(:user, current_sign_in_at: 6.days.ago)
 
-        expect(User.inactive).to match_array([specified])
+        expect(User.inactive).to contain_exactly(specified)
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe User, type: :model do
         specified = Fabricate(:user, email: 'specified@spec')
         Fabricate(:user, email: 'unspecified@spec')
 
-        expect(User.matches_email('specified')).to match_array([specified])
+        expect(User.matches_email('specified')).to contain_exactly(specified)
       end
     end
 
@@ -96,7 +96,7 @@ RSpec.describe User, type: :model do
         Fabricate(:session_activation, user: user2, ip: '2160:8888::24', session_id: '3')
         Fabricate(:session_activation, user: user2, ip: '2160:8888::25', session_id: '4')
 
-        expect(User.matches_ip('2160:2160::/32')).to match_array([user1])
+        expect(User.matches_ip('2160:2160::/32')).to contain_exactly(user1)
       end
     end
   end

--- a/spec/presenters/familiar_followers_presenter_spec.rb
+++ b/spec/presenters/familiar_followers_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe FamiliarFollowersPresenter do
 
       expect(result).to_not be_nil
       expect(result.id).to eq requested_accounts.first.id
-      expect(result.accounts).to match_array([familiar_follower])
+      expect(result.accounts).to contain_exactly(familiar_follower)
     end
 
     context 'when requested account hides followers' do

--- a/spec/services/activitypub/fetch_featured_collection_service_spec.rb
+++ b/spec/services/activitypub/fetch_featured_collection_service_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe ActivityPub::FetchFeaturedCollectionService, type: :service do
     end
 
     it 'sets expected posts as pinned posts' do
-      expect(actor.pinned_statuses.pluck(:uri)).to match_array ['https://example.com/account/pinned/1', 'https://example.com/account/pinned/2', 'https://example.com/account/pinned/4']
+      expect(actor.pinned_statuses.pluck(:uri)).to contain_exactly('https://example.com/account/pinned/1', 'https://example.com/account/pinned/2', 'https://example.com/account/pinned/4')
     end
   end
 

--- a/spec/services/update_status_service_spec.rb
+++ b/spec/services/update_status_service_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe UpdateStatusService, type: :service do
     end
 
     it 'keeps old mentions as silent mentions' do
-      expect(status.mentions.pluck(:account_id)).to match_array([alice.id, bob.id])
+      expect(status.mentions.pluck(:account_id)).to contain_exactly(alice.id, bob.id)
     end
   end
 


### PR DESCRIPTION
Since rubucop-rspec landed in a separate PR, this is updated to just do the cleanup for the new rule that was introduced