### PR TITLE
Refactor `Status.tagged_with_all` for brakeman SQL injection warning

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -103,11 +103,9 @@ class Status < ApplicationRecord
   scope :not_domain_blocked_by_account, ->(account) { account.excluded_from_timeline_domains.blank? ? left_outer_joins(:account) : left_outer_joins(:account).where('accounts.domain IS NULL OR accounts.domain NOT IN (?)', account.excluded_from_timeline_domains) }
   scope :tagged_with_all, lambda { |tag_ids|
     Array(tag_ids).map(&:to_i).reduce(self) do |result, id|
-      join_query_string = <<~SQL.squish
-        INNER JOIN statuses_tags t:tag_id ON t:tag_id.status_id = statuses.id AND t:tag_id.tag_id = :tag_id
+      result.where(<<~SQL.squish, tag_id: id)
+        EXISTS(SELECT 1 FROM statuses_tags WHERE statuses_tags.status_id = statuses.id AND statuses_tags.tag_id = :tag_id)
       SQL
-      sanitized_join_query = sanitize_sql_array([join_query_string, tag_id: id])
-      result.joins(sanitized_join_query)
     end
   }
   scope :tagged_with_none, lambda { |tag_ids|

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,29 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "19df3740b8d02a9fe0eb52c939b4b87d3a2a591162a6adfa8d64e9c26aeebe6d",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/status.rb",
-      "line": 106,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "result.joins(\"INNER JOIN statuses_tags t#{id} ON t#{id}.status_id = statuses.id AND t#{id}.tag_id = #{id}\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Status",
-        "method": null
-      },
-      "user_input": "id",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "71cf98c8235b5cfa9946b5db8fdc1a2f3a862566abb34e4542be6f3acae78233",
@@ -206,6 +183,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-07-11 16:08:58 +0200",
+  "updated": "2023-07-12 11:20:51 -0400",
   "brakeman_version": "6.0.0"
 }


### PR DESCRIPTION
Opening as an alternative to https://github.com/mastodon/mastodon/pull/25882

This one just narrowly fixes the brakeman sql injection warning by sanitizing the sql string, and does not change to use a subquery.

As far as I can tell the generated sql remains the same.