### PR TITLE
Allow spaces around commas in ALLOWED_PRIVATE_ADDRESSES

### DIFF
--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -340,7 +340,7 @@ class Request
       end
 
       def private_address_exceptions
-        @private_address_exceptions = (ENV['ALLOWED_PRIVATE_ADDRESSES'] || '').split(',').map { |addr| IPAddr.new(addr) }
+        @private_address_exceptions = (ENV['ALLOWED_PRIVATE_ADDRESSES'] || '').split(/(?:\s*,\s*|\s+)/).map { |addr| IPAddr.new(addr) }
       end
     end
   end


### PR DESCRIPTION
To be consistent with how TRUSTED_PROXY_IP is parsed:

https://github.com/mastodon/mastodon/blob/2cbdff97cedcf87f567effa782e0314c849334c6/config/environments/production.rb#L41