### PR TITLE
Allow reports with long comments from remote instances, but truncate

### DIFF
--- a/app/lib/activitypub/activity/flag.rb
+++ b/app/lib/activitypub/activity/flag.rb
@@ -16,7 +16,7 @@ class ActivityPub::Activity::Flag < ActivityPub::Activity
         @account,
         target_account,
         status_ids: target_statuses.nil? ? [] : target_statuses.map(&:id),
-        comment: @json['content'] || '',
+        comment: report_comment,
         uri: report_uri
       )
     end
@@ -34,5 +34,9 @@ class ActivityPub::Activity::Flag < ActivityPub::Activity
 
   def report_uri
     @json['id'] unless @json['id'].nil? || non_matching_uri_hosts?(@account.uri, @json['id'])
+  end
+
+  def report_comment
+    (@json['content'] || '')[0...5000]
   end
 end

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -28,6 +28,8 @@ class ActivityPub::TagManager
       return activity_account_status_url(target.account, target) if target.reblog?
 
       short_account_status_url(target.account, target)
+    when :flag
+      target.uri
     end
   end
 
@@ -43,6 +45,8 @@ class ActivityPub::TagManager
       account_status_url(target.account, target)
     when :emoji
       emoji_url(target)
+    when :flag
+      target.uri
     end
   end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -40,7 +40,10 @@ class Report < ApplicationRecord
   scope :resolved,   -> { where.not(action_taken_at: nil) }
   scope :with_accounts, -> { includes([:account, :target_account, :action_taken_by_account, :assigned_account].index_with({ user: [:invite_request, :invite] })) }
 
-  validates :comment, length: { maximum: 1_000 }
+  # A report is considered local if the reporter is local
+  delegate :local?, to: :account
+
+  validates :comment, length: { maximum: 1_000 }, if: :local?
   validates :rule_ids, absence: true, unless: :violation?
 
   validate :validate_rule_ids
@@ -50,10 +53,6 @@ class Report < ApplicationRecord
     spam: 1_000,
     violation: 2_000,
   }
-
-  def local?
-    false # Force uri_for to use uri attribute
-  end
 
   before_validation :set_uri, only: :create
 

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -121,10 +121,17 @@ describe Report do
   end
 
   describe 'validations' do
-    it 'is invalid if comment is longer than 1000 characters' do
+    let(:remote_account) { Fabricate(:account, domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
+
+    it 'is invalid if comment is longer than 1000 characters only if reporter is local' do
       report = Fabricate.build(:report, comment: Faker::Lorem.characters(number: 1001))
-      report.valid?
+      expect(report.valid?).to be false
       expect(report).to model_have_error_on_field(:comment)
+    end
+
+    it 'is valid if comment is longer than 1000 characters and reporter is not local' do
+      report = Fabricate.build(:report, account: remote_account, comment: Faker::Lorem.characters(number: 1001))
+      expect(report.valid?).to be true
     end
   end
 end

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe ReportService, type: :service do
   subject { described_class.new }
 
   let(:source_account) { Fabricate(:account) }
+  let(:target_account) { Fabricate(:account) }
+
+  context 'with a local account' do
+    it 'has a uri' do
+      report = subject.call(source_account, target_account)
+      expect(report.uri).to_not be_nil
+    end
+  end
 
   context 'with a remote account' do
     let(:remote_account) { Fabricate(:account, domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
@@ -35,7 +43,6 @@ RSpec.describe ReportService, type: :service do
       -> { described_class.new.call(source_account, target_account, status_ids: [status.id]) }
     end
 
-    let(:target_account) { Fabricate(:account) }
     let(:status) { Fabricate(:status, account: target_account, visibility: :direct) }
 
     context 'when it is addressed to the reporter' do
@@ -91,8 +98,7 @@ RSpec.describe ReportService, type: :service do
       -> {  described_class.new.call(source_account, target_account) }
     end
 
-    let!(:target_account) { Fabricate(:account) }
-    let!(:other_report)   { Fabricate(:report, target_account: target_account) }
+    let!(:other_report) { Fabricate(:report, target_account: target_account) }
 
     before do
       ActionMailer::Base.deliveries.clear


### PR DESCRIPTION
This is an attempted fix for #24975. I didn't understand exactly the logic for the following, which is to say my confidence in this PR not having unintended side-effects is low, despite all the tests passing:

```rb
  def local?
    false # Force uri_for to use uri attribute
  end
```

So added explicit `url_for` and `uri_for` handling for Flag's (reports), making `local?` become delegated to if the account making the report is local or not.

I do note that in `url_for`, the line `return target.url if target.respond_to?(:local?) && !target.local?` may not work if the target only has a `uri` and not `url` property/method, I'm not sure if this is intentional or not?

Further, I noticed that `generate_uri_for` is returning [not the value the code implies](https://discord.com/channels/231908446830723072/231908446830723072/1108508738219954236) it may be returning, and that there was no test coverage for using ReportService to create local reports, despite this being how ReportService is used (it's used for both API reports and ActivityPub Flag's)