### PR TITLE
Expand coverage for "system checks"

### DIFF
--- a/spec/lib/admin/system_check/base_check_spec.rb
+++ b/spec/lib/admin/system_check/base_check_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::SystemCheck::BaseCheck do
+  subject(:check) { described_class.new(user) }
+
+  let(:user) { Fabricate(:user) }
+
+  describe 'skip?' do
+    it 'returns false' do
+      expect(check.skip?).to be false
+    end
+  end
+
+  describe 'pass?' do
+    it 'raises not implemented error' do
+      expect { check.pass? }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'message' do
+    it 'raises not implemented error' do
+      expect { check.message }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/lib/admin/system_check/database_schema_check_spec.rb
+++ b/spec/lib/admin/system_check/database_schema_check_spec.rb
@@ -7,23 +7,7 @@ describe Admin::SystemCheck::DatabaseSchemaCheck do
 
   let(:user) { Fabricate(:user) }
 
-  describe 'skip?' do
-    context 'when user can view devops' do
-      before { allow(user).to receive(:can?).with(:view_devops).and_return(true) }
-
-      it 'returns false' do
-        expect(check.skip?).to be false
-      end
-    end
-
-    context 'when user cannot view devops' do
-      before { allow(user).to receive(:can?).with(:view_devops).and_return(false) }
-
-      it 'returns true' do
-        expect(check.skip?).to be true
-      end
-    end
-  end
+  it_behaves_like 'a check available to devops users'
 
   describe 'pass?' do
     context 'when database needs migration' do

--- a/spec/lib/admin/system_check/database_schema_check_spec.rb
+++ b/spec/lib/admin/system_check/database_schema_check_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::SystemCheck::DatabaseSchemaCheck do
+  subject(:check) { described_class.new(user) }
+
+  let(:user) { Fabricate(:user) }
+
+  describe 'skip?' do
+    context 'when user can view devops' do
+      before { allow(user).to receive(:can?).with(:view_devops).and_return(true) }
+
+      it 'returns false' do
+        expect(check.skip?).to be false
+      end
+    end
+
+    context 'when user cannot view devops' do
+      before { allow(user).to receive(:can?).with(:view_devops).and_return(false) }
+
+      it 'returns true' do
+        expect(check.skip?).to be true
+      end
+    end
+  end
+
+  describe 'pass?' do
+    context 'when database needs migration' do
+      before do
+        context = instance_double(ActiveRecord::MigrationContext, needs_migration?: true)
+        allow(ActiveRecord::Base.connection).to receive(:migration_context).and_return(context)
+      end
+
+      it 'returns false' do
+        expect(check.pass?).to be false
+      end
+    end
+
+    context 'when database does not need migration' do
+      before do
+        context = instance_double(ActiveRecord::MigrationContext, needs_migration?: false)
+        allow(ActiveRecord::Base.connection).to receive(:migration_context).and_return(context)
+      end
+
+      it 'returns true' do
+        expect(check.pass?).to be true
+      end
+    end
+  end
+
+  describe 'message' do
+    it 'sends class name symbol to message instance' do
+      allow(Admin::SystemCheck::Message).to receive(:new).with(:database_schema_check)
+
+      check.message
+
+      expect(Admin::SystemCheck::Message).to have_received(:new).with(:database_schema_check)
+    end
+  end
+end

