### PR TITLE
Add coverage for `CLI::Statuses` command

### DIFF
--- a/spec/lib/mastodon/cli/statuses_spec.rb
+++ b/spec/lib/mastodon/cli/statuses_spec.rb
@@ -4,9 +4,31 @@ require 'rails_helper'
 require 'mastodon/cli/statuses'
 
 describe Mastodon::CLI::Statuses do
+  let(:cli) { described_class.new }
+
   describe '.exit_on_failure?' do
     it 'returns true' do
       expect(described_class.exit_on_failure?).to be true
+    end
+  end
+
+  describe '#remove', use_transactional_tests: false do
+    context 'with small batch size' do
+      let(:options) { { batch_size: 0 } }
+
+      it 'exits with error message' do
+        expect { cli.invoke :remove, [], options }.to output(
+          a_string_including('Cannot run')
+        ).to_stdout.and raise_error(SystemExit)
+      end
+    end
+
+    context 'with default batch size' do
+      it 'removes unreferenced statuses' do
+        expect { cli.invoke :remove }.to output(
+          a_string_including('Done after')
+        ).to_stdout
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,6 +77,12 @@ RSpec.configure do |config|
   config.include Redisable
   config.include SignedRequestHelpers, type: :request
 
+  config.around(:each, use_transactional_tests: false) do |example|
+    self.use_transactional_tests = false
+    example.run
+    self.use_transactional_tests = true
+  end
+
   config.before :each, type: :cli do
     stub_stdout
     stub_reset_connection_pools


### PR DESCRIPTION
Basically a first pass to get coverage in place. SimpleCov shows 99 uncovered lines before this change, and 21 after.

Will submit future PRs to flesh out the code paths and options here (as opposed to just running with default and doing almost nothing).