### PR TITLE
Enable Rubocop Performance/DeleteSuffix

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -301,13 +301,6 @@ Performance/DeletePrefix:
     - 'app/services/resolve_account_service.rb'
     - 'app/services/tag_search_service.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: SafeMultiline.
-Performance/DeleteSuffix:
-  Exclude:
-    - 'lib/tasks/repo.rake'
-
 # Offense count: 19
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Performance/MapCompact:

--- a/lib/tasks/repo.rake
+++ b/lib/tasks/repo.rake
@@ -91,8 +91,8 @@ namespace :repo do
     missing_json_files = I18n.available_locales.reject { |locale| Rails.root.join('app', 'javascript', 'mastodon', 'locales', "#{locale}.json").exist? }
 
     locales_in_files = Dir[Rails.root.join('config', 'locales', '*.yml')].map do |path|
-      file_name = File.basename(path)
-      file_name.gsub(/\A(doorkeeper|devise|activerecord|simple_form)\./, '').gsub(/\.yml\z/, '').to_sym
+      file_name = File.basename(path, '.yml')
+      file_name.gsub(/\A(doorkeeper|devise|activerecord|simple_form)\./, '').to_sym
     end.uniq.compact
 
     missing_available_locales = locales_in_files - I18n.available_locales


### PR DESCRIPTION
File.basename can remove the suffix directly https://ruby-doc.org/core-1.8.7/File.html#method-c-basename