### PR TITLE
Fix check-i18n task complaining about translated files

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           yarn build:development
           yarn manage:translations
-          git diff --exit-code
+          git diff --exit-code -- app/javascript/mastodon/locales/defaultMessages.json app/javascript/mastodon/locales/en.json
 
       - name: Check locale file normalization
         run: bundle exec i18n-tasks check-normalized


### PR DESCRIPTION
The changes introduced in #24338 complain about Crowdin-managed translation files, this causes unneeded noise as Crowdin handles missing translations just fine.

cc @nschonni