### PR TITLE
Remove the u in Favorite for non-gb english

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -771,7 +771,7 @@ en:
         remove_from_report: Remove from report
         report: Report
       deleted: Deleted
-      favourites: Favourites
+      favourites: Favorites
       history: Version history
       in_reply_to: Replying to
       language: Language

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -852,14 +852,14 @@ en:
       statuses:
         allow: Allow post
         allow_account: Allow author
-        description_html: These are posts that your server knows about that are currently being shared and favourited a lot at the moment. It can help your new and returning users to find more people to follow. No posts are displayed publicly until you approve the author, and the author allows their account to be suggested to others. You can also allow or reject individual posts.
+        description_html: These are posts that your server knows about that are currently being shared and favorited a lot at the moment. It can help your new and returning users to find more people to follow. No posts are displayed publicly until you approve the author, and the author allows their account to be suggested to others. You can also allow or reject individual posts.
         disallow: Disallow post
         disallow_account: Disallow author
         no_status_selected: No trending posts were changed as none were selected
         not_discoverable: Author has not opted-in to being discoverable
         shared_by:
-          one: Shared or favourited one time
-          other: Shared and favourited %{friendly_count} times
+          one: Shared or favorited one time
+          other: Shared and favorited %{friendly_count} times
         title: Trending posts
       tags:
         current_score: Current score %{score}
@@ -1337,9 +1337,9 @@ en:
       sign_up:
         subject: "%{name} signed up"
     favourite:
-      body: 'Your post was favourited by %{name}:'
-      subject: "%{name} favourited your post"
-      title: New favourite
+      body: 'Your post was favorited by %{name}:'
+      subject: "%{name} favorited your post"
+      title: New favorite
     follow:
       body: "%{name} is now following you!"
       subject: "%{name} is now following you"
@@ -1572,10 +1572,10 @@ en:
     enabled_hint: Automatically deletes your posts once they reach a specified age threshold, unless they match one of the exceptions below
     exceptions: Exceptions
     explanation: Because deleting posts is an expensive operation, this is done slowly over time when the server is not otherwise busy. For this reason, your posts may be deleted a while after they reach the age threshold.
-    ignore_favs: Ignore favourites
+    ignore_favs: Ignore favorites
     ignore_reblogs: Ignore boosts
     interaction_exceptions: Exceptions based on interactions
-    interaction_exceptions_explanation: Note that there is no guarantee for posts to be deleted if they go below the favourite or boost threshold after having once gone over them.
+    interaction_exceptions_explanation: Note that there is no guarantee for posts to be deleted if they go below the favorite or boost threshold after having once gone over them.
     keep_direct: Keep direct messages
     keep_direct_hint: Doesn't delete any of your direct messages
     keep_media: Keep posts with media attachments
@@ -1586,8 +1586,8 @@ en:
     keep_polls_hint: Doesn't delete any of your polls
     keep_self_bookmark: Keep posts you bookmarked
     keep_self_bookmark_hint: Doesn't delete your own posts if you have bookmarked them
-    keep_self_fav: Keep posts you favourited
-    keep_self_fav_hint: Doesn't delete your own posts if you have favourited them
+    keep_self_fav: Keep posts you favorited
+    keep_self_fav_hint: Doesn't delete your own posts if you have favorited them
     min_age:
       '1209600': 2 weeks
       '15778476': 6 months
@@ -1598,8 +1598,8 @@ en:
       '63113904': 2 years
       '7889238': 3 months
     min_age_label: Age threshold
-    min_favs: Keep posts favourited at least
-    min_favs_hint: Doesn't delete any of your posts that has received at least this number of favourites. Leave blank to delete posts regardless of their number of favourites
+    min_favs: Keep posts favorited at least
+    min_favs_hint: Doesn't delete any of your posts that has received at least this number of favorites. Leave blank to delete posts regardless of their number of favorites
     min_reblogs: Keep posts boosted at least
     min_reblogs_hint: Doesn't delete any of your posts that has been boosted at least this number of times. Leave blank to delete posts regardless of their number of boosts
   stream_entries:

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -61,12 +61,12 @@ RSpec.describe NotificationMailer, type: :mailer do
     include_examples 'localized subject', 'notification_mailer.favourite.subject', name: 'bob'
 
     it 'renders the headers' do
-      expect(mail.subject).to eq('bob favourited your post')
+      expect(mail.subject).to eq('bob favorited your post')
       expect(mail[:to].value).to eq("#{receiver.account.username} <#{receiver.email}>")
     end
 
     it 'renders the body' do
-      expect(mail.body.encoded).to match('Your post was favourited by bob')
+      expect(mail.body.encoded).to match('Your post was favorited by bob')
       expect(mail.body.encoded).to include 'The body of the own status'
     end
   end


### PR DESCRIPTION
The American world of english does not include the -u in Favorite like en-GB does.