### PR TITLE
Change i18n-fallbacks to English

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # English when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [:en]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
Related #24381

This changes `config.i18n.fallbacks` from `true` to `[:en]`, because if `true`, untranslated strings in default locale may not able to read by user.

`config.i18n.fallbacks = true` seems using default locale for fallback-to locale.
https://guides.rubyonrails.org/v6.1/configuring.html#configuring-i18n
And the default locale is customizable by each servers with environment variable `DEFAULT_LOCALE`, but there are some locales translation is not completed yet and it has untranslated strings.

Therefore, if a fallback occurs in preferred locale (or default locale when not logged-in) and the string is not yet translated to default locale, the fallback fails and show up translation missing error. This error displays the i18n-key instead of the string. So user can't read what is described in there.

By this PR, missing strings in preferred locale will falls back to English regardless of default locale but we can avoid missing error and can read the string in English, because i18n in Mastodon is based on `en` locale and all strings will included in.

|Before|After|
|---|---|
|![config.i18n.fallbacks = true](https://user-images.githubusercontent.com/5103195/235270165-20ed1144-bb22-4aff-9867-fed06814fc02.png)|![config.i18n.fallbacks = [:en]](https://user-images.githubusercontent.com/5103195/235270176-d0d71a3e-6a61-456b-8644-8dfacbce552c.png)|