### PR TITLE
Fix POST `/api/v1/admin/domain_allows` returning 200 when no domain is specified

### DIFF
--- a/app/controllers/api/v1/admin/domain_allows_controller.rb
+++ b/app/controllers/api/v1/admin/domain_allows_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::Admin::DomainAllowsController < Api::BaseController
   def create
     authorize :domain_allow, :create?
 
-    @domain_allow = DomainAllow.find_by(resource_params)
+    @domain_allow = DomainAllow.find_by(domain: resource_params[:domain])
 
     if @domain_allow.nil?
       @domain_allow = DomainAllow.create!(resource_params)

--- a/spec/controllers/api/v1/admin/domain_allows_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/domain_allows_controller_spec.rb
@@ -128,5 +128,13 @@ RSpec.describe Api::V1::Admin::DomainAllowsController do
         expect(response).to have_http_status(422)
       end
     end
+
+    context 'when domain name is not specified' do
+      it 'returns http unprocessable entity' do
+        post :create
+
+        expect(response).to have_http_status(422)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix #19173.

The [documentation](https://docs.joinmastodon.org/methods/admin/domain_allows/#422-unprocessable-entity) specifies that when the required  `domain` parameter is not provided, the HTTP response should be 422. However, the actual behavior is an HTTP 200 status with the first `DomainAllow` record.