### PR TITLE
Refactor CLI classes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,7 +72,6 @@ Metrics/ModuleLength:
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsabcsize
 Metrics/AbcSize:
   Exclude:
-    - 'lib/mastodon/cli/*.rb'
     - db/*migrate/**/*
 
 # Reason:
@@ -85,8 +84,8 @@ Metrics/BlockNesting:
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricscyclomaticcomplexity
 Metrics/CyclomaticComplexity:
   Exclude:
-    - lib/mastodon/cli/*.rb
     - db/*migrate/**/*
+    - 'lib/mastodon/cli/media.rb'
 
 # Reason:
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsparameterlists

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -157,6 +157,7 @@ RSpec/AnyInstance:
     - 'spec/controllers/auth/sessions_controller_spec.rb'
     - 'spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb'
     - 'spec/controllers/settings/two_factor_authentication/recovery_codes_controller_spec.rb'
+    - 'spec/lib/mastodon/cli/federation_spec.rb'
     - 'spec/lib/request_spec.rb'
     - 'spec/lib/status_filter_spec.rb'
     - 'spec/models/account_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -118,7 +118,7 @@ Metrics/CyclomaticComplexity:
 
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/PerceivedComplexity:
-  Max: 27
+  Max: 25
 
 # Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers, AllowedPatterns.
 # SupportedStyles: snake_case, normalcase, non_integer
@@ -455,7 +455,6 @@ Rails/SkipsModelValidations:
     - 'db/post_migrate/20221206114142_backfill_admin_action_logs_again.rb'
     - 'lib/mastodon/cli/accounts.rb'
     - 'lib/mastodon/cli/federation.rb'
-    - 'lib/mastodon/cli/main.rb'
     - 'lib/mastodon/cli/maintenance.rb'
     - 'spec/controllers/api/v1/admin/accounts_controller_spec.rb'
     - 'spec/lib/activitypub/activity/follow_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -158,6 +158,7 @@ RSpec/AnyInstance:
     - 'spec/controllers/settings/two_factor_authentication/confirmations_controller_spec.rb'
     - 'spec/controllers/settings/two_factor_authentication/recovery_codes_controller_spec.rb'
     - 'spec/lib/mastodon/cli/federation_spec.rb'
+    - 'spec/lib/mastodon/cli/maintenance_spec.rb'
     - 'spec/lib/request_spec.rb'
     - 'spec/lib/status_filter_spec.rb'
     - 'spec/models/account_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -452,6 +452,7 @@ Rails/SkipsModelValidations:
     - 'db/post_migrate/20221101190723_backfill_admin_action_logs.rb'
     - 'db/post_migrate/20221206114142_backfill_admin_action_logs_again.rb'
     - 'lib/mastodon/cli/accounts.rb'
+    - 'lib/mastodon/cli/federation.rb'
     - 'lib/mastodon/cli/main.rb'
     - 'lib/mastodon/cli/maintenance.rb'
     - 'spec/controllers/api/v1/admin/accounts_controller_spec.rb'

--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -573,15 +573,7 @@ module Mastodon::CLI
       redirects to a different account that the one specified.
     LONG_DESC
     def migrate(username)
-      if options[:replay].present? && options[:target].present?
-        say('Use --replay or --target, not both', :red)
-        exit(1)
-      end
-
-      if options[:replay].blank? && options[:target].blank?
-        say('Use either --replay or --target', :red)
-        exit(1)
-      end
+      verify_migrate_options!
 
       account = Account.find_local(username)
 
@@ -632,6 +624,18 @@ module Mastodon::CLI
     end
 
     private
+
+    def verify_migrate_options!
+      if options[:replay].present? && options[:target].present?
+        say('Use --replay or --target, not both', :red)
+        exit(1)
+      end
+
+      if options[:replay].blank? && options[:target].blank?
+        say('Use either --replay or --target', :red)
+        exit(1)
+      end
+    end
 
     def assign_attributes_from_options(user)
       user.email = options[:email] if options[:email]

