### PR TITLE
Add sassc to Gemfile to prevent compilation errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'thor', '~> 1.2'
 gem 'rack', '~> 2.2.7'
 
 gem 'haml-rails', '~>2.0'
+gem 'sassc', '~> 2.4'
 gem 'pg', '~> 1.5'
 gem 'makara', '~> 0.5'
 gem 'pghero'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -644,6 +644,8 @@ GEM
     sanitize (6.0.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     scenic (1.7.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
@@ -879,6 +881,7 @@ DEPENDENCIES
   ruby-progressbar (~> 1.13)
   rubyzip (~> 2.3)
   sanitize (~> 6.0)
+  sassc (~> 2.4)
   scenic (~> 1.7)
   sidekiq (~> 6.5)
   sidekiq-bulk (~> 0.2.0)
@@ -901,3 +904,9 @@ DEPENDENCIES
   webpacker (~> 5.4)
   webpush!
   xorcist (~> 1.1)
+
+RUBY VERSION
+   ruby 3.2.2p53
+
+BUNDLED WITH
+   2.4.12


### PR DESCRIPTION
On current `main`, `RAILS_ENV=development bundle exec rails s` fails to start due to missing sassc, previously it didn't fail on commit 49fad26ecaf3f6251b20140dfa323bd945733eff, but checking changes to the Gemfile between that commit and main, and I can't see anything that'd cause this error.

I've also committed the `RUBY VERSION` and `BUNDLED WITH` sections in the `Gemfile.lock` as to ensure that a clean install on main does not result in a dirty `Gemfile.lock` (it seems these are always added), the versions listed are inline with the latest bundler release and `.ruby-version`.