### PR TITLE
Refactor `NotificationMailer` to use parameterization

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -12,11 +12,11 @@ class NotificationMailer < ApplicationMailer
     @type = action_name
   end
 
+  before_action :set_status, only: [:mention, :favourite, :reblog]
+
   default to: -> { email_address_with_name(@user.email, @me.username) }
 
   def mention
-    @status = @notification.target_status
-
     return unless @user.functional? && @status.present?
 
     locale_for_account(@me) do
@@ -37,7 +37,6 @@ class NotificationMailer < ApplicationMailer
 
   def favourite
     @account = @notification.from_account
-    @status  = @notification.target_status
 
     return unless @user.functional? && @status.present?
 
@@ -49,7 +48,6 @@ class NotificationMailer < ApplicationMailer
 
   def reblog
     @account = @notification.from_account
-    @status  = @notification.target_status
 
     return unless @user.functional? && @status.present?
 
@@ -70,6 +68,10 @@ class NotificationMailer < ApplicationMailer
   end
 
   private
+
+  def set_status
+    @status = @notification.target_status
+  end
 
   def thread_by_conversation(conversation)
     return if conversation.nil?

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 class NotificationMailer < ApplicationMailer
-  helper :accounts
-  helper :statuses
+  helper :accounts,
+         :statuses,
+         :routing
 
-  helper RoutingHelper
+  before_action do
+    @me = params[:recipient]
+    @user = @me.user
+  end
 
-  def mention(recipient, notification)
-    @me     = recipient
-    @user   = recipient.user
+  def mention(notification)
     @type   = 'mention'
     @status = notification.target_status
 
@@ -20,9 +22,7 @@ class NotificationMailer < ApplicationMailer
     end
   end
 
-  def follow(recipient, notification)
-    @me      = recipient
-    @user    = recipient.user
+  def follow(notification)
     @type    = 'follow'
     @account = notification.from_account
 
@@ -33,9 +33,7 @@ class NotificationMailer < ApplicationMailer
     end
   end
 
-  def favourite(recipient, notification)
-    @me      = recipient
-    @user    = recipient.user
+  def favourite(notification)
     @type    = 'favourite'
     @account = notification.from_account
     @status  = notification.target_status
@@ -48,9 +46,7 @@ class NotificationMailer < ApplicationMailer
     end
   end
 
-  def reblog(recipient, notification)
-    @me      = recipient
-    @user    = recipient.user
+  def reblog(notification)
     @type    = 'reblog'
     @account = notification.from_account
     @status  = notification.target_status
@@ -63,9 +59,7 @@ class NotificationMailer < ApplicationMailer
     end
   end
 
-  def follow_request(recipient, notification)
-    @me      = recipient
-    @user    = recipient.user
+  def follow_request(notification)
     @type    = 'follow_request'
     @account = notification.from_account
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -13,6 +13,7 @@ class NotificationMailer < ApplicationMailer
   end
 
   before_action :set_status, only: [:mention, :favourite, :reblog]
+  before_action :set_account, only: [:follow, :favourite, :reblog, :follow_request]
 
   default to: -> { email_address_with_name(@user.email, @me.username) }
 
@@ -26,8 +27,6 @@ class NotificationMailer < ApplicationMailer
   end
 
   def follow
-    @account = @notification.from_account
-
     return unless @user.functional?
 
     locale_for_account(@me) do
@@ -36,8 +35,6 @@ class NotificationMailer < ApplicationMailer
   end
 
   def favourite
-    @account = @notification.from_account
-
     return unless @user.functional? && @status.present?
 
     locale_for_account(@me) do
@@ -47,8 +44,6 @@ class NotificationMailer < ApplicationMailer
   end
 
   def reblog
-    @account = @notification.from_account
-
     return unless @user.functional? && @status.present?
 
     locale_for_account(@me) do
@@ -58,8 +53,6 @@ class NotificationMailer < ApplicationMailer
   end
 
   def follow_request
-    @account = @notification.from_account
-
     return unless @user.functional?
 
     locale_for_account(@me) do
@@ -71,6 +64,10 @@ class NotificationMailer < ApplicationMailer
 
   def set_status
     @status = @notification.target_status
+  end
+
+  def set_account
+    @account = @notification.from_account
   end
 
   def thread_by_conversation(conversation)

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -11,6 +11,8 @@ class NotificationMailer < ApplicationMailer
     @type = action_name
   end
 
