### PR TITLE
Fix missing GIF badge in account gallery

### DIFF
--- a/app/javascript/mastodon/features/account_gallery/components/media_item.jsx
+++ b/app/javascript/mastodon/features/account_gallery/components/media_item.jsx
@@ -128,7 +128,11 @@ export default class MediaItem extends ImmutablePureComponent {
         <div className='media-gallery__gifv'>
           {content}
 
-          {label && <span className='media-gallery__gifv__label'>{label}</span>}
+          {label && (
+            <div className='media-gallery__item__badges'>
+              <span className='media-gallery__gifv__label'>{label}</span>
+            </div>
+          )}
         </div>
       );
     }


### PR DESCRIPTION
The “GIF” badge has gone missing from the account gallery (not sure when).

The badge is present in the DOM but not visible due to a missing  wrapper div.