### PR TITLE
Fix check-i18n when there are missing strings in other languages than english

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Check for missing strings in English JSON
         run: |
           yarn build:development
-          yarn manage:translations
-          git diff --exit-code -- app/javascript/mastodon/locales/defaultMessages.json app/javascript/mastodon/locales/en.json
+          yarn manage:translations en
+          git diff --exit-code
 
       - name: Check locale file normalization
         run: bundle exec i18n-tasks check-normalized


### PR DESCRIPTION
Follow-up to #24501