### PR TITLE
Remove 16:9 cropping from web UI

### DIFF
--- a/app/javascript/mastodon/components/media_gallery.jsx
+++ b/app/javascript/mastodon/components/media_gallery.jsx
@@ -12,7 +12,7 @@ import { debounce } from 'lodash';
 
 import { Blurhash } from 'mastodon/components/blurhash';
 
-import { autoPlayGif, cropImages, displayMedia, useBlurhash } from '../initial_state';
+import { autoPlayGif, displayMedia, useBlurhash } from '../initial_state';
 
 import { IconButton } from './icon_button';
 
@@ -209,7 +209,6 @@ class MediaGallery extends PureComponent {
 
   static propTypes = {
     sensitive: PropTypes.bool,
-    standalone: PropTypes.bool,
     media: ImmutablePropTypes.list.isRequired,
     lang: PropTypes.string,
     size: PropTypes.object,
@@ -221,10 +220,6 @@ class MediaGallery extends PureComponent {
     visible: PropTypes.bool,
     autoplay: PropTypes.bool,
     onToggleVisibility: PropTypes.func,
-  };
-
-  static defaultProps = {
-    standalone: false,
   };
 
   state = {
@@ -295,7 +290,7 @@ class MediaGallery extends PureComponent {
   }
 
   render () {
-    const { media, lang, intl, sensitive, defaultWidth, standalone, autoplay } = this.props;
+    const { media, lang, intl, sensitive, defaultWidth, autoplay } = this.props;
     const { visible } = this.state;
     const width = this.state.width || defaultWidth;
 
@@ -303,16 +298,16 @@ class MediaGallery extends PureComponent {
 
     const style = {};
 
-    if (this.isFullSizeEligible() && (standalone || !cropImages)) {
+    if (this.isFullSizeEligible()) {
       style.aspectRatio = `${this.props.media.getIn([0, 'meta', 'small', 'aspect'])}`;
     } else {
-      style.aspectRatio = '16 / 9';
+      style.aspectRatio = '3 / 2';
     }
 
     const size     = media.take(4).size;
     const uncached = media.every(attachment => attachment.get('type') === 'unknown');
 
-    if (standalone && this.isFullSizeEligible()) {
+    if (this.isFullSizeEligible()) {
       children = <Item standalone autoplay={autoplay} onClick={this.handleClick} attachment={media.get(0)} lang={lang} displayWidth={width} visible={visible} />;
     } else {
       children = media.take(4).map((attachment, i) => <Item key={attachment.get('id')} autoplay={autoplay} onClick={this.handleClick} attachment={attachment} index={i} lang={lang} size={size} displayWidth={width} visible={visible || uncached} />);

--- a/app/javascript/mastodon/components/picture_in_picture_placeholder.jsx
+++ b/app/javascript/mastodon/components/picture_in_picture_placeholder.jsx
@@ -12,6 +12,7 @@ class PictureInPicturePlaceholder extends PureComponent {
 
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
+    aspectRatio: PropTypes.string,
   };
 
   handleClick = () => {
@@ -20,8 +21,10 @@ class PictureInPicturePlaceholder extends PureComponent {
   };
 
   render () {
+    const { aspectRatio } = this.props;
+
     return (
-      <div className='picture-in-picture-placeholder' role='button' tabIndex={0} onClick={this.handleClick}>
+      <div className='picture-in-picture-placeholder' style={{ aspectRatio }} role='button' tabIndex={0} onClick={this.handleClick}>
         <Icon id='window-restore' />
         <FormattedMessage id='picture_in_picture.restore' defaultMessage='Put it back' />
       </div>

--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -19,7 +19,6 @@ import Bundle from '../features/ui/components/bundle';
 import { MediaGallery, Video, Audio } from '../features/ui/util/async-components';
 import { displayMedia } from '../initial_state';
 
-import AttachmentList from './attachment_list';
 import { Avatar } from './avatar';
 import { AvatarOverlay } from './avatar_overlay';
 import { DisplayName } from './display_name';
@@ -191,17 +190,35 @@ class Status extends ImmutablePureComponent {
     this.props.onTranslate(this._properStatus());
   };
 
-  renderLoadingMediaGallery () {
-    return <div className='media-gallery' style={{ height: '110px' }} />;
+  getAttachmentAspectRatio () {
+    const attachments = this._properStatus().get('media_attachments');
+
+    if (attachments.getIn([0, 'type']) === 'video') {
+      return `${attachments.getIn([0, 'meta', 'original', 'width'])} / ${attachments.getIn([0, 'meta', 'original', 'height'])}`;
+    } else if (attachments.getIn([0, 'type']) === 'audio') {
+      return '16 / 9';
+    } else {
+      return (attachments.size === 1 && attachments.getIn([0, 'meta', 'small', 'aspect'])) ? attachments.getIn([0, 'meta', 'small', 'aspect']) : '3 / 2'
+    }
   }
 
-  renderLoadingVideoPlayer () {
-    return <div className='video-player' style={{ height: '110px' }} />;
-  }
+  renderLoadingMediaGallery = () => {
+    return (
+      <div className='media-gallery' style={{ aspectRatio: this.getAttachmentAspectRatio() }} />
+    );
+  };
 
-  renderLoadingAudioPlayer () {
-    return <div className='audio-player' style={{ height: '110px' }} />;
-  }
+  renderLoadingVideoPlayer = () => {
+    return (
+      <div className='video-player' style={{ aspectRatio: this.getAttachmentAspectRatio() }} />
+    );
+  };
+
+  renderLoadingAudioPlayer = () => {
+    return (
+      <div className='audio-player' style={{ aspectRatio: this.getAttachmentAspectRatio() }} />
+    );
+  };
 
   handleOpenVideo = (options) => {
     const status = this._properStatus();
@@ -426,18 +443,11 @@ class Status extends ImmutablePureComponent {
     }
 
     if (pictureInPicture.get('inUse')) {
-      media = <PictureInPicturePlaceholder />;
+      media = <PictureInPicturePlaceholder aspectRatio={this.getAttachmentAspectRatio()} />;
     } else if (status.get('media_attachments').size > 0) {
       const language = status.getIn(['translation', 'language']) || status.get('language');
 
-      if (this.props.muted) {
-        media = (
-          <AttachmentList
-            compact
-            media={status.get('media_attachments')}
-          />
-        );
-      } else if (status.getIn(['media_attachments', 0, 'type']) === 'audio') {
+      if (status.getIn(['media_attachments', 0, 'type']) === 'audio') {
         const attachment = status.getIn(['media_attachments', 0]);
         const description = attachment.getIn(['translation', 'description']) || attachment.get('description');
 
@@ -475,11 +485,11 @@ class Status extends ImmutablePureComponent {
               <Component
                 preview={attachment.get('preview_url')}
                 frameRate={attachment.getIn(['meta', 'original', 'frame_rate'])}
+                aspectRatio={`${attachment.getIn(['meta', 'original', 'width'])} / ${attachment.getIn(['meta', 'original', 'height'])}`}
                 blurhash={attachment.get('blurhash')}
                 src={attachment.get('url')}
                 alt={description}
                 lang={language}
-                inline
                 sensitive={status.get('sensitive')}
                 onOpenVideo={this.handleOpenVideo}
                 deployPictureInPicture={pictureInPicture.get('available') ? this.handleDeployPictureInPicture : undefined}
@@ -508,7 +518,7 @@ class Status extends ImmutablePureComponent {
           </Bundle>
         );
       }
-    } else if (status.get('spoiler_text').length === 0 && status.get('card') && !this.props.muted) {
+    } else if (status.get('spoiler_text').length === 0 && status.get('card')) {
       media = (
         <Card
           onOpenMedia={this.handleOpenMedia}

--- a/app/javascript/mastodon/features/ui/components/media_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/media_modal.jsx
@@ -172,6 +172,7 @@ class MediaModal extends ImmutablePureComponent {
             width={image.get('width')}
             height={image.get('height')}
             frameRate={image.getIn(['meta', 'original', 'frame_rate'])}
+            aspectRatio={`${image.getIn(['meta', 'original', 'width'])} / ${image.getIn(['meta', 'original', 'height'])}`}
             currentTime={currentTime || 0}
             autoPlay={autoPlay || false}
             volume={volume || 1}

--- a/app/javascript/mastodon/features/ui/components/video_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/video_modal.jsx
@@ -49,6 +49,7 @@ class VideoModal extends ImmutablePureComponent {
           <Video
             preview={media.get('preview_url')}
             frameRate={media.getIn(['meta', 'original', 'frame_rate'])}
+            aspectRatio={`${media.getIn(['meta', 'original', 'width'])} / ${media.getIn(['meta', 'original', 'height'])}`}
             blurhash={media.get('blurhash')}
             src={media.get('url')}
             currentTime={options.startTime}

--- a/app/javascript/mastodon/features/video/index.jsx
+++ b/app/javascript/mastodon/features/video/index.jsx
@@ -105,6 +105,7 @@ class Video extends PureComponent {
   static propTypes = {
     preview: PropTypes.string,
     frameRate: PropTypes.string,
+    aspectRatio: PropTypes.string,
     src: PropTypes.string.isRequired,
     alt: PropTypes.string,
     lang: PropTypes.string,
@@ -113,7 +114,6 @@ class Video extends PureComponent {
     onOpenVideo: PropTypes.func,
     onCloseVideo: PropTypes.func,
     detailed: PropTypes.bool,
-    inline: PropTypes.bool,
     editable: PropTypes.bool,
     alwaysVisible: PropTypes.bool,
     visible: PropTypes.bool,
@@ -500,14 +500,9 @@ class Video extends PureComponent {
   }
 
   render () {
-    const { preview, src, inline, onOpenVideo, onCloseVideo, intl, alt, lang, detailed, sensitive, editable, blurhash, autoFocus } = this.props;
+    const { preview, src, aspectRatio, onOpenVideo, onCloseVideo, intl, alt, lang, detailed, sensitive, editable, blurhash, autoFocus } = this.props;
     const { currentTime, duration, volume, buffer, dragging, paused, fullscreen, hovered, muted, revealed } = this.state;
     const progress = Math.min((currentTime / duration) * 100, 100);
-    const playerStyle = {};
-
-    if (inline) {
-      playerStyle.aspectRatio = '16 / 9';
-    }
 
     let preload;
 
@@ -527,95 +522,98 @@ class Video extends PureComponent {
       warning = <FormattedMessage id='status.media_hidden' defaultMessage='Media hidden' />;
     }
 
+    // The outer wrapper is necessary to avoid reflowing the layout when going into full screen
     return (
-      <div
-        role='menuitem'
-        className={classNames('video-player', { inactive: !revealed, detailed, inline: inline && !fullscreen, fullscreen, editable })}
-        style={playerStyle}
-        ref={this.setPlayerRef}
-        onMouseEnter={this.handleMouseEnter}
-        onMouseLeave={this.handleMouseLeave}
-        onClick={this.handleClickRoot}
-        onKeyDown={this.handleKeyDown}
-        tabIndex={0}
-      >
-        <Blurhash
-          hash={blurhash}
-          className={classNames('media-gallery__preview', {
-            'media-gallery__preview--hidden': revealed,
-          })}
-          dummy={!useBlurhash}
-        />
-
-        {(revealed || editable) && <video
-          ref={this.setVideoRef}
-          src={src}
-          poster={preview}
-          preload={preload}
-          role='button'
+      <div style={{ aspectRatio }}>
+        <div
+          role='menuitem'
+          className={classNames('video-player', { inactive: !revealed, detailed, fullscreen, editable })}
+          style={{ aspectRatio }}
+          ref={this.setPlayerRef}
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
+          onClick={this.handleClickRoot}
+          onKeyDown={this.handleKeyDown}
           tabIndex={0}
-          aria-label={alt}
-          title={alt}
-          lang={lang}
-          volume={volume}
-          onClick={this.togglePlay}
-          onKeyDown={this.handleVideoKeyDown}
-          onPlay={this.handlePlay}
-          onPause={this.handlePause}
-          onLoadedData={this.handleLoadedData}
-          onProgress={this.handleProgress}
-          onVolumeChange={this.handleVolumeChange}
-          style={{ ...playerStyle, width: '100%' }}
-        />}
+        >
+          <Blurhash
+            hash={blurhash}
+            className={classNames('media-gallery__preview', {
+              'media-gallery__preview--hidden': revealed,
+            })}
+            dummy={!useBlurhash}
+          />
 
-        <div className={classNames('spoiler-button', { 'spoiler-button--hidden': revealed || editable })}>
-          <button type='button' className='spoiler-button__overlay' onClick={this.toggleReveal}>
-            <span className='spoiler-button__overlay__label'>{warning}</span>
-          </button>
-        </div>
+          {(revealed || editable) && <video
+            ref={this.setVideoRef}
+            src={src}
+            poster={preview}
+            preload={preload}
+            role='button'
+            tabIndex={0}
+            aria-label={alt}
+            title={alt}
+            lang={lang}
+            volume={volume}
+            onClick={this.togglePlay}
+            onKeyDown={this.handleVideoKeyDown}
+            onPlay={this.handlePlay}
+            onPause={this.handlePause}
+            onLoadedData={this.handleLoadedData}
+            onProgress={this.handleProgress}
+            onVolumeChange={this.handleVolumeChange}
+            style={{ width: '100%' }}
+          />}
 
-        <div className={classNames('video-player__controls', { active: paused || hovered })}>
-          <div className='video-player__seek' onMouseDown={this.handleMouseDown} ref={this.setSeekRef}>
-            <div className='video-player__seek__buffer' style={{ width: `${buffer}%` }} />
-            <div className='video-player__seek__progress' style={{ width: `${progress}%` }} />
-
-            <span
-              className={classNames('video-player__seek__handle', { active: dragging })}
-              tabIndex={0}
-              style={{ left: `${progress}%` }}
-              onKeyDown={this.handleVideoKeyDown}
-            />
+          <div className={classNames('spoiler-button', { 'spoiler-button--hidden': revealed || editable })}>
+            <button type='button' className='spoiler-button__overlay' onClick={this.toggleReveal}>
+              <span className='spoiler-button__overlay__label'>{warning}</span>
+            </button>
           </div>
 
-          <div className='video-player__buttons-bar'>
-            <div className='video-player__buttons left'>
-              <button type='button' title={intl.formatMessage(paused ? messages.play : messages.pause)} aria-label={intl.formatMessage(paused ? messages.play : messages.pause)} className='player-button' onClick={this.togglePlay} autoFocus={autoFocus}><Icon id={paused ? 'play' : 'pause'} fixedWidth /></button>
-              <button type='button' title={intl.formatMessage(muted ? messages.unmute : messages.mute)} aria-label={intl.formatMessage(muted ? messages.unmute : messages.mute)} className='player-button' onClick={this.toggleMute}><Icon id={muted ? 'volume-off' : 'volume-up'} fixedWidth /></button>
+          <div className={classNames('video-player__controls', { active: paused || hovered })}>
+            <div className='video-player__seek' onMouseDown={this.handleMouseDown} ref={this.setSeekRef}>
+              <div className='video-player__seek__buffer' style={{ width: `${buffer}%` }} />
+              <div className='video-player__seek__progress' style={{ width: `${progress}%` }} />
 
-              <div className={classNames('video-player__volume', { active: this.state.hovered })} onMouseDown={this.handleVolumeMouseDown} ref={this.setVolumeRef}>
-                <div className='video-player__volume__current' style={{ width: `${volume * 100}%` }} />
-
-                <span
-                  className={classNames('video-player__volume__handle')}
-                  tabIndex={0}
-                  style={{ left: `${volume * 100}%` }}
-                />
-              </div>
-
-              {(detailed || fullscreen) && (
-                <span className='video-player__time'>
-                  <span className='video-player__time-current'>{formatTime(Math.floor(currentTime))}</span>
-                  <span className='video-player__time-sep'>/</span>
-                  <span className='video-player__time-total'>{formatTime(Math.floor(duration))}</span>
-                </span>
-              )}
+              <span
+                className={classNames('video-player__seek__handle', { active: dragging })}
+                tabIndex={0}
+                style={{ left: `${progress}%` }}
+                onKeyDown={this.handleVideoKeyDown}
+              />
             </div>
 
-            <div className='video-player__buttons right'>
-              {(!onCloseVideo && !editable && !fullscreen && !this.props.alwaysVisible) && <button type='button' title={intl.formatMessage(messages.hide)} aria-label={intl.formatMessage(messages.hide)} className='player-button' onClick={this.toggleReveal}><Icon id='eye-slash' fixedWidth /></button>}
-              {(!fullscreen && onOpenVideo) && <button type='button' title={intl.formatMessage(messages.expand)} aria-label={intl.formatMessage(messages.expand)} className='player-button' onClick={this.handleOpenVideo}><Icon id='expand' fixedWidth /></button>}
-              {onCloseVideo && <button type='button' title={intl.formatMessage(messages.close)} aria-label={intl.formatMessage(messages.close)} className='player-button' onClick={this.handleCloseVideo}><Icon id='compress' fixedWidth /></button>}
-              <button type='button' title={intl.formatMessage(fullscreen ? messages.exit_fullscreen : messages.fullscreen)} aria-label={intl.formatMessage(fullscreen ? messages.exit_fullscreen : messages.fullscreen)} className='player-button' onClick={this.toggleFullscreen}><Icon id={fullscreen ? 'compress' : 'arrows-alt'} fixedWidth /></button>
+            <div className='video-player__buttons-bar'>
+              <div className='video-player__buttons left'>
+                <button type='button' title={intl.formatMessage(paused ? messages.play : messages.pause)} aria-label={intl.formatMessage(paused ? messages.play : messages.pause)} className='player-button' onClick={this.togglePlay} autoFocus={autoFocus}><Icon id={paused ? 'play' : 'pause'} fixedWidth /></button>
+                <button type='button' title={intl.formatMessage(muted ? messages.unmute : messages.mute)} aria-label={intl.formatMessage(muted ? messages.unmute : messages.mute)} className='player-button' onClick={this.toggleMute}><Icon id={muted ? 'volume-off' : 'volume-up'} fixedWidth /></button>
+
+                <div className={classNames('video-player__volume', { active: this.state.hovered })} onMouseDown={this.handleVolumeMouseDown} ref={this.setVolumeRef}>
+                  <div className='video-player__volume__current' style={{ width: `${volume * 100}%` }} />
+
+                  <span
+                    className={classNames('video-player__volume__handle')}
+                    tabIndex={0}
+                    style={{ left: `${volume * 100}%` }}
+                  />
+                </div>
+
+                {(detailed || fullscreen) && (
+                  <span className='video-player__time'>
+                    <span className='video-player__time-current'>{formatTime(Math.floor(currentTime))}</span>
+                    <span className='video-player__time-sep'>/</span>
+                    <span className='video-player__time-total'>{formatTime(Math.floor(duration))}</span>
+                  </span>
+                )}
+              </div>
+
+              <div className='video-player__buttons right'>
+                {(!onCloseVideo && !editable && !fullscreen && !this.props.alwaysVisible) && <button type='button' title={intl.formatMessage(messages.hide)} aria-label={intl.formatMessage(messages.hide)} className='player-button' onClick={this.toggleReveal}><Icon id='eye-slash' fixedWidth /></button>}
+                {(!fullscreen && onOpenVideo) && <button type='button' title={intl.formatMessage(messages.expand)} aria-label={intl.formatMessage(messages.expand)} className='player-button' onClick={this.handleOpenVideo}><Icon id='expand' fixedWidth /></button>}
+                {onCloseVideo && <button type='button' title={intl.formatMessage(messages.close)} aria-label={intl.formatMessage(messages.close)} className='player-button' onClick={this.handleCloseVideo}><Icon id='compress' fixedWidth /></button>}
+                <button type='button' title={intl.formatMessage(fullscreen ? messages.exit_fullscreen : messages.fullscreen)} aria-label={intl.formatMessage(fullscreen ? messages.exit_fullscreen : messages.fullscreen)} className='player-button' onClick={this.toggleFullscreen}><Icon id={fullscreen ? 'compress' : 'arrows-alt'} fixedWidth /></button>
+              </div>
             </div>
           </div>
         </div>

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -51,7 +51,6 @@
  * @property {boolean} activity_api_enabled
  * @property {string} admin
  * @property {boolean=} boost_modal
- * @property {boolean} crop_images
  * @property {boolean=} delete_modal
  * @property {boolean=} disable_swiping
  * @property {string=} disabled_account_id
@@ -111,7 +110,6 @@ const getMeta = (prop) => initialState?.meta && initialState.meta[prop];
 export const activityApiEnabled = getMeta('activity_api_enabled');
 export const autoPlayGif = getMeta('auto_play_gif');
 export const boostModal = getMeta('boost_modal');
-export const cropImages = getMeta('crop_images');
 export const deleteModal = getMeta('delete_modal');
 export const disableSwiping = getMeta('disable_swiping');
 export const disabledAccountId = getMeta('disabled_account_id');

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -5172,9 +5172,9 @@ a.status-card.compact:hover {
   display: flex;
 }
 
-.video-modal__container {
+.video-modal .video-player {
+  max-height: 80vh;
   max-width: 100vw;
-  max-height: 100vh;
 }
 
 .audio-modal__container {
@@ -6192,7 +6192,7 @@ a.status-card.compact:hover {
   box-sizing: border-box;
   margin-top: 8px;
   overflow: hidden;
-  border-radius: 4px;
+  border-radius: 8px;
   position: relative;
   width: 100%;
   min-height: 64px;
@@ -6207,7 +6207,7 @@ a.status-card.compact:hover {
   box-sizing: border-box;
   display: block;
   position: relative;
-  border-radius: 4px;
+  border-radius: 8px;
   overflow: hidden;
 
   &--tall {
@@ -6293,7 +6293,7 @@ a.status-card.compact:hover {
   box-sizing: border-box;
   position: relative;
   background: darken($ui-base-color, 8%);
-  border-radius: 4px;
+  border-radius: 8px;
   padding-bottom: 44px;
   width: 100%;
 
@@ -6360,7 +6360,7 @@ a.status-card.compact:hover {
   position: relative;
   background: $base-shadow-color;
   max-width: 100%;
-  border-radius: 4px;
+  border-radius: 8px;
   box-sizing: border-box;
   color: $white;
   display: flex;
@@ -6377,8 +6377,6 @@ a.status-card.compact:hover {
 
   video {
     display: block;
-    max-width: 100vw;
-    max-height: 80vh;
     z-index: 1;
   }
 
@@ -6386,19 +6384,12 @@ a.status-card.compact:hover {
     width: 100% !important;
     height: 100% !important;
     margin: 0;
+    aspect-ratio: auto !important;
 
     video {
-      max-width: 100% !important;
-      max-height: 100% !important;
       width: 100% !important;
       height: 100% !important;
       outline: 0;
-    }
-  }
-
-  &.inline {
-    video {
-      object-fit: contain;
     }
   }
 

--- a/app/models/concerns/has_user_settings.rb
+++ b/app/models/concerns/has_user_settings.rb
@@ -91,10 +91,6 @@ module HasUserSettings
     settings['web.trends']
   end
 
-  def setting_crop_images
-    settings['web.crop_images']
-  end
-
   def setting_disable_swiping
     settings['web.disable_swiping']
   end

--- a/app/models/user_settings.rb
+++ b/app/models/user_settings.rb
@@ -17,7 +17,6 @@ class UserSettings
   setting :default_privacy, default: nil, in: %w(public unlisted private)
 
   namespace :web do
-    setting :crop_images, default: true
     setting :advanced_layout, default: false
     setting :trends, default: true
     setting :use_blurhash, default: true

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -48,13 +48,11 @@ class InitialStateSerializer < ActiveModel::Serializer
       store[:use_blurhash]      = object.current_account.user.setting_use_blurhash
       store[:use_pending_items] = object.current_account.user.setting_use_pending_items
       store[:show_trends]       = Setting.trends && object.current_account.user.setting_trends
-      store[:crop_images]       = object.current_account.user.setting_crop_images
     else
       store[:auto_play_gif] = Setting.auto_play_gif
       store[:display_media] = Setting.display_media
       store[:reduce_motion] = Setting.reduce_motion
       store[:use_blurhash]  = Setting.use_blurhash
-      store[:crop_images]   = Setting.crop_images
     end
 
     store[:disabled_account_id] = object.disabled_account.id.to_s if object.disabled_account

--- a/app/views/settings/preferences/appearance/show.html.haml
+++ b/app/views/settings/preferences/appearance/show.html.haml
@@ -37,11 +37,6 @@
       = ff.input :'web.disable_swiping', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_disable_swiping')
       = ff.input :'web.use_system_font', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_system_font_ui')
 
-    %h4= t 'appearance.toot_layout'
-
-    .fields-group
-      = ff.input :'web.crop_images', wrapper: :with_label, label: I18n.t('simple_form.labels.defaults.setting_crop_images')
-
     %h4= t 'appearance.discovery'
 
     .fields-group

--- a/config/locales/an.yml
+++ b/config/locales/an.yml
@@ -923,7 +923,6 @@ an:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Totz pueden contribuyir.
     sensitive_content: Conteniu sensible
-    toot_layout: Disenyo d'as publicacions
   application_mailer:
     notification_preferences: Cambiar preferencias de correu electronico
     salutation: "%{name}:"

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -982,7 +982,6 @@ ar:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: يمكن للجميع المساهمة.
     sensitive_content: المحتوى الحساس
-    toot_layout: شكل المنشور
   application_mailer:
     notification_preferences: تعديل تفضيلات البريد الإلكتروني
     salutation: "%{name}،"

--- a/config/locales/ast.yml
+++ b/config/locales/ast.yml
@@ -439,7 +439,6 @@ ast:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: tol mundu pue collaborar.
     sensitive_content: Conteníu sensible
-    toot_layout: Distribución de los artículos
   application_mailer:
     notification_preferences: Camudar les preferencies de los mensaxes de corréu electrónicu
   applications:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -1009,7 +1009,6 @@ be:
       guide_link: https://be.crowdin.com/project/mastodon/be
       guide_link_text: Кожны можа зрабіць унёсак.
     sensitive_content: Далікатны змест
-    toot_layout: Макет допісу
   application_mailer:
     notification_preferences: Змяніць налады эл. пошты
     salutation: "%{name},"

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -973,7 +973,6 @@ bg:
       guide_link: https://ru.crowdin.com/project/mastodon
       guide_link_text: Всеки може да участва.
     sensitive_content: Деликатно съдържание
-    toot_layout: Оформление на публикацията
   application_mailer:
     notification_preferences: Промяна на предпочитанията за имейл
     salutation: "%{name},"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -973,7 +973,6 @@ ca:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Tothom hi pot contribuir.
     sensitive_content: Contingut sensible
-    toot_layout: Disseny dels tuts
   application_mailer:
     notification_preferences: Canvia les preferències de correu
     salutation: "%{name},"

--- a/config/locales/ckb.yml
+++ b/config/locales/ckb.yml
@@ -571,7 +571,6 @@ ckb:
       body: ماستۆدۆن لەلایەن خۆبەخشەوە وەردەگێڕێت.
       guide_link_text: هەموو کەسێک دەتوانێت بەشداری بکات.
     sensitive_content: ناوەڕۆکی هەستیار
-    toot_layout: لۆی توت
   application_mailer:
     notification_preferences: گۆڕینی پەسەندکراوەکانی ئیمەیڵ
     salutation: "%{name},"

--- a/config/locales/co.yml
+++ b/config/locales/co.yml
@@ -537,7 +537,6 @@ co:
       guide_link: https://fr.crowdin.com/project/mastodon
       guide_link_text: Tuttu u mondu pò participà.
     sensitive_content: Cuntinutu sensibile
-    toot_layout: Urganizazione
   application_mailer:
     notification_preferences: Cambià e priferenze e-mail
     salutation: "%{name},"

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -997,7 +997,6 @@ cs:
       guide_link: https://cs.crowdin.com/project/mastodon
       guide_link_text: Zapojit se může každý.
     sensitive_content: Citlivý obsah
-    toot_layout: Rozložení příspěvků
   application_mailer:
     notification_preferences: Změnit předvolby e-mailů
     salutation: "%{name},"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1045,7 +1045,6 @@ cy:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Gall pawb gyfrannu.
     sensitive_content: Cynnwys sensitif
-    toot_layout: Cynllun postiad
   application_mailer:
     notification_preferences: Newid gosodiadau e-bost
     salutation: "%{name},"

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -973,7 +973,6 @@ da:
       guide_link: https://da.crowdin.com/project/mastodon
       guide_link_text: Alle kan bidrage.
     sensitive_content: Sensitivt indhold
-    toot_layout: Indlægslayout
   application_mailer:
     notification_preferences: Skift e-mailpræferencer
     salutation: "%{name}"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -973,7 +973,6 @@ de:
       guide_link: https://de.crowdin.com/project/mastodon/de
       guide_link_text: Alle können mitmachen und etwas dazu beitragen.
     sensitive_content: Inhaltswarnung
-    toot_layout: Timeline-Layout
   application_mailer:
     notification_preferences: E-Mail-Einstellungen ändern
     salutation: "%{name},"

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -961,7 +961,6 @@ el:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Μπορεί να συνεισφέρει ο οποιοσδήποτε.
     sensitive_content: Ευαίσθητο περιεχόμενο
-    toot_layout: Διαρρύθμιση αναρτήσεων
   application_mailer:
     notification_preferences: Αλλαγή προτιμήσεων email
     salutation: "%{name},"

--- a/config/locales/en-GB.yml
+++ b/config/locales/en-GB.yml
@@ -973,7 +973,6 @@ en-GB:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Everyone can contribute.
     sensitive_content: Sensitive content
-    toot_layout: Post layout
   application_mailer:
     notification_preferences: Change e-mail preferences
     salutation: "%{name},"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -973,7 +973,6 @@ en:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Everyone can contribute.
     sensitive_content: Sensitive content
-    toot_layout: Post layout
   application_mailer:
     notification_preferences: Change e-mail preferences
     salutation: "%{name},"

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -973,7 +973,6 @@ eo:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Ĉiu povas kontribui.
     sensitive_content: Tikla enhavo
-    toot_layout: Mesaĝo aranĝo
   application_mailer:
     notification_preferences: Ŝanĝi retmesaĝajn preferojn
     salutation: "%{name},"

--- a/config/locales/es-AR.yml
+++ b/config/locales/es-AR.yml
@@ -973,7 +973,6 @@ es-AR:
       guide_link: https://es.crowdin.com/project/mastodon
       guide_link_text: Todos pueden contribuir.
     sensitive_content: Contenido sensible
-    toot_layout: Diseño del mensaje
   application_mailer:
     notification_preferences: Cambiar configuración de correo electrónico
     salutation: "%{name}:"

--- a/config/locales/es-MX.yml
+++ b/config/locales/es-MX.yml
@@ -973,7 +973,6 @@ es-MX:
       guide_link: https://es.crowdin.com/project/mastodon
       guide_link_text: Todos pueden contribuir.
     sensitive_content: Contenido sensible
-    toot_layout: Diseño de los toots
   application_mailer:
     notification_preferences: Cambiar preferencias de correo electrónico
     salutation: "%{name}:"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -973,7 +973,6 @@ es:
       guide_link: https://es.crowdin.com/project/mastodon
       guide_link_text: Todos pueden contribuir.
     sensitive_content: Contenido sensible
-    toot_layout: Diseño de las publicaciones
   application_mailer:
     notification_preferences: Cambiar preferencias de correo electrónico
     salutation: "%{name}:"

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -973,7 +973,6 @@ et:
       guide_link: https://crowdin.com/project/mastodon/et
       guide_link_text: Panustada võib igaüks!
     sensitive_content: Tundlik sisu
-    toot_layout: Postituse väljanägemine
   application_mailer:
     notification_preferences: Muuda e-kirjade eelistusi
     salutation: "%{name}!"

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -972,7 +972,6 @@ eu:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Edonork lagundu dezake.
     sensitive_content: Eduki hunkigarria
-    toot_layout: Bidalketen diseinua
   application_mailer:
     notification_preferences: Aldatu e-mail hobespenak
     salutation: "%{name},"

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -821,7 +821,6 @@ fa:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: همه می‌توانند کمک کنند.
     sensitive_content: محتوای حساس
-    toot_layout: آرایش فرسته
   application_mailer:
     notification_preferences: تغییر ترجیحات ایمیل
     salutation: "%{name}،"

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -973,7 +973,6 @@ fi:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Kaikki voivat osallistua.
     sensitive_content: Arkaluonteinen sisältö
-    toot_layout: Viestin asettelu
   application_mailer:
     notification_preferences: Muuta sähköpostiasetuksia
     salutation: "%{name},"

--- a/config/locales/fo.yml
+++ b/config/locales/fo.yml
@@ -973,7 +973,6 @@ fo:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Øll kunnu geva íkast.
     sensitive_content: Viðkvæmt innihald
-    toot_layout: Uppseting av postum
   application_mailer:
     notification_preferences: Broyt teldupostastillingar
     salutation: "%{name}"

--- a/config/locales/fr-QC.yml
+++ b/config/locales/fr-QC.yml
@@ -973,7 +973,6 @@ fr-QC:
       guide_link: https://fr.crowdin.com/project/mastodon
       guide_link_text: Tout le monde peut y contribuer.
     sensitive_content: Contenu sensible
-    toot_layout: Agencement des messages
   application_mailer:
     notification_preferences: Modifier les préférences de courriel
     salutation: "%{name},"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -973,7 +973,6 @@ fr:
       guide_link: https://fr.crowdin.com/project/mastodon
       guide_link_text: Tout le monde peut y contribuer.
     sensitive_content: Contenu sensible
-    toot_layout: Agencement des messages
   application_mailer:
     notification_preferences: Modifier les préférences de courriel
     salutation: "%{name},"

--- a/config/locales/fy.yml
+++ b/config/locales/fy.yml
@@ -973,7 +973,6 @@ fy:
       guide_link: https://crowdin.com/project/mastodon/fy
       guide_link_text: Elkenien kin bydrage.
     sensitive_content: Gefoelige ynhâld
-    toot_layout: Lay-out fan berjochten
   application_mailer:
     notification_preferences: E-mailynstellingen wizigje
     salutation: "%{name},"

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -1009,7 +1009,6 @@ gd:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: "’S urrainn do neach sam bith cuideachadh."
     sensitive_content: Susbaint fhrionasach
-    toot_layout: Co-dhealbhachd nam postaichean
   application_mailer:
     notification_preferences: Atharraich roghainnean a’ phuist-d
     salutation: "%{name},"

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -973,7 +973,6 @@ gl:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Todas podemos contribuír.
     sensitive_content: Contido sensible
-    toot_layout: Disposición da publicación
   application_mailer:
     notification_preferences: Cambiar os axustes de email
     salutation: "%{name},"

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1009,7 +1009,6 @@ he:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: כולם יכולים לתרום.
     sensitive_content: תוכן רגיש
-    toot_layout: פריסת הודעה
   application_mailer:
     notification_preferences: שינוי העדפות דוא"ל
     salutation: "%{name},"

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -973,7 +973,6 @@ hu:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Bárki közreműködhet.
     sensitive_content: Kényes tartalom
-    toot_layout: Bejegyzések elrendezése
   application_mailer:
     notification_preferences: E-mail beállítások módosítása
     salutation: "%{name}!"

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -901,7 +901,6 @@ id:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Siapa saja bisa berkontribusi.
     sensitive_content: Konten sensitif
-    toot_layout: Tata letak kiriman
   application_mailer:
     notification_preferences: Ubah pilihan email
     salutation: "%{name},"

--- a/config/locales/io.yml
+++ b/config/locales/io.yml
@@ -880,7 +880,6 @@ io:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Omnu povas kontributar.
     sensitive_content: Sentoza kontenajo
-    toot_layout: Postostrukturo
   application_mailer:
     notification_preferences: Chanjez retpostopreferaji
     salutation: "%{name},"

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -975,7 +975,6 @@ is:
       guide_link: https://crowdin.com/project/mastodon/is
       guide_link_text: Allir geta tekið þátt.
     sensitive_content: Viðkvæmt efni
-    toot_layout: Framsetning færslu
   application_mailer:
     notification_preferences: Breyta kjörstillingum tölvupósts
     salutation: "%{name},"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -975,7 +975,6 @@ it:
       guide_link: https://it.crowdin.com/project/mastodon
       guide_link_text: Tutti possono contribuire.
     sensitive_content: Contenuto sensibile
-    toot_layout: Layout dei toot
   application_mailer:
     notification_preferences: Cambia preferenze email
     salutation: "%{name},"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -955,7 +955,6 @@ ja:
       guide_link: https://ja.crowdin.com/project/mastodon
       guide_link_text: 誰でも参加することができます。
     sensitive_content: 閲覧注意コンテンツ
-    toot_layout: 投稿のレイアウト
   application_mailer:
     notification_preferences: メール設定の変更
     salutation: "%{name}さん"

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -320,7 +320,6 @@ kk:
     confirmation_dialogs: Пікірталас диалогтары
     discovery: Пікірталас
     sensitive_content: Нәзік контент
-    toot_layout: Жазба формасы
   application_mailer:
     notification_preferences: Change e-mail prеferences
     settings: 'Change e-mail preferеnces: %{link}'

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -957,7 +957,6 @@ ko:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: 누구나 기여할 수 있습니다.
     sensitive_content: 민감한 내용
-    toot_layout: 게시물 레이아웃
   application_mailer:
     notification_preferences: 메일 설정 변경
     salutation: "%{name} 님,"

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -920,7 +920,6 @@ ku:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Herkes dikare beşdar bibe.
     sensitive_content: Naveroka hestiyarî
-    toot_layout: Xêzkirina şandîya
   application_mailer:
     notification_preferences: Sazkariyên e-nameyê biguherîne
     salutation: "%{name},"

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -979,7 +979,6 @@ lv:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Ikviens var piedalīties.
     sensitive_content: Sensitīvs saturs
-    toot_layout: Ziņas izskats
   application_mailer:
     notification_preferences: Mainīt e-pasta uztādījumus
     salutation: "%{name},"

--- a/config/locales/my.yml
+++ b/config/locales/my.yml
@@ -955,7 +955,6 @@ my:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: လူတိုင်းပါဝင်ကူညီနိုင်ပါတယ်။
     sensitive_content: သတိထားရသော အကြောင်းအရာ
-    toot_layout: ပို့စ်အပြင်အဆင်
   application_mailer:
     notification_preferences: အီးမေးလ် သတ်မှတ်ချက်များကို ပြောင်းပါ
     salutation: "%{name}"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -973,7 +973,6 @@ nl:
       guide_link: https://crowdin.com/project/mastodon/nl
       guide_link_text: Iedereen kan bijdragen.
     sensitive_content: Gevoelige inhoud
-    toot_layout: Lay-out van berichten
   application_mailer:
     notification_preferences: E-mailvoorkeuren wijzigen
     salutation: "%{name},"

--- a/config/locales/nn.yml
+++ b/config/locales/nn.yml
@@ -965,7 +965,6 @@ nn:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Alle kan bidra.
     sensitive_content: Ømtolig innhald
-    toot_layout: Tutoppsett
   application_mailer:
     notification_preferences: Endr e-post-innstillingane
     salutation: Hei %{name},

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -914,7 +914,6 @@
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Alle kan bidra.
     sensitive_content: Følsomt innhold
-    toot_layout: Innleggsoppsett
   application_mailer:
     notification_preferences: Endre E-postinnstillingene
     salutation: "%{name},"

--- a/config/locales/oc.yml
+++ b/config/locales/oc.yml
@@ -459,7 +459,6 @@ oc:
       body: Mastodon es traduch per de benevòls.
       guide_link_text: Tot lo monde pòt contribuïr.
     sensitive_content: Contengut sensible
-    toot_layout: Disposicion del tut
   application_mailer:
     notification_preferences: Cambiar las preferéncias de corrièl
     salutation: "%{name},"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1009,7 +1009,6 @@ pl:
       guide_link: https://pl.crowdin.com/project/mastodon
       guide_link_text: Każdy może wnieść swój wkład.
     sensitive_content: Wrażliwa zawartość
-    toot_layout: Wygląd wpisów
   application_mailer:
     notification_preferences: Zmień ustawienia e-maili
     salutation: "%{name},"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -973,7 +973,6 @@ pt-BR:
       guide_link: https://br.crowdin.com/project/mastodon
       guide_link_text: Todos podem contribuir.
     sensitive_content: Conteúdo sensível
-    toot_layout: Formato da publicação
   application_mailer:
     notification_preferences: Alterar preferências de e-mail
     salutation: "%{name},"

--- a/config/locales/pt-PT.yml
+++ b/config/locales/pt-PT.yml
@@ -973,7 +973,6 @@ pt-PT:
       guide_link: https://pt.crowdin.com/project/mastodon/
       guide_link_text: Todos podem contribuir.
     sensitive_content: Conteúdo problemático
-    toot_layout: Disposição da publicação
   application_mailer:
     notification_preferences: Alterar preferências de e-mail
     salutation: "%{name},"

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -408,7 +408,6 @@ ro:
     localization:
       guide_link_text: Toată lumea poate contribui.
     sensitive_content: Conținut sensibil
-    toot_layout: Aspect postare
   application_mailer:
     notification_preferences: Modifică preferințe e-mail
     settings: 'Modifică preferințe e-mail: %{link}'

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1009,7 +1009,6 @@ ru:
       guide_link: https://ru.crowdin.com/project/mastodon
       guide_link_text: Каждый может внести свой вклад.
     sensitive_content: Содержимое деликатного характера
-    toot_layout: Структура постов
   application_mailer:
     notification_preferences: Настроить уведомления можно здесь
     salutation: "%{name},"

--- a/config/locales/sc.yml
+++ b/config/locales/sc.yml
@@ -491,7 +491,6 @@ sc:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Chie si siat podet contribuire.
     sensitive_content: Cuntenutu sensìbile
-    toot_layout: Dispositzione de is tuts
   application_mailer:
     notification_preferences: Muda is preferèntzias de posta
     salutation: "%{name},"

--- a/config/locales/sco.yml
+++ b/config/locales/sco.yml
@@ -913,7 +913,6 @@ sco:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Awbody kin contribute.
     sensitive_content: Sensitive content
-    toot_layout: Post leyoot
   application_mailer:
     notification_preferences: Chynge email preferences
     salutation: "%{name},"

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -757,7 +757,6 @@ si:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: සෑම කෙනෙකුටම දායක විය හැකිය.
     sensitive_content: සංවේදී අන්තර්ගතය
-    toot_layout: පෝස්ට් පිරිසැලසුම
   application_mailer:
     notification_preferences: ඊමේල් මනාප වෙනස් කරන්න
     salutation: "%{name},"

--- a/config/locales/simple_form.an.yml
+++ b/config/locales/simple_form.an.yml
@@ -192,7 +192,6 @@ an:
         setting_always_send_emails: Ninviar siempre notificacions per correu
         setting_auto_play_gif: Reproducir automaticament los GIFs animaus
         setting_boost_modal: Amostrar finestra de confirmación antes de retutar
-        setting_crop_images: Retallar a 16x9 las imachens d'as publicacions no expandidas
         setting_default_language: Idioma de publicación
         setting_default_privacy: Privacidat de publicacions
         setting_default_sensitive: Marcar siempre imachens como sensibles

--- a/config/locales/simple_form.ar.yml
+++ b/config/locales/simple_form.ar.yml
@@ -200,7 +200,6 @@ ar:
         setting_always_send_emails: ارسل إشعارات البريد الإلكتروني دائماً
         setting_auto_play_gif: تشغيل تلقائي لِوَسائط جيف المتحركة
         setting_boost_modal: إظهار مربع حوار التأكيد قبل إعادة مشاركة أي منشور
-        setting_crop_images: قص الصور في المنشورات غير الموسعة إلى 16x9
         setting_default_language: لغة النشر
         setting_default_privacy: خصوصية المنشور
         setting_default_sensitive: اعتبر الوسائط دائما كمحتوى حساس

--- a/config/locales/simple_form.ast.yml
+++ b/config/locales/simple_form.ast.yml
@@ -111,7 +111,6 @@ ast:
         setting_always_send_emails: Unviar siempres los avisos per corréu electrónicu
         setting_auto_play_gif: Reproducir automáticamente los GIFs
         setting_boost_modal: Amosar el diálogu de confirmación enantes de compartir un artículu
-        setting_crop_images: Recortar les imáxenes de los artículos ensin espander a la proporción 16:9
         setting_default_language: Llingua de los artículos
         setting_default_privacy: Privacidá de los artículos
         setting_default_sensitive: Marcar siempres tol conteníu como sensible

--- a/config/locales/simple_form.be.yml
+++ b/config/locales/simple_form.be.yml
@@ -200,7 +200,6 @@ be:
         setting_always_send_emails: Заўжды дасылаць для апавяшчэнні эл. пошты
         setting_auto_play_gif: Аўтапрайграванне анімаваных GIF
         setting_boost_modal: Паказваць акно пацвярджэння перад пашырэннем
-        setting_crop_images: У неразгорнутых допісах абразаць відарысы да 16:9
         setting_default_language: Мова допісаў
         setting_default_privacy: Прыватнасць допісаў
         setting_default_sensitive: Заўсёды пазначаць кантэнт як далікатны

--- a/config/locales/simple_form.bg.yml
+++ b/config/locales/simple_form.bg.yml
@@ -200,7 +200,6 @@ bg:
         setting_always_send_emails: Все да се пращат известия по имейла
         setting_auto_play_gif: Самопускащи се анимирани гифчета
         setting_boost_modal: Показване на прозорец за потвърждение преди подсилване
-        setting_crop_images: Изрязване на образи в неразгънати публикации до 16x9
         setting_default_language: Език на публикуване
         setting_default_privacy: Поверителност на публикуване
         setting_default_sensitive: Все да се бележи мултимедията като деликатна

--- a/config/locales/simple_form.ca.yml
+++ b/config/locales/simple_form.ca.yml
@@ -200,7 +200,6 @@ ca:
         setting_always_send_emails: Envia'm sempre notificacions per correu electrònic
         setting_auto_play_gif: Reprodueix automàticament els GIF animats
         setting_boost_modal: Mostra la finestra de confirmació abans d'impulsar
-        setting_crop_images: Retalla les imatges en tuts no ampliats a 16x9
         setting_default_language: Llengua dels tuts
         setting_default_privacy: Privacitat dels tuts
         setting_default_sensitive: Marcar sempre el contingut gràfic com a sensible

--- a/config/locales/simple_form.ckb.yml
+++ b/config/locales/simple_form.ckb.yml
@@ -136,7 +136,6 @@ ckb:
         setting_aggregate_reblogs: گرووپی توتەکان یەکبخە
         setting_auto_play_gif: خۆکاربەخشکردنی GIFــەکان
         setting_boost_modal: پیشاندانی دیالۆگی دووپاتکردنەوە پێش دوبارە توتاندن
-        setting_crop_images: لە تووتی نەکراوە،وینەکان لە ئەندازی ۱٦×۹ ببڕە
         setting_default_language: زمانی نووسراوەکانتان
         setting_default_privacy: چوارچێوەی تایبەتێتی ئێوە
         setting_default_sensitive: هەمیشە نیشانکردنی میدیا وەک هەستیار

--- a/config/locales/simple_form.co.yml
+++ b/config/locales/simple_form.co.yml
@@ -137,7 +137,6 @@ co:
         setting_aggregate_reblogs: Gruppà e spartere indè e linee
         setting_auto_play_gif: Lettura autumatica di i GIF animati
         setting_boost_modal: Mustrà una cunfirmazione per sparte un statutu
-        setting_crop_images: Riquatrà i ritratti in 16x9 indè i statuti micca selezziunati
         setting_default_language: Lingua di pubblicazione
         setting_default_privacy: Cunfidenzialità di i statuti
         setting_default_sensitive: Sempre cunsiderà media cum’è sensibili

--- a/config/locales/simple_form.cs.yml
+++ b/config/locales/simple_form.cs.yml
@@ -195,7 +195,6 @@ cs:
         setting_always_send_emails: Vždy posílat e-mailová oznámení
         setting_auto_play_gif: Automaticky přehrávat animace GIF
         setting_boost_modal: Před boostnutím zobrazovat potvrzovací okno
-        setting_crop_images: Ořezávat obrázky v nerozbalených příspěvcích na 16x9
         setting_default_language: Jazyk příspěvků
         setting_default_privacy: Soukromí příspěvků
         setting_default_sensitive: Vždy označovat média jako citlivá

--- a/config/locales/simple_form.cy.yml
+++ b/config/locales/simple_form.cy.yml
@@ -200,7 +200,6 @@ cy:
         setting_always_send_emails: Anfonwch hysbysiadau e-bost bob amser
         setting_auto_play_gif: Chwarae GIFs wedi'u hanimeiddio yn awtomatig
         setting_boost_modal: Dangos deialog cadarnhau cyn rhoi hwb
-        setting_crop_images: Tocio delweddau o fewn postiadau nad ydynt wedi'u hehangu i 16x9
         setting_default_language: Iaith postio
         setting_default_privacy: Preifatrwydd cyhoeddi
         setting_default_sensitive: Marcio cyfryngau fel eu bod yn sensitif bob tro

--- a/config/locales/simple_form.da.yml
+++ b/config/locales/simple_form.da.yml
@@ -200,7 +200,6 @@ da:
         setting_always_send_emails: Send altid en e-mailnotifikationer
         setting_auto_play_gif: Autoafspil animerede GIF'er
         setting_boost_modal: Vis bekræftelsesdialog inden boosting
-        setting_crop_images: Beskær billeder i ikke-ekspanderede indlæg til 16x9
         setting_default_language: Sprog for indlæg
         setting_default_privacy: Fortrolighed for indlæg
         setting_default_sensitive: Markér altid medier som sensitive

--- a/config/locales/simple_form.de.yml
+++ b/config/locales/simple_form.de.yml
@@ -200,7 +200,6 @@ de:
         setting_always_send_emails: Benachrichtigungen immer senden
         setting_auto_play_gif: Animierte GIFs automatisch abspielen
         setting_boost_modal: Bestätigungsdialog beim Teilen eines Beitrags anzeigen
-        setting_crop_images: Bilder in nicht ausgeklappten Beiträgen auf 16:9 zuschneiden
         setting_default_language: Beitragssprache
         setting_default_privacy: Beitragssichtbarkeit
         setting_default_sensitive: Eigene Medien immer mit einer Inhaltswarnung versehen

--- a/config/locales/simple_form.el.yml
+++ b/config/locales/simple_form.el.yml
@@ -195,7 +195,6 @@ el:
         setting_always_send_emails: Πάντα να αποστέλλονται ειδοποίησεις μέσω email
         setting_auto_play_gif: Αυτόματη αναπαραγωγή των GIF
         setting_boost_modal: Επιβεβαίωση πριν την προώθηση
-        setting_crop_images: Περιορισμός των εικόνων σε μη-ανεπτυγμένα τουτ σε αναλογία 16x9
         setting_default_language: Γλώσσα δημοσιεύσεων
         setting_default_privacy: Ιδιωτικότητα δημοσιεύσεων
         setting_default_sensitive: Σημείωση όλων των πολυμέσων ως ευαίσθητου περιεχομένου

--- a/config/locales/simple_form.en-GB.yml
+++ b/config/locales/simple_form.en-GB.yml
@@ -200,7 +200,6 @@ en-GB:
         setting_always_send_emails: Always send e-mail notifications
         setting_auto_play_gif: Auto-play animated GIFs
         setting_boost_modal: Show confirmation dialogue before boosting
-        setting_crop_images: Crop images in non-expanded posts to 16x9
         setting_default_language: Posting language
         setting_default_privacy: Posting privacy
         setting_default_sensitive: Always mark media as sensitive

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -200,7 +200,6 @@ en:
         setting_always_send_emails: Always send e-mail notifications
         setting_auto_play_gif: Auto-play animated GIFs
         setting_boost_modal: Show confirmation dialog before boosting
-        setting_crop_images: Crop images in non-expanded posts to 16x9
         setting_default_language: Posting language
         setting_default_privacy: Posting privacy
         setting_default_sensitive: Always mark media as sensitive

--- a/config/locales/simple_form.eo.yml
+++ b/config/locales/simple_form.eo.yml
@@ -200,7 +200,6 @@ eo:
         setting_always_send_emails: Ĉiam sendi la sciigojn per retpoŝto
         setting_auto_play_gif: Aŭtomate ekigi GIF-ojn
         setting_boost_modal: Montri konfirman fenestron antaŭ ol diskonigi mesaĝon
-        setting_crop_images: Stuci bildojn en negrandigitaj mesaĝoj al 16x9
         setting_default_language: Publikada lingvo
         setting_default_privacy: Privateco de afiŝado
         setting_default_sensitive: Ĉiam marki plurmediojn kiel tiklaj

--- a/config/locales/simple_form.es-AR.yml
+++ b/config/locales/simple_form.es-AR.yml
@@ -200,7 +200,6 @@ es-AR:
         setting_always_send_emails: Siempre enviar notificaciones por correo electrónico
         setting_auto_play_gif: Reproducir automáticamente los GIFs animados
         setting_boost_modal: Mostrar diálogo de confirmación antes de adherir
-        setting_crop_images: Recortar imágenes en mensajes no expandidos a 16x9
         setting_default_language: Idioma de tus mensajes
         setting_default_privacy: Privacidad de mensajes
         setting_default_sensitive: Siempre marcar medios como sensibles

--- a/config/locales/simple_form.es-MX.yml
+++ b/config/locales/simple_form.es-MX.yml
@@ -200,7 +200,6 @@ es-MX:
         setting_always_send_emails: Enviar siempre notificaciones por correo
         setting_auto_play_gif: Reproducir automáticamente los GIFs animados
         setting_boost_modal: Mostrar ventana de confirmación antes de un Retoot
-        setting_crop_images: Recortar a 16x9 las imágenes de los toots no expandidos
         setting_default_language: Idioma de publicación
         setting_default_privacy: Privacidad de publicaciones
         setting_default_sensitive: Marcar siempre imágenes como sensibles

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -200,7 +200,6 @@ es:
         setting_always_send_emails: Enviar siempre notificaciones por correo
         setting_auto_play_gif: Reproducir automáticamente los GIFs animados
         setting_boost_modal: Mostrar ventana de confirmación antes de impulsar
-        setting_crop_images: Recortar a 16x9 las imágenes de las publicaciones no expandidas
         setting_default_language: Idioma de publicación
         setting_default_privacy: Privacidad de publicaciones
         setting_default_sensitive: Marcar siempre imágenes como sensibles

--- a/config/locales/simple_form.et.yml
+++ b/config/locales/simple_form.et.yml
@@ -200,7 +200,6 @@ et:
         setting_always_send_emails: Edasta kõik teavitused meilile
         setting_auto_play_gif: Esita GIF-e automaatselt
         setting_boost_modal: Näita enne jagamist kinnitusdialoogi
-        setting_crop_images: Laiendamata postitustes kärbi pildid 16:9 küljesuhtesse
         setting_default_language: Postituse keel
         setting_default_privacy: Postituse nähtavus
         setting_default_sensitive: Alati märgista meedia tundlikuks

--- a/config/locales/simple_form.eu.yml
+++ b/config/locales/simple_form.eu.yml
@@ -195,7 +195,6 @@ eu:
         setting_always_send_emails: Bidali beti eposta jakinarazpenak
         setting_auto_play_gif: Erreproduzitu GIF animatuak automatikoki
         setting_boost_modal: Erakutsi baieztapen elkarrizketa-koadroa bultzada eman aurretik
-        setting_crop_images: Moztu irudiak hedatu gabeko tootetan 16x9 proportzioan
         setting_default_language: Argitalpenen hizkuntza
         setting_default_privacy: Mezuen pribatutasuna
         setting_default_sensitive: Beti markatu edukiak hunkigarri gisa

--- a/config/locales/simple_form.fa.yml
+++ b/config/locales/simple_form.fa.yml
@@ -169,7 +169,6 @@ fa:
         setting_always_send_emails: فرستادن همیشگی آگاهی‌های رایانامه‌ای
         setting_auto_play_gif: پخش خودکار تصویرهای متحرک
         setting_boost_modal: نمایش پیغام تأیید پیش از تقویت کردن
-        setting_crop_images: در فرسته‌های ناگسترده، تصویرها را به ابعاد ‎۱۶×۹ کوچک کن
         setting_default_language: زبان نوشته‌های شما
         setting_default_privacy: حریم خصوصی نوشته‌ها
         setting_default_sensitive: همیشه تصاویر را به عنوان حساس علامت بزن

--- a/config/locales/simple_form.fi.yml
+++ b/config/locales/simple_form.fi.yml
@@ -200,7 +200,6 @@ fi:
         setting_always_send_emails: Lähetä aina sähköposti-ilmoituksia
         setting_auto_play_gif: Toista GIF-animaatiot automaattisesti
         setting_boost_modal: Kysy vahvistus ennen tehostusta
-        setting_crop_images: Rajaa kuvat avaamattomissa tuuttauksissa 16:9 kuvasuhteeseen
         setting_default_language: Julkaisujen kieli
         setting_default_privacy: Viestin näkyvyys
         setting_default_sensitive: Merkitse media aina arkaluontoiseksi

--- a/config/locales/simple_form.fo.yml
+++ b/config/locales/simple_form.fo.yml
@@ -200,7 +200,6 @@ fo:
         setting_always_send_emails: Send altíð fráboðanir við telduposti
         setting_auto_play_gif: Spæl teknimyndagjørdar GIFar sjálvvirkandi
         setting_boost_modal: Vís váttanarmynd, áðrenn tú stimbrar postar
-        setting_crop_images: Sker myndir til lutfallið 16x9 í postum, sum ikki eru víðkaðir
         setting_default_language: Mál, sum verður brúkt til postar
         setting_default_privacy: Hvussu privatir eru postar?
         setting_default_sensitive: Merk altíð miðlafílur sum viðkvæmar

--- a/config/locales/simple_form.fr-QC.yml
+++ b/config/locales/simple_form.fr-QC.yml
@@ -200,7 +200,6 @@ fr-QC:
         setting_always_send_emails: Toujours envoyer les notifications par courriel
         setting_auto_play_gif: Lire automatiquement les GIFs animés
         setting_boost_modal: Demander confirmation avant de partager un message
-        setting_crop_images: Recadrer en 16x9 les images des messages qui ne sont pas ouverts en vue détaillée
         setting_default_language: Langue de publication
         setting_default_privacy: Confidentialité des messages
         setting_default_sensitive: Toujours marquer les médias comme sensibles

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -200,7 +200,6 @@ fr:
         setting_always_send_emails: Toujours envoyer les notifications par courriel
         setting_auto_play_gif: Lire automatiquement les GIFs animés
         setting_boost_modal: Demander confirmation avant de partager un message
-        setting_crop_images: Recadrer en 16x9 les images des messages qui ne sont pas ouverts en vue détaillée
         setting_default_language: Langue de publication
         setting_default_privacy: Confidentialité des messages
         setting_default_sensitive: Toujours marquer les médias comme sensibles

--- a/config/locales/simple_form.fy.yml
+++ b/config/locales/simple_form.fy.yml
@@ -200,7 +200,6 @@ fy:
         setting_always_send_emails: Altyd e-mailmeldingen ferstjoere
         setting_auto_play_gif: Spylje animearre GIF’s automatysk ôf
         setting_boost_modal: Freegje foar it boosten fan in berjocht in befêstiging
-        setting_crop_images: Ofbyldingen bysnije oant 16x9 yn berjochten op tiidlinen
         setting_default_language: Taal fan jo berjochten
         setting_default_privacy: Sichtberheid fan nije berjochten
         setting_default_sensitive: Media altyd as gefoelich markearje

--- a/config/locales/simple_form.gd.yml
+++ b/config/locales/simple_form.gd.yml
@@ -200,7 +200,6 @@ gd:
         setting_always_send_emails: Cuir brathan puist-d an-còmhnaidh
         setting_auto_play_gif: Cluich GIFs beòthaichte gu fèin-obrachail
         setting_boost_modal: Seall còmhradh dearbhaidh mus dèan thu brosnachadh
-        setting_crop_images: Beàrr na dealbhan sna postaichean gun leudachadh air 16x9
         setting_default_language: Cànan postaidh
         setting_default_privacy: Prìobhaideachd postaidh
         setting_default_sensitive: Cuir comharra ri meadhanan an-còmhnaidh gu bheil iad frionasach

--- a/config/locales/simple_form.gl.yml
+++ b/config/locales/simple_form.gl.yml
@@ -200,7 +200,6 @@ gl:
         setting_always_send_emails: Enviar sempre notificacións por correo electrónico
         setting_auto_play_gif: Reprodución automática de GIFs animados
         setting_boost_modal: Solicitar confirmación antes de promover
-        setting_crop_images: Recortar imaxes a 16x9 en publicacións non despregadas
         setting_default_language: Idioma de publicación
         setting_default_privacy: Privacidade da publicación
         setting_default_sensitive: Marcar sempre multimedia como sensible

--- a/config/locales/simple_form.he.yml
+++ b/config/locales/simple_form.he.yml
@@ -200,7 +200,6 @@ he:
         setting_always_send_emails: תמיד שלח התראות לדוא"ל
         setting_auto_play_gif: ניגון אוטומטי של גיפים
         setting_boost_modal: הצגת דיאלוג אישור לפני הדהוד
-        setting_crop_images: קטום תמונות בהודעות לא מורחבות ל 16 על 9
         setting_default_language: שפת ברירת מחדל להודעה
         setting_default_privacy: פרטיות ההודעות
         setting_default_sensitive: תמיד לתת סימון "רגיש" למדיה

--- a/config/locales/simple_form.hu.yml
+++ b/config/locales/simple_form.hu.yml
@@ -200,7 +200,6 @@ hu:
         setting_always_send_emails: E-mail értesítések küldése mindig
         setting_auto_play_gif: GIF-ek automatikus lejátszása
         setting_boost_modal: Megerősítés kérése megtolás előtt
-        setting_crop_images: Képek 16x9-re vágása nem kinyitott bejegyzéseknél
         setting_default_language: Bejegyzések nyelve
         setting_default_privacy: Bejegyzések láthatósága
         setting_default_sensitive: Minden médiafájl megjelölése kényesként

--- a/config/locales/simple_form.hy.yml
+++ b/config/locales/simple_form.hy.yml
@@ -135,7 +135,6 @@ hy:
         setting_aggregate_reblogs: Տարծածները խմբաւորել հոսքում
         setting_auto_play_gif: Աւտոմատ մեկնարկել GIFs անիմացիաները
         setting_boost_modal: Ցուցադրել հաստատման պատուհանը տարածելուց առաջ
-        setting_crop_images: Ցոյց տալ գրառման նկարը 16x9 համամասնութեամբ
         setting_default_language: Հրապարակման լեզու
         setting_default_privacy: Հրապարակման գաղտնիութիւն
         setting_default_sensitive: Միշտ նշել մեդիան որպէս դիւրազգաց

--- a/config/locales/simple_form.id.yml
+++ b/config/locales/simple_form.id.yml
@@ -188,7 +188,6 @@ id:
         setting_always_send_emails: Selalu kirim notifikasi email
         setting_auto_play_gif: Mainkan otomatis animasi GIF
         setting_boost_modal: Tampilkan dialog konfirmasi dialog sebelum boost
-        setting_crop_images: Potong gambar ke 16x9 pada toot yang tidak dibentangkan
         setting_default_language: Bahasa posting
         setting_default_privacy: Privasi postingan
         setting_default_sensitive: Selalu tandai media sebagai sensitif

--- a/config/locales/simple_form.io.yml
+++ b/config/locales/simple_form.io.yml
@@ -186,7 +186,6 @@ io:
         setting_always_send_emails: Sempre sendez retpostoavizi
         setting_auto_play_gif: Automate pleez animigita GIFi
         setting_boost_modal: Montrez konfirmdialogo ante bustar
-        setting_crop_images: Ektranchez imaji en neexpansigita posti a 16x9
         setting_default_language: Postolinguo
         setting_default_privacy: Videbleso di la mesaji
         setting_default_sensitive: Sempre markizez medii quale sentoza

--- a/config/locales/simple_form.is.yml
+++ b/config/locales/simple_form.is.yml
@@ -200,7 +200,6 @@ is:
         setting_always_send_emails: Alltaf senda tilkynningar í tölvupósti
         setting_auto_play_gif: Spila sjálfkrafa GIF-hreyfimyndir
         setting_boost_modal: Sýna staðfestingarglugga fyrir endurbirtingu
-        setting_crop_images: Utansníða myndir í ekki-útfelldum færslum í 16x9
         setting_default_language: Tungumál sem skrifað er á
         setting_default_privacy: Gagnaleynd færslna
         setting_default_sensitive: Alltaf merkja myndefni sem viðkvæmt

--- a/config/locales/simple_form.it.yml
+++ b/config/locales/simple_form.it.yml
@@ -200,7 +200,6 @@ it:
         setting_always_send_emails: Manda sempre notifiche via email
         setting_auto_play_gif: Riproduci automaticamente le GIF animate
         setting_boost_modal: Mostra dialogo di conferma prima del boost
-        setting_crop_images: Ritaglia immagini in post non espansi a 16x9
         setting_default_language: Lingua dei post
         setting_default_privacy: Privacy dei post
         setting_default_sensitive: Segna sempre i media come sensibili

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -200,7 +200,6 @@ ja:
         setting_always_send_emails: 常にメール通知を送信する
         setting_auto_play_gif: アニメーションGIFを自動再生する
         setting_boost_modal: ブーストする前に確認ダイアログを表示する
-        setting_crop_images: 投稿の詳細以外では画像を16:9に切り抜く
         setting_default_language: 投稿する言語
         setting_default_privacy: 投稿の公開範囲
         setting_default_sensitive: メディアを常に閲覧注意としてマークする

--- a/config/locales/simple_form.kk.yml
+++ b/config/locales/simple_form.kk.yml
@@ -46,7 +46,6 @@ kk:
         setting_advanced_layout: Кеңейтілген веб-интерфейс қосу
         setting_auto_play_gif: GIF анимацияларды бірден қосу
         setting_boost_modal: Бөлісу алдында растау диалогын көрсету
-        setting_crop_images: Кеңейтілмеген жазбаларда суреттерді 16х9 көлеміне кес
         setting_default_language: Жазба тілі
         setting_default_privacy: Жазба құпиялылығы
         setting_default_sensitive: Медиаларды әрдайым нәзік ретінде белгілеу

--- a/config/locales/simple_form.ko.yml
+++ b/config/locales/simple_form.ko.yml
@@ -200,7 +200,6 @@ ko:
         setting_always_send_emails: 항상 이메일 알림 보내기
         setting_auto_play_gif: 애니메이션 GIF를 자동 재생
         setting_boost_modal: 부스트 전 확인 창을 표시
-        setting_crop_images: 확장되지 않은 게시물의 이미지를 16x9로 자르기
         setting_default_language: 게시물 언어
         setting_default_privacy: 게시물 프라이버시
         setting_default_sensitive: 미디어를 언제나 민감한 콘텐츠로 설정

--- a/config/locales/simple_form.ku.yml
+++ b/config/locales/simple_form.ku.yml
@@ -190,7 +190,6 @@ ku:
         setting_always_send_emails: Her dem agahdariya e-nameyê bişîne
         setting_auto_play_gif: GIF ên livok bi xweber bilîzine
         setting_boost_modal: Gotûbêja pejirandinê nîşan bide berî ku şandî werê bilindkirin
-        setting_crop_images: Wêneyên di nav şandiyên ku nehatine berfireh kirin wek 16×9 jê bike
         setting_default_language: Zimanê weşanê
         setting_default_privacy: Ewlehiya weşanê
         setting_default_sensitive: Her dem medya wek hestyar bide nîşan

--- a/config/locales/simple_form.lv.yml
+++ b/config/locales/simple_form.lv.yml
@@ -195,7 +195,6 @@ lv:
         setting_always_send_emails: Vienmēr sūtīt e-pasta paziņojumus
         setting_auto_play_gif: Automātiski atskaņot animētos GIF
         setting_boost_modal: Rādīt apstiprinājuma dialogu pirms izcelšanas
-        setting_crop_images: Apgrieziet attēlus neizvērstajās ziņās līdz 16x9
         setting_default_language: Publicēšanas valoda
         setting_default_privacy: Publicēšanas privātums
         setting_default_sensitive: Atļaut atzīmēt multividi kā sensitīvu

--- a/config/locales/simple_form.my.yml
+++ b/config/locales/simple_form.my.yml
@@ -200,7 +200,6 @@ my:
         setting_always_send_emails: အီးမေးလ်သတိပေးချက်များကို အမြဲပို့ပါ
         setting_auto_play_gif: ကာတွန်း GIF များကို အလိုအလျောက်ဖွင့်ပါ
         setting_boost_modal: Boost မလုပ်မီ အတည်ပြုချက်ပြပါ
-        setting_crop_images: အကျယ်မချဲ့ထားသော စာစုများတွင် ပုံများကို ၁၆း၉ အရွယ် ဖြတ်တောက်ပါ။
         setting_default_language: ပို့စ်တင်မည့်ဘာသာစကား
         setting_default_privacy: ပို့စ်ကို ဘယ်သူမြင်နိုင်မလဲ
         setting_default_sensitive: သတိထားရသောမီဒီယာအဖြစ် အမြဲအမှတ်အသားပြုပါ

--- a/config/locales/simple_form.nl.yml
+++ b/config/locales/simple_form.nl.yml
@@ -200,7 +200,6 @@ nl:
         setting_always_send_emails: Altijd e-mailmeldingen verzenden
         setting_auto_play_gif: Geanimeerde GIF's automatisch afspelen
         setting_boost_modal: Vraag voor het boosten van een bericht een bevestiging
-        setting_crop_images: Afbeeldingen in tijdlijnberichten bijsnijden tot 16x9
         setting_default_language: Taal van jouw berichten
         setting_default_privacy: Zichtbaarheid van nieuwe berichten
         setting_default_sensitive: Media altijd als gevoelig markeren

--- a/config/locales/simple_form.nn.yml
+++ b/config/locales/simple_form.nn.yml
@@ -195,7 +195,6 @@ nn:
         setting_always_send_emails: Alltid send epostvarsel
         setting_auto_play_gif: Spel av animerte GIF-ar automatisk
         setting_boost_modal: Vis stadfesting før framheving
-        setting_crop_images: Skjer bilete i ikkje-utvida tut til 16x9
         setting_default_language: Språk på innlegg
         setting_default_privacy: Privatliv
         setting_default_sensitive: Merk alltid media som nærtakande

--- a/config/locales/simple_form.no.yml
+++ b/config/locales/simple_form.no.yml
@@ -183,7 +183,6 @@
         setting_always_send_emails: Alltid send e-postvarslinger
         setting_auto_play_gif: Autoavspill animert GIF-filer
         setting_boost_modal: Vis bekreftelse før fremheving
-        setting_crop_images: Klipp bilder i ikke-utvidede innlegg til 16:9
         setting_default_language: Innleggsspråk
         setting_default_privacy: Postintegritet
         setting_default_sensitive: Merk alltid media som følsomt

--- a/config/locales/simple_form.oc.yml
+++ b/config/locales/simple_form.oc.yml
@@ -139,7 +139,6 @@ oc:
         setting_always_send_emails: Totjorn enviar los corrièls de notificacion
         setting_auto_play_gif: Lectura automatica dels GIFS animats
         setting_boost_modal: Mostrar una fenèstra de confirmacion abans de partejar un estatut
-        setting_crop_images: Retalhar los imatges dins los tuts pas desplegats a 16x9
         setting_default_language: Lenga de publicacion
         setting_default_privacy: Confidencialitat dels tuts
         setting_default_sensitive: Totjorn marcar los mèdias coma sensibles

--- a/config/locales/simple_form.pl.yml
+++ b/config/locales/simple_form.pl.yml
@@ -200,7 +200,6 @@ pl:
         setting_always_send_emails: Zawsze wysyłaj powiadomienia e-mail
         setting_auto_play_gif: Automatycznie odtwarzaj animowane GIFy
         setting_boost_modal: Pytaj o potwierdzenie przed podbiciem
-        setting_crop_images: Przycinaj obrazki w nierozwiniętych wpisach do 16x9
         setting_default_language: Język wpisów
         setting_default_privacy: Widoczność wpisów
         setting_default_sensitive: Zawsze oznaczaj zawartość multimedialną jako wrażliwą

--- a/config/locales/simple_form.pt-BR.yml
+++ b/config/locales/simple_form.pt-BR.yml
@@ -200,7 +200,6 @@ pt-BR:
         setting_always_send_emails: Sempre enviar notificações por e-mail
         setting_auto_play_gif: Reproduzir GIFs automaticamente
         setting_boost_modal: Solicitar confirmação antes de dar boost
-        setting_crop_images: Cortar imagens no formato 16x9 em publicações não expandidas
         setting_default_language: Idioma dos toots
         setting_default_privacy: Privacidade dos toots
         setting_default_sensitive: Sempre marcar mídia como sensível

--- a/config/locales/simple_form.pt-PT.yml
+++ b/config/locales/simple_form.pt-PT.yml
@@ -200,7 +200,6 @@ pt-PT:
         setting_always_send_emails: Enviar sempre notificações de email
         setting_auto_play_gif: Reproduzir GIF automaticamente
         setting_boost_modal: Solicitar confirmação antes de partilhar uma publicação
-        setting_crop_images: Recortar imagens para o formato 16x9 nas publicações não expandidas
         setting_default_language: Língua de publicação
         setting_default_privacy: Privacidade da publicação
         setting_default_sensitive: Marcar sempre os media como problemáticos

--- a/config/locales/simple_form.ro.yml
+++ b/config/locales/simple_form.ro.yml
@@ -124,7 +124,6 @@ ro:
         setting_aggregate_reblogs: Grupează impulsurile în fluxuri
         setting_auto_play_gif: Redă automat animațiile GIF
         setting_boost_modal: Arată dialogul de confirmare înainte de a impulsiona
-        setting_crop_images: Decupează imaginile în postările non-extinse la 16x9
         setting_default_language: În ce limbă postezi
         setting_default_privacy: Cine vede postările tale
         setting_default_sensitive: Întotdeauna marchează conținutul media ca fiind sensibil

--- a/config/locales/simple_form.ru.yml
+++ b/config/locales/simple_form.ru.yml
@@ -195,7 +195,6 @@ ru:
         setting_always_send_emails: Всегда отправлять уведомления по электронной почте
         setting_auto_play_gif: Автоматически проигрывать GIF анимации
         setting_boost_modal: Всегда спрашивать перед продвижением
-        setting_crop_images: Кадрировать изображения в нераскрытых постах до 16:9
         setting_default_language: Язык публикуемых постов
         setting_default_privacy: Видимость постов
         setting_default_sensitive: Всегда отмечать медиафайлы как «деликатного характера»

--- a/config/locales/simple_form.sc.yml
+++ b/config/locales/simple_form.sc.yml
@@ -141,7 +141,6 @@ sc:
         setting_aggregate_reblogs: Agrupa is cumpartziduras in is lìnias de tempus
         setting_auto_play_gif: Riprodui is GIF animadas in automàticu
         setting_boost_modal: Ammustra unu diàlogu de cunfirma in antis de cumpartzire
-        setting_crop_images: Retàllia a 16x9 is immàgines de is tuts no ismanniados
         setting_default_language: Idioma de publicatzione
         setting_default_privacy: Riservadesa de is publicatziones
         setting_default_sensitive: Marca semper is elementos multimediales comente sensìbiles

--- a/config/locales/simple_form.sco.yml
+++ b/config/locales/simple_form.sco.yml
@@ -188,7 +188,6 @@ sco:
         setting_always_send_emails: Aye sen email notifications
         setting_auto_play_gif: Auto-pley animatit GIFs
         setting_boost_modal: Shaw confirmation dialog afore heezin
-        setting_crop_images: Crap images in non-expandit posts tae 16x9
         setting_default_language: Postin leid
         setting_default_privacy: Postin privacy
         setting_default_sensitive: Aye mairk media as sensitive

--- a/config/locales/simple_form.si.yml
+++ b/config/locales/simple_form.si.yml
@@ -157,7 +157,6 @@ si:
         setting_always_send_emails: සෑම විටම විද්‍යුත් තැපැල් දැනුම්දීම් යවන්න
         setting_auto_play_gif: සජීවිකරණ GIF ස්වයංක්‍රීයව ධාවනය කරන්න
         setting_boost_modal: වැඩි කිරීමට පෙර තහවුරු කිරීමේ සංවාදය පෙන්වන්න
-        setting_crop_images: ප්‍රසාරණය නොකළ පළ කිරීම් වල පින්තූර 16x9 දක්වා කප්පාදු කරන්න
         setting_default_language: පළ කිරීමේ භාෂාව
         setting_default_privacy: පුද්ගලිකත්වය පළ කිරීම
         setting_default_sensitive: සෑම විටම මාධ්‍ය සංවේදී ලෙස සලකුණු කරන්න

--- a/config/locales/simple_form.sk.yml
+++ b/config/locales/simple_form.sk.yml
@@ -117,7 +117,6 @@ sk:
         setting_aggregate_reblogs: Zoskupuj vyzdvihnutia v časovej osi
         setting_auto_play_gif: Automaticky prehrávaj animované GIFy
         setting_boost_modal: Zobrazuj potvrdzovacie okno pred povýšením
-        setting_crop_images: Orež obrázky v nerozbalených príspevkoch na 16x9
         setting_default_language: Píšeš v jazyku
         setting_default_privacy: Súkromie príspevkov
         setting_default_sensitive: Označ všetky mediálne súbory ako chúlostivé

--- a/config/locales/simple_form.sl.yml
+++ b/config/locales/simple_form.sl.yml
@@ -198,7 +198,6 @@ sl:
         setting_always_send_emails: Vedno pošlji e-obvestila
         setting_auto_play_gif: Samodejno predvajanje animiranih GIF-ov
         setting_boost_modal: Pred izpostavljanjem pokaži potrditveno okno
-        setting_crop_images: Obreži slike v nerazširjenih objavah v razmerju 16:9
         setting_default_language: Jezik objavljanja
         setting_default_privacy: Zasebnost objave
         setting_default_sensitive: Vedno označi medije kot občutljive

--- a/config/locales/simple_form.sq.yml
+++ b/config/locales/simple_form.sq.yml
@@ -200,7 +200,6 @@ sq:
         setting_always_send_emails: Dërgo përherë njoftime me email
         setting_auto_play_gif: Vetëluaji GIF-et e animuar
         setting_boost_modal: Shfaq dialog ripohimi përpara përforcimi
-        setting_crop_images: Në mesazhe jo të zgjerueshëm, qethi figurat në 16x9
         setting_default_language: Gjuhë postimi
         setting_default_privacy: Privatësi postimi
         setting_default_sensitive: Mediave vëru përherë shenjë si rezervat

--- a/config/locales/simple_form.sr-Latn.yml
+++ b/config/locales/simple_form.sr-Latn.yml
@@ -200,7 +200,6 @@ sr-Latn:
         setting_always_send_emails: Uvek šalji obaveštenja e-poštom
         setting_auto_play_gif: Automatski reprodukuj animirane GIF-ove
         setting_boost_modal: Prikaži dijalog za potvrdu pre davanja podrške
-        setting_crop_images: Izreži slike u neproširenim objavama na 16x9
         setting_default_language: Jezik objavljivanja
         setting_default_privacy: Privatnost objava
         setting_default_sensitive: Uvek označi multimediju kao osetljivu

--- a/config/locales/simple_form.sr.yml
+++ b/config/locales/simple_form.sr.yml
@@ -200,7 +200,6 @@ sr:
         setting_always_send_emails: Увек шаљи обавештења е-поштом
         setting_auto_play_gif: Аутоматски репродукуј анимиране GIF-ове
         setting_boost_modal: Прикажи дијалог за потврду пре давања подршке
-        setting_crop_images: Изрежи слике у непроширеним објавама на 16x9
         setting_default_language: Језик објављивања
         setting_default_privacy: Приватност објава
         setting_default_sensitive: Увек означи мултимедију као осетљиву

--- a/config/locales/simple_form.sv.yml
+++ b/config/locales/simple_form.sv.yml
@@ -195,7 +195,6 @@ sv:
         setting_always_send_emails: Skicka alltid e-postnotiser
         setting_auto_play_gif: Spela upp GIF:ar automatiskt
         setting_boost_modal: Visa bekräftelsedialog innan boostning
-        setting_crop_images: Beskär bilder i icke-utökade inlägg till 16x9
         setting_default_language: Inläggsspråk
         setting_default_privacy: Inläggsintegritet
         setting_default_sensitive: Markera alltid media som känsligt

--- a/config/locales/simple_form.th.yml
+++ b/config/locales/simple_form.th.yml
@@ -200,7 +200,6 @@ th:
         setting_always_send_emails: ส่งการแจ้งเตือนอีเมลเสมอ
         setting_auto_play_gif: เล่น GIF แบบเคลื่อนไหวโดยอัตโนมัติ
         setting_boost_modal: แสดงกล่องโต้ตอบการยืนยันก่อนดัน
-        setting_crop_images: ครอบตัดภาพในโพสต์ที่ไม่ได้ขยายเป็น 16x9
         setting_default_language: ภาษาของการโพสต์
         setting_default_privacy: ความเป็นส่วนตัวของการโพสต์
         setting_default_sensitive: ทำเครื่องหมายสื่อว่าละเอียดอ่อนเสมอ

--- a/config/locales/simple_form.tr.yml
+++ b/config/locales/simple_form.tr.yml
@@ -200,7 +200,6 @@ tr:
         setting_always_send_emails: Her zaman e-posta bildirimleri gönder
         setting_auto_play_gif: Hareketli GIF'leri otomatik oynat
         setting_boost_modal: Boostlamadan önce onay iletişim kutusu göster
-        setting_crop_images: Genişletilmemiş gönderilerdeki resimleri 16x9 olarak kırp
         setting_default_language: Gönderi dili
         setting_default_privacy: Gönderi gizliliği
         setting_default_sensitive: Medyayı her zaman hassas olarak işaretle

--- a/config/locales/simple_form.uk.yml
+++ b/config/locales/simple_form.uk.yml
@@ -203,7 +203,6 @@ uk:
         setting_always_send_emails: Завжди надсилати сповіщення електронною поштою
         setting_auto_play_gif: Автоматично відтворювати анімовані GIF
         setting_boost_modal: Показувати діалог підтвердження під час поширення
-        setting_crop_images: Обрізати зображення в нерозгорнутих дописах до 16x9
         setting_default_language: Мова дописів
         setting_default_privacy: Видимість дописів
         setting_default_sensitive: Позначати медіа делікатними

--- a/config/locales/simple_form.vi.yml
+++ b/config/locales/simple_form.vi.yml
@@ -200,7 +200,6 @@ vi:
         setting_always_send_emails: Luôn gửi email thông báo
         setting_auto_play_gif: Tự động phát ảnh GIF
         setting_boost_modal: Yêu cầu xác nhận trước khi đăng lại tút
-        setting_crop_images: Hiển thị ảnh theo tỉ lệ 16x9
         setting_default_language: Ngôn ngữ đăng
         setting_default_privacy: Kiểu đăng
         setting_default_sensitive: Ảnh/video là nội dung nhạy cảm

--- a/config/locales/simple_form.zh-CN.yml
+++ b/config/locales/simple_form.zh-CN.yml
@@ -200,7 +200,6 @@ zh-CN:
         setting_always_send_emails: 总是发送电子邮件通知
         setting_auto_play_gif: 自动播放 GIF 动画
         setting_boost_modal: 在转嘟前询问我
-        setting_crop_images: 把未展开嘟文中的图片裁剪到 16x9
         setting_default_language: 发布语言
         setting_default_privacy: 嘟文默认可见范围
         setting_default_sensitive: 始终标记媒体为敏感内容

--- a/config/locales/simple_form.zh-HK.yml
+++ b/config/locales/simple_form.zh-HK.yml
@@ -194,7 +194,6 @@ zh-HK:
         setting_always_send_emails: 總是傳送電郵通知
         setting_auto_play_gif: 自動播放 GIF
         setting_boost_modal: 在轉推前詢問我
-        setting_crop_images: 將未展開文章中的圖片裁剪到 16x9
         setting_default_language: 文章語言
         setting_default_privacy: 文章預設為
         setting_default_sensitive: 預設我的內容為敏感內容

--- a/config/locales/simple_form.zh-TW.yml
+++ b/config/locales/simple_form.zh-TW.yml
@@ -200,7 +200,6 @@ zh-TW:
         setting_always_send_emails: 總是發送電子郵件通知
         setting_auto_play_gif: 自動播放 GIF 動畫
         setting_boost_modal: 轉嘟前先詢問我
-        setting_crop_images: 將未展開嘟文中的圖片裁剪至 16x9
         setting_default_language: 嘟文語言
         setting_default_privacy: 嘟文可見範圍
         setting_default_sensitive: 總是將媒體標記為敏感內容

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -684,7 +684,6 @@ sk:
       body: Mastodon je prekladaný dobrovoľníkmi.
       guide_link_text: Prispievať môže každý.
     sensitive_content: Chúlostivý obsah
-    toot_layout: Rozloženie príspevkov
   application_mailer:
     notification_preferences: Zmeň emailové voľby
     settings: 'Zmeň emailové voľby: %{link}'

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -1002,7 +1002,6 @@ sl:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Vsakdo lahko prispeva.
     sensitive_content: Občutljiva vsebina
-    toot_layout: Postavitev objave
   application_mailer:
     notification_preferences: Spremenite e-poštne nastavitve
     salutation: "%{name},"

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -973,7 +973,6 @@ sq:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Çdokush mund të kontribuojë.
     sensitive_content: Lëndë rezervat
-    toot_layout: Skemë mesazhesh
   application_mailer:
     notification_preferences: Ndryshoni parapëlqime email-i
     salutation: "%{name},"

--- a/config/locales/sr-Latn.yml
+++ b/config/locales/sr-Latn.yml
@@ -991,7 +991,6 @@ sr-Latn:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Svako može doprineti.
     sensitive_content: Osetljiv sadržaj
-    toot_layout: Raspored objava
   application_mailer:
     notification_preferences: Promeni preference E-pošte
     salutation: Poštovani %{name},

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -991,7 +991,6 @@ sr:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Свако може допринети.
     sensitive_content: Осетљив садржај
-    toot_layout: Распоред објава
   application_mailer:
     notification_preferences: Промени преференце Е-поште
     salutation: Поштовани %{name},

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -963,7 +963,6 @@ sv:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Alla kan bidra.
     sensitive_content: Känsligt innehåll
-    toot_layout: Inläggslayout
   application_mailer:
     notification_preferences: Ändra e-postinställningar
     salutation: "%{name},"

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -955,7 +955,6 @@ th:
       guide_link: https://crowdin.com/project/mastodon/th
       guide_link_text: ทุกคนสามารถมีส่วนร่วม
     sensitive_content: เนื้อหาที่ละเอียดอ่อน
-    toot_layout: เค้าโครงโพสต์
   application_mailer:
     notification_preferences: เปลี่ยนการกำหนดลักษณะอีเมล
     salutation: "%{name},"

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -973,7 +973,6 @@ tr:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Herkes katkıda bulunabilir.
     sensitive_content: Hassas içerik
-    toot_layout: Gönderi düzeni
   application_mailer:
     notification_preferences: E-posta tercihlerini değiştir
     salutation: "%{name},"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1009,7 +1009,6 @@ uk:
       guide_link: https://uk.crowdin.com/project/mastodon
       guide_link_text: Кожен може взяти участь.
     sensitive_content: Дражливий зміст
-    toot_layout: Зовнішній вигляд дописів
   application_mailer:
     notification_preferences: Змінити налаштування електронної пошти
     salutation: "%{name},"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -955,7 +955,6 @@ vi:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: Ai cũng có thể đóng góp.
     sensitive_content: Nội dung nhạy cảm
-    toot_layout: Tút
   application_mailer:
     notification_preferences: Thay đổi tùy chọn email
     salutation: "%{name},"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -955,7 +955,6 @@ zh-CN:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: 每个人都可以参与翻译。
     sensitive_content: 敏感内容
-    toot_layout: 嘟文布局
   application_mailer:
     notification_preferences: 更改电子邮件首选项
     salutation: "%{name}："

--- a/config/locales/zh-HK.yml
+++ b/config/locales/zh-HK.yml
@@ -941,7 +941,6 @@ zh-HK:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: 每個人都能貢獻。
     sensitive_content: 敏感內容
-    toot_layout: 發文介面
   application_mailer:
     notification_preferences: 更改電郵設定
     salutation: "%{name}："

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -959,7 +959,6 @@ zh-TW:
       guide_link: https://crowdin.com/project/mastodon
       guide_link_text: 每個人都能貢獻。
     sensitive_content: 敏感內容
-    toot_layout: 嘟文排版
   application_mailer:
     notification_preferences: 變更電子郵件設定
     salutation: "%{name}、"


### PR DESCRIPTION
Standalone pictures and videos will no longer be cropped to a 16:9 aspect ratio in the web app. Media galleries will now show as 3:2 instead of 16:9. Subsequently, the preference for disabling this behaviour has also been removed.