### PR TITLE
[Dependashlee] Bump brakeman from 5.4.1 to 6.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -162,7 +162,7 @@ group :development do
   gem 'letter_opener_web', '~> 2.0'
 
   # Security analysis CLI tools
-  gem 'brakeman', '~> 5.4', require: false
+  gem 'brakeman', '~> 6.0', require: false
   gem 'bundler-audit', '~> 0.9', require: false
 
   # Linter CLI for HAML files

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     blurhash (0.1.7)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
-    brakeman (5.4.1)
+    brakeman (6.0.0)
     browser (5.3.1)
     brpoplpush-redis_script (0.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -775,7 +775,7 @@ DEPENDENCIES
   binding_of_caller (~> 1.0)
   blurhash (~> 0.1)
   bootsnap (~> 1.16.0)
-  brakeman (~> 5.4)
+  brakeman (~> 6.0)
   browser
   bundler-audit (~> 0.9)
   capistrano (~> 3.17)


### PR DESCRIPTION
* Drop support for Ruby 1.8/1.9 syntax
* Raise minimum Ruby version to 3.0
* Add obsolete fingerprints to comparison report (https://github.com/presidentbeef/brakeman/issues/1758)
* Warn about missing CSRF protection when defaults are not loaded ([Chris Kruger](https://github.com/montdidier))
* Fix false positive with content_tag in newer Rails (https://github.com/presidentbeef/brakeman/issues/1778)
* Scan directories that include the word public
* Fix end-of-life dates for Ruby