### PR TITLE
Add ability to block sign-ups from IP using the CLI

### DIFF
--- a/lib/mastodon/ip_blocks_cli.rb
+++ b/lib/mastodon/ip_blocks_cli.rb
@@ -11,7 +11,7 @@ module Mastodon
       true
     end
 
-    option :severity, required: true, enum: %w(no_access sign_up_requires_approval), desc: 'Severity of the block'
+    option :severity, required: true, enum: %w(no_access sign_up_requires_approval sign_up_block), desc: 'Severity of the block'
     option :comment, aliases: [:c], desc: 'Optional comment'
     option :duration, aliases: [:d], type: :numeric, desc: 'Duration of the block in seconds'
     option :force, type: :boolean, aliases: [:f], desc: 'Overwrite existing blocks'


### PR DESCRIPTION
#19037 introduced the ability to block sign-ups from a specified IP address. However, only `sign_up_requires_approval` and `no_access`  blocks were available for the CLI.

This PR adds the ability to block IP addresses with the `sign_up_block` severity using the CLI.