### PR TITLE
Add support for server-specific emergency rules

### DIFF
--- a/app/controllers/admin/emergency_rules_controller.rb
+++ b/app/controllers/admin/emergency_rules_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  class EmergencyRulesController < BaseController
+    before_action :set_rule, except: [:index]
+
+    def index
+      authorize [:emergency, :rule], :index?
+
+      @rules = Emergency::Rule.all.to_a
+    end
+
+    def deactivate
+      authorize @rule, :deactivate?
+      # TODO: log?
+      @rule.deactivate!
+
+      redirect_to admin_emergency_rules_path, notice: I18n.t('admin.emergency_rules.deactivated_msg')
+    end
+
+    private
+
+    def set_rule
+      @rule = Emergency::Rule.find(params[:id])
+    end
+  end
+end

--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -36,4 +36,12 @@ module Admin::DashboardHelper
 
     content_tag(:time, l(timestamp), class: 'time-ago', datetime: timestamp.iso8601, title: l(timestamp))
   end
+
+  def emergency_rule_notice
+    return unless Emergency::Rule.any_active?
+
+    content_tag(:div, class: 'flash-message warning') do
+      I18n.t('admin.emergency_rules.notice_html', path: admin_emergency_rules_path).html_safe
+    end
+  end
 end

--- a/app/lib/emergency/tracker.rb
+++ b/app/lib/emergency/tracker.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class Emergency::Tracker
+  include Redisable
+
+  DURATIONS = {
+    minute: 1.minute.to_i,
+    hour: 1.hour.to_i,
+    day: 1.day.to_i,
+  }.freeze
+
+  RETENTION_FACTOR = 5
+
+  def initialize(prefix)
+    @prefix = prefix
+  end
+
+  def add(value = 1, at_time = Time.now.utc)
+    DURATIONS.each do |duration_type, duration|
+      key = key_at(at_time, duration_type)
+      redis.incrby(key, value)
+      redis.expire(key, duration * RETENTION_FACTOR)
+    end
+
+    # TODO: trigger stuff
+  end
+
+  class << self
+    def increment(prefix)
+      new(prefix).add
+    end
+  end
+
+  private
+
+  def key_at(at_time, duration_type)
+    subkey = begin
+      case duration_type
+      when :minute
+        at_time.beginning_of_minute.to_i
+      when :hour
+        at_time.beginning_of_hour.to_i
+      when :day
+        at_time.beginning_of_day.to_i
+      end
+    end
+
+    "emergency/tracking:#{@prefix}:#{duration_type}:#{subkey}"
+  end
+end

--- a/app/lib/rate_limiter.rb
+++ b/app/lib/rate_limiter.rb
@@ -61,7 +61,7 @@ class RateLimiter
   private
 
   def limits
-    @limits ||= [default_limit]
+    @limits ||= [default_limit, Emergency::RateLimitAction.get_rate_limits_for(@family, @by, last_epoch_time)].flatten.compact
   end
 
   def default_limit

--- a/app/lib/rate_limiter.rb
+++ b/app/lib/rate_limiter.rb
@@ -23,35 +23,53 @@ class RateLimiter
   def initialize(by, options = {})
     @by     = by
     @family = options[:family]
-    @limit  = FAMILIES[@family][:limit]
-    @period = FAMILIES[@family][:period].to_i
   end
 
   def record!
-    count = redis.multi do |transaction|
-      transaction.incr(key)
-      transaction.expire(key, (@period - (last_epoch_time % @period) + 1).to_i)
-    end.first
+    limits.each.with_index do |limit, index|
+      count = redis.multi do |transaction|
+        transaction.incr(limit[:key])
+        transaction.expire(limit[:key], (limit[:period] - (last_epoch_time % limit[:period]) + 1).to_i)
+      end.first
 
-    raise Mastodon::RateLimitExceededError if count.to_i > @limit
+      if count.to_i > limit[:limit]
+        limits.take(index).each { |earlier_limit| redis.decr(earlier_limit[:key]) }
+
+        raise Mastodon::RateLimitExceededError
+      end
+    end
   end
 
   def rollback!
-    redis.decr(key)
+    redis.pipelined do |pipeline|
+      limits.each { |limit| pipeline.decr(limit.key) }
+    end
   end
 
   def to_headers(now = Time.now.utc)
+    counts = redis.mget(limits.pluck(:key))
+    remaining_attempts = limits.zip(counts).map { |limit, count| [limit[:limit] - (count || 0).to_i, 0].max }
+    limit, remaining = limits.zip(remaining_attempts).min_by(&:second)
+
     {
-      'X-RateLimit-Limit' => @limit.to_s,
-      'X-RateLimit-Remaining' => [@limit - (redis.get(key) || 0).to_i, 0].max.to_s,
-      'X-RateLimit-Reset' => (now + (@period - (now.to_i % @period))).iso8601(6),
+      'X-RateLimit-Limit' => limit[:limit].to_s,
+      'X-RateLimit-Remaining' => remaining.to_s,
+      'X-RateLimit-Reset' => (now + (limit[:period] - (now.to_i % limit[:period]))).iso8601(6),
     }
   end
 
   private
 
