### PR TITLE
Add version suffixes to nightly & edge image builds

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -57,9 +57,16 @@ jobs:
             type=pep440,pattern=v{{major}}.{{minor}}
             type=ref,event=pr
 
+      - name: Generate version suffix
+        id: version_vars
+        if: github.repository == 'mastodon/mastodon' && github.event_name == 'push' && github.ref_name == 'main'
+        run: |
+          echo mastodon_version_suffix=\"+edge-$(git rev-parse --short HEAD)\" >> $GITHUB_OUTPUT
+
       - uses: docker/build-push-action@v4
         with:
           context: .
+          build-args: MASTODON_VERSION_SUFFIX=${{ steps.version_vars.outputs.mastodon_version_suffix }}
           platforms: linux/amd64,linux/arm64
           provenance: false
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -41,9 +41,15 @@ jobs:
           labels: |
             org.opencontainers.image.description=Nightly build image used for testing purposes
 
+      - name: Generate version suffix
+        id: version_vars
+        run: |
+          echo mastodon_version_suffix=\"+nightly-$(date +'%Y%m%d')\" >> $GITHUB_OUTPUT
+
       - uses: docker/build-push-action@v4
         with:
           context: .
+          build-args: MASTODON_VERSION_SUFFIX=${{ steps.version_vars.outputs.mastodon_version_suffix }}
           platforms: linux/amd64,linux/arm64
           provenance: false
           builder: ${{ steps.buildx.outputs.name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@
 # This needs to be bullseye-slim because the Ruby image is built on bullseye-slim
 ARG NODE_VERSION="16.20-bullseye-slim"
 
+# Use those args to specify your own version flags & suffixes
+ARG MASTODON_VERSION_FLAGS=""
+ARG MASTODON_VERSION_SUFFIX=""
+
 FROM ghcr.io/moritzheiber/ruby-jemalloc:3.2.2-slim as ruby
 FROM node:${NODE_VERSION} as build
 
@@ -84,7 +88,9 @@ COPY --chown=mastodon:mastodon --from=build /opt/mastodon /opt/mastodon
 ENV RAILS_ENV="production" \
     NODE_ENV="production" \
     RAILS_SERVE_STATIC_FILES="true" \
-    BIND="0.0.0.0"
+    BIND="0.0.0.0" \
+    MASTODON_VERSION_FLAGS="${MASTODON_VERSION_FLAGS}" \
+    MASTODON_VERSION_SUFFIX="${MASTODON_VERSION_SUFFIX}"
 
 # Set the run user
 USER mastodon

--- a/lib/mastodon/version.rb
+++ b/lib/mastodon/version.rb
@@ -17,11 +17,11 @@ module Mastodon
     end
 
     def flags
-      ''
+      ENV.fetch('MASTODON_VERSION_FLAGS', '')
     end
 
     def suffix
-      ''
+      ENV.fetch('MASTODON_VERSION_SUFFIX', '')
     end
 
     def to_a


### PR DESCRIPTION
This has 4 main changes:
- Allows Mastodon version suffixes & flags to be set from environment variables
- Allows those environment variables to be set from Docker build args when building a container image
- Set the version suffix to `+nightly-YYMMDD` when building a nightly image using Github actions
- Set the version suffix to `+edge-<short-commit-sha>` when building an edge image (push on `main` branch)

I went with the env variable route as it was the cleanest way to make it work with the docker build.

Pros: 
- Code changes are small
- No file patch, less risks of breaking
- Easy for people to use their own flags/suffixes for their custom build

Cons:
- Version is not tied to the build, if somebody runs the image with another value for the env variable, then it will change the displayed version

Alternatives are:
- Patching the `version.rb` file before copying it to the Docker image. This is risky
- Loading a custom Ruby file that monkey patches `Version#flags` and `Version#suffix`, not sure how to properly do it
- Read `tags` and `suffix` from a file, if present. Those files could be written by the Dockerfile, ensuring immutability