### PR TITLE
Add typechecking in CI

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -6,22 +6,28 @@ on:
     paths:
       - 'package.json'
       - 'yarn.lock'
+      - 'tsconfig.json'
       - '.nvmrc'
       - '.prettier*'
       - '.eslint*'
       - '**/*.js'
       - '**/*.jsx'
+      - '**/*.ts'
+      - '**/*.tsx'
       - '.github/workflows/lint-js.yml'
 
   pull_request:
     paths:
       - 'package.json'
       - 'yarn.lock'
+      - 'tsconfig.json'
       - '.nvmrc'
       - '.prettier*'
       - '.eslint*'
       - '**/*.js'
       - '**/*.jsx'
+      - '**/*.ts'
+      - '**/*.tsx'
       - '.github/workflows/lint-js.yml'
 
 jobs:
@@ -43,3 +49,6 @@ jobs:
 
       - name: ESLint
         run: yarn test:lint:js
+
+      - name: Typecheck
+        run: yarn test:typecheck

--- a/.prettierignore
+++ b/.prettierignore
@@ -70,6 +70,8 @@ app/javascript/styles/mastodon/reset.scss
 # Ignore Javascript pending https://github.com/mastodon/mastodon/pull/23631
 *.js
 *.jsx
+*.ts
+*.tsx
 
 # Ignore HTML till cleaned and included in CI
 *.html

--- a/app/javascript/mastodon/components/common_counter.jsx
+++ b/app/javascript/mastodon/components/common_counter.jsx
@@ -1,6 +1,5 @@
 // @ts-check
 import React from 'react';
-// @ts-expect-error
 import { FormattedMessage } from 'react-intl';
 
 /**

--- a/app/javascript/mastodon/components/hashtag.jsx
+++ b/app/javascript/mastodon/components/hashtag.jsx
@@ -1,7 +1,6 @@
 // @ts-check
 import React from 'react';
 import { Sparklines, SparklinesCurve } from 'react-sparklines';
-// @ts-expect-error
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';


### PR DESCRIPTION
Adds a call to the typechecking when the TypeScript files get changed. Also noticed that there is also the conflict between the TS and Prettier config that is still pending in 23631 so added it to the config