### PR TITLE
Remove Array.prototype.includes polyfill

### DIFF
--- a/app/javascript/mastodon/base_polyfills.js
+++ b/app/javascript/mastodon/base_polyfills.js
@@ -1,15 +1,10 @@
 import 'intl';
 import 'intl/locale-data/jsonp/en';
 import 'es6-symbol/implement';
-import includes from 'array-includes';
 import assign from 'object-assign';
 import values from 'object.values';
 import { decode as decodeBase64 } from './utils/base64';
 import promiseFinally from 'promise.prototype.finally';
-
-if (!Array.prototype.includes) {
-  includes.shim();
-}
 
 if (!Object.assign) {
   Object.assign = assign;

--- a/app/javascript/mastodon/load_polyfills.js
+++ b/app/javascript/mastodon/load_polyfills.js
@@ -12,7 +12,6 @@ function importExtraPolyfills() {
 
 function loadPolyfills() {
   const needsBasePolyfills = !(
-    Array.prototype.includes &&
     HTMLCanvasElement.prototype.toBlob &&
     window.Intl &&
     Object.assign &&

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@github/webauthn-json": "^2.1.1",
     "@rails/ujs": "^6.1.7",
     "abortcontroller-polyfill": "^1.7.5",
-    "array-includes": "^3.1.6",
     "arrow-key-navigation": "^1.2.0",
     "autoprefixer": "^10.4.14",
     "axios": "^1.3.4",


### PR DESCRIPTION
Support for everything but but  IE seems to be inplace https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#browser_compatibility.
Still used by a few ESLint plugins, so it doesn't drop out of the lockfile