### PR TITLE
Use Sidekiq `fake!` instead of `inline!` in specs

### DIFF
--- a/spec/controllers/admin/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/admin/disputes/appeals_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Admin::Disputes::AppealsController do
       expect(response).to redirect_to(disputes_strike_path(appeal.strike))
     end
 
-    it 'notifies target account about approved appeal' do
+    it 'notifies target account about approved appeal', :sidekiq_inline do
       expect(UserMailer.deliveries.size).to eq(1)
       expect(UserMailer.deliveries.first.to.first).to eq(target_account.user.email)
       expect(UserMailer.deliveries.first.subject).to eq(I18n.t('user_mailer.appeal_approved.subject', date: I18n.l(appeal.created_at)))
@@ -62,7 +62,7 @@ RSpec.describe Admin::Disputes::AppealsController do
       expect(response).to redirect_to(disputes_strike_path(appeal.strike))
     end
 
-    it 'notifies target account about rejected appeal' do
+    it 'notifies target account about rejected appeal', :sidekiq_inline do
       expect(UserMailer.deliveries.size).to eq(1)
       expect(UserMailer.deliveries.first.to.first).to eq(target_account.user.email)
       expect(UserMailer.deliveries.first.subject).to eq(I18n.t('user_mailer.appeal_rejected.subject', date: I18n.l(appeal.created_at)))

--- a/spec/controllers/admin/domain_blocks_controller_spec.rb
+++ b/spec/controllers/admin/domain_blocks_controller_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Admin::DomainBlocksController do
     end
   end
 
-  describe 'PUT #update' do
+  describe 'PUT #update', :sidekiq_inline do
     subject do
       post :update, params: { :id => domain_block.id, :domain_block => { domain: 'example.com', severity: new_severity }, 'confirm' => '' }
     end

--- a/spec/controllers/admin/resets_controller_spec.rb
+++ b/spec/controllers/admin/resets_controller_spec.rb
@@ -11,7 +11,7 @@ describe Admin::ResetsController do
     sign_in Fabricate(:user, role: UserRole.find_by(name: 'Admin')), scope: :user
   end
 
-  describe 'POST #create' do
+  describe 'POST #create', :sidekiq_inline do
     it 'redirects to admin accounts page' do
       expect do
         post :create, params: { account_id: account.id }

--- a/spec/controllers/api/v1/conversations_controller_spec.rb
+++ b/spec/controllers/api/v1/conversations_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::ConversationsController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  describe 'GET #index' do
+  describe 'GET #index', :sidekiq_inline do
     let(:scopes) { 'read:statuses' }
 
     before do

--- a/spec/controllers/api/v1/statuses/reblogs_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reblogs_controller_spec.rb
@@ -9,7 +9,7 @@ describe Api::V1::Statuses::ReblogsController do
   let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
   let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:statuses', application: app) }
 
-  context 'with an oauth token', :sidekiq_fake do
+  context 'with an oauth token' do
     before do
       allow(controller).to receive(:doorkeeper_token) { token }
     end
@@ -46,7 +46,7 @@ describe Api::V1::Statuses::ReblogsController do
       end
     end
 
-    describe 'POST #destroy' do
+    describe 'POST #destroy', :sidekiq_inline do
       context 'with public status' do
         let(:status) { Fabricate(:status, account: user.account) }
 

--- a/spec/controllers/auth/sessions_controller_spec.rb
+++ b/spec/controllers/auth/sessions_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Auth::SessionsController do
           expect(controller.current_user).to eq user
         end
 
-        it 'sends a suspicious sign-in mail' do
+        it 'sends a suspicious sign-in mail', :sidekiq_inline do
           expect(UserMailer.deliveries.size).to eq(1)
           expect(UserMailer.deliveries.first.to.first).to eq(user.email)
           expect(UserMailer.deliveries.first.subject).to eq(I18n.t('user_mailer.suspicious_sign_in.subject'))

--- a/spec/controllers/concerns/user_tracking_concern_spec.rb
+++ b/spec/controllers/concerns/user_tracking_concern_spec.rb
@@ -75,7 +75,7 @@ describe UserTrackingConcern do
         expect(redis.ttl("account:#{user.account_id}:regeneration")).to be >= 0
       end
 
