### PR TITLE
Adds new follower/following routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,8 @@ Rails.application.routes.draw do
   }
 
   get '/users/:username', to: redirect('/@%{username}'), constraints: lambda { |req| req.format.nil? || req.format.html? }
+  get '/users/:username/following', to: redirect('/@%{username}/following'), constraints: lambda { |req| req.format.nil? || req.format.html? }, as: :short_account_following
+  get '/users/:username/followers', to: redirect('/@%{username}/followers'), constraints: lambda { |req| req.format.nil? || req.format.html? }, as: :short_account_followers
   get '/users/:username/statuses/:id', to: redirect('/@%{username}/%{id}'), constraints: lambda { |req| req.format.nil? || req.format.html? }
   get '/authorize_follow', to: redirect { |_, request| "/authorize_interaction?#{request.params.to_query}" }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,8 +83,8 @@ Rails.application.routes.draw do
   }
 
   get '/users/:username', to: redirect('/@%{username}'), constraints: lambda { |req| req.format.nil? || req.format.html? }
-  get '/users/:username/following', to: redirect('/@%{username}/following'), constraints: lambda { |req| req.format.nil? || req.format.html? }, as: :short_account_following
-  get '/users/:username/followers', to: redirect('/@%{username}/followers'), constraints: lambda { |req| req.format.nil? || req.format.html? }, as: :short_account_followers
+  get '/users/:username/following', to: redirect('/@%{username}/following'), constraints: lambda { |req| req.format.nil? || req.format.html? }
+  get '/users/:username/followers', to: redirect('/@%{username}/followers'), constraints: lambda { |req| req.format.nil? || req.format.html? }
   get '/users/:username/statuses/:id', to: redirect('/@%{username}/%{id}'), constraints: lambda { |req| req.format.nil? || req.format.html? }
   get '/authorize_follow', to: redirect { |_, request| "/authorize_interaction?#{request.params.to_query}" }
 

--- a/spec/requests/follower_accounts_spec.rb
+++ b/spec/requests/follower_accounts_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'FollowerAccountsController', type: :request do
+  describe 'The follower_accounts route' do
+    it "returns a http 'moved_permanently' code" do
+      get '/users/:username/followers'
+
+      expect(response).to have_http_status(301)
+    end
+  end
+end

--- a/spec/requests/follower_accounts_spec.rb
+++ b/spec/requests/follower_accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'FollowerAccountsController', type: :request do
+RSpec.describe 'FollowerAccountsController' do
   describe 'The follower_accounts route' do
     it "returns a http 'moved_permanently' code" do
       get '/users/:username/followers'

--- a/spec/requests/following_accounts_spec.rb
+++ b/spec/requests/following_accounts_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'FollowingAccountsController', type: :request do
+  describe 'The following_accounts route' do
+    it "returns a http 'moved_permanently' code" do
+      get '/users/:username/following'
+
+      expect(response).to have_http_status(301)
+    end
+  end
+end

--- a/spec/requests/following_accounts_spec.rb
+++ b/spec/requests/following_accounts_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'FollowingAccountsController', type: :request do
+RSpec.describe 'FollowingAccountsController' do
   describe 'The following_accounts route' do
     it "returns a http 'moved_permanently' code" do
       get '/users/:username/following'


### PR DESCRIPTION
This PR fixes [#24078](https://github.com/mastodon/mastodon/issues/24078)

Production behavior:
![follower_following_error](https://user-images.githubusercontent.com/64037198/233357364-b0311106-3044-45d5-8c2e-2cd8de18f920.gif)


New behavior:
![follower_following_fixed](https://user-images.githubusercontent.com/64037198/233357418-e6311131-9ba9-44f4-baea-a6cc7fa2286e.gif)


To solve the issue I added two new paths that redirect to their expected routes. I also created request tests to verify that the paths created do indeed redirect the user as intended.