### PR TITLE
Add CLI Base class for command line code

### DIFF
--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -1,18 +1,10 @@
 # frozen_string_literal: true
 
 require 'set'
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Accounts < Thor
-    include Helper
-
-    def self.exit_on_failure?
-      true
-    end
-
+  class Accounts < Base
     option :all, type: :boolean
     desc 'rotate [USERNAME]', 'Generate and broadcast new keys'
     long_desc <<-LONG_DESC

--- a/lib/mastodon/cli/base.rb
+++ b/lib/mastodon/cli/base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../../../config/boot'
+require_relative '../../../config/environment'
+
+require 'thor'
+require_relative 'helper'
+
+module Mastodon
+  module CLI
+    class Base < Thor
+      include CLI::Helper
+
+      def self.exit_on_failure?
+        true
+      end
+    end
+  end
+end

--- a/lib/mastodon/cli/cache.rb
+++ b/lib/mastodon/cli/cache.rb
@@ -1,17 +1,9 @@
 # frozen_string_literal: true
 
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Cache < Thor
-    include Helper
-
-    def self.exit_on_failure?
-      true
-    end
-
+  class Cache < Base
     desc 'clear', 'Clear out the cache storage'
     def clear
       Rails.cache.clear

--- a/lib/mastodon/cli/canonical_email_blocks.rb
+++ b/lib/mastodon/cli/canonical_email_blocks.rb
@@ -1,18 +1,10 @@
 # frozen_string_literal: true
 
 require 'concurrent'
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class CanonicalEmailBlocks < Thor
-    include Helper
-
-    def self.exit_on_failure?
-      true
-    end
-
+  class CanonicalEmailBlocks < Base
     desc 'find EMAIL', 'Find a given e-mail address in the canonical e-mail blocks'
     long_desc <<-LONG_DESC
       When suspending a local user, a hash of a "canonical" version of their e-mail

--- a/lib/mastodon/cli/domains.rb
+++ b/lib/mastodon/cli/domains.rb
@@ -1,18 +1,10 @@
 # frozen_string_literal: true
 
 require 'concurrent'
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Domains < Thor
-    include Helper
-
-    def self.exit_on_failure?
-      true
-    end
-
+  class Domains < Base
     option :concurrency, type: :numeric, default: 5, aliases: [:c]
     option :verbose, type: :boolean, aliases: [:v]
     option :dry_run, type: :boolean

--- a/lib/mastodon/cli/email_domain_blocks.rb
+++ b/lib/mastodon/cli/email_domain_blocks.rb
@@ -1,18 +1,10 @@
 # frozen_string_literal: true
 
 require 'concurrent'
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class EmailDomainBlocks < Thor
-    include Helper
-
-    def self.exit_on_failure?
-      true
-    end
-
+  class EmailDomainBlocks < Base
     desc 'list', 'List blocked e-mail domains'
     def list
       EmailDomainBlock.where(parent_id: nil).order(id: 'DESC').find_each do |entry|

--- a/lib/mastodon/cli/emoji.rb
+++ b/lib/mastodon/cli/emoji.rb
@@ -1,16 +1,10 @@
 # frozen_string_literal: true
 
 require 'rubygems/package'
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Emoji < Thor
-    def self.exit_on_failure?
-      true
-    end
-
+  class Emoji < Base
     option :prefix
     option :suffix
     option :overwrite, type: :boolean

--- a/lib/mastodon/cli/feeds.rb
+++ b/lib/mastodon/cli/feeds.rb
@@ -1,17 +1,10 @@
 # frozen_string_literal: true
 
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Feeds < Thor
-    include Helper
+  class Feeds < Base
     include Redisable
-
-    def self.exit_on_failure?
-      true
-    end
 
     option :all, type: :boolean, default: false
     option :concurrency, type: :numeric, default: 5, aliases: [:c]

--- a/lib/mastodon/cli/ip_blocks.rb
+++ b/lib/mastodon/cli/ip_blocks.rb
@@ -1,16 +1,10 @@
 # frozen_string_literal: true
 
 require 'rubygems/package'
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class IpBlocks < Thor
-    def self.exit_on_failure?
-      true
-    end
-
+  class IpBlocks < Base
     option :severity, required: true, enum: %w(no_access sign_up_requires_approval sign_up_block), desc: 'Severity of the block'
     option :comment, aliases: [:c], desc: 'Optional comment'
     option :duration, aliases: [:d], type: :numeric, desc: 'Duration of the block in seconds'

