### PR TITLE
Cleanup and document bundle test/dev deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,54 +102,87 @@ gem 'json-ld'
 gem 'json-ld-preloaded', '~> 3.2'
 gem 'rdf-normalize', '~> 0.5'
 
-group :development, :test do
-  gem 'fabrication', '~> 2.30'
-  gem 'fuubar', '~> 2.5'
-  gem 'i18n-tasks', '~> 1.0', require: false
-  gem 'rspec-rails', '~> 6.0'
-  gem 'rspec_chunked', '~> 0.6'
-
-  gem 'rubocop-capybara', require: false
-  gem 'rubocop-performance', require: false
-  gem 'rubocop-rails', require: false
-  gem 'rubocop-rspec', require: false
-  gem 'rubocop', require: false
-end
-
-group :production, :test do
-  gem 'private_address_check', '~> 0.5'
-end
+gem 'private_address_check', '~> 0.5'
 
 group :test do
-  gem 'capybara', '~> 3.39'
-  gem 'climate_control'
-  gem 'faker', '~> 3.2'
-  gem 'json-schema', '~> 4.0'
-  gem 'rack-test', '~> 2.1'
-  gem 'rails-controller-testing', '~> 1.0'
-  gem 'rspec_junit_formatter', '~> 0.6'
+  # RSpec runner for rails
+  gem 'rspec-rails', '~> 6.0'
+
+  # Used to split testing into chunks in CI
+  gem 'rspec_chunked', '~> 0.6'
+
+  # RSpec progress bar formatter
+  gem 'fuubar', '~> 2.5'
+
+  # Extra RSpec extenion methods and helpers for sidekiq
   gem 'rspec-sidekiq', '~> 3.1'
+
+  # Browser integration testing
+  gem 'capybara', '~> 3.39'
+
+  # Used to mock environment variables
+  gem 'climate_control', '~> 0.2'
+
+  # Generating fake datafor specs
+  gem 'faker', '~> 3.2'
+
+  # Generate test objects for specs
+  gem 'fabrication', '~> 2.30'
+
+  # Add back helpers functions removed in Rails 5.1
+  gem 'rails-controller-testing', '~> 1.0'
+
+  # Validate schemas in specs
+  gem 'json-schema', '~> 4.0'
+
+  # Test harness fo rack components
+  gem 'rack-test', '~> 2.1'
+
+  # Coverage formatter for RSpec test if DISABLE_SIMPLECOV is false
   gem 'simplecov', '~> 0.22', require: false
+
+  # Stub web requests for specs
   gem 'webmock', '~> 3.18'
 end
 
 group :development do
+  # Code linting CLI and plugins
+  gem 'rubocop', require: false
+  gem 'rubocop-capybara', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
+
+  # Annotates modules with schema
   gem 'annotate', '~> 3.2'
+
+  # Enhanced error message pages for development
   gem 'better_errors', '~> 2.9'
   gem 'binding_of_caller', '~> 1.0'
+
+  # Preview mail in the browser
   gem 'letter_opener', '~> 1.8'
   gem 'letter_opener_web', '~> 2.0'
-  gem 'memory_profiler'
+
+  # Security analysis CLI tools
   gem 'brakeman', '~> 5.4', require: false
   gem 'bundler-audit', '~> 0.9', require: false
+
+  # Linter CLI for HAML files
   gem 'haml_lint', require: false
 
+  # Deployment automation
   gem 'capistrano', '~> 3.17'
   gem 'capistrano-rails', '~> 1.6'
   gem 'capistrano-rbenv', '~> 2.2'
   gem 'capistrano-yarn', '~> 2.0'
 
-  gem 'stackprof'
+  # Validate missing i18n keys
+  gem 'i18n-tasks', '~> 1.0', require: false
+
+  # Profiling tools
+  gem 'memory_profiler', require: false
+  gem 'stackprof', require: false
 end
 
 group :production do

--- a/Gemfile
+++ b/Gemfile
@@ -123,7 +123,7 @@ group :test do
   # Used to mock environment variables
   gem 'climate_control', '~> 0.2'
 
-  # Generating fake datafor specs
+  # Generating fake data for specs
   gem 'faker', '~> 3.2'
 
   # Generate test objects for specs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -605,8 +605,6 @@ GEM
       sidekiq (>= 2.4.0)
     rspec-support (3.12.0)
     rspec_chunked (0.6)
-    rspec_junit_formatter (0.6.0)
-      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.50.2)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -792,7 +790,7 @@ DEPENDENCIES
   capybara (~> 3.39)
   charlock_holmes (~> 0.7.7)
   chewy (~> 7.3)
-  climate_control
+  climate_control (~> 0.2)
   cocoon (~> 1.2)
   color_diff (~> 0.1)
   concurrent-ruby
@@ -870,7 +868,6 @@ DEPENDENCIES
   rspec-rails (~> 6.0)
   rspec-sidekiq (~> 3.1)
   rspec_chunked (~> 0.6)
-  rspec_junit_formatter (~> 0.6)
   rubocop
   rubocop-capybara
   rubocop-performance


### PR DESCRIPTION
Was replacing `rspec_junit_formatter` in another PR, but since it isn't used anymore since the CircleCI migration I thought it could just be dropped.
Since it was being touched, I took the opportunity to doucment the test/dev deps as I was looking to see if any others were also unused now