### PR TITLE
Fix `Lint/SendWithMixinArgument` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -107,11 +107,6 @@ Lint/OrAssignmentToConstant:
     - 'lib/sanitize_ext/sanitize_config.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-Lint/SendWithMixinArgument:
-  Exclude:
-    - 'config/application.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
 Lint/UnusedBlockArgument:
   Exclude:

--- a/config/application.rb
+++ b/config/application.rb
@@ -194,10 +194,10 @@ module Mastodon
     config.to_prepare do
       Doorkeeper::AuthorizationsController.layout 'modal'
       Doorkeeper::AuthorizedApplicationsController.layout 'admin'
-      Doorkeeper::Application.send :include, ApplicationExtension
-      Doorkeeper::AccessToken.send :include, AccessTokenExtension
-      Devise::FailureApp.send :include, AbstractController::Callbacks
-      Devise::FailureApp.send :include, Localized
+      Doorkeeper::Application.include ApplicationExtension
+      Doorkeeper::AccessToken.include AccessTokenExtension
+      Devise::FailureApp.include AbstractController::Callbacks
+      Devise::FailureApp.include Localized
     end
   end
 end


### PR DESCRIPTION
In older (< ~2.1 maybe?) rubies `include` was a private method and needed the `send`. In all non-EOL rubies I believe you can just call it directly.