### PR TITLE
Use default `bootsnap/setup` in boot.rb

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -6,12 +6,4 @@ end
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap' # Speed up boot time by caching expensive operations.
-
-Bootsnap.setup(
-  cache_dir:            File.expand_path('../tmp/cache', __dir__),
-  development_mode:     ENV.fetch('RAILS_ENV', 'development') == 'development',
-  load_path_cache:      true,
-  compile_cache_iseq:   false,
-  compile_cache_yaml:   false
-)
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
Mastodon added bootsnap before this feature existed.

Mastodon addition (2017-05-20): https://github.com/mastodon/mastodon/commit/c2f70829d9dc1afcc4bbad4aadb21e5053e1fb71

Bootsnap setup feature in release 1.1.0 (2017-06-19): https://github.com/Shopify/bootsnap/releases/tag/v1.1.0

Compared to the settings we had in place:

- `cache_dir` -- same value
- `development_mode` -- same detection based on RAILS_ENV/RACK_ENV/etc
- `load_path_cache` -- same value
- `compile_cache_iseq` -- defaults to true, we had false
- `compile_cache_yaml` -- defaults to true, we had false

For the last two compile features, there is an env var, `DISABLE_BOOTSNAP_COMPILE_CACHE` which can be set in environments (CI, etc) that want this feature disabled for whatever reason.

Part of the motivation here is that in my local performance profiling branch I noticed that on shorter spec runs (like, just one file or one small file group) where we use `I18n` in specs or code being tested the spec spends a lot of time in various `Psych` classes/methods. I'm able to see a pretty consistent 2-3 second speedup from enabling these bootsnap cache values, a good chunk of which I think is coming from caching the translations yaml for faster I18n loading.

This is something that happens only once the first time I18n is accessed in a given spec run -- so across the full suite the 2-3 seconds is not significant, but if you're in a coding loop running just one spec over and over that can actually be a large chunk of the time it takes to run (I was working on validator specs locally and the specs themselves are all < 1s but were taking ~3-5s in some part due to I18n loading).

