### PR TITLE
Add specs for Chewy importers

### DIFF
--- a/spec/lib/importer/accounts_index_importer_spec.rb
+++ b/spec/lib/importer/accounts_index_importer_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Importer::AccountsIndexImporter do
+  describe 'import!' do
+    let(:pool) { Concurrent::FixedThreadPool.new(5) }
+    let(:importer) { described_class.new(batch_size: 123, executor: pool) }
+
+    before { Fabricate(:account) }
+
+    it 'indexes relevant accounts' do
+      expect { importer.import! }.to update_index(AccountsIndex)
+    end
+  end
+end

--- a/spec/lib/importer/statuses_index_importer_spec.rb
+++ b/spec/lib/importer/statuses_index_importer_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Importer::StatusesIndexImporter do
+  describe 'import!' do
+    let(:pool) { Concurrent::FixedThreadPool.new(5) }
+    let(:importer) { described_class.new(batch_size: 123, executor: pool) }
+
+    before { Fabricate(:status) }
+
+    it 'indexes relevant statuses' do
+      expect { importer.import! }.to update_index(StatusesIndex)
+    end
+  end
+end

--- a/spec/lib/importer/tags_index_importer_spec.rb
+++ b/spec/lib/importer/tags_index_importer_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Importer::TagsIndexImporter do
+  describe 'import!' do
+    let(:pool) { Concurrent::FixedThreadPool.new(5) }
+    let(:importer) { described_class.new(batch_size: 123, executor: pool) }
+
+    before { Fabricate(:tag) }
+
+    it 'indexes relevant tags' do
+      expect { importer.import! }.to update_index(TagsIndex)
+    end
+  end
+end


### PR DESCRIPTION
For the Accounts, Statuses, and Tags importers -- add basic coverage which creates a record, runs the importer, and checks that the index was updated.