### PR TITLE
Use invariant colors on notification toasts

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9089,10 +9089,10 @@ noscript {
   width: auto;
   padding: 15px;
   margin: 0;
-  color: $primary-text-color;
+  color: $white;
   background: rgba($black, 0.85);
   backdrop-filter: blur(8px);
-  border: 1px solid rgba(lighten($ui-base-color, 4%), 0.85);
+  border: 1px solid rgba(lighten($classic-base-color, 4%), 0.85);
   border-radius: 8px;
   box-shadow: 0 10px 15px -3px rgba($base-shadow-color, 0.25),
     0 4px 6px -4px rgba($base-shadow-color, 0.25);
@@ -9120,7 +9120,7 @@ noscript {
   text-transform: uppercase;
   margin-inline-start: 10px;
   cursor: pointer;
-  color: $highlight-text-color;
+  color: $blurple-300;
   border-radius: 4px;
   padding: 0 4px;
 


### PR DESCRIPTION
Fixes #25910. This pull request fixes the problem by using invariant colors on all themes:

![Capture d’écran 2023-07-11 à 19 46 04](https://github.com/mastodon/mastodon/assets/411336/909e3945-5152-45ec-8020-f8514fb22513)

…and it still looks nice on dark, default mode:

![Capture d’écran 2023-07-11 à 19 47 05](https://github.com/mastodon/mastodon/assets/411336/9680c846-8c88-4bb5-a533-8b2b71101d73)