-      it 'regenerates feed when sign in is older than two weeks' do
+      it 'regenerates feed when sign in is older than two weeks', :sidekiq_inline do
         get :show
 
         expect_updated_sign_in_at(user)

--- a/spec/controllers/disputes/appeals_controller_spec.rb
+++ b/spec/controllers/disputes/appeals_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Disputes::AppealsController do
       post :create, params: { strike_id: strike.id, appeal: { text: 'Foo' } }
     end
 
-    it 'notifies staff about new appeal' do
+    it 'notifies staff about new appeal', :sidekiq_inline do
       expect(ActionMailer::Base.deliveries.first.to).to eq([admin.email])
     end
 

--- a/spec/controllers/settings/deletes_controller_spec.rb
+++ b/spec/controllers/settings/deletes_controller_spec.rb
@@ -50,7 +50,7 @@ describe Settings::DeletesController do
           delete :destroy, params: { form_delete_confirmation: { password: 'petsmoldoggos' } }
         end
 
-        it 'removes user record and redirects', :aggregate_failures do
+        it 'removes user record and redirects', :aggregate_failures, :sidekiq_inline do
           expect(response).to redirect_to '/auth/sign_in'
           expect(User.find_by(id: user.id)).to be_nil
           expect(user.account.reload).to be_suspended

--- a/spec/controllers/settings/exports_controller_spec.rb
+++ b/spec/controllers/settings/exports_controller_spec.rb
@@ -38,7 +38,7 @@ describe Settings::ExportsController do
       expect(response).to redirect_to(settings_export_path)
     end
 
-    it 'queues BackupWorker job by 1', :sidekiq_fake do
+    it 'queues BackupWorker job by 1' do
       expect do
         post :create
       end.to change(BackupWorker.jobs, :size).by(1)

--- a/spec/features/admin/accounts_spec.rb
+++ b/spec/features/admin/accounts_spec.rb
@@ -48,7 +48,7 @@ describe 'Admin::Accounts' do
       end
     end
 
-    context 'with action of `reject`' do
+    context 'with action of `reject`', :sidekiq_inline do
       it 'rejects and removes the account' do
         batch_checkbox_for(unapproved_user_account).check
 

--- a/spec/lib/activitypub/activity/create_spec.rb
+++ b/spec/lib/activitypub/activity/create_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ActivityPub::Activity::Create do
     stub_request(:get, 'http://example.com/emojib.png').to_return(body: attachment_fixture('emojo.png'), headers: { 'Content-Type' => 'application/octet-stream' })
   end
 
-  describe 'processing posts received out of order', :sidekiq_fake do
+  describe 'processing posts received out of order' do
     let(:follower) { Fabricate(:account, username: 'bob') }
 
     let(:object_json) do

--- a/spec/lib/activitypub/activity/delete_spec.rb
+++ b/spec/lib/activitypub/activity/delete_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ActivityPub::Activity::Delete do
         expect(Status.find_by(id: status.id)).to be_nil
       end
 
-      it 'sends delete activity to followers of rebloggers' do
+      it 'sends delete activity to followers of rebloggers', :sidekiq_inline do
         expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
       end
 

--- a/spec/lib/activitypub/activity/move_spec.rb
+++ b/spec/lib/activitypub/activity/move_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ActivityPub::Activity::Move do
       subject.perform
     end
 
-    context 'when all conditions are met' do
+    context 'when all conditions are met', :sidekiq_inline do
       it 'sets moved account on old account' do
         expect(old_account.reload.moved_to_account_id).to eq new_account.id
       end

--- a/spec/models/admin/account_action_spec.rb
+++ b/spec/models/admin/account_action_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Admin::AccountAction do
         expect(target_account).to be_suspended
       end
 
-      it 'queues Admin::SuspensionWorker by 1', :sidekiq_fake do
+      it 'queues Admin::SuspensionWorker by 1' do
         expect do
           subject
         end.to change { Admin::SuspensionWorker.jobs.size }.by 1

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe User do
     end
   end
 
