### PR TITLE
Improve follow recommendations SQL query

### DIFF
--- a/db/views/follow_recommendations_v02.sql
+++ b/db/views/follow_recommendations_v02.sql
@@ -10,10 +10,9 @@ FROM (
   FROM follows
   INNER JOIN account_summaries ON account_summaries.account_id = follows.target_account_id
   INNER JOIN users ON users.account_id = follows.account_id
-  LEFT OUTER JOIN follow_recommendation_suppressions ON follow_recommendation_suppressions.account_id = follows.target_account_id
   WHERE users.current_sign_in_at >= (now() - interval '30 days')
     AND account_summaries.sensitive = 'f'
-    AND follow_recommendation_suppressions.id IS NULL
+    AND NOT EXISTS (SELECT 1 FROM follow_recommendation_suppressions WHERE follow_recommendation_suppressions.account_id = follows.target_account_id)
   GROUP BY account_summaries.account_id
   HAVING count(follows.id) >= 5
   UNION ALL
@@ -23,10 +22,9 @@ FROM (
   FROM status_stats
   INNER JOIN statuses ON statuses.id = status_stats.status_id
   INNER JOIN account_summaries ON account_summaries.account_id = statuses.account_id
-  LEFT OUTER JOIN follow_recommendation_suppressions ON follow_recommendation_suppressions.account_id = statuses.account_id
   WHERE statuses.id >= ((date_part('epoch', now() - interval '30 days') * 1000)::bigint << 16)
     AND account_summaries.sensitive = 'f'
-    AND follow_recommendation_suppressions.id IS NULL
+    AND NOT EXISTS (SELECT 1 FROM follow_recommendation_suppressions WHERE follow_recommendation_suppressions.account_id = statuses.account_id)
   GROUP BY account_summaries.account_id
   HAVING sum(status_stats.reblogs_count + status_stats.favourites_count) >= 5
 ) t0


### PR DESCRIPTION
A server admin reported that this query took 29 hours to run on their instance, using PostgreSQL 14 with up-to-date vacuum & statistics.

After some investigation, we found out that the plan was very wrong and resulted in 300B+ rows being generated in a temporary table.

Switching from a `JOIN` to `NOT EXISTS` fixes the issue and the query is now behaving as expected.

This has been tested on PostgreSQL 12 on a large server, and performs the same as with the `JOIN` on this server.

Fixes #25191