### PR TITLE
Spec speed ups on `AccountsController` spec

### DIFF
--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -290,31 +290,26 @@ RSpec.describe AccountsController do
 
         it_behaves_like 'common RSS response'
 
-        it 'renders public status' do
+        it 'responds with correct statuses', :aggregate_failures do
+          # renders public status
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status))
-        end
 
-        it 'renders self-reply' do
+          # renders self-reply
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_self_reply))
-        end
 
-        it 'renders status with media' do
+          # renders status with media
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_media))
-        end
 
-        it 'does not render reblog' do
+          # does not render reblog
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reblog.reblog))
-        end
 
-        it 'does not render private status' do
+          # does not render private status
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_private))
-        end
 
-        it 'does not render direct status' do
+          # does not render direct status
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_direct))
-        end
 
-        it 'does not render reply to someone else' do
+          # does not render reply to someone else
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reply))
         end
       end
@@ -327,31 +322,26 @@ RSpec.describe AccountsController do
 
         it_behaves_like 'common RSS response'
 
-        it 'renders public status' do
+        it 'responds with correct statuses', :aggregate_failures do
+          # renders public status
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status))
-        end
 
-        it 'renders self-reply' do
+          # renders self-reply
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_self_reply))
-        end
 
-        it 'renders status with media' do
+          # renders status with media
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_media))
-        end
 
-        it 'does not render reblog' do
+          # does not render reblog
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reblog.reblog))
-        end
 
-        it 'does not render private status' do
+          # does not render private status
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_private))
-        end
 
-        it 'does not render direct status' do
+          # does not render direct status
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_direct))
-        end
 
-        it 'renders reply to someone else' do
+          # renders reply to someone else
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_reply))
         end
       end
@@ -364,31 +354,26 @@ RSpec.describe AccountsController do
 
         it_behaves_like 'common RSS response'
 
-        it 'does not render public status' do
+        it 'responds with correct statuses', :aggregate_failures do
+          # does not render public status
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status))
-        end
 
-        it 'does not render self-reply' do
+          # does not render self-reply
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_self_reply))
-        end
 
-        it 'renders status with media' do
+          # renders status with media
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_media))
-        end
 
-        it 'does not render reblog' do
+          # does not render reblog
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reblog.reblog))
-        end
 
-        it 'does not render private status' do
+          # does not render private status
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_private))
-        end
 
-        it 'does not render direct status' do
+          # does not render direct status
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_direct))
-        end
 
-        it 'does not render reply to someone else' do
+          # does not render reply to someone else
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reply))
         end
       end
@@ -406,35 +391,29 @@ RSpec.describe AccountsController do
 
         it_behaves_like 'common RSS response'
 
-        it 'does not render public status' do
+        it 'responds with correct statuses', :aggregate_failures do
+          # does not render public status
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status))
-        end
 
-        it 'does not render self-reply' do
+          # does not render self-reply
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_self_reply))
-        end
 
-        it 'does not render status with media' do
+          # does not render status with media
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_media))
-        end
 
-        it 'does not render reblog' do
+          # does not render reblog
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reblog.reblog))
-        end
 
-        it 'does not render private status' do
+          # does not render private status
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_private))
-        end
 
-        it 'does not render direct status' do
+          # does not render direct status
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_direct))
-        end
 
-        it 'does not render reply to someone else' do
+          # does not render reply to someone else
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reply))
-        end
 
-        it 'renders status with tag' do
+          # renders status with tag
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_tag))
         end
       end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe AccountsController do
             expect(response).to have_http_status(200)
           end
 
-          it_behaves_like 'cacheable response'
+          it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
         end
 
         context 'with a normal account in an RSS request' do

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -291,25 +291,12 @@ RSpec.describe AccountsController do
         it_behaves_like 'common RSS response'
 
         it 'responds with correct statuses', :aggregate_failures do
-          # renders public status
           expect(response.body).to include_status_tag(status)
-
-          # renders self-reply
           expect(response.body).to include_status_tag(status_self_reply)
-
-          # renders status with media
           expect(response.body).to include_status_tag(status_media)
-
-          # does not render reblog
           expect(response.body).to_not include_status_tag(status_reblog.reblog)
-
-          # does not render private status
           expect(response.body).to_not include_status_tag(status_private)
-
-          # does not render direct status
           expect(response.body).to_not include_status_tag(status_direct)
-
-          # does not render reply to someone else
           expect(response.body).to_not include_status_tag(status_reply)
         end
       end
@@ -323,25 +310,12 @@ RSpec.describe AccountsController do
         it_behaves_like 'common RSS response'
 
         it 'responds with correct statuses', :aggregate_failures do
-          # renders public status
           expect(response.body).to include_status_tag(status)
-
-          # renders self-reply
           expect(response.body).to include_status_tag(status_self_reply)
-
-          # renders status with media
           expect(response.body).to include_status_tag(status_media)
-
-          # does not render reblog
           expect(response.body).to_not include_status_tag(status_reblog.reblog)
-
-          # does not render private status
           expect(response.body).to_not include_status_tag(status_private)
-
-          # does not render direct status
           expect(response.body).to_not include_status_tag(status_direct)
-
-          # renders reply to someone else
           expect(response.body).to include_status_tag(status_reply)
         end
       end
@@ -355,25 +329,12 @@ RSpec.describe AccountsController do
         it_behaves_like 'common RSS response'
 
         it 'responds with correct statuses', :aggregate_failures do
-          # does not render public status
           expect(response.body).to_not include_status_tag(status)
-
-          # does not render self-reply
           expect(response.body).to_not include_status_tag(status_self_reply)
-
-          # renders status with media
           expect(response.body).to include_status_tag(status_media)
-
-          # does not render reblog
           expect(response.body).to_not include_status_tag(status_reblog.reblog)
-
-          # does not render private status
           expect(response.body).to_not include_status_tag(status_private)
-
-          # does not render direct status
           expect(response.body).to_not include_status_tag(status_direct)
-
-          # does not render reply to someone else
           expect(response.body).to_not include_status_tag(status_reply)
         end
       end
