### PR TITLE
Update strong-migrations-enabled migrations from 5.0 and 5.1 to 5.2

### DIFF
--- a/db/migrate/20170927215609_add_description_to_media_attachments.rb
+++ b/db/migrate/20170927215609_add_description_to_media_attachments.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToMediaAttachments < ActiveRecord::Migration[5.1]
+class AddDescriptionToMediaAttachments < ActiveRecord::Migration[5.2]
   def change
     add_column :media_attachments, :description, :text
   end

--- a/db/migrate/20170928082043_create_email_domain_blocks.rb
+++ b/db/migrate/20170928082043_create_email_domain_blocks.rb
@@ -1,4 +1,4 @@
-class CreateEmailDomainBlocks < ActiveRecord::Migration[5.1]
+class CreateEmailDomainBlocks < ActiveRecord::Migration[5.2]
   def change
     create_table :email_domain_blocks do |t|
       t.string :domain, null: false

--- a/db/migrate/20171005102658_create_account_moderation_notes.rb
+++ b/db/migrate/20171005102658_create_account_moderation_notes.rb
@@ -1,4 +1,4 @@
-class CreateAccountModerationNotes < ActiveRecord::Migration[5.1]
+class CreateAccountModerationNotes < ActiveRecord::Migration[5.2]
   def change
     create_table :account_moderation_notes do |t|
       t.text :content, null: false

--- a/db/migrate/20171005171936_add_disabled_to_custom_emojis.rb
+++ b/db/migrate/20171005171936_add_disabled_to_custom_emojis.rb
@@ -1,6 +1,6 @@
 require Rails.root.join('lib', 'mastodon', 'migration_helpers')
 
-class AddDisabledToCustomEmojis < ActiveRecord::Migration[5.1]
+class AddDisabledToCustomEmojis < ActiveRecord::Migration[5.2]
   include Mastodon::MigrationHelpers
 
   disable_ddl_transaction!

--- a/db/migrate/20171006142024_add_uri_to_custom_emojis.rb
+++ b/db/migrate/20171006142024_add_uri_to_custom_emojis.rb
@@ -1,4 +1,4 @@
-class AddUriToCustomEmojis < ActiveRecord::Migration[5.1]
+class AddUriToCustomEmojis < ActiveRecord::Migration[5.2]
   def change
     add_column :custom_emojis, :uri, :string
     add_column :custom_emojis, :image_remote_url, :string

--- a/db/migrate/20171010023049_add_foreign_key_to_account_moderation_notes.rb
+++ b/db/migrate/20171010023049_add_foreign_key_to_account_moderation_notes.rb
@@ -1,4 +1,4 @@
-class AddForeignKeyToAccountModerationNotes < ActiveRecord::Migration[5.1]
+class AddForeignKeyToAccountModerationNotes < ActiveRecord::Migration[5.2]
   def change
     safety_assured { add_foreign_key :account_moderation_notes, :accounts }
   end

--- a/db/migrate/20171010025614_change_accounts_nonnullable_in_account_moderation_notes.rb
+++ b/db/migrate/20171010025614_change_accounts_nonnullable_in_account_moderation_notes.rb
@@ -1,4 +1,4 @@
-class ChangeAccountsNonnullableInAccountModerationNotes < ActiveRecord::Migration[5.1]
+class ChangeAccountsNonnullableInAccountModerationNotes < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
       change_column_null :account_moderation_notes, :account_id, false

--- a/db/migrate/20171020084748_add_visible_in_picker_to_custom_emoji.rb
+++ b/db/migrate/20171020084748_add_visible_in_picker_to_custom_emoji.rb
@@ -1,4 +1,4 @@
-class AddVisibleInPickerToCustomEmoji < ActiveRecord::Migration[5.1]
+class AddVisibleInPickerToCustomEmoji < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
       add_column :custom_emojis, :visible_in_picker, :boolean, default: true, null: false

--- a/db/migrate/20171028221157_add_reblogs_to_follows.rb
+++ b/db/migrate/20171028221157_add_reblogs_to_follows.rb
@@ -1,6 +1,6 @@
 require Rails.root.join('lib', 'mastodon', 'migration_helpers')
 
