### PR TITLE
Add a Github Action to send translations to Crowdin for each merge in main

### DIFF
--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,24 @@
+name: Crowdin Action
+
+on:
+  push:
+    branches: [main]
+  pull_request: # TODO: remove me before merging
+
+jobs:
+  upload-translations-to-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: crowdin action
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: true
+          upload_translations: true
+          download_translations: false
+        env:
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
This is intended to replace the Crowdin-hosted process, which sometimes fails and does not provide any logs.

For now, it only uploads new translations to Crowdin when merging on `main`.