### PR TITLE
Exclude `lib/linter` from simplecov report

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 if ENV['DISABLE_SIMPLECOV'] != 'true'
   require 'simplecov'
   SimpleCov.start 'rails' do
+    add_filter 'lib/linter'
     add_group 'Policies', 'app/policies'
     add_group 'Presenters', 'app/presenters'
     add_group 'Serializers', 'app/serializers'


### PR DESCRIPTION
These are the haml middle dot checkers, which are used only in the linters and not required otherwise, but are showing up in code coverage report.