### PR TITLE
Add emergency mode to enable stricter rate limits

### DIFF
--- a/app/controllers/api/v1/admin/emergency_mode_controller.rb
+++ b/app/controllers/api/v1/admin/emergency_mode_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Api::V1::Admin::EmergencyModeController < Api::BaseController
+  include Authorization
+  include AccountableConcern
+
+  before_action -> { doorkeeper_authorize!! :'admin:read', ':admin:read:emergency_mode' }, only: :show
+  before_action -> { doorkeeper_authorize! :'admin:write', :'admin:write:emergency_mode' }, except: :show
+
+  def show
+    EmergencyMode.reason
+  end
+
+  def enable
+    # TODO: log action
+    EmergencyMode.enable!(params.require(:reason))
+  end
+
+  def disable
+    # TODO: log action
+    EmergencyMode.disable!
+  end
+end

--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -36,4 +36,13 @@ module Admin::DashboardHelper
 
     content_tag(:time, l(timestamp), class: 'time-ago', datetime: timestamp.iso8601, title: l(timestamp))
   end
+
+  def emergency_mode_notice
+    reason = EmergencyMode.reason
+    return if reason.blank?
+
+    content_tag(:div, class: 'flash-message') do
+      I18n.t('admin.emergency_mode.notice', reason: reason)
+    end
+  end
 end

--- a/app/lib/emergency_mode.rb
+++ b/app/lib/emergency_mode.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class EmergencyMode
+  class << self
+    include Redisable
+
+    def reason
+      with_redis do |redis|
+        redis.get('emergency_mode')
+      end
+    end
+
+    def remaining_seconds
+      with_redis do |redis|
+        redis.ttl('emergency_mode')
+      end
+    end
+
+    def enabled?
+      reason.present?
+    end
+
+    def enable!(reason, expires_in = 10.minutes)
+      with_redis do |redis|
+        redis.set('emergency_mode', reason, ex: expires_in.to_i)
+      end
+    end
+
+    def disable!
+      with_redis do |redis|
+        redis.del('emergency_mode')
+      end
+    end
+  end
+end

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -9,6 +9,8 @@
   = ' - '
   = l(@time_period.last)
 
+= emergency_mode_notice
+
 - unless @system_checks.empty?
   .flash-message-stack
     - @system_checks.each do |message|

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -1,6 +1,8 @@
 - content_for :page_title do
   = t('admin.reports.title')
 
+= emergency_mode_notice
+
 .filters
   .filter-subset
     %strong= t('admin.reports.status')

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -66,6 +66,14 @@ class Rack::Attack
     IpBlock.blocked?(req.remote_ip)
   end
 
+  throttle('throttle_posts_in_emergency/user', limit: 2, period: 1.minute) do |req|
+    req.authenticated_user_id if req.post? && req.path == '/api/v1/statuses' && Setting.emergency_mode
+  end
+
+  throttle('throttle_posts_in_emergency/ip', limit: 20, period: 1.minute) do |req|
+    req.throttleable_remote_ip if req.post? && req.path == '/api/v1/statuses' && Setting.emergency_mode
+  end
+
   throttle('throttle_authenticated_api', limit: 1_500, period: 5.minutes) do |req|
     req.authenticated_user_id if req.api_request?
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -67,11 +67,11 @@ class Rack::Attack
   end
 
   throttle('throttle_posts_in_emergency/user', limit: 2, period: 1.minute) do |req|
-    req.authenticated_user_id if req.post? && req.path == '/api/v1/statuses' && Setting.emergency_mode
+    req.authenticated_user_id if req.post? && req.path == '/api/v1/statuses' && EmergencyMode.enabled?
   end
 
   throttle('throttle_posts_in_emergency/ip', limit: 20, period: 1.minute) do |req|
-    req.throttleable_remote_ip if req.post? && req.path == '/api/v1/statuses' && Setting.emergency_mode
+    req.throttleable_remote_ip if req.post? && req.path == '/api/v1/statuses' && EmergencyMode.enabled?
   end
 
   throttle('throttle_authenticated_api', limit: 1_500, period: 5.minutes) do |req|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -433,6 +433,8 @@ en:
       resolved_dns_records_hint_html: The domain name resolves to the following MX domains, which are ultimately responsible for accepting e-mail. Blocking an MX domain will block sign-ups from any e-mail address which uses the same MX domain, even if the visible domain name is different. <strong>Be careful not to block major e-mail providers.</strong>
       resolved_through_html: Resolved through %{domain}
       title: Blocked e-mail domains
+    emergency_mode:
+      notice: 'Emergency mode is enabled: %{reason}'
     export_domain_allows:
       new:
         title: Import domain allows

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -268,6 +268,11 @@ namespace :api, format: false do
           post :test
         end
       end
+
+      resource :emergency_mode, only: [:show] do
+        post :enable, to: 'emergency_mode#enable'
+        post :disable, to: 'emergency_mode#disable'
+      end
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,6 +37,7 @@ defaults: &defaults
   show_domain_blocks_rationale: 'disabled'
   require_invite_text: false
   backups_retention_period: 7
+  emergency_mode: false
 
 development:
   <<: *defaults

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,7 +37,6 @@ defaults: &defaults
   show_domain_blocks_rationale: 'disabled'
   require_invite_text: false
   backups_retention_period: 7
-  emergency_mode: false
 
 development:
   <<: *defaults

--- a/lib/mastodon/settings_cli.rb
+++ b/lib/mastodon/settings_cli.rb
@@ -37,8 +37,32 @@ module Mastodon
     end
   end
 
+  class EmergencyCLI < Thor
+    def self.exit_on_failure?
+      true
+    end
+
+    desc 'enable', 'Enable emergency mode'
+    long_desc <<~LONG_DESC
+      Enable emergency mode, switching to stricter rate limits.
+    LONG_DESC
+    def enable
+      Setting.emergency_mode = true
+      say('OK', :green)
+    end
+
+    desc 'disable', 'Disable emergency mode'
+    def disable
+      Setting.emergency_mode = false
+      say('OK', :green)
+    end
+  end
+
   class SettingsCLI < Thor
     desc 'registrations SUBCOMMAND ...ARGS', 'Manage state of registrations'
     subcommand 'registrations', RegistrationsCLI
+
+    desc 'emergency SUBCOMMAND ...ARGS', 'Manage emergency mode'
+    subcommand 'emergency', EmergencyCLI
   end
 end

--- a/lib/mastodon/settings_cli.rb
+++ b/lib/mastodon/settings_cli.rb
@@ -42,18 +42,21 @@ module Mastodon
       true
     end
 
-    desc 'enable', 'Enable emergency mode'
+    desc 'enable REASON', 'Enable emergency mode for one hour'
     long_desc <<~LONG_DESC
       Enable emergency mode, switching to stricter rate limits.
+
+      The REASON will be shown to moderators in the administration
+      dashboard.
     LONG_DESC
-    def enable
-      Setting.emergency_mode = true
+    def enable(reason)
+      EmergencyMode.enable!(reason, 1.hour)
       say('OK', :green)
     end
 
     desc 'disable', 'Disable emergency mode'
     def disable
-      Setting.emergency_mode = false
+      EmergencyMode.disable!
       say('OK', :green)
     end
   end


### PR DESCRIPTION
Add a new “emergency mode” that has stricter posting rate limits.

Also add `tootctl settings emergency enable` and `tootctl settings emergency disable` to manage it.

It probably should be manageable via the admin UI and shown on the dashboard.

Also, I am not sure about the limits.