### PR TITLE
Reformat large text arg in `FetchLinkCardService` spec

### DIFF
--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -100,7 +100,14 @@ RSpec.describe FetchLinkCardService, type: :service do
   end
 
   context 'with a remote status' do
-    let(:status) { Fabricate(:status, account: Fabricate(:account, domain: 'example.com'), text: 'Habt ihr ein paar gute Links zu <a>foo</a> #<span class="tag"><a href="https://quitter.se/tag/wannacry" target="_blank" rel="tag noopener noreferrer" title="https://quitter.se/tag/wannacry">Wannacry</a></span> herumfliegen?   Ich will mal unter <br> <a href="https://github.com/qbi/WannaCry" target="_blank" rel="noopener noreferrer" title="https://github.com/qbi/WannaCry">https://github.com/qbi/WannaCry</a> was sammeln. !<a href="http://sn.jonkman.ca/group/416/id" target="_blank" rel="noopener noreferrer" title="http://sn.jonkman.ca/group/416/id">security</a>&nbsp;') }
+    let(:status) do
+      Fabricate(:status, account: Fabricate(:account, domain: 'example.com'), text: <<-TEXT)
+      Habt ihr ein paar gute Links zu <a>foo</a>
+      #<span class="tag"><a href="https://quitter.se/tag/wannacry" target="_blank" rel="tag noopener noreferrer" title="https://quitter.se/tag/wannacry">Wannacry</a></span> herumfliegen?
+      Ich will mal unter <br> <a href="https://github.com/qbi/WannaCry" target="_blank" rel="noopener noreferrer" title="https://github.com/qbi/WannaCry">https://github.com/qbi/WannaCry</a> was sammeln. !
+      <a href="http://sn.jonkman.ca/group/416/id" target="_blank" rel="noopener noreferrer" title="http://sn.jonkman.ca/group/416/id">security</a>&nbsp;
+      TEXT
+    end
 
     it 'parses out URLs' do
       expect(a_request(:get, 'https://github.com/qbi/WannaCry')).to have_been_made.at_least_once


### PR DESCRIPTION
Pulled out from https://github.com/mastodon/mastodon/pull/26093

Puts a long status text value into a heredoc.