### PR TITLE
Coverage for `Auth::OmniauthCallbacks` controller

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -109,6 +109,8 @@ jobs:
       PAM_CONTROLLED_SERVICE: pam_test_controlled
       OIDC_ENABLED: true
       OIDC_SCOPE: read
+      SAML_ENABLED: true
+      CAS_ENABLED: true
       BUNDLE_WITH: 'pam_authentication test'
       CI_JOBS: ${{ matrix.ci_job }}/4
 

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -107,6 +107,8 @@ jobs:
       PAM_ENABLED: true
       PAM_DEFAULT_SERVICE: pam_test
       PAM_CONTROLLED_SERVICE: pam_test_controlled
+      OIDC_ENABLED: true
+      OIDC_SCOPE: read
       BUNDLE_WITH: 'pam_authentication test'
       CI_JOBS: ${{ matrix.ci_job }}/4
 

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -4,57 +4,81 @@ require 'rails_helper'
 
 describe 'OmniAuth callbacks' do
   describe '#openid_connect', if: ENV['OIDC_ENABLED'] == 'true' && ENV['OIDC_SCOPE'].present? do
-    before do
-      mock_omniauth(:openid_connect, {
-        provider: 'openid_connect',
-        uid: '123',
-        info: {
-          verified: 'true',
-          email: 'user@host.example',
-        },
-      })
+    context 'with full information in response' do
+      before do
+        mock_omniauth(:openid_connect, {
+          provider: 'openid_connect',
+          uid: '123',
+          info: {
+            verified: 'true',
+            email: 'user@host.example',
+          },
+        })
+      end
+
+      context 'without a matching user' do
+        it 'creates a user and an identity and redirects to root path' do
+          expect { post user_openid_connect_omniauth_callback_path }
+            .to change(User, :count)
+            .by(1)
+            .and change(Identity, :count)
+            .by(1)
+          expect(User.last.email).to eq('user@host.example')
+          expect(Identity.find_by(user: User.last).uid).to eq('123')
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context 'with a matching user and no matching identity' do
+        before do
+          Fabricate(:user, email: 'user@host.example')
+        end
+
+        it 'matches the existing user, creates an identity, and redirects to root path' do
+          expect { post user_openid_connect_omniauth_callback_path }
+            .to not_change(User, :count)
+            .and change(Identity, :count).by(1)
+
+          expect(Identity.find_by(user: User.last).uid).to eq('123')
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context 'with a matching user and a matching identity' do
+        before do
+          user = Fabricate(:user, email: 'user@host.example')
+          Fabricate(:identity, user: user, uid: '123', provider: :openid_connect)
+        end
+
+        it 'matches the existing records and redirects to root path' do
+          expect { post user_openid_connect_omniauth_callback_path }
+            .to not_change(User, :count)
+            .and not_change(Identity, :count)
+
+          expect(response).to redirect_to(root_path)
+        end
+      end
     end
 
-    context 'without a matching user' do
-      it 'creates a user and an identity and redirects to root path' do
+    context 'with a response missing email address' do
+      before do
+        mock_omniauth(:openid_connect, {
+          provider: 'openid_connect',
+          uid: '123',
+          info: {
+            verified: 'true',
+          },
+        })
+      end
+
+      it 'redirects to the auth setup page' do
         expect { post user_openid_connect_omniauth_callback_path }
           .to change(User, :count)
           .by(1)
           .and change(Identity, :count)
           .by(1)
-        expect(User.last.email).to eq('user@host.example')
-        expect(Identity.find_by(user: User.last).uid).to eq('123')
-        expect(response).to redirect_to(root_path)
-      end
-    end
 
