### PR TITLE
Enable local account key generation spec

### DIFF
--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -951,10 +951,10 @@ RSpec.describe Account, type: :model do
   end
 
   context 'when is local' do
-    # Test disabled because test environment omits autogenerating keys for performance
-    xit 'generates keys' do
+    it 'generates keys' do
       account = Account.create!(domain: nil, username: Faker::Internet.user_name(separators: ['_']))
-      expect(account.keypair.private?).to be true
+      expect(account.keypair).to be_private
+      expect(account.keypair).to be_public
     end
   end
 


### PR DESCRIPTION
This spec was disabled because the `generate_keys` method previously did not run in the Rails test environment.

Since this change, it has run in the test environment, so we can re-enable this spec: https://github.com/mastodon/mastodon/commit/730c4053d642024b9949d72c8a9f1873532c6212#diff-b3ff5e3df6b875e9ecfde657ae21de84f4f43c942d3232761ed550cf0eecbce0R505