### PR TITLE
First pass at multi-database for read replica using Rails native adapter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -809,7 +809,6 @@ Style/FrozenStringLiteralComment:
     - 'config/initializers/httplog.rb'
     - 'config/initializers/inflections.rb'
     - 'config/initializers/mail_delivery_job.rb'
-    - 'config/initializers/makara.rb'
     - 'config/initializers/mime_types.rb'
     - 'config/initializers/oj.rb'
     - 'config/initializers/omniauth.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'rack', '~> 2.2.7'
 
 gem 'haml-rails', '~>2.0'
 gem 'pg', '~> 1.5'
-gem 'makara', '~> 0.5'
 gem 'pghero'
 gem 'dotenv-rails', '~> 2.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,8 +399,6 @@ GEM
       net-imap
       net-pop
       net-smtp
-    makara (0.5.1)
-      activerecord (>= 5.2.0)
     marcel (1.0.2)
     mario-redis-lock (1.2.1)
       redis (>= 3.0.5)
@@ -815,7 +813,6 @@ DEPENDENCIES
   letter_opener_web (~> 2.0)
   link_header (~> 0.0)
   lograge (~> 0.12)
-  makara (~> 0.5)
   mario-redis-lock (~> 1.2)
   memory_profiler
   mime-types (~> 3.4.1)

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::Timelines::HomeController < Api::BaseController
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 
   def show
-    Status.connected_to(role: :read, prevent_writes: true) do
+    ApplicationRecord.connected_to(role: :read, prevent_writes: true) do
       @statuses = load_statuses
       @relationships = StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
     end

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::Timelines::HomeController < Api::BaseController
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 
   def show
-    Status.connects_to(role: :read, prevent_writes: true) do
+    Status.connected_to(role: :read, prevent_writes: true) do
       @statuses = load_statuses
       @relationships = StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
     end

--- a/app/controllers/api/v1/timelines/home_controller.rb
+++ b/app/controllers/api/v1/timelines/home_controller.rb
@@ -6,11 +6,14 @@ class Api::V1::Timelines::HomeController < Api::BaseController
   after_action :insert_pagination_headers, unless: -> { @statuses.empty? }
 
   def show
-    @statuses = load_statuses
+    Status.connects_to(role: :read, prevent_writes: true) do
+      @statuses = load_statuses
+      @relationships = StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+    end
 
     render json: @statuses,
            each_serializer: REST::StatusSerializer,
-           relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id),
+           relationships: @relationships,
            status: account_home_feed.regenerating? ? 206 : 200
   end
 

--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -4,7 +4,7 @@ class FeedInsertWorker
   include Sidekiq::Worker
 
   def perform(status_id, id, type = 'home', options = {})
-    ActiveRecord.connects_to(role: :primary) do
+    ActiveRecord.connected_to(role: :primary) do
       @type      = type.to_sym
       @status    = Status.find(status_id)
       @options   = options.symbolize_keys

--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -18,7 +18,7 @@ class FeedInsertWorker
       end
     end
 
-    ActiveRecord.connects_to(role: :read, prevent_writes: true) do
+    ActiveRecord.connected_to(role: :read, prevent_writes: true) do
       check_and_insert
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -4,7 +4,7 @@ class FeedInsertWorker
   include Sidekiq::Worker
 
   def perform(status_id, id, type = 'home', options = {})
-    ActiveRecord.connected_to(role: :primary) do
+    ApplicationRecord.connected_to(role: :primary) do
       @type      = type.to_sym
       @status    = Status.find(status_id)
       @options   = options.symbolize_keys
@@ -18,7 +18,7 @@ class FeedInsertWorker
       end
     end
 
-    ActiveRecord.connected_to(role: :read, prevent_writes: true) do
+    ApplicationRecord.connected_to(role: :read, prevent_writes: true) do
       check_and_insert
     end
   rescue ActiveRecord::RecordNotFound

--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -4,19 +4,23 @@ class FeedInsertWorker
   include Sidekiq::Worker
 
   def perform(status_id, id, type = 'home', options = {})
