### PR TITLE
Spec coverage for settings/preferences/* controllers

### DIFF
--- a/app/controllers/settings/preferences/appearance_controller.rb
+++ b/app/controllers/settings/preferences/appearance_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Settings::Preferences::AppearanceController < Settings::PreferencesController
+class Settings::Preferences::AppearanceController < Settings::Preferences::BaseController
   private
 
   def after_update_redirect_path

--- a/app/controllers/settings/preferences/base_controller.rb
+++ b/app/controllers/settings/preferences/base_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Settings::PreferencesController < Settings::BaseController
+class Settings::Preferences::BaseController < Settings::BaseController
   def show; end
 
   def update

--- a/app/controllers/settings/preferences/base_controller.rb
+++ b/app/controllers/settings/preferences/base_controller.rb
@@ -15,7 +15,7 @@ class Settings::Preferences::BaseController < Settings::BaseController
   private
 
   def after_update_redirect_path
-    settings_preferences_path
+    raise 'Override in controller'
   end
 
   def user_params

--- a/app/controllers/settings/preferences/notifications_controller.rb
+++ b/app/controllers/settings/preferences/notifications_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Settings::Preferences::NotificationsController < Settings::PreferencesController
+class Settings::Preferences::NotificationsController < Settings::Preferences::BaseController
   private
 
   def after_update_redirect_path

--- a/app/controllers/settings/preferences/other_controller.rb
+++ b/app/controllers/settings/preferences/other_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Settings::Preferences::OtherController < Settings::PreferencesController
+class Settings::Preferences::OtherController < Settings::Preferences::BaseController
   private
 
   def after_update_redirect_path

--- a/spec/controllers/settings/preferences/appearance_controller_spec.rb
+++ b/spec/controllers/settings/preferences/appearance_controller_spec.rb
@@ -31,5 +31,11 @@ describe Settings::Preferences::AppearanceController do
 
       expect(response).to redirect_to(settings_preferences_appearance_path)
     end
+
+    it 'renders show on failure' do
+      put :update, params: { user: { locale: 'fake option' } }
+
+      expect(response).to render_template('preferences/appearance/show')
+    end
   end
 end

--- a/spec/controllers/settings/preferences/base_controller_spec.rb
+++ b/spec/controllers/settings/preferences/base_controller_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Settings::Preferences::BaseController do
+  describe 'after_update_redirect_path' do
+    it 'raises error when called' do
+      expect { described_class.new.send(:after_update_redirect_path) }.to raise_error(/Override/)
+    end
+  end
+end


### PR DESCRIPTION
Gets this block of `settings/preferences` controllers to 100% C0 coverage.

While in there, renamed what used to be an accessible controller but is now just a base class to reflect that.