### PR TITLE
Fix prev/next buttons color in media viewer

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5470,7 +5470,7 @@ a.status-card.compact:hover {
   background: transparent;
   box-sizing: border-box;
   border: 0;
-  color: rgba($primary-text-color, 0.7);
+  color: rgba($white, 0.7);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -5485,7 +5485,7 @@ a.status-card.compact:hover {
   &:hover,
   &:focus,
   &:active {
-    color: $primary-text-color;
+    color: $white;
   }
 }
 


### PR DESCRIPTION
They should always be white, regardless of the theme, like the other buttons

Fixes #25044

<img width="781" alt="image" src="https://github.com/mastodon/mastodon/assets/42070/5f2a6356-2eed-4748-9c14-62f93da719fe">
