### PR TITLE
Check domain suspensions before trying to fetch resources

### DIFF
--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -2,12 +2,15 @@
 
 class ActivityPub::FetchRemoteStatusService < BaseService
   include JsonLdHelper
+  include DomainControlHelper
   include Redisable
 
   DISCOVERIES_PER_REQUEST = 1000
 
   # Should be called when uri has already been checked for locality
   def call(uri, id: true, prefetched_body: nil, on_behalf_of: nil, expected_actor_uri: nil, request_id: nil)
+    return if domain_not_allowed?(uri)
+
     @request_id = request_id || "#{Time.now.utc.to_i}-status-#{uri}"
     @json = if prefetched_body.nil?
               fetch_resource(uri, id, on_behalf_of)


### PR DESCRIPTION
This would save resources when attempting to fetch a boosted post from a suspended domain, especially if that domain is unavailable.

However, we still need to evaluate the performance implication when the fetched post's origin is not blocked, as this adds a Ruby-PostgreSQL roundtrip.