### PR TITLE
Add Admin settings to forcefully expire invitation links

### DIFF
--- a/app/lib/vacuum/invites_vacuum.rb
+++ b/app/lib/vacuum/invites_vacuum.rb
@@ -13,13 +13,13 @@ class Vacuum::InvitesVacuum
   private
 
   def expire_invites!
-    invites = Invite.where('created_at < ?', @retention_period.ago)
+    invites = Invite.available.where('created_at < ?', @retention_period.ago)
     invites = if @max_uses.present?
                 invites.where('max_uses > ? OR max_uses IS NULL', @max_uses)
               else
                 invites.where(max_uses: nil)
               end
 
-    invites.reorder(nil).in_batches(&:expire!)
+    invites.reorder(nil).find_each(&:expire!)
   end
 end

--- a/app/lib/vacuum/invites_vacuum.rb
+++ b/app/lib/vacuum/invites_vacuum.rb
@@ -7,17 +7,17 @@ class Vacuum::InvitesVacuum
   end
 
   def perform
-    expire_invites! if retention_period?
+    expire_invites! if @retention_period.present?
   end
 
   private
 
   def expire_invites!
-    invites = Invite.where('created_at < ?', retention_period.ago)
-    invites = if max_uses.nil?
-                invites.where(max_uses: nil)
+    invites = Invite.where('created_at < ?', @retention_period.ago)
+    invites = if @max_uses.present?
+                invites.where('max_uses > ? OR max_uses IS NULL', @max_uses)
               else
-                invites.where('max_uses > ? OR max_uses IS NULL', max_uses)
+                invites.where(max_uses: nil)
               end
 
     invites.reorder(nil).in_batches(&:expire!)

--- a/app/lib/vacuum/invites_vacuum.rb
+++ b/app/lib/vacuum/invites_vacuum.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Vacuum::InvitesVacuum
+  def initialize(retention_period, max_uses)
+    @retention_period = retention_period
+    @max_uses = max_uses
+  end
+
+  def perform
+    expire_invites! if retention_period?
+  end
+
+  private
+
+  def expire_invites!
+    invites = Invite.where('created_at < ?', retention_period.ago)
+    invites = if max_uses.nil?
+                invites.where(max_uses: nil)
+              else
+                invites.where('max_uses > ? OR max_uses IS NULL', max_uses)
+              end
+
+    invites.reorder(nil).in_batches(&:expire!)
+  end
+end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -32,6 +32,8 @@ class Form::AdminSettings
     media_cache_retention_period
     content_cache_retention_period
     backups_retention_period
+    invite_expiration_period
+    invite_max_uses
     status_page_url
     captcha_enabled
   ).freeze
@@ -40,6 +42,8 @@ class Form::AdminSettings
     media_cache_retention_period
     content_cache_retention_period
     backups_retention_period
+    invite_expiration_period
+    invite_max_uses
   ).freeze
 
   BOOLEAN_KEYS = %i(
@@ -70,6 +74,7 @@ class Form::AdminSettings
   validates :show_domain_blocks, inclusion: { in: %w(disabled users all) }, if: -> { defined?(@show_domain_blocks) }
   validates :show_domain_blocks_rationale, inclusion: { in: %w(disabled users all) }, if: -> { defined?(@show_domain_blocks_rationale) }
   validates :media_cache_retention_period, :content_cache_retention_period, :backups_retention_period, numericality: { only_integer: true }, allow_blank: true, if: -> { defined?(@media_cache_retention_period) || defined?(@content_cache_retention_period) || defined?(@backups_retention_period) }
+  validates :invite_expiration_period, :invite_max_uses, numericality: { only_integer: true }, allow_blank: true, if: -> { defined?(@invite_expiration_period) || defined?(@invite_max_uses) }
   validates :site_short_description, length: { maximum: 200 }, if: -> { defined?(@site_short_description) }
   validates :status_page_url, url: true, allow_blank: true
   validate :validate_site_uploads

--- a/app/models/invite_retention_policy.rb
+++ b/app/models/invite_retention_policy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class InviteRetentionPolicy
+  def self.current
+    new
+  end
+
+  def invite_retention_period
+    retention_period Setting.invite_retention_period
+  end
+
+  def invite_max_uses
+    max_uses Setting.invite_max_uses
+  end
+
+  private
+
+  def retention_period(value)
+    value.days if value.is_a?(Integer) && value.positive?
+  end
+
+  def max_uses(value)
+    value if value.is_a?(Integer) && value.positive?
+  end
+end

--- a/app/views/admin/settings/registrations/show.html.haml
+++ b/app/views/admin/settings/registrations/show.html.haml
@@ -20,6 +20,10 @@
     .fields-row__column.fields-row__column-6.fields-group
       = f.input :require_invite_text, as: :boolean, wrapper: :with_label, disabled: !approved_registrations?
 
+  .fields-group
+    = f.input :invite_expiration_period, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
+    = f.input :invite_max_uses, wrapper: :with_block_label, input_html: { pattern: '[0-9]+' }
+
   - if captcha_available?
     .fields-group
       = f.input :captcha_enabled, as: :boolean, wrapper: :with_label, label: t('admin.settings.captcha_enabled.title'), hint: t('admin.settings.captcha_enabled.desc_html')

--- a/app/workers/scheduler/vacuum_scheduler.rb
+++ b/app/workers/scheduler/vacuum_scheduler.rb
@@ -73,6 +73,6 @@ class Scheduler::VacuumScheduler
   end
 
   def invites_retention_policy
-    InvitesRetentionPolicy.current
+    InviteRetentionPolicy.current
   end
 end

--- a/app/workers/scheduler/vacuum_scheduler.rb
+++ b/app/workers/scheduler/vacuum_scheduler.rb
@@ -25,6 +25,7 @@ class Scheduler::VacuumScheduler
       applications_vacuum,
       feeds_vacuum,
       imports_vacuum,
+      invites_vacuum,
     ]
   end
 
