### PR TITLE
Fix for "follows you" indicator in light web UI not readable

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4389,7 +4389,7 @@ a.status-card.compact:hover {
 }
 
 .relationship-tag {
-  color: $primary-text-color;
+  color: $white;
   margin-bottom: 4px;
   display: block;
   background-color: rgba($black, 0.45);


### PR DESCRIPTION
This fixes https://github.com/mastodon/mastodon/issues/25976 by using same white color used to fix similar issue for toast as resolved in https://github.com/mastodon/mastodon/pull/25919