### PR TITLE
Sync the Docs and the interface

### DIFF
--- a/config/locales/doorkeeper.en-GB.yml
+++ b/config/locales/doorkeeper.en-GB.yml
@@ -48,7 +48,7 @@ en-GB:
         title: New application
       show:
         actions: Actions
-        application_id: Client key
+        application_id: Client ID
         callback_urls: Callback URLs
         scopes: Scopes
         secret: Client secret

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -48,7 +48,7 @@ en:
         title: New application
       show:
         actions: Actions
-        application_id: Client key
+        application_id: Client ID
         callback_urls: Callback URLs
         scopes: Scopes
         secret: Client secret

--- a/config/locales/doorkeeper.sco.yml
+++ b/config/locales/doorkeeper.sco.yml
@@ -48,7 +48,7 @@ sco:
         title: New application
       show:
         actions: Actions
-        application_id: Client key
+        application_id: Client ID
         callback_urls: Cawback URLs
         scopes: Scopes
         secret: Client secret

--- a/config/locales/doorkeeper.zh-HK.yml
+++ b/config/locales/doorkeeper.zh-HK.yml
@@ -48,7 +48,7 @@ zh-HK:
         title: 新增應用程式
       show:
         actions: 操作
-        application_id: 用戶程式鑰匙 (Client key)
+        application_id: 用戶程式鑰匙 (Client ID)
         callback_urls: 回傳網址 (Callback URL)
         scopes: 權限範圍 (Scopes)
         secret: 用戶程式密碼 (Client secret)


### PR DESCRIPTION
In the offical api doc's the "Client key" is referenced as `Client_ID`,
this change updates the times that "Client key" is in the translation.

Signed-off-by: JJ Asghar <awesome@ibm.com>