### PR TITLE
Add support for custom sign-up URLs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,7 +52,7 @@ module ApplicationHelper
     if closed_registrations? || omniauth_only?
       'https://joinmastodon.org/#getting-started'
     else
-      new_user_registration_path
+      ENV.fetch('SSO_ACCOUNT_SIGN_UP', new_user_registration_path)
     end
   end
 

--- a/app/javascript/mastodon/features/interaction_modal/index.jsx
+++ b/app/javascript/mastodon/features/interaction_modal/index.jsx
@@ -9,6 +9,7 @@ import { openModal, closeModal } from 'mastodon/actions/modal';
 
 const mapStateToProps = (state, { accountId }) => ({
   displayNameHtml: state.getIn(['accounts', accountId, 'display_name_html']),
+  signupUrl: state.getIn(['server', 'server', 'registrations', 'sign_up_url'], '/auth/sign_up'),
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -81,6 +82,7 @@ class InteractionModal extends React.PureComponent {
     url: PropTypes.string,
     type: PropTypes.oneOf(['reply', 'reblog', 'favourite', 'follow']),
     onSignupClick: PropTypes.func.isRequired,
+    signupUrl: PropTypes.string.isRequired,
   };
 
   handleSignupClick = () => {
@@ -88,7 +90,7 @@ class InteractionModal extends React.PureComponent {
   };
 
   render () {
-    const { url, type, displayNameHtml } = this.props;
+    const { url, type, displayNameHtml, signupUrl } = this.props;
 
     const name = <bdi dangerouslySetInnerHTML={{ __html: displayNameHtml }} />;
 
@@ -121,7 +123,7 @@ class InteractionModal extends React.PureComponent {
 
     if (registrationsOpen) {
       signupButton = (
-        <a href='/auth/sign_up' className='button button--block button-tertiary'>
+        <a href={signupUrl} className='button button--block button-tertiary'>
           <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
         </a>
       );

--- a/app/javascript/mastodon/features/interaction_modal/index.jsx
+++ b/app/javascript/mastodon/features/interaction_modal/index.jsx
@@ -9,7 +9,7 @@ import { openModal, closeModal } from 'mastodon/actions/modal';
 
 const mapStateToProps = (state, { accountId }) => ({
   displayNameHtml: state.getIn(['accounts', accountId, 'display_name_html']),
-  signupUrl: state.getIn(['server', 'server', 'registrations', 'sign_up_url'], '/auth/sign_up'),
+  signupUrl: state.getIn(['server', 'server', 'registrations', 'url'], '/auth/sign_up'),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -16,6 +16,10 @@ const Account = connect(state => ({
   </Link>
 ));
 
+const mapStateToProps = (state) => ({
+  signupUrl: state.getIn(['server', 'server', 'registrations', 'sign_up_url'], '/auth/sign_up'),
+});
+
 const mapDispatchToProps = (dispatch) => ({
   openClosedRegistrationsModal() {
     dispatch(openModal('CLOSED_REGISTRATIONS'));
@@ -31,11 +35,12 @@ class Header extends React.PureComponent {
   static propTypes = {
     openClosedRegistrationsModal: PropTypes.func,
     location: PropTypes.object,
+    signupUrl: PropTypes.string.isRequired,
   };
 
   render () {
     const { signedIn } = this.context.identity;
-    const { location, openClosedRegistrationsModal } = this.props;
+    const { location, openClosedRegistrationsModal, signupUrl } = this.props;
 
     let content;
 
@@ -51,7 +56,7 @@ class Header extends React.PureComponent {
 
       if (registrationsOpen) {
         signupButton = (
-          <a href='/auth/sign_up' className='button'>
+          <a href={signupUrl} className='button'>
             <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
           </a>
         );
@@ -87,4 +92,4 @@ class Header extends React.PureComponent {
 
 }
 
-export default withRouter(connect(null, mapDispatchToProps)(Header));
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Header));

--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -17,7 +17,7 @@ const Account = connect(state => ({
 ));
 
 const mapStateToProps = (state) => ({
-  signupUrl: state.getIn(['server', 'server', 'registrations', 'sign_up_url'], '/auth/sign_up'),
+  signupUrl: state.getIn(['server', 'server', 'registrations', 'url'], '/auth/sign_up'),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
+++ b/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
@@ -14,7 +14,7 @@ const SignInBanner = () => {
 
   let signupButton;
 
-  const signupUrl = useAppSelector((state) => state.getIn(['server', 'server', 'registrations', 'sign_up_url'], '/auth/sign_up'));
+  const signupUrl = useAppSelector((state) => state.getIn(['server', 'server', 'registrations', 'url'], '/auth/sign_up'));
 
   if (registrationsOpen) {
     signupButton = (

--- a/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
+++ b/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
@@ -1,11 +1,11 @@
 import React, { useCallback } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useDispatch } from 'react-redux';
+import { useAppDispatch, useAppSelector } from 'mastodon/store';
 import { registrationsOpen } from 'mastodon/initial_state';
 import { openModal } from 'mastodon/actions/modal';
 
 const SignInBanner = () => {
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
 
   const openClosedRegistrationsModal = useCallback(
     () => dispatch(openModal('CLOSED_REGISTRATIONS')),
@@ -14,9 +14,11 @@ const SignInBanner = () => {
 
   let signupButton;
 
+  const signupUrl = useAppSelector((state) => state.getIn(['server', 'server', 'registrations', 'sign_up_url'], '/auth/sign_up'));
+
   if (registrationsOpen) {
     signupButton = (
-      <a href='/auth/sign_up' className='button button--block'>
+      <a href={signupUrl} className='button button--block'>
         <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
       </a>
     );

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -85,7 +85,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       enabled: registrations_enabled?,
       approval_required: Setting.registrations_mode == 'approved',
       message: registrations_enabled? ? nil : registrations_message,
-      sign_up_url: ENV.fetch('SSO_ACCOUNT_SIGN_UP', nil),
+      url: ENV.fetch('SSO_ACCOUNT_SIGN_UP', nil),
     }
   end
 

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -85,6 +85,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
       enabled: registrations_enabled?,
       approval_required: Setting.registrations_mode == 'approved',
       message: registrations_enabled? ? nil : registrations_message,
+      sign_up_url: ENV.fetch('SSO_ACCOUNT_SIGN_UP', nil),
     }
   end
 


### PR DESCRIPTION
Add new environment variable `SSO_ACCOUNT_SIGN_UP` which if set is used instead of `/auth/sign_in`.

This is reflected in `/api/v2/instance` as `registrations.sign_up_url`.

---

Fixes MAS-117