-    @type      = type.to_sym
-    @status    = Status.find(status_id)
-    @options   = options.symbolize_keys
+    ActiveRecord.connects_to(role: :primary) do
+      @type      = type.to_sym
+      @status    = Status.find(status_id)
+      @options   = options.symbolize_keys
 
-    case @type
-    when :home, :tags
-      @follower = Account.find(id)
-    when :list
-      @list     = List.find(id)
-      @follower = @list.account
+      case @type
+      when :home, :tags
+        @follower = Account.find(id)
+      when :list
+        @list     = List.find(id)
+        @follower = @list.account
+      end
     end
 
-    check_and_insert
+    ActiveRecord.connects_to(role: :read, prevent_writes: true) do
+      check_and_insert
+    end
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -27,10 +27,20 @@ test:
   port: <%= ENV['DB_PORT'] %>
 
 production:
-  <<: *default
-  database: <%= ENV['DB_NAME'] || 'mastodon_production' %>
-  username: <%= ENV['DB_USER'] || 'mastodon' %>
-  password: <%= (ENV['DB_PASS'] || '').to_json %>
-  host: <%= ENV['DB_HOST'] || 'localhost' %>
-  port: <%= ENV['DB_PORT'] || 5432 %>
-  prepared_statements: <%= ENV['PREPARED_STATEMENTS'] || 'true' %>
+  primary:
+    <<: *default
+    database: <%= ENV['DB_NAME'] || 'mastodon_production' %>
+    username: <%= ENV['DB_USER'] || 'mastodon' %>
+    password: <%= (ENV['DB_PASS'] || '').to_json %>
+    host: <%= ENV['DB_HOST'] || 'localhost' %>
+    port: <%= ENV['DB_PORT'] || 5432 %>
+    prepared_statements: <%= ENV['PREPARED_STATEMENTS'] || 'true' %>
+  read:
+    <<: *default
+    database: <%= ENV['DB_REPLICA_NAME'] ||ENV['DB_NAME'] || 'mastodon_production' %>
+    username: <%= ENV['DB_REPLICA_NAME'] ||ENV['DB_USER'] || 'mastodon' %>
+    password: <%= (ENV['DB_REPLICA_PASS'] || ENV['DB_PASS'] || '').to_json %>
+    host: <%= ENV['DB_REPLICA_HOST'] ||ENV['DB_HOST'] || 'localhost' %>
+    port: <%= ENV['DB_REPLICA_PORT'] ||ENV['DB_PORT'] || 5432 %>
+    prepared_statements: <%= ENV['PREPARED_STATEMENTS'] || 'true' %>
+    replica: true

--- a/config/database.yml
+++ b/config/database.yml
@@ -38,7 +38,7 @@ production:
   read:
     <<: *default
     database: <%= ENV['DB_REPLICA_NAME'] ||ENV['DB_NAME'] || 'mastodon_production' %>
-    username: <%= ENV['DB_REPLICA_NAME'] ||ENV['DB_USER'] || 'mastodon' %>
+    username: <%= ENV['DB_REPLICA_USER'] ||ENV['DB_USER'] || 'mastodon' %>
     password: <%= (ENV['DB_REPLICA_PASS'] || ENV['DB_PASS'] || '').to_json %>
     host: <%= ENV['DB_REPLICA_HOST'] ||ENV['DB_HOST'] || 'localhost' %>
     port: <%= ENV['DB_REPLICA_PORT'] ||ENV['DB_PORT'] || 5432 %>

--- a/config/initializers/makara.rb
+++ b/config/initializers/makara.rb
@@ -1,2 +1,0 @@
-Makara::Cookie::DEFAULT_OPTIONS[:same_site] = :lax
-Makara::Cookie::DEFAULT_OPTIONS[:secure]    = Rails.env.production? || ENV['LOCAL_HTTPS'] == 'true'


### PR DESCRIPTION
There's a desire to implement read replica usage. For mastodon instances without replicas this should just talk to the main database *as* a replica. More changes to come.

Write after test block to check queries to see what queries are done.