### PR TITLE
Add users index on unconfirmed_email

### DIFF
--- a/app/controllers/auth/confirmations_controller.rb
+++ b/app/controllers/auth/confirmations_controller.rb
@@ -28,24 +28,6 @@ class Auth::ConfirmationsController < Devise::ConfirmationsController
     resource.email = current_user.unconfirmed_email || current_user.email if user_signed_in?
   end
 
-  def create
-    # Since we don't allow users to request confirmation emails for other accounts when they
-    # are already logged in, so we can cut on the expensive queries by simply reusing the
-    # current user.
-    if user_signed_in?
-      self.resource = current_user
-      resource.send_confirmation_instructions
-    else
-      self.resource = current_user || User.send_confirmation_instructions(resource_params)
-    end
-
-    if successfully_sent?(resource)
-      respond_with({}, location: after_resending_confirmation_instructions_path_for(resource_name))
-    else
-      respond_with(resource)
-    end
-  end
-
   def confirm_captcha
     check_captcha! do |message|
       flash.now[:alert] = message

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_02_131023) do
+ActiveRecord::Schema.define(version: 2023_07_02_151753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1097,6 +1097,7 @@ ActiveRecord::Schema.define(version: 2023_07_02_131023) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, opclass: :text_pattern_ops, where: "(reset_password_token IS NOT NULL)"
     t.index ["role_id"], name: "index_users_on_role_id", where: "(role_id IS NOT NULL)"
+    t.index ["unconfirmed_email"], name: "index_users_on_unconfirmed_email", where: "(unconfirmed_email IS NOT NULL)"
   end
 
   create_table "web_push_subscriptions", force: :cascade do |t|


### PR DESCRIPTION
This fixes the issue addressed by #25669 in a more generic and maintainable way, and therefore reverts that change.

The extra index only took a few seconds to build and is only 2MB in size on a server as large as mastodon.social, so this seems pretty reasonable.