### PR TITLE
Fix logging of messages that are binary before closing their connection

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -1209,7 +1209,7 @@ const startServer = async () => {
 
     ws.on('message', (data, isBinary) => {
       if (isBinary) {
-        log.debug('Received binary data, closing connection');
+        log.warn('socket', 'Received binary data, closing connection');
         ws.close(1003, 'The mastodon streaming server does not support binary messages');
         return;
       }


### PR DESCRIPTION
The code I added in #25278 around logging when we close a connection for sending a binary message appears to have not been correct (I'd backported it from #24949 and forgotten to change `log.debug` to `log.warn`)

This fixes instability in the main branch identified by @vmstan