### PR TITLE
Rewrite `emoji_mart_data_light` as TS

### DIFF
--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -1,8 +1,21 @@
 import type { BaseEmoji, EmojiData, NimbleEmojiIndex } from 'emoji-mart';
 import type { Category, Data, Emoji } from 'emoji-mart/dist-es/utils/data';
 
-export type FilenameData = string[][];
+/*
+ * The 'search' property, although not defined in the [`Emoji`]{@link node_modules/@types/emoji-mart/dist-es/utils/data.d.ts#Emoji} type,
+ * is used in the application.
+ * This could be due to an oversight by the library maintainer.
+ * The `search` property is defined and used [here]{@link node_modules/emoji-mart/dist/utils/data.js#uncompress}.
+ */
 export type Search = string;
+/*
+ * The 'skins' property does not exist in the application data.
+ * This could be a potential area of refactoring or error handling.
+ * The non-existence of 'skins' property is evident at [this location]{@link app/javascript/mastodon/features/emoji/emoji_compressed.js:121}.
+ */
+export type Skins = null;
+
+export type FilenameData = string[][];
 export type ShortCodesToEmojiDataKey =
   | EmojiData['id']
   | BaseEmoji['native']
@@ -18,7 +31,6 @@ export type SearchData = [
 export interface ShortCodesToEmojiData {
   [key: ShortCodesToEmojiDataKey]: [FilenameData, SearchData];
 }
-export type Skins = null;
 
 export type EmojiCompressed = [
   ShortCodesToEmojiData,

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -22,3 +22,10 @@ export type EmojiCompressed = [
   Category[],
   ShortName[]
 ];
+
+// Since emoji_compressed.js is difficult to TS,
+// export we are temporarily allowing a default export
+// at this location to apply the TS type to the JS file export.
+declare const emojiCompressed: EmojiCompressed;
+
+export default emojiCompressed; // eslint-disable-line import/no-default-export

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -1,0 +1,24 @@
+export type FilenameData = string[];
+export type Native = string;
+export type ShortName = string;
+export type Search = string;
+export type Unified = string;
+
+export type SearchData = [Native, ShortName[], Search, Unified];
+
+export interface ShortCodesToEmojiData {
+  [key: string]: [FilenameData, SearchData];
+}
+export type Skins = null;
+export interface Category {
+  id: string;
+  name: string;
+  emojis: string[];
+}
+
+export type EmojiCompressed = [
+  ShortCodesToEmojiData,
+  Skins,
+  Category[],
+  ShortName[]
+];

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -40,9 +40,11 @@ export type EmojiCompressed = [
   Emoji['short_names']
 ];
 
-// Because emoji_compressed.js is difficult to change to TS,
-// export we are temporarily allowing a default export
-// at this location to apply the TS type to the JS file export.
+/*
+ * `emoji_compressed.js` uses `babel-plugin-preval`, which makes it difficult to convert to TypeScript.
+ * As a temporary solution, we are allowing a default export here to apply the TypeScript type `EmojiCompressed` to the JS file export.
+ * - {@link app/javascript/mastodon/features/emoji/emoji_compressed.js}
+ */
 declare const emojiCompressed: EmojiCompressed;
 
 export default emojiCompressed; // eslint-disable-line import/no-default-export

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -1,4 +1,4 @@
-export type FilenameData = string[];
+export type FilenameData = string[][];
 export type Native = string;
 export type ShortName = string;
 export type Search = string;

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -23,7 +23,7 @@ export type EmojiCompressed = [
   ShortName[]
 ];
 
-// Since emoji_compressed.js is difficult to TS,
+// Because emoji_compressed.js is difficult to change to TS,
 // export we are temporarily allowing a default export
 // at this location to apply the TS type to the JS file export.
 declare const emojiCompressed: EmojiCompressed;

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -31,13 +31,14 @@ export type SearchData = [
 export interface ShortCodesToEmojiData {
   [key: ShortCodesToEmojiDataKey]: [FilenameData, SearchData];
 }
+export type EmojisWithoutShortCodes = FilenameData[];
 
 export type EmojiCompressed = [
   ShortCodesToEmojiData,
   Skins,
   Category[],
   Data['aliases'],
-  Emoji['short_names']
+  EmojisWithoutShortCodes
 ];
 
 /*

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -1,30 +1,31 @@
-export type FilenameData = string[][];
-export type Native = string;
-export type ShortName = string;
-export type Search = string;
-export type Unified = string;
+import type { BaseEmoji, EmojiData, NimbleEmojiIndex } from 'emoji-mart';
+import type { Category, Data, Emoji } from 'emoji-mart/dist-es/utils/data';
 
-export type SearchData = [Native, ShortName[], Search, Unified];
+export type FilenameData = string[][];
+export type Search = string;
+export type ShortCodesToEmojiDataKey =
+  | EmojiData['id']
+  | BaseEmoji['native']
+  | keyof NimbleEmojiIndex['emojis'];
+
+export type SearchData = [
+  BaseEmoji['native'],
+  Emoji['short_names'],
+  Search,
+  Emoji['unified']
+];
 
 export interface ShortCodesToEmojiData {
-  [key: string]: [FilenameData, SearchData];
+  [key: ShortCodesToEmojiDataKey]: [FilenameData, SearchData];
 }
 export type Skins = null;
-export interface Category {
-  id: string;
-  name: string;
-  emojis: string[];
-}
-export interface Alias {
-  [key: string]: string;
-}
 
 export type EmojiCompressed = [
   ShortCodesToEmojiData,
   Skins,
   Category[],
-  Alias[],
-  ShortName[]
+  Data['aliases'],
+  Emoji['short_names']
 ];
 
 // Because emoji_compressed.js is difficult to change to TS,

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -15,11 +15,15 @@ export interface Category {
   name: string;
   emojis: string[];
 }
+export interface Alias {
+  [key: string]: string;
+}
 
 export type EmojiCompressed = [
   ShortCodesToEmojiData,
   Skins,
   Category[],
+  Alias[],
   ShortName[]
 ];
 

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -15,7 +15,7 @@ export type Search = string;
  */
 export type Skins = null;
 
-export type FilenameData = string[][];
+export type FilenameData = string[] | string[][];
 export type ShortCodesToEmojiDataKey =
   | EmojiData['id']
   | BaseEmoji['native']

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.js
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.js
@@ -118,6 +118,16 @@ Object.keys(emojiIndex.emojis).forEach(key => {
 // inconsistent behavior in dev mode
 module.exports = JSON.parse(JSON.stringify([
   shortCodesToEmojiData,
+  /*
+   * The property `skins` is not found in the current context.
+   * This could potentially lead to issues when interacting with modules or data structures
+   * that expect the presence of `skins` property.
+   * Currently, no definitions or references to `skins` property can be found in:
+   * - {@link node_modules/emoji-mart/dist/utils/data.js}
+   * - {@link node_modules/emoji-mart/data/all.json}
+   * - {@link app/javascript/mastodon/features/emoji/emoji_compressed.d.ts#Skins}
+   * Future refactorings or updates should consider adding definitions or handling for `skins` property.
+   */
   emojiMartData.skins,
   emojiMartData.categories,
   emojiMartData.aliases,

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -22,17 +22,14 @@ const [
   skins,
   categories,
   short_names,
-  emojisWithoutShortCodes, // eslint-disable-line @typescript-eslint/no-unused-vars
+  _emojisWithoutShortCodes,
 ] = emojiCompressed;
 
 const emojis: Emojis = {};
 
 // decompress
 Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
-  const [
-    filenameData, // eslint-disable-line @typescript-eslint/no-unused-vars
-    searchData,
-  ] = shortCodesToEmojiData[shortCode];
+  const [_filenameData, searchData] = shortCodesToEmojiData[shortCode];
   const native = searchData[0];
   let short_names = searchData[1];
   const search = searchData[2];

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -1,25 +1,22 @@
+/* eslint-disable */
+// @ts-nocheck
 // The output of this module is designed to mimic emoji-mart's
 // "data" object, such that we can use it for a light version of emoji-mart's
 // emojiIndex.search functionality.
 import emojiCompressed from './emoji_compressed';
 import { unicodeToUnifiedName } from './unicode_to_unified_name';
 
-const [ shortCodesToEmojiData, skins, categories, short_names ] = emojiCompressed;
+const [shortCodesToEmojiData, skins, categories, short_names] = emojiCompressed;
 
 const emojis = {};
 
 // decompress
 Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
-  let [
+  const [
     filenameData, // eslint-disable-line @typescript-eslint/no-unused-vars
     searchData,
   ] = shortCodesToEmojiData[shortCode];
-  let [
-    native,
-    short_names,
-    search,
-    unified,
-  ] = searchData;
+  let [native, short_names, search, unified] = searchData;
 
   if (!unified) {
     // unified name can be derived from unicodeToUnifiedName
@@ -35,9 +32,4 @@ Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
   };
 });
 
-export {
-  emojis,
-  skins,
-  categories,
-  short_names,
-};
+export { emojis, skins, categories, short_names };

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -1,14 +1,45 @@
-/* eslint-disable */
-// @ts-nocheck
 // The output of this module is designed to mimic emoji-mart's
 // "data" object, such that we can use it for a light version of emoji-mart's
 // emojiIndex.search functionality.
-import emojiCompressed from './emoji_compressed';
+import emojiCompressed_ from './emoji_compressed';
 import { unicodeToUnifiedName } from './unicode_to_unified_name';
 
+type FilenameData = string[];
+type Native = string;
+type ShortName = string;
+type Search = string;
+type Unified = string;
+
+type SearchData = [Native, ShortName[], Search, Unified];
+
+interface ShortCodesToEmojiData {
+  [key: string]: [FilenameData, SearchData];
+}
+type Skins = null;
+interface Category {
+  id: string;
+  name: string;
+  emojis: string[];
+}
+
+type Emojis = {
+  [key in keyof ShortCodesToEmojiData]: {
+    native: Native;
+    search: Search;
+    short_names: ShortName[];
+    unified: Unified;
+  };
+};
+
+const emojiCompressed = emojiCompressed_ as [
+  ShortCodesToEmojiData,
+  Skins,
+  Category[],
+  ShortName[]
+];
 const [shortCodesToEmojiData, skins, categories, short_names] = emojiCompressed;
 
-const emojis = {};
+const emojis: Emojis = {};
 
 // decompress
 Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
@@ -16,7 +47,7 @@ Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
     filenameData, // eslint-disable-line @typescript-eslint/no-unused-vars
     searchData,
   ] = shortCodesToEmojiData[shortCode];
-  let [native, short_names, search, unified] = searchData;
+  let [native, short_names, search, unified] = searchData; // eslint-disable-line prefer-const
 
   if (!unified) {
     // unified name can be derived from unicodeToUnifiedName

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -47,7 +47,10 @@ Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
     filenameData, // eslint-disable-line @typescript-eslint/no-unused-vars
     searchData,
   ] = shortCodesToEmojiData[shortCode];
-  let [native, short_names, search, unified] = searchData; // eslint-disable-line prefer-const
+  const native = searchData[0];
+  let short_names = searchData[1];
+  const search = searchData[2];
+  let unified = searchData[3];
 
   if (!unified) {
     // unified name can be derived from unicodeToUnifiedName

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -2,14 +2,13 @@
 // "data" object, such that we can use it for a light version of emoji-mart's
 // emojiIndex.search functionality.
 import type {
-  EmojiCompressed,
   Native,
   Search,
   ShortCodesToEmojiData,
   ShortName,
   Unified,
 } from './emoji_compressed';
-import emojiCompressed_ from './emoji_compressed';
+import emojiCompressed from './emoji_compressed';
 import { unicodeToUnifiedName } from './unicode_to_unified_name';
 
 type Emojis = {
@@ -21,7 +20,6 @@ type Emojis = {
   };
 };
 
-const emojiCompressed = emojiCompressed_ as EmojiCompressed;
 const [shortCodesToEmojiData, skins, categories, short_names] = emojiCompressed;
 
 const emojis: Emojis = {};

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -1,26 +1,16 @@
 // The output of this module is designed to mimic emoji-mart's
 // "data" object, such that we can use it for a light version of emoji-mart's
 // emojiIndex.search functionality.
+import type {
+  EmojiCompressed,
+  Native,
+  Search,
+  ShortCodesToEmojiData,
+  ShortName,
+  Unified,
+} from './emoji_compressed';
 import emojiCompressed_ from './emoji_compressed';
 import { unicodeToUnifiedName } from './unicode_to_unified_name';
-
-type FilenameData = string[];
-type Native = string;
-type ShortName = string;
-type Search = string;
-type Unified = string;
-
-type SearchData = [Native, ShortName[], Search, Unified];
-
-interface ShortCodesToEmojiData {
-  [key: string]: [FilenameData, SearchData];
-}
-type Skins = null;
-interface Category {
-  id: string;
-  name: string;
-  emojis: string[];
-}
 
 type Emojis = {
   [key in keyof ShortCodesToEmojiData]: {
@@ -31,12 +21,7 @@ type Emojis = {
   };
 };
 
-const emojiCompressed = emojiCompressed_ as [
-  ShortCodesToEmojiData,
-  Skins,
-  Category[],
-  ShortName[]
-];
+const emojiCompressed = emojiCompressed_ as EmojiCompressed;
 const [shortCodesToEmojiData, skins, categories, short_names] = emojiCompressed;
 
 const emojis: Emojis = {};

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -1,22 +1,19 @@
 // The output of this module is designed to mimic emoji-mart's
 // "data" object, such that we can use it for a light version of emoji-mart's
 // emojiIndex.search functionality.
-import type {
-  Native,
-  Search,
-  ShortCodesToEmojiData,
-  ShortName,
-  Unified,
-} from './emoji_compressed';
+import type { BaseEmoji } from 'emoji-mart';
+import type { Emoji } from 'emoji-mart/dist-es/utils/data';
+
+import type { Search, ShortCodesToEmojiData } from './emoji_compressed';
 import emojiCompressed from './emoji_compressed';
 import { unicodeToUnifiedName } from './unicode_to_unified_name';
 
 type Emojis = {
   [key in keyof ShortCodesToEmojiData]: {
-    native: Native;
+    native: BaseEmoji['native'];
     search: Search;
-    short_names: ShortName[];
-    unified: Unified;
+    short_names: Emoji['short_names'];
+    unified: Emoji['unified'];
   };
 };
 
@@ -42,7 +39,7 @@ Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
     unified = unicodeToUnifiedName(native);
   }
 
-  short_names = [shortCode].concat(short_names);
+  if (short_names) short_names = [shortCode].concat(short_names);
   emojis[shortCode] = {
     native,
     search,

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -17,9 +17,13 @@ type Emojis = {
   };
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const [shortCodesToEmojiData, skins, categories, aliases, short_names] =
-  emojiCompressed;
+const [
+  shortCodesToEmojiData,
+  skins,
+  categories,
+  short_names,
+  emojisWithoutShortCodes, // eslint-disable-line @typescript-eslint/no-unused-vars
+] = emojiCompressed;
 
 const emojis: Emojis = {};
 

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -20,7 +20,9 @@ type Emojis = {
   };
 };
 
-const [shortCodesToEmojiData, skins, categories, short_names] = emojiCompressed;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const [shortCodesToEmojiData, skins, categories, aliases, short_names] =
+  emojiCompressed;
 
 const emojis: Emojis = {};
 


### PR DESCRIPTION
This PR rewrites `emoji_mart_data_light` as TS.

The imported module `emoji_compressed.js`, it was difficult to rewrite to TS due to the convenience of using `babel-plugin-preval`, so I took the form of creating a result type.

Please feel free to share your thoughts, feedback, or suggestions. Any advice for further improvement is highly appreciated.