### PR TITLE
Update strong_migrations to version 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'simple-navigation', '~> 4.4'
 gem 'simple_form', '~> 5.2'
 gem 'sprockets-rails', '~> 3.4', require: 'sprockets/railtie'
 gem 'stoplight', '~> 3.0.1'
-gem 'strong_migrations', '~> 0.8'
+gem 'strong_migrations', '1.3.0'
 gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'
 gem 'tzinfo-data', '~> 1.2023'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -740,7 +740,7 @@ GEM
     stoplight (3.0.2)
       redlock (~> 1.0)
     stringio (3.0.8)
-    strong_migrations (0.8.0)
+    strong_migrations (1.3.0)
       activerecord (>= 5.2)
     swd (1.3.0)
       activesupport (>= 3)
@@ -942,7 +942,7 @@ DEPENDENCIES
   sprockets-rails (~> 3.4)
   stackprof
   stoplight (~> 3.0.1)
-  strong_migrations (~> 0.8)
+  strong_migrations (= 1.3.0)
   test-prof
   thor (~> 1.2)
   tty-prompt (~> 0.23)


### PR DESCRIPTION
I think we can go this high before some of our older migrations start to get flagged by the next version up.