### PR TITLE
Fix re-activated accounts being deleted by AccountDeletionWorker

### DIFF
--- a/app/workers/account_deletion_worker.rb
+++ b/app/workers/account_deletion_worker.rb
@@ -6,9 +6,12 @@ class AccountDeletionWorker
   sidekiq_options queue: 'pull', lock: :until_executed
 
   def perform(account_id, options = {})
+    account = Account.find(account_id)
+    return unless account.suspended?
+
     reserve_username = options.with_indifferent_access.fetch(:reserve_username, true)
     skip_activitypub = options.with_indifferent_access.fetch(:skip_activitypub, false)
-    DeleteAccountService.new.call(Account.find(account_id), reserve_username: reserve_username, skip_activitypub: skip_activitypub, reserve_email: false)
+    DeleteAccountService.new.call(account, reserve_username: reserve_username, skip_activitypub: skip_activitypub, reserve_email: false)
   rescue ActiveRecord::RecordNotFound
     true
   end


### PR DESCRIPTION
Fix an edge case where an account can get wrongfully deleted in the following scenario:
- the `pull` queue is delayed
- a new user tries to register, but requests their account to be deleted (e.g. because of not receiving an email because of a delayed `mailers` queue)
- a moderator manually confirms and unsuspends their account
- the `pull` queue catches up with the enqueued `AccountDeletionWorker` after the user has started using their account