--- a/spec/lib/admin/system_check/elasticsearch_check_spec.rb
+++ b/spec/lib/admin/system_check/elasticsearch_check_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::SystemCheck::ElasticsearchCheck do
+  subject(:check) { described_class.new(user) }
+
+  let(:user) { Fabricate(:user) }
+
+  describe 'skip?' do
+    context 'when user can view devops' do
+      before { allow(user).to receive(:can?).with(:view_devops).and_return(true) }
+
+      it 'returns false' do
+        expect(check.skip?).to be false
+      end
+    end
+
+    context 'when user cannot view devops' do
+      before { allow(user).to receive(:can?).with(:view_devops).and_return(false) }
+
+      it 'returns true' do
+        expect(check.skip?).to be true
+      end
+    end
+  end
+
+  describe 'pass?' do
+    context 'when chewy is enabled' do
+      before { allow(Chewy).to receive(:enabled?).and_return(true) }
+
+      context 'when running version is present and high enough' do
+        before do
+          allow(Chewy.client).to receive(:info)
+            .and_return({ 'version' => { 'number' => '999.99.9' } })
+        end
+
+        it 'returns true' do
+          expect(check.pass?).to be true
+        end
+      end
+
+      context 'when running version is present and too low' do
+        context 'when compatible version is too low' do
+          before do
+            allow(Chewy.client).to receive(:info)
+              .and_return({ 'version' => { 'number' => '1.2.3', 'minimum_wire_compatibility_version' => '1.0' } })
+          end
+
+          it 'returns false' do
+            expect(check.pass?).to be false
+          end
+        end
+
+        context 'when compatible version is high enough' do
+          before do
+            allow(Chewy.client).to receive(:info)
+              .and_return({ 'version' => { 'number' => '1.2.3', 'minimum_wire_compatibility_version' => '99.9' } })
+          end
+
+          it 'returns true' do
+            expect(check.pass?).to be true
+          end
+        end
+      end
+
+      context 'when running version is missing' do
+        before do
+          client = instance_double(Elasticsearch::Transport::Client)
+          allow(client).to receive(:info).and_raise(Elasticsearch::Transport::Transport::Error)
+          allow(Chewy).to receive(:client).and_return(client)
+        end
+
+        it 'returns false' do
+          expect(check.pass?).to be false
+        end
+      end
+    end
+
+    context 'when chewy is not enabled' do
+      before { allow(Chewy).to receive(:enabled?).and_return(false) }
+
+      it 'returns true' do
+        expect(check.pass?).to be true
+      end
+    end
+  end
+
+  describe 'message' do
+    context 'when running version is present' do
+      before { allow(Chewy.client).to receive(:info).and_return({ 'version' => { 'number' => '999.99.9' } }) }
+
+      it 'sends class name symbol to message instance' do
+        allow(Admin::SystemCheck::Message).to receive(:new)
+          .with(:elasticsearch_version_check, anything)
+
+        check.message
+
+        expect(Admin::SystemCheck::Message).to have_received(:new)
+          .with(:elasticsearch_version_check, 'Elasticsearch 999.99.9 is running while 7.x is required')
+      end
+    end
+
+    context 'when running version is missing' do
+      it 'sends class name symbol to message instance' do
+        allow(Admin::SystemCheck::Message).to receive(:new)
+          .with(:elasticsearch_running_check)
+
+        check.message
+
+        expect(Admin::SystemCheck::Message).to have_received(:new)
+          .with(:elasticsearch_running_check)
+      end
+    end
+  end
+end

--- a/spec/lib/admin/system_check/elasticsearch_check_spec.rb
+++ b/spec/lib/admin/system_check/elasticsearch_check_spec.rb
@@ -7,23 +7,7 @@ describe Admin::SystemCheck::ElasticsearchCheck do
 
   let(:user) { Fabricate(:user) }
 
-  describe 'skip?' do
-    context 'when user can view devops' do
-      before { allow(user).to receive(:can?).with(:view_devops).and_return(true) }
-
-      it 'returns false' do
-        expect(check.skip?).to be false
-      end
-    end
-
-    context 'when user cannot view devops' do
-      before { allow(user).to receive(:can?).with(:view_devops).and_return(false) }
-
-      it 'returns true' do
-        expect(check.skip?).to be true
-      end
-    end
-  end
+  it_behaves_like 'a check available to devops users'
 
   describe 'pass?' do
     context 'when chewy is enabled' do

