### PR TITLE
Change the wording of the dismissable explore prompt

### DIFF
--- a/app/javascript/mastodon/features/home_timeline/components/explore_prompt.tsx
+++ b/app/javascript/mastodon/features/home_timeline/components/explore_prompt.tsx
@@ -22,7 +22,7 @@ export const ExplorePrompt = () => (
     <p>
       <FormattedMessage
         id='home.explore_prompt.body'
-        defaultMessage="Your home feed will have a mix of posts from the hashtags you've chosen to follow, the people you've chosen to follow, and the posts they boost. It's looking pretty quiet right now, so how about:"
+        defaultMessage="Your home feed will have a mix of posts from the hashtags you've chosen to follow, the people you've chosen to follow, and the posts they boost. If that feels too quiet, you may want to:"
       />
     </p>
 

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -303,7 +303,7 @@
   "home.column_settings.basic": "Basic",
   "home.column_settings.show_reblogs": "Show boosts",
   "home.column_settings.show_replies": "Show replies",
-  "home.explore_prompt.body": "Your home feed will have a mix of posts from the hashtags you've chosen to follow, the people you've chosen to follow, and the posts they boost. It's looking pretty quiet right now, so how about:",
+  "home.explore_prompt.body": "Your home feed will have a mix of posts from the hashtags you've chosen to follow, the people you've chosen to follow, and the posts they boost. If that feels too quiet, you may want to:",
   "home.explore_prompt.title": "This is your home base within Mastodon.",
   "home.hide_announcements": "Hide announcements",
   "home.show_announcements": "Show announcements",


### PR DESCRIPTION
This is a very minor change, but I think it better expresses the intent of the banner.

It would also help if it was more obvious that this can be dismissed, and that doing so dismisses it for good.

## Before

> Your home feed will have a mix of posts from the hashtags you've chosen to follow, the people you've chosen to follow, and the posts they boost. It's looking pretty quiet right now, so how about:

![image](https://github.com/mastodon/mastodon/assets/384364/b1e59e89-9ebf-4dec-95d8-c37e6a691d2e)

## After

> Your home feed will have a mix of posts from the hashtags you've chosen to follow, the people you've chosen to follow, and the posts they boost. If that feels too quiet, you may want to:

![image](https://github.com/mastodon/mastodon/assets/384364/2b9138a7-bef4-4439-bb1f-0f2d9e93043d)
