### PR TITLE
Misc coverage improvements for `Admin::` and `Settings::` controllers

### DIFF
--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Admin::Disputes::AppealsController do
   let(:strike) { Fabricate(:account_warning, target_account: target_account, action: :suspend) }
   let(:appeal) { Fabricate(:appeal, strike: strike, account: target_account) }
 
+  describe 'GET #index' do
+    let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
+
+    it 'lists appeals' do
+      get :index
+
+      expect(response).to have_http_status(200)
+    end
+  end
+
   describe 'POST #approve' do
     let(:current_user) { Fabricate(:user, role: UserRole.find_by(name: 'Admin')) }
 

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -165,6 +165,17 @@ RSpec.describe Admin::DomainBlocksController do
     end
   end
 
+  describe 'GET #edit' do
+    let(:domain_block) { Fabricate(:domain_block) }
+
+    it 'returns http success' do
+      get :edit, params: { id: domain_block.id }
+
+      expect(assigns(:domain_block)).to be_instance_of(DomainBlock)
+      expect(response).to have_http_status(200)
+    end
+  end
+
   describe 'PUT #update' do
     subject do
       post :update, params: { :id => domain_block.id, :domain_block => { domain: 'example.com', severity: new_severity }, 'confirm' => '' }

--- a/spec/controllers/admin/export_domain_allows_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_allows_controller_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Admin::ExportDomainAllowsController do
     sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
   end
 
+  describe 'GET #new' do
+    it 'returns http success' do
+      get :new
+
+      expect(response).to have_http_status(200)
+    end
+  end
+
   describe 'GET #export' do
     it 'renders instances' do
       Fabricate(:domain_allow, domain: 'good.domain')

--- a/spec/controllers/admin/export_domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/export_domain_blocks_controller_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Admin::ExportDomainBlocksController do
     sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
   end
 
+  describe 'GET #new' do
+    it 'returns http success' do
+      get :new
+
+      expect(response).to have_http_status(200)
+    end
+  end
+
   describe 'GET #export' do
     it 'renders instances' do
       Fabricate(:domain_block, domain: 'bad.domain', severity: 'silence', public_comment: 'bad server')

--- a/spec/controllers/admin/instances_controller_spec.rb
+++ b/spec/controllers/admin/instances_controller_spec.rb
@@ -34,6 +34,63 @@ RSpec.describe Admin::InstancesController do
     end
   end
 
+  describe 'GET #show' do
+    it 'shows an instance page' do
+      get :show, params: { id: account_popular_main.domain }
+
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'POST #clear_delivery_errors' do
+    let(:tracker) { instance_double(DeliveryFailureTracker, clear_failures!: true) }
+
+    before { allow(DeliveryFailureTracker).to receive(:new).and_return(tracker) }
+
+    it 'clears instance delivery errors' do
+      post :clear_delivery_errors, params: { id: account_popular_main.domain }
+
+      expect(response).to redirect_to(admin_instance_path(account_popular_main.domain))
+      expect(tracker).to have_received(:clear_failures!)
+    end
+  end
+
+  describe 'POST #restart_delivery' do
+    let(:tracker) { instance_double(DeliveryFailureTracker, track_success!: true) }
+
+    before { allow(DeliveryFailureTracker).to receive(:new).and_return(tracker) }
+
+    context 'with an unavailable instance' do
+      before { Fabricate(:unavailable_domain, domain: account_popular_main.domain) }
+
+      it 'tracks success on the instance' do
+        post :restart_delivery, params: { id: account_popular_main.domain }
+
+        expect(response).to redirect_to(admin_instance_path(account_popular_main.domain))
+        expect(tracker).to have_received(:track_success!)
+      end
+    end
+
+    context 'with an available instance' do
+      it 'does not track success on the instance' do
+        post :restart_delivery, params: { id: account_popular_main.domain }
+
+        expect(response).to redirect_to(admin_instance_path(account_popular_main.domain))
+        expect(tracker).to_not have_received(:track_success!)
+      end
+    end
+  end
+
+  describe 'POST #stop_delivery' do
+    it 'clears instance delivery errors' do
+      expect do
+        post :stop_delivery, params: { id: account_popular_main.domain }
+      end.to change(UnavailableDomain, :count).by(1)
+
+      expect(response).to redirect_to(admin_instance_path(account_popular_main.domain))
+    end
+  end
+
   describe 'DELETE #destroy' do
     subject { delete :destroy, params: { id: Instance.first.id } }
 

--- a/spec/controllers/admin/settings/about_controller_spec.rb
+++ b/spec/controllers/admin/settings/about_controller_spec.rb
@@ -18,4 +18,12 @@ describe Admin::Settings::AboutController do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'PUT #update' do
+    it 'updates the settings' do
+      put :update, params: { form_admin_settings: { site_extended_description: 'new site description' } }
+
+      expect(response).to redirect_to(admin_settings_about_path)
+    end
+  end
 end

