### PR TITLE
Increase PR Rebase job retries

### DIFF
--- a/.github/workflows/rebase-needed.yml
+++ b/.github/workflows/rebase-needed.yml
@@ -23,5 +23,5 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           commentOnClean: This pull request has resolved merge conflicts and is ready for review.
           commentOnDirty: This pull request has merge conflicts that must be resolved before it can be merged.
-          retryMax: 10
+          retryMax: 30
           continueOnMissingPermissions: false


### PR DESCRIPTION
Noticed one of the jobs ran out of retries. Since this just runs once an hour, I increased the retries to 30, so it potentially keeps running till the next job might cancel it (https://github.com/eps1lon/actions-label-merge-conflict/tree/releases/2.x/#retryafter * https://github.com/eps1lon/actions-label-merge-conflict/tree/releases/2.x/#retrymax)