### PR TITLE
Fix crash when SSO_ACCOUNT_SETTINGS is not defined

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -128,7 +128,7 @@ class ApplicationController < ActionController::Base
   end
 
   def sso_account_settings
-    ENV.fetch('SSO_ACCOUNT_SETTINGS')
+    ENV.fetch('SSO_ACCOUNT_SETTINGS', nil)
   end
 
   def current_account


### PR DESCRIPTION
The setting was added in #24100 and it makes sense for it to be optional