### PR TITLE
Add coverage for `LanguageValidator`

### DIFF
--- a/app/validators/language_validator.rb
+++ b/app/validators/language_validator.rb
@@ -4,18 +4,20 @@ class LanguageValidator < ActiveModel::EachValidator
   include LanguagesHelper
 
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, :invalid) unless valid?(value)
+    @value = value
+
+    record.errors.add(attribute, :invalid) unless valid_locale_value?
   end
 
   private
 
-  def valid?(str)
-    if str.nil?
+  def valid_locale_value?
+    if @value.nil?
       true
-    elsif str.is_a?(Array)
-      str.all? { |x| valid_locale?(x) }
+    elsif @value.is_a?(Array)
+      @value.all? { |x| valid_locale?(x) }
     else
-      valid_locale?(str)
+      valid_locale?(@value)
     end
   end
 end

--- a/spec/validators/language_validator_spec.rb
+++ b/spec/validators/language_validator_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LanguageValidator do
+  let(:record_class) do
+    Class.new do
+      include ActiveModel::Validations
+      attr_accessor :locale
+
+      validates :locale, language: true
+    end
+  end
+  let(:record) { record_class.new }
+
+  describe '#validate_each' do
+    context 'with a nil value' do
+      it 'does not add errors' do
+        record.locale = nil
+
+        expect(record).to be_valid
+        expect(record.errors).to be_empty
+      end
+    end
+
+    context 'with an array of values' do
+      it 'does not add errors with array of existing locales' do
+        record.locale = %w(en fr)
+
+        expect(record).to be_valid
+        expect(record.errors).to be_empty
+      end
+
+      it 'adds errors with array having some non-existing locales' do
+        record.locale = %w(en fr missing)
+
+        expect(record).to_not be_valid
+        expect(record.errors.first.attribute).to eq(:locale)
+        expect(record.errors.first.type).to eq(:invalid)
+      end
+    end
+
+    context 'with a locale string' do
+      it 'does not add errors when string is an existing locale' do
+        record.locale = 'en'
+
+        expect(record).to be_valid
+        expect(record.errors).to be_empty
+      end
+
+      it 'adds errors when string is non-existing locale' do
+        record.locale = 'missing'
+
+        expect(record).to_not be_valid
+        expect(record.errors.first.attribute).to eq(:locale)
+        expect(record.errors.first.type).to eq(:invalid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The code path for the non-nil, non-array case was previously not exercised in the suite.

While in there, I did some lightweight method-rename refactor on the validator itself. As far as I can tell the behavior is the same, and coverage is now 100%.