### PR TITLE
Remove media attachment only when file was exist

### DIFF
--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -64,7 +64,7 @@ class AttachmentBatch
             keys << attachment.style_name_as_path(style)
           when :filesystem
             logger.debug { "Deleting #{attachment.path(style)}" }
-            FileUtils.remove_file(attachment.path(style))
+            FileUtils.remove_file(attachment.path(style), true)
           when :fog
             logger.debug { "Deleting #{attachment.path(style)}" }
             attachment.directory.files.new(key: attachment.path(style)).destroy


### PR DESCRIPTION
Follow up #23302

Some test was failed when using file system that fixed it.