### PR TITLE
Fix crash in `tootctl` commands making use of parallelization when Elasticsearch is enabled

### DIFF
--- a/lib/mastodon/cli_helper.rb
+++ b/lib/mastodon/cli_helper.rb
@@ -52,14 +52,16 @@ module Mastodon
 
             progress.log("Processing #{item.id}") if options[:verbose]
 
-            result = ActiveRecord::Base.connection_pool.with_connection do
-              yield(item)
-            ensure
-              RedisConfiguration.pool.checkin if Thread.current[:redis]
-              Thread.current[:redis] = nil
-            end
+            Chewy.strategy(:mastodon) do
+              result = ActiveRecord::Base.connection_pool.with_connection do
+                yield(item)
+              ensure
+                RedisConfiguration.pool.checkin if Thread.current[:redis]
+                Thread.current[:redis] = nil
+              end
 
-            aggregate.increment(result) if result.is_a?(Integer)
+              aggregate.increment(result) if result.is_a?(Integer)
+            end
           rescue => e
             progress.log pastel.red("Error processing #{item.id}: #{e}")
           ensure


### PR DESCRIPTION
Fixes #24149