### PR TITLE
libretranslate needs access to external network

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     restart: unless-stopped
     networks:
       - internal_network
+      - external_network
 
 volumes:
   postgres-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -66,7 +66,7 @@ services:
         hard: -1
 
   libretranslate:
-    image: libretranslate/libretranslate:v1.2.9
+    image: libretranslate/libretranslate:v1.3.9
     restart: unless-stopped
     networks:
       - internal_network


### PR DESCRIPTION
LibreTranslate downloads language models on first boot, so it needs access to the external network.

```
$ docker compose up libretranslate
[+] Running 1/0
 ⠿ Container devcontainer-libretranslate-1  Created                                                                                                                                             0.1s
Attaching to devcontainer-libretranslate-1
devcontainer-libretranslate-1  | (URLError(gaierror(-3, 'Temporary failure in name resolution')),)
devcontainer-libretranslate-1  | Updating language models
devcontainer-libretranslate-1  | Cannot update models (normal if you're offline): Local package index not found, use package.update_package_index() to load it
devcontainer-libretranslate-1  | Traceback (most recent call last):
devcontainer-libretranslate-1  |   File "/app/./venv/bin/libretranslate", line 33, in <module>
devcontainer-libretranslate-1  |     sys.exit(load_entry_point('libretranslate==1.3.10', 'console_scripts', 'libretranslate')())
devcontainer-libretranslate-1  |   File "/app/venv/lib/python3.10/site-packages/libretranslate/main.py", line 189, in main
devcontainer-libretranslate-1  |     app = create_app(args)
devcontainer-libretranslate-1  |   File "/app/venv/lib/python3.10/site-packages/libretranslate/app.py", line 156, in create_app
devcontainer-libretranslate-1  |     language_target_fallback = languages[0]
devcontainer-libretranslate-1  | IndexError: list i
```

After fixing that it seems that version < 1.3.8 is not permitted to download the models from the server.

```
$ docker compose up libretranslate
[+] Running 1/0
 ⠿ Container devcontainer-libretranslate-1  Created                                                                                                                         0.1s
 ⠋ libretranslate The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested          0.0s
Attaching to devcontainer-libretranslate-1
devcontainer-libretranslate-1  | (<HTTPError 403: 'Forbidden'>,)
devcontainer-libretranslate-1  | (<HTTPError 403: 'Forbidden'>,)
devcontainer-libretranslate-1  | (<HTTPError 403: 'Forbidden'>,)
devcontainer-libretranslate-1  | (<HTTPError 403: 'Forbidden'>,)
devcontainer-libretranslate-1  | Updating language models
devcontainer-libretranslate-1  | Found 58 models
devcontainer-libretranslate-1  | Downloading Arabic → English (1.0) ...
devcontainer-libretranslate-1  | Cannot update models (normal if you're offline): name 'url' is not defined
devcontainer-libretranslate-1  | Traceback (most recent call last):
devcontainer-libretranslate-1  |   File "/usr/local/bin/libretranslate", line 8, in <module>
devcontainer-libretranslate-1  |     sys.exit(main())
devcontainer-libretranslate-1  |   File "/usr/local/lib/python3.8/site-packages/app/main.py", line 121, in main
devcontainer-libretranslate-1  |     app = create_app(args)
devcontainer-libretranslate-1  |   File "/usr/local/lib/python3.8/site-packages/app/app.py", line 139, in create_app
devcontainer-libretranslate-1  |     frontend_argos_language_source = languages[0]
devcontainer-libretranslate-1  | IndexError: list index out of range
devcontainer-libretranslate-1 exited with code 1
```