### PR TITLE
Run the rebase conflict checker once an hour

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -1,17 +1,8 @@
 name: PR Needs Rebase
 
 on:
-  push:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'renovate/**'
-      - 'l10n_main'
-  pull_request_target:
-    branches-ignore:
-      - 'dependabot/**'
-      - 'renovate/**'
-      - 'l10n_main'
-    types: [synchronize]
+  schedule:
+    cron: '0 * * * *'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Previously this would run on every PR push, which sometimes meant it would get backlogged and cause PRs to show a failing build status when they were actually succeeding, but the conflict checker could not run fast enough.

This is a limitation of its design and of the github API it uses.

This changes the schedule so that instead of running the checker (which checks EVERY open PR) on every PR push or opening, we just run the checker once per hour.

This should lead to fewer false build status failures, and comes only at the (trivial?) cost of at most a 59 minute delay in marking a PR as needing a rebase, relative to the previous configuration.

Background here: https://github.com/mastodon/mastodon/pull/22020#issuecomment-1503262259

I'm not a GH actions expert, and would leave feedback both on the change here, but also if I have the scheduling syntax correct? @nschonni ?