### PR TITLE
Use large runners for docker and dont build on each push on main

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,8 +2,6 @@ name: Build container image
 on:
   workflow_dispatch:
   push:
-    branches:
-      - 'main'
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build-image:
-    runs-on: ubuntu-latest
+    runs-on: docker-builder
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -37,6 +37,7 @@ jobs:
             latest=auto
           tags: |
             type=raw,value=nightly
+            type=raw,value=edge
             type=schedule,pattern=nightly-{{date 'YYYY-MM-DD' tz='Etc/UTC'}}
           labels: |
             org.opencontainers.image.description=Nightly build image used for testing purposes

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build-nightly-image:
-    runs-on: ubuntu-latest
+    runs-on: docker-builder
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This should speed up Docker image builds.

Also I removed the docker image build for merges on main, we are building a new image daily and it should be enough, rather than wasting time and resources building one for each merge.

The nightly build also gets the edge tag, so people using this tag will still get updated.