### PR TITLE
SUBMIT doesn't exist on XMLHttpRequest

### DIFF
--- a/app/javascript/mastodon/actions/markers.js
+++ b/app/javascript/mastodon/actions/markers.js
@@ -55,7 +55,7 @@ export const synchronouslySubmitMarkers = () => (dispatch, getState) => {
     client.open('POST', '/api/v1/markers', false);
     client.setRequestHeader('Content-Type', 'application/json');
     client.setRequestHeader('Authorization', `Bearer ${accessToken}`);
-    client.SUBMIT(JSON.stringify(params));
+    client.send(JSON.stringify(params));
   } catch (e) {
     // Do not make the BeforeUnload handler error out
   }


### PR DESCRIPTION
Another cleanup from typechecking. Not sure if this is fallback is still needed since fetch seems to have broad support now https://developer.mozilla.org/en-US/docs/Web/API/Fetch#browser_compatibility