### PR TITLE
Update `UserMailer` to use paramaterization

### DIFF
--- a/app/controllers/admin/disputes/appeals_controller.rb
+++ b/app/controllers/admin/disputes/appeals_controller.rb
@@ -20,7 +20,7 @@ class Admin::Disputes::AppealsController < Admin::BaseController
     authorize @appeal, :approve?
     log_action :reject, @appeal
     @appeal.reject!(current_account)
-    UserMailer.appeal_rejected(@appeal.account.user, @appeal).deliver_later
+    UserMailer.with(user: @appeal.account.user).appeal_rejected(@appeal).deliver_later
     redirect_to disputes_strike_path(@appeal.strike)
   end
 

--- a/app/controllers/auth/sessions_controller.rb
+++ b/app/controllers/auth/sessions_controller.rb
@@ -147,7 +147,7 @@ class Auth::SessionsController < Devise::SessionsController
       user_agent: request.user_agent
     )
 
-    UserMailer.suspicious_sign_in(user, request.remote_ip, request.user_agent, Time.now.utc).deliver_later! if @login_is_suspicious
+    UserMailer.with(user: user).suspicious_sign_in(request.remote_ip, request.user_agent, Time.now.utc).deliver_later! if @login_is_suspicious
   end
 
   def suspicious_sign_in?(user)

--- a/app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb
+++ b/app/controllers/settings/two_factor_authentication/webauthn_credentials_controller.rb
@@ -48,7 +48,7 @@ module Settings
             if current_user.webauthn_credentials.size == 1
               UserMailer.webauthn_enabled(current_user).deliver_later!
             else
-              UserMailer.webauthn_credential_added(current_user, user_credential).deliver_later!
+              UserMailer.with(user: current_user).webauthn_credential_added(user_credential).deliver_later!
             end
           else
             flash[:error] = I18n.t('webauthn_credentials.create.error')
@@ -72,7 +72,7 @@ module Settings
             if current_user.webauthn_credentials.empty?
               UserMailer.webauthn_disabled(current_user).deliver_later!
             else
-              UserMailer.webauthn_credential_deleted(current_user, credential).deliver_later!
+              UserMailer.with(user: current_user).webauthn_credential_deleted(credential).deliver_later!
             end
           else
             flash[:error] = I18n.t('webauthn_credentials.destroy.error')

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 class UserMailer < Devise::Mailer
+  DEVISE_ACTIONS = [
+    :confirmation_instructions,
+    :email_changed,
+    :password_change,
+    :reset_password_instructions,
+    :two_factor_disabled,
+    :two_factor_enabled,
+    :two_factor_recovery_codes_changed,
+    :webauthn_disabled,
+    :webauthn_enabled,
+  ].freeze
+
   layout 'mailer'
 
   helper :accounts
@@ -11,7 +23,7 @@ class UserMailer < Devise::Mailer
   helper :routing
 
   before_action :set_instance
-  before_action :set_resource, only: [:welcome, :backup_ready, :warning, :appeal_approved, :appeal_rejected, :suspicious_sign_in, :webauthn_credential_added, :webauthn_credential_deleted]
+  before_action :set_resource, except: DEVISE_ACTIONS
 
   default to: -> { @resource.email }
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,7 +11,7 @@ class UserMailer < Devise::Mailer
   helper :routing
 
   before_action :set_instance
-  before_action :set_resource, only: [:welcome, :backup_ready, :warning, :appeal_approved, :appeal_rejected, :suspicious_sign_in]
+  before_action :set_resource, only: [:welcome, :backup_ready, :warning, :appeal_approved, :appeal_rejected, :suspicious_sign_in, :webauthn_credential_added, :webauthn_credential_deleted]
 
   default to: -> { @resource.email }
 
@@ -109,8 +109,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def webauthn_credential_added(user, webauthn_credential)
-    @resource = user
+  def webauthn_credential_added(webauthn_credential)
     @webauthn_credential = webauthn_credential
 
     return unless @resource.active_for_authentication?
@@ -120,8 +119,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def webauthn_credential_deleted(user, webauthn_credential)
-    @resource = user
+  def webauthn_credential_deleted(webauthn_credential)
     @webauthn_credential = webauthn_credential
 
     return unless @resource.active_for_authentication?

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,6 +11,7 @@ class UserMailer < Devise::Mailer
   helper :routing
 
   before_action :set_instance
