### PR TITLE
Add ability for moderators to block posting certain words/phrases

### DIFF
--- a/app/controllers/admin/phrase_blocks_controller.rb
+++ b/app/controllers/admin/phrase_blocks_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Admin
+  class PhraseBlocksController < BaseController
+    before_action :set_phrase_block, only: [:edit, :update, :destroy]
+
+    def index
+      authorize :phrase_block, :index?
+      @phrase_blocks = PhraseBlock.order(id: :desc).page(params[:page])
+    end
+
+    def new
+      authorize :phrase_block, :create?
+      @phrase_block = PhraseBlock.new
+    end
+
+    def edit
+      authorize @phrase_block, :update?
+    end
+
+    def create
+      authorize :phrase_block, :create?
+
+      @phrase_block = PhraseBlock.new(resource_params)
+
+      if @phrase_block.save
+        log_action :create, @phrase_block
+        redirect_to admin_phrase_blocks_path, notice: I18n.t('admin.phrase_blocks.created_msg')
+      else
+        render :new
+      end
+    end
+
+    def update
+      authorize @phrase_block, :update?
+      if @phrase_block.update(resource_params)
+        log_action :update, @phrase_block
+
+        redirect_to admin_phrase_blocks_path, notice: I18n.t('admin.phrase_blocks.updated_msg')
+      else
+        render action: :edit
+      end
+    end
+
+    def destroy
+      authorize @phrase_block, :destroy?
+      @phrase_block.destroy!
+      log_action :destroy, @phrase_block
+      redirect_to admin_phrase_blocks_path, notice: I18n.t('admin.phrase_blocks.destroyed_msg')
+    end
+
+    private
+
+    def set_phrase_block
+      @phrase_block = PhraseBlock.find(params[:id])
+    end
+
+    def resource_params
+      params.require(:phrase_block).permit(:phrase, :filter_type, :whole_word)
+    end
+  end
+end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -61,8 +61,8 @@ class Api::BaseController < ApplicationController
     render json: { error: 'Remote SSL certificate could not be verified' }, status: 503
   end
 
-  rescue_from Mastodon::NotPermittedError do
-    render json: { error: 'This action is not allowed' }, status: 403
+  rescue_from Mastodon::NotPermittedError do |e|
+    render json: { error: e.message.presence || 'This action is not allowed' }, status: 403
   end
 
   rescue_from Seahorse::Client::NetworkingError do |e|

--- a/app/helpers/admin/action_logs_helper.rb
+++ b/app/helpers/admin/action_logs_helper.rb
@@ -33,6 +33,8 @@ module Admin::ActionLogsHelper
       else
         I18n.t('admin.action_logs.deleted_account')
       end
+    when 'PhraseBlock'
+      link_to truncate(log.human_identifier), edit_admin_phrase_block_path(log.target_id)
     end
   end
 end

--- a/app/models/admin/action_log_filter.rb
+++ b/app/models/admin/action_log_filter.rb
@@ -26,6 +26,7 @@ class Admin::ActionLogFilter
     create_unavailable_domain: { target_type: 'UnavailableDomain', action: 'create' }.freeze,
     create_user_role: { target_type: 'UserRole', action: 'create' }.freeze,
     create_canonical_email_block: { target_type: 'CanonicalEmailBlock', action: 'create' }.freeze,
+    create_phrase_block: { target_type: 'PhraseBlock', action: 'create' }.freeze,
     demote_user: { target_type: 'User', action: 'demote' }.freeze,
     destroy_announcement: { target_type: 'Announcement', action: 'destroy' }.freeze,
     destroy_custom_emoji: { target_type: 'CustomEmoji', action: 'destroy' }.freeze,
@@ -38,6 +39,7 @@ class Admin::ActionLogFilter
     destroy_status: { target_type: 'Status', action: 'destroy' }.freeze,
     destroy_user_role: { target_type: 'UserRole', action: 'destroy' }.freeze,
     destroy_canonical_email_block: { target_type: 'CanonicalEmailBlock', action: 'destroy' }.freeze,
+    destroy_phrase_block: { target_type: 'PhraseBlock', action: 'destroy' }.freeze,
     disable_2fa_user: { target_type: 'User', action: 'disable' }.freeze,
     disable_custom_emoji: { target_type: 'CustomEmoji', action: 'disable' }.freeze,
     disable_user: { target_type: 'User', action: 'disable' }.freeze,
@@ -62,6 +64,7 @@ class Admin::ActionLogFilter
     update_status: { target_type: 'Status', action: 'update' }.freeze,
     update_user_role: { target_type: 'UserRole', action: 'update' }.freeze,
     update_ip_block: { target_type: 'IpBlock', action: 'update' }.freeze,
+    update_phrase_block: { target_type: 'PhraseBlock', action: 'update' }.freeze,
     unblock_email_account: { target_type: 'Account', action: 'unblock_email' }.freeze,
   }.freeze
 

