### PR TITLE
Rewrite `emoji_unicode_mapping_light` to TS

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_emoji.jsx
+++ b/app/javascript/mastodon/components/autosuggest_emoji.jsx
@@ -3,7 +3,7 @@ import { PureComponent } from 'react';
 
 import { assetHost } from 'mastodon/utils/config';
 
-import unicodeMapping from '../features/emoji/emoji_unicode_mapping_light';
+import { unicodeMapping } from '../features/emoji/emoji_unicode_mapping_light';
 
 export default class AutosuggestEmoji extends PureComponent {
 

--- a/app/javascript/mastodon/features/emoji/emoji.js
+++ b/app/javascript/mastodon/features/emoji/emoji.js
@@ -4,7 +4,7 @@ import { assetHost } from 'mastodon/utils/config';
 
 import { autoPlayGif } from '../../initial_state';
 
-import unicodeMapping from './emoji_unicode_mapping_light';
+import { unicodeMapping } from './emoji_unicode_mapping_light';
 
 const trie = new Trie(Object.keys(unicodeMapping));
 

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -15,7 +15,12 @@ export type Search = string;
  */
 export type Skins = null;
 
-export type FilenameData = string[] | string[][];
+export type Filename = string;
+export type UnicodeFilename = string;
+export type FilenameData = [
+  filename: Filename,
+  unicodeFilename?: UnicodeFilename
+][];
 export type ShortCodesToEmojiDataKey =
   | EmojiData['id']
   | BaseEmoji['native']

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -13,20 +13,20 @@ export type Search = string;
  * This could be a potential area of refactoring or error handling.
  * The non-existence of 'skins' property is evident at [this location]{@link app/javascript/mastodon/features/emoji/emoji_compressed.js:121}.
  */
-export type Skins = null;
+type Skins = null;
 
-export type Filename = string;
-export type UnicodeFilename = string;
+type Filename = string;
+type UnicodeFilename = string;
 export type FilenameData = [
   filename: Filename,
-  unicodeFilename?: UnicodeFilename
+  unicodeFilename?: UnicodeFilename,
 ][];
 export type ShortCodesToEmojiDataKey =
   | EmojiData['id']
   | BaseEmoji['native']
   | keyof NimbleEmojiIndex['emojis'];
 
-export type SearchData = [
+type SearchData = [
   BaseEmoji['native'],
   Emoji['short_names'],
   Search,
@@ -37,9 +37,9 @@ export type ShortCodesToEmojiData = Record<
   ShortCodesToEmojiDataKey,
   [FilenameData, SearchData]
 >;
-export type EmojisWithoutShortCodes = FilenameData[];
+type EmojisWithoutShortCodes = FilenameData[];
 
-export type EmojiCompressed = [
+type EmojiCompressed = [
   ShortCodesToEmojiData,
   Skins,
   Category[],

--- a/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.d.ts
@@ -37,7 +37,7 @@ export type ShortCodesToEmojiData = Record<
   ShortCodesToEmojiDataKey,
   [FilenameData, SearchData]
 >;
-type EmojisWithoutShortCodes = FilenameData[];
+type EmojisWithoutShortCodes = FilenameData;
 
 type EmojiCompressed = [
   ShortCodesToEmojiData,

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -31,8 +31,7 @@ const emojis: Emojis = {};
 Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
   const [_filenameData, searchData] = shortCodesToEmojiData[shortCode];
   const [native, _short_names, search, _unified] = searchData;
-  let short_names = searchData[1];
-  let unified = searchData[3];
+  let [_native, short_names, _search, unified] = searchData; // eslint-disable-line prefer-const
 
   if (!unified) {
     // unified name can be derived from unicodeToUnifiedName

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -30,9 +30,8 @@ const emojis: Emojis = {};
 // decompress
 Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
   const [_filenameData, searchData] = shortCodesToEmojiData[shortCode];
-  const native = searchData[0];
+  const [native, _short_names, search, _unified] = searchData;
   let short_names = searchData[1];
-  const search = searchData[2];
   let unified = searchData[3];
 
   if (!unified) {

--- a/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_mart_data_light.ts
@@ -30,20 +30,13 @@ const emojis: Emojis = {};
 // decompress
 Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
   const [_filenameData, searchData] = shortCodesToEmojiData[shortCode];
-  const [native, _short_names, search, _unified] = searchData;
-  let [_native, short_names, _search, unified] = searchData; // eslint-disable-line prefer-const
+  const [native, short_names, search, unified] = searchData;
 
-  if (!unified) {
-    // unified name can be derived from unicodeToUnifiedName
-    unified = unicodeToUnifiedName(native);
-  }
-
-  if (short_names) short_names = [shortCode].concat(short_names);
   emojis[shortCode] = {
     native,
     search,
-    short_names,
-    unified,
+    short_names: short_names ? [shortCode].concat(short_names) : undefined,
+    unified: unified ?? unicodeToUnifiedName(native),
   };
 });
 

--- a/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.ts
@@ -1,12 +1,20 @@
-/* eslint-disable */
-// @ts-nocheck
-
 // A mapping of unicode strings to an object containing the filename
 // (i.e. the svg filename) and a shortCode intended to be shown
 // as a "title" attribute in an HTML element (aka tooltip).
 
+import type {
+  FilenameData,
+  ShortCodesToEmojiDataKey,
+} from './emoji_compressed';
 import emojiCompressed from './emoji_compressed';
 import { unicodeToFilename } from './unicode_to_filename';
+
+type UnicodeMapping = {
+  [key in FilenameData[number][0]]: {
+    shortCode: ShortCodesToEmojiDataKey;
+    filename: FilenameData[number][number];
+  };
+};
 
 const [
   shortCodesToEmojiData,
@@ -17,28 +25,36 @@ const [
 ] = emojiCompressed;
 
 // decompress
-const unicodeMapping = {};
+const unicodeMapping: UnicodeMapping = {};
 
-function processEmojiMapData(emojiMapData, shortCode) {
-  let [native, filename] = emojiMapData;
+function processEmojiMapData(
+  emojiMapData: FilenameData[number],
+  shortCode?: ShortCodesToEmojiDataKey
+) {
+  const [native, _filename] = emojiMapData;
+  let filename = emojiMapData[1];
   if (!filename) {
     // filename name can be derived from unicodeToFilename
     filename = unicodeToFilename(native);
   }
   unicodeMapping[native] = {
-    shortCode: shortCode,
-    filename: filename,
+    shortCode,
+    filename,
   };
 }
 
-Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
-  let [filenameData] = shortCodesToEmojiData[shortCode];
-  filenameData.forEach((emojiMapData) =>
-    processEmojiMapData(emojiMapData, shortCode)
-  );
-});
+Object.keys(shortCodesToEmojiData).forEach(
+  (shortCode: ShortCodesToEmojiDataKey) => {
+    if (shortCode === undefined) return;
+    const [filenameData, _searchData] = shortCodesToEmojiData[shortCode];
+    filenameData.forEach((emojiMapData) => {
+      processEmojiMapData(emojiMapData, shortCode);
+    });
+  }
+);
+
 emojisWithoutShortCodes.forEach((emojiMapData) =>
   processEmojiMapData(emojiMapData)
 );
 
-export default unicodeMapping;
+export default unicodeMapping; // eslint-disable-line import/no-default-export

--- a/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.ts
@@ -29,7 +29,7 @@ const unicodeMapping: UnicodeMapping = {};
 
 function processEmojiMapData(
   emojiMapData: FilenameData[number],
-  shortCode?: ShortCodesToEmojiDataKey
+  shortCode?: ShortCodesToEmojiDataKey,
 ) {
   const [native, _filename] = emojiMapData;
   let filename = emojiMapData[1];
@@ -50,11 +50,11 @@ Object.keys(shortCodesToEmojiData).forEach(
     filenameData.forEach((emojiMapData) => {
       processEmojiMapData(emojiMapData, shortCode);
     });
-  }
+  },
 );
 
-emojisWithoutShortCodes.forEach((emojiMapData) =>
-  processEmojiMapData(emojiMapData)
-);
+emojisWithoutShortCodes.forEach((emojiMapData) => {
+  processEmojiMapData(emojiMapData);
+});
 
 export { unicodeMapping };

--- a/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.ts
@@ -1,3 +1,6 @@
+/* eslint-disable */
+// @ts-nocheck
+
 // A mapping of unicode strings to an object containing the filename
 // (i.e. the svg filename) and a shortCode intended to be shown
 // as a "title" attribute in an HTML element (aka tooltip).
@@ -17,7 +20,7 @@ const [
 const unicodeMapping = {};
 
 function processEmojiMapData(emojiMapData, shortCode) {
-  let [ native, filename ] = emojiMapData;
+  let [native, filename] = emojiMapData;
   if (!filename) {
     // filename name can be derived from unicodeToFilename
     filename = unicodeToFilename(native);
@@ -29,9 +32,13 @@ function processEmojiMapData(emojiMapData, shortCode) {
 }
 
 Object.keys(shortCodesToEmojiData).forEach((shortCode) => {
-  let [ filenameData ] = shortCodesToEmojiData[shortCode];
-  filenameData.forEach(emojiMapData => processEmojiMapData(emojiMapData, shortCode));
+  let [filenameData] = shortCodesToEmojiData[shortCode];
+  filenameData.forEach((emojiMapData) =>
+    processEmojiMapData(emojiMapData, shortCode)
+  );
 });
-emojisWithoutShortCodes.forEach(emojiMapData => processEmojiMapData(emojiMapData));
+emojisWithoutShortCodes.forEach((emojiMapData) =>
+  processEmojiMapData(emojiMapData)
+);
 
 export default unicodeMapping;

--- a/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.ts
+++ b/app/javascript/mastodon/features/emoji/emoji_unicode_mapping_light.ts
@@ -57,4 +57,4 @@ emojisWithoutShortCodes.forEach((emojiMapData) =>
   processEmojiMapData(emojiMapData)
 );
 
-export default unicodeMapping; // eslint-disable-line import/no-default-export
+export { unicodeMapping };

--- a/app/javascript/mastodon/features/getting_started/components/announcements.jsx
+++ b/app/javascript/mastodon/features/getting_started/components/announcements.jsx
@@ -18,7 +18,7 @@ import { AnimatedNumber } from 'mastodon/components/animated_number';
 import { Icon }  from 'mastodon/components/icon';
 import { IconButton } from 'mastodon/components/icon_button';
 import EmojiPickerDropdown from 'mastodon/features/compose/containers/emoji_picker_dropdown_container';
-import unicodeMapping from 'mastodon/features/emoji/emoji_unicode_mapping_light';
+import { unicodeMapping } from 'mastodon/features/emoji/emoji_unicode_mapping_light';
 import { autoPlayGif, reduceMotion, disableSwiping, mascot } from 'mastodon/initial_state';
 import { assetHost } from 'mastodon/utils/config';
 import { WithRouterPropTypes } from 'mastodon/utils/react_router';


### PR DESCRIPTION
This PR rewrites `emoji_unicode_mapping_light` to TS.

## Changelog

- `emoji_unicode_mapping_light.js` is now written in TS.
- `FilenameData` in `emoji_compressed.d.ts` has been fixed
- Refactored the type of `emoji_compressed.d.ts`
- With this change, the following imports have been rewritten: 
  - `app/javascript/mastodon/components/autosuggest_emoji.jsx`
  - `app/javascript/mastodon/features/emoji/emoji.js`
  - `app/javascript/mastodon/features/getting_started/components/announcements.jsx`
