### PR TITLE
Refactor Status.tagged_with_all to avoid brakeman sql injection warnings

### DIFF
--- a/app/models/tag_feed.rb
+++ b/app/models/tag_feed.rb
@@ -39,15 +39,15 @@ class TagFeed < PublicFeed
   private
 
   def tagged_with_any_scope
-    Status.group(:id).tagged_with(tags_for(Array(@tag.name) | Array(options[:any])))
+    Status.group('statuses.id').tagged_with(tags_for(Array(@tag.name) | Array(options[:any])))
   end
 
   def tagged_with_all_scope
-    Status.group(:id).tagged_with_all(tags_for(options[:all]))
+    Status.group('statuses.id').tagged_with_all(tags_for(options[:all]))
   end
 
   def tagged_with_none_scope
-    Status.group(:id).tagged_with_none(tags_for(options[:none]))
+    Status.group('statuses.id').tagged_with_none(tags_for(options[:none]))
   end
 
   def tags_for(names)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,29 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "19df3740b8d02a9fe0eb52c939b4b87d3a2a591162a6adfa8d64e9c26aeebe6d",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/status.rb",
-      "line": 106,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "result.joins(\"INNER JOIN statuses_tags t#{id} ON t#{id}.status_id = statuses.id AND t#{id}.tag_id = #{id}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Status",
-        "method": null
-      },
-      "user_input": "id",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "71cf98c8235b5cfa9946b5db8fdc1a2f3a862566abb34e4542be6f3acae78233",


### PR DESCRIPTION
Converts what had been a ruby loop into a subquery, solves brakeman warning about string interpolation directly in the query.