### PR TITLE
Sync CI and Docker Compose image versions

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - internal_network
 
   redis:
-    image: redis:6-alpine
+    image: redis:7-alpine
     restart: unless-stopped
     volumes:
       - redis-data:/data

--- a/.github/workflows/test-migrations-one-step.yml
+++ b/.github/workflows/test-migrations-one-step.yml
@@ -25,7 +25,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14.5
+        image: postgres:14-alpine
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres
@@ -38,7 +38,7 @@ jobs:
           - 5432:5432
 
       redis:
-        image: redis:7.0
+        image: redis:7-alpine
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/test-migrations-two-step.yml
+++ b/.github/workflows/test-migrations-two-step.yml
@@ -25,7 +25,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14.5
+        image: postgres:14-alpine
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres
@@ -37,7 +37,7 @@ jobs:
         ports:
           - 5432:5432
       redis:
-        image: redis:7.0
+        image: redis:7-alpine
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -63,7 +63,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14.5
+        image: postgres:14-alpine
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_USER: postgres
@@ -76,7 +76,7 @@ jobs:
           - 5432:5432
 
       redis:
-        image: redis:7.0
+        image: redis:7-alpine
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s


### PR DESCRIPTION
Was going to unpin the CI versions of the service containers, but though it might be better to sync up with the docker-compose image selections so it's consistent. These floating version images weren't available before on CircleCI