--- a/spec/lib/admin/system_check/media_privacy_check_spec.rb
+++ b/spec/lib/admin/system_check/media_privacy_check_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::SystemCheck::MediaPrivacyCheck do
+  subject(:check) { described_class.new(user) }
+
+  let(:user) { Fabricate(:user) }
+
+  describe 'skip?' do
+    context 'when user can view devops' do
+      before { allow(user).to receive(:can?).with(:view_devops).and_return(true) }
+
+      it 'returns false' do
+        expect(check.skip?).to be false
+      end
+    end
+
+    context 'when user cannot view devops' do
+      before { allow(user).to receive(:can?).with(:view_devops).and_return(false) }
+
+      it 'returns true' do
+        expect(check.skip?).to be true
+      end
+    end
+  end
+
+  describe 'pass?' do
+    context 'when the media cannot be listed' do
+      before do
+        stub_request(:get, /ngrok.io/).to_return(status: 200, body: 'a list of no files')
+      end
+
+      it 'returns true' do
+        expect(check.pass?).to be true
+      end
+    end
+  end
+
+  describe 'message' do
+    it 'sends values to message instance' do
+      allow(Admin::SystemCheck::Message).to receive(:new).with(nil, nil, nil, true)
+
+      check.message
+
+      expect(Admin::SystemCheck::Message).to have_received(:new).with(nil, nil, nil, true)
+    end
+  end
+end

--- a/spec/lib/admin/system_check/media_privacy_check_spec.rb
+++ b/spec/lib/admin/system_check/media_privacy_check_spec.rb
@@ -7,23 +7,7 @@ describe Admin::SystemCheck::MediaPrivacyCheck do
 
   let(:user) { Fabricate(:user) }
 
-  describe 'skip?' do
-    context 'when user can view devops' do
-      before { allow(user).to receive(:can?).with(:view_devops).and_return(true) }
-
-      it 'returns false' do
-        expect(check.skip?).to be false
-      end
-    end
-
-    context 'when user cannot view devops' do
-      before { allow(user).to receive(:can?).with(:view_devops).and_return(false) }
-
-      it 'returns true' do
-        expect(check.skip?).to be true
-      end
-    end
-  end
+  it_behaves_like 'a check available to devops users'
 
   describe 'pass?' do
     context 'when the media cannot be listed' do

--- a/spec/lib/admin/system_check/message_spec.rb
+++ b/spec/lib/admin/system_check/message_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::SystemCheck::Message do
+  subject(:check) { described_class.new(:key_value, :value_value, :action_value, :critical_value) }
+
+  it 'providers readers when initialized' do
+    expect(check.key).to eq :key_value
+    expect(check.value).to eq :value_value
+    expect(check.action).to eq :action_value
+    expect(check.critical).to eq :critical_value
+  end
+end

--- a/spec/lib/admin/system_check/rules_check_spec.rb
+++ b/spec/lib/admin/system_check/rules_check_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::SystemCheck::RulesCheck do
+  subject(:check) { described_class.new(user) }
+
+  let(:user) { Fabricate(:user) }
+
+  describe 'skip?' do
+    context 'when user can manage rules' do
+      before { allow(user).to receive(:can?).with(:manage_rules).and_return(true) }
+
+      it 'returns false' do
+        expect(check.skip?).to be false
+      end
+    end
+
+    context 'when user cannot manage rules' do
+      before { allow(user).to receive(:can?).with(:manage_rules).and_return(false) }
+
+      it 'returns true' do
+        expect(check.skip?).to be true
+      end
+    end
+  end
+
+  describe 'pass?' do
+    context 'when there is not a kept rule' do
+      it 'returns false' do
+        expect(check.pass?).to be false
+      end
+    end
+
+    context 'when there is a kept rule' do
+      before { Fabricate(:rule) }
+
+      it 'returns true' do
+        expect(check.pass?).to be true
+      end
+    end
+  end
+
+  describe 'message' do
+    it 'sends class name symbol to message instance' do
+      allow(Admin::SystemCheck::Message).to receive(:new).with(:rules_check, nil, '/admin/rules')
+
+      check.message
+
+      expect(Admin::SystemCheck::Message).to have_received(:new).with(:rules_check, nil, '/admin/rules')
+    end
+  end
+end

