### PR TITLE
Use an Immutable Record as the root state

### DIFF
--- a/app/javascript/mastodon/reducers/index.ts
+++ b/app/javascript/mastodon/reducers/index.ts
@@ -1,3 +1,5 @@
+import { Record as ImmutableRecord } from 'immutable';
+
 import { loadingBarReducer } from 'react-redux-loading-bar';
 import { combineReducers } from 'redux-immutable';
 
@@ -88,6 +90,22 @@ const reducers = {
   followed_tags,
 };
 
-const rootReducer = combineReducers(reducers);
+// We want the root state to be an ImmutableRecord, which is an object with a defined list of keys,
+// so it is properly typed and keys can be accessed using `state.<key>` syntax.
+// This will allow an easy conversion to a plain object once we no longer call `get` or `getIn` on the root state
+
+// By default with `combineReducers` it is a Collection, so we provide our own implementation to get a Record
+const initialRootState = Object.fromEntries(
+  Object.entries(reducers).map(([name, reducer]) => [
+    name,
+    reducer(undefined, {
+      // empty action
+    }),
+  ])
+);
+
+const RootStateRecord = ImmutableRecord(initialRootState, 'RootState');
+
+const rootReducer = combineReducers(reducers, RootStateRecord);
 
 export { rootReducer };


### PR DESCRIPTION
By default, `combineReducers` is a `Collection`, which cant be properly typed because the keys are not static.

We want the root state to be a `Record` so it can be fully typed and keys can be accessed with the `state.<key>` syntax.

This will allow an easy conversion to a plain object root state once we no longer call `get` or `getIn` on the root state.

It also means that the `useAppState()` hook will return a typed state where possible.