### PR TITLE
Change nightly version suffix to be consistent with docker image tag

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -28,6 +28,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate nightly version number
+        id: version_vars
+        run: |
+          echo mastodon_nightly_version=nightly-$(TZ="Etc/UTC" date +'%Y-%m-%d') >> $GITHUB_OUTPUT
+
       - uses: docker/metadata-action@v4
         id: meta
         with:
@@ -37,19 +42,16 @@ jobs:
             latest=auto
           tags: |
             type=raw,value=nightly
-            type=schedule,pattern=nightly-{{date 'YYYY-MM-DD' tz='Etc/UTC'}}
+            type=schedule,pattern=${{ steps.version_vars.outputs.mastodon_nightly_version }}
           labels: |
             org.opencontainers.image.description=Nightly build image used for testing purposes
-
-      - name: Generate version suffix
-        id: version_vars
-        run: |
-          echo mastodon_version_suffix=+nightly-$(TZ="Etc/UTC" date +'%Y-%m-%d') >> $GITHUB_OUTPUT
 
       - uses: docker/build-push-action@v4
         with:
           context: .
-          build-args: MASTODON_VERSION_SUFFIX=${{ steps.version_vars.outputs.mastodon_version_suffix }}
+          # The version suffix needs the plus character here so that it reads as
+          # v4.1.2+nightly-2022-03-05 instead of v4.1.2nightly-2022-03-05
+          build-args: MASTODON_VERSION_SUFFIX=+${{ steps.version_vars.outputs.mastodon_nightly_version }}
           platforms: linux/amd64,linux/arm64
           provenance: false
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Generate version suffix
         id: version_vars
         run: |
-          echo mastodon_version_suffix=+nightly-$(date 'YYYY-MM-DD' tz='Etc/UTC') >> $GITHUB_OUTPUT
+          echo mastodon_version_suffix=+nightly-$(TZ="Etc/UTC" date +'%Y-%m-%d') >> $GITHUB_OUTPUT
 
       - uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Generate version suffix
         id: version_vars
         run: |
-          echo mastodon_version_suffix=+nightly-$(date +'%Y%m%d') >> $GITHUB_OUTPUT
+          echo mastodon_version_suffix=+nightly-$(date 'YYYY-MM-DD' tz='Etc/UTC') >> $GITHUB_OUTPUT
 
       - uses: docker/build-push-action@v4
         with:


### PR DESCRIPTION
This was noticed in Discord that Docker Tags for nightly used `nightly-YYYY-MM-DD` format, when the suffix used `nightly-YYYYMMDD` format, additionally, the suffix wasn't in UTC, but the docker tag was.

I think it's fine to align the suffix with the docker tags, and is the least disruptive approach, though I'm not sure if it complies with any specific formatting (I can't find information about nightlies in either semver or pep440)