### PR TITLE
Change `tootctl media remove` flags for clarity

### DIFF
--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -21,10 +21,10 @@ module Mastodon
     option :concurrency, type: :numeric, default: 5, aliases: [:c]
     option :verbose, type: :boolean, default: false, aliases: [:v]
     option :dry_run, type: :boolean, default: false
-    # BEGIN depreciation
+    # BEGIN deprecation # TODO: How to tag deprecation? 
     option :prune_profiles, type: :boolean, default: false
     option :remove_headers, type: :boolean, default: false
-    # END depreciation
+    # END deprecation
     desc 'remove', 'Remove remote media files, headers or avatars'
     long_desc <<-DESC
     Removes locally cached copies of media attachments, avatars or profile headers from other servers.
@@ -50,9 +50,9 @@ module Mastodon
     DESC
     # rubocop:disable Metrics/PerceivedComplexity
     def remove
-      # BEGIN depreciation
+      # BEGIN deprecation 
       if options[:prune_profiles]
-        options[:avatars]=true
+        options[:avatars]=true # TODO: Use an alias for Thor options?
         options[:headers]=true
         say('--prune-profiles is deprecated and will be removed in the future.', :red, true)
       if options[:remove_headers]
@@ -60,10 +60,10 @@ module Mastodon
         say('--remove-headers is deprecated and will be removed in the future.', :red, true)
       if !(options[:prune_profiles] || options[:remove_headers] || options[:attachments] || options[:avatars] || options[:headers])
         options[:attachments]=true
-        option[:include_follows]=true
+        options[:include_follows]=true
         say('Usage of this command with no flags specifying media is deprecated and will be removed in the future.', :red, true)
       end
-      # END depreciation
+      # END deprecation
       time_ago        = options[:days].days.ago
       dry_run         = options[:dry_run] ? ' (DRY RUN)' : ''
 
@@ -90,7 +90,7 @@ module Mastodon
 
       if options[:attachments]
         processed, aggregate = parallelize_with_progress(MediaAttachment.cached.where.not(remote_url: '').where(created_at: ..time_ago)) do |media_attachment|
-          next if !options[:include_follows] && Follow.where(account: media_attachment.account).or(Follow.where(target_account: media_attachment.account)).exists?
+          next if !options[:include_follows] && Follow.where(account: media_attachment.account).or(Follow.where(target_account: media_attachment.account)).exists? # TODO: media_attachment.account works?
           next if media_attachment.file.blank?
 
           size = (media_attachment.file_file_size || 0) + (media_attachment.thumbnail_file_size || 0)

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -41,6 +41,7 @@ module Mastodon
     --days N
         Exclude media attachments that been posted in the past N days.
         Exclude accounts that have been updated in the past N days.
+        Defaults to N=7.
     --concurrency N
         The number of workers to use for this task.
         Defaults to N=5.

--- a/lib/mastodon/media_cli.rb
+++ b/lib/mastodon/media_cli.rb
@@ -39,7 +39,7 @@ module Mastodon
         Remove media even if a follow relationship exists.
         If this flag is not provided, only accounts that are not followed by or following anyone locally will have their media removed.
     --days N
-        Exclude media attachments that been posted in the past N days.
+        Exclude media attachments that have been posted in the past N days.
         Exclude accounts that have been updated in the past N days.
         Defaults to N=7.
     --concurrency N


### PR DESCRIPTION
Change `tootctl media remove` flags for clarity https://github.com/mastodon/mastodon/issues/23628

# changelog
* Add `tootctl media remove` flags `--attachments`, `--avatars` and `--headers`.
* Deprecate  `tootctl media remove` flags `--prune-profiles` and `--remove-headers`.
* Deprecate use of  `tootctl media remove` without flags specifying media.
* Fix throwing of error on use of `--verbose` flag with `tootctl media remove` https://github.com/mastodon/mastodon/issues/24070