### PR TITLE
Use Yarn production install for asset compile

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -40,7 +40,7 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      - run: yarn install --frozen-lockfile
+      - run: yarn --frozen-lockfile --production
       - name: Precompile assets
         # Previously had set this, but it's not supported
         # export NODE_OPTIONS=--openssl-legacy-provider

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     bundle config set --local without 'development test' && \
     bundle config set silence_root_warning true && \
     bundle install -j"$(nproc)" && \
-    yarn install --pure-lockfile --network-timeout 600000 && \
+    yarn install --pure-lockfile --production --network-timeout 600000 && \
     yarn cache clean
 
 FROM node:${NODE_VERSION}


### PR DESCRIPTION
Small tweak to reduce Docker install footprint, and ensure that the production asset complie still works without the dev dependencies