### PR TITLE
Enforce import order with ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,6 +198,55 @@ module.exports = {
     'import/no-useless-path-segments': 'error',
     'import/no-webpack-loader-syntax': 'error',
 
+    'import/order': [
+      'error',
+      {
+        alphabetize: { order: 'asc' },
+        'newlines-between': 'always',
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          ['index', 'sibling'],
+          'object',
+        ],
+        pathGroups: [
+          // React core packages
+          {
+            pattern: '{react,react-dom,react-dom/client,prop-types}',
+            group: 'builtin',
+            position: 'after',
+          },
+          // I18n
+          {
+            pattern: '{react-intl,intl-messageformat}',
+            group: 'builtin',
+            position: 'after',
+          },
+          // Common React utilities
+          {
+            pattern: '{classnames,react-helmet,react-router-dom}',
+            group: 'external',
+            position: 'before',
+          },
+          // Immutable / Redux / data store
+          {
+            pattern: '{immutable,react-redux,react-immutable-proptypes,react-immutable-pure-component,reselect}',
+            group: 'external',
+            position: 'before',
+          },
+          // Internal packages
+          {
+            pattern: '{mastodon/**}',
+            group: 'internal',
+            position: 'after',
+          },
+        ],
+        pathGroupsExcludedImportTypes: [],
+      },
+    ],
+
     'promise/always-return': 'off',
     'promise/catch-or-return': [
       'error',
@@ -285,55 +334,6 @@ module.exports = {
 
       rules: {
         'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
-
-        'import/order': [
-          'error',
-          {
-            alphabetize: { order: 'asc' },
-            'newlines-between': 'always',
-            groups: [
-              'builtin',
-              'external',
-              'internal',
-              'parent',
-              ['index', 'sibling'],
-              'object',
-            ],
-            pathGroups: [
-              // React core packages
-              {
-                pattern: '{react,react-dom,prop-types}',
-                group: 'builtin',
-                position: 'after',
-              },
-              // I18n
-              {
-                pattern: 'react-intl',
-                group: 'builtin',
-                position: 'after',
-              },
-              // Common React utilities
-              {
-                pattern: '{classnames,react-helmet}',
-                group: 'external',
-                position: 'before',
-              },
-              // Immutable / Redux / data store
-              {
-                pattern: '{immutable,react-redux,react-immutable-proptypes,react-immutable-pure-component,reselect}',
-                group: 'external',
-                position: 'before',
-              },
-              // Internal packages
-              {
-                pattern: '{mastodon/**}',
-                group: 'internal',
-                position: 'after',
-              },
-            ],
-            pathGroupsExcludedImportTypes: [],
-          },
-        ],
 
         '@typescript-eslint/consistent-type-definitions': ['warn', 'interface'],
         '@typescript-eslint/consistent-type-exports': 'error',

--- a/app/javascript/mastodon/actions/accounts.js
+++ b/app/javascript/mastodon/actions/accounts.js
@@ -1,4 +1,5 @@
 import api, { getLinks } from '../api';
+
 import { importFetchedAccount, importFetchedAccounts } from './importer';
 
 export const ACCOUNT_FETCH_REQUEST = 'ACCOUNT_FETCH_REQUEST';

--- a/app/javascript/mastodon/actions/announcements.js
+++ b/app/javascript/mastodon/actions/announcements.js
@@ -1,4 +1,5 @@
 import api from '../api';
+
 import { normalizeAnnouncement } from './importer/normalizer';
 
 export const ANNOUNCEMENTS_FETCH_REQUEST = 'ANNOUNCEMENTS_FETCH_REQUEST';

--- a/app/javascript/mastodon/actions/blocks.js
+++ b/app/javascript/mastodon/actions/blocks.js
@@ -1,4 +1,5 @@
 import api, { getLinks } from '../api';
+
 import { fetchRelationships } from './accounts';
 import { importFetchedAccounts } from './importer';
 import { openModal } from './modal';

--- a/app/javascript/mastodon/actions/bookmarks.js
+++ b/app/javascript/mastodon/actions/bookmarks.js
@@ -1,4 +1,5 @@
 import api, { getLinks } from '../api';
+
 import { importFetchedStatuses } from './importer';
 
 export const BOOKMARKED_STATUSES_FETCH_REQUEST = 'BOOKMARKED_STATUSES_FETCH_REQUEST';

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -1,9 +1,12 @@
+import { defineMessages } from 'react-intl';
+
 import axios from 'axios';
 import { throttle } from 'lodash';
-import { defineMessages } from 'react-intl';
+
 import api from 'mastodon/api';
 import { search as emojiSearch } from 'mastodon/features/emoji/emoji_mart_search_light';
 import { tagHistory } from 'mastodon/settings';
+
 import { showAlert, showAlertForError } from './alerts';
 import { useEmoji } from './emojis';
 import { importFetchedAccounts, importFetchedStatus } from './importer';

--- a/app/javascript/mastodon/actions/conversations.js
+++ b/app/javascript/mastodon/actions/conversations.js
@@ -1,4 +1,5 @@
 import api, { getLinks } from '../api';
+
 import {
   importFetchedAccounts,
   importFetchedStatuses,

--- a/app/javascript/mastodon/actions/directory.js
+++ b/app/javascript/mastodon/actions/directory.js
@@ -1,6 +1,7 @@
 import api from '../api';
-import { importFetchedAccounts } from './importer';
+
 import { fetchRelationships } from './accounts';
+import { importFetchedAccounts } from './importer';
 
 export const DIRECTORY_FETCH_REQUEST = 'DIRECTORY_FETCH_REQUEST';
 export const DIRECTORY_FETCH_SUCCESS = 'DIRECTORY_FETCH_SUCCESS';

--- a/app/javascript/mastodon/actions/favourites.js
+++ b/app/javascript/mastodon/actions/favourites.js
@@ -1,4 +1,5 @@
 import api, { getLinks } from '../api';
+
 import { importFetchedStatuses } from './importer';
 
 export const FAVOURITED_STATUSES_FETCH_REQUEST = 'FAVOURITED_STATUSES_FETCH_REQUEST';

--- a/app/javascript/mastodon/actions/filters.js
+++ b/app/javascript/mastodon/actions/filters.js
@@ -1,4 +1,5 @@
 import api from '../api';
+
 import { openModal } from './modal';
 
 export const FILTERS_FETCH_REQUEST = 'FILTERS_FETCH_REQUEST';

--- a/app/javascript/mastodon/actions/history.js
+++ b/app/javascript/mastodon/actions/history.js
@@ -1,4 +1,5 @@
 import api from '../api';
+
 import { importFetchedAccounts } from './importer';
 
 export const HISTORY_FETCH_REQUEST = 'HISTORY_FETCH_REQUEST';

--- a/app/javascript/mastodon/actions/importer/normalizer.js
+++ b/app/javascript/mastodon/actions/importer/normalizer.js
@@ -1,7 +1,8 @@
 import escapeTextContentForBrowser from 'escape-html';
+
 import emojify from '../../features/emoji/emoji';
-import { unescapeHTML } from '../../utils/html';
 import { expandSpoilers } from '../../initial_state';
+import { unescapeHTML } from '../../utils/html';
 
 const domParser = new DOMParser();
 

--- a/app/javascript/mastodon/actions/interactions.js
+++ b/app/javascript/mastodon/actions/interactions.js
@@ -1,4 +1,5 @@
 import api from '../api';
+
 import { importFetchedAccounts, importFetchedStatus } from './importer';
 
 export const REBLOG_REQUEST = 'REBLOG_REQUEST';

--- a/app/javascript/mastodon/actions/lists.js
+++ b/app/javascript/mastodon/actions/lists.js
@@ -1,6 +1,7 @@
 import api from '../api';
-import { importFetchedAccounts } from './importer';
+
 import { showAlertForError } from './alerts';
+import { importFetchedAccounts } from './importer';
 
 export const LIST_FETCH_REQUEST = 'LIST_FETCH_REQUEST';
 export const LIST_FETCH_SUCCESS = 'LIST_FETCH_SUCCESS';

--- a/app/javascript/mastodon/actions/markers.js
+++ b/app/javascript/mastodon/actions/markers.js
@@ -5,7 +5,6 @@ import { debounce } from 'lodash';
 import api from '../api';
 import { compareId } from '../compare_id';
 
-
 export const MARKERS_FETCH_REQUEST = 'MARKERS_FETCH_REQUEST';
 export const MARKERS_FETCH_SUCCESS = 'MARKERS_FETCH_SUCCESS';
 export const MARKERS_FETCH_FAIL    = 'MARKERS_FETCH_FAIL';

--- a/app/javascript/mastodon/actions/markers.js
+++ b/app/javascript/mastodon/actions/markers.js
@@ -1,7 +1,10 @@
-import api from '../api';
-import { debounce } from 'lodash';
-import { compareId } from '../compare_id';
 import { List as ImmutableList } from 'immutable';
+
+import { debounce } from 'lodash';
+
+import api from '../api';
+import { compareId } from '../compare_id';
+
 
 export const MARKERS_FETCH_REQUEST = 'MARKERS_FETCH_REQUEST';
 export const MARKERS_FETCH_SUCCESS = 'MARKERS_FETCH_SUCCESS';

--- a/app/javascript/mastodon/actions/mutes.js
+++ b/app/javascript/mastodon/actions/mutes.js
@@ -1,4 +1,5 @@
 import api, { getLinks } from '../api';
+
 import { fetchRelationships } from './accounts';
 import { importFetchedAccounts } from './importer';
 import { openModal } from './modal';

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -3,7 +3,6 @@ import { defineMessages } from 'react-intl';
 
 import { List as ImmutableList } from 'immutable';
 
-
 import { compareId } from 'mastodon/compare_id';
 import { usePendingItems as preferPendingItems } from 'mastodon/initial_state';
 
@@ -20,11 +19,6 @@ import {
 } from './importer';
 import { submitMarkers } from './markers';
 import { saveSettings } from './settings';
-
-
-
-
-
 
 export const NOTIFICATIONS_UPDATE      = 'NOTIFICATIONS_UPDATE';
 export const NOTIFICATIONS_UPDATE_NOOP = 'NOTIFICATIONS_UPDATE_NOOP';

--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -1,5 +1,16 @@
-import api, { getLinks } from '../api';
 import IntlMessageFormat from 'intl-messageformat';
+import { defineMessages } from 'react-intl';
+
+import { List as ImmutableList } from 'immutable';
+
+
+import { compareId } from 'mastodon/compare_id';
+import { usePendingItems as preferPendingItems } from 'mastodon/initial_state';
+
+import api, { getLinks } from '../api';
+import { unescapeHTML } from '../utils/html';
+import { requestNotificationPermission } from '../utils/notifications';
+
 import { fetchFollowRequests, fetchRelationships } from './accounts';
 import {
   importFetchedAccount,
@@ -9,12 +20,11 @@ import {
 } from './importer';
 import { submitMarkers } from './markers';
 import { saveSettings } from './settings';
-import { defineMessages } from 'react-intl';
-import { List as ImmutableList } from 'immutable';
-import { unescapeHTML } from '../utils/html';
-import { usePendingItems as preferPendingItems } from 'mastodon/initial_state';
-import { compareId } from 'mastodon/compare_id';
-import { requestNotificationPermission } from '../utils/notifications';
+
+
+
+
+
 
 export const NOTIFICATIONS_UPDATE      = 'NOTIFICATIONS_UPDATE';
 export const NOTIFICATIONS_UPDATE_NOOP = 'NOTIFICATIONS_UPDATE_NOOP';

--- a/app/javascript/mastodon/actions/pin_statuses.js
+++ b/app/javascript/mastodon/actions/pin_statuses.js
@@ -1,7 +1,8 @@
 import api from '../api';
+import { me } from '../initial_state';
+
 import { importFetchedStatuses } from './importer';
 
-import { me } from '../initial_state';
 
 export const PINNED_STATUSES_FETCH_REQUEST = 'PINNED_STATUSES_FETCH_REQUEST';
 export const PINNED_STATUSES_FETCH_SUCCESS = 'PINNED_STATUSES_FETCH_SUCCESS';

--- a/app/javascript/mastodon/actions/pin_statuses.js
+++ b/app/javascript/mastodon/actions/pin_statuses.js
@@ -3,7 +3,6 @@ import { me } from '../initial_state';
 
 import { importFetchedStatuses } from './importer';
 
-
 export const PINNED_STATUSES_FETCH_REQUEST = 'PINNED_STATUSES_FETCH_REQUEST';
 export const PINNED_STATUSES_FETCH_SUCCESS = 'PINNED_STATUSES_FETCH_SUCCESS';
 export const PINNED_STATUSES_FETCH_FAIL = 'PINNED_STATUSES_FETCH_FAIL';

--- a/app/javascript/mastodon/actions/polls.js
+++ b/app/javascript/mastodon/actions/polls.js
@@ -1,4 +1,5 @@
 import api from '../api';
+
 import { importFetchedPoll } from './importer';
 
 export const POLL_VOTE_REQUEST = 'POLL_VOTE_REQUEST';

--- a/app/javascript/mastodon/actions/push_notifications/index.js
+++ b/app/javascript/mastodon/actions/push_notifications/index.js
@@ -1,5 +1,5 @@
-import { setAlerts } from './setter';
 import { saveSettings } from './registerer';
+import { setAlerts } from './setter';
 
 export function changeAlerts(path, value) {
   return dispatch => {

--- a/app/javascript/mastodon/actions/push_notifications/registerer.js
+++ b/app/javascript/mastodon/actions/push_notifications/registerer.js
@@ -1,8 +1,10 @@
 import api from '../../api';
-import { decode as decodeBase64 } from '../../utils/base64';
-import { pushNotificationsSetting } from '../../settings';
-import { setBrowserSupport, setSubscription, clearSubscription } from './setter';
 import { me } from '../../initial_state';
+import { pushNotificationsSetting } from '../../settings';
+import { decode as decodeBase64 } from '../../utils/base64';
+
+import { setBrowserSupport, setSubscription, clearSubscription } from './setter';
+
 
 // Taken from https://www.npmjs.com/package/web-push
 const urlBase64ToUint8Array = (base64String) => {

--- a/app/javascript/mastodon/actions/push_notifications/registerer.js
+++ b/app/javascript/mastodon/actions/push_notifications/registerer.js
@@ -5,7 +5,6 @@ import { decode as decodeBase64 } from '../../utils/base64';
 
 import { setBrowserSupport, setSubscription, clearSubscription } from './setter';
 
-
 // Taken from https://www.npmjs.com/package/web-push
 const urlBase64ToUint8Array = (base64String) => {
   const padding = '='.repeat((4 - base64String.length % 4) % 4);

--- a/app/javascript/mastodon/actions/reports.js
+++ b/app/javascript/mastodon/actions/reports.js
@@ -1,4 +1,5 @@
 import api from '../api';
+
 import { openModal } from './modal';
 
 export const REPORT_SUBMIT_REQUEST = 'REPORT_SUBMIT_REQUEST';

--- a/app/javascript/mastodon/actions/search.js
+++ b/app/javascript/mastodon/actions/search.js
@@ -1,4 +1,5 @@
 import api from '../api';
+
 import { fetchRelationships } from './accounts';
 import { importFetchedAccounts, importFetchedStatuses } from './importer';
 

--- a/app/javascript/mastodon/actions/server.js
+++ b/app/javascript/mastodon/actions/server.js
@@ -1,4 +1,5 @@
 import api from '../api';
+
 import { importFetchedAccount } from './importer';
 
 export const SERVER_FETCH_REQUEST = 'Server_FETCH_REQUEST';

--- a/app/javascript/mastodon/actions/settings.js
+++ b/app/javascript/mastodon/actions/settings.js
@@ -1,5 +1,7 @@
-import api from '../api';
 import { debounce } from 'lodash';
+
+import api from '../api';
+
 import { showAlertForError } from './alerts';
 
 export const SETTING_CHANGE = 'SETTING_CHANGE';

--- a/app/javascript/mastodon/actions/statuses.js
+++ b/app/javascript/mastodon/actions/statuses.js
@@ -1,8 +1,8 @@
 import api from '../api';
 
-import { deleteFromTimelines } from './timelines';
-import { importFetchedStatus, importFetchedStatuses, importFetchedAccount } from './importer';
 import { ensureComposeIsVisible, setComposeToStatus } from './compose';
+import { importFetchedStatus, importFetchedStatuses, importFetchedAccount } from './importer';
+import { deleteFromTimelines } from './timelines';
 
 export const STATUS_FETCH_REQUEST = 'STATUS_FETCH_REQUEST';
 export const STATUS_FETCH_SUCCESS = 'STATUS_FETCH_SUCCESS';

--- a/app/javascript/mastodon/actions/store.js
+++ b/app/javascript/mastodon/actions/store.js
@@ -1,4 +1,5 @@
 import { Iterable, fromJS } from 'immutable';
+
 import { hydrateCompose } from './compose';
 import { importFetchedAccounts } from './importer';
 

--- a/app/javascript/mastodon/actions/streaming.js
+++ b/app/javascript/mastodon/actions/streaming.js
@@ -1,6 +1,17 @@
 // @ts-check
 
+import { getLocale } from '../locales';
 import { connectStream } from '../stream';
+
+import {
+  fetchAnnouncements,
+  updateAnnouncements,
+  updateReaction as updateAnnouncementsReaction,
+  deleteAnnouncement,
+} from './announcements';
+import { updateConversations } from './conversations';
+import { updateNotifications, expandNotifications } from './notifications';
+import { updateStatus } from './statuses';
 import {
   updateTimeline,
   deleteFromTimelines,
@@ -12,16 +23,6 @@ import {
   fillCommunityTimelineGaps,
   fillListTimelineGaps,
 } from './timelines';
-import { updateNotifications, expandNotifications } from './notifications';
-import { updateConversations } from './conversations';
-import { updateStatus } from './statuses';
-import {
-  fetchAnnouncements,
-  updateAnnouncements,
-  updateReaction as updateAnnouncementsReaction,
-  deleteAnnouncement,
-} from './announcements';
-import { getLocale } from '../locales';
 
 const { messages } = getLocale();
 

--- a/app/javascript/mastodon/actions/suggestions.js
+++ b/app/javascript/mastodon/actions/suggestions.js
@@ -1,6 +1,7 @@
 import api from '../api';
-import { importFetchedAccounts } from './importer';
+
 import { fetchRelationships } from './accounts';
+import { importFetchedAccounts } from './importer';
 
 export const SUGGESTIONS_FETCH_REQUEST = 'SUGGESTIONS_FETCH_REQUEST';
 export const SUGGESTIONS_FETCH_SUCCESS = 'SUGGESTIONS_FETCH_SUCCESS';

--- a/app/javascript/mastodon/actions/timelines.js
+++ b/app/javascript/mastodon/actions/timelines.js
@@ -1,9 +1,11 @@
-import { importFetchedStatus, importFetchedStatuses } from './importer';
-import { submitMarkers } from './markers';
-import api, { getLinks } from 'mastodon/api';
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+
+import api, { getLinks } from 'mastodon/api';
 import { compareId } from 'mastodon/compare_id';
 import { usePendingItems as preferPendingItems } from 'mastodon/initial_state';
+
+import { importFetchedStatus, importFetchedStatuses } from './importer';
+import { submitMarkers } from './markers';
 
 export const TIMELINE_UPDATE  = 'TIMELINE_UPDATE';
 export const TIMELINE_DELETE  = 'TIMELINE_DELETE';

--- a/app/javascript/mastodon/actions/trends.js
+++ b/app/javascript/mastodon/actions/trends.js
@@ -1,4 +1,5 @@
 import api, { getLinks } from '../api';
+
 import { importFetchedStatuses } from './importer';
 
 export const TRENDS_TAGS_FETCH_REQUEST = 'TRENDS_TAGS_FETCH_REQUEST';

--- a/app/javascript/mastodon/api.js
+++ b/app/javascript/mastodon/api.js
@@ -2,6 +2,7 @@
 
 import axios from 'axios';
 import LinkHeader from 'http-link-header';
+
 import ready from './ready';
 
 /**

--- a/app/javascript/mastodon/components/__tests__/autosuggest_emoji-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/autosuggest_emoji-test.jsx
@@ -1,4 +1,5 @@
 import renderer from 'react-test-renderer';
+
 import AutosuggestEmoji from '../autosuggest_emoji';
 
 describe('<AutosuggestEmoji />', () => {

--- a/app/javascript/mastodon/components/__tests__/avatar-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/avatar-test.jsx
@@ -1,5 +1,7 @@
-import renderer from 'react-test-renderer';
 import { fromJS } from 'immutable';
+
+import renderer from 'react-test-renderer';
+
 import { Avatar } from '../avatar';
 
 describe('<Avatar />', () => {

--- a/app/javascript/mastodon/components/__tests__/avatar_overlay-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/avatar_overlay-test.jsx
@@ -1,5 +1,7 @@
-import renderer from 'react-test-renderer';
 import { fromJS } from 'immutable';
+
+import renderer from 'react-test-renderer';
+
 import { AvatarOverlay } from '../avatar_overlay';
 
 describe('<AvatarOverlay', () => {

--- a/app/javascript/mastodon/components/__tests__/button-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/button-test.jsx
@@ -1,5 +1,6 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 import renderer from 'react-test-renderer';
+
 import Button from '../button';
 
 describe('<Button />', () => {

--- a/app/javascript/mastodon/components/__tests__/display_name-test.jsx
+++ b/app/javascript/mastodon/components/__tests__/display_name-test.jsx
@@ -1,5 +1,7 @@
-import renderer from 'react-test-renderer';
 import { fromJS }  from 'immutable';
+
+import renderer from 'react-test-renderer';
+
 import { DisplayName } from '../display_name';
 
 describe('<DisplayName />', () => {

--- a/app/javascript/mastodon/components/account.jsx
+++ b/app/javascript/mastodon/components/account.jsx
@@ -8,7 +8,6 @@ import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-
 import { counterRenderer } from 'mastodon/components/common_counter';
 import { EmptyAccount } from 'mastodon/components/empty_account';
 import ShortNumber from 'mastodon/components/short_number';
@@ -20,8 +19,6 @@ import { Avatar } from './avatar';
 import { DisplayName } from './display_name';
 import { IconButton } from './icon_button';
 import { RelativeTimestamp } from './relative_timestamp';
-
-
 
 const messages = defineMessages({
   follow: { id: 'account.follow', defaultMessage: 'Follow' },

--- a/app/javascript/mastodon/components/account.jsx
+++ b/app/javascript/mastodon/components/account.jsx
@@ -1,18 +1,27 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
+import classNames from 'classnames';
+import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+
+import { counterRenderer } from 'mastodon/components/common_counter';
+import { EmptyAccount } from 'mastodon/components/empty_account';
+import ShortNumber from 'mastodon/components/short_number';
+import { VerifiedBadge } from 'mastodon/components/verified_badge';
+
+import { me } from '../initial_state';
+
 import { Avatar } from './avatar';
 import { DisplayName } from './display_name';
 import { IconButton } from './icon_button';
-import { defineMessages, injectIntl } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { me } from '../initial_state';
 import { RelativeTimestamp } from './relative_timestamp';
-import { Link } from 'react-router-dom';
-import { counterRenderer } from 'mastodon/components/common_counter';
-import ShortNumber from 'mastodon/components/short_number';
-import classNames from 'classnames';
-import { VerifiedBadge } from 'mastodon/components/verified_badge';
-import { EmptyAccount } from 'mastodon/components/empty_account';
+
+
 
 const messages = defineMessages({
   follow: { id: 'account.follow', defaultMessage: 'Follow' },

--- a/app/javascript/mastodon/components/admin/Counter.jsx
+++ b/app/javascript/mastodon/components/admin/Counter.jsx
@@ -1,10 +1,15 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import api from 'mastodon/api';
+import { PureComponent } from 'react';
+
+
 import { FormattedNumber } from 'react-intl';
-import { Sparklines, SparklinesCurve } from 'react-sparklines';
+
 import classNames from 'classnames';
-import { Skeleton } from 'mastodon/components/skeleton';
+
+import { Sparklines, SparklinesCurve } from 'react-sparklines';
+
+import api from 'mastodon/api';
+import {Skeleton} from 'mastodon/components/skeleton';
 
 const percIncrease = (a, b) => {
   let percent;

--- a/app/javascript/mastodon/components/admin/Counter.jsx
+++ b/app/javascript/mastodon/components/admin/Counter.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-
 import { FormattedNumber } from 'react-intl';
 
 import classNames from 'classnames';
@@ -9,7 +8,7 @@ import classNames from 'classnames';
 import { Sparklines, SparklinesCurve } from 'react-sparklines';
 
 import api from 'mastodon/api';
-import {Skeleton} from 'mastodon/components/skeleton';
+import { Skeleton } from 'mastodon/components/skeleton';
 
 const percIncrease = (a, b) => {
   let percent;

--- a/app/javascript/mastodon/components/admin/Dimension.jsx
+++ b/app/javascript/mastodon/components/admin/Dimension.jsx
@@ -1,9 +1,11 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import api from 'mastodon/api';
+import { PureComponent } from 'react';
+
 import { FormattedNumber } from 'react-intl';
-import { roundTo10 } from 'mastodon/utils/numbers';
+
+import api from 'mastodon/api';
 import { Skeleton } from 'mastodon/components/skeleton';
+import { roundTo10 } from 'mastodon/utils/numbers';
 
 export default class Dimension extends PureComponent {
 

--- a/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
+++ b/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
@@ -1,8 +1,12 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import api from 'mastodon/api';
+import { PureComponent } from 'react';
+
+
 import { injectIntl, defineMessages } from 'react-intl';
+
 import classNames from 'classnames';
+
+import api from 'mastodon/api';
 
 const messages = defineMessages({
   other: { id: 'report.categories.other', defaultMessage: 'Other' },

--- a/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
+++ b/app/javascript/mastodon/components/admin/ReportReasonSelector.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-
 import { injectIntl, defineMessages } from 'react-intl';
 
 import classNames from 'classnames';

--- a/app/javascript/mastodon/components/admin/Retention.jsx
+++ b/app/javascript/mastodon/components/admin/Retention.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-
 import { FormattedMessage, FormattedNumber, FormattedDate } from 'react-intl';
 
 import classNames from 'classnames';

--- a/app/javascript/mastodon/components/admin/Retention.jsx
+++ b/app/javascript/mastodon/components/admin/Retention.jsx
@@ -1,8 +1,12 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import api from 'mastodon/api';
+import { PureComponent } from 'react';
+
+
 import { FormattedMessage, FormattedNumber, FormattedDate } from 'react-intl';
+
 import classNames from 'classnames';
+
+import api from 'mastodon/api';
 import { roundTo10 } from 'mastodon/utils/numbers';
 
 const dateForCohort = cohort => {

--- a/app/javascript/mastodon/components/admin/Trends.jsx
+++ b/app/javascript/mastodon/components/admin/Trends.jsx
@@ -1,8 +1,12 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import api from 'mastodon/api';
+import { PureComponent } from 'react';
+
+
 import { FormattedMessage } from 'react-intl';
+
 import classNames from 'classnames';
+
+import api from 'mastodon/api';
 import Hashtag from 'mastodon/components/hashtag';
 
 export default class Trends extends PureComponent {

--- a/app/javascript/mastodon/components/admin/Trends.jsx
+++ b/app/javascript/mastodon/components/admin/Trends.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-
 import { FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';

--- a/app/javascript/mastodon/components/attachment_list.jsx
+++ b/app/javascript/mastodon/components/attachment_list.jsx
@@ -1,8 +1,12 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import { FormattedMessage } from 'react-intl';
+
 import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import { Icon }  from 'mastodon/components/icon';
 
 const filename = url => url.split('/').pop().split('#')[0].split('?')[0];

--- a/app/javascript/mastodon/components/autosuggest_emoji.jsx
+++ b/app/javascript/mastodon/components/autosuggest_emoji.jsx
@@ -1,7 +1,10 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import unicodeMapping from '../features/emoji/emoji_unicode_mapping_light';
+import { PureComponent } from 'react';
+
 import { assetHost } from 'mastodon/utils/config';
+
+import unicodeMapping from '../features/emoji/emoji_unicode_mapping_light';
+
 
 export default class AutosuggestEmoji extends PureComponent {
 

--- a/app/javascript/mastodon/components/autosuggest_emoji.jsx
+++ b/app/javascript/mastodon/components/autosuggest_emoji.jsx
@@ -5,7 +5,6 @@ import { assetHost } from 'mastodon/utils/config';
 
 import unicodeMapping from '../features/emoji/emoji_unicode_mapping_light';
 
-
 export default class AutosuggestEmoji extends PureComponent {
 
   static propTypes = {

--- a/app/javascript/mastodon/components/autosuggest_hashtag.jsx
+++ b/app/javascript/mastodon/components/autosuggest_hashtag.jsx
@@ -5,7 +5,6 @@ import { FormattedMessage } from 'react-intl';
 
 import ShortNumber from 'mastodon/components/short_number';
 
-
 export default class AutosuggestHashtag extends PureComponent {
 
   static propTypes = {

--- a/app/javascript/mastodon/components/autosuggest_hashtag.jsx
+++ b/app/javascript/mastodon/components/autosuggest_hashtag.jsx
@@ -1,7 +1,10 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ShortNumber from 'mastodon/components/short_number';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
+import ShortNumber from 'mastodon/components/short_number';
+
 
 export default class AutosuggestHashtag extends PureComponent {
 

--- a/app/javascript/mastodon/components/autosuggest_input.jsx
+++ b/app/javascript/mastodon/components/autosuggest_input.jsx
@@ -1,10 +1,16 @@
+import PropTypes from 'prop-types';
+
+import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import AutosuggestAccountContainer from '../features/compose/containers/autosuggest_account_container';
+
 import AutosuggestEmoji from './autosuggest_emoji';
 import AutosuggestHashtag from './autosuggest_hashtag';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import PropTypes from 'prop-types';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import classNames from 'classnames';
+
+
 
 const textAtCursorMatchesToken = (str, caretPosition, searchTokens) => {
   let word;

--- a/app/javascript/mastodon/components/autosuggest_input.jsx
+++ b/app/javascript/mastodon/components/autosuggest_input.jsx
@@ -10,8 +10,6 @@ import AutosuggestAccountContainer from '../features/compose/containers/autosugg
 import AutosuggestEmoji from './autosuggest_emoji';
 import AutosuggestHashtag from './autosuggest_hashtag';
 
-
-
 const textAtCursorMatchesToken = (str, caretPosition, searchTokens) => {
   let word;
 

--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -12,9 +12,6 @@ import AutosuggestAccountContainer from '../features/compose/containers/autosugg
 import AutosuggestEmoji from './autosuggest_emoji';
 import AutosuggestHashtag from './autosuggest_hashtag';
 
-
-
-
 const textAtCursorMatchesToken = (str, caretPosition) => {
   let word;
 

--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -1,11 +1,19 @@
+import PropTypes from 'prop-types';
+
+import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import Textarea from 'react-textarea-autosize';
+
 import AutosuggestAccountContainer from '../features/compose/containers/autosuggest_account_container';
+
 import AutosuggestEmoji from './autosuggest_emoji';
 import AutosuggestHashtag from './autosuggest_hashtag';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import PropTypes from 'prop-types';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import Textarea from 'react-textarea-autosize';
-import classNames from 'classnames';
+
+
+
 
 const textAtCursorMatchesToken = (str, caretPosition) => {
   let word;

--- a/app/javascript/mastodon/components/avatar_composite.jsx
+++ b/app/javascript/mastodon/components/avatar_composite.jsx
@@ -1,7 +1,10 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+
 import { autoPlayGif } from '../initial_state';
+
 import { Avatar } from './avatar';
 
 export default class AvatarComposite extends PureComponent {

--- a/app/javascript/mastodon/components/button.jsx
+++ b/app/javascript/mastodon/components/button.jsx
@@ -1,5 +1,6 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import classNames from 'classnames';
 
 export default class Button extends PureComponent {

--- a/app/javascript/mastodon/components/column.jsx
+++ b/app/javascript/mastodon/components/column.jsx
@@ -1,6 +1,8 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { supportsPassiveEvents } from 'detect-passive-events';
+
 import { scrollTop } from '../scroll';
 
 const listenerOptions = supportsPassiveEvents ? { passive: true } : false;

--- a/app/javascript/mastodon/components/column_back_button.jsx
+++ b/app/javascript/mastodon/components/column_back_button.jsx
@@ -6,7 +6,6 @@ import { FormattedMessage } from 'react-intl';
 
 import { Icon }  from 'mastodon/components/icon';
 
-
 export default class ColumnBackButton extends PureComponent {
 
   static contextTypes = {

--- a/app/javascript/mastodon/components/column_back_button.jsx
+++ b/app/javascript/mastodon/components/column_back_button.jsx
@@ -1,8 +1,11 @@
-import { PureComponent } from 'react';
-import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import { Icon }  from 'mastodon/components/icon';
+import { PureComponent } from 'react';
 import { createPortal } from 'react-dom';
+
+import { FormattedMessage } from 'react-intl';
+
+import { Icon }  from 'mastodon/components/icon';
+
 
 export default class ColumnBackButton extends PureComponent {
 

--- a/app/javascript/mastodon/components/column_back_button_slim.jsx
+++ b/app/javascript/mastodon/components/column_back_button_slim.jsx
@@ -1,6 +1,8 @@
 import { FormattedMessage } from 'react-intl';
-import ColumnBackButton from './column_back_button';
+
 import { Icon }  from 'mastodon/components/icon';
+
+import ColumnBackButton from './column_back_button';
 
 export default class ColumnBackButtonSlim extends ColumnBackButton {
 

--- a/app/javascript/mastodon/components/column_header.jsx
+++ b/app/javascript/mastodon/components/column_header.jsx
@@ -1,8 +1,11 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 import { createPortal } from 'react-dom';
-import classNames from 'classnames';
+
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
+
+import classNames from 'classnames';
+
 import { Icon }  from 'mastodon/components/icon';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/components/dismissable_banner.jsx
+++ b/app/javascript/mastodon/components/dismissable_banner.jsx
@@ -1,8 +1,11 @@
-import { PureComponent } from 'react';
-import { IconButton } from './icon_button';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { injectIntl, defineMessages } from 'react-intl';
+
 import { bannerSettings } from 'mastodon/settings';
+
+import { IconButton } from './icon_button';
 
 const messages = defineMessages({
   dismiss: { id: 'dismissable_banner.dismiss', defaultMessage: 'Dismiss' },

--- a/app/javascript/mastodon/components/dropdown_menu.jsx
+++ b/app/javascript/mastodon/components/dropdown_menu.jsx
@@ -1,11 +1,18 @@
-import { PureComponent, cloneElement, Children } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { IconButton } from './icon_button';
-import Overlay from 'react-overlays/Overlay';
-import { supportsPassiveEvents } from 'detect-passive-events';
+import { PureComponent, cloneElement, Children } from 'react';
+
 import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+import { supportsPassiveEvents } from 'detect-passive-events';
+import Overlay from 'react-overlays/Overlay';
+
 import { CircularProgress } from 'mastodon/components/loading_indicator';
+
+import { IconButton } from './icon_button';
+
+
 
 const listenerOptions = supportsPassiveEvents ? { passive: true, capture: true } : true;
 let id = 0;

--- a/app/javascript/mastodon/components/dropdown_menu.jsx
+++ b/app/javascript/mastodon/components/dropdown_menu.jsx
@@ -12,8 +12,6 @@ import { CircularProgress } from 'mastodon/components/loading_indicator';
 
 import { IconButton } from './icon_button';
 
-
-
 const listenerOptions = supportsPassiveEvents ? { passive: true, capture: true } : true;
 let id = 0;
 

--- a/app/javascript/mastodon/components/edited_timestamp/containers/dropdown_menu_container.js
+++ b/app/javascript/mastodon/components/edited_timestamp/containers/dropdown_menu_container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import { openDropdownMenu, closeDropdownMenu } from 'mastodon/actions/dropdown_menu';
 import { fetchHistory } from 'mastodon/actions/history';
 import DropdownMenu from 'mastodon/components/dropdown_menu';

--- a/app/javascript/mastodon/components/edited_timestamp/index.jsx
+++ b/app/javascript/mastodon/components/edited_timestamp/index.jsx
@@ -1,12 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { FormattedMessage, injectIntl } from 'react-intl';
-import { Icon }  from 'mastodon/components/icon';
-import DropdownMenu from './containers/dropdown_menu_container';
+
 import { connect } from 'react-redux';
+
 import { openModal } from 'mastodon/actions/modal';
-import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
+import { Icon }  from 'mastodon/components/icon';
 import InlineAccount from 'mastodon/components/inline_account';
+import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
+
+import DropdownMenu from './containers/dropdown_menu_container';
 
 const mapDispatchToProps = (dispatch, { statusId }) => ({
 

--- a/app/javascript/mastodon/components/error_boundary.jsx
+++ b/app/javascript/mastodon/components/error_boundary.jsx
@@ -1,9 +1,13 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
-import { version, source_url } from 'mastodon/initial_state';
-import StackTrace from 'stacktrace-js';
+
 import { Helmet } from 'react-helmet';
+
+import StackTrace from 'stacktrace-js';
+
+import { version, source_url } from 'mastodon/initial_state';
 
 export default class ErrorBoundary extends PureComponent {
 

--- a/app/javascript/mastodon/components/hashtag.jsx
+++ b/app/javascript/mastodon/components/hashtag.jsx
@@ -1,13 +1,19 @@
 // @ts-check
-import { Component } from 'react';
-import { Sparklines, SparklinesCurve } from 'react-sparklines';
-import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import { Component } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import classNames from 'classnames';
 import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+import { Sparklines, SparklinesCurve } from 'react-sparklines';
+
+
 import ShortNumber from 'mastodon/components/short_number';
 import { Skeleton } from 'mastodon/components/skeleton';
-import classNames from 'classnames';
 
 class SilentErrorBoundary extends Component {
 

--- a/app/javascript/mastodon/components/hashtag.jsx
+++ b/app/javascript/mastodon/components/hashtag.jsx
@@ -11,7 +11,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import { Sparklines, SparklinesCurve } from 'react-sparklines';
 
-
 import ShortNumber from 'mastodon/components/short_number';
 import { Skeleton } from 'mastodon/components/skeleton';
 

--- a/app/javascript/mastodon/components/inline_account.jsx
+++ b/app/javascript/mastodon/components/inline_account.jsx
@@ -1,8 +1,10 @@
 import { PureComponent } from 'react';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
-import { makeGetAccount } from 'mastodon/selectors';
+
 import { Avatar } from 'mastodon/components/avatar';
+import { makeGetAccount } from 'mastodon/selectors';
 
 const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();

--- a/app/javascript/mastodon/components/intersection_observer_article.jsx
+++ b/app/javascript/mastodon/components/intersection_observer_article.jsx
@@ -1,7 +1,8 @@
-import { cloneElement, Component } from 'react';
 import PropTypes from 'prop-types';
-import scheduleIdleTask from '../features/ui/util/schedule_idle_task';
+import { cloneElement, Component } from 'react';
+
 import getRectFromEntry from '../features/ui/util/get_rect_from_entry';
+import scheduleIdleTask from '../features/ui/util/schedule_idle_task';
 
 // Diff these props in the "unrendered" state
 const updateOnPropsForUnrendered = ['id', 'index', 'listLength', 'cachedHeight'];

--- a/app/javascript/mastodon/components/load_gap.jsx
+++ b/app/javascript/mastodon/components/load_gap.jsx
@@ -1,6 +1,8 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { injectIntl, defineMessages } from 'react-intl';
+
 import { Icon }  from 'mastodon/components/icon';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/components/load_more.jsx
+++ b/app/javascript/mastodon/components/load_more.jsx
@@ -1,6 +1,7 @@
-import { PureComponent } from 'react';
-import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { FormattedMessage } from 'react-intl';
 
 export default class LoadMore extends PureComponent {
 

--- a/app/javascript/mastodon/components/load_pending.jsx
+++ b/app/javascript/mastodon/components/load_pending.jsx
@@ -1,6 +1,7 @@
-import { PureComponent } from 'react';
-import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { FormattedMessage } from 'react-intl';
 
 export default class LoadPending extends PureComponent {
 

--- a/app/javascript/mastodon/components/media_attachments.jsx
+++ b/app/javascript/mastodon/components/media_attachments.jsx
@@ -1,9 +1,12 @@
 import PropTypes from 'prop-types';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { MediaGallery, Video, Audio } from 'mastodon/features/ui/util/async-components';
-import Bundle from 'mastodon/features/ui/components/bundle';
+
 import noop from 'lodash/noop';
+
+import Bundle from 'mastodon/features/ui/components/bundle';
+import { MediaGallery, Video, Audio } from 'mastodon/features/ui/util/async-components';
 
 export default class MediaAttachments extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -1,13 +1,22 @@
-import { PureComponent } from 'react';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import { is } from 'immutable';
-import { IconButton } from './icon_button';
+import { PureComponent } from 'react';
+
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import classNames from 'classnames';
-import { autoPlayGif, cropImages, displayMedia, useBlurhash } from '../initial_state';
+
+import { is } from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+
 import { debounce } from 'lodash';
+
 import { Blurhash } from 'mastodon/components/blurhash';
+
+import { autoPlayGif, cropImages, displayMedia, useBlurhash } from '../initial_state';
+
+import { IconButton } from './icon_button';
 
 const messages = defineMessages({
   toggle_visible: { id: 'media_gallery.toggle_visible', defaultMessage: '{number, plural, one {Hide image} other {Hide images}}' },

--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -1,14 +1,12 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 
 import classNames from 'classnames';
 
 import { is } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-
 
 import { debounce } from 'lodash';
 

--- a/app/javascript/mastodon/components/modal_root.jsx
+++ b/app/javascript/mastodon/components/modal_root.jsx
@@ -1,8 +1,9 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import 'wicg-inert';
-import { createBrowserHistory } from 'history';
 import { multiply } from 'color-blend';
+import { createBrowserHistory } from 'history';
 
 export default class ModalRoot extends PureComponent {
 

--- a/app/javascript/mastodon/components/navigation_portal.jsx
+++ b/app/javascript/mastodon/components/navigation_portal.jsx
@@ -1,8 +1,10 @@
 import { PureComponent } from 'react';
+
 import { Switch, Route, withRouter } from 'react-router-dom';
-import { showTrends } from 'mastodon/initial_state';
-import Trends from 'mastodon/features/getting_started/containers/trends_container';
+
 import AccountNavigation from 'mastodon/features/account/navigation';
+import Trends from 'mastodon/features/getting_started/containers/trends_container';
+import { showTrends } from 'mastodon/initial_state';
 
 const DefaultNavigation = () => (
   showTrends ? (

--- a/app/javascript/mastodon/components/picture_in_picture_placeholder.jsx
+++ b/app/javascript/mastodon/components/picture_in_picture_placeholder.jsx
@@ -1,9 +1,14 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Icon }  from 'mastodon/components/icon';
-import { removePictureInPicture } from 'mastodon/actions/picture_in_picture';
-import { connect } from 'react-redux';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
+import { connect } from 'react-redux';
+
+import { removePictureInPicture } from 'mastodon/actions/picture_in_picture';
+import { Icon }  from 'mastodon/components/icon';
+
+
 
 class PictureInPicturePlaceholder extends PureComponent {
 

--- a/app/javascript/mastodon/components/picture_in_picture_placeholder.jsx
+++ b/app/javascript/mastodon/components/picture_in_picture_placeholder.jsx
@@ -8,8 +8,6 @@ import { connect } from 'react-redux';
 import { removePictureInPicture } from 'mastodon/actions/picture_in_picture';
 import { Icon }  from 'mastodon/components/icon';
 
-
-
 class PictureInPicturePlaceholder extends PureComponent {
 
   static propTypes = {

--- a/app/javascript/mastodon/components/poll.jsx
+++ b/app/javascript/mastodon/components/poll.jsx
@@ -1,14 +1,22 @@
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import classNames from 'classnames';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import classNames from 'classnames';
-import Motion from 'mastodon/features/ui/util/optional_motion';
-import spring from 'react-motion/lib/spring';
+
 import escapeTextContentForBrowser from 'escape-html';
-import emojify from 'mastodon/features/emoji/emoji';
-import { RelativeTimestamp } from './relative_timestamp';
+import spring from 'react-motion/lib/spring';
+
 import { Icon }  from 'mastodon/components/icon';
+import emojify from 'mastodon/features/emoji/emoji';
+import Motion from 'mastodon/features/ui/util/optional_motion';
+
+
+import { RelativeTimestamp } from './relative_timestamp';
+
 
 const messages = defineMessages({
   closed: {

--- a/app/javascript/mastodon/components/poll.jsx
+++ b/app/javascript/mastodon/components/poll.jsx
@@ -14,9 +14,7 @@ import { Icon }  from 'mastodon/components/icon';
 import emojify from 'mastodon/features/emoji/emoji';
 import Motion from 'mastodon/features/ui/util/optional_motion';
 
-
 import { RelativeTimestamp } from './relative_timestamp';
-
 
 const messages = defineMessages({
   closed: {

--- a/app/javascript/mastodon/components/regeneration_indicator.jsx
+++ b/app/javascript/mastodon/components/regeneration_indicator.jsx
@@ -1,4 +1,5 @@
 import { FormattedMessage } from 'react-intl';
+
 import illustration from 'mastodon/../images/elephant_ui_working.svg';
 
 const RegenerationIndicator = () => (

--- a/app/javascript/mastodon/components/scrollable_list.jsx
+++ b/app/javascript/mastodon/components/scrollable_list.jsx
@@ -19,7 +19,6 @@ import LoadMore from './load_more';
 import LoadPending from './load_pending';
 import LoadingIndicator from './loading_indicator';
 
-
 const MOUSE_IDLE_DELAY = 300;
 
 const listenerOptions = supportsPassiveEvents ? { passive: true } : false;

--- a/app/javascript/mastodon/components/scrollable_list.jsx
+++ b/app/javascript/mastodon/components/scrollable_list.jsx
@@ -1,17 +1,24 @@
-import { Children, cloneElement, PureComponent } from 'react';
-import ScrollContainer from 'mastodon/containers/scroll_container';
 import PropTypes from 'prop-types';
+import { Children, cloneElement, PureComponent } from 'react';
+
+import classNames from 'classnames';
+
+import { List as ImmutableList } from 'immutable';
+import { connect } from 'react-redux';
+
+import { supportsPassiveEvents } from 'detect-passive-events';
+import { throttle } from 'lodash';
+
+import ScrollContainer from 'mastodon/containers/scroll_container';
+
 import IntersectionObserverArticleContainer from '../containers/intersection_observer_article_container';
+import { attachFullscreenListener, detachFullscreenListener, isFullscreen } from '../features/ui/util/fullscreen';
+import IntersectionObserverWrapper from '../features/ui/util/intersection_observer_wrapper';
+
 import LoadMore from './load_more';
 import LoadPending from './load_pending';
-import IntersectionObserverWrapper from '../features/ui/util/intersection_observer_wrapper';
-import { throttle } from 'lodash';
-import { List as ImmutableList } from 'immutable';
-import classNames from 'classnames';
-import { supportsPassiveEvents } from 'detect-passive-events';
-import { attachFullscreenListener, detachFullscreenListener, isFullscreen } from '../features/ui/util/fullscreen';
 import LoadingIndicator from './loading_indicator';
-import { connect } from 'react-redux';
+
 
 const MOUSE_IDLE_DELAY = 300;
 

--- a/app/javascript/mastodon/components/server_banner.jsx
+++ b/app/javascript/mastodon/components/server_banner.jsx
@@ -1,14 +1,19 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+
+import { Link } from 'react-router-dom';
+
 import { connect } from 'react-redux';
+
+
 import { fetchServer } from 'mastodon/actions/server';
+import { ServerHeroImage } from 'mastodon/components/server_hero_image';
 import ShortNumber from 'mastodon/components/short_number';
 import { Skeleton } from 'mastodon/components/skeleton';
 import Account from 'mastodon/containers/account_container';
 import { domain } from 'mastodon/initial_state';
-import { ServerHeroImage } from 'mastodon/components/server_hero_image';
-import { Link } from 'react-router-dom';
 
 const messages = defineMessages({
   aboutActiveUsers: { id: 'server_banner.about_active_users', defaultMessage: 'People using this server during the last 30 days (Monthly Active Users)' },

--- a/app/javascript/mastodon/components/server_banner.jsx
+++ b/app/javascript/mastodon/components/server_banner.jsx
@@ -7,7 +7,6 @@ import { Link } from 'react-router-dom';
 
 import { connect } from 'react-redux';
 
-
 import { fetchServer } from 'mastodon/actions/server';
 import { ServerHeroImage } from 'mastodon/components/server_hero_image';
 import ShortNumber from 'mastodon/components/short_number';

--- a/app/javascript/mastodon/components/short_number.jsx
+++ b/app/javascript/mastodon/components/short_number.jsx
@@ -1,7 +1,10 @@
-import { memo } from 'react';
 import PropTypes from 'prop-types';
-import { toShortNumber, pluralReady, DECIMAL_UNITS } from '../utils/numbers';
+import { memo } from 'react';
+
 import { FormattedMessage, FormattedNumber } from 'react-intl';
+
+import { toShortNumber, pluralReady, DECIMAL_UNITS } from '../utils/numbers';
+
 // @ts-check
 
 /**

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -1,25 +1,31 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import { Avatar } from './avatar';
-import { AvatarOverlay } from './avatar_overlay';
-import { RelativeTimestamp } from './relative_timestamp';
-import { DisplayName } from './display_name';
-import StatusContent from './status_content';
-import StatusActionBar from './status_action_bar';
-import AttachmentList from './attachment_list';
-import Card from '../features/status/components/card';
+
 import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { MediaGallery, Video, Audio } from '../features/ui/util/async-components';
-import { HotKeys } from 'react-hotkeys';
+
 import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import { HotKeys } from 'react-hotkeys';
+
 import { Icon }  from 'mastodon/components/icon';
-import { displayMedia } from '../initial_state';
 import PictureInPicturePlaceholder from 'mastodon/components/picture_in_picture_placeholder';
 
+import Card from '../features/status/components/card';
 // We use the component (and not the container) since we do not want
 // to use the progress bar to show download progress
 import Bundle from '../features/ui/components/bundle';
+import { MediaGallery, Video, Audio } from '../features/ui/util/async-components';
+import { displayMedia } from '../initial_state';
+
+import AttachmentList from './attachment_list';
+import { Avatar } from './avatar';
+import { AvatarOverlay } from './avatar_overlay';
+import { DisplayName } from './display_name';
+import { RelativeTimestamp } from './relative_timestamp';
+import StatusActionBar from './status_action_bar';
+import StatusContent from './status_content';
 
 export const textForScreenReader = (intl, status, rebloggedByText = false) => {
   const displayName = status.getIn(['account', 'display_name']);

--- a/app/javascript/mastodon/components/status_action_bar.jsx
+++ b/app/javascript/mastodon/components/status_action_bar.jsx
@@ -1,13 +1,19 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { IconButton } from './icon_button';
-import DropdownMenuContainer from '../containers/dropdown_menu_container';
+
 import { defineMessages, injectIntl } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { me } from '../initial_state';
+
 import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
 import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_FEDERATION } from 'mastodon/permissions';
+
+import DropdownMenuContainer from '../containers/dropdown_menu_container';
+import { me } from '../initial_state';
+
+import { IconButton } from './icon_button';
 
 const messages = defineMessages({
   delete: { id: 'status.delete', defaultMessage: 'Delete' },

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -9,8 +9,6 @@ import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-
-
 import { Icon }  from 'mastodon/components/icon';
 import PollContainer from 'mastodon/containers/poll_container';
 import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_state';

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -1,12 +1,18 @@
-import { PureComponent } from 'react';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { FormattedMessage, injectIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
-import { connect } from 'react-redux';
+
 import classnames from 'classnames';
-import PollContainer from 'mastodon/containers/poll_container';
+import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+
+
 import { Icon }  from 'mastodon/components/icon';
+import PollContainer from 'mastodon/containers/poll_container';
 import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_state';
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)

--- a/app/javascript/mastodon/components/status_list.jsx
+++ b/app/javascript/mastodon/components/status_list.jsx
@@ -1,11 +1,17 @@
-import { debounce } from 'lodash';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import StatusContainer from '../containers/status_container';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import { debounce } from 'lodash';
+
+import RegenerationIndicator from 'mastodon/components/regeneration_indicator';
+
+import StatusContainer from '../containers/status_container';
+
+
 import LoadGap from './load_gap';
 import ScrollableList from './scrollable_list';
-import RegenerationIndicator from 'mastodon/components/regeneration_indicator';
 
 export default class StatusList extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/components/status_list.jsx
+++ b/app/javascript/mastodon/components/status_list.jsx
@@ -9,7 +9,6 @@ import RegenerationIndicator from 'mastodon/components/regeneration_indicator';
 
 import StatusContainer from '../containers/status_container';
 
-
 import LoadGap from './load_gap';
 import ScrollableList from './scrollable_list';
 

--- a/app/javascript/mastodon/containers/account_container.jsx
+++ b/app/javascript/mastodon/containers/account_container.jsx
@@ -1,7 +1,7 @@
-import { connect } from 'react-redux';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { makeGetAccount } from '../selectors';
-import Account from '../components/account';
+
+import { connect } from 'react-redux';
+
 import {
   followAccount,
   unfollowAccount,
@@ -12,7 +12,9 @@ import {
 } from '../actions/accounts';
 import { openModal } from '../actions/modal';
 import { initMuteModal } from '../actions/mutes';
+import Account from '../components/account';
 import { unfollowModal } from '../initial_state';
+import { makeGetAccount } from '../selectors';
 
 const messages = defineMessages({
   unfollowConfirm: { id: 'confirmations.unfollow.confirm', defaultMessage: 'Unfollow' },

--- a/app/javascript/mastodon/containers/admin_component.jsx
+++ b/app/javascript/mastodon/containers/admin_component.jsx
@@ -1,6 +1,8 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { IntlProvider, addLocaleData } from 'react-intl';
+
 import { getLocale } from '../locales';
 
 const { localeData, messages } = getLocale();

--- a/app/javascript/mastodon/containers/compose_container.jsx
+++ b/app/javascript/mastodon/containers/compose_container.jsx
@@ -1,13 +1,16 @@
-import { PureComponent } from 'react';
-import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
-import { store } from '../store';
-import { hydrateStore } from '../actions/store';
+import { PureComponent } from 'react';
+
 import { IntlProvider, addLocaleData } from 'react-intl';
-import { getLocale } from '../locales';
+
+import { Provider } from 'react-redux';
+
+import { fetchCustomEmojis } from '../actions/custom_emojis';
+import { hydrateStore } from '../actions/store';
 import Compose from '../features/standalone/compose';
 import initialState from '../initial_state';
-import { fetchCustomEmojis } from '../actions/custom_emojis';
+import { getLocale } from '../locales';
+import { store } from '../store';
 
 const { localeData, messages } = getLocale();
 addLocaleData(localeData);

--- a/app/javascript/mastodon/containers/domain_container.jsx
+++ b/app/javascript/mastodon/containers/domain_container.jsx
@@ -1,8 +1,10 @@
-import { connect } from 'react-redux';
-import { blockDomain, unblockDomain } from '../actions/domain_blocks';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { Domain } from '../components/domain';
+
+import { connect } from 'react-redux';
+
+import { blockDomain, unblockDomain } from '../actions/domain_blocks';
 import { openModal } from '../actions/modal';
+import { Domain } from '../components/domain';
 
 const messages = defineMessages({
   blockDomainConfirm: { id: 'confirmations.domain_block.confirm', defaultMessage: 'Block entire domain' },

--- a/app/javascript/mastodon/containers/dropdown_menu_container.js
+++ b/app/javascript/mastodon/containers/dropdown_menu_container.js
@@ -1,7 +1,9 @@
-import { openDropdownMenu, closeDropdownMenu } from '../actions/dropdown_menu';
-import { fetchRelationships } from 'mastodon/actions/accounts';
-import { openModal, closeModal } from '../actions/modal';
 import { connect } from 'react-redux';
+
+import { fetchRelationships } from 'mastodon/actions/accounts';
+
+import { openDropdownMenu, closeDropdownMenu } from '../actions/dropdown_menu';
+import { openModal, closeModal } from '../actions/modal';
 import DropdownMenu from '../components/dropdown_menu';
 import { isUserTouching } from '../is_mobile';
 

--- a/app/javascript/mastodon/containers/intersection_observer_article_container.js
+++ b/app/javascript/mastodon/containers/intersection_observer_article_container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
-import IntersectionObserverArticle from '../components/intersection_observer_article';
+
 import { setHeight } from '../actions/height_cache';
+import IntersectionObserverArticle from '../components/intersection_observer_article';
 
 const makeMapStateToProps = (state, props) => ({
   cachedHeight: state.getIn(['height_cache', props.saveHeightKey, props.id]),

--- a/app/javascript/mastodon/containers/mastodon.jsx
+++ b/app/javascript/mastodon/containers/mastodon.jsx
@@ -1,18 +1,23 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
-import { Helmet } from 'react-helmet';
+
 import { IntlProvider, addLocaleData } from 'react-intl';
-import { Provider as ReduxProvider } from 'react-redux';
+
+import { Helmet } from 'react-helmet';
 import { BrowserRouter, Route } from 'react-router-dom';
+
+import { Provider as ReduxProvider } from 'react-redux';
+
 import { ScrollContext } from 'react-router-scroll-4';
-import { store } from 'mastodon/store';
-import UI from 'mastodon/features/ui';
+
 import { fetchCustomEmojis } from 'mastodon/actions/custom_emojis';
 import { hydrateStore } from 'mastodon/actions/store';
 import { connectUserStream } from 'mastodon/actions/streaming';
 import ErrorBoundary from 'mastodon/components/error_boundary';
+import UI from 'mastodon/features/ui';
 import initialState, { title as siteTitle } from 'mastodon/initial_state';
 import { getLocale } from 'mastodon/locales';
+import { store } from 'mastodon/store';
 
 const { localeData, messages } = getLocale();
 addLocaleData(localeData);

--- a/app/javascript/mastodon/containers/media_container.jsx
+++ b/app/javascript/mastodon/containers/media_container.jsx
@@ -1,18 +1,21 @@
+import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { createPortal } from 'react-dom';
-import PropTypes from 'prop-types';
+
 import { IntlProvider, addLocaleData } from 'react-intl';
+
 import { fromJS } from 'immutable';
-import { getLocale } from 'mastodon/locales';
-import { getScrollbarWidth } from 'mastodon/utils/scrollbar';
-import MediaGallery from 'mastodon/components/media_gallery';
-import Poll from 'mastodon/components/poll';
+
 import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
+import MediaGallery from 'mastodon/components/media_gallery';
 import ModalRoot from 'mastodon/components/modal_root';
+import Poll from 'mastodon/components/poll';
+import Audio from 'mastodon/features/audio';
+import Card from 'mastodon/features/status/components/card';
 import MediaModal from 'mastodon/features/ui/components/media_modal';
 import Video from 'mastodon/features/video';
-import Card from 'mastodon/features/status/components/card';
-import Audio from 'mastodon/features/audio';
+import { getLocale } from 'mastodon/locales';
+import { getScrollbarWidth } from 'mastodon/utils/scrollbar';
 
 const { localeData, messages } = getLocale();
 addLocaleData(localeData);

--- a/app/javascript/mastodon/containers/poll_container.js
+++ b/app/javascript/mastodon/containers/poll_container.js
@@ -1,8 +1,9 @@
 import { connect } from 'react-redux';
+
 import { debounce } from 'lodash';
 
-import Poll from 'mastodon/components/poll';
 import { fetchPoll, vote } from 'mastodon/actions/polls';
+import Poll from 'mastodon/components/poll';
 
 const mapDispatchToProps = (dispatch, { pollId }) => ({
   refresh: debounce(

--- a/app/javascript/mastodon/containers/status_container.jsx
+++ b/app/javascript/mastodon/containers/status_container.jsx
@@ -1,11 +1,26 @@
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import { connect } from 'react-redux';
-import Status from '../components/status';
-import { makeGetStatus, makeGetPictureInPicture } from '../selectors';
+
+import {
+  unmuteAccount,
+  unblockAccount,
+} from '../actions/accounts';
+import { showAlertForError } from '../actions/alerts';
+import { initBlockModal } from '../actions/blocks';
+import { initBoostModal } from '../actions/boosts';
 import {
   replyCompose,
   mentionCompose,
   directCompose,
 } from '../actions/compose';
+import {
+  blockDomain,
+  unblockDomain,
+} from '../actions/domain_blocks';
+import {
+  initAddFilter,
+} from '../actions/filters';
 import {
   reblog,
   favourite,
@@ -16,6 +31,10 @@ import {
   pin,
   unpin,
 } from '../actions/interactions';
+import { openModal } from '../actions/modal';
+import { initMuteModal } from '../actions/mutes';
+import { deployPictureInPicture } from '../actions/picture_in_picture';
+import { initReport } from '../actions/reports';
 import {
   muteStatus,
   unmuteStatus,
@@ -27,26 +46,9 @@ import {
   translateStatus,
   undoStatusTranslation,
 } from '../actions/statuses';
-import {
-  unmuteAccount,
-  unblockAccount,
-} from '../actions/accounts';
-import {
-  blockDomain,
-  unblockDomain,
-} from '../actions/domain_blocks';
-import {
-  initAddFilter,
-} from '../actions/filters';
-import { initMuteModal } from '../actions/mutes';
-import { initBlockModal } from '../actions/blocks';
-import { initBoostModal } from '../actions/boosts';
-import { initReport } from '../actions/reports';
-import { openModal } from '../actions/modal';
-import { deployPictureInPicture } from '../actions/picture_in_picture';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import Status from '../components/status';
 import { boostModal, deleteModal } from '../initial_state';
-import { showAlertForError } from '../actions/alerts';
+import { makeGetStatus, makeGetPictureInPicture } from '../selectors';
 
 const messages = defineMessages({
   deleteConfirm: { id: 'confirmations.delete.confirm', defaultMessage: 'Delete' },

--- a/app/javascript/mastodon/features/about/index.jsx
+++ b/app/javascript/mastodon/features/about/index.jsx
@@ -1,17 +1,21 @@
-import { PureComponent } from 'react';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Column from 'mastodon/components/column';
-import LinkFooter from 'mastodon/features/ui/components/link_footer';
-import { Helmet } from 'react-helmet';
-import { fetchServer, fetchExtendedDescription, fetchDomainBlocks } from 'mastodon/actions/server';
-import Account from 'mastodon/containers/account_container';
-import { Skeleton } from 'mastodon/components/skeleton';
-import { Icon }  from 'mastodon/components/icon';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import classNames from 'classnames';
+import { Helmet } from 'react-helmet';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { fetchServer, fetchExtendedDescription, fetchDomainBlocks  } from 'mastodon/actions/server';
+import Column from 'mastodon/components/column';
+import { Icon  }  from 'mastodon/components/icon';
 import { ServerHeroImage } from 'mastodon/components/server_hero_image';
+import { Skeleton } from 'mastodon/components/skeleton';
+import Account from 'mastodon/containers/account_container';
+import LinkFooter from 'mastodon/features/ui/components/link_footer';
 
 const messages = defineMessages({
   title: { id: 'column.about', defaultMessage: 'About' },

--- a/app/javascript/mastodon/features/account/components/account_note.jsx
+++ b/app/javascript/mastodon/features/account/components/account_note.jsx
@@ -9,7 +9,6 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import Textarea from 'react-textarea-autosize';
 
-
 const messages = defineMessages({
   placeholder: { id: 'account_note.placeholder', defaultMessage: 'Click to add a note' },
 });

--- a/app/javascript/mastodon/features/account/components/account_note.jsx
+++ b/app/javascript/mastodon/features/account/components/account_note.jsx
@@ -1,10 +1,14 @@
-import { PureComponent } from 'react';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import Textarea from 'react-textarea-autosize';
+
 import { is } from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import Textarea from 'react-textarea-autosize';
+
 
 const messages = defineMessages({
   placeholder: { id: 'account_note.placeholder', defaultMessage: 'Click to add a note' },

--- a/app/javascript/mastodon/features/account/components/featured_tags.jsx
+++ b/app/javascript/mastodon/features/account/components/featured_tags.jsx
@@ -1,7 +1,10 @@
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import Hashtag from 'mastodon/components/hashtag';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/account/components/follow_request_note.jsx
+++ b/app/javascript/mastodon/features/account/components/follow_request_note.jsx
@@ -1,6 +1,8 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import { FormattedMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import { Icon }  from 'mastodon/components/icon';
 
 export default class FollowRequestNote extends ImmutablePureComponent {

--- a/app/javascript/mastodon/features/account/components/header.jsx
+++ b/app/javascript/mastodon/features/account/components/header.jsx
@@ -9,7 +9,6 @@ import { NavLink } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-
 import { Avatar } from 'mastodon/components/avatar';
 import Button from 'mastodon/components/button';
 import { counterRenderer } from 'mastodon/components/common_counter';
@@ -22,7 +21,6 @@ import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_FEDERATION } from 'mastodon/
 
 import AccountNoteContainer from '../containers/account_note_container';
 import FollowRequestNoteContainer from '../containers/follow_request_note_container';
-
 
 const messages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },

--- a/app/javascript/mastodon/features/account/components/header.jsx
+++ b/app/javascript/mastodon/features/account/components/header.jsx
@@ -1,21 +1,28 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import Button from 'mastodon/components/button';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { autoPlayGif, me, domain } from 'mastodon/initial_state';
+
 import classNames from 'classnames';
+import { Helmet } from 'react-helmet';
+import { NavLink } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+
+import { Avatar } from 'mastodon/components/avatar';
+import Button from 'mastodon/components/button';
+import { counterRenderer } from 'mastodon/components/common_counter';
 import { Icon }  from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
-import { Avatar } from 'mastodon/components/avatar';
-import { counterRenderer } from 'mastodon/components/common_counter';
 import ShortNumber from 'mastodon/components/short_number';
-import { NavLink } from 'react-router-dom';
 import DropdownMenuContainer from 'mastodon/containers/dropdown_menu_container';
+import { autoPlayGif, me, domain } from 'mastodon/initial_state';
+import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_FEDERATION } from 'mastodon/permissions';
+
 import AccountNoteContainer from '../containers/account_note_container';
 import FollowRequestNoteContainer from '../containers/follow_request_note_container';
-import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_FEDERATION } from 'mastodon/permissions';
-import { Helmet } from 'react-helmet';
+
 
 const messages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },

--- a/app/javascript/mastodon/features/account/containers/account_note_container.js
+++ b/app/javascript/mastodon/features/account/containers/account_note_container.js
@@ -1,5 +1,7 @@
 import { connect } from 'react-redux';
+
 import { submitAccountNote } from 'mastodon/actions/account_notes';
+
 import AccountNote from '../components/account_note';
 
 const mapStateToProps = (state, { account }) => ({

--- a/app/javascript/mastodon/features/account/containers/featured_tags_container.js
+++ b/app/javascript/mastodon/features/account/containers/featured_tags_container.js
@@ -1,7 +1,9 @@
-import { connect } from 'react-redux';
-import FeaturedTags from '../components/featured_tags';
-import { makeGetAccount } from 'mastodon/selectors';
 import { List as ImmutableList } from 'immutable';
+import { connect } from 'react-redux';
+
+import { makeGetAccount } from 'mastodon/selectors';
+
+import FeaturedTags from '../components/featured_tags';
 
 const mapStateToProps = () => {
   const getAccount = makeGetAccount();

--- a/app/javascript/mastodon/features/account/containers/follow_request_note_container.js
+++ b/app/javascript/mastodon/features/account/containers/follow_request_note_container.js
@@ -1,6 +1,8 @@
 import { connect } from 'react-redux';
-import FollowRequestNote from '../components/follow_request_note';
+
 import { authorizeFollowRequest, rejectFollowRequest } from 'mastodon/actions/accounts';
+
+import FollowRequestNote from '../components/follow_request_note';
 
 const mapDispatchToProps = (dispatch, { account }) => ({
   onAuthorize () {

--- a/app/javascript/mastodon/features/account/navigation.jsx
+++ b/app/javascript/mastodon/features/account/navigation.jsx
@@ -1,6 +1,8 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { connect } from 'react-redux';
+
 import FeaturedTags from 'mastodon/features/account/containers/featured_tags_container';
 import { normalizeForLookup } from 'mastodon/reducers/accounts_map';
 

--- a/app/javascript/mastodon/features/account_gallery/components/media_item.jsx
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.jsx
@@ -9,8 +9,6 @@ import { Blurhash } from 'mastodon/components/blurhash';
 import { Icon }  from 'mastodon/components/icon';
 import { autoPlayGif, displayMedia, useBlurhash } from 'mastodon/initial_state';
 
-
-
 export default class MediaItem extends ImmutablePureComponent {
 
   static propTypes = {

--- a/app/javascript/mastodon/features/account_gallery/components/media_item.jsx
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.jsx
@@ -1,10 +1,15 @@
-import { Blurhash } from 'mastodon/components/blurhash';
-import classNames from 'classnames';
-import { Icon }  from 'mastodon/components/icon';
-import { autoPlayGif, displayMedia, useBlurhash } from 'mastodon/initial_state';
 import PropTypes from 'prop-types';
+
+import classNames from 'classnames';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import { Blurhash } from 'mastodon/components/blurhash';
+import { Icon }  from 'mastodon/components/icon';
+import { autoPlayGif, displayMedia, useBlurhash } from 'mastodon/initial_state';
+
+
 
 export default class MediaItem extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/account_gallery/index.jsx
+++ b/app/javascript/mastodon/features/account_gallery/index.jsx
@@ -1,21 +1,31 @@
-import { connect } from 'react-redux';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import { lookupAccount, fetchAccount } from 'mastodon/actions/accounts';
-import { expandAccountMediaTimeline } from '../../actions/timelines';
-import LoadingIndicator from 'mastodon/components/loading_indicator';
-import Column from '../ui/components/column';
-import ColumnBackButton from 'mastodon/components/column_back_button';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { getAccountGallery } from 'mastodon/selectors';
-import MediaItem from './components/media_item';
-import HeaderContainer from '../account_timeline/containers/header_container';
-import ScrollContainer from 'mastodon/containers/scroll_container';
-import LoadMore from 'mastodon/components/load_more';
-import { openModal } from 'mastodon/actions/modal';
+
 import { FormattedMessage } from 'react-intl';
-import { normalizeForLookup } from 'mastodon/reducers/accounts_map';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+import { lookupAccount, fetchAccount } from 'mastodon/actions/accounts';
+import { openModal } from 'mastodon/actions/modal';
+import ColumnBackButton from 'mastodon/components/column_back_button';
+import LoadMore from 'mastodon/components/load_more';
+import LoadingIndicator from 'mastodon/components/loading_indicator';
+import ScrollContainer from 'mastodon/containers/scroll_container';
 import BundleColumnError from 'mastodon/features/ui/components/bundle_column_error';
+import { normalizeForLookup } from 'mastodon/reducers/accounts_map';
+import { getAccountGallery } from 'mastodon/selectors';
+
+import { expandAccountMediaTimeline } from '../../actions/timelines';
+import HeaderContainer from '../account_timeline/containers/header_container';
+import Column from '../ui/components/column';
+
+
+
+
+import MediaItem from './components/media_item';
+
+
 
 const mapStateToProps = (state, { params: { acct, id } }) => {
   const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);

--- a/app/javascript/mastodon/features/account_gallery/index.jsx
+++ b/app/javascript/mastodon/features/account_gallery/index.jsx
@@ -20,12 +20,7 @@ import { expandAccountMediaTimeline } from '../../actions/timelines';
 import HeaderContainer from '../account_timeline/containers/header_container';
 import Column from '../ui/components/column';
 
-
-
-
 import MediaItem from './components/media_item';
-
-
 
 const mapStateToProps = (state, { params: { acct, id } }) => {
   const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);

--- a/app/javascript/mastodon/features/account_timeline/components/header.jsx
+++ b/app/javascript/mastodon/features/account_timeline/components/header.jsx
@@ -1,11 +1,20 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import InnerHeader from '../../account/components/header';
+
+import { FormattedMessage } from 'react-intl';
+
+import { NavLink } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
+
+import InnerHeader from '../../account/components/header';
+
+
 import MemorialNote from './memorial_note';
 import MovedNote from './moved_note';
-import { FormattedMessage } from 'react-intl';
-import { NavLink } from 'react-router-dom';
+
+
 
 export default class Header extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/account_timeline/components/header.jsx
+++ b/app/javascript/mastodon/features/account_timeline/components/header.jsx
@@ -7,14 +7,10 @@ import { NavLink } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-
 import InnerHeader from '../../account/components/header';
-
 
 import MemorialNote from './memorial_note';
 import MovedNote from './moved_note';
-
-
 
 export default class Header extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/account_timeline/components/limited_account_hint.jsx
+++ b/app/javascript/mastodon/features/account_timeline/components/limited_account_hint.jsx
@@ -1,8 +1,11 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { revealAccount } from 'mastodon/actions/accounts';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
+import { connect } from 'react-redux';
+
+import { revealAccount } from 'mastodon/actions/accounts';
 import Button from 'mastodon/components/button';
 import { domain } from 'mastodon/initial_state';
 

--- a/app/javascript/mastodon/features/account_timeline/components/moved_note.jsx
+++ b/app/javascript/mastodon/features/account_timeline/components/moved_note.jsx
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-
 import { AvatarOverlay } from '../../../components/avatar_overlay';
 import { DisplayName } from '../../../components/display_name';
 

--- a/app/javascript/mastodon/features/account_timeline/components/moved_note.jsx
+++ b/app/javascript/mastodon/features/account_timeline/components/moved_note.jsx
@@ -1,9 +1,13 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import { FormattedMessage } from 'react-intl';
+
+import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
+
 import { AvatarOverlay } from '../../../components/avatar_overlay';
 import { DisplayName } from '../../../components/display_name';
-import { Link } from 'react-router-dom';
 
 export default class MovedNote extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/account_timeline/containers/header_container.jsx
+++ b/app/javascript/mastodon/features/account_timeline/containers/header_container.jsx
@@ -1,6 +1,9 @@
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import { connect } from 'react-redux';
-import { makeGetAccount, getAccountHidden } from '../../../selectors';
-import Header from '../components/header';
+
+import { openURL } from 'mastodon/actions/search';
+
 import {
   followAccount,
   unfollowAccount,
@@ -9,18 +12,18 @@ import {
   pinAccount,
   unpinAccount,
 } from '../../../actions/accounts';
-import { openURL } from 'mastodon/actions/search';
+import { initBlockModal } from '../../../actions/blocks';
 import {
   mentionCompose,
   directCompose,
 } from '../../../actions/compose';
-import { initMuteModal } from '../../../actions/mutes';
-import { initBlockModal } from '../../../actions/blocks';
-import { initReport } from '../../../actions/reports';
-import { openModal } from '../../../actions/modal';
 import { blockDomain, unblockDomain } from '../../../actions/domain_blocks';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import { openModal } from '../../../actions/modal';
+import { initMuteModal } from '../../../actions/mutes';
+import { initReport } from '../../../actions/reports';
 import { unfollowModal } from '../../../initial_state';
+import { makeGetAccount, getAccountHidden } from '../../../selectors';
+import Header from '../components/header';
 
 const messages = defineMessages({
   cancelFollowRequestConfirm: { id: 'confirmations.cancel_follow_request.confirm', defaultMessage: 'Withdraw request' },

--- a/app/javascript/mastodon/features/account_timeline/index.jsx
+++ b/app/javascript/mastodon/features/account_timeline/index.jsx
@@ -1,23 +1,33 @@
-import { connect } from 'react-redux';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import { lookupAccount, fetchAccount } from '../../actions/accounts';
-import { expandAccountFeaturedTimeline, expandAccountTimeline, connectTimeline, disconnectTimeline } from '../../actions/timelines';
-import StatusList from '../../components/status_list';
-import LoadingIndicator from '../../components/loading_indicator';
-import Column from '../ui/components/column';
-import HeaderContainer from './containers/header_container';
-import ColumnBackButton from '../../components/column_back_button';
-import { List as ImmutableList } from 'immutable';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import { FormattedMessage } from 'react-intl';
+
+import { List as ImmutableList } from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
 import { TimelineHint } from 'mastodon/components/timeline_hint';
-import { me } from 'mastodon/initial_state';
-import LimitedAccountHint from './components/limited_account_hint';
-import { getAccountHidden } from 'mastodon/selectors';
-import { fetchFeaturedTags } from '../../actions/featured_tags';
-import { normalizeForLookup } from 'mastodon/reducers/accounts_map';
 import BundleColumnError from 'mastodon/features/ui/components/bundle_column_error';
+import { me } from 'mastodon/initial_state';
+import { normalizeForLookup } from 'mastodon/reducers/accounts_map';
+import { getAccountHidden } from 'mastodon/selectors';
+
+import { lookupAccount, fetchAccount } from '../../actions/accounts';
+import { fetchFeaturedTags } from '../../actions/featured_tags';
+import { expandAccountFeaturedTimeline, expandAccountTimeline, connectTimeline, disconnectTimeline } from '../../actions/timelines';
+import ColumnBackButton from '../../components/column_back_button';
+import LoadingIndicator from '../../components/loading_indicator';
+import StatusList from '../../components/status_list';
+import Column from '../ui/components/column';
+
+import LimitedAccountHint from './components/limited_account_hint';
+import HeaderContainer from './containers/header_container';
+
+
+
+
+
 
 const emptyList = ImmutableList();
 

--- a/app/javascript/mastodon/features/account_timeline/index.jsx
+++ b/app/javascript/mastodon/features/account_timeline/index.jsx
@@ -24,11 +24,6 @@ import Column from '../ui/components/column';
 import LimitedAccountHint from './components/limited_account_hint';
 import HeaderContainer from './containers/header_container';
 
-
-
-
-
-
 const emptyList = ImmutableList();
 
 const mapStateToProps = (state, { params: { acct, id, tagged }, withReplies = false }) => {

--- a/app/javascript/mastodon/features/audio/index.jsx
+++ b/app/javascript/mastodon/features/audio/index.jsx
@@ -1,14 +1,23 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { formatTime, getPointerPosition, fileNameFromURL } from 'mastodon/features/video';
-import { Icon }  from 'mastodon/components/icon';
+
 import classNames from 'classnames';
-import { throttle, debounce } from 'lodash';
-import Visualizer from './visualizer';
-import { displayMedia, useBlurhash } from '../../initial_state';
-import { Blurhash } from '../../components/blurhash';
+
 import { is } from 'immutable';
+
+import { throttle, debounce } from 'lodash';
+
+import { Icon }  from 'mastodon/components/icon';
+import { formatTime, getPointerPosition, fileNameFromURL } from 'mastodon/features/video';
+
+
+import { Blurhash } from '../../components/blurhash';
+import { displayMedia, useBlurhash } from '../../initial_state';
+
+import Visualizer from './visualizer';
+
 
 const messages = defineMessages({
   play: { id: 'video.play', defaultMessage: 'Play' },

--- a/app/javascript/mastodon/features/audio/index.jsx
+++ b/app/javascript/mastodon/features/audio/index.jsx
@@ -12,12 +12,10 @@ import { throttle, debounce } from 'lodash';
 import { Icon }  from 'mastodon/components/icon';
 import { formatTime, getPointerPosition, fileNameFromURL } from 'mastodon/features/video';
 
-
 import { Blurhash } from '../../components/blurhash';
 import { displayMedia, useBlurhash } from '../../initial_state';
 
 import Visualizer from './visualizer';
-
 
 const messages = defineMessages({
   play: { id: 'video.play', defaultMessage: 'Play' },

--- a/app/javascript/mastodon/features/blocks/index.jsx
+++ b/app/javascript/mastodon/features/blocks/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-
 import { fetchBlocks, expandBlocks } from '../../actions/blocks';
 import ColumnBackButtonSlim from '../../components/column_back_button_slim';
 import LoadingIndicator from '../../components/loading_indicator';

--- a/app/javascript/mastodon/features/blocks/index.jsx
+++ b/app/javascript/mastodon/features/blocks/index.jsx
@@ -1,15 +1,20 @@
-import { connect } from 'react-redux';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
-import LoadingIndicator from '../../components/loading_indicator';
-import Column from '../ui/components/column';
-import ColumnBackButtonSlim from '../../components/column_back_button_slim';
-import AccountContainer from '../../containers/account_container';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+import { debounce } from 'lodash';
+
+
 import { fetchBlocks, expandBlocks } from '../../actions/blocks';
+import ColumnBackButtonSlim from '../../components/column_back_button_slim';
+import LoadingIndicator from '../../components/loading_indicator';
 import ScrollableList from '../../components/scrollable_list';
+import AccountContainer from '../../containers/account_container';
+import Column from '../ui/components/column';
 
 const messages = defineMessages({
   heading: { id: 'column.blocks', defaultMessage: 'Blocked users' },

--- a/app/javascript/mastodon/features/bookmarked_statuses/index.jsx
+++ b/app/javascript/mastodon/features/bookmarked_statuses/index.jsx
@@ -1,10 +1,15 @@
-import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
-import { Helmet } from 'react-helmet';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
+
+import { debounce } from 'lodash';
+
 import { fetchBookmarkedStatuses, expandBookmarkedStatuses } from 'mastodon/actions/bookmarks';
 import { addColumn, removeColumn, moveColumn } from 'mastodon/actions/columns';
 import ColumnHeader from 'mastodon/components/column_header';

--- a/app/javascript/mastodon/features/closed_registrations_modal/index.jsx
+++ b/app/javascript/mastodon/features/closed_registrations_modal/index.jsx
@@ -1,8 +1,10 @@
-import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
+
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { domain } from 'mastodon/initial_state';
+import { connect } from 'react-redux';
+
 import { fetchServer } from 'mastodon/actions/server';
+import { domain } from 'mastodon/initial_state';
 
 const mapStateToProps = state => ({
   message: state.getIn(['server', 'server', 'registrations', 'message']),

--- a/app/javascript/mastodon/features/community_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/community_timeline/components/column_settings.jsx
@@ -5,7 +5,6 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-
 import SettingToggle from '../../notifications/components/setting_toggle';
 
 class ColumnSettings extends PureComponent {

--- a/app/javascript/mastodon/features/community_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/community_timeline/components/column_settings.jsx
@@ -1,7 +1,11 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import { PureComponent } from 'react';
+
 import { injectIntl, FormattedMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+
 import SettingToggle from '../../notifications/components/setting_toggle';
 
 class ColumnSettings extends PureComponent {

--- a/app/javascript/mastodon/features/community_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/community_timeline/containers/column_settings_container.js
@@ -1,7 +1,8 @@
 import { connect } from 'react-redux';
-import ColumnSettings from '../components/column_settings';
-import { changeSetting } from '../../../actions/settings';
+
 import { changeColumnParams } from '../../../actions/columns';
+import { changeSetting } from '../../../actions/settings';
+import ColumnSettings from '../components/column_settings';
 
 const mapStateToProps = (state, { columnId }) => {
   const uuid = columnId;

--- a/app/javascript/mastodon/features/community_timeline/index.jsx
+++ b/app/javascript/mastodon/features/community_timeline/index.jsx
@@ -1,17 +1,26 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import StatusListContainer from '../ui/containers/status_list_container';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
+import { connect } from 'react-redux';
+
+import DismissableBanner from 'mastodon/components/dismissable_banner';
+import { domain } from 'mastodon/initial_state';
+
+import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
+import { connectCommunityStream } from '../../actions/streaming';
+import { expandCommunityTimeline } from '../../actions/timelines';
 import Column from '../../components/column';
 import ColumnHeader from '../../components/column_header';
-import { expandCommunityTimeline } from '../../actions/timelines';
-import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
+import StatusListContainer from '../ui/containers/status_list_container';
+
 import ColumnSettingsContainer from './containers/column_settings_container';
-import { connectCommunityStream } from '../../actions/streaming';
-import { Helmet } from 'react-helmet';
-import { domain } from 'mastodon/initial_state';
-import DismissableBanner from 'mastodon/components/dismissable_banner';
+
+
+
 
 const messages = defineMessages({
   title: { id: 'column.community', defaultMessage: 'Local timeline' },

--- a/app/javascript/mastodon/features/community_timeline/index.jsx
+++ b/app/javascript/mastodon/features/community_timeline/index.jsx
@@ -19,9 +19,6 @@ import StatusListContainer from '../ui/containers/status_list_container';
 
 import ColumnSettingsContainer from './containers/column_settings_container';
 
-
-
-
 const messages = defineMessages({
   title: { id: 'column.community', defaultMessage: 'Local timeline' },
 });

--- a/app/javascript/mastodon/features/compose/components/action_bar.jsx
+++ b/app/javascript/mastodon/features/compose/components/action_bar.jsx
@@ -1,8 +1,12 @@
-import { PureComponent } from 'react';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
+
 
 const messages = defineMessages({
   edit_profile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },

--- a/app/javascript/mastodon/features/compose/components/action_bar.jsx
+++ b/app/javascript/mastodon/features/compose/components/action_bar.jsx
@@ -7,7 +7,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
 
-
 const messages = defineMessages({
   edit_profile: { id: 'account.edit_profile', defaultMessage: 'Edit profile' },
   pins: { id: 'navigation_bar.pins', defaultMessage: 'Pinned posts' },

--- a/app/javascript/mastodon/features/compose/components/autosuggest_account.jsx
+++ b/app/javascript/mastodon/features/compose/components/autosuggest_account.jsx
@@ -1,7 +1,8 @@
-import { Avatar } from '../../../components/avatar';
-import { DisplayName } from '../../../components/display_name';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import { Avatar } from '../../../components/avatar';
+import { DisplayName } from '../../../components/display_name';
 
 export default class AutosuggestAccount extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/compose/components/character_counter.jsx
+++ b/app/javascript/mastodon/features/compose/components/character_counter.jsx
@@ -1,5 +1,6 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { length } from 'stringz';
 
 export default class CharacterCounter extends PureComponent {

--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -26,8 +26,6 @@ import UploadFormContainer from '../containers/upload_form_container';
 import WarningContainer from '../containers/warning_container';
 import { countableText } from '../util/counter';
 
-
-
 import CharacterCounter from './character_counter';
 
 const allowedAroundShortCode = '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\u0009\u000a\u000b\u000c\u000d';

--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -1,25 +1,34 @@
-import CharacterCounter from './character_counter';
-import Button from '../../../components/button';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import ReplyIndicatorContainer from '../containers/reply_indicator_container';
-import AutosuggestTextarea from '../../../components/autosuggest_textarea';
-import AutosuggestInput from '../../../components/autosuggest_input';
-import PollButtonContainer from '../containers/poll_button_container';
-import UploadButtonContainer from '../containers/upload_button_container';
+
 import { defineMessages, injectIntl } from 'react-intl';
-import SpoilerButtonContainer from '../containers/spoiler_button_container';
-import PrivacyDropdownContainer from '../containers/privacy_dropdown_container';
+
+import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import { length } from 'stringz';
+
+import { Icon }  from 'mastodon/components/icon';
+
+import AutosuggestInput from '../../../components/autosuggest_input';
+import AutosuggestTextarea from '../../../components/autosuggest_textarea';
+import Button from '../../../components/button';
 import EmojiPickerDropdown from '../containers/emoji_picker_dropdown_container';
+import LanguageDropdown from '../containers/language_dropdown_container';
+import PollButtonContainer from '../containers/poll_button_container';
 import PollFormContainer from '../containers/poll_form_container';
+import PrivacyDropdownContainer from '../containers/privacy_dropdown_container';
+import ReplyIndicatorContainer from '../containers/reply_indicator_container';
+import SpoilerButtonContainer from '../containers/spoiler_button_container';
+import UploadButtonContainer from '../containers/upload_button_container';
 import UploadFormContainer from '../containers/upload_form_container';
 import WarningContainer from '../containers/warning_container';
-import LanguageDropdown from '../containers/language_dropdown_container';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { length } from 'stringz';
 import { countableText } from '../util/counter';
-import { Icon }  from 'mastodon/components/icon';
-import classNames from 'classnames';
+
+
+
+import CharacterCounter from './character_counter';
 
 const allowedAroundShortCode = '><\u0085\u0020\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\u0009\u000a\u000b\u000c\u000d';
 

--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
@@ -1,13 +1,19 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { EmojiPicker as EmojiPickerAsync } from '../../ui/util/async-components';
-import Overlay from 'react-overlays/Overlay';
+
 import classNames from 'classnames';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+
 import { supportsPassiveEvents } from 'detect-passive-events';
-import { buildCustomEmojis, categoriesFromEmojis } from '../../emoji/emoji';
+import Overlay from 'react-overlays/Overlay';
+
 import { assetHost } from 'mastodon/utils/config';
+
+import { buildCustomEmojis, categoriesFromEmojis } from '../../emoji/emoji';
+import { EmojiPicker as EmojiPickerAsync } from '../../ui/util/async-components';
 
 const messages = defineMessages({
   emoji: { id: 'emoji_button.label', defaultMessage: 'Insert emoji' },

--- a/app/javascript/mastodon/features/compose/components/language_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/language_dropdown.jsx
@@ -1,13 +1,19 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { injectIntl, defineMessages } from 'react-intl';
-import TextIconButton from './text_icon_button';
-import Overlay from 'react-overlays/Overlay';
-import { supportsPassiveEvents } from 'detect-passive-events';
+
 import classNames from 'classnames';
+
+import { supportsPassiveEvents } from 'detect-passive-events';
+import fuzzysort from 'fuzzysort';
+import Overlay from 'react-overlays/Overlay';
+
 import { languages as preloadedLanguages } from 'mastodon/initial_state';
 import { loupeIcon, deleteIcon } from 'mastodon/utils/icons';
-import fuzzysort from 'fuzzysort';
+
+
+import TextIconButton from './text_icon_button';
 
 const messages = defineMessages({
   changeLanguage: { id: 'compose.language.change', defaultMessage: 'Change language' },

--- a/app/javascript/mastodon/features/compose/components/language_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/language_dropdown.jsx
@@ -12,7 +12,6 @@ import Overlay from 'react-overlays/Overlay';
 import { languages as preloadedLanguages } from 'mastodon/initial_state';
 import { loupeIcon, deleteIcon } from 'mastodon/utils/icons';
 
-
 import TextIconButton from './text_icon_button';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/compose/components/navigation_bar.jsx
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.jsx
@@ -1,11 +1,19 @@
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import ActionBar from './action_bar';
-import { Avatar } from '../../../components/avatar';
-import { Link } from 'react-router-dom';
-import { IconButton } from '../../../components/icon_button';
+
 import { FormattedMessage } from 'react-intl';
+
+import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
+
+import { Avatar } from '../../../components/avatar';
+import { IconButton } from '../../../components/icon_button';
+
+import ActionBar from './action_bar';
+
+
 
 export default class NavigationBar extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/compose/components/navigation_bar.jsx
+++ b/app/javascript/mastodon/features/compose/components/navigation_bar.jsx
@@ -7,13 +7,10 @@ import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-
 import { Avatar } from '../../../components/avatar';
 import { IconButton } from '../../../components/icon_button';
 
 import ActionBar from './action_bar';
-
-
 
 export default class NavigationBar extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/compose/components/poll_button.jsx
+++ b/app/javascript/mastodon/features/compose/components/poll_button.jsx
@@ -1,7 +1,9 @@
-import { PureComponent } from 'react';
-import { IconButton } from '../../../components/icon_button';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl } from 'react-intl';
+
+import { IconButton } from '../../../components/icon_button';
 
 const messages = defineMessages({
   add_poll: { id: 'poll_button.add_poll', defaultMessage: 'Add a poll' },

--- a/app/javascript/mastodon/features/compose/components/poll_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/poll_form.jsx
@@ -8,11 +8,9 @@ import classNames from 'classnames';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-
 import AutosuggestInput from 'mastodon/components/autosuggest_input';
 import { Icon }  from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
-
 
 const messages = defineMessages({
   option_placeholder: { id: 'compose_form.poll.option_placeholder', defaultMessage: 'Choice {number}' },

--- a/app/javascript/mastodon/features/compose/components/poll_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/poll_form.jsx
@@ -1,12 +1,18 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import classNames from 'classnames';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { IconButton } from 'mastodon/components/icon_button';
-import { Icon }  from 'mastodon/components/icon';
+
+
 import AutosuggestInput from 'mastodon/components/autosuggest_input';
-import classNames from 'classnames';
+import { Icon }  from 'mastodon/components/icon';
+import { IconButton } from 'mastodon/components/icon_button';
+
 
 const messages = defineMessages({
   option_placeholder: { id: 'compose_form.poll.option_placeholder', defaultMessage: 'Choice {number}' },

--- a/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/privacy_dropdown.jsx
@@ -1,11 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { injectIntl, defineMessages } from 'react-intl';
-import { IconButton } from '../../../components/icon_button';
-import Overlay from 'react-overlays/Overlay';
-import { supportsPassiveEvents } from 'detect-passive-events';
+
 import classNames from 'classnames';
+
+import { supportsPassiveEvents } from 'detect-passive-events';
+import Overlay from 'react-overlays/Overlay';
+
 import { Icon }  from 'mastodon/components/icon';
+
+import { IconButton } from '../../../components/icon_button';
 
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },

--- a/app/javascript/mastodon/features/compose/components/reply_indicator.jsx
+++ b/app/javascript/mastodon/features/compose/components/reply_indicator.jsx
@@ -1,11 +1,15 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import { Avatar } from '../../../components/avatar';
-import { IconButton } from '../../../components/icon_button';
-import { DisplayName } from '../../../components/display_name';
+
 import { defineMessages, injectIntl } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import AttachmentList from 'mastodon/components/attachment_list';
+
+import { Avatar } from '../../../components/avatar';
+import { DisplayName } from '../../../components/display_name';
+import { IconButton } from '../../../components/icon_button';
 
 const messages = defineMessages({
   cancel: { id: 'reply_indicator.cancel', defaultMessage: 'Cancel' },

--- a/app/javascript/mastodon/features/compose/components/search.jsx
+++ b/app/javascript/mastodon/features/compose/components/search.jsx
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-
 import { Icon }  from 'mastodon/components/icon';
 import { searchEnabled } from 'mastodon/initial_state';
 import { HASHTAG_REGEX } from 'mastodon/utils/hashtags';

--- a/app/javascript/mastodon/features/compose/components/search.jsx
+++ b/app/javascript/mastodon/features/compose/components/search.jsx
@@ -1,10 +1,15 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { searchEnabled } from 'mastodon/initial_state';
-import { Icon }  from 'mastodon/components/icon';
+
 import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+
+import { Icon }  from 'mastodon/components/icon';
+import { searchEnabled } from 'mastodon/initial_state';
 import { HASHTAG_REGEX } from 'mastodon/utils/hashtags';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/compose/components/search_results.jsx
+++ b/app/javascript/mastodon/features/compose/components/search_results.jsx
@@ -1,13 +1,18 @@
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import { Icon }  from 'mastodon/components/icon';
+import LoadMore from 'mastodon/components/load_more';
+
+import { ImmutableHashtag as Hashtag } from '../../../components/hashtag';
 import AccountContainer from '../../../containers/account_container';
 import StatusContainer from '../../../containers/status_container';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { ImmutableHashtag as Hashtag } from '../../../components/hashtag';
-import { Icon }  from 'mastodon/components/icon';
 import { searchEnabled } from '../../../initial_state';
-import LoadMore from 'mastodon/components/load_more';
+
 
 const messages = defineMessages({
   dismissSuggestion: { id: 'suggestions.dismiss', defaultMessage: 'Dismiss suggestion' },

--- a/app/javascript/mastodon/features/compose/components/search_results.jsx
+++ b/app/javascript/mastodon/features/compose/components/search_results.jsx
@@ -13,7 +13,6 @@ import AccountContainer from '../../../containers/account_container';
 import StatusContainer from '../../../containers/status_container';
 import { searchEnabled } from '../../../initial_state';
 
-
 const messages = defineMessages({
   dismissSuggestion: { id: 'suggestions.dismiss', defaultMessage: 'Dismiss suggestion' },
 });

--- a/app/javascript/mastodon/features/compose/components/text_icon_button.jsx
+++ b/app/javascript/mastodon/features/compose/components/text_icon_button.jsx
@@ -1,5 +1,5 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 
 const iconStyle = {
   height: null,

--- a/app/javascript/mastodon/features/compose/components/upload.jsx
+++ b/app/javascript/mastodon/features/compose/components/upload.jsx
@@ -1,10 +1,15 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import Motion from '../../ui/util/optional_motion';
-import spring from 'react-motion/lib/spring';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import { FormattedMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import spring from 'react-motion/lib/spring';
+
 import { Icon }  from 'mastodon/components/icon';
+
+import Motion from '../../ui/util/optional_motion';
 
 export default class Upload extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/compose/components/upload_button.jsx
+++ b/app/javascript/mastodon/features/compose/components/upload_button.jsx
@@ -1,9 +1,12 @@
-import { IconButton } from '../../../components/icon_button';
 import PropTypes from 'prop-types';
+
 import { defineMessages, injectIntl } from 'react-intl';
-import { connect } from 'react-redux';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+import { IconButton } from '../../../components/icon_button';
 
 const messages = defineMessages({
   upload: { id: 'upload_button.label', defaultMessage: 'Add images, a video or an audio file' },

--- a/app/javascript/mastodon/features/compose/components/upload_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/upload_form.jsx
@@ -1,8 +1,9 @@
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import UploadProgressContainer from '../containers/upload_progress_container';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import UploadContainer from '../containers/upload_container';
+
 import SensitiveButtonContainer from '../containers/sensitive_button_container';
+import UploadContainer from '../containers/upload_container';
+import UploadProgressContainer from '../containers/upload_progress_container';
 
 export default class UploadForm extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/compose/components/upload_progress.jsx
+++ b/app/javascript/mastodon/features/compose/components/upload_progress.jsx
@@ -1,9 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Motion from '../../ui/util/optional_motion';
-import spring from 'react-motion/lib/spring';
-import { Icon }  from 'mastodon/components/icon';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
+import spring from 'react-motion/lib/spring';
+
+import { Icon }  from 'mastodon/components/icon';
+
+import Motion from '../../ui/util/optional_motion';
+
+
+
 
 export default class UploadProgress extends PureComponent {
 

--- a/app/javascript/mastodon/features/compose/components/upload_progress.jsx
+++ b/app/javascript/mastodon/features/compose/components/upload_progress.jsx
@@ -9,9 +9,6 @@ import { Icon }  from 'mastodon/components/icon';
 
 import Motion from '../../ui/util/optional_motion';
 
-
-
-
 export default class UploadProgress extends PureComponent {
 
   static propTypes = {

--- a/app/javascript/mastodon/features/compose/components/warning.jsx
+++ b/app/javascript/mastodon/features/compose/components/warning.jsx
@@ -5,7 +5,6 @@ import spring from 'react-motion/lib/spring';
 
 import Motion from '../../ui/util/optional_motion';
 
-
 export default class Warning extends PureComponent {
 
   static propTypes = {

--- a/app/javascript/mastodon/features/compose/components/warning.jsx
+++ b/app/javascript/mastodon/features/compose/components/warning.jsx
@@ -1,7 +1,10 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Motion from '../../ui/util/optional_motion';
+import { PureComponent } from 'react';
+
 import spring from 'react-motion/lib/spring';
+
+import Motion from '../../ui/util/optional_motion';
+
 
 export default class Warning extends PureComponent {
 

--- a/app/javascript/mastodon/features/compose/containers/autosuggest_account_container.js
+++ b/app/javascript/mastodon/features/compose/containers/autosuggest_account_container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
-import AutosuggestAccount from '../components/autosuggest_account';
+
 import { makeGetAccount } from '../../../selectors';
+import AutosuggestAccount from '../components/autosuggest_account';
 
 const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import ComposeForm from '../components/compose_form';
+
 import {
   changeCompose,
   submitCompose,
@@ -10,6 +10,7 @@ import {
   insertEmojiCompose,
   uploadCompose,
 } from '../../../actions/compose';
+import ComposeForm from '../components/compose_form';
 
 const mapStateToProps = state => ({
   text: state.getIn(['compose', 'text']),

--- a/app/javascript/mastodon/features/compose/containers/emoji_picker_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/emoji_picker_dropdown_container.js
@@ -1,9 +1,10 @@
-import { connect } from 'react-redux';
-import EmojiPickerDropdown from '../components/emoji_picker_dropdown';
-import { changeSetting } from '../../../actions/settings';
-import { createSelector } from 'reselect';
 import { Map as ImmutableMap } from 'immutable';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
 import { useEmoji } from '../../../actions/emojis';
+import { changeSetting } from '../../../actions/settings';
+import EmojiPickerDropdown from '../components/emoji_picker_dropdown';
 
 const perLine = 8;
 const lines   = 2;

--- a/app/javascript/mastodon/features/compose/containers/language_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/language_dropdown_container.js
@@ -7,7 +7,6 @@ import { useLanguage } from 'mastodon/actions/languages';
 
 import LanguageDropdown from '../components/language_dropdown';
 
-
 const getFrequentlyUsedLanguages = createSelector([
   state => state.getIn(['settings', 'frequentlyUsedLanguages'], ImmutableMap()),
 ], languageCounters => (

--- a/app/javascript/mastodon/features/compose/containers/language_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/language_dropdown_container.js
@@ -1,9 +1,12 @@
+import { Map as ImmutableMap } from 'immutable';
 import { connect } from 'react-redux';
-import LanguageDropdown from '../components/language_dropdown';
+import { createSelector } from 'reselect';
+
 import { changeComposeLanguage } from 'mastodon/actions/compose';
 import { useLanguage } from 'mastodon/actions/languages';
-import { createSelector } from 'reselect';
-import { Map as ImmutableMap } from 'immutable';
+
+import LanguageDropdown from '../components/language_dropdown';
+
 
 const getFrequentlyUsedLanguages = createSelector([
   state => state.getIn(['settings', 'frequentlyUsedLanguages'], ImmutableMap()),

--- a/app/javascript/mastodon/features/compose/containers/navigation_container.js
+++ b/app/javascript/mastodon/features/compose/containers/navigation_container.js
@@ -1,9 +1,13 @@
-import { connect }   from 'react-redux';
 import { defineMessages, injectIntl } from 'react-intl';
-import NavigationBar from '../components/navigation_bar';
-import { logOut } from 'mastodon/utils/log_out';
+
+import { connect }   from 'react-redux';
+
+
 import { openModal } from 'mastodon/actions/modal';
+import { logOut } from 'mastodon/utils/log_out';
+
 import { me } from '../../../initial_state';
+import NavigationBar from '../components/navigation_bar';
 
 const messages = defineMessages({
   logoutMessage: { id: 'confirmations.logout.message', defaultMessage: 'Are you sure you want to log out?' },

--- a/app/javascript/mastodon/features/compose/containers/navigation_container.js
+++ b/app/javascript/mastodon/features/compose/containers/navigation_container.js
@@ -2,7 +2,6 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import { connect }   from 'react-redux';
 
-
 import { openModal } from 'mastodon/actions/modal';
 import { logOut } from 'mastodon/utils/log_out';
 

--- a/app/javascript/mastodon/features/compose/containers/poll_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/poll_button_container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
-import PollButton from '../components/poll_button';
+
 import { addPoll, removePoll } from '../../../actions/compose';
+import PollButton from '../components/poll_button';
 
 const mapStateToProps = state => ({
   unavailable: state.getIn(['compose', 'is_uploading']) || (state.getIn(['compose', 'media_attachments']).size > 0),

--- a/app/javascript/mastodon/features/compose/containers/poll_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/poll_form_container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import PollForm from '../components/poll_form';
+
 import {
   addPollOption,
   removePollOption,
@@ -9,6 +9,7 @@ import {
   fetchComposeSuggestions,
   selectComposeSuggestion,
 } from '../../../actions/compose';
+import PollForm from '../components/poll_form';
 
 const mapStateToProps = state => ({
   suggestions: state.getIn(['compose', 'suggestions']),

--- a/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
+++ b/app/javascript/mastodon/features/compose/containers/privacy_dropdown_container.js
@@ -1,8 +1,9 @@
 import { connect } from 'react-redux';
-import PrivacyDropdown from '../components/privacy_dropdown';
+
 import { changeComposeVisibility } from '../../../actions/compose';
 import { openModal, closeModal } from '../../../actions/modal';
 import { isUserTouching } from '../../../is_mobile';
+import PrivacyDropdown from '../components/privacy_dropdown';
 
 const mapStateToProps = state => ({
   value: state.getIn(['compose', 'privacy']),

--- a/app/javascript/mastodon/features/compose/containers/reply_indicator_container.js
+++ b/app/javascript/mastodon/features/compose/containers/reply_indicator_container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import { cancelReplyCompose } from '../../../actions/compose';
 import { makeGetStatus } from '../../../selectors';
 import ReplyIndicator from '../components/reply_indicator';

--- a/app/javascript/mastodon/features/compose/containers/search_container.js
+++ b/app/javascript/mastodon/features/compose/containers/search_container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import {
   changeSearch,
   clearSearch,
@@ -8,6 +9,7 @@ import {
   clickSearchResult,
   forgetSearchResult,
 } from 'mastodon/actions/search';
+
 import Search from '../components/search';
 
 const mapStateToProps = state => ({

--- a/app/javascript/mastodon/features/compose/containers/search_results_container.js
+++ b/app/javascript/mastodon/features/compose/containers/search_results_container.js
@@ -1,7 +1,9 @@
 import { connect } from 'react-redux';
-import SearchResults from '../components/search_results';
-import { fetchSuggestions, dismissSuggestion } from 'mastodon/actions/suggestions';
+
 import { expandSearch } from 'mastodon/actions/search';
+import { fetchSuggestions, dismissSuggestion } from 'mastodon/actions/suggestions';
+
+import SearchResults from '../components/search_results';
 
 const mapStateToProps = state => ({
   results: state.getIn(['search', 'results']),

--- a/app/javascript/mastodon/features/compose/containers/sensitive_button_container.jsx
+++ b/app/javascript/mastodon/features/compose/containers/sensitive_button_container.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 
 import { changeComposeSensitivity } from 'mastodon/actions/compose';
 
-
 const messages = defineMessages({
   marked: {
     id: 'compose_form.sensitive.marked',

--- a/app/javascript/mastodon/features/compose/containers/sensitive_button_container.jsx
+++ b/app/javascript/mastodon/features/compose/containers/sensitive_button_container.jsx
@@ -1,9 +1,14 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
-import { changeComposeSensitivity } from 'mastodon/actions/compose';
+import { PureComponent } from 'react';
+
 import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
+
+import classNames from 'classnames';
+
+import { connect } from 'react-redux';
+
+import { changeComposeSensitivity } from 'mastodon/actions/compose';
+
 
 const messages = defineMessages({
   marked: {

--- a/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/spoiler_button_container.js
@@ -1,7 +1,9 @@
-import { connect } from 'react-redux';
-import TextIconButton from '../components/text_icon_button';
-import { changeComposeSpoilerness } from '../../../actions/compose';
 import { injectIntl, defineMessages } from 'react-intl';
+
+import { connect } from 'react-redux';
+
+import { changeComposeSpoilerness } from '../../../actions/compose';
+import TextIconButton from '../components/text_icon_button';
 
 const messages = defineMessages({
   marked: { id: 'compose_form.spoiler.marked', defaultMessage: 'Text is hidden behind warning' },

--- a/app/javascript/mastodon/features/compose/containers/upload_button_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_button_container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
-import UploadButton from '../components/upload_button';
+
 import { uploadCompose } from '../../../actions/compose';
+import UploadButton from '../components/upload_button';
 
 const mapStateToProps = state => ({
   disabled: state.getIn(['compose', 'is_uploading']) || (state.getIn(['compose', 'media_attachments']).size + state.getIn(['compose', 'pending_media_attachments']) > 3 || state.getIn(['compose', 'media_attachments']).some(m => ['video', 'audio'].includes(m.get('type')))),

--- a/app/javascript/mastodon/features/compose/containers/upload_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
-import Upload from '../components/upload';
+
 import { undoUploadCompose, initMediaEditModal, submitCompose } from '../../../actions/compose';
+import Upload from '../components/upload';
 
 const mapStateToProps = (state, { id }) => ({
   media: state.getIn(['compose', 'media_attachments']).find(item => item.get('id') === id),

--- a/app/javascript/mastodon/features/compose/containers/upload_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_form_container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import UploadForm from '../components/upload_form';
 
 const mapStateToProps = state => ({

--- a/app/javascript/mastodon/features/compose/containers/upload_progress_container.js
+++ b/app/javascript/mastodon/features/compose/containers/upload_progress_container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import UploadProgress from '../components/upload_progress';
 
 const mapStateToProps = state => ({

--- a/app/javascript/mastodon/features/compose/containers/warning_container.jsx
+++ b/app/javascript/mastodon/features/compose/containers/warning_container.jsx
@@ -1,9 +1,13 @@
-import { connect } from 'react-redux';
-import Warning from '../components/warning';
 import PropTypes from 'prop-types';
+
 import { FormattedMessage } from 'react-intl';
+
+import { connect } from 'react-redux';
+
 import { me } from 'mastodon/initial_state';
 import { HASHTAG_PATTERN_REGEX } from 'mastodon/utils/hashtags';
+
+import Warning from '../components/warning';
 
 const mapStateToProps = state => ({
   needsLockWarning: state.getIn(['compose', 'privacy']) === 'private' && !state.getIn(['accounts', me, 'locked']),

--- a/app/javascript/mastodon/features/compose/index.jsx
+++ b/app/javascript/mastodon/features/compose/index.jsx
@@ -9,13 +9,7 @@ import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-
-
-
-
-
 import spring from 'react-motion/lib/spring';
-
 
 import { openModal } from 'mastodon/actions/modal';
 import Column from 'mastodon/components/column';

--- a/app/javascript/mastodon/features/compose/index.jsx
+++ b/app/javascript/mastodon/features/compose/index.jsx
@@ -1,24 +1,37 @@
-import { PureComponent } from 'react';
-import ComposeFormContainer from './containers/compose_form_container';
-import NavigationContainer from './containers/navigation_container';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { injectIntl, defineMessages } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
-import { changeComposing, mountCompose, unmountCompose } from '../../actions/compose';
-import { Link } from 'react-router-dom';
-import { injectIntl, defineMessages } from 'react-intl';
-import SearchContainer from './containers/search_container';
-import Motion from '../ui/util/optional_motion';
+
+
+
+
+
+
 import spring from 'react-motion/lib/spring';
-import SearchResultsContainer from './containers/search_results_container';
+
+
 import { openModal } from 'mastodon/actions/modal';
-import elephantUIPlane from '../../../images/elephant_ui_plane.svg';
-import { mascot } from '../../initial_state';
+import Column from 'mastodon/components/column';
 import { Icon }  from 'mastodon/components/icon';
 import { logOut } from 'mastodon/utils/log_out';
-import Column from 'mastodon/components/column';
-import { Helmet } from 'react-helmet';
+
+import elephantUIPlane from '../../../images/elephant_ui_plane.svg';
+import { changeComposing, mountCompose, unmountCompose } from '../../actions/compose';
+import { mascot } from '../../initial_state';
 import { isMobile } from '../../is_mobile';
+import Motion from '../ui/util/optional_motion';
+
+import ComposeFormContainer from './containers/compose_form_container';
+import NavigationContainer from './containers/navigation_container';
+import SearchContainer from './containers/search_container';
+import SearchResultsContainer from './containers/search_results_container';
 
 const messages = defineMessages({
   start: { id: 'getting_started.heading', defaultMessage: 'Getting started' },

--- a/app/javascript/mastodon/features/compose/util/url_regex.js
+++ b/app/javascript/mastodon/features/compose/util/url_regex.js
@@ -1,8 +1,8 @@
 import regexSupplant from 'twitter-text/dist/lib/regexSupplant';
-import validUrlPrecedingChars from 'twitter-text/dist/regexp/validUrlPrecedingChars';
 import validDomain from 'twitter-text/dist/regexp/validDomain';
 import validPortNumber from 'twitter-text/dist/regexp/validPortNumber';
 import validUrlPath from 'twitter-text/dist/regexp/validUrlPath';
+import validUrlPrecedingChars from 'twitter-text/dist/regexp/validUrlPrecedingChars';
 import validUrlQueryChars from 'twitter-text/dist/regexp/validUrlQueryChars';
 import validUrlQueryEndingChars from 'twitter-text/dist/regexp/validUrlQueryEndingChars';
 

--- a/app/javascript/mastodon/features/direct_timeline/components/conversation.jsx
+++ b/app/javascript/mastodon/features/direct_timeline/components/conversation.jsx
@@ -1,17 +1,23 @@
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import classNames from 'classnames';
+import { Link } from 'react-router-dom';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import StatusContent from 'mastodon/components/status_content';
+
+import { HotKeys } from 'react-hotkeys';
+
 import AttachmentList from 'mastodon/components/attachment_list';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import DropdownMenuContainer from 'mastodon/containers/dropdown_menu_container';
 import AvatarComposite from 'mastodon/components/avatar_composite';
-import { Link } from 'react-router-dom';
 import { IconButton } from 'mastodon/components/icon_button';
 import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
-import { HotKeys } from 'react-hotkeys';
+import StatusContent from 'mastodon/components/status_content';
+import DropdownMenuContainer from 'mastodon/containers/dropdown_menu_container';
 import { autoPlayGif } from 'mastodon/initial_state';
-import classNames from 'classnames';
+
 
 const messages = defineMessages({
   more: { id: 'status.more', defaultMessage: 'More' },

--- a/app/javascript/mastodon/features/direct_timeline/components/conversation.jsx
+++ b/app/javascript/mastodon/features/direct_timeline/components/conversation.jsx
@@ -18,7 +18,6 @@ import StatusContent from 'mastodon/components/status_content';
 import DropdownMenuContainer from 'mastodon/containers/dropdown_menu_container';
 import { autoPlayGif } from 'mastodon/initial_state';
 
-
 const messages = defineMessages({
   more: { id: 'status.more', defaultMessage: 'More' },
   open: { id: 'conversation.open', defaultMessage: 'View conversation' },

--- a/app/javascript/mastodon/features/direct_timeline/components/conversations_list.jsx
+++ b/app/javascript/mastodon/features/direct_timeline/components/conversations_list.jsx
@@ -1,9 +1,12 @@
 import PropTypes from 'prop-types';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import ConversationContainer from '../containers/conversation_container';
-import ScrollableList from '../../../components/scrollable_list';
+
 import { debounce } from 'lodash';
+
+import ScrollableList from '../../../components/scrollable_list';
+import ConversationContainer from '../containers/conversation_container';
 
 export default class ConversationsList extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/direct_timeline/containers/conversation_container.js
+++ b/app/javascript/mastodon/features/direct_timeline/containers/conversation_container.js
@@ -1,11 +1,14 @@
+import { defineMessages, injectIntl } from 'react-intl';
+
 import { connect } from 'react-redux';
-import Conversation from '../components/conversation';
-import { markConversationRead, deleteConversation } from 'mastodon/actions/conversations';
-import { makeGetStatus } from 'mastodon/selectors';
+
 import { replyCompose } from 'mastodon/actions/compose';
+import { markConversationRead, deleteConversation } from 'mastodon/actions/conversations';
 import { openModal } from 'mastodon/actions/modal';
 import { muteStatus, unmuteStatus, hideStatus, revealStatus } from 'mastodon/actions/statuses';
-import { defineMessages, injectIntl } from 'react-intl';
+import { makeGetStatus } from 'mastodon/selectors';
+
+import Conversation from '../components/conversation';
 
 const messages = defineMessages({
   replyConfirm: { id: 'confirmations.reply.confirm', defaultMessage: 'Reply' },

--- a/app/javascript/mastodon/features/direct_timeline/containers/conversations_list_container.js
+++ b/app/javascript/mastodon/features/direct_timeline/containers/conversations_list_container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
-import ConversationsList from '../components/conversations_list';
+
 import { expandConversations } from '../../../actions/conversations';
+import ConversationsList from '../components/conversations_list';
 
 const mapStateToProps = state => ({
   conversations: state.getIn(['conversations', 'items']),

--- a/app/javascript/mastodon/features/direct_timeline/index.jsx
+++ b/app/javascript/mastodon/features/direct_timeline/index.jsx
@@ -1,13 +1,18 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
-import { Helmet } from 'react-helmet';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
 import { connect } from 'react-redux';
+
 import { addColumn, removeColumn, moveColumn } from 'mastodon/actions/columns';
 import { mountConversations, unmountConversations, expandConversations } from 'mastodon/actions/conversations';
 import { connectDirectStream } from 'mastodon/actions/streaming';
 import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
+
 import ConversationsListContainer from './containers/conversations_list_container';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/directory/components/account_card.jsx
+++ b/app/javascript/mastodon/features/directory/components/account_card.jsx
@@ -1,15 +1,15 @@
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { makeGetAccount } from 'mastodon/selectors';
-import { Avatar } from 'mastodon/components/avatar';
-import { DisplayName } from 'mastodon/components/display_name';
-import { Link } from 'react-router-dom';
-import Button from 'mastodon/components/button';
+
 import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
-import { autoPlayGif, me, unfollowModal } from 'mastodon/initial_state';
-import ShortNumber from 'mastodon/components/short_number';
+
+import classNames from 'classnames';
+import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+
 import {
   followAccount,
   unfollowAccount,
@@ -17,7 +17,13 @@ import {
   unmuteAccount,
 } from 'mastodon/actions/accounts';
 import { openModal } from 'mastodon/actions/modal';
-import classNames from 'classnames';
+import { Avatar } from 'mastodon/components/avatar';
+import Button from 'mastodon/components/button';
+import { DisplayName } from 'mastodon/components/display_name';
+import ShortNumber from 'mastodon/components/short_number';
+import { autoPlayGif, me, unfollowModal } from 'mastodon/initial_state';
+import { makeGetAccount } from 'mastodon/selectors';
+
 
 const messages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },

--- a/app/javascript/mastodon/features/directory/components/account_card.jsx
+++ b/app/javascript/mastodon/features/directory/components/account_card.jsx
@@ -9,7 +9,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-
 import {
   followAccount,
   unfollowAccount,
@@ -23,7 +22,6 @@ import { DisplayName } from 'mastodon/components/display_name';
 import ShortNumber from 'mastodon/components/short_number';
 import { autoPlayGif, me, unfollowModal } from 'mastodon/initial_state';
 import { makeGetAccount } from 'mastodon/selectors';
-
 
 const messages = defineMessages({
   unfollow: { id: 'account.unfollow', defaultMessage: 'Unfollow' },

--- a/app/javascript/mastodon/features/directory/index.jsx
+++ b/app/javascript/mastodon/features/directory/index.jsx
@@ -1,19 +1,25 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
-import { defineMessages, injectIntl } from 'react-intl';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
+import { List as ImmutableList } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import Column from 'mastodon/components/column';
-import ColumnHeader from 'mastodon/components/column_header';
+import { connect } from 'react-redux';
+
 import { addColumn, removeColumn, moveColumn, changeColumnParams } from 'mastodon/actions/columns';
 import { fetchDirectory, expandDirectory } from 'mastodon/actions/directory';
-import { List as ImmutableList } from 'immutable';
-import AccountCard from './components/account_card';
-import { RadioButton } from 'mastodon/components/radio_button';
+import Column from 'mastodon/components/column';
+import ColumnHeader from 'mastodon/components/column_header';
 import LoadMore from 'mastodon/components/load_more';
-import ScrollContainer from 'mastodon/containers/scroll_container';
 import LoadingIndicator from 'mastodon/components/loading_indicator';
-import { Helmet } from 'react-helmet';
+import { RadioButton } from 'mastodon/components/radio_button';
+import ScrollContainer from 'mastodon/containers/scroll_container';
+
+import AccountCard from './components/account_card';
+
 
 const messages = defineMessages({
   title: { id: 'column.directory', defaultMessage: 'Browse profiles' },

--- a/app/javascript/mastodon/features/directory/index.jsx
+++ b/app/javascript/mastodon/features/directory/index.jsx
@@ -20,7 +20,6 @@ import ScrollContainer from 'mastodon/containers/scroll_container';
 
 import AccountCard from './components/account_card';
 
-
 const messages = defineMessages({
   title: { id: 'column.directory', defaultMessage: 'Browse profiles' },
   recentlyActive: { id: 'directory.recently_active', defaultMessage: 'Recently active' },

--- a/app/javascript/mastodon/features/domain_blocks/index.jsx
+++ b/app/javascript/mastodon/features/domain_blocks/index.jsx
@@ -8,8 +8,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-
-
 import { debounce } from 'lodash';
 
 import { fetchDomainBlocks, expandDomainBlocks } from '../../actions/domain_blocks';
@@ -18,7 +16,6 @@ import LoadingIndicator from '../../components/loading_indicator';
 import ScrollableList from '../../components/scrollable_list';
 import DomainContainer from '../../containers/domain_container';
 import Column from '../ui/components/column';
-
 
 const messages = defineMessages({
   heading: { id: 'column.domain_blocks', defaultMessage: 'Blocked domains' },

--- a/app/javascript/mastodon/features/domain_blocks/index.jsx
+++ b/app/javascript/mastodon/features/domain_blocks/index.jsx
@@ -1,16 +1,24 @@
-import { connect } from 'react-redux';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { debounce } from 'lodash';
-import LoadingIndicator from '../../components/loading_indicator';
-import Column from '../ui/components/column';
-import ColumnBackButtonSlim from '../../components/column_back_button_slim';
-import DomainContainer from '../../containers/domain_container';
-import { fetchDomainBlocks, expandDomainBlocks } from '../../actions/domain_blocks';
-import ScrollableList from '../../components/scrollable_list';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import { Helmet } from 'react-helmet';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+
+
+import { debounce } from 'lodash';
+
+import { fetchDomainBlocks, expandDomainBlocks } from '../../actions/domain_blocks';
+import ColumnBackButtonSlim from '../../components/column_back_button_slim';
+import LoadingIndicator from '../../components/loading_indicator';
+import ScrollableList from '../../components/scrollable_list';
+import DomainContainer from '../../containers/domain_container';
+import Column from '../ui/components/column';
+
 
 const messages = defineMessages({
   heading: { id: 'column.domain_blocks', defaultMessage: 'Blocked domains' },

--- a/app/javascript/mastodon/features/emoji/__tests__/emoji_index-test.js
+++ b/app/javascript/mastodon/features/emoji/__tests__/emoji_index-test.js
@@ -1,5 +1,6 @@
-import { pick } from 'lodash';
 import { emojiIndex } from 'emoji-mart';
+import { pick } from 'lodash';
+
 import { search } from '../emoji_mart_search_light';
 
 const trimEmojis = emoji => pick(emoji, ['id', 'unified', 'native', 'custom']);

--- a/app/javascript/mastodon/features/emoji/emoji.js
+++ b/app/javascript/mastodon/features/emoji/emoji.js
@@ -1,7 +1,10 @@
-import { autoPlayGif } from '../../initial_state';
-import unicodeMapping from './emoji_unicode_mapping_light';
-import { assetHost } from 'mastodon/utils/config';
 import Trie from 'substring-trie';
+
+import { assetHost } from 'mastodon/utils/config';
+
+import { autoPlayGif } from '../../initial_state';
+
+import unicodeMapping from './emoji_unicode_mapping_light';
 
 const trie = new Trie(Object.keys(unicodeMapping));
 

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.js
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.js
@@ -7,13 +7,14 @@
 // It's designed to be emitted in an array format to take up less space
 // over the wire.
 
-const { unicodeToFilename } = require('./unicode_to_filename');
-const { unicodeToUnifiedName } = require('./unicode_to_unified_name');
-const emojiMap = require('./emoji_map.json');
 const { emojiIndex } = require('emoji-mart');
+let data = require('emoji-mart/data/all.json');
 const { uncompress: emojiMartUncompress } = require('emoji-mart/dist/utils/data');
 
-let data = require('emoji-mart/data/all.json');
+const emojiMap = require('./emoji_map.json');
+const { unicodeToFilename } = require('./unicode_to_filename');
+const { unicodeToUnifiedName } = require('./unicode_to_unified_name');
+
 
 if(data.compressed) {
   data = emojiMartUncompress(data);

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.js
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.js
@@ -1,8 +1,8 @@
 // The output of this module is designed to mimic emoji-mart's
 // "data" object, such that we can use it for a light version of emoji-mart's
 // emojiIndex.search functionality.
-import { unicodeToUnifiedName } from './unicode_to_unified_name';
 import emojiCompressed from './emoji_compressed';
+import { unicodeToUnifiedName } from './unicode_to_unified_name';
 
 const [ shortCodesToEmojiData, skins, categories, short_names ] = emojiCompressed;
 

--- a/app/javascript/mastodon/features/emoji/emoji_picker.js
+++ b/app/javascript/mastodon/features/emoji/emoji_picker.js
@@ -1,5 +1,5 @@
-import Picker from 'emoji-mart/dist-es/components/picker/picker';
 import Emoji from 'emoji-mart/dist-es/components/emoji/emoji';
+import Picker from 'emoji-mart/dist-es/components/picker/picker';
 
 export {
   Picker,

--- a/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.js
+++ b/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.js
@@ -3,7 +3,6 @@
 // as a "title" attribute in an HTML element (aka tooltip).
 
 import emojiCompressed from './emoji_compressed';
-
 import { unicodeToFilename } from './unicode_to_filename';
 
 const [

--- a/app/javascript/mastodon/features/explore/components/story.jsx
+++ b/app/javascript/mastodon/features/explore/components/story.jsx
@@ -8,7 +8,6 @@ import { accountsCountRenderer } from 'mastodon/components/hashtag';
 import ShortNumber from 'mastodon/components/short_number';
 import { Skeleton } from 'mastodon/components/skeleton';
 
-
 export default class Story extends PureComponent {
 
   static propTypes = {

--- a/app/javascript/mastodon/features/explore/components/story.jsx
+++ b/app/javascript/mastodon/features/explore/components/story.jsx
@@ -1,10 +1,13 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import classNames from 'classnames';
+
 import { Blurhash } from 'mastodon/components/blurhash';
 import { accountsCountRenderer } from 'mastodon/components/hashtag';
 import ShortNumber from 'mastodon/components/short_number';
 import { Skeleton } from 'mastodon/components/skeleton';
-import classNames from 'classnames';
+
 
 export default class Story extends PureComponent {
 

--- a/app/javascript/mastodon/features/explore/index.jsx
+++ b/app/javascript/mastodon/features/explore/index.jsx
@@ -1,18 +1,26 @@
-import { PureComponent } from 'react';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+import { NavLink, Switch, Route } from 'react-router-dom';
+
+import { connect } from 'react-redux';
+
+
 import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
-import { NavLink, Switch, Route } from 'react-router-dom';
+import Search from 'mastodon/features/compose/containers/search_container';
+import { showTrends } from 'mastodon/initial_state';
+
 import Links from './links';
-import Tags from './tags';
+import SearchResults from './results';
 import Statuses from './statuses';
 import Suggestions from './suggestions';
-import Search from 'mastodon/features/compose/containers/search_container';
-import SearchResults from './results';
-import { Helmet } from 'react-helmet';
-import { showTrends } from 'mastodon/initial_state';
+import Tags from './tags';
+
+
 
 const messages = defineMessages({
   title: { id: 'explore.title', defaultMessage: 'Explore' },

--- a/app/javascript/mastodon/features/explore/index.jsx
+++ b/app/javascript/mastodon/features/explore/index.jsx
@@ -8,7 +8,6 @@ import { NavLink, Switch, Route } from 'react-router-dom';
 
 import { connect } from 'react-redux';
 
-
 import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
 import Search from 'mastodon/features/compose/containers/search_container';
@@ -19,8 +18,6 @@ import SearchResults from './results';
 import Statuses from './statuses';
 import Suggestions from './suggestions';
 import Tags from './tags';
-
-
 
 const messages = defineMessages({
   title: { id: 'explore.title', defaultMessage: 'Explore' },

--- a/app/javascript/mastodon/features/explore/links.jsx
+++ b/app/javascript/mastodon/features/explore/links.jsx
@@ -1,12 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import Story from './components/story';
-import LoadingIndicator from 'mastodon/components/loading_indicator';
-import { connect } from 'react-redux';
-import { fetchTrendingLinks } from 'mastodon/actions/trends';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { fetchTrendingLinks } from 'mastodon/actions/trends';
 import DismissableBanner from 'mastodon/components/dismissable_banner';
+import LoadingIndicator from 'mastodon/components/loading_indicator';
+
+import Story from './components/story';
 
 const mapStateToProps = state => ({
   links: state.getIn(['trends', 'links', 'items']),

--- a/app/javascript/mastodon/features/explore/results.jsx
+++ b/app/javascript/mastodon/features/explore/results.jsx
@@ -16,8 +16,6 @@ import LoadingIndicator from 'mastodon/components/loading_indicator';
 import Account from 'mastodon/containers/account_container';
 import Status from 'mastodon/containers/status_container';
 
-
-
 const messages = defineMessages({
   title: { id: 'search_results.title', defaultMessage: 'Search for {q}' },
 });

--- a/app/javascript/mastodon/features/explore/results.jsx
+++ b/app/javascript/mastodon/features/explore/results.jsx
@@ -1,16 +1,22 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import { PureComponent } from 'react';
+
 import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
-import { connect } from 'react-redux';
-import { expandSearch } from 'mastodon/actions/search';
-import Account from 'mastodon/containers/account_container';
-import Status from 'mastodon/containers/status_container';
-import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
+
+import { Helmet } from 'react-helmet';
+
 import { List as ImmutableList } from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { expandSearch } from 'mastodon/actions/search';
+import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
 import LoadMore from 'mastodon/components/load_more';
 import LoadingIndicator from 'mastodon/components/loading_indicator';
-import { Helmet } from 'react-helmet';
+import Account from 'mastodon/containers/account_container';
+import Status from 'mastodon/containers/status_container';
+
+
 
 const messages = defineMessages({
   title: { id: 'search_results.title', defaultMessage: 'Search for {q}' },

--- a/app/javascript/mastodon/features/explore/statuses.jsx
+++ b/app/javascript/mastodon/features/explore/statuses.jsx
@@ -1,12 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import StatusList from 'mastodon/components/status_list';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
-import { fetchTrendingStatuses, expandTrendingStatuses } from 'mastodon/actions/trends';
+
 import { debounce } from 'lodash';
+
+import { fetchTrendingStatuses, expandTrendingStatuses } from 'mastodon/actions/trends';
 import DismissableBanner from 'mastodon/components/dismissable_banner';
+import StatusList from 'mastodon/components/status_list';
 
 const mapStateToProps = state => ({
   statusIds: state.getIn(['status_lists', 'trending', 'items']),

--- a/app/javascript/mastodon/features/explore/suggestions.jsx
+++ b/app/javascript/mastodon/features/explore/suggestions.jsx
@@ -1,11 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import AccountCard from 'mastodon/features/directory/components/account_card';
-import LoadingIndicator from 'mastodon/components/loading_indicator';
-import { connect } from 'react-redux';
-import { fetchSuggestions } from 'mastodon/actions/suggestions';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { fetchSuggestions } from 'mastodon/actions/suggestions';
+import LoadingIndicator from 'mastodon/components/loading_indicator';
+import AccountCard from 'mastodon/features/directory/components/account_card';
+
+
 
 const mapStateToProps = state => ({
   suggestions: state.getIn(['suggestions', 'items']),

--- a/app/javascript/mastodon/features/explore/suggestions.jsx
+++ b/app/javascript/mastodon/features/explore/suggestions.jsx
@@ -10,8 +10,6 @@ import { fetchSuggestions } from 'mastodon/actions/suggestions';
 import LoadingIndicator from 'mastodon/components/loading_indicator';
 import AccountCard from 'mastodon/features/directory/components/account_card';
 
-
-
 const mapStateToProps = state => ({
   suggestions: state.getIn(['suggestions', 'items']),
   isLoading: state.getIn(['suggestions', 'isLoading']),

--- a/app/javascript/mastodon/features/explore/tags.jsx
+++ b/app/javascript/mastodon/features/explore/tags.jsx
@@ -1,12 +1,17 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { fetchTrendingHashtags } from 'mastodon/actions/trends';
+import DismissableBanner from 'mastodon/components/dismissable_banner';
 import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
 import LoadingIndicator from 'mastodon/components/loading_indicator';
-import { connect } from 'react-redux';
-import { fetchTrendingHashtags } from 'mastodon/actions/trends';
-import { FormattedMessage } from 'react-intl';
-import DismissableBanner from 'mastodon/components/dismissable_banner';
+
+
 
 const mapStateToProps = state => ({
   hashtags: state.getIn(['trends', 'tags', 'items']),

--- a/app/javascript/mastodon/features/explore/tags.jsx
+++ b/app/javascript/mastodon/features/explore/tags.jsx
@@ -11,8 +11,6 @@ import DismissableBanner from 'mastodon/components/dismissable_banner';
 import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
 import LoadingIndicator from 'mastodon/components/loading_indicator';
 
-
-
 const mapStateToProps = state => ({
   hashtags: state.getIn(['trends', 'tags', 'items']),
   isLoadingHashtags: state.getIn(['trends', 'tags', 'isLoading']),

--- a/app/javascript/mastodon/features/favourited_statuses/index.jsx
+++ b/app/javascript/mastodon/features/favourited_statuses/index.jsx
@@ -1,10 +1,15 @@
-import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import { Helmet } from 'react-helmet';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
+
+import { debounce } from 'lodash';
+
 import { addColumn, removeColumn, moveColumn } from 'mastodon/actions/columns';
 import { fetchFavouritedStatuses, expandFavouritedStatuses } from 'mastodon/actions/favourites';
 import ColumnHeader from 'mastodon/components/column_header';

--- a/app/javascript/mastodon/features/favourites/index.jsx
+++ b/app/javascript/mastodon/features/favourites/index.jsx
@@ -16,7 +16,6 @@ import ScrollableList from 'mastodon/components/scrollable_list';
 import AccountContainer from 'mastodon/containers/account_container';
 import Column from 'mastodon/features/ui/components/column';
 
-
 const messages = defineMessages({
   refresh: { id: 'refresh', defaultMessage: 'Refresh' },
 });

--- a/app/javascript/mastodon/features/favourites/index.jsx
+++ b/app/javascript/mastodon/features/favourites/index.jsx
@@ -1,16 +1,21 @@
 import PropTypes from 'prop-types';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
+
+import { fetchFavourites } from 'mastodon/actions/interactions';
 import ColumnHeader from 'mastodon/components/column_header';
 import { Icon }  from 'mastodon/components/icon';
-import { fetchFavourites } from 'mastodon/actions/interactions';
 import LoadingIndicator from 'mastodon/components/loading_indicator';
 import ScrollableList from 'mastodon/components/scrollable_list';
 import AccountContainer from 'mastodon/containers/account_container';
 import Column from 'mastodon/features/ui/components/column';
-import { Helmet } from 'react-helmet';
+
 
 const messages = defineMessages({
   refresh: { id: 'refresh', defaultMessage: 'Refresh' },

--- a/app/javascript/mastodon/features/filters/added_to_filter.jsx
+++ b/app/javascript/mastodon/features/filters/added_to_filter.jsx
@@ -1,10 +1,13 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
-import { toServerSideType } from 'mastodon/utils/filters';
-import Button from 'mastodon/components/button';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
+
+import Button from 'mastodon/components/button';
+import { toServerSideType } from 'mastodon/utils/filters';
 
 const mapStateToProps = (state, { filterId }) => ({
   filter: state.getIn(['filters', filterId]),

--- a/app/javascript/mastodon/features/filters/select_filter.jsx
+++ b/app/javascript/mastodon/features/filters/select_filter.jsx
@@ -1,11 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { connect } from 'react-redux';
+
+
+import fuzzysort from 'fuzzysort';
+
+import { Icon }  from 'mastodon/components/icon';
 import { toServerSideType } from 'mastodon/utils/filters';
 import { loupeIcon, deleteIcon } from 'mastodon/utils/icons';
-import { Icon }  from 'mastodon/components/icon';
-import fuzzysort from 'fuzzysort';
 
 const messages = defineMessages({
   search: { id: 'filter_modal.select_filter.search', defaultMessage: 'Search or create' },

--- a/app/javascript/mastodon/features/filters/select_filter.jsx
+++ b/app/javascript/mastodon/features/filters/select_filter.jsx
@@ -5,7 +5,6 @@ import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 
 import { connect } from 'react-redux';
 
-
 import fuzzysort from 'fuzzysort';
 
 import { Icon }  from 'mastodon/components/icon';

--- a/app/javascript/mastodon/features/follow_requests/components/account_authorize.jsx
+++ b/app/javascript/mastodon/features/follow_requests/components/account_authorize.jsx
@@ -1,11 +1,16 @@
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
 import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+
 import { Avatar } from '../../../components/avatar';
 import { DisplayName } from '../../../components/display_name';
 import { IconButton } from '../../../components/icon_button';
-import { defineMessages, injectIntl } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 
 const messages = defineMessages({
   authorize: { id: 'follow_request.authorize', defaultMessage: 'Authorize' },

--- a/app/javascript/mastodon/features/follow_requests/components/account_authorize.jsx
+++ b/app/javascript/mastodon/features/follow_requests/components/account_authorize.jsx
@@ -7,7 +7,6 @@ import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-
 import { Avatar } from '../../../components/avatar';
 import { DisplayName } from '../../../components/display_name';
 import { IconButton } from '../../../components/icon_button';

--- a/app/javascript/mastodon/features/follow_requests/containers/account_authorize_container.js
+++ b/app/javascript/mastodon/features/follow_requests/containers/account_authorize_container.js
@@ -1,7 +1,8 @@
 import { connect } from 'react-redux';
+
+import { authorizeFollowRequest, rejectFollowRequest } from '../../../actions/accounts';
 import { makeGetAccount } from '../../../selectors';
 import AccountAuthorize from '../components/account_authorize';
-import { authorizeFollowRequest, rejectFollowRequest } from '../../../actions/accounts';
 
 const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();

--- a/app/javascript/mastodon/features/follow_requests/index.jsx
+++ b/app/javascript/mastodon/features/follow_requests/index.jsx
@@ -1,16 +1,26 @@
-import { connect } from 'react-redux';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+
+
 import { debounce } from 'lodash';
-import Column from '../ui/components/column';
-import ColumnBackButtonSlim from '../../components/column_back_button_slim';
-import AccountAuthorizeContainer from './containers/account_authorize_container';
+
 import { fetchFollowRequests, expandFollowRequests } from '../../actions/accounts';
+import ColumnBackButtonSlim from '../../components/column_back_button_slim';
 import ScrollableList from '../../components/scrollable_list';
 import { me } from '../../initial_state';
-import { Helmet } from 'react-helmet';
+import Column from '../ui/components/column';
+
+import AccountAuthorizeContainer from './containers/account_authorize_container';
+
+
 
 const messages = defineMessages({
   heading: { id: 'column.follow_requests', defaultMessage: 'Follow requests' },

--- a/app/javascript/mastodon/features/follow_requests/index.jsx
+++ b/app/javascript/mastodon/features/follow_requests/index.jsx
@@ -8,8 +8,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-
-
 import { debounce } from 'lodash';
 
 import { fetchFollowRequests, expandFollowRequests } from '../../actions/accounts';
@@ -19,8 +17,6 @@ import { me } from '../../initial_state';
 import Column from '../ui/components/column';
 
 import AccountAuthorizeContainer from './containers/account_authorize_container';
-
-
 
 const messages = defineMessages({
   heading: { id: 'column.follow_requests', defaultMessage: 'Follow requests' },

--- a/app/javascript/mastodon/features/followed_tags/index.jsx
+++ b/app/javascript/mastodon/features/followed_tags/index.jsx
@@ -1,15 +1,23 @@
-import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
+
+import { debounce } from 'lodash';
+
+
+
+import { expandFollowedHashtags, fetchFollowedHashtags } from 'mastodon/actions/tags';
 import ColumnHeader from 'mastodon/components/column_header';
+import Hashtag from 'mastodon/components/hashtag';
 import ScrollableList from 'mastodon/components/scrollable_list';
 import Column from 'mastodon/features/ui/components/column';
-import { Helmet } from 'react-helmet';
-import Hashtag from 'mastodon/components/hashtag';
-import { expandFollowedHashtags, fetchFollowedHashtags } from 'mastodon/actions/tags';
+
 
 const messages = defineMessages({
   heading: { id: 'followed_tags', defaultMessage: 'Followed hashtags' },

--- a/app/javascript/mastodon/features/followed_tags/index.jsx
+++ b/app/javascript/mastodon/features/followed_tags/index.jsx
@@ -10,14 +10,11 @@ import { connect } from 'react-redux';
 
 import { debounce } from 'lodash';
 
-
-
 import { expandFollowedHashtags, fetchFollowedHashtags } from 'mastodon/actions/tags';
 import ColumnHeader from 'mastodon/components/column_header';
 import Hashtag from 'mastodon/components/hashtag';
 import ScrollableList from 'mastodon/components/scrollable_list';
 import Column from 'mastodon/features/ui/components/column';
-
 
 const messages = defineMessages({
   heading: { id: 'followed_tags', defaultMessage: 'Followed hashtags' },

--- a/app/javascript/mastodon/features/followers/index.jsx
+++ b/app/javascript/mastodon/features/followers/index.jsx
@@ -6,7 +6,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-
 import { debounce } from 'lodash';
 
 import { TimelineHint } from 'mastodon/components/timeline_hint';
@@ -27,7 +26,6 @@ import AccountContainer from '../../containers/account_container';
 import LimitedAccountHint from '../account_timeline/components/limited_account_hint';
 import HeaderContainer from '../account_timeline/containers/header_container';
 import Column from '../ui/components/column';
-
 
 const mapStateToProps = (state, { params: { acct, id } }) => {
   const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);

--- a/app/javascript/mastodon/features/followers/index.jsx
+++ b/app/javascript/mastodon/features/followers/index.jsx
@@ -1,26 +1,33 @@
-import { connect } from 'react-redux';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 import PropTypes from 'prop-types';
+
+import { FormattedMessage } from 'react-intl';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+
 import { debounce } from 'lodash';
-import LoadingIndicator from '../../components/loading_indicator';
+
+import { TimelineHint } from 'mastodon/components/timeline_hint';
+import BundleColumnError from 'mastodon/features/ui/components/bundle_column_error';
+import { normalizeForLookup } from 'mastodon/reducers/accounts_map';
+import { getAccountHidden } from 'mastodon/selectors';
+
 import {
   lookupAccount,
   fetchAccount,
   fetchFollowers,
   expandFollowers,
 } from '../../actions/accounts';
-import { FormattedMessage } from 'react-intl';
-import AccountContainer from '../../containers/account_container';
-import Column from '../ui/components/column';
-import HeaderContainer from '../account_timeline/containers/header_container';
 import ColumnBackButton from '../../components/column_back_button';
+import LoadingIndicator from '../../components/loading_indicator';
 import ScrollableList from '../../components/scrollable_list';
-import { TimelineHint } from 'mastodon/components/timeline_hint';
+import AccountContainer from '../../containers/account_container';
 import LimitedAccountHint from '../account_timeline/components/limited_account_hint';
-import { getAccountHidden } from 'mastodon/selectors';
-import { normalizeForLookup } from 'mastodon/reducers/accounts_map';
-import BundleColumnError from 'mastodon/features/ui/components/bundle_column_error';
+import HeaderContainer from '../account_timeline/containers/header_container';
+import Column from '../ui/components/column';
+
 
 const mapStateToProps = (state, { params: { acct, id } }) => {
   const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);

--- a/app/javascript/mastodon/features/following/index.jsx
+++ b/app/javascript/mastodon/features/following/index.jsx
@@ -27,7 +27,6 @@ import LimitedAccountHint from '../account_timeline/components/limited_account_h
 import HeaderContainer from '../account_timeline/containers/header_container';
 import Column from '../ui/components/column';
 
-
 const mapStateToProps = (state, { params: { acct, id } }) => {
   const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);
 

--- a/app/javascript/mastodon/features/following/index.jsx
+++ b/app/javascript/mastodon/features/following/index.jsx
@@ -1,26 +1,32 @@
-import { connect } from 'react-redux';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 import PropTypes from 'prop-types';
+
+import { FormattedMessage } from 'react-intl';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
 import { debounce } from 'lodash';
-import LoadingIndicator from '../../components/loading_indicator';
+
+import { TimelineHint } from 'mastodon/components/timeline_hint';
+import BundleColumnError from 'mastodon/features/ui/components/bundle_column_error';
+import { normalizeForLookup } from 'mastodon/reducers/accounts_map';
+import { getAccountHidden } from 'mastodon/selectors';
+
 import {
   lookupAccount,
   fetchAccount,
   fetchFollowing,
   expandFollowing,
 } from '../../actions/accounts';
-import { FormattedMessage } from 'react-intl';
-import AccountContainer from '../../containers/account_container';
-import Column from '../ui/components/column';
-import HeaderContainer from '../account_timeline/containers/header_container';
 import ColumnBackButton from '../../components/column_back_button';
+import LoadingIndicator from '../../components/loading_indicator';
 import ScrollableList from '../../components/scrollable_list';
-import { TimelineHint } from 'mastodon/components/timeline_hint';
+import AccountContainer from '../../containers/account_container';
 import LimitedAccountHint from '../account_timeline/components/limited_account_hint';
-import { getAccountHidden } from 'mastodon/selectors';
-import { normalizeForLookup } from 'mastodon/reducers/accounts_map';
-import BundleColumnError from 'mastodon/features/ui/components/bundle_column_error';
+import HeaderContainer from '../account_timeline/containers/header_container';
+import Column from '../ui/components/column';
+
 
 const mapStateToProps = (state, { params: { acct, id } }) => {
   const accountId = id || state.getIn(['accounts_map', normalizeForLookup(acct)]);

--- a/app/javascript/mastodon/features/getting_started/components/announcements.jsx
+++ b/app/javascript/mastodon/features/getting_started/components/announcements.jsx
@@ -1,19 +1,24 @@
-import { PureComponent } from 'react';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import ReactSwipeableViews from 'react-swipeable-views';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import { IconButton } from 'mastodon/components/icon_button';
-import { Icon }  from 'mastodon/components/icon';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl, FormattedMessage, FormattedDate } from 'react-intl';
-import { autoPlayGif, reduceMotion, disableSwiping, mascot } from 'mastodon/initial_state';
-import elephantUIPlane from 'mastodon/../images/elephant_ui_plane.svg';
-import unicodeMapping from 'mastodon/features/emoji/emoji_unicode_mapping_light';
+
 import classNames from 'classnames';
-import EmojiPickerDropdown from 'mastodon/features/compose/containers/emoji_picker_dropdown_container';
-import { AnimatedNumber } from 'mastodon/components/animated_number';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import TransitionMotion from 'react-motion/lib/TransitionMotion';
 import spring from 'react-motion/lib/spring';
+import ReactSwipeableViews from 'react-swipeable-views';
+
+import elephantUIPlane from 'mastodon/../images/elephant_ui_plane.svg';
+import { AnimatedNumber } from 'mastodon/components/animated_number';
+import { Icon }  from 'mastodon/components/icon';
+import { IconButton } from 'mastodon/components/icon_button';
+import EmojiPickerDropdown from 'mastodon/features/compose/containers/emoji_picker_dropdown_container';
+import unicodeMapping from 'mastodon/features/emoji/emoji_unicode_mapping_light';
+import { autoPlayGif, reduceMotion, disableSwiping, mascot } from 'mastodon/initial_state';
 import { assetHost } from 'mastodon/utils/config';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/getting_started/components/trends.jsx
+++ b/app/javascript/mastodon/features/getting_started/components/trends.jsx
@@ -1,9 +1,14 @@
-import ImmutablePureComponent from 'react-immutable-pure-component';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
+
 import { FormattedMessage } from 'react-intl';
+
 import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+
+import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
 
 export default class Trends extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/getting_started/components/trends.jsx
+++ b/app/javascript/mastodon/features/getting_started/components/trends.jsx
@@ -7,7 +7,6 @@ import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-
 import { ImmutableHashtag as Hashtag } from 'mastodon/components/hashtag';
 
 export default class Trends extends ImmutablePureComponent {

--- a/app/javascript/mastodon/features/getting_started/containers/announcements_container.js
+++ b/app/javascript/mastodon/features/getting_started/containers/announcements_container.js
@@ -1,8 +1,10 @@
-import { connect } from 'react-redux';
-import { addReaction, removeReaction, dismissAnnouncement } from 'mastodon/actions/announcements';
-import Announcements from '../components/announcements';
-import { createSelector } from 'reselect';
 import { Map as ImmutableMap } from 'immutable';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
+import { addReaction, removeReaction, dismissAnnouncement } from 'mastodon/actions/announcements';
+
+import Announcements from '../components/announcements';
 
 const customEmojiMap = createSelector([state => state.get('custom_emojis')], items => items.reduce((map, emoji) => map.set(emoji.get('shortcode'), emoji), ImmutableMap()));
 

--- a/app/javascript/mastodon/features/getting_started/containers/trends_container.js
+++ b/app/javascript/mastodon/features/getting_started/containers/trends_container.js
@@ -1,5 +1,7 @@
 import { connect } from 'react-redux';
+
 import { fetchTrendingHashtags } from 'mastodon/actions/trends';
+
 import Trends from '../components/trends';
 
 const mapStateToProps = state => ({

--- a/app/javascript/mastodon/features/getting_started/index.jsx
+++ b/app/javascript/mastodon/features/getting_started/index.jsx
@@ -1,19 +1,33 @@
-import Column from 'mastodon/components/column';
-import ColumnHeader from 'mastodon/components/column_header';
-import ColumnLink from '../ui/components/column_link';
-import ColumnSubheading from '../ui/components/column_subheading';
-import { defineMessages, injectIntl } from 'react-intl';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
+import { List as ImmutableList } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { me, showTrends } from '../../initial_state';
+import { connect } from 'react-redux';
+
 import { fetchFollowRequests } from 'mastodon/actions/accounts';
-import { List as ImmutableList } from 'immutable';
-import NavigationContainer from '../compose/containers/navigation_container';
+import Column from 'mastodon/components/column';
+import ColumnHeader from 'mastodon/components/column_header';
 import LinkFooter from 'mastodon/features/ui/components/link_footer';
+
+import { me, showTrends } from '../../initial_state';
+import NavigationContainer from '../compose/containers/navigation_container';
+import ColumnLink from '../ui/components/column_link';
+import ColumnSubheading from '../ui/components/column_subheading';
+
+
+
+
+
+
+
+
 import TrendsContainer from './containers/trends_container';
-import { Helmet } from 'react-helmet';
+
 
 const messages = defineMessages({
   home_timeline: { id: 'tabs_bar.home', defaultMessage: 'Home' },

--- a/app/javascript/mastodon/features/getting_started/index.jsx
+++ b/app/javascript/mastodon/features/getting_started/index.jsx
@@ -19,15 +19,7 @@ import NavigationContainer from '../compose/containers/navigation_container';
 import ColumnLink from '../ui/components/column_link';
 import ColumnSubheading from '../ui/components/column_subheading';
 
-
-
-
-
-
-
-
 import TrendsContainer from './containers/trends_container';
-
 
 const messages = defineMessages({
   home_timeline: { id: 'tabs_bar.home', defaultMessage: 'Home' },

--- a/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.jsx
@@ -5,7 +5,6 @@ import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-
 import { NonceProvider } from 'react-select';
 import AsyncSelect from 'react-select/async';
 import Toggle from 'react-toggle';

--- a/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/hashtag_timeline/components/column_settings.jsx
@@ -1,10 +1,15 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import Toggle from 'react-toggle';
-import AsyncSelect from 'react-select/async';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+
 import { NonceProvider } from 'react-select';
+import AsyncSelect from 'react-select/async';
+import Toggle from 'react-toggle';
+
 import SettingToggle from '../../notifications/components/setting_toggle';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/hashtag_timeline/containers/column_settings_container.js
@@ -1,7 +1,8 @@
 import { connect } from 'react-redux';
-import ColumnSettings from '../components/column_settings';
+
 import { changeColumnParams } from '../../../actions/columns';
 import api from '../../../api';
+import ColumnSettings from '../components/column_settings';
 
 const mapStateToProps = (state, { columnId }) => {
   const columns = state.getIn(['settings', 'columns']);

--- a/app/javascript/mastodon/features/hashtag_timeline/index.jsx
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.jsx
@@ -1,20 +1,33 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import StatusListContainer from '../ui/containers/status_list_container';
-import Column from 'mastodon/components/column';
-import ColumnHeader from 'mastodon/components/column_header';
-import ColumnSettingsContainer from './containers/column_settings_container';
-import { expandHashtagTimeline, clearTimeline } from 'mastodon/actions/timelines';
-import { addColumn, removeColumn, moveColumn } from 'mastodon/actions/columns';
+import { PureComponent } from 'react';
+
 import { injectIntl, FormattedMessage, defineMessages } from 'react-intl';
-import { connectHashtagStream } from 'mastodon/actions/streaming';
-import { isEqual } from 'lodash';
-import { fetchHashtag, followHashtag, unfollowHashtag } from 'mastodon/actions/tags';
-import { Icon }  from 'mastodon/components/icon';
+
 import classNames from 'classnames';
 import { Helmet } from 'react-helmet';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import { isEqual } from 'lodash';
+
+import { addColumn, removeColumn, moveColumn } from 'mastodon/actions/columns';
+import { connectHashtagStream } from 'mastodon/actions/streaming';
+import { fetchHashtag, followHashtag, unfollowHashtag } from 'mastodon/actions/tags';
+import { expandHashtagTimeline, clearTimeline } from 'mastodon/actions/timelines';
+import Column from 'mastodon/components/column';
+import ColumnHeader from 'mastodon/components/column_header';
+import { Icon }  from 'mastodon/components/icon';
+
+import StatusListContainer from '../ui/containers/status_list_container';
+
+import ColumnSettingsContainer from './containers/column_settings_container';
+
+
+
+
+
+
 
 const messages = defineMessages({
   followHashtag: { id: 'hashtag.follow', defaultMessage: 'Follow hashtag' },

--- a/app/javascript/mastodon/features/hashtag_timeline/index.jsx
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.jsx
@@ -23,12 +23,6 @@ import StatusListContainer from '../ui/containers/status_list_container';
 
 import ColumnSettingsContainer from './containers/column_settings_container';
 
-
-
-
-
-
-
 const messages = defineMessages({
   followHashtag: { id: 'hashtag.follow', defaultMessage: 'Follow hashtag' },
   unfollowHashtag: { id: 'hashtag.unfollow', defaultMessage: 'Unfollow hashtag' },

--- a/app/javascript/mastodon/features/home_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/home_timeline/components/column_settings.jsx
@@ -5,7 +5,6 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-
 import SettingToggle from '../../notifications/components/setting_toggle';
 
 class ColumnSettings extends PureComponent {

--- a/app/javascript/mastodon/features/home_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/home_timeline/components/column_settings.jsx
@@ -1,7 +1,11 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import { PureComponent } from 'react';
+
 import { injectIntl, FormattedMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+
 import SettingToggle from '../../notifications/components/setting_toggle';
 
 class ColumnSettings extends PureComponent {

--- a/app/javascript/mastodon/features/home_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/home_timeline/containers/column_settings_container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
-import ColumnSettings from '../components/column_settings';
+
 import { changeSetting, saveSettings } from '../../../actions/settings';
+import ColumnSettings from '../components/column_settings';
 
 const mapStateToProps = state => ({
   settings: state.getIn(['settings', 'home']),

--- a/app/javascript/mastodon/features/home_timeline/index.jsx
+++ b/app/javascript/mastodon/features/home_timeline/index.jsx
@@ -1,20 +1,31 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
-import { expandHomeTimeline } from '../../actions/timelines';
 import PropTypes from 'prop-types';
-import StatusListContainer from '../ui/containers/status_list_container';
-import Column from '../../components/column';
-import ColumnHeader from '../../components/column_header';
-import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import ColumnSettingsContainer from './containers/column_settings_container';
-import { Link } from 'react-router-dom';
-import { fetchAnnouncements, toggleShowAnnouncements } from 'mastodon/actions/announcements';
-import AnnouncementsContainer from 'mastodon/features/getting_started/containers/announcements_container';
+
 import classNames from 'classnames';
+import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
+
+import { connect } from 'react-redux';
+
+
+
+
+
+import { fetchAnnouncements, toggleShowAnnouncements } from 'mastodon/actions/announcements';
 import { IconWithBadge } from 'mastodon/components/icon_with_badge';
 import { NotSignedInIndicator } from 'mastodon/components/not_signed_in_indicator';
-import { Helmet } from 'react-helmet';
+import AnnouncementsContainer from 'mastodon/features/getting_started/containers/announcements_container';
+
+import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
+import { expandHomeTimeline } from '../../actions/timelines';
+import Column from '../../components/column';
+import ColumnHeader from '../../components/column_header';
+import StatusListContainer from '../ui/containers/status_list_container';
+
+import ColumnSettingsContainer from './containers/column_settings_container';
+
 
 const messages = defineMessages({
   title: { id: 'column.home', defaultMessage: 'Home' },

--- a/app/javascript/mastodon/features/home_timeline/index.jsx
+++ b/app/javascript/mastodon/features/home_timeline/index.jsx
@@ -9,10 +9,6 @@ import { Link } from 'react-router-dom';
 
 import { connect } from 'react-redux';
 
-
-
-
-
 import { fetchAnnouncements, toggleShowAnnouncements } from 'mastodon/actions/announcements';
 import { IconWithBadge } from 'mastodon/components/icon_with_badge';
 import { NotSignedInIndicator } from 'mastodon/components/not_signed_in_indicator';
@@ -25,7 +21,6 @@ import ColumnHeader from '../../components/column_header';
 import StatusListContainer from '../ui/containers/status_list_container';
 
 import ColumnSettingsContainer from './containers/column_settings_container';
-
 
 const messages = defineMessages({
   title: { id: 'column.home', defaultMessage: 'Home' },

--- a/app/javascript/mastodon/features/interaction_modal/index.jsx
+++ b/app/javascript/mastodon/features/interaction_modal/index.jsx
@@ -1,11 +1,15 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
-import { registrationsOpen } from 'mastodon/initial_state';
-import { connect } from 'react-redux';
-import { Icon }  from 'mastodon/components/icon';
+
 import classNames from 'classnames';
+
+import { connect } from 'react-redux';
+
 import { openModal, closeModal } from 'mastodon/actions/modal';
+import { Icon }  from 'mastodon/components/icon';
+import { registrationsOpen } from 'mastodon/initial_state';
 
 const mapStateToProps = (state, { accountId }) => ({
   displayNameHtml: state.getIn(['accounts', accountId, 'display_name_html']),

--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.jsx
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.jsx
@@ -1,9 +1,14 @@
-import Column from 'mastodon/components/column';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import ColumnHeader from 'mastodon/components/column_header';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import { Helmet } from 'react-helmet';
+
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import Column from 'mastodon/components/column';
+import ColumnHeader from 'mastodon/components/column_header';
+
 
 const messages = defineMessages({
   heading: { id: 'keyboard_shortcuts.heading', defaultMessage: 'Keyboard Shortcuts' },

--- a/app/javascript/mastodon/features/keyboard_shortcuts/index.jsx
+++ b/app/javascript/mastodon/features/keyboard_shortcuts/index.jsx
@@ -9,7 +9,6 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
 
-
 const messages = defineMessages({
   heading: { id: 'keyboard_shortcuts.heading', defaultMessage: 'Keyboard Shortcuts' },
 });

--- a/app/javascript/mastodon/features/list_adder/components/account.jsx
+++ b/app/javascript/mastodon/features/list_adder/components/account.jsx
@@ -1,10 +1,14 @@
-import { connect } from 'react-redux';
-import { makeGetAccount } from '../../../selectors';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+import { injectIntl } from 'react-intl';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+
 import { Avatar } from '../../../components/avatar';
 import { DisplayName } from '../../../components/display_name';
-import { injectIntl } from 'react-intl';
+import { makeGetAccount } from '../../../selectors';
+
 
 const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();

--- a/app/javascript/mastodon/features/list_adder/components/account.jsx
+++ b/app/javascript/mastodon/features/list_adder/components/account.jsx
@@ -4,11 +4,9 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-
 import { Avatar } from '../../../components/avatar';
 import { DisplayName } from '../../../components/display_name';
 import { makeGetAccount } from '../../../selectors';
-
 
 const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();

--- a/app/javascript/mastodon/features/list_adder/components/list.jsx
+++ b/app/javascript/mastodon/features/list_adder/components/list.jsx
@@ -1,11 +1,15 @@
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { IconButton }  from '../../../components/icon_button';
+
 import { defineMessages, injectIntl } from 'react-intl';
-import { removeFromListAdder, addToListAdder } from '../../../actions/lists';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
 import { Icon }  from 'mastodon/components/icon';
+
+import { removeFromListAdder, addToListAdder } from '../../../actions/lists';
+import { IconButton }  from '../../../components/icon_button';
 
 const messages = defineMessages({
   remove: { id: 'lists.account.remove', defaultMessage: 'Remove from list' },

--- a/app/javascript/mastodon/features/list_adder/index.jsx
+++ b/app/javascript/mastodon/features/list_adder/index.jsx
@@ -1,13 +1,17 @@
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { connect } from 'react-redux';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import { injectIntl } from 'react-intl';
-import { setupListAdder, resetListAdder } from '../../actions/lists';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import List from './components/list';
-import Account from './components/account';
+
+import { setupListAdder, resetListAdder } from '../../actions/lists';
 import NewListForm from '../lists/components/new_list_form';
+
+import Account from './components/account';
+import List from './components/list';
 // hack
 
 const getOrderedLists = createSelector([state => state.get('lists')], lists => {

--- a/app/javascript/mastodon/features/list_editor/components/account.jsx
+++ b/app/javascript/mastodon/features/list_editor/components/account.jsx
@@ -1,13 +1,16 @@
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { makeGetAccount } from '../../../selectors';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+import { removeFromListEditor, addToListEditor } from '../../../actions/lists';
 import { Avatar } from '../../../components/avatar';
 import { DisplayName } from '../../../components/display_name';
 import { IconButton } from '../../../components/icon_button';
-import { defineMessages, injectIntl } from 'react-intl';
-import { removeFromListEditor, addToListEditor } from '../../../actions/lists';
+import { makeGetAccount } from '../../../selectors';
 
 const messages = defineMessages({
   remove: { id: 'lists.account.remove', defaultMessage: 'Remove from list' },

--- a/app/javascript/mastodon/features/list_editor/components/edit_list_form.jsx
+++ b/app/javascript/mastodon/features/list_editor/components/edit_list_form.jsx
@@ -1,9 +1,13 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
+import { connect } from 'react-redux';
+
 import { changeListEditorTitle, submitListEditor } from '../../../actions/lists';
 import { IconButton } from '../../../components/icon_button';
-import { defineMessages, injectIntl } from 'react-intl';
+
 
 const messages = defineMessages({
   title: { id: 'lists.edit.submit', defaultMessage: 'Change title' },

--- a/app/javascript/mastodon/features/list_editor/components/edit_list_form.jsx
+++ b/app/javascript/mastodon/features/list_editor/components/edit_list_form.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import { changeListEditorTitle, submitListEditor } from '../../../actions/lists';
 import { IconButton } from '../../../components/icon_button';
 
-
 const messages = defineMessages({
   title: { id: 'lists.edit.submit', defaultMessage: 'Change title' },
 });

--- a/app/javascript/mastodon/features/list_editor/components/search.jsx
+++ b/app/javascript/mastodon/features/list_editor/components/search.jsx
@@ -1,10 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { PureComponent } from 'react';
+
+
 import { defineMessages, injectIntl } from 'react-intl';
-import { fetchListSuggestions, clearListSuggestions, changeListSuggestions } from '../../../actions/lists';
+
 import classNames from 'classnames';
+
+import { connect } from 'react-redux';
+
 import { Icon }  from 'mastodon/components/icon';
+
+import { fetchListSuggestions, clearListSuggestions, changeListSuggestions } from '../../../actions/lists';
 
 const messages = defineMessages({
   search: { id: 'lists.search', defaultMessage: 'Search among people you follow' },

--- a/app/javascript/mastodon/features/list_editor/components/search.jsx
+++ b/app/javascript/mastodon/features/list_editor/components/search.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
-
 import { defineMessages, injectIntl } from 'react-intl';
 
 import classNames from 'classnames';

--- a/app/javascript/mastodon/features/list_editor/index.jsx
+++ b/app/javascript/mastodon/features/list_editor/index.jsx
@@ -1,14 +1,19 @@
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { connect } from 'react-redux';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import { injectIntl } from 'react-intl';
-import { setupListEditor, clearListSuggestions, resetListEditor } from '../../actions/lists';
-import Account from './components/account';
-import Search from './components/search';
-import EditListForm from './components/edit_list_form';
-import Motion from '../ui/util/optional_motion';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
 import spring from 'react-motion/lib/spring';
+
+import { setupListEditor, clearListSuggestions, resetListEditor } from '../../actions/lists';
+import Motion from '../ui/util/optional_motion';
+
+import Account from './components/account';
+import EditListForm from './components/edit_list_form';
+import Search from './components/search';
 
 const mapStateToProps = state => ({
   accountIds: state.getIn(['listEditor', 'accounts', 'items']),

--- a/app/javascript/mastodon/features/list_timeline/index.jsx
+++ b/app/javascript/mastodon/features/list_timeline/index.jsx
@@ -1,9 +1,13 @@
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
-import { Helmet } from 'react-helmet';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
+
 import { addColumn, removeColumn, moveColumn } from 'mastodon/actions/columns';
 import { fetchList, deleteList, updateList } from 'mastodon/actions/lists';
 import { openModal } from 'mastodon/actions/modal';
@@ -14,8 +18,8 @@ import ColumnHeader from 'mastodon/components/column_header';
 import { Icon }  from 'mastodon/components/icon';
 import LoadingIndicator from 'mastodon/components/loading_indicator';
 import { RadioButton } from 'mastodon/components/radio_button';
-import StatusListContainer from 'mastodon/features/ui/containers/status_list_container';
 import BundleColumnError from 'mastodon/features/ui/components/bundle_column_error';
+import StatusListContainer from 'mastodon/features/ui/containers/status_list_container';
 
 const messages = defineMessages({
   deleteMessage: { id: 'confirmations.delete_list.message', defaultMessage: 'Are you sure you want to permanently delete this list?' },

--- a/app/javascript/mastodon/features/lists/components/new_list_form.jsx
+++ b/app/javascript/mastodon/features/lists/components/new_list_form.jsx
@@ -1,9 +1,13 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
+import { connect } from 'react-redux';
+
 import { changeListEditorTitle, submitListEditor } from 'mastodon/actions/lists';
 import Button from 'mastodon/components/button';
-import { defineMessages, injectIntl } from 'react-intl';
+
 
 const messages = defineMessages({
   label: { id: 'lists.new.title_placeholder', defaultMessage: 'New list title' },

--- a/app/javascript/mastodon/features/lists/components/new_list_form.jsx
+++ b/app/javascript/mastodon/features/lists/components/new_list_form.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import { changeListEditorTitle, submitListEditor } from 'mastodon/actions/lists';
 import Button from 'mastodon/components/button';
 
-
 const messages = defineMessages({
   label: { id: 'lists.new.title_placeholder', defaultMessage: 'New list title' },
   title: { id: 'lists.new.create', defaultMessage: 'Add list' },

--- a/app/javascript/mastodon/features/lists/index.jsx
+++ b/app/javascript/mastodon/features/lists/index.jsx
@@ -1,17 +1,22 @@
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import { Helmet } from 'react-helmet';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+
 import { fetchLists } from 'mastodon/actions/lists';
-import LoadingIndicator from 'mastodon/components/loading_indicator';
-import ScrollableList from 'mastodon/components/scrollable_list';
 import Column from 'mastodon/components/column';
 import ColumnHeader from 'mastodon/components/column_header';
+import LoadingIndicator from 'mastodon/components/loading_indicator';
+import ScrollableList from 'mastodon/components/scrollable_list';
 import ColumnLink from 'mastodon/features/ui/components/column_link';
 import ColumnSubheading from 'mastodon/features/ui/components/column_subheading';
+
 import NewListForm from './components/new_list_form';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/mutes/index.jsx
+++ b/app/javascript/mastodon/features/mutes/index.jsx
@@ -8,8 +8,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-
-
 import { debounce } from 'lodash';
 
 import { fetchMutes, expandMutes } from '../../actions/mutes';
@@ -18,7 +16,6 @@ import LoadingIndicator from '../../components/loading_indicator';
 import ScrollableList from '../../components/scrollable_list';
 import AccountContainer from '../../containers/account_container';
 import Column from '../ui/components/column';
-
 
 const messages = defineMessages({
   heading: { id: 'column.mutes', defaultMessage: 'Muted users' },

--- a/app/javascript/mastodon/features/mutes/index.jsx
+++ b/app/javascript/mastodon/features/mutes/index.jsx
@@ -1,16 +1,24 @@
-import { connect } from 'react-redux';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { debounce } from 'lodash';
-import LoadingIndicator from '../../components/loading_indicator';
-import Column from '../ui/components/column';
-import ColumnBackButtonSlim from '../../components/column_back_button_slim';
-import AccountContainer from '../../containers/account_container';
-import { fetchMutes, expandMutes } from '../../actions/mutes';
-import ScrollableList from '../../components/scrollable_list';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import { Helmet } from 'react-helmet';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+
+
+import { debounce } from 'lodash';
+
+import { fetchMutes, expandMutes } from '../../actions/mutes';
+import ColumnBackButtonSlim from '../../components/column_back_button_slim';
+import LoadingIndicator from '../../components/loading_indicator';
+import ScrollableList from '../../components/scrollable_list';
+import AccountContainer from '../../containers/account_container';
+import Column from '../ui/components/column';
+
 
 const messages = defineMessages({
   heading: { id: 'column.mutes', defaultMessage: 'Muted users' },

--- a/app/javascript/mastodon/features/notifications/components/clear_column_button.jsx
+++ b/app/javascript/mastodon/features/notifications/components/clear_column_button.jsx
@@ -1,6 +1,8 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
 import { Icon }  from 'mastodon/components/icon';
 
 export default class ClearColumnButton extends PureComponent {

--- a/app/javascript/mastodon/features/notifications/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.jsx
@@ -1,11 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+
+import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_REPORTS } from 'mastodon/permissions';
+
 import ClearColumnButton from './clear_column_button';
 import GrantPermissionButton from './grant_permission_button';
 import SettingToggle from './setting_toggle';
-import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_REPORTS } from 'mastodon/permissions';
 
 export default class ColumnSettings extends PureComponent {
 

--- a/app/javascript/mastodon/features/notifications/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/notifications/components/column_settings.jsx
@@ -5,7 +5,6 @@ import { FormattedMessage } from 'react-intl';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-
 import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_REPORTS } from 'mastodon/permissions';
 
 import ClearColumnButton from './clear_column_button';

--- a/app/javascript/mastodon/features/notifications/components/filter_bar.jsx
+++ b/app/javascript/mastodon/features/notifications/components/filter_bar.jsx
@@ -1,6 +1,8 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import { Icon }  from 'mastodon/components/icon';
 
 const tooltips = defineMessages({

--- a/app/javascript/mastodon/features/notifications/components/follow_request.jsx
+++ b/app/javascript/mastodon/features/notifications/components/follow_request.jsx
@@ -7,12 +7,9 @@ import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-
 import { Avatar } from 'mastodon/components/avatar';
 import { DisplayName } from 'mastodon/components/display_name';
 import { IconButton } from 'mastodon/components/icon_button';
-
-
 
 const messages = defineMessages({
   authorize: { id: 'follow_request.authorize', defaultMessage: 'Authorize' },

--- a/app/javascript/mastodon/features/notifications/components/follow_request.jsx
+++ b/app/javascript/mastodon/features/notifications/components/follow_request.jsx
@@ -1,11 +1,18 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
+import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+
 import { Avatar } from 'mastodon/components/avatar';
 import { DisplayName } from 'mastodon/components/display_name';
-import { Link } from 'react-router-dom';
 import { IconButton } from 'mastodon/components/icon_button';
-import { defineMessages, injectIntl } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+
+
 
 const messages = defineMessages({
   authorize: { id: 'follow_request.authorize', defaultMessage: 'Authorize' },

--- a/app/javascript/mastodon/features/notifications/components/grant_permission_button.jsx
+++ b/app/javascript/mastodon/features/notifications/components/grant_permission_button.jsx
@@ -1,5 +1,6 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
 
 export default class GrantPermissionButton extends PureComponent {

--- a/app/javascript/mastodon/features/notifications/components/notification.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notification.jsx
@@ -1,16 +1,26 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { injectIntl, FormattedMessage, defineMessages } from 'react-intl';
-import { HotKeys } from 'react-hotkeys';
 import PropTypes from 'prop-types';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { me } from 'mastodon/initial_state';
-import StatusContainer from 'mastodon/containers/status_container';
-import AccountContainer from 'mastodon/containers/account_container';
-import Report from './report';
-import FollowRequestContainer from '../containers/follow_request_container';
-import { Icon }  from 'mastodon/components/icon';
-import { Link } from 'react-router-dom';
+
+import { injectIntl, FormattedMessage, defineMessages } from 'react-intl';
+
 import classNames from 'classnames';
+import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import { HotKeys } from 'react-hotkeys';
+
+import { Icon }  from 'mastodon/components/icon';
+import AccountContainer from 'mastodon/containers/account_container';
+import StatusContainer from 'mastodon/containers/status_container';
+import { me } from 'mastodon/initial_state';
+
+import FollowRequestContainer from '../containers/follow_request_container';
+
+import Report from './report';
+
+
+
 
 const messages = defineMessages({
   favourite: { id: 'notification.favourite', defaultMessage: '{name} favourited your status' },

--- a/app/javascript/mastodon/features/notifications/components/notification.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notification.jsx
@@ -19,9 +19,6 @@ import FollowRequestContainer from '../containers/follow_request_container';
 
 import Report from './report';
 
-
-
-
 const messages = defineMessages({
   favourite: { id: 'notification.favourite', defaultMessage: '{name} favourited your status' },
   follow: { id: 'notification.follow', defaultMessage: '{name} followed you' },

--- a/app/javascript/mastodon/features/notifications/components/notifications_permission_banner.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notifications_permission_banner.jsx
@@ -11,8 +11,6 @@ import Button from 'mastodon/components/button';
 import { Icon }  from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
 
-
-
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
 });

--- a/app/javascript/mastodon/features/notifications/components/notifications_permission_banner.jsx
+++ b/app/javascript/mastodon/features/notifications/components/notifications_permission_banner.jsx
@@ -1,12 +1,17 @@
+import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
-import { Icon }  from 'mastodon/components/icon';
-import Button from 'mastodon/components/button';
-import { IconButton } from 'mastodon/components/icon_button';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { connect } from 'react-redux';
+
 import { requestBrowserPermission } from 'mastodon/actions/notifications';
 import { changeSetting } from 'mastodon/actions/settings';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import Button from 'mastodon/components/button';
+import { Icon }  from 'mastodon/components/icon';
+import { IconButton } from 'mastodon/components/icon_button';
+
+
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },

--- a/app/javascript/mastodon/features/notifications/components/report.jsx
+++ b/app/javascript/mastodon/features/notifications/components/report.jsx
@@ -1,7 +1,10 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
+
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import { AvatarOverlay } from 'mastodon/components/avatar_overlay';
 import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
 

--- a/app/javascript/mastodon/features/notifications/components/setting_toggle.jsx
+++ b/app/javascript/mastodon/features/notifications/components/setting_toggle.jsx
@@ -1,6 +1,8 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+
 import Toggle from 'react-toggle';
 
 export default class SettingToggle extends PureComponent {

--- a/app/javascript/mastodon/features/notifications/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/column_settings_container.js
@@ -1,11 +1,13 @@
-import { connect } from 'react-redux';
 import { defineMessages, injectIntl } from 'react-intl';
-import ColumnSettings from '../components/column_settings';
-import { changeSetting } from '../../../actions/settings';
+
+import { connect } from 'react-redux';
+
+import { showAlert } from '../../../actions/alerts';
+import { openModal } from '../../../actions/modal';
 import { setFilter, clearNotifications, requestBrowserPermission } from '../../../actions/notifications';
 import { changeAlerts as changePushNotifications } from '../../../actions/push_notifications';
-import { openModal } from '../../../actions/modal';
-import { showAlert } from '../../../actions/alerts';
+import { changeSetting } from '../../../actions/settings';
+import ColumnSettings from '../components/column_settings';
 
 const messages = defineMessages({
   clearMessage: { id: 'notifications.clear_confirmation', defaultMessage: 'Are you sure you want to permanently clear all your notifications?' },

--- a/app/javascript/mastodon/features/notifications/containers/filter_bar_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/filter_bar_container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
-import FilterBar from '../components/filter_bar';
+
 import { setFilter } from '../../../actions/notifications';
+import FilterBar from '../components/filter_bar';
 
 const makeMapStateToProps = state => ({
   selectedFilter: state.getIn(['settings', 'notifications', 'quickFilter', 'active']),

--- a/app/javascript/mastodon/features/notifications/containers/follow_request_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/follow_request_container.js
@@ -1,7 +1,9 @@
 import { connect } from 'react-redux';
-import { makeGetAccount } from 'mastodon/selectors';
-import FollowRequest from '../components/follow_request';
+
 import { authorizeFollowRequest, rejectFollowRequest } from 'mastodon/actions/accounts';
+import { makeGetAccount } from 'mastodon/selectors';
+
+import FollowRequest from '../components/follow_request';
 
 const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();

--- a/app/javascript/mastodon/features/notifications/containers/notification_container.js
+++ b/app/javascript/mastodon/features/notifications/containers/notification_container.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
-import { makeGetNotification, makeGetStatus, makeGetReport } from '../../../selectors';
-import Notification from '../components/notification';
+
 import { initBoostModal } from '../../../actions/boosts';
 import { mentionCompose } from '../../../actions/compose';
 import {
@@ -14,6 +13,8 @@ import {
   revealStatus,
 } from '../../../actions/statuses';
 import { boostModal } from '../../../initial_state';
+import { makeGetNotification, makeGetStatus, makeGetReport } from '../../../selectors';
+import Notification from '../components/notification';
 
 const makeMapStateToProps = () => {
   const getNotification = makeGetNotification();

--- a/app/javascript/mastodon/features/notifications/index.jsx
+++ b/app/javascript/mastodon/features/notifications/index.jsx
@@ -36,13 +36,6 @@ import ColumnSettingsContainer from './containers/column_settings_container';
 import FilterBarContainer from './containers/filter_bar_container';
 import NotificationContainer from './containers/notification_container';
 
-
-
-
-
-
-
-
 const messages = defineMessages({
   title: { id: 'column.notifications', defaultMessage: 'Notifications' },
   markAsRead : { id: 'notifications.mark_as_read', defaultMessage: 'Mark every notification as read' },

--- a/app/javascript/mastodon/features/notifications/index.jsx
+++ b/app/javascript/mastodon/features/notifications/index.jsx
@@ -1,9 +1,23 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
+import { List as ImmutableList } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import Column from '../../components/column';
-import ColumnHeader from '../../components/column_header';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
+import { debounce } from 'lodash';
+
+import { compareId } from 'mastodon/compare_id';
+import { Icon }  from 'mastodon/components/icon';
+import { NotSignedInIndicator } from 'mastodon/components/not_signed_in_indicator';
+
+import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
+import { submitMarkers } from '../../actions/markers';
 import {
   expandNotifications,
   scrollTopNotifications,
@@ -12,22 +26,22 @@ import {
   unmountNotifications,
   markNotificationsAsRead,
 } from '../../actions/notifications';
-import { submitMarkers } from '../../actions/markers';
-import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
-import NotificationContainer from './containers/notification_container';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import Column from '../../components/column';
+import ColumnHeader from '../../components/column_header';
+import LoadGap from '../../components/load_gap';
+import ScrollableList from '../../components/scrollable_list';
+
+import NotificationsPermissionBanner from './components/notifications_permission_banner';
 import ColumnSettingsContainer from './containers/column_settings_container';
 import FilterBarContainer from './containers/filter_bar_container';
-import { createSelector } from 'reselect';
-import { List as ImmutableList } from 'immutable';
-import { debounce } from 'lodash';
-import ScrollableList from '../../components/scrollable_list';
-import LoadGap from '../../components/load_gap';
-import { Icon }  from 'mastodon/components/icon';
-import { compareId } from 'mastodon/compare_id';
-import NotificationsPermissionBanner from './components/notifications_permission_banner';
-import { NotSignedInIndicator } from 'mastodon/components/not_signed_in_indicator';
-import { Helmet } from 'react-helmet';
+import NotificationContainer from './containers/notification_container';
+
+
+
+
+
+
+
 
 const messages = defineMessages({
   title: { id: 'column.notifications', defaultMessage: 'Notifications' },

--- a/app/javascript/mastodon/features/onboarding/components/progress_indicator.jsx
+++ b/app/javascript/mastodon/features/onboarding/components/progress_indicator.jsx
@@ -1,7 +1,10 @@
-import { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Check } from 'mastodon/components/check';
+import { Fragment } from 'react';
+
 import classNames from 'classnames';
+
+import { Check } from 'mastodon/components/check';
+
 
 const ProgressIndicator = ({ steps, completed }) => (
   <div className='onboarding__progress-indicator'>

--- a/app/javascript/mastodon/features/onboarding/components/progress_indicator.jsx
+++ b/app/javascript/mastodon/features/onboarding/components/progress_indicator.jsx
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 
 import { Check } from 'mastodon/components/check';
 
-
 const ProgressIndicator = ({ steps, completed }) => (
   <div className='onboarding__progress-indicator'>
     {(new Array(steps)).fill().map((_, i) => (

--- a/app/javascript/mastodon/features/onboarding/components/step.jsx
+++ b/app/javascript/mastodon/features/onboarding/components/step.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
-import { Icon }  from 'mastodon/components/icon';
+
 import { Check } from 'mastodon/components/check';
+import { Icon }  from 'mastodon/components/icon';
 
 const Step = ({ label, description, icon, completed, onClick, href }) => {
   const content = (

--- a/app/javascript/mastodon/features/onboarding/follows.jsx
+++ b/app/javascript/mastodon/features/onboarding/follows.jsx
@@ -1,16 +1,20 @@
-import { PureComponent } from 'react';
-import Column from 'mastodon/components/column';
-import ColumnBackButton from 'mastodon/components/column_back_button';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
+
 import { fetchSuggestions } from 'mastodon/actions/suggestions';
 import { markAsPartial } from 'mastodon/actions/timelines';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import Account from 'mastodon/containers/account_container';
+import Column from 'mastodon/components/column';
+import ColumnBackButton from 'mastodon/components/column_back_button';
 import { EmptyAccount } from 'mastodon/components/empty_account';
-import { FormattedMessage, FormattedHTMLMessage } from 'react-intl';
-import { makeGetAccount } from 'mastodon/selectors';
+import Account from 'mastodon/containers/account_container';
 import { me } from 'mastodon/initial_state';
+import { makeGetAccount } from 'mastodon/selectors';
+
 import ProgressIndicator from './components/progress_indicator';
 
 const mapStateToProps = () => {

--- a/app/javascript/mastodon/features/onboarding/index.jsx
+++ b/app/javascript/mastodon/features/onboarding/index.jsx
@@ -1,22 +1,30 @@
 import PropTypes from 'prop-types';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { connect } from 'react-redux';
-import { focusCompose } from 'mastodon/actions/compose';
-import Column from 'mastodon/features/ui/components/column';
+
+import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
+
 import { Helmet } from 'react-helmet';
-import illustration from 'mastodon/../images/elephant_ui_conversation.svg';
 import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+import { debounce } from 'lodash';
+
+import illustration from 'mastodon/../images/elephant_ui_conversation.svg';
+import { fetchAccount } from 'mastodon/actions/accounts';
+import { focusCompose } from 'mastodon/actions/compose';
+import { closeOnboarding } from 'mastodon/actions/onboarding';
+import Column from 'mastodon/features/ui/components/column';
 import { me } from 'mastodon/initial_state';
 import { makeGetAccount } from 'mastodon/selectors';
-import { closeOnboarding } from 'mastodon/actions/onboarding';
-import { fetchAccount } from 'mastodon/actions/accounts';
+
+import ArrowSmallRight from './components/arrow_small_right';
+import Step from './components/step';
 import Follows from './follows';
 import Share from './share';
-import Step from './components/step';
-import ArrowSmallRight from './components/arrow_small_right';
-import { FormattedMessage, injectIntl, defineMessages } from 'react-intl';
-import { debounce } from 'lodash';
+
+
 
 const messages = defineMessages({
   template: { id: 'onboarding.compose.template', defaultMessage: 'Hello #Mastodon!' },

--- a/app/javascript/mastodon/features/onboarding/index.jsx
+++ b/app/javascript/mastodon/features/onboarding/index.jsx
@@ -24,8 +24,6 @@ import Step from './components/step';
 import Follows from './follows';
 import Share from './share';
 
-
-
 const messages = defineMessages({
   template: { id: 'onboarding.compose.template', defaultMessage: 'Hello #Mastodon!' },
 });

--- a/app/javascript/mastodon/features/onboarding/share.jsx
+++ b/app/javascript/mastodon/features/onboarding/share.jsx
@@ -16,12 +16,7 @@ import ColumnBackButton from 'mastodon/components/column_back_button';
 import { Icon }  from 'mastodon/components/icon';
 import { me, domain } from 'mastodon/initial_state';
 
-
-
-
-
 import ArrowSmallRight from './components/arrow_small_right';
-
 
 const messages = defineMessages({
   shareableMessage: { id: 'onboarding.share.message', defaultMessage: 'I\'m {username} on #Mastodon! Come follow me at {url}' },

--- a/app/javascript/mastodon/features/onboarding/share.jsx
+++ b/app/javascript/mastodon/features/onboarding/share.jsx
@@ -1,16 +1,27 @@
+import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl, FormattedMessage, FormattedHTMLMessage } from 'react-intl';
+
+import classNames from 'classnames';
+import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
+import SwipeableViews from 'react-swipeable-views';
+
 import Column from 'mastodon/components/column';
 import ColumnBackButton from 'mastodon/components/column_back_button';
-import PropTypes from 'prop-types';
-import { me, domain } from 'mastodon/initial_state';
-import { connect } from 'react-redux';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { defineMessages, injectIntl, FormattedMessage, FormattedHTMLMessage } from 'react-intl';
-import classNames from 'classnames';
 import { Icon }  from 'mastodon/components/icon';
+import { me, domain } from 'mastodon/initial_state';
+
+
+
+
+
 import ArrowSmallRight from './components/arrow_small_right';
-import { Link } from 'react-router-dom';
-import SwipeableViews from 'react-swipeable-views';
+
 
 const messages = defineMessages({
   shareableMessage: { id: 'onboarding.share.message', defaultMessage: 'I\'m {username} on #Mastodon! Come follow me at {url}' },

--- a/app/javascript/mastodon/features/picture_in_picture/components/footer.jsx
+++ b/app/javascript/mastodon/features/picture_in_picture/components/footer.jsx
@@ -1,16 +1,21 @@
-import { connect } from 'react-redux';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import { IconButton } from 'mastodon/components/icon_button';
-import classNames from 'classnames';
-import { me, boostModal } from 'mastodon/initial_state';
+
 import { defineMessages, injectIntl } from 'react-intl';
+
+import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+
+import { initBoostModal } from 'mastodon/actions/boosts';
 import { replyCompose } from 'mastodon/actions/compose';
 import { reblog, favourite, unreblog, unfavourite } from 'mastodon/actions/interactions';
-import { makeGetStatus } from 'mastodon/selectors';
-import { initBoostModal } from 'mastodon/actions/boosts';
 import { openModal } from 'mastodon/actions/modal';
+import { IconButton } from 'mastodon/components/icon_button';
+import { me, boostModal } from 'mastodon/initial_state';
+import { makeGetStatus } from 'mastodon/selectors';
 
 const messages = defineMessages({
   reply: { id: 'status.reply', defaultMessage: 'Reply' },

--- a/app/javascript/mastodon/features/picture_in_picture/components/footer.jsx
+++ b/app/javascript/mastodon/features/picture_in_picture/components/footer.jsx
@@ -8,7 +8,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-
 import { initBoostModal } from 'mastodon/actions/boosts';
 import { replyCompose } from 'mastodon/actions/compose';
 import { reblog, favourite, unreblog, unfavourite } from 'mastodon/actions/interactions';

--- a/app/javascript/mastodon/features/picture_in_picture/components/header.jsx
+++ b/app/javascript/mastodon/features/picture_in_picture/components/header.jsx
@@ -1,12 +1,19 @@
-import { connect } from 'react-redux';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import { IconButton } from 'mastodon/components/icon_button';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
 import { Link } from 'react-router-dom';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+
+
 import { Avatar } from 'mastodon/components/avatar';
 import { DisplayName } from 'mastodon/components/display_name';
-import { defineMessages, injectIntl } from 'react-intl';
+import { IconButton } from 'mastodon/components/icon_button';
+
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },

--- a/app/javascript/mastodon/features/picture_in_picture/components/header.jsx
+++ b/app/javascript/mastodon/features/picture_in_picture/components/header.jsx
@@ -8,12 +8,9 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-
-
 import { Avatar } from 'mastodon/components/avatar';
 import { DisplayName } from 'mastodon/components/display_name';
 import { IconButton } from 'mastodon/components/icon_button';
-
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },

--- a/app/javascript/mastodon/features/picture_in_picture/index.jsx
+++ b/app/javascript/mastodon/features/picture_in_picture/index.jsx
@@ -1,11 +1,14 @@
-import { Component } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Video from 'mastodon/features/video';
-import Audio from 'mastodon/features/audio';
+import { Component } from 'react';
+
+import { connect } from 'react-redux';
+
 import { removePictureInPicture } from 'mastodon/actions/picture_in_picture';
-import Header from './components/header';
+import Audio from 'mastodon/features/audio';
+import Video from 'mastodon/features/video';
+
 import Footer from './components/footer';
+import Header from './components/header';
 
 const mapStateToProps = state => ({
   ...state.get('picture_in_picture'),

--- a/app/javascript/mastodon/features/pinned_statuses/index.jsx
+++ b/app/javascript/mastodon/features/pinned_statuses/index.jsx
@@ -1,13 +1,20 @@
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
 import { fetchPinnedStatuses } from '../../actions/pin_statuses';
-import Column from '../ui/components/column';
 import ColumnBackButtonSlim from '../../components/column_back_button_slim';
 import StatusList from '../../components/status_list';
-import { defineMessages, injectIntl } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { Helmet } from 'react-helmet';
+import Column from '../ui/components/column';
+
+
+
 
 const messages = defineMessages({
   heading: { id: 'column.pins', defaultMessage: 'Pinned post' },

--- a/app/javascript/mastodon/features/pinned_statuses/index.jsx
+++ b/app/javascript/mastodon/features/pinned_statuses/index.jsx
@@ -13,9 +13,6 @@ import ColumnBackButtonSlim from '../../components/column_back_button_slim';
 import StatusList from '../../components/status_list';
 import Column from '../ui/components/column';
 
-
-
-
 const messages = defineMessages({
   heading: { id: 'column.pins', defaultMessage: 'Pinned post' },
 });

--- a/app/javascript/mastodon/features/privacy_policy/index.jsx
+++ b/app/javascript/mastodon/features/privacy_policy/index.jsx
@@ -5,7 +5,6 @@ import { FormattedMessage, FormattedDate, injectIntl, defineMessages } from 'rea
 
 import { Helmet } from 'react-helmet';
 
-
 import api from 'mastodon/api';
 import Column from 'mastodon/components/column';
 import { Skeleton } from 'mastodon/components/skeleton';

--- a/app/javascript/mastodon/features/privacy_policy/index.jsx
+++ b/app/javascript/mastodon/features/privacy_policy/index.jsx
@@ -1,9 +1,13 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Helmet } from 'react-helmet';
+import { PureComponent } from 'react';
+
 import { FormattedMessage, FormattedDate, injectIntl, defineMessages } from 'react-intl';
-import Column from 'mastodon/components/column';
+
+import { Helmet } from 'react-helmet';
+
+
 import api from 'mastodon/api';
+import Column from 'mastodon/components/column';
 import { Skeleton } from 'mastodon/components/skeleton';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/public_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/public_timeline/components/column_settings.jsx
@@ -5,7 +5,6 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-
 import SettingToggle from '../../notifications/components/setting_toggle';
 
 class ColumnSettings extends PureComponent {

--- a/app/javascript/mastodon/features/public_timeline/components/column_settings.jsx
+++ b/app/javascript/mastodon/features/public_timeline/components/column_settings.jsx
@@ -1,7 +1,11 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import { PureComponent } from 'react';
+
 import { injectIntl, FormattedMessage } from 'react-intl';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+
+
 import SettingToggle from '../../notifications/components/setting_toggle';
 
 class ColumnSettings extends PureComponent {

--- a/app/javascript/mastodon/features/public_timeline/containers/column_settings_container.js
+++ b/app/javascript/mastodon/features/public_timeline/containers/column_settings_container.js
@@ -1,7 +1,8 @@
 import { connect } from 'react-redux';
-import ColumnSettings from '../components/column_settings';
-import { changeSetting } from '../../../actions/settings';
+
 import { changeColumnParams } from '../../../actions/columns';
+import { changeSetting } from '../../../actions/settings';
+import ColumnSettings from '../components/column_settings';
 
 const mapStateToProps = (state, { columnId }) => {
   const uuid = columnId;

--- a/app/javascript/mastodon/features/public_timeline/index.jsx
+++ b/app/javascript/mastodon/features/public_timeline/index.jsx
@@ -1,16 +1,25 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import StatusListContainer from '../ui/containers/status_list_container';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
+import { connect } from 'react-redux';
+
+import DismissableBanner from 'mastodon/components/dismissable_banner';
+
+import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
+import { connectPublicStream } from '../../actions/streaming';
+import { expandPublicTimeline } from '../../actions/timelines';
 import Column from '../../components/column';
 import ColumnHeader from '../../components/column_header';
-import { expandPublicTimeline } from '../../actions/timelines';
-import { addColumn, removeColumn, moveColumn } from '../../actions/columns';
+import StatusListContainer from '../ui/containers/status_list_container';
+
 import ColumnSettingsContainer from './containers/column_settings_container';
-import { connectPublicStream } from '../../actions/streaming';
-import { Helmet } from 'react-helmet';
-import DismissableBanner from 'mastodon/components/dismissable_banner';
+
+
+
 
 const messages = defineMessages({
   title: { id: 'column.public', defaultMessage: 'Federated timeline' },

--- a/app/javascript/mastodon/features/public_timeline/index.jsx
+++ b/app/javascript/mastodon/features/public_timeline/index.jsx
@@ -18,9 +18,6 @@ import StatusListContainer from '../ui/containers/status_list_container';
 
 import ColumnSettingsContainer from './containers/column_settings_container';
 
-
-
-
 const messages = defineMessages({
   title: { id: 'column.public', defaultMessage: 'Federated timeline' },
 });

--- a/app/javascript/mastodon/features/reblogs/index.jsx
+++ b/app/javascript/mastodon/features/reblogs/index.jsx
@@ -8,7 +8,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-
 import { Icon }  from 'mastodon/components/icon';
 
 import { fetchReblogs } from '../../actions/interactions';
@@ -17,8 +16,6 @@ import LoadingIndicator from '../../components/loading_indicator';
 import ScrollableList from '../../components/scrollable_list';
 import AccountContainer from '../../containers/account_container';
 import Column from '../ui/components/column';
-
-
 
 const messages = defineMessages({
   refresh: { id: 'refresh', defaultMessage: 'Refresh' },

--- a/app/javascript/mastodon/features/reblogs/index.jsx
+++ b/app/javascript/mastodon/features/reblogs/index.jsx
@@ -1,16 +1,24 @@
-import { connect } from 'react-redux';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import LoadingIndicator from '../../components/loading_indicator';
-import { fetchReblogs } from '../../actions/interactions';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { Helmet } from 'react-helmet';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+
+import { Icon }  from 'mastodon/components/icon';
+
+import { fetchReblogs } from '../../actions/interactions';
+import ColumnHeader from '../../components/column_header';
+import LoadingIndicator from '../../components/loading_indicator';
+import ScrollableList from '../../components/scrollable_list';
 import AccountContainer from '../../containers/account_container';
 import Column from '../ui/components/column';
-import ScrollableList from '../../components/scrollable_list';
-import { Icon }  from 'mastodon/components/icon';
-import ColumnHeader from '../../components/column_header';
-import { Helmet } from 'react-helmet';
+
+
 
 const messages = defineMessages({
   refresh: { id: 'refresh', defaultMessage: 'Refresh' },

--- a/app/javascript/mastodon/features/report/category.jsx
+++ b/app/javascript/mastodon/features/report/category.jsx
@@ -7,11 +7,9 @@ import { List as ImmutableList } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-
 import Button from 'mastodon/components/button';
 
 import Option from './components/option';
-
 
 const messages = defineMessages({
   dislike: { id: 'report.reasons.dislike', defaultMessage: 'I don\'t like it' },

--- a/app/javascript/mastodon/features/report/category.jsx
+++ b/app/javascript/mastodon/features/report/category.jsx
@@ -1,11 +1,17 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { List as ImmutableList } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+
 import Button from 'mastodon/components/button';
+
 import Option from './components/option';
-import { List as ImmutableList } from 'immutable';
+
 
 const messages = defineMessages({
   dislike: { id: 'report.reasons.dislike', defaultMessage: 'I don\'t like it' },

--- a/app/javascript/mastodon/features/report/comment.jsx
+++ b/app/javascript/mastodon/features/report/comment.jsx
@@ -1,8 +1,11 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
-import Button from 'mastodon/components/button';
+
 import Toggle from 'react-toggle';
+
+import Button from 'mastodon/components/button';
 
 const messages = defineMessages({
   placeholder: { id: 'report.placeholder', defaultMessage: 'Type or paste additional comments' },

--- a/app/javascript/mastodon/features/report/components/option.jsx
+++ b/app/javascript/mastodon/features/report/components/option.jsx
@@ -1,6 +1,8 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import classNames from 'classnames';
+
 import { Check } from 'mastodon/components/check';
 
 export default class Option extends PureComponent {

--- a/app/javascript/mastodon/features/report/components/status_check_box.jsx
+++ b/app/javascript/mastodon/features/report/components/status_check_box.jsx
@@ -1,14 +1,19 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { injectIntl, defineMessages } from 'react-intl';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import StatusContent from 'mastodon/components/status_content';
+
 import { Avatar } from 'mastodon/components/avatar';
 import { DisplayName } from 'mastodon/components/display_name';
-import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
-import Option from './option';
-import MediaAttachments from 'mastodon/components/media_attachments';
-import { injectIntl, defineMessages } from 'react-intl';
 import { Icon }  from 'mastodon/components/icon';
+import MediaAttachments from 'mastodon/components/media_attachments';
+import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
+import StatusContent from 'mastodon/components/status_content';
+
+import Option from './option';
+
 
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },

--- a/app/javascript/mastodon/features/report/components/status_check_box.jsx
+++ b/app/javascript/mastodon/features/report/components/status_check_box.jsx
@@ -14,7 +14,6 @@ import StatusContent from 'mastodon/components/status_content';
 
 import Option from './option';
 
-
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
   unlisted_short: { id: 'privacy.unlisted.short', defaultMessage: 'Unlisted' },

--- a/app/javascript/mastodon/features/report/containers/status_check_box_container.js
+++ b/app/javascript/mastodon/features/report/containers/status_check_box_container.js
@@ -1,6 +1,8 @@
 import { connect } from 'react-redux';
-import StatusCheckBox from '../components/status_check_box';
+
 import { makeGetStatus } from 'mastodon/selectors';
+
+import StatusCheckBox from '../components/status_check_box';
 
 const makeMapStateToProps = () => {
   const getStatus = makeGetStatus();

--- a/app/javascript/mastodon/features/report/rules.jsx
+++ b/app/javascript/mastodon/features/report/rules.jsx
@@ -1,9 +1,14 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
-import { FormattedMessage } from 'react-intl';
+
+
 import Button from 'mastodon/components/button';
+
 import Option from './components/option';
 
 const mapStateToProps = state => ({

--- a/app/javascript/mastodon/features/report/rules.jsx
+++ b/app/javascript/mastodon/features/report/rules.jsx
@@ -6,7 +6,6 @@ import { FormattedMessage } from 'react-intl';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-
 import Button from 'mastodon/components/button';
 
 import Option from './components/option';

--- a/app/javascript/mastodon/features/report/statuses.jsx
+++ b/app/javascript/mastodon/features/report/statuses.jsx
@@ -1,12 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import { OrderedSet } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
-import StatusCheckBox from 'mastodon/features/report/containers/status_check_box_container';
-import { OrderedSet } from 'immutable';
-import { FormattedMessage } from 'react-intl';
+
 import Button from 'mastodon/components/button';
 import LoadingIndicator from 'mastodon/components/loading_indicator';
+import StatusCheckBox from 'mastodon/features/report/containers/status_check_box_container';
+
 
 const mapStateToProps = (state, { accountId }) => ({
   availableStatusIds: OrderedSet(state.getIn(['timelines', `account:${accountId}:with_replies`, 'items'])),

--- a/app/javascript/mastodon/features/report/statuses.jsx
+++ b/app/javascript/mastodon/features/report/statuses.jsx
@@ -11,7 +11,6 @@ import Button from 'mastodon/components/button';
 import LoadingIndicator from 'mastodon/components/loading_indicator';
 import StatusCheckBox from 'mastodon/features/report/containers/status_check_box_container';
 
-
 const mapStateToProps = (state, { accountId }) => ({
   availableStatusIds: OrderedSet(state.getIn(['timelines', `account:${accountId}:with_replies`, 'items'])),
   isLoading: state.getIn(['timelines', `account:${accountId}:with_replies`, 'isLoading']),

--- a/app/javascript/mastodon/features/report/thanks.jsx
+++ b/app/javascript/mastodon/features/report/thanks.jsx
@@ -1,14 +1,17 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
-import Button from 'mastodon/components/button';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
+
 import {
   unfollowAccount,
   muteAccount,
   blockAccount,
 } from 'mastodon/actions/accounts';
+import Button from 'mastodon/components/button';
 
 const mapStateToProps = () => ({});
 

--- a/app/javascript/mastodon/features/standalone/compose/index.jsx
+++ b/app/javascript/mastodon/features/standalone/compose/index.jsx
@@ -1,8 +1,9 @@
 import { PureComponent } from 'react';
+
 import ComposeFormContainer from '../../compose/containers/compose_form_container';
-import NotificationsContainer from '../../ui/containers/notifications_container';
 import LoadingBarContainer from '../../ui/containers/loading_bar_container';
 import ModalContainer from '../../ui/containers/modal_container';
+import NotificationsContainer from '../../ui/containers/notifications_container';
 
 export default class Compose extends PureComponent {
 

--- a/app/javascript/mastodon/features/status/components/action_bar.jsx
+++ b/app/javascript/mastodon/features/status/components/action_bar.jsx
@@ -1,13 +1,19 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { IconButton } from '../../../components/icon_button';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl } from 'react-intl';
-import { me } from '../../../initial_state';
+
 import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+
 import { PERMISSION_MANAGE_USERS, PERMISSION_MANAGE_FEDERATION } from 'mastodon/permissions';
+
+import { IconButton } from '../../../components/icon_button';
+import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
+import { me } from '../../../initial_state';
+
 
 const messages = defineMessages({
   delete: { id: 'status.delete', defaultMessage: 'Delete' },

--- a/app/javascript/mastodon/features/status/components/action_bar.jsx
+++ b/app/javascript/mastodon/features/status/components/action_bar.jsx
@@ -14,7 +14,6 @@ import { IconButton } from '../../../components/icon_button';
 import DropdownMenuContainer from '../../../containers/dropdown_menu_container';
 import { me } from '../../../initial_state';
 
-
 const messages = defineMessages({
   delete: { id: 'status.delete', defaultMessage: 'Delete' },
   redraft: { id: 'status.redraft', defaultMessage: 'Delete & re-draft' },

--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -1,13 +1,21 @@
-import { PureComponent } from 'react';
+import punycode from 'punycode';
+
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import classnames from 'classnames';
+
 import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import { FormattedMessage } from 'react-intl';
-import punycode from 'punycode';
-import classnames from 'classnames';
+
+
+
+
+import { Blurhash } from 'mastodon/components/blurhash';
 import { Icon }  from 'mastodon/components/icon';
 import { useBlurhash } from 'mastodon/initial_state';
-import { Blurhash } from 'mastodon/components/blurhash';
 
 const IDNA_PREFIX = 'xn--';
 

--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -10,9 +10,6 @@ import classnames from 'classnames';
 import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-
-
-
 import { Blurhash } from 'mastodon/components/blurhash';
 import { Icon }  from 'mastodon/components/icon';
 import { useBlurhash } from 'mastodon/initial_state';

--- a/app/javascript/mastodon/features/status/components/detailed_status.jsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.jsx
@@ -8,7 +8,6 @@ import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 
-
 import { AnimatedNumber } from 'mastodon/components/animated_number';
 import EditedTimestamp from 'mastodon/components/edited_timestamp';
 import { Icon }  from 'mastodon/components/icon';
@@ -23,8 +22,6 @@ import scheduleIdleTask from '../../ui/util/schedule_idle_task';
 import Video from '../../video';
 
 import Card from './card';
-
-
 
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },
@@ -216,7 +213,7 @@ class DetailedStatus extends ImmutablePureComponent {
     } else if (this.context.router) {
       reblogLink = (
         <>
-           · 
+           ·
           <Link to={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}/reblogs`} className='detailed-status__link'>
             <Icon id={reblogIcon} />
             <span className='detailed-status__reblogs'>
@@ -228,7 +225,7 @@ class DetailedStatus extends ImmutablePureComponent {
     } else {
       reblogLink = (
         <>
-           · 
+           ·
           <a href={`/interact/${status.get('id')}?type=reblog`} className='detailed-status__link' onClick={this.handleModalLink}>
             <Icon id={reblogIcon} />
             <span className='detailed-status__reblogs'>
@@ -262,7 +259,7 @@ class DetailedStatus extends ImmutablePureComponent {
     if (status.get('edited_at')) {
       edited = (
         <>
-           · 
+           ·
           <EditedTimestamp statusId={status.get('id')} timestamp={status.get('edited_at')} />
         </>
       );

--- a/app/javascript/mastodon/features/status/components/detailed_status.jsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.jsx
@@ -1,21 +1,30 @@
 import PropTypes from 'prop-types';
+
+import { injectIntl, defineMessages, FormattedDate, FormattedMessage } from 'react-intl';
+
+import classNames from 'classnames';
+import { Link } from 'react-router-dom';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
+
+import { AnimatedNumber } from 'mastodon/components/animated_number';
+import EditedTimestamp from 'mastodon/components/edited_timestamp';
+import { Icon }  from 'mastodon/components/icon';
+import PictureInPicturePlaceholder from 'mastodon/components/picture_in_picture_placeholder';
+
 import { Avatar } from '../../../components/avatar';
 import { DisplayName } from '../../../components/display_name';
-import StatusContent from '../../../components/status_content';
 import MediaGallery from '../../../components/media_gallery';
-import { Link } from 'react-router-dom';
-import { injectIntl, defineMessages, FormattedDate, FormattedMessage } from 'react-intl';
-import Card from './card';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import Video from '../../video';
+import StatusContent from '../../../components/status_content';
 import Audio from '../../audio';
 import scheduleIdleTask from '../../ui/util/schedule_idle_task';
-import classNames from 'classnames';
-import { Icon }  from 'mastodon/components/icon';
-import { AnimatedNumber } from 'mastodon/components/animated_number';
-import PictureInPicturePlaceholder from 'mastodon/components/picture_in_picture_placeholder';
-import EditedTimestamp from 'mastodon/components/edited_timestamp';
+import Video from '../../video';
+
+import Card from './card';
+
+
 
 const messages = defineMessages({
   public_short: { id: 'privacy.public.short', defaultMessage: 'Public' },

--- a/app/javascript/mastodon/features/status/containers/detailed_status_container.js
+++ b/app/javascript/mastodon/features/status/containers/detailed_status_container.js
@@ -1,6 +1,10 @@
+import { defineMessages, injectIntl } from 'react-intl';
+
 import { connect } from 'react-redux';
-import DetailedStatus from '../components/detailed_status';
-import { makeGetStatus, makeGetPictureInPicture } from '../../../selectors';
+
+import { showAlertForError } from '../../../actions/alerts';
+import { initBlockModal } from '../../../actions/blocks';
+import { initBoostModal } from '../../../actions/boosts';
 import {
   replyCompose,
   mentionCompose,
@@ -14,6 +18,9 @@ import {
   pin,
   unpin,
 } from '../../../actions/interactions';
+import { openModal } from '../../../actions/modal';
+import { initMuteModal } from '../../../actions/mutes';
+import { initReport } from '../../../actions/reports';
 import {
   muteStatus,
   unmuteStatus,
@@ -21,14 +28,9 @@ import {
   hideStatus,
   revealStatus,
 } from '../../../actions/statuses';
-import { initMuteModal } from '../../../actions/mutes';
-import { initBlockModal } from '../../../actions/blocks';
-import { initBoostModal } from '../../../actions/boosts';
-import { initReport } from '../../../actions/reports';
-import { openModal } from '../../../actions/modal';
-import { defineMessages, injectIntl } from 'react-intl';
 import { boostModal, deleteModal } from '../../../initial_state';
-import { showAlertForError } from '../../../actions/alerts';
+import { makeGetStatus, makeGetPictureInPicture } from '../../../selectors';
+import DetailedStatus from '../components/detailed_status';
 
 const messages = defineMessages({
   deleteConfirm: { id: 'confirmations.delete.confirm', defaultMessage: 'Delete' },

--- a/app/javascript/mastodon/features/status/index.jsx
+++ b/app/javascript/mastodon/features/status/index.jsx
@@ -68,9 +68,6 @@ import { attachFullscreenListener, detachFullscreenListener, isFullscreen } from
 import ActionBar from './components/action_bar';
 import DetailedStatus from './components/detailed_status';
 
-
-
-
 const messages = defineMessages({
   deleteConfirm: { id: 'confirmations.delete.confirm', defaultMessage: 'Delete' },
   deleteMessage: { id: 'confirmations.delete.message', defaultMessage: 'Are you sure you want to delete this status?' },

--- a/app/javascript/mastodon/features/status/index.jsx
+++ b/app/javascript/mastodon/features/status/index.jsx
@@ -1,9 +1,51 @@
-import Immutable from 'immutable';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
 import classNames from 'classnames';
+import { Helmet } from 'react-helmet';
+
+import Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+
+import { HotKeys } from 'react-hotkeys';
+
+import { Icon }  from 'mastodon/components/icon';
+import LoadingIndicator from 'mastodon/components/loading_indicator';
+import ScrollContainer from 'mastodon/containers/scroll_container';
+import BundleColumnError from 'mastodon/features/ui/components/bundle_column_error';
+
+import {
+  unblockAccount,
+  unmuteAccount,
+} from '../../actions/accounts';
+import { initBlockModal } from '../../actions/blocks';
+import { initBoostModal } from '../../actions/boosts';
+import {
+  replyCompose,
+  mentionCompose,
+  directCompose,
+} from '../../actions/compose';
+import {
+  blockDomain,
+  unblockDomain,
+} from '../../actions/domain_blocks';
+import {
+  favourite,
+  unfavourite,
+  bookmark,
+  unbookmark,
+  reblog,
+  unreblog,
+  pin,
+  unpin,
+} from '../../actions/interactions';
+import { openModal } from '../../actions/modal';
+import { initMuteModal } from '../../actions/mutes';
+import { initReport } from '../../actions/reports';
 import {
   fetchStatus,
   muteStatus,
@@ -15,51 +57,19 @@ import {
   translateStatus,
   undoStatusTranslation,
 } from '../../actions/statuses';
-import LoadingIndicator from 'mastodon/components/loading_indicator';
-import DetailedStatus from './components/detailed_status';
-import ActionBar from './components/action_bar';
-import Column from '../ui/components/column';
-import {
-  favourite,
-  unfavourite,
-  bookmark,
-  unbookmark,
-  reblog,
-  unreblog,
-  pin,
-  unpin,
-} from '../../actions/interactions';
-import {
-  replyCompose,
-  mentionCompose,
-  directCompose,
-} from '../../actions/compose';
-import {
-  unblockAccount,
-  unmuteAccount,
-} from '../../actions/accounts';
-import {
-  blockDomain,
-  unblockDomain,
-} from '../../actions/domain_blocks';
-import { initMuteModal } from '../../actions/mutes';
-import { initBlockModal } from '../../actions/blocks';
-import { initBoostModal } from '../../actions/boosts';
-import { initReport } from '../../actions/reports';
-import { makeGetStatus, makeGetPictureInPicture } from '../../selectors';
-import ScrollContainer from 'mastodon/containers/scroll_container';
 import ColumnHeader from '../../components/column_header';
-import StatusContainer from '../../containers/status_container';
-import { openModal } from '../../actions/modal';
-import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { HotKeys } from 'react-hotkeys';
-import { boostModal, deleteModal } from '../../initial_state';
-import { attachFullscreenListener, detachFullscreenListener, isFullscreen } from '../ui/util/fullscreen';
 import { textForScreenReader, defaultMediaVisibility } from '../../components/status';
-import { Icon }  from 'mastodon/components/icon';
-import { Helmet } from 'react-helmet';
-import BundleColumnError from 'mastodon/features/ui/components/bundle_column_error';
+import StatusContainer from '../../containers/status_container';
+import { boostModal, deleteModal } from '../../initial_state';
+import { makeGetStatus, makeGetPictureInPicture } from '../../selectors';
+import Column from '../ui/components/column';
+import { attachFullscreenListener, detachFullscreenListener, isFullscreen } from '../ui/util/fullscreen';
+
+import ActionBar from './components/action_bar';
+import DetailedStatus from './components/detailed_status';
+
+
+
 
 const messages = defineMessages({
   deleteConfirm: { id: 'confirmations.delete.confirm', defaultMessage: 'Delete' },

--- a/app/javascript/mastodon/features/subscribed_languages_modal/index.jsx
+++ b/app/javascript/mastodon/features/subscribed_languages_modal/index.jsx
@@ -1,15 +1,19 @@
 import PropTypes from 'prop-types';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+
+import { is, List as ImmutableList, Set as ImmutableSet } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { is, List as ImmutableList, Set as ImmutableSet } from 'immutable';
-import { languages as preloadedLanguages } from 'mastodon/initial_state';
-import Option from 'mastodon/features/report/components/option';
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { IconButton } from 'mastodon/components/icon_button';
-import Button from 'mastodon/components/button';
+
 import { followAccount } from 'mastodon/actions/accounts';
+import Button from 'mastodon/components/button';
+import { IconButton } from 'mastodon/components/icon_button';
+import Option from 'mastodon/features/report/components/option';
+import { languages as preloadedLanguages } from 'mastodon/initial_state';
+
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },

--- a/app/javascript/mastodon/features/subscribed_languages_modal/index.jsx
+++ b/app/javascript/mastodon/features/subscribed_languages_modal/index.jsx
@@ -14,7 +14,6 @@ import { IconButton } from 'mastodon/components/icon_button';
 import Option from 'mastodon/features/report/components/option';
 import { languages as preloadedLanguages } from 'mastodon/initial_state';
 
-
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
 });

--- a/app/javascript/mastodon/features/ui/components/__tests__/column-test.jsx
+++ b/app/javascript/mastodon/features/ui/components/__tests__/column-test.jsx
@@ -1,4 +1,5 @@
 import { render, fireEvent, screen } from '@testing-library/react';
+
 import Column from '../column';
 
 describe('<Column />', () => {

--- a/app/javascript/mastodon/features/ui/components/actions_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/actions_modal.jsx
@@ -1,8 +1,11 @@
 import PropTypes from 'prop-types';
+
+import classNames from 'classnames';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import { IconButton } from '../../../components/icon_button';
-import classNames from 'classnames';
 
 export default class ActionsModal extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/ui/components/audio_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/audio_modal.jsx
@@ -1,8 +1,10 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import Audio from 'mastodon/features/audio';
-import { connect } from 'react-redux';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+import Audio from 'mastodon/features/audio';
 import Footer from 'mastodon/features/picture_in_picture/components/footer';
 
 const mapStateToProps = (state, { statusId }) => ({

--- a/app/javascript/mastodon/features/ui/components/block_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/block_modal.jsx
@@ -1,12 +1,15 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { injectIntl, FormattedMessage } from 'react-intl';
-import { makeGetAccount } from '../../../selectors';
-import Button from '../../../components/button';
-import { closeModal } from '../../../actions/modal';
+
+import { connect } from 'react-redux';
+
 import { blockAccount } from '../../../actions/accounts';
+import { closeModal } from '../../../actions/modal';
 import { initReport } from '../../../actions/reports';
+import Button from '../../../components/button';
+import { makeGetAccount } from '../../../selectors';
 
 
 const makeMapStateToProps = () => {

--- a/app/javascript/mastodon/features/ui/components/block_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/block_modal.jsx
@@ -11,7 +11,6 @@ import { initReport } from '../../../actions/reports';
 import Button from '../../../components/button';
 import { makeGetAccount } from '../../../selectors';
 
-
 const makeMapStateToProps = () => {
   const getAccount = makeGetAccount();
 

--- a/app/javascript/mastodon/features/ui/components/boost_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/boost_modal.jsx
@@ -1,18 +1,23 @@
-import { connect } from 'react-redux';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import Button from '../../../components/button';
-import StatusContent from '../../../components/status_content';
-import { Avatar } from '../../../components/avatar';
-import { RelativeTimestamp } from '../../../components/relative_timestamp';
-import { DisplayName } from '../../../components/display_name';
-import ImmutablePureComponent from 'react-immutable-pure-component';
-import { Icon }  from 'mastodon/components/icon';
-import AttachmentList from 'mastodon/components/attachment_list';
-import PrivacyDropdown from 'mastodon/features/compose/components/privacy_dropdown';
+
 import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
 import { changeBoostPrivacy } from 'mastodon/actions/boosts';
+import AttachmentList from 'mastodon/components/attachment_list';
+import { Icon }  from 'mastodon/components/icon';
+import PrivacyDropdown from 'mastodon/features/compose/components/privacy_dropdown';
+
+import { Avatar } from '../../../components/avatar';
+import Button from '../../../components/button';
+import { DisplayName } from '../../../components/display_name';
+import { RelativeTimestamp } from '../../../components/relative_timestamp';
+import StatusContent from '../../../components/status_content';
 
 const messages = defineMessages({
   cancel_reblog: { id: 'status.cancel_reblog_private', defaultMessage: 'Unboost' },

--- a/app/javascript/mastodon/features/ui/components/bundle.jsx
+++ b/app/javascript/mastodon/features/ui/components/bundle.jsx
@@ -1,5 +1,5 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
 
 const emptyComponent = () => null;
 const noop = () => { };

--- a/app/javascript/mastodon/features/ui/components/bundle_column_error.jsx
+++ b/app/javascript/mastodon/features/ui/components/bundle_column_error.jsx
@@ -1,11 +1,14 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { injectIntl, FormattedMessage } from 'react-intl';
-import Column from 'mastodon/components/column';
-import Button from 'mastodon/components/button';
+
+import classNames from 'classnames';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
-import classNames from 'classnames';
+
+import Button from 'mastodon/components/button';
+import Column from 'mastodon/components/column';
 import { autoPlayGif } from 'mastodon/initial_state';
 
 class GIF extends PureComponent {

--- a/app/javascript/mastodon/features/ui/components/bundle_modal_error.jsx
+++ b/app/javascript/mastodon/features/ui/components/bundle_modal_error.jsx
@@ -1,5 +1,6 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl } from 'react-intl';
 
 import { IconButton } from '../../../components/icon_button';

--- a/app/javascript/mastodon/features/ui/components/column.jsx
+++ b/app/javascript/mastodon/features/ui/components/column.jsx
@@ -1,9 +1,12 @@
-import { PureComponent } from 'react';
-import ColumnHeader from './column_header';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { debounce } from 'lodash';
-import { scrollTop } from '../../../scroll';
+
 import { isMobile } from '../../../is_mobile';
+import { scrollTop } from '../../../scroll';
+
+import ColumnHeader from './column_header';
 
 export default class Column extends PureComponent {
 

--- a/app/javascript/mastodon/features/ui/components/column_header.jsx
+++ b/app/javascript/mastodon/features/ui/components/column_header.jsx
@@ -1,6 +1,8 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import classNames from 'classnames';
+
 import { Icon }  from 'mastodon/components/icon';
 
 export default class ColumnHeader extends PureComponent {

--- a/app/javascript/mastodon/features/ui/components/column_link.jsx
+++ b/app/javascript/mastodon/features/ui/components/column_link.jsx
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types';
-import { NavLink } from 'react-router-dom';
-import { Icon }  from 'mastodon/components/icon';
+
 import classNames from 'classnames';
+import { NavLink } from 'react-router-dom';
+
+import { Icon }  from 'mastodon/components/icon';
 
 const ColumnLink = ({ icon, text, to, href, method, badge, transparent, ...other }) => {
   const className = classNames('column-link', { 'column-link--transparent': transparent });

--- a/app/javascript/mastodon/features/ui/components/column_loading.jsx
+++ b/app/javascript/mastodon/features/ui/components/column_loading.jsx
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import Column from '../../../components/column';
 import ColumnHeader from '../../../components/column_header';
-import ImmutablePureComponent from 'react-immutable-pure-component';
 
 export default class ColumnLoading extends ImmutablePureComponent {
 

--- a/app/javascript/mastodon/features/ui/components/columns_area.jsx
+++ b/app/javascript/mastodon/features/ui/components/columns_area.jsx
@@ -1,11 +1,13 @@
-import { Children, cloneElement } from 'react';
 import PropTypes from 'prop-types';
+import { Children, cloneElement } from 'react';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+
+import { supportsPassiveEvents } from 'detect-passive-events';
+
+import { scrollRight } from '../../../scroll';
 import BundleContainer from '../containers/bundle_container';
-import ColumnLoading from './column_loading';
-import DrawerLoading from './drawer_loading';
-import BundleColumnError from './bundle_column_error';
 import {
   Compose,
   Notifications,
@@ -19,10 +21,12 @@ import {
   ListTimeline,
   Directory,
 } from '../util/async-components';
+
+import BundleColumnError from './bundle_column_error';
+import ColumnLoading from './column_loading';
 import ComposePanel from './compose_panel';
+import DrawerLoading from './drawer_loading';
 import NavigationPanel from './navigation_panel';
-import { supportsPassiveEvents } from 'detect-passive-events';
-import { scrollRight } from '../../../scroll';
 
 const componentMap = {
   'COMPOSE': Compose,

--- a/app/javascript/mastodon/features/ui/components/compare_history_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/compare_history_modal.jsx
@@ -6,7 +6,6 @@ import { FormattedMessage } from 'react-intl';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
-
 import escapeTextContentForBrowser from 'escape-html';
 
 import { closeModal } from 'mastodon/actions/modal';

--- a/app/javascript/mastodon/features/ui/components/compare_history_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/compare_history_modal.jsx
@@ -1,15 +1,20 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
-import { FormattedMessage } from 'react-intl';
-import { closeModal } from 'mastodon/actions/modal';
-import emojify from 'mastodon/features/emoji/emoji';
+
+
 import escapeTextContentForBrowser from 'escape-html';
-import InlineAccount from 'mastodon/components/inline_account';
+
+import { closeModal } from 'mastodon/actions/modal';
 import { IconButton } from 'mastodon/components/icon_button';
-import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
+import InlineAccount from 'mastodon/components/inline_account';
 import MediaAttachments from 'mastodon/components/media_attachments';
+import { RelativeTimestamp } from 'mastodon/components/relative_timestamp';
+import emojify from 'mastodon/features/emoji/emoji';
 
 const mapStateToProps = (state, { statusId }) => ({
   language: state.getIn(['statuses', statusId, 'language']),

--- a/app/javascript/mastodon/features/ui/components/compose_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/compose_panel.jsx
@@ -11,7 +11,6 @@ import SearchContainer from 'mastodon/features/compose/containers/search_contain
 
 import LinkFooter from './link_footer';
 
-
 class ComposePanel extends PureComponent {
 
   static contextTypes = {

--- a/app/javascript/mastodon/features/ui/components/compose_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/compose_panel.jsx
@@ -1,12 +1,16 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import SearchContainer from 'mastodon/features/compose/containers/search_container';
+import { PureComponent } from 'react';
+
+import { connect } from 'react-redux';
+
+import { changeComposing, mountCompose, unmountCompose } from 'mastodon/actions/compose';
+import ServerBanner from 'mastodon/components/server_banner';
 import ComposeFormContainer from 'mastodon/features/compose/containers/compose_form_container';
 import NavigationContainer from 'mastodon/features/compose/containers/navigation_container';
+import SearchContainer from 'mastodon/features/compose/containers/search_container';
+
 import LinkFooter from './link_footer';
-import ServerBanner from 'mastodon/components/server_banner';
-import { changeComposing, mountCompose, unmountCompose } from 'mastodon/actions/compose';
+
 
 class ComposePanel extends PureComponent {
 

--- a/app/javascript/mastodon/features/ui/components/confirmation_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/confirmation_modal.jsx
@@ -1,6 +1,8 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { injectIntl, FormattedMessage } from 'react-intl';
+
 import Button from '../../../components/button';
 
 class ConfirmationModal extends PureComponent {

--- a/app/javascript/mastodon/features/ui/components/disabled_account_banner.jsx
+++ b/app/javascript/mastodon/features/ui/components/disabled_account_banner.jsx
@@ -7,8 +7,6 @@ import { Link } from 'react-router-dom';
 
 import { connect } from 'react-redux';
 
-
-
 import { openModal } from 'mastodon/actions/modal';
 import { disabledAccountId, movedToAccountId, domain } from 'mastodon/initial_state';
 import { logOut } from 'mastodon/utils/log_out';

--- a/app/javascript/mastodon/features/ui/components/disabled_account_banner.jsx
+++ b/app/javascript/mastodon/features/ui/components/disabled_account_banner.jsx
@@ -1,10 +1,16 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { PureComponent } from 'react';
+
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { disabledAccountId, movedToAccountId, domain } from 'mastodon/initial_state';
+
+import { Link } from 'react-router-dom';
+
+import { connect } from 'react-redux';
+
+
+
 import { openModal } from 'mastodon/actions/modal';
+import { disabledAccountId, movedToAccountId, domain } from 'mastodon/initial_state';
 import { logOut } from 'mastodon/utils/log_out';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/ui/components/embed_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/embed_modal.jsx
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
-import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+
+import ImmutablePureComponent from 'react-immutable-pure-component';
+
 import api from 'mastodon/api';
 import { IconButton } from 'mastodon/components/icon_button';
 

--- a/app/javascript/mastodon/features/ui/components/filter_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/filter_modal.jsx
@@ -1,12 +1,15 @@
-import { connect } from 'react-redux';
-import { fetchStatus } from 'mastodon/actions/statuses';
-import { fetchFilters, createFilter, createFilterStatus } from 'mastodon/actions/filters';
 import PropTypes from 'prop-types';
+
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+
 import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+import { fetchFilters, createFilter, createFilterStatus } from 'mastodon/actions/filters';
+import { fetchStatus } from 'mastodon/actions/statuses';
 import { IconButton } from 'mastodon/components/icon_button';
-import SelectFilter from 'mastodon/features/filters/select_filter';
 import AddedToFilter from 'mastodon/features/filters/added_to_filter';
+import SelectFilter from 'mastodon/features/filters/select_filter';
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },

--- a/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
@@ -9,7 +9,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 
-
 import Textarea from 'react-textarea-autosize';
 import { length } from 'stringz';
 // eslint-disable-next-line import/extensions

--- a/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
@@ -1,27 +1,34 @@
-import { PureComponent } from 'react';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+
+import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
-import { changeUploadCompose, uploadThumbnail, onChangeMediaDescription, onChangeMediaFocus } from '../../../actions/compose';
-import Video, { getPointerPosition } from '../../video';
-import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
-import { IconButton } from 'mastodon/components/icon_button';
-import Button from 'mastodon/components/button';
-import Audio from 'mastodon/features/audio';
+
+
 import Textarea from 'react-textarea-autosize';
-import UploadProgress from 'mastodon/features/compose/components/upload_progress';
-import CharacterCounter from 'mastodon/features/compose/components/character_counter';
 import { length } from 'stringz';
-import { Tesseract as fetchTesseract } from 'mastodon/features/ui/util/async-components';
-import { GIFV } from 'mastodon/components/gifv';
-import { me } from 'mastodon/initial_state';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import tesseractCorePath from 'tesseract.js-core/tesseract-core.wasm.js';
 // eslint-disable-next-line import/extensions
 import tesseractWorkerPath from 'tesseract.js/dist/worker.min.js';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import tesseractCorePath from 'tesseract.js-core/tesseract-core.wasm.js';
+
+import Button from 'mastodon/components/button';
+import { GIFV } from 'mastodon/components/gifv';
+import { IconButton } from 'mastodon/components/icon_button';
+import Audio from 'mastodon/features/audio';
+import CharacterCounter from 'mastodon/features/compose/components/character_counter';
+import UploadProgress from 'mastodon/features/compose/components/upload_progress';
+import { Tesseract as fetchTesseract } from 'mastodon/features/ui/util/async-components';
+import { me } from 'mastodon/initial_state';
 import { assetHost } from 'mastodon/utils/config';
+
+import { changeUploadCompose, uploadThumbnail, onChangeMediaDescription, onChangeMediaFocus } from '../../../actions/compose';
+import Video, { getPointerPosition } from '../../video';
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },

--- a/app/javascript/mastodon/features/ui/components/follow_requests_column_link.jsx
+++ b/app/javascript/mastodon/features/ui/components/follow_requests_column_link.jsx
@@ -1,11 +1,16 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
-import { fetchFollowRequests } from 'mastodon/actions/accounts';
-import { connect } from 'react-redux';
-import ColumnLink from 'mastodon/features/ui/components/column_link';
-import { IconWithBadge } from 'mastodon/components/icon_with_badge';
-import { List as ImmutableList } from 'immutable';
+import { Component } from 'react';
+
 import { injectIntl, defineMessages } from 'react-intl';
+
+import { List as ImmutableList } from 'immutable';
+import { connect } from 'react-redux';
+
+import { fetchFollowRequests } from 'mastodon/actions/accounts';
+import { IconWithBadge } from 'mastodon/components/icon_with_badge';
+import ColumnLink from 'mastodon/features/ui/components/column_link';
+
+
 
 const messages = defineMessages({
   text: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },

--- a/app/javascript/mastodon/features/ui/components/follow_requests_column_link.jsx
+++ b/app/javascript/mastodon/features/ui/components/follow_requests_column_link.jsx
@@ -10,8 +10,6 @@ import { fetchFollowRequests } from 'mastodon/actions/accounts';
 import { IconWithBadge } from 'mastodon/components/icon_with_badge';
 import ColumnLink from 'mastodon/features/ui/components/column_link';
 
-
-
 const messages = defineMessages({
   text: { id: 'navigation_bar.follow_requests', defaultMessage: 'Follow requests' },
 });

--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -7,7 +7,6 @@ import { Link, withRouter } from 'react-router-dom';
 
 import { connect } from 'react-redux';
 
-
 import { openModal } from 'mastodon/actions/modal';
 import { Avatar } from 'mastodon/components/avatar';
 import { WordmarkLogo, SymbolLogo } from 'mastodon/components/logo';

--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -1,12 +1,17 @@
-import { PureComponent } from 'react';
-import { WordmarkLogo, SymbolLogo } from 'mastodon/components/logo';
-import { Link, withRouter } from 'react-router-dom';
-import { FormattedMessage } from 'react-intl';
-import { registrationsOpen, me } from 'mastodon/initial_state';
-import { Avatar } from 'mastodon/components/avatar';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
+import { FormattedMessage } from 'react-intl';
+
+import { Link, withRouter } from 'react-router-dom';
+
 import { connect } from 'react-redux';
+
+
 import { openModal } from 'mastodon/actions/modal';
+import { Avatar } from 'mastodon/components/avatar';
+import { WordmarkLogo, SymbolLogo } from 'mastodon/components/logo';
+import { registrationsOpen, me } from 'mastodon/initial_state';
 
 const Account = connect(state => ({
   account: state.getIn(['accounts', me]),

--- a/app/javascript/mastodon/features/ui/components/image_loader.jsx
+++ b/app/javascript/mastodon/features/ui/components/image_loader.jsx
@@ -1,7 +1,10 @@
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
+
+import classNames from 'classnames';
+
 import { LoadingBar } from 'react-redux-loading-bar';
+
 import ZoomableImage from './zoomable_image';
 
 export default class ImageLoader extends PureComponent {

--- a/app/javascript/mastodon/features/ui/components/image_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/image_modal.jsx
@@ -1,8 +1,13 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl } from 'react-intl';
+
+import classNames from 'classnames';
+
+
 import { IconButton } from 'mastodon/components/icon_button';
+
 import ImageLoader from './image_loader';
 
 const messages = defineMessages({

--- a/app/javascript/mastodon/features/ui/components/image_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/image_modal.jsx
@@ -5,7 +5,6 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import classNames from 'classnames';
 
-
 import { IconButton } from 'mastodon/components/icon_button';
 
 import ImageLoader from './image_loader';

--- a/app/javascript/mastodon/features/ui/components/link_footer.jsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.jsx
@@ -7,7 +7,6 @@ import { Link } from 'react-router-dom';
 
 import { connect } from 'react-redux';
 
-
 import { openModal } from 'mastodon/actions/modal';
 import { domain, version, source_url, statusPageUrl, profile_directory as profileDirectory } from 'mastodon/initial_state';
 import { PERMISSION_INVITE_USERS } from 'mastodon/permissions';

--- a/app/javascript/mastodon/features/ui/components/link_footer.jsx
+++ b/app/javascript/mastodon/features/ui/components/link_footer.jsx
@@ -1,12 +1,17 @@
-import { connect } from 'react-redux';
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
+
 import { Link } from 'react-router-dom';
-import { domain, version, source_url, statusPageUrl, profile_directory as profileDirectory } from 'mastodon/initial_state';
-import { logOut } from 'mastodon/utils/log_out';
+
+import { connect } from 'react-redux';
+
+
 import { openModal } from 'mastodon/actions/modal';
+import { domain, version, source_url, statusPageUrl, profile_directory as profileDirectory } from 'mastodon/initial_state';
 import { PERMISSION_INVITE_USERS } from 'mastodon/permissions';
+import { logOut } from 'mastodon/utils/log_out';
 
 const messages = defineMessages({
   logoutMessage: { id: 'confirmations.logout.message', defaultMessage: 'Are you sure you want to log out?' },

--- a/app/javascript/mastodon/features/ui/components/list_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/list_panel.jsx
@@ -1,10 +1,15 @@
 import PropTypes from 'prop-types';
-import { createSelector } from 'reselect';
+
+import { withRouter } from 'react-router-dom';
+
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { createSelector } from 'reselect';
+
+
 import { fetchLists } from 'mastodon/actions/lists';
+
 import ColumnLink from './column_link';
 
 const getOrderedLists = createSelector([state => state.get('lists')], lists => {

--- a/app/javascript/mastodon/features/ui/components/list_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/list_panel.jsx
@@ -7,7 +7,6 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-
 import { fetchLists } from 'mastodon/actions/lists';
 
 import ColumnLink from './column_link';

--- a/app/javascript/mastodon/features/ui/components/media_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/media_modal.jsx
@@ -9,7 +9,6 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 
 import ReactSwipeableViews from 'react-swipeable-views';
 
-
 import { getAverageFromBlurhash } from 'mastodon/blurhash';
 import { GIFV } from 'mastodon/components/gifv';
 import { Icon }  from 'mastodon/components/icon';

--- a/app/javascript/mastodon/features/ui/components/media_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/media_modal.jsx
@@ -1,17 +1,24 @@
-import ReactSwipeableViews from 'react-swipeable-views';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import Video from 'mastodon/features/video';
-import classNames from 'classnames';
+
 import { defineMessages, injectIntl } from 'react-intl';
-import { IconButton } from 'mastodon/components/icon_button';
+
+import classNames from 'classnames';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import ImageLoader from './image_loader';
-import { Icon }  from 'mastodon/components/icon';
-import { GIFV } from 'mastodon/components/gifv';
-import { disableSwiping } from 'mastodon/initial_state';
-import Footer from 'mastodon/features/picture_in_picture/components/footer';
+
+import ReactSwipeableViews from 'react-swipeable-views';
+
+
 import { getAverageFromBlurhash } from 'mastodon/blurhash';
+import { GIFV } from 'mastodon/components/gifv';
+import { Icon }  from 'mastodon/components/icon';
+import { IconButton } from 'mastodon/components/icon_button';
+import Footer from 'mastodon/features/picture_in_picture/components/footer';
+import Video from 'mastodon/features/video';
+import { disableSwiping } from 'mastodon/initial_state';
+
+import ImageLoader from './image_loader';
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },

--- a/app/javascript/mastodon/features/ui/components/modal_root.jsx
+++ b/app/javascript/mastodon/features/ui/components/modal_root.jsx
@@ -1,18 +1,9 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { getScrollbarWidth } from 'mastodon/utils/scrollbar';
+import { PureComponent } from 'react';
+
+import { Helmet } from 'react-helmet';
+
 import Base from 'mastodon/components/modal_root';
-import BundleContainer from '../containers/bundle_container';
-import BundleModalError from './bundle_modal_error';
-import ModalLoading from './modal_loading';
-import ActionsModal from './actions_modal';
-import MediaModal from './media_modal';
-import VideoModal from './video_modal';
-import BoostModal from './boost_modal';
-import AudioModal from './audio_modal';
-import ConfirmationModal from './confirmation_modal';
-import FocalPointModal from './focal_point_modal';
-import ImageModal from './image_modal';
 import {
   MuteModal,
   BlockModal,
@@ -26,7 +17,22 @@ import {
   SubscribedLanguagesModal,
   ClosedRegistrationsModal,
 } from 'mastodon/features/ui/util/async-components';
-import { Helmet } from 'react-helmet';
+import { getScrollbarWidth } from 'mastodon/utils/scrollbar';
+
+import BundleContainer from '../containers/bundle_container';
+
+import ActionsModal from './actions_modal';
+import AudioModal from './audio_modal';
+import BoostModal from './boost_modal';
+import BundleModalError from './bundle_modal_error';
+import ConfirmationModal from './confirmation_modal';
+import FocalPointModal from './focal_point_modal';
+import ImageModal from './image_modal';
+import MediaModal from './media_modal';
+import ModalLoading from './modal_loading';
+import VideoModal from './video_modal';
+
+
 
 const MODAL_COMPONENTS = {
   'MEDIA': () => Promise.resolve({ default: MediaModal }),

--- a/app/javascript/mastodon/features/ui/components/modal_root.jsx
+++ b/app/javascript/mastodon/features/ui/components/modal_root.jsx
@@ -32,8 +32,6 @@ import MediaModal from './media_modal';
 import ModalLoading from './modal_loading';
 import VideoModal from './video_modal';
 
-
-
 const MODAL_COMPONENTS = {
   'MEDIA': () => Promise.resolve({ default: MediaModal }),
   'VIDEO': () => Promise.resolve({ default: VideoModal }),

--- a/app/javascript/mastodon/features/ui/components/mute_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/mute_modal.jsx
@@ -1,12 +1,16 @@
-import { PureComponent } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+
+import { connect } from 'react-redux';
+
 import Toggle from 'react-toggle';
-import Button from '../../../components/button';
-import { closeModal } from '../../../actions/modal';
+
 import { muteAccount } from '../../../actions/accounts';
+import { closeModal } from '../../../actions/modal';
 import { toggleHideNotifications, changeMuteDuration } from '../../../actions/mutes';
+import Button from '../../../components/button';
 
 const messages = defineMessages({
   minutes: { id: 'intervals.full.minutes', defaultMessage: '{number, plural, one {# minute} other {# minutes}}' },

--- a/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
@@ -1,16 +1,20 @@
-import { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Component } from 'react';
+
 import { defineMessages, injectIntl } from 'react-intl';
+
 import { Link } from 'react-router-dom';
+
 import { WordmarkLogo } from 'mastodon/components/logo';
+import NavigationPortal from 'mastodon/components/navigation_portal';
 import { timelinePreview, showTrends } from 'mastodon/initial_state';
+
 import ColumnLink from './column_link';
 import DisabledAccountBanner from './disabled_account_banner';
 import FollowRequestsColumnLink from './follow_requests_column_link';
 import ListPanel from './list_panel';
 import NotificationsCounterIcon from './notifications_counter_icon';
 import SignInBanner from './sign_in_banner';
-import NavigationPortal from 'mastodon/components/navigation_portal';
 
 const messages = defineMessages({
   home: { id: 'tabs_bar.home', defaultMessage: 'Home' },

--- a/app/javascript/mastodon/features/ui/components/notifications_counter_icon.js
+++ b/app/javascript/mastodon/features/ui/components/notifications_counter_icon.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import { IconWithBadge } from 'mastodon/components/icon_with_badge';
 
 const mapStateToProps = state => ({

--- a/app/javascript/mastodon/features/ui/components/report_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/report_modal.jsx
@@ -1,19 +1,22 @@
-import { connect } from 'react-redux';
-import { submitReport } from 'mastodon/actions/reports';
-import { expandAccountTimeline } from 'mastodon/actions/timelines';
-import { fetchServer } from 'mastodon/actions/server';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
-import { makeGetAccount } from 'mastodon/selectors';
+
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+
 import { OrderedSet } from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
+import { connect } from 'react-redux';
+
+import { submitReport } from 'mastodon/actions/reports';
+import { fetchServer } from 'mastodon/actions/server';
+import { expandAccountTimeline } from 'mastodon/actions/timelines';
 import { IconButton } from 'mastodon/components/icon_button';
 import Category from 'mastodon/features/report/category';
-import Statuses from 'mastodon/features/report/statuses';
-import Rules from 'mastodon/features/report/rules';
 import Comment from 'mastodon/features/report/comment';
+import Rules from 'mastodon/features/report/rules';
+import Statuses from 'mastodon/features/report/statuses';
 import Thanks from 'mastodon/features/report/thanks';
+import { makeGetAccount } from 'mastodon/selectors';
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },

--- a/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
+++ b/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
@@ -1,8 +1,11 @@
 import { useCallback } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
-import { registrationsOpen } from 'mastodon/initial_state';
+
 import { openModal } from 'mastodon/actions/modal';
+import { registrationsOpen } from 'mastodon/initial_state';
 
 const SignInBanner = () => {
   const dispatch = useAppDispatch();

--- a/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
+++ b/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
@@ -2,10 +2,10 @@ import { useCallback } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
-import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 import { openModal } from 'mastodon/actions/modal';
 import { registrationsOpen } from 'mastodon/initial_state';
+import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 const SignInBanner = () => {
   const dispatch = useAppDispatch();

--- a/app/javascript/mastodon/features/ui/components/upload_area.jsx
+++ b/app/javascript/mastodon/features/ui/components/upload_area.jsx
@@ -7,8 +7,6 @@ import spring from 'react-motion/lib/spring';
 
 import Motion from '../util/optional_motion';
 
-
-
 export default class UploadArea extends PureComponent {
 
   static propTypes = {

--- a/app/javascript/mastodon/features/ui/components/upload_area.jsx
+++ b/app/javascript/mastodon/features/ui/components/upload_area.jsx
@@ -1,8 +1,13 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import Motion from '../util/optional_motion';
-import spring from 'react-motion/lib/spring';
+import { PureComponent } from 'react';
+
 import { FormattedMessage } from 'react-intl';
+
+import spring from 'react-motion/lib/spring';
+
+import Motion from '../util/optional_motion';
+
+
 
 export default class UploadArea extends PureComponent {
 

--- a/app/javascript/mastodon/features/ui/components/video_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/video_modal.jsx
@@ -1,10 +1,12 @@
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import Video from 'mastodon/features/video';
-import { connect } from 'react-redux';
+
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import ImmutablePureComponent from 'react-immutable-pure-component';
-import Footer from 'mastodon/features/picture_in_picture/components/footer';
+import { connect } from 'react-redux';
+
 import { getAverageFromBlurhash } from 'mastodon/blurhash';
+import Footer from 'mastodon/features/picture_in_picture/components/footer';
+import Video from 'mastodon/features/video';
 
 const mapStateToProps = (state, { statusId }) => ({
   language: state.getIn(['statuses', statusId, 'language']),

--- a/app/javascript/mastodon/features/ui/components/zoomable_image.jsx
+++ b/app/javascript/mastodon/features/ui/components/zoomable_image.jsx
@@ -1,7 +1,10 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { IconButton } from 'mastodon/components/icon_button';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl } from 'react-intl';
+
+import { IconButton } from 'mastodon/components/icon_button';
+
 
 const messages = defineMessages({
   compress: { id: 'lightbox.compress', defaultMessage: 'Compress image view box' },

--- a/app/javascript/mastodon/features/ui/components/zoomable_image.jsx
+++ b/app/javascript/mastodon/features/ui/components/zoomable_image.jsx
@@ -5,7 +5,6 @@ import { defineMessages, injectIntl } from 'react-intl';
 
 import { IconButton } from 'mastodon/components/icon_button';
 
-
 const messages = defineMessages({
   compress: { id: 'lightbox.compress', defaultMessage: 'Compress image view box' },
   expand: { id: 'lightbox.expand', defaultMessage: 'Expand image view box' },

--- a/app/javascript/mastodon/features/ui/containers/bundle_container.js
+++ b/app/javascript/mastodon/features/ui/containers/bundle_container.js
@@ -1,8 +1,8 @@
 import { connect } from 'react-redux';
 
+import { fetchBundleRequest, fetchBundleSuccess, fetchBundleFail } from '../../../actions/bundles';
 import Bundle from '../components/bundle';
 
-import { fetchBundleRequest, fetchBundleSuccess, fetchBundleFail } from '../../../actions/bundles';
 
 const mapDispatchToProps = dispatch => ({
   onFetch () {

--- a/app/javascript/mastodon/features/ui/containers/bundle_container.js
+++ b/app/javascript/mastodon/features/ui/containers/bundle_container.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { fetchBundleRequest, fetchBundleSuccess, fetchBundleFail } from '../../../actions/bundles';
 import Bundle from '../components/bundle';
 
-
 const mapDispatchToProps = dispatch => ({
   onFetch () {
     dispatch(fetchBundleRequest());

--- a/app/javascript/mastodon/features/ui/containers/columns_area_container.js
+++ b/app/javascript/mastodon/features/ui/containers/columns_area_container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import ColumnsArea from '../components/columns_area';
 
 const mapStateToProps = state => ({

--- a/app/javascript/mastodon/features/ui/containers/loading_bar_container.js
+++ b/app/javascript/mastodon/features/ui/containers/loading_bar_container.js
@@ -1,4 +1,5 @@
 import { connect }    from 'react-redux';
+
 import LoadingBar from 'react-redux-loading-bar';
 
 const mapStateToProps = (state, ownProps) => ({

--- a/app/javascript/mastodon/features/ui/containers/modal_container.js
+++ b/app/javascript/mastodon/features/ui/containers/modal_container.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+
 import { openModal, closeModal } from '../../../actions/modal';
 import ModalRoot from '../components/modal_root';
 

--- a/app/javascript/mastodon/features/ui/containers/notifications_container.js
+++ b/app/javascript/mastodon/features/ui/containers/notifications_container.js
@@ -1,6 +1,9 @@
 import { injectIntl } from 'react-intl';
+
 import { connect } from 'react-redux';
+
 import { NotificationStack } from 'react-notification';
+
 import { dismissAlert } from '../../../actions/alerts';
 import { getAlerts } from '../../../selectors';
 

--- a/app/javascript/mastodon/features/ui/containers/status_list_container.js
+++ b/app/javascript/mastodon/features/ui/containers/status_list_container.js
@@ -1,9 +1,11 @@
-import { connect } from 'react-redux';
-import StatusList from '../../../components/status_list';
-import { scrollTopTimeline, loadPending } from '../../../actions/timelines';
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
+
 import { debounce } from 'lodash';
+
+import { scrollTopTimeline, loadPending } from '../../../actions/timelines';
+import StatusList from '../../../components/status_list';
 import { me } from '../../../initial_state';
 
 const makeGetStatusIds = (pending = false) => createSelector([

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -1,27 +1,36 @@
-import classNames from 'classnames';
-import { PureComponent } from 'react';
-import { HotKeys } from 'react-hotkeys';
-import { defineMessages, injectIntl } from 'react-intl';
-import { connect } from 'react-redux';
-import { Redirect, Route, withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import NotificationsContainer from './containers/notifications_container';
-import LoadingBarContainer from './containers/loading_bar_container';
-import ModalContainer from './containers/modal_container';
-import { layoutFromWindow } from 'mastodon/is_mobile';
+import { PureComponent } from 'react';
+
+import { defineMessages, injectIntl } from 'react-intl';
+
+import classNames from 'classnames';
+import { Redirect, Route, withRouter } from 'react-router-dom';
+
+import { connect } from 'react-redux';
+
 import { debounce } from 'lodash';
-import { uploadCompose, resetCompose, changeComposeSpoilerness } from '../../actions/compose';
-import { expandHomeTimeline } from '../../actions/timelines';
-import { expandNotifications } from '../../actions/notifications';
-import { fetchServer, fetchServerTranslationLanguages } from '../../actions/server';
-import { clearHeight } from '../../actions/height_cache';
+import { HotKeys } from 'react-hotkeys';
+
 import { focusApp, unfocusApp, changeLayout } from 'mastodon/actions/app';
 import { synchronouslySubmitMarkers, submitMarkers, fetchMarkers } from 'mastodon/actions/markers';
-import { WrappedSwitch, WrappedRoute } from './util/react_router_helpers';
+import { INTRODUCTION_VERSION } from 'mastodon/actions/onboarding';
+import PictureInPicture from 'mastodon/features/picture_in_picture';
+import { layoutFromWindow } from 'mastodon/is_mobile';
+
+import { uploadCompose, resetCompose, changeComposeSpoilerness } from '../../actions/compose';
+import { clearHeight } from '../../actions/height_cache';
+import { expandNotifications } from '../../actions/notifications';
+import { fetchServer, fetchServerTranslationLanguages } from '../../actions/server';
+import { expandHomeTimeline } from '../../actions/timelines';
+import initialState, { me, owner, singleUserMode, showTrends, trendsAsLanding } from '../../initial_state';
+
 import BundleColumnError from './components/bundle_column_error';
+import Header from './components/header';
 import UploadArea from './components/upload_area';
 import ColumnsAreaContainer from './containers/columns_area_container';
-import PictureInPicture from 'mastodon/features/picture_in_picture';
+import LoadingBarContainer from './containers/loading_bar_container';
+import ModalContainer from './containers/modal_container';
+import NotificationsContainer from './containers/notifications_container';
 import {
   Compose,
   Status,
@@ -55,9 +64,7 @@ import {
   About,
   PrivacyPolicy,
 } from './util/async-components';
-import initialState, { me, owner, singleUserMode, showTrends, trendsAsLanding } from '../../initial_state';
-import { INTRODUCTION_VERSION } from 'mastodon/actions/onboarding';
-import Header from './components/header';
+import { WrappedSwitch, WrappedRoute } from './util/react_router_helpers';
 
 // Dummy import, to make sure that <Status /> ends up in the application bundle.
 // Without this it ends up in ~8 very commonly used bundles.

--- a/app/javascript/mastodon/features/ui/util/optional_motion.js
+++ b/app/javascript/mastodon/features/ui/util/optional_motion.js
@@ -1,5 +1,7 @@
-import { reduceMotion } from '../../../initial_state';
-import ReducedMotion from './reduced_motion';
 import Motion from 'react-motion/lib/Motion';
+
+import { reduceMotion } from '../../../initial_state';
+
+import ReducedMotion from './reduced_motion';
 
 export default reduceMotion ? ReducedMotion : Motion;

--- a/app/javascript/mastodon/features/ui/util/react_router_helpers.jsx
+++ b/app/javascript/mastodon/features/ui/util/react_router_helpers.jsx
@@ -1,9 +1,12 @@
-import { Component, PureComponent, cloneElement, Children } from 'react';
 import PropTypes from 'prop-types';
+import { Component, PureComponent, cloneElement, Children } from 'react';
+
 import { Switch, Route } from 'react-router-dom';
+
 import StackTrace from 'stacktrace-js';
-import ColumnLoading from '../components/column_loading';
+
 import BundleColumnError from '../components/bundle_column_error';
+import ColumnLoading from '../components/column_loading';
 import BundleContainer from '../containers/bundle_container';
 
 // Small wrapper to pass multiColumn to the route components

--- a/app/javascript/mastodon/features/ui/util/reduced_motion.jsx
+++ b/app/javascript/mastodon/features/ui/util/reduced_motion.jsx
@@ -1,8 +1,9 @@
 // Like react-motion's Motion, but reduces all animations to cross-fades
 // for the benefit of users with motion sickness.
-import { Component } from 'react';
-import Motion from 'react-motion/lib/Motion';
 import PropTypes from 'prop-types';
+import { Component } from 'react';
+
+import Motion from 'react-motion/lib/Motion';
 
 const stylesToKeep = ['opacity', 'backgroundOpacity'];
 

--- a/app/javascript/mastodon/features/video/index.jsx
+++ b/app/javascript/mastodon/features/video/index.jsx
@@ -15,7 +15,6 @@ import { Icon }  from 'mastodon/components/icon';
 import { displayMedia, useBlurhash } from '../../initial_state';
 import { isFullscreen, requestFullscreen, exitFullscreen } from '../ui/util/fullscreen';
 
-
 const messages = defineMessages({
   play: { id: 'video.play', defaultMessage: 'Play' },
   pause: { id: 'video.pause', defaultMessage: 'Pause' },

--- a/app/javascript/mastodon/features/video/index.jsx
+++ b/app/javascript/mastodon/features/video/index.jsx
@@ -1,13 +1,20 @@
-import { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { is } from 'immutable';
-import { throttle } from 'lodash';
+
 import classNames from 'classnames';
-import { isFullscreen, requestFullscreen, exitFullscreen } from '../ui/util/fullscreen';
-import { displayMedia, useBlurhash } from '../../initial_state';
-import { Icon }  from 'mastodon/components/icon';
+
+import { is } from 'immutable';
+
+import { throttle } from 'lodash';
+
 import { Blurhash } from 'mastodon/components/blurhash';
+import { Icon }  from 'mastodon/components/icon';
+
+import { displayMedia, useBlurhash } from '../../initial_state';
+import { isFullscreen, requestFullscreen, exitFullscreen } from '../ui/util/fullscreen';
+
 
 const messages = defineMessages({
   play: { id: 'video.play', defaultMessage: 'Play' },

--- a/app/javascript/mastodon/main.jsx
+++ b/app/javascript/mastodon/main.jsx
@@ -1,10 +1,11 @@
 import { createRoot } from 'react-dom/client';
+
 import { setupBrowserNotifications } from 'mastodon/actions/notifications';
 import Mastodon from 'mastodon/containers/mastodon';
-import { store } from 'mastodon/store';
 import { me } from 'mastodon/initial_state';
-import ready from 'mastodon/ready';
 import * as perf from 'mastodon/performance';
+import ready from 'mastodon/ready';
+import { store } from 'mastodon/store';
 
 /**
  * @returns {Promise<void>}

--- a/app/javascript/mastodon/reducers/accounts.js
+++ b/app/javascript/mastodon/reducers/accounts.js
@@ -1,6 +1,7 @@
-import { ACCOUNT_IMPORT, ACCOUNTS_IMPORT } from 'mastodon/actions/importer';
-import { ACCOUNT_REVEAL } from 'mastodon/actions/accounts';
 import { Map as ImmutableMap, fromJS } from 'immutable';
+
+import { ACCOUNT_REVEAL } from 'mastodon/actions/accounts';
+import { ACCOUNT_IMPORT, ACCOUNTS_IMPORT } from 'mastodon/actions/importer';
 
 const initialState = ImmutableMap();
 

--- a/app/javascript/mastodon/reducers/accounts_counters.js
+++ b/app/javascript/mastodon/reducers/accounts_counters.js
@@ -1,10 +1,12 @@
+import { Map as ImmutableMap, fromJS } from 'immutable';
+
+import { me } from 'mastodon/initial_state';
+
 import {
   ACCOUNT_FOLLOW_SUCCESS,
   ACCOUNT_UNFOLLOW_SUCCESS,
 } from '../actions/accounts';
 import { ACCOUNT_IMPORT, ACCOUNTS_IMPORT } from '../actions/importer';
-import { Map as ImmutableMap, fromJS } from 'immutable';
-import { me } from 'mastodon/initial_state';
 
 const normalizeAccount = (state, account) => state.set(account.id, fromJS({
   followers_count: account.followers_count,

--- a/app/javascript/mastodon/reducers/accounts_map.js
+++ b/app/javascript/mastodon/reducers/accounts_map.js
@@ -1,6 +1,7 @@
-import { ACCOUNT_IMPORT, ACCOUNTS_IMPORT } from '../actions/importer';
-import { ACCOUNT_LOOKUP_FAIL } from '../actions/accounts';
 import { Map as ImmutableMap } from 'immutable';
+
+import { ACCOUNT_LOOKUP_FAIL } from '../actions/accounts';
+import { ACCOUNT_IMPORT, ACCOUNTS_IMPORT } from '../actions/importer';
 
 export const normalizeForLookup = str => str.toLowerCase();
 

--- a/app/javascript/mastodon/reducers/alerts.js
+++ b/app/javascript/mastodon/reducers/alerts.js
@@ -1,9 +1,10 @@
+import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+
 import {
   ALERT_SHOW,
   ALERT_DISMISS,
   ALERT_CLEAR,
 } from '../actions/alerts';
-import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
 
 const initialState = ImmutableList([]);
 

--- a/app/javascript/mastodon/reducers/announcements.js
+++ b/app/javascript/mastodon/reducers/announcements.js
@@ -1,3 +1,5 @@
+import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
+
 import {
   ANNOUNCEMENTS_FETCH_REQUEST,
   ANNOUNCEMENTS_FETCH_SUCCESS,
@@ -12,7 +14,6 @@ import {
   ANNOUNCEMENTS_DELETE,
   ANNOUNCEMENTS_DISMISS_SUCCESS,
 } from '../actions/announcements';
-import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 
 const initialState = ImmutableMap({
   items: ImmutableList(),

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -1,3 +1,5 @@
+import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
+
 import {
   COMPOSE_MOUNT,
   COMPOSE_UNMOUNT,
@@ -48,13 +50,12 @@ import {
   COMPOSE_SET_STATUS,
   COMPOSE_FOCUS,
 } from '../actions/compose';
-import { TIMELINE_DELETE } from '../actions/timelines';
-import { STORE_HYDRATE } from '../actions/store';
 import { REDRAFT } from '../actions/statuses';
-import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
-import { uuid } from '../uuid';
+import { STORE_HYDRATE } from '../actions/store';
+import { TIMELINE_DELETE } from '../actions/timelines';
 import { me } from '../initial_state';
 import { unescapeHTML } from '../utils/html';
+import { uuid } from '../uuid';
 
 const initialState = ImmutableMap({
   mounted: 0,

--- a/app/javascript/mastodon/reducers/contexts.js
+++ b/app/javascript/mastodon/reducers/contexts.js
@@ -1,10 +1,11 @@
+import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+
 import {
   ACCOUNT_BLOCK_SUCCESS,
   ACCOUNT_MUTE_SUCCESS,
 } from '../actions/accounts';
 import { CONTEXT_FETCH_SUCCESS } from '../actions/statuses';
 import { TIMELINE_DELETE, TIMELINE_UPDATE } from '../actions/timelines';
-import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
 import { compareId } from '../compare_id';
 
 const initialState = ImmutableMap({

--- a/app/javascript/mastodon/reducers/conversations.js
+++ b/app/javascript/mastodon/reducers/conversations.js
@@ -1,4 +1,8 @@
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+
+import { ACCOUNT_BLOCK_SUCCESS, ACCOUNT_MUTE_SUCCESS } from 'mastodon/actions/accounts';
+import { DOMAIN_BLOCK_SUCCESS } from 'mastodon/actions/domain_blocks';
+
 import {
   CONVERSATIONS_MOUNT,
   CONVERSATIONS_UNMOUNT,
@@ -9,8 +13,6 @@ import {
   CONVERSATIONS_READ,
   CONVERSATIONS_DELETE_SUCCESS,
 } from '../actions/conversations';
-import { ACCOUNT_BLOCK_SUCCESS, ACCOUNT_MUTE_SUCCESS } from 'mastodon/actions/accounts';
-import { DOMAIN_BLOCK_SUCCESS } from 'mastodon/actions/domain_blocks';
 import { compareId } from '../compare_id';
 
 const initialState = ImmutableMap({

--- a/app/javascript/mastodon/reducers/custom_emojis.js
+++ b/app/javascript/mastodon/reducers/custom_emojis.js
@@ -1,7 +1,8 @@
 import { List as ImmutableList, fromJS as ConvertToImmutable } from 'immutable';
+
 import { CUSTOM_EMOJIS_FETCH_SUCCESS } from '../actions/custom_emojis';
-import { search as emojiSearch } from '../features/emoji/emoji_mart_search_light';
 import { buildCustomEmojis } from '../features/emoji/emoji';
+import { search as emojiSearch } from '../features/emoji/emoji_mart_search_light';
 
 const initialState = ImmutableList([]);
 

--- a/app/javascript/mastodon/reducers/domain_lists.js
+++ b/app/javascript/mastodon/reducers/domain_lists.js
@@ -1,9 +1,10 @@
+import { Map as ImmutableMap, OrderedSet as ImmutableOrderedSet } from 'immutable';
+
 import {
   DOMAIN_BLOCKS_FETCH_SUCCESS,
   DOMAIN_BLOCKS_EXPAND_SUCCESS,
   DOMAIN_UNBLOCK_SUCCESS,
 } from '../actions/domain_blocks';
-import { Map as ImmutableMap, OrderedSet as ImmutableOrderedSet } from 'immutable';
 
 const initialState = ImmutableMap({
   blocks: ImmutableMap({

--- a/app/javascript/mastodon/reducers/dropdown_menu.js
+++ b/app/javascript/mastodon/reducers/dropdown_menu.js
@@ -1,4 +1,5 @@
 import Immutable from 'immutable';
+
 import {
   DROPDOWN_MENU_OPEN,
   DROPDOWN_MENU_CLOSE,

--- a/app/javascript/mastodon/reducers/filters.js
+++ b/app/javascript/mastodon/reducers/filters.js
@@ -1,6 +1,7 @@
-import { FILTERS_IMPORT } from '../actions/importer';
-import { FILTERS_FETCH_SUCCESS, FILTERS_CREATE_SUCCESS } from '../actions/filters';
 import { Map as ImmutableMap, is, fromJS } from 'immutable';
+
+import { FILTERS_FETCH_SUCCESS, FILTERS_CREATE_SUCCESS } from '../actions/filters';
+import { FILTERS_IMPORT } from '../actions/importer';
 
 const normalizeFilter = (state, filter) => {
   const normalizedFilter = fromJS({

--- a/app/javascript/mastodon/reducers/followed_tags.js
+++ b/app/javascript/mastodon/reducers/followed_tags.js
@@ -1,3 +1,5 @@
+import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
+
 import {
   FOLLOWED_HASHTAGS_FETCH_REQUEST,
   FOLLOWED_HASHTAGS_FETCH_SUCCESS,
@@ -6,7 +8,6 @@ import {
   FOLLOWED_HASHTAGS_EXPAND_SUCCESS,
   FOLLOWED_HASHTAGS_EXPAND_FAIL,
 } from 'mastodon/actions/tags';
-import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 
 const initialState = ImmutableMap({
   items: ImmutableList(),

--- a/app/javascript/mastodon/reducers/height_cache.js
+++ b/app/javascript/mastodon/reducers/height_cache.js
@@ -1,4 +1,5 @@
 import { Map as ImmutableMap } from 'immutable';
+
 import { HEIGHT_CACHE_SET, HEIGHT_CACHE_CLEAR } from '../actions/height_cache';
 
 const initialState = ImmutableMap();

--- a/app/javascript/mastodon/reducers/history.js
+++ b/app/javascript/mastodon/reducers/history.js
@@ -1,5 +1,6 @@
-import { HISTORY_FETCH_REQUEST, HISTORY_FETCH_SUCCESS, HISTORY_FETCH_FAIL } from 'mastodon/actions/history';
 import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
+
+import { HISTORY_FETCH_REQUEST, HISTORY_FETCH_SUCCESS, HISTORY_FETCH_FAIL } from 'mastodon/actions/history';
 
 const initialHistory = ImmutableMap({
   loading: false,

--- a/app/javascript/mastodon/reducers/list_adder.js
+++ b/app/javascript/mastodon/reducers/list_adder.js
@@ -1,4 +1,5 @@
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+
 import {
   LIST_ADDER_RESET,
   LIST_ADDER_SETUP,

--- a/app/javascript/mastodon/reducers/list_editor.js
+++ b/app/javascript/mastodon/reducers/list_editor.js
@@ -1,4 +1,5 @@
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
+
 import {
   LIST_CREATE_REQUEST,
   LIST_CREATE_FAIL,

--- a/app/javascript/mastodon/reducers/lists.js
+++ b/app/javascript/mastodon/reducers/lists.js
@@ -1,3 +1,5 @@
+import { Map as ImmutableMap, fromJS } from 'immutable';
+
 import {
   LIST_FETCH_SUCCESS,
   LIST_FETCH_FAIL,
@@ -6,7 +8,6 @@ import {
   LIST_UPDATE_SUCCESS,
   LIST_DELETE_SUCCESS,
 } from '../actions/lists';
-import { Map as ImmutableMap, fromJS } from 'immutable';
 
 const initialState = ImmutableMap();
 

--- a/app/javascript/mastodon/reducers/markers.js
+++ b/app/javascript/mastodon/reducers/markers.js
@@ -1,8 +1,9 @@
+import { Map as ImmutableMap } from 'immutable';
+
 import {
   MARKERS_SUBMIT_SUCCESS,
 } from '../actions/markers';
 
-import { Map as ImmutableMap } from 'immutable';
 
 const initialState = ImmutableMap({
   home: '0',

--- a/app/javascript/mastodon/reducers/media_attachments.js
+++ b/app/javascript/mastodon/reducers/media_attachments.js
@@ -1,5 +1,6 @@
-import { STORE_HYDRATE } from '../actions/store';
 import { Map as ImmutableMap } from 'immutable';
+
+import { STORE_HYDRATE } from '../actions/store';
 
 const initialState = ImmutableMap({
   accept_content_types: [],

--- a/app/javascript/mastodon/reducers/meta.js
+++ b/app/javascript/mastodon/reducers/meta.js
@@ -1,6 +1,7 @@
-import { STORE_HYDRATE } from 'mastodon/actions/store';
-import { changeLayout } from 'mastodon/actions/app';
 import { Map as ImmutableMap } from 'immutable';
+
+import { changeLayout } from 'mastodon/actions/app';
+import { STORE_HYDRATE } from 'mastodon/actions/store';
 import { layoutFromWindow } from 'mastodon/is_mobile';
 
 const initialState = ImmutableMap({

--- a/app/javascript/mastodon/reducers/modal.js
+++ b/app/javascript/mastodon/reducers/modal.js
@@ -1,7 +1,8 @@
+import { Stack as ImmutableStack, Map as ImmutableMap } from 'immutable';
+
+import { COMPOSE_UPLOAD_CHANGE_SUCCESS } from '../actions/compose';
 import { MODAL_OPEN, MODAL_CLOSE } from '../actions/modal';
 import { TIMELINE_DELETE } from '../actions/timelines';
-import { COMPOSE_UPLOAD_CHANGE_SUCCESS } from '../actions/compose';
-import { Stack as ImmutableStack, Map as ImmutableMap } from 'immutable';
 
 const initialState = ImmutableMap({
   ignoreFocus: false,

--- a/app/javascript/mastodon/reducers/notifications.js
+++ b/app/javascript/mastodon/reducers/notifications.js
@@ -1,3 +1,20 @@
+import { fromJS, Map as ImmutableMap, List as ImmutableList } from 'immutable';
+
+import { DOMAIN_BLOCK_SUCCESS } from 'mastodon/actions/domain_blocks';
+
+import {
+  ACCOUNT_BLOCK_SUCCESS,
+  ACCOUNT_MUTE_SUCCESS,
+  FOLLOW_REQUEST_AUTHORIZE_SUCCESS,
+  FOLLOW_REQUEST_REJECT_SUCCESS,
+} from '../actions/accounts';
+import {
+  focusApp,
+  unfocusApp,
+} from '../actions/app';
+import {
+  MARKERS_FETCH_SUCCESS,
+} from '../actions/markers';
 import {
   NOTIFICATIONS_UPDATE,
   NOTIFICATIONS_EXPAND_SUCCESS,
@@ -13,22 +30,7 @@ import {
   NOTIFICATIONS_SET_BROWSER_SUPPORT,
   NOTIFICATIONS_SET_BROWSER_PERMISSION,
 } from '../actions/notifications';
-import {
-  ACCOUNT_BLOCK_SUCCESS,
-  ACCOUNT_MUTE_SUCCESS,
-  FOLLOW_REQUEST_AUTHORIZE_SUCCESS,
-  FOLLOW_REQUEST_REJECT_SUCCESS,
-} from '../actions/accounts';
-import {
-  MARKERS_FETCH_SUCCESS,
-} from '../actions/markers';
-import {
-  focusApp,
-  unfocusApp,
-} from '../actions/app';
-import { DOMAIN_BLOCK_SUCCESS } from 'mastodon/actions/domain_blocks';
 import { TIMELINE_DELETE, TIMELINE_DISCONNECT } from '../actions/timelines';
-import { fromJS, Map as ImmutableMap, List as ImmutableList } from 'immutable';
 import { compareId } from '../compare_id';
 
 const initialState = ImmutableMap({

--- a/app/javascript/mastodon/reducers/picture_in_picture.js
+++ b/app/javascript/mastodon/reducers/picture_in_picture.js
@@ -1,4 +1,5 @@
 import { PICTURE_IN_PICTURE_DEPLOY, PICTURE_IN_PICTURE_REMOVE } from 'mastodon/actions/picture_in_picture';
+
 import { TIMELINE_DELETE } from '../actions/timelines';
 
 const initialState = {

--- a/app/javascript/mastodon/reducers/polls.js
+++ b/app/javascript/mastodon/reducers/polls.js
@@ -1,5 +1,6 @@
-import { POLLS_IMPORT } from 'mastodon/actions/importer';
 import { Map as ImmutableMap, fromJS } from 'immutable';
+
+import { POLLS_IMPORT } from 'mastodon/actions/importer';
 
 const importPolls = (state, polls) => state.withMutations(map => polls.forEach(poll => map.set(poll.id, fromJS(poll))));
 

--- a/app/javascript/mastodon/reducers/push_notifications.js
+++ b/app/javascript/mastodon/reducers/push_notifications.js
@@ -1,6 +1,7 @@
-import { STORE_HYDRATE } from '../actions/store';
-import { SET_BROWSER_SUPPORT, SET_SUBSCRIPTION, CLEAR_SUBSCRIPTION, SET_ALERTS } from '../actions/push_notifications';
 import Immutable from 'immutable';
+
+import { SET_BROWSER_SUPPORT, SET_SUBSCRIPTION, CLEAR_SUBSCRIPTION, SET_ALERTS } from '../actions/push_notifications';
+import { STORE_HYDRATE } from '../actions/store';
 
 const initialState = Immutable.Map({
   subscription: null,

--- a/app/javascript/mastodon/reducers/relationships.js
+++ b/app/javascript/mastodon/reducers/relationships.js
@@ -1,6 +1,8 @@
+import { Map as ImmutableMap, fromJS } from 'immutable';
+
 import {
-  NOTIFICATIONS_UPDATE,
-} from '../actions/notifications';
+  ACCOUNT_NOTE_SUBMIT_SUCCESS,
+} from '../actions/account_notes';
 import {
   ACCOUNT_FOLLOW_SUCCESS,
   ACCOUNT_FOLLOW_REQUEST,
@@ -23,9 +25,9 @@ import {
   DOMAIN_UNBLOCK_SUCCESS,
 } from '../actions/domain_blocks';
 import {
-  ACCOUNT_NOTE_SUBMIT_SUCCESS,
-} from '../actions/account_notes';
-import { Map as ImmutableMap, fromJS } from 'immutable';
+  NOTIFICATIONS_UPDATE,
+} from '../actions/notifications';
+
 
 const normalizeRelationship = (state, relationship) => state.set(relationship.id, fromJS(relationship));
 

--- a/app/javascript/mastodon/reducers/search.js
+++ b/app/javascript/mastodon/reducers/search.js
@@ -1,3 +1,10 @@
+import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
+
+import {
+  COMPOSE_MENTION,
+  COMPOSE_REPLY,
+  COMPOSE_DIRECT,
+} from '../actions/compose';
 import {
   SEARCH_CHANGE,
   SEARCH_CLEAR,
@@ -9,12 +16,6 @@ import {
   SEARCH_RESULT_CLICK,
   SEARCH_RESULT_FORGET,
 } from '../actions/search';
-import {
-  COMPOSE_MENTION,
-  COMPOSE_REPLY,
-  COMPOSE_DIRECT,
-} from '../actions/compose';
-import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
 
 const initialState = ImmutableMap({
   value: '',

--- a/app/javascript/mastodon/reducers/server.js
+++ b/app/javascript/mastodon/reducers/server.js
@@ -1,3 +1,5 @@
+import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
+
 import {
   SERVER_FETCH_REQUEST,
   SERVER_FETCH_SUCCESS,
@@ -12,7 +14,6 @@ import {
   SERVER_DOMAIN_BLOCKS_FETCH_SUCCESS,
   SERVER_DOMAIN_BLOCKS_FETCH_FAIL,
 } from 'mastodon/actions/server';
-import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 
 const initialState = ImmutableMap({
   server: ImmutableMap({

--- a/app/javascript/mastodon/reducers/settings.js
+++ b/app/javascript/mastodon/reducers/settings.js
@@ -1,11 +1,12 @@
-import { SETTING_CHANGE, SETTING_SAVE } from '../actions/settings';
-import { NOTIFICATIONS_FILTER_SET } from '../actions/notifications';
+import { Map as ImmutableMap, fromJS } from 'immutable';
+
 import { COLUMN_ADD, COLUMN_REMOVE, COLUMN_MOVE, COLUMN_PARAMS_CHANGE } from '../actions/columns';
-import { STORE_HYDRATE } from '../actions/store';
 import { EMOJI_USE } from '../actions/emojis';
 import { LANGUAGE_USE } from '../actions/languages';
 import { LIST_DELETE_SUCCESS, LIST_FETCH_FAIL } from '../actions/lists';
-import { Map as ImmutableMap, fromJS } from 'immutable';
+import { NOTIFICATIONS_FILTER_SET } from '../actions/notifications';
+import { SETTING_CHANGE, SETTING_SAVE } from '../actions/settings';
+import { STORE_HYDRATE } from '../actions/store';
 import { uuid } from '../uuid';
 
 const initialState = ImmutableMap({

--- a/app/javascript/mastodon/reducers/status_lists.js
+++ b/app/javascript/mastodon/reducers/status_lists.js
@@ -1,3 +1,17 @@
+import { Map as ImmutableMap, OrderedSet as ImmutableOrderedSet } from 'immutable';
+
+import {
+  ACCOUNT_BLOCK_SUCCESS,
+  ACCOUNT_MUTE_SUCCESS,
+} from '../actions/accounts';
+import {
+  BOOKMARKED_STATUSES_FETCH_REQUEST,
+  BOOKMARKED_STATUSES_FETCH_SUCCESS,
+  BOOKMARKED_STATUSES_FETCH_FAIL,
+  BOOKMARKED_STATUSES_EXPAND_REQUEST,
+  BOOKMARKED_STATUSES_EXPAND_SUCCESS,
+  BOOKMARKED_STATUSES_EXPAND_FAIL,
+} from '../actions/bookmarks';
 import {
   FAVOURITED_STATUSES_FETCH_REQUEST,
   FAVOURITED_STATUSES_FETCH_SUCCESS,
@@ -7,13 +21,13 @@ import {
   FAVOURITED_STATUSES_EXPAND_FAIL,
 } from '../actions/favourites';
 import {
-  BOOKMARKED_STATUSES_FETCH_REQUEST,
-  BOOKMARKED_STATUSES_FETCH_SUCCESS,
-  BOOKMARKED_STATUSES_FETCH_FAIL,
-  BOOKMARKED_STATUSES_EXPAND_REQUEST,
-  BOOKMARKED_STATUSES_EXPAND_SUCCESS,
-  BOOKMARKED_STATUSES_EXPAND_FAIL,
-} from '../actions/bookmarks';
+  FAVOURITE_SUCCESS,
+  UNFAVOURITE_SUCCESS,
+  BOOKMARK_SUCCESS,
+  UNBOOKMARK_SUCCESS,
+  PIN_SUCCESS,
+  UNPIN_SUCCESS,
+} from '../actions/interactions';
 import {
   PINNED_STATUSES_FETCH_SUCCESS,
 } from '../actions/pin_statuses';
@@ -25,19 +39,8 @@ import {
   TRENDS_STATUSES_EXPAND_SUCCESS,
   TRENDS_STATUSES_EXPAND_FAIL,
 } from '../actions/trends';
-import { Map as ImmutableMap, OrderedSet as ImmutableOrderedSet } from 'immutable';
-import {
-  FAVOURITE_SUCCESS,
-  UNFAVOURITE_SUCCESS,
-  BOOKMARK_SUCCESS,
-  UNBOOKMARK_SUCCESS,
-  PIN_SUCCESS,
-  UNPIN_SUCCESS,
-} from '../actions/interactions';
-import {
-  ACCOUNT_BLOCK_SUCCESS,
-  ACCOUNT_MUTE_SUCCESS,
-} from '../actions/accounts';
+
+
 
 const initialState = ImmutableMap({
   favourites: ImmutableMap({

--- a/app/javascript/mastodon/reducers/statuses.js
+++ b/app/javascript/mastodon/reducers/statuses.js
@@ -1,3 +1,6 @@
+import { Map as ImmutableMap, fromJS } from 'immutable';
+
+import { STATUS_IMPORT, STATUSES_IMPORT } from '../actions/importer';
 import {
   REBLOG_REQUEST,
   REBLOG_FAIL,
@@ -19,8 +22,6 @@ import {
   STATUS_FETCH_FAIL,
 } from '../actions/statuses';
 import { TIMELINE_DELETE } from '../actions/timelines';
-import { STATUS_IMPORT, STATUSES_IMPORT } from '../actions/importer';
-import { Map as ImmutableMap, fromJS } from 'immutable';
 
 const importStatus = (state, status) => state.set(status.id, fromJS(status));
 

--- a/app/javascript/mastodon/reducers/suggestions.js
+++ b/app/javascript/mastodon/reducers/suggestions.js
@@ -1,12 +1,15 @@
+import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
+
+import { ACCOUNT_BLOCK_SUCCESS, ACCOUNT_MUTE_SUCCESS } from 'mastodon/actions/accounts';
+import { DOMAIN_BLOCK_SUCCESS } from 'mastodon/actions/domain_blocks';
+
 import {
   SUGGESTIONS_FETCH_REQUEST,
   SUGGESTIONS_FETCH_SUCCESS,
   SUGGESTIONS_FETCH_FAIL,
   SUGGESTIONS_DISMISS,
 } from '../actions/suggestions';
-import { ACCOUNT_BLOCK_SUCCESS, ACCOUNT_MUTE_SUCCESS } from 'mastodon/actions/accounts';
-import { DOMAIN_BLOCK_SUCCESS } from 'mastodon/actions/domain_blocks';
-import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
+
 
 const initialState = ImmutableMap({
   items: ImmutableList(),

--- a/app/javascript/mastodon/reducers/tags.js
+++ b/app/javascript/mastodon/reducers/tags.js
@@ -1,3 +1,5 @@
+import { Map as ImmutableMap, fromJS } from 'immutable';
+
 import {
   HASHTAG_FETCH_SUCCESS,
   HASHTAG_FOLLOW_REQUEST,
@@ -5,7 +7,6 @@ import {
   HASHTAG_UNFOLLOW_REQUEST,
   HASHTAG_UNFOLLOW_FAIL,
 } from 'mastodon/actions/tags';
-import { Map as ImmutableMap, fromJS } from 'immutable';
 
 const initialState = ImmutableMap();
 

--- a/app/javascript/mastodon/reducers/timelines.js
+++ b/app/javascript/mastodon/reducers/timelines.js
@@ -1,3 +1,10 @@
+import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
+
+import {
+  ACCOUNT_BLOCK_SUCCESS,
+  ACCOUNT_MUTE_SUCCESS,
+  ACCOUNT_UNFOLLOW_SUCCESS,
+} from '../actions/accounts';
 import {
   TIMELINE_UPDATE,
   TIMELINE_DELETE,
@@ -11,12 +18,6 @@ import {
   TIMELINE_LOAD_PENDING,
   TIMELINE_MARK_AS_PARTIAL,
 } from '../actions/timelines';
-import {
-  ACCOUNT_BLOCK_SUCCESS,
-  ACCOUNT_MUTE_SUCCESS,
-  ACCOUNT_UNFOLLOW_SUCCESS,
-} from '../actions/accounts';
-import { Map as ImmutableMap, List as ImmutableList, OrderedSet as ImmutableOrderedSet, fromJS } from 'immutable';
 import { compareId } from '../compare_id';
 
 const initialState = ImmutableMap();

--- a/app/javascript/mastodon/reducers/trends.js
+++ b/app/javascript/mastodon/reducers/trends.js
@@ -1,3 +1,5 @@
+import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
+
 import {
   TRENDS_TAGS_FETCH_REQUEST,
   TRENDS_TAGS_FETCH_SUCCESS,
@@ -6,7 +8,6 @@ import {
   TRENDS_LINKS_FETCH_SUCCESS,
   TRENDS_LINKS_FETCH_FAIL,
 } from 'mastodon/actions/trends';
-import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
 
 const initialState = ImmutableMap({
   tags: ImmutableMap({

--- a/app/javascript/mastodon/reducers/user_lists.js
+++ b/app/javascript/mastodon/reducers/user_lists.js
@@ -1,6 +1,19 @@
+import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
+
 import {
-  NOTIFICATIONS_UPDATE,
-} from '../actions/notifications';
+  DIRECTORY_FETCH_REQUEST,
+  DIRECTORY_FETCH_SUCCESS,
+  DIRECTORY_FETCH_FAIL,
+  DIRECTORY_EXPAND_REQUEST,
+  DIRECTORY_EXPAND_SUCCESS,
+  DIRECTORY_EXPAND_FAIL,
+} from 'mastodon/actions/directory';
+import {
+  FEATURED_TAGS_FETCH_REQUEST,
+  FEATURED_TAGS_FETCH_SUCCESS,
+  FEATURED_TAGS_FETCH_FAIL,
+} from 'mastodon/actions/featured_tags';
+
 import {
   FOLLOWERS_FETCH_REQUEST,
   FOLLOWERS_FETCH_SUCCESS,
@@ -24,10 +37,6 @@ import {
   FOLLOW_REQUEST_REJECT_SUCCESS,
 } from '../actions/accounts';
 import {
-  REBLOGS_FETCH_SUCCESS,
-  FAVOURITES_FETCH_SUCCESS,
-} from '../actions/interactions';
-import {
   BLOCKS_FETCH_REQUEST,
   BLOCKS_FETCH_SUCCESS,
   BLOCKS_FETCH_FAIL,
@@ -35,6 +44,10 @@ import {
   BLOCKS_EXPAND_SUCCESS,
   BLOCKS_EXPAND_FAIL,
 } from '../actions/blocks';
+import {
+  REBLOGS_FETCH_SUCCESS,
+  FAVOURITES_FETCH_SUCCESS,
+} from '../actions/interactions';
 import {
   MUTES_FETCH_REQUEST,
   MUTES_FETCH_SUCCESS,
@@ -44,19 +57,10 @@ import {
   MUTES_EXPAND_FAIL,
 } from '../actions/mutes';
 import {
-  DIRECTORY_FETCH_REQUEST,
-  DIRECTORY_FETCH_SUCCESS,
-  DIRECTORY_FETCH_FAIL,
-  DIRECTORY_EXPAND_REQUEST,
-  DIRECTORY_EXPAND_SUCCESS,
-  DIRECTORY_EXPAND_FAIL,
-} from 'mastodon/actions/directory';
-import {
-  FEATURED_TAGS_FETCH_REQUEST,
-  FEATURED_TAGS_FETCH_SUCCESS,
-  FEATURED_TAGS_FETCH_FAIL,
-} from 'mastodon/actions/featured_tags';
-import { Map as ImmutableMap, List as ImmutableList, fromJS } from 'immutable';
+  NOTIFICATIONS_UPDATE,
+} from '../actions/notifications';
+
+
 
 const initialListState = ImmutableMap({
   next: null,

--- a/app/javascript/mastodon/selectors/index.js
+++ b/app/javascript/mastodon/selectors/index.js
@@ -1,6 +1,8 @@
-import { createSelector } from 'reselect';
 import { List as ImmutableList, Map as ImmutableMap } from 'immutable';
+import { createSelector } from 'reselect';
+
 import { toServerSideType } from 'mastodon/utils/filters';
+
 import { me } from '../initial_state';
 
 const getAccountBase         = (state, id) => state.getIn(['accounts', id], null);

--- a/app/javascript/mastodon/service_worker/entry.js
+++ b/app/javascript/mastodon/service_worker/entry.js
@@ -2,6 +2,7 @@ import { ExpirationPlugin } from 'workbox-expiration';
 import { precacheAndRoute } from 'workbox-precaching';
 import { registerRoute } from 'workbox-routing';
 import { CacheFirst } from 'workbox-strategies';
+
 import { handleNotificationClick, handlePush } from './web_push_notifications';
 
 const CACHE_NAME_PREFIX = 'mastodon-';

--- a/app/javascript/mastodon/service_worker/web_push_notifications.js
+++ b/app/javascript/mastodon/service_worker/web_push_notifications.js
@@ -1,5 +1,7 @@
 import IntlMessageFormat from 'intl-messageformat';
+
 import { unescape } from 'lodash';
+
 import locales from './web_push_locales';
 
 const MAX_NOTIFICATIONS = 5;

--- a/app/javascript/packs/admin.jsx
+++ b/app/javascript/packs/admin.jsx
@@ -1,8 +1,10 @@
 import './public-path';
-import { delegate } from '@rails/ujs';
-import ready from '../mastodon/ready';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+
+import { delegate } from '@rails/ujs';
+
+import ready from '../mastodon/ready';
 
 const setAnnouncementEndsAttributes = (target) => {
   const valid = target?.value && target?.validity?.valid;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,6 +1,6 @@
 import './public-path';
-import { loadPolyfills } from '../mastodon/polyfills';
 import { start } from '../mastodon/common';
+import { loadPolyfills } from '../mastodon/polyfills';
 
 start();
 

--- a/app/javascript/packs/public.jsx
+++ b/app/javascript/packs/public.jsx
@@ -1,22 +1,25 @@
+import { createRoot }  from 'react-dom/client';
+
 import './public-path';
+
+import * as IntlMessageFormat  from 'intl-messageformat';
+import { defineMessages } from 'react-intl';
+
+import { delegate }  from '@rails/ujs';
+import axios from 'axios';
 import escapeTextContentForBrowser from 'escape-html';
+import { createBrowserHistory }  from 'history';
+import { throttle } from 'lodash';
+
+import { start } from '../mastodon/common';
+import { timeAgoString }  from '../mastodon/components/relative_timestamp';
+import emojify  from '../mastodon/features/emoji/emoji';
+import loadKeyboardExtensions from '../mastodon/load_keyboard_extensions';
+import { getLocale }  from '../mastodon/locales';
 import { loadPolyfills } from '../mastodon/polyfills';
 import ready from '../mastodon/ready';
-import { start } from '../mastodon/common';
 
-import loadKeyboardExtensions from '../mastodon/load_keyboard_extensions';
 import 'cocoon-js-vanilla';
-import axios from 'axios';
-import { throttle } from 'lodash';
-import { defineMessages } from 'react-intl';
-import * as IntlMessageFormat  from 'intl-messageformat';
-import { timeAgoString }  from '../mastodon/components/relative_timestamp';
-import { delegate }  from '@rails/ujs';
-import emojify  from '../mastodon/features/emoji/emoji';
-import { getLocale }  from '../mastodon/locales';
-import React  from 'react';
-import { createRoot }  from 'react-dom/client';
-import { createBrowserHistory }  from 'history';
 
 start();
 

--- a/app/javascript/packs/share.jsx
+++ b/app/javascript/packs/share.jsx
@@ -1,10 +1,13 @@
 import './public-path';
-import { loadPolyfills } from '../mastodon/polyfills';
-import { start } from '../mastodon/common';
-import ready from '../mastodon/ready';
-import ComposeContainer  from '../mastodon/containers/compose_container';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+
+import { start } from '../mastodon/common';
+import ComposeContainer  from '../mastodon/containers/compose_container';
+import { loadPolyfills } from '../mastodon/polyfills';
+import ready from '../mastodon/ready';
+
+
 
 start();
 

--- a/app/javascript/packs/share.jsx
+++ b/app/javascript/packs/share.jsx
@@ -7,8 +7,6 @@ import ComposeContainer  from '../mastodon/containers/compose_container';
 import { loadPolyfills } from '../mastodon/polyfills';
 import ready from '../mastodon/ready';
 
-
-
 start();
 
 function loaded() {

--- a/app/javascript/packs/sign_up.js
+++ b/app/javascript/packs/sign_up.js
@@ -1,6 +1,7 @@
 import './public-path';
-import ready from '../mastodon/ready';
 import axios from 'axios';
+
+import ready from '../mastodon/ready';
 
 ready(() => {
   setInterval(() => {

--- a/app/javascript/packs/two_factor_authentication.js
+++ b/app/javascript/packs/two_factor_authentication.js
@@ -1,5 +1,6 @@
-import axios from 'axios';
 import * as WebAuthnJSON from '@github/webauthn-json';
+import axios from 'axios';
+
 import ready from '../mastodon/ready';
 import 'regenerator-runtime/runtime';
 

--- a/config/webpack/configuration.js
+++ b/config/webpack/configuration.js
@@ -1,9 +1,10 @@
 // Common configuration for webpacker loaded from config/webpacker.yml
 
+const { readFileSync } = require('fs');
 const { resolve } = require('path');
 const { env } = require('process');
+
 const { load } = require('js-yaml');
-const { readFileSync } = require('fs');
 
 const configPath = resolve('config', 'webpacker.yml');
 const settings = load(readFileSync(configPath), 'utf8')[env.RAILS_ENV || env.NODE_ENV];

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,8 +1,9 @@
 // Note: You must restart bin/webpack-dev-server for changes to take effect
 
 const { merge } = require('webpack-merge');
-const sharedConfig = require('./shared');
+
 const { settings, output } = require('./configuration');
+const sharedConfig = require('./shared');
 
 const watchOptions = {};
 

--- a/config/webpack/generateLocalePacks.js
+++ b/config/webpack/generateLocalePacks.js
@@ -4,8 +4,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const rimraf = require('rimraf');
+
 const { mkdirp } = require('mkdirp');
+const rimraf = require('rimraf');
 
 const localesJsonPath = path.join(__dirname, '../../app/javascript/mastodon/locales');
 const locales = fs.readdirSync(localesJsonPath).filter(filename => {

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -3,11 +3,13 @@
 const { createHash } = require('crypto');
 const { readFileSync } = require('fs');
 const { resolve } = require('path');
-const { merge } = require('webpack-merge');
-const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-const TerserPlugin = require('terser-webpack-plugin');
+
 const CompressionPlugin = require('compression-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
+const { merge } = require('webpack-merge');
 const { InjectManifest } = require('workbox-webpack-plugin');
+
 const sharedConfig = require('./shared');
 
 const root = resolve(__dirname, '..', '..');

--- a/config/webpack/rules/babel.js
+++ b/config/webpack/rules/babel.js
@@ -1,4 +1,5 @@
 const { join, resolve } = require('path');
+
 const { env, settings } = require('../configuration');
 
 module.exports = {

--- a/config/webpack/rules/file.js
+++ b/config/webpack/rules/file.js
@@ -1,4 +1,5 @@
 const { join } = require('path');
+
 const { settings } = require('../configuration');
 
 module.exports = {

--- a/config/webpack/rules/index.js
+++ b/config/webpack/rules/index.js
@@ -1,8 +1,8 @@
 const babel = require('./babel');
 const css = require('./css');
 const file = require('./file');
-const tesseract = require('./tesseract');
 const nodeModules = require('./node_modules');
+const tesseract = require('./tesseract');
 
 // Webpack loaders are processed in reverse order
 // https://webpack.js.org/concepts/loaders/#loader-features

--- a/config/webpack/rules/node_modules.js
+++ b/config/webpack/rules/node_modules.js
@@ -1,4 +1,5 @@
 const { join } = require('path');
+
 const { settings, env } = require('../configuration');
 
 module.exports = {

--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -1,14 +1,16 @@
 // Note: You must restart bin/webpack-dev-server for changes to take effect
 
-const webpack = require('webpack');
 const { basename, dirname, join, relative, resolve } = require('path');
+
 const { sync } = require('glob');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const AssetsManifestPlugin = require('webpack-assets-manifest');
 const extname = require('path-complete-extname');
+const webpack = require('webpack');
+const AssetsManifestPlugin = require('webpack-assets-manifest');
+
 const { env, settings, themes, output } = require('./configuration');
-const rules = require('./rules');
 const localePackPaths = require('./generateLocalePacks');
+const rules = require('./rules');
 
 const extensionGlob = `**/*{${settings.extensions.join(',')}}*`;
 const entryPath = join(settings.source_path, settings.source_entry_path);

--- a/config/webpack/tests.js
+++ b/config/webpack/tests.js
@@ -1,6 +1,7 @@
 // Note: You must restart bin/webpack-dev-server for changes to take effect
 
 const { merge } = require('webpack-merge');
+
 const sharedConfig = require('./shared');
 
 module.exports = merge(sharedConfig, {

--- a/config/webpack/translationRunner.js
+++ b/config/webpack/translationRunner.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+
+// eslint-disable-next-line import/order
 const { default: manageTranslations } = require('react-intl-translations-manager');
 
 const RFC5646_REGEXP = /^[a-z]{2,3}(?:-(?:x|[A-Za-z]{2,4}))*$/;

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -1,17 +1,18 @@
 // @ts-check
 
+const fs = require('fs');
+const http = require('http');
+const url = require('url');
+
 const dotenv = require('dotenv');
 const express = require('express');
-const http = require('http');
-const redis = require('redis');
+const { JSDOM } = require('jsdom');
+const log = require('npmlog');
 const pg = require('pg');
 const dbUrlToConfig = require('pg-connection-string').parse;
-const log = require('npmlog');
-const url = require('url');
+const redis = require('redis');
 const uuid = require('uuid');
-const fs = require('fs');
 const WebSocket = require('ws');
-const { JSDOM } = require('jsdom');
 
 const environment = process.env.NODE_ENV || 'development';
 


### PR DESCRIPTION
And I am here again with a big automated refactor!

In this PR, I enabled automatic re-ordering of `import` statements, to be able to group them together by similar groups, and then order them alphabetically inside each group.

It makes them consistent over files, make it easy to see what a file uses and easier to find the `import` line corresponding to the function you are looking for.

This was already applied for Typescript files, but this PR enabled it for every JS file.

First commit changes the ESLint config, second one is `yarn test:js:lint --fix` ran multiple times until it does not do any automated fix, then a few manual fixes on files that `eslint` did not manage to correct.

To understand how I specified the grouping, here is a recent count of all external imports (imported more than 1 time):

```
   2 fuzzysort
   2 history
   2 react-router-scroll-4
   2 react-sparklines
   2 stacktrace-js
   3 intl-messageformat
   3 react-swipeable-views
   3 react-textarea-autosize
   3 stringz
   4 axios
   4 escape-html
   4 react-redux-loading-bar
   4 react-toggle
   5 react-hotkeys
   5 react-test-renderer
   7 react-dom
   8 detect-passive-events
  11 reselect
  29 lodash
  32 react-helmet
  32 react-router-dom
  62 classnames
  72 immutable
  75 react-immutable-pure-component
 108 react-immutable-proptypes
 140 react-redux
 179 react-intl
 194 prop-types
 243 react
```
