### PR TITLE
Add test coverage for `Mastodon::AccountsCLI`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -326,6 +326,7 @@ RSpec/AnyInstance:
     - 'spec/validators/follow_limit_validator_spec.rb'
     - 'spec/workers/activitypub/delivery_worker_spec.rb'
     - 'spec/workers/web/push_notification_worker_spec.rb'
+    - 'spec/lib/mastodon/accounts_cli_spec.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: SkipBlocks, EnforcedStyle.

--- a/spec/lib/mastodon/accounts_cli_spec.rb
+++ b/spec/lib/mastodon/accounts_cli_spec.rb
@@ -849,4 +849,141 @@ RSpec.describe Mastodon::AccountsCLI do
       end
     end
   end
+
+  describe '#merge' do
+    context 'when "from_account" is not found' do
+      let(:to_account) { Fabricate(:account, domain: 'example.com') }
+      let(:arguments) { ['non_existent_username@domain.com', "#{to_account.username}@#{to_account.domain}"] }
+
+      it 'returns an error message' do
+        expect { cli.invoke(:merge, arguments) }
+          .to output(
+            a_string_including("No such account (#{arguments.first})")
+          ).to_stdout
+          .and raise_error(SystemExit)
+      end
+    end
+
+    context 'when "from_account" is local' do
+      let(:from_account) { Fabricate(:account, domain: nil) }
+      let(:to_account) { Fabricate(:account, domain: 'example.com') }
+      let(:arguments) { [from_account.username, "#{to_account.username}@#{to_account.domain}"] }
+
+      it 'returns an error message' do
+        expect { cli.invoke(:merge, arguments) }
+          .to output(
+            a_string_including("No such account (#{arguments.first})")
+          ).to_stdout
+          .and raise_error(SystemExit)
+      end
+    end
+
+    context 'when "to_account" is not found' do
+      let(:from_account) { Fabricate(:account, domain: 'example.com') }
+      let(:arguments) { ["#{from_account.username}@#{from_account.domain}", 'non_existent_username'] }
+
+      it 'returns an error message' do
+        expect { cli.invoke(:merge, arguments) }
+          .to output(
+            a_string_including("No such account (#{arguments.last})")
+          ).to_stdout
+          .and raise_error(SystemExit)
+      end
+    end
+
+    context 'when "to_account" is local' do
+      let(:from_account) { Fabricate(:account, domain: 'example.com') }
+      let(:to_account) { Fabricate(:account, domain: nil) }
+      let(:arguments) do
+        ["#{from_account.username}@#{from_account.domain}", "#{to_account.username}@#{to_account.domain}"]
+      end
+
+      it 'returns an error message' do
+        expect { cli.invoke(:merge, arguments) }
+          .to output(
+            a_string_including("No such account (#{arguments.last})")
+          ).to_stdout
+          .and raise_error(SystemExit)
+      end
+    end
+
+    context 'when "from_account" and "to_account" public keys do not match' do
+      let(:from_account) { instance_double(Account, username: 'bob', domain: 'example1.com', local?: false) }
+      let(:to_account) { instance_double(Account, username: 'bob', domain: 'example2.com', local?: false) }
+
+      let(:arguments) do
+        ["#{from_account.username}@#{from_account.domain}", "#{to_account.username}@#{to_account.domain}"]
+      end
+
+      before do
+        allow(Account).to receive(:find_remote).with(from_account.username, from_account.domain).and_return(from_account)
+        allow(Account).to receive(:find_remote).with(to_account.username, to_account.domain).and_return(to_account)
+        allow(from_account).to receive(:public_key).and_return('from_account')
+        allow(to_account).to receive(:public_key).and_return('to_account')
+      end
+
+      it 'returns a warning message' do
+        expect { cli.invoke(:merge, arguments) }
+          .to output(
+            a_string_including("Accounts don't have the same public key, might not be duplicates!\nOverride with --force")
+          ).to_stdout
+          .and raise_error(SystemExit)
+      end
+
+      context 'with --force option' do
+        let(:options) { { force: true } }
+
+        before do
+          allow(to_account).to receive(:merge_with!).with(from_account)
+          allow(from_account).to receive(:destroy)
+        end
+
+        it 'merges "from_account" into "to_account"' do
+          cli.invoke(:merge, arguments, options)
+
+          expect(to_account).to have_received(:merge_with!).with(from_account)
+        end
+
+        it 'deletes "from_account"' do
+          cli.invoke(:merge, arguments, options)
+
+          expect(from_account).to have_received(:destroy)
+        end
+      end
+    end
+
+    context 'when "from_account" and "to_account" public keys match' do
+      let(:from_account) { instance_double(Account, username: 'bob', domain: 'example1.com', local?: false) }
+      let(:to_account) { instance_double(Account, username: 'bob', domain: 'example2.com', local?: false) }
+
+      let(:arguments) do
+        ["#{from_account.username}@#{from_account.domain}", "#{to_account.username}@#{to_account.domain}"]
+      end
+
+      before do
+        allow(Account).to receive(:find_remote).with(from_account.username, from_account.domain).and_return(from_account)
+        allow(Account).to receive(:find_remote).with(to_account.username, to_account.domain).and_return(to_account)
+        allow(from_account).to receive(:public_key).and_return('pub_key')
+        allow(to_account).to receive(:public_key).and_return('pub_key')
+      end
+
+      it 'merges "from_account" into "to_account"' do
+        allow(to_account).to receive(:merge_with!).with(from_account)
+        allow(from_account).to receive(:destroy)
+
+        cli.invoke(:merge, arguments)
+
+        expect(to_account).to have_received(:merge_with!).with(from_account)
+      end
+
+      it 'deletes "from_account"' do
+        allow(to_account).to receive(:merge_with!).with(from_account)
+        allow(from_account).to receive(:destroy)
+
+        cli.invoke(:merge, arguments)
+
+        expect(from_account).to have_received(:destroy)
+      end
+    end
+  end
 end

