### PR TITLE
Fix UI Overlap with the loupe icon in the Explore Tab

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8155,7 +8155,7 @@ noscript {
 
   .search__input {
     border: 1px solid lighten($ui-base-color, 8%);
-    padding: 10px 28px 10px 10px;
+    padding: 10px;
   }
 
   .search__popout {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8156,6 +8156,7 @@ noscript {
   .search__input {
     border: 1px solid lighten($ui-base-color, 8%);
     padding: 10px;
+    padding-inline-end: 28px;
   }
 
   .search__popout {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8155,7 +8155,7 @@ noscript {
 
   .search__input {
     border: 1px solid lighten($ui-base-color, 8%);
-    padding: 10px;
+    padding: 10px 28px 10px 10px;
   }
 
   .search__popout {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5027,7 +5027,6 @@ a.status-card.compact:hover {
     position: absolute;
     top: 16px;
     inset-inline-end: 10px;
-    z-index: 2;
     display: inline-block;
     opacity: 0;
     transition: all 100ms linear;


### PR DESCRIPTION
This PR addresses two UI bugs in the Explore tab associated with the loupe icon:
1. The loupe icon protrudes over the surface of the header section.
2. The text entered in the search box overlaps with the loupe icon when it is long enough to reach the icon.

**Steps to reproduce (Issue 1):**
1. Navigate to the Explore tab.
2. Scroll down.

The loupe icon on the search box overlays the header section.

**Steps to reproduce (Issue 2):**
1. Navigate to the Explore tab.
2. Enter text in the search box until it reaches the loupe icon on the right.

The text overlaps with the loupe icon on the right side.

### Expected behavior:
The loupe icon should not overlay the header section when scrolling down the Explore tab, and the text entered in the search box should not overlap with the loupe icon, even when it is long enough to reach the icon.

### Screenshots:
I have attached screenshots to illustrate the issues and the effects of the proposed changes.

_Before the changes:_
![スクリーンショット 2023-07-22 135016](https://github.com/mastodon/mastodon/assets/28330543/0f8b1f43-f448-4220-bb5e-ec015ad9c7cc)
![スクリーンショット 2023-07-22 151215](https://github.com/mastodon/mastodon/assets/28330543/71d32251-4bd3-4084-9939-7f76abcba8c9)

_After the changes:_
![スクリーンショット 2023-07-22 135458](https://github.com/mastodon/mastodon/assets/28330543/c076d909-bd3c-4db7-ab1f-509aeea6883b)
![スクリーンショット 2023-07-22 152647](https://github.com/mastodon/mastodon/assets/28330543/eada130e-dcc7-40f5-bf26-f28b5a90f90f)

