### PR TITLE
Add API to get multiple accounts and statuses

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -7,15 +7,20 @@ class Api::V1::AccountsController < Api::BaseController
   before_action -> { doorkeeper_authorize! :follow, :write, :'write:blocks' }, only: [:block, :unblock]
   before_action -> { doorkeeper_authorize! :write, :'write:accounts' }, only: [:create]
 
-  before_action :require_user!, except: [:show, :create]
-  before_action :set_account, except: [:create]
-  before_action :check_account_approval, except: [:create]
-  before_action :check_account_confirmation, except: [:create]
+  before_action :require_user!, except: [:index, :show, :create]
+  before_action :set_account, except: [:index, :create]
+  before_action :set_accounts, only: [:index]
+  before_action :check_account_approval, except: [:index, :create]
+  before_action :check_account_confirmation, except: [:index, :create]
   before_action :check_enabled_registrations, only: [:create]
 
   skip_before_action :require_authenticated_user!, only: :create
 
   override_rate_limit_headers :follow, family: :follows
+
+  def index
+    render json: @accounts, each_serializer: REST::AccountSerializer
+  end
 
   def show
     render json: @account, serializer: REST::AccountSerializer
@@ -76,6 +81,10 @@ class Api::V1::AccountsController < Api::BaseController
     @account = Account.find(params[:id])
   end
 
+  def set_accounts
+    @accounts = Account.where(id: account_ids).without_unapproved
+  end
+
   def check_account_approval
     raise(ActiveRecord::RecordNotFound) if @account.local? && @account.user_pending?
   end
@@ -86,6 +95,14 @@ class Api::V1::AccountsController < Api::BaseController
 
   def relationships(**options)
     AccountRelationshipsPresenter.new([@account.id], current_user.account_id, **options)
+  end
+
+  def account_ids
+    Array(accounts_params[:ids]).uniq.map(&:to_i)
+  end
+
+  def accounts_params
+    params.permit(ids: [])
   end
 
   def account_params

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -13,6 +13,7 @@ class Api::V1::AccountsController < Api::BaseController
   before_action :check_account_approval, except: [:index, :create]
   before_action :check_account_confirmation, except: [:index, :create]
   before_action :check_enabled_registrations, only: [:create]
+  before_action :check_accounts_limit, only: [:index]
 
   skip_before_action :require_authenticated_user!, only: :create
 
@@ -91,6 +92,10 @@ class Api::V1::AccountsController < Api::BaseController
 
   def check_account_confirmation
     raise(ActiveRecord::RecordNotFound) if @account.local? && !@account.user_confirmed?
+  end
+
+  def check_accounts_limit
+    raise(Mastodon::ValidationError) if account_ids.size > DEFAULT_ACCOUNTS_LIMIT
   end
 
   def relationships(**options)

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -5,7 +5,8 @@ class Api::V1::StatusesController < Api::BaseController
 
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }, except: [:create, :update, :destroy]
   before_action -> { doorkeeper_authorize! :write, :'write:statuses' }, only:   [:create, :update, :destroy]
-  before_action :require_user!, except:  [:show, :context]
+  before_action :require_user!, except:  [:index, :show, :context]
+  before_action :set_statuses, only:     [:index]
   before_action :set_status, only:       [:show, :context]
   before_action :set_thread, only:       [:create]
 
@@ -22,6 +23,11 @@ class Api::V1::StatusesController < Api::BaseController
   ANCESTORS_LIMIT         = 40
   DESCENDANTS_LIMIT       = 60
   DESCENDANTS_DEPTH_LIMIT = 20
+
+  def index
+    @statuses = cache_collection(@statuses, Status)
+    render json: @statuses, each_serializer: REST::StatusSerializer
+  end
 
   def show
     @status = cache_collection([@status], Status).first
@@ -112,6 +118,10 @@ class Api::V1::StatusesController < Api::BaseController
 
   private
 
