### PR TITLE
Bump rubocop minimum ruby to 3.0.6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ require:
   - rubocop-capybara
 
 AllCops:
-  TargetRubyVersion: 2.7 # Set to minimum supported version of CI
+  TargetRubyVersion: 3.0.6 # Set to minimum supported version of CI
   DisplayCopNames: true
   DisplayStyleGuide: true
   ExtraDetails: true


### PR DESCRIPTION
[2.7 is deprecated past security patch support.](https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/). 

See https://github.com/mastodon/mastodon/pull/24320#issuecomment-1491940450