### PR TITLE
Add coverage for `CLI::Maintenance#fix_duplicates` command

### DIFF
--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -50,18 +50,5 @@ describe Mastodon::CLI::Maintenance do
         ).to_stdout.and raise_error(SystemExit)
       end
     end
-
-    context 'when the database is too new and the user does continue', use_transactional_tests: false do
-      before do
-        allow(cli.shell).to receive(:yes?).with('Continue anyway? (Yes/No)').and_return(true).once # Database too new query
-        allow(cli.shell).to receive(:yes?).with('Continue? (Yes/No)').and_return(true).once # General task warning
-      end
-
-      it 'removes duplicate records' do
-        expect { cli.invoke :fix_duplicates }.to output(
-          a_string_including('Finished')
-        ).to_stdout
-      end
-    end
   end
 end

--- a/spec/lib/mastodon/cli/maintenance_spec.rb
+++ b/spec/lib/mastodon/cli/maintenance_spec.rb
@@ -4,9 +4,64 @@ require 'rails_helper'
 require 'mastodon/cli/maintenance'
 
 describe Mastodon::CLI::Maintenance do
+  let(:cli) { described_class.new }
+
   describe '.exit_on_failure?' do
     it 'returns true' do
       expect(described_class.exit_on_failure?).to be true
+    end
+  end
+
+  describe '#fix_duplicates' do
+    context 'when the database version is too old' do
+      before do
+        allow(ActiveRecord::Migrator).to receive(:current_version).and_return(2000_01_01_000000) # Earlier than minimum
+      end
+
+      it 'Exits with error message' do
+        expect { cli.invoke :fix_duplicates }.to output(
+          a_string_including('is too old')
+        ).to_stdout.and raise_error(SystemExit)
+      end
+    end
+
+    context 'when the database version is too new and the user does not continue' do
+      before do
+        allow(ActiveRecord::Migrator).to receive(:current_version).and_return(2100_01_01_000000) # Later than maximum
+        allow(cli.shell).to receive(:yes?).with('Continue anyway? (Yes/No)').and_return(false).once
+      end
+
+      it 'Exits with error message' do
+        expect { cli.invoke :fix_duplicates }.to output(
+          a_string_including('more recent')
+        ).to_stdout.and raise_error(SystemExit)
+      end
+    end
+
+    context 'when Sidekiq is running' do
+      before do
+        allow(ActiveRecord::Migrator).to receive(:current_version).and_return(2022_01_01_000000) # Higher than minimum, lower than maximum
+        allow(Sidekiq::ProcessSet).to receive(:new).and_return [:process]
+      end
+
+      it 'Exits with error message' do
+        expect { cli.invoke :fix_duplicates }.to output(
+          a_string_including('Sidekiq is running')
+        ).to_stdout.and raise_error(SystemExit)
+      end
+    end
+
+    context 'when the database is too new and the user does continue', use_transactional_tests: false do
+      before do
+        allow(cli.shell).to receive(:yes?).with('Continue anyway? (Yes/No)').and_return(true).once # Database too new query
+        allow(cli.shell).to receive(:yes?).with('Continue? (Yes/No)').and_return(true).once # General task warning
+      end
+
+      it 'removes duplicate records' do
+        expect { cli.invoke :fix_duplicates }.to output(
+          a_string_including('Finished')
+        ).to_stdout
+      end
     end
   end
 end


### PR DESCRIPTION
This is a second pass which aims to further reduce the uncovered LOC from this class.

Prior to these changes the file was 678 lines long and simplecov report shows 309 missed lines in coverage. After the changes the file is 708 lines long and report shows 158 uncovered.

This is mainly an improvement on the first pass which just got any coverage at all in place for the CLI classes. We will need further refinements (I'll keep working in another branch) to actually exercise each de-duplication method code path to show that we do correctly de-dupe things where they exist.

Did a slight refactor (extracting well named methods in the setup/verify area) while in there.

