### PR TITLE
Remove queued_at value from pubsub payloads

### DIFF
--- a/app/workers/push_conversation_worker.rb
+++ b/app/workers/push_conversation_worker.rb
@@ -9,7 +9,7 @@ class PushConversationWorker
     message      = InlineRenderer.render(conversation, conversation.account, :conversation)
     timeline_id  = "timeline:direct:#{conversation.account_id}"
 
-    redis.publish(timeline_id, Oj.dump(event: :conversation, payload: message, queued_at: (Time.now.to_f * 1000.0).to_i))
+    redis.publish(timeline_id, Oj.dump(event: :conversation, payload: message))
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/app/workers/push_encrypted_message_worker.rb
+++ b/app/workers/push_encrypted_message_worker.rb
@@ -9,7 +9,7 @@ class PushEncryptedMessageWorker
     message           = InlineRenderer.render(encrypted_message, nil, :encrypted_message)
     timeline_id       = "timeline:#{encrypted_message.device.account_id}:#{encrypted_message.device.device_id}"
 
-    redis.publish(timeline_id, Oj.dump(event: :encrypted_message, payload: message, queued_at: (Time.now.to_f * 1000.0).to_i))
+    redis.publish(timeline_id, Oj.dump(event: :encrypted_message, payload: message))
   rescue ActiveRecord::RecordNotFound
     true
   end

--- a/app/workers/push_update_worker.rb
+++ b/app/workers/push_update_worker.rb
@@ -25,8 +25,7 @@ class PushUpdateWorker
   def message
     Oj.dump(
       event: update? ? :'status.update' : :update,
-      payload: @payload,
-      queued_at: (Time.now.to_f * 1000.0).to_i
+      payload: @payload
     )
   end
 


### PR DESCRIPTION
This value was added to some pubsub payloads a long time ago, but not consistently, so it couldn't actually be used for metrics. Most of the time logs using this value would display as "Delay: NaNms" because the redis pubsub message didn't contain the queued_at value.

The respective change to streaming server is made in https://github.com/mastodon/mastodon/pull/26172