### PR TITLE
Refactor: replace whitelist_mode mentions with limited_federation_mode

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -589,7 +589,7 @@ Style/FetchEnvVar:
     - 'app/lib/translation_service.rb'
     - 'config/environments/development.rb'
     - 'config/environments/production.rb'
-    - 'config/initializers/2_whitelist_mode.rb'
+    - 'config/initializers/2_limited_federation_mode.rb'
     - 'config/initializers/blacklists.rb'
     - 'config/initializers/cache_buster.rb'
     - 'config/initializers/content_security_policy.rb'

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -12,7 +12,7 @@ class AccountsController < ApplicationController
   before_action :require_account_signature!, if: -> { request.format == :json && authorized_fetch_mode? }
 
   skip_around_action :set_locale, if: -> { [:json, :rss].include?(request.format&.to_sym) }
-  skip_before_action :require_functional!, unless: :whitelist_mode?
+  skip_before_action :require_functional!, unless: :limited_federation_mode?
 
   def show
     respond_to do |format|

--- a/app/controllers/admin/instances_controller.rb
+++ b/app/controllers/admin/instances_controller.rb
@@ -65,7 +65,7 @@ module Admin
     end
 
     def filtered_instances
-      InstanceFilter.new(whitelist_mode? ? { allowed: true } : filter_params).results
+      InstanceFilter.new(limited_federation_mode? ? { allowed: true } : filter_params).results
     end
 
     def filter_params

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -8,7 +8,7 @@ class Api::BaseController < ApplicationController
   include AccessTokenTrackingConcern
   include ApiCachingConcern
 
-  skip_before_action :require_functional!, unless: :whitelist_mode?
+  skip_before_action :require_functional!, unless: :limited_federation_mode?
 
   before_action :require_authenticated_user!, if: :disallow_unauthenticated_api_access?
   before_action :require_not_suspended!
@@ -150,7 +150,7 @@ class Api::BaseController < ApplicationController
   end
 
   def disallow_unauthenticated_api_access?
-    ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] == 'true' || Rails.configuration.x.whitelist_mode
+    ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] == 'true' || Rails.configuration.x.limited_federation_mode
   end
 
   private

--- a/app/controllers/api/v1/instances/activity_controller.rb
+++ b/app/controllers/api/v1/instances/activity_controller.rb
@@ -3,7 +3,7 @@
 class Api::V1::Instances::ActivityController < Api::BaseController
   before_action :require_enabled_api!
 
-  skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
+  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
 
   vary_by ''
 
@@ -33,6 +33,6 @@ class Api::V1::Instances::ActivityController < Api::BaseController
   end
 
   def require_enabled_api!
-    head 404 unless Setting.activity_api_enabled && !whitelist_mode?
+    head 404 unless Setting.activity_api_enabled && !limited_federation_mode?
   end
 end

--- a/app/controllers/api/v1/instances/domain_blocks_controller.rb
+++ b/app/controllers/api/v1/instances/domain_blocks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Instances::DomainBlocksController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
+  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
 
   before_action :require_enabled_api!
   before_action :set_domain_blocks

--- a/app/controllers/api/v1/instances/extended_descriptions_controller.rb
+++ b/app/controllers/api/v1/instances/extended_descriptions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Instances::ExtendedDescriptionsController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
+  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
   skip_around_action :set_locale
 
   before_action :set_extended_description
@@ -10,7 +10,7 @@ class Api::V1::Instances::ExtendedDescriptionsController < Api::BaseController
 
   # Override `current_user` to avoid reading session cookies unless in whitelist mode
   def current_user
-    super if whitelist_mode?
+    super if limited_federation_mode?
   end
 
   def show

--- a/app/controllers/api/v1/instances/peers_controller.rb
+++ b/app/controllers/api/v1/instances/peers_controller.rb
@@ -3,14 +3,14 @@
 class Api::V1::Instances::PeersController < Api::BaseController
   before_action :require_enabled_api!
 
-  skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
+  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
   skip_around_action :set_locale
 
   vary_by ''
 
   # Override `current_user` to avoid reading session cookies unless in whitelist mode
   def current_user
-    super if whitelist_mode?
+    super if limited_federation_mode?
   end
 
   def index
@@ -21,6 +21,6 @@ class Api::V1::Instances::PeersController < Api::BaseController
   private
 
   def require_enabled_api!
