### PR TITLE
Add unsubscribe link to e-mails

### DIFF
--- a/app/controllers/mail_subscriptions_controller.rb
+++ b/app/controllers/mail_subscriptions_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class MailSubscriptionsController < ApplicationController
+  layout 'auth'
+
+  skip_before_action :require_functional!
+
+  before_action :set_body_classes
+  before_action :set_user
+  before_action :set_type
+
+  def show; end
+
+  def create
+    @user.settings[email_type_from_param] = false
+    @user.save!
+  end
+
+  private
+
+  def set_user
+    @user = GlobalID::Locator.locate_signed(params[:token], for: 'unsubscribe')
+  end
+
+  def set_body_classes
+    @body_classes = 'lighter'
+  end
+
+  def set_type
+    @type = email_type_from_param
+  end
+
+  def email_type_from_param
+    case params[:type]
+    when 'follow', 'reblog', 'favourite', 'mention', 'follow_request'
+      "notification_emails.#{params[:type]}"
+    else
+      raise ArgumentError
+    end
+  end
+end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -8,61 +8,71 @@ class NotificationMailer < ApplicationMailer
 
   def mention(recipient, notification)
     @me     = recipient
+    @user   = recipient.user
+    @type   = 'mention'
     @status = notification.target_status
 
-    return unless @me.user.functional? && @status.present?
+    return unless @user.functional? && @status.present?
 
     locale_for_account(@me) do
       thread_by_conversation(@status.conversation)
-      mail to: email_address_with_name(@me.user.email, @me.user.account.username), subject: I18n.t('notification_mailer.mention.subject', name: @status.account.acct)
+      mail to: email_address_with_name(@user.email, @me.username), subject: I18n.t('notification_mailer.mention.subject', name: @status.account.acct)
     end
   end
 
   def follow(recipient, notification)
     @me      = recipient
+    @user    = recipient.user
+    @type    = 'follow'
     @account = notification.from_account
 
-    return unless @me.user.functional?
+    return unless @user.functional?
 
     locale_for_account(@me) do
-      mail to: email_address_with_name(@me.user.email, @me.user.account.username), subject: I18n.t('notification_mailer.follow.subject', name: @account.acct)
+      mail to: email_address_with_name(@user.email, @me.username), subject: I18n.t('notification_mailer.follow.subject', name: @account.acct)
     end
   end
 
   def favourite(recipient, notification)
     @me      = recipient
+    @user    = recipient.user
+    @type    = 'favourite'
     @account = notification.from_account
     @status  = notification.target_status
 
-    return unless @me.user.functional? && @status.present?
+    return unless @user.functional? && @status.present?
 
     locale_for_account(@me) do
       thread_by_conversation(@status.conversation)
-      mail to: email_address_with_name(@me.user.email, @me.user.account.username), subject: I18n.t('notification_mailer.favourite.subject', name: @account.acct)
+      mail to: email_address_with_name(@user.email, @me.username), subject: I18n.t('notification_mailer.favourite.subject', name: @account.acct)
     end
   end
 
   def reblog(recipient, notification)
     @me      = recipient
+    @user    = recipient.user
+    @type    = 'reblog'
     @account = notification.from_account
     @status  = notification.target_status
 
-    return unless @me.user.functional? && @status.present?
+    return unless @user.functional? && @status.present?
 
     locale_for_account(@me) do
       thread_by_conversation(@status.conversation)
-      mail to: email_address_with_name(@me.user.email, @me.user.account.username), subject: I18n.t('notification_mailer.reblog.subject', name: @account.acct)
+      mail to: email_address_with_name(@user.email, @me.username), subject: I18n.t('notification_mailer.reblog.subject', name: @account.acct)
     end
   end
 
   def follow_request(recipient, notification)
     @me      = recipient
+    @user    = recipient.user
+    @type    = 'follow_request'
     @account = notification.from_account
 
-    return unless @me.user.functional?
+    return unless @user.functional?
 
     locale_for_account(@me) do
-      mail to: email_address_with_name(@me.user.email, @me.user.account.username), subject: I18n.t('notification_mailer.follow_request.subject', name: @account.acct)
+      mail to: email_address_with_name(@user.email, @me.username), subject: I18n.t('notification_mailer.follow_request.subject', name: @account.acct)
     end
   end
 

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -44,7 +44,11 @@
                             %tbody
                               %td.column-cell
                                 %p= t 'about.hosted_on', domain: site_hostname
-                                %p= link_to t('application_mailer.notification_preferences'), settings_preferences_notifications_url
+                                %p
+                                  = link_to t('application_mailer.notification_preferences'), settings_preferences_notifications_url
+                                  - if defined?(@type)
+                                    ·
+                                    = link_to t('application_mailer.unsubscribe'), unsubscribe_url(token: @user.to_sgid(for: 'unsubscribe').to_s, type: @type)
                               %td.column-cell.text-right
                                 = link_to root_url do
                                   = image_tag full_pack_url('media/images/mailer/logo.png'), alt: 'Mastodon', height: 24

