### PR TITLE
Fixes `latest` Docker tag

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -52,7 +52,7 @@ jobs:
           # Only tag with latest when ran against the latest stable branch
           # This needs to be updated after each minor version release
           flavor: |
-            latest=${{ startsWith(github.ref, 'refs/tags/v4.1.') && 'auto' || 'false' }}
+            latest=${{ startsWith(github.ref, 'refs/tags/v4.1.') }}
           tags: |
             type=edge,branch=main
             type=pep440,pattern={{raw}}


### PR DESCRIPTION
#25803 was incorrect

Fixes #25765

This comes from https://github.com/docker/metadata-action/issues/80#issuecomment-838764150