### PR TITLE
Make mastodon-streaming systemd unit templated

### DIFF
--- a/dist/mastodon-streaming.service
+++ b/dist/mastodon-streaming.service
@@ -1,51 +1,12 @@
 [Unit]
 Description=mastodon-streaming
 After=network.target
+Wants=mastodon-streaming@4000.service
 
 [Service]
-Type=simple
-User=mastodon
-WorkingDirectory=/home/mastodon/live
-Environment="NODE_ENV=production"
-Environment="PORT=4000"
-ExecStart=/usr/bin/node ./streaming
-TimeoutSec=15
-Restart=always
-LimitNOFILE=65536
-# Proc filesystem
-ProcSubset=pid
-ProtectProc=invisible
-# Capabilities
-CapabilityBoundingSet=
-# Security
-NoNewPrivileges=true
-# Sandboxing
-ProtectSystem=strict
-PrivateTmp=true
-PrivateDevices=true
-PrivateUsers=true
-ProtectHostname=true
-ProtectKernelLogs=true
-ProtectKernelModules=true
-ProtectKernelTunables=true
-ProtectControlGroups=true
-RestrictAddressFamilies=AF_INET
-RestrictAddressFamilies=AF_INET6
-RestrictAddressFamilies=AF_NETLINK
-RestrictAddressFamilies=AF_UNIX
-RestrictNamespaces=true
-LockPersonality=true
-RestrictRealtime=true
-RestrictSUIDSGID=true
-RemoveIPC=true
-PrivateMounts=true
-ProtectClock=true
-# System Call Filtering
-SystemCallArchitectures=native
-SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @memlock @mount @obsolete @privileged @resources @setuid
-SystemCallFilter=pipe
-SystemCallFilter=pipe2
-ReadWritePaths=/home/mastodon/live
+Type=oneshot
+ExecStart=/bin/echo "mastodon-streaming exists only to collectively start and stop mastodon-streaming@ instances, shimming over the migration to templated mastodon-streaming systemd unit"
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/mastodon-streaming@.service
+++ b/dist/mastodon-streaming@.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=mastodon-streaming on port %I
+After=network.target
+# handles using `systemctl restart mastodon-streaming`
+PartOf=mastodon-streaming.service
+ReloadPropagatedFrom=mastodon-streaming.service
+
+[Service]
+Type=simple
+User=mastodon
+WorkingDirectory=/home/mastodon/live
+Environment="NODE_ENV=production"
+Environment="PORT=%i"
+ExecStart=/usr/bin/node ./streaming
+TimeoutSec=15
+Restart=always
+LimitNOFILE=65536
+# Proc filesystem
+ProcSubset=pid
+ProtectProc=invisible
+# Capabilities
+CapabilityBoundingSet=
+# Security
+NoNewPrivileges=true
+# Sandboxing
+ProtectSystem=strict
+PrivateTmp=true
+PrivateDevices=true
+PrivateUsers=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET
+RestrictAddressFamilies=AF_INET6
+RestrictAddressFamilies=AF_NETLINK
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RemoveIPC=true
+PrivateMounts=true
+ProtectClock=true
+# System Call Filtering
+SystemCallArchitectures=native
+SystemCallFilter=~@cpu-emulation @debug @keyring @ipc @memlock @mount @obsolete @privileged @resources @setuid
+SystemCallFilter=pipe
+SystemCallFilter=pipe2
+ReadWritePaths=/home/mastodon/live
+
+[Install]
+WantedBy=multi-user.target mastodon-streaming.service

--- a/dist/nginx.conf
+++ b/dist/nginx.conf
@@ -8,7 +8,15 @@ upstream backend {
 }
 
 upstream streaming {
+    # Instruct nginx to send connections to the server with the least number of connections
+    # to ensure load is distributed evenly.
+    least_conn;
+
     server 127.0.0.1:4000 fail_timeout=0;
+    # Uncomment these lines for load-balancing multiple instances of streaming for scaling,
+    # this assumes your running the streaming server on ports 4000, 4001, and 4002:
+    # server 127.0.0.1:4001 fail_timeout=0;
+    # server 127.0.0.1:4002 fail_timeout=0;
 }
 
 proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=CACHE:10m inactive=7d max_size=1g;


### PR DESCRIPTION
As of https://github.com/mastodon/mastodon/pull/24655 the streaming service no longer runs multiple processes internally so to scale it, multiple separate instances listening on different ports need to be started. This PR updates the systemd unit file for the streaming service to use templating where the argument is the port on which to listen. Multiple streaming instances can then be started. E.g.:
```bash
systemctl enable --now mastodon-streaming@4000
systemctl enable --now mastodon-streaming@4001
```