### PR TITLE
Add missing numeric value for "dislike" category

### DIFF
--- a/app/javascript/mastodon/features/notifications/components/report.jsx
+++ b/app/javascript/mastodon/features/notifications/components/report.jsx
@@ -15,6 +15,7 @@ const messages = defineMessages({
   spam: { id: 'report_notification.categories.spam', defaultMessage: 'Spam' },
   legal: { id: 'report_notification.categories.legal', defaultMessage: 'Legal' },
   violation: { id: 'report_notification.categories.violation', defaultMessage: 'Rule violation' },
+  dislike: { id: 'report_notification.categories.dislike', defaultMessage: 'Dislike' },
 });
 
 class Report extends ImmutablePureComponent {

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -54,7 +54,7 @@ class Report < ApplicationRecord
     spam: 1_000,
     legal: 1_500,
     violation: 2_000,
-    dislike: 3_000
+    dislike: 3_000,
   }
 
   before_validation :set_uri, only: :create

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -54,6 +54,7 @@ class Report < ApplicationRecord
     spam: 1_000,
     legal: 1_500,
     violation: 2_000,
+    dislike: 3_000
   }
 
   before_validation :set_uri, only: :create


### PR DESCRIPTION
**Note: This is marked as a draft now. I got told that the "I don't like this" category should not create reports at all on Mastodon. If this is true, this PR can be closed, I guess.**

Reports that were submitted with the "I don't like this" category were not persisted on our database. The server reported an HTTP 500 with the following log message:

```log
Jul 08 14:23:55 queer-web-1 bundle[2653013]: [143315cc-f96c-4c8a-985c-06f12af68928] method=POST path=/api/v1/reports format=html controller=Api::V1::ReportsController action=create status=500 error='ArgumentError: 'dislike' is not a valid category' duration=40 view=0 db=6.34
Jul 08 14:23:55 queer-web-1 bundle[2653013]: [143315cc-f96c-4c8a-985c-06f12af68928]
Jul 08 14:23:55 queer-web-1 bundle[2653013]: [143315cc-f96c-4c8a-985c-06f12af68928] ArgumentError ('dislike' is not a valid category):
Jul 08 14:23:55 queer-web-1 bundle[2653013]: [143315cc-f96c-4c8a-985c-06f12af68928]
Jul 08 14:23:55 queer-web-1 bundle[2653013]: [143315cc-f96c-4c8a-985c-06f12af68928] app/services/report_service.rb:27:in `create_report!'
Jul 08 14:23:55 queer-web-1 bundle[2653013]: [143315cc-f96c-4c8a-985c-06f12af68928] app/services/report_service.rb:17:in `call'
Jul 08 14:23:55 queer-web-1 bundle[2653013]: [143315cc-f96c-4c8a-985c-06f12af68928] app/controllers/api/v1/reports_controller.rb:10:in `create'
Jul 08 14:23:55 queer-web-1 bundle[2653013]: [143315cc-f96c-4c8a-985c-06f12af68928] app/controllers/concerns/rate_limit_headers.rb:10:in `block in override_rate_limit_headers'
Jul 08 14:23:55 queer-web-1 bundle[2653013]: [143315cc-f96c-4c8a-985c-06f12af68928] app/controllers/concerns/localized.rb:11:in `set_locale'
Jul 08 14:23:55 queer-web-1 bundle[2653013]: [143315cc-f96c-4c8a-985c-06f12af68928] lib/mastodon/rack_middleware.rb:9:in `call'
```

And although queer.group does not run upstream Mastodon, but Hometown instead, the `category` enum doesn't have the `dislike` category either. Based on that, I assume that reports of type `dislike` aren't working either on "pure" Mastodon instances.

## Reproduction

1. Take a random toot. 
2. Report it with the "I don't like this" category.
3. Don't add any additional information, just continue.
4. Before this patch, the server responded with a 500, now it's working.