### PR TITLE
Update Jest testing to include Typescript

### DIFF
--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -9,6 +9,8 @@ on:
       - '.nvmrc'
       - '**/*.js'
       - '**/*.jsx'
+      - '**/*.ts'
+      - '**/*.tsx'
       - '**/*.snap'
       - '.github/workflows/test-js.yml'
 
@@ -19,6 +21,8 @@ on:
       - '.nvmrc'
       - '**/*.js'
       - '**/*.jsx'
+      - '**/*.ts'
+      - '**/*.tsx'
       - '**/*.snap'
       - '.github/workflows/test-js.yml'
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ const config = {
   setupFiles: ['raf/polyfill'],
   setupFilesAfterEnv: ['<rootDir>/app/javascript/mastodon/test_setup.js'],
   collectCoverageFrom: [
-    'app/javascript/mastodon/**/*.js',
+    'app/javascript/mastodon/**/*.{js,jsx,ts,tsx}',
     '!app/javascript/mastodon/features/emoji/emoji_compressed.js',
     '!app/javascript/mastodon/locales/locale-data/*.js',
     '!app/javascript/mastodon/service_worker/entry.js',


### PR DESCRIPTION
- Collect coverage for the new file types
- Run CI on the TypeScript file extensions