### PR TITLE
Fix crash when S3_ALIAS_HOST or S3_CLOUDFRONT_HOST have a path component

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -169,11 +169,11 @@ module ApplicationHelper
   end
 
   def storage_host
-    URI::HTTPS.build(host: storage_host_name).to_s
+    "https://#{storage_host_var}"
   end
 
   def storage_host?
-    storage_host_name.present?
+    storage_host_var.present?
   end
 
   def quote_wrap(text, line_width: 80, break_sequence: "\n")
@@ -234,7 +234,7 @@ module ApplicationHelper
 
   private
 
-  def storage_host_name
+  def storage_host_var
     ENV.fetch('S3_ALIAS_HOST', nil) || ENV.fetch('S3_CLOUDFRONT_HOST', nil)
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -208,6 +208,18 @@ describe ApplicationHelper do
       end
     end
 
+    context 'when S3 alias includes a path component' do
+      around do |example|
+        ClimateControl.modify S3_ALIAS_HOST: 's3.alias/path' do
+          example.run
+        end
+      end
+
+      it 'returns a correct URL' do
+        expect(helper.storage_host).to eq('https://s3.alias/path')
+      end
+    end
+
     context 'when S3 cloudfront is present' do
       around do |example|
         ClimateControl.modify S3_CLOUDFRONT_HOST: 's3.cloudfront' do
@@ -217,12 +229,6 @@ describe ApplicationHelper do
 
       it 'returns true' do
         expect(helper.storage_host).to eq('https://s3.cloudfront')
-      end
-    end
-
-    context 'when neither env value is present' do
-      it 'returns false' do
-        expect(helper.storage_host).to eq('https:')
       end
     end
   end


### PR DESCRIPTION
Those variables are allowed to have a path component despite their name.