### PR TITLE
Rubocop config adjust RE: Layout/LineLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,14 +38,10 @@ Layout/FirstHashElementIndentation:
 # Reason: Currently disabled in .rubocop_todo.yml
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinelength
 Layout/LineLength:
-  AllowedPatterns:
-    # Allow comments to be long lines
-    - !ruby/regexp / \# .*$/
-    - !ruby/regexp /^\# .*$/
-  Exclude:
-    - 'lib/mastodon/cli/*.rb'
-    - db/*migrate/**/*
-    - db/seeds/**/*
+  Max: 320 # Default of 120 causes a duplicate entry in generated todo file
+  AllowedPatterns: # Allow comments and rubocop instructions
+    - '^\s*#'
+    - '\s+# rubocop'
 
 # Reason:
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessaccessmodifier

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -112,7 +112,6 @@ Lint/UselessAssignment:
     - 'config/initializers/omniauth.rb'
     - 'db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb'
     - 'db/post_migrate/20190511152737_remove_suspended_silenced_account_fields.rb'
-    - 'spec/controllers/api/v1/bookmarks_controller_spec.rb'
     - 'spec/controllers/api/v1/favourites_controller_spec.rb'
     - 'spec/controllers/concerns/account_controller_concern_spec.rb'
     - 'spec/helpers/jsonld_helper_spec.rb'
@@ -359,43 +358,6 @@ RSpec/PendingWithoutReason:
 Rails/ApplicationController:
   Exclude:
     - 'app/controllers/health_controller.rb'
-
-# Configuration parameters: Database, Include.
-# SupportedDatabases: mysql, postgresql
-# Include: db/**/*.rb
-Rails/BulkChangeTable:
-  Exclude:
-    - 'db/migrate/20160222143943_add_profile_fields_to_accounts.rb'
-    - 'db/migrate/20160223162837_add_metadata_to_statuses.rb'
-    - 'db/migrate/20160305115639_add_devise_to_users.rb'
-    - 'db/migrate/20160314164231_add_owner_to_application.rb'
-    - 'db/migrate/20160926213048_remove_owner_from_application.rb'
-    - 'db/migrate/20161003142332_add_confirmable_to_users.rb'
-    - 'db/migrate/20170112154826_migrate_settings.rb'
-    - 'db/migrate/20170127165745_add_devise_two_factor_to_users.rb'
-    - 'db/migrate/20170322143850_change_primary_key_to_bigint_on_statuses.rb'
-    - 'db/migrate/20170330021336_add_counter_caches.rb'
-    - 'db/migrate/20170425202925_add_oembed_to_preview_cards.rb'
-    - 'db/migrate/20170427011934_re_add_owner_to_application.rb'
-    - 'db/migrate/20170520145338_change_language_filter_to_opt_out.rb'
-    - 'db/migrate/20170624134742_add_description_to_session_activations.rb'
-    - 'db/migrate/20170718211102_add_activitypub_to_accounts.rb'
-    - 'db/migrate/20171006142024_add_uri_to_custom_emojis.rb'
-    - 'db/migrate/20180812123222_change_relays_enabled.rb'
-    - 'db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb'
-    - 'db/migrate/20190805123746_add_capabilities_to_tags.rb'
-    - 'db/migrate/20190807135426_add_comments_to_domain_blocks.rb'
-    - 'db/migrate/20190815225426_add_last_status_at_to_tags.rb'
-    - 'db/migrate/20190901035623_add_max_score_to_tags.rb'
-    - 'db/migrate/20200417125749_add_storage_schema_version.rb'
-    - 'db/migrate/20200608113046_add_sign_in_token_to_users.rb'
-    - 'db/migrate/20211112011713_add_language_to_preview_cards.rb'
-    - 'db/migrate/20211231080958_add_category_to_reports.rb'
-    - 'db/migrate/20220202200743_add_trendable_to_accounts.rb'
-    - 'db/migrate/20220224010024_add_ips_to_email_domain_blocks.rb'
-    - 'db/migrate/20220227041951_add_last_used_at_to_oauth_access_tokens.rb'
-    - 'db/migrate/20220303000827_add_ordered_media_attachment_ids_to_status_edits.rb'
-    - 'db/migrate/20220824164433_add_human_identifier_to_admin_action_logs.rb'
 
 # Configuration parameters: Include.
 # Include: db/**/*.rb
