### PR TITLE
Fix tooltip for dates without time

### DIFF
--- a/app/javascript/packs/public.jsx
+++ b/app/javascript/packs/public.jsx
@@ -117,11 +117,12 @@ function main() {
       const datetime = new Date(content.getAttribute('datetime'));
       const now      = new Date();
 
-      content.title = dateTimeFormat.format(datetime);
+      const timeGiven = content.getAttribute('datetime').includes('T');
+      content.title = timeGiven ? dateTimeFormat.format(datetime) : dateFormat.format(datetime);
       content.textContent = timeAgoString({
         formatMessage: ({ id, defaultMessage }, values) => (new IntlMessageFormat(messages[id] || defaultMessage, locale)).format(values),
         formatDate: (date, options) => (new Intl.DateTimeFormat(locale, options)).format(date),
-      }, datetime, now, now.getFullYear(), content.getAttribute('datetime').includes('T'));
+      }, datetime, now, now.getFullYear(), timeGiven);
     });
 
     const reactComponents = document.querySelectorAll('[data-component]');


### PR DESCRIPTION
The `time-ago` formatter checks whether a date or a datetime is provided (whether the ISO 8601 string contains `T`) and passes this on to `timeAgoString`. But when formatting the `title` attribute it always formats a full date with timestamp. 

This is a screenshot from `/relationships` where we explicitly call `.to_date` when generating the `datetime`-attribute.

<img width="208" alt="image" src="https://user-images.githubusercontent.com/111346/227610081-fc21e966-7d82-4312-9552-b7f6d62e8c4d.png">
