### PR TITLE
Add more detailed type annotation for Account

### DIFF
--- a/app/javascript/types/resources.ts
+++ b/app/javascript/types/resources.ts
@@ -1,10 +1,54 @@
 import type { Record } from 'immutable';
 
-type AccountValues = {
-  id: number;
+type CustomEmoji = Record<{
+  shortcode: string;
+  static_url: string;
+  url: string;
+}>;
+
+type AccountField = Record<{
+  name: string;
+  value: string;
+  verified_at: string | null;
+}>;
+
+type AccountApiResponseValues = {
+  acct: string;
   avatar: string;
   avatar_static: string;
-  [key: string]: any;
+  bot: boolean;
+  created_at: string;
+  discoverable: boolean;
+  display_name: string;
+  emojis: CustomEmoji[];
+  fields: AccountField[];
+  followers_count: number;
+  following_count: number;
+  group: boolean;
+  header: string;
+  header_static: string;
+  id: string;
+  last_status_at: string;
+  locked: boolean;
+  note: string;
+  statuses_count: number;
+  url: string;
+  username: string;
 };
 
-export type Account = Record<AccountValues>;
+type NormalizedAccountField = Record<{
+  name_emojified: string;
+  value_emojified: string;
+  value_plain: string;
+}>;
+
+type NormalizedAccountValues = {
+  display_name_html: string;
+  fields: NormalizedAccountField[];
+  note_emojified: string;
+  note_plain: string;
+};
+
+export type Account = Record<
+  AccountApiResponseValues & NormalizedAccountValues
+>;


### PR DESCRIPTION
This PR adds more detailed type annotation for Account.

- AccountApiResponseValues are based on JSDoc comment from initial_state.js
- NormalizedAccountValues are appended at normalizer.js
  - account.moved may object, however it is reassigned with string. so I pending it.

In the future, it would be good to write API specifications in OpenAPI or JSON schema.
Then we can test the response by [commitee gem](https://github.com/interagent/committee) and we can generate type annotation.