### PR TITLE
Fix user archive takeout when using OpenStack Swift or S3 providers with no ACL support

### DIFF
--- a/app/controllers/backups_controller.rb
+++ b/app/controllers/backups_controller.rb
@@ -13,7 +13,11 @@ class BackupsController < ApplicationController
     when :s3
       redirect_to @backup.dump.expiring_url(10)
     when :fog
-      redirect_to @backup.dump.expiring_url(Time.now.utc + 10)
+      if Paperclip::Attachment.default_options.dig(:storage, :fog_credentials, :openstack_temp_url_key).present?
+        redirect_to @backup.dump.expiring_url(Time.now.utc + 10)
+      else
+        redirect_to full_asset_url(@backup.dump.url)
+      end
     when :filesystem
       redirect_to full_asset_url(@backup.dump.url)
     end

--- a/app/models/backup.rb
+++ b/app/models/backup.rb
@@ -18,6 +18,6 @@
 class Backup < ApplicationRecord
   belongs_to :user, inverse_of: :backups
 
-  has_attached_file :dump, s3_permissions: 'private'
+  has_attached_file :dump, s3_permissions: ->(*) { ENV['S3_PERMISSION'] == '' ? nil : 'private' }
   validates_attachment_content_type :dump, content_type: /\Aapplication/
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -130,6 +130,7 @@ elsif ENV['SWIFT_ENABLED'] == 'true'
       openstack_domain_name: ENV.fetch('SWIFT_DOMAIN_NAME') { 'default' },
       openstack_region: ENV['SWIFT_REGION'],
       openstack_cache_ttl: ENV.fetch('SWIFT_CACHE_TTL') { 60 },
+      openstack_temp_url_key: ENV['SWIFT_TEMP_URL_KEY'],
     },
     
     fog_file: { 'Cache-Control' => 'public, max-age=315576000, immutable' },


### PR DESCRIPTION
- add the `SWIFT_TEMP_URL_KEY` environment variable to generate OpenStack Swift signed temporary URLs
- do not attempt to generate signed temporary URLs if `SWIFT_TEMP_URL_KEY` is not defined (fixes #24146)
- fix archive storage on S3 providers that do not support the `private` canned ACL

The `SWIFT_TEMP_URL_KEY` option currently has very limited benefits, as OpenStack Swift does not support per-object ACLs, but it could nevertheless be useful in conjunction with filtering rules on reverse-proxies, or if we end up allowing separate buckets/containers for archives and other attachments.