### PR TITLE
Fix uncaught `ArgumentError` in POST/PUT `/api/v1/admin/domain_blocks/`

### DIFF
--- a/app/models/domain_block.rb
+++ b/app/models/domain_block.rb
@@ -24,6 +24,7 @@ class DomainBlock < ApplicationRecord
   enum severity: { silence: 0, suspend: 1, noop: 2 }
 
   validates :domain, presence: true, uniqueness: true, domain: true
+  validates :severity, inclusion: { in: severities.keys }
 
   has_many :accounts, foreign_key: :domain, primary_key: :domain, inverse_of: false
   delegate :count, to: :accounts, prefix: true
@@ -107,5 +108,11 @@ class DomainBlock < ApplicationRecord
 
   def domain_digest
     Digest::SHA256.hexdigest(domain)
+  end
+
+  def severity=(value)
+    super
+  rescue ArgumentError
+    @attributes.write_cast_value('severity', value)
   end
 end

--- a/spec/models/domain_block_spec.rb
+++ b/spec/models/domain_block_spec.rb
@@ -16,6 +16,23 @@ RSpec.describe DomainBlock do
       domain_block_2.valid?
       expect(domain_block_2).to model_have_error_on_field(:domain)
     end
+
+    context 'with a valid severity value' do
+      it 'is valid' do
+        domain_block = Fabricate.build(:domain_block, severity: :silence)
+
+        expect(domain_block).to be_valid
+      end
+    end
+
+    context 'with an invalid severity value' do
+      it 'is invalid' do
+        domain_block = Fabricate.build(:domain_block, severity: :invalid)
+
+        expect(domain_block).to be_invalid
+        expect(domain_block).to model_have_error_on_field(:severity)
+      end
+    end
   end
 
   describe '.blocked?' do

--- a/spec/requests/api/v1/admin/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/domain_blocks_spec.rb
@@ -205,6 +205,16 @@ RSpec.describe 'Domain Blocks' do
         expect(response).to have_http_status(422)
       end
     end
+
+    context 'when the given severity is invalid' do
+      let(:params) { { domain: 'foo.bar', severity: 'invalid' } }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response).to have_http_status(422)
+      end
+    end
   end
 
   describe 'PUT /api/v1/admin/domain_blocks/:id' do
@@ -246,6 +256,16 @@ RSpec.describe 'Domain Blocks' do
         put '/api/v1/admin/domain_blocks/-1', headers: headers
 
         expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when the given severity is invalid' do
+      let(:params) { { severity: 'invalid' } }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response).to have_http_status(422)
       end
     end
   end


### PR DESCRIPTION
Fixes #21775.

`Api::V1::Admin::DomainBlocksController`'s `#create` and `#update` raise uncaught `ArgumentError` when provided with an invalid `severity` value.