### PR TITLE
Add `authorized_fetch` server setting in addition to env var

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   include CacheConcern
   include DomainControlHelper
   include DatabaseHelper
+  include AuthorizedFetchHelper
 
   helper_method :current_account
   helper_method :current_session
@@ -50,10 +51,6 @@ class ApplicationController < ActionController::Base
   end
 
   private
-
-  def authorized_fetch_mode?
-    ENV['AUTHORIZED_FETCH'] == 'true' || Rails.configuration.x.limited_federation_mode
-  end
 
   def public_fetch_mode?
     !authorized_fetch_mode?

--- a/app/helpers/authorized_fetch_helper.rb
+++ b/app/helpers/authorized_fetch_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AuthorizedFetchHelper
+  def authorized_fetch_mode?
+    ENV.fetch('AUTHORIZED_FETCH') { Setting.authorized_fetch } == 'true' || Rails.configuration.x.limited_federation_mode
+  end
+
+  def authorized_fetch_overridden?
+    ENV.key?('AUTHORIZED_FETCH') || Rails.configuration.x.limited_federation_mode
+  end
+end

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -188,6 +188,7 @@
 }
 
 .information-badge,
+.simple_form .overridden,
 .simple_form .recommended,
 .simple_form .not_recommended {
   display: inline-block;
@@ -204,6 +205,7 @@
 }
 
 .information-badge,
+.simple_form .overridden,
 .simple_form .recommended,
 .simple_form .not_recommended {
   background-color: rgba($ui-secondary-color, 0.1);

--- a/app/javascript/styles/mastodon/forms.scss
+++ b/app/javascript/styles/mastodon/forms.scss
@@ -103,6 +103,7 @@ code {
         }
       }
 
