### PR TITLE
Bump `mkdirp` major version

### DIFF
--- a/config/webpack/generateLocalePacks.js
+++ b/config/webpack/generateLocalePacks.js
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
-const mkdirp = require('mkdirp');
+const { mkdirp } = require('mkdirp');
 
 const localesJsonPath = path.join(__dirname, '../../app/javascript/mastodon/locales');
 const locales = fs.readdirSync(localesJsonPath).filter(filename => {
@@ -48,5 +48,3 @@ setLocale({messages, localeData});
 });
 
 module.exports = outPaths;
-
-

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "mark-loader": "^0.1.6",
     "marky": "^1.2.5",
     "mini-css-extract-plugin": "^1.6.2",
-    "mkdirp": "^2.1.6",
+    "mkdirp": "^3.0.1",
     "npmlog": "^7.0.1",
     "path-complete-extname": "^1.0.0",
     "pg": "^8.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8251,10 +8251,10 @@ mkdirp@^1.0, mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-2.1.6.tgz#964fbcb12b2d8c5d6fbc62a963ac95a273e2cc19"
-  integrity sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==
+mkdirp@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
+  integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
 
 mousetrap@^1.5.2:
   version "1.6.5"


### PR DESCRIPTION
Replaces #24634 as there is a breaking change (no more default import).