### PR TITLE
Fix invalid/expired invites being processed on sign-up

### DIFF
--- a/app/controllers/auth/registrations_controller.rb
+++ b/app/controllers/auth/registrations_controller.rb
@@ -46,7 +46,7 @@ class Auth::RegistrationsController < Devise::RegistrationsController
     super(hash)
 
     resource.locale                 = I18n.locale
-    resource.invite_code            = params[:invite_code] if resource.invite_code.blank?
+    resource.invite_code            = @invite&.code if resource.invite_code.blank?
     resource.registration_form_time = session[:registration_form_time]
     resource.sign_up_ip             = request.remote_ip
 


### PR DESCRIPTION
When a user signs up by using an invitation, the invitation is processed even if it has expired or used up. This did not allow users to bypass closed registrations, but it could have made them unknowingly follow the account that issued the invitation.