### PR TITLE
Add missing primary keys to `accounts_tags` and `statuses_tags`

### DIFF
--- a/db/migrate/20230531153942_add_primary_key_to_accounts_tags_join_table.rb
+++ b/db/migrate/20230531153942_add_primary_key_to_accounts_tags_join_table.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddPrimaryKeyToAccountsTagsJoinTable < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    ActiveRecord::Base.transaction do
+      safety_assured do
+        execute 'ALTER TABLE accounts_tags ADD PRIMARY KEY USING INDEX index_accounts_tags_on_tag_id_and_account_id'
+
+        # Rename for consistency as the primary key's name is not represented in db/schema.rb
+        execute 'ALTER INDEX index_accounts_tags_on_tag_id_and_account_id RENAME TO accounts_tags_pkey'
+      end
+    end
+  end
+
+  def down
+    safety_assured do
+      # I have found no way to demote the primary key to an index, instead, re-create the index
+      execute 'CREATE UNIQUE INDEX CONCURRENTLY index_accounts_tags_on_tag_id_and_account_id ON accounts_tags (tag_id, account_id)'
+      execute 'ALTER TABLE accounts_tags DROP CONSTRAINT accounts_tags_pkey'
+    end
+  end
+end

--- a/db/migrate/20230531154811_add_primary_key_to_statuses_tags_join_table.rb
+++ b/db/migrate/20230531154811_add_primary_key_to_statuses_tags_join_table.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddPrimaryKeyToStatusesTagsJoinTable < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    ActiveRecord::Base.transaction do
+      safety_assured do
+        execute 'ALTER TABLE statuses_tags ADD PRIMARY KEY USING INDEX index_statuses_tags_on_tag_id_and_status_id'
+
+        # Rename for consistency as the primary key's name is not represented in db/schema.rb
+        execute 'ALTER INDEX index_statuses_tags_on_tag_id_and_status_id RENAME TO statuses_tags_pkey'
+      end
+    end
+  end
+
+  def down
+    safety_assured do
+      # I have found no way to demote the primary key to an index, instead, re-create the index
+      execute 'CREATE UNIQUE INDEX CONCURRENTLY index_statuses_tags_on_tag_id_and_status_id ON statuses_tags (tag_id, status_id)'
+      execute 'ALTER TABLE statuses_tags DROP CONSTRAINT statuses_tags_pkey'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_24_194155) do
+ActiveRecord::Schema.define(version: 2023_05_31_154811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -194,11 +194,10 @@ ActiveRecord::Schema.define(version: 2023_05_24_194155) do
     t.index ["url"], name: "index_accounts_on_url", opclass: :text_pattern_ops, where: "(url IS NOT NULL)"
   end
 
-  create_table "accounts_tags", id: false, force: :cascade do |t|
+  create_table "accounts_tags", primary_key: ["tag_id", "account_id"], force: :cascade do |t|
     t.bigint "account_id", null: false
     t.bigint "tag_id", null: false
     t.index ["account_id", "tag_id"], name: "index_accounts_tags_on_account_id_and_tag_id"
-    t.index ["tag_id", "account_id"], name: "index_accounts_tags_on_tag_id_and_account_id", unique: true
   end
 
   create_table "admin_action_logs", force: :cascade do |t|
@@ -979,11 +978,10 @@ ActiveRecord::Schema.define(version: 2023_05_24_194155) do
     t.index ["uri"], name: "index_statuses_on_uri", unique: true, opclass: :text_pattern_ops, where: "(uri IS NOT NULL)"
   end
 
-  create_table "statuses_tags", id: false, force: :cascade do |t|
+  create_table "statuses_tags", primary_key: ["tag_id", "status_id"], force: :cascade do |t|
     t.bigint "status_id", null: false
     t.bigint "tag_id", null: false
     t.index ["status_id"], name: "index_statuses_tags_on_status_id"
-    t.index ["tag_id", "status_id"], name: "index_statuses_tags_on_tag_id_and_status_id", unique: true
   end
 
   create_table "system_keys", force: :cascade do |t|


### PR DESCRIPTION
When investigating logical replication, @renchap found the following tables were lacking a primary key: `accounts_tags`, `preview_cards_statuses`, ~~`schema_migrations`~~ and `statuses_tags`

This PR aims to fix that. Unfortunately, `schema_migrations` is not managed by us, and `preview_cards_statuses` does not currently have a unique index.

When possible, this PR promotes existing unique indexes to composite primary keys. This seems to be well supported by a wide range of PostgreSQL versions, at least starting from PostgreSQL 10.

EDIT: `schema_migrations` seems to have a proper primary key on most installs, not sure why it doesn't have one on the database we examined.