### PR TITLE
Change logo version in header based on screen size in web UI

### DIFF
--- a/app/javascript/mastodon/components/logo.jsx
+++ b/app/javascript/mastodon/components/logo.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
+import logo from 'mastodon/../images/logo.svg';
 
-const Logo = () => (
-  <svg viewBox='0 0 261 66' className='logo' role='img'>
+export const WordmarkLogo = () => (
+  <svg viewBox='0 0 261 66' className='logo logo--wordmark' role='img'>
     <title>Mastodon</title>
     <use xlinkHref='#logo-symbol-wordmark' />
   </svg>
 );
 
-export default Logo;
+export const SymbolLogo = () => (
+  <img src={logo} alt='Mastodon' className='logo logo--icon' />
+);
+
+export default WordmarkLogo;

--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Logo from 'mastodon/components/logo';
+import { WordmarkLogo, SymbolLogo } from 'mastodon/components/logo';
 import { Link, withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { registrationsOpen, me } from 'mastodon/initial_state';
@@ -73,7 +73,10 @@ class Header extends React.PureComponent {
 
     return (
       <div className='ui__header'>
-        <Link to='/' className='ui__header__logo'><Logo /></Link>
+        <Link to='/' className='ui__header__logo'>
+          <WordmarkLogo />
+          <SymbolLogo />
+        </Link>
 
         <div className='ui__header__links'>
           {content}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2396,10 +2396,9 @@ $ui-header-height: 55px;
   height: $ui-header-height;
   position: sticky;
   top: 0;
-  z-index: 2;
+  z-index: 3;
   justify-content: space-between;
   align-items: center;
-  overflow: hidden;
 
   &__logo {
     display: inline-flex;
@@ -2408,6 +2407,20 @@ $ui-header-height: 55px;
     .logo {
       height: $ui-header-height - 30px;
       width: auto;
+    }
+
+    .logo--wordmark {
+      display: none;
+    }
+
+    @media screen and (min-width: 320px) {
+      .logo--wordmark {
+        display: block;
+      }
+
+      .logo--icon {
+        display: none;
+      }
     }
   }
 
@@ -5131,7 +5144,7 @@ a.status-card.compact:hover {
     background: $ui-base-color;
     border-radius: 0 0 4px 4px;
     box-shadow: 4px 4px 6px rgba($base-shadow-color, 0.4);
-    z-index: 2;
+    z-index: 99;
     font-size: 13px;
     padding: 15px 5px;
 


### PR DESCRIPTION
On very small screens, save space by turning wordmark logo into symbol logo. Side-effect of something else I was working on...