### PR TITLE
Fix inefficient query when requesting a new confirmation email from a logged-in account

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -28,6 +28,24 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
     resource.email = current_user.unconfirmed_email || current_user.email if user_signed_in?
   end
 
+  def create
+    # Since we don't allow users to request confirmation emails for other accounts when they
+    # are already logged in, so we can cut on the expensive queries by simply reusing the
+    # current user.
+    if user_signed_in?
+      self.resource = current_user
+      resource.send_confirmation_instructions
+    else
+      self.resource = current_user || User.send_confirmation_instructions(resource_params)
+    end
+
+    if successfully_sent?(resource)
+      respond_with({}, location: after_resending_confirmation_instructions_path_for(resource_name))
+    else
+      respond_with(resource)
+    end
+  end
+
   def confirm_captcha
     check_captcha! do |message|
       flash.now[:alert] = message


### PR DESCRIPTION
An alternative would be to add an index on `unconfirmed_email`, though I am unsure how large that index would be.