### PR TITLE
Change logged-out WebUI HTML pages to be cached for a few seconds

### DIFF
--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -8,7 +8,7 @@ class AboutController < ApplicationController
   before_action :set_instance_presenter
 
   def show
-    expires_in 0, public: true unless user_signed_in?
+    expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.day) unless user_signed_in?
   end
 
   private

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -17,7 +17,7 @@ class AccountsController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        expires_in 0, public: true unless user_signed_in?
+        expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.hour) unless user_signed_in?
 
         @rss_url = rss_url
       end

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -15,7 +15,7 @@ class FollowerAccountsController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        expires_in 0, public: true unless user_signed_in?
+        expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.hour) unless user_signed_in?
       end
 
       format.json do

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -15,7 +15,7 @@ class FollowingAccountsController < ApplicationController
   def index
     respond_to do |format|
       format.html do
-        expires_in 0, public: true unless user_signed_in?
+        expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.hour) unless user_signed_in?
       end
 
       format.json do

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
   before_action :set_instance_presenter
 
   def index
-    expires_in 0, public: true unless user_signed_in?
+    expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.day) unless user_signed_in?
   end
 
   private

--- a/app/controllers/privacy_controller.rb
+++ b/app/controllers/privacy_controller.rb
@@ -8,7 +8,7 @@ class PrivacyController < ApplicationController
   before_action :set_instance_presenter
 
   def show
-    expires_in 0, public: true if current_account.nil?
+    expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.day) unless user_signed_in?
   end
 
   private

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -21,7 +21,7 @@ class TagsController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        expires_in 0, public: true unless user_signed_in?
+        expires_in(15.seconds, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.hour) unless user_signed_in?
       end
 
       format.rss do


### PR DESCRIPTION
Set the same cache control values as anonymous API replies for `/`, `/about`, `/privacy-policy`.

I chose a lower `stale_if_error` to 1 hour for accounts and tags because those could get deleted after a moderation action, and you want that to be reflected in a timely fashion.