### PR TITLE
Fix anonymous visitors getting a session cookie on first visit

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -8,7 +8,6 @@ class Api::BaseController < ApplicationController
   include AccessTokenTrackingConcern
   include ApiCachingConcern
 
-  skip_before_action :store_current_location
   skip_before_action :require_functional!, unless: :whitelist_mode?
 
   before_action :require_authenticated_user!, if: :disallow_unauthenticated_api_access?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,7 @@ class ApplicationController < ActionController::Base
   helper_method :sso_account_settings
   helper_method :whitelist_mode?
   helper_method :body_class_string
+  helper_method :skip_csrf_meta_tags?
 
   rescue_from ActionController::ParameterMissing, Paperclip::AdapterRegistry::NoHandlerError, with: :bad_request
   rescue_from Mastodon::NotPermittedError, with: :forbidden
@@ -63,6 +64,10 @@ class ApplicationController < ActionController::Base
 
   def require_functional!
     redirect_to edit_user_registration_path unless current_user.functional?
+  end
+
+  def skip_csrf_meta_tags?
+    false
   end
 
   def after_sign_out_path_for(_resource_or_scope)

--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -10,6 +10,10 @@ module WebAppControllerConcern
     vary_by 'Accept, Accept-Language, Cookie'
   end
 
+  def skip_csrf_meta_tags?
+    current_user.nil?
+  end
+
   def set_app_body_class
     @body_classes = 'app-body'
   end

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -3,7 +3,6 @@
 class MediaController < ApplicationController
   include Authorization
 
-  skip_before_action :store_current_location
   skip_before_action :require_functional!, unless: :whitelist_mode?
 
   before_action :authenticate_user!, if: :whitelist_mode?

--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -6,7 +6,6 @@ class MediaProxyController < ApplicationController
   include Redisable
   include Lockable
 
-  skip_before_action :store_current_location
   skip_before_action :require_functional!
 
   before_action :authenticate_user!, if: :whitelist_mode?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,7 +30,7 @@
     = stylesheet_pack_tag current_theme, media: 'all', crossorigin: 'anonymous'
     = javascript_pack_tag 'common', crossorigin: 'anonymous'
     = javascript_pack_tag "locale_#{I18n.locale}", crossorigin: 'anonymous'
-    = csrf_meta_tags
+    = csrf_meta_tags unless skip_csrf_meta_tags?
     %meta{ name: 'style-nonce', content: request.content_security_policy_nonce }
 
     = stylesheet_link_tag '/inert.css', skip_pipeline: true, media: 'all', id: 'inert-style'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -132,25 +132,6 @@ describe ApplicationController, type: :controller do
     include_examples 'respond_with_error', 422
   end
 
-  describe 'before_action :store_current_location' do
-    it 'stores location for user if it is not devise controller' do
-      routes.draw { get 'success' => 'anonymous#success' }
-      get 'success'
-      expect(controller.stored_location_for(:user)).to eq '/success'
-    end
-
-    context do
-      controller Devise::SessionsController do
-      end
-
-      it 'does not store location for user if it is devise controller' do
-        @request.env['devise.mapping'] = Devise.mappings[:user]
-        get 'create'
-        expect(controller.stored_location_for(:user)).to be_nil
-      end
-    end
-  end
-
   describe 'before_action :check_suspension' do
     before do
       routes.draw { get 'success' => 'anonymous#success' }

--- a/spec/requests/anonymous_cookies_spec.rb
+++ b/spec/requests/anonymous_cookies_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+context 'when visited anonymously' do
+  around do |example|
+    old = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+
+    example.run
+
+    ActionController::Base.allow_forgery_protection = old
+  end
+
+  describe 'account pages' do
+    it 'do not set cookies' do
+      alice = Fabricate(:account, username: 'alice', display_name: 'Alice')
+      _status = Fabricate(:status, account: alice, text: 'Hello World')
+
+      get '/@alice'
+
+      expect(response.cookies).to be_empty
+    end
+  end
+
+  describe 'status pages' do
+    it 'do not set cookies' do
+      alice = Fabricate(:account, username: 'alice', display_name: 'Alice')
+      status = Fabricate(:status, account: alice, text: 'Hello World')
+
+      get short_account_status_url(alice, status)
+
+      expect(response.cookies).to be_empty
+    end
+  end
+
+  describe 'the /about page' do
+    it 'does not set cookies' do
+      get '/about'
+
+      expect(response.cookies).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
~~Not to be merged yet, as multiple controllers have incorrect caching behavior and will start to incorrectly cache pages that should behave differently when a user is logged in. See #24604~~

Currently, Mastodon sets a session cookie (server-encrypted cookie containing a few pieces of data) even for anonymous visitors.

They are mostly unnecessary and can make caching more complicated.

As far as I can see, the reasons those cookies are set in the first place are:
- CSRF protection: `csrf_meta_tags` is called on every rendered HTML page, while it's only necessary on pages with forms as well as the logged-in Web UI (to be able to log out)
- storing the page to return to after sign-up/login: this one is trickier, but I think we can change the logic to read the `Referrer` header the moment we enter the login/sign-up flow instead of storing the current page every time

However, if a session cookie is set, there are many more occasions in which it will be re-issued, as just reading from a session (which many Mastodon controllers do to see if the user is logged in) will cause a cookie to be re-issued. Maybe there should be some cleanup process to detect “empty” sessions and clean them.

## TODO

- [x] add basic tests for ensuring anonymous visitors don't get a session cookie
- [x] disable CSRF tags for anonymous visitors on the web app
- [x] change location to only be stored around devise calls
- [x] write tests for location storage
- [x] fix cache behavior throughout Mastodon (#24604)
- [ ] investigate clearing “empty” sessions