### PR TITLE
Fix inconsistent radius in drawer

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2963,6 +2963,8 @@ $ui-header-height: 55px;
   margin-bottom: 10px;
   display: flex;
   flex-direction: row;
+  border-radius: 4px;
+  overflow: hidden;
 
   a {
     transition: background 100ms ease-in;
@@ -7046,6 +7048,7 @@ noscript {
 
   .drawer__pager {
     height: 50vh;
+    border-radius: 4px;
   }
 
   .drawer__inner {


### PR DESCRIPTION
The search's radius radius is different form the header and the pager. This PR fixes the inconsistent radius in drawer by setting the header and the pager to `4px`.

Preview:
![Drawer with consistent radius for each part](https://user-images.githubusercontent.com/14016375/229675281-288be400-0e68-44d7-b07f-23f649cf6a63.png)
