### PR TITLE
Change default KeyGenerator digest to SHA1 to fix cookies in rolling upgrades

### DIFF
--- a/config/initializers/cookie_rotator.rb
+++ b/config/initializers/cookie_rotator.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# TODO: Remove after 4.2.0
+Rails.application.configure do
+  config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA1
+end
+
 Rails.application.config.after_initialize do
   Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
     authenticated_encrypted_cookie_salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
@@ -7,8 +12,9 @@ Rails.application.config.after_initialize do
 
     secret_key_base = Rails.application.secret_key_base
 
+    # TODO: Switch to SHA1 after 4.2.0
     key_generator = ActiveSupport::KeyGenerator.new(
-      secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
+      secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA256
     )
     key_len = ActiveSupport::MessageEncryptor.key_len
 


### PR DESCRIPTION
Follow-up to #25668

Rails 7 changed the default `KeyGenerator` digest algorithm from SHA1 to SHA256, thus breaking encrypted cookies.

The official Rails documentation suggests configuring encrypted cookie rotation from cookies using the SHA1 digest algorithm, which we did, and it covers a clean Rails 6 to Rails 7 update path.

However, larger Mastodon instances typically have multiple `puma` servers running, and performing a rolling update will almost surely make Rails 6 and Rails 7 code coexist for a few seconds or minutes, in which case a client might get served with Rails 7, upgrading the cookie from SHA1 to SHA256, then back to Rails 6, which won't be able to read the cookie.

This PR changes Rails' default digest back to SHA1 so generated encrypted cookies remain compatible with 4.1.4, allowing rolling upgrades where multiple versions of the code coexist for a short time, and sets cookie rotation to handle reading from cookies using the SHA256 digest, so that rolling upgrades to a later version switching to SHA256 are possible.

The idea is to change the digest back to Rails 7's default (SHA256) in 4.2.1 (and switch the rotation to handle SHA1 cookies).

cc @mjankowski 