-    head 404 unless Setting.peers_api_enabled && !whitelist_mode?
+    head 404 unless Setting.peers_api_enabled && !limited_federation_mode?
   end
 end

--- a/app/controllers/api/v1/instances/privacy_policies_controller.rb
+++ b/app/controllers/api/v1/instances/privacy_policies_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Instances::PrivacyPoliciesController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
+  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
 
   before_action :set_privacy_policy
 

--- a/app/controllers/api/v1/instances/rules_controller.rb
+++ b/app/controllers/api/v1/instances/rules_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Instances::RulesController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
+  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
   skip_around_action :set_locale
 
   before_action :set_rules
@@ -10,7 +10,7 @@ class Api::V1::Instances::RulesController < Api::BaseController
 
   # Override `current_user` to avoid reading session cookies unless in whitelist mode
   def current_user
-    super if whitelist_mode?
+    super if limited_federation_mode?
   end
 
   def index

--- a/app/controllers/api/v1/instances/translation_languages_controller.rb
+++ b/app/controllers/api/v1/instances/translation_languages_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Instances::TranslationLanguagesController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
+  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
 
   before_action :set_languages
 

--- a/app/controllers/api/v1/instances_controller.rb
+++ b/app/controllers/api/v1/instances_controller.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class Api::V1::InstancesController < Api::BaseController
-  skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
+  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
   skip_around_action :set_locale
 
   vary_by ''
 
   # Override `current_user` to avoid reading session cookies unless in whitelist mode
   def current_user
-    super if whitelist_mode?
+    super if limited_federation_mode?
   end
 
   def show

--- a/app/controllers/api/v1/peers/search_controller.rb
+++ b/app/controllers/api/v1/peers/search_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Peers::SearchController < Api::BaseController
   before_action :require_enabled_api!
   before_action :set_domains
 
-  skip_before_action :require_authenticated_user!, unless: :whitelist_mode?
+  skip_before_action :require_authenticated_user!, unless: :limited_federation_mode?
   skip_around_action :set_locale
 
   vary_by ''
@@ -17,7 +17,7 @@ class Api::V1::Peers::SearchController < Api::BaseController
   private
 
   def require_enabled_api!
-    head 404 unless Setting.peers_api_enabled && !whitelist_mode?
+    head 404 unless Setting.peers_api_enabled && !limited_federation_mode?
   end
 
   def set_domains

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
   helper_method :use_seamless_external_login?
   helper_method :omniauth_only?
   helper_method :sso_account_settings
-  helper_method :whitelist_mode?
+  helper_method :limited_federation_mode?
   helper_method :body_class_string
   helper_method :skip_csrf_meta_tags?
 
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::Base
   private
 
   def authorized_fetch_mode?
-    ENV['AUTHORIZED_FETCH'] == 'true' || Rails.configuration.x.whitelist_mode
+    ENV['AUTHORIZED_FETCH'] == 'true' || Rails.configuration.x.limited_federation_mode
   end
 
   def public_fetch_mode?

--- a/app/controllers/concerns/account_owned_concern.rb
+++ b/app/controllers/concerns/account_owned_concern.rb
@@ -4,7 +4,7 @@ module AccountOwnedConcern
   extend ActiveSupport::Concern
 
   included do
-    before_action :authenticate_user!, if: -> { whitelist_mode? && request.format != :json }
+    before_action :authenticate_user!, if: -> { limited_federation_mode? && request.format != :json }
     before_action :set_account, if: :account_required?
     before_action :check_account_approval, if: :account_required?
     before_action :check_account_suspension, if: :account_required?

--- a/app/controllers/concerns/api_caching_concern.rb
+++ b/app/controllers/concerns/api_caching_concern.rb
@@ -8,6 +8,6 @@ module ApiCachingConcern
   end
 
   def cache_even_if_authenticated!
-    expires_in(5.minutes, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.day) unless whitelist_mode?
+    expires_in(5.minutes, public: true, stale_while_revalidate: 30.seconds, stale_if_error: 1.day) unless limited_federation_mode?
   end
 end

--- a/app/controllers/follower_accounts_controller.rb
+++ b/app/controllers/follower_accounts_controller.rb
@@ -10,7 +10,7 @@ class FollowerAccountsController < ApplicationController
   before_action :require_account_signature!, if: -> { request.format == :json && authorized_fetch_mode? }
 
   skip_around_action :set_locale, if: -> { request.format == :json }
