### PR TITLE
Add coverage for `ExistingUsernameValidator`

### DIFF
--- a/app/validators/existing_username_validator.rb
+++ b/app/validators/existing_username_validator.rb
@@ -2,25 +2,40 @@
 
 class ExistingUsernameValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if value.blank?
+    @value = value
+    return if @value.blank?
 
-    usernames_and_domains = value.split(',').filter_map do |str|
-      username, domain = str.strip.gsub(/\A@/, '').split('@', 2)
+    if options[:multiple]
+      record.errors.add(attribute, not_found_multiple_message) if usernames_with_no_accounts.any?
+    elsif usernames_with_no_accounts.any? || usernames_and_domains.size > 1
+      record.errors.add(attribute, not_found_message)
+    end
+  end
+
+  private
+
+  def usernames_and_domains
+    @value.split(',').filter_map do |string|
+      username, domain = string.strip.gsub(/\A@/, '').split('@', 2)
       domain = nil if TagManager.instance.local_domain?(domain)
 
       next if username.blank?
 
-      [str, username, domain]
+      [string, username, domain]
     end
+  end
 
-    usernames_with_no_accounts = usernames_and_domains.filter_map do |(str, username, domain)|
-      str unless Account.find_remote(username, domain)
+  def usernames_with_no_accounts
+    usernames_and_domains.filter_map do |(string, username, domain)|
+      string unless Account.find_remote(username, domain)
     end
+  end
 
-    if options[:multiple]
-      record.errors.add(attribute, I18n.t('existing_username_validator.not_found_multiple', usernames: usernames_with_no_accounts.join(', '))) if usernames_with_no_accounts.any?
-    elsif usernames_with_no_accounts.any? || usernames_and_domains.size > 1
-      record.errors.add(attribute, I18n.t('existing_username_validator.not_found'))
-    end
+  def not_found_multiple_message
+    I18n.t('existing_username_validator.not_found_multiple', usernames: usernames_with_no_accounts.join(', '))
+  end
+
+  def not_found_message
+    I18n.t('existing_username_validator.not_found')
   end
 end

--- a/spec/validators/existing_username_validator_spec.rb
+++ b/spec/validators/existing_username_validator_spec.rb
@@ -70,7 +70,7 @@ describe ExistingUsernameValidator do
         end
 
         context 'when multiple is true' do
-          it 'adds errors to the record' do
+          it 'does not add errors to the record' do
             record.friends = 'user@example.com'
 
             expect(record).to be_valid

--- a/spec/validators/existing_username_validator_spec.rb
+++ b/spec/validators/existing_username_validator_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ExistingUsernameValidator do
+  let(:record_class) do
+    Class.new do
+      include ActiveModel::Validations
+      attr_accessor :contact, :friends
+
+      def self.name
+        'Record'
+      end
+
+      validates :contact, existing_username: true
+      validates :friends, existing_username: { multiple: true }
+    end
+  end
+  let(:record) { record_class.new }
+
+  describe '#validate_each' do
+    context 'with a nil value' do
+      it 'does not add errors' do
+        record.contact = nil
+
+        expect(record).to be_valid
+        expect(record.errors).to be_empty
+      end
+    end
+
+    context 'when there are no accounts' do
+      it 'adds errors to the record' do
+        record.contact = 'user@example.com'
+
+        expect(record).to_not be_valid
+        expect(record.errors.first.attribute).to eq(:contact)
+        expect(record.errors.first.type).to eq I18n.t('existing_username_validator.not_found')
+      end
+    end
+
+    context 'when there are accounts' do
+      before { Fabricate(:account, domain: 'example.com', username: 'user') }
+
+      context 'when the value does not match' do
+        it 'adds errors to the record' do
+          record.contact = 'friend@other.host'
+
+          expect(record).to_not be_valid
+          expect(record.errors.first.attribute).to eq(:contact)
+          expect(record.errors.first.type).to eq I18n.t('existing_username_validator.not_found')
+        end
+
+        context 'when multiple is true' do
+          it 'adds errors to the record' do
+            record.friends = 'friend@other.host'
+
+            expect(record).to_not be_valid
+            expect(record.errors.first.attribute).to eq(:friends)
+            expect(record.errors.first.type).to eq I18n.t('existing_username_validator.not_found_multiple', usernames: 'friend@other.host')
+          end
+        end
+      end
+
+      context 'when the value does match' do
+        it 'does not add errors to the record' do
+          record.contact = 'user@example.com'
+
+          expect(record).to be_valid
+          expect(record.errors).to be_empty
+        end
+
+        context 'when multiple is true' do
+          it 'adds errors to the record' do
+            record.friends = 'user@example.com'
+
+            expect(record).to be_valid
+            expect(record.errors).to be_empty
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The code path for the `multiple` option being present was previously not exercised in the suite.

While in there, I did some lightweight method-rename refactor on the validator itself. As far as I can tell the behavior is the same, and coverage is now 100%.