### PR TITLE
Fix ResolveURLService not resolving local URLs for remote content

### DIFF
--- a/app/services/resolve_url_service.rb
+++ b/app/services/resolve_url_service.rb
@@ -89,13 +89,28 @@ class ResolveURLService < BaseService
   def process_local_url
     recognized_params = Rails.application.routes.recognize_path(@url)
 
-    return unless recognized_params[:action] == 'show'
+    case recognized_params[:controller]
+    when 'statuses'
+      return unless recognized_params[:action] == 'show'
 
-    if recognized_params[:controller] == 'statuses'
       status = Status.find_by(id: recognized_params[:id])
       check_local_status(status)
-    elsif recognized_params[:controller] == 'accounts'
+    when 'accounts'
+      return unless recognized_params[:action] == 'show'
+
       Account.find_local(recognized_params[:username])
+    when 'home'
+      return unless recognized_params[:action] == 'index' && recognized_params[:username_with_domain].present?
+
+      if recognized_params[:any]&.match?(/\A[0-9]+\Z/)
+        status = Status.find_by(id: recognized_params[:any])
+        check_local_status(status)
+      elsif recognized_params[:any].blank?
+        username, domain = recognized_params[:username_with_domain].gsub(/\A@/, '').split('@')
+        return unless username.present? && domain.present?
+
+        Account.find_remote(username, domain)
+      end
     end
   end
 

--- a/spec/services/resolve_url_service_spec.rb
+++ b/spec/services/resolve_url_service_spec.rb
@@ -145,5 +145,35 @@ describe ResolveURLService, type: :service do
         expect(subject.call(url, on_behalf_of: account)).to eq(status)
       end
     end
+
+    context 'when searching for a local link of a remote private status' do
+      let(:account)    { Fabricate(:account) }
+      let(:poster)     { Fabricate(:account, username: 'foo', domain: 'example.com') }
+      let(:url)        { 'https://example.com/@foo/42' }
+      let(:uri)        { 'https://example.com/users/foo/statuses/42' }
+      let!(:status)    { Fabricate(:status, url: url, uri: uri, account: poster, visibility: :private) }
+      let(:search_url) { "https://#{Rails.configuration.x.local_domain}/@foo@example.com/#{status.id}" }
+
+      before do
+        stub_request(:get, url).to_return(status: 404) if url.present?
+        stub_request(:get, uri).to_return(status: 404)
+      end
+
+      context 'when the account follows the poster' do
+        before do
+          account.follow!(poster)
+        end
+
+        it 'returns the status' do
+          expect(subject.call(search_url, on_behalf_of: account)).to eq(status)
+        end
+      end
+
+      context 'when the account does not follow the poster' do
+        it 'does not return the status' do
+          expect(subject.call(search_url, on_behalf_of: account)).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes pasting `https://foo.example.com/@bob@bar.example.com` into `https://foo.example.com`'s search bar not finding `@bob@bar.example.com`.