### PR TITLE
Fix UI crash in moderation interface when opening the media modal

### DIFF
--- a/app/javascript/mastodon/features/ui/components/media_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/media_modal.jsx
@@ -3,7 +3,6 @@ import ReactSwipeableViews from 'react-swipeable-views';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
 import Video from 'mastodon/features/video';
-import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { defineMessages, injectIntl } from 'react-intl';
 import IconButton from 'mastodon/components/icon_button';
@@ -19,10 +18,6 @@ const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
   previous: { id: 'lightbox.previous', defaultMessage: 'Previous' },
   next: { id: 'lightbox.next', defaultMessage: 'Next' },
-});
-
-const mapStateToProps = (state, { statusId }) => ({
-  language: state.getIn(['statuses', statusId, 'language']),
 });
 
 class MediaModal extends ImmutablePureComponent {
@@ -133,7 +128,7 @@ class MediaModal extends ImmutablePureComponent {
   };
 
   render () {
-    const { media, language, statusId, intl, onClose } = this.props;
+    const { media, statusId, intl, onClose } = this.props;
     const { navigationHidden } = this.state;
 
     const index = this.getIndex();
@@ -153,7 +148,6 @@ class MediaModal extends ImmutablePureComponent {
             width={width}
             height={height}
             alt={image.get('description')}
-            lang={language}
             key={image.get('url')}
             onClick={this.toggleNavigation}
             zoomButtonHidden={this.state.zoomButtonHidden}
@@ -176,7 +170,6 @@ class MediaModal extends ImmutablePureComponent {
             onCloseVideo={onClose}
             detailed
             alt={image.get('description')}
-            lang={language}
             key={image.get('url')}
           />
         );
@@ -188,7 +181,6 @@ class MediaModal extends ImmutablePureComponent {
             height={height}
             key={image.get('url')}
             alt={image.get('description')}
-            lang={language}
             onClick={this.toggleNavigation}
           />
         );
@@ -256,4 +248,4 @@ class MediaModal extends ImmutablePureComponent {
 
 }
 
-export default connect(mapStateToProps, null, null, { forwardRef: true })(injectIntl(MediaModal));
+export default injectIntl(MediaModal);


### PR DESCRIPTION
A dependency on redux was introduced to the media modal in #23891, but this media modal is used in places were the redux store is not set up, causing the JS to crash.

This commit partially reverts #23891 to remove the media modal's dependency on redux, at the cost of `lang` attributes in that modal.