### PR TITLE
Fix description in /api/v1/instance

### DIFF
--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -21,7 +21,7 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
   end
 
   def description
-    Setting.site_description # Legacy
+    object.extended_description
   end
 
   def email

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,6 @@
 defaults: &defaults
   site_title: Mastodon
   site_short_description: ''
-  site_description: ''
   site_extended_description: ''
   site_terms: ''
   site_contact_username: ''


### PR DESCRIPTION
Solves #23946

Now, `/api/v1/instance` returns the same data as in the admin panel.

Also, `site_description` was removed from `config/settings.yml` since the field wasn't used anywhere in the codebase.


https://user-images.githubusercontent.com/34009891/229510447-0d2b325a-77e2-455c-81a1-7167bdb490ef.mp4

