### PR TITLE
Add client-side timeout on resend confirmation button

### DIFF
--- a/app/javascript/packs/sign_up.js
+++ b/app/javascript/packs/sign_up.js
@@ -13,4 +13,30 @@ ready(() => {
       console.error(error);
     });
   }, 5000);
+
+  document.querySelectorAll('.timer-button').forEach(button => {
+    let counter = 30;
+
+    const container = document.createElement('span');
+
+    const updateCounter = () => {
+      container.innerText = ` (${counter})`;
+    };
+
+    updateCounter();
+
+    const countdown = setInterval(() => {
+      counter--;
+
+      if (counter === 0) {
+        button.disabled = false;
+        button.removeChild(container);
+        clearInterval(countdown);
+      } else {
+        updateCounter();
+      }
+    }, 1000);
+
+    button.appendChild(container);
+  });
 });

--- a/app/views/auth/setup/show.html.haml
+++ b/app/views/auth/setup/show.html.haml
@@ -19,6 +19,6 @@
     = f.input :email, required: true, hint: false, input_html: { 'aria-label': t('simple_form.labels.defaults.email'), autocomplete: 'off' }
 
   .actions
-    = f.submit t('auth.resend_confirmation'), class: 'button'
+    = f.button :button, t('auth.resend_confirmation'), type: :submit, class: 'button timer-button', disabled: true
 
 .form-footer= render 'auth/shared/links'


### PR DESCRIPTION
The "Check your inbox" stage of the sign-up flow will now load with a disabled "resend confirmation link" button that will be enabled after 30 seconds. During that time, the remaining time will be rendered in the button, like "Resend confirmation link (24)".