### PR TITLE
Add colour to follow button when hashtag is being followed

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/index.jsx
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.jsx
@@ -191,8 +191,12 @@ class HashtagTimeline extends React.PureComponent {
     if (tag) {
       const following = tag.get('following');
 
+      const classes = classNames('column-header__button', {
+        active: following,
+      });
+
       followButton = (
-        <button className={classNames('column-header__button')} onClick={this.handleFollow} disabled={!signedIn} active={following} title={intl.formatMessage(following ? messages.unfollowHashtag : messages.followHashtag)} aria-label={intl.formatMessage(following ? messages.unfollowHashtag : messages.followHashtag)}>
+        <button className={classes} onClick={this.handleFollow} disabled={!signedIn} title={intl.formatMessage(following ? messages.unfollowHashtag : messages.followHashtag)} aria-label={intl.formatMessage(following ? messages.unfollowHashtag : messages.followHashtag)}>
           <Icon id={following ? 'user-times' : 'user-plus'} fixedWidth className='column-header__icon' />
         </button>
       );


### PR DESCRIPTION
The change in #21629 has no effect. `<button>` has no `active` attribute (unlike `<IconButton>`).