### PR TITLE
Add `allow_other_host: true` to backups controller

### DIFF
--- a/app/controllers/backups_controller.rb
+++ b/app/controllers/backups_controller.rb
@@ -11,15 +11,15 @@ class BackupsController < ApplicationController
   def download
     case Paperclip::Attachment.default_options[:storage]
     when :s3
-      redirect_to @backup.dump.expiring_url(10)
+      redirect_to @backup.dump.expiring_url(10), allow_other_host: true
     when :fog
       if Paperclip::Attachment.default_options.dig(:fog_credentials, :openstack_temp_url_key).present?
-        redirect_to @backup.dump.expiring_url(Time.now.utc + 10)
+        redirect_to @backup.dump.expiring_url(Time.now.utc + 10), allow_other_host: true
       else
-        redirect_to full_asset_url(@backup.dump.url)
+        redirect_to full_asset_url(@backup.dump.url), allow_other_host: true
       end
     when :filesystem
-      redirect_to full_asset_url(@backup.dump.url)
+      redirect_to full_asset_url(@backup.dump.url), allow_other_host: true
     end
   end
 


### PR DESCRIPTION
Extracted in advance from https://github.com/mastodon/mastodon/pull/24241