--- a/lib/mastodon/cli/main.rb
+++ b/lib/mastodon/cli/main.rb
@@ -1,29 +1,25 @@
 # frozen_string_literal: true
 
-require 'thor'
-require_relative 'media'
-require_relative 'emoji'
+require_relative 'base'
+
 require_relative 'accounts'
+require_relative 'cache'
+require_relative 'canonical_email_blocks'
+require_relative 'domains'
+require_relative 'email_domain_blocks'
+require_relative 'emoji'
 require_relative 'feeds'
+require_relative 'ip_blocks'
+require_relative 'maintenance'
+require_relative 'media'
+require_relative 'preview_cards'
 require_relative 'search'
 require_relative 'settings'
 require_relative 'statuses'
-require_relative 'domains'
-require_relative 'preview_cards'
-require_relative 'cache'
 require_relative 'upgrade'
-require_relative 'email_domain_blocks'
-require_relative 'canonical_email_blocks'
-require_relative 'ip_blocks'
-require_relative 'maintenance'
-require_relative '../version'
 
 module Mastodon::CLI
-  class Main < Thor
-    def self.exit_on_failure?
-      true
-    end
-
+  class Main < Base
     desc 'media SUBCOMMAND ...ARGS', 'Manage media files'
     subcommand 'media', Media
 

--- a/lib/mastodon/cli/maintenance.rb
+++ b/lib/mastodon/cli/maintenance.rb
@@ -1,18 +1,10 @@
 # frozen_string_literal: true
 
 require 'tty-prompt'
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Maintenance < Thor
-    include Helper
-
-    def self.exit_on_failure?
-      true
-    end
-
+  class Maintenance < Base
     MIN_SUPPORTED_VERSION = 2019_10_01_213028
     MAX_SUPPORTED_VERSION = 2022_11_04_133904
 

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -1,19 +1,12 @@
 # frozen_string_literal: true
 
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Media < Thor
+  class Media < Base
     include ActionView::Helpers::NumberHelper
-    include Helper
 
     VALID_PATH_SEGMENTS_SIZE = [7, 10].freeze
-
-    def self.exit_on_failure?
-      true
-    end
 
     option :days, type: :numeric, default: 7, aliases: [:d]
     option :prune_profiles, type: :boolean, default: false

--- a/lib/mastodon/cli/preview_cards.rb
+++ b/lib/mastodon/cli/preview_cards.rb
@@ -1,18 +1,11 @@
 # frozen_string_literal: true
 
 require 'tty-prompt'
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class PreviewCards < Thor
+  class PreviewCards < Base
     include ActionView::Helpers::NumberHelper
-    include Helper
-
-    def self.exit_on_failure?
-      true
-    end
 
     option :days, type: :numeric, default: 180
     option :concurrency, type: :numeric, default: 5, aliases: [:c]

