### PR TITLE
Disable some metrics cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,6 +95,11 @@ Metrics/CyclomaticComplexity:
     - lib/mastodon/cli/*.rb
     - db/*migrate/**/*
 
+# Reason:
+# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsparameterlists
+Metrics/ParameterLists:
+  CountKeywordArgs: false
+
 # Reason: Prevailing style is argument file paths
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsfilepath
 Rails/FilePath:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,28 @@ Lint/UselessAccessModifier:
   ContextCreatingMethods:
     - class_methods
 
+## Disable most Metrics/*Length cops
+# Reason: those are often triggered and force significant refactors when this happend
+#         but the team feel they are not really improving the code quality.
+
+# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsblocklength
+Metrics/BlockLength:
+  Enabled: false
+
+# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsclasslength
+Metrics/ClassLength:
+  Enabled: false
+
+# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmethodlength
+Metrics/MethodLength:
+  Enabled: false
+
+# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmodulelength
+Metrics/ModuleLength:
+  Enabled: false
+
+## End Disable Metrics/*Length cops
+
 # Reason: Currently disabled in .rubocop_todo.yml
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsabcsize
 Metrics/AbcSize:
@@ -60,87 +82,11 @@ Metrics/AbcSize:
     - 'lib/mastodon/cli/*.rb'
     - db/*migrate/**/*
 
-# Reason: Some functions cannot be broken up, but others may be refactor candidates
-# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsblocklength
-Metrics/BlockLength:
-  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
-  Exclude:
-    - 'config/routes.rb'
-    - 'lib/mastodon/cli/*.rb'
-    - 'lib/tasks/*.rake'
-    - 'app/models/concerns/account_associations.rb'
-    - 'app/models/concerns/account_interactions.rb'
-    - 'app/models/concerns/ldap_authenticable.rb'
-    - 'app/models/concerns/omniauthable.rb'
-    - 'app/models/concerns/pam_authenticable.rb'
-    - 'app/models/concerns/remotable.rb'
-    - 'app/services/suspend_account_service.rb'
-    - 'app/services/unsuspend_account_service.rb'
-    - 'app/views/accounts/show.rss.ruby'
-    - 'app/views/tags/show.rss.ruby'
-    - 'config/environments/development.rb'
-    - 'config/environments/production.rb'
-    - 'config/initializers/devise.rb'
-    - 'config/initializers/doorkeeper.rb'
-    - 'config/initializers/omniauth.rb'
-    - 'config/initializers/simple_form.rb'
-    - 'config/navigation.rb'
-    - 'config/routes.rb'
-    - 'config/routes/*.rb'
-    - 'db/post_migrate/20221101190723_backfill_admin_action_logs.rb'
-    - 'db/post_migrate/20221206114142_backfill_admin_action_logs_again.rb'
-    - 'lib/paperclip/gif_transcoder.rb'
-
 # Reason:
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricsblocknesting
 Metrics/BlockNesting:
   Exclude:
     - 'lib/mastodon/cli/*.rb'
-
-# Reason: Some Excluded files would be candidates for refactoring but not currently addressed
-# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsclasslength
-Metrics/ClassLength:
-  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
-  Exclude:
-    - 'lib/mastodon/cli/*.rb'
-    - 'app/controllers/admin/accounts_controller.rb'
-    - 'app/controllers/api/base_controller.rb'
-    - 'app/controllers/api/v1/admin/accounts_controller.rb'
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/auth/registrations_controller.rb'
-    - 'app/controllers/auth/sessions_controller.rb'
-    - 'app/lib/activitypub/activity.rb'
-    - 'app/lib/activitypub/activity/create.rb'
-    - 'app/lib/activitypub/tag_manager.rb'
-    - 'app/lib/feed_manager.rb'
-    - 'app/lib/link_details_extractor.rb'
-    - 'app/lib/request.rb'
-    - 'app/lib/text_formatter.rb'
-    - 'app/lib/user_settings_decorator.rb'
-    - 'app/mailers/user_mailer.rb'
-    - 'app/models/account.rb'
-    - 'app/models/admin/account_action.rb'
-    - 'app/models/form/account_batch.rb'
-    - 'app/models/media_attachment.rb'
-    - 'app/models/status.rb'
-    - 'app/models/tag.rb'
-    - 'app/models/user.rb'
-    - 'app/serializers/activitypub/actor_serializer.rb'
-    - 'app/serializers/activitypub/note_serializer.rb'
-    - 'app/serializers/rest/status_serializer.rb'
-    - 'app/services/account_search_service.rb'
-    - 'app/services/activitypub/process_account_service.rb'
-    - 'app/services/activitypub/process_status_update_service.rb'
-    - 'app/services/backup_service.rb'
-    - 'app/services/bulk_import_service.rb'
-    - 'app/services/delete_account_service.rb'
-    - 'app/services/fan_out_on_write_service.rb'
-    - 'app/services/fetch_link_card_service.rb'
-    - 'app/services/import_service.rb'
-    - 'app/services/notify_service.rb'
-    - 'app/services/post_status_service.rb'
-    - 'app/services/update_status_service.rb'
-    - 'lib/paperclip/color_extractor.rb'
 
 # Reason: Currently disabled in .rubocop_todo.yml
 # https://docs.rubocop.org/rubocop/cops_metrics.html#metricscyclomaticcomplexity
