### PR TITLE
Update password max length to allow passwords up to 1024000 chars

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -267,7 +267,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 8..72
+  config.password_length = 8..1024000
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -267,7 +267,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 8..1024000
+  config.password_length = 8..10240
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
The current limitations of 72 is exceptionally small. This should hopefully be more than enough for anyone to ever ever ask for.