### PR TITLE
Move localized subject mailer shared example to separate file

### DIFF
--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -8,19 +8,6 @@ RSpec.describe NotificationMailer do
   let(:foreign_status) { Fabricate(:status, account: sender, text: 'The body of the foreign status') }
   let(:own_status)     { Fabricate(:status, account: receiver.account, text: 'The body of the own status') }
 
-  shared_examples 'localized subject' do |*args, **kwrest|
-    it 'renders subject localized for the locale of the receiver' do
-      locale = :de
-      receiver.update!(locale: locale)
-      expect(mail.subject).to eq I18n.t(*args, **kwrest.merge(locale: locale))
-    end
-
-    it 'renders subject localized for the default locale if the locale of the receiver is unavailable' do
-      receiver.update!(locale: nil)
-      expect(mail.subject).to eq I18n.t(*args, **kwrest.merge(locale: I18n.default_locale))
-    end
-  end
-
   describe 'mention' do
     let(:mention) { Mention.create!(account: receiver.account, status: foreign_status) }
     let(:notification) { Notification.create!(account: receiver.account, activity: mention) }

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -5,19 +5,6 @@ require 'rails_helper'
 describe UserMailer do
   let(:receiver) { Fabricate(:user) }
 
-  shared_examples 'localized subject' do |*args, **kwrest|
-    it 'renders subject localized for the locale of the receiver' do
-      locale = :de
-      receiver.update!(locale: locale)
-      expect(mail.subject).to eq I18n.t(*args, **kwrest.merge(locale: locale))
-    end
-
-    it 'renders subject localized for the default locale if the locale of the receiver is unavailable' do
-      receiver.update!(locale: nil)
-      expect(mail.subject).to eq I18n.t(*args, **kwrest.merge(locale: I18n.default_locale))
-    end
-  end
-
   describe 'confirmation_instructions' do
     let(:mail) { described_class.confirmation_instructions(receiver, 'spec') }
 

--- a/spec/support/examples/mailers.rb
+++ b/spec/support/examples/mailers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+shared_examples 'localized subject' do |*args, **kwrest|
+  it 'renders subject localized for the locale of the receiver' do
+    locale = :de
+    receiver.update!(locale: locale)
+    expect(mail.subject).to eq I18n.t(*args, **kwrest.merge(locale: locale))
+  end
+
+  it 'renders subject localized for the default locale if the locale of the receiver is unavailable' do
+    receiver.update!(locale: nil)
+    expect(mail.subject).to eq I18n.t(*args, **kwrest.merge(locale: I18n.default_locale))
+  end
+end


### PR DESCRIPTION
Both mailer specs had same exact shared example code; extract it to its own spot.