### PR TITLE
Update capistrano config lock version to match bundle

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lock '3.17.1'
+lock '3.17.2'
 
 set :repo_url, ENV.fetch('REPO', 'https://github.com/mastodon/mastodon.git')
 set :branch, ENV.fetch('BRANCH', 'main')


### PR DESCRIPTION
Running `bundle exec cap ...` commands errors out with a mismatch currently.