### PR TITLE
Run Rubocop with lint-staged on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write",
+    "Capfile|Gemfile|*.{rb,ruby,ru,rake}": "bundle exec rubocop -a",
     "*.{js,jsx,ts,tsx}": "eslint --fix",
     "*.{css,scss}": "stylelint --fix"
   }


### PR DESCRIPTION
Allow Rubocop to make any autofix that is marked safe while committing files. This does include rewriting code, but will fail if that autofix is "unsafe" and would require the `-A` flag. Unfixable cops will block the commit without passing a `--no-verify` flag when committing to override the pre-commit hook.