### PR TITLE
Prevent UserCleanupScheduler from overwhelming streaming

### DIFF
--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -109,9 +109,7 @@ class RemoveStatusService < BaseService
     # without us being able to do all the fancy stuff
 
     @status.reblogs.rewhere(deleted_at: [nil, @status.deleted_at]).includes(:account).reorder(nil).find_each do |reblog|
-      # We don't pass through deliver_quietly? here as the Reblog may be much
-      # newer than the status being removed
-      RemoveStatusService.new.call(reblog, original_removed: true)
+      RemoveStatusService.new.call(reblog, original_removed: true, deliver_quietly: deliver_quietly?)
     end
   end
 

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -12,7 +12,7 @@ class RemoveStatusService < BaseService
   # @option  [Boolean] :immediate
   # @option  [Boolean] :preserve
   # @option  [Boolean] :original_removed
-  # @option  [Boolean] :deliver_quietly
+  # @option  [Boolean] :skip_streaming
   def call(status, **options)
     @payload  = Oj.dump(event: :delete, payload: status.id.to_s)
     @status   = status
@@ -53,7 +53,7 @@ class RemoveStatusService < BaseService
 
   private
 
-  # The following FeedManager calls all do not result in redis publish's for
+  # The following FeedManager calls all do not result in redis publishes for
   # streaming, as the `:update` option is false
 
   def remove_from_self
@@ -79,7 +79,7 @@ class RemoveStatusService < BaseService
     # followers. Here we send a delete to actively mentioned accounts
     # that may not follow the account
 
-    return if deliver_quietly?
+    return if skip_streaming?
 
     @status.active_mentions.find_each do |mention|
       redis.publish("timeline:#{mention.account_id}", @payload)
@@ -109,7 +109,7 @@ class RemoveStatusService < BaseService
     # without us being able to do all the fancy stuff
 
     @status.reblogs.rewhere(deleted_at: [nil, @status.deleted_at]).includes(:account).reorder(nil).find_each do |reblog|
-      RemoveStatusService.new.call(reblog, original_removed: true, deliver_quietly: deliver_quietly?)
+      RemoveStatusService.new.call(reblog, original_removed: true, skip_streaming: skip_streaming?)
     end
   end
 
@@ -120,7 +120,7 @@ class RemoveStatusService < BaseService
 
     return unless @status.public_visibility?
 
-    return if deliver_quietly?
+    return if skip_streaming?
 
     @status.tags.map(&:name).each do |hashtag|
       redis.publish("timeline:hashtag:#{hashtag.mb_chars.downcase}", @payload)
@@ -131,7 +131,7 @@ class RemoveStatusService < BaseService
   def remove_from_public
     return unless @status.public_visibility?
 
-    return if deliver_quietly?
+    return if skip_streaming?
 
     redis.publish('timeline:public', @payload)
     redis.publish(@status.local? ? 'timeline:public:local' : 'timeline:public:remote', @payload)
@@ -140,7 +140,7 @@ class RemoveStatusService < BaseService
   def remove_from_media
     return unless @status.public_visibility?
 
-    return if deliver_quietly?
+    return if skip_streaming?
 
     redis.publish('timeline:public:media', @payload)
     redis.publish(@status.local? ? 'timeline:public:local:media' : 'timeline:public:remote:media', @payload)
@@ -156,7 +156,7 @@ class RemoveStatusService < BaseService
     @options[:immediate] || !(@options[:preserve] || @status.reported?)
   end
 
-  def deliver_quietly?
-    !!@options[:deliver_quietly]
+  def skip_streaming?
+    !!@options[:skip_streaming]
   end
 end

--- a/app/services/remove_status_service.rb
+++ b/app/services/remove_status_service.rb
@@ -12,6 +12,7 @@ class RemoveStatusService < BaseService
   # @option  [Boolean] :immediate
   # @option  [Boolean] :preserve
   # @option  [Boolean] :original_removed
+  # @option  [Boolean] :deliver_quietly
   def call(status, **options)
     @payload  = Oj.dump(event: :delete, payload: status.id.to_s)
     @status   = status
@@ -52,6 +53,9 @@ class RemoveStatusService < BaseService
 
   private
 