+  default to: -> { email_address_with_name(@user.email, @me.username) }
+
   def mention(notification)
     @status = notification.target_status
 
@@ -18,7 +20,7 @@ class NotificationMailer < ApplicationMailer
 
     locale_for_account(@me) do
       thread_by_conversation(@status.conversation)
-      mail to: email_address_with_name(@user.email, @me.username), subject: I18n.t('notification_mailer.mention.subject', name: @status.account.acct)
+      mail subject: I18n.t('notification_mailer.mention.subject', name: @status.account.acct)
     end
   end
 
@@ -28,7 +30,7 @@ class NotificationMailer < ApplicationMailer
     return unless @user.functional?
 
     locale_for_account(@me) do
-      mail to: email_address_with_name(@user.email, @me.username), subject: I18n.t('notification_mailer.follow.subject', name: @account.acct)
+      mail subject: I18n.t('notification_mailer.follow.subject', name: @account.acct)
     end
   end
 
@@ -40,7 +42,7 @@ class NotificationMailer < ApplicationMailer
 
     locale_for_account(@me) do
       thread_by_conversation(@status.conversation)
-      mail to: email_address_with_name(@user.email, @me.username), subject: I18n.t('notification_mailer.favourite.subject', name: @account.acct)
+      mail subject: I18n.t('notification_mailer.favourite.subject', name: @account.acct)
     end
   end
 
@@ -52,7 +54,7 @@ class NotificationMailer < ApplicationMailer
 
     locale_for_account(@me) do
       thread_by_conversation(@status.conversation)
-      mail to: email_address_with_name(@user.email, @me.username), subject: I18n.t('notification_mailer.reblog.subject', name: @account.acct)
+      mail subject: I18n.t('notification_mailer.reblog.subject', name: @account.acct)
     end
   end
 
@@ -62,7 +64,7 @@ class NotificationMailer < ApplicationMailer
     return unless @user.functional?
 
     locale_for_account(@me) do
-      mail to: email_address_with_name(@user.email, @me.username), subject: I18n.t('notification_mailer.follow_request.subject', name: @account.acct)
+      mail subject: I18n.t('notification_mailer.follow_request.subject', name: @account.acct)
     end
   end
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -5,13 +5,7 @@ class NotificationMailer < ApplicationMailer
          :statuses,
          :routing
 
-  before_action do
-    @notification = params[:notification]
-    @me = params[:recipient]
-    @user = @me.user
-    @type = action_name
-  end
-
+  before_action :process_params
   before_action :set_status, only: [:mention, :favourite, :reblog]
   before_action :set_account, only: [:follow, :favourite, :reblog, :follow_request]
 
@@ -61,6 +55,13 @@ class NotificationMailer < ApplicationMailer
   end
 
   private
+
+  def process_params
+    @notification = params[:notification]
+    @me = params[:recipient]
+    @user = @me.user
+    @type = action_name
+  end
 
   def set_status
     @status = @notification.target_status

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -16,7 +16,7 @@ class NotificationMailer < ApplicationMailer
 
     locale_for_account(@me) do
       thread_by_conversation(@status.conversation)
-      mail subject: I18n.t('notification_mailer.mention.subject', name: @status.account.acct)
+      mail subject: default_i18n_subject(name: @status.account.acct)
     end
   end
 
@@ -24,7 +24,7 @@ class NotificationMailer < ApplicationMailer
     return unless @user.functional?
 
     locale_for_account(@me) do
-      mail subject: I18n.t('notification_mailer.follow.subject', name: @account.acct)
+      mail subject: default_i18n_subject(name: @account.acct)
     end
   end
 
@@ -33,7 +33,7 @@ class NotificationMailer < ApplicationMailer
 
     locale_for_account(@me) do
       thread_by_conversation(@status.conversation)
-      mail subject: I18n.t('notification_mailer.favourite.subject', name: @account.acct)
+      mail subject: default_i18n_subject(name: @account.acct)
     end
   end
 
@@ -42,7 +42,7 @@ class NotificationMailer < ApplicationMailer
 
     locale_for_account(@me) do
       thread_by_conversation(@status.conversation)
-      mail subject: I18n.t('notification_mailer.reblog.subject', name: @account.acct)
+      mail subject: default_i18n_subject(name: @account.acct)
     end
   end
 