@@ -60,7 +61,18 @@ class Scheduler::VacuumScheduler
     Vacuum::ApplicationsVacuum.new
   end
 
+  def invites_vacuum
+    Vacuum::InvitesVacuum.new(
+      invites_retention_policy.invite_retention_period,
+      invites_retention_policy.invite_max_uses
+    )
+  end
+
   def content_retention_policy
     ContentRetentionPolicy.current
+  end
+
+  def invites_retention_policy
+    InvitesRetentionPolicy.current
   end
 end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -83,6 +83,8 @@ en:
         closed_registrations_message: Displayed when sign-ups are closed
         content_cache_retention_period: All posts and boosts from other servers will be deleted after the specified number of days. Some posts may not be recoverable. All related bookmarks, favourites and boosts will also be lost and impossible to undo.
         custom_css: You can apply custom styles on the web version of Mastodon.
+        invite_expiration_period: If set to a positive number, invitation links will expire after the specified number of days.
+        invite_max_uses: If set, invite links with fewer than the specified number of uses will not be forced to expire.
         mascot: Overrides the illustration in the advanced web interface.
         media_cache_retention_period: Downloaded media files will be deleted after the specified number of days when set to a positive value, and re-downloaded on demand.
         peers_api_enabled: A list of domain names this server has encountered in the fediverse. No data is included here about whether you federate with a given server, just that your server knows about it. This is used by services that collect statistics on federation in a general sense.
@@ -242,6 +244,8 @@ en:
         closed_registrations_message: Custom message when sign-ups are not available
         content_cache_retention_period: Content cache retention period
         custom_css: Custom CSS
+        invite_expiration_period: Invitation link force expiration period
+        invite_max_uses: Max uses threshold for force expiration of invitation link
         mascot: Custom mascot (legacy)
         media_cache_retention_period: Media cache retention period
         peers_api_enabled: Publish list of discovered servers in the API

--- a/config/locales/simple_form.ko.yml
+++ b/config/locales/simple_form.ko.yml
@@ -83,6 +83,8 @@ ko:
         closed_registrations_message: 새 가입을 차단했을 때 표시됩니다
         content_cache_retention_period: 다른 서버의 게시물과 부스트들은 지정한 일수가 지나면 삭제될 것입니다. 몇몇 게시물들은 복구가 불가능할 것입니다. 관련된 북마크, 좋아요, 부스트 또한 잃어버릴 것이며 취소도 할 수 없습니다.
         custom_css: 사용자 지정 스타일을 웹 버전의 마스토돈에 지정할 수 있습니다.
+        invite_expiration_period: 양수로 설정된 경우 지정된 일수가 지난 초대 링크들은 강제로 만료될 것입니다.
+        invite_max_uses: 설정한 경우 지정한 수 이하의 최대 사용횟수를 가진 초대 링크는 강제로 만료되지 않을 것입니다.
         mascot: 고급 웹 인터페이스의 그림을 대체합니다.
         media_cache_retention_period: 양수로 설정된 경우 다운로드된 미디어 파일들은 지정된 일수가 지나면 삭제될 것이고 필요할 때 다시 다운로드 될 것입니다.
         peers_api_enabled: 이 서버가 연합우주에서 만났던 서버들에 대한 도메인 네임의 목록입니다. 해당 서버와 어떤 연합을 했는지에 대한 정보는 전혀 포함되지 않고, 단순히 그 서버를 알고 있는지에 대한 것입니다. 이것은 일반적으로 연합에 대한 통계를 수집할 때 사용됩니다.
@@ -242,6 +244,8 @@ ko:
         closed_registrations_message: 가입이 불가능 할 때의 사용자 지정 메시지
         content_cache_retention_period: 콘텐츠 캐시 유지 기한
         custom_css: 사용자 정의 CSS