--- a/spec/lib/mastodon/accounts_cli_spec.rb
+++ b/spec/lib/mastodon/accounts_cli_spec.rb
@@ -500,4 +500,38 @@ RSpec.describe Mastodon::AccountsCLI do
       end
     end
   end
+
+  describe '#backup' do
+    context 'when given USERNAME is not found' do
+      let(:arguments) { ['non_existent_username'] }
+
+      it 'returns an error message' do
+        expect { described_class.new.invoke(:backup, arguments) }
+          .to output(
+            a_string_including('No user with such username')
+          ).to_stdout
+          .and raise_error(SystemExit)
+      end
+    end
+
+    context 'when given USERNAME is found' do
+      let(:user) { Fabricate(:user) }
+      let(:arguments) { [user.account.username] }
+
+      it 'creates a backup job' do
+        allow(BackupWorker).to receive(:perform_async).once
+
+        described_class.new.invoke(:backup, arguments)
+
+        expect(BackupWorker).to have_received(:perform_async).once
+      end
+
+      it 'outputs a success message' do
+        expect { described_class.new.invoke(:backup, arguments) }
+          .to output(
+            a_string_including('OK')
+          ).to_stdout
+      end
+    end
+  end
 end

--- a/spec/lib/mastodon/accounts_cli_spec.rb
+++ b/spec/lib/mastodon/accounts_cli_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe Mastodon::AccountsCLI do
       context 'with --approve option' do
         let(:options) { { email: 'tootctl@example.com', approve: true } }
 
+        before { Form::AdminSettings.new(registrations_mode: 'approved').save }
+
         it 'creates a new approved user' do
           described_class.new.invoke(:create, arguments, options)
 

--- a/spec/lib/mastodon/accounts_cli_spec.rb
+++ b/spec/lib/mastodon/accounts_cli_spec.rb
@@ -4,44 +4,64 @@ require 'rails_helper'
 require 'mastodon/accounts_cli'
 
 RSpec.describe Mastodon::AccountsCLI do
+  let(:cli) { described_class.new }
+
   describe '#create' do
+    shared_examples 'a new user with given email address and username' do
+      it 'creates a new user with the correct email address' do
+        cli.invoke(:create, arguments, options)
+
+        user = User.find_by(email: options[:email])
+
+        expect(user).to be_present
+      end
+
+      it 'creates a new account with the correct username' do
+        cli.invoke(:create, arguments, options)
+
+        account = Account.find_by(username: 'tootctl_username')
+
+        expect(account).to be_present
+      end
+
+      it "returns OK and new user's password" do
+        allow(SecureRandom).to receive(:hex).and_return('test_password')
+
+        expect { cli.invoke(:create, arguments, options) }
+          .to output(
+            a_string_including("OK\nNew password: test_password")
+          ).to_stdout
+      end
+    end
+
     context 'when required USERNAME and --email are provided' do
       let(:arguments) { ['tootctl_username'] }
 
       context 'with USERNAME and --email only' do
         let(:options) { { email: 'tootctl@example.com' } }
 
-        it 'creates a new user with the correct email address' do
-          described_class.new.invoke(:create, arguments, options)
+        include_examples 'a new user with given email address and username'
 
-          user = User.find_by(email: 'tootctl@example.com')
+        context 'with invalid --email value' do
+          let(:options) { { email: 'invalid' } }
 
-          expect(user).to be_present
-        end
-
-        it 'creates a new account with the correct username' do
-          described_class.new.invoke(:create, arguments, options)
-
-          account = Account.find_by(username: 'tootctl_username')
-
-          expect(account).to be_present
-        end
-
-        it "returns OK and new user's password" do
-          allow(SecureRandom).to receive(:hex).and_return('test_password')
-
-          expect { described_class.new.invoke(:create, arguments, options) }
-            .to output(
-              a_string_including("OK\nNew password: test_password")
-            ).to_stdout
+          it 'returns an error message' do
+            expect { cli.invoke(:create, arguments, options) }
+              .to output(
+                a_string_including('Failure/Error: email')
+              ).to_stdout
+              .and raise_error(SystemExit)
+          end
         end
       end
 
       context 'with --confirmed option' do
         let(:options) { { email: 'tootctl@example.com', confirmed: true } }
 
+        include_examples 'a new user with given email address and username'
+
         it 'creates a new confirmed user' do
-          described_class.new.invoke(:create, arguments, options)
+          cli.invoke(:create, arguments, options)
 
           user = User.find_by(email: options[:email])
 
@@ -54,8 +74,10 @@ RSpec.describe Mastodon::AccountsCLI do
 
         before { Form::AdminSettings.new(registrations_mode: 'approved').save }
 
+        include_examples 'a new user with given email address and username'
+
         it 'creates a new approved user' do
-          described_class.new.invoke(:create, arguments, options)
+          cli.invoke(:create, arguments, options)
 
           user = User.find_by(email: options[:email])
 
@@ -65,15 +87,18 @@ RSpec.describe Mastodon::AccountsCLI do
 
       context 'with --role option' do
         context 'when role exists' do
-          let(:options) { { email: 'tootctl@example.com', role: 'Owner' } }
+          let(:default_role) { Fabricate(:user_role) }
+          let(:options) { { email: 'tootctl@example.com', role: default_role.name } }
+
+          include_examples 'a new user with given email address and username'
 
           it 'creates a new user with given role' do
-            described_class.new.invoke(:create, arguments, options)
+            cli.invoke(:create, arguments, options)
 
             user = User.find_by(email: options[:email])
             role = user.role
 
-            expect(role.name).to eq('Owner')
+            expect(role.name).to eq(default_role.name)
           end
         end
 
@@ -81,7 +106,7 @@ RSpec.describe Mastodon::AccountsCLI do
           let(:options) { { email: 'tootctl@example.com', role: '404' } }
 
           it 'returns error informing the given role name was not found' do
-            expect { described_class.new.invoke(:create, arguments, options) }
+            expect { cli.invoke(:create, arguments, options) }
               .to output(
                 a_string_including('Cannot find user role with that name')
               ).to_stdout
