### PR TITLE
Don't skipLibCheck for TypeScript

### DIFF
--- a/app/javascript/mastodon/service_worker/entry.js
+++ b/app/javascript/mastodon/service_worker/entry.js
@@ -1,3 +1,8 @@
+// from https://joshuatz.com/posts/2021/strongly-typed-service-workers/
+/// <reference no-default-lib="true"/>
+/// <reference lib="esnext" />
+/// <reference lib="webworker" />
+
 import { ExpirationPlugin } from 'workbox-expiration';
 import { precacheAndRoute } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';

--- a/app/javascript/mastodon/service_worker/web_push_locales.js
+++ b/app/javascript/mastodon/service_worker/web_push_locales.js
@@ -1,3 +1,7 @@
+/// <reference no-default-lib="true"/>
+/// <reference lib="esnext" />
+/// <reference lib="webworker" />
+
 /* eslint-disable import/no-commonjs --
    We need to use CommonJS here as its imported into a preval file (`emoji_compressed.js`) */
 

--- a/app/javascript/mastodon/service_worker/web_push_notifications.js
+++ b/app/javascript/mastodon/service_worker/web_push_notifications.js
@@ -1,3 +1,7 @@
+/// <reference no-default-lib="true"/>
+/// <reference lib="esnext" />
+/// <reference lib="webworker" />
+
 import { IntlMessageFormat } from 'intl-messageformat';
 
 import { unescape } from 'lodash';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "baseUrl": "./",
     "incremental": true,
     "tsBuildInfoFile": "tmp/cache/tsconfig.tsbuildinfo",


### PR DESCRIPTION
This still doesn't work with the mixed WebWorker and DOM code. Tried the first method from https://joshuatz.com/posts/2021/strongly-typed-service-workers/, but I didn't get it to work.
Maybe @renchap or @takayamaki have an idea to get the rest done. I'm going to submit the one functional issue with the duplicated typing in a separate PR too