### PR TITLE
Remove MastodonMap TS type

### DIFF
--- a/app/javascript/types/resources.ts
+++ b/app/javascript/types/resources.ts
@@ -1,4 +1,4 @@
-import type { MastodonMap } from './util';
+import type { Record } from 'immutable';
 
 type AccountValues = {
   id: number;
@@ -6,4 +6,5 @@ type AccountValues = {
   avatar_static: string;
   [key: string]: any;
 };
-export type Account = MastodonMap<AccountValues>;
+
+export type Account = Record<AccountValues>;

--- a/app/javascript/types/util.ts
+++ b/app/javascript/types/util.ts
@@ -1,7 +1,1 @@
-export interface MastodonMap<T> {
-  get<K extends keyof T>(key: K): T[K];
-  has<K extends keyof T>(key: K): boolean;
-  set<K extends keyof T>(key: K, value: T[K]): this;
-}
-
 export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
Accounts are initialized using `fromJS` in `reducers/accounts.js`, which created an ImmutableJS `Record`, so let's use the proper type.

https://github.com/mastodon/mastodon/blob/e38b39194075bec88af2f3a5134137563024d391/app/javascript/mastodon/reducers/accounts.js#L16

@takayamaki can you please review?