--- a/lib/mastodon/cli/federation.rb
+++ b/lib/mastodon/cli/federation.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Mastodon::CLI
+  class Federation < Base
+    default_task :self_destruct
+
+    option :dry_run, type: :boolean
+    desc 'self-destruct', 'Erase the server from the federation'
+    long_desc <<~LONG_DESC
+      Erase the server from the federation by broadcasting account delete
+      activities to all known other servers. This allows a "clean exit" from
+      running a Mastodon server, as it leaves next to no cache behind on
+      other servers.
+
+      This command is always interactive and requires confirmation twice.
+
+      No local data is actually deleted, because emptying the
+      database or removing files is much faster through other, external
+      means, such as e.g. deleting the entire VPS. However, because other
+      servers will delete data about local users, but no local data will be
+      updated (such as e.g. followers), there will be a state mismatch
+      that will lead to glitches and issues if you then continue to run and use
+      the server.
+
+      So either you know exactly what you are doing, or you are starting
+      from a blank slate afterwards by manually clearing out all the local
+      data!
+    LONG_DESC
+    def self_destruct
+      require 'tty-prompt'
+
+      prompt = TTY::Prompt.new
+
+      exit(1) unless prompt.ask('Type in the domain of the server to confirm:', required: true) == Rails.configuration.x.local_domain
+
+      unless dry_run?
+        prompt.warn('This operation WILL NOT be reversible. It can also take a long time.')
+        prompt.warn('While the data won\'t be erased locally, the server will be in a BROKEN STATE afterwards.')
+        prompt.warn('A running Sidekiq process is required. Do not shut it down until queues clear.')
+
+        exit(1) if prompt.no?('Are you sure you want to proceed?')
+      end
+
+      inboxes   = Account.inboxes
+      processed = 0
+
+      Setting.registrations_mode = 'none' unless dry_run?
+
+      if inboxes.empty?
+        Account.local.without_suspended.in_batches.update_all(suspended_at: Time.now.utc, suspension_origin: :local) unless dry_run?
+        prompt.ok('It seems like your server has not federated with anything')
+        prompt.ok('You can shut it down and delete it any time')
+        return
+      end
+
+      prompt.warn('Do NOT interrupt this process...')
+
+      delete_account = lambda do |account|
+        payload = ActiveModelSerializers::SerializableResource.new(
+          account,
+          serializer: ActivityPub::DeleteActorSerializer,
+          adapter: ActivityPub::Adapter
+        ).as_json
+
+        json = Oj.dump(ActivityPub::LinkedDataSignature.new(payload).sign!(account))
+
+        unless dry_run?
+          ActivityPub::DeliveryWorker.push_bulk(inboxes, limit: 1_000) do |inbox_url|
+            [json, account.id, inbox_url]
+          end
+
+          account.suspend!(block_email: false)
+        end
+
+        processed += 1
+      end
+
+      Account.local.without_suspended.find_each { |account| delete_account.call(account) }
+      Account.local.suspended.joins(:deletion_request).find_each { |account| delete_account.call(account) }
+
+      prompt.ok("Queued #{inboxes.size * processed} items into Sidekiq for #{processed} accounts#{dry_run_mode_suffix}")
+      prompt.ok('Wait until Sidekiq processes all items, then you can shut everything down and delete the data')
+    rescue TTY::Reader::InputInterrupt
+      exit(1)
+    end
+  end
+end

--- a/lib/mastodon/cli/main.rb
+++ b/lib/mastodon/cli/main.rb
@@ -8,6 +8,7 @@ require_relative 'canonical_email_blocks'
 require_relative 'domains'
 require_relative 'email_domain_blocks'
 require_relative 'emoji'
+require_relative 'federation'
 require_relative 'feeds'
 require_relative 'ip_blocks'
 require_relative 'maintenance'
@@ -65,85 +66,8 @@ module Mastodon::CLI
     desc 'maintenance SUBCOMMAND ...ARGS', 'Various maintenance utilities'
     subcommand 'maintenance', Maintenance
 
-    option :dry_run, type: :boolean
     desc 'self-destruct', 'Erase the server from the federation'
