### PR TITLE
Add TypeScript support for `mastodon` alias and image imports

### DIFF
--- a/app/javascript/mastodon/components/hashtag.jsx
+++ b/app/javascript/mastodon/components/hashtag.jsx
@@ -5,9 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Link } from 'react-router-dom';
-// @ts-expect-error
 import ShortNumber from 'mastodon/components/short_number';
-// @ts-expect-error
 import Skeleton from 'mastodon/components/skeleton';
 import classNames from 'classnames';
 

--- a/app/javascript/types/image.d.ts
+++ b/app/javascript/types/image.d.ts
@@ -1,0 +1,34 @@
+declare module '*.avif' {
+  const path: string;
+  export default path;
+}
+
+declare module '*.gif' {
+  const path: string;
+  export default path;
+}
+
+declare module '*.jpg' {
+  const path: string;
+  export default path;
+}
+
+declare module '*.jpg' {
+  const path: string;
+  export default path;
+}
+
+declare module '*.png' {
+  const path: string;
+  export default path;
+}
+
+declare module '*.svg' {
+  const path: string;
+  export default path;
+}
+
+declare module '*.webp' {
+  const path: string;
+  export default path;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,9 @@
       "mastodon/*": ["app/javascript/mastodon/*"]
     }
   },
-  "include": ["app/javascript/mastodon", "app/javascript/packs"]
+  "include": [
+    "app/javascript/mastodon",
+    "app/javascript/packs",
+    "app/javascript/types"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,12 @@
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": "./",
+    "paths": {
+      "mastodon": ["app/javascript/mastodon"],
+      "mastodon/*": ["app/javascript/mastodon/*"]
+    }
   },
   "include": ["app/javascript/mastodon", "app/javascript/packs"]
 }


### PR DESCRIPTION
This PR adds TypeScript support for the `mastodon` alias used throughout the codebase. By updating the `tsconfig.json` configuration, TypeScript can now resolve the alias correctly.

In addition, due to the changes in the import statements for images, I've added the necessary type declarations for various image formats (e.g., `.jpg`, `.png`, `.svg`, etc.) to avoid any type errors.

Here is a summary of the changes included in this PR:

1. Updated `tsconfig.json` to add the `mastodon` alias and its corresponding path.
2. Added type declarations for image formats to ensure proper handling during import.

With these changes, the project should now be fully compatible with TypeScript for the `mastodon` alias and image imports.

Please let me know if there are any concerns or if you require any additional changes.