### PR TITLE
Remove usage of random sample values in specs

### DIFF
--- a/spec/controllers/auth/registrations_controller_spec.rb
+++ b/spec/controllers/auth/registrations_controller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Auth::RegistrationsController do
   end
 
   describe 'POST #create' do
-    let(:accept_language) { Rails.application.config.i18n.available_locales.sample.to_s }
+    let(:accept_language) { 'de' }
 
     before do
       session[:registration_form_time] = 5.seconds.ago

--- a/spec/fabricators/notification_fabricator.rb
+++ b/spec/fabricators/notification_fabricator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Fabricator(:notification) do
-  activity fabricator: [:mention, :status, :follow, :follow_request, :favourite].sample
+  activity fabricator: :status
   account
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NotificationMailer do
 
   shared_examples 'localized subject' do |*args, **kwrest|
     it 'renders subject localized for the locale of the receiver' do
-      locale = %i(de en).sample
+      locale = :de
       receiver.update!(locale: locale)
       expect(mail.subject).to eq I18n.t(*args, **kwrest.merge(locale: locale))
     end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -7,7 +7,7 @@ describe UserMailer do
 
   shared_examples 'localized subject' do |*args, **kwrest|
     it 'renders subject localized for the locale of the receiver' do
-      locale = I18n.available_locales.sample
+      locale = :de
       receiver.update!(locale: locale)
       expect(mail.subject).to eq I18n.t(*args, **kwrest.merge(locale: locale))
     end


### PR DESCRIPTION
This leads to unrelated intermittent spec failures when a locale gets selected which doesn't have a full translation and causes a view rendering to fail.

Example failure run: https://github.com/mastodon/mastodon/actions/runs/4888044572/jobs/8725358720?pr=24241