+      .overridden,
       .recommended,
       .not_recommended {
         position: absolute;

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -3,6 +3,8 @@
 class Form::AdminSettings
   include ActiveModel::Model
 
+  include AuthorizedFetchHelper
+
   KEYS = %i(
     site_contact_username
     site_contact_email
@@ -34,6 +36,7 @@ class Form::AdminSettings
     backups_retention_period
     status_page_url
     captcha_enabled
+    authorized_fetch
   ).freeze
 
   INTEGER_KEYS = %i(
@@ -54,12 +57,17 @@ class Form::AdminSettings
     noindex
     require_invite_text
     captcha_enabled
+    authorized_fetch
   ).freeze
 
   UPLOAD_KEYS = %i(
     thumbnail
     mascot
   ).freeze
+
+  OVERRIDEN_SETTINGS = {
+    authorized_fetch: :authorized_fetch_mode?,
+  }.freeze
 
   attr_accessor(*KEYS)
 
@@ -80,6 +88,8 @@ class Form::AdminSettings
 
       stored_value = if UPLOAD_KEYS.include?(key)
                        SiteUpload.where(var: key).first_or_initialize(var: key)
+                     elsif OVERRIDEN_SETTINGS.include?(key)
+                       public_send(OVERRIDEN_SETTINGS[key])
                      else
                        Setting.public_send(key)
                      end

--- a/app/services/concerns/payloadable.rb
+++ b/app/services/concerns/payloadable.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Payloadable
+  include AuthorizedFetchHelper
+
   # @param [ActiveModelSerializers::Model] record
   # @param [ActiveModelSerializers::Serializer] serializer
   # @param [Hash] options
@@ -23,6 +25,6 @@ module Payloadable
   end
 
   def signing_enabled?
-    ENV['AUTHORIZED_FETCH'] != 'true' && !Rails.configuration.x.limited_federation_mode
+    !authorized_fetch_mode?
   end
 end

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -39,6 +39,11 @@
   .fields-group
     = f.input :peers_api_enabled, as: :boolean, wrapper: :with_label, recommended: :recommended
 
+  %h4= t('admin.settings.security.federation_authentication')
+
+  .fields-group
+    = f.input :authorized_fetch, as: :boolean, wrapper: :with_label, label: t('admin.settings.security.authorized_fetch'), warning_hint: authorized_fetch_overridden? ? t('admin.settings.security.authorized_fetch_overridden_hint') : nil, hint: t('admin.settings.security.authorized_fetch_hint'), disabled: authorized_fetch_overridden?
+
   %h4= t('admin.settings.discovery.follow_recommendations')
 
   .fields-group

--- a/app/views/admin/settings/discovery/show.html.haml
+++ b/app/views/admin/settings/discovery/show.html.haml
@@ -42,7 +42,7 @@
   %h4= t('admin.settings.security.federation_authentication')
 
   .fields-group
-    = f.input :authorized_fetch, as: :boolean, wrapper: :with_label, label: t('admin.settings.security.authorized_fetch'), warning_hint: authorized_fetch_overridden? ? t('admin.settings.security.authorized_fetch_overridden_hint') : nil, hint: t('admin.settings.security.authorized_fetch_hint'), disabled: authorized_fetch_overridden?
+    = f.input :authorized_fetch, as: :boolean, wrapper: :with_label, label: t('admin.settings.security.authorized_fetch'), warning_hint: authorized_fetch_overridden? ? t('admin.settings.security.authorized_fetch_overridden_hint') : nil, hint: t('admin.settings.security.authorized_fetch_hint'), disabled: authorized_fetch_overridden?, recommended: authorized_fetch_overridden? ? :overridden : nil
 
   %h4= t('admin.settings.discovery.follow_recommendations')
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -50,7 +50,7 @@ ignore_unused:
   - 'activerecord.errors.*'
   - '{devise,pagination,doorkeeper}.*'
   - '{date,datetime,time,number}.*'
-  - 'simple_form.{yes,no,recommended,not_recommended}'
+  - 'simple_form.{yes,no,recommended,not_recommended,overridden}'
   - 'simple_form.{placeholders,hints,labels}.*'
   - 'simple_form.{error_notification,required}.:'
   - 'errors.messages.*'

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -97,7 +97,8 @@ SimpleForm.setup do |config|
       end
     end
 
-    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :warning_hint, wrap_with: { tag: :span, class: [:hint, 'warning-hint'] }
+    b.use :hint, wrap_with: { tag: :span, class: :hint }
     b.use :error, wrap_with: { tag: :span, class: :error }
   end
 
@@ -111,8 +112,8 @@ SimpleForm.setup do |config|
   config.wrappers :with_block_label, class: [:input, :with_block_label], hint_class: :field_with_hint, error_class: :field_with_errors do |b|
     b.use :html5
     b.use :label
-    b.use :hint, wrap_with: { tag: :span, class: :hint }
     b.use :warning_hint, wrap_with: { tag: :span, class: [:hint, 'warning-hint'] }
+    b.use :hint, wrap_with: { tag: :span, class: :hint }
     b.use :input, wrap_with: { tag: :div, class: :label_input }
     b.use :error, wrap_with: { tag: :span, class: :error }
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -770,6 +770,11 @@ en:
           approved: Approval required for sign up
           none: Nobody can sign up
           open: Anyone can sign up
+      security:
+        authorized_fetch: Require authentication from federated servers
+        authorized_fetch_hint: Requiring authentication from federated servers enables stricter enforcement of both user-level and server-level blocks. However, this comes at the cost of a performance penalty, reduces the reach of your replies, and may introduce compatibility issues with some federated services. In addition, this will not prevent dedicated actors from fetching your public posts and accounts.
+        authorized_fetch_overridden_hint: You are currently unable to change this setting because it is overridden by an environment variable.
+        federation_authentication: Federation authentication enforcement
       title: Server settings
     site_uploads:
       delete: Delete uploaded file

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -317,6 +317,7 @@ en:
         url: Endpoint URL
     'no': 'No'
     not_recommended: Not recommended
+    overridden: Overridden
     recommended: Recommended
     required:
       mark: "*"


### PR DESCRIPTION
The environment variable is still usable and overrides the setting.

There are two reasons this does not completely replace the environment variable:
- using an environment variable saves the cost of doing a Redis call on every page hit
- a migration path from environment variable to setting is not an obvious thing to do

This is primarily meant to hosted server administrators who cannot easily set env variables.

![image](https://github.com/mastodon/mastodon/assets/384364/481a5bc6-5104-4220-833f-a78707b611fe)
![image](https://github.com/mastodon/mastodon/assets/384364/31af79fa-3a77-4729-a072-8436808ca6dc)
