### PR TITLE
Remove references to non-existent actions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1670,8 +1670,6 @@ Rails/InverseOf:
 # Include: app/controllers/**/*.rb, app/mailers/**/*.rb
 Rails/LexicallyScopedActionFilter:
   Exclude:
-    - 'app/controllers/admin/domain_blocks_controller.rb'
-    - 'app/controllers/admin/email_domain_blocks_controller.rb'
     - 'app/controllers/auth/passwords_controller.rb'
     - 'app/controllers/auth/registrations_controller.rb'
     - 'app/controllers/auth/sessions_controller.rb'

--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class DomainBlocksController < BaseController
-    before_action :set_domain_block, only: [:show, :destroy, :edit, :update]
+    before_action :set_domain_block, only: [:destroy, :edit, :update]
 
     def batch
       authorize :domain_block, :create?

--- a/app/controllers/admin/email_domain_blocks_controller.rb
+++ b/app/controllers/admin/email_domain_blocks_controller.rb
@@ -2,8 +2,6 @@
 
 module Admin
   class EmailDomainBlocksController < BaseController
-    before_action :set_email_domain_block, only: [:show, :destroy]
-
     def index
       authorize :email_domain_block, :index?
 
@@ -58,10 +56,6 @@ module Admin
     end
 
     private
-
-    def set_email_domain_block
-      @email_domain_block = EmailDomainBlock.find(params[:id])
-    end
 
     def set_resolved_records
       Resolv::DNS.open do |dns|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -229,7 +229,7 @@ Rails.application.routes.draw do
     get '/dashboard', to: 'dashboard#index'
 
     resources :domain_allows, only: [:new, :create, :show, :destroy]
-    resources :domain_blocks, only: [:new, :create, :show, :destroy, :update, :edit] do
+    resources :domain_blocks, only: [:new, :create, :destroy, :update, :edit] do
       collection do
         post :batch
       end


### PR DESCRIPTION
Removes before_action references to two `show` actions which don't exist, and to a route which points to a non-existent action.

The admin/domain_blocks#show action was removed in bd53dd521064b12261b82105624cf5f8b9ca9d69 but the route was not removed and the before_action wasn't changed.

The admin/email_domain_blocks#show and #destroy have never existed, and may have been erroneously copy/pasted in when created.