### PR TITLE
Remove the `sr` locale override .rb files

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -150,13 +150,6 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 27
 
-# Configuration parameters: ExpectMatchingDefinition, CheckDefinitionPathHierarchy, CheckDefinitionPathHierarchyRoots, Regex, IgnoreExecutableScripts, AllowedAcronyms.
-# CheckDefinitionPathHierarchyRoots: lib, spec, test, src
-# AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
-Naming/FileName:
-  Exclude:
-    - 'config/locales/sr-Latn.rb'
-
 # Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers, AllowedPatterns.
 # SupportedStyles: snake_case, normalcase, non_integer
 # AllowedIdentifiers: capture3, iso8601, rfc1123_date, rfc822, rfc2822, rfc3339, x86_64
@@ -844,8 +837,6 @@ Style/RedundantConstantBase:
   Exclude:
     - 'config/environments/production.rb'
     - 'config/initializers/sidekiq.rb'
-    - 'config/locales/sr-Latn.rb'
-    - 'config/locales/sr.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: SafeForConstants.

--- a/config/locales/sr-Latn.rb
+++ b/config/locales/sr-Latn.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_i18n/common_pluralizations/romanian'
-
-::RailsI18n::Pluralization::Romanian.with_locale(:'sr-Latn')

--- a/config/locales/sr.rb
+++ b/config/locales/sr.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_i18n/common_pluralizations/romanian'
-
-::RailsI18n::Pluralization::Romanian.with_locale(:sr)


### PR DESCRIPTION
History here:

2019-06 - Files added to Mastodon: https://github.com/mastodon/mastodon/pull/11061

Same Day - Details of the issue added on upstream: https://github.com/svenfuchs/rails-i18n/issues/853

2021-05 - Upstream fix: https://github.com/svenfuchs/rails-i18n/pull/925/files

2022-01 - Upstream fix part two: https://github.com/svenfuchs/rails-i18n/pull/972/files

2022-02 - Upstream release with fixes: https://github.com/svenfuchs/rails-i18n/blob/master/CHANGELOG.md#702-2022-02-12

It looks like these files were only in place to nudge the pluralization rules, which have since been fixed in `rails-i18n`.

There were no specs added with the original change - https://github.com/mastodon/mastodon/pull/11061 - although there were subsequently specs added (around locale recognition, not correct pluralization) which do use `sr-Latn`. Because of that, I'm sort of taking the word of those PRs that this fixes the issue. Not totally necessary, but would be nice to add a spec here showing the behavior that our config was putting in place and double check that it still works now on newer rails-i18n version. Happy to do that if I can get some guidance on what was failing originally (looks like many pluralizations?). I did some locale console testing to be sure that some translations using counts in both locales still worked.

