### PR TITLE
Fixes launching of the devcontainer and adds support for Docker Desktop

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,8 +15,9 @@
   "forwardPorts": [3000, 4000],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": ".devcontainer/post-create.sh",
-  "waitFor": "postCreateCommand",
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postStartCommand": ".devcontainer/post-create.sh",
+  "waitFor": "postStartCommand",
 
   // Configure tool-specific properties.
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,9 +15,9 @@
   "forwardPorts": [3000, 4000],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
-  "postStartCommand": ".devcontainer/post-create.sh",
-  "waitFor": "postStartCommand",
+  "onCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  "waitFor": "postCreateCommand",
 
   // Configure tool-specific properties.
   "customizations": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       RAILS_ENV: development
       NODE_ENV: development
-
+      BIND: 0.0.0.0
       REDIS_HOST: redis
       REDIS_PORT: '6379'
       DB_HOST: db
@@ -23,6 +23,10 @@ services:
       LIBRE_TRANSLATE_ENDPOINT: http://libretranslate:5000
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
+    ports:
+      - '127.0.0.1:3000:3000'
+      - '127.0.0.1:4000:4000'
+      - '127.0.0.1:80:3000'
     networks:
       - external_network
       - internal_network
@@ -66,15 +70,19 @@ services:
         hard: -1
 
   libretranslate:
-    image: libretranslate/libretranslate:v1.2.9
+    image: libretranslate/libretranslate:v1.3.10
     restart: unless-stopped
+    volumes:
+      - lt-data:/home/libretranslate/.local
     networks:
+      - external_network
       - internal_network
 
 volumes:
   postgres-data:
   redis-data:
   es-data:
+  lt-data:
 
 networks:
   external_network:

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -14,6 +14,9 @@ git checkout -- Gemfile.lock
 # [re]create, migrate, and seed the test database
 RAILS_ENV=test ./bin/rails db:setup
 
+# [re]create, migrate, and seed the test database
+RAILS_ENV=development ./bin/rails db:setup
+
 # Precompile assets for development
 RAILS_ENV=development ./bin/rails assets:precompile
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -14,7 +14,7 @@ git checkout -- Gemfile.lock
 # [re]create, migrate, and seed the test database
 RAILS_ENV=test ./bin/rails db:setup
 
-# [re]create, migrate, and seed the test database
+# [re]create, migrate, and seed the development database
 RAILS_ENV=development ./bin/rails db:setup
 
 # Precompile assets for development


### PR DESCRIPTION
Added binding to 0.0.0.0 and port definitions to the devcontainer docker-compose, because the forwardPorts setting in devcontainer.json does not seem to work with Docker Desktop
Added create, migrate, and seed the development database
Also updated `libretranslate` container to latest so it's mulit-architecture so it doesn't need emulation on Macs with Apple Silicone