### PR TITLE
Fix a missing redirection on getting-started in multi column mode

### DIFF
--- a/app/javascript/mastodon/features/ui/index.jsx
+++ b/app/javascript/mastodon/features/ui/index.jsx
@@ -184,6 +184,7 @@ class SwitchingColumnsArea extends PureComponent {
 
           {singleColumn ? <Redirect from='/deck' to='/home' exact /> : null}
           {singleColumn && pathName.startsWith('/deck/') ? <Redirect from={pathName} to={pathName.slice(5)} /> : null}
+          {!singleColumn && pathName === '/getting-started' ? <Redirect from='/getting-started' to='/deck/getting-started' exact /> : null}
 
           <WrappedRoute path='/getting-started' component={GettingStarted} content={children} />
           <WrappedRoute path='/keyboard-shortcuts' component={KeyboardShortcuts} content={children} />


### PR DESCRIPTION
As we intend to always have `/deck` (or any prefix if so we want in the future) in the beginning of the URLs when using the advanced interface, let's catch the specific case of `/getting-started`, the homepage of that mode, to make sure it always starts with `/deck` when the setting is enabled.