### PR TITLE
Remove the search button from UI header when logged out

### DIFF
--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -91,7 +91,6 @@ class Header extends PureComponent {
 
       content = (
         <>
-          {location.pathname !== '/search' && <Link to='/search' className='button button-secondary' aria-label={intl.formatMessage(messages.search)}><Icon id='search' /></Link>}
           {signupButton}
           <a href='/auth/sign_in' className='button button-tertiary'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Login' /></a>
         </>


### PR DESCRIPTION
Fixes #25628

An alternative may be to hide it based on screen width, but this is likely to not work well with all translations, and the search feature is less useful for logged-out users than logged-in users.