+        invite_expiration_period: 초대 링크 강제 만료 기한
+        invite_max_uses: 초대 링크 강제 만료 최대 사용횟수 임계값
         mascot: 사용자 정의 마스코트 (legacy)
         media_cache_retention_period: 미디어 캐시 유지 기한
         peers_api_enabled: API에 발견 된 서버들의 목록 발행

--- a/spec/lib/vacuum/invites_vacuum_spec.rb
+++ b/spec/lib/vacuum/invites_vacuum_spec.rb
@@ -19,19 +19,19 @@ RSpec.describe Vacuum::InvitesVacuum do
     end
 
     it 'expires unlimited invitation link' do
-      expect(invite_unlimited.expired?).to be true
+      expect(invite_unlimited.reload.expired?).to be true
     end
 
     it 'expires invitation link that have huge max uses' do
-      expect(invite_huge_max_uses.expired?).to be true
+      expect(invite_huge_max_uses.reload.expired?).to be true
     end
 
     it 'does not expires invitation link that have small max uses' do
-      expect(invite_small_max_uses.expired?).to be false
+      expect(invite_small_max_uses.reload.expired?).to be false
     end
 
     it 'expires invitation link that will expire' do
-      expect(invite_will_expires.expired?).to be true
+      expect(invite_will_expires.reload.expired?).to be true
     end
   end
 end

--- a/spec/lib/vacuum/invites_vacuum_spec.rb
+++ b/spec/lib/vacuum/invites_vacuum_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe Vacuum::InvitesVacuum do
   let(:retention_period) { 7.days }
   let(:retention_max_uses) { 10 }
 
+  let(:user) { Fabricate(:user) }
+
   describe '#perform' do
-    invite_unlimited = Fabricate(:invite, max_uses: nil, expires_at: nil)
-    invite_huge_max_uses = Fabricate(:invite, max_uses: 100, expires_at: nil)
-    invite_small_max_uses = Fabricate(:invite, max_uses: 2, expires_at: nil)
-    invite_will_expires = Fabricate(:invite, max_uses: nil, created_at: 1.hour.ago, expires_at: 1.hour.from_now)
+    let!(:invite_unlimited) { Fabricate(:invite, user: user, max_uses: nil, created_at: 10.days.ago, expires_at: nil) }
+    let!(:invite_huge_max_uses) { Fabricate(:invite, max_uses: 100, created_at: 10.days.ago, expires_at: nil) }
+    let!(:invite_small_max_uses) { Fabricate(:invite, max_uses: 2, created_at: 10.days.ago, expires_at: nil) }
+    let!(:invite_will_expires_later) { Fabricate(:invite, max_uses: nil, created_at: 1.hour.ago, expires_at: 1.hour.from_now) }
 
     before do
       subject.perform
@@ -31,7 +33,7 @@ RSpec.describe Vacuum::InvitesVacuum do
     end
 
     it 'expires invitation link that will expire' do
-      expect(invite_will_expires.reload.expired?).to be true
+      expect(invite_will_expires_later.reload.expired?).to be false
     end
   end
 end

--- a/spec/lib/vacuum/invites_vacuum_spec.rb
+++ b/spec/lib/vacuum/invites_vacuum_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Vacuum::InvitesVacuum do
+  subject { described_class.new(retention_period, retention_max_uses) }
+
+  let(:retention_period) { 7.days }
+  let(:retention_max_uses) { 10 }
+
+  describe '#perform' do
+    invite_unlimited = Fabricate(:invite, max_uses: nil, expires_at: nil)
+    invite_huge_max_uses = Fabricate(:invite, max_uses: 100, expires_at: nil)
+    invite_small_max_uses = Fabricate(:invite, max_uses: 2, expires_at: nil)
+    invite_will_expires = Fabricate(:invite, max_uses: nil, created_at: 1.hour.ago, expires_at: 1.hour.from_now)
+
+    before do
+      subject.perform
+    end
+
+    it 'expires unlimited invitation link' do
+      expect(invite_unlimited.expired?).to be true
+    end
+
+    it 'expires invitation link that have huge max uses' do
+      expect(invite_huge_max_uses.expired?).to be true
+    end
+
+    it 'does not expires invitation link that have small max uses' do
+      expect(invite_small_max_uses.expired?).to be false
+    end
+
+    it 'expires invitation link that will expire' do
+      expect(invite_will_expires.expired?).to be true
+    end
+  end
+end


### PR DESCRIPTION
Users were able to create infinite amount of invitation link even registration is permanently closed.
This PR adds Admin settings to forcefully expire invitation links that passed some duration.
Optionaly admin can set threshold that invitation link having "max uses" fewer than this, Can be bypassed.

Related: #26102