### PR TITLE
Fix  `tootctl accounts approve --number N` not aproving N earliest registrations

### DIFF
--- a/lib/mastodon/accounts_cli.rb
+++ b/lib/mastodon/accounts_cli.rb
@@ -545,7 +545,7 @@ module Mastodon
         User.pending.find_each(&:approve!)
         say('OK', :green)
       elsif options[:number]&.positive?
-        User.pending.limit(options[:number]).each(&:approve!)
+        User.pending.order(created_at: :asc).limit(options[:number]).each(&:approve!)
         say('OK', :green)
       elsif username.present?
         account = Account.find_local(username)


### PR DESCRIPTION
Related to #24596 and #24597. This PR fixes the issue discussed in #24597.

When using the CLI to approve the N earliest registrations, the order in which accounts are approved is unspecified. Thus, there's no guarantee the N earliest accounts are being approved.

This PR adds and ordering in pending accounts closed on `created_at` in `Mastodon::AccountsCLI#approve` to guarantee the order in which accounts are being approved when using the `--number` options.