### PR TITLE
migrate test for `GET /api/v1/accounts/{account_id}` to request spec

### DIFF
--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -55,20 +55,6 @@ RSpec.describe Api::V1::AccountsController do
     end
   end
 
-  describe 'GET #show' do
-    let(:scopes) { 'read:accounts' }
-
-    before do
-      get :show, params: { id: user.account.id }
-    end
-
-    it 'returns http success' do
-      expect(response).to have_http_status(200)
-    end
-
-    it_behaves_like 'forbidden for wrong scope', 'write:statuses'
-  end
-
   describe 'POST #follow' do
     let(:scopes) { 'write:follows' }
     let(:other_account) { Fabricate(:account, username: 'bob', locked: locked) }

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -14,6 +14,15 @@ describe 'GET /api/v1/accounts/{account_id}' do
     end
   end
 
+  it 'returns 404 if account not found' do
+    get '/api/v1/accounts/1'
+
+    aggregate_failures do
+      expect(response).to have_http_status(404)
+      expect(body_as_json[:error]).to eq('Record not found')
+    end
+  end
+
   context 'when with token' do
     it 'returns account entity as 200 OK if token is valid' do
       account = Fabricate(:account)

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'GET /api/v1/accounts/{account_id}' do
+  it 'returns account entity as 200 OK' do
+    account = Fabricate(:account)
+
+    get "/api/v1/accounts/#{account.id}"
+
+    aggregate_failures do
+      expect(response).to have_http_status(200)
+      expect(body_as_json[:id]).to eq(account.id.to_s)
+    end
+  end
+end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -13,4 +13,32 @@ describe 'GET /api/v1/accounts/{account_id}' do
       expect(body_as_json[:id]).to eq(account.id.to_s)
     end
   end
+
+  context 'when with token' do
+    it 'returns account entity as 200 OK if token is valid' do
+      account = Fabricate(:account)
+      user = Fabricate(:user, account: account)
+      token = Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read:accounts').token
+
+      get "/api/v1/accounts/#{account.id}", headers: { Authorization: "Bearer #{token}" }
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(body_as_json[:id]).to eq(account.id.to_s)
+      end
+    end
+
+    it 'returns 403 if scope of token is invalid' do
+      account = Fabricate(:account)
+      user = Fabricate(:user, account: account)
+      token = Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:statuses').token
+
+      get "/api/v1/accounts/#{account.id}", headers: { Authorization: "Bearer #{token}" }
+
+      aggregate_failures do
+        expect(response).to have_http_status(403)
+        expect(body_as_json[:error]).to eq('This action is outside the authorized scopes')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR migrates spec for `GET /api/v1/accounts/{account_id}` to request spec from controller spec.

Now, rspec official team recommends to write [request spec](https://rspec.info/features/6-0/rspec-rails/request-specs/request-spec/) instead of controller spec.

https://rspec.info/blog/2016/07/rspec-3-5-has-been-released/#rails-support-for-rails-5:~:text=The%20official%20recommendation%20of%20the%20Rails%20team%20and%20the%20RSpec%20core%20team%20is%20to%20write%20request%20specs%20instead

By using request spec, we can test based on more real behavior.
Mocks are only required when communicating with external systems.