### PR TITLE
Consistent usage of CLI `dry_run?` method

### DIFF
--- a/lib/mastodon/cli/accounts.rb
+++ b/lib/mastodon/cli/accounts.rb
@@ -217,7 +217,6 @@ module Mastodon::CLI
         exit(1)
       end
 
-      dry_run = dry_run? ? ' (DRY RUN)' : ''
       account = nil
 
       if username.present?
@@ -234,9 +233,9 @@ module Mastodon::CLI
         end
       end
 
-      say("Deleting user with #{account.statuses_count} statuses, this might take a while...#{dry_run}")
+      say("Deleting user with #{account.statuses_count} statuses, this might take a while...#{dry_run_mode_suffix}")
       DeleteAccountService.new.call(account, reserve_email: false) unless dry_run?
-      say("OK#{dry_run}", :green)
+      say("OK#{dry_run_mode_suffix}", :green)
     end
 
     option :force, type: :boolean, aliases: [:f], description: 'Override public key check'
@@ -332,7 +331,6 @@ module Mastodon::CLI
     LONG_DESC
     def cull(*domains)
       skip_threshold = 7.days.ago
-      dry_run        = dry_run? ? ' (DRY RUN)' : ''
       skip_domains   = Concurrent::Set.new
 
       query = Account.remote.where(protocol: :activitypub)
@@ -358,7 +356,7 @@ module Mastodon::CLI
         end
       end
 
-      say("Visited #{processed} accounts, removed #{culled}#{dry_run}", :green)
+      say("Visited #{processed} accounts, removed #{culled}#{dry_run_mode_suffix}", :green)
 
       unless skip_domains.empty?
         say('The following domains were not available during the check:', :yellow)
@@ -381,8 +379,6 @@ module Mastodon::CLI
       specified with space-separated USERNAMES.
     LONG_DESC
     def refresh(*usernames)
-      dry_run = dry_run? ? ' (DRY RUN)' : ''
-
       if options[:domain] || options[:all]
         scope  = Account.remote
         scope  = scope.where(domain: options[:domain]) if options[:domain]
@@ -395,7 +391,7 @@ module Mastodon::CLI
           account.save
         end
 
-        say("Refreshed #{processed} accounts#{dry_run}", :green, true)
+        say("Refreshed #{processed} accounts#{dry_run_mode_suffix}", :green, true)
       elsif !usernames.empty?
         usernames.each do |user|
           user, domain = user.split('@')
@@ -417,7 +413,7 @@ module Mastodon::CLI
           end
         end
 
-        say("OK#{dry_run}", :green)
+        say("OK#{dry_run_mode_suffix}", :green)
       else
         say('No account(s) given', :red)
         exit(1)
@@ -568,8 +564,6 @@ module Mastodon::CLI
       - not muted/blocked by us
     LONG_DESC
     def prune
-      dry_run = dry_run? ? ' (dry run)' : ''
-
       query = Account.remote.where.not(actor_type: %i(Application Service))
       query = query.where('NOT EXISTS (SELECT 1 FROM mentions WHERE account_id = accounts.id)')
       query = query.where('NOT EXISTS (SELECT 1 FROM favourites WHERE account_id = accounts.id)')
@@ -589,7 +583,7 @@ module Mastodon::CLI
         1
       end
 
-      say("OK, pruned #{deleted} accounts#{dry_run}", :green)
+      say("OK, pruned #{deleted} accounts#{dry_run_mode_suffix}", :green)
     end
 
     option :force, type: :boolean

--- a/lib/mastodon/cli/domains.rb
+++ b/lib/mastodon/cli/domains.rb
@@ -34,7 +34,7 @@ module Mastodon::CLI
       When the --purge-domain-blocks option is given, also purge matching domain blocks.
     LONG_DESC
     def purge(*domains)
-      dry_run            = options[:dry_run] ? ' (DRY RUN)' : ''
+      dry_run            = dry_run? ? ' (DRY RUN)' : ''
       domains            = domains.map { |domain| TagManager.instance.normalize_domain(domain) }
       account_scope      = Account.none
       domain_block_scope = DomainBlock.none
@@ -79,21 +79,21 @@ module Mastodon::CLI
 
       # Actually perform the deletions
       processed, = parallelize_with_progress(account_scope) do |account|
