### PR TITLE
Add logging of websocket send errors

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -819,7 +819,11 @@ const startServer = async () => {
       return;
     }
 
-    ws.send(JSON.stringify({ stream: streamName, event, payload }));
+    ws.send(JSON.stringify({ stream: streamName, event, payload }), (err) => {
+      if (err) {
+        log.error(req.requestId, `Failed to send to websocket: ${err}`);
+      }
+    });
   };
 
   /**


### PR DESCRIPTION
This is in accordance with the best practices stated at: http://adilapapaya.com/docs/ws/\#errorhandlingbestpractices

For some reason, a significant amount of CPU usage for streaming was coming from capturing a large stacktrace in response to send errors, these errors were being discarded, but the performance hit was already happening. This change logs errors captured when attempting to send to a websocket, hopefully giving more insight into why writes are failing, such that we can prevent them in the future. This change is based on @imsofi's work in profiling the websocket server in production.