+  # The following FeedManager calls all do not result in redis publish's for
+  # streaming, as the `:update` option is false
+
   def remove_from_self
     FeedManager.instance.unpush_from_home(@account, @status)
   end
@@ -74,6 +78,8 @@ class RemoveStatusService < BaseService
     # and therefore the delete is already handled by sending it to all
     # followers. Here we send a delete to actively mentioned accounts
     # that may not follow the account
+
+    return if deliver_quietly?
 
     @status.active_mentions.find_each do |mention|
       redis.publish("timeline:#{mention.account_id}", @payload)
@@ -103,6 +109,8 @@ class RemoveStatusService < BaseService
     # without us being able to do all the fancy stuff
 
     @status.reblogs.rewhere(deleted_at: [nil, @status.deleted_at]).includes(:account).reorder(nil).find_each do |reblog|
+      # We don't pass through deliver_quietly? here as the Reblog may be much
+      # newer than the status being removed
       RemoveStatusService.new.call(reblog, original_removed: true)
     end
   end
@@ -114,6 +122,8 @@ class RemoveStatusService < BaseService
 
     return unless @status.public_visibility?
 
+    return if deliver_quietly?
+
     @status.tags.map(&:name).each do |hashtag|
       redis.publish("timeline:hashtag:#{hashtag.mb_chars.downcase}", @payload)
       redis.publish("timeline:hashtag:#{hashtag.mb_chars.downcase}:local", @payload) if @status.local?
@@ -123,12 +133,16 @@ class RemoveStatusService < BaseService
   def remove_from_public
     return unless @status.public_visibility?
 
+    return if deliver_quietly?
+
     redis.publish('timeline:public', @payload)
     redis.publish(@status.local? ? 'timeline:public:local' : 'timeline:public:remote', @payload)
   end
 
   def remove_from_media
     return unless @status.public_visibility?
+
+    return if deliver_quietly?
 
     redis.publish('timeline:public:media', @payload)
     redis.publish(@status.local? ? 'timeline:public:local:media' : 'timeline:public:remote:media', @payload)
@@ -142,5 +156,9 @@ class RemoveStatusService < BaseService
 
   def permanently?
     @options[:immediate] || !(@options[:preserve] || @status.reported?)
+  end
+
+  def deliver_quietly?
+    !!@options[:deliver_quietly]
   end
 end

--- a/app/workers/scheduler/user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/user_cleanup_scheduler.rb
@@ -24,7 +24,7 @@ class Scheduler::UserCleanupScheduler
   def clean_discarded_statuses!
     Status.unscoped.discarded.where('deleted_at <= ?', 30.days.ago).find_in_batches do |statuses|
       RemovalWorker.push_bulk(statuses) do |status|
-        [status.id, { 'immediate' => true, 'deliver_quietly' => true }]
+        [status.id, { 'immediate' => true, 'skip_streaming' => true }]
       end
     end
   end

--- a/app/workers/scheduler/user_cleanup_scheduler.rb
+++ b/app/workers/scheduler/user_cleanup_scheduler.rb
@@ -24,7 +24,7 @@ class Scheduler::UserCleanupScheduler
   def clean_discarded_statuses!
     Status.unscoped.discarded.where('deleted_at <= ?', 30.days.ago).find_in_batches do |statuses|
       RemovalWorker.push_bulk(statuses) do |status|
-        [status.id, { 'immediate' => true }]
+        [status.id, { 'immediate' => true, 'deliver_quietly' => true }]
       end
     end
   end


### PR DESCRIPTION
UserCleanupScheduler is only processing statuses that have been deleted more than 30 days ago, as such, the likelihood of these statuses still being in any streams is quite low, so this change ensures that we don't have it publish a heap of useless messages to redis.

A single run of UserCleanupScheduler could previously have been amplifying traffic throughout the infrastructure of redis/sidekiq/streaming, and also causing excessive load on clients connected to streaming, as they'd be receiving a heap of messages about deleted statuses, even though those statuses had already been deleted a month earlier.

I did look into tests for this, however, there is no existing test coverage of the `redis.publish` calls from what I can see.