### PR TITLE
Add support for DB_SSLMODE=require in streaming API

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -119,6 +119,7 @@ const pgConfigFromEnv = (env) => {
         baseConfig.ssl = false;
         break;
       case 'no-verify':
+      case 'require':
         baseConfig.ssl = { rejectUnauthorized: false };
         break;
       default:


### PR DESCRIPTION
There were several attempts to fix #11445, the latest I've found in #23960 (which is a fix for #21431).

Sadly the way it was done is by adding `no-verify` instead of `require`. While `no-verify` is supported by the node module, it is not supported by any other standard libraries, including the ruby ones.

Since there is no distiction made in documentation between `DB_SSLMODE` for streaming and the other backends and it's assumed the same values are used everywhere, commonly used values need to be supported.

A lot of workarounds already exist that essentially do the same.

Fixes #11445
Fixes #26034