### PR TITLE
Add `publicly_searchable` attribute to statuses index

### DIFF
--- a/app/chewy/statuses_index.rb
+++ b/app/chewy/statuses_index.rb
@@ -63,13 +63,14 @@ class StatusesIndex < Chewy::Index
   end
 
   root date_detection: false do
-    field :id, type: 'long'
-    field :account_id, type: 'long'
+    field(:id, type: 'long')
+    field(:account_id, type: 'long')
 
-    field :text, type: 'text', value: ->(status) { status.searchable_text } do
-      field :stemmed, type: 'text', analyzer: 'content'
+    field(:text, type: 'text', value: ->(status) { status.searchable_text }) do
+      field(:stemmed, type: 'text', analyzer: 'content')
     end
 
-    field :searchable_by, type: 'long', value: ->(status, crutches) { status.searchable_by(crutches) }
+    field(:searchable_by, type: 'long', value: ->(status, crutches) { status.searchable_by(crutches) })
+    field(:publicly_searchable, type: 'boolean', value: ->(status) { status.publicly_searchable? })
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -125,7 +125,7 @@ class Account < ApplicationRecord
   scope :not_domain_blocked_by_account, ->(account) { where(arel_table[:domain].eq(nil).or(arel_table[:domain].not_in(account.excluded_from_timeline_domains))) }
 
   after_update_commit :trigger_update_webhooks
-  after_update :update_statuses_index!, if: :saved_change_to_discoverable? and Chewy.enabled?
+  after_update :enqueue_update_statuses_index, if: :saved_change_to_discoverable? and Chewy.enabled?
 
   delegate :email,
            :unconfirmed_email,

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -79,6 +79,7 @@ class Account < ApplicationRecord
   include DomainMaterializable
   include AccountMerging
   include AccountSearch
+  include AccountStatusesSearch
 
   enum protocol: { ostatus: 0, activitypub: 1 }
   enum suspension_origin: { local: 0, remote: 1 }, _prefix: true
@@ -124,6 +125,7 @@ class Account < ApplicationRecord
   scope :not_domain_blocked_by_account, ->(account) { where(arel_table[:domain].eq(nil).or(arel_table[:domain].not_in(account.excluded_from_timeline_domains))) }
 
   after_update_commit :trigger_update_webhooks
+  after_update :update_statuses_index!, if: :saved_change_to_discoverable? and Chewy.enabled?
 
   delegate :email,
            :unconfirmed_email,

--- a/app/models/concerns/account_statuses_search.rb
+++ b/app/models/concerns/account_statuses_search.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module AccountStatusesSearch
+  extend ActiveSupport::Concern
+
+  def update_statuses_index!
+    Chewy.strategy(:sidekiq) do
+      StatusesIndex.import(query: Status.where(account_id: id))
+    end
+  end
+end

--- a/app/models/concerns/account_statuses_search.rb
+++ b/app/models/concerns/account_statuses_search.rb
@@ -4,6 +4,11 @@ module AccountStatusesSearch
   extend ActiveSupport::Concern
 
   def update_statuses_index!
+    return unless Chewy.enabled?
+
+    # This might not scale if a user has a TON of statuses.
+    # If that is the case, perhaps for users with many statuses, we should:
+    # (1) get all their statuses and (2) submit requests to ES in batches.
     Chewy.strategy(:sidekiq) do
       StatusesIndex.import(query: Status.where(account_id: id))
     end

--- a/app/models/concerns/account_statuses_search.rb
+++ b/app/models/concerns/account_statuses_search.rb
@@ -3,6 +3,10 @@
 module AccountStatusesSearch
   extend ActiveSupport::Concern
 
+  def enqueue_update_statuses_index
+    UpdateStatusIndexWorker.perform_async(id)
+  end
+
   def update_statuses_index!
     return unless Chewy.enabled?
 