@@ -50,7 +50,7 @@ class NotificationMailer < ApplicationMailer
     return unless @user.functional?
 
     locale_for_account(@me) do
-      mail subject: I18n.t('notification_mailer.follow_request.subject', name: @account.acct)
+      mail subject: default_i18n_subject(name: @account.acct)
     end
   end
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -8,10 +8,10 @@ class NotificationMailer < ApplicationMailer
   before_action do
     @me = params[:recipient]
     @user = @me.user
+    @type = action_name
   end
 
   def mention(notification)
-    @type   = 'mention'
     @status = notification.target_status
 
     return unless @user.functional? && @status.present?
@@ -23,7 +23,6 @@ class NotificationMailer < ApplicationMailer
   end
 
   def follow(notification)
-    @type    = 'follow'
     @account = notification.from_account
 
     return unless @user.functional?
@@ -34,7 +33,6 @@ class NotificationMailer < ApplicationMailer
   end
 
   def favourite(notification)
-    @type    = 'favourite'
     @account = notification.from_account
     @status  = notification.target_status
 
@@ -47,7 +45,6 @@ class NotificationMailer < ApplicationMailer
   end
 
   def reblog(notification)
-    @type    = 'reblog'
     @account = notification.from_account
     @status  = notification.target_status
 
@@ -60,7 +57,6 @@ class NotificationMailer < ApplicationMailer
   end
 
   def follow_request(notification)
-    @type    = 'follow_request'
     @account = notification.from_account
 
     return unless @user.functional?

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -6,6 +6,7 @@ class NotificationMailer < ApplicationMailer
          :routing
 
   before_action do
+    @notification = params[:notification]
     @me = params[:recipient]
     @user = @me.user
     @type = action_name
@@ -13,8 +14,8 @@ class NotificationMailer < ApplicationMailer
 
   default to: -> { email_address_with_name(@user.email, @me.username) }
 
-  def mention(notification)
-    @status = notification.target_status
+  def mention
+    @status = @notification.target_status
 
     return unless @user.functional? && @status.present?
 
@@ -24,8 +25,8 @@ class NotificationMailer < ApplicationMailer
     end
   end
 
-  def follow(notification)
-    @account = notification.from_account
+  def follow
+    @account = @notification.from_account
 
     return unless @user.functional?
 
@@ -34,9 +35,9 @@ class NotificationMailer < ApplicationMailer
     end
   end
 
-  def favourite(notification)
-    @account = notification.from_account
-    @status  = notification.target_status
+  def favourite
+    @account = @notification.from_account
+    @status  = @notification.target_status
 
     return unless @user.functional? && @status.present?
 
@@ -46,9 +47,9 @@ class NotificationMailer < ApplicationMailer
     end
   end
 
-  def reblog(notification)
-    @account = notification.from_account
-    @status  = notification.target_status
+  def reblog
+    @account = @notification.from_account
+    @status  = @notification.target_status
 
     return unless @user.functional? && @status.present?
 
@@ -58,8 +59,8 @@ class NotificationMailer < ApplicationMailer
     end
   end
 
-  def follow_request(notification)
-    @account = notification.from_account
+  def follow_request
+    @account = @notification.from_account
 
     return unless @user.functional?
 

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -162,7 +162,12 @@ class NotifyService < BaseService
   end
 
   def send_email!
-    NotificationMailer.public_send(@notification.type, @recipient, @notification).deliver_later(wait: 2.minutes) if NotificationMailer.respond_to?(@notification.type)
+    return unless NotificationMailer.respond_to?(@notification.type)
+
+    NotificationMailer
+      .with(recipient: @recipient)
+      .public_send(@notification.type, @notification)
+      .deliver_later(wait: 2.minutes)
   end
 
   def email_needed?

--- a/app/services/notify_service.rb
+++ b/app/services/notify_service.rb
@@ -165,8 +165,8 @@ class NotifyService < BaseService
     return unless NotificationMailer.respond_to?(@notification.type)
 
     NotificationMailer
-      .with(recipient: @recipient)
-      .public_send(@notification.type, @notification)
+      .with(recipient: @recipient, notification: @notification)
+      .public_send(@notification.type)
       .deliver_later(wait: 2.minutes)
   end
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe NotificationMailer do
 
   describe 'mention' do
     let(:mention) { Mention.create!(account: receiver.account, status: foreign_status) }
