### PR TITLE
Extract shared examples from api specs

### DIFF
--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -13,14 +13,6 @@ RSpec.describe Api::V1::AccountsController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'POST #create' do
     let(:app) { Fabricate(:application) }
     let(:token) { Doorkeeper::AccessToken.find_or_create_for(application: app, resource_owner: nil, scopes: 'read write', use_refresh_token: false) }

--- a/spec/controllers/api/v1/admin/account_actions_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/account_actions_controller_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe Api::V1::Admin::AccountActionsController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'POST #create' do
     context 'with type of disable' do
       before do

--- a/spec/controllers/api/v1/admin/account_actions_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/account_actions_controller_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe Api::V1::Admin::AccountActionsController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/controllers/api/v1/admin/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/accounts_controller_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe Api::V1::Admin::AccountsController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET #index' do
     let!(:remote_account)       { Fabricate(:account, domain: 'example.org') }
     let!(:other_remote_account) { Fabricate(:account, domain: 'foo.bar') }

--- a/spec/controllers/api/v1/admin/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/accounts_controller_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe Api::V1::Admin::AccountsController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/controllers/api/v1/admin/trends/links/preview_card_providers_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/links/preview_card_providers_controller_spec.rb
@@ -16,14 +16,6 @@ describe Api::V1::Admin::Trends::Links::PreviewCardProvidersController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/controllers/api/v1/admin/trends/links/preview_card_providers_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/links/preview_card_providers_controller_spec.rb
@@ -16,14 +16,6 @@ describe Api::V1::Admin::Trends::Links::PreviewCardProvidersController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET #index' do
     it 'returns http success' do
       get :index, params: { account_id: account.id, limit: 2 }

--- a/spec/controllers/api/v1/admin/trends/links_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/links_controller_spec.rb
@@ -16,14 +16,6 @@ describe Api::V1::Admin::Trends::LinksController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET #index' do
     it 'returns http success' do
       get :index, params: { account_id: account.id, limit: 2 }

--- a/spec/controllers/api/v1/admin/trends/links_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/links_controller_spec.rb
@@ -16,14 +16,6 @@ describe Api::V1::Admin::Trends::LinksController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/controllers/api/v1/admin/trends/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/statuses_controller_spec.rb
@@ -16,14 +16,6 @@ describe Api::V1::Admin::Trends::StatusesController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/controllers/api/v1/admin/trends/statuses_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/statuses_controller_spec.rb
@@ -16,14 +16,6 @@ describe Api::V1::Admin::Trends::StatusesController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET #index' do
     it 'returns http success' do
       get :index, params: { account_id: account.id, limit: 2 }

--- a/spec/controllers/api/v1/admin/trends/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/tags_controller_spec.rb
@@ -16,14 +16,6 @@ describe Api::V1::Admin::Trends::TagsController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/controllers/api/v1/admin/trends/tags_controller_spec.rb
+++ b/spec/controllers/api/v1/admin/trends/tags_controller_spec.rb
@@ -16,14 +16,6 @@ describe Api::V1::Admin::Trends::TagsController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET #index' do
     it 'returns http success' do
       get :index, params: { account_id: account.id, limit: 2 }

--- a/spec/controllers/api/v1/domain_blocks_controller_spec.rb
+++ b/spec/controllers/api/v1/domain_blocks_controller_spec.rb
@@ -13,14 +13,6 @@ RSpec.describe Api::V1::DomainBlocksController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET #show' do
     let(:scopes) { 'read:blocks' }
 

--- a/spec/controllers/api/v2/admin/accounts_controller_spec.rb
+++ b/spec/controllers/api/v2/admin/accounts_controller_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe Api::V2::Admin::AccountsController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET #index' do
     let!(:remote_account)       { Fabricate(:account, domain: 'example.org') }
     let!(:other_remote_account) { Fabricate(:account, domain: 'foo.bar') }

