### PR TITLE
Reduce request cache spec db queries

### DIFF
--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -119,7 +119,7 @@ module TestEndpoints
 end
 
 describe 'Caching behavior' do
-  shared_examples 'cachable response' do
+  shared_examples 'cachable response' do |http_success: false|
     it 'does not set cookies and sets correct cache control headers' do
       expect(response.cookies).to be_empty
 
@@ -128,13 +128,17 @@ describe 'Caching behavior' do
       expect(response.cache_control[:private]).to be_falsy
       expect(response.cache_control[:no_store]).to be_falsy
       expect(response.cache_control[:no_cache]).to be_falsy
+
+      expect(response).to have_http_status(200) if http_success
     end
   end
 
-  shared_examples 'non-cacheable response' do
+  shared_examples 'non-cacheable response' do |http_success: false|
     it 'sets private cache control' do
       expect(response.cache_control[:private]).to be_truthy
       expect(response.cache_control[:no_store]).to be_truthy
+
+      expect(response).to have_http_status(200) if http_success
     end
   end
 
@@ -322,11 +326,7 @@ describe 'Caching behavior' do
       describe endpoint do
         before { get endpoint }
 
-        it_behaves_like 'non-cacheable response'
-
-        it 'returns HTTP success' do
-          expect(response).to have_http_status(200)
-        end
+        it_behaves_like 'non-cacheable response', http_success: true
       end
     end
 
@@ -371,11 +371,7 @@ describe 'Caching behavior' do
           get endpoint, headers: { 'Authorization' => "Bearer #{token.token}" }
         end
 
-        it_behaves_like 'non-cacheable response'
-
-        it 'returns HTTP success' do
-          expect(response).to have_http_status(200)
-        end
+        it_behaves_like 'non-cacheable response', http_success: true
       end
     end
 
@@ -402,11 +398,7 @@ describe 'Caching behavior' do
       context 'when allowed for local users only' do
         let(:show_domain_blocks) { 'users' }
 
-        it_behaves_like 'non-cacheable response'
-
-        it 'returns HTTP success' do
-          expect(response).to have_http_status(200)
-        end
+        it_behaves_like 'non-cacheable response', http_success: true
       end
 
       context 'when disabled' do
@@ -429,11 +421,7 @@ describe 'Caching behavior' do
         get '/actor', sign_with: remote_actor, headers: { 'Accept' => 'application/activity+json' }
       end
 
-      it_behaves_like 'cachable response'
-
-      it 'returns HTTP success' do
-        expect(response).to have_http_status(200)
-      end
+      it_behaves_like 'cachable response', http_success: true
     end
 
     TestEndpoints::REQUIRE_SIGNATURE.each do |endpoint|
@@ -442,11 +430,7 @@ describe 'Caching behavior' do
           get endpoint, sign_with: remote_actor, headers: { 'Accept' => 'application/activity+json' }
         end
 
-        it_behaves_like 'non-cacheable response'
-
-        it 'returns HTTP success' do
-          expect(response).to have_http_status(200)
-        end
+        it_behaves_like 'non-cacheable response', http_success: true
       end
     end
   end
@@ -464,11 +448,7 @@ describe 'Caching behavior' do
           get '/actor', headers: { 'Accept' => 'application/activity+json' }
         end
 
-        it_behaves_like 'cachable response'
-
-        it 'returns HTTP success' do
-          expect(response).to have_http_status(200)
-        end
+        it_behaves_like 'cachable response', http_success: true
       end
 
       (TestEndpoints::REQUIRE_SIGNATURE + TestEndpoints::AuthorizedFetch::REQUIRE_SIGNATURE).each do |endpoint|
@@ -494,11 +474,7 @@ describe 'Caching behavior' do
           get '/actor', sign_with: remote_actor, headers: { 'Accept' => 'application/activity+json' }
         end
 
-        it_behaves_like 'cachable response'
-
-        it 'returns HTTP success' do
-          expect(response).to have_http_status(200)
-        end
+        it_behaves_like 'cachable response', http_success: true
       end
 
       (TestEndpoints::REQUIRE_SIGNATURE + TestEndpoints::AuthorizedFetch::REQUIRE_SIGNATURE).each do |endpoint|
@@ -507,11 +483,7 @@ describe 'Caching behavior' do
             get endpoint, sign_with: remote_actor, headers: { 'Accept' => 'application/activity+json' }
           end
 
-          it_behaves_like 'non-cacheable response'
-
-          it 'returns HTTP success' do
-            expect(response).to have_http_status(200)
-          end
+          it_behaves_like 'non-cacheable response', http_success: true
         end
       end
     end
