### PR TITLE
Fix `null` signUp URL handling from #25014

### DIFF
--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -21,7 +21,7 @@ const Account = connect(state => ({
 ));
 
 const mapStateToProps = (state) => ({
-  signupUrl: state.getIn(['server', 'server', 'registrations', 'url'], '/auth/sign_up'),
+  signupUrl: state.getIn(['server', 'server', 'registrations', 'url'], null) || '/auth/sign_up',
 });
 
 const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
Fixes this issue in `main`:

```
Warning: Failed prop type: The prop `signupUrl` is marked as required in `Header`, but its value is `null`.
    at Header (webpack-internal:///./app/javascript/mastodon/features/ui/components/header.jsx:58:1)
```


It was introduced in #25014


`state.server.server.registrations.url` is `null` (like all other sibling values), and `getIn(…, default)` only returns `default` if the key does not exists.
But when undefined server-side, the key exists (with `null` value), which results in a `null` `signupUrl` prop