### PR TITLE
Fix import data field type

### DIFF
--- a/app/views/settings/imports/index.html.haml
+++ b/app/views/settings/imports/index.html.haml
@@ -7,7 +7,7 @@
 
   .fields-row
     .fields-group.fields-row__column.fields-row__column-6
-      = f.input :data, wrapper: :with_block_label, hint: t('simple_form.hints.imports.data')
+      = f.input :data, as: :file, wrapper: :with_block_label, hint: t('simple_form.hints.imports.data')
     .fields-group.fields-row__column.fields-row__column-6
       = f.input :mode, as: :radio_buttons, collection: Import::MODES, label_method: ->(mode) { safe_join([I18n.t("imports.modes.#{mode}"), content_tag(:span, I18n.t("imports.modes.#{mode}_long"), class: 'hint')]) }, collection_wrapper_tag: 'ul', item_wrapper_tag: 'li'
 


### PR DESCRIPTION
The import field to attaching CSV file appears as `type="text"` now. So I added a haml-expression to specify `type="file"`.

|Before|After|
|-|-|
|![Screenshot before](https://user-images.githubusercontent.com/5103195/236498178-ca7be199-47f9-4e16-98eb-b372bcc753c2.png)|![Screenshot after](https://user-images.githubusercontent.com/5103195/236501660-e2458c98-46b1-43ba-b52e-469b4ff4b0cb.png)|
