### PR TITLE
Add CLI area progress bar helper

### DIFF
--- a/lib/mastodon/cli/base.rb
+++ b/lib/mastodon/cli/base.rb
@@ -31,7 +31,7 @@ module Mastodon
 
       def reset_connection_pools!
         ActiveRecord::Base.establish_connection(
-          ActiveRecord::Base.configurations[Rails.env]
+          ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).first.configuration_hash
             .dup
             .tap { |config| config['pool'] = options[:concurrency] + 1 }
         )

--- a/lib/mastodon/cli/base.rb
+++ b/lib/mastodon/cli/base.rb
@@ -4,15 +4,38 @@ require_relative '../../../config/boot'
 require_relative '../../../config/environment'
 
 require 'thor'
-require_relative 'helper'
+require_relative 'progress_helper'
 
 module Mastodon
   module CLI
     class Base < Thor
-      include CLI::Helper
+      include ProgressHelper
 
       def self.exit_on_failure?
         true
+      end
+
+      private
+
+      def pastel
+        @pastel ||= Pastel.new
+      end
+
+      def dry_run?
+        options[:dry_run]
+      end
+
+      def dry_run_mode_suffix
+        dry_run? ? ' (DRY RUN)' : ''
+      end
+
+      def reset_connection_pools!
+        ActiveRecord::Base.establish_connection(
+          ActiveRecord::Base.configurations[Rails.env]
+            .dup
+            .tap { |config| config['pool'] = options[:concurrency] + 1 }
+        )
+        RedisConfiguration.establish_pool(options[:concurrency])
       end
     end
   end

--- a/lib/mastodon/cli/progress_helper.rb
+++ b/lib/mastodon/cli/progress_helper.rb
@@ -9,12 +9,19 @@ HttpLog.configuration.logger = dev_null
 Paperclip.options[:log]      = false
 Chewy.logger                 = dev_null
 
+require 'ruby-progressbar/outputs/null'
+
 module Mastodon::CLI
   module ProgressHelper
     PROGRESS_FORMAT = '%c/%u |%b%i| %e'
 
     def create_progress_bar(total = nil)
-      ProgressBar.create(total: total, format: PROGRESS_FORMAT)
+      ProgressBar.create(
+        {
+          total: total,
+          format: PROGRESS_FORMAT,
+        }.merge(progress_output_options)
+      )
     end
 
     def parallelize_with_progress(scope)
@@ -69,6 +76,12 @@ module Mastodon::CLI
       progress.stop
 
       [total.value, aggregate.value]
+    end
+
+    private
+
+    def progress_output_options
+      Rails.env.test? ? { output: ProgressBar::Outputs::Null } : {}
     end
   end
 end

--- a/lib/mastodon/cli/progress_helper.rb
+++ b/lib/mastodon/cli/progress_helper.rb
@@ -11,7 +11,7 @@ Chewy.logger                 = dev_null
 
 module Mastodon::CLI
   module ProgressHelper
-    PROGRESS_FORMAT = '%c/%u |%b%i| %e'.freeze
+    PROGRESS_FORMAT = '%c/%u |%b%i| %e'
 
     def create_progress_bar(total = nil)
       ProgressBar.create(total: total, format: PROGRESS_FORMAT)

--- a/lib/mastodon/cli/progress_helper.rb
+++ b/lib/mastodon/cli/progress_helper.rb
@@ -10,22 +10,11 @@ Paperclip.options[:log]      = false
 Chewy.logger                 = dev_null
 
 module Mastodon::CLI
-  module Helper
-    def dry_run?
-      options[:dry_run]
-    end
-
-    def dry_run_mode_suffix
-      dry_run? ? ' (DRY RUN)' : ''
-    end
+  module ProgressHelper
+    PROGRESS_FORMAT = '%c/%u |%b%i| %e'.freeze
 
     def create_progress_bar(total = nil)
-      ProgressBar.create(total: total, format: '%c/%u |%b%i| %e')
-    end
-
-    def reset_connection_pools!
-      ActiveRecord::Base.establish_connection(ActiveRecord::Base.configurations[Rails.env].dup.tap { |config| config['pool'] = options[:concurrency] + 1 })
-      RedisConfiguration.establish_pool(options[:concurrency])
+      ProgressBar.create(total: total, format: PROGRESS_FORMAT)
     end
 
     def parallelize_with_progress(scope)
@@ -80,10 +69,6 @@ module Mastodon::CLI
       progress.stop
 
       [total.value, aggregate.value]
-    end
-
-    def pastel
-      @pastel ||= Pastel.new
     end
   end
 end


### PR DESCRIPTION
- Extracts progressbar specific stuff to well named helper
- Leaves non-progress things in CLI Base class
- Slight refactor on creating a progress bar - format held in a constant, and null progress bar format used in Rails test env (reduce noise during spec runs)
- Update rails DB config line to fix deprecation warning