### PR TITLE
Don't run Rubocop excluded files for lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write",
-    "Capfile|Gemfile|*.{rb,ruby,ru,rake}": "bundle exec rubocop -a",
+    "Capfile|Gemfile|*.{rb,ruby,ru,rake}": "bundle exec rubocop --force-exclusion -a",
     "*.{js,jsx,ts,tsx}": "eslint --fix",
     "*.{css,scss}": "stylelint --fix"
   }


### PR DESCRIPTION
Not sure why this isn't the default behaviour, but it seems like Rubocop will run on Excluded files if they are explicitly passed in the command line like when invoked by `lint-staged`

Found this flag from the CLI help
```
        --force-exclusion            Any files excluded by `Exclude` in configuration
                                     files will be excluded, even if given explicitly
                                     as arguments.
```

Fixes #25038