### PR TITLE
Change preview cards from a has_and_belongs_to_many to a belongs_to relationship

### DIFF
--- a/app/controllers/api/v1/conversations_controller.rb
+++ b/app/controllers/api/v1/conversations_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::ConversationsController < Api::BaseController
                          account: :account_stat,
                          last_status: [
                            :media_attachments,
-                           :preview_cards,
+                           :preview_card,
                            :status_stat,
                            :tags,
                            {

--- a/app/models/admin/status_batch_action.rb
+++ b/app/models/admin/status_batch_action.rb
@@ -74,7 +74,7 @@ class Admin::StatusBatchAction
 
     # Can't use a transaction here because UpdateStatusService queues
     # Sidekiq jobs
-    statuses.includes(:media_attachments, :preview_cards).find_each do |status|
+    statuses.includes(:media_attachments, :preview_card).find_each do |status|
       next if status.discarded? || !(status.with_media? || status.with_preview_card?)
 
       authorize([:admin, status], :update?)

--- a/app/models/preview_card.rb
+++ b/app/models/preview_card.rb
@@ -48,7 +48,7 @@ class PreviewCard < ApplicationRecord
   enum type: { link: 0, photo: 1, video: 2, rich: 3 }
   enum link_type: { unknown: 0, article: 1 }
 
-  has_and_belongs_to_many :statuses
+  has_many :statuses, dependent: :nullify
   has_one :trend, class_name: 'PreviewCardTrend', inverse_of: :preview_card, dependent: :destroy
 
   has_attached_file :image, processors: [:thumbnail, :blurhash_transcoder], styles: ->(f) { image_styles(f) }, convert_options: { all: '-quality 90 +profile "!icc,*" +set modify-date +set create-date' }, validate_media_type: false

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -72,7 +72,8 @@ class Status < ApplicationRecord
   has_many :media_attachments, dependent: :nullify
 
   has_and_belongs_to_many :tags
-  has_and_belongs_to_many :preview_cards
+
+  belongs_to :preview_card, optional: true
 
   has_one :notification, as: :activity, dependent: :destroy
   has_one :status_stat, inverse_of: :status
@@ -139,14 +140,14 @@ class Status < ApplicationRecord
                    :conversation,
                    :status_stat,
                    :tags,
-                   :preview_cards,
+                   :preview_card,
                    :preloadable_poll,
                    account: [:account_stat, user: :role],
                    active_mentions: { account: :account_stat },
                    reblog: [
                      :application,
                      :tags,
-                     :preview_cards,
+                     :preview_card,
                      :media_attachments,
                      :conversation,
                      :status_stat,
@@ -247,10 +248,6 @@ class Status < ApplicationRecord
     reblog
   end
 
-  def preview_card
-    preview_cards.first
-  end
-
   def hidden?
     !distributable?
   end
@@ -266,7 +263,7 @@ class Status < ApplicationRecord
   end
 
   def with_preview_card?
-    preview_cards.any?
+    preview_card.present?
   end
 
   def non_sensitive_with_media?

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -27,6 +27,7 @@
 #  edited_at                    :datetime
 #  trendable                    :boolean
 #  ordered_media_attachment_ids :bigint(8)        is an Array
+#  preview_card_id              :bigint(8)
 #
 
 class Status < ApplicationRecord

--- a/app/models/trends/links.rb
+++ b/app/models/trends/links.rb
@@ -52,9 +52,7 @@ class Trends::Links < Trends::Base
                   !(original_status.account.silenced? || status.account.silenced?) &&
                   !(original_status.spoiler_text? || original_status.sensitive?)
 
-    original_status.preview_cards.each do |preview_card|
-      add(preview_card, status.account_id, at_time) if preview_card.appropriate_for_trends?
-    end
+    add(original_status.preview_card, status.account_id, at_time) if original_status.preview_card&.appropriate_for_trends?
   end
 
   def add(preview_card, account_id, at_time = Time.now.utc)

--- a/app/services/activitypub/process_status_update_service.rb
+++ b/app/services/activitypub/process_status_update_service.rb
@@ -281,7 +281,7 @@ class ActivityPub::ProcessStatusUpdateService < BaseService
   end
 
   def reset_preview_card!
-    @status.preview_cards.clear
+    @status.update(preview_card: nil)
     LinkCrawlWorker.perform_in(rand(1..59).seconds, @status.id)
   end
 

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -19,7 +19,7 @@ class FetchLinkCardService < BaseService
     @status       = status
     @original_url = parse_urls
 
-    return if @original_url.nil? || @status.preview_cards.any?
+    return if @original_url.nil? || @status.with_preview_card?
 
     @url = @original_url.to_s
 
@@ -63,7 +63,7 @@ class FetchLinkCardService < BaseService
   end
 
   def attach_card
-    @status.preview_cards << @card
+    @status.update!(preview_card: @card)
     Rails.cache.delete(@status)
     Trends.links.register(@status)
   end

--- a/app/services/update_status_service.rb
+++ b/app/services/update_status_service.rb
@@ -123,7 +123,7 @@ class UpdateStatusService < BaseService
   def reset_preview_card!
     return unless @status.text_previously_changed?
 
-    @status.preview_cards.clear
+    @status.update!(preview_card: nil)
     LinkCrawlWorker.perform_async(@status.id)
   end
 

--- a/db/migrate/20230601124507_add_preview_card_to_statuses.rb
+++ b/db/migrate/20230601124507_add_preview_card_to_statuses.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddPreviewCardToStatuses < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :statuses, :preview_card, null: true, index: { algorithm: :concurrently, where: 'preview_card_id IS NOT NULL' }
+  end
+end

--- a/db/migrate/20230601124839_add_preview_card_foreign_key_to_statuses.rb
+++ b/db/migrate/20230601124839_add_preview_card_foreign_key_to_statuses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPreviewCardForeignKeyToStatuses < ActiveRecord::Migration[6.1]
+  def change
+    add_foreign_key :statuses, :preview_cards, on_delete: :nullify, validate: false
+  end
+end

--- a/db/migrate/20230601125204_validate_add_preview_card_foreign_key_to_statuses.rb
+++ b/db/migrate/20230601125204_validate_add_preview_card_foreign_key_to_statuses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateAddPreviewCardForeignKeyToStatuses < ActiveRecord::Migration[6.1]
+  def change
+    validate_foreign_key :statuses, :preview_cards
+  end
+end

--- a/db/post_migrate/20230601132637_backfill_status_preview_card.rb
+++ b/db/post_migrate/20230601132637_backfill_status_preview_card.rb
@@ -6,13 +6,38 @@ class BackfillStatusPreviewCard < ActiveRecord::Migration[6.1]
   class PreviewCardStatusJoin < ApplicationRecord
     self.table_name = 'preview_cards_statuses'
     self.primary_key = 'status_id'
+
+    # This is similar to ActiveRecord::Batch::in_batches but it yield
+    # primary keys instead of a relationship with `where(primary_key: …)`.
+    # It's simplified to only work on the primary key and not any other column.
+    # This is all to avoid an unnecessary SQL round-trip on each batch.
+    def self.pluck_in_batches
+      relation = all.reorder(status_id: :desc).limit(1_000)
+      relation.skip_query_cache!
+
+      batch_relation = relation
+
+      loop do
+        batch = batch_relation.pluck('DISTINCT status_id')
+
+        break if batch.empty?
+
+        primary_key_offset = batch.last
+
+        yield batch
+
+        break if batch.size < 1_000
+
+        batch_relation = relation.where(status_id: ...primary_key_offset)
+      end
+    end
   end
 
   class Status < ApplicationRecord; end
 
   def up
-    PreviewCardStatusJoin.in_batches(order: :desc) do |preview_card_status_join|
-      Status.where(id: preview_card_status_join.ids)
+    PreviewCardStatusJoin.pluck_in_batches do |ids|
+      Status.where(id: ids)
             .update_all( # rubocop:disable Rails/SkipsModelValidations
               'preview_card_id = (SELECT preview_card_id FROM preview_cards_statuses WHERE status_id = statuses.id LIMIT 1)'
             )

--- a/db/post_migrate/20230601132637_backfill_status_preview_card.rb
+++ b/db/post_migrate/20230601132637_backfill_status_preview_card.rb
@@ -11,7 +11,7 @@ class BackfillStatusPreviewCard < ActiveRecord::Migration[6.1]
   class Status < ApplicationRecord; end
 
   def up
-    PreviewCardStatusJoin.in_batches do |preview_card_status_join|
+    PreviewCardStatusJoin.in_batches(order: :desc) do |preview_card_status_join|
       Status.where(id: preview_card_status_join.ids)
             .update_all( # rubocop:disable Rails/SkipsModelValidations
               'preview_card_id = (SELECT preview_card_id FROM preview_cards_statuses WHERE status_id = statuses.id LIMIT 1)'

--- a/db/post_migrate/20230601132637_backfill_status_preview_card.rb
+++ b/db/post_migrate/20230601132637_backfill_status_preview_card.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class BackfillStatusPreviewCard < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  class PreviewCardStatusJoin < ApplicationRecord
+    self.table_name = 'preview_cards_statuses'
+    self.primary_key = 'status_id'
+  end
+
+  class Status < ApplicationRecord; end
+
+  def up
+    PreviewCardStatusJoin.in_batches do |preview_card_status_join|
+      Status.where(id: preview_card_status_join.ids)
+            .update_all( # rubocop:disable Rails/SkipsModelValidations
+              'preview_card_id = (SELECT preview_card_id FROM preview_cards_statuses WHERE status_id = statuses.id LIMIT 1)'
+            )
+    end
+  end
+
+  def down; end
+end

--- a/db/post_migrate/20230601142652_drop_join_table_preview_cards_statuses.rb
+++ b/db/post_migrate/20230601142652_drop_join_table_preview_cards_statuses.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DropJoinTablePreviewCardsStatuses < ActiveRecord::Migration[6.1]
+  def change
+    drop_join_table :preview_cards, :statuses do |t|
+      t.index [:status_id, :preview_card_id]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_01_125204) do
+ActiveRecord::Schema.define(version: 2023_06_01_132637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_01_132637) do
+ActiveRecord::Schema.define(version: 2023_06_01_142652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -800,12 +800,6 @@ ActiveRecord::Schema.define(version: 2023_06_01_132637) do
     t.boolean "trendable"
     t.integer "link_type"
     t.index ["url"], name: "index_preview_cards_on_url", unique: true
-  end
-
-  create_table "preview_cards_statuses", id: false, force: :cascade do |t|
-    t.bigint "preview_card_id", null: false
-    t.bigint "status_id", null: false
-    t.index ["status_id", "preview_card_id"], name: "index_preview_cards_statuses_on_status_id_and_preview_card_id"
   end
 
   create_table "relays", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_31_154811) do
+ActiveRecord::Schema.define(version: 2023_06_01_125204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -967,6 +967,7 @@ ActiveRecord::Schema.define(version: 2023_05_31_154811) do
     t.datetime "edited_at"
     t.boolean "trendable"
     t.bigint "ordered_media_attachment_ids", array: true
+    t.bigint "preview_card_id"
     t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20190820", order: { id: :desc }, where: "(deleted_at IS NULL)"
     t.index ["account_id"], name: "index_statuses_on_account_id"
     t.index ["deleted_at"], name: "index_statuses_on_deleted_at", where: "(deleted_at IS NOT NULL)"
@@ -974,6 +975,7 @@ ActiveRecord::Schema.define(version: 2023_05_31_154811) do
     t.index ["id", "account_id"], name: "index_statuses_public_20200119", order: { id: :desc }, where: "((deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id", where: "(in_reply_to_account_id IS NOT NULL)"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id", where: "(in_reply_to_id IS NOT NULL)"
+    t.index ["preview_card_id"], name: "index_statuses_on_preview_card_id", where: "(preview_card_id IS NOT NULL)"
     t.index ["reblog_of_id", "account_id"], name: "index_statuses_on_reblog_of_id_and_account_id"
     t.index ["uri"], name: "index_statuses_on_uri", unique: true, opclass: :text_pattern_ops, where: "(uri IS NOT NULL)"
   end
@@ -1243,6 +1245,7 @@ ActiveRecord::Schema.define(version: 2023_05_31_154811) do
   add_foreign_key "status_trends", "statuses", on_delete: :cascade
   add_foreign_key "statuses", "accounts", column: "in_reply_to_account_id", name: "fk_c7fa917661", on_delete: :nullify
   add_foreign_key "statuses", "accounts", name: "fk_9bda1543f7", on_delete: :cascade
+  add_foreign_key "statuses", "preview_cards", on_delete: :nullify
   add_foreign_key "statuses", "statuses", column: "in_reply_to_id", on_delete: :nullify
   add_foreign_key "statuses", "statuses", column: "reblog_of_id", on_delete: :cascade
   add_foreign_key "statuses_tags", "statuses", on_delete: :cascade

--- a/lib/tasks/tests.rake
+++ b/lib/tasks/tests.rake
@@ -63,6 +63,11 @@ namespace :tests do
         puts 'Account domains not properly normalized'
         exit(1)
       end
+
+      unless Status.find(12).preview_card&.url == 'https://joinmastodon.org/'
+        puts 'Preview cards not preserved as expected'
+        exit(1)
+      end
     end
 
     desc 'Populate the database with test data for 2.4.3'
@@ -238,6 +243,11 @@ namespace :tests do
           (10, 2, '@admin hey!', NULL, 1, 3, now(), now()),
           (11, 1, '@user hey!', 10, 1, 3, now(), now());
 
+        INSERT INTO "statuses"
+          (id, account_id, text, created_at, updated_at)
+        VALUES
+          (12, 1, 'check out https://joinmastodon.org/', now(), now());
+
         -- mentions (from previous statuses)
 
         INSERT INTO "mentions"
@@ -326,6 +336,21 @@ namespace :tests do
           (1, 6, 2, 'Follow', 2, now(), now()),
           (2, 2, 1, 'Mention', 4, now(), now()),
           (3, 1, 2, 'Mention', 5, now(), now());
+
+        -- preview cards
+
+        INSERT INTO "preview_cards"
+          (id, url, title, created_at, updated_at)
+        VALUES
+          (1, 'https://joinmastodon.org/', 'Mastodon - Decentralized social media', now(), now());
+
+        -- many-to-many association between preview cards and statuses
+
+        INSERT INTO "preview_cards_statuses"
+          (status_id, preview_card_id)
+        VALUES
+          (12, 1),
+          (12, 1);
       SQL
     end
   end

--- a/spec/helpers/media_component_helper_spec.rb
+++ b/spec/helpers/media_component_helper_spec.rb
@@ -49,7 +49,7 @@ describe MediaComponentHelper do
   end
 
   describe 'render_card_component' do
-    let(:status) { Fabricate(:status, preview_cards: [Fabricate(:preview_card)]) }
+    let(:status) { Fabricate(:status, preview_card: Fabricate(:preview_card)) }
     let(:result) { helper.render_card_component(status) }
 
     before do

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe FetchLinkCardService, type: :service do
 
       it 'works with SJIS' do
         expect(a_request(:get, 'http://example.com/sjis')).to have_been_made.at_least_once
-        expect(status.preview_cards.first.title).to eq('SJISのページ')
+        expect(status.preview_card.title).to eq('SJISのページ')
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe FetchLinkCardService, type: :service do
 
       it 'works with SJIS even with wrong charset header' do
         expect(a_request(:get, 'http://example.com/sjis_with_wrong_charset')).to have_been_made.at_least_once
-        expect(status.preview_cards.first.title).to eq('SJISのページ')
+        expect(status.preview_card.title).to eq('SJISのページ')
       end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe FetchLinkCardService, type: :service do
 
       it 'works with koi8-r' do
         expect(a_request(:get, 'http://example.com/koi8-r')).to have_been_made.at_least_once
-        expect(status.preview_cards.first.title).to eq('Московя начинаетъ только въ XVI ст. привлекать внимане иностранцевъ.')
+        expect(status.preview_card.title).to eq('Московя начинаетъ только въ XVI ст. привлекать внимане иностранцевъ.')
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe FetchLinkCardService, type: :service do
 
       it 'works with windows-1251' do
         expect(a_request(:get, 'http://example.com/windows-1251')).to have_been_made.at_least_once
-        expect(status.preview_cards.first.title).to eq('сэмпл текст')
+        expect(status.preview_card.title).to eq('сэмпл текст')
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe FetchLinkCardService, type: :service do
 
       it 'works with Japanese path string' do
         expect(a_request(:get, 'http://example.com/日本語')).to have_been_made.at_least_once
-        expect(status.preview_cards.first.title).to eq('SJISのページ')
+        expect(status.preview_card.title).to eq('SJISのページ')
       end
     end
 

--- a/spec/services/update_status_service_spec.rb
+++ b/spec/services/update_status_service_spec.rb
@@ -23,11 +23,10 @@ RSpec.describe UpdateStatusService, type: :service do
   end
 
   context 'when text changes' do
-    let!(:status) { Fabricate(:status, text: 'Foo') }
+    let!(:status) { Fabricate(:status, text: 'Foo', preview_card: preview_card) }
     let(:preview_card) { Fabricate(:preview_card) }
 
     before do
-      status.preview_cards << preview_card
       subject.call(status, status.account_id, text: 'Bar')
     end
 
@@ -45,11 +44,10 @@ RSpec.describe UpdateStatusService, type: :service do
   end
 
   context 'when content warning changes' do
-    let!(:status) { Fabricate(:status, text: 'Foo', spoiler_text: '') }
+    let!(:status) { Fabricate(:status, text: 'Foo', spoiler_text: '', preview_card: preview_card) }
     let(:preview_card) { Fabricate(:preview_card) }
 
     before do
-      status.preview_cards << preview_card
       subject.call(status, status.account_id, text: 'Foo', spoiler_text: 'Bar')
     end
 


### PR DESCRIPTION
A post normally has one preview card at most, but this is not enforced in the database schema. Instead, this is represented as a many-to-many relationship without a primary key or any uniqueness constraint.

This PR changes the database schema so that posts have at most a preview card through a `belongs_to` relationship and a `preview_card_id`, dropping the need for the extra table and making sure all of our tables have a primary key.

This, however, involves a bunch of very heavy migrations.