### PR TITLE
Fix translations for changing theme 

### DIFF
--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -10,7 +10,7 @@
       = f.input :locale, collection: I18n.available_locales, wrapper: :with_label, include_blank: false, label_method: lambda { |locale| native_locale_name(locale) }, selected: I18n.locale, hint: false
     .fields-group.fields-row__column.fields-row__column-6
       = f.simple_fields_for :settings, current_user.settings do |ff|
-        = ff.input :theme, collection: Themes.instance.names, label_method: lambda { |theme| I18n.t("themes.#{theme}", default: theme) }, wrapper: :with_label, include_blank: false, hint: false
+        = ff.input :theme, collection: Themes.instance.names, label_method: lambda { |theme| I18n.t("themes.#{theme}", default: theme) }, wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_theme'), include_blank: false, hint: false
 
   - unless I18n.locale == :en
     .flash-message.translation-prompt


### PR DESCRIPTION
In order to pick up the correct theme translation, we need to explicitly mention which label we want.

You can see on mastodon.social the theme says `Theme` in both English and Hebrew (Hebrew was chosen at random)
<img width="1195" alt="Screenshot 2023-06-07 at 5 42 09 PM" src="https://github.com/mastodon/mastodon/assets/15234688/aecc5301-f6f5-46d0-81f5-1738b95440a9">

<img width="895" alt="Screenshot 2023-06-07 at 5 43 14 PM" src="https://github.com/mastodon/mastodon/assets/15234688/dcbc43d0-eeeb-4b45-b510-a52b4f152bf2">


With this fix, you can see the correct translations are being picked up


In English see `Site theme`
<img width="949" alt="Screenshot 2023-06-07 at 5 58 09 PM" src="https://github.com/mastodon/mastodon/assets/15234688/44b8a765-69ee-4e7b-b353-43c6d3053ef7">

And in Hebrew `ערכת העיצוב של האתר`
<img width="897" alt="Screenshot 2023-06-07 at 5 58 50 PM" src="https://github.com/mastodon/mastodon/assets/15234688/57ca2f21-392c-42d0-b0f9-96ee2e163432">