-class AddReblogsToFollows < ActiveRecord::Migration[5.1]
+class AddReblogsToFollows < ActiveRecord::Migration[5.2]
   include Mastodon::MigrationHelpers
 
   disable_ddl_transaction!

--- a/db/migrate/20171107143332_add_memorial_to_accounts.rb
+++ b/db/migrate/20171107143332_add_memorial_to_accounts.rb
@@ -1,6 +1,6 @@
 require Rails.root.join('lib', 'mastodon', 'migration_helpers')
 
-class AddMemorialToAccounts < ActiveRecord::Migration[5.1]
+class AddMemorialToAccounts < ActiveRecord::Migration[5.2]
   include Mastodon::MigrationHelpers
 
   disable_ddl_transaction!

--- a/db/migrate/20171107143624_add_disabled_to_users.rb
+++ b/db/migrate/20171107143624_add_disabled_to_users.rb
@@ -1,6 +1,6 @@
 require Rails.root.join('lib', 'mastodon', 'migration_helpers')
 
-class AddDisabledToUsers < ActiveRecord::Migration[5.1]
+class AddDisabledToUsers < ActiveRecord::Migration[5.2]
   include Mastodon::MigrationHelpers
 
   disable_ddl_transaction!

--- a/db/migrate/20171109012327_add_moderator_to_accounts.rb
+++ b/db/migrate/20171109012327_add_moderator_to_accounts.rb
@@ -1,6 +1,6 @@
 require Rails.root.join('lib', 'mastodon', 'migration_helpers')
 
-class AddModeratorToAccounts < ActiveRecord::Migration[5.1]
+class AddModeratorToAccounts < ActiveRecord::Migration[5.2]
   include Mastodon::MigrationHelpers
 
   disable_ddl_transaction!

--- a/db/migrate/20171114080328_add_index_domain_to_email_domain_blocks.rb
+++ b/db/migrate/20171114080328_add_index_domain_to_email_domain_blocks.rb
@@ -1,4 +1,4 @@
-class AddIndexDomainToEmailDomainBlocks < ActiveRecord::Migration[5.1]
+class AddIndexDomainToEmailDomainBlocks < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change

--- a/db/migrate/20171114231651_create_lists.rb
+++ b/db/migrate/20171114231651_create_lists.rb
@@ -1,4 +1,4 @@
-class CreateLists < ActiveRecord::Migration[5.1]
+class CreateLists < ActiveRecord::Migration[5.2]
   def change
     create_table :lists do |t|
       t.references :account, foreign_key: { on_delete: :cascade }

--- a/db/migrate/20171116161857_create_list_accounts.rb
+++ b/db/migrate/20171116161857_create_list_accounts.rb
@@ -1,4 +1,4 @@
-class CreateListAccounts < ActiveRecord::Migration[5.1]
+class CreateListAccounts < ActiveRecord::Migration[5.2]
   def change
     create_table :list_accounts do |t|
       t.belongs_to :list, foreign_key: { on_delete: :cascade }, null: false

--- a/db/migrate/20171118012443_add_moved_to_account_id_to_accounts.rb
+++ b/db/migrate/20171118012443_add_moved_to_account_id_to_accounts.rb
@@ -1,4 +1,4 @@
-class AddMovedToAccountIdToAccounts < ActiveRecord::Migration[5.1]
+class AddMovedToAccountIdToAccounts < ActiveRecord::Migration[5.2]
   def change
     add_column :accounts, :moved_to_account_id, :bigint, null: true, default: nil
     safety_assured { add_foreign_key :accounts, :accounts, column: :moved_to_account_id, on_delete: :nullify }

--- a/db/migrate/20171119172437_create_admin_action_logs.rb
+++ b/db/migrate/20171119172437_create_admin_action_logs.rb
@@ -1,4 +1,4 @@
-class CreateAdminActionLogs < ActiveRecord::Migration[5.1]
+class CreateAdminActionLogs < ActiveRecord::Migration[5.2]
   def change
     create_table :admin_action_logs do |t|
       t.belongs_to :account, foreign_key: { on_delete: :cascade }

