### PR TITLE
WIP: Dockerfile: add an arch-independent build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,131 @@
 # syntax=docker/dockerfile:1.4
 # This needs to be bullseye-slim because the Ruby image is built on bullseye-slim
 ARG NODE_VERSION="16.20-bullseye-slim"
+ARG RUBY_JEMALLOC="ghcr.io/moritzheiber/ruby-jemalloc:3.2.2-slim"
 
-FROM ghcr.io/moritzheiber/ruby-jemalloc:3.2.2-slim as ruby
-FROM node:${NODE_VERSION} as build
+# builder-native is a stage that builds npm packages and precompiles assets in the native arch of the builder.
+# This allows said CPU-intensive task to run 10x faster than it would under an emulated architecture.
+# Outputs of this stage are arch-independent and thus copied over by the arch-dependent stages.
+FROM --platform=$BUILDPLATFORM $RUBY_JEMALLOC as ruby-native
+FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} as builder-native
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY --link --from=ruby-native /opt/ruby /opt/ruby
+
+ENV DEBIAN_FRONTEND="noninteractive" \
+    PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
+
+# TODO: Unclear which of the following env vars are needed for build and which ones are needed for dist.
+# Use those args to specify your own version flags & suffixes
+ARG MASTODON_VERSION_FLAGS=""
+ARG MASTODON_VERSION_SUFFIX=""
+
+ENV RAILS_ENV="production" \
+    NODE_ENV="production" \
+    RAILS_SERVE_STATIC_FILES="true" \
+    BIND="0.0.0.0" \
+    MASTODON_VERSION_FLAGS="${MASTODON_VERSION_FLAGS}" \
+    MASTODON_VERSION_SUFFIX="${MASTODON_VERSION_SUFFIX}"
+
+ARG UID="991"
+ARG GID="991"
+RUN groupadd -g "${GID}" mastodon && \
+    useradd -l -u "$UID" -g "${GID}" -m -d /opt/mastodon mastodon
+WORKDIR /opt/mastodon
+
+# TODO: Clarify which of these are runtime deps, as they can be removed form this step.
+# Ignoring these here since we don't want to pin any versions and the Debian image removes apt-get content after use
+# hadolint ignore=DL3008,DL3009
+RUN echo "Etc/UTC" > /etc/localtime && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install \
+        build-essential \
+        ca-certificates \
+        ffmpeg \
+        file \
+        git \
+        imagemagick \
+        libgdbm-dev \
+        libgmp-dev \
+        libicu67 \
+        libicu-dev \
+        libidn11 \
+        libidn11-dev \
+        libjemalloc2 \
+        libjemalloc-dev \
+        libpq5 \
+        libpq-dev \
+        libreadline8 \
+        libssl1.1 \
+        libssl-dev \
+        libyaml-0-2 \
+        procps \
+        python3 \
+        tzdata \
+        wget \
+        whois \
+        zlib1g-dev \
+        shared-mime-info
+
+USER mastodon
+
+# Instal NPM deps in native arch.
+COPY package.json yarn.lock /opt/mastodon/
+
+RUN yarn install --pure-lockfile --production --network-timeout 600000 && \
+    yarn cache clean
+
+# Build ruby packages and assets in native arch.
+# Ruby packages will need to be re-built in emulated arches, but assets will be reused from this stage.
+COPY --chown=mastodon:mastodon . /opt/mastodon
+
+RUN bundle config set --local deployment 'true' && \
+    bundle config set --local without 'development test' && \
+    bundle config set silence_root_warning true && \
+    bundle install -j"$(nproc)"
+
+RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile
+
+
+# target contains the common steps for the arch-specific stages.
+FROM $RUBY_JEMALLOC as ruby
+FROM node:${NODE_VERSION} as target
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 COPY --link --from=ruby /opt/ruby /opt/ruby
 
 ENV DEBIAN_FRONTEND="noninteractive" \
-    PATH="${PATH}:/opt/ruby/bin"
+    PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# TODO: Unclear which of the following env vars are needed for build and which ones are needed for dist.
+# Use those args to specify your own version flags & suffixes
+ARG MASTODON_VERSION_FLAGS=""
+ARG MASTODON_VERSION_SUFFIX=""
 
+ENV RAILS_ENV="production" \
+    NODE_ENV="production" \
+    RAILS_SERVE_STATIC_FILES="true" \
+    BIND="0.0.0.0" \
+    MASTODON_VERSION_FLAGS="${MASTODON_VERSION_FLAGS}" \
+    MASTODON_VERSION_SUFFIX="${MASTODON_VERSION_SUFFIX}"
+
+ARG UID="991"
+ARG GID="991"
+RUN groupadd -g "${GID}" mastodon && \
+    useradd -l -u "$UID" -g "${GID}" -m -d /opt/mastodon mastodon
 WORKDIR /opt/mastodon
-COPY Gemfile* package.json yarn.lock /opt/mastodon/
 
-# hadolint ignore=DL3008
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends build-essential \
+# Builder is the arch-specific build stage.
+FROM target as builder
+
+# Ignoring these here since we don't want to pin any versions and the Debian image removes apt-get content after use
+# hadolint ignore=DL3008,DL3009
+RUN echo "Etc/UTC" > /etc/localtime && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install \
+        build-essential \
         git \
         libicu-dev \
         libidn11-dev \
@@ -31,37 +139,27 @@ RUN apt-get update && \
         ca-certificates \
         libreadline8 \
         python3 \
