### PR TITLE
Change wording of the setting to block direct messages from people you don't follow

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -263,7 +263,7 @@ en:
       interactions:
         must_be_follower: Block notifications from non-followers
         must_be_following: Block notifications from people you don't follow
-        must_be_following_dm: Block direct messages from people you don't follow
+        must_be_following_dm: Block direct message notifications from people you don't follow
       invite:
         comment: Comment
       invite_request:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -263,7 +263,7 @@ en:
       interactions:
         must_be_follower: Block notifications from non-followers
         must_be_following: Block notifications from people you don't follow
-        must_be_following_dm: Block direct message notifications from people you don't follow
+        must_be_following_dm: Block notifications for private mentions from people you don't follow
       invite:
         comment: Comment
       invite_request:


### PR DESCRIPTION
This doesn't actually block the direct messages. It only blocks the notifications. Previous wording causes confusion.

https://bne.social/@phocks/110388130765839663