### PR TITLE
Fix request URL normalisation for bare domain and 8-bit characters

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -76,8 +76,8 @@ class Request
     HTTP::URI.new(
       scheme: uri.normalized_scheme,
       authority: uri.normalized_authority,
-      path: Addressable::URI.normalize_path(uri.path).presence || '/',
-      query: uri.query
+      path: Addressable::URI.normalize_path(encode_non_ascii(uri.path)).presence || '/',
+      query: encode_non_ascii(uri.query)
     )
   end
 
@@ -149,6 +149,12 @@ class Request
       end
 
       %w(http https).include?(parsed_url.scheme) && parsed_url.host.present?
+    end
+
+    NON_ASCII_PATTERN = /[^\x00-\x7F]+/
+
+    def encode_non_ascii(str)
+      str&.gsub(NON_ASCII_PATTERN) { |substr| CGI.escape(substr.encode(Encoding::UTF_8)) }
     end
 
     def http_client

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -76,7 +76,7 @@ class Request
     HTTP::URI.new(
       scheme: uri.normalized_scheme,
       authority: uri.normalized_authority,
-      path: Addressable::URI.normalize_path(uri.path),
+      path: Addressable::URI.normalize_path(uri.path).presence || '/',
       query: uri.query
     )
   end

--- a/spec/lib/request_spec.rb
+++ b/spec/lib/request_spec.rb
@@ -95,6 +95,27 @@ describe Request do
       end
     end
 
+    context 'with bare domain URL' do
+      let(:url) { 'http://example.com' }
+
+      before do
+        stub_request(:get, 'http://example.com')
+      end
+
+      it 'normalizes path' do
+        subject.perform do |response|
+          expect(response.request.uri.path).to eq '/'
+        end
+      end
+
+      it 'normalizes path used for request signing' do
+        subject.perform do |response|
+          headers = subject.instance_variable_get(:@headers)
+          expect(headers[Request::REQUEST_TARGET]).to eq 'get /'
+        end
+      end
+    end
+
     context 'with unnormalized URL' do
       let(:url) { 'HTTP://EXAMPLE.com:80/foo%41%3A?bar=%41%3A#baz' }
 
@@ -114,15 +135,22 @@ describe Request do
         end
       end
 
-      it 'does modify path' do
+      it 'does not modify path' do
         subject.perform do |response|
           expect(response.request.uri.path).to eq '/foo%41%3A'
         end
       end
 
-      it 'does modify query string' do
+      it 'does not modify query string' do
         subject.perform do |response|
           expect(response.request.uri.query).to eq 'bar=%41%3A'
+        end
+      end
+
+      it 'does not modify path used for request signing' do
+        subject.perform do |response|
+          headers = subject.instance_variable_get(:@headers)
+          expect(headers[Request::REQUEST_TARGET]).to eq 'get /foo%41%3A'
         end
       end
 


### PR DESCRIPTION
As mentioned in https://github.com/mastodon/mastodon/pull/26219#issuecomment-1660761265 we need to normalise an empty path to `/`.

I realised that `expect(a_request(:get, 'http://...')).to have_been_made` is not a reliable way to check exactly what was sent over the wire. The URLs are both normalised before being compared, and that defeats the purpose for this test. So I have added tests for `response.request.headline` (.e.g `GET / HTTP/1.1`) instead.

This change to the tests revealed that the new normaliser does not encode 8-bit characters. 8-bit characters are not permitted in URLs according to RFC 3986, but they sometimes occur in user input. They are not permitted raw in the HTTP request line either, so they _must_ be dealt with.

\*sigh* I hope this issue will be fixed in http.rb or Addressable, so we don't have to reinvent this wheel.