### PR TITLE
Add coverage for `URLValidator`

### DIFF
--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,16 +1,31 @@
 # frozen_string_literal: true
 
 class URLValidator < ActiveModel::EachValidator
+  VALID_SCHEMES = %w(http https).freeze
+
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, :invalid) unless compliant?(value)
+    @value = value
+
+    record.errors.add(attribute, :invalid) unless compliant_url?
   end
 
   private
 
-  def compliant?(url)
-    parsed_url = Addressable::URI.parse(url)
-    parsed_url && %w(http https).include?(parsed_url.scheme) && parsed_url.host
+  def compliant_url?
+    parsed_url.present? && valid_url_scheme? && valid_url_host?
+  end
+
+  def parsed_url
+    Addressable::URI.parse(@value)
   rescue Addressable::URI::InvalidURIError
     false
+  end
+
+  def valid_url_scheme?
+    VALID_SCHEMES.include?(parsed_url.scheme)
+  end
+
+  def valid_url_host?
+    parsed_url.host.present?
   end
 end

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -16,7 +16,7 @@ class URLValidator < ActiveModel::EachValidator
   end
 
   def parsed_url
-    @parsed_url ||= Addressable::URI.parse(@value)
+    Addressable::URI.parse(@value)
   rescue Addressable::URI::InvalidURIError
     false
   end

--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -16,7 +16,7 @@ class URLValidator < ActiveModel::EachValidator
   end
 
   def parsed_url
-    Addressable::URI.parse(@value)
+    @parsed_url ||= Addressable::URI.parse(@value)
   rescue Addressable::URI::InvalidURIError
     false
   end


### PR DESCRIPTION
The code path for the `InvalidURIError` rescue was previously not exercised in the suite.

While in there, I did some lightweight method-rename refactor on the validator itself. As far as I can tell the behavior is the same, and coverage is now 100%.