-    long_desc <<~LONG_DESC
-      Erase the server from the federation by broadcasting account delete
-      activities to all known other servers. This allows a "clean exit" from
-      running a Mastodon server, as it leaves next to no cache behind on
-      other servers.
-
-      This command is always interactive and requires confirmation twice.
-
-      No local data is actually deleted, because emptying the
-      database or removing files is much faster through other, external
-      means, such as e.g. deleting the entire VPS. However, because other
-      servers will delete data about local users, but no local data will be
-      updated (such as e.g. followers), there will be a state mismatch
-      that will lead to glitches and issues if you then continue to run and use
-      the server.
-
-      So either you know exactly what you are doing, or you are starting
-      from a blank slate afterwards by manually clearing out all the local
-      data!
-    LONG_DESC
-    def self_destruct
-      require 'tty-prompt'
-
-      prompt = TTY::Prompt.new
-
-      exit(1) unless prompt.ask('Type in the domain of the server to confirm:', required: true) == Rails.configuration.x.local_domain
-
-      unless dry_run?
-        prompt.warn('This operation WILL NOT be reversible. It can also take a long time.')
-        prompt.warn('While the data won\'t be erased locally, the server will be in a BROKEN STATE afterwards.')
-        prompt.warn('A running Sidekiq process is required. Do not shut it down until queues clear.')
-
-        exit(1) if prompt.no?('Are you sure you want to proceed?')
-      end
-
-      inboxes   = Account.inboxes
-      processed = 0
-
-      Setting.registrations_mode = 'none' unless dry_run?
-
-      if inboxes.empty?
-        Account.local.without_suspended.in_batches.update_all(suspended_at: Time.now.utc, suspension_origin: :local) unless dry_run?
-        prompt.ok('It seems like your server has not federated with anything')
-        prompt.ok('You can shut it down and delete it any time')
-        return
-      end
-
-      prompt.warn('Do NOT interrupt this process...')
-
-      delete_account = lambda do |account|
-        payload = ActiveModelSerializers::SerializableResource.new(
-          account,
-          serializer: ActivityPub::DeleteActorSerializer,
-          adapter: ActivityPub::Adapter
-        ).as_json
-
-        json = Oj.dump(ActivityPub::LinkedDataSignature.new(payload).sign!(account))
-
-        unless dry_run?
-          ActivityPub::DeliveryWorker.push_bulk(inboxes, limit: 1_000) do |inbox_url|
-            [json, account.id, inbox_url]
-          end
-
-          account.suspend!(block_email: false)
-        end
-
-        processed += 1
-      end
-
-      Account.local.without_suspended.find_each { |account| delete_account.call(account) }
-      Account.local.suspended.joins(:deletion_request).find_each { |account| delete_account.call(account) }
-
-      prompt.ok("Queued #{inboxes.size * processed} items into Sidekiq for #{processed} accounts#{dry_run_mode_suffix}")
-      prompt.ok('Wait until Sidekiq processes all items, then you can shut everything down and delete the data')
-    rescue TTY::Reader::InputInterrupt
-      exit(1)
-    end
+    subcommand 'self_destruct', Federation
 
     map %w(--version -v) => :version
 

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module Mastodon::CLI
   class Maintenance < Base
     MIN_SUPPORTED_VERSION = 2019_10_01_213028
-    MAX_SUPPORTED_VERSION = 2022_11_04_133904
+    MAX_SUPPORTED_VERSION = 2022_12_06_114142
 
     # Stubs to enjoy ActiveRecord queries while not depending on a particular
     # version of the code/database
@@ -509,7 +509,7 @@ module Mastodon::CLI
       if ActiveRecord::Migrator.current_version < 2021_04_21_121431
         ActiveRecord::Base.connection.add_index :tags, 'lower((name)::text)', name: 'index_tags_on_name_lower', unique: true
       else
-        ActiveRecord::Base.connection.execute 'CREATE UNIQUE INDEX CONCURRENTLY index_tags_on_name_lower_btree ON tags (lower(name) text_pattern_ops)'
+        ActiveRecord::Base.connection.execute 'CREATE UNIQUE INDEX index_tags_on_name_lower_btree ON tags (lower(name) text_pattern_ops)'
       end
     end
 
