### PR TITLE
Increase rate-limit for authenticated users on media proxy endpoints

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -82,6 +82,10 @@ class Rack::Attack
     req.authenticated_user_id if req.post? && req.path.match?(%r{\A/api/v\d+/media\z}i)
   end
 
+  throttle('throttle_authenticated_media_proxy', limit: 100, period: 5.minutes) do |req|
+    req.authenticated_user_id if req.path.start_with?('/media_proxy')
+  end
+
   throttle('throttle_media_proxy', limit: 30, period: 10.minutes) do |req|
     req.throttleable_remote_ip if req.path.start_with?('/media_proxy')
   end


### PR DESCRIPTION
As reported in the issue #16582 , rate-limiting was causing issues for authenticated users who were viewing cached remote profiles with numerous media files that had expired on the local instance. With the current limit set at 30 requests per 10 minutes, users would quickly reach this limit, leading to HTTP 429 "Too many requests" errors.

To remove this issue, I increased the rate limit for authenticated users on the media proxy endpoints to 100 requests per 5 minutes. This change should significantly improve the user experience, for users who are viewing old remote profiles.