### PR TITLE
Autofix Rubocop Rails/ResponseParsedBody

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1724,15 +1724,6 @@ Rails/RakeEnvironment:
     - 'lib/tasks/repo.rake'
     - 'lib/tasks/statistics.rake'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: Include.
-# Include: spec/controllers/**/*.rb, spec/requests/**/*.rb, test/controllers/**/*.rb, test/integration/**/*.rb
-Rails/ResponseParsedBody:
-  Exclude:
-    - 'spec/controllers/follower_accounts_controller_spec.rb'
-    - 'spec/controllers/following_accounts_controller_spec.rb'
-    - 'spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb'
-
 # Configuration parameters: Include.
 # Include: db/**/*.rb
 Rails/ReversibleMigration:

--- a/spec/controllers/follower_accounts_controller_spec.rb
+++ b/spec/controllers/follower_accounts_controller_spec.rb
@@ -41,7 +41,7 @@ describe FollowerAccountsController do
     context 'when format is json' do
       subject(:response) { get :index, params: { account_username: alice.username, page: page, format: :json } }
 
-      subject(:body) { JSON.parse(response.body) }
+      subject(:body) { response.parsed_body }
 
       context 'with page' do
         let(:page) { 1 }

--- a/spec/controllers/following_accounts_controller_spec.rb
+++ b/spec/controllers/following_accounts_controller_spec.rb
@@ -41,7 +41,7 @@ describe FollowingAccountsController do
     context 'when format is json' do
       subject(:response) { get :index, params: { account_username: alice.username, page: page, format: :json } }
 
-      subject(:body) { JSON.parse(response.body) }
+      subject(:body) { response.parsed_body }
 
       context 'with page' do
         let(:page) { 1 }

--- a/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
+++ b/spec/controllers/settings/two_factor_authentication/webauthn_credentials_controller_spec.rb
@@ -140,7 +140,7 @@ describe Settings::TwoFactorAuthentication::WebauthnCredentialsController do
           it 'includes existing credentials in list of excluded credentials' do
             get :options
 
-            excluded_credentials_ids = JSON.parse(response.body)['excludeCredentials'].pluck('id')
+            excluded_credentials_ids = response.parsed_body['excludeCredentials'].pluck('id')
             expect(excluded_credentials_ids).to match_array(user.webauthn_credentials.pluck(:external_id))
           end
         end


### PR DESCRIPTION
Since rubucop-rails landed in a separate PR, this is updated to just do the cleanup for one of the new rules that was introduced