### PR TITLE
fix poll input active style

### DIFF
--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -128,6 +128,11 @@
       border-width: 4px;
     }
 
+    &.active {
+      background-color: $ui-button-focus-background-color;
+      border-color: $ui-button-focus-background-color;
+    }
+
     &::-moz-focus-inner {
       outline: 0 !important;
       border: 0;


### PR DESCRIPTION
resolves #26160

light theme
<img width="340" alt="CleanShot 2023-07-25 at 20 45 50@2x" src="https://github.com/mastodon/mastodon/assets/17292/df7c590f-d52a-4184-be6c-55840170affb">

dark theme
<img width="185" alt="CleanShot 2023-07-25 at 21 05 27@2x" src="https://github.com/mastodon/mastodon/assets/17292/d1d660ef-2cbb-41c3-aabb-6eccc58491b5">

