### PR TITLE
Improve dismissable banner buttons when they dont fit on 1 line

### DIFF
--- a/app/javascript/mastodon/features/home_timeline/components/explore_prompt.jsx
+++ b/app/javascript/mastodon/features/home_timeline/components/explore_prompt.jsx
@@ -15,9 +15,11 @@ export const ExplorePrompt = () => (
     <h1><FormattedMessage id='home.explore_prompt.title' defaultMessage='This is your home base within Mastodon.' /></h1>
     <p><FormattedMessage id='home.explore_prompt.body' defaultMessage="Your home feed will have a mix of posts from the hashtags you've chosen to follow, the people you've chosen to follow, and the posts they boost. It's looking pretty quiet right now, so how about:" /></p>
 
-    <div className='dismissable-banner__message__actions'>
-      <Link to='/explore' className='button'><FormattedMessage id='home.actions.go_to_explore' defaultMessage="See what's trending" /></Link>
-      <Link to='/explore/suggestions' className='button button-tertiary'><FormattedMessage id='home.actions.go_to_suggestions' defaultMessage='Find people to follow' /></Link>
+    <div className='dismissable-banner__message__wrapper'>
+      <div className='dismissable-banner__message__actions'>
+        <Link to='/explore' className='button'><FormattedMessage id='home.actions.go_to_explore' defaultMessage="See what's trending" /></Link>
+        <Link to='/explore/suggestions' className='button button-tertiary'><FormattedMessage id='home.actions.go_to_suggestions' defaultMessage='Find people to follow' /></Link>
+      </div>
     </div>
   </DismissableBanner>
 );

--- a/app/javascript/mastodon/features/home_timeline/components/explore_prompt.jsx
+++ b/app/javascript/mastodon/features/home_timeline/components/explore_prompt.jsx
@@ -15,7 +15,7 @@ export const ExplorePrompt = () => (
     <h1><FormattedMessage id='home.explore_prompt.title' defaultMessage='This is your home base within Mastodon.' /></h1>
     <p><FormattedMessage id='home.explore_prompt.body' defaultMessage="Your home feed will have a mix of posts from the hashtags you've chosen to follow, the people you've chosen to follow, and the posts they boost. It's looking pretty quiet right now, so how about:" /></p>
 
-    <div className='dismissable-banner__message__wrapper'>
+    <div className='dismissable-banner__message__actions__wrapper'>
       <div className='dismissable-banner__message__actions'>
         <Link to='/explore' className='button'><FormattedMessage id='home.actions.go_to_explore' defaultMessage="See what's trending" /></Link>
         <Link to='/explore/suggestions' className='button button-tertiary'><FormattedMessage id='home.actions.go_to_suggestions' defaultMessage='Find people to follow' /></Link>

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8768,9 +8768,18 @@ noscript {
 
     &__actions {
       display: flex;
-      align-items: center;
+      flex-wrap: wrap;
       gap: 4px;
       margin-top: 30px;
+
+      &__wrapper {
+        display: flex;
+      }
+
+      .button {
+        display: block;
+        flex-grow: 1;
+      }
     }
 
     .button-tertiary {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8770,10 +8770,10 @@ noscript {
       display: flex;
       flex-wrap: wrap;
       gap: 4px;
-      margin-top: 30px;
 
       &__wrapper {
         display: flex;
+        margin-top: 30px;
       }
 
       .button {


### PR DESCRIPTION
When they do not fit on one line, the banner buttons are now full width on their own line.

Before
<img src="https://github.com/mastodon/mastodon/assets/42070/9ce0ff2b-141b-446e-a13c-c012c99d2d59" width=400>

After

<img src="https://github.com/mastodon/mastodon/assets/42070/2280421d-f7db-45cd-8144-f9c3eec72324" width=400>