### PR TITLE
Prevent duplicate concurrent calls of `/api/*/instance` in web UI

### DIFF
--- a/app/javascript/mastodon/actions/server.js
+++ b/app/javascript/mastodon/actions/server.js
@@ -19,6 +19,10 @@ export const SERVER_DOMAIN_BLOCKS_FETCH_SUCCESS = 'SERVER_DOMAIN_BLOCKS_FETCH_SU
 export const SERVER_DOMAIN_BLOCKS_FETCH_FAIL    = 'SERVER_DOMAIN_BLOCKS_FETCH_FAIL';
 
 export const fetchServer = () => (dispatch, getState) => {
+  if (getState().getIn(['server', 'server', 'isLoading'])) {
+    return;
+  }
+
   dispatch(fetchServerRequest());
 
   api(getState)
@@ -66,6 +70,10 @@ const fetchServerTranslationLanguagesFail = error => ({
 });
 
 export const fetchExtendedDescription = () => (dispatch, getState) => {
+  if (getState().getIn(['server', 'extendedDescription', 'isLoading'])) {
+    return;
+  }
+
   dispatch(fetchExtendedDescriptionRequest());
 
   api(getState)
@@ -89,6 +97,10 @@ const fetchExtendedDescriptionFail = error => ({
 });
 
 export const fetchDomainBlocks = () => (dispatch, getState) => {
+  if (getState().getIn(['server', 'domainBlocks', 'isLoading'])) {
+    return;
+  }
+
   dispatch(fetchDomainBlocksRequest());
 
   api(getState)

--- a/app/javascript/mastodon/features/about/index.jsx
+++ b/app/javascript/mastodon/features/about/index.jsx
@@ -161,7 +161,7 @@ class About extends PureComponent {
           </Section>
 
           <Section title={intl.formatMessage(messages.rules)}>
-            {!isLoading && (server.get('rules').isEmpty() ? (
+            {!isLoading && (server.get('rules', []).isEmpty() ? (
               <p><FormattedMessage id='about.not_available' defaultMessage='This information has not been made available on this server.' /></p>
             ) : (
               <ol className='rules-list'>

--- a/app/javascript/mastodon/reducers/server.js
+++ b/app/javascript/mastodon/reducers/server.js
@@ -17,15 +17,15 @@ import {
 
 const initialState = ImmutableMap({
   server: ImmutableMap({
-    isLoading: true,
+    isLoading: false,
   }),
 
   extendedDescription: ImmutableMap({
-    isLoading: true,
+    isLoading: false,
   }),
 
   domainBlocks: ImmutableMap({
-    isLoading: true,
+    isLoading: false,
     isAvailable: true,
     items: ImmutableList(),
   }),


### PR DESCRIPTION
Currently sends same API requests when loaded two or more components which fetches `/api/*/instance` in web UI.

This PR adds cancelling concurrent request logic into fetching for `/api/v2/instance`, `/api/v1/instance/extended_description` and `/api/v1/instance/domain_blocks`.

![](https://github.com/mastodon/mastodon/assets/5103195/ad6f4e3a-994d-4066-9bcb-d5a2a99dac6f)

By this, number of sending requests to `/api/v2/instance` reduces to 1 from 3 in about page when logged out as a case.
