### PR TITLE
Auto report as spam if status contains url from blocked email domains

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -78,6 +78,15 @@ class FetchLinkCardService < BaseService
              links.filter_map { |a| Addressable::URI.parse(a['href']) unless skip_link?(a) }.filter_map(&:normalize)
            end
 
+    url_hosts = urls.map(&:host)
+    unless EmailDomainBlock.where(domain: url_hosts).empty?
+      @report = ReportService.new.call(
+        Account.representative,
+        @status.account,
+        comment: 'Automatically flagged for malicious or spam link', category: :spam, forward: false, status_ids: [@status.id]
+      )
+    end
+
     urls.reject { |uri| bad_url?(uri) }.first
   end
 


### PR DESCRIPTION
This PR adds a check to the FetchLinkCardService so that if the status contains a URL to a domain that is a blocked email domain, it will automatically report it as spam