### PR TITLE
I18n pluralization errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,7 @@ GEM
     httplog (1.6.2)
       rack (>= 2.0)
       rainbow (>= 2.0.0)
-    i18n (1.12.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.0.12)
       activesupport (>= 4.0.2)

--- a/spec/views/shared/_error_messages.html.haml_spec.rb
+++ b/spec/views/shared/_error_messages.html.haml_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'shared/_error_messages.html.haml' do
+  let(:status) { Status.new }
+
+  before { status.errors.add :base, :invalid }
+
+  context 'with a locale that has `one` and `other` plural values' do
+    around do |example|
+      I18n.with_locale(:en) do
+        example.run
+      end
+    end
+
+    it 'renders the view with one error' do
+      render partial: 'shared/error_messages', locals: { object: status }
+
+      expect(rendered).to match(/is invalid/)
+    end
+  end
+
+  context 'with a locale that has only `other` plural value' do
+    around do |example|
+      I18n.with_locale(:my) do
+        example.run
+      end
+    end
+
+    it 'renders the view with one error' do
+      render partial: 'shared/error_messages', locals: { object: status }
+
+      expect(rendered).to match(/is invalid/)
+    end
+  end
+end


### PR DESCRIPTION
As discovered and discussed on https://github.com/mastodon/mastodon/pull/24869

This view spec would have passed on `main` branch with i18n gem version 1.12.0, but then failed on Rails 7 branch and flagged this issue more quickly than a spec run happening to hit the right (failing) locale.

Separately, I realized that rails 7 with i18n gem version 1.12.0 is the exact failing combination. Rails 6 works with 1.11.0, 1.12.0 and 1.13.0. Rails 7 works with 1.11.0 and 1.13.0, but fails on 1.12.0 (the i18n gem improved pluralization in 1.11.0, reverted that in 1.12.0 due to other side effects, and then more successfully improved it again in 1.13.0).

Assuming this is merged, I will rebase my rails 7 branch again to confirm what I just wrote.