### PR TITLE
Remove unused `NotificationMailer#digest` preview

### DIFF
--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -32,9 +32,4 @@ class NotificationMailerPreview < ActionMailer::Preview
     r = Status.where.not(reblog_of_id: nil).first
     NotificationMailer.reblog(r.reblog.account, Notification.find_by(activity: r))
   end
-
-  # Preview this email at http://localhost:3000/rails/mailers/notification_mailer/digest
-  def digest
-    NotificationMailer.digest(Account.first, since: 90.days.ago)
-  end
 end


### PR DESCRIPTION
Mailer method was removed here 0b3e4fd5de392969b624719b2eb3f86277b6ac1f but preview wasn't removed.