### PR TITLE
Fix overflow behavior of account rows

### DIFF
--- a/app/javascript/mastodon/components/account.jsx
+++ b/app/javascript/mastodon/components/account.jsx
@@ -143,7 +143,7 @@ class Account extends ImmutablePureComponent {
     const firstVerifiedField = account.get('fields').find(item => !!item.get('verified_at'));
 
     if (firstVerifiedField) {
-      verification = <>· <VerifiedBadge link={firstVerifiedField.get('value')} /></>;
+      verification = <> <span className='separator'>·</span> <VerifiedBadge link={firstVerifiedField.get('value')} /></>;
     }
 
     return (

--- a/app/javascript/mastodon/components/account.jsx
+++ b/app/javascript/mastodon/components/account.jsx
@@ -143,7 +143,7 @@ class Account extends ImmutablePureComponent {
     const firstVerifiedField = account.get('fields').find(item => !!item.get('verified_at'));
 
     if (firstVerifiedField) {
-      verification = <> <span className='separator'>·</span> <VerifiedBadge link={firstVerifiedField.get('value')} /></>;
+      verification = <> <span className='separator' aria-hidden='true'>·</span> <VerifiedBadge link={firstVerifiedField.get('value')} /></>;
     }
 
     return (

--- a/app/javascript/mastodon/components/account.jsx
+++ b/app/javascript/mastodon/components/account.jsx
@@ -154,7 +154,7 @@ class Account extends ImmutablePureComponent {
               <Avatar account={account} size={size} />
             </div>
 
-            <div>
+            <div className='account__contents'>
               <DisplayName account={account} />
               {!minimal && <><ShortNumber value={account.get('followers_count')} renderer={counterRenderer('followers')} /> {verification} {muteTimeRemaining}</>}
             </div>

--- a/app/javascript/mastodon/components/account.jsx
+++ b/app/javascript/mastodon/components/account.jsx
@@ -143,7 +143,7 @@ class Account extends ImmutablePureComponent {
     const firstVerifiedField = account.get('fields').find(item => !!item.get('verified_at'));
 
     if (firstVerifiedField) {
-      verification = <> <span className='separator' aria-hidden='true'>·</span> <VerifiedBadge link={firstVerifiedField.get('value')} /></>;
+      verification = <VerifiedBadge link={firstVerifiedField.get('value')} />;
     }
 
     return (
@@ -156,7 +156,11 @@ class Account extends ImmutablePureComponent {
 
             <div className='account__contents'>
               <DisplayName account={account} />
-              {!minimal && <><ShortNumber value={account.get('followers_count')} renderer={counterRenderer('followers')} /> {verification} {muteTimeRemaining}</>}
+              {!minimal && (
+                <div className='account__details'>
+                  <ShortNumber value={account.get('followers_count')} renderer={counterRenderer('followers')} /> {verification} {muteTimeRemaining}
+                </div>
+              )}
             </div>
           </Link>
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3328,23 +3328,6 @@ $ui-header-height: 55px;
   }
 }
 
-.scrollable,
-.search-results__section {
-  container: list-layout / inline-size;
-}
-
-@container list-layout (inline-size < 420px) {
-  .account__wrapper {
-    .separator {
-      display: none;
-    }
-
-    .verified-badge {
-      display: flex;
-    }
-  }
-}
-
 .column-back-button {
   box-sizing: border-box;
   width: 100%;
@@ -7833,6 +7816,12 @@ noscript {
 
 .account__contents {
   overflow: hidden;
+}
+
+.account__details {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 1em;
 }
 
 .verified-badge {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7837,7 +7837,12 @@ noscript {
   color: $valid-value-color;
   gap: 4px;
   overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  > span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
   a {
     color: inherit;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -7831,6 +7831,10 @@ noscript {
   }
 }
 
+.account__contents {
+  overflow: hidden;
+}
+
 .verified-badge {
   display: inline-flex;
   align-items: center;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3328,6 +3328,23 @@ $ui-header-height: 55px;
   }
 }
 
+.scrollable,
+.search-results__section {
+  container: list-layout / inline-size;
+}
+
+@container list-layout (inline-size < 420px) {
+  .account__wrapper {
+    .separator {
+      display: none;
+    }
+
+    .verified-badge {
+      display: flex;
+    }
+  }
+}
+
 .column-back-button {
   box-sizing: border-box;
   width: 100%;


### PR DESCRIPTION
Fixes #24859

Currently, the line-wrapping of the accounts component is pretty erratic, because overflow is allowed for one of the containing `div` elements.

~~Setting that element to `overflow: hidden` is possible and leads to better wrapping overall, but it leaves the decorative separator “·” hanging at the end of the line~~

This adds `overflow: hidden` on the appropriate containers and move `text-overflow: ellipsis` on the appropriate container for properly truncating links.

The wrapping is automatically handled by the browser through a flexbox, at the cost of the removal of the decorative separator. That separator is replaced by a gap:

https://github.com/mastodon/mastodon/assets/384364/27f95f9c-bec8-484d-8028-ca3e681870c5

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/5cc4cf3e-715d-4774-b398-281d9e38605f)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/2242d50c-2a4e-47b5-9f2f-690249ae89c6)