### PR TITLE
Fix missing translation strings in en.json and defaultMessages.json

### DIFF
--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -950,6 +950,15 @@
   {
     "descriptors": [
       {
+        "defaultMessage": "In Memoriam.",
+        "id": "account.in_memoriam"
+      }
+    ],
+    "path": "app/javascript/mastodon/features/account_timeline/components/memorial_note.json"
+  },
+  {
+    "descriptors": [
+      {
         "defaultMessage": "{name} has indicated that their new account is now:",
         "id": "account.moved_to"
       },

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -39,6 +39,7 @@
   "account.follows_you": "Follows you",
   "account.go_to_profile": "Go to profile",
   "account.hide_reblogs": "Hide boosts from @{name}",
+  "account.in_memoriam": "In Memoriam.",
   "account.joined_short": "Joined",
   "account.languages": "Change subscribed languages",
   "account.link_verified_on": "Ownership of this link was checked on {date}",


### PR DESCRIPTION
Follow-up to #23614