### PR TITLE
Remove `sleep` in request pool spec

### DIFF
--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -87,12 +87,24 @@ describe RequestPool do
   describe 'Reaper' do
     subject { described_class::Reaper }
 
-    describe 'initialize' do
+    describe '#initialize' do
       it 'sets pool and frequency values' do
         reaper = subject.new(5, 10)
 
         expect(reaper.pool).to eq(5)
         expect(reaper.frequency).to eq(10)
+      end
+    end
+
+    describe '#run' do
+      context 'with a negative frequency' do
+        it 'does not run a thread loop' do
+          reaper = subject.new(5, -10)
+
+          allow(Thread).to receive(:new)
+          expect(reaper.run).to be_nil
+          expect(Thread).to_not have_received(:new)
+        end
       end
     end
   end

--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -106,6 +106,24 @@ describe RequestPool do
           expect(Thread).to_not have_received(:new)
         end
       end
+
+      context 'with valid pool and frequency' do
+        let(:frequency) { 10 }
+        let(:pool) { instance_double(described_class) }
+        let(:reaper) { subject.new(pool, frequency) }
+
+        before do
+          allow(reaper).to receive(:sleep).with(frequency)
+          allow(pool).to receive(:flush).and_raise(Timeout::Error)
+          allow(Thread).to receive(:new).and_yield(frequency, pool)
+        end
+
+        it 'runs a thread in a sleep/flush loop' do
+          expect { reaper.run }.to raise_error(Timeout::Error)
+          expect(reaper).to have_received(:sleep).with(frequency).once
+          expect(pool).to have_received(:flush).once
+        end
+      end
     end
   end
 end

--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -69,4 +69,18 @@ describe RequestPool do
       end
     end
   end
+
+  describe '.current' do
+    it 'returns a new instance of the class' do
+      pool = described_class.current
+
+      expect(pool).to be_a(described_class)
+    end
+
+    it 'caches the instance' do
+      pool = described_class.current
+
+      expect(described_class.current).to eq(pool)
+    end
+  end
 end

--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -83,4 +83,17 @@ describe RequestPool do
       expect(described_class.current).to eq(pool)
     end
   end
+
+  describe 'Reaper' do
+    subject { described_class::Reaper }
+
+    describe 'initialize' do
+      it 'sets pool and frequency values' do
+        reaper = subject.new(5, 10)
+
+        expect(reaper.pool).to eq(5)
+        expect(reaper.frequency).to eq(10)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `RequestPool` uses a persistent http connection and passes a timeout value specifying when to close when idle for too long.

Previously the spec was using a `sleep` loop to simulate this timeout. This change instead stubs out the `seconds_idle` method on the `Connection`, which simulates an idle timeout having occured without the need for a long `sleep` duration in the spec.

Drops this one example from ~61 seconds to basically zero.