### PR TITLE
Fit the max-width of media in .prose to parent box

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8249,11 +8249,13 @@ noscript {
   img {
     margin-top: 2em;
     margin-bottom: 2em;
+    max-width: 100%;
   }
 
   video {
     margin-top: 2em;
     margin-bottom: 2em;
+    max-width: 100%;
   }
 
   figure {


### PR DESCRIPTION
Minor CSS fix for #24179, where images and videos in `.prose` box can overflow on pages such as the About and Privacy Policy.

Before:
![Screenshot before](https://user-images.githubusercontent.com/5103195/226378705-b0eac6bb-c3f7-4323-80c9-711648247b0c.png)

After:
![Screenshot after](https://user-images.githubusercontent.com/5103195/226378795-1ee4ba19-469b-4729-9154-35233ac8e512.png)