-    let(:mail) { described_class.with(recipient: receiver.account).mention(Notification.create!(account: receiver.account, activity: mention)) }
+    let(:notification) { Notification.create!(account: receiver.account, activity: mention) }
+    let(:mail) { described_class.with(recipient: receiver.account).mention(notification) }
 
     include_examples 'localized subject', 'notification_mailer.mention.subject', name: 'bob'
 
@@ -40,7 +41,8 @@ RSpec.describe NotificationMailer do
 
   describe 'follow' do
     let(:follow) { sender.follow!(receiver.account) }
-    let(:mail) { described_class.with(recipient: receiver.account).follow(Notification.create!(account: receiver.account, activity: follow)) }
+    let(:notification) { Notification.create!(account: receiver.account, activity: follow) }
+    let(:mail) { described_class.with(recipient: receiver.account).follow(notification) }
 
     include_examples 'localized subject', 'notification_mailer.follow.subject', name: 'bob'
 
@@ -56,7 +58,8 @@ RSpec.describe NotificationMailer do
 
   describe 'favourite' do
     let(:favourite) { Favourite.create!(account: sender, status: own_status) }
-    let(:mail) { described_class.with(recipient: own_status.account).favourite(Notification.create!(account: receiver.account, activity: favourite)) }
+    let(:notification) { Notification.create!(account: receiver.account, activity: favourite) }
+    let(:mail) { described_class.with(recipient: own_status.account).favourite(notification) }
 
     include_examples 'localized subject', 'notification_mailer.favourite.subject', name: 'bob'
 
@@ -73,7 +76,8 @@ RSpec.describe NotificationMailer do
 
   describe 'reblog' do
     let(:reblog) { Status.create!(account: sender, reblog: own_status) }
-    let(:mail) { described_class.with(recipient: own_status.account).reblog(Notification.create!(account: receiver.account, activity: reblog)) }
+    let(:notification) { Notification.create!(account: receiver.account, activity: reblog) }
+    let(:mail) { described_class.with(recipient: own_status.account).reblog(notification) }
 
     include_examples 'localized subject', 'notification_mailer.reblog.subject', name: 'bob'
 
@@ -90,7 +94,8 @@ RSpec.describe NotificationMailer do
 
   describe 'follow_request' do
     let(:follow_request) { Fabricate(:follow_request, account: sender, target_account: receiver.account) }
-    let(:mail) { described_class.with(recipient: receiver.account).follow_request(Notification.create!(account: receiver.account, activity: follow_request)) }
+    let(:notification) { Notification.create!(account: receiver.account, activity: follow_request) }
+    let(:mail) { described_class.with(recipient: receiver.account).follow_request(notification) }
 
     include_examples 'localized subject', 'notification_mailer.follow_request.subject', name: 'bob'
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe NotificationMailer do
   describe 'mention' do
     let(:mention) { Mention.create!(account: receiver.account, status: foreign_status) }
     let(:notification) { Notification.create!(account: receiver.account, activity: mention) }
-    let(:mail) { described_class.with(recipient: receiver.account, notification: notification).mention }
+    let(:mail) { prepared_mailer_for(receiver.account).mention }
 
     include_examples 'localized subject', 'notification_mailer.mention.subject', name: 'bob'
 
@@ -42,7 +42,7 @@ RSpec.describe NotificationMailer do
   describe 'follow' do
     let(:follow) { sender.follow!(receiver.account) }
     let(:notification) { Notification.create!(account: receiver.account, activity: follow) }
-    let(:mail) { described_class.with(recipient: receiver.account, notification: notification).follow }
+    let(:mail) { prepared_mailer_for(receiver.account).follow }
 
     include_examples 'localized subject', 'notification_mailer.follow.subject', name: 'bob'
 
@@ -59,7 +59,7 @@ RSpec.describe NotificationMailer do
   describe 'favourite' do
     let(:favourite) { Favourite.create!(account: sender, status: own_status) }
     let(:notification) { Notification.create!(account: receiver.account, activity: favourite) }
-    let(:mail) { described_class.with(recipient: own_status.account, notification: notification).favourite }
+    let(:mail) { prepared_mailer_for(own_status.account).favourite }
 
     include_examples 'localized subject', 'notification_mailer.favourite.subject', name: 'bob'
 
