### PR TITLE
Fix Rails/ActiveRecordCallbacksOrder cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1148,19 +1148,6 @@ RSpec/VerifiedDoubles:
     - 'spec/workers/feed_insert_worker_spec.rb'
     - 'spec/workers/regeneration_worker_spec.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/ActiveRecordCallbacksOrder:
-  Exclude:
-    - 'app/models/account.rb'
-    - 'app/models/account_conversation.rb'
-    - 'app/models/announcement_reaction.rb'
-    - 'app/models/block.rb'
-    - 'app/models/media_attachment.rb'
-    - 'app/models/session_activation.rb'
-    - 'app/models/status.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Rails/ApplicationController:
   Exclude:

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -535,9 +535,9 @@ class Account < ApplicationRecord
     @emojis ||= CustomEmoji.from_text(emojifiable_text, domain)
   end
 
-  before_create :generate_keys
   before_validation :prepare_contents, if: :local?
   before_validation :prepare_username, on: :create
+  before_create :generate_keys
   before_destroy :clean_feed_manager
 
   def ensure_keys!

--- a/app/models/account_conversation.rb
+++ b/app/models/account_conversation.rb
@@ -17,13 +17,12 @@
 class AccountConversation < ApplicationRecord
   include Redisable
 
+  before_validation :set_last_status
   after_commit :push_to_streaming_api
 
   belongs_to :account
   belongs_to :conversation
   belongs_to :last_status, class_name: 'Status'
-
-  before_validation :set_last_status
 
   def participant_account_ids=(arr)
     self[:participant_account_ids] = arr.sort

--- a/app/models/announcement_reaction.rb
+++ b/app/models/announcement_reaction.rb
@@ -14,6 +14,7 @@
 #
 
 class AnnouncementReaction < ApplicationRecord
+  before_validation :set_custom_emoji
   after_commit :queue_publish
 
   belongs_to :account
@@ -22,8 +23,6 @@ class AnnouncementReaction < ApplicationRecord
 
   validates :name, presence: true
   validates_with ReactionValidator
-
-  before_validation :set_custom_emoji
 
   private
 

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -25,8 +25,8 @@ class Block < ApplicationRecord
     false # Force uri_for to use uri attribute
   end
 
-  after_commit :remove_blocking_cache
   before_validation :set_uri, only: :create
+  after_commit :remove_blocking_cache
 
   private
 

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -271,11 +271,11 @@ class MediaAttachment < ApplicationRecord
     delay_processing? && attachment_name == :file
   end
 
-  after_commit :enqueue_processing, on: :create
-  after_commit :reset_parent_cache, on: :update
-
   before_create :set_unknown_type
   before_create :set_processing
+
+  after_commit :enqueue_processing, on: :create
+  after_commit :reset_parent_cache, on: :update
 
   after_post_process :set_meta
 

--- a/app/models/session_activation.rb
+++ b/app/models/session_activation.rb
@@ -36,8 +36,8 @@ class SessionActivation < ApplicationRecord
     detection.platform.id
   end
 
-  before_create :assign_access_token
   before_save   :assign_user_agent
+  before_create :assign_access_token
 
   class << self
     def active?(id)


### PR DESCRIPTION
Replaces https://github.com/mastodon/mastodon/pull/24191

The only interesting thing here beyond the reordering was adding the one `prepend` to ensure that callback runs earlier than dependent destroy callbacks.