### PR TITLE
Add check preventing Sidekiq workers from running with Makara configured

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,7 +4,7 @@ require_relative '../../lib/mastodon/sidekiq_middleware'
 
 Sidekiq.configure_server do |config|
   if Rails.configuration.database_configuration.dig('production', 'adapter') == 'postgresql_makara'
-    STDERR.puts 'ERROR: Makara is not supported in Mastodon sidekiq workers'
+    STDERR.puts 'ERROR: Database replication is not currently supported in Sidekiq workers. Check your configuration.'
     exit 1
   end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,6 +3,11 @@
 require_relative '../../lib/mastodon/sidekiq_middleware'
 
 Sidekiq.configure_server do |config|
+  if Rails.configuration.database_configuration.dig('production', 'adapter') == 'postgresql_makara'
+    STDERR.puts 'ERROR: Makara is not supported in Mastodon sidekiq workers'
+    exit 1
+  end
+
   config.redis = REDIS_SIDEKIQ_PARAMS
 
   config.server_middleware do |chain|


### PR DESCRIPTION
Given the unpredictable and potentially destructive failure modes of using a read-replica in sidekiq jobs, this should not only be a documentation warning, but it should be prevented by the code itself.

Targeting the 4.1 branch as `main` has completely removed Makara support.