-  describe 'scopes' do
+  describe 'scopes', :sidekiq_inline do
     describe 'recent' do
       it 'returns an array of recent users ordered by id' do
         first_user = Fabricate(:user)
@@ -452,7 +452,7 @@ RSpec.describe User do
         expect(user.confirmed_at).to be_present
       end
 
-      it 'delivers mails' do
+      it 'delivers mails', :sidekiq_inline do
         expect(ActionMailer::Base.deliveries.count).to eq 2
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,6 @@ Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
 WebMock.disable_net_connect!(allow: Chewy.settings[:host], allow_localhost: RUN_SYSTEM_SPECS)
-Sidekiq::Testing.inline!
 Sidekiq.logger = nil
 
 # System tests config
@@ -96,11 +95,8 @@ RSpec.configure do |config|
     self.use_transactional_tests = true
   end
 
-  config.around(:each, :sidekiq_fake) do |example|
-    Sidekiq::Testing.fake! do
-      example.run
-      Sidekiq::Worker.clear_all
-    end
+  config.around(:each, :sidekiq_inline) do |example|
+    Sidekiq::Testing.inline!(&example)
   end
 
   config.before :each, type: :cli do

--- a/spec/requests/api/v1/featured_tags_spec.rb
+++ b/spec/requests/api/v1/featured_tags_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe 'FeaturedTags' do
       expect(body).to be_empty
     end
 
-    it 'deletes the featured tag' do
+    it 'deletes the featured tag', :sidekiq_inline do
       delete "/api/v1/featured_tags/#{id}", headers: headers
 
       featured_tag = FeaturedTag.find_by(id: id)

--- a/spec/requests/api/v1/notifications_spec.rb
+++ b/spec/requests/api/v1/notifications_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Notifications' do
   let(:scopes)  { 'read:notifications write:notifications' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  describe 'GET /api/v1/notifications' do
+  describe 'GET /api/v1/notifications', :sidekiq_inline do
     subject do
       get '/api/v1/notifications', headers: headers, params: params
     end

--- a/spec/requests/api/v1/statuses/favourites_spec.rb
+++ b/spec/requests/api/v1/statuses/favourites_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Favourites' do
+RSpec.describe 'Favourites', :sidekiq_inline do
   let(:user)    { Fabricate(:user) }
   let(:scopes)  { 'write:favourites' }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
@@ -70,7 +70,7 @@ RSpec.describe 'Favourites' do
     end
   end
 
-  describe 'POST /api/v1/statuses/:status_id/unfavourite', :sidekiq_fake do
+  describe 'POST /api/v1/statuses/:status_id/unfavourite' do
     subject do
       post "/api/v1/statuses/#{status.id}/unfavourite", headers: headers
     end
@@ -88,9 +88,7 @@ RSpec.describe 'Favourites' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(user.account.favourited?(status)).to be true
 
-        UnfavouriteWorker.drain
         expect(user.account.favourited?(status)).to be false
       end
 
@@ -113,9 +111,7 @@ RSpec.describe 'Favourites' do
         subject
 
         expect(response).to have_http_status(200)
-        expect(user.account.favourited?(status)).to be true
 
-        UnfavouriteWorker.drain
         expect(user.account.favourited?(status)).to be false
       end
 

--- a/spec/requests/api/v1/timelines/home_spec.rb
+++ b/spec/requests/api/v1/timelines/home_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Home' do
+describe 'Home', :sidekiq_inline do
   let(:user)    { Fabricate(:user) }
   let(:scopes)  { 'read:statuses' }
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }

--- a/spec/search/models/concerns/account/statuses_search_spec.rb
+++ b/spec/search/models/concerns/account/statuses_search_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Account::StatusesSearch do
+describe Account::StatusesSearch, :sidekiq_inline do
   describe 'a non-indexable account becoming indexable' do
     let(:account) { Account.find_by(username: 'search_test_account_1') }
 

--- a/spec/services/activitypub/fetch_remote_status_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_status_service_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe ActivityPub::FetchRemoteStatusService, type: :service do
     end
   end
 