@@ -148,18 +94,6 @@ Metrics/CyclomaticComplexity:
   Exclude:
     - lib/mastodon/cli/*.rb
     - db/*migrate/**/*
-
-# Reason: Currently disabled in .rubocop_todo.yml
-# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmethodlength
-Metrics/MethodLength:
-  CountAsOne: [array, heredoc]
-  Exclude:
-    - 'lib/mastodon/cli/*.rb'
-
-# Reason:
-# https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmodulelength
-Metrics/ModuleLength:
-  CountAsOne: [array, heredoc]
 
 # Reason: Prevailing style is argument file paths
 # https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsfilepath

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -154,12 +154,6 @@ Lint/Void:
 Metrics/AbcSize:
   Max: 150
 
-# Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
-# AllowedMethods: refine
-Metrics/BlockLength:
-  Exclude:
-    - 'app/models/concerns/status_safe_reblog_insert.rb'
-
 # Configuration parameters: CountBlocks, Max.
 Metrics/BlockNesting:
   Exclude:
@@ -168,19 +162,6 @@ Metrics/BlockNesting:
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/CyclomaticComplexity:
   Max: 25
-
-# Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
-Metrics/MethodLength:
-  Max: 58
-
-# Configuration parameters: CountComments, Max, CountAsOne.
-Metrics/ModuleLength:
-  Exclude:
-    - 'app/controllers/concerns/signature_verification.rb'
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/jsonld_helper.rb'
-    - 'app/models/concerns/account_interactions.rb'
-    - 'app/models/concerns/has_user_settings.rb'
 
 # Configuration parameters: Max, CountKeywordArgs, MaxOptionalParameters.
 Metrics/ParameterLists:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -163,14 +163,6 @@ Metrics/BlockNesting:
 Metrics/CyclomaticComplexity:
   Max: 25
 
-# Configuration parameters: Max, CountKeywordArgs, MaxOptionalParameters.
-Metrics/ParameterLists:
-  Exclude:
-    - 'app/models/concerns/account_interactions.rb'
-    - 'app/services/activitypub/fetch_remote_account_service.rb'
-    - 'app/services/activitypub/fetch_remote_actor_service.rb'
-    - 'app/services/activitypub/fetch_remote_status_service.rb'
-
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/PerceivedComplexity:
   Max: 28

--- a/app/helpers/languages_helper.rb
+++ b/app/helpers/languages_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ModuleLength
-
 module LanguagesHelper
   ISO_639_1 = {
     aa: ['Afar', 'Afaraf'].freeze,


### PR DESCRIPTION
This comes from a discussion with @ClearlyClaire

Some `Metrics/*Length` cops are often ignored and/or triggered when working on the code-base.

The team feels that they do not bring much regarding code quality, and rather the increasing their limits, ignoring them when they are triggered, or doing big reworks, it might be better to remove them.

The other metrics cops are fine, and refactors should probably focus on reducing the various complexity cops limits rather than only working on scope length.

The `Metrics/ParameterLists` has also been configured with `CountKeywordArgs: false`, as this fits the coding style better and allows to remove the currently ignored files for this cop.