### PR TITLE
Link to the Identity provider's account settings from the account settings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -121,7 +121,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sso_account_settings
-    ENV["SSO_ACCOUNT_SETTINGS"] if ENV["SSO_ACCOUNT_SETTINGS"]
+    ENV.fetch('SSO_ACCOUNT_SETTINGS')
   end
 
   def current_account

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,8 @@ class ApplicationController < ActionController::Base
   helper_method :current_theme
   helper_method :single_user_mode?
   helper_method :use_seamless_external_login?
+  helper_method :omniauth_only?
+  helper_method :sso_account_settings
   helper_method :whitelist_mode?
 
   rescue_from ActionController::ParameterMissing, Paperclip::AdapterRegistry::NoHandlerError, with: :bad_request
@@ -112,6 +114,14 @@ class ApplicationController < ActionController::Base
 
   def use_seamless_external_login?
     Devise.pam_authentication || Devise.ldap_authentication
+  end
+
+  def omniauth_only?
+    ENV['OMNIAUTH_ONLY'] == 'true'
+  end
+
+  def sso_account_settings
+    ENV["SSO_ACCOUNT_SETTINGS"] if ENV["SSO_ACCOUNT_SETTINGS"]
   end
 
   def current_account

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -91,10 +91,6 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     Setting.registrations_mode != 'none' || @invite&.valid_for_use?
   end
 
-  def omniauth_only?
-    ENV['OMNIAUTH_ONLY'] == 'true'
-  end
-
   def ip_blocked?
     IpBlock.where(severity: :sign_up_block).where('ip >>= ?', request.remote_ip.to_s).exists?
   end

--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -91,6 +91,10 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     Setting.registrations_mode != 'none' || @invite&.valid_for_use?
   end
 
+  def omniauth_only?
+    ENV['OMNIAUTH_ONLY'] == 'true'
+  end
+
   def ip_blocked?
     IpBlock.where(severity: :sign_up_block).where('ip >>= ?', request.remote_ip.to_s).exists?
   end

--- a/app/views/auth/registrations/edit.html.haml
+++ b/app/views/auth/registrations/edit.html.haml
@@ -8,7 +8,7 @@
 = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'auth_edit', novalidate: false }) do |f|
   = render 'shared/error_messages', object: resource
 
-  - if !use_seamless_external_login? || resource.encrypted_password.present?
+  - if (!use_seamless_external_login? || resource.encrypted_password.present?) && !omniauth_only?
     .fields-row
       .fields-row__column.fields-group.fields-row__column-6
         = f.input :email, wrapper: :with_label, input_html: { 'aria-label': t('simple_form.labels.defaults.email') }, required: true, disabled: current_account.suspended?
@@ -23,6 +23,8 @@
 
     .actions
       = f.button :button, t('generic.save_changes'), type: :submit, class: 'button', disabled: current_account.suspended?
+  - elsif omniauth_only?
+    = link_to t('users.go_to_sso_account_settings'), sso_account_settings
   - else
     %p.hint= t('users.seamless_external_login')
 

--- a/app/views/auth/registrations/edit.html.haml
+++ b/app/views/auth/registrations/edit.html.haml
@@ -23,7 +23,7 @@
 
     .actions
       = f.button :button, t('generic.save_changes'), type: :submit, class: 'button', disabled: current_account.suspended?
-  - elsif omniauth_only?
+  - elsif omniauth_only? && sso_account_settings.present?
     = link_to t('users.go_to_sso_account_settings'), sso_account_settings
   - else
     %p.hint= t('users.seamless_external_login')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1674,6 +1674,7 @@ en:
       title: Welcome aboard, %{name}!
   users:
     follow_limit_reached: You cannot follow more than %{limit} people
+    go_to_sso_account_settings: Go to your identity provider's account settings
     invalid_otp_token: Invalid two-factor code
     otp_lost_help_html: If you lost access to both, you may get in touch with %{email}
     seamless_external_login: You are logged in via an external service, so password and e-mail settings are not available.


### PR DESCRIPTION
When using SSO with an identity provider as the sole authentication method (OMNIAUTH_ONLY=true), Mastodon doesn't store the user's email or password and so cannot change these values. 

This PR replaces the change email/password forms by a link to the URI contained within the SSO_ACCOUNT_SETTINGS variable. 