@@ -93,42 +118,36 @@ RSpec.describe Mastodon::AccountsCLI do
       context 'with --reattach option' do
         context "when account's user is present" do
           let(:options) { { email: 'tootctl_new@example.com', reattach: true } }
-          let(:account) { Account.new(username: 'tootctl_username') }
+          let(:user) { Fabricate.build(:user, email: 'tootctl@example.com') }
 
-          before { User.create(email: 'tootctl@example.com', password: '12345678', agreement: true, account: account) }
+          before { Fabricate(:account, username: 'tootctl_username', user: user) }
 
           it 'returns username already in use error message' do
-            expect { described_class.new.invoke(:create, arguments, options) }
+            expect { cli.invoke(:create, arguments, options) }
               .to output(
                 a_string_including("The chosen username is currently in use\nUse --force to reattach it anyway and delete the other user")
               ).to_stdout
+          end
+
+          context 'with --force option' do
+            let(:options) { { email: 'tootctl_new@example.com', reattach: true, force: true } }
+
+            it 'reattaches the account and deletes the other user' do
+              cli.invoke(:create, arguments, options)
+
+              user = Account.find_by(username: 'tootctl_username').user
+
+              expect(user.email).to eq(options[:email])
+            end
           end
         end
 
         context "when account's user is not present" do
           let(:options) { { email: 'tootctl@example.com', reattach: true } }
 
-          before { Account.create(username: 'tootctl_username') }
+          before { Fabricate(:account, username: 'tootctl_username', user: nil) }
 
-          it 'creates a new user with the correct email address' do
-            described_class.new.invoke(:create, arguments, options)
-
-            user = User.find_by(email: 'tootctl@example.com')
-
-            expect(user).to be_present
-          end
-        end
-      end
-
-      context 'with invalid --email value' do
-        let(:options) { { email: 'invalid' } }
-
-        it 'returns an error message' do
-          expect { described_class.new.invoke(:create, arguments, options) }
-            .to output(
-              a_string_including('Failure/Error: email')
-            ).to_stdout
-            .and raise_error(SystemExit)
+          include_examples 'a new user with given email address and username'
         end
       end
     end
@@ -137,7 +156,7 @@ RSpec.describe Mastodon::AccountsCLI do
       let(:arguments) { ['tootctl_username'] }
 
       it 'raise Thor::RequiredArgumentMissingError' do
-        expect { described_class.new.invoke(:create, arguments) }
+        expect { cli.invoke(:create, arguments) }
           .to raise_error(Thor::RequiredArgumentMissingError)
       end
     end
@@ -148,7 +167,7 @@ RSpec.describe Mastodon::AccountsCLI do
       let(:arguments) { ['non_existent_username'] }
 
       it 'returns an error message' do
-        expect { described_class.new.invoke(:modify, arguments) }
+        expect { cli.invoke(:modify, arguments) }
           .to output(
             a_string_including('No user with such username')
           ).to_stdout
@@ -162,14 +181,14 @@ RSpec.describe Mastodon::AccountsCLI do
 
       context 'when no option is provided' do
         it 'returns successfull message' do
-          expect { described_class.new.invoke(:modify, arguments) }
+          expect { cli.invoke(:modify, arguments) }
             .to output(
               a_string_including('OK')
             ).to_stdout
         end
 
         it 'does not modify the user' do
-          described_class.new.invoke(:modify, arguments)
+          cli.invoke(:modify, arguments)
 
           user_after_modify = User.find_by(email: user.email)
 
@@ -182,7 +201,7 @@ RSpec.describe Mastodon::AccountsCLI do
           let(:options) { { role: '404' } }
 
           it 'returns an error message' do
-            expect { described_class.new.invoke(:modify, arguments, options) }
+            expect { cli.invoke(:modify, arguments, options) }
               .to output(
                 a_string_including('Cannot find user role with that name')
               ).to_stdout
@@ -191,14 +210,15 @@ RSpec.describe Mastodon::AccountsCLI do
         end
 
         context 'when given role is found' do
-          let(:options) { { role: 'Owner' } }
+          let(:default_role) { Fabricate(:user_role) }
+          let(:options) { { role: default_role.name } }
 
           it "updates the user's role" do
-            described_class.new.invoke(:modify, arguments, options)
+            cli.invoke(:modify, arguments, options)
 
             role = user.reload.role
 
-            expect(role.name).to eq('Owner')
+            expect(role.name).to eq(default_role.name)
           end
         end
       end
@@ -209,7 +229,7 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:user) { Fabricate(:user, role: role) }
 
         it "removes user's role successfully" do
-          described_class.new.invoke(:modify, arguments, options)
+          cli.invoke(:modify, arguments, options)
 
           role = user.reload.role
 
@@ -222,13 +242,13 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:options) { { email: 'new_email@email.com' } }
 
         it "sets 'unconfirmed_email' with given email adress" do
-          described_class.new.invoke(:modify, arguments, options)
+          cli.invoke(:modify, arguments, options)
 
           expect(user.reload.unconfirmed_email).to eq(options[:email])
         end
 
         it 'does not update original email address' do
-          described_class.new.invoke(:modify, arguments, options)
+          cli.invoke(:modify, arguments, options)
 
           expect(user.reload.email).to eq('old_email@email.com')
         end
@@ -238,13 +258,13 @@ RSpec.describe Mastodon::AccountsCLI do
           let(:options) { { email: 'new_email@email.com', confirm: true } }
 
           it "updates the user's email address" do
-            described_class.new.invoke(:modify, arguments, options)
+            cli.invoke(:modify, arguments, options)
 
             expect(user.reload.email).to eq(options[:email])
           end
 
           it "set user's email address as confirmed" do
-            described_class.new.invoke(:modify, arguments, options)
+            cli.invoke(:modify, arguments, options)
 
             expect(user.reload.confirmed?).to be(true)
           end
@@ -256,7 +276,7 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:options) { { confirm: true } }
 
         it "confirms user's email address" do
