### PR TITLE
Change composer highlight border size to be more noticeable

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3118,7 +3118,7 @@ $ui-header-height: 55px;
 
   &.active {
     transition: none;
-    box-shadow: 0 0 0 2px rgba(lighten($highlight-text-color, 8%), 0.7);
+    box-shadow: 0 0 0 6px rgba(lighten($highlight-text-color, 8%), 0.7);
   }
 }
 


### PR DESCRIPTION
One of the features introduced for the new onboarding flow in #24619 was to pre-fill the compose form and highlight it upon clicking “Make your first post” button. However, the compose form can be quite some distance away on the screen and the highlight border is not enough to draw attention to it.

This PR increases the border's size to make it more noticeable.

[screencast.webm](https://github.com/mastodon/mastodon/assets/384364/49c511e2-8176-4032-a5bf-2af7153d85b3)

Note that it is still not very noticeable, and another UX issue is that actually publishing the post provides very little feedback (since the screen the user is not is not their timeline and does not show their posts)