-        shared-mime-info && \
-    bundle config set --local deployment 'true' && \
+        shared-mime-info
+
+USER mastodon
+
+COPY --chown=mastodon:mastodon . /opt/mastodon
+
+# Ruby installation is arch-dependent so unfortunately we need to run it again.
+RUN bundle config set --local deployment 'true' && \
     bundle config set --local without 'development test' && \
     bundle config set silence_root_warning true && \
-    bundle install -j"$(nproc)" && \
-    yarn install --pure-lockfile --production --network-timeout 600000 && \
-    yarn cache clean
+    bundle install -j"$(nproc)"
 
-FROM node:${NODE_VERSION}
-
-# Use those args to specify your own version flags & suffixes
-ARG MASTODON_VERSION_FLAGS=""
-ARG MASTODON_VERSION_SUFFIX=""
-
-ARG UID="991"
-ARG GID="991"
-
-COPY --link --from=ruby /opt/ruby /opt/ruby
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-ENV DEBIAN_FRONTEND="noninteractive" \
-    PATH="${PATH}:/opt/ruby/bin:/opt/mastodon/bin"
+# Finally, target installs runtime deps and copies outputs from the non-arch specific and the arch-specific stages.
+FROM target
 
 # Ignoring these here since we don't want to pin any versions and the Debian image removes apt-get content after use
 # hadolint ignore=DL3008,DL3009
-RUN apt-get update && \
-    echo "Etc/UTC" > /etc/localtime && \
-    groupadd -g "${GID}" mastodon && \
-    useradd -l -u "$UID" -g "${GID}" -m -d /opt/mastodon mastodon && \
-    apt-get -y --no-install-recommends install whois \
+RUN echo "Etc/UTC" > /etc/localtime && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install \
+        whois \
         wget \
         procps \
         libssl1.1 \
@@ -76,28 +174,10 @@ RUN apt-get update && \
         ca-certificates \
         tzdata \
         libreadline8 \
-        tini && \
-    ln -s /opt/mastodon /mastodon
+        tini
 
-# Note: no, cleaning here since Debian does this automatically
-# See the file /etc/apt/apt.conf.d/docker-clean within the Docker image's filesystem
-
-COPY --chown=mastodon:mastodon . /opt/mastodon
-COPY --chown=mastodon:mastodon --from=build /opt/mastodon /opt/mastodon
-
-ENV RAILS_ENV="production" \
-    NODE_ENV="production" \
-    RAILS_SERVE_STATIC_FILES="true" \
-    BIND="0.0.0.0" \
-    MASTODON_VERSION_FLAGS="${MASTODON_VERSION_FLAGS}" \
-    MASTODON_VERSION_SUFFIX="${MASTODON_VERSION_SUFFIX}"
-
-# Set the run user
-USER mastodon
-WORKDIR /opt/mastodon
-
-# Precompile assets
-RUN OTP_SECRET=precompile_placeholder SECRET_KEY_BASE=precompile_placeholder rails assets:precompile
+COPY --chown=mastodon:mastodon --from=builder-native /opt/mastodon /opt/mastodon
+COPY --chown=mastodon:mastodon --from=builder /opt/mastodon /opt/mastodon
 
 # Set the work dir and the container entry point
 ENTRYPOINT ["/usr/bin/tini", "--"]


### PR DESCRIPTION
This PR modifies the Dockerfile to, according to my tests, significantly speed up build times. On my workstation I measure:

On `main`:
```
$ docker buildx prune -a
$ time docker buildx build --platform=linux/arm64,linux/amd64 -t mastodon:main ./
docker buildx build --platform=linux/arm64,linux/amd64 -t mastodon:main ./  7.50s user 3.23s system 0% cpu 56:47.50 total
```


With this PR:
```
$ docker buildx prune -a
$ time docker buildx build --platform=linux/arm64,linux/amd64 -t mastodon:pr ./
docker buildx build --platform=linux/arm64,linux/amd64 -t mastodon:pr ./  3.60s user 1.54s system 0% cpu 11:50.26 total
```

Which is around a 5x time reduction.

## How it works

The biggest bottleneck of the build process is the `rails assets:precompile` command, which takes several thousand seconds to run for the arm architecture. The reason for this is that `buildx` runs all the commands specifies in the Dockerfile for foreing architectures in qemu. IO-bound commands are okay with this, but CPU-bound commands take a huge peformance hit.

A solution for this is using `FROM --platform=$BUILDPLATFORM`, which will cause buildx to, when building for foreing architectures, execute a build stage using the native arch instead of the emulated arch. The caveat is that `FROM --platform=$BUILDPLATFORM` can only be used from named tags, not from intermediate stages. This means that if we want to run `rails assets:precompile` in the native arch, the `RUN` directive that executes it must be on a stage that `FROM`s an upstream image, not another stage. My understanding is that `rails assets:precompile` needs to be run after `bundle install` (if this is _not_ the case LMK, it would greatly simplify this PR), so this PR has to duplicate the previous steps required to run `rails assets:precompile`.

For these reasons, the only way for this to work is to duplicate all the Dockerfile instructions that need to be performed before `rails assets:precompile` on a native stage.

## Remaining work

- [ ] TODOs in the code
- [ ] This Dockerfile will run some commands twice when building for a single arch, which is not great.
- [ ] Testing the arm64 image is actually valid

A debug build of the image can be found here: https://github.com/users/roobre/packages/container/package/mastodon-25829