@@ -77,7 +77,7 @@ RSpec.describe NotificationMailer do
   describe 'reblog' do
     let(:reblog) { Status.create!(account: sender, reblog: own_status) }
     let(:notification) { Notification.create!(account: receiver.account, activity: reblog) }
-    let(:mail) { described_class.with(recipient: own_status.account, notification: notification).reblog }
+    let(:mail) { prepared_mailer_for(own_status.account).reblog }
 
     include_examples 'localized subject', 'notification_mailer.reblog.subject', name: 'bob'
 
@@ -95,7 +95,7 @@ RSpec.describe NotificationMailer do
   describe 'follow_request' do
     let(:follow_request) { Fabricate(:follow_request, account: sender, target_account: receiver.account) }
     let(:notification) { Notification.create!(account: receiver.account, activity: follow_request) }
-    let(:mail) { described_class.with(recipient: receiver.account, notification: notification).follow_request }
+    let(:mail) { prepared_mailer_for(receiver.account).follow_request }
 
     include_examples 'localized subject', 'notification_mailer.follow_request.subject', name: 'bob'
 
@@ -107,5 +107,11 @@ RSpec.describe NotificationMailer do
     it 'renders the body' do
       expect(mail.body.encoded).to match('bob has requested to follow you')
     end
+  end
+
+  private
+
+  def prepared_mailer_for(recipient)
+    described_class.with(recipient: recipient, notification: notification)
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe NotificationMailer do
 
   describe 'mention' do
     let(:mention) { Mention.create!(account: receiver.account, status: foreign_status) }
-    let(:mail) { described_class.mention(receiver.account, Notification.create!(account: receiver.account, activity: mention)) }
+    let(:mail) { described_class.with(recipient: receiver.account).mention(Notification.create!(account: receiver.account, activity: mention)) }
 
     include_examples 'localized subject', 'notification_mailer.mention.subject', name: 'bob'
 
@@ -40,7 +40,7 @@ RSpec.describe NotificationMailer do
 
   describe 'follow' do
     let(:follow) { sender.follow!(receiver.account) }
-    let(:mail) { described_class.follow(receiver.account, Notification.create!(account: receiver.account, activity: follow)) }
+    let(:mail) { described_class.with(recipient: receiver.account).follow(Notification.create!(account: receiver.account, activity: follow)) }
 
     include_examples 'localized subject', 'notification_mailer.follow.subject', name: 'bob'
 
@@ -56,7 +56,7 @@ RSpec.describe NotificationMailer do
 
   describe 'favourite' do
     let(:favourite) { Favourite.create!(account: sender, status: own_status) }
-    let(:mail) { described_class.favourite(own_status.account, Notification.create!(account: receiver.account, activity: favourite)) }
+    let(:mail) { described_class.with(recipient: own_status.account).favourite(Notification.create!(account: receiver.account, activity: favourite)) }
 
     include_examples 'localized subject', 'notification_mailer.favourite.subject', name: 'bob'
 
@@ -73,7 +73,7 @@ RSpec.describe NotificationMailer do
 
   describe 'reblog' do
     let(:reblog) { Status.create!(account: sender, reblog: own_status) }
-    let(:mail) { described_class.reblog(own_status.account, Notification.create!(account: receiver.account, activity: reblog)) }
+    let(:mail) { described_class.with(recipient: own_status.account).reblog(Notification.create!(account: receiver.account, activity: reblog)) }
 
     include_examples 'localized subject', 'notification_mailer.reblog.subject', name: 'bob'
 
@@ -90,7 +90,7 @@ RSpec.describe NotificationMailer do
 
   describe 'follow_request' do
     let(:follow_request) { Fabricate(:follow_request, account: sender, target_account: receiver.account) }
-    let(:mail) { described_class.follow_request(receiver.account, Notification.create!(account: receiver.account, activity: follow_request)) }
+    let(:mail) { described_class.with(recipient: receiver.account).follow_request(Notification.create!(account: receiver.account, activity: follow_request)) }
 
     include_examples 'localized subject', 'notification_mailer.follow_request.subject', name: 'bob'
 

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe NotificationMailer do
   describe 'mention' do
     let(:mention) { Mention.create!(account: receiver.account, status: foreign_status) }
     let(:notification) { Notification.create!(account: receiver.account, activity: mention) }
