### PR TITLE
Update display_media typing to string

### DIFF
--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -55,7 +55,7 @@
  * @property {boolean=} delete_modal
  * @property {boolean=} disable_swiping
  * @property {string=} disabled_account_id
- * @property {boolean} display_media
+ * @property {string} display_media
  * @property {string} domain
  * @property {boolean=} expand_spoilers
  * @property {boolean} limited_federation_mode


### PR DESCRIPTION
TypeScript checking was flagging that this was marked as a boolean, but is actually a string of `hide_all` or `show_all` in its use.