### PR TITLE
Move migration_helpers Rubocop ignore to config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ AllCops:
     - 'Vagrantfile'
     - 'vendor/**/*'
     - 'lib/json_ld/*' # Generated files
+    - 'lib/mastodon/migration_helpers.rb' # Vendored from GitLab
     - 'lib/templates/**/*'
 
 # Reason: Prefer Hashes without extreme indentation

--- a/lib/mastodon/migration_helpers.rb
+++ b/lib/mastodon/migration_helpers.rb
@@ -37,7 +37,6 @@
 
 # This is bad form, but there are enough differences that it's impractical to do
 # otherwise:
-# rubocop:disable all
 
 module Mastodon
   module MigrationHelpers
@@ -977,5 +976,3 @@ into similar problems in the future (e.g. when new tables are created).
     end
   end
 end
-
-# rubocop:enable all


### PR DESCRIPTION
The file mentions that it's originally from https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/gitlab/database/migration_helpers.rb, but it looks like they've drifted apart now.