-  def key
-    @key ||= "rate_limit:#{@by.id}:#{@family}:#{(last_epoch_time / @period).to_i}"
+  def limits
+    @limits ||= [default_limit]
+  end
+
+  def default_limit
+    {
+      limit: FAMILIES[@family][:limit],
+      period: FAMILIES[@family][:period].to_i,
+      key: "rate_limit:#{@by.id}:#{@family}:#{(last_epoch_time / FAMILIES[@family][:period].to_i).to_i}",
+    }
   end
 
   def last_epoch_time

--- a/app/models/emergency.rb
+++ b/app/models/emergency.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Emergency
+  def self.table_name_prefix
+    'emergency_'
+  end
+end

--- a/app/models/emergency/rate_limit_action.rb
+++ b/app/models/emergency/rate_limit_action.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: emergency_rate_limit_actions
+#
+#  id                :bigint(8)        not null, primary key
+#  emergency_rule_id :bigint(8)        not null
+#  new_users_only    :boolean          default(FALSE), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+class Emergency::RateLimitAction < ApplicationRecord
+  belongs_to :emergency_rule, class_name: 'Emergency::Rule', inverse_of: :rate_limit_actions
+
+  FAMILIES = {
+    follows: {
+      limit: 10,
+      period: 1.hour.freeze,
+    }.freeze,
+
+    statuses: {
+      limit: 1,
+      period: 5.minutes.freeze,
+    }.freeze,
+
+    reports: {
+      limit: 1,
+      period: 10.minutes.freeze,
+    }.freeze,
+  }.freeze
+
+  after_commit :invalidate_cache!
+
+  class << self
+    def get_rate_limits_for(family, by, last_epoch_time)
+      return unless by.is_a?(Account) && by.user.present?
+
+      # Cache a compact representation of the rate limits so we can save queries to the cache
+      records = Rails.cache.fetch('emergency_rate_limits:cache') do
+        all.map { |action| [action.id, action.emergency_rule_id, action.new_users_only?] }
+      end
+
+      return if records.nil?
+
+      rules_triggered_at = Emergency::Rule.triggered_at(records.map(&:second))
+
+      records.zip(rules_triggered_at).filter_map do |(action_id, _, new_users_only), triggered_at|
+        next if triggered_at.nil? # Skip inactive rules
+        next if new_users_only && (by.user.confirmed_at.nil? || triggered_at > by.user.confirmed_at)
+
+        {
+          limit: FAMILIES[family][:limit],
+          period: FAMILIES[family][:period].to_i,
+          key: "emergency_rate_limit:#{action_id}:#{by.id}:#{family}:#{(last_epoch_time / FAMILIES[family][:period].to_i).to_i}",
+        }
+      end
+    end
+  end
+
+  private
+
+  def invalidate_cache!
+    Rails.cache.delete('emergency_rate_limits:cache')
+  end
+end

--- a/app/models/emergency/rule.rb
+++ b/app/models/emergency/rule.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: emergency_rules
+#
+#  id         :bigint(8)        not null, primary key
+#  name       :string           not null
+#  duration   :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Emergency::Rule < ApplicationRecord
+  include Redisable
+
+  has_many :triggers, class_name: 'Emergency::Trigger', foreign_key: 'emergency_rule_id', inverse_of: :emergency_rule, dependent: :destroy
+  has_many :rate_limit_actions, class_name: 'Emergency::RateLimitAction', foreign_key: 'emergency_rule_id', inverse_of: :emergency_rule, dependent: :destroy
+
+  validates :name, presence: true
+
+  def active?
+    with_redis { |redis| redis.get(redis_key).present? }
+  end
+
+  def deactivate!
+    with_redis { |redis| redis.del(redis_key) }
+  end
+
+  def triggered_at
+    raw = with_redis { |redis| redis.get(redis_key) }
+    Time.at(raw.to_i).utc if raw.present?
+  end
+
+  def trigger!(event_start)
+    Emergency::Rule.redis_set_if_lower!(redis_key, event_start.to_i, ex: duration)
+  end
+
+  class << self
+    include Redisable
+
+    LUA_SET_IF_LOWER = <<~LUA
+      local key, new_value, expiration = KEYS[1], ARGV[1], ARGV[2]
+      local value = redis.call('GET', key)
+      if (not value) or tonumber(value) > tonumber(new_value) then
+        if expiration then
+          return redis.call('SET', key, new_value, 'EX', expiration)
+        else
+          return redis.call('SET', key, new_value)
+        end
+      else
+        if expiration then
+          return redis.call('EXPIRE', key, expiration)
+        else
+          return redis.call('PERSIST', key)
+        end
+      end
+    LUA
+
+    def redis_set_if_lower!(key, value, ex: nil) # rubocop:disable Naming/MethodParameterName
+      with_redis do |redis|
+        if @lua_set_if_lower_sha.nil?
+          raw_conn = redis.respond_to?(:redis) ? redis.redis : redis
+          @lua_set_if_lower_sha = raw_conn.script(:load, LUA_SET_IF_LOWER)
+        end
+
+        args = [value]
+        args << ex if ex.present?
+        redis.evalsha(@lua_set_if_lower_sha, [key], args)
+      rescue Redis::CommandError => e
+        raise unless e.message.start_with?('NOSCRIPT')
+
+        @lua_set_if_lower_sha = nil
+        retry
+      end
+    end
+
+    def triggered_at(ids)
+      return [] if ids.empty?
+
+      with_redis do |redis|
+        redis.mget(ids.map { |rule_id| "emergency_rules:triggered_at:#{rule_id}" }).map { |raw| Time.at(raw.to_i).utc if raw.present? }
+      end
+    end
+
+    def any_active?
+      triggered_at(pluck(:id)).any?
+    end
+  end
+
+  private
+
+  def redis_key
+    "emergency_rules:triggered_at:#{id}"
+  end
+end

