### PR TITLE
Drop EOL Ruby 2.7

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -104,7 +104,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '.ruby-version'
@@ -135,10 +134,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version}}
           bundler-cache: true
-
-      - name: Update system gems
-        if: matrix.ruby-version == '2.7'
-        run: gem update --system
 
       - name: Load database schema
         run: './bin/rails db:create db:schema:load db:seed'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ require:
   - rubocop-capybara
 
 AllCops:
-  TargetRubyVersion: 2.7 # Set to minimum supported version of CI
+  TargetRubyVersion: 3.0 # Set to minimum supported version of CI
   DisplayCopNames: true
   DisplayStyleGuide: true
   ExtraDetails: true

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -182,11 +182,6 @@ Lint/OrAssignmentToConstant:
   Exclude:
     - 'lib/sanitize_ext/sanitize_config.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/RedundantDirGlobSort:
-  Exclude:
-    - 'db/seeds.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 Lint/SendWithMixinArgument:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -2263,17 +2263,6 @@ Style/RedundantFetchBlock:
     - 'config/puma.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-Style/RedundantFreeze:
-  Exclude:
-    - 'app/lib/emoji_formatter.rb'
-    - 'app/lib/plain_text_formatter.rb'
-    - 'app/lib/text_formatter.rb'
-    - 'app/models/account.rb'
-    - 'app/models/concerns/omniauthable.rb'
-    - 'app/services/fetch_oembed_service.rb'
-    - 'config/initializers/rack_attack.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 Style/RedundantRegexpCharacterClass:
   Exclude:
     - 'app/lib/link_details_extractor.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -173,11 +173,6 @@ Lint/EmptyClass:
   Exclude:
     - 'spec/controllers/api/base_controller_spec.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Lint/NonDeterministicRequireOrder:
-  Exclude:
-    - 'spec/rails_helper.rb'
-
 Lint/NonLocalExitFromIterator:
   Exclude:
     - 'app/helpers/jsonld_helper.rb'
@@ -186,6 +181,11 @@ Lint/NonLocalExitFromIterator:
 Lint/OrAssignmentToConstant:
   Exclude:
     - 'lib/sanitize_ext/sanitize_config.rb'
+
+# This cop supports unsafe autocorrection (--autocorrect-all).
+Lint/RedundantDirGlobSort:
+  Exclude:
+    - 'db/seeds.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 Lint/SendWithMixinArgument:
@@ -2207,16 +2207,11 @@ Style/MapToHash:
 # SupportedStyles: literals, strict
 Style/MutableConstant:
   Exclude:
-    - 'app/lib/link_details_extractor.rb'
     - 'app/models/account.rb'
-    - 'app/models/custom_emoji.rb'
     - 'app/models/tag.rb'
-    - 'app/services/account_search_service.rb'
     - 'app/services/delete_account_service.rb'
-    - 'app/services/fetch_link_card_service.rb'
-    - 'app/services/resolve_url_service.rb'
     - 'config/initializers/twitter_regex.rb'
-    - 'lib/mastodon/snowflake.rb'
+    - 'lib/mastodon/migration_warning.rb'
     - 'spec/controllers/api/base_controller_spec.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
@@ -2271,6 +2266,17 @@ Style/RedundantFetchBlock:
     - 'config/initializers/devise.rb'
     - 'config/initializers/paperclip.rb'
     - 'config/puma.rb'
+
+# This cop supports safe autocorrection (--autocorrect).
+Style/RedundantFreeze:
+  Exclude:
+    - 'app/lib/emoji_formatter.rb'
+    - 'app/lib/plain_text_formatter.rb'
+    - 'app/lib/text_formatter.rb'
+    - 'app/models/account.rb'
+    - 'app/models/concerns/omniauthable.rb'
+    - 'app/services/fetch_oembed_service.rb'
+    - 'config/initializers/rack_attack.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 Style/RedundantRegexpCharacterClass:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '>= 2.7.0', '< 3.3.0'
+ruby '>= 3.0.0'
 
 gem 'pkg-config', '~> 1.5'
 

--- a/app/lib/emoji_formatter.rb
+++ b/app/lib/emoji_formatter.rb
@@ -3,7 +3,7 @@
 class EmojiFormatter
   include RoutingHelper
 
