### PR TITLE
Accept image/webp and image/gif on thumbnail input

### DIFF
--- a/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
@@ -330,7 +330,7 @@ class FocalPointModal extends ImmutablePureComponent {
                     id='upload-modal__thumbnail'
                     ref={this.setFileInputRef}
                     type='file'
-                    accept='image/png,image/jpeg'
+                    accept='image/png,image/jpeg,image/webp,image/gif'
                     onChange={this.handleThumbnailChange}
                     style={{ display: 'none' }}
                     disabled={isUploadingThumbnail || is_changing_upload}


### PR DESCRIPTION
webp and gif are supported by the server, but require changing windows file picker to show "All Files" instead of "Custom Files" to upload them. I've been regularly uploading webp's as thumbnails so it would be nice not to have to do this step.

BTW, the server also accepts heic files, but that results in a 404 url.