### PR TITLE
Tag images with the latest tag only when running against the latest stable branch

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -49,8 +49,10 @@ jobs:
           images: |
             tootsuite/mastodon
             ghcr.io/mastodon/mastodon
+          # Only tag with latest when ran against the latest stable branch
+          # This needs to be updated after each minor version release
           flavor: |
-            latest=auto
+            latest=${{ startsWith(github.ref, 'refs/tags/v4.1.') && 'auto' || 'false' }}
           tags: |
             type=edge,branch=main
             type=pep440,pattern={{raw}}


### PR DESCRIPTION
Fixes #25765