### PR TITLE
Update rubocop rules for linelength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,14 +38,7 @@ Layout/FirstHashElementIndentation:
 # Reason: Currently disabled in .rubocop_todo.yml
 # https://docs.rubocop.org/rubocop/cops_layout.html#layoutlinelength
 Layout/LineLength:
-  AllowedPatterns:
-    # Allow comments to be long lines
-    - !ruby/regexp / \# .*$/
-    - !ruby/regexp /^\# .*$/
-  Exclude:
-    - 'lib/mastodon/cli/*.rb'
-    - db/*migrate/**/*
-    - db/seeds/**/*
+  Max: 320 # Default of 120 causes a duplicate entry in generated todo file
 
 # Reason:
 # https://docs.rubocop.org/rubocop/cops_lint.html#lintuselessaccessmodifier

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,6 +40,13 @@ Layout/LeadingCommentSpace:
     - 'config/initializers/omniauth.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
+# Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
+# URISchemes: http, https
+Layout/LineLength:
+  Exclude:
+    - 'app/models/account.rb'
+
+# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: require_no_space, require_space
 Layout/SpaceInLambdaLiteral:
@@ -112,7 +119,6 @@ Lint/UselessAssignment:
     - 'config/initializers/omniauth.rb'
     - 'db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb'
     - 'db/post_migrate/20190511152737_remove_suspended_silenced_account_fields.rb'
-    - 'spec/controllers/api/v1/bookmarks_controller_spec.rb'
     - 'spec/controllers/api/v1/favourites_controller_spec.rb'
     - 'spec/controllers/concerns/account_controller_concern_spec.rb'
     - 'spec/helpers/jsonld_helper_spec.rb'
@@ -129,7 +135,7 @@ Lint/UselessAssignment:
 
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 150
+  Max: 143
 
 # Configuration parameters: CountBlocks, Max.
 Metrics/BlockNesting:
@@ -359,43 +365,6 @@ RSpec/PendingWithoutReason:
 Rails/ApplicationController:
   Exclude:
     - 'app/controllers/health_controller.rb'
-
-# Configuration parameters: Database, Include.
-# SupportedDatabases: mysql, postgresql
-# Include: db/**/*.rb
-Rails/BulkChangeTable:
-  Exclude:
-    - 'db/migrate/20160222143943_add_profile_fields_to_accounts.rb'
-    - 'db/migrate/20160223162837_add_metadata_to_statuses.rb'
-    - 'db/migrate/20160305115639_add_devise_to_users.rb'
-    - 'db/migrate/20160314164231_add_owner_to_application.rb'
-    - 'db/migrate/20160926213048_remove_owner_from_application.rb'
-    - 'db/migrate/20161003142332_add_confirmable_to_users.rb'
-    - 'db/migrate/20170112154826_migrate_settings.rb'
-    - 'db/migrate/20170127165745_add_devise_two_factor_to_users.rb'
-    - 'db/migrate/20170322143850_change_primary_key_to_bigint_on_statuses.rb'
-    - 'db/migrate/20170330021336_add_counter_caches.rb'
-    - 'db/migrate/20170425202925_add_oembed_to_preview_cards.rb'
-    - 'db/migrate/20170427011934_re_add_owner_to_application.rb'
-    - 'db/migrate/20170520145338_change_language_filter_to_opt_out.rb'
-    - 'db/migrate/20170624134742_add_description_to_session_activations.rb'
-    - 'db/migrate/20170718211102_add_activitypub_to_accounts.rb'
-    - 'db/migrate/20171006142024_add_uri_to_custom_emojis.rb'
-    - 'db/migrate/20180812123222_change_relays_enabled.rb'
-    - 'db/migrate/20190511134027_add_silenced_at_suspended_at_to_accounts.rb'
-    - 'db/migrate/20190805123746_add_capabilities_to_tags.rb'
-    - 'db/migrate/20190807135426_add_comments_to_domain_blocks.rb'
-    - 'db/migrate/20190815225426_add_last_status_at_to_tags.rb'
-    - 'db/migrate/20190901035623_add_max_score_to_tags.rb'
-    - 'db/migrate/20200417125749_add_storage_schema_version.rb'
-    - 'db/migrate/20200608113046_add_sign_in_token_to_users.rb'
-    - 'db/migrate/20211112011713_add_language_to_preview_cards.rb'
-    - 'db/migrate/20211231080958_add_category_to_reports.rb'
-    - 'db/migrate/20220202200743_add_trendable_to_accounts.rb'
-    - 'db/migrate/20220224010024_add_ips_to_email_domain_blocks.rb'
-    - 'db/migrate/20220227041951_add_last_used_at_to_oauth_access_tokens.rb'
-    - 'db/migrate/20220303000827_add_ordered_media_attachment_ids_to_status_edits.rb'
-    - 'db/migrate/20220824164433_add_human_identifier_to_admin_action_logs.rb'
 
 # Configuration parameters: Include.
 # Include: db/**/*.rb
