### PR TITLE
Clean up unused application records

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -524,6 +524,7 @@ RSpec/LetSetup:
     - 'spec/controllers/oauth/tokens_controller_spec.rb'
     - 'spec/controllers/settings/imports_controller_spec.rb'
     - 'spec/lib/activitypub/activity/delete_spec.rb'
+    - 'spec/lib/vacuum/applications_vacuum_spec.rb'
     - 'spec/lib/vacuum/preview_cards_vacuum_spec.rb'
     - 'spec/models/account_spec.rb'
     - 'spec/models/account_statuses_cleanup_policy_spec.rb'

--- a/app/lib/application_extension.rb
+++ b/app/lib/application_extension.rb
@@ -4,6 +4,8 @@ module ApplicationExtension
   extend ActiveSupport::Concern
 
   included do
+    has_many :created_users, class_name: 'User', foreign_key: 'created_by_application_id', inverse_of: :created_by_application
+
     validates :name, length: { maximum: 60 }
     validates :website, url: true, length: { maximum: 2_000 }, if: :website?
     validates :redirect_uri, length: { maximum: 2_000 }

--- a/app/lib/vacuum/applications_vacuum.rb
+++ b/app/lib/vacuum/applications_vacuum.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Vacuum::ApplicationsVacuum
+  def perform
+    Doorkeeper::Application.where(owner_id: nil)
+                           .where.missing(:created_users, :access_tokens, :access_grants)
+                           .where(created_at: ...1.day.ago)
+                           .in_batches.delete_all
+  end
+end

--- a/app/workers/scheduler/vacuum_scheduler.rb
+++ b/app/workers/scheduler/vacuum_scheduler.rb
@@ -22,6 +22,7 @@ class Scheduler::VacuumScheduler
       preview_cards_vacuum,
       backups_vacuum,
       access_tokens_vacuum,
+      applications_vacuum,
       feeds_vacuum,
       imports_vacuum,
     ]
@@ -53,6 +54,10 @@ class Scheduler::VacuumScheduler
 
   def imports_vacuum
     Vacuum::ImportsVacuum.new
+  end
+
+  def applications_vacuum
+    Vacuum::ApplicationsVacuum.new
   end
 
   def content_retention_policy

--- a/spec/lib/vacuum/applications_vacuum_spec.rb
+++ b/spec/lib/vacuum/applications_vacuum_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Vacuum::ApplicationsVacuum do
+  subject { described_class.new }
+
+  describe '#perform' do
+    let!(:app1) { Fabricate(:application, created_at: 1.month.ago) }
+    let!(:app2) { Fabricate(:application, created_at: 1.month.ago) }
+    let!(:app3) { Fabricate(:application, created_at: 1.month.ago) }
+    let!(:app4) { Fabricate(:application, created_at: 1.month.ago, owner: Fabricate(:user)) }
+    let!(:app5) { Fabricate(:application, created_at: 1.month.ago) }
+    let!(:app6) { Fabricate(:application, created_at: 1.hour.ago) }
+
+    let!(:active_access_token) { Fabricate(:access_token, application: app1) }
+    let!(:active_access_grant) { Fabricate(:access_grant, application: app2) }
+    let!(:user) { Fabricate(:user, created_by_application: app3) }
+
+    before do
+      subject.perform
+    end
+
+    it 'does not delete applications with valid access tokens' do
+      expect { app1.reload }.to_not raise_error
+    end
+
+    it 'does not delete applications with valid access grants' do
+      expect { app2.reload }.to_not raise_error
+    end
+
+    it 'does not delete applications that were used to create users' do
+      expect { app3.reload }.to_not raise_error
+    end
+
+    it 'does not delete owned applications' do
+      expect { app4.reload }.to_not raise_error
+    end
+
+    it 'does not delete applications registered less than a day ago' do
+      expect { app6.reload }.to_not raise_error
+    end
+
+    it 'deletes unused applications' do
+      expect { app5.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+end


### PR DESCRIPTION
Clean up OAuth application records older than one day that cannot be associated with any user, that is, if all of these apply:
- they were not created from the “Development” tab (`/settings/applications`) by a logged-in user
- they were not used to register a user (app sign-up)
- they currently have no valid access grant or access token

Client apps should largely be unaffected, as the usual flow is to register an app immediately before letting a user sign in or sign up.

:warning: However, this may break client apps that store client secrets and reuse them across accounts, if they do not properly handle being invalidated.