-  skip_before_action :require_functional!, unless: :whitelist_mode?
+  skip_before_action :require_functional!, unless: :limited_federation_mode?
 
   def index
     respond_to do |format|

--- a/app/controllers/following_accounts_controller.rb
+++ b/app/controllers/following_accounts_controller.rb
@@ -10,7 +10,7 @@ class FollowingAccountsController < ApplicationController
   before_action :require_account_signature!, if: -> { request.format == :json && authorized_fetch_mode? }
 
   skip_around_action :set_locale, if: -> { request.format == :json }
-  skip_before_action :require_functional!, unless: :whitelist_mode?
+  skip_before_action :require_functional!, unless: :limited_federation_mode?
 
   def index
     respond_to do |format|

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -3,9 +3,9 @@
 class MediaController < ApplicationController
   include Authorization
 
-  skip_before_action :require_functional!, unless: :whitelist_mode?
+  skip_before_action :require_functional!, unless: :limited_federation_mode?
 
-  before_action :authenticate_user!, if: :whitelist_mode?
+  before_action :authenticate_user!, if: :limited_federation_mode?
   before_action :set_media_attachment
   before_action :verify_permitted_status!
   before_action :check_playable, only: :player

--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -8,7 +8,7 @@ class MediaProxyController < ApplicationController
 
   skip_before_action :require_functional!
 
-  before_action :authenticate_user!, if: :whitelist_mode?
+  before_action :authenticate_user!, if: :limited_federation_mode?
 
   rescue_from ActiveRecord::RecordInvalid, with: :not_found
   rescue_from Mastodon::UnexpectedResponseError, with: :not_found

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -17,7 +17,7 @@ class StatusesController < ApplicationController
   after_action :set_link_headers
 
   skip_around_action :set_locale, if: -> { request.format == :json }
-  skip_before_action :require_functional!, only: [:show, :embed], unless: :whitelist_mode?
+  skip_before_action :require_functional!, only: [:show, :embed], unless: :limited_federation_mode?
 
   content_security_policy only: :embed do |policy|
     policy.frame_ancestors(false)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -10,13 +10,13 @@ class TagsController < ApplicationController
   vary_by -> { public_fetch_mode? ? 'Accept, Accept-Language, Cookie' : 'Accept, Accept-Language, Cookie, Signature' }
 
   before_action :require_account_signature!, if: -> { request.format == :json && authorized_fetch_mode? }
-  before_action :authenticate_user!, if: :whitelist_mode?
+  before_action :authenticate_user!, if: :limited_federation_mode?
   before_action :set_local
   before_action :set_tag
   before_action :set_statuses, if: -> { request.format == :rss }
   before_action :set_instance_presenter
 
-  skip_before_action :require_functional!, unless: :whitelist_mode?
+  skip_before_action :require_functional!, unless: :limited_federation_mode?
 
   def show
     respond_to do |format|

--- a/app/helpers/domain_control_helper.rb
+++ b/app/helpers/domain_control_helper.rb
@@ -10,14 +10,14 @@ module DomainControlHelper
                uri_or_domain
              end
 
-    if whitelist_mode?
+    if limited_federation_mode?
       !DomainAllow.allowed?(domain)
     else
       DomainBlock.blocked?(domain)
     end
   end
 
-  def whitelist_mode?
-    Rails.configuration.x.whitelist_mode
+  def limited_federation_mode?
+    Rails.configuration.x.limited_federation_mode
   end
 end

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -22,7 +22,7 @@ class InitialStateSerializer < ActiveModel::Serializer
       repository: Mastodon::Version.repository,
       source_url: instance_presenter.source_url,
       version: instance_presenter.version,
-      limited_federation_mode: Rails.configuration.x.whitelist_mode,
+      limited_federation_mode: Rails.configuration.x.limited_federation_mode,
       mascot: instance_presenter.mascot&.file&.url,
       profile_directory: Setting.profile_directory,
       trends_enabled: Setting.trends,

--- a/app/services/concerns/payloadable.rb
+++ b/app/services/concerns/payloadable.rb
@@ -23,6 +23,6 @@ module Payloadable
   end
 
   def signing_enabled?
-    ENV['AUTHORIZED_FETCH'] != 'true' && !Rails.configuration.x.whitelist_mode
+    ENV['AUTHORIZED_FETCH'] != 'true' && !Rails.configuration.x.limited_federation_mode
   end
 end

