### PR TITLE
Load `rspec-rails` gem in `test` + `development`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,9 +99,6 @@ gem 'rdf-normalize', '~> 0.5'
 gem 'private_address_check', '~> 0.5'
 
 group :test do
-  # RSpec runner for rails
-  gem 'rspec-rails', '~> 6.0'
-
   # Used to split testing into chunks in CI
   gem 'rspec_chunked', '~> 0.6'
 
@@ -177,6 +174,11 @@ group :development do
   # Profiling tools
   gem 'memory_profiler', require: false
   gem 'stackprof', require: false
+end
+
+group :development, :test do
+  # RSpec runner for rails
+  gem 'rspec-rails', '~> 6.0'
 end
 
 group :production do


### PR DESCRIPTION
The rails mailer previews only run in development mode, and they default to looking in `test/mailers/previews` as a load path for previews.

The `rspec-rails` gem sets the path to `spec/mailers/previews`, but was only being loaded in the test environment.

This change makes it so that `rspec-rails` is loaded in both test and development environments, and thus sets the preview load path correctly in the development environment.