### PR TITLE
emoji_map: don't forcibly emojify arrows with Emoji_Presentation=No

### DIFF
--- a/app/javascript/mastodon/features/emoji/emoji_compressed.js
+++ b/app/javascript/mastodon/features/emoji/emoji_compressed.js
@@ -22,7 +22,8 @@ if(data.compressed) {
 
 const emojiMartData = data;
 
-const excluded       = ['®', '©', '™'];
+const excluded       = ['®', '©', '™',
+                        '⬆', '↗', '➡', '↘', '⬇', '↙', '⬅', '↖', '↕', '↔', '↩', '↪', '⤴', '⤵'];
 const skinTones      = ['🏻', '🏼', '🏽', '🏾', '🏿'];
 const shortcodeMap   = {};
 


### PR DESCRIPTION
With patch (development instance, 586b1c9dca07c894af4248f59c847e7a3bf6d786):
![image](https://github.com/mastodon/mastodon/assets/6709544/460eeefc-058f-45aa-a0de-95c60a4fbfe5)
Without patch (101010.pl, plain 4.1.4):
![image](https://github.com/mastodon/mastodon/assets/6709544/d2936f3b-cd67-44f7-9fac-b0cf6f90d370)

Message contents:
```
p	(U+0070, UTF-8 70       ): LATIN SMALL LETTER P
l	(U+006C, UTF-8 6c       ): LATIN SMALL LETTER L
a	(U+0061, UTF-8 61       ): LATIN SMALL LETTER A
i	(U+0069, UTF-8 69       ): LATIN SMALL LETTER I
n	(U+006E, UTF-8 6e       ): LATIN SMALL LETTER N
:	(U+003A, UTF-8 3a       ): COLON
 	(U+0020, UTF-8 20       ): SPACE
↔	(U+2194, UTF-8 e2 86 94 ): LEFT RIGHT ARROW
e	(U+0065, UTF-8 65       ): LATIN SMALL LETTER E
m	(U+006D, UTF-8 6d       ): LATIN SMALL LETTER M
o	(U+006F, UTF-8 6f       ): LATIN SMALL LETTER O
:	(U+003A, UTF-8 3a       ): COLON
 	(U+0020, UTF-8 20       ): SPACE
↔	(U+2194, UTF-8 e2 86 94 ): LEFT RIGHT ARROW
️	(U+FE0F, UTF-8 ef b8 8f ): VARIATION SELECTOR-16
s	(U+0073, UTF-8 73       ): LATIN SMALL LETTER S
1	(U+0031, UTF-8 31       ): DIGIT ONE
5	(U+0035, UTF-8 35       ): DIGIT FIVE
:	(U+003A, UTF-8 3a       ): COLON
 	(U+0020, UTF-8 20       ): SPACE
↔	(U+2194, UTF-8 e2 86 94 ): LEFT RIGHT ARROW
︎	(U+FE0E, UTF-8 ef b8 8e ): VARIATION SELECTOR-15
```

See #26089 for motivation and discussion; in short: these arrows are arrows, not emoji, by default. The emoji picker adds selector 16 to emojify them. Other mastodon front-ends already render this correctly.