### PR TITLE
Fix uncaught NoMethodError error in `/api/v1/admin/canonical_email_blocks/test`

### DIFF
--- a/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
@@ -58,6 +58,8 @@ class Api::V1::Admin::CanonicalEmailBlocksController < Api::BaseController
   end
 
   def set_canonical_email_blocks_from_test
+    raise(Mastodon::ValidationError, "Email can't be blank") if params[:email].blank?
+
     @canonical_email_blocks = CanonicalEmailBlock.matching_email(params[:email])
   end
 

--- a/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
@@ -58,9 +58,7 @@ class Api::V1::Admin::CanonicalEmailBlocksController < Api::BaseController
   end
 
   def set_canonical_email_blocks_from_test
-    params.require(:email)
-
-    @canonical_email_blocks = CanonicalEmailBlock.matching_email(params[:email])
+    @canonical_email_blocks = CanonicalEmailBlock.matching_email(params.require(:email))
   end
 
   def set_canonical_email_block

--- a/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
+++ b/app/controllers/api/v1/admin/canonical_email_blocks_controller.rb
@@ -58,7 +58,7 @@ class Api::V1::Admin::CanonicalEmailBlocksController < Api::BaseController
   end
 
   def set_canonical_email_blocks_from_test
-    raise(Mastodon::ValidationError, "Email can't be blank") if params[:email].blank?
+    params.require(:email)
 
     @canonical_email_blocks = CanonicalEmailBlock.matching_email(params[:email])
   end

--- a/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
@@ -23,10 +23,10 @@ describe Api::V1::Admin::CanonicalEmailBlocksController do
 
   describe 'POST #test' do
     context 'when required email is not provided' do
-      it 'returns http unprocessable entity' do
+      it 'returns http bad request' do
         post :test
 
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(400)
       end
     end
 

--- a/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
@@ -20,4 +20,52 @@ describe Api::V1::Admin::CanonicalEmailBlocksController do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe 'POST #test' do
+    context 'when required email is not provided' do
+      it 'returns http unprocessable entity' do
+        post :test
+
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when required email is provided' do
+      let(:params) { { email: 'example@email.com' } }
+
+      context 'when there is a matching canonical email block' do
+        let!(:canonical_email_block) { CanonicalEmailBlock.create(params) }
+
+        it 'returns http success' do
+          post :test, params: params
+
+          expect(response).to have_http_status(200)
+        end
+
+        it 'returns expected canonical email hash' do
+          post :test, params: params
+
+          json = body_as_json
+
+          expect(json[0][:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
+        end
+      end
+
+      context 'when there is no matching canonical email block' do
+        it 'returns http success' do
+          post :test, params: params
+
+          expect(response).to have_http_status(200)
+        end
+
+        it 'returns an empty list' do
+          post :test, params: params
+
+          json = body_as_json
+
+          expect(json).to be_empty
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix #21774.
Add some test coverage for `the /api/v1/admin/canonical_email_blocks/test` endpoint.