--- a/spec/lib/admin/system_check/sidekiq_process_check_spec.rb
+++ b/spec/lib/admin/system_check/sidekiq_process_check_spec.rb
@@ -7,23 +7,7 @@ describe Admin::SystemCheck::SidekiqProcessCheck do
 
   let(:user) { Fabricate(:user) }
 
-  describe 'skip?' do
-    context 'when user can view devops' do
-      before { allow(user).to receive(:can?).with(:view_devops).and_return(true) }
-
-      it 'returns false' do
-        expect(check.skip?).to be false
-      end
-    end
-
-    context 'when user cannot view devops' do
-      before { allow(user).to receive(:can?).with(:view_devops).and_return(false) }
-
-      it 'returns true' do
-        expect(check.skip?).to be true
-      end
-    end
-  end
+  it_behaves_like 'a check available to devops users'
 
   describe 'pass?' do
     context 'when missing queues is empty' do

--- a/spec/lib/admin/system_check/sidekiq_process_check_spec.rb
+++ b/spec/lib/admin/system_check/sidekiq_process_check_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::SystemCheck::SidekiqProcessCheck do
+  subject(:check) { described_class.new(user) }
+
+  let(:user) { Fabricate(:user) }
+
+  describe 'skip?' do
+    context 'when user can view devops' do
+      before { allow(user).to receive(:can?).with(:view_devops).and_return(true) }
+
+      it 'returns false' do
+        expect(check.skip?).to be false
+      end
+    end
+
+    context 'when user cannot view devops' do
+      before { allow(user).to receive(:can?).with(:view_devops).and_return(false) }
+
+      it 'returns true' do
+        expect(check.skip?).to be true
+      end
+    end
+  end
+
+  describe 'pass?' do
+    context 'when missing queues is empty' do
+      before do
+        process_set = instance_double(Sidekiq::ProcessSet, reduce: [])
+        allow(Sidekiq::ProcessSet).to receive(:new).and_return(process_set)
+      end
+
+      it 'returns true' do
+        expect(check.pass?).to be true
+      end
+    end
+
+    context 'when missing queues is not empty' do
+      before do
+        process_set = instance_double(Sidekiq::ProcessSet, reduce: [:something])
+        allow(Sidekiq::ProcessSet).to receive(:new).and_return(process_set)
+      end
+
+      it 'returns false' do
+        expect(check.pass?).to be false
+      end
+    end
+  end
+
+  describe 'message' do
+    it 'sends values to message instance' do
+      allow(Admin::SystemCheck::Message).to receive(:new).with(:sidekiq_process_check, 'default, push, mailers, pull, scheduler, ingress')
+
+      check.message
+
+      expect(Admin::SystemCheck::Message).to have_received(:new).with(:sidekiq_process_check, 'default, push, mailers, pull, scheduler, ingress')
+    end
+  end
+end

--- a/spec/lib/admin/system_check_spec.rb
+++ b/spec/lib/admin/system_check_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::SystemCheck do
+  let(:user) { Fabricate(:user) }
+
+  describe 'perform' do
+    let(:result) { described_class.perform(user) }
+
+    it 'runs all the checks' do
+      expect(result).to be_an(Array)
+    end
+  end
+end

--- a/spec/support/examples/lib/admin/checks.rb
+++ b/spec/support/examples/lib/admin/checks.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+shared_examples 'a check available to devops users' do
+  describe 'skip?' do
+    context 'when user can view devops' do
+      before { allow(user).to receive(:can?).with(:view_devops).and_return(true) }
+
+      it 'returns false' do
+        expect(check.skip?).to be false
+      end
+    end
+
+    context 'when user cannot view devops' do
+      before { allow(user).to receive(:can?).with(:view_devops).and_return(false) }
+
+      it 'returns true' do
+        expect(check.skip?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
These were previously only exercised in the admin/dashboard controller spec - but in there they are mostly stubbed out.

There are some paths in the media privacy check this doesn't exercise - may add more there in future when I can into what those are doing in full.