-        DeleteAccountService.new.call(account, reserve_username: false, skip_side_effects: true) unless options[:dry_run]
+        DeleteAccountService.new.call(account, reserve_username: false, skip_side_effects: true) unless dry_run?
       end
 
       say("Removed #{processed} accounts#{dry_run}", :green)
 
       if options[:purge_domain_blocks]
         domain_block_count = domain_block_scope.count
-        domain_block_scope.in_batches.destroy_all unless options[:dry_run]
+        domain_block_scope.in_batches.destroy_all unless dry_run?
         say("Removed #{domain_block_count} domain blocks#{dry_run}", :green)
       end
 
       custom_emojis_count = emoji_scope.count
-      emoji_scope.in_batches.destroy_all unless options[:dry_run]
+      emoji_scope.in_batches.destroy_all unless dry_run?
 
-      Instance.refresh unless options[:dry_run]
+      Instance.refresh unless dry_run?
 
       say("Removed #{custom_emojis_count} custom emojis#{dry_run}", :green)
     end

--- a/lib/mastodon/cli/domains.rb
+++ b/lib/mastodon/cli/domains.rb
@@ -34,7 +34,6 @@ module Mastodon::CLI
       When the --purge-domain-blocks option is given, also purge matching domain blocks.
     LONG_DESC
     def purge(*domains)
-      dry_run            = dry_run? ? ' (DRY RUN)' : ''
       domains            = domains.map { |domain| TagManager.instance.normalize_domain(domain) }
       account_scope      = Account.none
       domain_block_scope = DomainBlock.none
@@ -82,12 +81,12 @@ module Mastodon::CLI
         DeleteAccountService.new.call(account, reserve_username: false, skip_side_effects: true) unless dry_run?
       end
 
-      say("Removed #{processed} accounts#{dry_run}", :green)
+      say("Removed #{processed} accounts#{dry_run_mode_suffix}", :green)
 
       if options[:purge_domain_blocks]
         domain_block_count = domain_block_scope.count
         domain_block_scope.in_batches.destroy_all unless dry_run?
-        say("Removed #{domain_block_count} domain blocks#{dry_run}", :green)
+        say("Removed #{domain_block_count} domain blocks#{dry_run_mode_suffix}", :green)
       end
 
       custom_emojis_count = emoji_scope.count
@@ -95,7 +94,7 @@ module Mastodon::CLI
 
       Instance.refresh unless dry_run?
 
-      say("Removed #{custom_emojis_count} custom emojis#{dry_run}", :green)
+      say("Removed #{custom_emojis_count} custom emojis#{dry_run_mode_suffix}", :green)
     end
 
     option :concurrency, type: :numeric, default: 50, aliases: [:c]

--- a/lib/mastodon/cli/feeds.rb
+++ b/lib/mastodon/cli/feeds.rb
@@ -18,11 +18,11 @@ module Mastodon::CLI
       Otherwise, a single user specified by USERNAME.
     LONG_DESC
     def build(username = nil)
-      dry_run = options[:dry_run] ? '(DRY RUN)' : ''
+      dry_run = dry_run? ? '(DRY RUN)' : ''
 
       if options[:all] || username.nil?
         processed, = parallelize_with_progress(Account.joins(:user).merge(User.active)) do |account|
-          PrecomputeFeedService.new.call(account) unless options[:dry_run]
+          PrecomputeFeedService.new.call(account) unless dry_run?
         end
 
         say("Regenerated feeds for #{processed} accounts #{dry_run}", :green, true)
@@ -34,7 +34,7 @@ module Mastodon::CLI
           exit(1)
         end
 
-        PrecomputeFeedService.new.call(account) unless options[:dry_run]
+        PrecomputeFeedService.new.call(account) unless dry_run?
 
         say("OK #{dry_run}", :green, true)
       else

--- a/lib/mastodon/cli/feeds.rb
+++ b/lib/mastodon/cli/feeds.rb
@@ -18,14 +18,12 @@ module Mastodon::CLI
       Otherwise, a single user specified by USERNAME.
     LONG_DESC
     def build(username = nil)
-      dry_run = dry_run? ? '(DRY RUN)' : ''
-
       if options[:all] || username.nil?
         processed, = parallelize_with_progress(Account.joins(:user).merge(User.active)) do |account|
           PrecomputeFeedService.new.call(account) unless dry_run?
         end
 
