### PR TITLE
Change searching with # to include account index 

### DIFF
--- a/app/services/account_search_service.rb
+++ b/app/services/account_search_service.rb
@@ -133,8 +133,12 @@ class AccountSearchService < BaseService
   end
 
   def must_clause
-    fields = %w(username username.* display_name display_name.*)
-    fields << 'text' << 'text.*' if options[:use_searchable_text]
+    if options[:start_with_hashtag]
+      fields = %w(text text.*)
+    else
+      fields = %w(username username.* display_name display_name.*)
+      fields << 'text' << 'text.*' if options[:use_searchable_text]
+    end
 
     [
       {

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -33,7 +33,8 @@ class SearchService < BaseService
       resolve: @resolve,
       offset: @offset,
       use_searchable_text: true,
-      following: @following
+      following: @following,
+      start_with_hashtag: @query.start_with?('#')
     )
   end
 
@@ -95,7 +96,7 @@ class SearchService < BaseService
   end
 
   def account_searchable?
-    account_search? && !(@query.start_with?('#') || (@query.include?('@') && @query.include?(' ')))
+    account_search? && !(@query.include?('@') && @query.include?(' '))
   end
 
   def hashtag_searchable?

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -92,7 +92,7 @@ class SearchService < BaseService
   def full_text_searchable?
     return false unless Chewy.enabled?
 
-    statuses_search? && !@account.nil? && !((@query.start_with?('#') || @query.include?('@')) && !@query.include?(' '))
+    statuses_search? && !@account.nil? && !(@query.include?('@') && !@query.include?(' '))
   end
 
   def account_searchable?

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -68,7 +68,7 @@ describe SearchService, type: :service do
           allow(AccountSearchService).to receive(:new).and_return(service)
 
           results = subject.call(query, nil, 10)
-          expect(service).to have_received(:call).with(query, nil, limit: 10, offset: 0, resolve: false, use_searchable_text: true, following: false)
+          expect(service).to have_received(:call).with(query, nil, limit: 10, offset: 0, resolve: false, start_with_hashtag: false, use_searchable_text: true, following: false)
           expect(results).to eq empty_results.merge(accounts: [account])
         end
       end
@@ -90,15 +90,6 @@ describe SearchService, type: :service do
 
           results = subject.call(query, nil, 10)
           expect(Tag).to_not have_received(:search_for)
-          expect(results).to eq empty_results
-        end
-
-        it 'does not include account when starts with # character' do
-          query = '#tag'
-          allow(AccountSearchService).to receive(:new)
-
-          results = subject.call(query, nil, 10)
-          expect(AccountSearchService).to_not have_received(:new)
           expect(results).to eq empty_results
         end
       end


### PR DESCRIPTION
This PR is a follow up to https://github.com/mastodon/mastodon/pull/25599

It allows that when a search query begins with a hashtag (`#`) accounts and statuses can be searched (but only the `texts` field on the accounts index will be searched.)

Note: This PR gets rid of some of the limitations that are in place with regards to search where the first character in the search query is a `#`.  

Here is an example of the query submitted to the Accounts Index from the logs (locally in a VM)
```
14:10:02 web.1     |   AccountsIndex Search (6.6ms) {:index=>["accounts"], :body=>{:size=>5, :from=>0, :query=>{:function_score=>{:query=>{:bool=>{:must=>[{:multi_match=>{:query=>"#foo", :fields=>["text", "text.*"], :type=>"best_fields", :operator=>"or"}}], :should=>[{:multi_match=>{:query=>"#foo", :fields=>["username", "username.*", "display_name", "display_name.*"], :type=>"best_fields", :operator=>"and", :boost=>10}}, {:terms=>{:id=>[110612443111415190], :boost=>100}}]}}, :functions=>[{:script_score=>{:script=>{:source=>"(Math.max(doc['followers_count'].value, 0) + 0.0) / (Math.max(doc['followers_count'].value, 0) + Math.max(doc['following_count'].value, 0) + 1)"}}}, {:script_score=>{:script=>{:source=>"Math.log10(Math.max(doc['followers_count'].value, 0) + 2)"}}}, {:gauss=>{:last_status_at=>{:scale=>"30d", :offset=>"30d", :decay=>0.3}}}]}}}}

```

`anne`'s bio (`text`) says that they are "`Working at #foo`". 
<img width="575" alt="Screenshot 2023-06-29 at 10 32 09 AM" src="https://github.com/mastodon/mastodon/assets/15234688/b0acb22b-c7ad-4e8b-ad07-3e08236e5557">

You can also see that `any_user` can now find `anne` pretty easily.
<img width="885" alt="Screenshot 2023-06-30 at 3 09 57 PM" src="https://github.com/mastodon/mastodon/assets/15234688/f16113af-fb73-4f34-9ff2-337421d0a0b0">