### PR TITLE
Fix changelog referencing wrong API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@ All notable changes to this project will be documented in this file.
 - Add instance activity API endpoint toggle back to the admin interface ([dariusk](https://github.com/mastodon/mastodon/pull/22833))
 - Add setting for status page URL ([Gargron](https://github.com/mastodon/mastodon/pull/23390), [ClearlyClaire](https://github.com/mastodon/mastodon/pull/23499))
   - REST API changes:
-    - Add `configuration.urls.status` attribute to the object returned by `GET /api/v1/instance`
+    - Add `configuration.urls.status` attribute to the object returned by `GET /api/v2/instance`
 - Add `account.approved` webhook ([Saiv46](https://github.com/mastodon/mastodon/pull/22938))
 - Add 12 hours option to polls ([Pleclown](https://github.com/mastodon/mastodon/pull/21131))
 - Add dropdown menu item to open admin interface for remote domains ([ClearlyClaire](https://github.com/mastodon/mastodon/pull/21895))


### PR DESCRIPTION
This also needs to be fixed in the GitHub release for v4.1.0