### PR TITLE
Refactor Dockerfile and speed up build times via buildkit caches and layers

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: hadolint/hadolint-action@v3.1.0
+      # - uses: hadolint/hadolint-action@v3.1.0
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         id: buildx

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -45,15 +45,7 @@ jobs:
       - uses: docker/metadata-action@v4
         id: meta
         with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=auto
-          tags: |
-            type=edge,branch=main
-            type=pep440,pattern={{raw}}
-            type=pep440,pattern=v{{major}}.{{minor}}
-            type=ref,event=pr
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Generate version suffix
         id: version_vars
@@ -64,7 +56,6 @@ jobs:
       - uses: docker/build-push-action@v4
         with:
           context: .
-          build-args: MASTODON_VERSION_SUFFIX=${{ steps.version_vars.outputs.mastodon_version_suffix }}
           platforms: linux/amd64,linux/arm64
           provenance: false
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build-image:
-    runs-on: macos-13
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      # - uses: hadolint/hadolint-action@v3.1.0
+      - uses: hadolint/hadolint-action@v3.1.0
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
         id: buildx

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'speed-up-docker-build'
     tags:
       - '*'
   pull_request:
@@ -23,6 +24,10 @@ env:
 jobs:
   build-image:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,4 +1,5 @@
 name: Build container image
+
 on:
   workflow_dispatch:
   push:
@@ -15,6 +16,10 @@ permissions:
   contents: read
   packages: write
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   build-image:
     runs-on: ubuntu-latest
@@ -28,28 +33,20 @@ jobs:
       - uses: hadolint/hadolint-action@v3.1.0
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: github.repository == 'mastodon/mastodon' && github.event_name != 'pull_request'
+        id: buildx
 
       - name: Log in to the Github Container registry
         uses: docker/login-action@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-        if: github.repository == 'mastodon/mastodon' && github.event_name != 'pull_request'
 
       - uses: docker/metadata-action@v4
         id: meta
         with:
           images: |
-            tootsuite/mastodon
-            ghcr.io/mastodon/mastodon
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=auto
           tags: |
@@ -71,7 +68,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           provenance: false
           builder: ${{ steps.buildx.outputs.name }}
