### PR TITLE
Remove `Permissions-Policy` header from all responses

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -138,7 +138,6 @@ Rails.application.configure do
     'X-Frame-Options'        => 'DENY',
     'X-Content-Type-Options' => 'nosniff',
     'X-XSS-Protection'       => '0',
-    'Permissions-Policy'     => 'interest-cohort=()',
     'Referrer-Policy'        => 'same-origin',
   }
 


### PR DESCRIPTION
Since we do not use `document.interestCohort()` in our JavaScript, I believe this header may not be necessary and may be wasting bandwidth since it's included on all responses.