-        say("Regenerated feeds for #{processed} accounts #{dry_run}", :green, true)
+        say("Regenerated feeds for #{processed} accounts #{dry_run_mode_suffix}", :green, true)
       elsif username.present?
         account = Account.find_local(username)
 
@@ -36,7 +34,7 @@ module Mastodon::CLI
 
         PrecomputeFeedService.new.call(account) unless dry_run?
 
-        say("OK #{dry_run}", :green, true)
+        say("OK #{dry_run_mode_suffix}", :green, true)
       else
         say('No account(s) given', :red)
         exit(1)

--- a/lib/mastodon/cli/helper.rb
+++ b/lib/mastodon/cli/helper.rb
@@ -15,6 +15,10 @@ module Mastodon::CLI
       options[:dry_run]
     end
 
+    def dry_run_mode_suffix
+      dry_run? ? ' (DRY RUN)' : ''
+    end
+
     def create_progress_bar(total = nil)
       ProgressBar.create(total: total, format: '%c/%u |%b%i| %e')
     end

--- a/lib/mastodon/cli/main.rb
+++ b/lib/mastodon/cli/main.rb
@@ -104,7 +104,6 @@ module Mastodon::CLI
 
       inboxes   = Account.inboxes
       processed = 0
-      dry_run   = dry_run? ? ' (DRY RUN)' : ''
 
       Setting.registrations_mode = 'none' unless dry_run?
 
@@ -140,7 +139,7 @@ module Mastodon::CLI
       Account.local.without_suspended.find_each { |account| delete_account.call(account) }
       Account.local.suspended.joins(:deletion_request).find_each { |account| delete_account.call(account) }
 
-      prompt.ok("Queued #{inboxes.size * processed} items into Sidekiq for #{processed} accounts#{dry_run}")
+      prompt.ok("Queued #{inboxes.size * processed} items into Sidekiq for #{processed} accounts#{dry_run_mode_suffix}")
       prompt.ok('Wait until Sidekiq processes all items, then you can shut everything down and delete the data')
     rescue TTY::Reader::InputInterrupt
       exit(1)

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -35,12 +35,12 @@ module Mastodon::CLI
         say('--prune-profiles and --remove-headers should not be specified simultaneously', :red, true)
         exit(1)
       end
+
       if options[:include_follows] && !(options[:prune_profiles] || options[:remove_headers])
         say('--include-follows can only be used with --prune-profiles or --remove-headers', :red, true)
         exit(1)
       end
       time_ago        = options[:days].days.ago
-      dry_run         = dry_run? ? ' (DRY RUN)' : ''
 
       if options[:prune_profiles] || options[:remove_headers]
         processed, aggregate = parallelize_with_progress(Account.remote.where({ last_webfingered_at: ..time_ago, updated_at: ..time_ago })) do |account|
@@ -60,7 +60,7 @@ module Mastodon::CLI
           size
         end
 
-        say("Visited #{processed} accounts and removed profile media totaling #{number_to_human_size(aggregate)}#{dry_run}", :green, true)
+        say("Visited #{processed} accounts and removed profile media totaling #{number_to_human_size(aggregate)}#{dry_run_mode_suffix}", :green, true)
       end
 
       unless options[:prune_profiles] || options[:remove_headers]
@@ -78,7 +78,7 @@ module Mastodon::CLI
           size
         end
 
-        say("Removed #{processed} media attachments (approx. #{number_to_human_size(aggregate)})#{dry_run}", :green, true)
+        say("Removed #{processed} media attachments (approx. #{number_to_human_size(aggregate)})#{dry_run_mode_suffix}", :green, true)
       end
     end
 
@@ -97,7 +97,6 @@ module Mastodon::CLI
       progress        = create_progress_bar(nil)
       reclaimed_bytes = 0
       removed         = 0
-      dry_run         = dry_run? ? ' (DRY RUN)' : ''
       prefix          = options[:prefix]
 
       case Paperclip::Attachment.default_options[:storage]
@@ -216,7 +215,7 @@ module Mastodon::CLI
       progress.total = progress.progress
       progress.finish
 
-      say("Removed #{removed} orphans (approx. #{number_to_human_size(reclaimed_bytes)})#{dry_run}", :green, true)
+      say("Removed #{removed} orphans (approx. #{number_to_human_size(reclaimed_bytes)})#{dry_run_mode_suffix}", :green, true)
     end
 
     option :account, type: :string
@@ -246,8 +245,6 @@ module Mastodon::CLI
       not be re-downloaded. To force re-download of every URL, use --force.
     DESC
     def refresh
