### PR TITLE
Change unauthenticated responses to be cached in REST API

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,12 +6,15 @@ class Api::BaseController < ApplicationController
 
   include RateLimitHeaders
   include AccessTokenTrackingConcern
+  include ApiCachingConcern
 
   skip_before_action :store_current_location
   skip_before_action :require_functional!, unless: :whitelist_mode?
 
   before_action :require_authenticated_user!, if: :disallow_unauthenticated_api_access?
   before_action :require_not_suspended!
+
+  vary_by 'Authorization'
 
   protect_from_forgery with: :null_session
 

--- a/app/controllers/api/v1/accounts/follower_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/follower_accounts_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::Accounts::FollowerAccountsController < Api::BaseController
   after_action :insert_pagination_headers
 
   def index
+    cache_if_unauthenticated!
     @accounts = load_accounts
     render json: @accounts, each_serializer: REST::AccountSerializer
   end

--- a/app/controllers/api/v1/accounts/following_accounts_controller.rb
+++ b/app/controllers/api/v1/accounts/following_accounts_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::Accounts::FollowingAccountsController < Api::BaseController
   after_action :insert_pagination_headers
 
   def index
+    cache_if_unauthenticated!
     @accounts = load_accounts
     render json: @accounts, each_serializer: REST::AccountSerializer
   end

--- a/app/controllers/api/v1/accounts/lookup_controller.rb
+++ b/app/controllers/api/v1/accounts/lookup_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::Accounts::LookupController < Api::BaseController
   before_action :set_account
 
   def show
+    cache_if_unauthenticated!
     render json: @account, serializer: REST::AccountSerializer
   end
 

--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   after_action :insert_pagination_headers, unless: -> { truthy_param?(:pinned) }
 
   def index
+    cache_if_unauthenticated!
     @statuses = load_statuses
     render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
   end

--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -18,6 +18,7 @@ class Api::V1::AccountsController < Api::BaseController
   override_rate_limit_headers :follow, family: :follows
 
   def show
+    cache_if_unauthenticated!
     render json: @account, serializer: REST::AccountSerializer
   end
 

--- a/app/controllers/api/v1/custom_emojis_controller.rb
+++ b/app/controllers/api/v1/custom_emojis_controller.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 class Api::V1::CustomEmojisController < Api::BaseController
+  vary_by ''
+
   def index
-    expires_in 3.minutes, public: true
+    cache_even_if_authenticated!
     render_with_cache(each_serializer: REST::CustomEmojiSerializer) { CustomEmoji.listed.includes(:category) }
   end
 end

--- a/app/controllers/api/v1/directories_controller.rb
+++ b/app/controllers/api/v1/directories_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::DirectoriesController < Api::BaseController
   before_action :set_accounts
 
   def show
+    cache_if_unauthenticated!
     render json: @accounts, each_serializer: REST::AccountSerializer
   end
 

--- a/app/controllers/api/v1/instances/activity_controller.rb
+++ b/app/controllers/api/v1/instances/activity_controller.rb
@@ -5,8 +5,10 @@ class Api::V1::Instances::ActivityController < Api::BaseController
 
   skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
 
+  vary_by ''
+
   def show
-    expires_in 1.day, public: true
+    cache_even_if_authenticated!
     render_with_cache json: :activity, expires_in: 1.day
   end
 

--- a/app/controllers/api/v1/instances/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/instances/domain_blocks_controller.rb
@@ -6,8 +6,10 @@ class Api::V1::Instances::DomainBlocksController < Api::BaseController
   before_action :require_enabled_api!
   before_action :set_domain_blocks
 
+  vary_by ''
+
   def index
-    expires_in 3.minutes, public: true
+    cache_even_if_authenticated!
     render json: @domain_blocks, each_serializer: REST::DomainBlockSerializer, with_comment: (Setting.show_domain_blocks_rationale == 'all' || (Setting.show_domain_blocks_rationale == 'users' && user_signed_in?))
   end
 

--- a/app/controllers/api/v1/instances/extended_descriptions_controller.rb
+++ b/app/controllers/api/v1/instances/extended_descriptions_controller.rb
@@ -5,8 +5,10 @@ class Api::V1::Instances::ExtendedDescriptionsController < Api::BaseController
 
   before_action :set_extended_description
 
+  vary_by ''
+
   def show
-    expires_in 3.minutes, public: true
+    cache_even_if_authenticated!
     render json: @extended_description, serializer: REST::ExtendedDescriptionSerializer
   end
 

