### PR TITLE
Fix tab arrows on RTL layouts

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6685,7 +6685,7 @@ a.status-card.compact:hover {
         content: '';
         position: absolute;
         bottom: 0;
-        inset-inline-start: 50%;
+        left: 50%;
         width: 0;
         height: 0;
         transform: translateX(-50%);


### PR DESCRIPTION
Fix regression introduced by #23944: in this case, `left: 50%` was used together with `translateX(-50%)` and was independent from text direction, using `right: 50%` would require changing to `translateX(50%)`.