@@ -936,9 +898,3 @@ Style/WordArray:
     - 'config/initializers/cors.rb'
     - 'spec/controllers/settings/imports_controller_spec.rb'
     - 'spec/models/form/import_spec.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
-# URISchemes: http, https
-Layout/LineLength:
-  Max: 701

--- a/app/helpers/context_helper.rb
+++ b/app/helpers/context_helper.rb
@@ -21,7 +21,14 @@ module ContextHelper
     blurhash: { 'toot' => 'http://joinmastodon.org/ns#', 'blurhash' => 'toot:blurhash' },
     discoverable: { 'toot' => 'http://joinmastodon.org/ns#', 'discoverable' => 'toot:discoverable' },
     voters_count: { 'toot' => 'http://joinmastodon.org/ns#', 'votersCount' => 'toot:votersCount' },
-    olm: { 'toot' => 'http://joinmastodon.org/ns#', 'Device' => 'toot:Device', 'Ed25519Signature' => 'toot:Ed25519Signature', 'Ed25519Key' => 'toot:Ed25519Key', 'Curve25519Key' => 'toot:Curve25519Key', 'EncryptedMessage' => 'toot:EncryptedMessage', 'publicKeyBase64' => 'toot:publicKeyBase64', 'deviceId' => 'toot:deviceId', 'claim' => { '@type' => '@id', '@id' => 'toot:claim' }, 'fingerprintKey' => { '@type' => '@id', '@id' => 'toot:fingerprintKey' }, 'identityKey' => { '@type' => '@id', '@id' => 'toot:identityKey' }, 'devices' => { '@type' => '@id', '@id' => 'toot:devices' }, 'messageFranking' => 'toot:messageFranking', 'messageType' => 'toot:messageType', 'cipherText' => 'toot:cipherText' },
+    olm: {
+      'toot' => 'http://joinmastodon.org/ns#', 'Device' => 'toot:Device', 'Ed25519Signature' => 'toot:Ed25519Signature', 'Ed25519Key' => 'toot:Ed25519Key', 'Curve25519Key' => 'toot:Curve25519Key', 'EncryptedMessage' => 'toot:EncryptedMessage', 'publicKeyBase64' => 'toot:publicKeyBase64', 'deviceId' => 'toot:deviceId',
+      'claim' => { '@type' => '@id', '@id' => 'toot:claim' },
+      'fingerprintKey' => { '@type' => '@id', '@id' => 'toot:fingerprintKey' },
+      'identityKey' => { '@type' => '@id', '@id' => 'toot:identityKey' },
+      'devices' => { '@type' => '@id', '@id' => 'toot:devices' },
+      'messageFranking' => 'toot:messageFranking', 'messageType' => 'toot:messageType', 'cipherText' => 'toot:cipherText'
+    },
     suspended: { 'toot' => 'http://joinmastodon.org/ns#', 'suspended' => 'toot:suspended' },
   }.freeze
 

--- a/app/lib/status_cache_hydrator.rb
+++ b/app/lib/status_cache_hydrator.rb
@@ -11,7 +11,7 @@ class StatusCacheHydrator
 
     # If we're delivering to the author who disabled the display of the application used to create the
     # status, we need to hydrate the application, since it was not rendered for the basic payload
-    payload[:application] = @status.application.present? ? ActiveModelSerializers::SerializableResource.new(@status.application, serializer: REST::StatusSerializer::ApplicationSerializer).as_json : nil if payload[:application].nil? && @status.account_id == account_id
+    payload[:application] = payload_application if payload[:application].nil? && @status.account_id == account_id
 
     # We take advantage of the fact that some relationships can only occur with an original status, not
     # the reblog that wraps it, so we can assume that some values are always false
@@ -19,11 +19,13 @@ class StatusCacheHydrator
       payload[:muted]      = false
       payload[:bookmarked] = false
       payload[:pinned]     = false if @status.account_id == account_id
