### PR TITLE
Fix user settings migration script failing in some cases

### DIFF
--- a/db/migrate/20230215074423_move_user_settings.rb
+++ b/db/migrate/20230215074423_move_user_settings.rb
@@ -52,7 +52,7 @@ class MoveUserSettings < ActiveRecord::Migration[6.1]
     end
 
     def value
-      YAML.safe_load(self[:value], permitted_classes: [ActiveSupport::HashWithIndifferentAccess]) if self[:value].present?
+      YAML.safe_load(self[:value], permitted_classes: [ActiveSupport::HashWithIndifferentAccess, Symbol]) if self[:value].present?
     end
   end
 


### PR DESCRIPTION
An admin on glitch-soc has reported the migration failing because of one occurrence of the `notifications` setting hash having symbols as keys.

I have not investigated whether that could be caused by glitch-soc-only code but I think that is unlikely, and the fix is simple in either case.