### PR TITLE
Fix cross-origin loading of locales

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -29,7 +29,7 @@
     = stylesheet_pack_tag 'common', media: 'all', crossorigin: 'anonymous'
     = stylesheet_pack_tag current_theme, media: 'all', crossorigin: 'anonymous'
     = javascript_pack_tag 'common', crossorigin: 'anonymous'
-    = preload_pack_asset "locale/#{I18n.locale}-json.js"
+    = preload_pack_asset "locale/#{I18n.locale}-json.js", crossorigin: 'anonymous'
     = csrf_meta_tags unless skip_csrf_meta_tags?
     %meta{ name: 'style-nonce', content: request.content_security_policy_nonce }
 

--- a/app/views/layouts/embedded.html.haml
+++ b/app/views/layouts/embedded.html.haml
@@ -14,7 +14,7 @@
     = stylesheet_pack_tag 'common', media: 'all', crossorigin: 'anonymous'
     = stylesheet_pack_tag Setting.default_settings['theme'], media: 'all', crossorigin: 'anonymous'
     = javascript_pack_tag 'common', integrity: true, crossorigin: 'anonymous'
-    = preload_pack_asset "locale/#{I18n.locale}-json.js"
+    = preload_pack_asset "locale/#{I18n.locale}-json.js", crossorigin: 'anonymous'
     = render_initial_state
     = javascript_pack_tag 'public', integrity: true, crossorigin: 'anonymous'
   %body.embed


### PR DESCRIPTION
Since #24906, the Web UI fails to load on Chromium when the server uses `CDN_HOST`.

This is because Chromium refuses to check integrity without enabling CORS, and the `link` tag lacks the `crossorigin` attribute.