--- a/app/services/unallow_domain_service.rb
+++ b/app/services/unallow_domain_service.rb
@@ -4,7 +4,7 @@ class UnallowDomainService < BaseService
   include DomainControlHelper
 
   def call(domain_allow)
-    suspend_accounts!(domain_allow.domain) if whitelist_mode?
+    suspend_accounts!(domain_allow.domain) if limited_federation_mode?
 
     domain_allow.destroy
   end

--- a/app/views/admin/instances/index.html.haml
+++ b/app/views/admin/instances/index.html.haml
@@ -5,7 +5,7 @@
   = javascript_pack_tag 'admin', async: true, crossorigin: 'anonymous'
 
 - content_for :heading_actions do
-  - if whitelist_mode?
+  - if limited_federation_mode?
     = link_to t('admin.domain_allows.add_new'), new_admin_domain_allow_path, class: 'button', id: 'add-instance-button'
     = link_to t('admin.domain_allows.export'), export_admin_export_domain_allows_path(format: :csv), class: 'button'
     = link_to t('admin.domain_allows.import'), new_admin_export_domain_allow_path, class: 'button'
@@ -20,7 +20,7 @@
     %ul
       %li= filter_link_to t('admin.instances.moderation.all'), limited: nil
 
-      - unless whitelist_mode?
+      - unless limited_federation_mode?
         %li= filter_link_to t('admin.instances.moderation.limited'), limited: '1'
 
   .filter-subset
@@ -30,7 +30,7 @@
       %li= filter_link_to t('admin.instances.delivery.failing'), availability: 'failing'
       %li= filter_link_to t('admin.instances.delivery.unavailable'), availability: 'unavailable'
 
-- unless whitelist_mode?
+- unless limited_federation_mode?
   = form_tag admin_instances_url, method: 'GET', class: 'simple_form' do
     .fields-group
       - InstanceFilter::KEYS.each do |key|

--- a/app/views/admin/instances/show.html.haml
+++ b/app/views/admin/instances/show.html.haml
@@ -36,7 +36,7 @@
 
 %h3= t('admin.instances.content_policies.title')
 
-- if whitelist_mode?
+- if limited_federation_mode?
   %p= t('admin.instances.content_policies.limited_federation_mode_description_html')
 
   - if @instance.domain_allow

--- a/config/initializers/2_limited_federation_mode.rb
+++ b/config/initializers/2_limited_federation_mode.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.x.limited_federation_mode = (ENV['LIMITED_FEDERATION_MODE'] || ENV['WHITELIST_MODE']) == 'true'
+
+  warn 'WARN: The environment variable WHITELIST_MODE has been replaced with LIMITED_FEDERATION_MODE, you should rename this environment variable in your configuration.' if ENV.key?('WHITELIST_MODE')
+end

--- a/config/initializers/2_whitelist_mode.rb
+++ b/config/initializers/2_whitelist_mode.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-Rails.application.configure do
-  config.x.whitelist_mode = (ENV['LIMITED_FEDERATION_MODE'] || ENV['WHITELIST_MODE']) == 'true'
-end

--- a/config/navigation.rb
+++ b/config/navigation.rb
@@ -40,7 +40,7 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :accounts, safe_join([fa_icon('users fw'), t('admin.accounts.title')]), admin_accounts_path(origin: 'local'), highlights_on: %r{/admin/accounts|/admin/pending_accounts|/admin/disputes|/admin/users}, if: -> { current_user.can?(:manage_users) }
       s.item :invites, safe_join([fa_icon('user-plus fw'), t('admin.invites.title')]), admin_invites_path, if: -> { current_user.can?(:manage_invites) }
       s.item :follow_recommendations, safe_join([fa_icon('user-plus fw'), t('admin.follow_recommendations.title')]), admin_follow_recommendations_path, highlights_on: %r{/admin/follow_recommendations}, if: -> { current_user.can?(:manage_taxonomies) }