-    let(:mail) { described_class.with(recipient: receiver.account).mention(notification) }
+    let(:mail) { described_class.with(recipient: receiver.account, notification: notification).mention }
 
     include_examples 'localized subject', 'notification_mailer.mention.subject', name: 'bob'
 
@@ -42,7 +42,7 @@ RSpec.describe NotificationMailer do
   describe 'follow' do
     let(:follow) { sender.follow!(receiver.account) }
     let(:notification) { Notification.create!(account: receiver.account, activity: follow) }
-    let(:mail) { described_class.with(recipient: receiver.account).follow(notification) }
+    let(:mail) { described_class.with(recipient: receiver.account, notification: notification).follow }
 
     include_examples 'localized subject', 'notification_mailer.follow.subject', name: 'bob'
 
@@ -59,7 +59,7 @@ RSpec.describe NotificationMailer do
   describe 'favourite' do
     let(:favourite) { Favourite.create!(account: sender, status: own_status) }
     let(:notification) { Notification.create!(account: receiver.account, activity: favourite) }
-    let(:mail) { described_class.with(recipient: own_status.account).favourite(notification) }
+    let(:mail) { described_class.with(recipient: own_status.account, notification: notification).favourite }
 
     include_examples 'localized subject', 'notification_mailer.favourite.subject', name: 'bob'
 
@@ -77,7 +77,7 @@ RSpec.describe NotificationMailer do
   describe 'reblog' do
     let(:reblog) { Status.create!(account: sender, reblog: own_status) }
     let(:notification) { Notification.create!(account: receiver.account, activity: reblog) }
-    let(:mail) { described_class.with(recipient: own_status.account).reblog(notification) }
+    let(:mail) { described_class.with(recipient: own_status.account, notification: notification).reblog }
 
     include_examples 'localized subject', 'notification_mailer.reblog.subject', name: 'bob'
 
@@ -95,7 +95,7 @@ RSpec.describe NotificationMailer do
   describe 'follow_request' do
     let(:follow_request) { Fabricate(:follow_request, account: sender, target_account: receiver.account) }
     let(:notification) { Notification.create!(account: receiver.account, activity: follow_request) }
-    let(:mail) { described_class.with(recipient: receiver.account).follow_request(notification) }
+    let(:mail) { described_class.with(recipient: receiver.account, notification: notification).follow_request }
 
     include_examples 'localized subject', 'notification_mailer.follow_request.subject', name: 'bob'
 

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -6,31 +6,41 @@ class NotificationMailerPreview < ActionMailer::Preview
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/mention
   def mention
     activity = Mention.last
-    NotificationMailer.with(recipient: activity.account).mention(notification_for(activity))
+    NotificationMailer
+      .with(recipient: activity.account, notification: notification_for(activity))
+      .mention
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/follow
   def follow
     activity = Follow.last
-    NotificationMailer.with(recipient: activity.target_account).follow(notification_for(activity))
+    NotificationMailer
+      .with(recipient: activity.target_account, notification: notification_for(activity))
+      .follow
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/follow_request
   def follow_request
     activity = Follow.last
-    NotificationMailer.with(recipient: activity.target_account).follow_request(notification_for(activity))
+    NotificationMailer
+      .with(recipient: activity.target_account, notification: notification_for(activity))
+      .follow_request
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/favourite
   def favourite
     activity = Favourite.last
-    NotificationMailer.with(recipient: activity.status.account).favourite(notification_for(activity))
+    NotificationMailer
+      .with(recipient: activity.status.account, notification: notification_for(activity))
+      .favourite
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/reblog
   def reblog
     activity = Status.where.not(reblog_of_id: nil).first
-    NotificationMailer.with(recipient: activity.reblog.account).reblog(notification_for(activity))
+    NotificationMailer
+      .with(recipient: activity.reblog.account, notification: notification_for(activity))
+      .reblog
   end
 
   def notification_for(activity)

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -6,44 +6,39 @@ class NotificationMailerPreview < ActionMailer::Preview
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/mention
   def mention
     activity = Mention.last
-    NotificationMailer
-      .with(recipient: activity.account, notification: notification_for(activity))
-      .mention
+    mailer_for(activity.account, activity).mention
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/follow
   def follow
     activity = Follow.last
-    NotificationMailer
-      .with(recipient: activity.target_account, notification: notification_for(activity))
-      .follow
+    mailer_for(activity.target_account, activity).follow
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/follow_request
   def follow_request
     activity = Follow.last
