### PR TITLE
Remove unused iOS agent sniffing function

### DIFF
--- a/app/javascript/mastodon/is_mobile.ts
+++ b/app/javascript/mastodon/is_mobile.ts
@@ -16,10 +16,6 @@ export const layoutFromWindow = (): LayoutType => {
   }
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error
-const iOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && window.MSStream != null;
-
 const listenerOptions = supportsPassiveEvents ? { passive: true } : false;
 
 let userTouching = false;
@@ -33,5 +29,3 @@ const touchListener = () => {
 window.addEventListener('touchstart', touchListener, listenerOptions);
 
 export const isUserTouching = () => userTouching;
-
-export const isIOS = () => iOS;


### PR DESCRIPTION
As per @ClearlyClaire's comment (https://github.com/mastodon/mastodon/pull/23631#issuecomment-1539845318)

Extracted from @nshonni's work here: #23631

