### PR TITLE
Add `forward_to_domains` parameter to `POST /api/v1/reports`

### DIFF
--- a/app/controllers/api/v1/reports_controller.rb
+++ b/app/controllers/api/v1/reports_controller.rb
@@ -23,6 +23,6 @@ class Api::V1::ReportsController < Api::BaseController
   end
 
   def report_params
-    params.permit(:account_id, :comment, :category, :forward, status_ids: [], rule_ids: [])
+    params.permit(:account_id, :comment, :category, :forward, forward_to_domains: [], status_ids: [], rule_ids: [])
   end
 end

--- a/app/javascript/mastodon/features/report/comment.jsx
+++ b/app/javascript/mastodon/features/report/comment.jsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
 
-import { OrderedSet } from 'immutable';
+import { OrderedSet, List as ImmutableList } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { shallowEqual } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -46,11 +46,11 @@ const Comment = ({ comment, domain, statusIds, isRemote, isSubmitting, selectedD
   }, [handleClick]);
 
   // Memoize accountIds since we don't want it to trigger `useEffect` on each render
-  const accountIds = useAppSelector((state) => selectRepliedToAccountIds(state, statusIds));
+  const accountIds = useAppSelector((state) => domain ? selectRepliedToAccountIds(state, statusIds) : ImmutableList());
 
   // While we could memoize `availableDomains`, it is pretty inexpensive to recompute
   const accountsMap = useAppSelector((state) => state.get('accounts'));
