### PR TITLE
Add instant theme preview on user appearance settings form

### DIFF
--- a/app/javascript/packs/public.jsx
+++ b/app/javascript/packs/public.jsx
@@ -302,7 +302,7 @@ function main() {
     input.readonly = oldReadOnly;
   });
 
-  delegate(document, '#user_settings_attributes_theme', 'change', (evt) => {
+  delegate(document, '#user_settings_attributes_theme, #form_admin_settings_theme', 'change', (evt) => {
     const themeTags = document.querySelectorAll('link[data-theme-preview]');
 
     for (const themeTag of themeTags) {

--- a/app/javascript/packs/public.jsx
+++ b/app/javascript/packs/public.jsx
@@ -302,6 +302,18 @@ function main() {
     input.readonly = oldReadOnly;
   });
 
+  delegate(document, '#user_settings_attributes_theme', 'change', (evt) => {
+    const themeTags = document.querySelectorAll('link[data-theme-preview]');
+
+    for (const themeTag of themeTags) {
+      if (themeTag.getAttribute('data-theme-preview') === evt.target.value) {
+        themeTag.setAttribute('rel', 'stylesheet');
+      } else {
+        themeTag.setAttribute('rel', 'preload');
+      }
+    }
+  });
+
   const toggleSidebar = () => {
     const sidebar = document.querySelector('.sidebar ul');
     const toggleButton = document.querySelector('.sidebar__toggle__icon');

--- a/app/views/admin/settings/appearance/show.html.haml
+++ b/app/views/admin/settings/appearance/show.html.haml
@@ -1,6 +1,10 @@
 - content_for :header_tags do
   = javascript_pack_tag 'admin', async: true, crossorigin: 'anonymous'
 
+- content_for :header_tags do
+  - Themes.instance.names.each do |theme|
+    = stylesheet_pack_tag theme, media: 'all', crossorigin: 'anonymous', 'data-theme-preview': theme, rel: 'preload', as: 'style'
+
 - content_for :page_title do
   = t('admin.settings.appearance.title')
 

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -4,6 +4,10 @@
 - content_for :heading_actions do
   = button_tag t('generic.save_changes'), class: 'button', form: 'edit_user'
 
+- content_for :header_tags do
+  - Themes.instance.names.each do |theme|
+    = stylesheet_pack_tag theme, media: 'all', crossorigin: 'anonymous', 'data-theme-preview': theme, rel: 'preload', as: 'style'
+
 = simple_form_for current_user, url: settings_preferences_appearance_path, html: { method: :put, id: 'edit_user' } do |f|
   .fields-row
     .fields-group.fields-row__column.fields-row__column-6


### PR DESCRIPTION
# Overview 

Lets user instantly see how exactly theme they are about to choose looks like. 

# Preview

![ezgif-3-a57cafa310](https://user-images.githubusercontent.com/903437/233140819-5e8680a6-bfd0-4fc2-84dc-e9b28fea5348.gif)

