### PR TITLE
Fix spacing of middle dots in the detailed status meta section

### DIFF
--- a/app/javascript/mastodon/features/status/components/detailed_status.jsx
+++ b/app/javascript/mastodon/features/status/components/detailed_status.jsx
@@ -217,7 +217,7 @@ class DetailedStatus extends ImmutablePureComponent {
     } else if (this.context.router) {
       reblogLink = (
         <>
-           ·
+          {' · '}
           <Link to={`/@${status.getIn(['account', 'acct'])}/${status.get('id')}/reblogs`} className='detailed-status__link'>
             <Icon id={reblogIcon} />
             <span className='detailed-status__reblogs'>
@@ -229,7 +229,7 @@ class DetailedStatus extends ImmutablePureComponent {
     } else {
       reblogLink = (
         <>
-           ·
+          {' · '}
           <a href={`/interact/${status.get('id')}?type=reblog`} className='detailed-status__link' onClick={this.handleModalLink}>
             <Icon id={reblogIcon} />
             <span className='detailed-status__reblogs'>
@@ -263,7 +263,7 @@ class DetailedStatus extends ImmutablePureComponent {
     if (status.get('edited_at')) {
       edited = (
         <>
-           ·
+          {' · '}
           <EditedTimestamp statusId={status.get('id')} timestamp={status.get('edited_at')} />
         </>
       );


### PR DESCRIPTION
The whitespace here seems to have been accidentally removed in #25093.

before/after: 
<img width="599" alt="Screenshot_2023-06-02 09 13 05" src="https://github.com/mastodon/mastodon/assets/25517624/85761fb4-c187-4116-b7e0-33832e59d25a">
<img width="598" alt="Screenshot_2023-06-02 09 13 19" src="https://github.com/mastodon/mastodon/assets/25517624/e0cc5640-e42f-4a5e-aea7-9a9498e0c677">
