### PR TITLE
Fix height of announcements not being updated when using reduced animations

### DIFF
--- a/app/javascript/mastodon/features/getting_started/components/announcements.jsx
+++ b/app/javascript/mastodon/features/getting_started/components/announcements.jsx
@@ -418,7 +418,7 @@ class Announcements extends ImmutablePureComponent {
         <img className='announcements__mastodon' alt='' draggable='false' src={mascot || elephantUIPlane} />
 
         <div className='announcements__container'>
-          <ReactSwipeableViews animateHeight={!reduceMotion} adjustHeight={reduceMotion} index={index} onChangeIndex={this.handleChangeIndex}>
+          <ReactSwipeableViews animateHeight animateTransitions={!reduceMotion} index={index} onChangeIndex={this.handleChangeIndex}>
             {announcements.map((announcement, idx) => (
               <Announcement
                 key={announcement.get('id')}


### PR DESCRIPTION
Opening the announcements dropdown triggers a warning in the developer console. 

```
Warning: React does not recognize the `adjustHeight` prop on a DOM element. If
  you intentionally want it to appear in the DOM as a custom attribute, spell it as
  lowercase `adjustheight` instead. If you accidentally passed it from a parent
  component, remove it from the DOM element.
    in div (created by ReactSwipableView)
    in ReactSwipableView (at announcements.jsx:421)
    in div (at announcements.jsx:420)
    in div (at announcements.jsx:417)
    in Announcements (created by InjectIntl(Announcements))
    in InjectIntl(Announcements) (created by Connect(InjectIntl(Announcements)))
    in Connect(InjectIntl(Announcements)) (at home_timeline/index.jsx:150)
    in div (at column_header.jsx:150)
```

The `adjustHeight` attribute was added in https://github.com/oliviertassinari/react-swipeable-views/pull/537 which was included in version 0.13.5. But according to the Git history, 0.13.7 was branched off 0.13.3, so all changes released in 0.13.4, .5. and .6 were lost. I don't know why.

I think `animateTransitions` is what we need, disabling animations while still adjusting height to match each slide.