### PR TITLE
Change hashtags at the end of the post to render out-of-band

### DIFF
--- a/app/helpers/formatting_helper.rb
+++ b/app/helpers/formatting_helper.rb
@@ -15,7 +15,7 @@ module FormattingHelper
   module_function :extract_status_plain_text
 
   def status_content_format(status)
-    html_aware_format(status.text, status.local?, preloaded_accounts: [status.account] + (status.respond_to?(:active_mentions) ? status.active_mentions.map(&:account) : []))
+    html_aware_format(status.text, status.local?, strip_rich_entities: true, preloaded_accounts: [status.account] + (status.respond_to?(:active_mentions) ? status.active_mentions.map(&:account) : []))
   end
 
   def rss_status_content_format(status)


### PR DESCRIPTION
People will often put all of the hashtags relevant to the post at the end of the post, but it looks spammy. Others avoid using hashtags this way because it looks spammy, and therefore lose out on discoverability. Since hashtags on Mastodon are out-of-band on the protocol and API level anyway, we can continue to allow them to be input the usual way but render them out-of-band in a more clean manner.

![Screen Shot 2023-08-06 at 21 38 23](https://github.com/mastodon/mastodon/assets/184731/e81edc2e-6185-414d-860d-5d1519178820)

___

Fixes MAS-141