### PR TITLE
Wrap db:setup with Chewy.strategy(:mastodon)

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-Dir[Rails.root.join('db', 'seeds', '*.rb')].sort.each do |seed|
-  load seed
+Chewy.strategy(:mastodon) do
+  Dir[Rails.root.join('db', 'seeds', '*.rb')].sort.each do |seed|
+    load seed
+  end
 end


### PR DESCRIPTION
`RAILS_ENV=development ./bin/rails db:setup` fails with the error:
```
Chewy::UndefinedUpdateStrategy:   Index update strategy is undefined for current context.
  Please wrap your code with `Chewy.strategy(:strategy_name) block.`
```
This wraps it in `Chewy.strategy(:mastodon)` to fix the error.
Fixes #24255 