### PR TITLE
Fix videos being improperly positioned on safari

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6447,13 +6447,6 @@ a.status-card.compact:hover {
   &--wide {
     grid-column: span 2;
   }
-
-  &.standalone {
-    .media-gallery__item-gifv-thumbnail {
-      transform: none;
-      top: 0;
-    }
-  }
 }
 
 .media-gallery__item-thumbnail {
@@ -6501,11 +6494,7 @@ a.status-card.compact:hover {
   cursor: zoom-in;
   height: 100%;
   object-fit: cover;
-  position: relative;
-  top: 50%;
-  transform: translateY(-50%);
   width: 100%;
-  z-index: 1;
 }
 
 .media-gallery__item-thumbnail-label {
@@ -6604,6 +6593,8 @@ a.status-card.compact:hover {
   border-radius: 4px;
   box-sizing: border-box;
   color: $white;
+  display: flex;
+  align-items: center;
 
   &.editable {
     border-radius: 0;
@@ -6638,9 +6629,6 @@ a.status-card.compact:hover {
   &.inline {
     video {
       object-fit: contain;
-      position: relative;
-      top: 50%;
-      transform: translateY(-50%);
     }
   }
 


### PR DESCRIPTION
`top: 50%` did not work reliably on Safari whenever the container height's was a result of using `aspect-ratio`.

Instead, use flexbox's `align-items: center`, which seems to work everywhere.