### PR TITLE
Remove empty HTTP error translations

### DIFF
--- a/config/locales/af.yml
+++ b/config/locales/af.yml
@@ -91,13 +91,7 @@ af:
       approve_appeal: Aanvaar appèl
       reject_appeal: Verwerp appèl
   errors:
-    '400': The request you submitted was invalid or malformed.
     '403': Jy het nie toestemming om hierdie bladsy te sien nie.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   exports:
     bookmarks: Boekmerke
     lists: Lyste

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -224,13 +224,5 @@ bn:
     report_notes:
       created_msg: রিপোর্ট নোট সফলভাবে তৈরি করা হয়েছে!
       destroyed_msg: রিপোর্ট নোট সফলভাবে মোছা হয়েছে!
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   verification:
     verification: সত্যতা নির্ধারণ

--- a/config/locales/br.yml
+++ b/config/locales/br.yml
@@ -334,14 +334,6 @@ br:
       created_at: Deiziad
       title_actions:
         none: Diwall
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   exports:
     archive_takeout:
       date: Deiziad

--- a/config/locales/bs.yml
+++ b/config/locales/bs.yml
@@ -1,10 +1,2 @@
 ---
 bs:
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/ga.yml
+++ b/config/locales/ga.yml
@@ -361,14 +361,6 @@ ga:
       title_actions:
         none: Rabhadh
       your_appeal_pending: Chuir tú achomharc isteach
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   exports:
     archive_takeout:
       date: Dáta

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -7,14 +7,6 @@ hi:
       upload_check_privacy_error_object_storage:
         action: अधिक जानकारी हेतु यहां क्लिक करें।
         message_html: "<strong> आपके वेब सर्वर का कन्फिगरेशन सही नहीं है। उपयोगकर्ताओं की निजता खतरे में है। </strong>"
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   relationships:
     follow_failure: चुने हुए अकाउंट्स में से कुछ को फ़ॉलो नहीं किया जा सकता
   sessions:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -73,14 +73,6 @@ hr:
       less_than_x_seconds: Upravo sada
       over_x_years: "%{count}god"
       x_months: "%{count}mj"
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   exports:
     archive_takeout:
       date: Datum

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -529,15 +529,10 @@ hy:
   domain_validator:
     invalid_domain: անվաւէր տիրոյթի անուն
   errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
     '404': Էջը, որը փնտրում ես գոյութիւն չունի։
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
     '429': Չափազանց շատ հարցումներ
     '500':
       title: Էջը ճիշտ չէ
-    '503': The page could not be served due to a temporary server failure.
   existing_username_validator:
     not_found: չյաջողուեց գտնել այս ծածկագրով լոկալ օգտատիրոջ
     not_found_multiple: չյաջողուեց գտնել %{usernames}

--- a/config/locales/ig.yml
+++ b/config/locales/ig.yml
@@ -1,10 +1,2 @@
 ---
 ig:
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -263,10 +263,8 @@ ka:
     proceed: ანგარიშის გაუქმება
     success_msg: თქვენი ანგარიში წარმატებით გაუქმდა
   errors:
-    '400': The request you submitted was invalid or malformed.
     '403': ამ გვერდის ხილვის უფლება არ გაქვთ.
     '404': გვერდი რომელსაც ეძებთ არ არსებობს.
-    '406': This page is not available in the requested format.
     '410': გვერდი რომელსაც ეძებდით აღარ არსებობს.
     '422':
       content: უსაფრთხოების ვერიფიკაცია ვერ მოხერხდა. ბლოკავთ ქუქის?
@@ -275,7 +273,6 @@ ka:
     '500':
       content: ბოდიში, ჩვენ მხარეს რაღაც არია.
       title: გვერდი არაა სწორი
-    '503': The page could not be served due to a temporary server failure.
     noscript_html: მასტოდონ ვებ-აპლიკაციის გამოყენებისთვის, გთხოვთ ჩართოთ ჯავასკრიპტი. სხვა შემთხვევაში, მასტოდონის თქვენი პატფორმისთვის სცადეთ გამოიყენოთ ერთ-ერთი <a href="%{apps_path}">მშობლიური აპლიკაცია</a>.
   exports:
     archive_takeout:

--- a/config/locales/kn.yml
+++ b/config/locales/kn.yml
@@ -1,10 +1,2 @@
 ---
 kn:
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/kw.yml
+++ b/config/locales/kw.yml
@@ -5,13 +5,5 @@ kw:
       email: Ebost
       followers: Holyoryon
       title: Akontow
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   settings:
     account: Akont

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -298,10 +298,8 @@ lt:
     proceed: Ištrinti paskyrą
     success_msg: Jūsų paskyra sėkmingai ištrinta
   errors:
-    '400': The request you submitted was invalid or malformed.
     '403': Jūs neturie prieigos matyti šiam puslapiui.
     '404': Puslapis nerastas.
-    '406': This page is not available in the requested format.
     '410': Puslapis neegzistuoja.
     '422':
       content: Apsaugos patvirtinmas klaidingas. Ar jūs blokuojate sausainius?
@@ -310,7 +308,6 @@ lt:
     '500':
       content: Atsiprašome, tačiau mūsų pusėje įvyko klaida.
       title: Netinkamas puslapis
-    '503': The page could not be served due to a temporary server failure.
     noscript_html: Kad naudotumėtės Mastodon web aplikacija, prašome įsijungti JavaScript. Alternatyviai, pabandykite viena iš <a href="%{apps_path}">vietinių aplikacijų</a> Mastodon savo platformai.
   exports:
     archive_takeout:

