### PR TITLE
Remove redundant response caching

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -31,7 +31,7 @@ class AccountsController < ApplicationController
 
       format.json do
         expires_in 3.minutes, public: !(authorized_fetch_mode? && signed_request_account.present?)
-        render_with_cache json: @account, content_type: 'application/activity+json', serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter
+        render json: @account, content_type: 'application/activity+json', serializer: ActivityPub::ActorSerializer, adapter: ActivityPub::Adapter
       end
     end
   end

--- a/app/controllers/activitypub/collections_controller.rb
+++ b/app/controllers/activitypub/collections_controller.rb
@@ -12,7 +12,7 @@ class ActivityPub::CollectionsController < ActivityPub::BaseController
 
   def show
     expires_in 3.minutes, public: public_fetch_mode?
-    render_with_cache json: collection_presenter, content_type: 'application/activity+json', serializer: ActivityPub::CollectionSerializer, adapter: ActivityPub::Adapter
+    render json: collection_presenter, content_type: 'application/activity+json', serializer: ActivityPub::CollectionSerializer, adapter: ActivityPub::Adapter
   end
 
   private

--- a/app/controllers/api/v1/custom_emojis_controller.rb
+++ b/app/controllers/api/v1/custom_emojis_controller.rb
@@ -5,6 +5,6 @@ class Api::V1::CustomEmojisController < Api::BaseController
 
   def index
     expires_in 3.minutes, public: true
-    render_with_cache(each_serializer: REST::CustomEmojiSerializer) { CustomEmoji.listed.includes(:category) }
+    render json: CustomEmoji.listed.includes(:category), each_serializer: REST::CustomEmojiSerializer
   end
 end

--- a/app/controllers/api/v1/instances/activity_controller.rb
+++ b/app/controllers/api/v1/instances/activity_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Instances::ActivityController < Api::BaseController
 
   def show
     expires_in 1.day, public: true
-    render_with_cache json: :activity, expires_in: 1.day
+    render json: activity
   end
 
   private

--- a/app/controllers/api/v1/instances/peers_controller.rb
+++ b/app/controllers/api/v1/instances/peers_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Instances::PeersController < Api::BaseController
 
   def index
     expires_in 1.day, public: true
-    render_with_cache(expires_in: 1.day) { Instance.where.not(domain: DomainBlock.select(:domain)).pluck(:domain) }
+    render json: Instance.where.not(domain: DomainBlock.select(:domain)).pluck(:domain)
   end
 
   private

--- a/app/controllers/api/v1/instances_controller.rb
+++ b/app/controllers/api/v1/instances_controller.rb
@@ -6,6 +6,6 @@ class Api::V1::InstancesController < Api::BaseController
 
   def show
     expires_in 3.minutes, public: true
-    render_with_cache json: InstancePresenter.new, serializer: REST::V1::InstanceSerializer, root: 'instance'
+    render json: InstancePresenter.new, serializer: REST::V1::InstanceSerializer, root: 'instance'
   end
 end

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::Trends::StatusesController < Api::BaseController
   after_action :insert_pagination_headers
 
   def index
+    expires_in 3.minutes, public: true unless user_signed_in?
     render json: @statuses, each_serializer: REST::StatusSerializer
   end
 

--- a/app/controllers/api/v2/instances_controller.rb
+++ b/app/controllers/api/v2/instances_controller.rb
@@ -3,6 +3,6 @@
 class Api::V2::InstancesController < Api::V1::InstancesController
   def show
     expires_in 3.minutes, public: true
-    render_with_cache json: InstancePresenter.new, serializer: REST::InstanceSerializer, root: 'instance'
+    render json: InstancePresenter.new, serializer: REST::InstanceSerializer, root: 'instance'
   end
 end

--- a/app/controllers/concerns/cache_concern.rb
+++ b/app/controllers/concerns/cache_concern.rb
@@ -155,27 +155,6 @@ module CacheConcern
     end
   end
 
