### PR TITLE
Fix uncaught TypeError in POST `/api/v1/featured_tags`

### DIFF
--- a/app/controllers/api/v1/featured_tags_controller.rb
+++ b/app/controllers/api/v1/featured_tags_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::FeaturedTagsController < Api::BaseController
   end
 
   def create
-    featured_tag = CreateFeaturedTagService.new.call(current_account, featured_tag_params[:name])
+    featured_tag = CreateFeaturedTagService.new.call(current_account, featured_tag_params)
     render json: featured_tag, serializer: REST::FeaturedTagSerializer
   end
 

--- a/app/controllers/api/v1/featured_tags_controller.rb
+++ b/app/controllers/api/v1/featured_tags_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::FeaturedTagsController < Api::BaseController
   end
 
   def create
-    featured_tag = CreateFeaturedTagService.new.call(current_account, featured_tag_params)
+    featured_tag = CreateFeaturedTagService.new.call(current_account, params.require(:name))
     render json: featured_tag, serializer: REST::FeaturedTagSerializer
   end
 


### PR DESCRIPTION
My bad about #25063, it ended up breaking the correct behavior.

This line:
https://github.com/mastodon/mastodon/blob/45d98959aca118f8f44ca66d7d358354e43c7d4c/app/controllers/api/v1/featured_tags_controller.rb#L36

Actually returns a string, not a hash. So, this line:
https://github.com/mastodon/mastodon/blob/45d98959aca118f8f44ca66d7d358354e43c7d4c/app/controllers/api/v1/featured_tags_controller.rb#L16
Raises a `TypeError`.