-          described_class.new.invoke(:modify, arguments, options)
+          cli.invoke(:modify, arguments, options)
 
           expect(user.reload.confirmed?).to be(true)
         end
@@ -267,7 +287,7 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:options) { { approve: true } }
 
         it 'approves user' do
-          described_class.new.invoke(:modify, arguments, options)
+          cli.invoke(:modify, arguments, options)
 
           expect(user.reload.approved?).to be(true)
         end
@@ -278,7 +298,7 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:options) { { disable: true } }
 
         it 'disables the user' do
-          described_class.new.invoke(:modify, arguments, options)
+          cli.invoke(:modify, arguments, options)
 
           expect(user.reload.disabled).to be(true)
         end
@@ -289,7 +309,7 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:options) { { enable: true } }
 
         it 'enables the user' do
-          described_class.new.invoke(:modify, arguments, options)
+          cli.invoke(:modify, arguments, options)
 
           expect(user.reload.disabled).to be(false)
         end
@@ -301,7 +321,7 @@ RSpec.describe Mastodon::AccountsCLI do
         it "outputs new user's password" do
           allow(SecureRandom).to receive(:hex).and_return('new_password')
 
-          expect { described_class.new.invoke(:modify, arguments, options) }
+          expect { cli.invoke(:modify, arguments, options) }
             .to output(
               a_string_including('new_password')
             ).to_stdout
@@ -313,9 +333,22 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:options) { { disable_2fa: true } }
 
         it "sets 'otp_required_for_login' to false" do
-          described_class.new.invoke(:modify, arguments, options)
+          cli.invoke(:modify, arguments, options)
 
           expect(user.reload.otp_required_for_login).to be(false)
+        end
+      end
+
+      context 'when provided data is invalid' do
+        let(:user) { Fabricate(:user) }
+        let(:options) { { email: 'invalid' } }
+
+        it 'returns an error message' do
+          expect { cli.invoke(:modify, arguments, options) }
+            .to output(
+              a_string_including('Failure/Error: email')
+            ).to_stdout
+            .and raise_error(SystemExit)
         end
       end
     end
@@ -328,7 +361,7 @@ RSpec.describe Mastodon::AccountsCLI do
       let(:options) { { email: user.email } }
 
       it 'returns an error message' do
-        expect { described_class.new.invoke(:delete, arguments, options) }
+        expect { cli.invoke(:delete, arguments, options) }
           .to output(
             a_string_including('Use username or --email, not both')
           ).to_stdout
@@ -338,7 +371,7 @@ RSpec.describe Mastodon::AccountsCLI do
 
     context 'when neither USERNAME nor --email are provided' do
       it 'returns an error message' do
-        expect { described_class.new.invoke(:delete) }
+        expect { cli.invoke(:delete) }
           .to output(
             a_string_including('No username provided')
           ).to_stdout
@@ -351,7 +384,7 @@ RSpec.describe Mastodon::AccountsCLI do
       let(:arguments) { [user.account.username] }
 
       it 'deletes user successfully' do
-        described_class.new.invoke(:delete, arguments)
+        cli.invoke(:delete, arguments)
 
         deleleted_user = Account.find_local(user.account.username)&.user
 
@@ -362,13 +395,13 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:options) { { dry_run: true } }
 
         it 'does not delete the user' do
-          described_class.new.invoke(:delete, arguments, options)
+          cli.invoke(:delete, arguments, options)
 
           expect(user.reload).to be_present
         end
 
         it 'outputs (DRY RUN) message' do
-          expect { described_class.new.invoke(:delete, arguments, options) }
+          expect { cli.invoke(:delete, arguments, options) }
             .to output(
               a_string_including('OK (DRY RUN)')
             ).to_stdout
@@ -379,7 +412,7 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:arguments) { ['non_exitent_username'] }
 
         it 'returns an error message' do
-          expect { described_class.new.invoke(:delete, arguments) }
+          expect { cli.invoke(:delete, arguments) }
             .to output(
               a_string_including('No user with such username')
             ).to_stdout
@@ -393,7 +426,7 @@ RSpec.describe Mastodon::AccountsCLI do
       let(:options) { { email: user.email } }
 
       it 'deletes user successfully' do
-        described_class.new.invoke(:delete, nil, options)
+        cli.invoke(:delete, nil, options)
 
         deleleted_user = Account.find_local(user.account.username)&.user
 
@@ -404,13 +437,13 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:options) { { email: user.email, dry_run: true } }
 
         it 'does not delete the user' do
-          described_class.new.invoke(:delete, nil, options)
+          cli.invoke(:delete, nil, options)
 
           expect(user.reload).to be_present
         end
 
         it 'outputs (DRY RUN) message' do
-          expect { described_class.new.invoke(:delete, nil, options) }
+          expect { cli.invoke(:delete, nil, options) }
             .to output(
               a_string_including('OK (DRY RUN)')
             ).to_stdout
@@ -421,7 +454,7 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:options) { { email: '404@404.com' } }
 
         it 'returns an error message' do
-          expect { described_class.new.invoke(:delete, nil, options) }
+          expect { cli.invoke(:delete, nil, options) }
             .to output(
               a_string_including('No user with such email')
             ).to_stdout
@@ -441,7 +474,7 @@ RSpec.describe Mastodon::AccountsCLI do
       end
 
       it 'approves all pending registrations' do
-        described_class.new.invoke(:approve, nil, options)
+        cli.invoke(:approve, nil, options)
 
         expect(User.pluck(:approved).all?(true)).to be(true)
       end
@@ -458,7 +491,7 @@ RSpec.describe Mastodon::AccountsCLI do
         end
 
         it 'approves the N earliest pending registrations' do
-          described_class.new.invoke(:approve, nil, options)
+          cli.invoke(:approve, nil, options)
 
           n_earliest_pending_registrations = User.order(created_at: :asc).first(options[:number])
 
@@ -466,7 +499,7 @@ RSpec.describe Mastodon::AccountsCLI do
         end
 
         it 'does not approve the remaining pending registrations' do
