### PR TITLE
Fix `ArgumentError` in `/api/v1/admin/accounts/:id/action`

### DIFF
--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -26,6 +26,7 @@ class Admin::AccountAction
   alias include_statuses? include_statuses
 
   validates :type, :target_account, :current_account, presence: true
+  validates :type, inclusion: { in: TYPES }
 
   def initialize(attributes = {})
     @send_email_notification = true

--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -72,6 +72,10 @@ class Admin::AccountAction
         TYPES - %w(none disable)
       end
     end
+
+    def i18n_scope
+      :activerecord
+    end
   end
 
   private

--- a/spec/models/admin/account_action_spec.rb
+++ b/spec/models/admin/account_action_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe Admin::AccountAction do
       end
     end
 
+    context 'when type is invalid' do
+      let(:type) { 'whatever' }
+
+      it 'raises an invalid record error' do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context 'when type is not given' do
+      let(:type) { '' }
+
+      it 'raises an invalid record error' do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
     it 'creates Admin::ActionLog' do
       expect do
         subject


### PR DESCRIPTION
Fixes #25385.

When the record is invalid, this is returned: `translation missing: en.activemodel.errors.messages.record_invalid`.
This message is also returned when no `type` is provided. Where should I add this missing translation?