### PR TITLE
Fix missing translation in pagination gap tags

### DIFF
--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -6,4 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 %span.page.gap
-  = t('pagination.truncate').html_safe
+  = sanitize t('pagination.truncate')

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -6,4 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 %span.page.gap
-  = sanitize t('pagination.truncate')
+  = sanitize t('pagination.truncate'), tags: [], attributes: []

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -6,4 +6,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 %span.page.gap
-  = sanitize t('pagination.truncate'), tags: [], attributes: []
+  != t('pagination.truncate')

--- a/app/views/kaminari/_gap.html.haml
+++ b/app/views/kaminari/_gap.html.haml
@@ -1,0 +1,9 @@
+-#
+  Non-link tag that stands for skipped pages...
+  available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+%span.page.gap
+  = t('pagination.truncate').html_safe


### PR DESCRIPTION
Fix for #24261, where i18n of paginator's gap is fallbacks or displayed as translation missing error "Truncate".