--- a/app/models/phrase_block.rb
+++ b/app/models/phrase_block.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: phrase_blocks
+#
+#  id          :bigint(8)        not null, primary key
+#  phrase      :text             not null
+#  filter_type :integer          default("text"), not null
+#  whole_word  :boolean          default(TRUE), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+class PhraseBlock < ApplicationRecord
+  enum filter_type: { text: 0, regexp: 1 }, _suffix: :type
+
+  validates :phrase, presence: true
+  validates :phrase, regex: true, if: :regexp_type?
+
+  after_commit :invalidate_cache!
+
+  def to_log_human_identifier
+    if regexp_type?
+      "/#{phrase}/"
+    else
+      phrase
+    end
+  end
+
+  def to_regexp
+    if regexp_type?
+      /#{phrase}/i
+    elsif whole_word?
+      sb = /\A[[:word:]]/.match?(phrase) ? '\b' : ''
+      eb = /[[:word:]]\z/.match?(phrase) ? '\b' : ''
+
+      /(?mix:#{sb}#{Regexp.escape(phrase)}#{eb})/
+    else
+      /#{Regexp.escape(phrase)}/i
+    end
+  end
+
+  def self.cached_regexp
+    Rails.cache.fetch('phrase_blocks:regexp') do
+      Regexp.union(PhraseBlock.all.to_a.map(&:to_regexp))
+    end
+  end
+
+  private
+
+  def invalidate_cache!
+    Rails.cache.delete('phrase_blocks:regexp')
+  end
+end

--- a/app/policies/phrase_block_policy.rb
+++ b/app/policies/phrase_block_policy.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class PhraseBlockPolicy < ApplicationPolicy
+  def index?
+    role.can?(:manage_blocks)
+  end
+
+  def create?
+    role.can?(:manage_blocks)
+  end
+
+  def destroy?
+    role.can?(:manage_blocks)
+  end
+
+  def update?
+    role.can?(:manage_blocks)
+  end
+end

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -43,6 +43,8 @@ class PostStatusService < BaseService
     validate_media!
     preprocess_attributes!
 
+    screen_for_spam!
+
     if scheduled?
       schedule_status!
     else
@@ -60,6 +62,10 @@ class PostStatusService < BaseService
   end
 
   private
+
+  def screen_for_spam!
+    raise Mastodon::NotPermittedError, I18n.t('statuses.errors.blocked_content') if PhraseBlock.cached_regexp.match?(@text)
+  end
 
   def preprocess_attributes!
     @sensitive    = (@options[:sensitive].nil? ? @account.user&.setting_default_sensitive : @options[:sensitive]) || @options[:spoiler_text].present?

--- a/app/validators/regex_validator.rb
+++ b/app/validators/regex_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RegexValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    Regexp.new(value)
+  rescue RegexpError => e
+    record.errors.add(attribute, I18n.t('regex_validator.invalid_regexp', error: e.to_s))
+  end
+end

--- a/app/views/admin/phrase_blocks/_fields.html.haml
+++ b/app/views/admin/phrase_blocks/_fields.html.haml
@@ -1,0 +1,8 @@
+.fields-group
+  = f.input :phrase, as: :string, wrapper: :with_block_label, label: t('admin.phrase_blocks.phrase'), hint: t('admin.phrase_blocks.phrase_hint')
+
+.fields-group
+  = f.input :filter_type, as: :radio_buttons, collection: %i(text regexp), label: t('admin.phrase_blocks.type.title'), label_method: ->(type) { safe_join([t("admin.phrase_blocks.types.#{type}"), content_tag(:span, I18n.t("admin.phrase_blocks.types.#{type}_hint"), class: 'hint')]) }
+
+.fields-group
+  = f.input :whole_word, wrapper: :with_label

--- a/app/views/admin/phrase_blocks/_phrase_block.html.haml
+++ b/app/views/admin/phrase_blocks/_phrase_block.html.haml
@@ -1,0 +1,11 @@
+
+%tr
+  %td
+    %samp= phrase_block.phrase
+  %td
+    = t("admin.phrase_blocks.types.#{phrase_block.filter_type}")
+  %td
+    - if can?(:update, phrase_block)
+      = table_link_to 'pencil', t('filters.edit.title'), edit_admin_phrase_block_path(phrase_block)
+    - if can?(:destroy, phrase_block)
+      = table_link_to 'trash', t('admin.phrase_blocks.delete'), admin_phrase_block_path(phrase_block), method: :delete

--- a/app/views/admin/phrase_blocks/edit.html.haml
+++ b/app/views/admin/phrase_blocks/edit.html.haml
@@ -1,0 +1,10 @@
+- content_for :page_title do
+  = t('admin.phrase_blocks.edit.title')
+
+= simple_form_for @phrase_block, url: admin_phrase_block_path(@phrase_block), method: :put do |f|
+  = render 'shared/error_messages', object: @phrase_block
+
+  = render 'fields', f: f
+
+  .actions
+    = f.button :button, t('generic.save_changes'), type: :submit

--- a/app/views/admin/phrase_blocks/index.html.haml
+++ b/app/views/admin/phrase_blocks/index.html.haml
@@ -1,0 +1,25 @@
+- content_for :page_title do
+  = t('admin.phrase_blocks.title')
+
+- if can?(:create, :phrase_block)
+  - content_for :heading_actions do
+    = link_to t('admin.phrase_blocks.add_new'), new_admin_phrase_block_path, class: 'button'
+
+.flash-message.warning= t('beta_feature.notice')
+
+%p= t('admin.phrase_blocks.description_html')
+
+- if @phrase_blocks.empty?
+  .muted-hint.center-text= t 'admin.phrase_blocks.empty'
+- else
+  .table-wrapper
+    %table.table
+      %thead
+        %tr
+          %th= t('admin.phrase_blocks.text')
+          %th= t('admin.phrase_blocks.type.title')
+          %th
+      %tbody
+        = render partial: 'phrase_block', collection: @phrase_blocks
+
+= paginate @phrase_blocks

--- a/app/views/admin/phrase_blocks/new.html.haml
+++ b/app/views/admin/phrase_blocks/new.html.haml
@@ -1,0 +1,12 @@
+- content_for :page_title do
+  = t('admin.phrase_blocks.new.title')
+
+.flash-message.warning= t('beta_feature.notice')
+
+= simple_form_for @phrase_block, url: admin_phrase_blocks_path do |f|
+  = render 'shared/error_messages', object: @phrase_block
+
+  = render 'fields', f: f
+
+  .actions
+    = f.button :button, t('.create'), type: :submit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1452,6 +1452,8 @@ en:
     errors:
       limit_reached: Limit of different reactions reached
       unrecognized_emoji: is not a recognized emoji
+  regex_validator:
+    invalid_regexp: 'error parsing regular expression: %{error}'
   relationships:
     activity: Account activity
     confirm_follow_selected_followers: Are you sure you want to follow selected followers?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -547,6 +547,30 @@ en:
         title: Create new IP rule
       no_ip_block_selected: No IP rules were changed as none were selected
       title: IP rules
+    phrase_blocks:
+      add_new: Add new filter
+      created_msg: Banned word successfully added!
+      delete: Delete
+      description_html: Banned words prevent making posts that include a banned word or expression. This is meant to be used as an emergency anti-spam measure. Trying to send a post that includes a banned word or expression will result in an error.
+      destroyed_msg: Banned word successfully removed!
+      edit:
+        title: Edit banned word
+      empty: There is no banned word or expression yet.
+      new:
+        create: Create
+        title: Add banned word
+      phrase: Keyword, phrase or regular expression
+      phrase_hint: Forbid making posts containing this keyword, phrase, or regular expression. Attempting to do so will return an error.
+      text: Banned word or expression
+      title: Banned words
+      type:
+        title: Filter type
+      types:
+        regexp: Regular expression
+        regexp_hint: Use regular expressions if you want to prevent posts featuring more advanced patterns.
+        text: Simple text
+        text_hint: Use this for simple recurring keywords or if you do not know regular expressions.
+      updated_msg: Banned word successfully updated!
     relationships:
       title: "%{acct}'s relationships"
     relays:
@@ -1054,6 +1078,8 @@ en:
       return: Show the user's profile
       web: Go to web
     title: Follow %{acct}
+  beta_feature:
+    notice: This feature is in beta and may be changed, replaced or removed at any point in the future.
   challenge:
     confirm: Continue
     hint_html: "<strong>Tip:</strong> We won't ask you for your password again for the next hour."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1577,6 +1577,7 @@ en:
       other: 'contained the disallowed hashtags: %{tags}'
     edited_at_html: Edited %{date}
     errors:
+      blocked_content: This post includes forbidden words or expressions
       in_reply_not_found: The post you are trying to reply to does not appear to exist.
     open_in_web: Open in web
     over_character_limit: character limit of %{max} exceeded

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -47,6 +47,7 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :instances, safe_join([fa_icon('cloud fw'), t('admin.instances.title')]), admin_instances_path(limited: whitelist_mode? ? nil : '1'), highlights_on: %r{/admin/instances|/admin/domain_blocks|/admin/domain_allows}, if: -> { current_user.can?(:manage_federation) }
       s.item :email_domain_blocks, safe_join([fa_icon('envelope fw'), t('admin.email_domain_blocks.title')]), admin_email_domain_blocks_path, highlights_on: %r{/admin/email_domain_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :ip_blocks, safe_join([fa_icon('ban fw'), t('admin.ip_blocks.title')]), admin_ip_blocks_path, highlights_on: %r{/admin/ip_blocks}, if: -> { current_user.can?(:manage_blocks) }
+      s.item :phrase_blocks, safe_join([fa_icon('trash fw'), t('admin.phrase_blocks.title')]), admin_phrase_blocks_path, highlights_on: %r{/admin/phrase_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :action_logs, safe_join([fa_icon('bars fw'), t('admin.action_logs.title')]), admin_action_logs_path, if: -> { current_user.can?(:view_audit_log) }
     end
 

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -30,6 +30,8 @@ namespace :admin do
     end
   end
 
+  resources :phrase_blocks, except: [:show]
+
   resources :action_logs, only: [:index]
   resources :warning_presets, except: [:new]
 

--- a/db/migrate/20230515084229_create_phrase_blocks.rb
+++ b/db/migrate/20230515084229_create_phrase_blocks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreatePhraseBlocks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :phrase_blocks do |t|
+      t.text :phrase, null: false
+      t.integer :filter_type, null: false, default: 0
+      t.boolean :whole_word, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_30_155710) do
+ActiveRecord::Schema.define(version: 2023_05_15_084229) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -719,6 +719,14 @@ ActiveRecord::Schema.define(version: 2023_03_30_155710) do
     t.bigint "size"
     t.datetime "captured_at"
     t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
+  end
+
+  create_table "phrase_blocks", force: :cascade do |t|
+    t.text "phrase", null: false
+    t.integer "filter_type", default: 0, null: false
+    t.boolean "whole_word", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "poll_votes", force: :cascade do |t|

--- a/spec/controllers/admin/phrase_blocks_controller_spec.rb
+++ b/spec/controllers/admin/phrase_blocks_controller_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::PhraseBlocksController do
+  render_views
+
+  before do
+    sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
+  end
+
+  describe 'GET #index' do
+    around do |example|
+      default_per_page = PhraseBlock.default_per_page
+      PhraseBlock.paginates_per 1
+      example.run
+      PhraseBlock.paginates_per default_per_page
+    end
+
+    it 'renders registration filters' do
+      2.times { Fabricate(:phrase_block) }
+
+      get :index, params: { page: 2 }
+
+      assigned = assigns(:phrase_blocks)
+      expect(assigned.count).to eq 1
+      expect(assigned.klass).to be PhraseBlock
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET #new' do
+    it 'assigns a new phrase block' do
+      get :new
+
+      expect(assigns(:phrase_block)).to be_instance_of(PhraseBlock)
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'POST #create' do
+    it 'returns to phrase blocks page when succeeded to save' do
+      post :create, params: { phrase_block: { phrase: 'bitcoin.spam' } }
+
+      expect(flash[:notice]).to eq I18n.t('admin.phrase_blocks.created_msg')
+      expect(response).to redirect_to(admin_phrase_blocks_path)
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'returns to phrase blocks page when succeeded destroying' do
+      phrase_block = Fabricate(:phrase_block)
+      delete :destroy, params: { id: phrase_block.id }
+
+      expect(flash[:notice]).to eq I18n.t('admin.phrase_blocks.destroyed_msg')
+      expect(response).to redirect_to(admin_phrase_blocks_path)
+    end
+  end
+end

--- a/spec/fabricators/phrase_block_fabricator.rb
+++ b/spec/fabricators/phrase_block_fabricator.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Fabricator(:phrase_block) do
+  phrase 'spammy words'
+end

--- a/spec/models/phrase_block_spec.rb
+++ b/spec/models/phrase_block_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PhraseBlock do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/phrase_block_spec.rb
+++ b/spec/models/phrase_block_spec.rb
@@ -3,5 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe PhraseBlock do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#to_regexp' do
+    context 'when using a text block' do
+      let(:phrase_block) { Fabricate(:phrase_block, phrase: 'evil spam message', filter_type: :text) }
+
+      it 'matches the expected text' do
+        expect(phrase_block.to_regexp.match?('this post contains an evil spam message!')).to be true
+        expect(phrase_block.to_regexp.match?('this post contains a moderately spammy message!')).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
I am not sure that this is the best approach, but we do need this kind of feature.

![image](https://github.com/mastodon/mastodon/assets/384364/a1398c16-29a5-468f-8233-2f57192bde84)

I decided to add a “beta feature” banner given I'm really not sure about the approach and we may be iterating quickly before we settle on something more stable.

This system **prevents posting, with an explicit error message**: on the one hand, this provides greater transparency to end-users that could be erroneously blocked, and avoids erroneously surfacing legitimate private conversations or generating too much reports; on the other hand, this **immediately informs spammers** that they have been caught and do not help the moderators **identifying them**.

This is about **textual content**, not specifically links, because some of the spam waves we recently had to deal with did not actually post links.