### PR TITLE
Fix: Streaming server memory leak in HTTP EventSource cleanup

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -864,10 +864,11 @@ const startServer = async () => {
    * @param {function(): void} [closeHandler]
    * @returns {function(string[]): void}
    */
-  const streamHttpEnd = (req, closeHandler = undefined) => (ids) => {
+
+  const streamHttpEnd = (req, closeHandler = undefined) => (ids, listener) => {
     req.on('close', () => {
       ids.forEach(id => {
-        unsubscribe(id);
+        unsubscribe(id, listener);
       });
 
       if (closeHandler) {

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -225,7 +225,7 @@ const startServer = async () => {
   /**
    * @callback SubscriptionListener
    * @param {ReturnType<parseJSON>} json of the message
-   * @returns voids
+   * @returns void
    */
 
   /**

--- a/streaming/index.js
+++ b/streaming/index.js
@@ -223,8 +223,14 @@ const startServer = async () => {
   };
 
   /**
+   * @callback SubscriptionListener
+   * @param {ReturnType<parseJSON>} json of the message
+   * @returns voids
+   */
+
+  /**
    * @param {string} channel
-   * @param {function(string): void} callback
+   * @param {SubscriptionListener} callback
    */
   const subscribe = (channel, callback) => {
     log.silly(`Adding listener for ${channel}`);
@@ -241,7 +247,7 @@ const startServer = async () => {
 
   /**
    * @param {string} channel
-   * @param {function(Object<string, any>): void} callback
+   * @param {SubscriptionListener} callback
    */
   const unsubscribe = (channel, callback) => {
     log.silly(`Removing listener for ${channel}`);
@@ -613,9 +619,9 @@ const startServer = async () => {
    * @param {string[]} ids
    * @param {any} req
    * @param {function(string, string): void} output
-   * @param {function(string[], function(string): void): void} attachCloseHandler
+   * @param {undefined | function(string[], SubscriptionListener): void} attachCloseHandler
    * @param {boolean=} needsFiltering
-   * @returns {function(object): void}
+   * @returns {SubscriptionListener}
    */
   const streamFrom = (ids, req, output, attachCloseHandler, needsFiltering = false) => {
     const accountId = req.accountId || req.remoteAddress;
@@ -633,6 +639,7 @@ const startServer = async () => {
     // The listener used to process each message off the redis subscription,
     // message here is an object with an `event` and `payload` property. Some
     // events also include a queued_at value, but this is being removed shortly.
+    /** @type {SubscriptionListener} */
     const listener = message => {
       const { event, payload } = message;
 
@@ -825,7 +832,7 @@ const startServer = async () => {
       subscribe(`${redisPrefix}${id}`, listener);
     });
 
-    if (attachCloseHandler) {
+    if (typeof attachCloseHandler === 'function') {
       attachCloseHandler(ids.map(id => `${redisPrefix}${id}`), listener);
     }
 
@@ -862,7 +869,7 @@ const startServer = async () => {
   /**
    * @param {any} req
    * @param {function(): void} [closeHandler]
-   * @returns {function(string[]): void}
+   * @returns {function(string[], SubscriptionListener): void}
    */
 
   const streamHttpEnd = (req, closeHandler = undefined) => (ids, listener) => {
@@ -1132,7 +1139,7 @@ const startServer = async () => {
    * @typedef WebSocketSession
    * @property {any} socket
    * @property {any} request
-   * @property {Object.<string, { listener: function(string): void, stopHeartbeat: function(): void }>} subscriptions
+   * @property {Object.<string, { listener: SubscriptionListener, stopHeartbeat: function(): void }>} subscriptions
    */
 
   /**


### PR DESCRIPTION
This was discovered in #24949, but never got the attention it needed. This pulls the fix out into a separate PR: https://github.com/mastodon/mastodon/pull/24949/commits/74b22f2af7eacf3eb46516f943fd135b71736d41

Essentially when EventSource streams ended, they failed to actually remove the listener from subscription callbacks/listeners invoked by Redis receiving a new event.

The change to `attachCloseHandler` was just to ensure type safety (it was giving a type assert when trying to verify I'd correctly handled the unsubscribe correctly everywhere):
```diff
-    if (attachCloseHandler) {
+    if (typeof attachCloseHandler === 'function') {
```