### PR TITLE
Add Ruby & Bundler versions to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -882,3 +882,9 @@ DEPENDENCIES
   webpacker (~> 5.4)
   webpush!
   xorcist (~> 1.1)
+
+RUBY VERSION
+   ruby 3.2.2p53
+
+BUNDLED WITH
+   2.4.13


### PR DESCRIPTION
This was causing issues with Ruby 2.6 when this was introduced, but now that we only support modern Ruby, all bundler versions should understand this.

This avoids the need to manually remove those from the lock-file before each commit.

It should also improve consistency in installation and across bundler updates.