### PR TITLE
Use native Docker Builder for arm64

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -25,8 +25,25 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@v3.1.0
-      - uses: docker/setup-qemu-action@v2
+      # The same driver needs to be used for every node, so we want a local TCP builder for the AMD64 build
+      - name: Start a local Docker Builder
+        run: |
+          docker run --rm -d --name buildkitd -p 1234:1234 --privileged moby/buildkit:latest --addr tcp://0.0.0.0:1234
       - uses: docker/setup-buildx-action@v2
+        with:
+          driver: remote
+          endpoint: tcp://localhost:1234
+          platforms: linux/amd64
+          append: |
+            - endpoint: tcp://${{ vars.DOCKER_BUILDER_HETZNER_ARM64_01_HOST }}:13865
+              platforms: linux/arm64
+              name: mastodon-docker-builder-arm64-01
+              driver-opts:
+                - servername=mastodon-docker-builder-arm64-01
+        env:
+          BUILDER_NODE_1_AUTH_TLS_CACERT: ${{ secrets.DOCKER_BUILDER_HETZNER_ARM64_01_CACERT }}
+          BUILDER_NODE_1_AUTH_TLS_CERT: ${{ secrets.DOCKER_BUILDER_HETZNER_ARM64_01_CERT }}
+          BUILDER_NODE_1_AUTH_TLS_KEY: ${{ secrets.DOCKER_BUILDER_HETZNER_ARM64_01_KEY }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -18,8 +18,25 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@v3.1.0
-      - uses: docker/setup-qemu-action@v2
+      # The same driver needs to be used for every node, so we want a local TCP builder for the AMD64 build
+      - name: Start a local Docker Builder
+        run: |
+          docker run --rm -d --name buildkitd -p 1234:1234 --privileged moby/buildkit:latest --addr tcp://0.0.0.0:1234
       - uses: docker/setup-buildx-action@v2
+        with:
+          driver: remote
+          endpoint: tcp://localhost:1234
+          platforms: linux/amd64
+          append: |
+            - endpoint: tcp://${{ vars.DOCKER_BUILDER_HETZNER_ARM64_01_HOST }}:13865
+              platforms: linux/arm64
+              name: mastodon-docker-builder-arm64-01
+              driver-opts:
+                - servername=mastodon-docker-builder-arm64-01
+        env:
+          BUILDER_NODE_1_AUTH_TLS_CACERT: ${{ secrets.DOCKER_BUILDER_HETZNER_ARM64_01_CACERT }}
+          BUILDER_NODE_1_AUTH_TLS_CERT: ${{ secrets.DOCKER_BUILDER_HETZNER_ARM64_01_CERT }}
+          BUILDER_NODE_1_AUTH_TLS_KEY: ${{ secrets.DOCKER_BUILDER_HETZNER_ARM64_01_KEY }}
 
       - name: Log in to the Github Container registry
         uses: docker/login-action@v2


### PR DESCRIPTION
(Please do not merge yet)

This uses a Docker Builder running on a 4-core ARM64 Hetzner Cloud server, managed by the project.

Credentials are in Github Secrets.

If configure 2 docker builders:
- an `amd64` builder, running locally in the Github hosted runner, but accessed using TCP. It is started as a TCP runner manually, if you let the setup action do it, is used the `docker-container` driver, and you need the same driver everywhere
- an `arm64` remote runner over TCP, on the Hetzner cloud server

Container build time for both archs: 4 minutes.

We may be able to do it in a simpler way by exposing the Docker Daemon over TCP on the Hetzner Cloud Server (with mTLS auth) and use a remote `docker-container` endpoint, rather that using the `remote` driver.

Once we deploy Tailscale, we will probably want this to go through Tailscale, and maybe even use the `ssh` authentication method.