### PR TITLE
Fail ESLint for Warnings in CI

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -48,7 +48,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: ESLint
-        run: yarn test:lint:js
+        run: yarn test:lint:js --max-warnings 0
 
       - name: Typecheck
         run: yarn test:typecheck

--- a/app/javascript/mastodon/components/column_back_button.jsx
+++ b/app/javascript/mastodon/components/column_back_button.jsx
@@ -21,10 +21,9 @@ export default class ColumnBackButton extends React.PureComponent {
 
     if (onClick) {
       onClick();
-    } 
     // Check if there is a previous page in the app to go back to per https://stackoverflow.com/a/70532858/9703201
     // When upgrading to V6, check `location.key !== 'default'` instead per https://github.com/remix-run/history/blob/main/docs/api-reference.md#location
-    else if (router.location.key) {
+    } else if (router.location.key) {
       router.history.goBack();
     } else {
       router.history.push('/');


### PR DESCRIPTION
Last PR added a very minor warning, but it would start to show up in subsequent PRs.
I changed the CI so the ESLint job will fail for any warnings, so they can either be accepted by adding an `eslint-disable` or fixed before landing