--- a/app/models/concerns/status_search.rb
+++ b/app/models/concerns/status_search.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module StatusSearch
+  extend ActiveSupport::Concern
+
+  def publicly_searchable?
+    public_visibility? && account.discoverable?
+  end
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -37,6 +37,7 @@ class Status < ApplicationRecord
   include StatusSnapshotConcern
   include RateLimitable
   include StatusSafeReblogInsert
+  include StatusSearch
 
   rate_limit by: :account, family: :statuses
 

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -39,25 +39,15 @@ class SearchService < BaseService
   end
 
   def perform_statuses_search!
-    definition = parsed_query.apply(StatusesIndex.filter(term: { searchable_by: @account.id }))
-
-    definition = definition.filter(term: { account_id: @options[:account_id] }) if @options[:account_id].present?
-
-    if @options[:min_id].present? || @options[:max_id].present?
-      range      = {}
-      range[:gt] = @options[:min_id].to_i if @options[:min_id].present?
-      range[:lt] = @options[:max_id].to_i if @options[:max_id].present?
-      definition = definition.filter(range: { id: range })
-    end
-
-    results             = definition.limit(@limit).offset(@offset).objects.compact
-    account_ids         = results.map(&:account_id)
-    account_domains     = results.map(&:account_domain)
-    preloaded_relations = @account.relations_map(account_ids, account_domains)
-
-    results.reject { |status| StatusFilter.new(status, @account, preloaded_relations).filtered? }
-  rescue Faraday::ConnectionFailed, Parslet::ParseFailed
-    []
+    StatusSearchService.new.call(
+      @query,
+      @account,
+      limit: @limit,
+      offset: @offset,
+      account_id: @options[:account_id],
+      min_id: @options[:min_id],
+      max_id: @options[:max_id]
+    )
   end
 
   def perform_hashtags_search!
@@ -113,9 +103,5 @@ class SearchService < BaseService
 
   def statuses_search?
     @options[:type].blank? || @options[:type] == 'statuses'
-  end
-
-  def parsed_query
-    SearchQueryTransformer.new.apply(SearchQueryParser.new.parse(@query))
   end
 end

--- a/app/services/status_search_service.rb
+++ b/app/services/status_search_service.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class StatusSearchService < BaseService
+  def call(query, account = nil, options = {})
+    @query   = query&.strip
+    @account = account
+    @options = options
+    @limit   = options[:limit].to_i
+    @offset  = options[:offset].to_i
+
+    status_search_results
+  end
+
+  private
+
+  def status_search_results
+    definition = search_definition
+
+    definition = definition.filter(term: { account_id: @options[:account_id] }) if @options[:account_id].present?
+
+    if @options[:min_id].present? || @options[:max_id].present?
+      range      = {}
+      range[:gt] = @options[:min_id].to_i if @options[:min_id].present?
+      range[:lt] = @options[:max_id].to_i if @options[:max_id].present?
+      definition = definition.filter(range: { id: range })
+    end
+
+    results             = definition.limit(@limit).offset(@offset).objects.compact
+    account_ids         = results.map(&:account_id)
+    account_domains     = results.map(&:account_domain)
+    preloaded_relations = @account.relations_map(account_ids, account_domains)
+
+    results.reject { |status| StatusFilter.new(status, @account, preloaded_relations).filtered? }
+  rescue Faraday::ConnectionFailed, Parslet::ParseFailed
+    []
+  end
+
+  def search_definition
+    non_publicly_searchable_clauses = non_publicly_searchable
+    publicly_searchable_clauses = publicly_searchable
+
+    filter = {
+      bool: {
+        should: [
+          non_publicly_searchable_clauses,
+          publicly_searchable_clauses,
+        ],
+        minimum_should_match: 1,
+      },
+    }
+
+    StatusesIndex.query(filter)
+  end
+
+  def publicly_searchable
+    parsed_query.apply(
+      {
+        bool: {
+          must: [
+            { term: { publicly_searchable: true } },
+          ],
+        },
+      }
+    )
+  end
+
+  def non_publicly_searchable
+    parsed_query.apply(
+      {
+        bool: {
+          must: [
+            { term: { publicly_searchable: false } },
+          ],
+          filter: [
+            { term: { searchable_by: @account.id } },
+          ],
+        },
+      }
+    )
+  end
+
+  def parsed_query
+    SearchQueryTransformer.new.apply(SearchQueryParser.new.parse(@query))
+  end
+end

