### PR TITLE
Fix user settings not getting validated

### DIFF
--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -72,7 +72,10 @@ class UserSettings
 
     raise KeyError, "Undefined setting: #{key}" unless self.class.definition_for?(key)
 
-    typecast_value = self.class.definition_for(key).type_cast(value)
+    setting_definition = self.class.definition_for(key)
+    typecast_value = setting_definition.type_cast(value)
+
+    raise ArgumentError, "Invalid value for setting #{key}: #{typecast_value}" if setting_definition.in.present? && setting_definition.in.exclude?(typecast_value)
 
     if typecast_value.nil?
       @original_hash.delete(key)

--- a/spec/models/user_settings_spec.rb
+++ b/spec/models/user_settings_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe UserSettings do
         expect(subject[:always_send_emails]).to be true
       end
     end
+
+    context 'when the setting has a closed set of values' do
+      it 'updates the attribute when given a valid value' do
+        expect { subject[:'web.display_media'] = :show_all }.to change { subject[:'web.display_media'] }.from('default').to('show_all')
+      end
+
+      it 'raises an error when given an invalid value' do
+        expect { subject[:'web.display_media'] = 'invalid value' }.to raise_error ArgumentError
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
While #23630 included a `in:` syntax to the user settings DSL, this wasn't used for anything.

This PR actually checks against those, similar to Rails' `inclusion` validations.