### PR TITLE
Handle Surrogate Pairs in truncate()

### DIFF
--- a/app/javascript/mastodon/features/status/index.jsx
+++ b/app/javascript/mastodon/features/status/index.jsx
@@ -166,8 +166,9 @@ const makeMapStateToProps = () => {
 };
 
 const truncate = (str, num) => {
-  if (str.length > num) {
-    return str.slice(0, num) + '…';
+  const arr = Array.from(str);
+  if (arr.length > num) {
+    return arr.slice(0, num).join('') + '…';
   } else {
     return str;
   }


### PR DESCRIPTION
The current truncate function does not handle Unicode surrogate pairs correctly. The string was incorrectly truncated because it was treating them as two separate characters.

```js
truncate(`12😀`, 3)
// '12\uD83D…'
```

This PR updates the truncate function to handle surrogate pairs correctly. Convert the string to an array using the Array.from() method. This method treats a surrogate pair as a single character. This function now correctly truncates strings even if they contain surrogate pairs.


```js
truncate(`12😀`, 3)
// '12😀'
truncate(`12😀`, 2)
// '12…'
```
This update ensures that the function works as expected for all kinds of strings, making it more useful and reliable.