### PR TITLE
Fix follow link style in embeds

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -22,7 +22,7 @@ module AccountsHelper
   def account_action_button(account)
     return if account.memorial? || account.moved?
 
-    link_to ActivityPub::TagManager.instance.url_for(account), class: 'button', target: '_new' do
+    link_to ActivityPub::TagManager.instance.url_for(account), class: 'button logo-button', target: '_new' do
       safe_join([logo_as_symbol, t('accounts.follow')])
     end
   end

--- a/app/javascript/styles/mastodon/statuses.scss
+++ b/app/javascript/styles/mastodon/statuses.scss
@@ -77,6 +77,18 @@
   }
 }
 
+.button.logo-button svg {
+  width: 20px;
+  height: auto;
+  vertical-align: middle;
+  margin-inline-end: 5px;
+  fill: $primary-text-color;
+
+  @media screen and (max-width: $no-gap-breakpoint) {
+    display: none;
+  }
+}
+
 .embed {
   .status__content[data-spoiler='folded'] {
     .e-content {


### PR DESCRIPTION
Fix regression introduced by #25903

This does not fully revert to the style before #25903 (which seems to have smaller margins/padding) but fixes the issue with the SVG taking all the space and breaking the button.

Alternatively, since the SVG is hidden from narrow views, which are the intended one for embeds, maybe we could simply unconditionally remove it.

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/6a260aad-63ee-4b7e-ba73-2e43f234e18b)
![image](https://github.com/mastodon/mastodon/assets/384364/508c4bf6-a1b2-428b-96e4-78f4c9bb6254)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/51a6296b-9a8d-4d74-b5f5-bf6e72d3c573)
![image](https://github.com/mastodon/mastodon/assets/384364/49cedf88-1ae9-4dd9-8174-e91ea54289e0)
