### PR TITLE
Omniauth 2.0 version bump

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,3 +1,0 @@
----
-ignore:
-  - CVE-2015-9284 # Mitigation following https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284#mitigating-in-rails-applications

--- a/Gemfile
+++ b/Gemfile
@@ -35,11 +35,12 @@ group :pam_authentication, optional: true do
 end
 
 gem 'net-ldap', '~> 0.18'
-gem 'omniauth-cas', '~> 2.0'
-gem 'omniauth-saml', '~> 1.10'
+
+gem 'omniauth-cas', github: 'stanhu/omniauth-cas', branch: 'sh-update-omniauth2'
+gem 'omniauth-saml', '~> 2.0'
 gem 'omniauth_openid_connect', '~> 0.6.1'
-gem 'omniauth', '~> 1.9'
-gem 'omniauth-rails_csrf_protection', '~> 0.1'
+gem 'omniauth', '~> 2.0'
+gem 'omniauth-rails_csrf_protection', '~> 1.0'
 
 gem 'color_diff', '~> 0.1'
 gem 'discard', '~> 1.2'

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,9 @@ end
 
 gem 'net-ldap', '~> 0.18'
 
-gem 'omniauth-cas', github: 'stanhu/omniauth-cas', branch: 'sh-update-omniauth2'
+# TODO: Point back at released omniauth-cas gem when PR merged
+# https://github.com/dlindahl/omniauth-cas/pull/68
+gem 'omniauth-cas', github: 'stanhu/omniauth-cas', ref: '4211e6d05941b4a981f9a36b49ec166cecd0e271'
 gem 'omniauth-saml', '~> 2.0'
 gem 'omniauth_openid_connect', '~> 0.6.1'
 gem 'omniauth', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 GIT
   remote: https://github.com/stanhu/omniauth-cas.git
   revision: 4211e6d05941b4a981f9a36b49ec166cecd0e271
-  branch: sh-update-omniauth2
+  ref: 4211e6d05941b4a981f9a36b49ec166cecd0e271
   specs:
     omniauth-cas (2.0.0)
       addressable (~> 2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,16 @@ GIT
     rails-settings-cached (0.6.6)
       rails (>= 4.2.0)
 
+GIT
+  remote: https://github.com/stanhu/omniauth-cas.git
+  revision: 4211e6d05941b4a981f9a36b49ec166cecd0e271
+  branch: sh-update-omniauth2
+  specs:
+    omniauth-cas (2.0.0)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      omniauth (>= 1.2, < 3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -472,19 +482,16 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oj (3.15.0)
-    omniauth (1.9.2)
+    omniauth (2.1.1)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
-    omniauth-cas (2.0.0)
-      addressable (~> 2.3)
-      nokogiri (~> 1.5)
-      omniauth (~> 1.2)
-    omniauth-rails_csrf_protection (0.1.2)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
-      omniauth (>= 1.3.1)
-    omniauth-saml (1.10.3)
-      omniauth (~> 1.3, >= 1.3.2)
-      ruby-saml (~> 1.9)
+      omniauth (~> 2.0)
+    omniauth-saml (2.1.0)
+      omniauth (~> 2.0)
+      ruby-saml (~> 1.12)
     omniauth_openid_connect (0.6.1)
       omniauth (>= 1.9, < 3)
       openid_connect (~> 1.1)
@@ -542,6 +549,8 @@ GEM
       httpclient
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
+    rack-protection (3.0.5)
+      rack
     rack-proxy (0.7.6)
       rack
     rack-test (2.1.0)
@@ -871,10 +880,10 @@ DEPENDENCIES
   nokogiri (~> 1.15)
   nsa!
   oj (~> 3.14)
-  omniauth (~> 1.9)
-  omniauth-cas (~> 2.0)
-  omniauth-rails_csrf_protection (~> 0.1)
-  omniauth-saml (~> 1.10)
+  omniauth (~> 2.0)
+  omniauth-cas!
+  omniauth-rails_csrf_protection (~> 1.0)
+  omniauth-saml (~> 2.0)
   omniauth_openid_connect (~> 0.6.1)
   ox (~> 2.14)
   parslet


### PR DESCRIPTION
Updates a collection of interacting gems:

- omniauth to version 2.1.1
- omniauth_rails_csrf_protection to version 1.0.1
- omniauth-saml to 2.1.0
- omniauth-cas to a PR fork branch

Minimal set of changes to get omniauth to update.

Presumably this is not viable as-is and we need to either wait for that PR - https://github.com/dlindahl/omniauth-cas/pull/68 - to be merged, or otherwise feel more secure about the cas gem.

Separately ... I was sort of surprised that there were no code changes at all to make here. Upgrade guide implies there may be breaking changes - https://github.com/omniauth/omniauth/wiki/Upgrading-to-2.0 - but I see a clean spec run locally. On the other hand, there's very very little direct spec coverage of the various omniauth strategies from what I can see, so its possible that there is breakage with the update and its just not surfaced in specs. In that case it might be worth adding some "happy path" specs along side this change to show that what worked before in omniauth flows didnt break with the update.
