### PR TITLE
Remove uppercase text formatting globally

### DIFF
--- a/app/javascript/styles/mastodon/_mixins.scss
+++ b/app/javascript/styles/mastodon/_mixins.scss
@@ -35,7 +35,6 @@
   box-shadow: 2px 4px 15px rgba($base-shadow-color, 0.4);
 
   h4 {
-    text-transform: uppercase;
     color: $light-text-color;
     font-size: 13px;
     font-weight: 500;

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -129,7 +129,6 @@
 
   .older,
   .newer {
-    text-transform: uppercase;
     color: $secondary-text-color;
   }
 

--- a/app/javascript/styles/mastodon/admin.scss
+++ b/app/javascript/styles/mastodon/admin.scss
@@ -292,7 +292,6 @@ $content-width: 840px;
     }
 
     h4 {
-      text-transform: uppercase;
       font-size: 13px;
       font-weight: 700;
       color: $darker-text-color;
@@ -501,7 +500,6 @@ body,
 
     strong {
       font-weight: 500;
-      text-transform: uppercase;
       font-size: 12px;
 
       @each $lang in $cjk-langs {
@@ -520,7 +518,6 @@ body,
       display: inline-block;
       color: $darker-text-color;
       text-decoration: none;
-      text-transform: uppercase;
       font-size: 12px;
       font-weight: 500;
       border-bottom: 2px solid $ui-base-color;
@@ -845,7 +842,6 @@ a.name-tag,
       flex: 0 0 auto;
       font-weight: 500;
       color: $darker-text-color;
-      text-transform: uppercase;
       text-align: end;
 
       a {
@@ -1191,7 +1187,6 @@ a.name-tag,
   &__label {
     padding: 0 20px;
     padding-bottom: 10px;
-    text-transform: uppercase;
     color: $darker-text-color;
     font-weight: 500;
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1036,7 +1036,6 @@ body > [data-popper-placement] {
   font-weight: 700;
   font-size: 11px;
   padding: 0 6px;
-  text-transform: uppercase;
   line-height: 20px;
   cursor: pointer;
   vertical-align: top;
@@ -1632,7 +1631,6 @@ a .account__avatar {
 
   & > span {
     display: block;
-    text-transform: uppercase;
     font-size: 11px;
     color: $darker-text-color;
   }
@@ -3252,7 +3250,6 @@ $ui-header-height: 55px;
   padding: 8px 20px;
   font-size: 12px;
   font-weight: 500;
-  text-transform: uppercase;
   cursor: default;
 }
 
@@ -3284,7 +3281,6 @@ $ui-header-height: 55px;
       border-bottom: 1px solid lighten($ui-base-color, 8%);
       padding: 10px;
       font-size: 12px;
-      text-transform: uppercase;
       font-weight: 500;
 
       a {
@@ -3923,7 +3919,6 @@ a.status-card.compact:hover {
   color: $dark-text-color;
   font-size: 12px;
   font-weight: 400;
-  text-transform: uppercase;
   overflow: visible;
   position: absolute;
   top: 50%;
@@ -4269,7 +4264,6 @@ a.status-card.compact:hover {
   margin-bottom: 4px;
   display: block;
   background-color: $base-overlay-background;
-  text-transform: uppercase;
   font-size: 11px;
   font-weight: 500;
   padding: 4px;
@@ -4581,7 +4575,6 @@ a.status-card.compact:hover {
 
   span {
     font-size: 12px;
-    text-transform: uppercase;
     font-weight: 500;
     display: block;
   }
@@ -4834,7 +4827,6 @@ a.status-card.compact:hover {
     padding: 15px 5px;
 
     h4 {
-      text-transform: uppercase;
       color: $dark-text-color;
       font-weight: 500;
       padding: 0 10px;
@@ -5385,7 +5377,6 @@ a.status-card.compact:hover {
     font-weight: 500;
     color: $inverted-text-color;
     margin-bottom: 5px;
-    text-transform: uppercase;
     font-size: 12px;
   }
 
@@ -7386,7 +7377,6 @@ noscript {
       dt {
         width: auto;
         background: transparent;
-        text-transform: uppercase;
         color: $dark-text-color;
       }
 
@@ -7461,7 +7451,6 @@ noscript {
       font-size: 12px;
       font-weight: 500;
       color: $darker-text-color;
-      text-transform: uppercase;
       margin-bottom: 5px;
     }
 
@@ -8233,7 +8222,6 @@ noscript {
   }
 
   h4 {
-    text-transform: uppercase;
     color: $darker-text-color;
     margin-bottom: 10px;
     font-weight: 600;
@@ -8741,7 +8729,6 @@ noscript {
 
     h4 {
       font-size: 15px;
-      text-transform: uppercase;
       color: $darker-text-color;
       font-weight: 500;
       margin-bottom: 20px;

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -510,7 +510,6 @@ code {
     height: auto;
     padding: 10px;
     text-decoration: none;
-    text-transform: uppercase;
     text-align: center;
     box-sizing: border-box;
     cursor: pointer;
@@ -785,7 +784,6 @@ code {
 
   a {
     color: $highlight-text-color;
-    text-transform: uppercase;
     text-decoration: none;
     font-weight: 700;
 

--- a/app/javascript/styles/mastodon/widgets.scss
+++ b/app/javascript/styles/mastodon/widgets.scss
@@ -84,7 +84,6 @@
 
   h4 {
     padding: 10px;
-    text-transform: uppercase;
     font-weight: 700;
     font-size: 13px;
     color: $darker-text-color;
@@ -303,7 +302,6 @@
 
   thead th {
     text-align: center;
-    text-transform: uppercase;
     color: $darker-text-color;
     font-weight: 700;
     padding: 10px;


### PR DESCRIPTION
This PR removes all `text-decoration: uppercase` CSS to improve accessibility. 