### PR TITLE
Limit the anchor width on the navigation panel

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2963,6 +2963,7 @@ $ui-header-height: 55px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
 
   & > a {
     flex: 0 0 auto;


### PR DESCRIPTION
On the default theme, the navigation panel anchors stretched all the way to the full width of the navigation panel. Because the background of the anchor element is either transparent or the same as the navigation panel. Keep in mind that the anchor only changes text color when mouse is over the element, i.e. the background color of the anchor element doesn't change when mouse is over it. It appears those areas on the right sides are "empty". This constantly triggers accidental clicks if the mouse pointer is rested on visually empty area of the navigation panel. 

![image](https://github.com/mastodon/mastodon/assets/9455555/194b5830-5a76-421a-8437-1e0f2f9490e6)

Unless this is an intentional design, it would be better to limit the width of the anchor to only the text children of itself. Therefore we only allow clicks when the mouse pointer is actually on the text. This reduces a lot of accidental clicks on the navigation panel.

This is what it looks like after the change on three different screen width:
navigation panel shrink to icons(no changes):
![image](https://github.com/mastodon/mastodon/assets/9455555/9bb5d525-cf59-4209-b5c1-61c0f1d63196)

two column layout with navigation panel showing both icon and text:
![image](https://github.com/mastodon/mastodon/assets/9455555/7f517dae-28a5-4e14-83b3-9fbfa50c1879)
 
three column layout with navigation panel showing both icon and text:
![image](https://github.com/mastodon/mastodon/assets/9455555/aa83274a-7942-47de-8cf5-d3ac46c66201)