-      payload[:filtered]   = CustomFilter.apply_cached_filters(CustomFilter.cached_filters_for(account_id), @status.reblog).map { |filter| ActiveModelSerializers::SerializableResource.new(filter, serializer: REST::FilterResultSerializer).as_json }
+      payload[:filtered]   = CustomFilter
+                             .apply_cached_filters(CustomFilter.cached_filters_for(account_id), @status.reblog)
+                             .map { |filter| serialized_filter(filter) }
 
       # If the reblogged status is being delivered to the author who disabled the display of the application
       # used to create the status, we need to hydrate it here too
-      payload[:reblog][:application] = @status.reblog.application.present? ? ActiveModelSerializers::SerializableResource.new(@status.reblog.application, serializer: REST::StatusSerializer::ApplicationSerializer).as_json : nil if payload[:reblog][:application].nil? && @status.reblog.account_id == account_id
+      payload[:reblog][:application] = payload_reblog_application if payload[:reblog][:application].nil? && @status.reblog.account_id == account_id
 
       payload[:reblog][:favourited] = Favourite.where(account_id: account_id, status_id: @status.reblog_of_id).exists?
       payload[:reblog][:reblogged]  = Status.where(account_id: account_id, reblog_of_id: @status.reblog_of_id).exists?
@@ -51,7 +53,9 @@ class StatusCacheHydrator
       payload[:muted]      = ConversationMute.where(account_id: account_id, conversation_id: @status.conversation_id).exists?
       payload[:bookmarked] = Bookmark.where(account_id: account_id, status_id: @status.id).exists?
       payload[:pinned]     = StatusPin.where(account_id: account_id, status_id: @status.id).exists? if @status.account_id == account_id
-      payload[:filtered]   = CustomFilter.apply_cached_filters(CustomFilter.cached_filters_for(account_id), @status).map { |filter| ActiveModelSerializers::SerializableResource.new(filter, serializer: REST::FilterResultSerializer).as_json }
+      payload[:filtered]   = CustomFilter
+                             .apply_cached_filters(CustomFilter.cached_filters_for(account_id), @status)
+                             .map { |filter| serialized_filter(filter) }
 
       if payload[:poll]
         payload[:poll][:voted] = @status.account_id == account_id
@@ -60,5 +64,36 @@ class StatusCacheHydrator
     end
 
     payload
+  end
+
+  private
+
+  def serialized_filter(filter)
+    ActiveModelSerializers::SerializableResource.new(
+      filter,
+      serializer: REST::FilterResultSerializer
+    ).as_json
+  end
+
+  def payload_application
+    @status.application.present? ? serialized_status_application_json : nil
+  end
+
+  def serialized_status_application_json
+    ActiveModelSerializers::SerializableResource.new(
+      @status.application,
+      serializer: REST::StatusSerializer::ApplicationSerializer
+    ).as_json
+  end
+
+  def payload_reblog_application
+    @status.reblog.application.present? ? serialized_status_reblog_application_json : nil
+  end
+
+  def serialized_status_reblog_application_json
+    ActiveModelSerializers::SerializableResource.new(
+      @status.reblog.application,
+      serializer: REST::StatusSerializer::ApplicationSerializer
+    ).as_json
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -71,6 +71,7 @@ class Account < ApplicationRecord
   include AccountAssociations
   include AccountAvatar
   include AccountFinderConcern
+  include AccountFollowable
   include AccountHeader
   include AccountInteractions
   include Paginable
@@ -122,7 +123,6 @@ class Account < ApplicationRecord
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }
   scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).left_outer_joins(:account_stat) }
-  scope :followable_by, ->(account) { joins(arel_table.join(Follow.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:id].eq(Follow.arel_table[:target_account_id]).and(Follow.arel_table[:account_id].eq(account.id))).join_sources).where(Follow.arel_table[:id].eq(nil)).joins(arel_table.join(FollowRequest.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:id].eq(FollowRequest.arel_table[:target_account_id]).and(FollowRequest.arel_table[:account_id].eq(account.id))).join_sources).where(FollowRequest.arel_table[:id].eq(nil)) }
   scope :by_recent_status, -> { order(Arel.sql('(case when account_stats.last_status_at is null then 1 else 0 end) asc, account_stats.last_status_at desc, accounts.id desc')) }
   scope :by_recent_sign_in, -> { order(Arel.sql('(case when users.current_sign_in_at is null then 1 else 0 end) asc, users.current_sign_in_at desc, accounts.id desc')) }
   scope :popular, -> { order('account_stats.followers_count desc') }

