### PR TITLE
Explicitly enable `@babel/plugin-proposal-optional-chaining` to fix build failures

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -20,6 +20,7 @@ module.exports = (api) => {
     plugins: [
       ['react-intl', { messagesDir: './build/messages' }],
       'preval',
+      '@babel/plugin-proposal-optional-chaining',
       '@babel/plugin-proposal-nullish-coalescing-operator',
     ],
     overrides: [


### PR DESCRIPTION
Alternative to #24502

Merging #24382 earlier today caused issues in `production` environments with lots of errors of this kind:

```
ERROR in ./app/javascript/mastodon/ready.js 5:181
Module parse failed: Unexpected token (5:181)
File was processed with these loaders:
 * ./node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
|  * @param {(() => void) | (() => Promise<void>)} callback
|  * @returns {Promise<void>}
>  */export default function ready(callback){return new Promise((resolve,reject)=>{function loaded(){let result;try{result=callback();}catch(err){reject(err);return;}if(typeof result?.then==='function'){result.then(resolve).catch(reject);}else{resolve();}}if(['interactive','complete'].includes(document.readyState)){loaded();}else{document.addEventListener('DOMContentLoaded',loaded);}});}
 @ ./app/javascript/packs/error.js 1:22-59 1:59-64
```

That is caused by some part of our toolchain (`webpack`?) choking on the optional chaining operator (`?.`).

This used to be transpiled but this somehow changed with #24502, so this PR explicitly enables it, in a way similar to #24374.