### PR TITLE
Move link header setting to after_action

### DIFF
--- a/app/controllers/concerns/account_controller_concern.rb
+++ b/app/controllers/concerns/account_controller_concern.rb
@@ -10,7 +10,8 @@ module AccountControllerConcern
 
   included do
     before_action :set_instance_presenter
-    before_action :set_link_headers, if: -> { request.format.nil? || request.format == :html }
+
+    after_action :set_link_headers, if: -> { request.format.nil? || request.format == :html }
   end
 
   private

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -9,10 +9,11 @@ class StatusesController < ApplicationController
   before_action :require_account_signature!, only: [:show, :activity], if: -> { request.format == :json && authorized_fetch_mode? }
   before_action :set_status
   before_action :set_instance_presenter
-  before_action :set_link_headers
   before_action :redirect_to_original, only: :show
   before_action :set_cache_headers
   before_action :set_body_classes, only: :embed
+
+  after_action :set_link_headers
 
   skip_around_action :set_locale, if: -> { request.format == :json }
   skip_before_action :require_functional!, only: [:show, :embed], unless: :whitelist_mode?


### PR DESCRIPTION
Because of an interaction with the Rails 7 `preload_pack_asset` (called from web_app partial) and the setting of these link headers, there's an error in the rails code sending the link headers:

https://github.com/rails/rails/blob/v7.0.4.3/actionview/lib/action_view/helpers/asset_tag_helper.rb#L558

When these headers are set in a before action which is before the views are rendered, they are present in the response['Link'] when that code runs, and it errors out while trying to send the link headers related to the preload of assets.

Moving to the after action means that they are still in the http response sent back, but they aren't there yet when the view renders, and so this code runs without error.

_(Extracted in advance from #24241)_