### PR TITLE
Fix light theme select option for hashtags

### DIFF
--- a/app/javascript/styles/mastodon-light/diff.scss
+++ b/app/javascript/styles/mastodon-light/diff.scss
@@ -424,6 +424,10 @@ html {
   border-bottom: 0;
 }
 
+.column-settings__hashtags .column-select__option {
+  color: $white;
+}
+
 .dashboard__quick-access,
 .focal-point__preview strong,
 .admin-wrapper .content__heading__tabs a.selected {


### PR DESCRIPTION
resolves #26303


<img width="353" alt="CleanShot 2023-08-03 at 21 09 28@2x" src="https://github.com/mastodon/mastodon/assets/17292/21be5cc8-8fae-4454-8916-d33496aace8b">
