### PR TITLE
Tweaks to rails static file serving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,6 @@ COPY --chown=mastodon:mastodon --from=build /opt/mastodon /opt/mastodon
 
 ENV RAILS_ENV="production" \
     NODE_ENV="production" \
-    RAILS_SERVE_STATIC_FILES="true" \
     BIND="0.0.0.0"
 
 # Set the run user

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,9 +19,12 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  # Unless explicitly disabled, serve static files via puma. This has been the
+  # default for Dockerfile for a very long time already.
+  config.public_file_server.enabled = (ENV['RAILS_SERVE_STATIC_FILES'] || "true") == "true"
+  config.public_file_server.headers = {
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+  }
 
   ActiveSupport::Logger.new(STDOUT).tap do |logger|
     logger.formatter = config.log_formatter


### PR DESCRIPTION
Serve static assets using cache headers, fixing https://github.com/mastodon/mastodon/issues/24021

Also change default of RAILS_SERVE_STATIC_FILES, since the Dockerfile
already explicitly sets this value to `true` since 2017:

https://github.com/mastodon/mastodon/commit/ae78d012acfd245228815f4e404f0cfa15c97f55

...while the initial commit from 2016 does not intend to do that:

https://github.com/mastodon/mastodon/commit/9c4856bdb11fc9311ab30a97224cee3dfaec492f

So this change just brings non-dockerized deployments in line with
dockerized ones