@@ -670,7 +670,7 @@ module Mastodon::CLI
     end
 
     def remove_index_if_exists!(table, name)
-      ActiveRecord::Base.connection.remove_index(table, name: name)
+      ActiveRecord::Base.connection.remove_index(table, name: name) if ActiveRecord::Base.connection.index_name_exists?(table, name)
     rescue ArgumentError, ActiveRecord::StatementInvalid
       nil
     end

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -670,7 +670,11 @@ module Mastodon::CLI
     end
 
     def remove_index_if_exists!(table, name)
-      ActiveRecord::Base.connection.remove_index(table, name: name) if ActiveRecord::Base.connection.index_name_exists?(table, name)
+      if ActiveRecord::Base.connection.index_name_exists?(table, name)
+        ActiveRecord::Base
+          .connection
+          .remove_index(table, name: name)
+      end
     rescue ArgumentError, ActiveRecord::StatementInvalid
       nil
     end

--- a/lib/mastodon/cli/upgrade.rb
+++ b/lib/mastodon/cli/upgrade.rb
@@ -125,27 +125,12 @@ module Mastodon::CLI
         progress.log("Moving #{previous_path} to #{upgraded_path}") if options[:verbose]
 
         begin
-          unless dry_run?
-            FileUtils.mkdir_p(File.dirname(upgraded_path))
-            FileUtils.mv(previous_path, upgraded_path)
-
-            begin
-              FileUtils.rmdir(File.dirname(previous_path), parents: true)
-            rescue Errno::ENOTEMPTY
-              # OK
-            end
-          end
+          move_previous_to_upgraded
         rescue => e
           progress.log(pastel.red("Error processing #{previous_path}: #{e}"))
           success = false
 
-          unless dry_run?
-            begin
-              FileUtils.rmdir(File.dirname(upgraded_path), parents: true)
-            rescue Errno::ENOTEMPTY
-              # OK
-            end
-          end
+          remove_directory
         end
       end
 
@@ -154,6 +139,29 @@ module Mastodon::CLI
       # all styles are updated
       attachment.instance_write(:storage_schema_version, previous_storage_schema_version)
       success
+    end
+
+    def move_previous_to_upgraded(previous_path, upgraded_path)
+      return if dry_run?
+
+      FileUtils.mkdir_p(File.dirname(upgraded_path))
+      FileUtils.mv(previous_path, upgraded_path)
+
+      begin
+        FileUtils.rmdir(File.dirname(previous_path), parents: true)
+      rescue Errno::ENOTEMPTY
+        # OK
+      end
+    end
+
+    def remove_directory(path)
+      return if dry_run?
+
+      begin
+        FileUtils.rmdir(File.dirname(path), parents: true)
+      rescue Errno::ENOTEMPTY
+        # OK
+      end
     end
   end
 end

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -8,6 +8,75 @@ describe Mastodon::CLI::Accounts do
 
   it_behaves_like 'A CLI Sub-Command'
 