--- a/app/models/concerns/account_followable.rb
+++ b/app/models/concerns/account_followable.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module AccountFollowable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :followable_by, ->(account) { without_follows(account).without_follow_requests(account) }
+  end
+
+  class_methods do
+    def without_follows(account)
+      joins(follows_join(account)).where(follows_id_nil)
+    end
+
+    def follows_join(account)
+      arel_table.join(Follow.arel_table, Arel::Nodes::OuterJoin)
+                .on(follows_join_conditions(account))
+                .join_sources
+    end
+
+    def follows_join_conditions(account)
+      arel_table[:id].eq(Follow.arel_table[:target_account_id])
+                     .and(Follow.arel_table[:account_id].eq(account.id))
+    end
+
+    def follows_id_nil
+      Follow.arel_table[:id].eq(nil)
+    end
+
+    def without_follow_requests(account)
+      joins(follow_requests_join(account)).where(follow_requests_id_nil)
+    end
+
+    def follow_requests_join(account)
+      arel_table.join(FollowRequest.arel_table, Arel::Nodes::OuterJoin)
+                .on(follow_requests_join_conditions(account))
+                .join_sources
+    end
+
+    def follow_requests_join_conditions(account)
+      arel_table[:id].eq(FollowRequest.arel_table[:target_account_id])
+                     .and(FollowRequest.arel_table[:account_id].eq(account.id))
+    end
+
+    def follow_requests_id_nil
+      FollowRequest.arel_table[:id].eq(nil)
+    end
+  end
+end

--- a/config/initializers/twitter_regex.rb
+++ b/config/initializers/twitter_regex.rb
@@ -26,7 +26,9 @@ module Twitter::TwitterText
         )
       \)
     /iox
+    # rubocop:disable Layout/LineLength
     UCHARS = '\u{A0}-\u{D7FF}\u{F900}-\u{FDCF}\u{FDF0}-\u{FFEF}\u{10000}-\u{1FFFD}\u{20000}-\u{2FFFD}\u{30000}-\u{3FFFD}\u{40000}-\u{4FFFD}\u{50000}-\u{5FFFD}\u{60000}-\u{6FFFD}\u{70000}-\u{7FFFD}\u{80000}-\u{8FFFD}\u{90000}-\u{9FFFD}\u{A0000}-\u{AFFFD}\u{B0000}-\u{BFFFD}\u{C0000}-\u{CFFFD}\u{D0000}-\u{DFFFD}\u{E1000}-\u{EFFFD}\u{E000}-\u{F8FF}\u{F0000}-\u{FFFFD}\u{100000}-\u{10FFFD}'
