### PR TITLE
Preserve translation on status re-import

### DIFF
--- a/app/javascript/mastodon/actions/importer/index.js
+++ b/app/javascript/mastodon/actions/importer/index.js
@@ -81,7 +81,7 @@ export function importFetchedStatuses(statuses) {
       }
 
       if (status.poll && status.poll.id) {
-        pushUnique(polls, normalizePoll(status.poll));
+        pushUnique(polls, normalizePoll(status.poll, getState().getIn(['polls', status.poll.id])));
       }
     }
 
@@ -95,7 +95,7 @@ export function importFetchedStatuses(statuses) {
 }
 
 export function importFetchedPoll(poll) {
-  return dispatch => {
-    dispatch(importPolls([normalizePoll(poll)]));
+  return (dispatch, getState) => {
+    dispatch(importPolls([normalizePoll(poll, getState().getIn(['polls', poll.id]))]));
   };
 }


### PR DESCRIPTION
Fixes #21299.

The fix is relevant not only when favouriting a post but also e.g. when voting in a poll or refreshing poll results.