### PR TITLE
Remove invalid X-Frame-Options: ALLOWALL

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -45,6 +45,6 @@ class MediaController < ApplicationController
   end
 
   def allow_iframing
-    response.headers['X-Frame-Options'] = 'ALLOWALL'
+    response.headers.delete('X-Frame-Options')
   end
 end

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -45,7 +45,7 @@ class StatusesController < ApplicationController
     return not_found if @status.hidden? || @status.reblog?
 
     expires_in 180, public: true
-    response.headers['X-Frame-Options'] = 'ALLOWALL'
+    response.headers.delete('X-Frame-Options')
 
     render layout: 'embedded'
   end


### PR DESCRIPTION
I can't actually find where or when `ALLOWALL` was proposed, but it's not standard nor supported by browsers I tried.