### PR TITLE
Add polling and automatic redirection to `/start` on email confirmation

### DIFF
--- a/app/controllers/api/v1/emails/confirmations_controller.rb
+++ b/app/controllers/api/v1/emails/confirmations_controller.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 
 class Api::V1::Emails::ConfirmationsController < Api::BaseController
-  before_action -> { doorkeeper_authorize! :write, :'write:accounts' }
-  before_action :require_user_owned_by_application!
-  before_action :require_user_not_confirmed!
+  before_action -> { authorize_if_got_token! :read, :'read:accounts' }, only: :check
+  before_action -> { doorkeeper_authorize! :write, :'write:accounts' }, except: :check
+  before_action :require_user_owned_by_application!, except: :check
+  before_action :require_user_not_confirmed!, except: :check
 
   def create
     current_user.update!(email: params[:email]) if params.key?(:email)
     current_user.resend_confirmation_instructions
 
     render_empty
+  end
+
+  def check
+    render json: current_user.confirmed?
   end
 
   private

--- a/app/javascript/packs/sign_up.js
+++ b/app/javascript/packs/sign_up.js
@@ -1,0 +1,15 @@
+import './public-path';
+import ready from '../mastodon/ready';
+import axios from 'axios';
+
+ready(() => {
+  setInterval(() => {
+    axios.get('/api/v1/emails/check_confirmation').then((response) => {
+      if (response.data) {
+        window.location = '/start';
+      }
+    }).catch(error => {
+      console.error(error);
+    });
+  }, 5000);
+});

--- a/app/views/auth/setup/show.html.haml
+++ b/app/views/auth/setup/show.html.haml
@@ -1,6 +1,8 @@
 - content_for :page_title do
   = t('auth.setup.title')
 
+= javascript_pack_tag 'sign_up', crossorigin: 'anonymous'
+
 = simple_form_for(@user, url: auth_setup_path) do |f|
   = render 'auth/shared/progress', stage: 'confirm'
 

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -109,6 +109,7 @@ namespace :api, format: false do
 
     namespace :emails do
       resources :confirmations, only: [:create]
+      get :check_confirmation, to: 'confirmations#check'
     end
 
     resource :instance, only: [:show] do

--- a/spec/controllers/api/v1/emails/confirmations_controller_spec.rb
+++ b/spec/controllers/api/v1/emails/confirmations_controller_spec.rb
@@ -63,4 +63,72 @@ RSpec.describe Api::V1::Emails::ConfirmationsController do
       end
     end
   end
+
+  describe '#check' do
+    let(:scopes) { 'read' }
+
+    context 'with an oauth token' do
+      before do
+        allow(controller).to receive(:doorkeeper_token) { token }
+      end
+
+      context 'when the account is not confirmed' do
+        it 'returns http success' do
+          get :check
+          expect(response).to have_http_status(200)
+        end
+
+        it 'returns false' do
+          get :check
+          expect(body_as_json).to be false
+        end
+      end
+
+      context 'when the account is confirmed' do
+        let(:confirmed_at) { Time.now.utc }
+
+        it 'returns http success' do
+          get :check
+          expect(response).to have_http_status(200)
+        end
+
+        it 'returns true' do
+          get :check
+          expect(body_as_json).to be true
+        end
+      end
+    end
+
+    context 'with an authentication cookie' do
+      before do
+        sign_in user, scope: :user
+      end
+
+      context 'when the account is not confirmed' do
+        it 'returns http success' do
+          get :check
+          expect(response).to have_http_status(200)
+        end
+
+        it 'returns false' do
+          get :check
+          expect(body_as_json).to be false
+        end
+      end
+
+      context 'when the account is confirmed' do
+        let(:confirmed_at) { Time.now.utc }
+
+        it 'returns http success' do
+          get :check
+          expect(response).to have_http_status(200)
+        end
+
+        it 'returns true' do
+          get :check
+          expect(body_as_json).to be true
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds a new API endpoint `GET /api/v1/emails/check_confirmation` that returns `true` if the current user is confirmed and `false` otherwise (requires the `read` or `read:accounts` OAuth scope).

Add polling to `/auth/setup` so that the user is automatically redirect to `/start` when verified. This is useful if they, for instance, sign up on their computer but check their confirmation email on mobile.

---

Fixes MAS-150