### PR TITLE
Add forwarding of reported replies to servers being replied to

### DIFF
--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -17,24 +17,45 @@ RSpec.describe ReportService, type: :service do
 
   context 'with a remote account' do
     let(:remote_account) { Fabricate(:account, domain: 'example.com', protocol: :activitypub, inbox_url: 'http://example.com/inbox') }
+    let(:forward) { false }
 
     before do
       stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
     end
 
-    it 'sends ActivityPub payload when forward is true' do
-      subject.call(source_account, remote_account, forward: true)
-      expect(a_request(:post, 'http://example.com/inbox')).to have_been_made
+    context 'when forward is true' do
+      let(:forward) { true }
+
+      it 'sends ActivityPub payload when forward is true' do
+        subject.call(source_account, remote_account, forward: forward)
+        expect(a_request(:post, 'http://example.com/inbox')).to have_been_made
+      end
+
+      it 'has an uri' do
+        report = subject.call(source_account, remote_account, forward: forward)
+        expect(report.uri).to_not be_nil
+      end
+
+      context 'when reporting a reply' do
+        let(:remote_thread_account) { Fabricate(:account, domain: 'foo.com', protocol: :activitypub, inbox_url: 'http://foo.com/inbox') }
+        let(:reported_status) { Fabricate(:status, account: remote_account, thread: Fabricate(:status, account: remote_thread_account)) }
+
+        before do
+          stub_request(:post, 'http://foo.com/inbox').to_return(status: 200)
+        end
+
+        it 'sends ActivityPub payload to the author of the replied-to post' do
+          subject.call(source_account, remote_account, status_ids: [reported_status.id], forward: forward)
+          expect(a_request(:post, 'http://foo.com/inbox')).to have_been_made
+        end
+      end
     end
 
-    it 'does not send anything when forward is false' do
-      subject.call(source_account, remote_account, forward: false)
-      expect(a_request(:post, 'http://example.com/inbox')).to_not have_been_made
-    end
-
-    it 'has an uri' do
-      report = subject.call(source_account, remote_account, forward: true)
-      expect(report.uri).to_not be_nil
+    context 'when forward is false' do
+      it 'does not send anything' do
+        subject.call(source_account, remote_account, forward: forward)
+        expect(a_request(:post, 'http://example.com/inbox')).to_not have_been_made
+      end
     end
   end
 


### PR DESCRIPTION
When you get an abusive reply from another server, people from *another* server may see it first and report it, but you wouldn't be able to benefit from that report because *your* moderators wouldn't receive it. This changes that.
___

Fixes MAS-138