### PR TITLE
Check if json body is null on Activitipub::ProcessingWorker

### DIFF
--- a/app/services/activitypub/process_collection_service.rb
+++ b/app/services/activitypub/process_collection_service.rb
@@ -8,6 +8,8 @@ class ActivityPub::ProcessCollectionService < BaseService
     @json    = original_json = Oj.load(body, mode: :strict)
     @options = options
 
+    return unless @json.is_a?(Hash)
+
     begin
       @json = compact(@json) if @json['signature'].is_a?(Hash)
     rescue JSON::LD::JsonLdError => e

--- a/app/workers/activitypub/processing_worker.rb
+++ b/app/workers/activitypub/processing_worker.rb
@@ -12,7 +12,6 @@ class ActivityPub::ProcessingWorker
     end
 
     return if actor.nil?
-    return if body.nil?
 
     ActivityPub::ProcessCollectionService.new.call(body, actor, override_timestamps: true, delivered_to_account_id: delivered_to_account_id, delivery: true)
   rescue ActiveRecord::RecordInvalid => e

--- a/app/workers/activitypub/processing_worker.rb
+++ b/app/workers/activitypub/processing_worker.rb
@@ -12,6 +12,7 @@ class ActivityPub::ProcessingWorker
     end
 
     return if actor.nil?
+    return if body.nil?
 
     ActivityPub::ProcessCollectionService.new.call(body, actor, override_timestamps: true, delivered_to_account_id: delivered_to_account_id, delivery: true)
   rescue ActiveRecord::RecordInvalid => e


### PR DESCRIPTION
Somehow, some server gives activitypub json body as `null`
This PR fixes that edge case

On sidekiq:

| Queue | Job | Arguments | Error |
| -- | -- | -- | -- |
ingress | ActivityPub::ProcessingWorker | 110727797548590094, "null", nil, "Account" | NoMethodError: undefined method `[]' for nil:NilClass

On Sentry:
![image](https://github.com/mastodon/mastodon/assets/5047683/b491b7ea-33cd-4b4d-a3b6-e2ec60137eb4)
