### PR TITLE
Fix design issues with recent react-intl upgrade

### DIFF
--- a/app/javascript/mastodon/locales/intl_provider.tsx
+++ b/app/javascript/mastodon/locales/intl_provider.tsx
@@ -48,6 +48,7 @@ export const IntlProvider: React.FC<
       locale={locale}
       messages={messages}
       onError={onProviderError}
+      textComponent='span'
       {...props}
     >
       {children}


### PR DESCRIPTION
The `react-intl` upgrade changed the behavior of `Formatted*` components to not wrap translated messages in `span` tags anymore. While this is a pretty good change, it changes the DOM structure and breaks some of Mastodon's styling.

Finding all the places where this change breaks the styling may be a better long-term solution, but it's also a much more involved one, so this commit changes `react-intl`'s configuration to always wrap formatted messages in a `span` tag.

See also: https://formatjs.io/docs/react-intl/upgrade-guide-3x#breaking-api-changes