### PR TITLE
Enable paperclip for account attachment examples

### DIFF
--- a/spec/support/examples/models/concerns/account_avatar.rb
+++ b/spec/support/examples/models/concerns/account_avatar.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples 'AccountAvatar' do |fabricator|
-  describe 'static avatars' do
+  describe 'static avatars', paperclip_processing: true do
     describe 'when GIF' do
       it 'creates a png static style' do
         account = Fabricate(fabricator, avatar: attachment_fixture('avatar.gif'))


### PR DESCRIPTION
As discussed: https://github.com/mastodon/mastodon/pull/25359#issuecomment-1587258669