### PR TITLE
Ignore ActiveRecord::RecordInvalid in RedownloadAvatarWorker

### DIFF
--- a/app/workers/redownload_avatar_worker.rb
+++ b/app/workers/redownload_avatar_worker.rb
@@ -16,6 +16,7 @@ class RedownloadAvatarWorker
     account.reset_avatar!
     account.save!
   rescue ActiveRecord::RecordNotFound
+  rescue ActiveRecord::RecordInvalid
     # Do nothing
   rescue Mastodon::UnexpectedResponseError => e
     response = e.response


### PR DESCRIPTION
This PR resolves this issue from sidekiq

`ActiveRecord::RecordInvalid: Validation failed: Avatar must be less than 4 MB, Avatar file size must be less than 4 MB`