### PR TITLE
Move ESLint configs to overrides

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
     browser: true,
     node: true,
     es6: true,
-    jest: true,
   },
 
   globals: {
@@ -42,9 +41,7 @@ module.exports = {
       presets: ['@babel/react', '@babel/env'],
     },
   },
-  extends: [
-    'plugin:import/typescript',
-  ],
+
   settings: {
     react: {
       version: 'detect',
@@ -203,6 +200,7 @@ module.exports = {
       {
         devDependencies: [
           'config/webpack/**',
+          'app/javascript/mastodon/performance.js',
           'app/javascript/mastodon/test_setup.js',
           'app/javascript/**/__tests__/**',
         ],
@@ -236,6 +234,36 @@ module.exports = {
 
       parserOptions: {
         sourceType: 'script',
+      },
+    },
+    {
+      files: [
+        '**/*.ts',
+        '**/*.tsx',
+      ],
+
+      extends: [
+        'eslint:recommended',
+        'plugin:@typescript-eslint/recommended',
+        'plugin:react/recommended',
+        'plugin:jsx-a11y/recommended',
+        'plugin:import/recommended',
+        'plugin:import/typescript',
+        'plugin:promise/recommended',
+      ],
+
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'off',
+      },
+    },
+    {
+      files: [
+        '**/__tests__/*.js',
+        '**/__tests__/*.jsx',
+      ],
+
+      env: {
+        jest: true,
       },
     },
   ],

--- a/app/javascript/mastodon/performance.js
+++ b/app/javascript/mastodon/performance.js
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV === 'development') {
     // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1331135
     performance.setResourceTimingBufferSize(Infinity);
   }
-  // eslint-disable-next-line import/no-extraneous-dependencies
+
   marky = require('marky');
   // allows us to easily do e.g. ReactPerf.printWasted() while debugging
   //window.ReactPerf = require('react-addons-perf');

--- a/app/javascript/mastodon/utils/notifications.js
+++ b/app/javascript/mastodon/utils/notifications.js
@@ -3,7 +3,7 @@
 
 const checkNotificationPromise = () => {
   try {
-    // eslint-disable-next-line promise/catch-or-return
+    // eslint-disable-next-line promise/valid-params, promise/catch-or-return
     Notification.requestPermission().then();
   } catch(e) {
     return false;

--- a/app/javascript/packs/public-path.js
+++ b/app/javascript/packs/public-path.js
@@ -17,4 +17,5 @@ function formatPublicPath(host = '', path = '') {
 
 const cdnHost = document.querySelector('meta[name=cdn-host]');
 
+// eslint-disable-next-line no-undef
 __webpack_public_path__ = formatPublicPath(cdnHost ? cdnHost.content : '', process.env.PUBLIC_OUTPUT_PATH);

--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write",
-    "*.{js,jsx}": "eslint --fix",
+    "*.{js,jsx,ts,tsx}": "eslint --fix",
     "*.{css,scss}": "stylelint --fix"
   }
 }


### PR DESCRIPTION
Noticed the Typescript PR created a duplicate `extends` key. Not sure why ESLint doesn't flag that, but I moved the TypeScript related overrides into separate overrides.
Also added the commit hooks to cover the ESLint calls for the TypeScript files