### PR TITLE
Change emoji picker icon

### DIFF
--- a/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
+++ b/app/javascript/mastodon/features/compose/components/emoji_picker_dropdown.jsx
@@ -389,7 +389,7 @@ class EmojiPickerDropdown extends PureComponent {
           {button || <img
             className={classNames('emojione', { 'pulse-loading': active && loading })}
             alt='🙂'
-            src={`${assetHost}/emoji/1f602.svg`}
+            src={`${assetHost}/emoji/1f642.svg`}
           />}
         </div>
 


### PR DESCRIPTION
Sometimes a 😂 Face with Tears of Joy emoji isn't what you want. It sets the wrong tone.

Sometimes everything is awful.

This pull request recognises that a more culturally and emotional neutral emoji might be best for this scenario. Say hello to 🙂 Slightly Smiling Face. He's happy, but not sarcastically so. He's still there even if things aren't so bad. He's the OG.

Face with Tears of Joy is [very often used in a cruel, mocking manner](https://www.theguardian.com/commentisfree/2016/nov/24/tears-of-joy-emoji-worst-gloat-about-human-suffering). I don't want to see him in my Mastodon interface. He is emoji use at it's worst and Mastodon should be a much more chill place.