### PR TITLE
Disable paperclip processing in specs

### DIFF
--- a/spec/models/media_attachment_spec.rb
+++ b/spec/models/media_attachment_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe MediaAttachment do
+RSpec.describe MediaAttachment, paperclip_processing: true do
   describe 'local?' do
     subject { media_attachment.local? }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -94,6 +94,12 @@ RSpec.configure do |config|
     stub_jsonld_contexts!
   end
 
+  config.before(:each) do |example|
+    unless example.metadata[:paperclip_processing]
+      allow_any_instance_of(Paperclip::Attachment).to receive(:post_process).and_return(true) # rubocop:disable RSpec/AnyInstance
+    end
+  end
+
   config.after :each do
     Rails.cache.clear
     redis.del(redis.keys)

--- a/spec/support/examples/models/concerns/account_avatar.rb
+++ b/spec/support/examples/models/concerns/account_avatar.rb
@@ -17,7 +17,7 @@ shared_examples 'AccountAvatar' do |fabricator|
     end
   end
 
-  describe 'base64-encoded files' do
+  describe 'base64-encoded files', paperclip_processing: true do
     let(:base64_attachment) { "data:image/jpeg;base64,#{Base64.encode64(attachment_fixture('attachment.jpg').read)}" }
     let(:account) { Fabricate(fabricator, avatar: base64_attachment) }
 

--- a/spec/support/examples/models/concerns/account_header.rb
+++ b/spec/support/examples/models/concerns/account_header.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples 'AccountHeader' do |fabricator|
-  describe 'base64-encoded files' do
+  describe 'base64-encoded files', paperclip_processing: true do
     let(:base64_attachment) { "data:image/jpeg;base64,#{Base64.encode64(attachment_fixture('attachment.jpg').read)}" }
     let(:account) { Fabricate(fabricator, header: base64_attachment) }
 


### PR DESCRIPTION
Most of the specs which use fabricators with attachments don't actually do anything with the attachments, but they are currently processed anyway, which takes time.

This change stubs out the post-processing on paperclip attachments, but allows examples to opt back in to the normal behavior with rspec metadata.

In my local spec runs this change cuts about ~30s off the full spec suite run. Curious to see impact on CI runs as well.