-  context 'with statuses referencing other statuses' do
+  context 'with statuses referencing other statuses', :sidekiq_inline do
     before do
       stub_const 'ActivityPub::FetchRemoteStatusService::DISCOVERIES_PER_REQUEST', 5
     end

--- a/spec/services/activitypub/process_account_service_spec.rb
+++ b/spec/services/activitypub/process_account_service_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe ActivityPub::ProcessAccountService, type: :service do
       end
     end
 
-    it 'creates accounts without exceeding rate limit' do
+    it 'creates accounts without exceeding rate limit', :sidekiq_inline do
       expect { subject.call('user1', 'foo.test', payload) }
         .to create_some_remote_accounts
         .and create_fewer_than_rate_limit_accounts

--- a/spec/services/authorize_follow_service_spec.rb
+++ b/spec/services/authorize_follow_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe AuthorizeFollowService, type: :service do
       expect(bob.following?(sender)).to be true
     end
 
-    it 'sends an accept activity' do
+    it 'sends an accept activity', :sidekiq_inline do
       expect(a_request(:post, bob.inbox_url)).to have_been_made.once
     end
   end

--- a/spec/services/batched_remove_status_service_spec.rb
+++ b/spec/services/batched_remove_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BatchedRemoveStatusService, type: :service do
+RSpec.describe BatchedRemoveStatusService, :sidekiq_inline, type: :service do
   subject { described_class.new }
 
   let!(:alice)  { Fabricate(:account) }

--- a/spec/services/block_domain_service_spec.rb
+++ b/spec/services/block_domain_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe BlockDomainService, type: :service do
       expect(already_banned_account.reload.silenced_at).to_not eq DomainBlock.find_by(domain: 'evil.org').created_at
     end
 
-    it 'leaves the domains status and attachments, but clears media' do
+    it 'leaves the domains status and attachments, but clears media', :sidekiq_inline do
       expect { bad_status_plain.reload }.to_not raise_error
       expect { bad_status_with_attachment.reload }.to_not raise_error
       expect { bad_attachment.reload }.to_not raise_error

--- a/spec/services/block_service_spec.rb
+++ b/spec/services/block_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe BlockService, type: :service do
       expect(sender.blocking?(bob)).to be true
     end
 
-    it 'sends a block activity' do
+    it 'sends a block activity', :sidekiq_inline do
       expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
     end
   end

--- a/spec/services/bulk_import_service_spec.rb
+++ b/spec/services/bulk_import_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BulkImportService do
     import.update(total_items: import.rows.count)
   end
 
-  describe '#call', :sidekiq_fake do
+  describe '#call' do
     context 'when importing follows' do
       let(:import_type) { 'following' }
       let(:overwrite)   { false }

--- a/spec/services/delete_account_service_spec.rb
+++ b/spec/services/delete_account_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe DeleteAccountService, type: :service do
     end
   end
 
-  describe '#call on local account' do
+  describe '#call on local account', :sidekiq_inline do
     before do
       stub_request(:post, remote_alice.inbox_url).to_return(status: 201)
       stub_request(:post, remote_bob.inbox_url).to_return(status: 201)
@@ -83,7 +83,7 @@ RSpec.describe DeleteAccountService, type: :service do
     end
   end
 
-  describe '#call on remote account' do
+  describe '#call on remote account', :sidekiq_inline do
     before do
       stub_request(:post, account.inbox_url).to_return(status: 201)
     end

--- a/spec/services/fan_out_on_write_service_spec.rb
+++ b/spec/services/fan_out_on_write_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe FanOutOnWriteService, type: :service do
       expect(home_feed_of(alice)).to include status.id
     end
 
-    it 'is added to the home feed of a follower' do
+    it 'is added to the home feed of a follower', :sidekiq_inline do
       expect(home_feed_of(bob)).to include status.id
       expect(home_feed_of(tom)).to include status.id
     end
@@ -62,7 +62,7 @@ RSpec.describe FanOutOnWriteService, type: :service do
       expect(home_feed_of(alice)).to include status.id
     end
 
-    it 'is added to the home feed of the mentioned follower' do
+    it 'is added to the home feed of the mentioned follower', :sidekiq_inline do
       expect(home_feed_of(bob)).to include status.id
     end
 
