### PR TITLE
Remove unused `redis_info` method Admin::Dashboard

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -14,15 +14,5 @@ module Admin
       @pending_tags_count    = Tag.pending_review.count
       @pending_appeals_count = Appeal.pending.count
     end
-
-    private
-
-    def redis_info
-      @redis_info ||= if redis.is_a?(Redis::Namespace)
-                        redis.redis.info
-                      else
-                        redis.info
-                      end
-    end
   end
 end


### PR DESCRIPTION
Last remaining usage was removed previously: https://github.com/mastodon/mastodon/commit/07341e7aa60fe7c7d4f298136af99276820940e7