+  describe 'delete' do
+    before { Fabricate(:account, username: 'Clorple') }
+
+    context 'with dry_run flag' do
+      it 'runs without making changes' do
+        expect { described_class.new.invoke(:delete, ['Clorple'], { dry_run: true }) }.to output(
+          a_string_including('OK (DRY RUN)')
+        ).to_stdout
+      end
+    end
+  end
+
+  describe 'fix_duplicates' do
+    before do
+      Fabricate(:account, domain: 'example.com', uri: 'duplicate')
+      Fabricate(:account, domain: 'example.com', uri: 'duplicate')
+    end
+
+    context 'with dry_run flag' do
+      it 'runs without making changes' do
+        expect { described_class.new.invoke(:fix_duplicates, [], { dry_run: true }) }.to output(
+          a_string_including('Duplicates found')
+        ).to_stdout
+      end
+    end
+  end
+
+  describe 'cull' do
+    before do
+      Fabricate(:account, domain: 'example.com')
+    end
+
+    context 'with dry_run flag' do
+      it 'runs without making changes' do
+        expect { described_class.new.invoke(:cull, ['example.com'], { dry_run: true }) }.to output(
+          a_string_including('(DRY RUN)')
+        ).to_stdout
+      end
+    end
+  end
+
+  describe 'refresh' do
+    before do
+      Fabricate(:account, username: 'glorp')
+    end
+
+    context 'with dry_run flag' do
+      it 'runs without making changes' do
+        expect { described_class.new.invoke(:refresh, ['glorp'], { dry_run: true }) }.to output(
+          a_string_including('(DRY RUN)')
+        ).to_stdout
+      end
+    end
+  end
+
+  describe 'prune' do
+    before do
+      Fabricate(:account, domain: 'example.com')
+    end
+
+    context 'with dry_run flag' do
+      it 'runs without making changes' do
+        expect { described_class.new.invoke(:prune, [], { dry_run: true }) }.to output(
+          a_string_including('(DRY RUN)')
+        ).to_stdout
+      end
+    end
+  end
+
   describe '#create' do
     shared_examples 'a new user with given email address and username' do
       it 'creates a new user with the specified email address' do

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -89,6 +89,24 @@ describe Mastodon::CLI::Accounts do
     end
   end
 
+  describe 'modify' do
+    before { Fabricate(:account, username: 'josh') }
+    it 'updates an existing user' do
+      expect { described_class.new.invoke(:modify, ['josh'], { email: 'josh@example.com' }) }.to output(
+        a_string_including('OK')
+      ).to_stdout
+    end
+  end
+
+  describe 'reset-relationships' do
+    before { Fabricate(:account, username: 'josh') }
+    it 'resets follows and followers for an account' do
+      expect { described_class.new.invoke(:reset_relationships, ['josh'], { follows: true, followers: true }) }.to output(
+        a_string_including('Processed 0 relationships')
+      ).to_stdout
+    end
+  end
+
   describe '#create' do
     shared_examples 'a new user with given email address and username' do
       it 'creates a new user with the specified email address' do

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -77,6 +77,18 @@ describe Mastodon::CLI::Accounts do
     end
   end
 
+  describe 'rotate' do
+    before do
+      Fabricate(:account, username: 'Teddy')
+    end
+
+    it 'rotates keys for all accounts' do
+      expect { described_class.new.invoke(:rotate, [], { all: true }) }.to output(
+        a_string_including('OK')
+      ).to_stdout
+    end
+  end
+
   describe '#create' do
     shared_examples 'a new user with given email address and username' do
       it 'creates a new user with the specified email address' do

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -6,11 +6,7 @@ require 'mastodon/cli/accounts'
 describe Mastodon::CLI::Accounts do
   let(:cli) { described_class.new }
 
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 
   describe '#create' do
     shared_examples 'a new user with given email address and username' do

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -91,6 +91,7 @@ describe Mastodon::CLI::Accounts do
 
   describe 'modify' do
     before { Fabricate(:account, username: 'josh') }
