### PR TITLE
Change Identity to not destroy associated User on destroy

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -13,7 +13,7 @@
 #
 
 class Identity < ApplicationRecord
-  belongs_to :user, dependent: :destroy
+  belongs_to :user
   validates :uid, presence: true, uniqueness: { scope: :provider }
   validates :provider, presence: true
 


### PR DESCRIPTION
Fixes #25066

This should not change anything to Mastodon's normal operation, as no code is currently destroying Identity objects. However, it should prevent admin errors as described in #25066.