-          described_class.new.invoke(:approve, nil, options)
+          cli.invoke(:approve, nil, options)
 
           pending_registrations = User.order(created_at: :asc).last(total_users - options[:number])
 
@@ -478,7 +511,7 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:options) { { number: -1 } }
 
         it 'returns an error message' do
-          expect { described_class.new.invoke(:approve, nil, options) }
+          expect { cli.invoke(:approve, nil, options) }
             .to output(
               a_string_including('Number must be positive')
             ).to_stdout
@@ -496,14 +529,14 @@ RSpec.describe Mastodon::AccountsCLI do
         end
 
         it 'approves all users' do
-          described_class.new.invoke(:approve, nil, options)
+          cli.invoke(:approve, nil, options)
 
           expect(User.pluck(:approved).all?(true)).to be(true)
         end
 
         it 'does not raise any error' do
-          expect { described_class.new.invoke(:approve, nil, options) }
-            .to_not raise_error(SystemExit)
+          expect { cli.invoke(:approve, nil, options) }
+            .to_not raise_error
         end
       end
     end
@@ -516,7 +549,7 @@ RSpec.describe Mastodon::AccountsCLI do
         before { user.update(approved: false) }
 
         it 'approves user successfully' do
-          described_class.new.invoke(:approve, arguments)
+          cli.invoke(:approve, arguments)
 
           expect(user.reload.approved?).to be(true)
         end
@@ -526,9 +559,9 @@ RSpec.describe Mastodon::AccountsCLI do
         let(:arguments) { ['non_existent_username'] }
 
         it 'returns an error message' do
-          expect { described_class.new.invoke(:approve, arguments) }
+          expect { cli.invoke(:approve, arguments) }
             .to output(
-              a_string_including('No such accoun')
+              a_string_including('No such account')
             ).to_stdout
             .and raise_error(SystemExit)
         end
@@ -541,7 +574,7 @@ RSpec.describe Mastodon::AccountsCLI do
       let(:arguments) { ['non_existent_username'] }
 
       it 'returns an error message' do
-        expect { described_class.new.invoke(:backup, arguments) }
+        expect { cli.invoke(:backup, arguments) }
           .to output(
             a_string_including('No user with such username')
           ).to_stdout
@@ -556,13 +589,13 @@ RSpec.describe Mastodon::AccountsCLI do
       it 'creates a backup job' do
         allow(BackupWorker).to receive(:perform_async).once
 
-        described_class.new.invoke(:backup, arguments)
+        cli.invoke(:backup, arguments)
 
         expect(BackupWorker).to have_received(:perform_async).once
       end
 
       it 'outputs a success message' do
-        expect { described_class.new.invoke(:backup, arguments) }
+        expect { cli.invoke(:backup, arguments) }
           .to output(
             a_string_including('OK')
           ).to_stdout
@@ -575,7 +608,7 @@ RSpec.describe Mastodon::AccountsCLI do
       let(:arguments) { ['non_existent_username'] }
 
       it 'returns an error message' do
-        expect { described_class.new.invoke(:follow, arguments) }
+        expect { cli.invoke(:follow, arguments) }
           .to output(
             a_string_including('No such account')
           ).to_stdout
@@ -584,16 +617,16 @@ RSpec.describe Mastodon::AccountsCLI do
     end
 
     context 'when provided USERNAME is found' do
-      let(:target_account) { Fabricate(:user).account }
-      let!(:users) { Fabricate.times(10, :user) }
+      let(:target_account) { Fabricate(:account) }
+      let!(:accounts) { Fabricate.times(10, :account) }
       let(:arguments) { [target_account.username] }
 
       before { allow_any_instance_of(Mastodon::CLIHelper).to receive(:reset_connection_pools!) }
 
       it 'all local accounts follow specified account successfully' do
-        described_class.new.invoke(:follow, arguments)
+        cli.invoke(:follow, arguments)
 
-        result = users.all? { |user| target_account.followed_by?(user.account) }
+        result = accounts.all? { |account| target_account.followed_by?(account) }
 
         expect(result).to be(true)
       end
@@ -605,7 +638,7 @@ RSpec.describe Mastodon::AccountsCLI do
       let(:arguments) { ['non_existent_username'] }
 
       it 'returns an error message' do
-        expect { described_class.new.invoke(:unfollow, arguments) }
+        expect { cli.invoke(:unfollow, arguments) }
           .to output(
             a_string_including('No such account')
           ).to_stdout
@@ -614,20 +647,20 @@ RSpec.describe Mastodon::AccountsCLI do
     end
 
     context 'when provided USERNAME is found' do
-      let(:target_account) { Fabricate(:user).account }
-      let(:users) { Fabricate.times(5, :user) }
+      let(:target_account) { Fabricate(:account) }
+      let(:accounts) { Fabricate.times(5, :account) }
       let(:arguments) { [target_account.username] }
 
       before do
-        users.each { |user| FollowService.new.call(user.account, target_account) }
+        accounts.each { |account| target_account.follow!(account) }
 
         allow_any_instance_of(Mastodon::CLIHelper).to receive(:reset_connection_pools!)
       end
 
       it 'all local accounts unfollow specified account successfully' do
-        described_class.new.invoke(:unfollow, arguments)
+        cli.invoke(:unfollow, arguments)
 
-        result = users.all? { |user| target_account.followed_by?(user.account) }
+        result = accounts.all? { |account| target_account.followed_by?(account) }
 
         expect(result).to be(false)
       end
@@ -636,11 +669,11 @@ RSpec.describe Mastodon::AccountsCLI do
 
   describe '#reset_relationships' do
     context 'when no option is provided' do
-      let(:target_account) { Fabricate(:target_account).account }
+      let(:target_account) { Fabricate(:account) }
       let(:arguments) { [target_account.username] }
 
       it 'returns an error message' do
-        expect { described_class.new.invoke(:reset_relationships, arguments) }
+        expect { cli.invoke(:reset_relationships, arguments) }
           .to output(
             a_string_including('Please specify either --follows or --followers, or both')
           ).to_stdout