-    NotificationMailer
-      .with(recipient: activity.target_account, notification: notification_for(activity))
-      .follow_request
+    mailer_for(activity.target_account, activity).follow_request
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/favourite
   def favourite
     activity = Favourite.last
-    NotificationMailer
-      .with(recipient: activity.status.account, notification: notification_for(activity))
-      .favourite
+    mailer_for(activity.status.account, activity).favourite
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/reblog
   def reblog
     activity = Status.where.not(reblog_of_id: nil).first
-    NotificationMailer
-      .with(recipient: activity.reblog.account, notification: notification_for(activity))
-      .reblog
+    mailer_for(activity.reblog.account, activity).reblog
   end
 
-  def notification_for(activity)
-    Notification.find_by(activity: activity)
+  private
+
+  def mailer_for(account, activity)
+    NotificationMailer.with(
+      recipient: account,
+      notification: Notification.find_by(activity: activity)
+    )
   end
 end

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -5,31 +5,35 @@
 class NotificationMailerPreview < ActionMailer::Preview
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/mention
   def mention
-    m = Mention.last
-    NotificationMailer.with(recipient: m.account).mention(Notification.find_by(activity: m))
+    activity = Mention.last
+    NotificationMailer.with(recipient: activity.account).mention(notification_for(activity))
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/follow
   def follow
-    f = Follow.last
-    NotificationMailer.with(recipient: m.target_account).follow(Notification.find_by(activity: f))
+    activity = Follow.last
+    NotificationMailer.with(recipient: activity.target_account).follow(notification_for(activity))
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/follow_request
   def follow_request
-    f = Follow.last
-    NotificationMailer.with(recipient: f.target_account).follow_request(Notification.find_by(activity: f))
+    activity = Follow.last
+    NotificationMailer.with(recipient: activity.target_account).follow_request(notification_for(activity))
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/favourite
   def favourite
-    f = Favourite.last
-    NotificationMailer.with(recipient: f.status.account).favourite(Notification.find_by(activity: f))
+    activity = Favourite.last
+    NotificationMailer.with(recipient: activity.status.account).favourite(notification_for(activity))
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/reblog
   def reblog
-    r = Status.where.not(reblog_of_id: nil).first
-    NotificationMailer.with(recipient: r.reblog.account).reblog(Notification.find_by(activity: r))
+    activity = Status.where.not(reblog_of_id: nil).first
+    NotificationMailer.with(recipient: activity.reblog.account).reblog(notification_for(activity))
+  end
+
+  def notification_for(activity)
+    Notification.find_by(activity: activity)
   end
 end

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -6,30 +6,30 @@ class NotificationMailerPreview < ActionMailer::Preview
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/mention
   def mention
     m = Mention.last
-    NotificationMailer.mention(m.account, Notification.find_by(activity: m))
+    NotificationMailer.with(recipient: m.account).mention(Notification.find_by(activity: m))
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/follow
   def follow
     f = Follow.last
-    NotificationMailer.follow(f.target_account, Notification.find_by(activity: f))
+    NotificationMailer.with(recipient: m.target_account).follow(Notification.find_by(activity: f))
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/follow_request
   def follow_request
     f = Follow.last
-    NotificationMailer.follow_request(f.target_account, Notification.find_by(activity: f))
+    NotificationMailer.with(recipient: f.target_account).follow_request(Notification.find_by(activity: f))
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/favourite
   def favourite
     f = Favourite.last
-    NotificationMailer.favourite(f.status.account, Notification.find_by(activity: f))
+    NotificationMailer.with(recipient: f.status.account).favourite(Notification.find_by(activity: f))
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/reblog
   def reblog
     r = Status.where.not(reblog_of_id: nil).first
-    NotificationMailer.reblog(r.reblog.account, Notification.find_by(activity: r))
+    NotificationMailer.with(recipient: r.reblog.account).reblog(Notification.find_by(activity: r))
   end
 end


### PR DESCRIPTION
These methods were all pretty similar with a lot of common setup, so I extracted that into a parameterized setup using `with` when the mailer is called and `before_action`s in the mailer to set i-vars.

Also did some readability refactor in the spec and preview while in there.

If diff seems excessive - going one commit at a time is probably more sensical.

I think the Admin and User mailers both have similar opportunity and will do those after this if merged.