### PR TITLE
Fix uncaught `ActiveRecord::StatementInvalid` in Mastodon::IpBlocksCLI

### DIFF
--- a/lib/mastodon/ip_blocks_cli.rb
+++ b/lib/mastodon/ip_blocks_cli.rb
@@ -36,6 +36,12 @@ module Mastodon
       failed    = 0
 
       addresses.each do |address|
+        unless valid_ip_address?(address)
+          say("#{address} is invalid", :red)
+          failed += 1
+          next
+        end
+
         ip_block = IpBlock.find_by(ip: address)
 
         if ip_block.present? && !options[:force]
@@ -79,6 +85,12 @@ module Mastodon
       skipped   = 0
 
       addresses.each do |address|
+        unless valid_ip_address?(address)
+          say("#{address} is invalid", :yellow)
+          skipped += 1
+          next
+        end
+
         ip_blocks = if options[:force]
                       IpBlock.where('ip >>= ?', address)
                     else
@@ -125,6 +137,13 @@ module Mastodon
       else
         :red
       end
+    end
+
+    def valid_ip_address?(ip_address)
+      IPAddr.new(ip_address)
+      true
+    rescue IPAddr::InvalidAddressError
+      false
     end
   end
 end


### PR DESCRIPTION
Fix #24860.

I've kept the current behavior of skipping execution when something is wrong with one of the given IP addresses, instead of exiting with a failure.

In `#add`, I'm not sure if the best would be to count an invalid IP address as `skipped` or `failed`.