### PR TITLE
Add per-test timeouts to AutoStatusesCleanupScheduler tests

### DIFF
--- a/spec/workers/scheduler/accounts_statuses_cleanup_scheduler_spec.rb
+++ b/spec/workers/scheduler/accounts_statuses_cleanup_scheduler_spec.rb
@@ -75,6 +75,12 @@ describe Scheduler::AccountsStatusesCleanupScheduler do
   end
 
   describe '#perform' do
+    around do |example|
+      Timeout.timeout(30) do
+        example.run
+      end
+    end
+
     before do
       # Policies for the accounts
       Fabricate(:account_statuses_cleanup_policy, account: account1)


### PR DESCRIPTION
There was previously an infinite loop in that part of the code, fixed by #24840