### PR TITLE
Fix missing translation strings for importing lists

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -65,8 +65,8 @@ ignore_unused:
   - 'move_handler.carry_{mutes,blocks}_over_text'
   - 'admin_mailer.*.subject'
   - 'notification_mailer.*'
-  - 'imports.overwrite_preambles.{following,blocking,muting,domain_blocking,bookmarks}_html'
-  - 'imports.preambles.{following,blocking,muting,domain_blocking,bookmarks}_html'
+  - 'imports.overwrite_preambles.{following,blocking,muting,domain_blocking,bookmarks,lists}_html'
+  - 'imports.preambles.{following,blocking,muting,domain_blocking,bookmarks,lists}_html'
   - 'mail_subscriptions.unsubscribe.emails.*'
   - 'preferences.other' # some locales are missing other keys, therefore leading i18n-tasks to detect `preferences` as plural and not finding use
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1278,15 +1278,15 @@ en:
       bookmarks_html: You are about to <strong>replace your bookmarks</strong> with up to <strong>%{total_items} posts</strong> from <strong>%{filename}</strong>.
       domain_blocking_html: You are about to <strong>replace your domain block list</strong> with up to <strong>%{total_items} domains</strong> from <strong>%{filename}</strong>.
       following_html: You are about to <strong>follow</strong> up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong> and <strong>stop following anyone else</strong>.
-      muting_html: You are about to <strong>replace your list of muted accounts</strong> with up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong>.
       lists_html: You are about to <strong>replace your lists</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{total_items} accounts</strong> will be added to new lists.
+      muting_html: You are about to <strong>replace your list of muted accounts</strong> with up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong>.
     preambles:
       blocking_html: You are about to <strong>block</strong> up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong>.
       bookmarks_html: You are about to add up to <strong>%{total_items} posts</strong> from <strong>%{filename}</strong> to your <strong>bookmarks</strong>.
       domain_blocking_html: You are about to <strong>block</strong> up to <strong>%{total_items} domains</strong> from <strong>%{filename}</strong>.
       following_html: You are about to <strong>follow</strong> up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong>.
-      muting_html: You are about to <strong>mute</strong> up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong>.
       lists_html: You are about to add up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong> to your <strong>lists</strong>. New lists will be created if there is no list to add to.
+      muting_html: You are about to <strong>mute</strong> up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong>.
     preface: You can import data that you have exported from another server, such as a list of the people you are following or blocking.
     recent_imports: Recent imports
     states:
@@ -1302,8 +1302,8 @@ en:
       bookmarks: Importing bookmarks
       domain_blocking: Importing blocked domains
       following: Importing followed accounts
-      muting: Importing muted accounts
       lists: Importing lists
+      muting: Importing muted accounts
     type: Import type
     type_groups:
       constructive: Follows & Bookmarks
@@ -1313,8 +1313,8 @@ en:
       bookmarks: Bookmarks
       domain_blocking: Domain blocking list
       following: Following list
-      muting: Muting list
       lists: Lists
+      muting: Muting list
     upload: Upload
   invites:
     delete: Deactivate

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1279,12 +1279,14 @@ en:
       domain_blocking_html: You are about to <strong>replace your domain block list</strong> with up to <strong>%{total_items} domains</strong> from <strong>%{filename}</strong>.
       following_html: You are about to <strong>follow</strong> up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong> and <strong>stop following anyone else</strong>.
       muting_html: You are about to <strong>replace your list of muted accounts</strong> with up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong>.
+      lists_html: You are about to <strong>replace your lists</strong> with contents of <strong>%{filename}</strong>. Up to <strong>%{total_items} accounts</strong> will be added to new lists.
     preambles:
       blocking_html: You are about to <strong>block</strong> up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong>.
       bookmarks_html: You are about to add up to <strong>%{total_items} posts</strong> from <strong>%{filename}</strong> to your <strong>bookmarks</strong>.
       domain_blocking_html: You are about to <strong>block</strong> up to <strong>%{total_items} domains</strong> from <strong>%{filename}</strong>.
       following_html: You are about to <strong>follow</strong> up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong>.
       muting_html: You are about to <strong>mute</strong> up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong>.
+      lists_html: You are about to add up to <strong>%{total_items} accounts</strong> from <strong>%{filename}</strong> to your <strong>lists</strong>. New lists will be created if there is no list to add to.
     preface: You can import data that you have exported from another server, such as a list of the people you are following or blocking.
     recent_imports: Recent imports
     states:
@@ -1301,6 +1303,7 @@ en:
       domain_blocking: Importing blocked domains
       following: Importing followed accounts
       muting: Importing muted accounts
+      lists: Importing lists
     type: Import type
     type_groups:
       constructive: Follows & Bookmarks
@@ -1311,6 +1314,7 @@ en:
       domain_blocking: Domain blocking list
       following: Following list
       muting: Muting list
+      lists: Lists
     upload: Upload
   invites:
     delete: Deactivate


### PR DESCRIPTION
This fixes translation missing errors in the importing lists feature.

Followup to #25203

|Before|After|
|---|---|
|![](https://github.com/mastodon/mastodon/assets/5103195/f1aeba01-7609-4619-9ea3-11a0d6ada589)|![](https://github.com/mastodon/mastodon/assets/5103195/5289daf2-679e-423b-9e76-25938a31eba7)|
![](https://github.com/mastodon/mastodon/assets/5103195/8db41b85-72b2-47c2-bdea-b867a1d8154a)|![](https://github.com/mastodon/mastodon/assets/5103195/1f9ddadf-1072-4f61-bf4e-bfdc1ec70e2e)|