--- a/spec/controllers/api/v2/admin/accounts_controller_spec.rb
+++ b/spec/controllers/api/v2/admin/accounts_controller_spec.rb
@@ -15,14 +15,6 @@ RSpec.describe Api::V2::Admin::AccountsController do
     allow(controller).to receive(:doorkeeper_token) { token }
   end
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'Canonical Email Blocks' do
   let(:scopes)  { 'admin:read:canonical_email_blocks admin:write:canonical_email_blocks' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/canonical_email_blocks_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'Canonical Email Blocks' do
   let(:scopes)  { 'admin:read:canonical_email_blocks admin:write:canonical_email_blocks' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET /api/v1/admin/canonical_email_blocks' do
     subject do
       get '/api/v1/admin/canonical_email_blocks', headers: headers, params: params

--- a/spec/requests/api/v1/admin/domain_allows_spec.rb
+++ b/spec/requests/api/v1/admin/domain_allows_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'Domain Allows' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET /api/v1/admin/domain_allows' do
     subject do
       get '/api/v1/admin/domain_allows', headers: headers, params: params

--- a/spec/requests/api/v1/admin/domain_allows_spec.rb
+++ b/spec/requests/api/v1/admin/domain_allows_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'Domain Allows' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/requests/api/v1/admin/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/domain_blocks_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'Domain Blocks' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/requests/api/v1/admin/domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/domain_blocks_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'Domain Blocks' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET /api/v1/admin/domain_blocks' do
     subject do
       get '/api/v1/admin/domain_blocks', headers: headers, params: params

--- a/spec/requests/api/v1/admin/email_domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/email_domain_blocks_spec.rb
@@ -10,16 +10,6 @@ RSpec.describe 'Email Domain Blocks' do
   let(:scopes)  { 'admin:read:email_domain_blocks admin:write:email_domain_blocks' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/requests/api/v1/admin/email_domain_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/email_domain_blocks_spec.rb
@@ -10,16 +10,6 @@ RSpec.describe 'Email Domain Blocks' do
   let(:scopes)  { 'admin:read:email_domain_blocks admin:write:email_domain_blocks' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET /api/v1/admin/email_domain_blocks' do
     subject do
       get '/api/v1/admin/email_domain_blocks', headers: headers, params: params

--- a/spec/requests/api/v1/admin/ip_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/ip_blocks_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'IP Blocks' do
   let(:scopes)  { 'admin:read:ip_blocks admin:write:ip_blocks' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET /api/v1/admin/ip_blocks' do
     subject do
       get '/api/v1/admin/ip_blocks', headers: headers, params: params

--- a/spec/requests/api/v1/admin/ip_blocks_spec.rb
+++ b/spec/requests/api/v1/admin/ip_blocks_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'IP Blocks' do
   let(:scopes)  { 'admin:read:ip_blocks admin:write:ip_blocks' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'Reports' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong role' do |wrong_role|
-    let(:role) { UserRole.find_by(name: wrong_role) }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET /api/v1/admin/reports' do
     subject do
       get '/api/v1/admin/reports', headers: headers, params: params

--- a/spec/requests/api/v1/admin/reports_spec.rb
+++ b/spec/requests/api/v1/admin/reports_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'Reports' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      subject
-
-      expect(response).to have_http_status(403)
-    end
-  end
-
   shared_examples 'forbidden for wrong role' do |wrong_role|
     let(:role) { UserRole.find_by(name: wrong_role) }
 

--- a/spec/requests/api/v1/featured_tags_spec.rb
+++ b/spec/requests/api/v1/featured_tags_spec.rb
@@ -8,14 +8,6 @@ RSpec.describe 'FeaturedTags' do
   let(:scopes)  { 'read:accounts write:accounts' }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  shared_examples 'forbidden for wrong scope' do |wrong_scope|
-    let(:scopes) { wrong_scope }
-
-    it 'returns http forbidden' do
-      expect(response).to have_http_status(403)
-    end
-  end
-
   describe 'GET /api/v1/featured_tags' do
     context 'with wrong scope' do
       before do

--- a/spec/support/examples/api.rb
+++ b/spec/support/examples/api.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+shared_examples 'forbidden for wrong scope' do |wrong_scope|
+  let(:scopes) { wrong_scope }
+
+  it 'returns http forbidden' do
+    # Some examples have a subject which needs to be called to make a request
+    subject if request.nil?
+
+    expect(response).to have_http_status(403)
+  end
+end

--- a/spec/support/examples/api.rb
+++ b/spec/support/examples/api.rb
@@ -10,3 +10,14 @@ shared_examples 'forbidden for wrong scope' do |wrong_scope|
     expect(response).to have_http_status(403)
   end
 end
+
+shared_examples 'forbidden for wrong role' do |wrong_role|
+  let(:role) { UserRole.find_by(name: wrong_role) }
+
+  it 'returns http forbidden' do
+    # Some examples have a subject which needs to be called to make a request
+    subject if request.nil?
+
+    expect(response).to have_http_status(403)
+  end
+end


### PR DESCRIPTION
Many of the controller and request specs for the API have shared examples to help test the wrong scope or wrong role use cases, but they were defining the same shared examples over and over in each spec.

This change extracts those to a new location and deletes the repetitive code in the specs.