### PR TITLE
Rails 7 compatibility fix for `Admin::Metrics::Dimension` classes

### DIFF
--- a/app/lib/admin/metrics/dimension/instance_accounts_dimension.rb
+++ b/app/lib/admin/metrics/dimension/instance_accounts_dimension.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::Metrics::Dimension::InstanceAccountsDimension < Admin::Metrics::Dimension::BaseDimension
+  include Admin::Metrics::Dimension::QueryHelper
   include LanguagesHelper
 
   def self.with_params?
@@ -14,19 +15,23 @@ class Admin::Metrics::Dimension::InstanceAccountsDimension < Admin::Metrics::Dim
   protected
 
   def perform_query
-    sql = <<-SQL.squish
+    dimension_data_rows.map { |row| { key: row['username'], human_key: row['username'], value: row['value'].to_s } }
+  end
+
+  def sql_array
+    [sql_query_string, { domain: params[:domain], limit: @limit }]
+  end
+
+  def sql_query_string
+    <<~SQL.squish
       SELECT accounts.username, count(follows.*) AS value
       FROM accounts
       LEFT JOIN follows ON follows.target_account_id = accounts.id
-      WHERE accounts.domain = $1
+      WHERE accounts.domain = :domain
       GROUP BY accounts.id, follows.target_account_id
       ORDER BY value DESC
-      LIMIT $2
+      LIMIT :limit
     SQL
-
-    rows = ActiveRecord::Base.connection.select_all(sql, nil, [[nil, params[:domain]], [nil, @limit]])
-
-    rows.map { |row| { key: row['username'], human_key: row['username'], value: row['value'].to_s } }
   end
 
   def params

--- a/app/lib/admin/metrics/dimension/instance_languages_dimension.rb
+++ b/app/lib/admin/metrics/dimension/instance_languages_dimension.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::Metrics::Dimension::InstanceLanguagesDimension < Admin::Metrics::Dimension::BaseDimension
+  include Admin::Metrics::Dimension::QueryHelper
   include LanguagesHelper
 
   def self.with_params?
@@ -14,21 +15,33 @@ class Admin::Metrics::Dimension::InstanceLanguagesDimension < Admin::Metrics::Di
   protected
 
   def perform_query
-    sql = <<-SQL.squish
+    dimension_data_rows.map { |row| { key: row['language'], human_key: standard_locale_name(row['language']), value: row['value'].to_s } }
+  end
+
+  def sql_array
+    [sql_query_string, { domain: params[:domain], earliest_status_id: earliest_status_id, latest_status_id: latest_status_id, limit: @limit }]
+  end
+
+  def sql_query_string
+    <<~SQL.squish
       SELECT COALESCE(statuses.language, 'und') AS language, count(*) AS value
       FROM statuses
       INNER JOIN accounts ON accounts.id = statuses.account_id
-      WHERE accounts.domain = $1
-        AND statuses.id BETWEEN $2 AND $3
+      WHERE accounts.domain = :domain
+        AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
         AND statuses.reblog_of_id IS NULL
       GROUP BY COALESCE(statuses.language, 'und')
       ORDER BY count(*) DESC
-      LIMIT $4
+      LIMIT :limit
     SQL
+  end
 
-    rows = ActiveRecord::Base.connection.select_all(sql, nil, [[nil, params[:domain]], [nil, Mastodon::Snowflake.id_at(@start_at, with_random: false)], [nil, Mastodon::Snowflake.id_at(@end_at, with_random: false)], [nil, @limit]])
+  def earliest_status_id
+    Mastodon::Snowflake.id_at(@start_at, with_random: false)
+  end
 
-    rows.map { |row| { key: row['language'], human_key: standard_locale_name(row['language']), value: row['value'].to_s } }
+  def latest_status_id
+    Mastodon::Snowflake.id_at(@end_at, with_random: false)
   end
 
   def params

--- a/app/lib/admin/metrics/dimension/languages_dimension.rb
+++ b/app/lib/admin/metrics/dimension/languages_dimension.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::Metrics::Dimension::LanguagesDimension < Admin::Metrics::Dimension::BaseDimension
+  include Admin::Metrics::Dimension::QueryHelper
   include LanguagesHelper
 
   def key
