### PR TITLE
Change dropdown menu vertical margins to waste less space

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1990,7 +1990,7 @@ a.account__display-name {
 
 .dropdown-menu__separator {
   border-bottom: 1px solid var(--dropdown-border-color);
-  margin: 5px 0;
+  margin: 4px 0;
   height: 0;
 }
 
@@ -2021,7 +2021,7 @@ a.account__display-name {
   &__container {
     &__header {
       border-bottom: 1px solid var(--dropdown-border-color);
-      padding: 10px 14px;
+      padding: 6px 14px;
       padding-bottom: 14px;
       margin-bottom: 4px;
       font-size: 13px;
@@ -2078,7 +2078,7 @@ a.account__display-name {
     font: inherit;
     display: block;
     width: 100%;
-    padding: 10px 14px;
+    padding: 6px 14px;
     border: 0;
     margin: 0;
     background: transparent;


### PR DESCRIPTION
#25107 changed the dropdowns in a way that fits the overall design of Mastodon better. However, it also introduced a lot of vertical padding, so much so that it is easy for dropdown menus to overflow the screen.

This PR reduces this padding so that dropdown menus can fit better.

## Before

![Screenshot 2023-07-17 at 12-05-50 Mastodon](https://github.com/mastodon/mastodon/assets/384364/75e8ae9c-5fc7-4325-af14-53de7570406d)

## After

![Screenshot 2023-07-17 at 12-06-16 Mastodon](https://github.com/mastodon/mastodon/assets/384364/cc9c4296-4088-4767-92c3-55caf49afb1f)