### PR TITLE
Use valid email address for first account

### DIFF
--- a/db/seeds/04_admin.rb
+++ b/db/seeds/04_admin.rb
@@ -2,6 +2,7 @@
 
 if Rails.env.development?
   domain = ENV['LOCAL_DOMAIN'] || Rails.configuration.x.local_domain
+  domain = domain.gsub(/:\d+$/, '')
 
   admin = Account.where(username: 'admin').first_or_initialize(username: 'admin')
   admin.save(validate: false)


### PR DESCRIPTION
When running `rake db:seed` in development, the first user is created with the email address **admin@localhost:3000**. This is not a valid email address, but most things work fine anyway. But e.g. in the email previews on http://localhost:3000/rails/mailers/user_mailer/welcome, it raises an exception.

Strip the port number, so the default email is **admin@localhost** instead.