### PR TITLE
Fixes to the new Image build actions

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: version_vars
+        env:
+          TZ: Etc/UTC
         run: |
-          echo mastodon_version_suffix=+nightly-$(date +'%Y%m%d') >> $GITHUB_OUTPUT
+          echo mastodon_version_suffix=nightly-$(date +'%Y-%m-%d')>> $GITHUB_OUTPUT
     outputs:
       suffix: ${{ steps.version_vars.outputs.mastodon_version_suffix }}
 
@@ -27,7 +29,8 @@ jobs:
       push_to_images: |
         tootsuite/mastodon
         ghcr.io/mastodon/mastodon
-      version_suffix: ${{ needs.compute-suffix.outputs.suffix }}
+      # The `+` is important here, result will be v4.1.2+nightly-2022-03-05
+      version_suffix: +${{ needs.compute-suffix.outputs.suffix }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes
       flavor: |
@@ -35,5 +38,5 @@ jobs:
       tags: |
         type=raw,value=edge
         type=raw,value=nightly
-        type=schedule,pattern=nightly-{{date 'YYYY-MM-DD' tz='Etc/UTC'}}
+        type=schedule,pattern=${{ needs.compute-suffix.outputs.suffix }}
     secrets: inherit

--- a/.github/workflows/build-push-pr.yml
+++ b/.github/workflows/build-push-pr.yml
@@ -10,8 +10,15 @@ permissions:
 jobs:
   compute-suffix:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'build-image') }}
+    # This is only allowed to run if:
+    # - the PR branch is in the `mastodon/mastodon` repository
+    # - the PR is not a draft
+    # - the PR has the "build-image" label
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft && contains(github.event.pull_request.labels.*.name, 'build-image') }}
     steps:
+      # Repository needs to be cloned so `git rev-parse` below works
+      - name: Clone repository
+        uses: actions/checkout@v3
       - id: version_vars
         run: |
           echo mastodon_version_suffix=+pr-${{ github.event.pull_request.number }}-$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT


### PR DESCRIPTION
- Normalize the nightly version numbers to use dashes everywhere, similar to #25026
- Fix short sha extraction in PR image builds
- Run the PR image builds using the workflow from `main`, so they are trusted and can access the secrets (`pull_request_target` does this)