### PR TITLE
fix: remove port 80 mapping in devcontainer

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -26,7 +26,6 @@ services:
     ports:
       - '127.0.0.1:3000:3000'
       - '127.0.0.1:4000:4000'
-      - '127.0.0.1:80:3000'
     networks:
       - external_network
       - internal_network


### PR DESCRIPTION
This change leaves ports 3000 and 4000 mapped, but removes port 80.

On MacOS and possible other OSes, mapping port 80 requires a preference
change on docker as it's a privileged port. The devcontainer fails to
run without this change, which is a annoying. Additionally, this mapping
will fail for anyone that already has port 80 mapped for some other
purpose.
