### PR TITLE
change button colors to improve contrast for accessibility

### DIFF
--- a/app/javascript/styles/mastodon/variables.scss
+++ b/app/javascript/styles/mastodon/variables.scss
@@ -3,6 +3,8 @@ $black: #000000; // Black
 $white: #ffffff; // White
 $red-600: #b7253d !default; // Deep Carmine
 $red-500: #df405a !default; // Cerise
+$blurple-900: #2f0c7a; // Persian Indigo
+$blurple-700: #4323a3; // Tekhelet
 $blurple-600: #563acc; // Iris
 $blurple-500: #6364ff; // Brand purple
 $blurple-300: #858afa; // Faded Blue
@@ -40,8 +42,8 @@ $ui-primary-color: $classic-primary-color !default; // Lighter
 $ui-secondary-color: $classic-secondary-color !default; // Lightest
 $ui-highlight-color: $classic-highlight-color !default;
 $ui-button-color: $white !default;
-$ui-button-background-color: $blurple-500 !default;
-$ui-button-focus-background-color: $blurple-600 !default;
+$ui-button-background-color: $blurple-600 !default;
+$ui-button-focus-background-color: $blurple-700 !default;
 
 $ui-button-secondary-color: $grey-100 !default;
 $ui-button-secondary-border-color: $grey-100 !default;
@@ -50,7 +52,7 @@ $ui-button-secondary-focus-color: $white !default;
 
 $ui-button-tertiary-color: $blurple-300 !default;
 $ui-button-tertiary-border-color: $blurple-300 !default;
-$ui-button-tertiary-focus-background-color: $blurple-600 !default;
+$ui-button-tertiary-focus-background-color: $blurple-700 !default;
 $ui-button-tertiary-focus-color: $white !default;
 
 $ui-button-destructive-background-color: $red-500 !default;


### PR DESCRIPTION
resolves #25722 

### Improve button contrast for accessibility
I bumped button colors down to a darker blurple #563acc. I felt burple-900 was a bit dark for a hover effect so I added blurple-700.

<img width="676" alt="CleanShot 2023-07-08 at 10 21 57@2x" src="https://github.com/mastodon/mastodon/assets/17292/4fd608aa-9bb5-4ca1-8725-bbdc46fcb620">
<img width="664" alt="CleanShot 2023-07-08 at 10 22 06@2x" src="https://github.com/mastodon/mastodon/assets/17292/680aa6df-1faa-4b02-b864-a4b2afc48bb7">
<img width="950" alt="CleanShot 2023-07-08 at 13 26 35@2x" src="https://github.com/mastodon/mastodon/assets/17292/e9a74e21-3d40-43f5-9fe0-946f2d9467ed">
