### PR TITLE
Fix `Lint/Void` cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -142,12 +142,6 @@ Lint/UselessAssignment:
     - 'spec/services/resolve_url_service_spec.rb'
     - 'spec/views/statuses/show.html.haml_spec.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: CheckForMethodsWithNoSideEffects.
-Lint/Void:
-  Exclude:
-    - 'spec/services/resolve_account_service_spec.rb'
-
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
   Max: 150

--- a/spec/services/resolve_account_service_spec.rb
+++ b/spec/services/resolve_account_service_spec.rb
@@ -209,11 +209,6 @@ RSpec.describe ResolveAccountService, type: :service do
     fail_occurred  = false
     return_values  = Concurrent::Array.new
 
-    # Preload classes that throw circular dependency errors in threads
-    Account
-    TagManager
-    DomainBlock
-
     threads = Array.new(5) do
       Thread.new do
         true while wait_for_start


### PR DESCRIPTION
My suspicion is that whatever load order problem this was solving has since been solved by one of ruby/rails/zeitwerk, but there's not much detail in the commit that added it as to whether this was an intermittent failure being fixed, or an every run failure.