@@ -392,28 +353,13 @@ RSpec.describe AccountsController do
         it_behaves_like 'common RSS response'
 
         it 'responds with correct statuses', :aggregate_failures do
-          # does not render public status
           expect(response.body).to_not include_status_tag(status)
-
-          # does not render self-reply
           expect(response.body).to_not include_status_tag(status_self_reply)
-
-          # does not render status with media
           expect(response.body).to_not include_status_tag(status_media)
-
-          # does not render reblog
           expect(response.body).to_not include_status_tag(status_reblog.reblog)
-
-          # does not render private status
           expect(response.body).to_not include_status_tag(status_private)
-
-          # does not render direct status
           expect(response.body).to_not include_status_tag(status_direct)
-
-          # does not render reply to someone else
           expect(response.body).to_not include_status_tag(status_reply)
-
-          # renders status with tag
           expect(response.body).to include_status_tag(status_tag)
         end
       end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe AccountsController do
 
         it_behaves_like 'common RSS response'
 
-        it 'responds with correct statuses', :aggregate_failures do
+        it 'responds with correct statuses with replies', :aggregate_failures do
           expect(response.body).to include_status_tag(status)
           expect(response.body).to include_status_tag(status_self_reply)
           expect(response.body).to include_status_tag(status_media)
@@ -328,7 +328,7 @@ RSpec.describe AccountsController do
 
         it_behaves_like 'common RSS response'
 
-        it 'responds with correct statuses', :aggregate_failures do
+        it 'responds with correct statuses with media', :aggregate_failures do
           expect(response.body).to_not include_status_tag(status)
           expect(response.body).to_not include_status_tag(status_self_reply)
           expect(response.body).to include_status_tag(status_media)
@@ -352,7 +352,7 @@ RSpec.describe AccountsController do
 
         it_behaves_like 'common RSS response'
 
-        it 'responds with correct statuses', :aggregate_failures do
+        it 'responds with correct statuses with a tag', :aggregate_failures do
           expect(response.body).to_not include_status_tag(status)
           expect(response.body).to_not include_status_tag(status_self_reply)
           expect(response.body).to_not include_status_tag(status_media)

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -88,13 +88,10 @@ RSpec.describe AccountsController do
 
         shared_examples 'common HTML response' do
           it 'returns a standard HTML response', :aggregate_failures do
-            # returns http success
             expect(response).to have_http_status(200)
 
-            # returns Link header
             expect(response.headers['Link'].to_s).to include ActivityPub::TagManager.instance.uri_for(account)
 
-            # renders show template
             expect(response).to render_template(:show)
           end
         end
@@ -154,13 +151,10 @@ RSpec.describe AccountsController do
           end
 
           it 'returns a JSON version of the account', :aggregate_failures do
-            # returns http success
             expect(response).to have_http_status(200)
 
-            # returns application/activity+json
             expect(response.media_type).to eq 'application/activity+json'
 
-            # renders account
             expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
           end
 
@@ -184,16 +178,12 @@ RSpec.describe AccountsController do
           end
 
           it 'returns a private JSON version of the account', :aggregate_failures do
-            # returns http success
             expect(response).to have_http_status(200)
 
-            # returns application/activity+json
             expect(response.media_type).to eq 'application/activity+json'
 
-            # returns private Cache-Control header
             expect(response.headers['Cache-Control']).to include 'private'
 
-            # renders account
             expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
           end
         end
@@ -207,13 +197,10 @@ RSpec.describe AccountsController do
           end
 
           it 'returns a JSON version of the account', :aggregate_failures do
-            # returns http success
             expect(response).to have_http_status(200)
 
-            # returns application/activity+json
             expect(response.media_type).to eq 'application/activity+json'
 
-            # renders account
             expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
           end
 
@@ -223,19 +210,14 @@ RSpec.describe AccountsController do
             let(:authorized_fetch_mode) { true }
 
             it 'returns a private signature JSON version of the account', :aggregate_failures do
-              # returns http success
               expect(response).to have_http_status(200)
 
-              # returns application/activity+json
               expect(response.media_type).to eq 'application/activity+json'
 
-              # returns private Cache-Control header
               expect(response.headers['Cache-Control']).to include 'private'
 
-              # returns Vary header with Signature
               expect(response.headers['Vary']).to include 'Signature'
 
-              # renders account
               expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
             end
           end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -7,41 +7,41 @@ RSpec.describe AccountsController do
 
   let(:account) { Fabricate(:account) }
 
+  shared_examples 'unapproved account check' do
+    before { account.user.update(approved: false) }
+
+    it 'returns http not found' do
+      get :show, params: { username: account.username, format: format }
+
+      expect(response).to have_http_status(404)
+    end
+  end
+
+  shared_examples 'permanently suspended account check' do
+    before do
+      account.suspend!
+      account.deletion_request.destroy
+    end
+
+    it 'returns http gone' do
+      get :show, params: { username: account.username, format: format }
+
+      expect(response).to have_http_status(410)
+    end
+  end
+
+  shared_examples 'temporarily suspended account check' do |code: 403|
+    before { account.suspend! }
+
+    it 'returns http forbidden' do
+      get :show, params: { username: account.username, format: format }
+
+      expect(response).to have_http_status(code)
+    end
+  end
+
   describe 'GET #show' do
     context 'with basic account status checks' do
-      shared_examples 'unapproved account check' do
-        before { account.user.update(approved: false) }
-
-        it 'returns http not found' do
-          get :show, params: { username: account.username, format: format }
-
-          expect(response).to have_http_status(404)
-        end
-      end
-
-      shared_examples 'permanently suspended account check' do
-        before do
-          account.suspend!
-          account.deletion_request.destroy
-        end
-
-        it 'returns http gone' do
-          get :show, params: { username: account.username, format: format }
-
-          expect(response).to have_http_status(410)
-        end
-      end
-
-      shared_examples 'temporarily suspended account check' do |code: 403|
-        before { account.suspend! }
-
-        it 'returns http forbidden' do
-          get :show, params: { username: account.username, format: format }
-
-          expect(response).to have_http_status(code)
-        end
-      end
-
       context 'with HTML' do
         let(:format) { 'html' }
 

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe AccountsController do
   let(:account) { Fabricate(:account) }
 
   describe 'GET #show' do
