### PR TITLE
Remove duplicate  JPG type

### DIFF
--- a/app/javascript/types/image.d.ts
+++ b/app/javascript/types/image.d.ts
@@ -14,11 +14,6 @@ declare module '*.jpg' {
   export default path;
 }
 
-declare module '*.jpg' {
-  const path: string;
-  export default path;
-}
-
 declare module '*.png' {
   const path: string;
   export default path;


### PR DESCRIPTION
Maybe this was supposed to be a second one for "jpeg" instead, but right now its a duplicate that was flagged when `skipLibCheck` was turned on during complication