@@ -535,11 +507,7 @@ describe 'Caching behavior' do
           get '/actor', headers: { 'Accept' => 'application/activity+json' }
         end
 
-        it_behaves_like 'cachable response'
-
-        it 'returns HTTP success' do
-          expect(response).to have_http_status(200)
-        end
+        it_behaves_like 'cachable response', http_success: true
       end
 
       (TestEndpoints::REQUIRE_SIGNATURE + TestEndpoints::AuthorizedFetch::REQUIRE_SIGNATURE).each do |endpoint|
@@ -566,11 +534,7 @@ describe 'Caching behavior' do
           get '/actor', sign_with: remote_actor, headers: { 'Accept' => 'application/activity+json' }
         end
 
-        it_behaves_like 'cachable response'
-
-        it 'returns HTTP success' do
-          expect(response).to have_http_status(200)
-        end
+        it_behaves_like 'cachable response', http_success: true
       end
 
       (TestEndpoints::REQUIRE_SIGNATURE + TestEndpoints::AuthorizedFetch::REQUIRE_SIGNATURE).each do |endpoint|
@@ -579,11 +543,7 @@ describe 'Caching behavior' do
             get endpoint, sign_with: remote_actor, headers: { 'Accept' => 'application/activity+json' }
           end
 
-          it_behaves_like 'non-cacheable response'
-
-          it 'returns HTTP success' do
-            expect(response).to have_http_status(200)
-          end
+          it_behaves_like 'non-cacheable response', http_success: true
         end
       end
     end
@@ -596,11 +556,7 @@ describe 'Caching behavior' do
           get '/actor', sign_with: remote_actor, headers: { 'Accept' => 'application/activity+json' }
         end
 
-        it_behaves_like 'cachable response'
-
-        it 'returns HTTP success' do
-          expect(response).to have_http_status(200)
-        end
+        it_behaves_like 'cachable response', http_success: true
       end
 
       (TestEndpoints::REQUIRE_SIGNATURE + TestEndpoints::AuthorizedFetch::REQUIRE_SIGNATURE).each do |endpoint|
@@ -681,11 +637,7 @@ describe 'Caching behavior' do
             get endpoint, headers: { 'Authorization' => "Bearer #{token.token}" }
           end
 
-          it_behaves_like 'non-cacheable response'
-
-          it 'returns HTTP success' do
-            expect(response).to have_http_status(200)
-          end
+          it_behaves_like 'non-cacheable response', http_success: true
         end
       end
     end

--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -120,11 +120,9 @@ end
 
 describe 'Caching behavior' do
   shared_examples 'cachable response' do
-    it 'does not set cookies' do
+    it 'does not set cookies and sets correct cache control headers' do
       expect(response.cookies).to be_empty
-    end
 
-    it 'sets public cache control' do
       # expect(response.cache_control[:max_age]&.to_i).to be_positive
       expect(response.cache_control[:public]).to be_truthy
       expect(response.cache_control[:private]).to be_falsy
@@ -141,11 +139,9 @@ describe 'Caching behavior' do
   end
 
   shared_examples 'non-cacheable error' do
-    it 'does not return HTTP success' do
+    it 'does not return HTTP success or set public cache control' do
       expect(response).to_not have_http_status(200)
-    end
 
-    it 'does not have cache headers' do
       expect(response.cache_control[:public]).to be_falsy
     end
   end


### PR DESCRIPTION
This is another multi-part one that might make more sense going commit by commit in review.

The "before" on this is that it took about ~31s to run this spec file by itself and the file runs ~33.4k db queries (of these, ~2700 are factory creates) across 434 examples.

The structure of this file is that its looping through collections of URLs which are in various known caching categories, and then asserting against the results of getting them in various scenarios (signed in, signed out, signatures, etc).

The collective changes here:

- In the existing shared examples, combine a few examples to reduce number of full setup/request cycles -- drops to 303 examples, ~24k queries, ~23s time.
- Move the `before` block which is running before every example to be a `before(:context)` instead so that it runs once on the whole file -- drops to ~4700 queries, ~10s run time.
- Make the "check for http success" assertion which was present in many of the blocks which also used the cacheable shared examples into an argument to those examples, and include the check in the shared example assertions when present -- drops to ~3700 queries, 248 examples, takes ~8s to run (including load time).

Total reductions:

- ~33k queries down to ~3700
- ~2700 factory creations down to 8
- Run time from ~31s to ~8s
- Examples from 434 to 248

I'll leave a few comments on PR as well.
