### PR TITLE
feat(gha): add a tagged container with the hash+timestamp

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -28,6 +28,12 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
 
+      - name: Set variables
+        id: vars
+        run: |
+          echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -53,6 +59,7 @@ jobs:
             latest=auto
           tags: |
             type=edge,branch=main
+            type=edge,branch=main,suffix=-${{ steps.vars.outputs.sha_short }}-${{ steps.vars.outputs.timestamp }}
             type=pep440,pattern={{raw}}
             type=pep440,pattern=v{{major}}.{{minor}}
             type=ref,event=pr


### PR DESCRIPTION
This PR add a tag for the `main` branch build, that allow to track new image every time something is merged in main

The format is `ghcr.io/mastodon/mastodon:edge-commit-hash-timestamp`

For exemple, with Flux you can add an [ImageRepository](https://fluxcd.io/flux/components/image/imagerepositories/) that points to `ghcr.io/mastodon/mastodon` and setup an [ImagePolicy](https://fluxcd.io/flux/components/image/imagepolicies/) like this : 

```YAML
apiVersion: image.toolkit.fluxcd.io/v1beta1
kind: ImagePolicy
metadata:
  name: mastodon-edge
  namespace: default
spec:
  imageRepositoryRef:
    name: mastodon-edge
  filterTags:
    pattern: '^edge-[a-f0-9]+-(?P<ts>[0-9]+)'
    extract: '$ts'
  policy:
    numerical:
      order: asc
```

And combined with an [ImageUpdateAutomation](https://fluxcd.io/flux/components/image/imageupdateautomations/), every time there's a new `:edge-xxx` tag, Flux will update the GitOps repo with this latest tag, and every deployments will be updated