### PR TITLE
Remove reference to deleted statsd config file

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1236,11 +1236,6 @@ Style/GlobalStdStream:
     - 'config/environments/development.rb'
     - 'config/environments/production.rb'
 
-# Configuration parameters: AllowedVariables.
-Style/GlobalVars:
-  Exclude:
-    - 'config/initializers/statsd.rb'
-
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
 Style/GuardClause:
@@ -1374,7 +1369,6 @@ Style/RedundantConstantBase:
   Exclude:
     - 'config/environments/production.rb'
     - 'config/initializers/sidekiq.rb'
-    - 'config/initializers/statsd.rb'
     - 'config/locales/sr-Latn.rb'
     - 'config/locales/sr.rb'
 


### PR DESCRIPTION
File removed in https://github.com/mastodon/mastodon/pull/25265 but didn't remove the rubocop ref.