-          push: ${{ github.repository == 'mastodon/mastodon' && github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -23,15 +23,15 @@ env:
 
 jobs:
   build-image:
-    runs-on: ubuntu-latest
+    runs-on: macos-13
 
     permissions:
       contents: read
       packages: write
 
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+    # concurrency:
+    #   group: ${{ github.workflow }}-${{ github.ref }}
+    #   cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - .github/workflows/build-image.yml
       - Dockerfile
+
 permissions:
   contents: read
   packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ FROM base-layer AS build-layer
 # See: https://github.com/hadolint/hadolint/wiki/DL3008
 # hadolint ignore=DL3008,DL3009
 RUN \
-  --mount=type=cache,target=/var/cache/apt,id=build-apt-cache-${TARGETPLATFORM} \
+  # --mount=type=cache,target=/var/cache/apt,id=build-apt-cache-${TARGETPLATFORM} \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     build-essential \
@@ -161,7 +161,7 @@ FROM build-layer AS bundle-install
 # even though the "parsed" content is the same, and makes the file read-only and immutable
 # inside the build step, preventing "quiet" changes to the files
 RUN \
-  --mount=type=cache,target=/opt/mastodon/vendor/cache,id=bundle-cache-${TARGETPLATFORM} \
+  # --mount=type=cache,target=/opt/mastodon/vendor/cache,id=bundle-cache-${TARGETPLATFORM} \
   --mount=type=bind,source=Gemfile,target=Gemfile \
   --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
   bundle config set --local without 'development test' && \
@@ -170,7 +170,7 @@ RUN \
 
 # Install gems from the cache above
 RUN \
-  --mount=type=cache,target=/opt/mastodon/vendor/cache,id=bundle-cache-${TARGETPLATFORM} \
+  # --mount=type=cache,target=/opt/mastodon/vendor/cache,id=bundle-cache-${TARGETPLATFORM} \
   --mount=type=bind,source=Gemfile,target=Gemfile \
   --mount=type=bind,source=Gemfile.lock,target=Gemfile.lock \
   bundle config set --local deployment 'true' && \
@@ -191,7 +191,7 @@ ENV YARN_CACHE_FOLDER=/opt/mastodon/cache/.yarn
 # even though the "parsed" content is the same, and makes the file read-only and immutable
 # inside the build step, preventing "quiet" changes to the files
 RUN \
-  --mount=type=cache,target=/opt/mastodon/cache/.yarn,id=yarn-cache-${TARGETPLATFORM} \
+  # --mount=type=cache,target=/opt/mastodon/cache/.yarn,id=yarn-cache-${TARGETPLATFORM} \
   --mount=type=bind,source=package.json,target=package.json \
   --mount=type=bind,source=yarn.lock,target=yarn.lock \
   yarn install --pure-lockfile --production --network-timeout 600000
@@ -204,7 +204,7 @@ FROM base-layer AS runtime-layer
 
 # hadolint ignore=DL3008,DL3009
 RUN \
-  --mount=type=cache,target=/var/cache/apt,id=runtime-apt-cache-${TARGETPLATFORM} \
+  # --mount=type=cache,target=/var/cache/apt,id=runtime-apt-cache-${TARGETPLATFORM} \
   apt-get update && \
   apt-get -y --no-install-recommends install \
     ca-certificates \
@@ -249,7 +249,7 @@ COPY --chown=mastodon:mastodon --from=yarn-install /opt/mastodon /opt/mastodon
 FROM --platform=$BUILDPLATFORM runtime-layer AS assets-precompile
 
 RUN \
-  --mount=type=cache,target=/opt/mastodon/tmp/cache,uid=${UID},gid=${GID},id=assets-cache-${BUILDPLATFORM},sharing=locked \
+  # --mount=type=cache,target=/opt/mastodon/tmp/cache,uid=${UID},gid=${GID},id=assets-cache-${BUILDPLATFORM},sharing=locked \
   OTP_SECRET=precompile_placeholder \
   SECRET_KEY_BASE=precompile_placeholder \
   rails assets:precompile

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,9 @@ FROM shared-build-layer AS bundle-install
 
 # Download and cache gems without "installing" them
 #
-# Note: Instead of copying Gemfile and Gemfile.lock, we bind them to the container at build time
+# By splitting "cache" from "install" we can avoid [Could not find $GEM_NAME in cached gems or installed locally]
+#
+# NOTE: Instead of copying Gemfile and Gemfile.lock, we bind them to the container at build time
 # this avoids the issue of the files "changing" (e.g. a newline) invalidating the cache,
 # even though the "parsed" content is the same, and makes the file read-only and immutable
 # inside the build step, preventing "quiet" changes to the files

--- a/Dockerfile
+++ b/Dockerfile
@@ -242,11 +242,8 @@ COPY --chown=mastodon:mastodon --from=yarn-install /opt/mastodon /opt/mastodon
 ##########################################################################################
 # Assets layer
 ##########################################################################################
-#
-# NOTE: We force the platform to be the "native" build platform (e.g. linux/amd64 in GitHub Actions)
-# for this step, since web assets don't depend on "server-side" CPU architectures, and being able
-# to skip CPU emulation will significantly speed things up
-FROM --platform=$BUILDPLATFORM runtime-layer AS assets-precompile
+
+FROM runtime-layer AS assets-precompile
 
 RUN \
   # --mount=type=cache,target=/opt/mastodon/tmp/cache,uid=${UID},gid=${GID},id=assets-cache-${BUILDPLATFORM},sharing=locked \

--- a/Dockerfile
+++ b/Dockerfile
@@ -239,12 +239,15 @@ COPY --chown=mastodon:mastodon --from=yarn-install /opt/mastodon /opt/mastodon
 ##########################################################################################
 # Final layer
 ##########################################################################################
-
+#
+# NOTE: We force the platform to be the "native" build platform (e.g. linux/amd64 in GitHub Actions)
+# for this step, since web assets don't depend on "server-side" CPU architectures, and being able
+# to skip CPU emulation will significantly speed things up
 FROM --platform=$BUILDPLATFORM runtime-layer
 
 # Precompile assets
 RUN \
-  --mount=type=cache,target=/opt/mastodon/tmp/cache,uid=${UID},gid=${GID},id=assets-cache-${TARGETPLATFORM} \
+  --mount=type=cache,target=/opt/mastodon/tmp/cache,uid=${UID},gid=${GID},id=assets-cache-${BUILDPLATFORM},sharing=locked \
   OTP_SECRET=precompile_placeholder \
   SECRET_KEY_BASE=precompile_placeholder \
   rails assets:precompile

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ ARG NODE_VERSION="16.20-bullseye-slim"
 # See: https://github.com/moritzheiber/ruby-jemalloc-docker/pkgs/container/ruby-jemalloc
 ARG RUBY_VERSION="3.2.2-slim"
 
+ARG TARGETPLATFORM="${TARGETPLATFORM}"
+ARG BUILDPLATFORM="${BUILDPLATFORM}"
+
 ##########################################################################################
 # Ruby image, referenced here for easier alias (ruby-layer) reference later
 ##########################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -230,7 +230,7 @@ COPY --chown=mastodon:mastodon --from=yarn-install /opt/mastodon /opt/mastodon
 # Final layer
 ##########################################################################################
 
-FROM --platform=amd64 runtime-layer
+FROM --platform=$BUILDPLATFORM runtime-layer
 
 # Precompile assets
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -260,7 +260,7 @@ RUN \
 
 FROM runtime-layer
 
-COPY --chown=mastodon:mastodon --from=assets-precompile /opt/mastodon /opt/mastodon
+COPY --chown=mastodon:mastodon --from=assets-precompile /opt/mastodon/public /opt/mastodon/public
 
 # Set the work dir and the container entry point
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,16 @@ FROM ghcr.io/moritzheiber/ruby-jemalloc:${RUBY_VERSION} AS ruby-layer
 
 FROM node:${NODE_VERSION} AS base-layer
 
+# Make sure multiarch TARGETPLATFORM is available for interpolation
+#
+# See: https://docs.docker.com/build/building/multi-platform/
+ARG TARGETPLATFORM
+
+# See: https://docs.docker.com/build/building/multi-platform/
+#
+# Make sure multiarch BUILDPLATFORM is available for interpolation
+ARG BUILDPLATFORM
+
 # Linux UID (user id) for the mastodon user, change with [--build-arg UID=1234]
 ARG UID="991"
 
@@ -191,7 +201,7 @@ FROM base-layer AS runtime-layer
 
 # hadolint ignore=DL3008,DL3009
 RUN \
-  --mount=type=cache,target=/var/cache/apt,id=runtime-apt-cache-${TARGETPLATFORM},sharing=locked \
+  --mount=type=cache,target=/var/cache/apt,id=runtime-apt-cache-${TARGETPLATFORM} \
   apt-get update && \
   apt-get -y --no-install-recommends install \
     ca-certificates \

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -132,3 +132,5 @@ Rails.application.configure do
 
   config.x.otp_secret = ENV.fetch('OTP_SECRET')
 end
+
+# some silly file change in ruby


### PR DESCRIPTION
👋 Hello!

## Context

I noticed that in both the mastodon/mastodon and glitch-soc fork that builds can sometimes take hours, usually spending hours of time on work that could be effectively cached.

Since I work with CI/CD and have spent way too many cycles of my life in `Dockerfile` optimizations, I thought I would give it a shot on improving it for Mastodon, since it would make my own Mastodon server build times faster too 🎉  win/win.

I'm by no means a Ruby on Rails or `bundle` expert, so might not have aced the usage entirely (I did learn a bit from external resources on how to achieve the caching outcome though). 

## Changes

I fully recognize (and apologize for) the diff being very hard to read, given the amount of changes, so will do my best to outline changes at a high level here.

### Caching 

* Utilize the `RUN --mount=type=cache` to cache `apt-get update` and `apt-get install` operations
* Utilize the `RUN --mount=type=cache` to cache `bundle install` 
* Utilize the `RUN --mount=type=cache` to cache `yarn install` 
* Ensure apt caches aren't automatically cleaned by removing the apt script from the `base` layer

### Other

* Configure TimeZone via `TZ` (can have huge positive impact on performance!)
* Sorted packages alphabetically so it's easier to scan
* Slightly reformatted some Dockerfile statements to be easier to scan
* Expose some additional `ENV` as `ARG` for on-demand changing (useful during testing)
* Restructured the layers into multiple specific ones (e.g. `bundle` and `yarn`). The layering allow each to run in parallel rather than sequential
* Added comments to most statements in the `Dockerfile` with external references (docs) and reason for the statement to be there (hopefully useful for future maintainers) 

## Docker image sizes

This is the output of `docker build .` from (1) this PR (2) main and (3) DockerHub pull

```
jippi/mastodon              latest    b41bea14ec78   32 seconds ago      1.18GB
jippi/mastodon-main         latest    edfb04bd73e9   34 minutes ago      1.22GB
ghcr.io/mastodon/mastodon   latest    97e47539355f   28 hours ago        1.42GB
```

## Docker build times

Measured on an M1 Pro w/ 16GB RAM

```
this branch with no caches: 158.6s
this branch with no bundle caches, warm yarn: 104.2s
this branch with hot caches: 2.9s
```