### PR TITLE
Fix: support both DATABASE_URL and DB_PASS

### DIFF
--- a/streaming/index.js
+++ b/streaming/index.js
@@ -109,6 +109,11 @@ const pgConfigFromEnv = (env) => {
 
   if (env.DATABASE_URL) {
     baseConfig = dbUrlToConfig(env.DATABASE_URL);
+
+    // Support overriding the database password in the connection URL
+    if (!baseConfig.password && env.DB_PASS) {
+      baseConfig.password = env.DB_PASS;
+    }
   } else {
     baseConfig = pgConfigs[environment];
 


### PR DESCRIPTION
This fixes https://github.com/mastodon/mastodon/issues/26288, but we do need to refactor this credential handling to be entirely consistent with Ruby/Rails