### PR TITLE
add test cases for GET /api/v1/accounts/{account_id} about behavior of each attributes in request spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,12 @@ AllCops:
     - 'lib/json_ld/*' # Generated files
     - 'lib/templates/**/*'
 
+RSpec:
+  Language:
+    Includes:
+      Examples:
+        - they
+
 # Reason: Prefer Hashes without extreme indentation
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutfirsthashelementindentation
 Layout/FirstHashElementIndentation:

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -328,4 +328,25 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about following_count' do
+    it 'is number of followers' do
+      account = Fabricate(:account)
+      2.times do
+        followee = Fabricate(:account)
+        Fabricate(:follow, account: account, target_account: followee)
+      end
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:followers_count]).to eq(0)
+        expect(response_body[:following_count]).to eq(2)
+        expect(response_body[:statuses_count]).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -421,4 +421,46 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about fields' do
+    it 'is empty in default' do
+      account = Fabricate(:account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:fields]).to eq([])
+      end
+    end
+
+    it 'presents fields when account has fields' do # rubocop:disable RSpec/ExampleLength
+      account = Fabricate(:account, fields: [{
+        name: 'field1_name',
+        value: 'field1_value',
+        verified_at: nil,
+      }, {
+        name: 'field2_name',
+        value: 'field2_value',
+        verified_at: '2023-05-20T20:00:00Z',
+      }])
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:fields]).to contain_exactly({
+          name: 'field1_name',
+          value: 'field1_value',
+          verified_at: nil,
+        }, {
+          name: 'field2_name',
+          value: 'field2_value',
+          verified_at: '2023-05-20T20:00:00.000+00:00',
+        })
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -307,4 +307,25 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about followers_count' do
+    it 'is number of followers' do
+      account = Fabricate(:account)
+      2.times do
+        follower = Fabricate(:account)
+        Fabricate(:follow, account: follower, target_account: account)
+      end
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:followers_count]).to eq(2)
+        expect(response_body[:following_count]).to eq(0)
+        expect(response_body[:statuses_count]).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -383,4 +383,42 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about emojis' do
+    it 'is empty in default' do
+      account = Fabricate(:account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:emojis]).to eq([])
+      end
+    end
+
+    it 'presents emojis when account uses custom emoji' do
+      Fabricate(:custom_emoji, shortcode: 'foo_emoji')
+      Fabricate(:custom_emoji, shortcode: 'bar_emoji')
+      account = Fabricate(:account, display_name: ':foo_emoji:', note: 'This line includes :bar_emoji:. However, :baz_emoji: is not registerd.')
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:emojis]).to contain_exactly({
+          shortcode: 'foo_emoji',
+          url: be_an_http_url,
+          static_url: be_an_http_url,
+          visible_in_picker: true,
+        }, {
+          shortcode: 'bar_emoji',
+          url: be_an_http_url,
+          static_url: be_an_http_url,
+          visible_in_picker: true,
+        })
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -160,4 +160,45 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about bot' do
+    it 'is false in default' do
+      account = Fabricate(:account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:bot]).to be(false)
+      end
+    end
+
+    it 'is true when account setted as bot' do
+      account = Fabricate(:account, bot: true)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:bot]).to be(true)
+      end
+    end
+
+    it 'is false when account is suspended even if value in bot column is true' do
+      account = Fabricate(:account, bot: true, suspended: true)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:bot]).to be(false)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -65,4 +65,31 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about acct' do
+    it 'is equal to username when account is local' do
+      account = Fabricate(:account, username: 'local_username')
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:acct]).to eq('local_username')
+      end
+    end
+
+    it 'includes domain of remote instance when account is remote' do
+      account = Fabricate(:account, username: 'remote_username', domain: 'remote.example.com')
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:acct]).to eq('remote_username@remote.example.com')
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -119,4 +119,45 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about locked' do
+    it 'is false in default' do
+      account = Fabricate(:account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:locked]).to be(false)
+      end
+    end
+
+    it 'is true when account is locked' do
+      account = Fabricate(:account, locked: true)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:locked]).to be(true)
+      end
+    end
+
+    it 'is false when account is suspended even if value in locked column is true' do
+      account = Fabricate(:account, locked: true, suspended: true)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:locked]).to be(false)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -545,4 +545,47 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about noindex' do
+    it 'is false in default' do
+      account = Fabricate(:account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:noindex]).to be(false)
+      end
+    end
+
+    it 'is true when account setted as noindex' do
+      user = Fabricate(:user, settings: { noindex: true })
+      account = Fabricate(:account, user: user)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:noindex]).to be(true)
+      end
+    end
+
+    it 'is true when account is suspended' do
+      user = Fabricate(:user, settings: { noindex: true })
+      account = Fabricate(:account, user: user, suspended: true)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:noindex]).to be(true)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -50,4 +50,19 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about username' do
+    it 'is equal to value in username column' do
+      account = Fabricate(:account, username: 'local_username')
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:username]).to eq('local_username')
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -504,4 +504,45 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about group' do
+    it 'is false in default' do
+      account = Fabricate(:account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:group]).to be(false)
+      end
+    end
+
+    it 'is true when type of account are Group' do
+      account = Fabricate(:account, actor_type: :Group)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:group]).to be(true)
+      end
+    end
+
+    it 'is true even if account is suspended' do
+      account = Fabricate(:account, actor_type: :Group, suspended: true)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:group]).to be(true)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -289,4 +289,22 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about image_urls' do
+    they 'are HTTP URI' do
+      account = Fabricate(:account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:avatar]).to be_an_http_url
+        expect(response_body[:avatar_static]).to be_an_http_url
+        expect(response_body[:header]).to be_an_http_url
+        expect(response_body[:header_static]).to be_an_http_url
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -92,4 +92,31 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about display_name' do
+    it 'is equal to value in display_name column' do
+      account = Fabricate(:account, display_name: 'this is display_name')
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:display_name]).to eq('this is display_name')
+      end
+    end
+
+    it 'is empty if account is suspended' do
+      account = Fabricate(:account, display_name: 'this is display_name', suspended: true)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:display_name]).to eq('')
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -258,4 +258,35 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about url' do
+    it 'presents url that build by ActivityPub::TagManager when local account' do
+      account = Fabricate(:account, username: 'local_username')
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:url]).to be_an_http_url
+        expect(URI.parse(response_body[:url]).path).to eq('/@local_username')
+        expect(response_body[:url]).to eq(ActivityPub::TagManager.instance.url_for(account))
+      end
+    end
+
+    it 'presents value of url column when remote account' do
+      account = Fabricate(:account, username: 'remote_username', domain: 'remote.example.com', url: 'https://remote.example.com/users/remote_username')
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:url]).to eq('https://remote.example.com/users/remote_username')
+        expect(response_body[:url]).to eq(ActivityPub::TagManager.instance.url_for(account))
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -349,4 +349,22 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about statuses_count' do
+    it 'is number of followers' do
+      account = Fabricate(:account)
+      Fabricate(:status, account: account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:followers_count]).to eq(0)
+        expect(response_body[:following_count]).to eq(0)
+        expect(response_body[:statuses_count]).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -201,4 +201,19 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about created_at' do
+    it 'is truncated by day as UTC' do
+      account = Fabricate(:account, created_at: '2023/5/30 12:34:56 +00:00')
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:created_at]).to eq('2023-05-30T00:00:00.000Z')
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -463,4 +463,45 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about discoverable' do
+    it 'is true in default' do
+      account = Fabricate(:account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:discoverable]).to be(true)
+      end
+    end
+
+    it 'is false when account setted as undiscoverable' do
+      account = Fabricate(:account, discoverable: false)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:discoverable]).to be(false)
+      end
+    end
+
+    it 'is false when account is suspended even if value in discoverable column is true' do
+      account = Fabricate(:account, discoverable: true, suspended: true)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:discoverable]).to be(false)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -367,4 +367,20 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about last_status_at' do
+    it 'is number of followers' do
+      account = Fabricate(:account)
+      status = Fabricate(:status, account: account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:id]).to eq(account.id.to_s)
+        expect(response_body[:last_status_at]).to eq(status.created_at.strftime('%Y-%m-%d'))
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/accounts_show_spec.rb
+++ b/spec/requests/api/v1/accounts_show_spec.rb
@@ -588,4 +588,36 @@ describe 'GET /api/v1/accounts/{account_id}' do
       end
     end
   end