-      s.item :instances, safe_join([fa_icon('cloud fw'), t('admin.instances.title')]), admin_instances_path(limited: whitelist_mode? ? nil : '1'), highlights_on: %r{/admin/instances|/admin/domain_blocks|/admin/domain_allows}, if: -> { current_user.can?(:manage_federation) }
+      s.item :instances, safe_join([fa_icon('cloud fw'), t('admin.instances.title')]), admin_instances_path(limited: limited_federation_mode? ? nil : '1'), highlights_on: %r{/admin/instances|/admin/domain_blocks|/admin/domain_allows}, if: -> { current_user.can?(:manage_federation) }
       s.item :email_domain_blocks, safe_join([fa_icon('envelope fw'), t('admin.email_domain_blocks.title')]), admin_email_domain_blocks_path, highlights_on: %r{/admin/email_domain_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :ip_blocks, safe_join([fa_icon('ban fw'), t('admin.ip_blocks.title')]), admin_ip_blocks_path, highlights_on: %r{/admin/ip_blocks}, if: -> { current_user.can?(:manage_blocks) }
       s.item :action_logs, safe_join([fa_icon('bars fw'), t('admin.action_logs.title')]), admin_action_logs_path, if: -> { current_user.can?(:view_audit_log) }
@@ -54,7 +54,7 @@ SimpleNavigation::Configuration.run do |navigation|
       s.item :announcements, safe_join([fa_icon('bullhorn fw'), t('admin.announcements.title')]), admin_announcements_path, highlights_on: %r{/admin/announcements}, if: -> { current_user.can?(:manage_announcements) }
       s.item :custom_emojis, safe_join([fa_icon('smile-o fw'), t('admin.custom_emojis.title')]), admin_custom_emojis_path, highlights_on: %r{/admin/custom_emojis}, if: -> { current_user.can?(:manage_custom_emojis) }
       s.item :webhooks, safe_join([fa_icon('inbox fw'), t('admin.webhooks.title')]), admin_webhooks_path, highlights_on: %r{/admin/webhooks}, if: -> { current_user.can?(:manage_webhooks) }
-      s.item :relays, safe_join([fa_icon('exchange fw'), t('admin.relays.title')]), admin_relays_path, highlights_on: %r{/admin/relays}, if: -> { !whitelist_mode? && current_user.can?(:manage_federation) }
+      s.item :relays, safe_join([fa_icon('exchange fw'), t('admin.relays.title')]), admin_relays_path, highlights_on: %r{/admin/relays}, if: -> { !limited_federation_mode? && current_user.can?(:manage_federation) }
     end
 
     n.item :sidekiq, safe_join([fa_icon('diamond fw'), 'Sidekiq']), sidekiq_path, link_html: { target: 'sidekiq' }, if: -> { current_user.can?(:view_devops) }

--- a/spec/requests/cache_spec.rb
+++ b/spec/requests/cache_spec.rb
@@ -508,12 +508,12 @@ describe 'Caching behavior' do
   context 'when enabling LIMITED_FEDERATION_MODE mode' do
     around do |example|
       ClimateControl.modify LIMITED_FEDERATION_MODE: 'true' do
-        old_whitelist_mode = Rails.configuration.x.whitelist_mode
-        Rails.configuration.x.whitelist_mode = true
+        old_limited_federation_mode = Rails.configuration.x.limited_federation_mode
+        Rails.configuration.x.limited_federation_mode = true
 
         example.run
 
-        Rails.configuration.x.whitelist_mode = old_whitelist_mode
+        Rails.configuration.x.limited_federation_mode = old_limited_federation_mode
       end
     end
 

--- a/spec/services/unallow_domain_service_spec.rb
+++ b/spec/services/unallow_domain_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe UnallowDomainService, type: :service do
 
   context 'with limited federation mode' do
     before do
-      allow(Rails.configuration.x).to receive(:whitelist_mode).and_return(true)
+      allow(Rails.configuration.x).to receive(:limited_federation_mode).and_return(true)
     end
 
     describe '#call' do
@@ -40,7 +40,7 @@ RSpec.describe UnallowDomainService, type: :service do
 
   context 'without limited federation mode' do
     before do
-      allow(Rails.configuration.x).to receive(:whitelist_mode).and_return(false)
+      allow(Rails.configuration.x).to receive(:limited_federation_mode).and_return(false)
     end
 
     describe '#call' do


### PR DESCRIPTION
The environment variable had already been renamed in the [3.2.0 release](https://github.com/mastodon/mastodon/releases/tag/v3.2.0#:~:text=Environment%20variables%20changed%20(old%20versions%20continue%20to%20work)%3A), this changeset just updates the language across the codebase to be less racially charged. 

Additionally, if instances are still configured with the $WHITELIST_MODE environment variable, we now print a message asking people to migrate to LIMITED_FEDERATION_MODE instead.

I know Mastodon often has an internal versus external language thing going on, but in this case there's zero reason to have the internal language not match the external language, and this makes the codebase safer for BIPOC to read and contribute to.