+
     it 'updates an existing user' do
       expect { described_class.new.invoke(:modify, ['josh'], { email: 'josh@example.com' }) }.to output(
         a_string_including('OK')
@@ -100,6 +101,7 @@ describe Mastodon::CLI::Accounts do
 
   describe 'reset-relationships' do
     before { Fabricate(:account, username: 'josh') }
+
     it 'resets follows and followers for an account' do
       expect { described_class.new.invoke(:reset_relationships, ['josh'], { follows: true, followers: true }) }.to output(
         a_string_including('Processed 0 relationships')

--- a/spec/lib/mastodon/cli/cache_spec.rb
+++ b/spec/lib/mastodon/cli/cache_spec.rb
@@ -64,4 +64,17 @@ describe Mastodon::CLI::Cache do
       end
     end
   end
+
+  describe 'recount' do
+    context 'with an account' do
+      before { Fabricate(:account) }
+
+      it 're-calculates account records in the cache' do
+        expect { described_class.new.invoke(:recount, ['accounts']) }.to output(
+          a_string_including('OK')
+        ).to_stdout
+      end
+    end
+
+  end
 end

--- a/spec/lib/mastodon/cli/cache_spec.rb
+++ b/spec/lib/mastodon/cli/cache_spec.rb
@@ -75,6 +75,5 @@ describe Mastodon::CLI::Cache do
         ).to_stdout
       end
     end
-
   end
 end

--- a/spec/lib/mastodon/cli/cache_spec.rb
+++ b/spec/lib/mastodon/cli/cache_spec.rb
@@ -6,11 +6,7 @@ require 'mastodon/cli/cache'
 describe Mastodon::CLI::Cache do
   let(:cli) { described_class.new }
 
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 
   describe '#clear' do
     before { allow(Rails.cache).to receive(:clear) }

--- a/spec/lib/mastodon/cli/canonical_email_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/canonical_email_blocks_spec.rb
@@ -6,11 +6,7 @@ require 'mastodon/cli/canonical_email_blocks'
 describe Mastodon::CLI::CanonicalEmailBlocks do
   let(:cli) { described_class.new }
 
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 
   describe '#find' do
     let(:arguments) { ['user@example.com'] }

--- a/spec/lib/mastodon/cli/domains_spec.rb
+++ b/spec/lib/mastodon/cli/domains_spec.rb
@@ -4,9 +4,5 @@ require 'rails_helper'
 require 'mastodon/cli/domains'
 
 describe Mastodon::CLI::Domains do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 end

--- a/spec/lib/mastodon/cli/domains_spec.rb
+++ b/spec/lib/mastodon/cli/domains_spec.rb
@@ -5,4 +5,18 @@ require 'mastodon/cli/domains'
 
 describe Mastodon::CLI::Domains do
   it_behaves_like 'A CLI Sub-Command'
+
+  describe 'purge' do
+    before do
+      Fabricate(:account, domain: 'example.com')
+    end
+
+    context 'with dry_run flag' do
+      it 'runs without making changes' do
+        expect { described_class.new.invoke(:purge, ['example.com'], { dry_run: true }) }.to output(
+          a_string_including('(DRY RUN)')
+        ).to_stdout
+      end
+    end
+  end
 end

--- a/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
@@ -5,4 +5,32 @@ require 'mastodon/cli/email_domain_blocks'
 
 describe Mastodon::CLI::EmailDomainBlocks do
   it_behaves_like 'A CLI Sub-Command'
+
+  describe 'list' do
+    before { Fabricate(:email_domain_block, domain: 'newbie.woot') }
+
+    it 'lists records' do
+      expect { described_class.new.invoke(:list) }.to output(
+        a_string_including('newbie')
+      ).to_stdout
+    end
+  end
+
+  describe 'add' do
+    it 'makes a block' do
+      expect { described_class.new.invoke(:add, ['domain.example']) }.to output(
+        a_string_including('Added 1')
+      ).to_stdout
+    end
+  end
+
+  describe 'remove' do
+    before { Fabricate(:email_domain_block, domain: 'domain.example') }
+
+    it 'deletes a block' do
+      expect { described_class.new.invoke(:remove, ['domain.example']) }.to output(
+        a_string_including('Removed 1')
+      ).to_stdout
+    end
+  end
 end

--- a/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
@@ -4,9 +4,5 @@ require 'rails_helper'
 require 'mastodon/cli/email_domain_blocks'
 
 describe Mastodon::CLI::EmailDomainBlocks do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 end

--- a/spec/lib/mastodon/cli/emoji_spec.rb
+++ b/spec/lib/mastodon/cli/emoji_spec.rb
@@ -5,4 +5,12 @@ require 'mastodon/cli/emoji'
 
 describe Mastodon::CLI::Emoji do
   it_behaves_like 'A CLI Sub-Command'
+
+  describe 'purge' do
+    it 'removes the emoji' do
+      expect { described_class.new.invoke(:purge) }.to output(
+        a_string_including('OK')
+      ).to_stdout
+    end
+  end
 end

--- a/spec/lib/mastodon/cli/emoji_spec.rb
+++ b/spec/lib/mastodon/cli/emoji_spec.rb
@@ -4,9 +4,5 @@ require 'rails_helper'
 require 'mastodon/cli/emoji'
 
 describe Mastodon::CLI::Emoji do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 end

--- a/spec/lib/mastodon/cli/federation_spec.rb
+++ b/spec/lib/mastodon/cli/federation_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/federation'
+
+describe Mastodon::CLI::Federation do
+  it_behaves_like 'A CLI Sub-Command'
+
+  describe 'self_destruct' do
+    before do
+      allow_any_instance_of(Thor::Shell::Basic).to receive(:ask).and_return Rails.configuration.x.local_domain
+    end
+
+    context 'with dry_run flag' do
+      it 'runs without making changes' do
+        expect { described_class.new.invoke(:self_destruct, [], { dry_run: true }) }.to output(
+          a_string_including('has not federated')
+        ).to_stdout
+      end
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/feeds_spec.rb
+++ b/spec/lib/mastodon/cli/feeds_spec.rb
@@ -6,11 +6,7 @@ require 'mastodon/cli/feeds'
 describe Mastodon::CLI::Feeds do
   let(:cli) { described_class.new }
 
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 
   describe '#build' do
     before { Fabricate(:account) }

--- a/spec/lib/mastodon/cli/feeds_spec.rb
+++ b/spec/lib/mastodon/cli/feeds_spec.rb
@@ -61,4 +61,12 @@ describe Mastodon::CLI::Feeds do
       redis.keys('feed:*')
     end
   end
+
+  describe 'clear' do
+    it 'clears out redis feeds' do
+      expect { described_class.new.invoke(:clear) }.to output(
+        a_string_including('OK')
+      ).to_stdout
+    end
+  end
 end

--- a/spec/lib/mastodon/cli/ip_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/ip_blocks_spec.rb
@@ -6,11 +6,7 @@ require 'mastodon/cli/ip_blocks'
 describe Mastodon::CLI::IpBlocks do
   let(:cli) { described_class.new }
 
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 
   describe '#add' do
     let(:ip_list) do

--- a/spec/lib/mastodon/cli/main_spec.rb
+++ b/spec/lib/mastodon/cli/main_spec.rb
@@ -4,11 +4,7 @@ require 'rails_helper'
 require 'mastodon/cli/main'
 
 describe Mastodon::CLI::Main do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 
   describe 'version' do
     it 'returns the Mastodon version' do

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -5,4 +5,17 @@ require 'mastodon/cli/maintenance'
 
 describe Mastodon::CLI::Maintenance do
   it_behaves_like 'A CLI Sub-Command'
+
+  describe 'fix_duplicates' do
+    before do
+      allow_any_instance_of(Thor::Shell::Basic).to receive(:yes?).with('Continue anyway? (Yes/No)').and_return true
+      allow_any_instance_of(Thor::Shell::Basic).to receive(:yes?).with('Continue? (Yes/No)').and_return true
+    end
+
+    it 'fixes db dupes and rebuilds indexes' do
+      expect { described_class.new.invoke(:fix_duplicates) }.to output(
+        a_string_including('Finished!')
+      ).to_stdout
+    end
+  end
 end

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -4,9 +4,5 @@ require 'rails_helper'
 require 'mastodon/cli/maintenance'
 
 describe Mastodon::CLI::Maintenance do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 end

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -5,4 +5,12 @@ require 'mastodon/cli/media'
 
 describe Mastodon::CLI::Media do
   it_behaves_like 'A CLI Sub-Command'
+
+  describe 'usage' do
+    it 'calculates used disk space' do
+      expect { described_class.new.invoke(:usage) }.to output(
+        a_string_including('Settings')
+      ).to_stdout
+    end
+  end
 end

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -4,9 +4,5 @@ require 'rails_helper'
 require 'mastodon/cli/media'
 
 describe Mastodon::CLI::Media do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 end

--- a/spec/lib/mastodon/cli/preview_cards_spec.rb
+++ b/spec/lib/mastodon/cli/preview_cards_spec.rb
@@ -4,9 +4,5 @@ require 'rails_helper'
 require 'mastodon/cli/preview_cards'
 
 describe Mastodon::CLI::PreviewCards do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 end

--- a/spec/lib/mastodon/cli/search_spec.rb
+++ b/spec/lib/mastodon/cli/search_spec.rb
@@ -4,9 +4,5 @@ require 'rails_helper'
 require 'mastodon/cli/search'
 
 describe Mastodon::CLI::Search do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 end

--- a/spec/lib/mastodon/cli/settings_spec.rb
+++ b/spec/lib/mastodon/cli/settings_spec.rb
@@ -4,11 +4,7 @@ require 'rails_helper'
 require 'mastodon/cli/settings'
 
 describe Mastodon::CLI::Settings do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 
   describe 'subcommand "registrations"' do
     let(:cli) { Mastodon::CLI::Registrations.new }

--- a/spec/lib/mastodon/cli/statuses_spec.rb
+++ b/spec/lib/mastodon/cli/statuses_spec.rb
@@ -4,9 +4,5 @@ require 'rails_helper'
 require 'mastodon/cli/statuses'
 
 describe Mastodon::CLI::Statuses do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 end

--- a/spec/lib/mastodon/cli/upgrade_spec.rb
+++ b/spec/lib/mastodon/cli/upgrade_spec.rb
@@ -5,4 +5,12 @@ require 'mastodon/cli/upgrade'
 
 describe Mastodon::CLI::Upgrade do
   it_behaves_like 'A CLI Sub-Command'
+
+  describe 'storage-schema' do
+    it 'updates the schema for attachments' do
+      expect { described_class.new.invoke(:storage_schema) }.to output(
+        a_string_including('Upgraded')
+      ).to_stdout
+    end
+  end
 end

--- a/spec/lib/mastodon/cli/upgrade_spec.rb
+++ b/spec/lib/mastodon/cli/upgrade_spec.rb
@@ -4,9 +4,5 @@ require 'rails_helper'
 require 'mastodon/cli/upgrade'
 
 describe Mastodon::CLI::Upgrade do
-  describe '.exit_on_failure?' do
-    it 'returns true' do
-      expect(described_class.exit_on_failure?).to be true
-    end
-  end
+  it_behaves_like 'A CLI Sub-Command'
 end

--- a/spec/support/examples/lib/cli/subcommand.rb
+++ b/spec/support/examples/lib/cli/subcommand.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+shared_examples 'A CLI Sub-Command' do
+  describe 'Subclass of Base' do
+    it 'descends from CLI base class' do
+      expect(described_class).to be < Mastodon::CLI::Base
+    end
+  end
+
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end


### PR DESCRIPTION
Followup on https://github.com/mastodon/mastodon/pull/23978

This makes some changes to the CLI-related classes that are called by `tootctl` script...

- Moves all classes under a `CLI::` namespace, and renames file to be in a cli/ folder (instead of _cli.rb names)
- Misc rubocop shuffling to accomodate that movement
- Add a `CLI::Base` class which all subcommands inherit from, and which includes common methods
- Move some of the previous `CLIHelper` module methods into the base class
- Rename the `CLIHelper` module to `CLI::ProgressHelper` since all remaining methods are related to progress bar output
- I tried to chip away a bit at some of the rubocop todo items where it was easy to do so
- Overall spec coverage is improved a bit since #23978 which just got some files to load, but is not close to 100% yet. Some of the code paths here are tricky to exercise in specs or slightly awkward to work with.

In theory the `tootctl` command and all subcommand functionality should not have changed here.

Opening as draft for now to get initial feedback - and because I want to use the PR review process to leave a few of my own comments on things I had questions about and encountered while in here. There are also a few exceptions to the last statement (that nothing changed) and I will leave comments about those to call them out while still in draft.

Because of the bulk file move here this might be hard to review from just the diff and it may be easier to step through a commit at a time or something. Not sure. If that's a huge issue, I could open a separate PR with *just the move*, get that merged in first, then step through these other changes in subsequent PR where seeing the diff may be easier.