--- a/lib/mastodon/cli/search.rb
+++ b/lib/mastodon/cli/search.rb
@@ -1,13 +1,9 @@
 # frozen_string_literal: true
 
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Search < Thor
-    include Helper
-
+  class Search < Base
     # Indices are sorted by amount of data to be expected in each, so that
     # smaller indices can go online sooner
     INDICES = [

--- a/lib/mastodon/cli/settings.rb
+++ b/lib/mastodon/cli/settings.rb
@@ -1,15 +1,9 @@
 # frozen_string_literal: true
 
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Registrations < Thor
-    def self.exit_on_failure?
-      true
-    end
-
+  class Registrations < Base
     desc 'open', 'Open registrations'
     def open
       Setting.registrations_mode = 'open'
@@ -37,7 +31,7 @@ module Mastodon::CLI
     end
   end
 
-  class Settings < Thor
+  class Settings < Base
     desc 'registrations SUBCOMMAND ...ARGS', 'Manage state of registrations'
     subcommand 'registrations', Registrations
   end

--- a/lib/mastodon/cli/statuses.rb
+++ b/lib/mastodon/cli/statuses.rb
@@ -1,17 +1,10 @@
 # frozen_string_literal: true
 
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Statuses < Thor
-    include Helper
+  class Statuses < Base
     include ActionView::Helpers::NumberHelper
-
-    def self.exit_on_failure?
-      true
-    end
 
     option :days, type: :numeric, default: 90
     option :batch_size, type: :numeric, default: 1_000, aliases: [:b], desc: 'Number of records in each batch'

--- a/lib/mastodon/cli/upgrade.rb
+++ b/lib/mastodon/cli/upgrade.rb
@@ -1,17 +1,9 @@
 # frozen_string_literal: true
 
-require_relative '../../../config/boot'
-require_relative '../../../config/environment'
-require_relative 'helper'
+require_relative 'base'
 
 module Mastodon::CLI
-  class Upgrade < Thor
-    include Helper
-
-    def self.exit_on_failure?
-      true
-    end
-
+  class Upgrade < Base
     CURRENT_STORAGE_SCHEMA_VERSION = 1
 
     option :dry_run, type: :boolean, default: false

--- a/spec/lib/mastodon/cli/accounts_spec.rb
+++ b/spec/lib/mastodon/cli/accounts_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/accounts'
+
+describe Mastodon::CLI::Accounts do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/cache_spec.rb
+++ b/spec/lib/mastodon/cli/cache_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/cache'
+
+describe Mastodon::CLI::Cache do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/canonical_email_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/canonical_email_blocks_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/canonical_email_blocks'
+
+describe Mastodon::CLI::CanonicalEmailBlocks do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/domains_spec.rb
+++ b/spec/lib/mastodon/cli/domains_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/domains'
+
+describe Mastodon::CLI::Domains do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/email_domain_blocks_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/email_domain_blocks'
+
+describe Mastodon::CLI::EmailDomainBlocks do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/emoji_spec.rb
+++ b/spec/lib/mastodon/cli/emoji_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/emoji'
+
+describe Mastodon::CLI::Emoji do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/feeds_spec.rb
+++ b/spec/lib/mastodon/cli/feeds_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/feeds'
+
+describe Mastodon::CLI::Feeds do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/ip_blocks_spec.rb
+++ b/spec/lib/mastodon/cli/ip_blocks_spec.rb
@@ -3,8 +3,14 @@
 require 'rails_helper'
 require 'mastodon/cli/ip_blocks'
 
-RSpec.describe Mastodon::CLI::IpBlocks do
+describe Mastodon::CLI::IpBlocks do
   let(:cli) { described_class.new }
+
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
 
   describe '#add' do
     let(:ip_list) do

--- a/spec/lib/mastodon/cli/main_spec.rb
+++ b/spec/lib/mastodon/cli/main_spec.rb
@@ -4,6 +4,12 @@ require 'rails_helper'
 require 'mastodon/cli/main'
 
 describe Mastodon::CLI::Main do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+
   describe 'version' do
     it 'returns the Mastodon version' do
       expect { described_class.new.invoke(:version) }.to output(

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/maintenance'
+
+describe Mastodon::CLI::Maintenance do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/media_spec.rb
+++ b/spec/lib/mastodon/cli/media_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/media'
+
+describe Mastodon::CLI::Media do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/preview_cards_spec.rb
+++ b/spec/lib/mastodon/cli/preview_cards_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/preview_cards'
+
+describe Mastodon::CLI::PreviewCards do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/search_spec.rb
+++ b/spec/lib/mastodon/cli/search_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/search'
+
+describe Mastodon::CLI::Search do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/settings_spec.rb
+++ b/spec/lib/mastodon/cli/settings_spec.rb
@@ -3,7 +3,13 @@
 require 'rails_helper'
 require 'mastodon/cli/settings'
 
-RSpec.describe Mastodon::CLI::Settings do
+describe Mastodon::CLI::Settings do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+
   describe 'subcommand "registrations"' do
     let(:cli) { Mastodon::CLI::Registrations.new }
 

--- a/spec/lib/mastodon/cli/statuses_spec.rb
+++ b/spec/lib/mastodon/cli/statuses_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/statuses'
+
+describe Mastodon::CLI::Statuses do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end

--- a/spec/lib/mastodon/cli/upgrade_spec.rb
+++ b/spec/lib/mastodon/cli/upgrade_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'mastodon/cli/upgrade'
+
+describe Mastodon::CLI::Upgrade do
+  describe '.exit_on_failure?' do
+    it 'returns true' do
+      expect(described_class.exit_on_failure?).to be true
+    end
+  end
+end


### PR DESCRIPTION
_Extracted from https://github.com/mastodon/mastodon/pull/24134_

Adds a `CLI::Base` class, which (for now) does these things:

- Inherit from `Thor`
- Include the CLI helper module
- require boot and environment files
- define the `self.exit_on_failure?` method

All CLI classes changed to inherit from this Base class, instead of from Thor.

Some basic specs added to at least load each class and call the exit_on_failure? method