### PR TITLE
Reduce `sleep` time in request pool spec

### DIFF
--- a/app/lib/request_pool.rb
+++ b/app/lib/request_pool.rb
@@ -28,8 +28,9 @@ class RequestPool
   end
 
   MAX_IDLE_TIME = 30
-  WAIT_TIMEOUT  = 5
   MAX_POOL_SIZE = ENV.fetch('MAX_REQUEST_POOL_SIZE', 512).to_i
+  REAPER_FREQUENCY = 30
+  WAIT_TIMEOUT = 5
 
   class Connection
     attr_reader :site, :last_used_at, :created_at, :in_use, :dead, :fresh
@@ -98,7 +99,7 @@ class RequestPool
 
   def initialize
     @pool   = ConnectionPool::SharedConnectionPool.new(size: MAX_POOL_SIZE, timeout: WAIT_TIMEOUT) { |site| Connection.new(site) }
-    @reaper = Reaper.new(self, 30)
+    @reaper = Reaper.new(self, REAPER_FREQUENCY)
     @reaper.run
   end
 

--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -48,16 +48,22 @@ describe RequestPool do
       expect(subject.size).to be > 1
     end
 
-    it 'closes idle connections' do
-      stub_request(:get, 'http://example.com/').to_return(status: 200, body: 'Hello!')
-
-      subject.with('http://example.com') do |http_client|
-        http_client.get('/').flush
+    context 'with an idle connection' do
+      before do
+        stub_const('RequestPool::MAX_IDLE_TIME', 0.2) # Lower the idle time limit to 0.2 seconds
+        stub_const('RequestPool::REAPER_FREQUENCY', 0.1) # Run the reaper every 0.1 seconds
+        stub_request(:get, 'http://example.com/').to_return(status: 200, body: 'Hello!')
       end
 
-      expect(subject.size).to eq 1
-      sleep RequestPool::MAX_IDLE_TIME + 30 + 1
-      expect(subject.size).to eq 0
+      it 'closes the connections' do
+        subject.with('http://example.com') do |http_client|
+          http_client.get('/').flush
+        end
+
+        expect(subject.size).to eq 1
+        sleep RequestPool::MAX_IDLE_TIME + 0.1 # Wait slightly longer than idle time
+        expect(subject.size).to eq 0
+      end
     end
   end
 end

--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -60,9 +60,11 @@ describe RequestPool do
           http_client.get('/').flush
         end
 
-        expect(subject.size).to eq 1
+        expect { wait_for_idle_timeout }.to change(subject, :size).from(1).to(0)
+      end
+
+      def wait_for_idle_timeout
         sleep RequestPool::MAX_IDLE_TIME + 0.1 # Wait slightly longer than idle time
-        expect(subject.size).to eq 0
       end
     end
   end

--- a/spec/lib/request_pool_spec.rb
+++ b/spec/lib/request_pool_spec.rb
@@ -50,8 +50,8 @@ describe RequestPool do
 
     context 'with an idle connection' do
       before do
-        stub_const('RequestPool::MAX_IDLE_TIME', 0.2) # Lower the idle time limit to 0.2 seconds
-        stub_const('RequestPool::REAPER_FREQUENCY', 0.1) # Run the reaper every 0.1 seconds
+        stub_const('RequestPool::MAX_IDLE_TIME', 1) # Lower idle time limit to 1 seconds
+        stub_const('RequestPool::REAPER_FREQUENCY', 0.1) # Run reaper every 0.1 seconds
         stub_request(:get, 'http://example.com/').to_return(status: 200, body: 'Hello!')
       end
 
@@ -60,11 +60,12 @@ describe RequestPool do
           http_client.get('/').flush
         end
 
-        expect { wait_for_idle_timeout }.to change(subject, :size).from(1).to(0)
+        expect { reaper_observes_idle_timeout }.to change(subject, :size).from(1).to(0)
       end
 
-      def wait_for_idle_timeout
-        sleep RequestPool::MAX_IDLE_TIME + 0.1 # Wait slightly longer than idle time
+      def reaper_observes_idle_timeout
+        # One full idle period and 2 reaper cycles more
+        sleep RequestPool::MAX_IDLE_TIME + (RequestPool::REAPER_FREQUENCY * 2)
       end
     end
   end


### PR DESCRIPTION
As an alternative to https://github.com/mastodon/mastodon/pull/25403 - this approach just stubs the idle time constant to a lower value to speed up this spec run. Goes from about ~61s to ~0.5s locally for me.

I had to add a new constant (`REAPER_FREQUENCY`) in the `RequestPool` class as well, because if we make the idle time low but the reaper is still only running every 30 seconds, it won't actually happen faster in the spec and we don't get the time improvement.