### PR TITLE
Extract `AccountFollowable` concern for `Account.followable_by` scope

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -76,6 +76,7 @@ class Account < ApplicationRecord
   include Account::Avatar
   include Account::Counters
   include Account::FinderConcern
+  include Account::Followable
   include Account::Header
   include Account::Interactions
   include Account::Merging
@@ -129,7 +130,6 @@ class Account < ApplicationRecord
   scope :without_unapproved, -> { left_outer_joins(:user).merge(User.approved.confirmed).or(remote) }
   scope :searchable, -> { without_unapproved.without_suspended.where(moved_to_account_id: nil) }
   scope :discoverable, -> { searchable.without_silenced.where(discoverable: true).joins(:account_stat) }
-  scope :followable_by, ->(account) { joins(arel_table.join(Follow.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:id].eq(Follow.arel_table[:target_account_id]).and(Follow.arel_table[:account_id].eq(account.id))).join_sources).where(Follow.arel_table[:id].eq(nil)).joins(arel_table.join(FollowRequest.arel_table, Arel::Nodes::OuterJoin).on(arel_table[:id].eq(FollowRequest.arel_table[:target_account_id]).and(FollowRequest.arel_table[:account_id].eq(account.id))).join_sources).where(FollowRequest.arel_table[:id].eq(nil)) }
   scope :by_recent_status, -> { includes(:account_stat).merge(AccountStat.order('last_status_at DESC NULLS LAST')).references(:account_stat) }
   scope :by_recent_activity, -> { left_joins(:user, :account_stat).order(coalesced_activity_timestamps.desc).order(id: :desc) }
   scope :popular, -> { order('account_stats.followers_count desc') }

--- a/app/models/concerns/account/followable.rb
+++ b/app/models/concerns/account/followable.rb
@@ -4,22 +4,12 @@ module Account::Followable
   extend ActiveSupport::Concern
 
   included do
+    scope :without_follows, ->(account) { joins(follows_join(account)).where(follows_id_nil) }
+    scope :without_follow_requests, ->(account) { joins(follow_requests_join(account)).where(follow_requests_id_nil) }
     scope :followable_by, ->(account) { without_follows(account).without_follow_requests(account) }
   end
 
   class_methods do
-    def without_follows(account)
-      joins(follows_join(account))
-        .where(follows_id_nil)
-    end
-
-    def without_follow_requests(account)
-      joins(follow_requests_join(account))
-        .where(follow_requests_id_nil)
-    end
-
-    private
-
     def follows_join(account)
       arel_table
         .join(Follow.arel_table, Arel::Nodes::OuterJoin)

--- a/app/models/concerns/account/followable.rb
+++ b/app/models/concerns/account/followable.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Account::Followable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :followable_by, ->(account) { without_follows(account).without_follow_requests(account) }
+  end
+
+  class_methods do
+    def without_follows(account)
+      joins(follows_join(account))
+        .where(follows_id_nil)
+    end
+
+    def without_follow_requests(account)
+      joins(follow_requests_join(account))
+        .where(follow_requests_id_nil)
+    end
+
+    private
+
+    def follows_join(account)
+      arel_table
+        .join(Follow.arel_table, Arel::Nodes::OuterJoin)
+        .on(follows_join_conditions(account))
+        .join_sources
+    end
+
+    def follow_requests_join(account)
+      arel_table
+        .join(FollowRequest.arel_table, Arel::Nodes::OuterJoin)
+        .on(follow_requests_join_conditions(account))
+        .join_sources
+    end
+
+    def follows_join_conditions(account)
+      arel_table[:id]
+        .eq(Follow.arel_table[:target_account_id])
+        .and(Follow.arel_table[:account_id].eq(account.id))
+    end
+
+    def follow_requests_join_conditions(account)
+      arel_table[:id]
+        .eq(FollowRequest.arel_table[:target_account_id])
+        .and(FollowRequest.arel_table[:account_id].eq(account.id))
+    end
+
+    def follows_id_nil
+      Follow
+        .arel_table[:id]
+        .eq(nil)
+    end
+
+    def follow_requests_id_nil
+      FollowRequest
+        .arel_table[:id]
+        .eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
Pulled out from https://github.com/mastodon/mastodon/pull/26093

This scope was sort of complicated and hard to follow and parse visually.

This change pulls the whole thing out into a concern which does nothing but build the scope back up from better-named private methods. From my local testing, a) the generated sql hasn't changed, b) the specs which exercise this method seem fine with the change.