--- a/app/views/mail_subscriptions/create.html.haml
+++ b/app/views/mail_subscriptions/create.html.haml
@@ -1,0 +1,9 @@
+- content_for :page_title do
+  = t('mail_subscriptions.unsubscribe.title')
+
+.simple_form
+  %h1.title= t('mail_subscriptions.unsubscribe.complete')
+  %p.lead
+    = t('mail_subscriptions.unsubscribe.success_html', domain: content_tag(:strong, site_hostname), type: content_tag(:strong, I18n.t(@type, scope: 'mail_subscriptions.unsubscribe.emails')), email: content_tag(:strong, @user.email))
+  %p.lead
+    = t('mail_subscriptions.unsubscribe.resubscribe_html', settings_path: settings_preferences_notifications_path)

--- a/app/views/mail_subscriptions/show.html.haml
+++ b/app/views/mail_subscriptions/show.html.haml
@@ -1,0 +1,12 @@
+- content_for :page_title do
+  = t('mail_subscriptions.unsubscribe.title')
+
+.simple_form
+  %h1.title= t('mail_subscriptions.unsubscribe.title')
+  %p.lead
+    = t('mail_subscriptions.unsubscribe.confirmation_html', domain: content_tag(:strong, site_hostname), type: content_tag(:strong, I18n.t(@type, scope: 'mail_subscriptions.unsubscribe.emails')), email: content_tag(:strong, @user.email), settings_path: settings_preferences_notifications_path)
+
+  = form_tag unsubscribe_path, method: :post do
+    = hidden_field_tag :token, params[:token]
+    = hidden_field_tag :type, params[:type]
+    = button_tag t('mail_subscriptions.unsubscribe.action'), type: :submit

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -66,6 +66,7 @@ ignore_unused:
   - 'notification_mailer.*'
   - 'imports.overwrite_preambles.{following,blocking,muting,domain_blocking,bookmarks}_html'
   - 'imports.preambles.{following,blocking,muting,domain_blocking,bookmarks}_html'
+  - 'mail_subscriptions.unsubscribe.emails.*'
 
 ignore_inconsistent_interpolations:
   - '*.one'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -978,6 +978,7 @@ en:
     notification_preferences: Change e-mail preferences
     salutation: "%{name},"
     settings: 'Change e-mail preferences: %{link}'
+    unsubscribe: Unsubscribe
     view: 'View:'
     view_profile: View profile
     view_status: View post
@@ -1342,6 +1343,21 @@ en:
     failed_sign_in_html: Failed sign-in attempt with %{method} from %{ip} (%{browser})
     successful_sign_in_html: Successful sign-in with %{method} from %{ip} (%{browser})
     title: Authentication history
+  mail_subscriptions:
+    unsubscribe:
+      action: Yes, unsubscribe
+      complete: Unsubscribed
+      confirmation_html: Are you sure you want to unsubscribe from receiving %{type} for Mastodon on %{domain} to your e-mail at %{email}? You can always re-subscribe from your <a href="%{settings_path}">e-mail notification settings</a>.
+      emails:
+        notification_emails:
+          favourite: favorite notification e-mails
+          follow: follow notification e-mails
+          follow_request: follow request e-mails
+          mention: mention notification e-mails
+          reblog: boost notification e-mails
+      resubscribe_html: If you've unsubscribed by mistake, you can re-subscribe from your <a href="%{settings_path}">e-mail notification settings</a>.
+      success_html: You'll no longer receive %{type} for Mastodon on %{domain} to your e-mail at %{email}.
+      title: Unsubscribe
   media_attachments:
     validations:
       images_and_video: Cannot attach a video to a post that already contains images

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,8 @@ Rails.application.routes.draw do
   devise_scope :user do
     get '/invite/:invite_code', to: 'auth/registrations#new', as: :public_invite
 
+    resource :unsubscribe, only: [:show, :create], controller: :mail_subscriptions
+
     namespace :auth do
       resource :setup, only: [:show, :update], controller: :setup
       resource :challenge, only: [:create], controller: :challenges


### PR DESCRIPTION
The link does not require to be logged in to work. The links expire after 1 month (Rails default).

|Confirmation|Success|
|--|--|
|![Screen Shot 2023-06-12 at 09 08 02](https://github.com/mastodon/mastodon/assets/184731/6009eb49-06aa-47f3-8646-4e97bdaa1f2d)|![Screen Shot 2023-06-12 at 09 08 05](https://github.com/mastodon/mastodon/assets/184731/6351fd4f-19a8-408d-9882-e942f55cafa7)|

___

Fixes MAS-144