### PR TITLE
Update pg to version 1.5.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -490,7 +490,7 @@ GEM
     parslet (2.0.0)
     pastel (0.8.0)
       tty-color (~> 0.5)
-    pg (1.5.2)
+    pg (1.5.3)
     pghero (3.3.3)
       activerecord (>= 6)
     pkg-config (1.5.1)


### PR DESCRIPTION
Includes a change which [silences deprecation warnings](https://github.com/ged/ruby-pg/pull/528) from output.