### PR TITLE
Update `attr_encrypted` & `devise-two-factor` gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,10 @@ gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
 gem 'chewy', '~> 7.3'
 gem 'devise', '~> 4.9'
-gem 'devise-two-factor', '~> 4.0'
+# The below `v4.x` branch allows attr_encrypted 4.x, which is required for Rails 7.
+# Once a new gem version is pushed, we can go back to released gem and off of github branch.
+gem 'devise-two-factor', github: 'tinfoil/devise-two-factor', branch: 'v4.x'
+gem 'attr_encrypted', '~> 4.0'
 
 group :pam_authentication, optional: true do
   gem 'devise_pam_authenticatable2', '~> 9.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,18 @@ GIT
     rails-settings-cached (0.6.6)
       rails (>= 4.2.0)
 
+GIT
+  remote: https://github.com/tinfoil/devise-two-factor.git
+  revision: e685f91ce62d036259885fbe31fcb4fa930bcfcb
+  branch: v4.x
+  specs:
+    devise-two-factor (4.0.2)
+      activesupport (< 7.1)
+      attr_encrypted (>= 1.3, < 5, != 2)
+      devise (~> 4.0)
+      railties (< 7.1)
+      rotp (~> 6.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -104,7 +116,7 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
-    attr_encrypted (3.1.0)
+    attr_encrypted (4.0.0)
       encryptor (~> 3.0.0)
     attr_required (1.0.1)
     awrence (1.2.1)
@@ -206,12 +218,6 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-two-factor (4.0.2)
-      activesupport (< 7.1)
-      attr_encrypted (>= 1.3, < 4, != 2)
-      devise (~> 4.0)
-      railties (< 7.1)
-      rotp (~> 6.0)
     devise_pam_authenticatable2 (9.2.0)
       devise (>= 4.0.0)
       rpam2 (~> 4.0)
@@ -769,6 +775,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10)
   addressable (~> 2.8)
   annotate (~> 3.2)
+  attr_encrypted (~> 4.0)
   aws-sdk-s3 (~> 1.120)
   better_errors (~> 2.9)
   binding_of_caller (~> 1.0)
@@ -790,7 +797,7 @@ DEPENDENCIES
   concurrent-ruby
   connection_pool
   devise (~> 4.9)
-  devise-two-factor (~> 4.0)
+  devise-two-factor!
   devise_pam_authenticatable2 (~> 9.2)
   discard (~> 1.2)
   doorkeeper (~> 5.6)


### PR DESCRIPTION
Bumps these gems to versions which work with and allow Rails 7.

The attr_encrypted change was to rename an internally used method which conflicted with a method which now exists in Rails 7. The devise-two-factor change was to rename it's own usage of that same method. The renamed method (`encrypted_attributes`) is not used directly by Mastodon.

_(Extracted in advance from #24241)_