### PR TITLE
Serialize status webhook events in REST API format

### DIFF
--- a/app/serializers/rest/admin/webhook_event_serializer.rb
+++ b/app/serializers/rest/admin/webhook_event_serializer.rb
@@ -7,6 +7,8 @@ class REST::Admin::WebhookEventSerializer < ActiveModel::Serializer
       REST::Admin::AccountSerializer
     when 'Report'
       REST::Admin::ReportSerializer
+    when 'Status'
+      REST::StatusSerializer
     else
       super
     end


### PR DESCRIPTION
Followup to mastodon/mastodon#24133. The default serializer for statuses is _similar_ to the REST API format, but not identical, and doesn't include the HTML content or associated account. (There is no admin API-specific serializer for statuses.)