### PR TITLE
Add support for importing lists

### DIFF
--- a/app/controllers/settings/imports_controller.rb
+++ b/app/controllers/settings/imports_controller.rb
@@ -12,6 +12,7 @@ class Settings::ImportsController < Settings::BaseController
     muting: 'muted_accounts_failures.csv',
     domain_blocking: 'blocked_domains_failures.csv',
     bookmarks: 'bookmarks_failures.csv',
+    lists: 'lists_failures.csv',
   }.freeze
 
   TYPE_TO_HEADERS_MAP = {
@@ -20,6 +21,7 @@ class Settings::ImportsController < Settings::BaseController
     muting: ['Account address', 'Hide notifications'],
     domain_blocking: false,
     bookmarks: false,
+    lists: false,
   }.freeze
 
   def index
@@ -49,6 +51,8 @@ class Settings::ImportsController < Settings::BaseController
               csv << [row.data['domain']]
             when :bookmarks
               csv << [row.data['uri']]
+            when :lists
+              csv << [row.data['list_name'], row.data['acct']]
             end
           end
         end

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -30,6 +30,7 @@ class BulkImport < ApplicationRecord
     muting: 2,
     domain_blocking: 3,
     bookmarks: 4,
+    lists: 5,
   }
 
   enum state: {

--- a/app/views/settings/imports/index.html.haml
+++ b/app/views/settings/imports/index.html.haml
@@ -3,7 +3,7 @@
 
 = simple_form_for @import, url: settings_imports_path do |f|
   .field-group
-    = f.input :type, as: :grouped_select, collection: { constructive: %i(following bookmarks), destructive: %i(muting blocking domain_blocking) }, wrapper: :with_block_label, include_blank: false, label_method: ->(type) { I18n.t("imports.types.#{type}") }, group_label_method: ->(group) { I18n.t("imports.type_groups.#{group.first}") }, group_method: :last, hint: t('imports.preface')
+    = f.input :type, as: :grouped_select, collection: { constructive: %i(following bookmarks lists), destructive: %i(muting blocking domain_blocking) }, wrapper: :with_block_label, include_blank: false, label_method: ->(type) { I18n.t("imports.types.#{type}") }, group_label_method: ->(group) { I18n.t("imports.type_groups.#{group.first}") }, group_method: :last, hint: t('imports.preface')
 
   .fields-row
     .fields-group.fields-row__column.fields-row__column-6

--- a/spec/fixtures/files/lists.csv
+++ b/spec/fixtures/files/lists.csv
@@ -1,0 +1,3 @@
+Mastodon project,gargron@example.com
+Mastodon project,mastodon@example.com
+test,foo@example.com

--- a/spec/models/form/import_spec.rb
+++ b/spec/models/form/import_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe Form::Import do
     it_behaves_like 'too many CSV rows', 'muting', 'imports.txt', 1
     it_behaves_like 'too many CSV rows', 'domain_blocking', 'domain_blocks.csv', 2
     it_behaves_like 'too many CSV rows', 'bookmarks', 'bookmark-imports.txt', 3
+    it_behaves_like 'too many CSV rows', 'lists', 'lists.csv', 2
 
     # Importing list of addresses with no headers into various types
     it_behaves_like 'valid import', 'following', 'imports.txt'
@@ -97,6 +98,9 @@ RSpec.describe Form::Import do
 
     # Importing bookmarks list with no headers into expected type
     it_behaves_like 'valid import', 'bookmarks', 'bookmark-imports.txt'
+
+    # Importing lists with no headers into expected type
+    it_behaves_like 'valid import', 'lists', 'lists.csv'
 
     # Importing followed accounts with headers into various compatible types
     it_behaves_like 'valid import', 'following', 'following_accounts.csv'
@@ -271,6 +275,12 @@ RSpec.describe Form::Import do
     it_behaves_like 'on successful import', 'muting', 'merge', 'muted_accounts.csv', [
       { 'acct' => 'user@example.com', 'hide_notifications' => true },
       { 'acct' => 'user@test.com', 'hide_notifications' => false },
+    ]
+
+    it_behaves_like 'on successful import', 'lists', 'merge', 'lists.csv', [
+      { 'acct' => 'gargron@example.com', 'list_name' => 'Mastodon project' },
+      { 'acct' => 'mastodon@example.com', 'list_name' => 'Mastodon project' },
+      { 'acct' => 'foo@example.com', 'list_name' => 'test' },
     ]
 
     # Based on the bug report 20571 where UTF-8 encoded domains were rejecting import of their users


### PR DESCRIPTION
This PR introduces the ability to import lists as exported by Mastodon since v2.8.

Whenever a listed account is not already followed, an attempt will be made to follow it.

Fixes #15015

---

Fixes MAS-33