### PR TITLE
Add direct link to the Single-Sign On provider if there is only one sign up method available

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -135,7 +135,7 @@ Lint/UselessAssignment:
 
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 143
+  Max: 146
 
 # Configuration parameters: CountBlocks, Max.
 Metrics/BlockNesting:

--- a/app/controllers/concerns/web_app_controller_concern.rb
+++ b/app/controllers/concerns/web_app_controller_concern.rb
@@ -11,7 +11,7 @@ module WebAppControllerConcern
   end
 
   def skip_csrf_meta_tags?
-    current_user.nil?
+    !(ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1) && current_user.nil?
   end
 
   def set_app_body_class

--- a/app/javascript/mastodon/features/interaction_modal/index.jsx
+++ b/app/javascript/mastodon/features/interaction_modal/index.jsx
@@ -13,7 +13,7 @@ import { openModal, closeModal } from 'mastodon/actions/modal';
 import api from 'mastodon/api';
 import Button from 'mastodon/components/button';
 import { Icon }  from 'mastodon/components/icon';
-import { registrationsOpen } from 'mastodon/initial_state';
+import { registrationsOpen, sso_redirect } from 'mastodon/initial_state';
 
 const messages = defineMessages({
   loginPrompt: { id: 'interaction_modal.login.prompt', defaultMessage: 'Domain of your home server, e.g. mastodon.social' },
@@ -328,18 +328,36 @@ class InteractionModal extends React.PureComponent {
     }
 
     let signupButton;
+    let signUpOrSignInButton;
 
-    if (registrationsOpen) {
-      signupButton = (
-        <a href='/auth/sign_up' className='link-button'>
-          <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+    if (sso_redirect) {
+      signUpOrSignInButton = (
+        <a href={sso_redirect} data-method='post' className='button button--block button-tertiary'>
+          <FormattedMessage id='sign_in_banner.sso_redirect' defaultMessage='Login or Register' />
         </a>
-      );
+      )
     } else {
-      signupButton = (
-        <button className='link-button' onClick={this.handleSignupClick}>
-          <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
-        </button>
+      if(registrationsOpen) {
+        signupButton = (
+          <a href='/auth/sign_up' className='link-button'>
+            <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+          </a>
+        );
+      } else {
+        signupButton = (
+          <button className='button button--block button-tertiary' onClick={this.handleSignupClick}>
+            <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+          </button>
+        );
+      }
+
+      signUpOrSignInButton = (
+        <>
+          <a href='/auth/sign_in' className='button button--block'>
+            <FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Login' />
+          </a>
+          {signupButton}
+        </>
       );
     }
 
@@ -348,6 +366,13 @@ class InteractionModal extends React.PureComponent {
         <div className='interaction-modal__lead'>
           <h3><span className='interaction-modal__icon'>{icon}</span> {title}</h3>
           <p>{actionDescription} <strong><FormattedMessage id='interaction_modal.sign_in' defaultMessage='You are not logged in to this server. Where is your account hosted?' /></strong></p>
+        </div>
+
+        <div className='interaction-modal__choices'>
+          <div className='interaction-modal__choices__choice'>
+            <h3><FormattedMessage id='interaction_modal.on_this_server' defaultMessage='On this server' /></h3>
+            {signUpOrSignInButton}
+          </div>
         </div>
 
         <IntlLoginForm resourceUrl={url} />

--- a/app/javascript/mastodon/features/ui/components/header.jsx
+++ b/app/javascript/mastodon/features/ui/components/header.jsx
@@ -12,7 +12,7 @@ import { fetchServer } from 'mastodon/actions/server';
 import { Avatar } from 'mastodon/components/avatar';
 import { Icon } from 'mastodon/components/icon';
 import { WordmarkLogo, SymbolLogo } from 'mastodon/components/logo';
-import { registrationsOpen, me } from 'mastodon/initial_state';
+import { registrationsOpen, me, sso_redirect } from 'mastodon/initial_state';
 
 const Account = connect(state => ({
   account: state.getIn(['accounts', me]),
@@ -73,28 +73,35 @@ class Header extends PureComponent {
         </>
       );
     } else {
-      let signupButton;
 
-      if (registrationsOpen) {
-        signupButton = (
-          <a href={signupUrl} className='button'>
-            <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
-          </a>
-        );
+      if (sso_redirect) {
+        content = (
+            <a href={sso_redirect} data-method='post' className='button button--block button-tertiary'><FormattedMessage id='sign_in_banner.sso_redirect' defaultMessage='Login or Register' /></a>
+        )
       } else {
-        signupButton = (
-          <button className='button' onClick={openClosedRegistrationsModal}>
-            <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
-          </button>
+        let signupButton;
+
+        if (registrationsOpen) {
+          signupButton = (
+            <a href={signupUrl} className='button'>
+              <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+            </a>
+          );
+        } else {
+          signupButton = (
+            <button className='button' onClick={openClosedRegistrationsModal}>
+              <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
+            </button>
+          );
+        }
+
+        content = (
+          <>
+            {signupButton}
+            <a href='/auth/sign_in' className='button button-tertiary'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Login' /></a>
+          </>
         );
       }
-
-      content = (
-        <>
-          {signupButton}
-          <a href='/auth/sign_in' className='button button-tertiary'><FormattedMessage id='sign_in_banner.sign_in' defaultMessage='Login' /></a>
-        </>
-      );
     }
 
     return (

--- a/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
+++ b/app/javascript/mastodon/features/ui/components/sign_in_banner.jsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 
 import { openModal } from 'mastodon/actions/modal';
-import { registrationsOpen } from 'mastodon/initial_state';
+import { registrationsOpen, sso_redirect } from 'mastodon/initial_state';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 const SignInBanner = () => {
@@ -17,7 +17,16 @@ const SignInBanner = () => {
 
   let signupButton;
 
-  const signupUrl = useAppSelector((state) => state.getIn(['server', 'server', 'registrations', 'url'], null) || '/auth/sign_up');
+      const signupUrl = useAppSelector((state) => state.getIn(['server', 'server', 'registrations', 'url'], null) || '/auth/sign_up');
+
+      if (sso_redirect) {
+    return (
+      <div className='sign-in-banner'>
+        <p><FormattedMessage id='sign_in_banner.text' defaultMessage='Login to follow profiles or hashtags, favorite, share and reply to posts. You can also interact from your account on a different server.' /></p>
+        <a href={sso_redirect} data-method='post' className='button button--block button-tertiary'><FormattedMessage id='sign_in_banner.sso_redirect' defaultMessage='Login or Register' /></a>
+      </div>
+    )
+  }
 
   if (registrationsOpen) {
     signupButton = (

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -80,6 +80,7 @@
  * @property {boolean} use_blurhash
  * @property {boolean=} use_pending_items
  * @property {string} version
+ * @property {string} sso_redirect
  */
 
 /**
@@ -141,5 +142,6 @@ export const version = getMeta('version');
 export const languages = initialState?.languages;
 // @ts-expect-error
 export const statusPageUrl = getMeta('status_page_url');
+export const sso_redirect = getMeta('sso_redirect');
 
 export default initialState;

--- a/app/javascript/mastodon/locales/en.json
+++ b/app/javascript/mastodon/locales/en.json
@@ -598,6 +598,7 @@
   "server_banner.server_stats": "Server stats:",
   "sign_in_banner.create_account": "Create account",
   "sign_in_banner.sign_in": "Login",
+  "sign_in_banner.sso_redirect": "Login or Register",
   "sign_in_banner.text": "Login to follow profiles or hashtags, favorite, share and reply to posts. You can also interact from your account on a different server.",
   "status.admin_account": "Open moderation interface for @{name}",
   "status.admin_domain": "Open moderation interface for {domain}",

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -11,6 +11,8 @@ class InitialStateSerializer < ActiveModel::Serializer
   has_one :role, serializer: REST::RoleSerializer
 
   def meta
+    sso_redirect = "/auth/auth/#{Devise.omniauth_providers[0]}" if ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1
+
     store = {
       streaming_api_base_url: Rails.configuration.x.streaming_api_base_url,
       access_token: object.token,
@@ -32,6 +34,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       single_user_mode: Rails.configuration.x.single_user_mode,
       trends_as_landing_page: Setting.trends_as_landing_page,
       status_page_url: Setting.status_page_url,
+      sso_redirect: sso_redirect,
     }
 
     if object.current_account

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -11,8 +11,6 @@ class InitialStateSerializer < ActiveModel::Serializer
   has_one :role, serializer: REST::RoleSerializer
 
   def meta
-    sso_redirect = "/auth/auth/#{Devise.omniauth_providers[0]}" if ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1
-
     store = {
       streaming_api_base_url: Rails.configuration.x.streaming_api_base_url,
       access_token: object.token,
@@ -110,5 +108,9 @@ class InitialStateSerializer < ActiveModel::Serializer
 
   def instance_presenter
     @instance_presenter ||= InstancePresenter.new
+  end
+
+  def sso_redirect
+    "/auth/auth/#{Devise.omniauth_providers[0]}" if ENV['OMNIAUTH_ONLY'] == 'true' && Devise.omniauth_providers.length == 1
   end
 end


### PR DESCRIPTION
At the moment, when an instance is set up with `OMNIAUTH_ONLY=true`  and just one authentication method, a user has to visit the `/auth/sign_in` page only to click on the one authentication method provided.

This PR changes that by redirecting users directly to the SSO provider from the web app, if OMNIAUTH_ONLY is enabled and only one method is configured.

This behavior has been tried and tested already for several months on the instance [`babka.social`](https://babka.social)

Revises parts of #24584 to add a CSRF token to all sessions if the above condition applies to the instance when loading the web app.

This also addresses https://github.com/mastodon/mastodon/issues/24114