### PR TITLE
Change /api/v1/peers/search to be case-insensitive when using Elasticsearch

### DIFF
--- a/app/controllers/api/v1/peers/search_controller.rb
+++ b/app/controllers/api/v1/peers/search_controller.rb
@@ -27,7 +27,7 @@ class Api::V1::Peers::SearchController < Api::BaseController
       @domains = InstancesIndex.query(function_score: {
         query: {
           prefix: {
-            domain: params[:q],
+            domain: TagManager.instance.normalize_domain(params[:q].strip),
           },
         },
 


### PR DESCRIPTION
Pre-normalize the input. This may cause issues for partial IDNs, but less so than what we had before.