### PR TITLE
Add support for a new API parameter "client_type"

### DIFF
--- a/app/controllers/api/v1/accounts/statuses_controller.rb
+++ b/app/controllers/api/v1/accounts/statuses_controller.rb
@@ -9,7 +9,8 @@ class Api::V1::Accounts::StatusesController < Api::BaseController
   def index
     cache_if_unauthenticated!
     @statuses = load_statuses
-    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+    return_source = params[:client_type] == 'editor'
+    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id), source_requested: return_source
   end
 
   private


### PR DESCRIPTION
This pull request is another attempt to provide a mechanism by which clients that download a user's own statuses for archival or editing purposes may efficiently obtain a list of all the statuses in "source" format.

In contrast with #24317, which took a more complex approach trying to add a "format" parameter that would be interpreted on several disparate API methods, this PR instead suggests that we start small with a "client_type" parameter that can be used to inform the server what kind of semantics should be applied when returning data.

In this PR the only API call point where the parameter is added is in the `statuses` entity on `accounts`.

The hope is that the smaller scale of this PR will make it easier to review and more palatable to accept as at least a short-term fix for the problem at hand. Please let me know if you have any questions or concerns, and thanks!