### PR TITLE
Override default Action Mailer `preview_path`

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -192,7 +192,9 @@ module Mastodon
     # config.autoload_paths += Dir[Rails.root.join('app', 'api', '*')]
 
     config.active_job.queue_adapter = :sidekiq
+
     config.action_mailer.deliver_later_queue_name = 'mailers'
+    config.action_mailer.preview_path = Rails.root.join('spec', 'mailers', 'previews')
 
     # We use our own middleware for this
     config.public_file_server.enabled = false


### PR DESCRIPTION
The default for [`config.action_mailer.preview_path`](https://guides.rubyonrails.org/configuring.html#config-action-mailer-preview-path) is [`test/mailers/previews`](https://github.com/rails/rails/blob/7-0-stable/actionmailer/lib/action_mailer/railtie.rb#L28).

Mastodon stores its test in `spec/` rather than `test/`, so update the setting accordingly, so previews are accessible on http://localhost:3000/rails/mailers.
