### PR TITLE
Fix various edge cases with local moves

### DIFF
--- a/app/models/list_account.rb
+++ b/app/models/list_account.rb
@@ -18,6 +18,7 @@ class ListAccount < ApplicationRecord
   belongs_to :follow_request, optional: true
 
   validates :account_id, uniqueness: { scope: :list_id }
+  validate :validate_relationship
 
   before_validation :set_follow
 
@@ -29,5 +30,13 @@ class ListAccount < ApplicationRecord
     self.follow = Follow.find_by!(account_id: list.account_id, target_account_id: account.id)
   rescue ActiveRecord::RecordNotFound
     self.follow_request = FollowRequest.find_by!(account_id: list.account_id, target_account_id: account.id)
+  end
+
+  def validate_relationship
+    return if list.account_id == account_id
+
+    errors.add(:account_id, 'follow relationship missing') if follow_id.nil? && follow_request_id.nil?
+    errors.add(:follow, 'mismatched accounts') if follow_id.present? && follow.target_account_id != account_id
+    errors.add(:follow_request, 'mismatched accounts') if follow_request_id.present? && follow_request.target_account_id != account_id
   end
 end

--- a/app/services/follow_migration_service.rb
+++ b/app/services/follow_migration_service.rb
@@ -33,6 +33,16 @@ class FollowMigrationService < FollowService
     follow_request
   end
 
+  def change_follow_options!
+    migrate_list_accounts!
+    super
+  end
+
+  def change_follow_request_options!
+    migrate_list_accounts!
+    super
+  end
+
   def direct_follow!
     follow = super
 
@@ -45,6 +55,8 @@ class FollowMigrationService < FollowService
   def migrate_list_accounts!
     ListAccount.where(follow_id: @original_follow.id).includes(:list).find_each do |list_account|
       list_account.list.accounts << @target_account
+    rescue ActiveRecord::RecordInvalid
+      nil
     end
   end
 end

--- a/app/workers/move_worker.rb
+++ b/app/workers/move_worker.rb
@@ -31,6 +31,32 @@ class MoveWorker
   def rewrite_follows!
     num_moved = 0
 
+    # First, approve pending follow requests for the new account,
+    # this allows correctly processing list memberships with pending
+    # follow requests
+    FollowRequest.where(account: @source_account.followers, target_account_id: @target_account.id).find_each do |follow_request|
+      ListAccount.where(follow_id: follow_request.id).includes(:list).find_each do |list_account|
+        list_account.list.accounts << @target_account
+      rescue ActiveRecord::RecordInvalid
+        nil
+      end
+
+      follow_request.authorize!
+    end
+
+    # Then handle accounts that follow both the old and new account
+    @source_account.passive_relationships
+                   .where(account: Account.local)
+                   .where(account: @target_account.followers.local)
+                   .in_batches do |follows|
+      ListAccount.where(follow: follows).includes(:list).find_each do |list_account|
+        list_account.list.accounts << @target_account
+      rescue ActiveRecord::RecordInvalid
+        nil
+      end
+    end
+
+    # Finally, handle the common case of accounts not following the new account
     @source_account.passive_relationships
                    .where(account: Account.local)
                    .where.not(account: @target_account.followers.local)


### PR DESCRIPTION
There were some edge cases with `MoveWorker#rewrite_follows!` even before #24808, but #24808 added some more.

I am not happy with the complexity of `rewrite_follows!`, but using `FollowMigrationService` on each follow relationship may be a bit much, and some changes would be needed to avoid introducing follow notifications on move.