### PR TITLE
Rewrite `<AutosuggestHashtag />` as FC and TS

### DIFF
--- a/app/javascript/mastodon/components/autosuggest_hashtag.tsx
+++ b/app/javascript/mastodon/components/autosuggest_hashtag.tsx
@@ -1,22 +1,25 @@
-/* eslint-disable */
-// @ts-nocheck
-
-import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
 import ShortNumber from 'mastodon/components/short_number';
 
-export default class AutosuggestHashtag extends PureComponent {
-  static propTypes = {
-    tag: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      url: PropTypes.string,
-      history: PropTypes.array,
-    }).isRequired,
+interface Props {
+  tag: {
+    name: string;
+    url?: string;
+    history?: Array<{
+      uses: number;
+      accounts: string;
+      day: string;
+    }>;
+    following?: boolean;
+    type: 'hashtag';
   };
+}
 
+// eslint-disable-next-line react/prefer-stateless-function, import/no-default-export
+export default class AutosuggestHashtag extends PureComponent<Props> {
   render() {
     const { tag } = this.props;
     const weeklyUses = tag.history && (

--- a/app/javascript/mastodon/components/autosuggest_hashtag.tsx
+++ b/app/javascript/mastodon/components/autosuggest_hashtag.tsx
@@ -18,8 +18,8 @@ interface Props {
   };
 }
 
-// eslint-disable-next-line react/prefer-stateless-function, import/no-default-export
-export default class AutosuggestHashtag extends PureComponent<Props> {
+// eslint-disable-next-line react/prefer-stateless-function
+export class AutosuggestHashtag extends PureComponent<Props> {
   render() {
     const { tag } = this.props;
     const weeklyUses = tag.history && (

--- a/app/javascript/mastodon/components/autosuggest_hashtag.tsx
+++ b/app/javascript/mastodon/components/autosuggest_hashtag.tsx
@@ -1,5 +1,3 @@
-import { PureComponent } from 'react';
-
 import { FormattedMessage } from 'react-intl';
 
 import ShortNumber from 'mastodon/components/short_number';
@@ -18,31 +16,27 @@ interface Props {
   };
 }
 
-// eslint-disable-next-line react/prefer-stateless-function
-export class AutosuggestHashtag extends PureComponent<Props> {
-  render() {
-    const { tag } = this.props;
-    const weeklyUses = tag.history && (
-      <ShortNumber
-        value={tag.history.reduce((total, day) => total + day.uses * 1, 0)}
-      />
-    );
+export const AutosuggestHashtag: React.FC<Props> = ({ tag }) => {
+  const weeklyUses = tag.history && (
+    <ShortNumber
+      value={tag.history.reduce((total, day) => total + day.uses * 1, 0)}
+    />
+  );
 
-    return (
-      <div className='autosuggest-hashtag'>
-        <div className='autosuggest-hashtag__name'>
-          #<strong>{tag.name}</strong>
-        </div>
-        {tag.history !== undefined && (
-          <div className='autosuggest-hashtag__uses'>
-            <FormattedMessage
-              id='autosuggest_hashtag.per_week'
-              defaultMessage='{count} per week'
-              values={{ count: weeklyUses }}
-            />
-          </div>
-        )}
+  return (
+    <div className='autosuggest-hashtag'>
+      <div className='autosuggest-hashtag__name'>
+        #<strong>{tag.name}</strong>
       </div>
-    );
-  }
-}
+      {tag.history !== undefined && (
+        <div className='autosuggest-hashtag__uses'>
+          <FormattedMessage
+            id='autosuggest_hashtag.per_week'
+            defaultMessage='{count} per week'
+            values={{ count: weeklyUses }}
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/app/javascript/mastodon/components/autosuggest_hashtag.tsx
+++ b/app/javascript/mastodon/components/autosuggest_hashtag.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable */
+// @ts-nocheck
+
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 
@@ -6,7 +9,6 @@ import { FormattedMessage } from 'react-intl';
 import ShortNumber from 'mastodon/components/short_number';
 
 export default class AutosuggestHashtag extends PureComponent {
-
   static propTypes = {
     tag: PropTypes.shape({
       name: PropTypes.string.isRequired,
@@ -40,5 +42,4 @@ export default class AutosuggestHashtag extends PureComponent {
       </div>
     );
   }
-
 }

--- a/app/javascript/mastodon/components/autosuggest_input.jsx
+++ b/app/javascript/mastodon/components/autosuggest_input.jsx
@@ -8,7 +8,7 @@ import ImmutablePureComponent from 'react-immutable-pure-component';
 import AutosuggestAccountContainer from '../features/compose/containers/autosuggest_account_container';
 
 import AutosuggestEmoji from './autosuggest_emoji';
-import AutosuggestHashtag from './autosuggest_hashtag';
+import { AutosuggestHashtag } from './autosuggest_hashtag';
 
 const textAtCursorMatchesToken = (str, caretPosition, searchTokens) => {
   let word;

--- a/app/javascript/mastodon/components/autosuggest_textarea.jsx
+++ b/app/javascript/mastodon/components/autosuggest_textarea.jsx
@@ -10,7 +10,7 @@ import Textarea from 'react-textarea-autosize';
 import AutosuggestAccountContainer from '../features/compose/containers/autosuggest_account_container';
 
 import AutosuggestEmoji from './autosuggest_emoji';
-import AutosuggestHashtag from './autosuggest_hashtag';
+import { AutosuggestHashtag } from './autosuggest_hashtag';
 
 const textAtCursorMatchesToken = (str, caretPosition) => {
   let word;


### PR DESCRIPTION
This PR rewrites `<AutosuggestHashtag />` as FC and TS.

## Changelog

- `<AutosuggestHashtag />` now is written in FC and TS
- With this change, the import of the following files has changed
  - /app/javascript/mastodon/components/autosuggest_input.jsx
  - /app/javascript/mastodon/components/autosuggest_textarea.jsx