### PR TITLE
Use released version 4.1.0 of devise-two-factor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,10 +30,7 @@ gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
 gem 'chewy', '~> 7.3'
 gem 'devise', '~> 4.9'
-# The below `v4.x` branch allows attr_encrypted 4.x, which is required for Rails 7.
-# Once a new gem version is pushed, we can go back to released gem and off of github branch.
-gem 'devise-two-factor', github: 'tinfoil/devise-two-factor', branch: 'v4.x'
-gem 'attr_encrypted', '~> 4.0'
+gem 'devise-two-factor', '~> 4.1'
 
 group :pam_authentication, optional: true do
   gem 'devise_pam_authenticatable2', '~> 9.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,18 +27,6 @@ GIT
     rails-settings-cached (0.6.6)
       rails (>= 4.2.0)
 
-GIT
-  remote: https://github.com/tinfoil/devise-two-factor.git
-  revision: e685f91ce62d036259885fbe31fcb4fa930bcfcb
-  branch: v4.x
-  specs:
-    devise-two-factor (4.0.2)
-      activesupport (< 7.1)
-      attr_encrypted (>= 1.3, < 5, != 2)
-      devise (~> 4.0)
-      railties (< 7.1)
-      rotp (~> 6.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -218,6 +206,12 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-two-factor (4.1.0)
+      activesupport (< 7.1)
+      attr_encrypted (>= 1.3, < 5, != 2)
+      devise (~> 4.0)
+      railties (< 7.1)
+      rotp (~> 6.0)
     devise_pam_authenticatable2 (9.2.0)
       devise (>= 4.0.0)
       rpam2 (~> 4.0)
@@ -776,7 +770,6 @@ DEPENDENCIES
   active_model_serializers (~> 0.10)
   addressable (~> 2.8)
   annotate (~> 3.2)
-  attr_encrypted (~> 4.0)
   aws-sdk-s3 (~> 1.120)
   better_errors (~> 2.9)
   binding_of_caller (~> 1.0)
@@ -798,7 +791,7 @@ DEPENDENCIES
   concurrent-ruby
   connection_pool
   devise (~> 4.9)
-  devise-two-factor!
+  devise-two-factor (~> 4.1)
   devise_pam_authenticatable2 (~> 9.2)
   discard (~> 1.2)
   doorkeeper (~> 5.6)


### PR DESCRIPTION
This gem version has been actually released now - https://github.com/tinfoil/devise-two-factor/commit/d1310afaef24f265ddac0f6f261cbd394fb3273d - and pushed to rubygems. We can rely on release version instead of github branch.

I also removed the explicit bundling of `attr_encrypted` (I had added it as part of rails 7 WIP, but its pulled in by devise-two-factor as a dep).

After this is in, I'll rebase my rails 7 branch and comment again over there with outstanding items.