### PR TITLE
Fix AccountsStatusesCleanupScheduler not spreading deletes across accounts correctly

### DIFF
--- a/app/workers/scheduler/accounts_statuses_cleanup_scheduler.rb
+++ b/app/workers/scheduler/accounts_statuses_cleanup_scheduler.rb
@@ -42,7 +42,7 @@ class Scheduler::AccountsStatusesCleanupScheduler
       num_processed_accounts = 0
 
       scope = AccountStatusesCleanupPolicy.where(enabled: true)
-      scope.where(Account.arel_table[:id].gt(first_policy_id)) if first_policy_id.present?
+      scope = scope.where(id: first_policy_id...) if first_policy_id.present?
       scope.find_each(order: :asc) do |policy|
         num_deleted = AccountStatusesCleanupService.new.call(policy, [budget, PER_ACCOUNT_BUDGET].min)
         num_processed_accounts += 1 unless num_deleted.zero?
@@ -78,14 +78,14 @@ class Scheduler::AccountsStatusesCleanupScheduler
   end
 
   def last_processed_id
-    redis.get('account_statuses_cleanup_scheduler:last_account_id')
+    redis.get('account_statuses_cleanup_scheduler:last_policy_id')
   end
 
   def save_last_processed_id(id)
     if id.nil?
-      redis.del('account_statuses_cleanup_scheduler:last_account_id')
+      redis.del('account_statuses_cleanup_scheduler:last_policy_id')
     else
-      redis.set('account_statuses_cleanup_scheduler:last_account_id', id, ex: 1.hour.seconds)
+      redis.set('account_statuses_cleanup_scheduler:last_policy_id', id, ex: 1.hour.seconds)
     end
   end
 end


### PR DESCRIPTION
Instead of starting from where it left off when running out of budget, it would start from the beginning on each run, meaning users that enabled the feature last would have none of their posts deleted until everyone who enabled the feature before them would have all of their posts cleared.