### PR TITLE
Fix trending publishers table not rendering correctly on narrow screens

### DIFF
--- a/app/views/admin/trends/links/preview_card_providers/index.html.haml
+++ b/app/views/admin/trends/links/preview_card_providers/index.html.haml
@@ -29,7 +29,7 @@
   - Trends::PreviewCardProviderFilter::KEYS.each do |key|
     = hidden_field_tag key, params[key] if params[key].present?
 
-  .batch-table.optional
+  .batch-table
     .batch-table__toolbar
       %label.batch-table__toolbar__select.batch-checkbox-all
         = check_box_tag :batch_checkbox_all, nil, false


### PR DESCRIPTION
Fixes https://github.com/mastodon/mastodon/issues/25944

Changes this table view to match the other .batch-table views used in the rest of trending.