-  DISALLOWED_BOUNDING_REGEX = /[[:alnum:]:]/.freeze
+  DISALLOWED_BOUNDING_REGEX = /[[:alnum:]:]/
 
   attr_reader :html, :custom_emojis, :options
 

--- a/app/lib/plain_text_formatter.rb
+++ b/app/lib/plain_text_formatter.rb
@@ -3,7 +3,7 @@
 class PlainTextFormatter
   include ActionView::Helpers::TextHelper
 
-  NEWLINE_TAGS_RE = /(<br \/>|<br>|<\/p>)+/.freeze
+  NEWLINE_TAGS_RE = /(<br \/>|<br>|<\/p>)+/
 
   attr_reader :text, :local
 

--- a/app/lib/text_formatter.rb
+++ b/app/lib/text_formatter.rb
@@ -5,7 +5,7 @@ class TextFormatter
   include ERB::Util
   include RoutingHelper
 
-  URL_PREFIX_REGEX = /\A(https?:\/\/(www\.)?|xmpp:)/.freeze
+  URL_PREFIX_REGEX = /\A(https?:\/\/(www\.)?|xmpp:)/
 
   DEFAULT_REL = %w(nofollow noopener noreferrer).freeze
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -410,7 +410,7 @@ class Account < ApplicationRecord
   end
 
   class << self
-    DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’]/.freeze
+    DISALLOWED_TSQUERY_CHARACTERS = /['?\\:‘’]/
     TEXTSEARCH = "(setweight(to_tsvector('simple', accounts.display_name), 'A') || setweight(to_tsvector('simple', accounts.username), 'B') || setweight(to_tsvector('simple', coalesce(accounts.domain, '')), 'C'))"
 
     REPUTATION_SCORE_FUNCTION = '(greatest(0, coalesce(s.followers_count, 0)) / (greatest(0, coalesce(s.following_count, 0)) + 1.0))'

--- a/app/models/concerns/omniauthable.rb
+++ b/app/models/concerns/omniauthable.rb
@@ -4,7 +4,7 @@ module Omniauthable
   extend ActiveSupport::Concern
 
   TEMP_EMAIL_PREFIX = 'change@me'
-  TEMP_EMAIL_REGEX  = /\A#{TEMP_EMAIL_PREFIX}/.freeze
+  TEMP_EMAIL_REGEX  = /\A#{TEMP_EMAIL_PREFIX}/
 
   included do
     devise :omniauthable

--- a/app/services/fetch_oembed_service.rb
+++ b/app/services/fetch_oembed_service.rb
@@ -2,7 +2,7 @@
 
 class FetchOEmbedService
   ENDPOINT_CACHE_EXPIRES_IN = 24.hours.freeze
-  URL_REGEX                 = /(=(http[s]?(%3A|:)(\/\/|%2F%2F)))([^&]*)/i.freeze
+  URL_REGEX                 = /(=(http[s]?(%3A|:)(\/\/|%2F%2F)))([^&]*)/i
 
   attr_reader :url, :options, :format, :endpoint_url
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -98,8 +98,8 @@ class Rack::Attack
     req.throttleable_remote_ip if req.paging_request? && req.unauthenticated?
   end
 
-  API_DELETE_REBLOG_REGEX = /\A\/api\/v1\/statuses\/[\d]+\/unreblog\z/.freeze
-  API_DELETE_STATUS_REGEX = /\A\/api\/v1\/statuses\/[\d]+\z/.freeze
+  API_DELETE_REBLOG_REGEX = /\A\/api\/v1\/statuses\/[\d]+\/unreblog\z/
+  API_DELETE_STATUS_REGEX = /\A\/api\/v1\/statuses\/[\d]+\z/
 
   throttle('throttle_api_delete', limit: 30, period: 30.minutes) do |req|
     req.authenticated_user_id if (req.post? && req.path.match?(API_DELETE_REBLOG_REGEX)) || (req.delete? && req.path.match?(API_DELETE_STATUS_REGEX))

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Chewy.strategy(:mastodon) do
-  Dir[Rails.root.join('db', 'seeds', '*.rb')].sort.each do |seed|
+  Dir[Rails.root.join('db', 'seeds', '*.rb')].each do |seed|
     load seed
   end
 end


### PR DESCRIPTION
End of life date isn't actually till March 31st, so opening as a draft for now.
I regen'd the Rubocop TODOs, and included the fixes for the cops on things no longer required for 3.0+ Ruby