### PR TITLE
Fix oversight in backup service

### DIFF
--- a/app/services/backup_service.rb
+++ b/app/services/backup_service.rb
@@ -101,8 +101,8 @@ class BackupService < BaseService
     actor[:likes]       = 'likes.json'
     actor[:bookmarks]   = 'bookmarks.json'
 
-    download_to_zip(tar, account.avatar, "avatar#{File.extname(account.avatar.path)}") if account.avatar.exists?
-    download_to_zip(tar, account.header, "header#{File.extname(account.header.path)}") if account.header.exists?
+    download_to_zip(zipfile, account.avatar, "avatar#{File.extname(account.avatar.path)}") if account.avatar.exists?
+    download_to_zip(zipfile, account.header, "header#{File.extname(account.header.path)}") if account.header.exists?
 
     json = Oj.dump(actor)
 


### PR DESCRIPTION
It seems like b233da5996c7bfcf7a9373bdc7029feb04c704b8 missed a spot when switching to zip files, causing the process to fail at the actor dump step. This should fix that.