--- a/spec/controllers/admin/settings/appearance_controller_spec.rb
+++ b/spec/controllers/admin/settings/appearance_controller_spec.rb
@@ -18,4 +18,12 @@ describe Admin::Settings::AppearanceController do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'PUT #update' do
+    it 'updates the settings' do
+      put :update, params: { form_admin_settings: { custom_css: 'html { display: inline; }' } }
+
+      expect(response).to redirect_to(admin_settings_appearance_path)
+    end
+  end
 end

--- a/spec/controllers/admin/settings/content_retention_controller_spec.rb
+++ b/spec/controllers/admin/settings/content_retention_controller_spec.rb
@@ -18,4 +18,12 @@ describe Admin::Settings::ContentRetentionController do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'PUT #update' do
+    it 'updates the settings' do
+      put :update, params: { form_admin_settings: { media_cache_retention_period: '2' } }
+
+      expect(response).to redirect_to(admin_settings_content_retention_path)
+    end
+  end
 end

--- a/spec/controllers/admin/settings/discovery_controller_spec.rb
+++ b/spec/controllers/admin/settings/discovery_controller_spec.rb
@@ -18,4 +18,12 @@ describe Admin::Settings::DiscoveryController do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'PUT #update' do
+    it 'updates the settings' do
+      put :update, params: { form_admin_settings: { trends: '1' } }
+
+      expect(response).to redirect_to(admin_settings_discovery_path)
+    end
+  end
 end

--- a/spec/controllers/admin/settings/registrations_controller_spec.rb
+++ b/spec/controllers/admin/settings/registrations_controller_spec.rb
@@ -18,4 +18,12 @@ describe Admin::Settings::RegistrationsController do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'PUT #update' do
+    it 'updates the settings' do
+      put :update, params: { form_admin_settings: { registrations_mode: 'open' } }
+
+      expect(response).to redirect_to(admin_settings_registrations_path)
+    end
+  end
 end

--- a/spec/controllers/admin/tags_controller_spec.rb
+++ b/spec/controllers/admin/tags_controller_spec.rb
@@ -20,4 +20,26 @@ RSpec.describe Admin::TagsController do
       expect(response).to have_http_status(200)
     end
   end
+
+  describe 'PUT #update' do
+    let!(:tag) { Fabricate(:tag, listable: false) }
+
+    context 'with valid params' do
+      it 'updates the tag' do
+        put :update, params: { id: tag.id, tag: { listable: '1' } }
+
+        expect(response).to redirect_to(admin_tag_path(tag.id))
+        expect(tag.reload).to be_listable
+      end
+    end
+
+    context 'with invalid params' do
+      it 'does not update the tag' do
+        put :update, params: { id: tag.id, tag: { name: 'cant-change-name' } }
+
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:show)
+      end
+    end
+  end
 end

--- a/spec/controllers/admin/webhooks_controller_spec.rb
+++ b/spec/controllers/admin/webhooks_controller_spec.rb
@@ -86,6 +86,24 @@ describe Admin::WebhooksController do
       end
     end
 
+    describe 'POST #enable' do
+      it 'enables the webhook' do
+        post :enable, params: { id: webhook.id }
+
+        expect(webhook.reload).to be_enabled
+        expect(response).to redirect_to(admin_webhook_path(webhook))
+      end
+    end
+
+    describe 'POST #disable' do
+      it 'disables the webhook' do
+        post :disable, params: { id: webhook.id }
+
+        expect(webhook.reload).to_not be_enabled
+        expect(response).to redirect_to(admin_webhook_path(webhook))
+      end
+    end
+
     describe 'DELETE #destroy' do
       it 'destroys the record' do
         expect do

--- a/spec/controllers/settings/imports_controller_spec.rb
+++ b/spec/controllers/settings/imports_controller_spec.rb
@@ -252,6 +252,19 @@ RSpec.describe Settings::ImportsController do
 
       include_examples 'export failed rows', "https://foo.com/1\nhttps://foo.com/2\n"
     end
+
+    context 'with lists' do
+      let(:import_type) { 'lists' }
+
+      let!(:rows) do
+        [
+          { 'list_name' => 'Amigos', 'acct' => 'user@example.com' },
+          { 'list_name' => 'Frenemies', 'acct' => 'user@org.org' },
+        ].map { |data| Fabricate(:bulk_import_row, bulk_import: bulk_import, data: data) }
+      end
+
+      include_examples 'export failed rows', "Amigos,user@example.com\nFrenemies,user@org.org\n"
+    end
   end
 
   describe 'POST #create' do


### PR DESCRIPTION
This is nudging close to 100%, and continues to round that out. After these additions, we are down to a) a bunch of `batch` actions covered by another PR, b) some edge case failure paths that need more effort to exercise in specs, c) a few callbacks/overrides that also need more effort.