### PR TITLE
Fix stale apt index in github actions

### DIFF
--- a/.github/workflows/lint-haml.yml
+++ b/.github/workflows/lint-haml.yml
@@ -30,7 +30,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install native Ruby dependencies
-        run: sudo apt-get install -y libicu-dev libidn11-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libicu-dev libidn11-dev
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test-migrations-one-step.yml
+++ b/.github/workflows/test-migrations-one-step.yml
@@ -64,7 +64,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install native Ruby dependencies
-        run: sudo apt-get install -y libicu-dev libidn11-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libicu-dev libidn11-dev
 
       - name: Set up bundler cache
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test-migrations-two-step.yml
+++ b/.github/workflows/test-migrations-two-step.yml
@@ -63,7 +63,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install native Ruby dependencies
-        run: sudo apt-get install -y libicu-dev libidn11-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libicu-dev libidn11-dev
 
       - name: Set up bundler cache
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -32,7 +32,9 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install native Ruby dependencies
-        run: sudo apt-get install -y libicu-dev libidn11-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libicu-dev libidn11-dev
 
       - name: Set up bundler cache
         uses: ruby/setup-ruby@v1
@@ -118,6 +120,9 @@ jobs:
         with:
           path: './public'
           name: ${{ github.sha }}
+
+      - name: Update package index
+        run: sudo apt-get update
 
       - name: Install native Ruby dependencies
         run: sudo apt-get install -y libicu-dev libidn11-dev


### PR DESCRIPTION
The containers are not guaranteed to have an up-to-date apt index, so trying to install packages without updating the index first may result in errors, as seen in recent builds: https://github.com/mastodon/mastodon/actions/runs/4562332642/jobs/8049462164

This is documented in https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners