### PR TITLE
Fix incorrect box shadow on avatar in thread view 

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1784,7 +1784,6 @@ a.account__display-name {
 .status__avatar {
   width: 46px;
   height: 46px;
-  box-shadow: 0 0 0 2px $ui-base-color;
 }
 
 .muted {


### PR DESCRIPTION
Fixes #24791

I believe the `box-shadow` was added in a misguided attempt to hide the thread line under the avatar. That is actually handled by the `.status__line--full::before` rule. Both rules use a slightly incorrect color in the light theme.