### PR TITLE
Issue 26048: swap "muting" and "blocking" list options in settings -> Data Exports

### DIFF
--- a/app/views/settings/exports/show.html.haml
+++ b/app/views/settings/exports/show.html.haml
@@ -25,13 +25,13 @@
         %td= number_with_delimiter @export.total_followers
         %td
       %tr
-        %th= t('exports.blocks')
-        %td= number_with_delimiter @export.total_blocks
-        %td= table_link_to 'download', t('exports.csv'), settings_exports_blocks_path(format: :csv)
-      %tr
         %th= t('exports.mutes')
         %td= number_with_delimiter @export.total_mutes
         %td= table_link_to 'download', t('exports.csv'), settings_exports_mutes_path(format: :csv)
+      %tr
+        %th= t('exports.blocks')
+        %td= number_with_delimiter @export.total_blocks
+        %td= table_link_to 'download', t('exports.csv'), settings_exports_blocks_path(format: :csv)
       %tr
         %th= t('exports.domain_blocks')
         %td= number_with_delimiter @export.total_domain_blocks

--- a/app/views/settings/imports/index.html.haml
+++ b/app/views/settings/imports/index.html.haml
@@ -3,7 +3,7 @@
 
 = simple_form_for @import, url: settings_imports_path do |f|
   .field-group
-    = f.input :type, as: :grouped_select, collection: { constructive: %i(following bookmarks lists), destructive: %i(blocking muting domain_blocking) }, wrapper: :with_block_label, include_blank: false, label_method: ->(type) { I18n.t("imports.types.#{type}") }, group_label_method: ->(group) { I18n.t("imports.type_groups.#{group.first}") }, group_method: :last, hint: t('imports.preface')
+    = f.input :type, as: :grouped_select, collection: { constructive: %i(following bookmarks lists), destructive: %i(muting blocking domain_blocking) }, wrapper: :with_block_label, include_blank: false, label_method: ->(type) { I18n.t("imports.types.#{type}") }, group_label_method: ->(group) { I18n.t("imports.type_groups.#{group.first}") }, group_method: :last, hint: t('imports.preface')
 
   .fields-row
     .fields-group.fields-row__column.fields-row__column-6

--- a/app/views/settings/imports/index.html.haml
+++ b/app/views/settings/imports/index.html.haml
@@ -3,7 +3,7 @@
 
 = simple_form_for @import, url: settings_imports_path do |f|
   .field-group
-    = f.input :type, as: :grouped_select, collection: { constructive: %i(following bookmarks lists), destructive: %i(muting blocking domain_blocking) }, wrapper: :with_block_label, include_blank: false, label_method: ->(type) { I18n.t("imports.types.#{type}") }, group_label_method: ->(group) { I18n.t("imports.type_groups.#{group.first}") }, group_method: :last, hint: t('imports.preface')
+    = f.input :type, as: :grouped_select, collection: { constructive: %i(following bookmarks lists), destructive: %i(blocking muting domain_blocking) }, wrapper: :with_block_label, include_blank: false, label_method: ->(type) { I18n.t("imports.types.#{type}") }, group_label_method: ->(group) { I18n.t("imports.type_groups.#{group.first}") }, group_method: :last, hint: t('imports.preface')
 
   .fields-row
     .fields-group.fields-row__column.fields-row__column-6


### PR DESCRIPTION
Proposed resolution to issue https://github.com/mastodon/mastodon/issues/26048 incorporating feedback from PR https://github.com/mastodon/mastodon/pull/26049

We swap the options in `Data Exports` instead of `Imports` to preserve the least-to-most-severe ordering implied by mute -> block -> domain block.