### PR TITLE
Add a Github Action to send translations to Crowdin for each merge in main

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -23,6 +23,7 @@ jobs:
           git config --global http.version HTTP/1.1
           git config --global http.postBuffer 157286400
 
+      # Download the translation files from Crowdin
       - name: crowdin action
         uses: crowdin/github-action@v1
         with:
@@ -30,18 +31,42 @@ jobs:
           upload_translations: false
           download_translations: true
           crowdin_branch_name: main
-          localization_branch_name: i18n/crowdin/translations
-          create_pull_request: true
-          pull_request_title: 'New Crowdin Translations (automated)'
-          pull_request_body: |
-            New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)
-
-            See `.github/workflows/crowdin-download.yml
-
-            This PR will be updated every day with new translations.'
-          pull_request_labels: 'i18n'
-
+          push_translations: false
+          create_pull_request: false
         env:
           CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # As the files are extracted from a Docker container, they belong to root:root
+      # We need to fix this before the next steps
+      - name: Fix file permissions
+        run: sudo chown -R runner:docker .
+
+      # This is needed to run the normalize step
+      - name: Install native Ruby dependencies
+        run: sudo apt-get install -y libicu-dev libidn11-dev
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Run i18n normalize task
+        run: bundle exec i18n-tasks normalize
+
+      # Create or update the pull request
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5.0.2
+        with:
+          commit-message: 'New Crowdin translations'
+          title: 'New Crowdin Translations (automated)'
+          body: |
+            New Crowdin translations, automated with Github Actions
+
+            See `.github/workflows/crowdin-download.yml`
+
+            This PR will be updated every day with new translations.
+          branch: i18n/crowdin/translations
+          base: main
+          labels: i18n

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -1,0 +1,47 @@
+name: Crowdin / Download translations
+on:
+  schedule:
+    - cron: '17 4 * * *' # Every day
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  download-translations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Increase Git http.postBuffer
+        # This is needed due to a bug in Ubuntu's cURL version?
+        # See https://github.com/orgs/community/discussions/55820
+        run: |
+          git config --global http.version HTTP/1.1
+          git config --global http.postBuffer 157286400
+
+      - name: crowdin action
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          crowdin_branch_name: main
+          localization_branch_name: i18n/crowdin/translations
+          create_pull_request: true
+          pull_request_title: 'New Crowdin Translations (automated)'
+          pull_request_body: |
+            New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)
+
+            See `.github/workflows/crowdin-download.yml
+
+            This PR will be updated every day with new translations.'
+          pull_request_labels: 'i18n'
+
+        env:
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -61,12 +61,16 @@ jobs:
         with:
           commit-message: 'New Crowdin translations'
           title: 'New Crowdin Translations (automated)'
+          author: 'GitHub Actions <noreply@github.com>'
           body: |
             New Crowdin translations, automated with Github Actions
 
             See `.github/workflows/crowdin-download.yml`
 
             This PR will be updated every day with new translations.
+
+            Due to a limitation in Github Actions, checks are not running on this PR without manual action.
+            If you want to run the checks, then close and re-open it.
           branch: i18n/crowdin/translations
           base: main
           labels: i18n

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,35 @@
+name: Crowdin / Upload translations
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - crowdin.yml
+      - app/javascript/mastodon/locales/en.json
+      - config/locales/en.yml
+      - config/locales/simple_form.en.yml
+      - config/locales/activerecord.en.yml
+      - config/locales/devise.en.yml
+      - config/locales/doorkeeper.en.yml
+      - .github/workflows/crowdin-upload.yml
+
+jobs:
+  upload-translations:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: crowdin action
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          crowdin_branch_name: main
+
+        env:
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,10 @@
+# This is needed for the Github Action
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+
 skip_untranslated_strings: 1
 commit_message: '[ci skip]'
+preserve_hierarchy: true
 files:
   - source: /app/javascript/mastodon/locales/en.json
     translation: /app/javascript/mastodon/locales/%two_letters_code%.json


### PR DESCRIPTION
This is intended to replace the Crowdin-hosted process, which sometimes fails and does not provide any logs.

It introduces 2 new Github workflows:
- "Crowdin / Upload translations" triggered on merges in `main` when a source translation file is changed, which will upload the source files to Crowdin. [Sample job run](https://github.com/mastodon/mastodon/actions/runs/5512497464/jobs/10049405228)
- "Crowd / Download translations" triggered once a day, which downloads the translations from Crowdin, updates a branch, and opens a PR if it does not exists. [Sample job run](https://github.com/mastodon/mastodon/actions/runs/5512865934/jobs/10050242490)

Here is an example PR it will open: https://github.com/mastodon/mastodon/pull/25891 (please note that the PR text has been improved in this PR)

If this works fine, then we can probably tweak it to also upload and download files from Crowdin for `stable-X` branches, allowing to have translation updates in patch releases.