### PR TITLE
Disable RTK safety middlewares

### DIFF
--- a/app/javascript/mastodon/store/index.ts
+++ b/app/javascript/mastodon/store/index.ts
@@ -8,7 +8,21 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 export const store = configureStore({
   reducer: rootReducer,
   middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware()
+    getDefaultMiddleware({
+      // In development, Redux Toolkit enables 2 default middlewares to detect
+      // common issues with states. Unfortunately, our use of ImmutableJS for state
+      // triggers both, so lets disable them until our state is fully refactored
+
+      // https://redux-toolkit.js.org/api/serializabilityMiddleware
+      // This checks recursively that every values in the state are serializable in JSON
+      // Which is not the case, as we use ImmutableJS structures, but also File objects
+      serializableCheck: false,
+
+      // https://redux-toolkit.js.org/api/immutabilityMiddleware
+      // This checks recursively if every value in the state is immutable (ie, a JS primitive type)
+      // But this is not the case, as our Root State is an ImmutableJS map, which is an object
+      immutableCheck: false,
+    })
       .concat(
         loadingBarMiddleware({
           promiseTypeSuffixes: ['REQUEST', 'SUCCESS', 'FAIL'],


### PR DESCRIPTION
In development, Redux Toolkit enables 2 default middlewares to detect common issues with states. Unfortunately, our use of ImmutableJS for state triggers both, so lets disable them until our state is fully refactored.

- [`serializableCheck`](https://redux-toolkit.js.org/api/serializabilityMiddleware): this checks recursively that every values in the state are serializable in JSON, which is not the case, as we use ImmutableJS structures, but also File objects

- [`immutabilityCheck`](https://redux-toolkit.js.org/api/immutabilityMiddleware): this checks recursively if every value in the state is immutable (ie, a JS primitive type), but this is not the case as our Root State is an ImmutableJS map, which is an object