### PR TITLE
Refactor `Status._insert_record` slightly and tighten the test around reblogs of discarded statuses

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -391,33 +391,41 @@ class Status < ApplicationRecord
     super || build_status_stat
   end
 
-  # Hack to use a "INSERT INTO ... SELECT ..." query instead of "INSERT INTO ... VALUES ..." query
+  # This is a hack to ensure that no reblogs of discarded statuses are created,
+  # as this cannot be enforced through database constraints the same way we do
+  # for reblogs of deleted statuses.
+  #
+  # To achieve this, we redefine the internal method responsible for issuing
+  # the "INSERT" statement and replace the "INSERT INTO ... VALUES ..." query
+  # with an "INSERT INTO ... SELECT ..." query with a "WHERE deleted_at IS NULL"
+  # clause on the reblogged status to ensure consistency at the database level.
+  #
+  # Otherwise, the code is kept as close as possible to ActiveRecord::Persistence
+  # code, and actually calls it if we are not handling a reblog.
   def self._insert_record(values)
-    if values.is_a?(Hash) && values['reblog_of_id'].present?
-      primary_key = self.primary_key
-      primary_key_value = nil
+    return super unless values.is_a?(Hash) && values['reblog_of_id'].present?
 
-      if primary_key
-        primary_key_value = values[primary_key]
+    primary_key = self.primary_key
+    primary_key_value = nil
 
-        if !primary_key_value && prefetch_primary_key?
-          primary_key_value = next_sequence_value
-          values[primary_key] = primary_key_value
-        end
+    if primary_key
+      primary_key_value = values[primary_key]
+
+      if !primary_key_value && prefetch_primary_key?
+        primary_key_value = next_sequence_value
+        values[primary_key] = primary_key_value
       end
-
-      # The following line is where we differ from stock ActiveRecord implementation
-      im = _compile_reblog_insert(values)
-
-      # Since we are using SELECT instead of VALUES, a non-error `nil` return is possible.
-      # For our purposes, it's equivalent to a foreign key constraint violation
-      result = connection.insert(im, "#{self} Create", primary_key || false, primary_key_value)
-      raise ActiveRecord::InvalidForeignKey, "(reblog_of_id)=(#{values['reblog_of_id']}) is not present in table \"statuses\"" if result.nil?
-
-      result
-    else
-      super
     end
+
+    # The following line is where we differ from stock ActiveRecord implementation
+    im = _compile_reblog_insert(values)
+
+    # Since we are using SELECT instead of VALUES, a non-error `nil` return is possible.
+    # For our purposes, it's equivalent to a foreign key constraint violation
+    result = connection.insert(im, "#{self} Create", primary_key || false, primary_key_value)
+    raise ActiveRecord::InvalidForeignKey, "(reblog_of_id)=(#{values['reblog_of_id']}) is not present in table \"statuses\"" if result.nil?
+
+    result
   end
 
   def self._compile_reblog_insert(values)

--- a/spec/services/reblog_service_spec.rb
+++ b/spec/services/reblog_service_spec.rb
@@ -38,7 +38,10 @@ RSpec.describe ReblogService, type: :service do
     let(:status) { Fabricate(:status, account: alice, visibility: :public) }
 
     before do
-      status.discard
+      # Update the in-database attribute without reflecting the change in
+      # the object. This cannot simulate all race conditions, but it is
+      # pretty close.
+      Status.where(id: status.id).update_all(deleted_at: Time.now.utc) # rubocop:disable Rails/SkipsModelValidations
     end
 
     it 'raises an exception' do


### PR DESCRIPTION
This brings no functional change, only some minor refactoring as well as improving one test. This was done while investigating the changes needed to update to Rails 7 (see https://github.com/mastodon/mastodon/pull/17693#issuecomment-1482843193 and https://github.com/mastodon/mastodon/pull/24241#issuecomment-1504933784) but it's orthogonal to that.

- refactors `Status._insert_record` to use a guard condition rather than an `if/else` statement, which should make it slightly easier to compare to the related `ActiveRecord` code
- improve comments about this hack
- tighten the test case for reblogging discarded statuses so it would catch an issue with the proposed alternative here https://github.com/mastodon/mastodon/pull/24241/commits/d8d5704cb8f161c3303d6d60ca66e5b745a58d02