### PR TITLE
Fixes theme translation being stuck as default "Theme"

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -10,7 +10,7 @@
       = f.input :locale, collection: I18n.available_locales, wrapper: :with_label, include_blank: false, label_method: lambda { |locale| native_locale_name(locale) }, selected: I18n.locale, hint: false
     .fields-group.fields-row__column.fields-row__column-6
       = f.simple_fields_for :settings, current_user.settings do |ff|
-        = ff.input :theme, collection: Themes.instance.names, label_method: lambda { |theme| I18n.t("themes.#{theme}", default: theme) }, wrapper: :with_label, include_blank: false, hint: false
+        = ff.input :setting_theme, collection: Themes.instance.names, label_method: lambda { |theme| I18n.t("themes.#{theme}", default: theme) }, wrapper: :with_label, include_blank: false, hint: false
 
   - unless I18n.locale == :en
     .flash-message.translation-prompt


### PR DESCRIPTION
In https://github.com/mastodon/mastodon/commit/a9b5598c97fc4d3302b61b260097ef41c2ebe377#diff-bf9332fa8ac0693c428f414b4e5a5e449733574c0dde406561e91903d7721f68L12 `f.input` was changed to `ff.input` and along the way `setting_theme` was changed to `theme`.

This resulted in the `theme` label to always say the word `Theme` instead of, at least in en `Site theme`.

Example in English (this should read `Site Theme`) as per https://github.com/mastodon/mastodon/blob/main/config/locales/simple_form.en.yml#L216
<img width="1155" alt="Screenshot 2023-06-07 at 4 02 13 PM" src="https://github.com/mastodon/mastodon/assets/15234688/5160153e-347e-4bf5-b396-ab53b9d5004e">

Example in Hebrew (`Theme` instead of `ערכת העיצוב של האתר`)
<img width="911" alt="Screenshot 2023-06-07 at 4 04 14 PM" src="https://github.com/mastodon/mastodon/assets/15234688/b825eee4-d5f0-4b85-a465-1d96dc2eea3e">

