### PR TITLE
tootctl: add --approve option to tootctl accounts create

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -57,6 +57,7 @@ module Mastodon
     option :role
     option :reattach, type: :boolean
     option :force, type: :boolean
+    option :approve, type: :boolean
     desc 'create USERNAME', 'Create a new user account'
     long_desc <<-LONG_DESC
       Create a new user account with a given USERNAME and an
@@ -72,6 +73,8 @@ module Mastodon
       account is still in use by someone else, you can supply
       the --force option to delete the old record and reattach the
       username to the new account anyway.
+
+      With the --approve option, the account will be approved.
     LONG_DESC
     def create(username)
       role_id  = nil
@@ -89,7 +92,7 @@ module Mastodon
 
       account  = Account.new(username: username)
       password = SecureRandom.hex
-      user     = User.new(email: options[:email], password: password, agreement: true, approved: true, role_id: role_id, confirmed_at: options[:confirmed] ? Time.now.utc : nil, bypass_invite_request_check: true)
+      user     = User.new(email: options[:email], password: password, agreement: true, role_id: role_id, confirmed_at: options[:confirmed] ? Time.now.utc : nil, bypass_invite_request_check: true)
 
       if options[:reattach]
         account = Account.find_local(username) || Account.new(username: username)
@@ -111,6 +114,8 @@ module Mastodon
           user.confirmed_at = nil
           user.confirm!
         end
+
+        user.approve! if options[:approve]
 
         say('OK', :green)
         say("New password: #{password}")


### PR DESCRIPTION
This PR fixes #22870.

When creating an account using `tootctl accounts create`, the admin has to go to the web interface and "approve" the new user. Another option is using `tootctl accounts modify` with the `--approve` option.

In `Mastodon::AccountsCLI#create`, the `approved` attribute was set to `true` by default. As shown in:
https://github.com/mastodon/mastodon/blob/af49d93fd6168c089530240a9ab4eccb975b8c42/lib/mastodon/accounts_cli.rb#L92 

However, this value is being overwritten by some callback in the `User` model.

This PR adds an `--approve` option to the `tootctl accounts create` using the `#approve!` method present in the `User` model. When using this option, the admin can create an "approved" account without further steps from the CLI.

PS: I wasn't able to write tests for this. I'd appreciate it if anyone could provide me with an example of how to test the CLI.