### PR TITLE
Storage: add :azure to remaining callers

### DIFF
--- a/app/controllers/backups_controller.rb
+++ b/app/controllers/backups_controller.rb
@@ -10,7 +10,7 @@ class BackupsController < ApplicationController
 
   def download
     case Paperclip::Attachment.default_options[:storage]
-    when :s3
+    when :s3, :azure
       redirect_to @backup.dump.expiring_url(10), allow_other_host: true
     when :fog
       if Paperclip::Attachment.default_options.dig(:fog_credentials, :openstack_temp_url_key).present?

--- a/app/lib/attachment_batch.rb
+++ b/app/lib/attachment_batch.rb
@@ -76,6 +76,9 @@ class AttachmentBatch
           when :fog
             logger.debug { "Deleting #{attachment.path(style)}" }
             attachment.directory.files.new(key: attachment.path(style)).destroy
+          when :azure
+            logger.debug { "Deleting #{attachment.path(style)}" }
+            attachment.destroy
           end
         end
       end

--- a/app/services/suspend_account_service.rb
+++ b/app/services/suspend_account_service.rb
@@ -85,7 +85,7 @@ class SuspendAccountService < BaseService
             rescue Aws::S3::Errors::NotImplemented => e
               Rails.logger.error "Error trying to change ACL on #{attachment.s3_object(style).key}: #{e.message}"
             end
-          when :fog
+          when :fog, :azure
             # Not supported
           when :filesystem
             begin

--- a/app/services/unsuspend_account_service.rb
+++ b/app/services/unsuspend_account_service.rb
@@ -81,7 +81,7 @@ class UnsuspendAccountService < BaseService
             rescue Aws::S3::Errors::NotImplemented => e
               Rails.logger.error "Error trying to change ACL on #{attachment.s3_object(style).key}: #{e.message}"
             end
-          when :fog
+          when :fog, :azure
             # Not supported
           when :filesystem
             begin

--- a/lib/mastodon/cli/media.rb
+++ b/lib/mastodon/cli/media.rb
@@ -158,6 +158,9 @@ module Mastodon::CLI
       when :fog
         say('The fog storage driver is not supported for this operation at this time', :red)
         exit(1)
+      when :azure
+        say('The azure storage driver is not supported for this operation at this time', :red)
+        exit(1)
       when :filesystem
         require 'find'
 

--- a/lib/mastodon/cli/upgrade.rb
+++ b/lib/mastodon/cli/upgrade.rb
@@ -46,6 +46,8 @@ module Mastodon::CLI
                           upgrade_storage_s3(progress, attachment, style)
                         when :fog
                           upgrade_storage_fog(progress, attachment, style)
+                        when :azure
+                          upgrade_storage_azure(progress, attachment, style)
                         when :filesystem
                           upgrade_storage_filesystem(progress, attachment, style)
                         end
@@ -102,6 +104,11 @@ module Mastodon::CLI
 
     def upgrade_storage_fog(_progress, _attachment, _style)
       say('The fog storage driver is not supported for this operation at this time', :red)
+      exit(1)
+    end
+
+    def upgrade_storage_azure(_progress, _attachment, _style)
+      say('The azure storage driver is not supported for this operation at this time', :red)
       exit(1)
     end
 


### PR DESCRIPTION
This is a small followup to #23607. That branch added support to Azure in all of the key places, but this morning a user alerted me to missing support in the backups controller. I've added `:azure` to all of the places that have backend-specific code, and tested with the backups controller.