--- a/app/workers/update_status_index_worker.rb
+++ b/app/workers/update_status_index_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class UpdateStatusIndexWorker
+  include Sidekiq::Worker
+
+  def perform(account_id)
+    account = Account.find(account_id)
+    return unless account
+
+    account.update_statuses_index!
+  end
+end

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -15,4 +15,111 @@ describe SearchQueryTransformer do
       expect(transformer.filter_clauses.first).to be_nil
     end
   end
+
+  describe '#apply' do
+    subject(:applied_query) do
+      described_class.new.apply(
+        SearchQueryParser.new.parse(search_term)
+      ).apply(query)
+    end
+
+    let(:query) { { bool: {} } }
+    let(:search_term) { '' }
+
+    context 'when query is just a bool' do
+      it 'returns a hash of bool' do
+        expect(applied_query).to eq(query)
+      end
+    end
+
+    context 'when should_clauses are present' do
+      let(:search_term) { 'test' }
+
+      it 'adds should clauses to the query' do
+        expect(applied_query[:bool][:should].length).to eq(1)
+        expect(applied_query[:bool][:should][0][:multi_match][:query]).to eq(search_term)
+      end
+
+      it 'sets minimum_should_match to 1' do
+        expect(applied_query[:bool][:minimum_should_match]).to eq(1)
+      end
+    end
+
+    context 'when must_clauses are present' do
+      let(:search_term) { '+test' }
+
+      it 'adds must clauses to the query' do
+        expect(applied_query[:bool][:must].length).to eq(1)
+        expect(applied_query[:bool][:must][0][:multi_match][:query]).to eq(search_term[1..])
+      end
+    end
+
+    context 'when must_not_clauses are present' do
+      let(:search_term) { '-test' }
+
+      it 'adds must_not clauses to the query' do
+        expect(applied_query[:bool][:must_not].length).to eq(1)
+        expect(applied_query[:bool][:must_not][0][:multi_match][:query]).to eq(search_term[1..])
+      end
+    end
+
+    context 'when filter_clauses are present' do
+      let(:search_term) { 'from:@test_account@example.com' }
+
+      it 'adds filter clauses to the query' do
+        account = Fabricate(:account, username: 'test_account', domain: 'example.com')
+
+        expect(applied_query[:bool][:filter].length).to eq(1)
+        expect(applied_query[:bool][:filter][0][:term][:account_id]).to eq(account.id)
+        puts "Final count of Account records: #{Account.count}"
+      end
+    end
+
+    context 'when all clauses are present' do
+      let(:should_term) { 'should' }
+      let(:must_term) { '+must' }
+      let(:must_not_term) { '-nope' }
+      let(:filter_term) { 'from:@test_account@example.com' }
+      let(:search_term) { "#{should_term} #{must_term} #{must_not_term} #{filter_term}" }
+
+      it 'adds all clauses to the query' do
+        account = Fabricate(:account, username: 'test_account', domain: 'example.com')
+
+        expect(applied_query[:bool][:should][0][:multi_match][:query]).to eq(should_term)
+        expect(applied_query[:bool][:must][0][:multi_match][:query]).to eq(must_term[1..])
+        expect(applied_query[:bool][:must_not][0][:multi_match][:query]).to eq(must_not_term[1..])
+        expect(applied_query[:bool][:filter][0][:term][:account_id]).to eq(account.id)
+      end
+
+      it 'sets minimum_should_match to 1' do
+        Fabricate(:account, username: 'test_account', domain: 'example.com')
+
+        expect(applied_query[:bool][:minimum_should_match]).to eq(1)
+      end
+    end
+
+    context 'when all clauses are present and query has all clauses too' do
+      let(:should_term) { 'should' }
+      let(:must_term) { '+must' }
+      let(:must_not_term) { '-nope' }
+      let(:filter_term) { 'from:@test_account@example.com' }
+      let(:search_term) { "#{should_term} #{must_term} #{must_not_term} #{filter_term}" }
+      let(:query) { { bool: { should: [{ term: { exists: true } }], must: [{ term: { exists: true } }], must_not: [{ term: { exists: true } }], filter: [{ term: { exists: true } }] } } }
+
+      it 'adds all clauses to the arrays in the query' do
+        Fabricate(:account, username: 'test_account', domain: 'example.com')
+
+        expect(applied_query[:bool][:should].length).to eq(2)
+        expect(applied_query[:bool][:must].length).to eq(2)
+        expect(applied_query[:bool][:must_not].length).to eq(2)
+        expect(applied_query[:bool][:filter].length).to eq(2)
+      end
+
+      it 'sets minimum_should_match to 1' do
+        Fabricate(:account, username: 'test_account', domain: 'example.com')
+
+        expect(applied_query[:bool][:minimum_should_match]).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Goal 
The idea here is to allow `public` posts by `discoverable` users to show up in search results. This is done by adding a new `publicly_searchable` field in the Statuses Index. 