+  before_action :set_resource, only: :welcome
 
   default to: -> { @resource.email }
 
@@ -130,9 +131,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def welcome(user)
-    @resource = user
-
+  def welcome
     return unless @resource.active_for_authentication?
 
     I18n.with_locale(locale) do
@@ -199,6 +198,10 @@ class UserMailer < Devise::Mailer
 
   def set_instance
     @instance = Rails.configuration.x.local_domain
+  end
+
+  def set_resource
+    @resource = params[:user]
   end
 
   def locale

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,7 +11,7 @@ class UserMailer < Devise::Mailer
   helper :routing
 
   before_action :set_instance
-  before_action :set_resource, only: [:welcome, :backup_ready, :warning, :appeal_approved, :appeal_rejected]
+  before_action :set_resource, only: [:welcome, :backup_ready, :warning, :appeal_approved, :appeal_rejected, :suspicious_sign_in]
 
   default to: -> { @resource.email }
 
@@ -174,8 +174,7 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def suspicious_sign_in(user, remote_ip, user_agent, timestamp)
-    @resource   = user
+  def suspicious_sign_in(remote_ip, user_agent, timestamp)
     @remote_ip  = remote_ip
     @user_agent = user_agent
     @detection  = Browser.new(user_agent)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,7 +11,7 @@ class UserMailer < Devise::Mailer
   helper :routing
 
   before_action :set_instance
-  before_action :set_resource, only: :welcome
+  before_action :set_resource, only: [:welcome, :backup_ready]
 
   default to: -> { @resource.email }
 
@@ -139,9 +139,8 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def backup_ready(user, backup)
-    @resource = user
-    @backup   = backup
+  def backup_ready(backup)
+    @backup = backup
 
     return unless @resource.active_for_authentication?
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,7 +11,7 @@ class UserMailer < Devise::Mailer
   helper :routing
 
   before_action :set_instance
-  before_action :set_resource, only: [:welcome, :backup_ready]
+  before_action :set_resource, only: [:welcome, :backup_ready, :warning]
 
   default to: -> { @resource.email }
 
@@ -149,13 +149,12 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def warning(user, warning)
-    @resource = user
+  def warning(warning)
     @warning  = warning
     @statuses = @warning.statuses.includes(:account, :preloadable_poll, :media_attachments, active_mentions: [:account])
 
     I18n.with_locale(locale) do
-      mail subject: I18n.t("user_mailer.warning.subject.#{@warning.action}", acct: "@#{user.account.local_username_and_domain}")
+      mail subject: I18n.t("user_mailer.warning.subject.#{@warning.action}", acct: "@#{@resource.account.local_username_and_domain}")
     end
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,7 +11,7 @@ class UserMailer < Devise::Mailer
   helper :routing
 
   before_action :set_instance
-  before_action :set_resource, only: [:welcome, :backup_ready, :warning]
+  before_action :set_resource, only: [:welcome, :backup_ready, :warning, :appeal_approved, :appeal_rejected]
 
   default to: -> { @resource.email }
 
@@ -158,18 +158,16 @@ class UserMailer < Devise::Mailer
     end
   end
 
-  def appeal_approved(user, appeal)
-    @resource = user
-    @appeal   = appeal
+  def appeal_approved(appeal)
+    @appeal = appeal
 
     I18n.with_locale(locale) do
       mail subject: default_i18n_subject(date: l(@appeal.created_at))
     end
   end
 
-  def appeal_rejected(user, appeal)
-    @resource = user
-    @appeal   = appeal
+  def appeal_rejected(appeal)
+    @appeal = appeal
 
     I18n.with_locale(locale) do
       mail subject: default_i18n_subject(date: l(@appeal.created_at))

--- a/app/models/admin/account_action.rb
+++ b/app/models/admin/account_action.rb
@@ -159,7 +159,7 @@ class Admin::AccountAction
   end
 
   def process_email!
-    UserMailer.warning(target_account.user, warning).deliver_later! if warnable?
+    UserMailer.with(user: target_account.user).warning(warning).deliver_later! if warnable?
   end
 
   def warnable?

--- a/app/models/admin/status_batch_action.rb
+++ b/app/models/admin/status_batch_action.rb
@@ -65,7 +65,7 @@ class Admin::StatusBatchAction
       statuses.each { |status| Tombstone.find_or_create_by(uri: status.uri, account: status.account, by_moderator: true) } unless target_account.local?
     end
 
