### PR TITLE
Fix uncaught NoMethodError in POST `/api/v1/featured_tags`

### DIFF
--- a/app/controllers/api/v1/featured_tags_controller.rb
+++ b/app/controllers/api/v1/featured_tags_controller.rb
@@ -33,6 +33,6 @@ class Api::V1::FeaturedTagsController < Api::BaseController
   end
 
   def featured_tag_params
-    params.permit(:name)
+    params.require(:name)
   end
 end


### PR DESCRIPTION
Fixes #25062.

I intend to make a follow-up PR with test coverage for this endpoint. So, the tests addressing this bug will be added in that PR.