### PR TITLE
Wrong type for user setting when default is defined by lambda

### DIFF
--- a/app/models/user_settings/setting.rb
+++ b/app/models/user_settings/setting.rb
@@ -19,7 +19,8 @@ class UserSettings::Setting
   end
 
   def type
-    if @default_value.is_a?(TrueClass) || @default_value.is_a?(FalseClass)
+    case default_value
+    when TrueClass, FalseClass
       ActiveModel::Type::Boolean.new
     else
       ActiveModel::Type::String.new

--- a/spec/models/user_settings/setting_spec.rb
+++ b/spec/models/user_settings/setting_spec.rb
@@ -30,6 +30,38 @@ RSpec.describe UserSettings::Setting do
     it 'returns a type' do
       expect(subject.type).to be_a ActiveModel::Type::Value
     end
+
+    context 'when default value is a boolean' do
+      let(:default) { false }
+
+      it 'returns boolean' do
+        expect(subject.type).to be_a ActiveModel::Type::Boolean
+      end
+    end
+
+    context 'when default value is a string' do
+      let(:default) { '' }
+
+      it 'returns string' do
+        expect(subject.type).to be_a ActiveModel::Type::String
+      end
+    end
+
+    context 'when default value is a lambda returning a boolean' do
+      let(:default) { -> { false } }
+
+      it 'returns boolean' do
+        expect(subject.type).to be_a ActiveModel::Type::Boolean
+      end
+    end
+
+    context 'when default value is a lambda returning a string' do
+      let(:default) { -> { '' } }
+
+      it 'returns boolean' do
+        expect(subject.type).to be_a ActiveModel::Type::String
+      end
+    end
   end
 
   describe '#type_cast' do


### PR DESCRIPTION
`UserSettings::Setting#type` always returns string if the default value is defined by a lambda like it is for `noindex`:

https://github.com/mastodon/mastodon/blob/68a192e7186733885b1d70160170c4772fab7242/app/models/user_settings.rb#L13

<img width="311" alt="image" src="https://user-images.githubusercontent.com/111346/228925800-359b88af-dbb0-4235-86ec-ede00bdf94a5.png">
