### PR TITLE
Change LinkCrawlWorker Retry Count to 3

### DIFF
--- a/app/workers/link_crawl_worker.rb
+++ b/app/workers/link_crawl_worker.rb
@@ -3,7 +3,7 @@
 class LinkCrawlWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'pull', retry: 0
+  sidekiq_options queue: 'pull', retry: 3
 
   def perform(status_id)
     FetchLinkCardService.new.call(Status.find(status_id))


### PR DESCRIPTION
This PR increases the number of times LinkCrawlWorker's job retries after failure from 0 to 3.

In my case, after applying this change, the number of dead jobs accumulated in Sidekiq has dramatically decreased, so I suggest introducing it upstream as well.