### PR TITLE
Add missing role attrs to serializer

### DIFF
--- a/app/serializers/rest/role_serializer.rb
+++ b/app/serializers/rest/role_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::RoleSerializer < ActiveModel::Serializer
-  attributes :id, :name, :permissions, :color, :highlighted
+  attributes :id, :name, :permissions, :color, :highlighted, :position, :created_at, :updated_at
 
   def id
     object.id.to_s


### PR DESCRIPTION
`position`, `created_at`, and `updated_at` are [documented](https://docs.joinmastodon.org/entities/Role/) as being present, but weren't actually until now.