### PR TITLE
Reset model in migration after removing column

### DIFF
--- a/db/post_migrate/20190511152737_remove_suspended_silenced_account_fields.rb
+++ b/db/post_migrate/20190511152737_remove_suspended_silenced_account_fields.rb
@@ -34,6 +34,7 @@ class RemoveSuspendedSilencedAccountFields < ActiveRecord::Migration[5.2]
       remove_column :accounts, :suspended, :boolean, null: false, default: false
       remove_column :accounts, :silenced, :boolean, null: false, default: false
     end
+    Account.reset_column_information
   end
 
   def down


### PR DESCRIPTION
Migrations (in Rails 7) were failing to run all the way through (start with fresh empty db, run `db:migrate`) because the `Account` class still had the `silenced` column as part of the cached schema when the `AddInstanceActor` migration tried to run the `Account.create` line in the up part of that migration.

Previously the classes must have been reloaded between migrations, but now in Rails 7 they are staying at least partially cached between migrations.

This change explicitly resets the column information after the removal of column in the earlier migration.

It looks like this is the only migration which:

- Has a class definition inside the migration
- Removes a column in the `up` method
- That class is used in later migrations to insert data

So this is likely the only correction to make in a previous migration.

Description of using this method in migrations - https://guides.rubyonrails.org/v3.2/migrations.html#using-models-in-your-migrations

_(Extracted in advance from #24241)_