### PR TITLE
Remove unused InstancePresenter methods

### DIFF
--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -22,10 +22,6 @@ class InstancePresenter < ActiveModelSerializers::Model
     ContactPresenter.new
   end
 
-  def closed_registrations_message
-    Setting.closed_registrations_message
-  end
-
   def description
     Setting.site_short_description
   end

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -30,10 +30,6 @@ class InstancePresenter < ActiveModelSerializers::Model
     Setting.site_extended_description
   end
 
-  def privacy_policy
-    Setting.site_terms
-  end
-
   def status_page_url
     Setting.status_page_url
   end


### PR DESCRIPTION
It looks like these were both removed in the refactor of the about/privacy/etc pages over to the web UI.

As far as I can tell the last use of `closed_registrations_message` was removed here - https://github.com/mastodon/mastodon/commit/58d5b28cb00ffadfeb7a3e1e03f7ae0d3b0d8486#diff-69343a0a48faa1cb0c231481fbc8b7457bfbb2b3fa486b4e27152da87b04fbaaL37 - and the last use of `privacy_policy` was removed here - https://github.com/mastodon/mastodon/commit/a2ba01132603174c43c5788a95f9ee127b684c0a#diff-62a16346f4cdd391df5446c13f6b1c508d190e96aba13cd9df1f22684c95a045L7

Both of the underlying settings are still used in various places, just not through the instance presenter (I think!?).