### PR TITLE
Ignore the brakeman `PermitAttributes` check

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -58,75 +58,6 @@
       "note": ""
     },
     {
-      "warning_type": "Mass Assignment",
-      "warning_code": 105,
-      "fingerprint": "874be88fedf4c680926845e9a588d3197765a6ccbfdd76466b44cc00151c612e",
-      "check_name": "PermitAttributes",
-      "message": "Potentially dangerous key allowed for mass assignment",
-      "file": "app/controllers/api/v1/admin/reports_controller.rb",
-      "line": 88,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.permit(:resolved, :account_id, :target_account_id)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Api::V1::Admin::ReportsController",
-        "method": "filter_params"
-      },
-      "user_input": ":account_id",
-      "confidence": "High",
-      "cwe_id": [
-        915
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Mass Assignment",
-      "warning_code": 105,
-      "fingerprint": "ab5035dd1a9f8c3a8d92fb2c37e8fe86fede4f87c91b71aa32e89c9eede602fc",
-      "check_name": "PermitAttributes",
-      "message": "Potentially dangerous key allowed for mass assignment",
-      "file": "app/controllers/api/v1/notifications_controller.rb",
-      "line": 77,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.permit(:account_id, :types => ([]), :exclude_types => ([]))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Api::V1::NotificationsController",
-        "method": "browserable_params"
-      },
-      "user_input": ":account_id",
-      "confidence": "High",
-      "cwe_id": [
-        915
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Mass Assignment",
-      "warning_code": 105,
-      "fingerprint": "b0dd0a26d24f5ede9713fe49210e9638be5f5548af9eee0b5a16fe9dbc80ffcd",
-      "check_name": "PermitAttributes",
-      "message": "Potentially dangerous key allowed for mass assignment",
-      "file": "app/controllers/api/v2/search_controller.rb",
-      "line": 42,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.permit(:type, :offset, :min_id, :max_id, :account_id, :following)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Api::V2::SearchController",
-        "method": "search_params"
-      },
-      "user_input": ":account_id",
-      "confidence": "High",
-      "cwe_id": [
-        915
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "cd5cfd7f40037fbfa753e494d7129df16e358bfc43ef0da3febafbf4ee1ed3ac",
@@ -156,29 +87,6 @@
       "confidence": "Weak",
       "cwe_id": [
         79
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Mass Assignment",
-      "warning_code": 105,
-      "fingerprint": "d0511f0287aea4ed9511f5a744f880cb15af77a8ec88f81b7365b00b642cf427",
-      "check_name": "PermitAttributes",
-      "message": "Potentially dangerous key allowed for mass assignment",
-      "file": "app/controllers/api/v1/reports_controller.rb",
-      "line": 26,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.permit(:account_id, :comment, :category, :forward, :forward_to_domains => ([]), :status_ids => ([]), :rule_ids => ([]))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Api::V1::ReportsController",
-        "method": "report_params"
-      },
-      "user_input": ":account_id",
-      "confidence": "High",
-      "cwe_id": [
-        915
       ],
       "note": ""
     }

--- a/config/brakeman.yml
+++ b/config/brakeman.yml
@@ -1,0 +1,3 @@
+---
+:skip_checks:
+  - CheckPermitAttributes


### PR DESCRIPTION
Avoids brakeman mass assignment warning.

This check includes a hard-coded reference to `account_id`, which we use (safely) in a bunch of places.

In the event we introduced an unsafe permit, it would likely be caught by other Mass Assignment checks, and we are only going to get false positives from this particular check (for example: all the ignores being removed in this PR are GET requests where we are forming filter/search options, and none are doing assignment).