### PR TITLE
Fix sounds not being loaded from assets host

### DIFF
--- a/app/javascript/mastodon/store/middlewares/sounds.ts
+++ b/app/javascript/mastodon/store/middlewares/sounds.ts
@@ -1,5 +1,8 @@
 import type { Middleware, AnyAction } from 'redux';
 
+import ready from 'mastodon/ready';
+import { assetHost } from 'mastodon/utils/config';
+
 import type { RootState } from '..';
 
 interface AudioSource {
@@ -35,18 +38,20 @@ export const soundsMiddleware = (): Middleware<
   Record<string, never>,
   RootState
 > => {
-  const soundCache: { [key: string]: HTMLAudioElement } = {
-    boop: createAudio([
+  const soundCache: { [key: string]: HTMLAudioElement } = {};
+
+  void ready(() => {
+    soundCache.boop = createAudio([
       {
-        src: '/sounds/boop.ogg',
+        src: `${assetHost}/sounds/boop.ogg`,
         type: 'audio/ogg',
       },
       {
-        src: '/sounds/boop.mp3',
+        src: `${assetHost}/sounds/boop.mp3`,
         type: 'audio/mpeg',
       },
-    ]),
-  };
+    ]);
+  });
 
   return () =>
     (next) =>


### PR DESCRIPTION
Fixes #25827.

Quite an easy fix, beside a little trap I stumbled upon: we can't read the `assetHost` too soon, as it may return an empty value. I added a call to `ready` before it fills the `soundCache` object with the sounds, and everything seems to work fine locally.