### PR TITLE
Remove `pkg-config` gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@
 source 'https://rubygems.org'
 ruby '>= 3.0.0'
 
-gem 'pkg-config', '~> 1.5'
-
 gem 'puma', '~> 6.3'
 gem 'rails', '~> 6.1.7'
 gem 'sprockets', '~> 3.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -478,7 +478,6 @@ GEM
     pg (1.5.3)
     pghero (3.3.3)
       activerecord (>= 6)
-    pkg-config (1.5.1)
     posix-spawn (0.3.15)
     premailer (1.21.0)
       addressable
@@ -833,7 +832,6 @@ DEPENDENCIES
   parslet
   pg (~> 1.5)
   pghero
-  pkg-config (~> 1.5)
   posix-spawn
   premailer-rails
   private_address_check (~> 0.5)


### PR DESCRIPTION
This was introduced in #1717 to allow installing `nokogiri` on OpenBSD,
but does not seem needed anymore.

See:
- https://github.com/sparklemotion/nokogiri/issues/1885#issuecomment-633125119
- https://nokogiri.org/tutorials/installing_nokogiri.html#openbsd-7