### PR TITLE
Improve test coverage for `/api/v1/admin/email_domain_blocks`

### DIFF
--- a/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
@@ -116,4 +116,50 @@ describe Api::V1::Admin::EmailDomainBlocksController do
       end
     end
   end
+
+  describe 'GET #show' do
+    let!(:email_domain_block) { Fabricate(:email_domain_block) }
+    let(:params) { { id: email_domain_block } }
+
+    context 'with wrong scope' do
+      before do
+        get :show, params: params
+      end
+
+      it_behaves_like 'forbidden for wrong scope', 'read:statuses'
+    end
+
+    context 'with wrong role' do
+      before do
+        get :show, params: params
+      end
+
+      it_behaves_like 'forbidden for wrong role', ''
+      it_behaves_like 'forbidden for wrong role', 'Moderator'
+    end
+
+    context 'when email domain block exists' do
+      it 'returns http success' do
+        get :show, params: params
+
+        expect(response).to have_http_status(200)
+      end
+
+      it 'returns the correct blocked domain' do
+        get :show, params: params
+
+        json = body_as_json
+
+        expect(json[:domain]).to eq(email_domain_block.domain)
+      end
+    end
+
+    context 'when email domain block does not exist' do
+      it 'returns http not found' do
+        get :show, params: { id: 0 }
+
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
 end

--- a/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 describe Api::V1::Admin::EmailDomainBlocksController do
   render_views
 
-  let(:role) { UserRole.find_by(name: 'Admin') }
+  let(:role)    { UserRole.find_by(name: 'Admin') }
   let(:user)    { Fabricate(:user, role: role) }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:account) { Fabricate(:account) }
-  let(:scopes) { 'admin:read:email_domain_blocks admin:write:email_domain_blocks' }
+  let(:scopes)  { 'admin:read:email_domain_blocks admin:write:email_domain_blocks' }
 
   before do
     allow(controller).to receive(:doorkeeper_token) { token }

--- a/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
@@ -119,7 +119,7 @@ describe Api::V1::Admin::EmailDomainBlocksController do
 
   describe 'GET #show' do
     let!(:email_domain_block) { Fabricate(:email_domain_block) }
-    let(:params) { { id: email_domain_block } }
+    let(:params) { { id: email_domain_block.id } }
 
     context 'with wrong scope' do
       before do

--- a/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
@@ -162,4 +162,59 @@ describe Api::V1::Admin::EmailDomainBlocksController do
       end
     end
   end
+
+  describe 'POST #create' do
+    let(:params) { { domain: 'example.com' } }
+
+    context 'with wrong scope' do
+      before do
+        post :create, params: params
+      end
+
+      it_behaves_like 'forbidden for wrong scope', 'read:statuses'
+    end
+
+    context 'with wrong role' do
+      before do
+        post :create, params: params
+      end
+
+      it_behaves_like 'forbidden for wrong role', ''
+      it_behaves_like 'forbidden for wrong role', 'Moderator'
+    end
+
+    it 'returns http success' do
+      post :create, params: params
+
+      expect(response).to have_http_status(200)
+    end
+
+    it 'returns the correct blocked email domain' do
+      post :create, params: params
+
+      json = body_as_json
+
+      expect(json[:domain]).to eq(params[:domain])
+    end
+
+    context 'when domain param is not provided' do
+      let(:params) { { domain: '' } }
+
+      it 'returns http unprocessable entity' do
+        post :create, params: params
+
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when provided domain name has an invalid character' do
+      let(:params) { { domain: 'do\uD800.com' } }
+
+      it 'returns http unprocessable entity' do
+        post :create, params: params
+
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
 end

--- a/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
@@ -216,6 +216,18 @@ describe Api::V1::Admin::EmailDomainBlocksController do
         expect(response).to have_http_status(422)
       end
     end
+
+    context 'when provided domain is already blocked' do
+      before do
+        EmailDomainBlock.create(params)
+      end
+
+      it 'returns http unprocessable entity' do
+        post :create, params: params
+
+        expect(response).to have_http_status(422)
+      end
+    end
   end
 
   describe 'DELETE #destroy' do

--- a/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/email_domain_blocks_controller_spec.rb
@@ -217,4 +217,56 @@ describe Api::V1::Admin::EmailDomainBlocksController do
       end
     end
   end
+
+  describe 'DELETE #destroy' do
+    let!(:email_domain_block) { Fabricate(:email_domain_block) }
+    let(:params) { { id: email_domain_block.id } }
+
+    context 'with wrong scope' do
+      before do
+        delete :destroy, params: params
+      end
+
+      it_behaves_like 'forbidden for wrong scope', 'read:statuses'
+    end
+
+    context 'with wrong role' do
+      before do
+        delete :destroy, params: params
+      end
+
+      it_behaves_like 'forbidden for wrong role', ''
+      it_behaves_like 'forbidden for wrong role', 'Moderator'
+    end
+
+    it 'returns http success' do
+      delete :destroy, params: params
+
+      expect(response).to have_http_status(200)
+    end
+
+    it 'returns an empty body' do
+      delete :destroy, params: params
+
+      json = body_as_json
+
+      expect(json).to be_empty
+    end
+
+    it 'deletes email domain block' do
+      delete :destroy, params: params
+
+      email_domain_block = EmailDomainBlock.find_by(id: params[:id])
+
+      expect(email_domain_block).to be_nil
+    end
+
+    context 'when email domain block does not exist' do
+      it 'returns http not found' do
+        delete :destroy, params: { id: 0 }
+
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR improves the test coverage for the `Api::V1::Admin::EmailDomainBlocksController` class.