### PR TITLE
Make Webpack fail on failed imports

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -64,6 +64,7 @@ module.exports = {
 
   module: {
     rules: Object.keys(rules).map(key => rules[key]),
+    strictExportPresence: true,
   },
 
   plugins: [


### PR DESCRIPTION
Previously, when we tried to import a default import that was not declared, Webpack displayed a warning but continued building.

Now, this will fail the build.

For example, if moving `loadPolyfills` from a default export to a named import, this code:

```
import { loadPolyfills } from `mastodon/load_polyfills
```

Makes the Webpack build fail with:

```
ERROR in ./app/javascript/packs/public.jsx 5:259-272
"export 'default' (imported as 'loadPolyfills') was not found in '../mastodon/load_polyfills'
```

Previously this was only displayed as a warning, and lots in the Webpack's output.

Fixes #24813