-    context 'with a matching user and no matching identity' do
-      before do
-        Fabricate(:user, email: 'user@host.example')
-      end
-
-      it 'matches the existing user, creates an identity, and redirects to root path' do
-        expect { post user_openid_connect_omniauth_callback_path }
-          .to not_change(User, :count)
-          .and change(Identity, :count).by(1)
-
-        expect(Identity.find_by(user: User.last).uid).to eq('123')
-        expect(response).to redirect_to(root_path)
-      end
-    end
-
-    context 'with a matching user and a matching identity' do
-      before do
-        user = Fabricate(:user, email: 'user@host.example')
-        Fabricate(:identity, user: user, uid: '123', provider: :openid_connect)
-      end
-
-      it 'matches the existing records and redirects to root path' do
-        expect { post user_openid_connect_omniauth_callback_path }
-          .to not_change(User, :count)
-          .and not_change(Identity, :count)
-
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(auth_setup_path(missing_email: '1'))
       end
     end
   end

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -4,6 +4,17 @@ require 'rails_helper'
 
 describe 'OmniAuth callbacks' do
   describe '#openid_connect', if: ENV['OIDC_ENABLED'] == 'true' && ENV['OIDC_SCOPE'].present? do
+    before do
+      mock_omniauth(:openid_connect, {
+        provider: 'openid_connect',
+        uid: '123',
+        info: {
+          verified: 'true',
+          email: 'user@host.example',
+        },
+      })
+    end
+
     context 'without a matching user' do
       it 'creates a user and an identity and redirects to root path' do
         expect { post user_openid_connect_omniauth_callback_path }

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -81,5 +81,19 @@ describe 'OmniAuth callbacks' do
         expect(response).to redirect_to(auth_setup_path(missing_email: '1'))
       end
     end
+
+    context 'when a user cannot be built' do
+      before do
+        allow(User).to receive(:find_for_oauth).and_return(User.new)
+      end
+
+      it 'redirects to the new user signup page' do
+        expect { post user_openid_connect_omniauth_callback_path }
+          .to not_change(User, :count)
+          .and not_change(Identity, :count)
+
+        expect(response).to redirect_to(new_user_registration_url)
+      end
+    end
   end
 end

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -23,6 +23,9 @@ describe 'OmniAuth callbacks' do
             .by(1)
             .and change(Identity, :count)
             .by(1)
+            .and change(LoginActivity, :count)
+            .by(1)
+
           expect(User.last.email).to eq('user@host.example')
           expect(Identity.find_by(user: User.last).uid).to eq('123')
           expect(response).to redirect_to(root_path)
@@ -37,7 +40,10 @@ describe 'OmniAuth callbacks' do
         it 'matches the existing user, creates an identity, and redirects to root path' do
           expect { post user_openid_connect_omniauth_callback_path }
             .to not_change(User, :count)
-            .and change(Identity, :count).by(1)
+            .and change(Identity, :count)
+            .by(1)
+            .and change(LoginActivity, :count)
+            .by(1)
 
           expect(Identity.find_by(user: User.last).uid).to eq('123')
           expect(response).to redirect_to(root_path)
@@ -54,6 +60,8 @@ describe 'OmniAuth callbacks' do
           expect { post user_openid_connect_omniauth_callback_path }
             .to not_change(User, :count)
             .and not_change(Identity, :count)
+            .and change(LoginActivity, :count)
+            .by(1)
 
           expect(response).to redirect_to(root_path)
         end
@@ -77,6 +85,8 @@ describe 'OmniAuth callbacks' do
           .by(1)
           .and change(Identity, :count)
           .by(1)
+          .and change(LoginActivity, :count)
+          .by(1)
 
         expect(response).to redirect_to(auth_setup_path(missing_email: '1'))
       end
@@ -91,6 +101,7 @@ describe 'OmniAuth callbacks' do
         expect { post user_openid_connect_omniauth_callback_path }
           .to not_change(User, :count)
           .and not_change(Identity, :count)
+          .and not_change(LoginActivity, :count)
 
         expect(response).to redirect_to(new_user_registration_url)
       end

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -4,14 +4,44 @@ require 'rails_helper'
 
 describe 'OmniAuth callbacks' do
   describe '#openid_connect', if: ENV['OIDC_ENABLED'] == 'true' && ENV['OIDC_SCOPE'].present? do
-    context 'with a user and an identify' do
+    context 'without a matching user' do
+      it 'creates a user and an identity and redirects to root path' do
+        expect { post user_openid_connect_omniauth_callback_path }
+          .to change(User, :count)
+          .by(1)
+          .and change(Identity, :count)
+          .by(1)
+        expect(User.last.email).to eq('user@host.example')
+        expect(Identity.find_by(user: User.last).uid).to eq('123')
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'with a matching user and no matching identity' do
       before do