@@ -83,7 +83,7 @@ RSpec.describe FanOutOnWriteService, type: :service do
       expect(home_feed_of(alice)).to include status.id
     end
 
-    it 'is added to the home feed of a follower' do
+    it 'is added to the home feed of a follower', :sidekiq_inline do
       expect(home_feed_of(bob)).to include status.id
       expect(home_feed_of(tom)).to include status.id
     end
@@ -101,7 +101,7 @@ RSpec.describe FanOutOnWriteService, type: :service do
       expect(home_feed_of(alice)).to include status.id
     end
 
-    it 'is added to the home feed of the mentioned follower' do
+    it 'is added to the home feed of the mentioned follower', :sidekiq_inline do
       expect(home_feed_of(bob)).to include status.id
     end
 
@@ -114,7 +114,7 @@ RSpec.describe FanOutOnWriteService, type: :service do
       expect(redis).to_not have_received(:publish).with('timeline:public', anything)
     end
 
-    context 'when handling status updates', :sidekiq_fake do
+    context 'when handling status updates' do
       before do
         subject.call(status)
 
@@ -123,8 +123,6 @@ RSpec.describe FanOutOnWriteService, type: :service do
         status.snapshot!(account_id: status.account_id)
 
         redis.set("subscribed:timeline:#{eve.id}:notifications", '1')
-
-        Sidekiq::Worker.clear_all
       end
 
       it 'pushes the update to mentioned users through the notifications streaming channel' do

--- a/spec/services/favourite_service_spec.rb
+++ b/spec/services/favourite_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe FavouriteService, type: :service do
       expect(status.favourites.first).to_not be_nil
     end
 
-    it 'sends a like activity' do
+    it 'sends a like activity', :sidekiq_inline do
       expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
     end
   end

--- a/spec/services/follow_service_spec.rb
+++ b/spec/services/follow_service_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe FollowService, type: :service do
       expect(FollowRequest.find_by(account: sender, target_account: bob)).to_not be_nil
     end
 
-    it 'sends a follow activity to the inbox' do
+    it 'sends a follow activity to the inbox', :sidekiq_inline do
       expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
     end
   end

--- a/spec/services/import_service_spec.rb
+++ b/spec/services/import_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe ImportService, type: :service do
+RSpec.describe ImportService, :sidekiq_inline, type: :service do
   include RoutingHelper
 
   let!(:account) { Fabricate(:account, locked: false) }

--- a/spec/services/mute_service_spec.rb
+++ b/spec/services/mute_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe MuteService, type: :service do
       redis.del(home_timeline_key)
     end
 
-    it "clears account's statuses" do
+    it "clears account's statuses", :sidekiq_inline do
       FeedManager.instance.push_to_home(account, status)
       FeedManager.instance.push_to_home(account, other_account_status)
 

--- a/spec/services/notify_service_spec.rb
+++ b/spec/services/notify_service_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe NotifyService, type: :service do
     context 'when email notification is enabled' do
       let(:enabled) { true }
 
-      it 'sends email' do
+      it 'sends email', :sidekiq_inline do
         expect { subject }.to change(ActionMailer::Base.deliveries, :count).by(1)
       end
     end

--- a/spec/services/reblog_service_spec.rb
+++ b/spec/services/reblog_service_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ReblogService, type: :service do
       expect(ActivityPub::DistributionWorker).to have_received(:perform_async)
     end
 
-    it 'sends an announce activity to the author' do
+    it 'sends an announce activity to the author', :sidekiq_inline do
       expect(a_request(:post, bob.inbox_url)).to have_been_made.once
     end
   end

--- a/spec/services/reject_follow_service_spec.rb
+++ b/spec/services/reject_follow_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RejectFollowService, type: :service do
       expect(bob.following?(sender)).to be false
     end
 
-    it 'sends a reject activity' do
+    it 'sends a reject activity', :sidekiq_inline do
       expect(a_request(:post, bob.inbox_url)).to have_been_made.once
     end
   end

--- a/spec/services/remove_from_followers_service_spec.rb
+++ b/spec/services/remove_from_followers_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RemoveFromFollowersService, type: :service do
       expect(bob.followed_by?(sender)).to be false
     end
 