@@ -653,7 +686,7 @@ RSpec.describe Mastodon::AccountsCLI do
       let(:arguments) { ['non_existent_username'] }
 
       it 'returns an error message' do
-        expect { described_class.new.invoke(:reset_relationships, arguments, options) }
+        expect { cli.invoke(:reset_relationships, arguments, options) }
           .to output(
             a_string_including('No such account')
           ).to_stdout
@@ -663,18 +696,18 @@ RSpec.describe Mastodon::AccountsCLI do
 
     context 'when provided USERNAME is found' do
       context 'with --follows option' do
-        let(:target_account) { Fabricate(:user).account }
+        let(:target_account) { Fabricate(:account) }
         let(:arguments) { [target_account.username] }
         let(:options) { { follows: true } }
-        let(:total_relantionships) { 10 }
+        let(:total_relationships) { 10 }
 
         before do
-          users = Fabricate.times(total_relantionships, :user)
-          users.each { |user| target_account.follow!(user.account) }
+          accounts = Fabricate.times(total_relationships, :account)
+          accounts.each { |account| target_account.follow!(account) }
         end
 
         it 'resets all "following" relationships from target_account' do
-          described_class.new.invoke(:reset_relationships, arguments, options)
+          cli.invoke(:reset_relationships, arguments, options)
 
           expect(target_account.reload.following).to be_empty
         end
@@ -682,64 +715,64 @@ RSpec.describe Mastodon::AccountsCLI do
         it 'calls BootstrapTimelineWorker once' do
           allow(BootstrapTimelineWorker).to receive(:perform_async).once
 
-          described_class.new.invoke(:reset_relationships, arguments, options)
+          cli.invoke(:reset_relationships, arguments, options)
 
           expect(BootstrapTimelineWorker).to have_received(:perform_async)
         end
 
         it 'outputs success message' do
-          expect { described_class.new.invoke(:reset_relationships, arguments, options) }
+          expect { cli.invoke(:reset_relationships, arguments, options) }
             .to output(
-              a_string_including("Processed #{total_relantionships} relationships")
+              a_string_including("Processed #{total_relationships} relationships")
             ).to_stdout
         end
       end
 
       context 'with --followers option' do
-        let(:target_account) { Fabricate(:user).account }
+        let(:target_account) { Fabricate(:account) }
         let(:arguments) { [target_account.username] }
         let(:options) { { followers: true } }
-        let(:total_relantionships) { 10 }
+        let(:total_relationships) { 10 }
 
         before do
-          users = Fabricate.times(total_relantionships, :user)
-          users.each { |user| user.account.follow!(target_account) }
+          accounts = Fabricate.times(total_relationships, :account)
+          accounts.each { |account| account.follow!(target_account) }
         end
 
         it 'resets all "followers" relationships' do
-          described_class.new.invoke(:reset_relationships, arguments, options)
+          cli.invoke(:reset_relationships, arguments, options)
 
           expect(target_account.reload.followers).to be_empty
         end
 
         it 'outputs success message' do
-          expect { described_class.new.invoke(:reset_relationships, arguments, options) }
+          expect { cli.invoke(:reset_relationships, arguments, options) }
             .to output(
-              a_string_including("Processed #{total_relantionships} relationships")
+              a_string_including("Processed #{total_relationships} relationships")
             ).to_stdout
         end
       end
 
       context 'with --follows and --followers options' do
-        let(:target_account) { Fabricate(:user).account }
+        let(:target_account) { Fabricate(:account) }
         let(:arguments) { [target_account.username] }
         let(:options) { { followers: true, follows: true } }
-        let(:total_relantionships) { 16 }
+        let(:total_relationships) { 16 }
 
         before do
-          users = Fabricate.times(total_relantionships, :user)
-          users.first(8).each { |user| user.account.follow!(target_account) }
-          users.last(8).each { |user| target_account.follow!(user.account) }
+          accounts = Fabricate.times(total_relationships, :account)
+          accounts.first(8).each { |account| account.follow!(target_account) }
+          accounts.last(8).each { |account| target_account.follow!(account) }
         end
 
         it 'resets all "followers" relationships' do
-          described_class.new.invoke(:reset_relationships, arguments, options)
+          cli.invoke(:reset_relationships, arguments, options)
 
           expect(target_account.reload.followers).to be_empty
         end
 
         it 'resets all "following" relationships' do
-          described_class.new.invoke(:reset_relationships, arguments, options)
+          cli.invoke(:reset_relationships, arguments, options)
 
           expect(target_account.reload.following).to be_empty
         end
@@ -747,15 +780,15 @@ RSpec.describe Mastodon::AccountsCLI do
         it 'calls BootstrapTimelineWorker once' do
           allow(BootstrapTimelineWorker).to receive(:perform_async).once
 
-          described_class.new.invoke(:reset_relationships, arguments, options)
+          cli.invoke(:reset_relationships, arguments, options)
 
           expect(BootstrapTimelineWorker).to have_received(:perform_async)
         end
 
         it 'outputs success message' do
-          expect { described_class.new.invoke(:reset_relationships, arguments, options) }
+          expect { cli.invoke(:reset_relationships, arguments, options) }
             .to output(
-              a_string_including("Processed #{total_relantionships} relationships")
+              a_string_including("Processed #{total_relationships} relationships")
             ).to_stdout
         end
       end
@@ -765,7 +798,7 @@ RSpec.describe Mastodon::AccountsCLI do
   describe '#rotate' do
     context 'when neither USERNAME nor --all option are provided' do
       it 'returns an error message' do
-        expect { described_class.new.invoke(:rotate, nil, nil) }
+        expect { cli.invoke(:rotate, nil, nil) }
           .to output(
             a_string_including('No account(s) given')
           ).to_stdout
@@ -777,7 +810,7 @@ RSpec.describe Mastodon::AccountsCLI do
       let(:arguments) { ['non_existent_username'] }
 
       it 'returns an error message' do
-        expect { described_class.new.invoke(:rotate, arguments) }
+        expect { cli.invoke(:rotate, arguments) }
           .to output(
             a_string_including('No such account')
           ).to_stdout