-        user = Fabricate(:user, email: 'user@host.example')
-        Fabricate(:identity, user: user, uid: '123')
+        Fabricate(:user, email: 'user@host.example')
       end
 
-      it 'redirects to root path' do
-        post user_openid_connect_omniauth_callback_path
+      it 'matches the existing user, creates an identity, and redirects to root path' do
+        expect { post user_openid_connect_omniauth_callback_path }
+          .to not_change(User, :count)
+          .and change(Identity, :count).by(1)
+
+        expect(Identity.find_by(user: User.last).uid).to eq('123')
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'with a matching user and a matching identity' do
+      before do
+        user = Fabricate(:user, email: 'user@host.example')
+        Fabricate(:identity, user: user, uid: '123', provider: :openid_connect)
+      end
+
+      it 'matches the existing records and redirects to root path' do
+        expect { post user_openid_connect_omniauth_callback_path }
+          .to not_change(User, :count)
+          .and not_change(Identity, :count)
 
         expect(response).to redirect_to(root_path)
       end

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -3,16 +3,18 @@
 require 'rails_helper'
 
 describe 'OmniAuth callbacks' do
-  context 'when openid_connect is enabled', if: ENV['OIDC_ENABLED'] == 'true' && ENV['OIDC_SCOPE'].present? do
-    before do
-      user = Fabricate(:user, email: 'user@host.example')
-      Fabricate(:identity, user: user, uid: '123')
-    end
+  describe '#openid_connect', if: ENV['OIDC_ENABLED'] == 'true' && ENV['OIDC_SCOPE'].present? do
+    context 'with a user and an identify' do
+      before do
+        user = Fabricate(:user, email: 'user@host.example')
+        Fabricate(:identity, user: user, uid: '123')
+      end
 
-    it 'responds' do
-      post user_openid_connect_omniauth_callback_path
+      it 'redirects to root path' do
+        post user_openid_connect_omniauth_callback_path
 
-      expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 end

--- a/spec/requests/omniauth_callbacks_spec.rb
+++ b/spec/requests/omniauth_callbacks_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'OmniAuth callbacks' do
+  context 'when openid_connect is enabled', if: ENV['OIDC_ENABLED'] == 'true' && ENV['OIDC_SCOPE'].present? do
+    before do
+      user = Fabricate(:user, email: 'user@host.example')
+      Fabricate(:identity, user: user, uid: '123')
+    end
+
+    it 'responds' do
+      post user_openid_connect_omniauth_callback_path
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/support/omniauth_mocks.rb
+++ b/spec/support/omniauth_mocks.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 OmniAuth.config.test_mode = true
-OmniAuth.config.mock_auth[:openid_connect] = OmniAuth::AuthHash.new({
-  provider: 'openid_connect',
-  uid: '123',
-  info: {
-    verified: 'true',
-    email: 'user@host.example',
-  },
-})
+
+def mock_omniauth(provider, data)
+  OmniAuth.config.mock_auth[provider] = OmniAuth::AuthHash.new(data)
+end

--- a/spec/support/omniauth_mocks.rb
+++ b/spec/support/omniauth_mocks.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+OmniAuth.config.test_mode = true
+OmniAuth.config.mock_auth[:openid_connect] = OmniAuth::AuthHash.new({
+  provider: 'openid_connect',
+  uid: '123',
+  info: {
+    verified: 'true',
+    email: 'user@host.example',
+  },
+})


### PR DESCRIPTION
Adds coverage for the "happy path" of finding a user with matching email and uid via the openid_connection omniauth provider.

This spec only runs when the OIDC_ENABLED env var is set to `true` and the OIDC_SCOPES value is present. These are required at minimum to load/configure the provider.

This adds an omniauth test mock, which for now is hard coded to values usable by this one specific example.

Related to https://github.com/mastodon/mastodon/pull/24209#issuecomment-1648072048

Opening this for feedback. Some obvious next steps:

- We would almost definitely want to set up some CI coverage similar to what is in place for the PAM stuff where we have a focused spec run that sets the env vars and just runs this one spec.
- Refactor the mock setup here to be more versatile
- Add at least more coverage for more of the code paths with openid_connect
- Maybe also add coverage for SAML/CAS/etc
- Maybe configure some other provider mock (github?) and get some coverage for that

