### PR TITLE
fix read more button overlapping thread line bug

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1127,6 +1127,8 @@ body > [data-popper-placement] {
   }
 
   &--in-thread {
+    $thread-margin: 46px + 10px;
+
     border-bottom: 0;
 
     .status__content,
@@ -1137,8 +1139,12 @@ body > [data-popper-placement] {
     .attachment-list,
     .picture-in-picture-placeholder,
     .status-card {
-      margin-inline-start: 46px + 10px;
-      width: calc(100% - (46px + 10px));
+      margin-inline-start: $thread-margin;
+      width: calc(100% - ($thread-margin));
+    }
+
+    .status__content__read-more-button {
+      margin-inline-start: $thread-margin;
     }
   }
 


### PR DESCRIPTION
resolves #25648

adds margin to match other thread elements.

<img width="376" alt="CleanShot 2023-07-04 at 22 24 35@2x" src="https://github.com/mastodon/mastodon/assets/17292/9d468365-a402-41d3-9204-f54817adcf70">

