### PR TITLE
Fix export style of `<LoadGap />` based on `<Domain />`

### DIFF
--- a/app/javascript/mastodon/components/load_gap.tsx
+++ b/app/javascript/mastodon/components/load_gap.tsx
@@ -16,21 +16,21 @@ interface Props {
   intl: InjectedIntl;
 }
 
-export const LoadGap = injectIntl<Props>(
-  ({ disabled, maxId, onClick, intl }) => {
-    const handleClick = useCallback(() => {
-      onClick(maxId);
-    }, [maxId, onClick]);
+const _LoadGap: React.FC<Props> = ({ disabled, maxId, onClick, intl }) => {
+  const handleClick = useCallback(() => {
+    onClick(maxId);
+  }, [maxId, onClick]);
 
-    return (
-      <button
-        className='load-more load-gap'
-        disabled={disabled}
-        onClick={handleClick}
-        aria-label={intl.formatMessage(messages.load_more)}
-      >
-        <Icon id='ellipsis-h' />
-      </button>
-    );
-  }
-);
+  return (
+    <button
+      className='load-more load-gap'
+      disabled={disabled}
+      onClick={handleClick}
+      aria-label={intl.formatMessage(messages.load_more)}
+    >
+      <Icon id='ellipsis-h' />
+    </button>
+  );
+};
+
+export const LoadGap = injectIntl(_LoadGap);


### PR DESCRIPTION
This PR updates the export style of the `<LoadGap />`, following the style used in the `<Domain />`.
