### PR TITLE
Add superapp index on `oauth_applications`

### DIFF
--- a/db/migrate/20230702131023_add_superapp_index_to_applications.rb
+++ b/db/migrate/20230702131023_add_superapp_index_to_applications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddSuperappIndexToApplications < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :oauth_applications, :superapp, where: 'superapp = true', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_30_145300) do
+ActiveRecord::Schema.define(version: 2023_07_02_131023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -700,6 +700,7 @@ ActiveRecord::Schema.define(version: 2023_06_30_145300) do
     t.bigint "owner_id"
     t.boolean "confidential", default: true, null: false
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
+    t.index ["superapp"], name: "index_oauth_applications_on_superapp", where: "(superapp = true)"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 


### PR DESCRIPTION
Querying the superapp currently accounts for ~2% of all database query time because of the lack of index.

Under normal circumstances, the index should only hold one row, so its size should be negligible.