### PR TITLE
Fix not shown announcements in hometimeline.

### DIFF
--- a/app/javascript/mastodon/actions/importer/normalizer.js
+++ b/app/javascript/mastodon/actions/importer/normalizer.js
@@ -138,7 +138,7 @@ export function normalizePollOptionTranslation(translation, poll) {
 
 export function normalizeAnnouncement(announcement) {
   const normalAnnouncement = { ...announcement };
-  const emojiMap = makeEmojiMap.emojis(normalAnnouncement);
+  const emojiMap = makeEmojiMap(normalAnnouncement.emojis);
 
   normalAnnouncement.contentHtml = emojify(normalAnnouncement.content, emojiMap);
 


### PR DESCRIPTION
My Mastodon server running in  https://github.com/mastodon/mastodon/commit/5fae2de454806730742b7be7435ae1c4fb97cf3c.

I found that announcement has not shown in hometimeline.

hometimeline:
![image](https://github.com/mastodon/mastodon/assets/26062441/6ec875be-25bc-4b14-b91b-1a1f288bcd26)

active annoucement:
![image](https://github.com/mastodon/mastodon/assets/26062441/47ea36ef-50ec-40bc-a920-708d7f882f11)


So, that fix it.