-  const availableDomains = OrderedSet([domain]).union(accountIds.map((accountId) => accountsMap.getIn([accountId, 'acct'], '').split('@')[1]).filter(domain => !!domain));
+  const availableDomains = domain ? OrderedSet([domain]).union(accountIds.map((accountId) => accountsMap.getIn([accountId, 'acct'], '').split('@')[1]).filter(domain => !!domain)) : OrderedSet();
 
   useEffect(() => {
     if (loadedRef.current) {

--- a/app/javascript/mastodon/features/report/comment.jsx
+++ b/app/javascript/mastodon/features/report/comment.jsx
@@ -1,137 +1,121 @@
 import PropTypes from 'prop-types';
-import { PureComponent } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
-import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
+import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
 
 import { OrderedSet } from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import { connect } from 'react-redux';
+import { shallowEqual } from 'react-redux';
 import { createSelector } from 'reselect';
 
 import Toggle from 'react-toggle';
 
 import { fetchAccount } from 'mastodon/actions/accounts';
 import Button from 'mastodon/components/button';
+import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 const messages = defineMessages({
   placeholder: { id: 'report.placeholder', defaultMessage: 'Type or paste additional comments' },
 });
 
-const getAvailableDomains = createSelector([
-  state => state.get('statuses'),
-  state => state.get('accounts'),
-  (_, { domain }) => domain,
-  (_, { statusIds }) => statusIds,
-], (statusMap, accountMap, domain, statusIds) => {
-  return OrderedSet([domain]).union(
-    statusIds.map((statusId) =>
-      accountMap.getIn([statusMap.getIn([statusId, 'in_reply_to_account_id']), 'acct'], '').split('@')[1]
-    ).filter(domain => !!domain)
-  );
-});
+const selectRepliedToAccountIds = createSelector(
+  [
+    (state) => state.get('statuses'),
+    (_, statusIds) => statusIds,
+  ],
+  (statusesMap, statusIds) => statusIds.map((statusId) => statusesMap.getIn([statusId, 'in_reply_to_account_id'])),
+  {
+    resultEqualityCheck: shallowEqual,
+  }
+);
 
-const mapStateToProps = (state, { domain, statusIds }) => ({
-  availableDomains: getAvailableDomains(state, { domain, statusIds }),
-});
+const Comment = ({ comment, domain, statusIds, isRemote, isSubmitting, selectedDomains, onSubmit, onChangeComment, onToggleDomain }) => {
+  const intl = useIntl();
 
-const mapDispatchToProps = (dispatch, { statusIds }) => ({
-  fetchUnknownAccounts() {
-    dispatch((_, getState) => {
-      const state = getState();
-      const statusMap = state.get('statuses');
-      const accountMap = state.get('accounts');
+  const dispatch = useAppDispatch();
+  const loadedRef = useRef(false);
 
-      const unknownAccounts = OrderedSet(
-        statusIds.map(statusId => statusMap.getIn([statusId, 'in_reply_to_account_id']))
-                 .filter(accountId => accountId && !accountMap.has(accountId))
-      );
+  const handleClick = useCallback(() => onSubmit(), [onSubmit]);
+  const handleChange = useCallback((e) => onChangeComment(e.target.value), [onChangeComment]);
+  const handleToggleDomain = useCallback(e => onToggleDomain(e.target.value, e.target.checked), [onToggleDomain]);
 
-      unknownAccounts.forEach((accountId) => {
-        dispatch(fetchAccount(accountId));
-      });
-    });
-  },
-});
-
-class Comment extends PureComponent {
-
-  static propTypes = {
-    onSubmit: PropTypes.func.isRequired,
-    comment: PropTypes.string.isRequired,
-    onChangeComment: PropTypes.func.isRequired,
-    intl: PropTypes.object.isRequired,
-    isSubmitting: PropTypes.bool,
-    selectedDomains: ImmutablePropTypes.set.isRequired,
-    isRemote: PropTypes.bool,
-    domain: PropTypes.string,
-    onToggleDomain: PropTypes.func.isRequired,
-    availableDomains: ImmutablePropTypes.set.isRequired,
-    fetchUnknownAccounts: PropTypes.func.isRequired,
-  };
-
-  handleClick = () => {
-    const { onSubmit } = this.props;
-    onSubmit();
-  };
-
-  handleChange = e => {
-    const { onChangeComment } = this.props;
-    onChangeComment(e.target.value);
-  };
-
-  handleKeyDown = e => {
+  const handleKeyDown = useCallback((e) => {
     if (e.keyCode === 13 && (e.ctrlKey || e.metaKey)) {
-      this.handleClick();
+      handleClick();
     }
-  };
+  }, [handleClick]);
 
-  handleToggleDomain = e => {
-    const { onToggleDomain } = this.props;
-    onToggleDomain(e.target.value, e.target.checked);
-  };
+  // Memoize accountIds since we don't want it to trigger `useEffect` on each render
+  const accountIds = useAppSelector((state) => selectRepliedToAccountIds(state, statusIds));
 
-  componentDidMount () {
-    this.props.fetchUnknownAccounts();
-  }
+  // While we could memoize `availableDomains`, it is pretty inexpensive to recompute
+  const accountsMap = useAppSelector((state) => state.get('accounts'));
+  const availableDomains = OrderedSet([domain]).union(accountIds.map((accountId) => accountsMap.getIn([accountId, 'acct'], '').split('@')[1]).filter(domain => !!domain));
 
-  render () {
-    const { comment, isRemote, availableDomains, selectedDomains, isSubmitting, intl } = this.props;
+  useEffect(() => {
+    if (loadedRef.current) {
+      return;
+    }
 
-    return (
-      <>
-        <h3 className='report-dialog-modal__title'><FormattedMessage id='report.comment.title' defaultMessage='Is there anything else you think we should know?' /></h3>
+    loadedRef.current = true;
 
-        <textarea
-          className='report-dialog-modal__textarea'
-          placeholder={intl.formatMessage(messages.placeholder)}
-          value={comment}
-          onChange={this.handleChange}
-          onKeyDown={this.handleKeyDown}
-          disabled={isSubmitting}
-        />
+    // First, pre-select known domains
+    availableDomains.forEach((domain) => {
+      onToggleDomain(domain, true);
+    });
 
-        {isRemote && (
-          <>
-            <p className='report-dialog-modal__lead'><FormattedMessage id='report.forward_hint' defaultMessage='The account is from another server. Send an anonymized copy of the report there as well?' /></p>
+    // Then, fetch missing replied-to accounts
+    const unknownAccounts = OrderedSet(accountIds.filter(accountId => accountId && !accountsMap.has(accountId)));
+    unknownAccounts.forEach((accountId) => {
+      dispatch(fetchAccount(accountId));
+    });
+  });
 
-            { availableDomains.map((domain) => (
-              <label className='report-dialog-modal__toggle' key={`toggle-${domain}`}>
-                <Toggle checked={selectedDomains.includes(domain)} disabled={isSubmitting} onChange={this.handleToggleDomain} value={domain} />
-                <FormattedMessage id='report.forward' defaultMessage='Forward to {target}' values={{ target: domain }} />
-              </label>
-            ))}
-          </>
-        )}
+  return (
+    <>
+      <h3 className='report-dialog-modal__title'><FormattedMessage id='report.comment.title' defaultMessage='Is there anything else you think we should know?' /></h3>
 
-        <div className='flex-spacer' />
+      <textarea
+        className='report-dialog-modal__textarea'
+        placeholder={intl.formatMessage(messages.placeholder)}
+        value={comment}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        disabled={isSubmitting}
+      />
 
-        <div className='report-dialog-modal__actions'>
-          <Button onClick={this.handleClick} disabled={isSubmitting}><FormattedMessage id='report.submit' defaultMessage='Submit report' /></Button>
-        </div>
-      </>
-    );
-  }
+      {isRemote && (
+        <>
+          <p className='report-dialog-modal__lead'><FormattedMessage id='report.forward_hint' defaultMessage='The account is from another server. Send an anonymized copy of the report there as well?' /></p>
 
+          { availableDomains.map((domain) => (
+            <label className='report-dialog-modal__toggle' key={`toggle-${domain}`}>
+              <Toggle checked={selectedDomains.includes(domain)} disabled={isSubmitting} onChange={handleToggleDomain} value={domain} />
+              <FormattedMessage id='report.forward' defaultMessage='Forward to {target}' values={{ target: domain }} />
+            </label>
+          ))}
+        </>
+      )}
+
+      <div className='flex-spacer' />
+
+      <div className='report-dialog-modal__actions'>
+        <Button onClick={handleClick} disabled={isSubmitting}><FormattedMessage id='report.submit' defaultMessage='Submit report' /></Button>
+      </div>
+    </>
+  );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(Comment));
+Comment.propTypes = {
+  comment: PropTypes.string.isRequired,
+  domain: PropTypes.string,
+  statusIds: ImmutablePropTypes.list.isRequired,
+  isRemote: PropTypes.bool,
+  isSubmitting: PropTypes.bool,
+  selectedDomains: ImmutablePropTypes.set.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  onChangeComment: PropTypes.func.isRequired,
+  onToggleDomain: PropTypes.func.isRequired,
+};
+
+export default Comment;

--- a/app/javascript/mastodon/features/report/comment.jsx
+++ b/app/javascript/mastodon/features/report/comment.jsx
@@ -3,12 +3,54 @@ import { PureComponent } from 'react';
 
 import { injectIntl, defineMessages, FormattedMessage } from 'react-intl';
 
+import { OrderedSet } from 'immutable';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+
 import Toggle from 'react-toggle';
 
+import { fetchAccount } from 'mastodon/actions/accounts';
 import Button from 'mastodon/components/button';
 
 const messages = defineMessages({
   placeholder: { id: 'report.placeholder', defaultMessage: 'Type or paste additional comments' },
+});
+
+const getAvailableDomains = createSelector([
+  state => state.get('statuses'),
+  state => state.get('accounts'),
+  (_, { domain }) => domain,
+  (_, { statusIds }) => statusIds,
+], (statusMap, accountMap, domain, statusIds) => {
+  return OrderedSet([domain]).union(
+    statusIds.map((statusId) =>
+      accountMap.getIn([statusMap.getIn([statusId, 'in_reply_to_account_id']), 'acct'], '').split('@')[1]
+    ).filter(domain => !!domain)
+  );
+});
+
+const mapStateToProps = (state, { domain, statusIds }) => ({
+  availableDomains: getAvailableDomains(state, { domain, statusIds }),
+});
+
+const mapDispatchToProps = (dispatch, { statusIds }) => ({
+  fetchUnknownAccounts() {
+    dispatch((_, getState) => {
+      const state = getState();
+      const statusMap = state.get('statuses');
+      const accountMap = state.get('accounts');
+
+      const unknownAccounts = OrderedSet(
+        statusIds.map(statusId => statusMap.getIn([statusId, 'in_reply_to_account_id']))
+                 .filter(accountId => accountId && !accountMap.has(accountId))
+      );
+
+      unknownAccounts.forEach((accountId) => {
+        dispatch(fetchAccount(accountId));
+      });
+    });
+  },
 });
 
 class Comment extends PureComponent {
@@ -19,10 +61,12 @@ class Comment extends PureComponent {
     onChangeComment: PropTypes.func.isRequired,
     intl: PropTypes.object.isRequired,
     isSubmitting: PropTypes.bool,
-    forward: PropTypes.bool,
+    selectedDomains: ImmutablePropTypes.set.isRequired,
     isRemote: PropTypes.bool,
     domain: PropTypes.string,
-    onChangeForward: PropTypes.func.isRequired,
+    onToggleDomain: PropTypes.func.isRequired,
+    availableDomains: ImmutablePropTypes.set.isRequired,
+    fetchUnknownAccounts: PropTypes.func.isRequired,
   };
 
   handleClick = () => {
@@ -41,13 +85,17 @@ class Comment extends PureComponent {
     }
   };
 
-  handleForwardChange = e => {
-    const { onChangeForward } = this.props;
-    onChangeForward(e.target.checked);
+  handleToggleDomain = e => {
+    const { onToggleDomain } = this.props;
+    onToggleDomain(e.target.value, e.target.checked);
   };
 
+  componentDidMount () {
+    this.props.fetchUnknownAccounts();
+  }
+
   render () {
-    const { comment, isRemote, forward, domain, isSubmitting, intl } = this.props;
+    const { comment, isRemote, availableDomains, selectedDomains, isSubmitting, intl } = this.props;
 
     return (
       <>
@@ -66,10 +114,12 @@ class Comment extends PureComponent {
           <>
             <p className='report-dialog-modal__lead'><FormattedMessage id='report.forward_hint' defaultMessage='The account is from another server. Send an anonymized copy of the report there as well?' /></p>
 
-            <label className='report-dialog-modal__toggle'>
-              <Toggle checked={forward} disabled={isSubmitting} onChange={this.handleForwardChange} />
-              <FormattedMessage id='report.forward' defaultMessage='Forward to {target}' values={{ target: domain }} />
-            </label>
+            { availableDomains.map((domain) => (
+              <label className='report-dialog-modal__toggle' key={`toggle-${domain}`}>
+                <Toggle checked={selectedDomains.includes(domain)} disabled={isSubmitting} onChange={this.handleToggleDomain} value={domain} />
+                <FormattedMessage id='report.forward' defaultMessage='Forward to {target}' values={{ target: domain }} />
+              </label>
+            ))}
           </>
         )}
 
@@ -84,4 +134,4 @@ class Comment extends PureComponent {
 
 }
 
-export default injectIntl(Comment);
+export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(Comment));

--- a/app/javascript/mastodon/features/ui/components/report_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/report_modal.jsx
@@ -89,22 +89,18 @@ class ReportModal extends ImmutablePureComponent {
   };
 
   handleDomainToggle = (domain, checked) => {
-    const { selectedDomains } = this.state;
-
     if (checked) {
-      this.setState({ selectedDomains: selectedDomains.add(domain) });
+      this.setState((state) => ({ selectedDomains: state.selectedDomains.add(domain) }));
     } else {
-      this.setState({ selectedDomains: selectedDomains.remove(domain) });
+      this.setState((state) => ({ selectedDomains: state.selectedDomains.remove(domain) }));
     }
   };
 
   handleRuleToggle = (ruleId, checked) => {
-    const { selectedRuleIds } = this.state;
-
     if (checked) {
-      this.setState({ selectedRuleIds: selectedRuleIds.add(ruleId) });
+      this.setState((state) => ({ selectedRuleIds: state.selectedRuleIds.add(ruleId) }));
     } else {
-      this.setState({ selectedRuleIds: selectedRuleIds.remove(ruleId) });
+      this.setState((state) => ({ selectedRuleIds: state.selectedRuleIds.remove(ruleId) }));
     }
   };
 

--- a/app/javascript/mastodon/features/ui/components/report_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/report_modal.jsx
@@ -45,25 +45,26 @@ class ReportModal extends ImmutablePureComponent {
   state = {
     step: 'category',
     selectedStatusIds: OrderedSet(this.props.statusId ? [this.props.statusId] : []),
+    selectedDomains: OrderedSet(),
     comment: '',
     category: null,
     selectedRuleIds: OrderedSet(),
-    forward: true,
     isSubmitting: false,
     isSubmitted: false,
   };
 
   handleSubmit = () => {
     const { dispatch, accountId } = this.props;
-    const { selectedStatusIds, comment, category, selectedRuleIds, forward } = this.state;
+    const { selectedStatusIds, selectedDomains, comment, category, selectedRuleIds } = this.state;
 
     this.setState({ isSubmitting: true });
 
     dispatch(submitReport({
       account_id: accountId,
       status_ids: selectedStatusIds.toArray(),
+      selected_domains: selectedDomains.toArray(),
       comment,
-      forward,
+      forward: selectedDomains.size > 0,
       category,
       rule_ids: selectedRuleIds.toArray(),
     }, this.handleSuccess, this.handleFail));
@@ -87,6 +88,16 @@ class ReportModal extends ImmutablePureComponent {
     }
   };
 
+  handleDomainToggle = (domain, checked) => {
+    const { selectedDomains } = this.state;
+
+    if (checked) {
+      this.setState({ selectedDomains: selectedDomains.add(domain) });
+    } else {
+      this.setState({ selectedDomains: selectedDomains.remove(domain) });
+    }
+  };
+
   handleRuleToggle = (ruleId, checked) => {
     const { selectedRuleIds } = this.state;
 
@@ -103,10 +114,6 @@ class ReportModal extends ImmutablePureComponent {
 
   handleChangeComment = comment => {
     this.setState({ comment });
-  };
-
-  handleChangeForward = forward => {
-    this.setState({ forward });
   };
 
   handleNextStep = step => {
@@ -136,8 +143,8 @@ class ReportModal extends ImmutablePureComponent {
       step,
       selectedStatusIds,
       selectedRuleIds,
+      selectedDomains,
       comment,
-      forward,
       category,
       isSubmitting,
       isSubmitted,
@@ -185,10 +192,11 @@ class ReportModal extends ImmutablePureComponent {
           isSubmitting={isSubmitting}
           isRemote={isRemote}
           comment={comment}
-          forward={forward}
           domain={domain}
           onChangeComment={this.handleChangeComment}
-          onChangeForward={this.handleChangeForward}
+          statusIds={selectedStatusIds}
+          selectedDomains={selectedDomains}
+          onToggleDomain={this.handleDomainToggle}
         />
       );
       break;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5784,6 +5784,7 @@ a.status-card.compact:hover {
   &__toggle {
     display: flex;
     align-items: center;
+    margin-bottom: 10px;
 
     & > span {
       font-size: 17px;

--- a/app/services/report_service.rb
+++ b/app/services/report_service.rb
@@ -16,7 +16,11 @@ class ReportService < BaseService
 
     create_report!
     notify_staff!
-    forward_to_origin! if forward?
+
+    if forward?
+      forward_to_origin!
+      forward_to_replied_to!
+    end
 
     @report
   end
@@ -29,7 +33,7 @@ class ReportService < BaseService
       status_ids: reported_status_ids,
       comment: @comment,
       uri: @options[:uri],
-      forwarded: forward?,
+      forwarded: forward_to_origin?,
       category: @category,
       rule_ids: @rule_ids
     )
@@ -45,11 +49,15 @@ class ReportService < BaseService
   end
 
   def forward_to_origin!
+    return unless forward_to_origin?
+
     # Send report to the server where the account originates from
     ActivityPub::DeliveryWorker.perform_async(payload, some_local_account.id, @target_account.inbox_url)
+  end
 
+  def forward_to_replied_to!
     # Send report to servers to which the account was replying to, so they also have a chance to act
-    inbox_urls = Account.remote.where(id: Status.where(id: reported_status_ids).where.not(in_reply_to_account_id: nil).select(:in_reply_to_account_id)).inboxes - [@target_account.inbox_url]
+    inbox_urls = Account.remote.where(domain: forward_to_domains).where(id: Status.where(id: reported_status_ids).where.not(in_reply_to_account_id: nil).select(:in_reply_to_account_id)).inboxes - [@target_account.inbox_url]
 
     inbox_urls.each do |inbox_url|
       ActivityPub::DeliveryWorker.perform_async(payload, some_local_account.id, inbox_url)
@@ -58,6 +66,14 @@ class ReportService < BaseService
 
   def forward?
     !@target_account.local? && ActiveModel::Type::Boolean.new.cast(@options[:forward])
+  end
+
+  def forward_to_origin?
+    forward? && forward_to_domains.include?(@target_account.domain)
+  end
+
+  def forward_to_domains
+    @forward_to_domains ||= (@options[:forward_to_domains] || [@target_account.domain]).filter_map { |domain| TagManager.instance.normalize_domain(domain&.strip) }.uniq
   end
 
   def reported_status_ids


### PR DESCRIPTION
Follow-up to #25341 preventing breaking API changes, misleading situations, and giving back agency to the end-user.

This adds a `forward_to_domains` parameter so the user can pick which remote domains to forward the report to among the reported user's domain and the domains of the posts this was in reply to.

If `forward_to_domains` is omitted, the behavior is the same as before #25341, that is, it will only forward to the reported user's domain.

Also changes the report modal accordingly (the first domain is always the domain of the user being reported, the order of the other domains is dictated by the order of the selected replies):
![image](https://github.com/mastodon/mastodon/assets/384364/d714a559-ed44-4a2d-9b52-d82e62853590)

This allows forwarding reports to directly affected users' servers while still having the option to avoid forwarding to known-malicious servers or to servers to which the violated policies do not apply.