### PR TITLE
Cleanup old translationRunner

### DIFF
--- a/config/webpack/translationRunner.js
+++ b/config/webpack/translationRunner.js
@@ -1,3 +1,0 @@
-console.error("The localisation functionality has been refactored, please see the Localisation section in the development documentation (https://docs.joinmastodon.org/dev/code/#localizations)");
-
-process.exit(1);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "lint:sass": "stylelint \"**/*.{css,scss}\" && prettier --check \"**/*.{css,scss}\"",
     "lint:yml": "prettier --check \"**/*.{yaml,yml}\"",
     "lint": "yarn lint:js && yarn lint:json && yarn lint:sass && yarn lint:yml",
-    "manage:translations": "node ./config/webpack/translationRunner.js",
     "postversion": "git push --tags",
     "prepare": "husky install",
     "start": "node ./streaming/index.js",


### PR DESCRIPTION
This was stubbed out after upgrading react-i18n. Opening the PR so it can land after it's decided it's been long enough to keep