@@ -793,7 +826,7 @@ RSpec.describe Mastodon::AccountsCLI do
         old_private_key = account.private_key
         old_public_key = account.public_key
 
-        described_class.new.invoke(:rotate, arguments)
+        cli.invoke(:rotate, arguments)
         account.reload
 
         expect(account.private_key).to_not eq(old_private_key)
@@ -803,12 +836,10 @@ RSpec.describe Mastodon::AccountsCLI do
 
     context 'when --all option is provided' do
       let(:accounts) { Fabricate.times(3, :account) }
-      let(:options) { { all: true } }
 
       before { allow(Account).to receive(:local).and_return(Account.where(id: accounts.map(&:id))) }
 
       it 'rotates keys for all local accounts' do
-        cli = described_class.new
         allow(cli).to receive(:rotate_keys_for_account).exactly(3).times
 
         cli.options = { all: true }

--- a/spec/lib/mastodon/accounts_cli_spec.rb
+++ b/spec/lib/mastodon/accounts_cli_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/accounts_cli'
+
+RSpec.describe Mastodon::AccountsCLI do
+  describe '#create' do
+    context 'when required USERNAME and --email are provided' do
+      let(:arguments) { ['tootctl_username'] }
+
+      context 'with USERNAME and --email only' do
+        let(:options) { { email: 'tootctl@example.com' } }
+
+        it 'creates a new user with the correct email address' do
+          described_class.new.invoke(:create, arguments, options)
+
+          user = User.find_by(email: 'tootctl@example.com')
+
+          expect(user).to be_present
+        end
+
+        it 'creates a new account with the correct username' do
+          described_class.new.invoke(:create, arguments, options)
+
+          account = Account.find_by(username: 'tootctl_username')
+
+          expect(account).to be_present
+        end
+
+        it "returns OK and new user's password" do
+          allow(SecureRandom).to receive(:hex).and_return('test_password')
+
+          expect { described_class.new.invoke(:create, arguments, options) }
+            .to output(
+              a_string_including("OK\nNew password: test_password")
+            ).to_stdout
+        end
+      end
+
+      context 'with --confirmed option' do
+        let(:options) { { email: 'tootctl@example.com', confirmed: true } }
+
+        it 'creates a new confirmed user' do
+          described_class.new.invoke(:create, arguments, options)
+
+          user = User.find_by(email: options[:email])
+
+          expect(user.confirmed?).to be(true)
+        end
+      end
+
+      context 'with --approve option' do
+        let(:options) { { email: 'tootctl@example.com', approve: true } }
+
+        it 'creates a new approved user' do
+          described_class.new.invoke(:create, arguments, options)
+
+          user = User.find_by(email: options[:email])
+
+          expect(user.approved?).to be(true)
+        end
+      end
+
+      context 'with --role option' do
+        context 'when role exists' do
+          let(:options) { { email: 'tootctl@example.com', role: 'Owner' } }
+
+          it 'creates a new user with given role' do
+            described_class.new.invoke(:create, arguments, options)
+
+            user = User.find_by(email: options[:email])
+            role = user.role
+
+            expect(role.name).to eq('Owner')
+          end
+        end
+
+        context 'when role does not exist' do
+          let(:options) { { email: 'tootctl@example.com', role: '404' } }
+
+          it 'returns error informing the given role name was not found' do
+            expect { described_class.new.invoke(:create, arguments, options) }
+              .to output(
+                a_string_including('Cannot find user role with that name')
+              ).to_stdout
+              .and raise_error(SystemExit)
+          end
+        end
+      end
+
+      context 'with --reattach option' do
+        context "when account's user is present" do
+          let(:options) { { email: 'tootctl_new@example.com', reattach: true } }
+          let(:account) { Account.new(username: 'tootctl_username') }
+
+          before { User.create(email: 'tootctl@example.com', password: '12345678', agreement: true, account: account) }
+
+          it 'returns username already in use error message' do
+            expect { described_class.new.invoke(:create, arguments, options) }
+              .to output(
+                a_string_including("The chosen username is currently in use\nUse --force to reattach it anyway and delete the other user")
+              ).to_stdout
+          end
+        end
+
+        context "when account's user is not present" do
+          let(:options) { { email: 'tootctl@example.com', reattach: true } }
+
+          before { Account.create(username: 'tootctl_username') }
+
+          it 'creates a new user with the correct email address' do
+            described_class.new.invoke(:create, arguments, options)
+
+            user = User.find_by(email: 'tootctl@example.com')
+
+            expect(user).to be_present
+          end
+        end
+      end
+
+      context 'with invalid --email value' do
+        let(:options) { { email: 'invalid' } }
+
+        it 'returns an error message' do
+          expect { described_class.new.invoke(:create, arguments, options) }
+            .to output(
+              a_string_including('Failure/Error: email')
+            ).to_stdout
+            .and raise_error(SystemExit)
+        end
+      end
+    end
+
+    context 'when required --email option is not provided' do
+      let(:arguments) { ['tootctl_username'] }
+
+      it 'raise Thor::RequiredArgumentMissingError' do
+        expect { described_class.new.invoke(:create, arguments) }
+          .to raise_error(Thor::RequiredArgumentMissingError)
+      end
+    end
+  end
+end

--- a/spec/lib/mastodon/accounts_cli_spec.rb
+++ b/spec/lib/mastodon/accounts_cli_spec.rb
@@ -140,4 +140,182 @@ RSpec.describe Mastodon::AccountsCLI do
       end
     end
   end
