### PR TITLE
Fix timeout on invalid set of exclusionary parameters in `/api/v1/timelines/public`

### DIFF
--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -45,11 +45,11 @@ class PublicFeed
   end
 
   def local_only?
-    options[:local]
+    options[:local] && !options[:remote]
   end
 
   def remote_only?
-    options[:remote]
+    options[:remote] && !options[:local]
   end
 
   def account?

--- a/spec/requests/api/v1/timelines/public_spec.rb
+++ b/spec/requests/api/v1/timelines/public_spec.rb
@@ -56,6 +56,13 @@ describe 'Public' do
         it_behaves_like 'a successful request to the public timeline'
       end
 
+      context 'with local and remote params' do
+        let(:params) { { local: true, remote: true } }
+        let(:expected_statuses) { [local_status, remote_status, media_status] }
+
+        it_behaves_like 'a successful request to the public timeline'
+      end
+
       context 'with only_media param' do
         let(:params) { { only_media: true } }
         let(:expected_statuses) { [media_status] }


### PR DESCRIPTION
This PR is an attempt to fix #22024.

I'm not quite sure this solves the timeout problem as I can't replicate it locally.

With this change, both `local_only?` and `remote_only?` return false, as if no parameter were given, or as if both `remote` and `local` were `false`.

I'm not quite sure this is the best approach, maybe returning HTTP 400 as suggested in the issue?

I appreciate any suggestions!