-  def render_with_cache(**options)
-    raise ArgumentError, 'only JSON render calls are supported' unless options.key?(:json) || block_given?
-
-    key        = options.delete(:key) || [[params[:controller], params[:action]].join('/'), options[:json].respond_to?(:cache_key) ? options[:json].cache_key : nil, options[:fields].nil? ? nil : options[:fields].join(',')].compact.join(':')
-    expires_in = options.delete(:expires_in) || 3.minutes
-    body       = Rails.cache.read(key, raw: true)
-
-    if body
-      render(options.except(:json, :serializer, :each_serializer, :adapter, :fields).merge(json: body))
-    else
-      if block_given?
-        options[:json] = yield
-      elsif options[:json].is_a?(Symbol)
-        options[:json] = send(options[:json])
-      end
-
-      render(options)
-      Rails.cache.write(key, response.body, expires_in: expires_in, raw: true)
-    end
-  end
-
   def set_cache_headers
     response.headers['Vary'] = public_fetch_mode? ? 'Accept' : 'Accept, Signature'
   end

--- a/app/controllers/emojis_controller.rb
+++ b/app/controllers/emojis_controller.rb
@@ -8,7 +8,7 @@ class EmojisController < ApplicationController
     respond_to do |format|
       format.json do
         expires_in 3.minutes, public: true
-        render_with_cache json: @emoji, content_type: 'application/activity+json', serializer: ActivityPub::EmojiSerializer, adapter: ActivityPub::Adapter
+        render json: @emoji, content_type: 'application/activity+json', serializer: ActivityPub::EmojiSerializer, adapter: ActivityPub::Adapter
       end
     end
   end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -30,20 +30,20 @@ class StatusesController < ApplicationController
 
       format.json do
         expires_in 3.minutes, public: @status.distributable? && public_fetch_mode?
-        render_with_cache json: @status, content_type: 'application/activity+json', serializer: ActivityPub::NoteSerializer, adapter: ActivityPub::Adapter
+        render json: @status, content_type: 'application/activity+json', serializer: ActivityPub::NoteSerializer, adapter: ActivityPub::Adapter
       end
     end
   end
 
   def activity
     expires_in 3.minutes, public: @status.distributable? && public_fetch_mode?
-    render_with_cache json: ActivityPub::ActivityPresenter.from_status(@status), content_type: 'application/activity+json', serializer: ActivityPub::ActivitySerializer, adapter: ActivityPub::Adapter
+    render json: ActivityPub::ActivityPresenter.from_status(@status), content_type: 'application/activity+json', serializer: ActivityPub::ActivitySerializer, adapter: ActivityPub::Adapter
   end
 
   def embed
     return not_found if @status.hidden? || @status.reblog?
 
-    expires_in 180, public: true
+    expires_in 3.minutes, public: true
     response.headers['X-Frame-Options'] = 'ALLOWALL'
 
     render layout: 'embedded'

--- a/app/controllers/well_known/nodeinfo_controller.rb
+++ b/app/controllers/well_known/nodeinfo_controller.rb
@@ -8,12 +8,12 @@ module WellKnown
 
     def index
       expires_in 3.days, public: true
-      render_with_cache json: {}, serializer: NodeInfo::DiscoverySerializer, adapter: NodeInfo::Adapter, expires_in: 3.days, root: 'nodeinfo'
+      render json: {}, serializer: NodeInfo::DiscoverySerializer, adapter: NodeInfo::Adapter, root: 'nodeinfo'
     end
 
     def show
       expires_in 30.minutes, public: true
-      render_with_cache json: {}, serializer: NodeInfo::Serializer, adapter: NodeInfo::Adapter, expires_in: 30.minutes, root: 'nodeinfo'
+      render json: {}, serializer: NodeInfo::Serializer, adapter: NodeInfo::Adapter, root: 'nodeinfo'
     end
   end
 end


### PR DESCRIPTION
The responses are cached in Redis for the same duration as HTTP cache, so they're already getting cached by the reverse proxy (when properly configured, which should be the default with out nginx configuration). So writing the cache to Redis is just an extra roundtrip for no reason.