A status is `publicly_searchable` is the status's visibility is `public` and if the account is `discoverable`. 

Note: This will only work on instances with Elastic Search enabled.

I think about this PR as having three (3) distinct steps
1. Add the `publicly_searchable` field and data into the statuses index in Elastic Search.
2. Create a job to run for all users who have changed their `discoverable` attribute in a given interval
3. Use that data and change how the actual search queries work.

## Drawback
If a user toggles between `discoverable` and `non-discoverable`, we need to update all of their statuses in the index.
Each status requires two database look ups. One for the status's visibility, one of the account's discoverability.

Note that there are a few changes to `app/chewy/statuses_index.rb` but most of that is to align this file with how `app/chewy/accounts_index.rb` defines its fields. 

## What Changed in the Index
A New Test User who is not `discoverable`
<img width="875" alt="Screenshot 2023-07-12 at 3 42 02 PM" src="https://github.com/mastodon/mastodon/assets/15234688/be1f2df9-4e8f-441e-a496-f0e87b843ac4">

Creates a public post
<img width="577" alt="Screenshot 2023-07-12 at 3 42 38 PM" src="https://github.com/mastodon/mastodon/assets/15234688/50e8d40e-8c7f-47c7-9345-0a49521da0ca">

Field in ES shows it is not `publicly_searchable`
<img width="499" alt="Screenshot 2023-07-12 at 3 43 12 PM" src="https://github.com/mastodon/mastodon/assets/15234688/42c3d936-2162-4a79-aa6f-a99ee0104402">

They then update their preferences to be `discoverable`
<img width="877" alt="Screenshot 2023-07-12 at 3 43 41 PM" src="https://github.com/mastodon/mastodon/assets/15234688/3fd6a65c-841e-4198-b3ca-773ab30d7e89">

And the field updates to be `publicly_searchable`
<img width="522" alt="Screenshot 2023-07-12 at 3 44 11 PM" src="https://github.com/mastodon/mastodon/assets/15234688/363d87be-6267-4a0b-a7bd-70450644164d">

## Search Example
A user posts a `publicly_searchable` post
<img width="578" alt="Screenshot 2023-07-28 at 10 10 13 AM" src="https://github.com/mastodon/mastodon/assets/15234688/837a1321-250c-41e1-ad2d-e2d5a8199c23">

A different user posts a post that is NOT `publicly_searchable`
<img width="583" alt="Screenshot 2023-07-28 at 10 09 39 AM" src="https://github.com/mastodon/mastodon/assets/15234688/2eec0339-25f0-4160-9563-bfd4fb09ae9a">

The admin can only find the `publicly_searchable` post by searching for it.
<img width="886" alt="Screenshot 2023-07-28 at 10 10 42 AM" src="https://github.com/mastodon/mastodon/assets/15234688/6973cbb6-55d6-4db5-9859-e7a876081eb7">