--- a/app/controllers/api/v1/instances/peers_controller.rb
+++ b/app/controllers/api/v1/instances/peers_controller.rb
@@ -5,8 +5,10 @@ class Api::V1::Instances::PeersController < Api::BaseController
 
   skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
 
+  vary_by ''
+
   def index
-    expires_in 1.day, public: true
+    cache_even_if_authenticated!
     render_with_cache(expires_in: 1.day) { Instance.where.not(domain: DomainBlock.select(:domain)).pluck(:domain) }
   end
 

--- a/app/controllers/api/v1/instances/privacy_policies_controller.rb
+++ b/app/controllers/api/v1/instances/privacy_policies_controller.rb
@@ -5,8 +5,10 @@ class Api::V1::Instances::PrivacyPoliciesController < Api::BaseController
 
   before_action :set_privacy_policy
 
+  vary_by ''
+
   def show
-    expires_in 1.day, public: true
+    cache_even_if_authenticated!
     render json: @privacy_policy, serializer: REST::PrivacyPolicySerializer
   end
 

--- a/app/controllers/api/v1/instances/rules_controller.rb
+++ b/app/controllers/api/v1/instances/rules_controller.rb
@@ -5,7 +5,10 @@ class Api::V1::Instances::RulesController < Api::BaseController
 
   before_action :set_rules
 
+  vary_by ''
+
   def index
+    cache_even_if_authenticated!
     render json: @rules, each_serializer: REST::RuleSerializer
   end
 

--- a/app/controllers/api/v1/instances/translation_languages_controller.rb
+++ b/app/controllers/api/v1/instances/translation_languages_controller.rb
@@ -5,8 +5,10 @@ class Api::V1::Instances::TranslationLanguagesController < Api::BaseController
 
   before_action :set_languages
 
+  vary_by ''
+
   def show
-    expires_in 1.day, public: true
+    cache_even_if_authenticated!
     render json: @languages
   end
 

--- a/app/controllers/api/v1/instances_controller.rb
+++ b/app/controllers/api/v1/instances_controller.rb
@@ -3,8 +3,10 @@
 class Api::V1::InstancesController < Api::BaseController
   skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
 
+  vary_by ''
+
   def show
-    expires_in 3.minutes, public: true
+    cache_even_if_authenticated!
     render_with_cache json: InstancePresenter.new, serializer: REST::V1::InstanceSerializer, root: 'instance'
   end
 end

--- a/app/controllers/api/v1/polls_controller.rb
+++ b/app/controllers/api/v1/polls_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::PollsController < Api::BaseController
   before_action :refresh_poll
 
   def show
+    cache_if_unauthenticated!
     render json: @poll, serializer: REST::PollSerializer, include_results: true
   end
 

--- a/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/favourited_by_accounts_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::Statuses::FavouritedByAccountsController < Api::BaseController
   after_action :insert_pagination_headers
 
   def index
+    cache_if_unauthenticated!
     @accounts = load_accounts
     render json: @accounts, each_serializer: REST::AccountSerializer
   end

--- a/app/controllers/api/v1/statuses/histories_controller.rb
+++ b/app/controllers/api/v1/statuses/histories_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::Statuses::HistoriesController < Api::BaseController
   before_action :set_status
 
   def show
+    cache_if_unauthenticated!
     render json: @status.edits.includes(:account, status: [:account]), each_serializer: REST::StatusEditSerializer
   end
 

--- a/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
+++ b/app/controllers/api/v1/statuses/reblogged_by_accounts_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::Statuses::RebloggedByAccountsController < Api::BaseController
   after_action :insert_pagination_headers
 
   def index
+    cache_if_unauthenticated!
     @accounts = load_accounts
     render json: @accounts, each_serializer: REST::AccountSerializer
   end

--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -24,11 +24,14 @@ class Api::V1::StatusesController < Api::BaseController
   DESCENDANTS_DEPTH_LIMIT = 20
 
   def show
+    cache_if_unauthenticated!
     @status = cache_collection([@status], Status).first
     render json: @status, serializer: REST::StatusSerializer
   end
 
   def context
+    cache_if_unauthenticated!
+
     ancestors_limit         = CONTEXT_LIMIT
     descendants_limit       = CONTEXT_LIMIT
     descendants_depth_limit = nil

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::TagsController < Api::BaseController
   override_rate_limit_headers :follow, family: :follows
 
   def show
+    cache_if_unauthenticated!
     render json: @tag, serializer: REST::TagSerializer
   end
 