+  def set_statuses
+    @statuses = Status.permitted_statuses_from_ids(status_ids, current_account)
+  end
+
   def set_status
     @status = Status.find(params[:id])
     authorize @status, :show?
@@ -124,6 +134,14 @@ class Api::V1::StatusesController < Api::BaseController
     authorize(@thread, :show?) if @thread.present?
   rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
     render json: { error: I18n.t('statuses.errors.in_reply_not_found') }, status: 404
+  end
+
+  def status_ids
+    Array(statuses_params[:ids]).uniq.map(&:to_i)
+  end
+
+  def statuses_params
+    params.permit(ids: [])
   end
 
   def status_params

--- a/app/models/concerns/status_threading_concern.rb
+++ b/app/models/concerns/status_threading_concern.rb
@@ -3,6 +3,23 @@
 module StatusThreadingConcern
   extend ActiveSupport::Concern
 
+  class_methods do
+    def permitted_statuses_from_ids(ids, account, stable: false)
+      statuses    = Status.with_accounts(ids).to_a
+      account_ids = statuses.map(&:account_id).uniq
+      domains     = statuses.filter_map(&:account_domain).uniq
+      relations   = account&.relations_map(account_ids, domains) || {}
+
+      statuses.reject! { |status| StatusFilter.new(status, account, relations).filtered? }
+
+      if stable
+        statuses.sort_by! { |status| ids.index(status.id) }
+      else
+        statuses
+      end
+    end
+  end
+
   def ancestors(limit, account = nil)
     find_statuses_from_tree_path(ancestor_ids(limit), account)
   end
@@ -76,15 +93,7 @@ module StatusThreadingConcern
   end
 
   def find_statuses_from_tree_path(ids, account, promote: false)
-    statuses    = Status.with_accounts(ids).to_a
-    account_ids = statuses.map(&:account_id).uniq
-    domains     = statuses.filter_map(&:account_domain).uniq
-    relations   = account&.relations_map(account_ids, domains) || {}
-
-    statuses.reject! { |status| StatusFilter.new(status, account, relations).filtered? }
-
-    # Order ancestors/descendants by tree path
-    statuses.sort_by! { |status| ids.index(status.id) }
+    statuses = Status.permitted_statuses_from_ids(ids, account, stable: true)
 
     # Bring self-replies to the top
     if promote

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -436,7 +436,7 @@ Rails.application.routes.draw do
 
     # JSON / REST API
     namespace :v1 do
-      resources :statuses, only: [:create, :show, :update, :destroy] do
+      resources :statuses, only: [:index, :create, :show, :update, :destroy] do
         scope module: :statuses do
           resources :reblogged_by, controller: :reblogged_by_accounts, only: :index
           resources :favourited_by, controller: :favourited_by_accounts, only: :index
@@ -581,7 +581,7 @@ Rails.application.routes.draw do
         resources :familiar_followers, only: :index
       end
 
-      resources :accounts, only: [:create, :show] do
+      resources :accounts, only: [:index, :create, :show] do
         resources :statuses, only: :index, controller: 'accounts/statuses'
         resources :followers, only: :index, controller: 'accounts/follower_accounts'
         resources :following, only: :index, controller: 'accounts/following_accounts'


### PR DESCRIPTION
Add an API to get accounts and statuses by ID.

```
GET /api/v1/accounts?ids[]=1&ids[]=2
GET /api/v1/statuses?ids[]=1&ids[]=2
```

- The `ids` parameter can request up to DEFAULT_ACCOUNTS_LIMIT (=40) for accounts and DEFAULT_STATUSES_LIMIT (=20) for statuses, and a 422 Mastodon::ValidationError will occur if exceeded.

I have multiple needs.

- We want to update the accounts and statuses we hold to the latest information, including additional information (favorites, boosts, edit history, etc.)
- To save resources, if we only keep the ID and purge other payloads, we want to retrieve it again when needed
- We want to get only what we need from an API response that only returns an ID

___

Fixes MAS-52