--- a/app/models/emergency/rule.rb
+++ b/app/models/emergency/rule.rb
@@ -15,6 +15,7 @@ class Emergency::Rule < ApplicationRecord
 
   has_many :triggers, class_name: 'Emergency::Trigger', foreign_key: 'emergency_rule_id', inverse_of: :emergency_rule, dependent: :destroy
   has_many :rate_limit_actions, class_name: 'Emergency::RateLimitAction', foreign_key: 'emergency_rule_id', inverse_of: :emergency_rule, dependent: :destroy
+  has_many :setting_override_actions, class_name: 'Emergency::SettingOverrideAction', foreign_key: 'emergency_rule_id', inverse_of: :emergency_rule, dependent: :destroy
 
   validates :name, presence: true
 

--- a/app/models/emergency/setting_override_action.rb
+++ b/app/models/emergency/setting_override_action.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: emergency_setting_override_actions
+#
+#  id                :bigint(8)        not null, primary key
+#  emergency_rule_id :bigint(8)        not null
+#  setting           :string           not null
+#  value             :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+class Emergency::SettingOverrideAction < ApplicationRecord
+  belongs_to :emergency_rule, class_name: 'Emergency::Rule', inverse_of: :setting_override_actions
+
+  # When multiple values are allowed, and rules define multiple overrides,
+  # the first one in the allowed list takes precedence, e.g. if a rule
+  # sets the registration mode to `approved` and another to `none`, and
+  # both rules are active, the mode is switched to `none` because this is
+  # the first value to appear in the list below.
+  ALLOWED_SETTINGS = {
+    'registrations_mode' => %w(none approved),
+    'captcha_enabled' => %w(true),
+  }.freeze
+
+  validates :setting, presence: true, inclusion: { in: ALLOWED_SETTINGS.keys }
+
+  after_commit :invalidate_cache!
+
+  class << self
+    def overridden_setting(key)
+      return nil unless ALLOWED_SETTINGS.key?(key)
+
+      candidates = Rails.cache.fetch("emergency_setting_override:#{key}") do
+        where(setting: key).pluck(:emergency_rule_id, :value)
+      end
+
+      return nil if candidates.empty?
+
+      rules_triggered_at = Emergency::Rule.triggered_at(candidates.map(&:first))
+
+      values = candidates.map(&:second).zip(rules_triggered_at).filter_map { |value, triggered_at| value if triggered_at.present? }
+      return nil if values.empty?
+
+      ALLOWED_SETTINGS[key].first { |value| values.include?(value) }
+    end
+  end
+
+  private
+
+  def invalidate_cache!
+    Rails.cache.delete("emergency_setting_override:#{setting}")
+  end
+end

--- a/app/models/emergency/trigger.rb
+++ b/app/models/emergency/trigger.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: emergency_triggers
+#
+#  id                :bigint(8)        not null, primary key
+#  emergency_rule_id :bigint(8)        not null
+#  event             :string           not null
+#  threshold         :integer          not null
+#  duration_bucket   :integer          not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+class Emergency::Trigger < ApplicationRecord
+  belongs_to :emergency_rule, class_name: 'Emergency::Rule', inverse_of: :triggers
+
+  validates :event, inclusion: { in: %w(local:signups local:confirmations local:posts) }
+
+  enum duration_bucket: {
+    minute: 0,
+    hour: 1,
+    day: 2,
+  }
+
+  after_commit :invalidate_thresholds_cache!
+
+  class << self
+    def process_event(event, at_time, counts)
+      # If we haven't reached the lowest threshold, we can avoid database queries
+      return if thresholds(event).none? { |bucket, threshold| counts[bucket.to_sym] && counts[bucket.to_sym] >= threshold }
+
+      scope = none
+      counts.each do |key, count|
+        scope = scope.or(where(event: event, duration_bucket: key, threshold: ..count))
+      end
+
+      scope.joins(:emergency_rule).to_a.group_by(&:emergency_rule).each do |rule, triggers|
+        event_time = triggers.map(&:duration_bucket).map do |bucket|
+          case bucket.to_sym
+          when :minute
+            at_time.beginning_of_minute
+          when :hour
+            at_time.beginning_of_hour
+          when :day
+            at_time.beginning_of_day
+          end
+        end.min
+
+        rule.trigger!(event_time)
+      end
+    end
+
+    def thresholds(event)
+      Rails.cache.fetch("emergency_rules:triggers:thresholds:#{event}") do
+        Emergency::Trigger.where(event: event).group(:duration_bucket).minimum(:threshold)
+      end
+    end
+  end
+
+  private
+
+  def invalidate_thresholds_cache!
+    Rails.cache.delete("emergency_rules:triggers:thresholds:#{event}")
+  end
+end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -91,7 +91,9 @@ class Form::AdminSettings
                      elsif OVERRIDEN_SETTINGS.include?(key)
                        public_send(OVERRIDEN_SETTINGS[key])
                      else
