### PR TITLE
Update strong_migrations to 1.4.4

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,7 +46,6 @@
       matchManagers: ['bundler'],
       matchPackageNames: [
         'sprockets', // Requires manual upgrade https://github.com/rails/sprockets/blob/master/UPGRADING.md#guide-to-upgrading-from-sprockets-3x-to-4x
-        'strong_migrations', // Requires manual upgrade
         'sidekiq', // Requires manual upgrade
         'sidekiq-unique-jobs', // Requires manual upgrades and sync with Sidekiq version
         'redis', // Requires manual upgrade and sync with Sidekiq version

--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem 'simple-navigation', '~> 4.4'
 gem 'simple_form', '~> 5.2'
 gem 'sprockets-rails', '~> 3.4', require: 'sprockets/railtie'
 gem 'stoplight', '~> 3.0.1'
-gem 'strong_migrations', '~> 0.8'
+gem 'strong_migrations', '~> 1.4'
 gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'
 gem 'tzinfo-data', '~> 1.2023'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,7 +682,7 @@ GEM
     stackprof (0.2.25)
     stoplight (3.0.1)
       redlock (~> 1.0)
-    strong_migrations (0.8.0)
+    strong_migrations (1.4.4)
       activerecord (>= 5.2)
     swd (1.3.0)
       activesupport (>= 3)
@@ -879,7 +879,7 @@ DEPENDENCIES
   sprockets-rails (~> 3.4)
   stackprof
   stoplight (~> 3.0.1)
-  strong_migrations (~> 0.8)
+  strong_migrations (~> 1.4)
   thor (~> 1.2)
   tty-prompt (~> 0.23)
   twitter-text (~> 3.1.0)


### PR DESCRIPTION
The 0.8.0 patch was reverted in https://github.com/mastodon/mastodon/pull/17540 because it dropped some old Ruby compat. Looks like Dependabot stopped opening PRs after that, but I noted on my own fork it tried to update it to the latest, so opening here to see if anything in CI falls over with the new 1.x release