### PR TITLE
Remove `ActiveModel::Errors#to_h` deprecation warning in `Mastodon::AccountsCLI`

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -120,10 +120,10 @@ module Mastodon
         say('OK', :green)
         say("New password: #{password}")
       else
-        user.errors.to_h.each do |key, error|
+        user.errors.to_hash.each do |key, error|
           say('Failure/Error: ', :red)
           say(key)
-          say("    #{error}", :red)
+          say("    #{error.join(', ')}", :red)
         end
 
         exit(1)
@@ -196,10 +196,10 @@ module Mastodon
         say('OK', :green)
         say("New password: #{password}") if options[:reset_password]
       else
-        user.errors.to_h.each do |key, error|
+        user.errors.to_hash.each do |key, error|
           say('Failure/Error: ', :red)
           say(key)
-          say("    #{error}", :red)
+          say("    #{error.join(', ')}", :red)
         end
 
         exit(1)


### PR DESCRIPTION
Remove the deprecation warning regarding the `#create` and `#modify` methods in `Mastodon::AccountsCLI`.

The deprecation warning is the following:
```
DEPRECATION WARNING: ActiveModel::Errors#to_h is deprecated and will be removed in Rails 7.0. (ActiveSupport::DeprecationException)
Please use `ActiveModel::Errors.to_hash` instead. The values in the hash returned by `ActiveModel::Errors.to_hash` is an array of error messages.
```