-      dry_run = dry_run? ? ' (DRY RUN)' : ''
-
       if options[:status]
         scope = MediaAttachment.where(status_id: options[:status])
       elsif options[:account]
@@ -283,7 +280,7 @@ module Mastodon::CLI
         media_attachment.file_file_size + (media_attachment.thumbnail_file_size || 0)
       end
 
-      say("Downloaded #{processed} media attachments (approx. #{number_to_human_size(aggregate)})#{dry_run}", :green, true)
+      say("Downloaded #{processed} media attachments (approx. #{number_to_human_size(aggregate)})#{dry_run_mode_suffix}", :green, true)
     end
 
     desc 'usage', 'Calculate disk space consumed by Mastodon'

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -40,7 +40,7 @@ module Mastodon::CLI
         say('--include-follows can only be used with --prune-profiles or --remove-headers', :red, true)
         exit(1)
       end
-      time_ago        = options[:days].days.ago
+      time_ago = options[:days].days.ago
 
       if options[:prune_profiles] || options[:remove_headers]
         processed, aggregate = parallelize_with_progress(Account.remote.where({ last_webfingered_at: ..time_ago, updated_at: ..time_ago })) do |account|

--- a/lib/mastodon/cli/preview_cards.rb
+++ b/lib/mastodon/cli/preview_cards.rb
@@ -27,7 +27,6 @@ module Mastodon::CLI
     DESC
     def remove
       time_ago = options[:days].days.ago
-      dry_run  = dry_run? ? ' (DRY RUN)' : ''
       link     = options[:link] ? 'link-type ' : ''
       scope    = PreviewCard.cached
       scope    = scope.where(type: :link) if options[:link]
@@ -46,7 +45,7 @@ module Mastodon::CLI
         size
       end
 
-      say("Removed #{processed} #{link}preview cards (approx. #{number_to_human_size(aggregate)})#{dry_run}", :green, true)
+      say("Removed #{processed} #{link}preview cards (approx. #{number_to_human_size(aggregate)})#{dry_run_mode_suffix}", :green, true)
     end
   end
 end

--- a/lib/mastodon/cli/preview_cards.rb
+++ b/lib/mastodon/cli/preview_cards.rb
@@ -27,7 +27,7 @@ module Mastodon::CLI
     DESC
     def remove
       time_ago = options[:days].days.ago
-      dry_run  = options[:dry_run] ? ' (DRY RUN)' : ''
+      dry_run  = dry_run? ? ' (DRY RUN)' : ''
       link     = options[:link] ? 'link-type ' : ''
       scope    = PreviewCard.cached
       scope    = scope.where(type: :link) if options[:link]
@@ -38,7 +38,7 @@ module Mastodon::CLI
 
         size = preview_card.image_file_size
 
-        unless options[:dry_run]
+        unless dry_run?
           preview_card.image.destroy
           preview_card.save
         end

--- a/lib/mastodon/cli/upgrade.rb
+++ b/lib/mastodon/cli/upgrade.rb
@@ -17,7 +17,6 @@ module Mastodon::CLI
     LONG_DESC
     def storage_schema
       progress = create_progress_bar(nil)
-      dry_run  = dry_run? ? ' (DRY RUN)' : ''
       records  = 0
 
       klasses = [
@@ -69,7 +68,7 @@ module Mastodon::CLI
       progress.total = progress.progress
       progress.finish
 
-      say("Upgraded storage schema of #{records} records#{dry_run}", :green, true)
+      say("Upgraded storage schema of #{records} records#{dry_run_mode_suffix}", :green, true)
     end
 
     private


### PR DESCRIPTION
Ever since - https://github.com/mastodon/mastodon/commit/c3ca3801f2b8a44db09b83da2e64130eb2c41ef1#diff-89ed984e14010d92970c3f0f542e814ad54e3724a94d5d6917f1137ec40e7860R13 - about 3 years ago, there's been a `dry_run?` method available to the CLI, but it was used inconsistently. Now that there's a common base class and all CLI commands have access to this helper method, this PR makes more consistent usage of it.

There are basically two changes here:

- Update all the locations that were checking `options[:dry_run]` directly to instead use the `dry_run?` helper which wraps this check.
- Add a `dry_run_mode_suffix` method which helps build strings and avoids setting `dry_run` local vars in many of the commands.
