### PR TITLE
Add `lang` attribute to trending links

### DIFF
--- a/app/javascript/mastodon/features/explore/components/story.jsx
+++ b/app/javascript/mastodon/features/explore/components/story.jsx
@@ -13,6 +13,7 @@ export default class Story extends PureComponent {
   static propTypes = {
     url: PropTypes.string,
     title: PropTypes.string,
+    lang: PropTypes.string,
     publisher: PropTypes.string,
     sharedTimes: PropTypes.number,
     thumbnail: PropTypes.string,
@@ -26,7 +27,7 @@ export default class Story extends PureComponent {
   handleImageLoad = () => this.setState({ thumbnailLoaded: true });
 
   render () {
-    const { url, title, publisher, sharedTimes, thumbnail, blurhash } = this.props;
+    const { url, title, lang, publisher, sharedTimes, thumbnail, blurhash } = this.props;
 
     const { thumbnailLoaded } = this.state;
 
@@ -34,7 +35,7 @@ export default class Story extends PureComponent {
       <a className='story' href={url} target='blank' rel='noopener'>
         <div className='story__details'>
           <div className='story__details__publisher'>{publisher ? publisher : <Skeleton width={50} />}</div>
-          <div className='story__details__title'>{title ? title : <Skeleton />}</div>
+          <div className='story__details__title' lang={lang}>{title ? title : <Skeleton />}</div>
           <div className='story__details__shared'>{typeof sharedTimes === 'number' ? <ShortNumber value={sharedTimes} renderer={accountsCountRenderer} /> : <Skeleton width={100} />}</div>
         </div>
 

--- a/app/javascript/mastodon/features/explore/components/story.jsx
+++ b/app/javascript/mastodon/features/explore/components/story.jsx
@@ -34,7 +34,7 @@ export default class Story extends PureComponent {
     return (
       <a className='story' href={url} target='blank' rel='noopener'>
         <div className='story__details'>
-          <div className='story__details__publisher'>{publisher ? publisher : <Skeleton width={50} />}</div>
+          <div className='story__details__publisher' lang={lang}>{publisher ? publisher : <Skeleton width={50} />}</div>
           <div className='story__details__title' lang={lang}>{title ? title : <Skeleton />}</div>
           <div className='story__details__shared'>{typeof sharedTimes === 'number' ? <ShortNumber value={sharedTimes} renderer={accountsCountRenderer} /> : <Skeleton width={100} />}</div>
         </div>

--- a/app/javascript/mastodon/features/explore/links.jsx
+++ b/app/javascript/mastodon/features/explore/links.jsx
@@ -58,6 +58,7 @@ class Links extends PureComponent {
         {isLoading ? (<LoadingIndicator />) : links.map(link => (
           <Story
             key={link.get('id')}
+            lang={link.get('language')}
             url={link.get('url')}
             title={link.get('title')}
             publisher={link.get('provider_name')}


### PR DESCRIPTION
For better accessibility, add `lang` attribute to the element containing the title of trending links.