### PR TITLE
Drop support for Node.js 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mastodon/mastodon",
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "scripts": {
     "postversion": "git push --tags",


### PR DESCRIPTION
This version is no longer supported since 30/04/2023, and we have dependencies dropping this version as well.

Our recommended version (`.nvmrc` and docs) is Node 16.

We might want to consider upgrading the recommended to Node 18 in another PR.