### PR TITLE
Add MacOS M1/2 setup steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To set up **MacOS** for native development, complete the following steps:
 - Run `brew install redis`
 - Run `brew install imagemagick`
 - Install Foreman or a similar tool (such as [overmind](https://github.com/DarthSim/overmind)) to handle multiple process launching.
-- Navigate to Mastodon's root directory and run `brew install nvm` then `nvm use` (Node 16.20.1 at time of writing)
+- Navigate to Mastodon's root directory and run `brew install nvm` then `nvm use` to use the version from .nvmrc
 - Run `corepack enable && yarn set version classic`
 - Run `bundle exec rails db:setup` (optionally prepend `RAILS_ENV=development` to target the dev environment)
 - Finally, run `overmind start -f Procfile.dev`

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ A **Vagrant** configuration is included for development purposes. To use it, com
 - Run `vagrant ssh -c "cd /vagrant && foreman start"`
 - Open `http://mastodon.local` in your browser
 
-To set up **M1/2 MacOS** for native development, complete the following steps:
+To set up **MacOS** for native development, complete the following steps:
 
-- Install Ruby 3.2 (using [rbenv](https://github.com/rbenv/rbenv) for easy installation and management of ruby versions)
+- Install the latest stable Ruby version (use a ruby version manager for easy installation and management of ruby versions)
 - Run `brew install postgresql@15`
 - Run `brew install redis`
 - Run `brew install imagemagick`

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A **Vagrant** configuration is included for development purposes. To use it, com
 To set up **MacOS** for native development, complete the following steps:
 
 - Install the latest stable Ruby version (use a ruby version manager for easy installation and management of ruby versions)
-- Run `brew install postgresql@15`
+- Run `brew install postgresql@14`
 - Run `brew install redis`
 - Run `brew install imagemagick`
 - Install Foreman or a similar tool (such as [overmind](https://github.com/DarthSim/overmind)) to handle multiple process launching.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ A **Vagrant** configuration is included for development purposes. To use it, com
 - Run `vagrant ssh -c "cd /vagrant && foreman start"`
 - Open `http://mastodon.local` in your browser
 
+To set up **M1/2 MacOS** for native development, complete the following steps:
+
+- Install Ruby 3.2 (using [rbenv](https://github.com/rbenv/rbenv) for easy installation and management of ruby versions)
+- Run `brew install postgresql@15`
+- Run `brew install redis`
+- Run `brew install imagemagick`
+- Install Foreman or a similar tool (such as [overmind](https://github.com/DarthSim/overmind)) to handle multiple process launching.
+- Navigate to Mastodon's root directory and run `brew install nvm` then `nvm use` (Node 16.20.1 at time of writing)
+- Run `corepack enable && yarn set version classic`
+- Run `bundle exec rails db:setup` (optionally prepend `RAILS_ENV=development` to target the dev environment)
+- Finally, run `overmind start -f Procfile.dev`
+
 ### Getting Started with GitHub Codespaces
 
 To get started, create a codespace for this repository by clicking this 👇


### PR DESCRIPTION
Adding setup steps from @renchap's response to https://github.com/mastodon/mastodon/discussions/25441
Verified this on my own M2 machine and it works for native setup, thought it would be useful for others.