### PR TITLE
Requeue expiration notification

### DIFF
--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -141,9 +141,9 @@ class UpdateStatusService < BaseService
     poll = @status.preloadable_poll
 
     # If the poll had no expiration date set but now has, or now has a sooner
-    # expiration date, and people have voted, schedule a notification
+    # expiration date, schedule a notification
 
-    return unless poll.present? && poll.expires_at.present? && poll.votes.exists?
+    return unless poll.present? && poll.expires_at.present?
 
     PollExpirationNotifyWorker.remove_from_scheduled(poll.id) if @previous_expires_at.present? && @previous_expires_at > poll.expires_at
     PollExpirationNotifyWorker.perform_at(poll.expires_at + 5.minutes, poll.id)

--- a/app/workers/poll_expiration_notify_worker.rb
+++ b/app/workers/poll_expiration_notify_worker.rb
@@ -3,7 +3,7 @@
 class PollExpirationNotifyWorker
   include Sidekiq::Worker
 
-  sidekiq_options lock: :until_executed
+  sidekiq_options lock: :until_executing
 
   def perform(poll_id)
     @poll = Poll.find(poll_id)

--- a/spec/workers/poll_expiration_notify_worker_spec.rb
+++ b/spec/workers/poll_expiration_notify_worker_spec.rb
@@ -4,10 +4,69 @@ require 'rails_helper'
 
 describe PollExpirationNotifyWorker do
   let(:worker) { described_class.new }
+  let(:account) { Fabricate(:account, domain: remote? ? 'example.com' : nil) }
+  let(:status) { Fabricate(:status, account: account) }
+  let(:poll) { Fabricate(:poll, status: status, account: account) }
+  let(:remote?) { false }
+  let(:poll_vote) { Fabricate(:poll_vote, poll: poll) }
 
-  describe 'perform' do
+  describe '#perform' do
+    around do |example|
+      Sidekiq::Testing.fake! do
+        example.run
+      end
+    end
+
     it 'runs without error for missing record' do
       expect { worker.perform(nil) }.to_not raise_error
+    end
+
+    context 'when poll is not expired' do
+      it 'requeues job' do
+        worker.perform(poll.id)
+        expect(described_class.sidekiq_options_hash['lock']).to be :until_executing
+        expect(described_class).to have_enqueued_sidekiq_job(poll.id).at(poll.expires_at + 5.minutes)
+      end
+    end
+
+    context 'when poll is expired' do
+      before do
+        poll_vote
+
+        travel_to poll.expires_at + 5.minutes
+
+        worker.perform(poll.id)
+      end
+
+      context 'when poll is local' do
+        it 'notifies voters' do
+          expect(ActivityPub::DistributePollUpdateWorker).to have_enqueued_sidekiq_job(poll.status.id)
+        end
+
+        it 'notifies owner' do
+          expect(LocalNotificationWorker).to have_enqueued_sidekiq_job(poll.account.id, poll.id, 'Poll', 'poll')
+        end
+
+        it 'notifies local voters' do
+          expect(LocalNotificationWorker).to have_enqueued_sidekiq_job(poll_vote.account.id, poll.id, 'Poll', 'poll')
+        end
+      end
+
+      context 'when poll is remote' do
+        let(:remote?) { true }
+
+        it 'does not notify remote voters' do
+          expect(ActivityPub::DistributePollUpdateWorker).to_not have_enqueued_sidekiq_job(poll.status.id)
+        end
+
+        it 'does not notify owner' do
+          expect(LocalNotificationWorker).to_not have_enqueued_sidekiq_job(poll.account.id, poll.id, 'Poll', 'poll')
+        end
+
+        it 'notifies local voters' do
+          expect(LocalNotificationWorker).to have_enqueued_sidekiq_job(poll_vote.account.id, poll.id, 'Poll', 'poll')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #24271.

I think there are two issues:
- The Sidekiq job uses the `until_executed` locking strategy, so the attempt to schedule a new execution from within the worker itself in [PollExpirationNotifyWorker#requeue!](https://github.com/mastodon/mastodon/blob/a766804e02dfe3d2c47267d14f1797eca93c837b/app/workers/poll_expiration_notify_worker.rb#L35-L37) fails silently.
- The notification is only rescheduled if the poll has votes. The notification worker not only notifies the voters but also the owner, so I don't think we need to check for `votes.any?` here. Even if there were no votes, I assume the owner would like to know when the poll expires.