-    it 'sends a reject activity' do
+    it 'sends a reject activity', :sidekiq_inline do
       expect(a_request(:post, sender.inbox_url)).to have_been_made.once
     end
   end

--- a/spec/services/remove_status_service_spec.rb
+++ b/spec/services/remove_status_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe RemoveStatusService, type: :service do
+RSpec.describe RemoveStatusService, :sidekiq_inline, type: :service do
   subject { described_class.new }
 
   let!(:alice)  { Fabricate(:account) }

--- a/spec/services/report_service_spec.rb
+++ b/spec/services/report_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ReportService, type: :service do
       stub_request(:post, 'http://example.com/inbox').to_return(status: 200)
     end
 
-    context 'when forward is true' do
+    context 'when forward is true', :sidekiq_inline do
       let(:forward) { true }
 
       it 'sends ActivityPub payload when forward is true' do

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe ResolveAccountService, type: :service do
       expect(account.uri).to eq 'https://ap.example.com/users/foo'
     end
 
-    it 'merges accounts' do
+    it 'merges accounts', :sidekiq_inline do
       account = subject.call('foo@ap.example.com')
 
       expect(status.reload.account_id).to eq account.id

--- a/spec/services/suspend_account_service_spec.rb
+++ b/spec/services/suspend_account_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe SuspendAccountService, type: :service do
+RSpec.describe SuspendAccountService, :sidekiq_inline, type: :service do
   shared_examples 'common behavior' do
     subject { described_class.new.call(account) }
 

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe UnallowDomainService, type: :service do
   let!(:already_banned_account) { Fabricate(:account, username: 'badguy', domain: 'evil.org', suspended: true, silenced: true) }
   let!(:domain_allow) { Fabricate(:domain_allow, domain: 'evil.org') }
 
-  context 'with limited federation mode' do
+  context 'with limited federation mode', :sidekiq_inline do
     before do
       allow(Rails.configuration.x).to receive(:limited_federation_mode).and_return(true)
     end

--- a/spec/services/unblock_service_spec.rb
+++ b/spec/services/unblock_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe UnblockService, type: :service do
       expect(sender.blocking?(bob)).to be false
     end
 
-    it 'sends an unblock activity' do
+    it 'sends an unblock activity', :sidekiq_inline do
       expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
     end
   end

--- a/spec/services/unfollow_service_spec.rb
+++ b/spec/services/unfollow_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UnfollowService, type: :service do
     end
   end
 