-    let(:format) { 'html' }
-
     let!(:status) { Fabricate(:status, account: account) }
     let!(:status_reply) { Fabricate(:status, account: account, thread: Fabricate(:status)) }
     let!(:status_self_reply) { Fabricate(:status, account: account, thread: status) }

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -292,25 +292,25 @@ RSpec.describe AccountsController do
 
         it 'responds with correct statuses', :aggregate_failures do
           # renders public status
-          expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status))
+          expect(response.body).to include_status_tag(status)
 
           # renders self-reply
-          expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_self_reply))
+          expect(response.body).to include_status_tag(status_self_reply)
 
           # renders status with media
-          expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_media))
+          expect(response.body).to include_status_tag(status_media)
 
           # does not render reblog
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reblog.reblog))
+          expect(response.body).to_not include_status_tag(status_reblog.reblog)
 
           # does not render private status
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_private))
+          expect(response.body).to_not include_status_tag(status_private)
 
           # does not render direct status
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_direct))
+          expect(response.body).to_not include_status_tag(status_direct)
 
           # does not render reply to someone else
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reply))
+          expect(response.body).to_not include_status_tag(status_reply)
         end
       end
 
@@ -324,25 +324,25 @@ RSpec.describe AccountsController do
 
         it 'responds with correct statuses', :aggregate_failures do
           # renders public status
-          expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status))
+          expect(response.body).to include_status_tag(status)
 
           # renders self-reply
-          expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_self_reply))
+          expect(response.body).to include_status_tag(status_self_reply)
 
           # renders status with media
-          expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_media))
+          expect(response.body).to include_status_tag(status_media)
 
           # does not render reblog
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reblog.reblog))
+          expect(response.body).to_not include_status_tag(status_reblog.reblog)
 
           # does not render private status
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_private))
+          expect(response.body).to_not include_status_tag(status_private)
 
           # does not render direct status
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_direct))
+          expect(response.body).to_not include_status_tag(status_direct)
 
           # renders reply to someone else
-          expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_reply))
+          expect(response.body).to include_status_tag(status_reply)
         end
       end
 
@@ -356,25 +356,25 @@ RSpec.describe AccountsController do
 
         it 'responds with correct statuses', :aggregate_failures do
           # does not render public status
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status))
+          expect(response.body).to_not include_status_tag(status)
 
           # does not render self-reply
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_self_reply))
+          expect(response.body).to_not include_status_tag(status_self_reply)
 
           # renders status with media
-          expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_media))
+          expect(response.body).to include_status_tag(status_media)
 
           # does not render reblog
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reblog.reblog))
+          expect(response.body).to_not include_status_tag(status_reblog.reblog)
 
           # does not render private status
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_private))
+          expect(response.body).to_not include_status_tag(status_private)
 
           # does not render direct status
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_direct))
+          expect(response.body).to_not include_status_tag(status_direct)
 
           # does not render reply to someone else
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reply))
+          expect(response.body).to_not include_status_tag(status_reply)
         end
       end
 
@@ -393,30 +393,34 @@ RSpec.describe AccountsController do
 
         it 'responds with correct statuses', :aggregate_failures do
           # does not render public status
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status))
+          expect(response.body).to_not include_status_tag(status)
 
           # does not render self-reply
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_self_reply))
+          expect(response.body).to_not include_status_tag(status_self_reply)
 
           # does not render status with media
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_media))
+          expect(response.body).to_not include_status_tag(status_media)
 
           # does not render reblog
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reblog.reblog))
+          expect(response.body).to_not include_status_tag(status_reblog.reblog)
 
           # does not render private status
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_private))
+          expect(response.body).to_not include_status_tag(status_private)
 
           # does not render direct status
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_direct))
+          expect(response.body).to_not include_status_tag(status_direct)
 
           # does not render reply to someone else
-          expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status_reply))
+          expect(response.body).to_not include_status_tag(status_reply)
 
           # renders status with tag
-          expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status_tag))
+          expect(response.body).to include_status_tag(status_tag)
         end
       end
     end
+  end
+
+  def include_status_tag(status)
+    include ActivityPub::TagManager.instance.url_for(status)
   end
 end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe AccountsController do
         end
       end
 
-      shared_examples 'common response characteristics' do
+      shared_examples 'common HTML response' do
         it 'returns http success' do
           expect(response).to have_http_status(200)
         end
@@ -85,7 +85,7 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format }
         end
 
-        it_behaves_like 'common response characteristics'
+        it_behaves_like 'common HTML response'
       end
 
       context 'with replies' do
@@ -94,7 +94,7 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format }
         end
 
-        it_behaves_like 'common response characteristics'
+        it_behaves_like 'common HTML response'
       end
 
       context 'with media' do
@@ -103,7 +103,7 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format }
         end
 
-        it_behaves_like 'common response characteristics'
+        it_behaves_like 'common HTML response'
       end
 
       context 'with tag' do
@@ -117,7 +117,7 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format, tag: tag.to_param }
         end
 
-        it_behaves_like 'common response characteristics'
+        it_behaves_like 'common HTML response'
       end
     end
 
@@ -287,7 +287,7 @@ RSpec.describe AccountsController do
         end
       end
 
-      shared_examples 'common response characteristics' do
+      shared_examples 'common RSS response' do
         it 'returns http success' do
           expect(response).to have_http_status(200)
         end
@@ -300,7 +300,7 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format }
         end
 
-        it_behaves_like 'common response characteristics'
+        it_behaves_like 'common RSS response'
 
         it 'renders public status' do
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status))
@@ -337,7 +337,7 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format }
         end
 
-        it_behaves_like 'common response characteristics'
+        it_behaves_like 'common RSS response'
 
         it 'renders public status' do
           expect(response.body).to include(ActivityPub::TagManager.instance.url_for(status))
