### PR TITLE
Update uri to version 0.12.2 (CVE fix)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -716,7 +716,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
-    uri (0.12.1)
+    uri (0.12.2)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2023/06/29/redos-in-uri-CVE-2023-36617/