### PR TITLE
Remove unused methods in 2FA OTP Auth Controller

### DIFF
--- a/app/controllers/settings/two_factor_authentication/otp_authentication_controller.rb
+++ b/app/controllers/settings/two_factor_authentication/otp_authentication_controller.rb
@@ -22,17 +22,8 @@ module Settings
 
       private
 
-      def confirmation_params
-        params.require(:form_two_factor_confirmation).permit(:otp_attempt)
-      end
-
       def verify_otp_not_enabled
         redirect_to settings_two_factor_authentication_methods_path if current_user.otp_enabled?
-      end
-
-      def acceptable_code?
-        current_user.validate_and_consume_otp!(confirmation_params[:otp_attempt]) ||
-          current_user.invalidate_otp_backup_code!(confirmation_params[:otp_attempt])
       end
     end
   end


### PR DESCRIPTION
In a previous refactor  - https://github.com/mastodon/mastodon/commit/e8d41bc2fe9418613cdc118c8674fc5fe7856685 - the approach here was changed to not do this logic until the next confirmation step, but the methods were left behind.