### PR TITLE
Change moderation search an account using the username with @

### DIFF
--- a/app/models/account_filter.rb
+++ b/app/models/account_filter.rb
@@ -55,7 +55,7 @@ class AccountFilter
     when 'by_domain'
       Account.where(domain: value.to_s.strip)
     when 'username'
-      Account.matches_username(value.to_s.strip)
+      Account.matches_username(value.to_s.strip.delete_prefix('@'))
     when 'display_name'
       Account.matches_display_name(value.to_s.strip)
     when 'email'

--- a/spec/models/account_filter_spec.rb
+++ b/spec/models/account_filter_spec.rb
@@ -44,4 +44,23 @@ describe AccountFilter do
       expect(filter.results).to match_array [remote_account_one]
     end
   end
+
+  describe 'with username' do
+    let!(:local_account) { Fabricate(:account, domain: nil, username: 'validUserName') }
+
+    it 'works with @ at the beginning of the username' do
+      filter = described_class.new(username: '@validUserName')
+      expect(filter.results).to match_array [local_account]
+    end
+
+    it 'does not work with more than one @ at the beginning of the username' do
+      filter = described_class.new(username: '@@validUserName')
+      expect(filter.results).to_not match_array [local_account]
+    end
+
+    it 'does not work with @ outside the beginning of the username' do
+      filter = described_class.new(username: 'validUserName@')
+      expect(filter.results).to_not match_array [local_account]
+    end
+  end
 end


### PR DESCRIPTION
Solves #23919 

Now in moderation, the admin can search for an account using the username @. I.E: @xyz will find the username xyz

Related video showing the feature:

https://user-images.githubusercontent.com/34009891/227573235-b16a4dd3-9655-4ee2-8af0-33c0916bb217.mp4

