### PR TITLE
Do not translate URLs and mentions, preserve hashtag links

### DIFF
--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -104,9 +104,10 @@ class StatusContent extends React.PureComponent {
         link.addEventListener('click', this.onMentionClick.bind(this, mention), false);
         link.setAttribute('title', mention.get('acct'));
         link.setAttribute('href', `/@${mention.get('acct')}`);
-      } else if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
-        link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
-        link.setAttribute('href', `/tags/${link.text.slice(1)}`);
+      } else if (link.dataset.hashtag || link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
+        const tag = link.dataset.hashtag || link.text.replace(/^#/, '');
+        link.addEventListener('click', this.onHashtagClick.bind(this, tag), false);
+        link.setAttribute('href', `/tags/${tag}`);
       } else {
         link.setAttribute('title', link.href);
         link.classList.add('unhandled-link');
@@ -168,8 +169,6 @@ class StatusContent extends React.PureComponent {
   };
 
   onHashtagClick = (hashtag, e) => {
-    hashtag = hashtag.replace(/^#/, '');
-
     if (this.context.router && e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       this.context.router.history.push(`/tags/${hashtag}`);

--- a/app/javascript/mastodon/features/getting_started/components/announcements.jsx
+++ b/app/javascript/mastodon/features/getting_started/components/announcements.jsx
@@ -67,8 +67,8 @@ class Content extends ImmutablePureComponent {
       if (mention) {
         link.addEventListener('click', this.onMentionClick.bind(this, mention), false);
         link.setAttribute('title', mention.get('acct'));
-      } else if (link.textContent[0] === '#' || (link.previousSibling && link.previousSibling.textContent && link.previousSibling.textContent[link.previousSibling.textContent.length - 1] === '#')) {
-        link.addEventListener('click', this.onHashtagClick.bind(this, link.text), false);
+      } else if (link.dataset.hashtag) {
+        link.addEventListener('click', this.onHashtagClick.bind(this, link.dataset.hashtag), false);
       } else {
         let status = this.props.announcement.get('statuses').find(item => link.href === item.get('url'));
         if (status) {
@@ -91,8 +91,6 @@ class Content extends ImmutablePureComponent {
   };
 
   onHashtagClick = (hashtag, e) => {
-    hashtag = hashtag.replace(/^#/, '');
-
     if (this.context.router && e.button === 0 && !(e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       this.context.router.history.push(`/tags/${hashtag}`);

--- a/app/lib/text_formatter.rb
+++ b/app/lib/text_formatter.rb
@@ -90,7 +90,7 @@ class TextFormatter
     url     = tag_url(hashtag)
 
     <<~HTML.squish
-      <a href="#{h(url)}" class="mention hashtag" rel="tag">#<span>#{h(hashtag)}</span></a>
+      <a href="#{h(url)}" class="mention hashtag" rel="tag" data-hashtag="#{h(hashtag)}">#<span>#{h(hashtag)}</span></a>
     HTML
   end
 

--- a/app/lib/text_formatter.rb
+++ b/app/lib/text_formatter.rb
@@ -79,7 +79,7 @@ class TextFormatter
     cutoff      = url[prefix.length..-1].length > 30
 
     <<~HTML.squish
-      <a href="#{h(url)}" target="_blank" rel="#{rel.join(' ')}"><span class="invisible">#{h(prefix)}</span><span class="#{cutoff ? 'ellipsis' : ''}">#{h(display_url)}</span><span class="invisible">#{h(suffix)}</span></a>
+      <a href="#{h(url)}" target="_blank" rel="#{rel.join(' ')}" translate="no"><span class="invisible">#{h(prefix)}</span><span class="#{cutoff ? 'ellipsis' : ''}">#{h(display_url)}</span><span class="invisible">#{h(suffix)}</span></a>
     HTML
   rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
     h(entity[:url])
@@ -122,7 +122,7 @@ class TextFormatter
     display_username = same_username_hits&.positive? || with_domains? ? account.pretty_acct : account.username
 
     <<~HTML.squish
-      <span class="h-card"><a href="#{h(url)}" class="u-url mention">@<span>#{h(display_username)}</span></a></span>
+      <span class="h-card" translate="no"><a href="#{h(url)}" class="u-url mention">@<span>#{h(display_username)}</span></a></span>
     HTML
   end
 

--- a/spec/lib/text_formatter_spec.rb
+++ b/spec/lib/text_formatter_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe TextFormatter do
       let(:text)  { '#hashtag' }
 
       it 'creates a hashtag link' do
-        expect(subject).to include '/tags/hashtag" class="mention hashtag" rel="tag">#<span>hashtag</span></a>'
+        expect(subject).to include '/tags/hashtag" class="mention hashtag" rel="tag" data-hashtag="hashtag">#<span>hashtag</span></a>'
       end
     end
 
@@ -284,7 +284,7 @@ RSpec.describe TextFormatter do
       let(:text)  { '#hashtagタグ' }
 
       it 'creates a hashtag link' do
-        expect(subject).to include '/tags/hashtag%E3%82%BF%E3%82%B0" class="mention hashtag" rel="tag">#<span>hashtagタグ</span></a>'
+        expect(subject).to include '/tags/hashtag%E3%82%BF%E3%82%B0" class="mention hashtag" rel="tag" data-hashtag="hashtagタグ">#<span>hashtagタグ</span></a>'
       end
     end
 

--- a/spec/lib/text_formatter_spec.rb
+++ b/spec/lib/text_formatter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe TextFormatter do
       let(:text) { '@alice' }
 
       it 'creates a mention link' do
-        expect(subject).to include '<a href="https://cb6e6126.ngrok.io/@alice" class="u-url mention">@<span>alice</span></a></span>'
+        expect(subject).to include '<span class="h-card" translate="no"><a href="https://cb6e6126.ngrok.io/@alice" class="u-url mention">@<span>alice</span></a></span>'
       end
     end
 


### PR DESCRIPTION
Fixes #21859 (except for hashtags, see below).

Both translation services handle long URLs in the status body poorly:
- DeepL messes up  the `<span>`s with class `ellipsis`  and `invisible` and ends up displaying only “h” (see screenshot of [this status](https://mastodon.social/@Mastodon/110036246553464473) below) or even nothing.
- LibreTranslate tries to translate the words in the URL, e.g. “hotels.com” would become “hoteller.com” when translated into Danish (not a real example).

Adding a `translate="no"` attribute to an element tells DeepL/LibreTranslate not to translate the contents (see documentation for [DeepL](https://www.deepl.com/docs-api/html/) and [LibreTranslate](https://github.com/argosopentech/translate-html/commit/cfc8e8296a41ac98ebed70108d49f34415810b02#diff-1e28df2252539b6ed2b9b023697c7b9aa500df738b8798e6f129edceec057ca8R33)). I have added this attribute to URLs and username mentions. 

#21859 suggests not translating hashtags, but I decided to do that anyway. Tags are often used instead of regular words, so I think _“I love #cats”_ should be translated into _“Ich liebe #Katzen”_ but with the link intact, so clicking on _#Katzen_ takes you to the page of the original tag, `/tags/cats`. I implemented this by adding a `data-hashtag` attribute to hashtags links.

BTW I don't understand the point of the `onHashtagClick` handler. Isn't the `<a href="/tags/foo">` link sufficient? Previously there was only the click handler－the href was added/fixed in #20540.


![image](https://user-images.githubusercontent.com/111346/226709333-15b9b561-4204-4fad-bd6b-706c438a23bc.png)

___

Fixes MAS-16