### PR TITLE
change column link to add a better keyboard focus indicator

### DIFF
--- a/app/javascript/styles/mastodon/basics.scss
+++ b/app/javascript/styles/mastodon/basics.scss
@@ -164,7 +164,7 @@ body {
 a {
   &:focus {
     border-radius: 4px;
-    outline: $ui-button-icon-focus-outline;
+    outline: $ui-button-focus-outline;
   }
 
   &:focus:not(:focus-visible) {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3283,6 +3283,8 @@ $ui-header-height: 55px;
   text-decoration: none;
   overflow: hidden;
   white-space: nowrap;
+  border: 0;
+  border-left: 4px solid transparent;
 
   &:hover,
   &:focus,
@@ -3292,6 +3294,11 @@ $ui-header-height: 55px;
 
   &:focus {
     outline: 0;
+  }
+
+  &:focus-visible {
+    border-color: $ui-button-focus-outline-color;
+    border-radius: 0;
   }
 
   &--transparent {
@@ -3956,7 +3963,7 @@ a.status-card {
   }
 
   &:focus-visible {
-    outline: $ui-button-icon-focus-outline;
+    outline: $ui-button-focus-outline;
   }
 
   &.active {

--- a/app/javascript/styles/mastodon/variables.scss
+++ b/app/javascript/styles/mastodon/variables.scss
@@ -43,6 +43,8 @@ $ui-highlight-color: $classic-highlight-color !default;
 $ui-button-color: $white !default;
 $ui-button-background-color: $blurple-500 !default;
 $ui-button-focus-background-color: $blurple-600 !default;
+$ui-button-focus-outline-color: $blurple-400 !default;
+$ui-button-focus-outline: solid 2px $ui-button-focus-outline-color !default;
 
 $ui-button-secondary-color: $grey-100 !default;
 $ui-button-secondary-border-color: $grey-100 !default;
@@ -57,7 +59,7 @@ $ui-button-tertiary-focus-color: $white !default;
 $ui-button-destructive-background-color: $red-500 !default;
 $ui-button-destructive-focus-background-color: $red-600 !default;
 
-$ui-button-icon-focus-outline: solid 2px $blurple-400 !default;
+$ui-button-icon-focus-outline: $ui-button-focus-outline !default;
 $ui-button-icon-hover-background-color: rgba(140, 141, 255, 40%) !default;
 
 // Variables for texts


### PR DESCRIPTION
resolves  #12275 #11319

Related issues: https://github.com/mastodon/mastodon/issues/19931 #19928

This uses a similar style to new notification items on the notifications page.

![2023-08-01 21 22 52](https://github.com/mastodon/mastodon/assets/17292/c5daa2a1-41ee-422e-98b3-bc3685ce9bf1)

light
<img width="216" alt="CleanShot 2023-08-01 at 19 59 14@2x" src="https://github.com/mastodon/mastodon/assets/17292/74addc24-2909-4c54-a5a2-527f07bb03fc">

dark
<img width="189" alt="CleanShot 2023-08-01 at 19 59 37@2x" src="https://github.com/mastodon/mastodon/assets/17292/72bacb90-6a2c-4eff-9876-05a5e1271fe0">

advanced
<img width="352" alt="CleanShot 2023-08-01 at 19 59 56@2x" src="https://github.com/mastodon/mastodon/assets/17292/9b33f2a8-6d4a-4e34-96d9-4b8da96918b3">

