### PR TITLE
Fix account header image missing in low-res

### DIFF
--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -36,10 +36,6 @@
     @media screen and (max-width: 600px) {
       height: 200px;
     }
-
-    @media screen and (max-width: $no-gap-breakpoint) {
-      display: none;
-    }
   }
 
   &__bar {


### PR DESCRIPTION
On `/settings/profile`, if you resize the browser window, the header image disappears when the window is below a certain size (or is zoomed). This is confusing.

I don't see why this is necessary. The image is automatically resized and looks nice even at very narrow window sizes.

AFAICT this CSS rule only applies to the settings page, not the React frontend. It was added in #8068 back when account pages were rendered server-side.  