-  describe 'remote ActivityPub' do
+  describe 'remote ActivityPub', :sidekiq_inline do
     let(:bob) { Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
 
     before do
@@ -38,7 +38,7 @@ RSpec.describe UnfollowService, type: :service do
     end
   end
 
-  describe 'remote ActivityPub (reverse)' do
+  describe 'remote ActivityPub (reverse)', :sidekiq_inline do
     let(:bob) { Fabricate(:account, username: 'bob', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
 
     before do

--- a/spec/services/unsuspend_account_service_spec.rb
+++ b/spec/services/unsuspend_account_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe UnsuspendAccountService, type: :service do
         remote_follower.follow!(account)
       end
 
-      it 'merges back into feeds of local followers and sends update' do
+      it 'merges back into feeds of local followers and sends update', :sidekiq_inline do
         subject
 
         expect_feeds_merged

--- a/spec/services/update_account_service_spec.rb
+++ b/spec/services/update_account_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe UpdateAccountService, type: :service do
   subject { described_class.new }
 
-  describe 'switching form locked to unlocked accounts' do
+  describe 'switching form locked to unlocked accounts', :sidekiq_inline do
     let(:account) { Fabricate(:account, locked: true) }
     let(:alice)   { Fabricate(:account) }
     let(:bob)     { Fabricate(:account) }

--- a/spec/services/update_status_service_spec.rb
+++ b/spec/services/update_status_service_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe UpdateStatusService, type: :service do
     end
   end
 
-  context 'when poll changes', :sidekiq_fake do
+  context 'when poll changes' do
     let(:account) { Fabricate(:account) }
     let!(:status) { Fabricate(:status, text: 'Foo', account: account, poll_attributes: { options: %w(Foo Bar), account: account, multiple: false, hide_totals: false, expires_at: 7.days.from_now }) }
     let!(:poll)   { status.poll }

--- a/spec/system/new_statuses_spec.rb
+++ b/spec/system/new_statuses_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'NewStatuses' do
+describe 'NewStatuses', :sidekiq_inline do
   include ProfileStories
 
   subject { page }

--- a/spec/workers/backup_worker_spec.rb
+++ b/spec/workers/backup_worker_spec.rb
@@ -14,7 +14,7 @@ describe BackupWorker do
     let(:backup) { Fabricate(:backup) }
     let!(:other_backup) { Fabricate(:backup, user: backup.user) }
 
-    it 'sends the backup to the service and removes other backups' do
+    it 'sends the backup to the service and removes other backups', :sidekiq_inline do
       expect do
         worker.perform(backup.id)
       end.to change(UserMailer.deliveries, :size).by(1)

--- a/spec/workers/move_worker_spec.rb
+++ b/spec/workers/move_worker_spec.rb
@@ -104,7 +104,7 @@ describe MoveWorker do
   end
 
   shared_examples 'lists handling' do
-    it 'puts the new account on the list and makes valid lists', sidekiq: :inline do
+    it 'puts the new account on the list and makes valid lists', :sidekiq_inline do
       subject.perform(source_account.id, target_account.id)
 
       expect(list.accounts.include?(target_account)).to be true
@@ -159,7 +159,7 @@ describe MoveWorker do
 
   describe '#perform' do
     context 'when both accounts are distant' do
-      it 'calls UnfollowFollowWorker', :sidekiq_fake do
+      it 'calls UnfollowFollowWorker' do
         subject.perform(source_account.id, target_account.id)
         expect(UnfollowFollowWorker).to have_enqueued_sidekiq_job(local_follower.id, source_account.id, target_account.id, false)
       end
@@ -170,7 +170,7 @@ describe MoveWorker do
     context 'when target account is local' do
       let(:target_account) { Fabricate(:account) }
 
-      it 'calls UnfollowFollowWorker', :sidekiq_fake do
+      it 'calls UnfollowFollowWorker' do
         subject.perform(source_account.id, target_account.id)
         expect(UnfollowFollowWorker).to have_enqueued_sidekiq_job(local_follower.id, source_account.id, target_account.id, true)
       end

--- a/spec/workers/poll_expiration_notify_worker_spec.rb
+++ b/spec/workers/poll_expiration_notify_worker_spec.rb
@@ -10,7 +10,7 @@ describe PollExpirationNotifyWorker do
   let(:remote?) { false }
   let(:poll_vote) { Fabricate(:poll_vote, poll: poll) }
 
-  describe '#perform', :sidekiq_fake do
+  describe '#perform' do
     it 'runs without error for missing record' do
       expect { worker.perform(nil) }.to_not raise_error
     end


### PR DESCRIPTION
In the spirit of previous PRs about paperclip processing (https://github.com/mastodon/mastodon/pull/25359) and factory build (https://github.com/mastodon/mastodon/pull/25360) -- there are many places throughout the spec suite which are running background sidekiq jobs inline, but where the specs don't need that to happen and aren't verifying anything related to that happening.

The default mode for sidekiq testing is to run in `fake` mode (makes job information accessible to specs, but doesn't actually run the jobs), but we were overriding that to run in `inline` mode.

This changes removes that override so that we go back to `fake` mode, and adds an opt-in for examples to get the inline behavior in specs where it's actually required.

In my local spec suite runs this change drops the full run from ~8:45 or so to around ~6:05 (~2:30 improvement).

One sort of awkward thing here is the mix of opting in to the inline behavior at different levels (describe, context, it) in this diff. I tried to keep this consistent at first, but there are some specs where we have what should be one-time setup code running once for every example because `before(:each)` is the default. I suspect there is good opportunity here for more speedup refactoring and might grab that next ... but I decided to limit this PR to the narrow sidekiq mode speedup instead of also changing those here.
