### PR TITLE
Allow `==` when null checking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,7 +71,7 @@ module.exports = {
     'comma-style': ['warn', 'last'],
     'consistent-return': 'error',
     'dot-notation': 'error',
-    eqeqeq: 'error',
+    eqeqeq: ['error', 'always', { 'null': 'ignore' }],
     indent: ['warn', 2],
     'jsx-quotes': ['error', 'prefer-single'],
     'no-case-declarations': 'off',

--- a/app/javascript/mastodon/components/short_number.jsx
+++ b/app/javascript/mastodon/components/short_number.jsx
@@ -32,17 +32,14 @@ function ShortNumber({ value, renderer, children }) {
   const shortNumber = toShortNumber(value);
   const [, division] = shortNumber;
 
-  // eslint-disable-next-line eqeqeq
   if (children != null && renderer != null) {
     console.warn('Both renderer prop and renderer as a child provided. This is a mistake and you really should fix that. Only renderer passed as a child will be used.');
   }
 
-  // eslint-disable-next-line eqeqeq
   const customRenderer = children != null ? children : renderer;
 
   const displayNumber = <ShortNumberCounter value={shortNumber} />;
 
-  // eslint-disable-next-line eqeqeq
   return customRenderer != null
     ? customRenderer(displayNumber, pluralReady(value, division))
     : displayNumber;

--- a/app/javascript/mastodon/utils/numbers.js
+++ b/app/javascript/mastodon/utils/numbers.js
@@ -60,7 +60,6 @@ export function toShortNumber(sourceNumber) {
  * // => 1790
  */
 export function pluralReady(sourceNumber, division) {
-  // eslint-disable-next-line eqeqeq
   if (division == null || division < DECIMAL_UNITS.HUNDRED) {
     return sourceNumber;
   }


### PR DESCRIPTION
This PR change eslint config to allow `==` when null checking.
By this PR, we can null or undefined checking at the once.

https://eslint.org/docs/latest/rules/eqeqeq#allow-null

```
fusagiko@yuika22:~/src/mastodon$ node 
Welcome to Node.js v16.20.0.
Type ".help" for more information.
> null == null
true
> null == undefined
true
> null == 0
false
> null == ""
false
> null == false
false
> false == 0
true
> false == ""
true
>
```

Of course eslint can detect if it's not null checking.

```
fusagiko@yuika22:~/src/mastodon$ git diff 
diff --git a/app/javascript/mastodon/compare_id.js b/app/javascript/mastodon/compare_id.js
index d2bd74f44..fe6483944 100644
--- a/app/javascript/mastodon/compare_id.js
+++ b/app/javascript/mastodon/compare_id.js
@@ -1,5 +1,5 @@
 export default function compareId (id1, id2) {
-  if (id1 === id2) {
+  if (id1 == id2) {
     return 0;
   }
 
fusagiko@yuika22:~/src/mastodon$ yarn test:lint:js
yarn run v1.22.19
$ eslint --ext=.js,.jsx,.ts,.tsx . --cache --report-unused-disable-directives

/home/fusagiko/src/mastodon/app/javascript/mastodon/compare_id.js
  2:11  error  Expected '===' and instead saw '=='  eqeqeq

/home/fusagiko/src/mastodon/app/javascript/mastodon/components/status.jsx
  523:13  warning  Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element  jsx-a11y/no-static-element-interactions

✖ 2 problems (1 error, 1 warning)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
fusagiko@yuika22:~/src/mastodon$ 
```