### PR TITLE
Use CSS to trim long card descriptions

### DIFF
--- a/app/helpers/statuses_helper.rb
+++ b/app/helpers/statuses_helper.rb
@@ -175,7 +175,6 @@ module StatusesHelper
   def render_card_component(status, **options)
     component_params = {
       sensitive: sensitized?(status, current_account),
-      maxDescription: 160,
       card: ActiveModelSerializers::SerializableResource.new(status.preview_card, serializer: REST::PreviewCardSerializer).as_json,
     }.merge(**options)
 

--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -25,16 +25,6 @@ const getHostname = url => {
   return parser.hostname;
 };
 
-const trim = (text, len) => {
-  const cut = text.indexOf(' ', len);
-
-  if (cut === -1) {
-    return text;
-  }
-
-  return text.slice(0, cut) + (text.length > len ? '…' : '');
-};
-
 const domParser = new DOMParser();
 
 const addAutoPlay = html => {
@@ -62,7 +52,6 @@ export default class Card extends React.PureComponent {
 
   static propTypes = {
     card: ImmutablePropTypes.map,
-    maxDescription: PropTypes.number,
     onOpenMedia: PropTypes.func.isRequired,
     compact: PropTypes.bool,
     defaultWidth: PropTypes.number,
@@ -71,7 +60,6 @@ export default class Card extends React.PureComponent {
   };
 
   static defaultProps = {
-    maxDescription: 50,
     compact: false,
   };
 
@@ -184,7 +172,7 @@ export default class Card extends React.PureComponent {
   }
 
   render () {
-    const { card, maxDescription, compact } = this.props;
+    const { card, compact } = this.props;
     const { width, embedded, revealed } = this.state;
 
     if (card === null) {
@@ -203,7 +191,7 @@ export default class Card extends React.PureComponent {
     const description = (
       <div className='status-card__content' lang={language}>
         {title}
-        {!(horizontal || compact) && <p className='status-card__description'>{trim(card.get('description') || '', maxDescription)}</p>}
+        {!(horizontal || compact) && <p className='status-card__description' title={card.get('description')}>{card.get('description')}</p>}
         <span className='status-card__host'>{provider}</span>
       </div>
     );

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3468,6 +3468,10 @@ a.status-card {
 
 .status-card__description {
   color: $darker-text-color;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .status-card__host {


### PR DESCRIPTION
It seems somewhat arbitrary to truncate preview card descriptions to 50 characters (and 160 characters in embed view).

I assume this truncation is mostly to prevent very long descriptions from breaking the layout. For better use of the allocated screen estate, I suggest we use CSS to trim the description to a whole number of lines (with this patch: after 2 lines) like we do for the preview card title (truncated after 1 line).