### PR TITLE
Fix always redirecting to onboarding in web UI

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -83,8 +83,10 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
   def after_confirmation_path_for(_resource_name, user)
     if user.created_by_application && truthy_param?(:redirect_to_app)
       user.created_by_application.confirmation_redirect_uri
+    elsif user_signed_in?
+      web_url('start')
     else
-      super
+      new_user_session_path
     end
   end
 end

--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -393,11 +393,6 @@ class UI extends PureComponent {
       navigator.serviceWorker.addEventListener('message', this.handleServiceWorkerPostMessage);
     }
 
-    // On first launch, redirect to the follow recommendations page
-    if (signedIn && this.props.firstLaunch) {
-      this.context.router.history.replace('/start');
-    }
-
     if (signedIn) {
       this.props.dispatch(fetchMarkers());
       this.props.dispatch(expandHomeTimeline());


### PR DESCRIPTION
Instead, only redirect to onboarding after the confirmation step. That way, when people try to open new tabs or open profiles or other links, the tabs won't be hijacked by the onboarding...