@@ -10,18 +11,22 @@ class Admin::Metrics::Dimension::LanguagesDimension < Admin::Metrics::Dimension:
   protected
 
   def perform_query
-    sql = <<-SQL.squish
+    dimension_data_rows.map { |row| { key: row['locale'], human_key: standard_locale_name(row['locale']), value: row['value'].to_s } }
+  end
+
+  def sql_array
+    [sql_query_string, { start_at: @start_at, end_at: @end_at, limit: @limit }]
+  end
+
+  def sql_query_string
+    <<~SQL.squish
       SELECT locale, count(*) AS value
       FROM users
-      WHERE current_sign_in_at BETWEEN $1 AND $2
+      WHERE current_sign_in_at BETWEEN :start_at AND :end_at
         AND locale IS NOT NULL
       GROUP BY locale
       ORDER BY count(*) DESC
-      LIMIT $3
+      LIMIT :limit
     SQL
-
-    rows = ActiveRecord::Base.connection.select_all(sql, nil, [[nil, @start_at], [nil, @end_at], [nil, @limit]])
-
-    rows.map { |row| { key: row['locale'], human_key: standard_locale_name(row['locale']), value: row['value'].to_s } }
   end
 end

--- a/app/lib/admin/metrics/dimension/query_helper.rb
+++ b/app/lib/admin/metrics/dimension/query_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Admin::Metrics::Dimension::QueryHelper
+  protected
+
+  def dimension_data_rows
+    ActiveRecord::Base.connection.select_all(sanitized_sql_string)
+  end
+
+  def sanitized_sql_string
+    ActiveRecord::Base.sanitize_sql_array(sql_array)
+  end
+end

--- a/app/lib/admin/metrics/dimension/servers_dimension.rb
+++ b/app/lib/admin/metrics/dimension/servers_dimension.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Admin::Metrics::Dimension::ServersDimension < Admin::Metrics::Dimension::BaseDimension
+  include Admin::Metrics::Dimension::QueryHelper
+
   def key
     'servers'
   end
@@ -8,18 +10,30 @@ class Admin::Metrics::Dimension::ServersDimension < Admin::Metrics::Dimension::B
   protected
 
   def perform_query
-    sql = <<-SQL.squish
+    dimension_data_rows.map { |row| { key: row['domain'] || Rails.configuration.x.local_domain, human_key: row['domain'] || Rails.configuration.x.local_domain, value: row['value'].to_s } }
+  end
+
+  def sql_array
+    [sql_query_string, { earliest_status_id: earliest_status_id, latest_status_id: latest_status_id, limit: @limit }]
+  end
+
+  def sql_query_string
+    <<~SQL.squish
       SELECT accounts.domain, count(*) AS value
       FROM statuses
       INNER JOIN accounts ON accounts.id = statuses.account_id
-      WHERE statuses.id BETWEEN $1 AND $2
+      WHERE statuses.id BETWEEN :earliest_status_id AND :latest_status_id
       GROUP BY accounts.domain
       ORDER BY count(*) DESC
-      LIMIT $3
+      LIMIT :limit
     SQL
+  end
 
-    rows = ActiveRecord::Base.connection.select_all(sql, nil, [[nil, Mastodon::Snowflake.id_at(@start_at)], [nil, Mastodon::Snowflake.id_at(@end_at)], [nil, @limit]])
+  def earliest_status_id
+    Mastodon::Snowflake.id_at(@start_at)
+  end
 
-    rows.map { |row| { key: row['domain'] || Rails.configuration.x.local_domain, human_key: row['domain'] || Rails.configuration.x.local_domain, value: row['value'].to_s } }
+  def latest_status_id
+    Mastodon::Snowflake.id_at(@end_at)
   end
 end

--- a/app/lib/admin/metrics/dimension/sources_dimension.rb
+++ b/app/lib/admin/metrics/dimension/sources_dimension.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Admin::Metrics::Dimension::SourcesDimension < Admin::Metrics::Dimension::BaseDimension
+  include Admin::Metrics::Dimension::QueryHelper
+
   def key
     'sources'
   end
