### PR TITLE
Prefer the stored location as after_sign_in_path in Omniauth Callback Controller

### DIFF
--- a/app/controllers/auth/omniauth_callbacks_controller.rb
+++ b/app/controllers/auth/omniauth_callbacks_controller.rb
@@ -33,7 +33,7 @@ class Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def after_sign_in_path_for(resource)
     if resource.email_present?
-      root_path
+      stored_location_for(resource) || root_path
     else
       auth_setup_path(missing_email: '1')
     end


### PR DESCRIPTION
This PR addresses #18481 and #23457.

These issue detail that when using an App on an instance that uses SSO, instead of being redirected after sign in to the /oauth/authorize dialog and eventually back to their own app, they were given a a Web View of the mastodon web page.

I found that this issue is caused by the `after_sign_in_path_for` in the Omniauth Callbacks Controller overriding the `after_sign_path_for` method used by [`sign_in_and_redirect`](https://github.com/heartcombo/devise/blob/7d1dc56fdba2402c452c4224567077b23184637e/lib/devise/controllers/helpers.rb#L235) and thus ignored the `stored_location_for` value of the user.

By preferring the stored location when available over redirecting to the root path, we enable the use of both third-party apps with SSO instances and make it more convenient to use the Mastodon Web App itself by redirecting to the previously viewed content after login.