--- a/config/locales/mk.yml
+++ b/config/locales/mk.yml
@@ -1,10 +1,2 @@
 ---
 mk:
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/ml.yml
+++ b/config/locales/ml.yml
@@ -78,14 +78,6 @@ ml:
         all: എല്ലാം
   authorize_follow:
     following: 'വിജയകരം! നിങ്ങൾ ഇപ്പോൾ പിന്തുടരുന്നു:'
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   filters:
     contexts:
       notifications: അറിയിപ്പുകൾ

--- a/config/locales/mr.yml
+++ b/config/locales/mr.yml
@@ -1,10 +1,2 @@
 ---
 mr:
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -560,7 +560,6 @@ oc:
   domain_validator:
     invalid_domain: es pas un nom de domeni valid
   errors:
-    '400': The request you submitted was invalid or malformed.
     '403': Avètz pas l’autorizacion de veire aquesta pagina.
     '404': La pagina que cercatz existís pas aquí.
     '406': La pagina es pas disponibla dins lo format demandat.
@@ -572,7 +571,6 @@ oc:
     '500':
       content: Un quicomet a pas foncionat coma caliá.
       title: Aquesta pagina es pas corrècta
-    '503': The page could not be served due to a temporary server failure.
     noscript_html: Per utilizar l’aplicacion web de Mastodon, mercés d’activar JavaScript. O podètz utilizar <a href="%{apps_path}">una aplicacion</a> per vòstra plataforma coma alernativa.
   existing_username_validator:
     not_found: impossible de trobar un utilizaire local amb aqueste nom d’utilizaire

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -492,10 +492,8 @@ ro:
       email_change_html: Puteți <a href="%{path}">schimba adresa de e-mail</a> fără a șterge contul dvs
       email_contact_html: Dacă tot nu ajunge, puteți trimite e-mail la <a href="mailto:%{email}">%{email}</a> pentru ajutor
   errors:
-    '400': The request you submitted was invalid or malformed.
     '403': Nu ai permisiunea să vizitezi această pagină.
     '404': Pagina pe care o cauți nu există.
-    '406': This page is not available in the requested format.
     '410': Pagina pe care o cauți nu mai există.
     '422':
       content: Verificarea securității a eșuat. Ai blocat cookiurile?
@@ -504,7 +502,6 @@ ro:
     '500':
       content: Ne pare rău, dar ceva a funcționat greșit. Încercați din nou!?
       title: Această pagină nu este corectă
-    '503': The page could not be served due to a temporary server failure.
     noscript_html: Pentru a utiliza o aplicație web Mastodon, te rog activează JavaScript. Alternativ, încearcă una din <a href="%{apps_path}">aplicațiile native</a> Mastodon pentru platforma ta.
   exports:
     archive_takeout:

--- a/config/locales/sa.yml
+++ b/config/locales/sa.yml
@@ -1,10 +1,2 @@
 ---
 sa:
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/szl.yml
+++ b/config/locales/szl.yml
@@ -1,10 +1,2 @@
 ---
 szl:
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -197,14 +197,6 @@ ta:
     errors:
       invalid_key: ஒரு முறையான Ed25519 அல்லது Curve25519 key அல்ல
       invalid_signature: ஒரு முறையான Ed25519 அடையாளம் அல்ல
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   filters:
     index:
       empty: தடுப்புகள் ஏதும் இல்லை.

--- a/config/locales/te.yml
+++ b/config/locales/te.yml
@@ -70,11 +70,3 @@ te:
       moderation_notes: మోడరేషన్ నోట్స్
       most_recent_activity: ఇటీవల యాక్టివిటీ
       most_recent_ip: ఇటీవలి IP
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/tt.yml
+++ b/config/locales/tt.yml
@@ -140,14 +140,6 @@ tt:
       x_minutes: "%{count}м"
       x_months: "%{count}ай"
       x_seconds: "%{count}сек"
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   exports:
     archive_takeout:
       date: Көне

--- a/config/locales/ug.yml
+++ b/config/locales/ug.yml
@@ -1,10 +1,2 @@
 ---
 ug:
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -1,10 +1,2 @@
 ---
 ur:
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -39,11 +39,3 @@ uz:
       most_recent_ip: Eng oxirgi IP
       perform_full_suspension: To'xtatilgan
       reject: Rad etish
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.

--- a/config/locales/zgh.yml
+++ b/config/locales/zgh.yml
@@ -83,14 +83,6 @@ zgh:
     title: ⴹⴼⵕ %{acct}
   deletes:
     proceed: ⴽⴽⵙ ⴰⵎⵉⴹⴰⵏ
-  errors:
-    '400': The request you submitted was invalid or malformed.
-    '403': You don't have permission to view this page.
-    '404': The page you are looking for isn't here.
-    '406': This page is not available in the requested format.
-    '410': The page you were looking for doesn't exist here anymore.
-    '429': Too many requests
-    '503': The page could not be served due to a temporary server failure.
   exports:
     archive_takeout:
       date: ⴰⵣⵎⵣ

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,6 @@
 commit_message: '[ci skip]'
+skip_untranslated_strings: true
+
 files:
   - source: /app/javascript/mastodon/locales/en.json
     translation: /app/javascript/mastodon/locales/%two_letters_code%.json


### PR DESCRIPTION
Crowdin seems to trip up on this particular set of strings on the sync. Seeing if removing the full untranslated key (or just the missed strings) get's it back in sync