### PR TITLE
Do not normalize URL before fetching it

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -87,7 +87,7 @@ class Request
     raise ArgumentError if url.blank?
 
     @verb        = verb
-    @url         = Addressable::URI.parse(url)
+    @url         = URI_NORMALIZER.call(url)
     @http_client = options.delete(:http_client)
     @allow_local = options.delete(:allow_local)
     @options     = options.merge(socket_class: use_proxy? || @allow_local ? ProxySocket : Socket)

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -74,7 +74,7 @@ class Request
     raise ArgumentError if url.blank?
 
     @verb        = verb
-    @url         = Addressable::URI.parse(url).normalize
+    @url         = Addressable::URI.parse(url)
     @http_client = options.delete(:http_client)
     @allow_local = options.delete(:allow_local)
     @options     = options.merge(socket_class: use_proxy? || @allow_local ? ProxySocket : Socket)

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -68,14 +68,16 @@ class Request
   # about 15s in total
   TIMEOUT = { connect_timeout: 5, read_timeout: 10, write_timeout: 10, read_deadline: 30 }.freeze
 
+  # Workaround for overly-eager decoding of percent-encoded characters in Addressable::URI#normalized_path
+  # https://github.com/sporkmonger/addressable/issues/366
   URI_NORMALIZER = lambda do |uri|
-    uri = HTTP::URI.parse uri
+    uri = HTTP::URI.parse(uri)
 
     HTTP::URI.new(
-      scheme:    uri.normalized_scheme,
+      scheme: uri.normalized_scheme,
       authority: uri.normalized_authority,
-      path:      uri.path,
-      query:     uri.query,
+      path: Addressable::URI.normalize_path(uri.path),
+      query: uri.query
     )
   end
 

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -68,6 +68,17 @@ class Request
   # about 15s in total
   TIMEOUT = { connect_timeout: 5, read_timeout: 10, write_timeout: 10, read_deadline: 30 }.freeze
 
+  URI_NORMALIZER = lambda do |uri|
+    uri = HTTP::URI.parse uri
+
+    HTTP::URI.new(
+      scheme:    uri.normalized_scheme,
+      authority: uri.normalized_authority,
+      path:      uri.path,
+      query:     uri.query,
+    )
+  end
+
   include RoutingHelper
 
   def initialize(verb, url, **options)
@@ -139,7 +150,7 @@ class Request
     end
 
     def http_client
-      HTTP.use(:auto_inflate).follow(max_hops: 3)
+      HTTP.use(:auto_inflate).use(normalize_uri: { normalizer: URI_NORMALIZER }).follow(max_hops: 3)
     end
   end
 

--- a/spec/controllers/concerns/signature_verification_spec.rb
+++ b/spec/controllers/concerns/signature_verification_spec.rb
@@ -202,7 +202,7 @@ describe SignatureVerification do
 
         request.headers.merge!(fake_request.headers)
 
-        stub_request(:get, 'http://localhost:5000/actor#main-key').to_raise(Mastodon::HostValidationError)
+        stub_request(:get, 'http://localhost:5000/actor').to_raise(Mastodon::HostValidationError)
       end
 
       describe '#signed_request?' do

--- a/spec/controllers/concerns/signature_verification_spec.rb
+++ b/spec/controllers/concerns/signature_verification_spec.rb
@@ -133,7 +133,7 @@ describe SignatureVerification do
       before do
         get :success
 
-        fake_request = Request.new(:get, request.url + '/../success')
+        fake_request = Request.new(:get, 'http://test.host/subdir/../success')
         fake_request.on_behalf_of(author)
 
         request.headers.merge!(fake_request.headers)

--- a/spec/controllers/concerns/signature_verification_spec.rb
+++ b/spec/controllers/concerns/signature_verification_spec.rb
@@ -129,6 +129,37 @@ describe SignatureVerification do
       end
     end
 
+    context 'with non-normalized URL' do
+      before do
+        get :success
+
+        fake_request = Request.new(:get, request.url + '/../success')
+        fake_request.on_behalf_of(author)
+
+        request.headers.merge!(fake_request.headers)
+
+        allow(controller).to receive(:actor_refresh_key!).and_return(author)
+      end
+
+      describe '#build_signed_string' do
+        it 'includes the normalized request path' do
+          expect(controller.send(:build_signed_string)).to start_with "(request-target): get /success\n"
+        end
+      end
+
+      describe '#signed_request?' do
+        it 'returns true' do
+          expect(controller.signed_request?).to be true
+        end
+      end
+
+      describe '#signed_request_actor' do
+        it 'returns an account' do
+          expect(controller.signed_request_account).to eq author
+        end
+      end
+    end
+
     context 'with request with unparsable Date header' do
       before do
         get :success

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -95,7 +95,7 @@ describe Request do
       end
     end
 
-    context 'with escape sequence in path' do
+    context 'with unnormalized URL' do
       let(:url) { 'HTTP://EXAMPLE.com:80/foo%41%3A?bar=%41%3A#baz' }
 
       before do

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -132,6 +132,26 @@ describe Request do
         end
       end
     end
+
+    context 'with non-ASCII URL' do
+      let(:url) { 'http://éxample:80/föo?bär=1' }
+
+      before do
+        stub_request(:get, 'http://xn--xample-9ua/f%C3%B6o?b%C3%A4r=1')
+      end
+
+      it 'IDN-encodes host' do
+        subject.perform do |response|
+          expect(response.request.uri.authority).to eq 'xn--xample-9ua'
+        end
+      end
+
+      it 'percent-escapes path and query string' do
+        subject.perform
+
+        expect(a_request(:get, 'http://xn--xample-9ua/f%C3%B6o?b%C3%A4r=1')).to have_been_made
+      end
+    end
   end
 
   describe "response's body_with_limit method" do


### PR DESCRIPTION
`Request#perform` invokes `Addressable::URI#normalize` on the requested URL, so the HTTP client may end up requesting a slightly different than requested.

This is usually harmless, but it sometimes causes trouble in practice. As mentioned in #14983, link previews for articles on [The Guardian](https://www.theguardian.com) have no image. The `og:image` tag on article pages refers to URLs on https://i.guim.co.uk/img/... and includes a query string argument `overlay-align=bottom%2Cleft`. `#normalize` changes this to `overlay-align=bottom,left`, but this breaks the URL.

The behaviour of i.guim.co.uk is unusual, but AFAICT The Guardian does not violate the HTTP 1.1 spec. [RFC 26216 section 3.2.3](https://datatracker.ietf.org/doc/html/rfc2616#section-3.2.3) mentions that characters outside the _reserved_ and _unsafe_ may be optionally percent-encoded. `,` is in the _reserved_ set, so I assume it cannot just be percent-encoded/decoded.

In any case, I don't see why a HTTP client should change the URL it is asked to fetch. If we want to fix up e.g. user-provided URLs typed into statuses, I think we should do it elsewhere.