### PR TITLE
Add allow_other_host in redirects which may go outside app

### DIFF
--- a/app/controllers/api/v1/streaming_controller.rb
+++ b/app/controllers/api/v1/streaming_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::StreamingController < Api::BaseController
     if Rails.configuration.x.streaming_api_base_url == request.host
       not_found
     else
-      redirect_to streaming_api_url, status: 301
+      redirect_to streaming_api_url, status: 301, allow_other_host: true
     end
   end
 

--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -23,7 +23,7 @@ class MediaProxyController < ApplicationController
       redownload! if @media_attachment.needs_redownload? && !reject_media?
     end
 
-    redirect_to full_asset_url(@media_attachment.file.url(version))
+    redirect_to full_asset_url(@media_attachment.file.url(version)), allow_other_host: true
   end
 
   private

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -70,6 +70,6 @@ class StatusesController < ApplicationController
   end
 
   def redirect_to_original
-    redirect_to ActivityPub::TagManager.instance.url_for(@status.reblog) if @status.reblog?
+    redirect_to(ActivityPub::TagManager.instance.url_for(@status.reblog), allow_other_host: true) if @status.reblog?
   end
 end


### PR DESCRIPTION
Blog post explaining change - https://blog.saeloun.com/2022/02/08/rails-7-raise-unsafe-redirect-error

As noted in that post, we may want to add a rescue somewhere to do something reasonable with any places this happens but wasn't allowed.

_(Extracted in advance from #24241)_