### PR TITLE
Update parser to match .ruby-version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,7 @@ GEM
     orm_adapter (0.5.0)
     ox (2.14.14)
     parallel (1.22.1)
-    parser (3.2.1.1)
+    parser (3.2.2.0)
       ast (~> 2.4.1)
     parslet (2.0.0)
     pastel (0.8.0)


### PR DESCRIPTION
Get ride of the warning `warning: parser/current is loading parser/ruby32, which recognizes 3.2.1-compliant syntax, but you are running 3.2.2.` since the base version has been bumped