### PR TITLE
Add translate="no" to outgoing mentions and links

### DIFF
--- a/app/lib/text_formatter.rb
+++ b/app/lib/text_formatter.rb
@@ -79,7 +79,7 @@ class TextFormatter
     cutoff      = url[prefix.length..-1].length > 30
 
     <<~HTML.squish
-      <a href="#{h(url)}" target="_blank" rel="#{rel.join(' ')}"><span class="invisible">#{h(prefix)}</span><span class="#{cutoff ? 'ellipsis' : ''}">#{h(display_url)}</span><span class="invisible">#{h(suffix)}</span></a>
+      <a href="#{h(url)}" target="_blank" rel="#{rel.join(' ')}" translate="no"><span class="invisible">#{h(prefix)}</span><span class="#{cutoff ? 'ellipsis' : ''}">#{h(display_url)}</span><span class="invisible">#{h(suffix)}</span></a>
     HTML
   rescue Addressable::URI::InvalidURIError, IDN::Idna::IdnaError
     h(entity[:url])
@@ -122,7 +122,7 @@ class TextFormatter
     display_username = same_username_hits&.positive? || with_domains? ? account.pretty_acct : account.username
 
     <<~HTML.squish
-      <span class="h-card"><a href="#{h(url)}" class="u-url mention">@<span>#{h(display_username)}</span></a></span>
+      <span class="h-card" translate="no"><a href="#{h(url)}" class="u-url mention">@<span>#{h(display_username)}</span></a></span>
     HTML
   end
 

--- a/lib/sanitize_ext/sanitize_config.rb
+++ b/lib/sanitize_ext/sanitize_config.rb
@@ -36,6 +36,11 @@ class Sanitize
       node['class'] = class_list.join(' ')
     end
 
+    TRANSLATE_TRANSFORMER = lambda do |env|
+      node = env[:node]
+      node.remove_attribute('translate') unless node['translate'] == 'no'
+    end
+
     UNSUPPORTED_HREF_TRANSFORMER = lambda do |env|
       return unless env[:node_name] == 'a'
 
@@ -63,8 +68,8 @@ class Sanitize
       elements: %w(p br span a del pre blockquote code b strong u i em ul ol li),
 
       attributes: {
-        'a' => %w(href rel class),
-        'span' => %w(class),
+        'a' => %w(href rel class translate),
+        'span' => %w(class translate),
         'ol' => %w(start reversed),
         'li' => %w(value),
       },
@@ -80,6 +85,7 @@ class Sanitize
 
       transformers: [
         CLASS_WHITELIST_TRANSFORMER,
+        TRANSLATE_TRANSFORMER,
         UNSUPPORTED_ELEMENTS_TRANSFORMER,
         UNSUPPORTED_HREF_TRANSFORMER,
       ]

--- a/spec/lib/sanitize_config_spec.rb
+++ b/spec/lib/sanitize_config_spec.rb
@@ -38,6 +38,14 @@ describe Sanitize::Config do
       expect(Sanitize.fragment('<a href="http://example.com">Test</a>', subject)).to eq '<a href="http://example.com" rel="nofollow noopener noreferrer" target="_blank">Test</a>'
     end
 
+    it 'keeps a with translate="no"' do
+      expect(Sanitize.fragment('<a href="http://example.com" translate="no">Test</a>', subject)).to eq '<a href="http://example.com" translate="no" rel="nofollow noopener noreferrer" target="_blank">Test</a>'
+    end
+
+    it 'removes "translate" attribute with invalid value' do
+      expect(Sanitize.fragment('<a href="http://example.com" translate="foo">Test</a>', subject)).to eq '<a href="http://example.com" rel="nofollow noopener noreferrer" target="_blank">Test</a>'
+    end
+
     it 'removes a with unparsable href' do
       expect(Sanitize.fragment('<a href=" https://google.fr">Test</a>', subject)).to eq 'Test'
     end


### PR DESCRIPTION
This partially addresses MAS-16 by adding `translate="no"` to outgoing mentions and links, and accept that attribute on incoming messages.

I left out hashtags and did not arbitrarily add to incoming links, because hashtags and links from other software may be a word worth translating within a sentence.