### PR TITLE
Rubocop fix: `Perfomance/UnfreezeString`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,8 +161,6 @@ Naming/VariableNumber:
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Performance/UnfreezeString:
   Exclude:
-    - 'app/lib/text_formatter.rb'
-    - 'app/validators/status_length_validator.rb'
     - 'lib/tasks/mastodon.rake'
 
 RSpec/AnyInstance:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -158,11 +158,6 @@ Naming/VariableNumber:
     - 'spec/models/domain_block_spec.rb'
     - 'spec/models/user_spec.rb'
 
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Performance/UnfreezeString:
-  Exclude:
-    - 'lib/tasks/mastodon.rake'
-
 RSpec/AnyInstance:
   Exclude:
     - 'spec/controllers/activitypub/inboxes_controller_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -161,7 +161,6 @@ Naming/VariableNumber:
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Performance/UnfreezeString:
   Exclude:
-    - 'app/lib/rss/builder.rb'
     - 'app/lib/text_formatter.rb'
     - 'app/validators/status_length_validator.rb'
     - 'lib/tasks/mastodon.rake'

--- a/app/lib/rss/builder.rb
+++ b/app/lib/rss/builder.rb
@@ -14,13 +14,14 @@ class RSS::Builder
   end
 
   def to_xml
-    ('<?xml version="1.0" encoding="UTF-8"?>'.dup << Ox.dump(wrap_in_document, effort: :tolerant)).force_encoding('UTF-8')
+    Ox.dump(wrap_in_document, effort: :tolerant).force_encoding('UTF-8')
   end
 
   private
 
   def wrap_in_document
     Ox::Document.new(version: '1.0').tap do |document|
+      document << xml_instruct
       document << Ox::Element.new('rss').tap do |rss|
         rss['version']        = '2.0'
         rss['xmlns:webfeeds'] = 'http://webfeeds.org/rss/1.0'
@@ -28,6 +29,13 @@ class RSS::Builder
 
         rss << @dsl.to_element
       end
+    end
+  end
+
+  def xml_instruct
+    Ox::Instruct.new(:xml).tap do |instruct|
+      instruct[:version] = '1.0'
+      instruct[:encoding] = 'UTF-8'
     end
   end
 end

--- a/app/lib/text_formatter.rb
+++ b/app/lib/text_formatter.rb
@@ -75,7 +75,7 @@ class TextFormatter
       entity[:indices].first
     end
 
-    result = ''.dup
+    result = +''
 
     last_index = entities.reduce(0) do |index, entity|
       indices = entity[:indices]

--- a/app/validators/status_length_validator.rb
+++ b/app/validators/status_length_validator.rb
@@ -45,7 +45,7 @@ class StatusLengthValidator < ActiveModel::Validator
 
   def rewrite_entities(str, entities)
     entities.sort_by! { |entity| entity[:indices].first }
-    result = ''.dup
+    result = +''
 
     last_index = entities.reduce(0) do |index, entity|
       result << str[index...entity[:indices].first]

--- a/app/views/well_known/host_meta/show.xml.ruby
+++ b/app/views/well_known/host_meta/show.xml.ruby
@@ -2,6 +2,13 @@
 
 doc = Ox::Document.new(version: '1.0')
 
+ins = Ox::Instruct.new(:xml).tap do |instruct|
+  instruct[:version] = '1.0'
+  instruct[:encoding] = 'UTF-8'
+end
+
+doc << ins
+
 doc << Ox::Element.new('XRD').tap do |xrd|
   xrd['xmlns'] = 'http://docs.oasis-open.org/ns/xri/xrd-1.0'
 
@@ -11,4 +18,4 @@ doc << Ox::Element.new('XRD').tap do |xrd|
   end
 end
 
-"<?xml version=\"1.0\" encoding=\"UTF-8\"?>#{Ox.dump(doc, effort: :tolerant)}".force_encoding('UTF-8')
+Ox.dump(doc, effort: :tolerant).force_encoding('UTF-8')

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -438,12 +438,7 @@ namespace :mastodon do
           "#{key}=#{escaped}"
         end.join("\n")
 
-        generated_header = "# Generated with mastodon:setup on #{Time.now.utc}\n\n".dup
-
-        if incompatible_syntax
-          generated_header << "# Some variables in this file will be interpreted differently whether you are\n"
-          generated_header << "# using docker-compose or not.\n\n"
-        end
+        generated_header = generate_header(incompatible_syntax)
 
         Rails.root.join('.env.production').write("#{generated_header}#{env_contents}\n")
 
@@ -536,6 +531,19 @@ namespace :mastodon do
       vapid_key = Webpush.generate_key
       puts "VAPID_PRIVATE_KEY=#{vapid_key.private_key}"
       puts "VAPID_PUBLIC_KEY=#{vapid_key.public_key}"
+    end
+  end
+
+  private
+
+  def generate_header(include_warning)
+    default_message = "# Generated with mastodon:setup on #{Time.now.utc}\n\n"
+
+    default_message.tap do |string|
+      if include_warning
+        string << "# Some variables in this file will be interpreted differently whether you are\n"
+        string << "# using docker-compose or not.\n\n"
+      end
     end
   end
 end


### PR DESCRIPTION
This is the last of the `Performance/` cops to fix.

Changes in three areas:

- Refactor the RSS builder (and host meta well known view) to use `Ox::Instruct`, so they no longer need the unfrozen string
- Extract a private method in the `mastodon:setup` rake task to build the config string
- Use the unary plus operator in the text formatter and status length validator
