### PR TITLE
Better explanation in onboarding text

### DIFF
--- a/app/javascript/mastodon/features/onboarding/follows.jsx
+++ b/app/javascript/mastodon/features/onboarding/follows.jsx
@@ -64,7 +64,7 @@ class Follows extends React.PureComponent {
             ))}
           </div>
 
-          <p className='onboarding__lead'><FormattedHTMLMessage id='onboarding.tips.accounts_from_other_servers' defaultMessage='<strong>Did you know?</strong> Since Mastodon is decentralized, some profiles you come across will be hosted on servers other than yours. And yet you can interact with them seamlessly! Their server is in the second half of their username!' values={{ strong: text => <strong>{text}</strong> }} /></p>
+          <p className='onboarding__lead'><FormattedHTMLMessage id='onboarding.tips.accounts_from_other_servers' defaultMessage='<strong>Did you know?</strong> Since Mastodon is decentralized, you regularly run into people using a different server than you. And yet you can interact with them seamlessly! Their server is in the second half of their username!' values={{ strong: text => <strong>{text}</strong> }} /></p>
 
           <div className='onboarding__footer'>
             <button className='link-button' onClick={onBack}><FormattedMessage id='onboarding.actions.back' defaultMessage='Take me back' /></button>

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -3195,7 +3195,7 @@
         "id": "onboarding.follows.lead"
       },
       {
-        "defaultMessage": "<strong>Did you know?</strong> Since Mastodon is decentralized, some profiles you come across will be hosted on servers other than yours. And yet you can interact with them seamlessly! Their server is in the second half of their username!",
+        "defaultMessage": "<strong>Did you know?</strong> Since Mastodon is decentralized, you regularly run into people using a different server than you. And yet you can interact with them seamlessly! Their server is in the second half of their username!",
         "id": "onboarding.tips.accounts_from_other_servers"
       },
       {

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -462,7 +462,7 @@
   "onboarding.steps.setup_profile.title": "Customize your profile",
   "onboarding.steps.share_profile.body": "Let your friends know how to find you on Mastodon!",
   "onboarding.steps.share_profile.title": "Share your profile",
-  "onboarding.tips.accounts_from_other_servers": "<strong>Did you know?</strong> Since Mastodon is decentralized, some profiles you come across will be hosted on servers other than yours. And yet you can interact with them seamlessly! Their server is in the second half of their username!",
+  "onboarding.tips.accounts_from_other_servers": "<strong>Did you know?</strong> Since Mastodon is decentralized, you regularly run into people using a different server than you. And yet you can interact with them seamlessly! Their server is in the second half of their username!",
   "password_confirmation.exceeds_maxlength": "Password confirmation exceeds the maximum password length",
   "password_confirmation.mismatching": "Password confirmation does not match",
   "picture_in_picture.restore": "Put it back",


### PR DESCRIPTION
'Some profiles' is incorrect, that really depends on the server size of the user. I don't have statistics about how many remote accounts users are following by average, but in the 6 years I'm here most of my followers are on a remote server. So because we don't know for all people if _some_, _a lot_ or _most accounts_ are on another server,  I made this text agnostic.