### PR TITLE
Redirect logged out users to canonical URLs for remote accounts

### DIFF
--- a/app/javascript/mastodon/features/account_timeline/index.jsx
+++ b/app/javascript/mastodon/features/account_timeline/index.jsx
@@ -69,6 +69,10 @@ RemoteHint.propTypes = {
 
 class AccountTimeline extends ImmutablePureComponent {
 
+  static contextTypes = {
+    identity: PropTypes.object,
+  };
+
   static propTypes = {
     params: PropTypes.shape({
       acct: PropTypes.string,
@@ -92,7 +96,11 @@ class AccountTimeline extends ImmutablePureComponent {
   };
 
   _load () {
-    const { accountId, withReplies, params: { tagged }, dispatch } = this.props;
+    const { accountId, withReplies, remote, remoteUrl, params: { tagged }, dispatch } = this.props;
+
+    if (remote && !this.context.identity.signedIn) {
+      window.location.replace(remoteUrl);
+    }
 
     dispatch(fetchAccount(accountId));
 


### PR DESCRIPTION
This is clearer for users (showing all posts, as one would expect), while patching a potential vector for leaking information to search engines/etc.

Related: #20744