### PR TITLE
Add default post text to onboarding flow in web UI

### DIFF
--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -126,9 +126,10 @@ export function resetCompose() {
   };
 }
 
-export const focusCompose = routerHistory => dispatch => {
+export const focusCompose = (routerHistory, defaultText) => dispatch => {
   dispatch({
     type: COMPOSE_FOCUS,
+    defaultText,
   });
 
   ensureComposeIsVisible(routerHistory);

--- a/app/javascript/mastodon/features/onboarding/index.jsx
+++ b/app/javascript/mastodon/features/onboarding/index.jsx
@@ -16,8 +16,12 @@ import Follows from './follows';
 import Share from './share';
 import Step from './components/step';
 import ArrowSmallRight from './components/arrow_small_right';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
 import { debounce } from 'lodash';
+
+const messages = defineMessages({
+  template: { id: 'onboarding.compose.template', defaultMessage: 'Hello #Mastodon!' },
+});
 
 const mapStateToProps = () => {
   const getAccount = makeGetAccount();
@@ -61,10 +65,10 @@ class Onboarding extends ImmutablePureComponent {
   };
 
   handleComposeClick = () => {
-    const { dispatch } = this.props;
+    const { dispatch, intl } = this.props;
     const { router } = this.context;
 
-    dispatch(focusCompose(router.history));
+    dispatch(focusCompose(router.history, intl.formatMessage(messages.template)));
   };
 
   handleShareClick = () => {
@@ -138,4 +142,4 @@ class Onboarding extends ImmutablePureComponent {
 
 }
 
-export default connect(mapStateToProps)(Onboarding);
+export default connect(mapStateToProps)(injectIntl(Onboarding));

--- a/app/javascript/mastodon/locales/defaultMessages.json
+++ b/app/javascript/mastodon/locales/defaultMessages.json
@@ -3212,6 +3212,10 @@
   {
     "descriptors": [
       {
+        "defaultMessage": "Hello #Mastodon!",
+        "id": "onboarding.compose.template"
+      },
+      {
         "defaultMessage": "You've made it!",
         "id": "onboarding.start.title"
       },

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -445,6 +445,7 @@
   "onboarding.actions.close": "Don't show this screen again",
   "onboarding.actions.go_to_explore": "See what's trending",
   "onboarding.actions.go_to_home": "Go to your home feed",
+  "onboarding.compose.template": "Hello #Mastodon!",
   "onboarding.follows.empty": "Unfortunately, no results can be shown right now. You can try using search or browsing the explore page to find people to follow, or try again later.",
   "onboarding.follows.lead": "You curate your own home feed. The more people you follow, the more active and interesting it will be. These profiles may be a good starting point—you can always unfollow them later!",
   "onboarding.follows.title": "Popular on Mastodon",

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -528,7 +528,7 @@ export default function compose(state = initialState, action) {
   case COMPOSE_LANGUAGE_CHANGE:
     return state.set('language', action.language);
   case COMPOSE_FOCUS:
-    return state.set('focusDate', new Date());
+    return state.set('focusDate', new Date()).update('text', text => text.length > 0 ? text : action.defaultText);
   default:
     return state;
   }


### PR DESCRIPTION
When clicking on "Make your first post", pre-fills the compose box with "Hello #Mastodon" besides highlighting and focusing it.

___

Fixes MAS-135