### PR TITLE
Use correct naming on controller concern specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -131,12 +131,6 @@ RSpec/FilePath:
   Exclude:
     - 'spec/config/initializers/rack_attack_spec.rb' # namespaces usually have separate folder
     - 'spec/lib/sanitize_config_spec.rb' # namespaces usually have separate folder
-    - 'spec/controllers/concerns/account_controller_concern_spec.rb' # Concerns describe ApplicationController and don't fit naming
-    - 'spec/controllers/concerns/export_controller_concern_spec.rb'
-    - 'spec/controllers/concerns/localized_spec.rb'
-    - 'spec/controllers/concerns/rate_limit_headers_spec.rb'
-    - 'spec/controllers/concerns/signature_verification_spec.rb'
-    - 'spec/controllers/concerns/user_tracking_concern_spec.rb'
 
 # Reason:
 # https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecnamedsubject

--- a/spec/controllers/concerns/account_controller_concern_spec.rb
+++ b/spec/controllers/concerns/account_controller_concern_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-describe ApplicationController do
-  controller do
+describe AccountControllerConcern do
+  controller(ApplicationController) do
     include AccountControllerConcern
 
     def success

--- a/spec/controllers/concerns/export_controller_concern_spec.rb
+++ b/spec/controllers/concerns/export_controller_concern_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-describe ApplicationController do
-  controller do
+describe ExportControllerConcern do
+  controller(ApplicationController) do
     include ExportControllerConcern
 
     def index

--- a/spec/controllers/concerns/localized_spec.rb
+++ b/spec/controllers/concerns/localized_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-describe ApplicationController do
-  controller do
+describe Localized do
+  controller(ApplicationController) do
     include Localized
 
     def success

--- a/spec/controllers/concerns/rate_limit_headers_spec.rb
+++ b/spec/controllers/concerns/rate_limit_headers_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-describe ApplicationController do
-  controller do
+describe RateLimitHeaders do
+  controller(ApplicationController) do
     include RateLimitHeaders
 
     def show

--- a/spec/controllers/concerns/signature_verification_spec.rb
+++ b/spec/controllers/concerns/signature_verification_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ApplicationController do
+describe SignatureVerification do
   let(:wrapped_actor_class) do
     Class.new do
       attr_reader :wrapped_account
@@ -15,7 +15,7 @@ describe ApplicationController do
     end
   end
 
-  controller do
+  controller(ApplicationController) do
     include SignatureVerification
 
     before_action :require_actor_signature!, only: [:signature_required]

--- a/spec/controllers/concerns/user_tracking_concern_spec.rb
+++ b/spec/controllers/concerns/user_tracking_concern_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-describe ApplicationController do
-  controller do
+describe UserTrackingConcern do
+  controller(ApplicationController) do
     include UserTrackingConcern
 
     def show


### PR DESCRIPTION
Changes the controller concern specs to call `describe` on the actual concern module being tested; and then alters the anonymous controller being created to descend from `ApplicationController` so that they can remain inferred type controller specs from the directory they are in.