@@ -8,18 +10,22 @@ class Admin::Metrics::Dimension::SourcesDimension < Admin::Metrics::Dimension::B
   protected
 
   def perform_query
-    sql = <<-SQL.squish
+    dimension_data_rows.map { |row| { key: row['name'] || 'web', human_key: row['name'] || I18n.t('admin.dashboard.website'), value: row['value'].to_s } }
+  end
+
+  def sql_array
+    [sql_query_string, { start_at: @start_at, end_at: @end_at, limit: @limit }]
+  end
+
+  def sql_query_string
+    <<~SQL.squish
       SELECT oauth_applications.name, count(*) AS value
       FROM users
       LEFT JOIN oauth_applications ON oauth_applications.id = users.created_by_application_id
-      WHERE users.created_at BETWEEN $1 AND $2
+      WHERE users.created_at BETWEEN :start_at AND :end_at
       GROUP BY oauth_applications.name
       ORDER BY count(*) DESC
-      LIMIT $3
+      LIMIT :limit
     SQL
-
-    rows = ActiveRecord::Base.connection.select_all(sql, nil, [[nil, @start_at], [nil, @end_at], [nil, @limit]])
-
-    rows.map { |row| { key: row['name'] || 'web', human_key: row['name'] || I18n.t('admin.dashboard.website'), value: row['value'].to_s } }
   end
 end

--- a/app/lib/admin/metrics/dimension/tag_languages_dimension.rb
+++ b/app/lib/admin/metrics/dimension/tag_languages_dimension.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::Metrics::Dimension::TagLanguagesDimension < Admin::Metrics::Dimension::BaseDimension
+  include Admin::Metrics::Dimension::QueryHelper
   include LanguagesHelper
 
   def self.with_params?
@@ -14,20 +15,36 @@ class Admin::Metrics::Dimension::TagLanguagesDimension < Admin::Metrics::Dimensi
   protected
 
   def perform_query
-    sql = <<-SQL.squish
+    dimension_data_rows.map { |row| { key: row['language'], human_key: standard_locale_name(row['language']), value: row['value'].to_s } }
+  end
+
+  def sql_array
+    [sql_query_string, { tag_id: tag_id, earliest_status_id: earliest_status_id, latest_status_id: latest_status_id, limit: @limit }]
+  end
+
+  def sql_query_string
+    <<~SQL.squish
       SELECT COALESCE(statuses.language, 'und') AS language, count(*) AS value
       FROM statuses
       INNER JOIN statuses_tags ON statuses_tags.status_id = statuses.id
-      WHERE statuses_tags.tag_id = $1
-        AND statuses.id BETWEEN $2 AND $3
+      WHERE statuses_tags.tag_id = :tag_id
+        AND statuses.id BETWEEN :earliest_status_id AND :latest_status_id
       GROUP BY COALESCE(statuses.language, 'und')
       ORDER BY count(*) DESC
-      LIMIT $4
+      LIMIT :limit
     SQL
+  end
 
-    rows = ActiveRecord::Base.connection.select_all(sql, nil, [[nil, params[:id]], [nil, Mastodon::Snowflake.id_at(@start_at, with_random: false)], [nil, Mastodon::Snowflake.id_at(@end_at, with_random: false)], [nil, @limit]])
+  def tag_id
+    params[:id]
+  end
 
-    rows.map { |row| { key: row['language'], human_key: standard_locale_name(row['language']), value: row['value'].to_s } }
+  def earliest_status_id
+    Mastodon::Snowflake.id_at(@start_at, with_random: false)
+  end
+
+  def latest_status_id
+    Mastodon::Snowflake.id_at(@end_at, with_random: false)
   end
 
   def params

--- a/spec/lib/admin/metrics/dimension/instance_accounts_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/instance_accounts_dimension_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Dimension::InstanceAccountsDimension do
+  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+
+  let(:start_at) { 2.days.ago }
+  let(:end_at) { Time.now.utc }
+  let(:limit) { 10 }
+  let(:params) { ActionController::Parameters.new }
+
+  describe '#data' do
+    it 'runs data query without error' do
+      expect { dimension.data }.to_not raise_error
+    end
+  end
+end