-                       Setting.public_send(key)
+                       # Avoid any of the emergency overrides by not doing
+                       # Setting.public_send(key)
+                       Setting[key.to_s]
                      end
 
       instance_variable_set(:"@#{key}", stored_value)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -96,6 +96,12 @@ class Setting < ApplicationRecord
       hash = content.empty? ? {} : YAML.safe_load(ERB.new(content).result, aliases: true).to_hash
       @default_settings = (hash[Rails.env] || {}).freeze
     end
+
+    Emergency::SettingOverrideAction::ALLOWED_SETTINGS.each_key do |key|
+      define_method(key) do
+        Emergency::SettingOverrideAction.overridden_setting(key) || self[key]
+      end
+    end
   end
 
   # get the value field, YAML decoded

--- a/app/policies/emergency/rule_policy.rb
+++ b/app/policies/emergency/rule_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Emergency::RulePolicy < ApplicationPolicy
+  def create?
+    false # TODO
+  end
+
+  def index?
+    role.can?(:manage_reports, :view_audit_log, :manage_users, :manage_invites, :manage_taxonomies, :manage_federation, :manage_blocks)
+  end
+
+  def deactivate?
+    role.can?(:manage_reports, :view_audit_log, :manage_users, :manage_invites, :manage_taxonomies, :manage_federation, :manage_blocks)
+  end
+end

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -49,6 +49,8 @@ class PostStatusService < BaseService
       process_status!
     end
 
+    Emergency::Tracker.increment('local:posts')
+
     redis.setex(idempotency_key, 3_600, @status.id) if idempotency_given?
 
     unless scheduled?

--- a/app/views/admin/accounts/index.html.haml
+++ b/app/views/admin/accounts/index.html.haml
@@ -1,6 +1,8 @@
 - content_for :page_title do
   = t('admin.accounts.title')
 
+= emergency_rule_notice
+
 = form_tag admin_accounts_url, method: 'GET', class: 'simple_form' do
   .filters
     .filter-subset.filter-subset--with-select

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -1,3 +1,5 @@
+= emergency_rule_notice
+
 - content_for :page_title do
   = t('admin.dashboard.title')
 

--- a/app/views/admin/emergency_rules/_emergency_rule.html.haml
+++ b/app/views/admin/emergency_rules/_emergency_rule.html.haml
@@ -1,0 +1,24 @@
+.filters-list__item
+  .filters-list__item__title
+    = emergency_rule.name
+
+    - if emergency_rule.active?
+      .expiration
+        - if can?(:deactivate, emergency_rule)
+          = link_to t('admin.emergency_rules.index.deactivate'), deactivate_admin_emergency_rule_path(emergency_rule.id), method: :post, class: 'button button-tertiary button--destructive'
+        - else
+          = t('admin.emergency_rules.active')
+
+  .filters-list__item__permissions
+    %ul.permissions-list
+      = render partial: 'trigger', collection: emergency_rule.triggers
+      = render partial: 'rate_limit_action', collection: emergency_rule.rate_limit_actions
+      = render partial: 'setting_override_action', collection: emergency_rule.setting_override_actions
+
+  .announcements-list__item__action-bar
+    .announcements-list__item__meta
+      -# TODO: history
+      - if emergency_rule.duration.present?
+        = t('admin.emergency_rules.expires_after_duration', duration: distance_of_time_in_words(Time.at(0).utc, Time.at(emergency_rule.duration).utc))
+      - else
+        = t('admin.emergency_rules.no_expiration')

--- a/app/views/admin/emergency_rules/_rate_limit_action.html.haml
+++ b/app/views/admin/emergency_rules/_rate_limit_action.html.haml
@@ -1,0 +1,8 @@
+%li.permissions-list__item
+  .permissions-list__item__icon
+    = fa_icon('gavel')
+  .permissions-list__item__text
+    .permissions-list__item__text__title
+      = rate_limit_action.new_users_only? ? t('admin.emergency_rules.rate_limit_actions.new_users_title') : t('admin.emergency_rules.rate_limit_actions.title')
+    .permissions-list__item__text__type
+      = rate_limit_action.new_users_only? ? t('admin.emergency_rules.rate_limit_actions.new_users_description') : t('admin.emergency_rules.rate_limit_actions.description')

--- a/app/views/admin/emergency_rules/_setting_override_action.html.haml
+++ b/app/views/admin/emergency_rules/_setting_override_action.html.haml
@@ -1,0 +1,8 @@
+%li.permissions-list__item
+  .permissions-list__item__icon
+    = fa_icon('gavel')
+  .permissions-list__item__text
+    .permissions-list__item__text__title
+      = t("admin.emergency_rules.setting_override_actions.#{setting_override_action.setting}.title_#{setting_override_action.value}")
+    .permissions-list__item__text__type
+      = t('admin.emergency_rules.setting_override_actions.description')

--- a/app/views/admin/emergency_rules/_trigger.html.haml
+++ b/app/views/admin/emergency_rules/_trigger.html.haml
@@ -1,0 +1,9 @@
+%li.permissions-list__item
+  .permissions-list__item__icon
+    = fa_icon('cogs')
+  .permissions-list__item__text
+    .permissions-list__item__text__title
+      = t("admin.emergency_rules.triggers.title.#{trigger.event}")
+    .permissions-list__item__text__type
+      - period = t("admin.emergency_rules.triggers.periods.#{trigger.duration_bucket}")
+      = t('admin.emergency_rules.triggers.description', threshold: trigger.threshold, period: period)

