### PR TITLE
Change selected items style in the 'add or remove from lists' popover

### DIFF
--- a/app/javascript/mastodon/features/list_adder/components/list.jsx
+++ b/app/javascript/mastodon/features/list_adder/components/list.jsx
@@ -55,7 +55,7 @@ class List extends ImmutablePureComponent {
     }
 
     return (
-      <div className='list'>
+      <div className={`list ${added ? 'remove' : ''}`}>
         <div className='list__wrapper'>
           <div className='list__display-name'>
             <Icon id='list-ul' icon={ListAltIcon} className='column-link__icon' />

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7741,6 +7741,21 @@ noscript {
   .list {
     padding: 10px;
     border-bottom: 1px solid var(--background-border-color);
+
+    &.remove {
+      background-color: lighten($ui-base-color, 26%);
+
+      & .list__wrapper .account__relationship .icon-button {
+        color: darken($action-button-color, 10%);
+
+        &:hover,
+        &:active,
+        &:focus {
+          color: darken($action-button-color, 17%);
+          background-color: rgba($ui-base-color, 0.15);
+        }
+      }
+    }
   }
 
   .list__wrapper {


### PR DESCRIPTION
This PR resolves #23550

With this change, a selected item in the `add or remove from lists` popover will have a different color:

### Dark Theme
![dark](https://user-images.githubusercontent.com/30778707/230082341-38e9c703-3a3b-454e-945e-5615a9c57f78.png)

### Light Theme
![light](https://user-images.githubusercontent.com/30778707/230082385-1a70a7dc-0a4b-4c3e-95e1-c60cc3b1a662.png)

### High Contrast Theme
![contrast](https://user-images.githubusercontent.com/30778707/230082438-d7bb5e00-6d63-4a19-8501-4c7ba8ef9604.png)