@@ -374,7 +374,7 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format }
         end
 
-        it_behaves_like 'common response characteristics'
+        it_behaves_like 'common RSS response'
 
         it 'does not render public status' do
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status))
@@ -416,7 +416,7 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format, tag: tag.to_param }
         end
 
-        it_behaves_like 'common response characteristics'
+        it_behaves_like 'common RSS response'
 
         it 'does not render public status' do
           expect(response.body).to_not include(ActivityPub::TagManager.instance.url_for(status))

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -158,20 +158,18 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format }
         end
 
-        it 'returns http success' do
+        it 'returns a JSON version of the account', :aggregate_failures do
+          # returns http success
           expect(response).to have_http_status(200)
-        end
 
-        it 'returns application/activity+json' do
+          # returns application/activity+json
           expect(response.media_type).to eq 'application/activity+json'
+
+          # renders account
+          expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
         end
 
         it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
-
-        it 'renders account' do
-          json = body_as_json
-          expect(json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
-        end
 
         context 'with authorized fetch mode' do
           let(:authorized_fetch_mode) { true }
@@ -190,21 +188,18 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format }
         end
 
-        it 'returns http success' do
+        it 'returns a private JSON version of the account', :aggregate_failures do
+          # returns http success
           expect(response).to have_http_status(200)
-        end
 
-        it 'returns application/activity+json' do
+          # returns application/activity+json
           expect(response.media_type).to eq 'application/activity+json'
-        end
 
-        it 'returns private Cache-Control header' do
+          # returns private Cache-Control header
           expect(response.headers['Cache-Control']).to include 'private'
-        end
 