-    UserMailer.warning(target_account.user, @warning).deliver_later! if warnable?
+    UserMailer.with(user: target_account.user).warning(@warning).deliver_later! if warnable?
     RemovalWorker.push_bulk(status_ids) { |status_id| [status_id, { 'preserve' => target_account.local?, 'immediate' => !target_account.local? }] }
   end
 
@@ -101,7 +101,7 @@ class Admin::StatusBatchAction
       text: text
     )
 
-    UserMailer.warning(target_account.user, @warning).deliver_later! if warnable?
+    UserMailer.with(user: target_account.user).warning(@warning).deliver_later! if warnable?
   end
 
   def handle_report!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -460,7 +460,7 @@ class User < ApplicationRecord
     BootstrapTimelineWorker.perform_async(account_id)
     ActivityTracker.increment('activity:accounts:local')
     ActivityTracker.record('activity:logins', id)
-    UserMailer.welcome(self).deliver_later
+    UserMailer.with(user: self).welcome.deliver_later
     TriggerWebhookWorker.perform_async('account.approved', 'Account', account_id)
   end
 

--- a/app/services/approve_appeal_service.rb
+++ b/app/services/approve_appeal_service.rb
@@ -78,6 +78,6 @@ class ApproveAppealService < BaseService
   end
 
   def notify_target_account!
-    UserMailer.appeal_approved(target_account.user, @appeal).deliver_later
+    UserMailer.with(user: target_account.user).appeal_approved(@appeal).deliver_later
   end
 end

--- a/app/workers/backup_worker.rb
+++ b/app/workers/backup_worker.rb
@@ -23,6 +23,6 @@ class BackupWorker
     BackupService.new.call(backup)
 
     user.backups.where.not(id: backup.id).destroy_all
-    UserMailer.backup_ready(user, backup).deliver_later
+    UserMailer.with(user: user).backup_ready(backup).deliver_later
   end
 end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -71,7 +71,7 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/welcome
   def welcome
-    UserMailer.welcome(User.first)
+    UserMailer.with(user: User.first).welcome
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/backup_ready

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -86,7 +86,7 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/appeal_approved
   def appeal_approved
-    UserMailer.appeal_approved(User.first, Appeal.last)
+    UserMailer.with(user: User.first).appeal_approved(Appeal.last)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/suspicious_sign_in

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -81,7 +81,7 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/warning
   def warning
-    UserMailer.warning(User.first, AccountWarning.last)
+    UserMailer.with(user: User.first).warning(AccountWarning.last)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/appeal_approved

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -48,13 +48,13 @@ class UserMailerPreview < ActionMailer::Preview
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/webauthn_credential_added
   def webauthn_credential_added
     webauthn_credential = WebauthnCredential.new(nickname: 'USB Key')
-    UserMailer.webauthn_credential_added(User.first, webauthn_credential)
+    UserMailer.with(user: User.first).webauthn_credential_added(webauthn_credential)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/webauthn_credential_deleted
   def webauthn_credential_deleted
     webauthn_credential = WebauthnCredential.new(nickname: 'USB Key')
-    UserMailer.webauthn_credential_deleted(User.first, webauthn_credential)
+    UserMailer.with(user: User.first).webauthn_credential_deleted(webauthn_credential)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/reconfirmation_instructions

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -91,6 +91,6 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/suspicious_sign_in
   def suspicious_sign_in
