### PR TITLE
Change default setting to block DMs from non-followed

### DIFF
--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -48,7 +48,7 @@ class UserSettings
   namespace :interactions do
     setting :must_be_follower, default: false
     setting :must_be_following, default: false
-    setting :must_be_following_dm, default: false
+    setting :must_be_following_dm, default: true
   end
 
   def initialize(original_hash)


### PR DESCRIPTION
I don’t think we should have open DMs by default. This changes that for new accounts. This is the default setting on all other platforms. 