### PR TITLE
Add an explanation banner on switching to single column mode

### DIFF
--- a/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
@@ -31,6 +31,7 @@ const messages = defineMessages({
   about: { id: 'navigation_bar.about', defaultMessage: 'About' },
   search: { id: 'navigation_bar.search', defaultMessage: 'Search' },
   advancedInterface: { id: 'navigation_bar.advanced_interface', defaultMessage: 'Open in advanced web interface' },
+  openedInClassicInterface: { id: 'navigation_bar.opened_in_classic_interface', defaultMessage: 'This page was opened in the classic web interface.' },
 });
 
 class NavigationPanel extends Component {
@@ -57,12 +58,18 @@ class NavigationPanel extends Component {
         <div className='navigation-panel__logo'>
           <Link to='/' className='column-link column-link--logo'><WordmarkLogo /></Link>
 
-          {transientSingleColumn && (
-            <a href={`/deck${location.pathname}`} className='button button--block'>
-              {intl.formatMessage(messages.advancedInterface)}
-            </a>
+          {transientSingleColumn ? (
+            <div class='switch-to-advanced'>
+              <div class='switch-to-advanced__label'>
+                {intl.formatMessage(messages.openedInClassicInterface)}
+              </div>
+              <a href={`/deck${location.pathname}`} className='button button-tertiary button--block'>
+                {intl.formatMessage(messages.advancedInterface)}
+              </a>
+            </div>
+          ) : (
+            <hr />
           )}
-          <hr />
         </div>
 
         {signedIn && (

--- a/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
@@ -60,10 +60,9 @@ class NavigationPanel extends Component {
 
           {transientSingleColumn ? (
             <div class='switch-to-advanced'>
-              <div class='switch-to-advanced__label'>
-                {intl.formatMessage(messages.openedInClassicInterface)}
-              </div>
-              <a href={`/deck${location.pathname}`} className='button button-tertiary button--block'>
+              {intl.formatMessage(messages.openedInClassicInterface)}
+              {" "}
+              <a href={`/deck${location.pathname}`} class='switch-to-advanced__toggle'>
                 {intl.formatMessage(messages.advancedInterface)}
               </a>
             </div>

--- a/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
@@ -31,7 +31,7 @@ const messages = defineMessages({
   about: { id: 'navigation_bar.about', defaultMessage: 'About' },
   search: { id: 'navigation_bar.search', defaultMessage: 'Search' },
   advancedInterface: { id: 'navigation_bar.advanced_interface', defaultMessage: 'Open in advanced web interface' },
-  openedInClassicInterface: { id: 'navigation_bar.opened_in_classic_interface', defaultMessage: 'This page was opened in the classic web interface.' },
+  openedInClassicInterface: { id: 'navigation_bar.opened_in_classic_interface', defaultMessage: 'Posts, accounts, and other specific pages are opened by default in the classic web interface.' },
 });
 
 class NavigationPanel extends Component {

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -410,7 +410,7 @@
   "navigation_bar.lists": "Lists",
   "navigation_bar.logout": "Logout",
   "navigation_bar.mutes": "Muted users",
-  "navigation_bar.opened_in_classic_interface": "This page was opened in the classic web interface.",
+  "navigation_bar.opened_in_classic_interface": "Posts, accounts, and other specific pages are opened by default in the classic web interface.",
   "navigation_bar.personal": "Personal",
   "navigation_bar.pins": "Pinned posts",
   "navigation_bar.preferences": "Preferences",

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -410,6 +410,7 @@
   "navigation_bar.lists": "Lists",
   "navigation_bar.logout": "Logout",
   "navigation_bar.mutes": "Muted users",
+  "navigation_bar.opened_in_classic_interface": "This page was opened in the classic web interface.",
   "navigation_bar.personal": "Personal",
   "navigation_bar.pins": "Pinned posts",
   "navigation_bar.preferences": "Preferences",

--- a/app/javascript/mastodon/locales/fr.json
+++ b/app/javascript/mastodon/locales/fr.json
@@ -409,7 +409,7 @@
   "navigation_bar.lists": "Listes",
   "navigation_bar.logout": "Déconnexion",
   "navigation_bar.mutes": "Comptes masqués",
-  "navigation_bar.opened_in_classic_interface": "Cette page a été ouverte dans l’interface web classique.",
+  "navigation_bar.opened_in_classic_interface": "Les messages, les comptes et les pages spécifiques sont ouvertes dans l’interface classique.",
   "navigation_bar.personal": "Personnel",
   "navigation_bar.pins": "Messages épinglés",
   "navigation_bar.preferences": "Préférences",

--- a/app/javascript/mastodon/locales/fr.json
+++ b/app/javascript/mastodon/locales/fr.json
@@ -409,6 +409,7 @@
   "navigation_bar.lists": "Listes",
   "navigation_bar.logout": "Déconnexion",
   "navigation_bar.mutes": "Comptes masqués",
+  "navigation_bar.opened_in_classic_interface": "Cette page a été ouverte dans l’interface web classique.",
   "navigation_bar.personal": "Personnel",
   "navigation_bar.pins": "Messages épinglés",
   "navigation_bar.preferences": "Préférences",

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3275,13 +3275,14 @@ $ui-header-height: 55px;
   background-color: $classic-base-color;
   padding: 15px;
   border-radius: 4px;
-  font-size: 15px;
-  line-height: 22px;
   margin-top: 4px;
   margin-bottom: 12px;
+  font-size: 13px;
+  line-height: 18px;
 
-  .switch-to-advanced__label {
-    margin-bottom: 8px;
+  .switch-to-advanced__toggle {
+    color: $ui-button-tertiary-color;
+    font-weight: bold;
   }
 }
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3270,6 +3270,21 @@ $ui-header-height: 55px;
   border-color: $ui-highlight-color;
 }
 
+.switch-to-advanced {
+  color: $classic-primary-color;
+  background-color: $classic-base-color;
+  padding: 15px;
+  border-radius: 4px;
+  font-size: 15px;
+  line-height: 22px;
+  margin-top: 4px;
+  margin-bottom: 12px;
+
+  .switch-to-advanced__label {
+    margin-bottom: 8px;
+  }
+}
+
 .column-link {
   background: lighten($ui-base-color, 8%);
   color: $primary-text-color;


### PR DESCRIPTION
In #25893, I have added a button to switch back to the advanced interface, without much of a context.

Some have suggested that we could improve that upon, for example by adding a little bit of text and demoting the button as a `tertiary` button. So… here we go!

![Screenshot](https://github.com/mastodon/mastodon/assets/411336/c0d25d6e-7e91-4e2c-8361-f8c33092c817)

_(screenshot updated with clearer text)_