### PR TITLE
Fix replica being used even if not explicitly defined

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -5,7 +5,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   include Remotable
 
-  connects_to database: { writing: :primary, reading: :read }
+  connects_to database: { writing: :primary, reading: ENV['DB_REPLICA_NAME'] || ENV['READ_DATABASE_URL'] ? :read : :primary }
 
   class << self
     def update_index(_type_name, *_args, &_block)


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/pull/25977#issuecomment-1638792771

I am not sure whether this is the best way to handle it, but I think we should not try to use a replica unless it is explicitly defined.

cc @zunda @krainboltgreene