### PR TITLE
Fix broken links in account gallery

### DIFF
--- a/app/javascript/mastodon/features/account_gallery/components/media_item.jsx
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.jsx
@@ -74,7 +74,7 @@ export default class MediaItem extends ImmutablePureComponent {
       if (['audio', 'video'].includes(attachment.get('type'))) {
         content = (
           <img
-            src={attachment.get('preview_url') || attachment.getIn(['account', 'avatar_static'])}
+            src={attachment.get('preview_url') || status.getIn(['account', 'avatar_static'])}
             alt={attachment.get('description')}
             lang={status.get('language')}
             onLoad={this.handleImageLoad}

--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -121,8 +121,8 @@ export const getAccountGallery = createSelector([
   let medias = ImmutableList();
 
   statusIds.forEach(statusId => {
-    const status = statuses.get(statusId);
-    medias = medias.concat(status.get('media_attachments').map(media => media.set('status', status).set('account', account)));
+    const status = statuses.get(statusId).set('account', account);
+    medias = medias.concat(status.get('media_attachments').map(media => media.set('status', status)));
   });
 
   return medias;


### PR DESCRIPTION
The links from the account gallery are broken.

In _features/account_gallery/components/media_item.jsx_ account attributes are accessed in two different ways, `attachment.getIn(['account', 'avatar_static'])` and `status.getIn(['account', 'acct'])`, but only one of them works. Stick to the latter variant.

### Steps to reproduce
1. Open account gallery, e.g. https://mastodon.social/@Mastodon/media.
2. Right-click on any image and select _Open Link in New Tab_ from the browser's context menu.

### Expected result
Detailed status view should open, e.g. https://mastodon.social/@mastodon/108562814389725733.

### Actual result
404 page opens, because URL contains “undefined” instead of account name, e.g. https://mastodon.social/@undefined/108562814389725733
