### PR TITLE
Fix autocomplete suggestions being cut off in compose form

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3111,10 +3111,10 @@ $ui-header-height: 55px;
 .compose-form__highlightable {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   flex: 0 1 auto;
   border-radius: 4px;
   transition: box-shadow 300ms linear;
+  min-height: 0;
 
   &.active {
     transition: none;
@@ -3156,7 +3156,6 @@ $ui-header-height: 55px;
 
   .compose-form {
     flex: 1;
-    overflow-y: hidden;
     display: flex;
     flex-direction: column;
     min-height: 310px;


### PR DESCRIPTION
Fixes #25263

This seems ok but this needs to be more widely tested

Tested:
- [x] on Firefox
  - [x] single-column: with attachments, with long posts
  - [x] in mobile view: with attachments, with long posts
  - [x] in advanced interface: with attachments, with long posts
- [x] on Chromium
  - [x] single-column: with attachments, with long posts
  - [x] in mobile view: with attachments, with long posts
  - [x] in advanced interface: with attachments, with long posts