-    UserMailer.suspicious_sign_in(User.first, '127.0.0.1', 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0', Time.now.utc)
+    UserMailer.with(user: User.first).suspicious_sign_in('127.0.0.1', 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:75.0) Gecko/20100101 Firefox/75.0', Time.now.utc)
   end
 end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -76,7 +76,7 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/backup_ready
   def backup_ready
-    UserMailer.backup_ready(User.first, Backup.first)
+    UserMailer.with(user: User.first).backup_ready(Backup.first)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/warning

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -227,7 +227,7 @@ describe UserMailer do
   end
 
   describe '#welcome' do
-    let(:mail) { described_class.welcome(receiver) }
+    let(:mail) { described_class.with(user: receiver).welcome }
 
     it 'renders welcome mail' do
       expect(mail)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -137,7 +137,7 @@ describe UserMailer do
 
   describe '#appeal_approved' do
     let(:appeal) { Fabricate(:appeal, account: receiver.account, approved_at: Time.now.utc) }
-    let(:mail) { described_class.appeal_approved(receiver, appeal) }
+    let(:mail) { described_class.with(user: receiver).appeal_approved(appeal) }
 
     it 'renders appeal_approved notification' do
       expect(mail)
@@ -149,7 +149,7 @@ describe UserMailer do
 
   describe '#appeal_rejected' do
     let(:appeal) { Fabricate(:appeal, account: receiver.account, rejected_at: Time.now.utc) }
-    let(:mail) { described_class.appeal_rejected(receiver, appeal) }
+    let(:mail) { described_class.with(user: receiver).appeal_rejected(appeal) }
 
     it 'renders appeal_rejected notification' do
       expect(mail)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -121,7 +121,7 @@ describe UserMailer do
     let(:ip) { '192.168.0.1' }
     let(:agent) { 'NCSA_Mosaic/2.0 (Windows 3.1)' }
     let(:timestamp) { Time.now.utc }
-    let(:mail) { described_class.suspicious_sign_in(receiver, ip, agent, timestamp) }
+    let(:mail) { described_class.with(user: receiver).suspicious_sign_in(ip, agent, timestamp) }
 
     it 'renders suspicious sign in notification' do
       receiver.update!(locale: nil)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -89,7 +89,7 @@ describe UserMailer do
 
   describe '#warning' do
     let(:strike) { Fabricate(:account_warning, target_account: receiver.account, text: 'dont worry its just the testsuite', action: 'suspend') }
-    let(:mail)   { described_class.warning(receiver, strike) }
+    let(:mail)   { described_class.with(user: receiver).warning(strike) }
 
     it 'renders warning notification' do
       receiver.update!(locale: nil)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -239,7 +239,7 @@ describe UserMailer do
 
   describe '#backup_ready' do
     let(:backup) { Fabricate(:backup) }
-    let(:mail) { described_class.backup_ready(receiver, backup) }
+    let(:mail) { described_class.with(user: receiver).backup_ready(backup) }
 
     it 'renders backup_ready mail' do
       expect(mail)

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -103,7 +103,7 @@ describe UserMailer do
 
   describe '#webauthn_credential_deleted' do
     let(:credential) { Fabricate(:webauthn_credential, user_id: receiver.id) }
-    let(:mail) { described_class.webauthn_credential_deleted(receiver, credential) }
+    let(:mail) { described_class.with(user: receiver).webauthn_credential_deleted(credential) }
 
     it 'renders webauthn credential deleted notification' do
       receiver.update!(locale: nil)
@@ -216,7 +216,7 @@ describe UserMailer do
 
   describe '#webauthn_credential_added' do
     let(:credential) { Fabricate.build(:webauthn_credential) }
-    let(:mail) { described_class.webauthn_credential_added(receiver, credential) }
+    let(:mail) { described_class.with(user: receiver).webauthn_credential_added(credential) }
 
     it 'renders webauthn_credential_added mail' do
       expect(mail)

--- a/spec/requests/api/v1/admin/account_actions_spec.rb
+++ b/spec/requests/api/v1/admin/account_actions_spec.rb
@@ -13,7 +13,13 @@ RSpec.describe 'Account actions' do
     it 'notifies the user about the action taken' do
       expect { subject }
         .to have_enqueued_job(ActionMailer::MailDeliveryJob)
-        .with('UserMailer', 'warning', 'deliver_now!', args: [User, AccountWarning])
+        .with(
+          'UserMailer',
+          'warning',
+          'deliver_now!',
+          params: { user: User },
+          args: [AccountWarning]
+        )
     end
   end
 


### PR DESCRIPTION
Similar to previous PRs for `NotificationMailer` and `AdminMailer`.

Summary:

- Adds missing spec coverage for the welcome and backup_ready mailers
- Add before_action for setting common instance vars
- Add default `to` value
- Add parameterization to almost all mailers (did not do the devise-descended ones in this PR)
- Use `default_i18n_subject` where it works, or a custom devise version where it doesn't (the built-in one does not pick up the right i18n scope from parent classes. Might revisit this in future PR).
- Fix one bug (I think!?) where the appeal_rejected mailer was not actually being sent

