### PR TITLE
Remove unused `picture_hint` helper method

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -24,13 +24,4 @@ module SettingsHelper
       safe_join([image_tag(account.avatar.url, width: 15, height: 15, alt: display_name(account), class: 'avatar'), content_tag(:span, account.acct, class: 'username')], ' ')
     end
   end
-
-  def picture_hint(hint, picture)
-    if picture.original_filename.nil?
-      hint
-    else
-      link = link_to t('generic.delete'), settings_profile_picture_path(picture.name.to_s), data: { method: :delete }
-      safe_join([hint, link], '<br/>'.html_safe)
-    end
-  end
 end


### PR DESCRIPTION
Last usage removed: https://github.com/mastodon/mastodon/commit/bca649ba79ee4fcb33e04084dbd7aa5d275adbf7#diff-fbe1974172bd37504b136a12619f12b7c85884707cc4636807a74841a9f652b5L20