### PR TITLE
Remove Ruby GC config from spec helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-GC.disable
-
 if ENV['DISABLE_SIMPLECOV'] != 'true'
   require 'simplecov'
   SimpleCov.start 'rails' do
@@ -12,8 +10,6 @@ if ENV['DISABLE_SIMPLECOV'] != 'true'
     add_group 'Validators', 'app/validators'
   end
 end
-
-gc_counter = -1
 
 RSpec.configure do |config|
   config.example_status_persistence_file_path = 'tmp/rspec/examples.txt'
@@ -37,20 +33,7 @@ RSpec.configure do |config|
   end
 
   config.after :suite do
-    gc_counter = 0
     FileUtils.rm_rf(Dir[Rails.root.join('spec', 'test_files')])
-  end
-
-  config.after :each do
-    gc_counter += 1
-
-    if gc_counter > 19
-      GC.enable
-      GC.start
-      GC.disable
-
-      gc_counter = 0
-    end
   end
 end
 


### PR DESCRIPTION
I think this perf improvement was useful in the ruby 1.x and 2.x days when the GC had issues -- but I suspect that any GC gains are a) quite marginal at this point given GC improvement since then, b) outweighed by the extra cycles spent in this after hook maintaining the counter and turning the GC on/off.

In my local perf branch I see a full spec run drop from ~5:05 to ~4:10 with this change alone. Curious to see how CI acts on this one as well.