--- a/app/controllers/api/v1/timelines/public_controller.rb
+++ b/app/controllers/api/v1/timelines/public_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::Timelines::PublicController < Api::BaseController
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 
   def show
+    cache_if_unauthenticated!
     @statuses = load_statuses
     render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
   end

--- a/app/controllers/api/v1/timelines/tag_controller.rb
+++ b/app/controllers/api/v1/timelines/tag_controller.rb
@@ -5,6 +5,7 @@ class Api::V1::Timelines::TagController < Api::BaseController
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 
   def show
+    cache_if_unauthenticated!
     @statuses = load_statuses
     render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
   end

--- a/app/controllers/api/v1/trends/links_controller.rb
+++ b/app/controllers/api/v1/trends/links_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::Trends::LinksController < Api::BaseController
+  vary_by 'Authorization, Accept-Language'
+
   before_action :set_links
 
   after_action :insert_pagination_headers
@@ -8,6 +10,7 @@ class Api::V1::Trends::LinksController < Api::BaseController
   DEFAULT_LINKS_LIMIT = 10
 
   def index
+    cache_if_unauthenticated!
     render json: @links, each_serializer: REST::Trends::LinkSerializer
   end
 

--- a/app/controllers/api/v1/trends/statuses_controller.rb
+++ b/app/controllers/api/v1/trends/statuses_controller.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class Api::V1::Trends::StatusesController < Api::BaseController
+  vary_by 'Authorization, Accept-Language'
+
   before_action :set_statuses
 
   after_action :insert_pagination_headers
 
   def index
+    cache_if_unauthenticated!
     render json: @statuses, each_serializer: REST::StatusSerializer
   end
 

--- a/app/controllers/api/v1/trends/tags_controller.rb
+++ b/app/controllers/api/v1/trends/tags_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::Trends::TagsController < Api::BaseController
   DEFAULT_TAGS_LIMIT = 10
 
   def index
+    cache_if_unauthenticated!
     render json: @tags, each_serializer: REST::TagSerializer, relationships: TagRelationshipsPresenter.new(@tags, current_user&.account_id)
   end
 

--- a/app/controllers/api/v2/instances_controller.rb
+++ b/app/controllers/api/v2/instances_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::V2::InstancesController < Api::V1::InstancesController
   def show
-    expires_in 3.minutes, public: true
+    cache_even_if_authenticated!
     render_with_cache json: InstancePresenter.new, serializer: REST::InstanceSerializer, root: 'instance'
   end
 end

--- a/app/controllers/concerns/api_caching_concern.rb
+++ b/app/controllers/concerns/api_caching_concern.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ApiCachingConcern
+  extend ActiveSupport::Concern
+
+  def cache_if_unauthenticated!
+    expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.day) unless user_signed_in?
+  end
+
+  def cache_even_if_authenticated!
+    expires_in(5.minutes, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.day) unless whitelist_mode?
+  end
+end


### PR DESCRIPTION
Allow REST API responses that don't require authorization to be cached when accessed without authentication.

Uniformly I have chosen to add `stale-while-revalidate` of 60 seconds and `stale-if-error` of 24 hours to the cache headers.

The list of publicly accessible APIs is:

- GET /api/v1/accounts/:id/followers
- GET /api/v1/accounts/:id/following
- GET /api/v1/accounts/lookup
- GET /api/v1/accounts/:id/statuses
- GET /api/v1/accounts/:id
- GET /api/v1/directory
- GET /api/v1/polls/:id
- GET /api/v1/statuses/:id/favourited_by
- GET /api/v1/statuses/:id/reblogged_by
- GET /api/v1/statuses/:id/history
- GET /api/v1/statuses/:id/context
- GET /api/v1/statuses/:id
- GET /api/v1/tags/:id
- GET /api/v1/timelines/public
- GET /api/v1/timelines/tag/:id
- GET /api/v1/trends/tags
- GET /api/v1/trends/statuses
- GET /api/v1/trends/links

I chose to use a uniform 15 seconds time-to-live for all of the above responses. Even though some of them may update much less frequently than that, it takes care of traffic spikes and is a good starting point that shouldn't cause too much trouble.

Additionally, there are authorization-independent public APIs:

- GET /api/v1/instance
- GET /api/v1/instance/activity
- GET /api/v1/instance/peers
- GET /api/v1/instance/rules
- GET /api/v1/instance/extended_description
- GET /api/v1/instance/privacy_policy
- GET /api/v2/instance
- GET /api/v1/custom_emojis

For these, I have adjusted some of the time-to-live values and added the staleness directives that were previously missing.

___

Fixes MAS-103