+
+  describe 'about roles' do
+    it 'is empty in default' do
+      account = Fabricate(:account)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:roles]).to eq([])
+      end
+    end
+
+    it 'presents roles when account has roles' do
+      admin_role = UserRole.find_by(name: 'Admin')
+      admin_user = Fabricate(:user, role: admin_role)
+      account = Fabricate(:account, user: admin_user)
+
+      get "/api/v1/accounts/#{account.id}"
+      response_body = body_as_json
+
+      aggregate_failures do
+        expect(response).to have_http_status(200)
+        expect(response_body[:roles]).to contain_exactly({
+          color: '',
+          name: 'Admin',
+          id: admin_role.id.to_s,
+        })
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ end
 gc_counter = -1
 
 RSpec.configure do |config|
+  config.alias_example_to :they
   config.example_status_persistence_file_path = 'tmp/rspec/examples.txt'
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/matchers/json/be_an_http_url.rb
+++ b/spec/support/matchers/json/be_an_http_url.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :be_an_http_url do
+  match do |string|
+    URI::DEFAULT_PARSER.make_regexp(%w(https http)).match(string).to_s == string
+  end
+
+  failure_message do |string|
+    "#{string} is not an HTTP URL."
+  end
+end


### PR DESCRIPTION
This PR adds test cases about behavior of each attributes in GET /api/v1/accounts/{account_id}.

These test cases are intended to describe the actual behavior of each attribute.
It is important that they are independent from which json serializer the implementation uses.