--- a/spec/lib/admin/metrics/dimension/instance_languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/instance_languages_dimension_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Dimension::InstanceLanguagesDimension do
+  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+
+  let(:start_at) { 2.days.ago }
+  let(:end_at) { Time.now.utc }
+  let(:limit) { 10 }
+  let(:params) { ActionController::Parameters.new }
+
+  describe '#data' do
+    it 'runs data query without error' do
+      expect { dimension.data }.to_not raise_error
+    end
+  end
+end

--- a/spec/lib/admin/metrics/dimension/languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/languages_dimension_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Dimension::LanguagesDimension do
+  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+
+  let(:start_at) { 2.days.ago }
+  let(:end_at) { Time.now.utc }
+  let(:limit) { 10 }
+  let(:params) { ActionController::Parameters.new }
+
+  describe '#data' do
+    it 'runs data query without error' do
+      expect { dimension.data }.to_not raise_error
+    end
+  end
+end

--- a/spec/lib/admin/metrics/dimension/servers_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/servers_dimension_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Dimension::ServersDimension do
+  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+
+  let(:start_at) { 2.days.ago }
+  let(:end_at) { Time.now.utc }
+  let(:limit) { 10 }
+  let(:params) { ActionController::Parameters.new }
+
+  describe '#data' do
+    it 'runs data query without error' do
+      expect { dimension.data }.to_not raise_error
+    end
+  end
+end

--- a/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/software_versions_dimension_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Dimension::SoftwareVersionsDimension do
+  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+
+  let(:start_at) { 2.days.ago }
+  let(:end_at) { Time.now.utc }
+  let(:limit) { 10 }
+  let(:params) { ActionController::Parameters.new }
+
+  describe '#data' do
+    it 'runs data query without error' do
+      expect { dimension.data }.to_not raise_error
+    end
+  end
+end

--- a/spec/lib/admin/metrics/dimension/sources_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/sources_dimension_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Dimension::SourcesDimension do
+  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+
+  let(:start_at) { 2.days.ago }
+  let(:end_at) { Time.now.utc }
+  let(:limit) { 10 }
+  let(:params) { ActionController::Parameters.new }
+
+  describe '#data' do
+    it 'runs data query without error' do
+      expect { dimension.data }.to_not raise_error
+    end
+  end
+end

--- a/spec/lib/admin/metrics/dimension/space_usage_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/space_usage_dimension_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Dimension::SpaceUsageDimension do
+  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+
+  let(:start_at) { 2.days.ago }
+  let(:end_at) { Time.now.utc }
+  let(:limit) { 10 }
+  let(:params) { ActionController::Parameters.new }
+
+  describe '#data' do
+    it 'runs data query without error' do
+      expect { dimension.data }.to_not raise_error
+    end
+  end
+end

--- a/spec/lib/admin/metrics/dimension/tag_languages_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/tag_languages_dimension_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Dimension::TagLanguagesDimension do
+  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+
+  let(:start_at) { 2.days.ago }
+  let(:end_at) { Time.now.utc }
+  let(:limit) { 10 }
+  let(:params) { ActionController::Parameters.new }
+
+  describe '#data' do
+    it 'runs data query without error' do
+      expect { dimension.data }.to_not raise_error
+    end
+  end
+end

--- a/spec/lib/admin/metrics/dimension/tag_servers_dimension_spec.rb
+++ b/spec/lib/admin/metrics/dimension/tag_servers_dimension_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Admin::Metrics::Dimension::TagServersDimension do
+  subject(:dimension) { described_class.new(start_at, end_at, limit, params) }
+
+  let(:start_at) { 2.days.ago }
+  let(:end_at) { Time.now.utc }
+  let(:limit) { 10 }
+  let(:params) { ActionController::Parameters.new }
+
+  describe '#data' do
+    it 'runs data query without error' do
+      expect { dimension.data }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
Basically the same Rails 7 compatibility changes as https://github.com/mastodon/mastodon/pull/25236

Also like that other one, these specs are "better than nothing" but not much more. Just wanted to force the error to occur in the Rails 7 branch and then fix it with the refactor.

There could probably be some further consolidation/cleanup between the `Dimension` and `Measure` classes after both are merged, and of course more nuanced spec improvement unrelated to Rails upgrade.