### PR TITLE
Refactor domains cli to remove model call from regex

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -34,30 +34,6 @@
       "note": ""
     },
     {
-      "warning_type": "Denial of Service",
-      "warning_code": 76,
-      "fingerprint": "7b6abba5699755348e7ee82a4694bfbf574b41c7cce2d0db0f7c11ae3f983c72",
-      "check_name": "RegexDoS",
-      "message": "Model attribute used in regular expression",
-      "file": "lib/mastodon/cli/domains.rb",
-      "line": 128,
-      "link": "https://brakemanscanner.org/docs/warning_types/denial_of_service/",
-      "code": "/\\.?(#{DomainBlock.where(:severity => 1).pluck(:domain).map do\n Regexp.escape(domain)\n end.join(\"|\")})$/",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Mastodon::CLI::Domains",
-        "method": "crawl"
-      },
-      "user_input": "DomainBlock.where(:severity => 1).pluck(:domain)",
-      "confidence": "Weak",
-      "cwe_id": [
-        20,
-        185
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "cd5cfd7f40037fbfa753e494d7129df16e358bfc43ef0da3febafbf4ee1ed3ac",

--- a/lib/mastodon/cli/domains.rb
+++ b/lib/mastodon/cli/domains.rb
@@ -125,7 +125,7 @@ module Mastodon::CLI
       failed          = Concurrent::AtomicFixnum.new(0)
       start_at        = Time.now.to_f
       seed            = start ? [start] : Instance.pluck(:domain)
-      blocked_domains = /\.?(#{DomainBlock.where(severity: 1).pluck(:domain).map { |domain| Regexp.escape(domain) }.join('|')})$/
+      blocked_domains = /\.?(#{Regexp.union(domain_block_suspended_domains).source})$/
       progress        = create_progress_bar
 
       pool = Concurrent::ThreadPoolExecutor.new(min_threads: 0, max_threads: options[:concurrency], idletime: 10, auto_terminate: true, max_queue: 0)
@@ -188,6 +188,10 @@ module Mastodon::CLI
     end
 
     private
+
+    def domain_block_suspended_domains
+      DomainBlock.suspend.pluck(:domain)
+    end
 
     def stats_to_summary(stats, processed, failed, start_at)
       stats.compact!


### PR DESCRIPTION
Solves brakeman warning.