### PR TITLE
Fix emoji picker button scrolling with textarea content in single-column view

### DIFF
--- a/app/javascript/mastodon/features/compose/components/compose_form.jsx
+++ b/app/javascript/mastodon/features/compose/components/compose_form.jsx
@@ -280,13 +280,12 @@ class ComposeForm extends ImmutablePureComponent {
             autoFocus={autoFocus}
             lang={this.props.lang}
           >
-            <EmojiPickerDropdown onPickEmoji={this.handleEmojiPick} />
-
             <div className='compose-form__modifiers'>
               <UploadFormContainer />
               <PollFormContainer />
             </div>
           </AutosuggestTextarea>
+          <EmojiPickerDropdown onPickEmoji={this.handleEmojiPick} />
 
           <div className='compose-form__buttons-wrapper'>
             <div className='compose-form__buttons'>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3117,6 +3117,7 @@ $ui-header-height: 55px;
   border-radius: 4px;
   transition: box-shadow 300ms linear;
   min-height: 0;
+  position: relative;
 
   &.active {
     transition: none;


### PR DESCRIPTION
Supersedes #23615

This only fixes the compose panel in the single-column view, as the whole form scrolls in the other views (advanced interface, and dedicated compose view).

A minor issue is that whenever the browser uses classic scrollbars, the emoji picker button is not shifted by the scrollbar gutter and instead is drawn above it:

![image](https://github.com/mastodon/mastodon/assets/384364/49769a47-9225-44fc-9fe0-94e173e8634f)

Overlay scrollbars work fine:

![image](https://github.com/mastodon/mastodon/assets/384364/97d64019-5221-42d7-a9da-09daff2c3c15)