+    # rubocop:enable Layout/LineLength
     REGEXEN[:valid_url_query_chars] = %r{[a-z0-9!?*'();:&=+$/%#\[\]\-_.,~|@\^#{UCHARS}]}iou
     REGEXEN[:valid_url_query_ending_chars] = %r{[a-z0-9_&=#/\-#{UCHARS}]}iou
     REGEXEN[:valid_url_path] = %r{(?:

--- a/db/migrate/20161203164520_add_from_account_id_to_notifications.rb
+++ b/db/migrate/20161203164520_add_from_account_id_to_notifications.rb
@@ -4,10 +4,39 @@ class AddFromAccountIdToNotifications < ActiveRecord::Migration[5.0]
   def up
     add_column :notifications, :from_account_id, :integer
 
-    Notification.where(from_account_id: nil).where(activity_type: 'Status').update_all('from_account_id = (SELECT statuses.account_id FROM notifications AS notifications1 INNER JOIN statuses ON notifications1.activity_id = statuses.id WHERE notifications1.activity_type = \'Status\' AND notifications1.id = notifications.id)')
-    Notification.where(from_account_id: nil).where(activity_type: 'Mention').update_all('from_account_id = (SELECT statuses.account_id FROM notifications AS notifications1 INNER JOIN mentions ON notifications1.activity_id = mentions.id INNER JOIN statuses ON mentions.status_id = statuses.id WHERE notifications1.activity_type = \'Mention\' AND notifications1.id = notifications.id)')
-    Notification.where(from_account_id: nil).where(activity_type: 'Favourite').update_all('from_account_id = (SELECT favourites.account_id FROM notifications AS notifications1 INNER JOIN favourites ON notifications1.activity_id = favourites.id WHERE notifications1.activity_type = \'Favourite\' AND notifications1.id = notifications.id)')
-    Notification.where(from_account_id: nil).where(activity_type: 'Follow').update_all('from_account_id = (SELECT follows.account_id FROM notifications AS notifications1 INNER JOIN follows ON notifications1.activity_id = follows.id WHERE notifications1.activity_type = \'Follow\' AND notifications1.id = notifications.id)')
+    Notification.where(from_account_id: nil).where(activity_type: 'Status').update_all(<<~SQL.squish)
+      from_account_id = (
+        SELECT statuses.account_id
+        FROM notifications AS notifications1
+        INNER JOIN statuses ON notifications1.activity_id = statuses.id
+        WHERE notifications1.activity_type = 'Status' AND notifications1.id = notifications.id
+      )
+    SQL
+    Notification.where(from_account_id: nil).where(activity_type: 'Mention').update_all(<<~SQL.squish)
+      from_account_id = (
+        SELECT statuses.account_id
+        FROM notifications AS notifications1
+        INNER JOIN mentions ON notifications1.activity_id = mentions.id
+        INNER JOIN statuses ON mentions.status_id = statuses.id
+        WHERE notifications1.activity_type = 'Mention' AND notifications1.id = notifications.id
+      )
+    SQL
+    Notification.where(from_account_id: nil).where(activity_type: 'Favourite').update_all(<<~SQL.squish)
+      from_account_id = (
+        SELECT favourites.account_id
+        FROM notifications AS notifications1
+        INNER JOIN favourites ON notifications1.activity_id = favourites.id
+        WHERE notifications1.activity_type = 'Favourite' AND notifications1.id = notifications.id
+      )
+    SQL
+    Notification.where(from_account_id: nil).where(activity_type: 'Follow').update_all(<<~SQL.squish)
+      from_account_id = (
+        SELECT follows.account_id
+        FROM notifications AS notifications1
+        INNER JOIN follows ON notifications1.activity_id = follows.id
+        WHERE notifications1.activity_type = 'Follow' AND notifications1.id = notifications.id
+      )
+    SQL
   end
 
   def down

--- a/spec/services/activitypub/fetch_remote_key_service_spec.rb
+++ b/spec/services/activitypub/fetch_remote_key_service_spec.rb
@@ -8,7 +8,17 @@ RSpec.describe ActivityPub::FetchRemoteKeyService, type: :service do
   let(:webfinger) { { subject: 'acct:alice@example.com', links: [{ rel: 'self', href: 'https://example.com/alice' }] } }
 
   let(:public_key_pem) do
-    "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu3L4vnpNLzVH31MeWI39\n4F0wKeJFsLDAsNXGeOu0QF2x+h1zLWZw/agqD2R3JPU9/kaDJGPIV2Sn5zLyUA9S\n6swCCMOtn7BBR9g9sucgXJmUFB0tACH2QSgHywMAybGfmSb3LsEMNKsGJ9VsvYoh\n8lDET6X4Pyw+ZJU0/OLo/41q9w+OrGtlsTm/PuPIeXnxa6BLqnDaxC+4IcjG/FiP\nahNCTINl/1F/TgSSDZ4Taf4U9XFEIFw8wmgploELozzIzKq+t8nhQYkgAkt64euW\npva3qL5KD1mTIZQEP+LZvh3s2WHrLi3fhbdRuwQ2c0KkJA2oSTFPDpqqbPGZ3Qvu\nHQIDAQAB\n-----END PUBLIC KEY-----\n"
+    <<~TEXT
+      -----BEGIN PUBLIC KEY-----
+      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu3L4vnpNLzVH31MeWI39
+      4F0wKeJFsLDAsNXGeOu0QF2x+h1zLWZw/agqD2R3JPU9/kaDJGPIV2Sn5zLyUA9S
+      6swCCMOtn7BBR9g9sucgXJmUFB0tACH2QSgHywMAybGfmSb3LsEMNKsGJ9VsvYoh
+      8lDET6X4Pyw+ZJU0/OLo/41q9w+OrGtlsTm/PuPIeXnxa6BLqnDaxC+4IcjG/FiP
+      ahNCTINl/1F/TgSSDZ4Taf4U9XFEIFw8wmgploELozzIzKq+t8nhQYkgAkt64euW
+      pva3qL5KD1mTIZQEP+LZvh3s2WHrLi3fhbdRuwQ2c0KkJA2oSTFPDpqqbPGZ3Qvu
+      HQIDAQAB
+      -----END PUBLIC KEY-----
+    TEXT
   end
 
   let(:public_key_id) { 'https://example.com/alice#main-key' }

--- a/spec/services/activitypub/process_collection_service_spec.rb
+++ b/spec/services/activitypub/process_collection_service_spec.rb
@@ -100,8 +100,18 @@ RSpec.describe ActivityPub::ProcessCollectionService, type: :service do
                     username: 'bob',
                     domain: 'example.com',
                     uri: 'https://example.com/users/bob',
-                    public_key: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuuYyoyfsRkYnXRotMsId\nW3euBDDfiv9oVqOxUVC7bhel8KednIMrMCRWFAkgJhbrlzbIkjVr68o1MP9qLcn7\nCmH/BXHp7yhuFTr4byjdJKpwB+/i2jNEsvDH5jR8WTAeTCe0x/QHg21V3F7dSI5m\nCCZ/1dSIyOXLRTWVlfDlm3rE4ntlCo+US3/7oSWbg/4/4qEnt1HC32kvklgScxua\n4LR5ATdoXa5bFoopPWhul7MJ6NyWCyQyScUuGdlj8EN4kmKQJvphKHrI9fvhgOuG\nTvhTR1S5InA4azSSchY0tXEEw/VNxraeX0KPjbgr6DPcwhPd/m0nhVDq0zVyVBBD\nMwIDAQAB\n-----END PUBLIC KEY-----\n",
-                    private_key: nil)
+                    private_key: nil,
+                    public_key: <<~TEXT)
+                      -----BEGIN PUBLIC KEY-----
+                      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuuYyoyfsRkYnXRotMsId
+                      W3euBDDfiv9oVqOxUVC7bhel8KednIMrMCRWFAkgJhbrlzbIkjVr68o1MP9qLcn7
+                      CmH/BXHp7yhuFTr4byjdJKpwB+/i2jNEsvDH5jR8WTAeTCe0x/QHg21V3F7dSI5m
+                      CCZ/1dSIyOXLRTWVlfDlm3rE4ntlCo+US3/7oSWbg/4/4qEnt1HC32kvklgScxua
+                      4LR5ATdoXa5bFoopPWhul7MJ6NyWCyQyScUuGdlj8EN4kmKQJvphKHrI9fvhgOuG
+                      TvhTR1S5InA4azSSchY0tXEEw/VNxraeX0KPjbgr6DPcwhPd/m0nhVDq0zVyVBBD
+                      MwIDAQAB
+                      -----END PUBLIC KEY-----
+                    TEXT
         end
 
         let(:payload) do
@@ -125,7 +135,14 @@ RSpec.describe ActivityPub::ProcessCollectionService, type: :service do
               type: 'RsaSignature2017',
               creator: 'https://example.com/users/bob#main-key',
               created: '2022-03-09T21:57:25Z',
-              signatureValue: 'WculK0LelTQ0MvGwU9TPoq5pFzFfGYRDCJqjZ232/Udj4CHqDTGOSw5UTDLShqBOyycCkbZGrQwXG+dpyDpQLSe1UVPZ5TPQtc/9XtI57WlS2nMNpdvRuxGnnb2btPdesXZ7n3pCxo0zjaXrJMe0mqQh5QJO22mahb4bDwwmfTHgbD3nmkD+fBfGi+UV2qWwqr+jlV4L4JqNkh0gWljF5KTePLRRZCuWiQ/FAt7c67636cdIPf7fR+usjuZltTQyLZKEGuK8VUn2Gkfsx5qns7Vcjvlz1JqlAjyO8HPBbzTTHzUG2nUOIgC3PojCSWv6mNTmRGoLZzOscCAYQA6cKw==',
+              signatureValue: 'WculK0LelTQ0MvGwU9TPoq5pFzFfGYRDCJqjZ232/Udj4' \
+                              'CHqDTGOSw5UTDLShqBOyycCkbZGrQwXG+dpyDpQLSe1UV' \
+                              'PZ5TPQtc/9XtI57WlS2nMNpdvRuxGnnb2btPdesXZ7n3p' \
+                              'Cxo0zjaXrJMe0mqQh5QJO22mahb4bDwwmfTHgbD3nmkD+' \
+                              'fBfGi+UV2qWwqr+jlV4L4JqNkh0gWljF5KTePLRRZCuWi' \
+                              'Q/FAt7c67636cdIPf7fR+usjuZltTQyLZKEGuK8VUn2Gk' \
+                              'fsx5qns7Vcjvlz1JqlAjyO8HPBbzTTHzUG2nUOIgC3Poj' \
+                              'CSWv6mNTmRGoLZzOscCAYQA6cKw==',
             },
             '@id': 'https://example.com/users/bob/statuses/107928807471117876/activity',
             '@type': 'https://www.w3.org/ns/activitystreams#Create',

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -100,7 +100,14 @@ RSpec.describe FetchLinkCardService, type: :service do
   end
 
   context 'with a remote status' do
-    let(:status) { Fabricate(:status, account: Fabricate(:account, domain: 'example.com'), text: 'Habt ihr ein paar gute Links zu <a>foo</a> #<span class="tag"><a href="https://quitter.se/tag/wannacry" target="_blank" rel="tag noopener noreferrer" title="https://quitter.se/tag/wannacry">Wannacry</a></span> herumfliegen?   Ich will mal unter <br> <a href="https://github.com/qbi/WannaCry" target="_blank" rel="noopener noreferrer" title="https://github.com/qbi/WannaCry">https://github.com/qbi/WannaCry</a> was sammeln. !<a href="http://sn.jonkman.ca/group/416/id" target="_blank" rel="noopener noreferrer" title="http://sn.jonkman.ca/group/416/id">security</a>&nbsp;') }
+    let(:status) do
+      Fabricate(:status, account: Fabricate(:account, domain: 'example.com'), text: <<-TEXT)
+      Habt ihr ein paar gute Links zu <a>foo</a>
+      #<span class="tag"><a href="https://quitter.se/tag/wannacry" target="_blank" rel="tag noopener noreferrer" title="https://quitter.se/tag/wannacry">Wannacry</a></span> herumfliegen?
+      Ich will mal unter <br> <a href="https://github.com/qbi/WannaCry" target="_blank" rel="noopener noreferrer" title="https://github.com/qbi/WannaCry">https://github.com/qbi/WannaCry</a> was sammeln. !
+      <a href="http://sn.jonkman.ca/group/416/id" target="_blank" rel="noopener noreferrer" title="http://sn.jonkman.ca/group/416/id">security</a>&nbsp;
+      TEXT
+    end
 
     it 'parses out URLs' do
       expect(a_request(:get, 'https://github.com/qbi/WannaCry')).to have_been_made.at_least_once


### PR DESCRIPTION
As noted here - https://github.com/mastodon/mastodon/pull/26002#issuecomment-1643979994 - there's an upstream bug in rubocop todo generator now where certain configuration interactions around the `Layout/LineLength` setting wind up generating duplicate entries in the todo file. In our case because we also have the yaml lint running, this means there's a manual cleanup step involved in regenerating that file.

This PR starts by just regenerating the todo file (there were some changes from recent commits).

Then I added a high-ish `Max` config value for linelength. Then I stepped through one reduction at a time, dropping the limit a bit and fixing things.

I landed on 320 because when I tried to drop down much further there were so many violations that it just bailed on listing them and excluded the rule -- and I didn't want to do too many more corrections on what started as a configuration fix.

Basically all the changes here are (in my opinion) also nice renaming/readability refactors, so that's a nice side effect of the line length reductions as well.

This repeats some of https://github.com/mastodon/mastodon/pull/24174 but does not go as far in reducing the limit, and I tried to avoid adding `rubocop:disable` where possible and actually fix the violations.

Let me know if you'd prefer these be submitted as more explicit readability/naming refactors instead (which regenerate line limit as side effect) -- there's basically 1-2 files changing in each commit here and it would be easy to convert to that approach in individual PRs.

After the config changes the goal of "you can regenerate a new todo file and dont need to manually edit it to remove duplicate LineLength entries" appears to be achievd.