### PR TITLE
Align argument type to keyword argument for private process method in FetchResourceService

### DIFF
--- a/app/services/fetch_resource_service.rb
+++ b/app/services/fetch_resource_service.rb
@@ -19,7 +19,7 @@ class FetchResourceService < BaseService
 
   private
 
-  def process(url, terminal = false)
+  def process(url, terminal: false)
     @url = url
 
     perform_request { |response| process_response(response, terminal) }


### PR DESCRIPTION
Introduce type signature for my mastodon source code, and found `process` method in `FetchResourceService` that using diffarent argument type.

```ruby
  #  define process method this line, and using optional terminal argument.
  def process(url, terminal = false)
    @url = url

    perform_request { |response| process_response(response, terminal) }
  end

  def process_html(response)
    page      = Nokogiri::HTML(response.body_with_limit)
    json_link = page.xpath('//link[@rel="alternate"]').find { |link| ACTIVITY_STREAM_LINK_TYPES.include?(link['type']) }

    # but, using keyword argument in this line.
    process(json_link['href'], terminal: true) unless json_link.nil?
  end
```

So, I thought better to align to keyword argument .