### PR TITLE
Feat (issue #20694): Support dash in tags like #Code-E

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -27,7 +27,7 @@ class Tag < ApplicationRecord
   has_many :featured_tags, dependent: :destroy, inverse_of: :tag
   has_many :followers, through: :passive_relationships, source: :account
 
-  HASHTAG_SEPARATORS = "_\u00B7\u30FB\u200c"
+  HASHTAG_SEPARATORS = "[-]_\u00B7\u30FB\u200c"
   HASHTAG_FIRST_SEQUENCE_CHUNK_ONE = "[[:word:]_][[:word:]#{HASHTAG_SEPARATORS}]*[[:alpha:]#{HASHTAG_SEPARATORS}]"
   HASHTAG_FIRST_SEQUENCE_CHUNK_TWO = "[[:word:]#{HASHTAG_SEPARATORS}]*[[:word:]_]"
   HASHTAG_FIRST_SEQUENCE = "(#{HASHTAG_FIRST_SEQUENCE_CHUNK_ONE}#{HASHTAG_FIRST_SEQUENCE_CHUNK_TWO})"

--- a/spec/lib/extractor_spec.rb
+++ b/spec/lib/extractor_spec.rb
@@ -47,6 +47,12 @@ describe Extractor do
       expect(extracted).to eq [{ hashtag: 'hashtag', indices: [0, 8] }]
     end
 
+    it 'does not exclude normal hash text that includes dash(-)' do
+      text = '#hash-tag'
+      extracted = Extractor.extract_hashtags_with_indices(text)
+      expect(extracted).to eq [{ hashtag: 'hash-tag', indices: [0, 9] }]
+    end
+
     it 'excludes http://' do
       text = '#hashtaghttp://'
       extracted = Extractor.extract_hashtags_with_indices(text)

--- a/spec/lib/hashtag_normalizer_spec.rb
+++ b/spec/lib/hashtag_normalizer_spec.rb
@@ -25,5 +25,9 @@ describe HashtagNormalizer do
     it 'keeps valid characters' do
       expect(subject.normalize('a·b')).to eq 'a·b'
     end
+
+    it 'keeps dash(-) character' do
+      expect(subject.normalize('a-')).to eq 'a-'
+    end
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe Tag do
       expect(subject.match('hello #test_').to_s).to eq ' #test_'
     end
 
+    it 'matches includes dash(-)' do
+      expect(subject.match('hello #test-10').to_s).to eq ' #test-10'
+    end
+
     it 'matches underscores in the middle' do
       expect(subject.match('hello #one_two_three').to_s).to eq ' #one_two_three'
     end


### PR DESCRIPTION
Closes issues: #20694 #20693 #23508

Support dash in tags like [#DJ_Code-E](https://diasp.org/tags/dj_code-e)

**Screenshot**

![image](https://user-images.githubusercontent.com/23138717/227815082-a242a54b-d616-4130-94c6-2f479a19d2e2.png)