--- a/db/migrate/20171122120436_add_index_account_and_reblog_of_id_to_statuses.rb
+++ b/db/migrate/20171122120436_add_index_account_and_reblog_of_id_to_statuses.rb
@@ -1,4 +1,4 @@
-class AddIndexAccountAndReblogOfIdToStatuses < ActiveRecord::Migration[5.1]
+class AddIndexAccountAndReblogOfIdToStatuses < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def up

--- a/db/migrate/20171125024930_create_invites.rb
+++ b/db/migrate/20171125024930_create_invites.rb
@@ -1,4 +1,4 @@
-class CreateInvites < ActiveRecord::Migration[5.1]
+class CreateInvites < ActiveRecord::Migration[5.2]
   def change
     create_table :invites do |t|
       t.belongs_to :user, foreign_key: { on_delete: :cascade }

--- a/db/migrate/20171125031751_add_invite_id_to_users.rb
+++ b/db/migrate/20171125031751_add_invite_id_to_users.rb
@@ -1,4 +1,4 @@
-class AddInviteIdToUsers < ActiveRecord::Migration[5.1]
+class AddInviteIdToUsers < ActiveRecord::Migration[5.2]
   def change
     safety_assured { add_reference :users, :invite, null: true, default: nil, foreign_key: { on_delete: :nullify }, index: false }
   end

--- a/db/migrate/20171125185353_add_index_reblog_of_id_and_account_to_statuses.rb
+++ b/db/migrate/20171125185353_add_index_reblog_of_id_and_account_to_statuses.rb
@@ -1,4 +1,4 @@
-class AddIndexReblogOfIdAndAccountToStatuses < ActiveRecord::Migration[5.1]
+class AddIndexReblogOfIdAndAccountToStatuses < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change

--- a/db/migrate/20171125190735_remove_old_reblog_index_on_statuses.rb
+++ b/db/migrate/20171125190735_remove_old_reblog_index_on_statuses.rb
@@ -1,4 +1,4 @@
-class RemoveOldReblogIndexOnStatuses < ActiveRecord::Migration[5.1]
+class RemoveOldReblogIndexOnStatuses < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def up

--- a/db/migrate/20171129172043_add_index_on_stream_entries.rb
+++ b/db/migrate/20171129172043_add_index_on_stream_entries.rb
@@ -1,4 +1,4 @@
-class AddIndexOnStreamEntries < ActiveRecord::Migration[5.1]
+class AddIndexOnStreamEntries < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change

--- a/db/migrate/20171130000000_add_embed_url_to_preview_cards.rb
+++ b/db/migrate/20171130000000_add_embed_url_to_preview_cards.rb
@@ -1,6 +1,6 @@
 require Rails.root.join('lib', 'mastodon', 'migration_helpers')
 
-class AddEmbedURLToPreviewCards < ActiveRecord::Migration[5.1]
+class AddEmbedURLToPreviewCards < ActiveRecord::Migration[5.2]
   include Mastodon::MigrationHelpers
 
   disable_ddl_transaction!

--- a/db/migrate/20171201000000_change_account_id_nonnullable_in_lists.rb
+++ b/db/migrate/20171201000000_change_account_id_nonnullable_in_lists.rb
@@ -1,4 +1,4 @@
-class ChangeAccountIdNonnullableInLists < ActiveRecord::Migration[5.1]
+class ChangeAccountIdNonnullableInLists < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
       change_column_null :lists, :account_id, false

--- a/db/migrate/20171212195226_remove_duplicate_indexes_in_lists.rb
+++ b/db/migrate/20171212195226_remove_duplicate_indexes_in_lists.rb
@@ -1,4 +1,4 @@
-class RemoveDuplicateIndexesInLists < ActiveRecord::Migration[5.1]
+class RemoveDuplicateIndexesInLists < ActiveRecord::Migration[5.2]
   def change
     remove_index :list_accounts, name: 'index_list_accounts_on_account_id'
     remove_index :list_accounts, name: 'index_list_accounts_on_list_id'

--- a/db/migrate/20171226094803_more_faster_index_on_notifications.rb
+++ b/db/migrate/20171226094803_more_faster_index_on_notifications.rb
@@ -1,4 +1,4 @@
-class MoreFasterIndexOnNotifications < ActiveRecord::Migration[5.1]
+class MoreFasterIndexOnNotifications < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change

