### PR TITLE
Fix custom signup URL may not loaded

### DIFF
--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -8,6 +8,7 @@ import { Link, withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { openModal } from 'mastodon/actions/modal';
+import { fetchServer } from 'mastodon/actions/server';
 import { Avatar } from 'mastodon/components/avatar';
 import { WordmarkLogo, SymbolLogo } from 'mastodon/components/logo';
 import { registrationsOpen, me } from 'mastodon/initial_state';
@@ -28,6 +29,9 @@ const mapDispatchToProps = (dispatch) => ({
   openClosedRegistrationsModal() {
     dispatch(openModal({ modalType: 'CLOSED_REGISTRATIONS' }));
   },
+  dispatchServer() {
+    dispatch(fetchServer());
+  }
 });
 
 class Header extends PureComponent {
@@ -40,7 +44,13 @@ class Header extends PureComponent {
     openClosedRegistrationsModal: PropTypes.func,
     location: PropTypes.object,
     signupUrl: PropTypes.string.isRequired,
+    dispatchServer: PropTypes.func
   };
+
+  componentDidMount () {
+    const { dispatchServer } = this.props;
+    dispatchServer();
+  }
 
   render () {
     const { signedIn } = this.context.identity;


### PR DESCRIPTION
This PR fixes the following bug.

# Steps to reproduce the problem

1. Logout from Mastodon.
2. Move to some user's profile.
3. Set browser viewport width to <1000px
4. Perform reload.

# Expected behaviour

The signup button is linked to customized signup URL instead of `/auth/sign_up` if set environment variable `SSO_ACCOUNT_SIGN_UP`.

# Actual behaviour

The signup button is linked to default signup URL `/auth/sign_up`.

# Detailed description

https://github.com/mastodon/mastodon/assets/5103195/21de620b-ab32-4c55-86bd-4c11f3a9fe50

The problem especially affects mobile users.

I think, to use the custom URL, we need to load `registrations.sign_up_url` in `/api/v2/instance`, but in narrow viewport, there are no components showed which loads it.
So I added logic fetching the server information into `<Header />` component to resolve this.