### PR TITLE
Fix translate button position

### DIFF
--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -44,7 +44,7 @@ class TranslateButton extends PureComponent {
     }
 
     return (
-      <button className='status__content__read-more-button' onClick={onClick}>
+      <button className='status__content__translate-button' onClick={onClick}>
         <FormattedMessage id='status.translate' defaultMessage='Translate' />
       </button>
     );

--- a/app/javascript/styles/contrast/diff.scss
+++ b/app/javascript/styles/contrast/diff.scss
@@ -15,7 +15,8 @@
 .status__content a,
 .link-footer a,
 .reply-indicator__content a,
-.status__content__read-more-button {
+.status__content__read-more-button,
+.status__content__translate-button {
   text-decoration: underline;
 
   &:hover,

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -981,7 +981,8 @@ body > [data-popper-placement] {
   max-height: 22px * 15; // 15 lines is roughly above 500 characters
 }
 
-.status__content__read-more-button {
+.status__content__read-more-button,
+.status__content__translate-button {
   display: block;
   font-size: 15px;
   line-height: 22px;


### PR DESCRIPTION
Regression from #25706

The "Read more" and "Translate" buttons are not in the same place in the DOM.

I added a specific class for the Translate button, then added it where the Read More button was targeted, except on what was added by the mentioned PR as it was incorrect.