--- a/db/migrate/20180106000232_add_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
+++ b/db/migrate/20180106000232_add_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
@@ -1,4 +1,4 @@
-class AddIndexOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Migration[5.1]
+class AddIndexOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change

--- a/db/migrate/20180109143959_add_remember_token_to_users.rb
+++ b/db/migrate/20180109143959_add_remember_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddRememberTokenToUsers < ActiveRecord::Migration[5.1]
+class AddRememberTokenToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :remember_token, :string, null: true
   end

--- a/db/migrate/20180204034416_create_identities.rb
+++ b/db/migrate/20180204034416_create_identities.rb
@@ -1,7 +1,7 @@
-class CreateIdentities < ActiveRecord::Migration[5.0]
+class CreateIdentities < ActiveRecord::Migration[5.2]
   def change
-    create_table :identities do |t|
-      t.references :user, foreign_key: { on_delete: :cascade }
+    create_table :identities, id: :integer do |t|
+      t.references :user, type: :integer, foreign_key: { on_delete: :cascade }
       t.string :provider, null: false, default: ''
       t.string :uid, null: false, default: ''
 

--- a/db/migrate/20180206000000_change_user_id_nonnullable.rb
+++ b/db/migrate/20180206000000_change_user_id_nonnullable.rb
@@ -1,4 +1,4 @@
-class ChangeUserIdNonnullable < ActiveRecord::Migration[5.1]
+class ChangeUserIdNonnullable < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
       change_column_null :invites, :user_id, false

--- a/db/migrate/20180211015820_create_backups.rb
+++ b/db/migrate/20180211015820_create_backups.rb
@@ -1,4 +1,4 @@
-class CreateBackups < ActiveRecord::Migration[5.1]
+class CreateBackups < ActiveRecord::Migration[5.2]
   def change
     create_table :backups do |t|
       t.references :user, foreign_key: { on_delete: :nullify }

--- a/db/migrate/20180304013859_add_featured_collection_url_to_accounts.rb
+++ b/db/migrate/20180304013859_add_featured_collection_url_to_accounts.rb
@@ -1,4 +1,4 @@
-class AddFeaturedCollectionURLToAccounts < ActiveRecord::Migration[5.1]
+class AddFeaturedCollectionURLToAccounts < ActiveRecord::Migration[5.2]
   def change
     add_column :accounts, :featured_collection_url, :string
   end

--- a/db/migrate/20180310000000_change_columns_in_notifications_nonnullable.rb
+++ b/db/migrate/20180310000000_change_columns_in_notifications_nonnullable.rb
@@ -1,4 +1,4 @@
-class ChangeColumnsInNotificationsNonnullable < ActiveRecord::Migration[5.1]
+class ChangeColumnsInNotificationsNonnullable < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
       change_column_null :notifications, :activity_id, false

--- a/db/migrate/20180402031200_add_assigned_account_id_to_reports.rb
+++ b/db/migrate/20180402031200_add_assigned_account_id_to_reports.rb
@@ -1,4 +1,4 @@
-class AddAssignedAccountIdToReports < ActiveRecord::Migration[5.1]
+class AddAssignedAccountIdToReports < ActiveRecord::Migration[5.2]
   def change
     safety_assured { add_reference :reports, :assigned_account, null: true, default: nil, foreign_key: { on_delete: :nullify, to_table: :accounts }, index: false }
   end

--- a/db/migrate/20180402040909_create_report_notes.rb
+++ b/db/migrate/20180402040909_create_report_notes.rb
@@ -1,4 +1,4 @@
-class CreateReportNotes < ActiveRecord::Migration[5.1]
+class CreateReportNotes < ActiveRecord::Migration[5.2]
   def change
     create_table :report_notes do |t|
       t.text :content, null: false

--- a/db/migrate/20180410204633_add_fields_to_accounts.rb
+++ b/db/migrate/20180410204633_add_fields_to_accounts.rb
@@ -1,4 +1,4 @@
-class AddFieldsToAccounts < ActiveRecord::Migration[5.1]
+class AddFieldsToAccounts < ActiveRecord::Migration[5.2]
   def change
     add_column :accounts, :fields, :jsonb
   end

