### PR TITLE
Clean up apt cache files in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN apt-get update && \
         tzdata \
         libreadline8 \
         tini && \
+    rm -rf /var/lib/apt/lists/* && \
     ln -s /opt/mastodon /mastodon
 
 # Note: no, cleaning here since Debian does this automatically


### PR DESCRIPTION
This will help minimize the size of released Docker images ;)