### PR TITLE
Webhooks for local status.create, status.update, account.update

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -245,7 +245,7 @@ Metrics/BlockNesting:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 368
+  Max: 375
 
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/CyclomaticComplexity:

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -122,6 +122,8 @@ class Account < ApplicationRecord
   scope :not_excluded_by_account, ->(account) { where.not(id: account.excluded_from_timeline_account_ids) }
   scope :not_domain_blocked_by_account, ->(account) { where(arel_table[:domain].eq(nil).or(arel_table[:domain].not_in(account.excluded_from_timeline_domains))) }
 
+  after_update_commit :trigger_update_webhooks
+
   delegate :email,
            :unconfirmed_email,
            :current_sign_in_at,
@@ -592,5 +594,10 @@ class Account < ApplicationRecord
     return unless local?
 
     CanonicalEmailBlock.where(reference_account: self).delete_all
+  end
+
+  # NOTE: the `account.created` webhook is triggered by the `User` model, not `Account`.
+  def trigger_update_webhooks
+    TriggerWebhookWorker.perform_async('account.updated', 'Account', id) if local?
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -541,9 +541,11 @@ class Status < ApplicationRecord
 
   def trigger_create_webhooks
     TriggerWebhookWorker.perform_async('status.created', 'Status', id) if local?
+    TriggerWebhookWorker.perform_async('status.created.distributable', 'Status', id) if local? && distributable?
   end
 
   def trigger_update_webhooks
     TriggerWebhookWorker.perform_async('status.updated', 'Status', id) if local?
+    TriggerWebhookWorker.perform_async('status.updated.distributable', 'Status', id) if local? && distributable?
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -541,11 +541,9 @@ class Status < ApplicationRecord
 
   def trigger_create_webhooks
     TriggerWebhookWorker.perform_async('status.created', 'Status', id) if local?
-    TriggerWebhookWorker.perform_async('status.created.distributable', 'Status', id) if local? && distributable?
   end
 
   def trigger_update_webhooks
     TriggerWebhookWorker.perform_async('status.updated', 'Status', id) if local?
-    TriggerWebhookWorker.perform_async('status.updated.distributable', 'Status', id) if local? && distributable?
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -111,6 +111,9 @@ class Status < ApplicationRecord
     where('NOT EXISTS (SELECT * FROM statuses_tags forbidden WHERE forbidden.status_id = statuses.id AND forbidden.tag_id IN (?))', tag_ids)
   }
 
+  after_create_commit :trigger_create_webhooks
+  after_update_commit :trigger_update_webhooks
+
   cache_associated :application,
                    :media_attachments,
                    :conversation,
@@ -534,5 +537,13 @@ class Status < ApplicationRecord
     account&.decrement_count!(:statuses_count)
     reblog&.decrement_count!(:reblogs_count) if reblog?
     thread&.decrement_count!(:replies_count) if in_reply_to_id.present? && distributable?
+  end
+
+  def trigger_create_webhooks
+    TriggerWebhookWorker.perform_async('status.created', 'Status', id) if local?
+  end
+
+  def trigger_update_webhooks
+    TriggerWebhookWorker.perform_async('status.updated', 'Status', id) if local?
   end
 end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -20,7 +20,9 @@ class Webhook < ApplicationRecord
     account.updated
     report.created
     status.created
+    status.created.distributable
     status.updated
+    status.updated.distributable
   ).freeze
 
   scope :enabled, -> { where(enabled: true) }

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -17,7 +17,10 @@ class Webhook < ApplicationRecord
   EVENTS = %w(
     account.approved
     account.created
+    account.updated
     report.created
+    status.created
+    status.updated
   ).freeze
 
   scope :enabled, -> { where(enabled: true) }

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -20,9 +20,7 @@ class Webhook < ApplicationRecord
     account.updated
     report.created
     status.created
-    status.created.distributable
     status.updated
-    status.updated.distributable
   ).freeze
 
   scope :enabled, -> { where(enabled: true) }

--- a/app/workers/webhooks/delivery_worker.rb
+++ b/app/workers/webhooks/delivery_worker.rb
@@ -19,7 +19,7 @@ class Webhooks::DeliveryWorker
   private
 
   def perform_request
-    request = Request.new(:post, @webhook.url, body: @body)
+    request = Request.new(:post, @webhook.url, body: @body, allow_local: true)
 
     request.add_headers(
       'Content-Type' => 'application/json',


### PR DESCRIPTION
This enables admin-configured webhooks to receive instance-local statuses and updated accounts for moderation purposes: for example, identifying spam links and flagging spam posts for review through the admin API.

It also allows webhooks to send data to local network addresses. See mastodon/mastodon#21926 where we recently made that change for local LibreTranslate.