### PR TITLE
WIP: Forward the category and local rules violated when forwarding reports

### DIFF
--- a/app/serializers/activitypub/flag_serializer.rb
+++ b/app/serializers/activitypub/flag_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ActivityPub::FlagSerializer < ActivityPub::Serializer
-  attributes :id, :type, :actor, :content
+  attributes :id, :type, :actor, :content, :summary
   attribute :virtual_object, key: :object
 
   def id
@@ -20,7 +20,15 @@ class ActivityPub::FlagSerializer < ActivityPub::Serializer
     [ActivityPub::TagManager.instance.uri_for(object.target_account)] + object.statuses.map { |s| ActivityPub::TagManager.instance.uri_for(s) }
   end
 
+  def summary
+    object.category
+  end
+
   def content
-    object.comment
+    if object.violation?
+      "Comment:\n#{object.comment}\n\nViolated #{Rails.configuration.x.local_domain}'s Rules: \n- #{object.rules.map(&:text).join("\n -")}"
+    else
+      object.comment
+    end
   end
 end


### PR DESCRIPTION
This is based off some discussion in #future-ideas to forward the category and rule's violated when forwarding a report to a remote server. It's probably rough, and I might be abusing the "summary" field, but in testing in the rails console, I think it gives useful information to a Moderator when receiving a third-party report.

Example's of the outgoing `Flag` Activity:

```rb
# Rule Violation:

{"@context"=>"https://www.w3.org/ns/activitystreams",
 :id=>"http://mastodon.local:3000/72756dab-3568-45bf-bf2c-22bc1dae710d",
 :type=>"Flag",
 :actor=>"https://mastodon.example/@example",
 :content=>"Comment:\nKeeps mentioning me after I've asked them to stop\n\nViolated mastodon.local:3000's Rules: \n- Don't be annoying. Play nice in the fedi.",
 :summary=>"violation",
 :object=>["http://mastodon.local:3000/users/alvina11"]}

# Spam

{"@context"=>"https://www.w3.org/ns/activitystreams",
 :id=>"http://mastodon.local:3000/474cd89d-c9c9-489f-8ab8-2c1f557c1c3d",
 :type=>"Flag",
 :actor=>"https://mastodon.example/@example",
 :content=>"Casino spam, yay",
 :summary=>"spam",
 :object=>["http://mastodon.local:3000/users/malik_mcdermott1"]}

# Other

{"@context"=>"https://www.w3.org/ns/activitystreams",
 :id=>"http://mastodon.local:3000/d78eb94b-d95a-40ad-aca0-8ff6737d5804",
 :type=>"Flag",
 :actor=>"https://mastodon.example/@example",
 :content=>"I dunno, something",
 :summary=>"other",
 :object=>["http://mastodon.local:3000/users/jae3"]}
```

Whilst we do send out the summary of "violation" on the receiving end we need to downgrade it to "other" as a violation must have local rule_ids that match, and that is unlikely to happen. Potentially we could create a category of "remote_violation" or something to better capture / communicate this?