--- a/app/views/admin/emergency_rules/index.html.haml
+++ b/app/views/admin/emergency_rules/index.html.haml
@@ -1,0 +1,13 @@
+- content_for :page_title do
+  = t('admin.emergency_rules.index.title')
+
+- content_for :heading_actions do
+  = link_to t('admin.emergency_rules.index.add'), new_admin_emergency_rule_path, class: 'button' if can?(:create, [:emergency, :rule])
+
+  %p.lead= t('admin.emergency_rules.index.preamble')
+
+- if @rules.empty?
+  .muted-hint.center-text= t 'admin.emergency_rules.index.empty'
+- else
+  .applications-list
+    = render partial: 'emergency_rule', collection: @rules

--- a/app/views/admin/reports/index.html.haml
+++ b/app/views/admin/reports/index.html.haml
@@ -1,6 +1,8 @@
 - content_for :page_title do
   = t('admin.reports.title')
 
+= emergency_rule_notice
+
 .filters
   .filter-subset
     %strong= t('admin.reports.status')

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -60,6 +60,7 @@ ignore_unused:
   - 'admin.action_logs.actions.*'
   - 'admin.reports.summary.action_preambles.*'
   - 'admin.reports.summary.actions.*'
+  - 'admin.emergency_rules.setting_override_actions.*.title_*'
   - 'admin_mailer.new_appeal.actions.*'
   - 'statuses.attached.*'
   - 'move_handler.carry_{mutes,blocks}_over_text'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -452,7 +452,7 @@ en:
         add: Add new rule
         deactivate: Deactivate
         empty: There are currently no emergency rules set up on this server.
-        preamble: Emergency rules are configurable automated rules meant to give moderators some time to breath when the server is facing an unusual surge of activity.
+        preamble: Emergency rules are configurable automated rules meant to give moderators some time to breathe when the server is facing an unusual surge of activity.
         title: Emergency rules
       no_expiration: Needs to be manually disabled once triggered
       notice_html: An <a href="%{path}">emergency rule</a> is currently enabled.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,6 +444,40 @@ en:
       resolved_dns_records_hint_html: The domain name resolves to the following MX domains, which are ultimately responsible for accepting e-mail. Blocking an MX domain will block sign-ups from any e-mail address which uses the same MX domain, even if the visible domain name is different. <strong>Be careful not to block major e-mail providers.</strong>
       resolved_through_html: Resolved through %{domain}
       title: Blocked e-mail domains
+    emergency_rules:
+      active: Active
+      deactivated_msg: Successfully deactivated emergency rule
+      expires_after_duration: Deactivates %{duration} after most recent trigger
+      index:
+        add: Add new rule
+        deactivate: Deactivate
+        empty: There are currently no emergency rules set up on this server.
+        preamble: Emergency rules are configurable automated rules meant to give moderators some time to breath when the server is facing an unusual surge of activity.
+        title: Emergency rules
+      no_expiration: Needs to be manually disabled once triggered
+      notice_html: An <a href="%{path}">emergency rule</a> is currently enabled.
+      rate_limit_actions:
+        description: All local accounts get heavily rate-limited when this rule is active
+        new_users_description: Accounts confirmed around or after this rule got triggered get heavily rate-limited
+        new_users_title: Heavily rate-limit new users
+        title: Heavily rate-limit users
+      setting_override_actions:
+        captcha_enabled:
+          title_true: Enable CAPTCHA
+        description: Overrides the server settings when this rule is active
+        registrations_mode:
+          title_approved: Switch registrations to approval-based
+          title_none: Close registrations
+      triggers:
+        description: Triggers when reaching %{threshold} per %{period}
+        periods:
+          day: day
+          hour: hour
+          minute: minute
+        title:
+          local:confirmations: New account confirmations
+          local:posts: New posts
+          local:signups: New registrations
     export_domain_allows:
       new:
         title: Import domain allows

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -49,6 +49,7 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :email_domain_blocks, safe_join([fa_icon('envelope fw'), t('admin.email_domain_blocks.title')]), admin_email_domain_blocks_path, highlights_on: %r{/admin/email_domain_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :ip_blocks, safe_join([fa_icon('ban fw'), t('admin.ip_blocks.title')]), admin_ip_blocks_path, highlights_on: %r{/admin/ip_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :action_logs, safe_join([fa_icon('bars fw'), t('admin.action_logs.title')]), admin_action_logs_path, if: -> { current_user.can?(:view_audit_log) }
+      s.item :emergency_rules, safe_join([fa_icon('shield fw'), t('admin.emergency_rules.index.title')]), admin_emergency_rules_path, highlights_on: %r{/admin/emergency_rules}
     end
 
     n.item :admin, safe_join([fa_icon('cogs fw'), t('admin.title')]), nil, if: -> { current_user.can?(:view_dashboard, :manage_settings, :manage_rules, :manage_announcements, :manage_custom_emojis, :manage_webhooks, :manage_federation) && !self_destruct } do |s|

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -203,4 +203,10 @@ namespace :admin do
   end
 
   resources :software_updates, only: [:index]
+
+  resources :emergency_rules do
+    member do
+      post :deactivate
+    end
+  end
 end

--- a/db/migrate/20240219140214_create_emergency_rules.rb
+++ b/db/migrate/20240219140214_create_emergency_rules.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateEmergencyRules < ActiveRecord::Migration[6.1]
+  def change
+    create_table :emergency_rules do |t|
+      t.string :name, null: false
+      t.integer :duration
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240219140956_create_emergency_triggers.rb
+++ b/db/migrate/20240219140956_create_emergency_triggers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateEmergencyTriggers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :emergency_triggers do |t|
+      t.belongs_to :emergency_rule, foreign_key: { on_delete: :cascade }, null: false
+
+      t.string :event, null: false
+      t.integer :threshold, null: false
+      t.integer :duration_bucket, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240219141645_create_emergency_rate_limit_actions.rb
+++ b/db/migrate/20240219141645_create_emergency_rate_limit_actions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateEmergencyRateLimitActions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :emergency_rate_limit_actions do |t|
+      t.belongs_to :emergency_rule, foreign_key: { on_delete: :cascade }, null: false
+
+      t.boolean :new_users_only, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240219171126_create_emergency_setting_override_actions.rb
+++ b/db/migrate/20240219171126_create_emergency_setting_override_actions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateEmergencySettingOverrideActions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :emergency_setting_override_actions do |t|
+      t.belongs_to :emergency_rule, foreign_key: { on_delete: :cascade }, null: false
+
+      t.string :setting, null: false
+      t.string :value, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_19_141645) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_19_171126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -452,6 +452,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_19_141645) do
     t.integer "duration"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "emergency_setting_override_actions", force: :cascade do |t|