+
+  describe '#modify' do
+    context 'when given username is not found' do
+      let(:arguments) { ['non_existent_username'] }
+
+      it 'returns an error message' do
+        expect { described_class.new.invoke(:modify, arguments) }
+          .to output(
+            a_string_including('No user with such username')
+          ).to_stdout
+          .and raise_error(SystemExit)
+      end
+    end
+
+    context 'when given username is found' do
+      let(:user) { Fabricate(:user) }
+      let(:arguments) { [user.account.username] }
+
+      context 'when no option is provided' do
+        it 'returns successfull message' do
+          expect { described_class.new.invoke(:modify, arguments) }
+            .to output(
+              a_string_including('OK')
+            ).to_stdout
+        end
+
+        it 'does not modify the user' do
+          described_class.new.invoke(:modify, arguments)
+
+          user_after_modify = User.find_by(email: user.email)
+
+          expect(user).to eq(user_after_modify)
+        end
+      end
+
+      context 'with --role option' do
+        context 'when given role is not found' do
+          let(:options) { { role: '404' } }
+
+          it 'returns an error message' do
+            expect { described_class.new.invoke(:modify, arguments, options) }
+              .to output(
+                a_string_including('Cannot find user role with that name')
+              ).to_stdout
+              .and raise_error(SystemExit)
+          end
+        end
+
+        context 'when given role is found' do
+          let(:options) { { role: 'Owner' } }
+
+          it "updates the user's role" do
+            described_class.new.invoke(:modify, arguments, options)
+
+            role = user.reload.role
+
+            expect(role.name).to eq('Owner')
+          end
+        end
+      end
+
+      context 'with --remove-role option' do
+        let(:options) { { remove_role: true } }
+        let(:role) { Fabricate(:user_role) }
+        let(:user) { Fabricate(:user, role: role) }
+
+        it "removes user's role successfully" do
+          described_class.new.invoke(:modify, arguments, options)
+
+          role = user.reload.role
+
+          expect(role.name).to be_empty
+        end
+      end
+
+      context 'with --email option' do
+        let(:user) { Fabricate(:user, email: 'old_email@email.com') }
+        let(:options) { { email: 'new_email@email.com' } }
+
+        it "sets 'unconfirmed_email' with given email adress" do
+          described_class.new.invoke(:modify, arguments, options)
+
+          expect(user.reload.unconfirmed_email).to eq(options[:email])
+        end
+
+        it 'does not update original email address' do
+          described_class.new.invoke(:modify, arguments, options)
+
+          expect(user.reload.email).to eq('old_email@email.com')
+        end
+
+        context 'with --confirm option' do
+          let(:user) { Fabricate(:user, email: 'old_email@email.com', confirmed_at: nil) }
+          let(:options) { { email: 'new_email@email.com', confirm: true } }
+
+          it "updates the user's email address" do
+            described_class.new.invoke(:modify, arguments, options)
+
+            expect(user.reload.email).to eq(options[:email])
+          end
+
+          it "set user's email address as confirmed" do
+            described_class.new.invoke(:modify, arguments, options)
+
+            expect(user.reload.confirmed?).to be(true)
+          end
+        end
+      end
+
+      context 'with --confirm option' do
+        let(:user) { Fabricate(:user, confirmed_at: nil) }
+        let(:options) { { confirm: true } }
+
+        it "confirms user's email address" do
+          described_class.new.invoke(:modify, arguments, options)
+
+          expect(user.reload.confirmed?).to be(true)
+        end
+      end
+
+      context 'with --approve option' do
+        let(:user) { Fabricate(:user, approved: false) }
+        let(:options) { { approve: true } }
+
+        it 'approves user' do
+          described_class.new.invoke(:modify, arguments, options)
+
+          expect(user.reload.approved?).to be(true)
+        end
+      end
+
+      context 'with --disable option' do
+        let(:user) { Fabricate(:user, disabled: false) }
+        let(:options) { { disable: true } }
+
+        it 'disables the user' do
+          described_class.new.invoke(:modify, arguments, options)
+
+          expect(user.reload.disabled).to be(true)
+        end
+      end
+
+      context 'with --enable option' do
+        let(:user) { Fabricate(:user, disabled: true) }
+        let(:options) { { enable: true } }
+
+        it 'enables the user' do
+          described_class.new.invoke(:modify, arguments, options)
+
+          expect(user.reload.disabled).to be(false)
+        end
+      end
+
+      context 'with --reset-password option' do
+        let(:options) { { reset_password: true } }
+
+        it "outputs new user's password" do
+          allow(SecureRandom).to receive(:hex).and_return('new_password')
+
+          expect { described_class.new.invoke(:modify, arguments, options) }
+            .to output(
+              a_string_including('new_password')
+            ).to_stdout
+        end
+      end
+
+      context 'with --disable-2fa option' do
+        let(:user) { Fabricate(:user, otp_required_for_login: true) }
+        let(:options) { { disable_2fa: true } }
+
+        it "sets 'otp_required_for_login' to false" do
+          described_class.new.invoke(:modify, arguments, options)
+
+          expect(user.reload.otp_required_for_login).to be(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## This PR adds test coverage for `Mastodon::AccountsCLI`

Sorry for the huge PR, I should've split it in two at least. But I tried making commits as organized as possible to help with the review.

### Methods covered:
- [x] Add  tests for `Mastodon::AccountsCLI#rotate`
- [x] Add  tests for `Mastodon::AccountsCLI#create`
- [x] Add  tests for `Mastodon::AccountsCLI#modify`
- [x] Add  tests for `Mastodon::AccountsCLI#delete`
- [x] Add  tests for `Mastodon::AccountsCLI#merge`
- [x] Add  tests for `Mastodon::AccountsCLI#fix_duplicates`
- [x] Add  tests for `Mastodon::AccountsCLI#backup`
- [x] Add  tests for `Mastodon::AccountsCLI#cull`
- [x] Add  tests for `Mastodon::AccountsCLI#refresh`
- [x] Add  tests for `Mastodon::AccountsCLI#follow`
- [x] Add  tests for `Mastodon::AccountsCLI#unfollow`
- [x] Add  tests for `Mastodon::AccountsCLI#reset_relantionships`
- [x] Add  tests for `Mastodon::AccountsCLI#approve`
- [x] Add  tests for `Mastodon::AccountsCLI#prune`
- [x] Add  tests for `Mastodon::AccountsCLI#migrate`

### Coverage: 98.94%