### PR TITLE
Improve test coverage for `/api/v1/admin/canonical_email_blocks`

### DIFF
--- a/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
@@ -127,6 +127,23 @@ describe Api::V1::Admin::CanonicalEmailBlocksController do
   end
 
   describe 'POST #test' do
+    context 'with wrong scope' do
+      before do
+        post :test
+      end
+
+      it_behaves_like 'forbidden for wrong scope', 'read:statuses'
+    end
+
+    context 'with wrong role' do
+      before do
+        post :test, params: { email: 'whatever@email.com' }
+      end
+
+      it_behaves_like 'forbidden for wrong role', ''
+      it_behaves_like 'forbidden for wrong role', 'Moderator'
+    end
+
     context 'when required email is not provided' do
       it 'returns http bad request' do
         post :test

--- a/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
@@ -282,4 +282,40 @@ describe Api::V1::Admin::CanonicalEmailBlocksController do
       end
     end
   end
+
+  describe 'DELETE #destroy' do
+    let!(:canonical_email_block) { Fabricate(:canonical_email_block) }
+    let(:params) { { id: canonical_email_block.id } }
+
+    context 'with wrong scope' do
+      before do
+        delete :destroy, params: params
+      end
+
+      it_behaves_like 'forbidden for wrong scope', 'read:statuses'
+    end
+
+    context 'with wrong role' do
+      before do
+        delete :destroy, params: params
+      end
+
+      it_behaves_like 'forbidden for wrong role', ''
+      it_behaves_like 'forbidden for wrong role', 'Moderator'
+    end
+
+    it 'returns http success' do
+      delete :destroy, params: params
+
+      expect(response).to have_http_status(200)
+    end
+
+    context 'when canonical email block is not found' do
+      it 'returns http not found' do
+        delete :destroy, params: { id: 0 }
+
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
 end

--- a/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
@@ -76,6 +76,44 @@ describe Api::V1::Admin::CanonicalEmailBlocksController do
 
         expect(json.pluck(:canonical_email_hash)).to match_array(expected_email_hashes)
       end
+
+      context 'with limit param' do
+        let(:params) { { limit: 2 } }
+
+        it 'returns only the requested number of canonical email blocks' do
+          get :index, params: params
+
+          json = body_as_json
+
+          expect(json.size).to eq(params[:limit])
+        end
+      end
+
+      context 'with since_id param' do
+        let(:params) { { since_id: canonical_email_blocks[1].id } }
+
+        it 'returns only the canonical email blocks after since_id' do
+          get :index, params: params
+
+          canonical_email_blocks_ids = canonical_email_blocks.pluck(:id).map(&:to_s)
+          json = body_as_json
+
+          expect(json.pluck(:id)).to match_array(canonical_email_blocks_ids[2..])
+        end
+      end
+
+      context 'with max_id param' do
+        let(:params) { { max_id: canonical_email_blocks[3].id } }
+
+        it 'returns only the canonical email blocks before max_id' do
+          get :index, params: params
+
+          canonical_email_blocks_ids = canonical_email_blocks.pluck(:id).map(&:to_s)
+          json = body_as_json
+
+          expect(json.pluck(:id)).to match_array(canonical_email_blocks_ids[..2])
+        end
+      end
     end
   end
 

--- a/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
@@ -79,6 +79,53 @@ describe Api::V1::Admin::CanonicalEmailBlocksController do
     end
   end
 
+  describe 'GET #show' do
+    let!(:canonical_email_block) { Fabricate(:canonical_email_block) }
+    let(:params) { { id: canonical_email_block.id } }
+
+    context 'with wrong scope' do
+      before do
+        get :show, params: params
+      end
+
+      it_behaves_like 'forbidden for wrong scope', 'read:statuses'
+    end
+
+    context 'with wrong role' do
+      before do
+        get :show, params: params
+      end
+
+      it_behaves_like 'forbidden for wrong role', ''
+      it_behaves_like 'forbidden for wrong role', 'Moderator'
+    end
+
+    context 'when canonical email block exists' do
+      it 'returns http success' do
+        get :show, params: params
+
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns canonical email block data correctly' do
+        get :show, params: params
+
+        json = body_as_json
+
+        expect(json[:id]).to eq(canonical_email_block.id.to_s)
+        expect(json[:canonical_email_hash]).to eq(canonical_email_block.canonical_email_hash)
+      end
+    end
+
+    context 'when canonical block does not exist' do
+      it 'returns http not found' do
+        get :show, params: { id: 0 }
+
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
   describe 'POST #test' do
     context 'when required email is not provided' do
       it 'returns http bad request' do

--- a/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/canonical_email_blocks_controller_spec.rb
@@ -8,7 +8,6 @@ describe Api::V1::Admin::CanonicalEmailBlocksController do
   let(:role)    { UserRole.find_by(name: 'Admin') }
   let(:user)    { Fabricate(:user, role: role) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
-  let(:account) { Fabricate(:account) }
   let(:scopes)  { 'admin:read:canonical_email_blocks admin:write:canonical_email_blocks' }
 
   before do

--- a/spec/fabricators/canonical_email_block_fabricator.rb
+++ b/spec/fabricators/canonical_email_block_fabricator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 Fabricator(:canonical_email_block) do
-  email 'test@example.com'
+  email { sequence(:email) { |i| "#{i}#{Faker::Internet.email}" } }
   reference_account { Fabricate(:account) }
 end


### PR DESCRIPTION
This PR improves test coverage for the `Api::V1::Admin::CanonicalEmailBlocksController` class.