+    t.bigint "emergency_rule_id", null: false
+    t.string "setting", null: false
+    t.string "value", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["emergency_rule_id"], name: "index_emergency_setting_override_actions_on_emergency_rule_id"
   end
 
   create_table "emergency_triggers", force: :cascade do |t|
@@ -1250,6 +1259,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_19_141645) do
   add_foreign_key "devices", "oauth_access_tokens", column: "access_token_id", on_delete: :cascade
   add_foreign_key "email_domain_blocks", "email_domain_blocks", column: "parent_id", on_delete: :cascade
   add_foreign_key "emergency_rate_limit_actions", "emergency_rules", on_delete: :cascade
+  add_foreign_key "emergency_setting_override_actions", "emergency_rules", on_delete: :cascade
   add_foreign_key "emergency_triggers", "emergency_rules", on_delete: :cascade
   add_foreign_key "encrypted_messages", "accounts", column: "from_account_id", on_delete: :cascade
   add_foreign_key "encrypted_messages", "devices", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_11_033014) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_19_141645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -437,6 +437,31 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_11_033014) do
     t.bigint "parent_id"
     t.boolean "allow_with_approval", default: false, null: false
     t.index ["domain"], name: "index_email_domain_blocks_on_domain", unique: true
+  end
+
+  create_table "emergency_rate_limit_actions", force: :cascade do |t|
+    t.bigint "emergency_rule_id", null: false
+    t.boolean "new_users_only", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["emergency_rule_id"], name: "index_emergency_rate_limit_actions_on_emergency_rule_id"
+  end
+
+  create_table "emergency_rules", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "duration"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "emergency_triggers", force: :cascade do |t|
+    t.bigint "emergency_rule_id", null: false
+    t.string "event", null: false
+    t.integer "threshold", null: false
+    t.integer "duration_bucket", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["emergency_rule_id"], name: "index_emergency_triggers_on_emergency_rule_id"
   end
 
   create_table "encrypted_messages", id: :bigint, default: -> { "timestamp_id('encrypted_messages'::text)" }, force: :cascade do |t|
@@ -1224,6 +1249,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_11_033014) do
   add_foreign_key "devices", "accounts", on_delete: :cascade
   add_foreign_key "devices", "oauth_access_tokens", column: "access_token_id", on_delete: :cascade
   add_foreign_key "email_domain_blocks", "email_domain_blocks", column: "parent_id", on_delete: :cascade
+  add_foreign_key "emergency_rate_limit_actions", "emergency_rules", on_delete: :cascade
+  add_foreign_key "emergency_triggers", "emergency_rules", on_delete: :cascade
   add_foreign_key "encrypted_messages", "accounts", column: "from_account_id", on_delete: :cascade
   add_foreign_key "encrypted_messages", "devices", on_delete: :cascade
   add_foreign_key "favourites", "accounts", name: "fk_5eb6c2b873", on_delete: :cascade

--- a/spec/fabricators/emergency/rate_limit_action_fabricator.rb
+++ b/spec/fabricators/emergency/rate_limit_action_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator('Emergency::RateLimitAction') do
+  emergency_rule { Fabricate('Emergency::Rule') }
+  new_users_only false
+end

--- a/spec/fabricators/emergency/rule_fabricator.rb
+++ b/spec/fabricators/emergency/rule_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator('Emergency::Rule') do
+  name         'server lockdown'
+  duration     5.minutes.to_i
+end

--- a/spec/fabricators/emergency/setting_override_action_fabricator.rb
+++ b/spec/fabricators/emergency/setting_override_action_fabricator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Fabricator('Emergency::SettingOverrideAction') do
+  emergency_rule { Fabricate('Emergency::Rule') }
+  setting        'registrations_mode'
+  value          'closed'
+end

--- a/spec/fabricators/emergency/trigger_fabricator.rb
+++ b/spec/fabricators/emergency/trigger_fabricator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Fabricator('Emergency::Trigger') do
+  emergency_rule { Fabricate('Emergency::Rule') }
+  event           'local:signups'
+  threshold       1
+  duration_bucket 1
+end

