### PR TITLE
Make it possible to upload audio and video to Heroku app

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,1 +1,1 @@
-LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/app/.apt/lib/x86_64-linux-gnu:/app/.apt/usr/lib/x86_64-linux-gnu/mesa:/app/.apt/usr/lib/x86_64-linux-gnu/pulseaudio
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/app/.apt/lib/x86_64-linux-gnu:/app/.apt/usr/lib/x86_64-linux-gnu/mesa:/app/.apt/usr/lib/x86_64-linux-gnu/pulseaudio:/app/.apt/usr/lib/x86_64-linux-gnu/openblas-pthread

--- a/Aptfile
+++ b/Aptfile
@@ -1,4 +1,5 @@
 ffmpeg
+libopenblas0-pthread
 libpq-dev
 libxdamage1
 libxfixes3

--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -15,7 +15,8 @@ class Api::V1::MediaController < Api::BaseController
     render json: @media_attachment, serializer: REST::MediaAttachmentSerializer
   rescue Paperclip::Errors::NotIdentifiedByImageMagickError
     render json: file_type_error, status: 422
-  rescue Paperclip::Error
+  rescue Paperclip::Error => e
+    Rails.logger.error "#{e.class}: #{e.message}"
     render json: processing_error, status: 500
   end
 

--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -6,7 +6,8 @@ class Api::V2::MediaController < Api::V1::MediaController
     render json: @media_attachment, serializer: REST::MediaAttachmentSerializer, status: @media_attachment.not_processed? ? 202 : 200
   rescue Paperclip::Errors::NotIdentifiedByImageMagickError
     render json: file_type_error, status: 422
-  rescue Paperclip::Error
+  rescue Paperclip::Error => e
+    Rails.logger.error "#{e.class}: #{e.message}"
     render json: processing_error, status: 500
   end
 end


### PR DESCRIPTION
Add libopenblas0-pthread needed for the ffprobe command on Heroku-22 Stack. Without the package, the command errors:

```
ffprobe: error while loading shared libraries: libblas.so.3: cannot open shared object file: No such file or directory
```

Also, log Paperclip errors for easier debug in the future. Without libopenblas0-pthread, uploading an audio or video attachemnt leaves the log like the below:

```
Paperclip::Errors::CommandNotFoundError: Could not run the `ffprobe` command. Please install ffmpeg.
```