@@ -936,9 +905,3 @@ Style/WordArray:
     - 'config/initializers/cors.rb'
     - 'spec/controllers/settings/imports_controller_spec.rb'
     - 'spec/models/form/import_spec.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
-# URISchemes: http, https
-Layout/LineLength:
-  Max: 701

--- a/config/initializers/twitter_regex.rb
+++ b/config/initializers/twitter_regex.rb
@@ -26,9 +26,9 @@ module Twitter::TwitterText
         )
       \)
     /iox
-    # rubocop:disable
+    # rubocop:disable Layout/LineLength
     UCHARS = '\u{A0}-\u{D7FF}\u{F900}-\u{FDCF}\u{FDF0}-\u{FFEF}\u{10000}-\u{1FFFD}\u{20000}-\u{2FFFD}\u{30000}-\u{3FFFD}\u{40000}-\u{4FFFD}\u{50000}-\u{5FFFD}\u{60000}-\u{6FFFD}\u{70000}-\u{7FFFD}\u{80000}-\u{8FFFD}\u{90000}-\u{9FFFD}\u{A0000}-\u{AFFFD}\u{B0000}-\u{BFFFD}\u{C0000}-\u{CFFFD}\u{D0000}-\u{DFFFD}\u{E1000}-\u{EFFFD}\u{E000}-\u{F8FF}\u{F0000}-\u{FFFFD}\u{100000}-\u{10FFFD}'
-    # rubocop:enable
+    # rubocop:enable Layout/LineLength
     REGEXEN[:valid_url_query_chars] = %r{[a-z0-9!?*'();:&=+$/%#\[\]\-_.,~|@\^#{UCHARS}]}iou
     REGEXEN[:valid_url_query_ending_chars] = %r{[a-z0-9_&=#/\-#{UCHARS}]}iou
     REGEXEN[:valid_url_path] = %r{(?:


### PR DESCRIPTION
This is a narrower version of https://github.com/mastodon/mastodon/pull/26093 which I had originally opened with a bunch of code changes as well. You can see some line by line explanation on that one, along with all the linked PRs which have since been merged to bring down some line lengths. This PR more narrowly:

- Regnerates the todo to remove some things changed since last regeneration (bulk change table, bookmarks) unrelated to this config change
- Removes the line length exceptions for comments and the previously excluded files
- Adds a new limit of 320 which solves the double-rule regeneration bug in rubocop referenced in the original PR
- Makes ones rule modification in the regex.rb file (I had rebase issue in another PR and it wasnt correct)

We are left with just one exclusion for linelength in account.rb, which will go away if/when this PR or something similar is merged - https://github.com/mastodon/mastodon/pull/26179 - and we could regenerate again to get that removed.

As future PRs continue to refactor things we could keep knocking down the 320 config option when possible.
