### PR TITLE
Remove duplicate react helper method definitions

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -155,18 +155,6 @@ module ApplicationHelper
     tag(:meta, content: content, property: property)
   end
 
-  def react_component(name, props = {}, &block)
-    if block.nil?
-      content_tag(:div, nil, data: { component: name.to_s.camelcase, props: Oj.dump(props) })
-    else
-      content_tag(:div, data: { component: name.to_s.camelcase, props: Oj.dump(props) }, &block)
-    end
-  end
-
-  def react_admin_component(name, props = {})
-    content_tag(:div, nil, data: { 'admin-component': name.to_s.camelcase, props: Oj.dump({ locale: I18n.locale }.merge(props)) })
-  end
-
   def body_classes
     output = body_class_string.split
     output << "theme-#{current_theme.parameterize}"


### PR DESCRIPTION
These methods were previously moved to a ReactHelper module, but these definitions were not removed at the same time.

Should have been removed as part of - https://github.com/mastodon/mastodon/pull/24072/files - but I either forgot to do this or lost it in a rebase. 