### PR TITLE
Introduce statsd host and port vars

### DIFF
--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
-if ENV['STATSD_ADDR'].present?
-  host, port = ENV['STATSD_ADDR'].split(':')
+if ENV.key?('STATSD_ADDR')
+  statsd_host, _, statsd_port = ENV.fetch('STATSD_ADDR', nil).rpartition(':')
+else
+  statsd_host = ENV.fetch('STATSD_HOST', nil)
+  statsd_port = ENV.fetch('STATSD_PORT', nil)
+end
 
-  $statsd = ::Statsd.new(host, port)
+if statsd_host.is_a?(String) && statsd_port.is_a?(String)
+  $statsd = ::Statsd.new(statsd_host, statsd_port)
   $statsd.namespace = ENV.fetch('STATSD_NAMESPACE') { ['Mastodon', Rails.env].join('.') }
 
   ::NSA.inform_statsd($statsd) do |informant|


### PR DESCRIPTION
Currently, we cannot use `[::1]:9125` as the StatsD address for Mastodon since Mastodon cannot parse it correctly.
This PR resolves it by direct passing the host and port.

Alternatively, we can fix the parsing method for `STATSD_ADDR` same as socket addresses, but it may cause confusion when we use domain names including `[]`.