--- a/spec/models/emergency/rate_limit_action_spec.rb
+++ b/spec/models/emergency/rate_limit_action_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Emergency::RateLimitAction do
+  describe 'get_rate_limits_for' do
+    let(:rule) { Fabricate('Emergency::Rule') }
+    let(:account) { Fabricate(:user).account }
+    let(:new_users_only) { false }
+
+    before do
+      rule.rate_limit_actions.create!(new_users_only: new_users_only)
+    end
+
+    context 'when no rule is enabled' do
+      it 'returns an empty array' do
+        expect(described_class.get_rate_limits_for(:statuses, account, Time.now.utc.to_i)).to eq []
+      end
+    end
+
+    context 'when a rule is enabled' do
+      before do
+        rule.trigger!(Time.now.utc)
+      end
+
+      context 'when the limit applies to all accounts' do
+        it 'returns a rate limit' do
+          expect(described_class.get_rate_limits_for(:statuses, account, Time.now.utc.to_i).size).to eq 1
+        end
+      end
+
+      context 'when the limit applies to new users only' do
+        let(:new_users_only) { true }
+
+        context 'when the user is new' do
+          it 'returns a rate limit' do
+            expect(described_class.get_rate_limits_for(:statuses, account, Time.now.utc.to_i).size).to eq 1
+          end
+        end
+
+        context 'when the user is old' do
+          let(:account) { Fabricate(:user, confirmed_at: 1.month.ago).account }
+
+          it 'returns an empty array' do
+            expect(described_class.get_rate_limits_for(:statuses, account, Time.now.utc.to_i)).to eq []
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/emergency/rule_spec.rb
+++ b/spec/models/emergency/rule_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Emergency::Rule do
+  describe '#active?' do
+    context 'when the rule is not active' do
+      let(:rule) { Fabricate(:'Emergency::Rule') }
+
+      it 'returns false' do
+        expect(rule.active?).to be false
+      end
+    end
+
+    context 'when the rule is active' do
+      let(:rule) { Fabricate(:'Emergency::Rule') }
+
+      before do
+        rule.trigger!(1.hour.ago)
+      end
+
+      it 'returns true' do
+        expect(rule.active?).to be true
+      end
+    end
+  end
+
+  describe '#deactivate!' do
+    let(:rule) { Fabricate(:'Emergency::Rule', name: 'active') }
+
+    before do
+      rule.trigger!(1.hour.ago)
+    end
+
+    it 'nullifies triggered_at' do
+      expect { rule.deactivate! }.to change(rule, :triggered_at).to(nil)
+    end
+  end
+
+  describe '#trigger!' do
+    context 'when the rule is inactive' do
+      subject(:trigger!) { rule.trigger!(Time.now.utc.beginning_of_day) }
+
+      let(:rule) { Fabricate(:'Emergency::Rule', duration: duration) }
+
+      context 'when the rule has a set duration' do
+        let(:duration) { 60 }
+
+        it 'sets triggered_at' do
+          expect { trigger! }.to change(rule, :triggered_at).from(nil)
+        end
+      end
+
+      context 'when the rule has no set duration' do
+        let(:duration) { nil }
+
+        it 'sets triggered_at' do
+          expect { trigger! }.to change(rule, :triggered_at).from(nil)
+        end
+      end
+    end
+
+    context 'when the rule is already active' do
+      subject(:trigger!) { rule.trigger!(Time.now.utc.beginning_of_day) }
+
+      let(:rule) { Fabricate(:'Emergency::Rule', duration: duration) }
+
+      before do
+        rule.trigger!(1.day.ago)
+      end
+
+      context 'when the rule has a set duration' do
+        let(:duration) { 60 }
+
+        it 'does not change triggered_at' do
+          expect { trigger! }.to_not change(rule, :triggered_at)
+        end
+      end
+
+      context 'when the rule has no set duration' do
+        let(:duration) { nil }
+
+        it 'does not change triggered_at' do
+          expect { trigger! }.to_not change(rule, :triggered_at)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/emergency/setting_override_action_spec.rb
+++ b/spec/models/emergency/setting_override_action_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Emergency::SettingOverrideAction do
+  describe 'overridden_setting' do
+    let(:rule) { Fabricate('Emergency::Rule') }
+    let(:account) { Fabricate(:user).account }
+    let(:new_users_only) { false }
+
+    before do
+      rule.setting_override_actions.create!(setting: 'registrations_mode', value: 'none')
+    end
+
+    context 'when no rule is enabled' do
+      it 'returns nil' do
+        expect(described_class.overridden_setting(:registrations_mode)).to be_nil
+      end
+    end
+
+    context 'when triggering a rule' do
+      it 'correctly invalidates cache and closes registrations' do
+        expect { rule.trigger!(Time.now.utc) }.to change { described_class.overridden_setting('registrations_mode') }.from(nil).to('none')
+      end
+    end
+
+    context 'when deactivating a rule' do
+      before do
+        rule.trigger!(Time.now.utc)
+      end
+
+      it 'correctly invalidates cache and opens registrations' do
+        expect { rule.deactivate! }.to change { described_class.overridden_setting('registrations_mode') }.from('none').to(nil)
+      end
+    end
+  end
+end

