### PR TITLE
Fix LinkCrawlWorker crashing on `null` `created_at`

### DIFF
--- a/app/lib/link_details_extractor.rb
+++ b/app/lib/link_details_extractor.rb
@@ -124,7 +124,7 @@ class LinkDetailsExtractor
       author_url: author_url || '',
       embed_url: embed_url || '',
       language: language,
-      created_at: published_at,
+      created_at: published_at.presence || Time.now.utc,
     }
   end
 


### PR DESCRIPTION
See https://github.com/mastodon/mastodon/pull/26136#issuecomment-1647907155