-        it 'renders account' do
-          json = body_as_json
-          expect(json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+          # renders account
+          expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
         end
       end
 
@@ -216,43 +211,37 @@ RSpec.describe AccountsController do
           get :show, params: { username: account.username, format: format }
         end
 
-        it 'returns http success' do
+        it 'returns a JSON version of the account', :aggregate_failures do
+          # returns http success
           expect(response).to have_http_status(200)
-        end
 
-        it 'returns application/activity+json' do
+          # returns application/activity+json
           expect(response.media_type).to eq 'application/activity+json'
+
+          # renders account
+          expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
         end
 
         it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
 
-        it 'renders account' do
-          json = body_as_json
-          expect(json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
-        end
-
         context 'with authorized fetch mode' do
           let(:authorized_fetch_mode) { true }
 
-          it 'returns http success' do
+          it 'returns a private signature JSON version of the account', :aggregate_failures do
+            # returns http success
             expect(response).to have_http_status(200)
-          end
 
-          it 'returns application/activity+json' do
+            # returns application/activity+json
             expect(response.media_type).to eq 'application/activity+json'
-          end
 
-          it 'returns private Cache-Control header' do
+            # returns private Cache-Control header
             expect(response.headers['Cache-Control']).to include 'private'
-          end
 
-          it 'returns Vary header with Signature' do
+            # returns Vary header with Signature
             expect(response.headers['Vary']).to include 'Signature'
-          end
 
-          it 'renders account' do
-            json = body_as_json
-            expect(json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+            # renders account
+            expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
           end
         end
       end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -291,12 +291,12 @@ RSpec.describe AccountsController do
         it_behaves_like 'common RSS response'
 
         it 'responds with correct statuses', :aggregate_failures do
-          expect(response.body).to include_status_tag(status)
-          expect(response.body).to include_status_tag(status_self_reply)
           expect(response.body).to include_status_tag(status_media)
-          expect(response.body).to_not include_status_tag(status_reblog.reblog)
-          expect(response.body).to_not include_status_tag(status_private)
+          expect(response.body).to include_status_tag(status_self_reply)
+          expect(response.body).to include_status_tag(status)
           expect(response.body).to_not include_status_tag(status_direct)
+          expect(response.body).to_not include_status_tag(status_private)
+          expect(response.body).to_not include_status_tag(status_reblog.reblog)
           expect(response.body).to_not include_status_tag(status_reply)
         end
       end
@@ -310,13 +310,13 @@ RSpec.describe AccountsController do
         it_behaves_like 'common RSS response'
 
         it 'responds with correct statuses with replies', :aggregate_failures do
-          expect(response.body).to include_status_tag(status)
-          expect(response.body).to include_status_tag(status_self_reply)
           expect(response.body).to include_status_tag(status_media)
-          expect(response.body).to_not include_status_tag(status_reblog.reblog)
-          expect(response.body).to_not include_status_tag(status_private)
-          expect(response.body).to_not include_status_tag(status_direct)
           expect(response.body).to include_status_tag(status_reply)
+          expect(response.body).to include_status_tag(status_self_reply)
+          expect(response.body).to include_status_tag(status)
+          expect(response.body).to_not include_status_tag(status_direct)
+          expect(response.body).to_not include_status_tag(status_private)
+          expect(response.body).to_not include_status_tag(status_reblog.reblog)
         end
       end
 
@@ -329,13 +329,13 @@ RSpec.describe AccountsController do
         it_behaves_like 'common RSS response'
 
         it 'responds with correct statuses with media', :aggregate_failures do
-          expect(response.body).to_not include_status_tag(status)
-          expect(response.body).to_not include_status_tag(status_self_reply)
           expect(response.body).to include_status_tag(status_media)
-          expect(response.body).to_not include_status_tag(status_reblog.reblog)
-          expect(response.body).to_not include_status_tag(status_private)
           expect(response.body).to_not include_status_tag(status_direct)
+          expect(response.body).to_not include_status_tag(status_private)
+          expect(response.body).to_not include_status_tag(status_reblog.reblog)
           expect(response.body).to_not include_status_tag(status_reply)
+          expect(response.body).to_not include_status_tag(status_self_reply)
+          expect(response.body).to_not include_status_tag(status)
         end
       end
 
@@ -353,14 +353,14 @@ RSpec.describe AccountsController do
         it_behaves_like 'common RSS response'
 
         it 'responds with correct statuses with a tag', :aggregate_failures do
-          expect(response.body).to_not include_status_tag(status)
-          expect(response.body).to_not include_status_tag(status_self_reply)
-          expect(response.body).to_not include_status_tag(status_media)
-          expect(response.body).to_not include_status_tag(status_reblog.reblog)
-          expect(response.body).to_not include_status_tag(status_private)
-          expect(response.body).to_not include_status_tag(status_direct)
-          expect(response.body).to_not include_status_tag(status_reply)
           expect(response.body).to include_status_tag(status_tag)
+          expect(response.body).to_not include_status_tag(status_direct)
+          expect(response.body).to_not include_status_tag(status_media)
+          expect(response.body).to_not include_status_tag(status_private)
+          expect(response.body).to_not include_status_tag(status_reblog.reblog)
+          expect(response.body).to_not include_status_tag(status_reply)
+          expect(response.body).to_not include_status_tag(status_self_reply)
+          expect(response.body).to_not include_status_tag(status)
         end
       end
     end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -8,224 +8,186 @@ RSpec.describe AccountsController do
   let(:account) { Fabricate(:account) }
 
   describe 'GET #show' do
-    let!(:status) { Fabricate(:status, account: account) }
-    let!(:status_reply) { Fabricate(:status, account: account, thread: Fabricate(:status)) }
-    let!(:status_self_reply) { Fabricate(:status, account: account, thread: status) }
-    let!(:status_media) { Fabricate(:status, account: account) }
-    let!(:status_pinned) { Fabricate(:status, account: account) }
-    let!(:status_private) { Fabricate(:status, account: account, visibility: :private) }
-    let!(:status_direct) { Fabricate(:status, account: account, visibility: :direct) }
-    let!(:status_reblog) { Fabricate(:status, account: account, reblog: Fabricate(:status)) }
-
-    before do
-      status_media.media_attachments << Fabricate(:media_attachment, account: account, type: :image)
-      account.pinned_statuses << status_pinned
-      account.pinned_statuses << status_private
-    end
-
-    shared_examples 'preliminary checks' do
-      context 'when account is not approved' do
-        before do
-          account.user.update(approved: false)
-        end
-
-        it 'returns http not found' do
-          get :show, params: { username: account.username, format: format }
-          expect(response).to have_http_status(404)
-        end
-      end
-    end
-
-    context 'with HTML' do
-      let(:format) { 'html' }
-
-      it_behaves_like 'preliminary checks'
-
-      context 'when account is permanently suspended' do
-        before do
-          account.suspend!
-          account.deletion_request.destroy
-        end
-
-        it 'returns http gone' do
-          get :show, params: { username: account.username, format: format }
-          expect(response).to have_http_status(410)
-        end
-      end
-
-      context 'when account is temporarily suspended' do
-        before do
-          account.suspend!
-        end
-
-        it 'returns http forbidden' do
-          get :show, params: { username: account.username, format: format }
-          expect(response).to have_http_status(403)
-        end
-      end
-
-      shared_examples 'common HTML response' do
-        it 'returns a standard HTML response', :aggregate_failures do
-          # returns http success
-          expect(response).to have_http_status(200)
-
-          # returns Link header
-          expect(response.headers['Link'].to_s).to include ActivityPub::TagManager.instance.uri_for(account)
-
-          # renders show template
-          expect(response).to render_template(:show)
-        end
-      end
-
-      context 'with a normal account in an HTML request' do
-        before do
-          get :show, params: { username: account.username, format: format }
-        end
-
-        it_behaves_like 'common HTML response'
-      end
-
-      context 'with replies' do
-        before do
-          allow(controller).to receive(:replies_requested?).and_return(true)
-          get :show, params: { username: account.username, format: format }
-        end
-
-        it_behaves_like 'common HTML response'
-      end
-
-      context 'with media' do
-        before do
-          allow(controller).to receive(:media_requested?).and_return(true)
-          get :show, params: { username: account.username, format: format }
-        end
-
-        it_behaves_like 'common HTML response'
-      end
-
-      context 'with tag' do
-        let(:tag) { Fabricate(:tag) }
-
-        let!(:status_tag) { Fabricate(:status, account: account) }
-
-        before do
-          allow(controller).to receive(:tag_requested?).and_return(true)
-          status_tag.tags << tag
-          get :show, params: { username: account.username, format: format, tag: tag.to_param }
-        end
-
-        it_behaves_like 'common HTML response'
-      end
-    end
-
-    context 'with JSON' do
-      let(:authorized_fetch_mode) { false }
-      let(:format) { 'json' }
+    context 'with existing statuses' do
+      let!(:status) { Fabricate(:status, account: account) }
+      let!(:status_reply) { Fabricate(:status, account: account, thread: Fabricate(:status)) }
+      let!(:status_self_reply) { Fabricate(:status, account: account, thread: status) }
+      let!(:status_media) { Fabricate(:status, account: account) }
+      let!(:status_pinned) { Fabricate(:status, account: account) }
+      let!(:status_private) { Fabricate(:status, account: account, visibility: :private) }
+      let!(:status_direct) { Fabricate(:status, account: account, visibility: :direct) }
+      let!(:status_reblog) { Fabricate(:status, account: account, reblog: Fabricate(:status)) }
 
       before do
-        allow(controller).to receive(:authorized_fetch_mode?).and_return(authorized_fetch_mode)
+        status_media.media_attachments << Fabricate(:media_attachment, account: account, type: :image)
+        account.pinned_statuses << status_pinned
+        account.pinned_statuses << status_private
       end
 
-      it_behaves_like 'preliminary checks'
+      shared_examples 'preliminary checks' do
+        context 'when account is not approved' do
+          before do
+            account.user.update(approved: false)
+          end
 
-      context 'when account is suspended permanently' do
-        before do
-          account.suspend!
-          account.deletion_request.destroy
-        end
-
-        it 'returns http gone' do
-          get :show, params: { username: account.username, format: format }
-          expect(response).to have_http_status(410)
-        end
-      end
-
-      context 'when account is suspended temporarily' do
-        before do
-          account.suspend!
-        end
-
-        it 'returns http success' do
-          get :show, params: { username: account.username, format: format }
-          expect(response).to have_http_status(200)
-        end
-      end
-
-      context 'with a normal account in a JSON request' do
-        before do
-          get :show, params: { username: account.username, format: format }
-        end
-
-        it 'returns a JSON version of the account', :aggregate_failures do
-          # returns http success
-          expect(response).to have_http_status(200)
-
-          # returns application/activity+json
-          expect(response.media_type).to eq 'application/activity+json'
-
-          # renders account
-          expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
-        end
-
-        it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
-
-        context 'with authorized fetch mode' do
-          let(:authorized_fetch_mode) { true }
-
-          it 'returns http unauthorized' do
-            expect(response).to have_http_status(401)
+          it 'returns http not found' do
+            get :show, params: { username: account.username, format: format }
+            expect(response).to have_http_status(404)
           end
         end
       end
 
-      context 'when signed in' do
-        let(:user) { Fabricate(:user) }
+      context 'with HTML' do
+        let(:format) { 'html' }
 
-        before do
-          sign_in(user)
-          get :show, params: { username: account.username, format: format }
+        it_behaves_like 'preliminary checks'
+
+        context 'when account is permanently suspended' do
+          before do
+            account.suspend!
+            account.deletion_request.destroy
+          end
+
+          it 'returns http gone' do
+            get :show, params: { username: account.username, format: format }
+            expect(response).to have_http_status(410)
+          end
         end
 
-        it 'returns a private JSON version of the account', :aggregate_failures do
-          # returns http success
-          expect(response).to have_http_status(200)
+        context 'when account is temporarily suspended' do
+          before do
+            account.suspend!
+          end
 
-          # returns application/activity+json
-          expect(response.media_type).to eq 'application/activity+json'
+          it 'returns http forbidden' do
+            get :show, params: { username: account.username, format: format }
+            expect(response).to have_http_status(403)
+          end
+        end
 
-          # returns private Cache-Control header
-          expect(response.headers['Cache-Control']).to include 'private'
+        shared_examples 'common HTML response' do
+          it 'returns a standard HTML response', :aggregate_failures do
+            # returns http success
+            expect(response).to have_http_status(200)
 
-          # renders account
-          expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+            # returns Link header
+            expect(response.headers['Link'].to_s).to include ActivityPub::TagManager.instance.uri_for(account)
+
+            # renders show template
+            expect(response).to render_template(:show)
+          end
+        end
+
+        context 'with a normal account in an HTML request' do
+          before do
+            get :show, params: { username: account.username, format: format }
+          end
+
+          it_behaves_like 'common HTML response'
+        end
+
+        context 'with replies' do
+          before do
+            allow(controller).to receive(:replies_requested?).and_return(true)
+            get :show, params: { username: account.username, format: format }
+          end
+
+          it_behaves_like 'common HTML response'
+        end
+
+        context 'with media' do
+          before do
+            allow(controller).to receive(:media_requested?).and_return(true)
+            get :show, params: { username: account.username, format: format }
+          end
+
+          it_behaves_like 'common HTML response'
+        end
+
+        context 'with tag' do
+          let(:tag) { Fabricate(:tag) }
+
+          let!(:status_tag) { Fabricate(:status, account: account) }
+
+          before do
+            allow(controller).to receive(:tag_requested?).and_return(true)
+            status_tag.tags << tag
+            get :show, params: { username: account.username, format: format, tag: tag.to_param }
+          end
+
+          it_behaves_like 'common HTML response'
         end
       end
 
-      context 'with signature' do
-        let(:remote_account) { Fabricate(:account, domain: 'example.com') }
+      context 'with JSON' do
+        let(:authorized_fetch_mode) { false }
+        let(:format) { 'json' }
 
         before do
-          allow(controller).to receive(:signed_request_actor).and_return(remote_account)
-          get :show, params: { username: account.username, format: format }
+          allow(controller).to receive(:authorized_fetch_mode?).and_return(authorized_fetch_mode)
         end
 
-        it 'returns a JSON version of the account', :aggregate_failures do
-          # returns http success
-          expect(response).to have_http_status(200)
+        it_behaves_like 'preliminary checks'
 
-          # returns application/activity+json
-          expect(response.media_type).to eq 'application/activity+json'
+        context 'when account is suspended permanently' do
+          before do
+            account.suspend!
+            account.deletion_request.destroy
+          end
 
-          # renders account
-          expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+          it 'returns http gone' do
+            get :show, params: { username: account.username, format: format }
+            expect(response).to have_http_status(410)
+          end
         end
 
-        it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
+        context 'when account is suspended temporarily' do
+          before do
+            account.suspend!
+          end
 
-        context 'with authorized fetch mode' do
-          let(:authorized_fetch_mode) { true }
+          it 'returns http success' do
+            get :show, params: { username: account.username, format: format }
+            expect(response).to have_http_status(200)
+          end
+        end
 
-          it 'returns a private signature JSON version of the account', :aggregate_failures do
+        context 'with a normal account in a JSON request' do
+          before do
+            get :show, params: { username: account.username, format: format }
+          end
+
+          it 'returns a JSON version of the account', :aggregate_failures do
+            # returns http success
+            expect(response).to have_http_status(200)
+
+            # returns application/activity+json
+            expect(response.media_type).to eq 'application/activity+json'
+
+            # renders account
+            expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+          end
+
+          it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
+
+          context 'with authorized fetch mode' do
+            let(:authorized_fetch_mode) { true }
+
+            it 'returns http unauthorized' do
+              expect(response).to have_http_status(401)
+            end
+          end
+        end
+
+        context 'when signed in' do
+          let(:user) { Fabricate(:user) }
+
+          before do
+            sign_in(user)
+            get :show, params: { username: account.username, format: format }
+          end
+
+          it 'returns a private JSON version of the account', :aggregate_failures do
             # returns http success
             expect(response).to have_http_status(200)
 
@@ -235,130 +197,170 @@ RSpec.describe AccountsController do
             # returns private Cache-Control header
             expect(response.headers['Cache-Control']).to include 'private'
 
-            # returns Vary header with Signature
-            expect(response.headers['Vary']).to include 'Signature'
-
             # renders account
             expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
           end
         end
-      end
-    end
 
-    context 'with RSS' do
-      let(:format) { 'rss' }
+        context 'with signature' do
+          let(:remote_account) { Fabricate(:account, domain: 'example.com') }
 
-      it_behaves_like 'preliminary checks'
+          before do
+            allow(controller).to receive(:signed_request_actor).and_return(remote_account)
+            get :show, params: { username: account.username, format: format }
+          end
 
-      context 'when account is permanently suspended' do
-        before do
-          account.suspend!
-          account.deletion_request.destroy
-        end
+          it 'returns a JSON version of the account', :aggregate_failures do
+            # returns http success
+            expect(response).to have_http_status(200)
 
-        it 'returns http gone' do
-          get :show, params: { username: account.username, format: format }
-          expect(response).to have_http_status(410)
-        end
-      end
+            # returns application/activity+json
+            expect(response.media_type).to eq 'application/activity+json'
 
-      context 'when account is temporarily suspended' do
-        before do
-          account.suspend!
-        end
+            # renders account
+            expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+          end
 
-        it 'returns http forbidden' do
-          get :show, params: { username: account.username, format: format }
-          expect(response).to have_http_status(403)
-        end
-      end
+          it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
 
-      shared_examples 'common RSS response' do
-        it 'returns http success' do
-          expect(response).to have_http_status(200)
-        end
+          context 'with authorized fetch mode' do
+            let(:authorized_fetch_mode) { true }
 
-        it_behaves_like 'cacheable response', expects_vary: 'Accept, Accept-Language, Cookie'
-      end
+            it 'returns a private signature JSON version of the account', :aggregate_failures do
+              # returns http success
+              expect(response).to have_http_status(200)
 
-      context 'with a normal account in an RSS request' do
-        before do
-          get :show, params: { username: account.username, format: format }
-        end
+              # returns application/activity+json
+              expect(response.media_type).to eq 'application/activity+json'
 
-        it_behaves_like 'common RSS response'
+              # returns private Cache-Control header
+              expect(response.headers['Cache-Control']).to include 'private'
 
-        it 'responds with correct statuses', :aggregate_failures do
-          expect(response.body).to include_status_tag(status_media)
-          expect(response.body).to include_status_tag(status_self_reply)
-          expect(response.body).to include_status_tag(status)
-          expect(response.body).to_not include_status_tag(status_direct)
-          expect(response.body).to_not include_status_tag(status_private)
-          expect(response.body).to_not include_status_tag(status_reblog.reblog)
-          expect(response.body).to_not include_status_tag(status_reply)
+              # returns Vary header with Signature
+              expect(response.headers['Vary']).to include 'Signature'
+
+              # renders account
+              expect(body_as_json).to include(:id, :type, :preferredUsername, :inbox, :publicKey, :name, :summary)
+            end
+          end
         end
       end
 
-      context 'with replies' do
-        before do
-          allow(controller).to receive(:replies_requested?).and_return(true)
-          get :show, params: { username: account.username, format: format }
+      context 'with RSS' do
+        let(:format) { 'rss' }
+
+        it_behaves_like 'preliminary checks'
+
+        context 'when account is permanently suspended' do
+          before do
+            account.suspend!
+            account.deletion_request.destroy
+          end
+
+          it 'returns http gone' do
+            get :show, params: { username: account.username, format: format }
+            expect(response).to have_http_status(410)
+          end
         end
 
-        it_behaves_like 'common RSS response'
+        context 'when account is temporarily suspended' do
+          before do
+            account.suspend!
+          end
 
-        it 'responds with correct statuses with replies', :aggregate_failures do
-          expect(response.body).to include_status_tag(status_media)
-          expect(response.body).to include_status_tag(status_reply)
-          expect(response.body).to include_status_tag(status_self_reply)
-          expect(response.body).to include_status_tag(status)
-          expect(response.body).to_not include_status_tag(status_direct)
-          expect(response.body).to_not include_status_tag(status_private)
-          expect(response.body).to_not include_status_tag(status_reblog.reblog)
-        end
-      end
-
-      context 'with media' do
-        before do
-          allow(controller).to receive(:media_requested?).and_return(true)
-          get :show, params: { username: account.username, format: format }
+          it 'returns http forbidden' do
+            get :show, params: { username: account.username, format: format }
+            expect(response).to have_http_status(403)
+          end
         end
 
-        it_behaves_like 'common RSS response'
+        shared_examples 'common RSS response' do
+          it 'returns http success' do
+            expect(response).to have_http_status(200)
+          end
 
-        it 'responds with correct statuses with media', :aggregate_failures do
-          expect(response.body).to include_status_tag(status_media)
-          expect(response.body).to_not include_status_tag(status_direct)
-          expect(response.body).to_not include_status_tag(status_private)
-          expect(response.body).to_not include_status_tag(status_reblog.reblog)
-          expect(response.body).to_not include_status_tag(status_reply)
-          expect(response.body).to_not include_status_tag(status_self_reply)
-          expect(response.body).to_not include_status_tag(status)
-        end
-      end
-
-      context 'with tag' do
-        let(:tag) { Fabricate(:tag) }
-
-        let!(:status_tag) { Fabricate(:status, account: account) }
-
-        before do
-          allow(controller).to receive(:tag_requested?).and_return(true)
-          status_tag.tags << tag
-          get :show, params: { username: account.username, format: format, tag: tag.to_param }
+          it_behaves_like 'cacheable response'
         end
 
-        it_behaves_like 'common RSS response'
+        context 'with a normal account in an RSS request' do
+          before do
+            get :show, params: { username: account.username, format: format }
+          end
 
-        it 'responds with correct statuses with a tag', :aggregate_failures do
-          expect(response.body).to include_status_tag(status_tag)
-          expect(response.body).to_not include_status_tag(status_direct)
-          expect(response.body).to_not include_status_tag(status_media)
-          expect(response.body).to_not include_status_tag(status_private)
-          expect(response.body).to_not include_status_tag(status_reblog.reblog)
-          expect(response.body).to_not include_status_tag(status_reply)
-          expect(response.body).to_not include_status_tag(status_self_reply)
-          expect(response.body).to_not include_status_tag(status)
+          it_behaves_like 'common RSS response'
+
+          it 'responds with correct statuses', :aggregate_failures do
+            expect(response.body).to include_status_tag(status_media)
+            expect(response.body).to include_status_tag(status_self_reply)
+            expect(response.body).to include_status_tag(status)
+            expect(response.body).to_not include_status_tag(status_direct)
+            expect(response.body).to_not include_status_tag(status_private)
+            expect(response.body).to_not include_status_tag(status_reblog.reblog)
+            expect(response.body).to_not include_status_tag(status_reply)
+          end
+        end
+
+        context 'with replies' do
+          before do
+            allow(controller).to receive(:replies_requested?).and_return(true)
+            get :show, params: { username: account.username, format: format }
+          end
+
+          it_behaves_like 'common RSS response'
+
+          it 'responds with correct statuses with replies', :aggregate_failures do
+            expect(response.body).to include_status_tag(status_media)
+            expect(response.body).to include_status_tag(status_reply)
+            expect(response.body).to include_status_tag(status_self_reply)
+            expect(response.body).to include_status_tag(status)
+            expect(response.body).to_not include_status_tag(status_direct)
+            expect(response.body).to_not include_status_tag(status_private)
+            expect(response.body).to_not include_status_tag(status_reblog.reblog)
+          end
+        end
+
+        context 'with media' do
+          before do
+            allow(controller).to receive(:media_requested?).and_return(true)
+            get :show, params: { username: account.username, format: format }
+          end
+
+          it_behaves_like 'common RSS response'
+
+          it 'responds with correct statuses with media', :aggregate_failures do
+            expect(response.body).to include_status_tag(status_media)
+            expect(response.body).to_not include_status_tag(status_direct)
+            expect(response.body).to_not include_status_tag(status_private)
+            expect(response.body).to_not include_status_tag(status_reblog.reblog)
+            expect(response.body).to_not include_status_tag(status_reply)
+            expect(response.body).to_not include_status_tag(status_self_reply)
+            expect(response.body).to_not include_status_tag(status)
+          end
+        end
+
+        context 'with tag' do
+          let(:tag) { Fabricate(:tag) }
+
+          let!(:status_tag) { Fabricate(:status, account: account) }
+
+          before do
+            allow(controller).to receive(:tag_requested?).and_return(true)
+            status_tag.tags << tag
+            get :show, params: { username: account.username, format: format, tag: tag.to_param }
+          end
+
+          it_behaves_like 'common RSS response'
+
+          it 'responds with correct statuses with a tag', :aggregate_failures do
+            expect(response.body).to include_status_tag(status_tag)
+            expect(response.body).to_not include_status_tag(status_direct)
+            expect(response.body).to_not include_status_tag(status_media)
+            expect(response.body).to_not include_status_tag(status_private)
+            expect(response.body).to_not include_status_tag(status_reblog.reblog)
+            expect(response.body).to_not include_status_tag(status_reply)
+            expect(response.body).to_not include_status_tag(status_self_reply)
+            expect(response.body).to_not include_status_tag(status)
+          end
         end
       end
     end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -67,15 +67,14 @@ RSpec.describe AccountsController do
       end
 
       shared_examples 'common HTML response' do
-        it 'returns http success' do
+        it 'returns a standard HTML response', :aggregate_failures do
+          # returns http success
           expect(response).to have_http_status(200)
-        end
 
-        it 'returns Link header' do
+          # returns Link header
           expect(response.headers['Link'].to_s).to include ActivityPub::TagManager.instance.uri_for(account)
-        end
 
-        it 'renders show template' do
+          # renders show template
           expect(response).to render_template(:show)
         end
       end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe AccountsController do
   shared_examples 'temporarily suspended account check' do |code: 403|
     before { account.suspend! }
 
-    it 'returns http forbidden' do
+    it 'returns appropriate http response code' do
       get :show, params: { username: account.username, format: format }
 
       expect(response).to have_http_status(code)


### PR DESCRIPTION
As noted towards the end of https://github.com/mastodon/mastodon/pull/25369#issue-1751452769 - when I was working on the various Sidekiq/Fabricate/Paperclip spec speedup PRs, another pattern I noticed was lots of spec files where we have a (moderately expensive) setup step happening in a `before` block which is getting run for every example in it's context.

This is sometimes fine if the setup is trivial and the examples are complex and would become severely unreadable by combining them, but in other areas there's an expensive setup and the examples are all checking against the same result ... and because of the `before` running for each one it's expensive to do.

Before doing a widescale change like this on the whole suite, I wanted to open this as an example of what I'm thinking. I tried to pick a spec which was repetitive enough that I guessed there might be speedups, but simple enough that it wouldn't be overwhelming to change/review.

The diff here is pretty noisy and it will almost definitely be easier to understand the changes by stepping through one commit at a time - I think they are pretty atomic/descriptive on their own.

All that said, the changes here:
- There was a block of checks within each format (rss, json, html) which didn't need any of the status records to exist because they are purely checking on responses based on the account status. I put a context around the status creation, and pulled those checks out into a different one with just the account but not the statuses.
- Many of the checks within the RSS context were just asserting the present of tag manager URLs from the response body ... but each example was repeating the whole request. I lumped these into single examples per context and tried to extract/refactor a but on method naming so its clear what the assertions are.
- Magnitude not as large as RSS area, but also combined some checks in the html/json response contexts.

Before changes this spec was taking ~23 seconds to run locally. After changes it takes ~11s locally. I have no idea if this magnitude of change is higher/lower/normal etc for this one file vs the whole rest of the spec.

Would love feedback here before I do more of this on other specs.
