### PR TITLE
Remove unused Settings::Extend module

### DIFF
--- a/app/lib/settings/extend.rb
+++ b/app/lib/settings/extend.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module Settings
-  module Extend
-    def settings
-      @settings ||= ScopedSettings.new(self)
-    end
-  end
-end


### PR DESCRIPTION
Last usage removed in https://github.com/mastodon/mastodon/commit/a9b5598c97fc4d3302b61b260097ef41c2ebe377#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bL54