--- a/spec/models/emergency/trigger_spec.rb
+++ b/spec/models/emergency/trigger_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Emergency::Trigger do
+  describe 'process_event' do
+    subject(:process_event) { described_class.process_event(event_name, at_time, counts) }
+
+    let(:rule) { Fabricate('Emergency::Rule') }
+    let(:at_time) { Time.now.utc }
+    let(:event_name) { 'local:signups' }
+
+    before do
+      rule.triggers.create!(event: 'local:signups', threshold: 10, duration_bucket: :hour)
+    end
+
+    context 'when called below the threshold' do
+      let(:counts) do
+        { minute: 9, hour: 9, day: 15 }
+      end
+
+      it 'does not trigger the rule' do
+        expect { process_event }.to_not change(rule, :triggered_at)
+      end
+    end
+
+    context 'when called meeting the threshold' do
+      let(:counts) do
+        { minute: 9, hour: 10, day: 15 }
+      end
+
+      it 'triggers the rule' do
+        expect { process_event }.to (change { rule.reload.triggered_at }).from(nil).to(at_time.beginning_of_hour)
+      end
+    end
+
+    context 'when called above the threshold' do
+      let(:counts) do
+        { minute: 9, hour: 11, day: 15 }
+      end
+
+      it 'triggers the rule' do
+        expect { process_event }.to (change { rule.reload.triggered_at }).from(nil).to(at_time.beginning_of_hour)
+      end
+    end
+
+    context 'when called with an unrelated event' do
+      let(:event_name) { 'local:posts' }
+      let(:counts) do
+        { minute: 11, hour: 11, day: 11 }
+      end
+
+      it 'does not trigger the rule' do
+        expect { process_event }.to_not(change { rule.reload.triggered_at })
+      end
+    end
+  end
+end

--- a/spec/requests/admin/emergency_rules_controller_spec.rb
+++ b/spec/requests/admin/emergency_rules_controller_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::EmergencyRulesController do
+  before do
+    Fabricate('Emergency::Trigger')
+    Fabricate('Emergency::SettingOverrideAction')
+    Fabricate('Emergency::RateLimitAction')
+  end
+
+  describe 'the index route' do
+    context 'when not logged in' do
+      it 'returns HTTP forbidden' do
+        get '/admin/emergency_rules'
+
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context 'when logged in as a regular user' do
+      before do
+        sign_in Fabricate(:user), scope: :user
+      end
+
+      it 'returns HTTP forbidden' do
+        get '/admin/emergency_rules'
+
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context 'when logged in as a moderator' do
+      let(:user)  { Fabricate(:user, role: UserRole.find_by!(name: 'Moderator')) }
+
+      before do
+        sign_in user, scope: :user
+      end
+
+      it 'returns HTTP success' do
+        get '/admin/emergency_rules'
+
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe 'the deactivation route' do
+    let(:rule) { Fabricate('Emergency::Rule') }
+
+    before do
+      rule.trigger!(1.day.ago)
+    end
+
+    context 'when not logged in' do
+      it 'returns HTTP forbidden' do
+        post "/admin/emergency_rules/#{rule.id}/deactivate"
+
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context 'when logged in as a regular user' do
+      before do
+        sign_in Fabricate(:user), scope: :user
+      end
+
+      it 'returns HTTP forbidden' do
+        post "/admin/emergency_rules/#{rule.id}/deactivate"
+
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context 'when logged in as a moderator' do
+      let(:user)  { Fabricate(:user, role: UserRole.find_by!(name: 'Moderator')) }
+
+      before do
+        sign_in user, scope: :user
+      end
+
+      it 'redirects' do
+        post "/admin/emergency_rules/#{rule.id}/deactivate"
+
+        expect(response).to redirect_to '/admin/emergency_rules'
+      end
+
+      it 'deactivates the rule' do
+        expect { post "/admin/emergency_rules/#{rule.id}/deactivate" }.to change { rule.reload.active? }.from(true).to(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Supersedes #24986

Provides an (eventually) admin-editable set of rules made of triggers and actions.

The goal is not to triage spammers and abusers from legitimate users, but to provide a stop-gap measure when a server is facing an unusual surge of activity.

![image](https://github.com/mastodon/mastodon/assets/384364/eac23556-52f2-45f9-a2f1-7e2fa223b318)

![image](https://github.com/mastodon/mastodon/assets/384364/8f5ea63c-04c6-4390-9d5f-0f9c5009297a)

## Triggers

- number of local registrations in the last minute/hour/day reaches a threshold
- number of local account confirmations in the last minute/hour/day reaches a threshold
- number of local posts in the last minute/hour/day reaches a threshold

## Actions

- override a setting (currently, captcha and registrations mode)
- set harsher rate limits (currently not configurable, but can be set to only affect accounts during/after the event that initially triggered the rule)

## Technical details

Rule definitions are stored in database and cached in Rails' cache for quick access.

The time at which an event has triggered a rule is stored in Redis, and the rule's expiration is handled by the redis key expiring.

The hot spots (rate limiting code and settings) fetch a summary of the relevant rules from Rails' cache (and failing that, build it from database), then issue a Redis MGET to know which rules are active.

Event start and rule expiry is set atomically through a lua script, uploaded on need and which reference is stored in a class variable.

## TODO

- [x] optimize triggers
- [x] optimize rate limits
- [x] optimize settings override
- [x] move the Redis lua script to somewhere that makes sense

## Postponed to a subsequent PR if this one gets accepted

- emergency rule creation and edition interface
- emergency rule API
- trigger webhook on API
- history of rule activations