--- a/db/migrate/20180514130000_improve_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
+++ b/db/migrate/20180514130000_improve_index_on_statuses_for_api_v1_accounts_account_id_statuses.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-class ImproveIndexOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Migration[5.1]
+class ImproveIndexOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change
-    #  These changes ware reverted by migration 20180514140000.
+    #  These changes were reverted by migration 20180514140000.
     #  add_index :statuses, [:account_id, :id, :visibility], where: 'visibility IN (0, 1, 2)', algorithm: :concurrently
     #  add_index :statuses, [:account_id, :id], where: 'visibility = 3', algorithm: :concurrently
     #  remove_index :statuses, column: [:account_id, :id, :visibility, :updated_at], order: { id: :desc }, algorithm: :concurrently, name: :index_statuses_20180106

--- a/db/migrate/20180514140000_revert_index_change_on_statuses_for_api_v1_accounts_account_id_statuses.rb
+++ b/db/migrate/20180514140000_revert_index_change_on_statuses_for_api_v1_accounts_account_id_statuses.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RevertIndexChangeOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Migration[5.1]
+class RevertIndexChangeOnStatusesForApiV1AccountsAccountIdStatuses < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def change

--- a/db/migrate/20180831171112_create_bookmarks.rb
+++ b/db/migrate/20180831171112_create_bookmarks.rb
@@ -1,4 +1,4 @@
-class CreateBookmarks < ActiveRecord::Migration[5.1]
+class CreateBookmarks < ActiveRecord::Migration[5.2]
   def change
     create_table :bookmarks do |t|
       t.references :account, null: false

--- a/db/migrate/20191031163205_change_list_account_follow_nullable.rb
+++ b/db/migrate/20191031163205_change_list_account_follow_nullable.rb
@@ -1,4 +1,4 @@
-class ChangeListAccountFollowNullable < ActiveRecord::Migration[5.1]
+class ChangeListAccountFollowNullable < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
       change_column_null :list_accounts, :follow_id, true

--- a/db/migrate/20200622213645_media_attachment_ids_to_timestamp_ids.rb
+++ b/db/migrate/20200622213645_media_attachment_ids_to_timestamp_ids.rb
@@ -1,4 +1,4 @@
-class MediaAttachmentIdsToTimestampIds < ActiveRecord::Migration[5.1]
+class MediaAttachmentIdsToTimestampIds < ActiveRecord::Migration[5.2]
   def up
     # Set up the media_attachments.id column to use our timestamp-based IDs.
     safety_assured do

--- a/db/migrate/20200917192924_add_notify_to_follows.rb
+++ b/db/migrate/20200917192924_add_notify_to_follows.rb
@@ -1,6 +1,6 @@
 require Rails.root.join('lib', 'mastodon', 'migration_helpers')
 
-class AddNotifyToFollows < ActiveRecord::Migration[5.1]
+class AddNotifyToFollows < ActiveRecord::Migration[5.2]
   include Mastodon::MigrationHelpers
 
   disable_ddl_transaction!

--- a/db/migrate/20210306164523_account_ids_to_timestamp_ids.rb
+++ b/db/migrate/20210306164523_account_ids_to_timestamp_ids.rb
@@ -1,4 +1,4 @@
-class AccountIdsToTimestampIds < ActiveRecord::Migration[5.1]
+class AccountIdsToTimestampIds < ActiveRecord::Migration[5.2]
   def up
     # Set up the accounts.id column to use our timestamp-based IDs.
     safety_assured do

--- a/db/post_migrate/20210308133107_remove_subscription_expires_at_from_accounts.rb
+++ b/db/post_migrate/20210308133107_remove_subscription_expires_at_from_accounts.rb
@@ -1,7 +1,7 @@
-class RemoveSubscriptionExpiresAtFromAccounts < ActiveRecord::Migration[5.0]
+class RemoveSubscriptionExpiresAtFromAccounts < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
-      remove_column :accounts, :subscription_expires_at, :datetime, null: true, default: nil
+      remove_column :accounts, :subscription_expires_at, :datetime, null: true, default: nil, precision: nil
     end
   end
 end


### PR DESCRIPTION
Follow-up to #24270

There should not be any functional change, but I wanted to be sure we did not mess up any migration.