### PR TITLE
Add scheduled job to lockdown excessive registrations

### DIFF
--- a/app/workers/scheduler/user_registration_protection_scheduler.rb
+++ b/app/workers/scheduler/user_registration_protection_scheduler.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Scheduler::UserRegistrationProtectionScheduler
+  include Sidekiq::Worker
+
+  def perform
+    return unless User.where(created_at: (Time.now.utc - 5.minutes)..Time.now.utc).count > ENV.fetch('MAX_REGISTRATIONS_THRESHOLD', 1_000).to_i
+
+    Setting.registrations_mode = if Setting.registrations_mode == 'open'
+                                   'approved'
+                                 else
+                                   'none'
+                                 end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -26,6 +26,10 @@
       every: '5m'
       class: Scheduler::IndexingScheduler
       queue: scheduler
+    user_registration_protection_scheduler:
+      every: '5m'
+      class: Scheduler::UserRegistrationProtectionScheduler
+      queue: scheduler
     vacuum_scheduler:
       cron: '<%= Random.rand(0..59) %> <%= Random.rand(3..5) %> * * *'
       class: Scheduler::VacuumScheduler


### PR DESCRIPTION
Since the recent spam attacks on mastodon.social have included a massive increase in new user registrations, this job will automatically lockdown user registrations if they become excessive.
The job runs every 5 minutes and checks how many new Users have been created in the previous 5 minutes. If it exceeds `MAX_REGISTRATIONS_THRESHOLD` (default is 1000), then it will restrict open signups to approved, or approved to closed.