### PR TITLE
Change feed merge, unmerge and regeneration workers to use a replica

### DIFF
--- a/app/workers/merge_worker.rb
+++ b/app/workers/merge_worker.rb
@@ -5,7 +5,14 @@ class MergeWorker
   include Redisable
 
   def perform(from_account_id, into_account_id)
-    FeedManager.instance.merge_into_home(Account.find(from_account_id), Account.find(into_account_id))
+    ApplicationRecord.connected_to(role: :primary) do
+      @from_account = Account.find(from_account_id)
+      @into_account = Account.find(into_account_id)
+    end
+
+    ApplicationRecord.connected_to(role: :read, prevent_writes: true) do
+      FeedManager.instance.merge_into_home(@from_account, @into_account)
+    end
   rescue ActiveRecord::RecordNotFound
     true
   ensure

--- a/app/workers/unmerge_worker.rb
+++ b/app/workers/unmerge_worker.rb
@@ -6,7 +6,14 @@ class UnmergeWorker
   sidekiq_options queue: 'pull'
 
   def perform(from_account_id, into_account_id)
-    FeedManager.instance.unmerge_from_home(Account.find(from_account_id), Account.find(into_account_id))
+    ApplicationRecord.connected_to(role: :primary) do
+      @from_account = Account.find(from_account_id)
+      @into_account = Account.find(into_account_id)
+    end
+
+    ApplicationRecord.connected_to(role: :read, prevent_writes: true) do
+      FeedManager.instance.unmerge_from_home(@from_account, @into_account)
+    end
   rescue ActiveRecord::RecordNotFound
     true
   end


### PR DESCRIPTION
These workers retrieve a lot of statuses and related information, but don't have to write anything back to the database.