### PR TITLE
ApplicationHelper spec coverage, unused removal, tiny refactor

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -169,11 +169,11 @@ module ApplicationHelper
   end
 
   def storage_host
-    "https://#{ENV['S3_ALIAS_HOST'].presence || ENV['S3_CLOUDFRONT_HOST']}"
+    URI::HTTPS.build(host: storage_host_name).to_s
   end
 
   def storage_host?
-    ENV['S3_ALIAS_HOST'].present? || ENV['S3_CLOUDFRONT_HOST'].present?
+    storage_host_name.present?
   end
 
   def quote_wrap(text, line_width: 80, break_sequence: "\n")
@@ -230,5 +230,11 @@ module ApplicationHelper
 
   def prerender_custom_emojis(html, custom_emojis, other_options = {})
     EmojiFormatter.new(html, custom_emojis, other_options.merge(animate: prefers_autoplay?)).to_s
+  end
+
+  private
+
+  def storage_host_name
+    ENV.fetch('S3_ALIAS_HOST', nil) || ENV.fetch('S3_CLOUDFRONT_HOST', nil)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,10 +32,6 @@ module ApplicationHelper
     paths.any? { |path| current_page?(path) } ? 'active' : ''
   end
 
-  def active_link_to(label, path, **options)
-    link_to label, path, options.merge(class: active_nav_class(path))
-  end
-
   def show_landing_strip?
     !user_signed_in? && !single_user_mode?
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -123,6 +123,38 @@ describe ApplicationHelper do
     end
   end
 
+  describe 'available_sign_up_path' do
+    context 'when registrations are closed' do
+      before do
+        without_partial_double_verification do
+          allow(Setting).to receive(:registrations_mode).and_return('none')
+        end
+      end
+
+      it 'redirects to joinmastodon site' do
+        expect(helper.available_sign_up_path).to match(/joinmastodon.org/)
+      end
+    end
+
+    context 'when in omniauth only mode' do
+      around do |example|
+        ClimateControl.modify OMNIAUTH_ONLY: 'true' do
+          example.run
+        end
+      end
+
+      it 'redirects to joinmastodon site' do
+        expect(helper.available_sign_up_path).to match(/joinmastodon.org/)
+      end
+    end
+
+    context 'when registrations are allowed' do
+      it 'returns a link to the registration page' do
+        expect(helper.available_sign_up_path).to eq(new_user_registration_path)
+      end
+    end
+  end
+
   describe 'title' do
     around do |example|
       site_title = Setting.site_title

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -181,6 +181,28 @@ describe ApplicationHelper do
     end
   end
 
+  describe 'visibility_icon' do
+    it 'returns a globe icon for a public visible status' do
+      result = helper.visibility_icon Status.new(visibility: 'public')
+      expect(result).to match(/globe/)
+    end
+
+    it 'returns an unlock icon for a unlisted visible status' do
+      result = helper.visibility_icon Status.new(visibility: 'unlisted')
+      expect(result).to match(/unlock/)
+    end
+
+    it 'returns a lock icon for a private visible status' do
+      result = helper.visibility_icon Status.new(visibility: 'private')
+      expect(result).to match(/lock/)
+    end
+
+    it 'returns an at icon for a direct visible status' do
+      result = helper.visibility_icon Status.new(visibility: 'direct')
+      expect(result).to match(/at/)
+    end
+  end
+
   describe 'title' do
     around do |example|
       site_title = Setting.site_title

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -181,6 +181,20 @@ describe ApplicationHelper do
     end
   end
 
+  describe 'quote_wrap' do
+    it 'indents and quote wraps text' do
+      text = <<~TEXT
+        Hello this is a nice message for you to quote.
+        Be careful because it has two lines.
+      TEXT
+
+      expect(helper.quote_wrap(text)).to eq <<~EXPECTED.strip
+        > Hello this is a nice message for you to quote.
+        > Be careful because it has two lines.
+      EXPECTED
+    end
+  end
+
   describe 'storage_host' do
     context 'when S3 alias is present' do
       around do |example|

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -155,6 +155,32 @@ describe ApplicationHelper do
     end
   end
 
+  describe 'omniauth_only?' do
+    context 'when env var is set to true' do
+      around do |example|
+        ClimateControl.modify OMNIAUTH_ONLY: 'true' do
+          example.run
+        end
+      end
+
+      it 'returns true' do
+        expect(helper).to be_omniauth_only
+      end
+    end
+
+    context 'when env var is not set' do
+      around do |example|
+        ClimateControl.modify OMNIAUTH_ONLY: nil do
+          example.run
+        end
+      end
+
+      it 'returns false' do
+        expect(helper).to_not be_omniauth_only
+      end
+    end
+  end
+
   describe 'title' do
     around do |example|
       site_title = Setting.site_title

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -181,6 +181,38 @@ describe ApplicationHelper do
     end
   end
 
+  describe 'storage_host?' do
+    context 'when S3 alias is present' do
+      around do |example|
+        ClimateControl.modify S3_ALIAS_HOST: 's3.alias' do
+          example.run
+        end
+      end
+
+      it 'returns true' do
+        expect(helper.storage_host?).to be true
+      end
+    end
+
+    context 'when S3 cloudfront is present' do
+      around do |example|
+        ClimateControl.modify S3_CLOUDFRONT_HOST: 's3.cloudfront' do
+          example.run
+        end
+      end
+
+      it 'returns true' do
+        expect(helper.storage_host?).to be true
+      end
+    end
+
+    context 'when neither env value is present' do
+      it 'returns false' do
+        expect(helper.storage_host?).to be false
+      end
+    end
+  end
+
   describe 'visibility_icon' do
     it 'returns a globe icon for a public visible status' do
       result = helper.visibility_icon Status.new(visibility: 'public')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -181,6 +181,38 @@ describe ApplicationHelper do
     end
   end
 
+  describe 'storage_host' do
+    context 'when S3 alias is present' do
+      around do |example|
+        ClimateControl.modify S3_ALIAS_HOST: 's3.alias' do
+          example.run
+        end
+      end
+
+      it 'returns true' do
+        expect(helper.storage_host).to eq('https://s3.alias')
+      end
+    end
+
+    context 'when S3 cloudfront is present' do
+      around do |example|
+        ClimateControl.modify S3_CLOUDFRONT_HOST: 's3.cloudfront' do
+          example.run
+        end
+      end
+
+      it 'returns true' do
+        expect(helper.storage_host).to eq('https://s3.cloudfront')
+      end
+    end
+
+    context 'when neither env value is present' do
+      it 'returns false' do
+        expect(helper.storage_host).to eq('https:')
+      end
+    end
+  end
+
   describe 'storage_host?' do
     context 'when S3 alias is present' do
       around do |example|


### PR DESCRIPTION
- Adds specs coverage to some methods which were not hit
- Removes unused active_link_to method
- Small refactor to how asset hosts are checked