### PR TITLE
Fix Back button going outside the app

### DIFF
--- a/app/javascript/mastodon/components/column_back_button.jsx
+++ b/app/javascript/mastodon/components/column_back_button.jsx
@@ -21,7 +21,10 @@ export default class ColumnBackButton extends React.PureComponent {
 
     if (onClick) {
       onClick();
-    } else if (window.history && window.history.state) {
+    } 
+    // Check if there is pervious page in the app to go back to per https://stackoverflow.com/a/70532858/9703201
+    // When upgrading to V6, check location.key !== 'default' instead per https://github.com/remix-run/history/blob/main/docs/api-reference.md#location
+    else if (router.location.key) {
       router.history.goBack();
     } else {
       router.history.push('/');

--- a/app/javascript/mastodon/components/column_back_button.jsx
+++ b/app/javascript/mastodon/components/column_back_button.jsx
@@ -22,8 +22,8 @@ export default class ColumnBackButton extends React.PureComponent {
     if (onClick) {
       onClick();
     } 
-    // Check if there is pervious page in the app to go back to per https://stackoverflow.com/a/70532858/9703201
-    // When upgrading to V6, check location.key !== 'default' instead per https://github.com/remix-run/history/blob/main/docs/api-reference.md#location
+    // Check if there is a previous page in the app to go back to per https://stackoverflow.com/a/70532858/9703201
+    // When upgrading to V6, check `location.key !== 'default'` instead per https://github.com/remix-run/history/blob/main/docs/api-reference.md#location
     else if (router.location.key) {
       router.history.goBack();
     } else {


### PR DESCRIPTION
This fixes the case of clicking Back when coming from another site that linked to a Mastodon post taking you back to that site instead of to Mastodon's main feed. For an example, look at https://news.ycombinator.com/item?id=35810902 and visit the Mastodon post, and then click Back and end up back on the Hacker News post.