### PR TITLE
Fix wrong documentation link

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -157,7 +157,7 @@ Metrics/MethodLength:
     - 'lib/mastodon/*_cli.rb'
 
 # Reason:
-# https://docs.rubocop.org/rubocop/cops_style.html#stylerescuestandarderror
+# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmodulelength
 Metrics/ModuleLength:
   CountAsOne: [array, heredoc]
 


### PR DESCRIPTION
I found a wrong documentation link for `Metrics/ModuleLength` in `.rubocop.yml`.

```diff
# Reason:
-# https://docs.rubocop.org/rubocop/cops_style.html#stylerescuestandarderror
+# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmodulelength
Metrics/ModuleLength:
  CountAsOne: [array, heredoc]
```

It was introduced in https://github.com/mastodon/mastodon/commit/1f19d5e5e84731f781e13e4cedab386c294bee2f#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cR156-R157.