### PR TITLE
Remove unused routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,8 +103,6 @@ Rails.application.routes.draw do
 
     resources :followers, only: [:index], controller: :follower_accounts
     resources :following, only: [:index], controller: :following_accounts
-    resource :follow, only: [:create], controller: :account_follow
-    resource :unfollow, only: [:create], controller: :account_unfollow
 
     resource :outbox, only: [:show], module: :activitypub
     resource :inbox, only: [:create], module: :activitypub

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,7 +162,7 @@ Rails.application.routes.draw do
   get '/backups/:id/download', to: 'backups#download', as: :download_backup, format: false
 
   resource :authorize_interaction, only: [:show, :create]
-  resource :share, only: [:show, :create]
+  resource :share, only: [:show]
 
   draw(:admin)
 

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -75,7 +75,7 @@ namespace :admin do
     end
   end
 
-  resources :rules
+  resources :rules, only: [:index, :create, :edit, :update, :destroy]
 
   resources :webhooks do
     member do

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -3,7 +3,7 @@
 namespace :admin do
   get '/dashboard', to: 'dashboard#index'
 
-  resources :domain_allows, only: [:new, :create, :show, :destroy]
+  resources :domain_allows, only: [:new, :create, :destroy]
   resources :domain_blocks, only: [:new, :create, :destroy, :update, :edit] do
     collection do
       post :batch

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -31,7 +31,7 @@ namespace :admin do
   end
 
   resources :action_logs, only: [:index]
-  resources :warning_presets, except: [:new]
+  resources :warning_presets, except: [:new, :show]
 
   resources :announcements, except: [:show] do
     member do


### PR DESCRIPTION
Each commit has a note about where it was introduced.

The follow/unfollow ones used to point to actual controllers which were deleted at some point. The rest of them I think never actually had corresponding actions.