### PR TITLE
Fix verified badge in account lists potentially including rel="me" links

### DIFF
--- a/app/javascript/mastodon/components/verified_badge.tsx
+++ b/app/javascript/mastodon/components/verified_badge.tsx
@@ -1,11 +1,27 @@
 import { Icon } from './icon';
 
+const domParser = new DOMParser();
+
+const stripRelMe = (html: string) => {
+  const document = domParser.parseFromString(html, 'text/html').documentElement;
+
+  document.querySelectorAll<HTMLAnchorElement>('a[rel]').forEach((link) => {
+    link.rel = link.rel
+      .split(' ')
+      .filter((x: string) => x !== 'me')
+      .join(' ');
+  });
+
+  const body = document.querySelector('body');
+  return body ? { __html: body.innerHTML } : undefined;
+};
+
 interface Props {
   link: string;
 }
 export const VerifiedBadge: React.FC<Props> = ({ link }) => (
   <span className='verified-badge'>
     <Icon id='check' className='verified-badge__mark' />
-    <span dangerouslySetInnerHTML={{ __html: link }} />
+    <span dangerouslySetInnerHTML={stripRelMe(link)} />
   </span>
 );


### PR DESCRIPTION
Since the account component includes the verification badge, it's possible for pages like https://mastodon.social/@Gargron/following to render `rel="me"` links to users other than the one owning the page.