### PR TITLE
Rename “read” database to “replica” for consistency

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -5,7 +5,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   include Remotable
 
-  connects_to database: { writing: :primary, reading: ENV['DB_REPLICA_NAME'] || ENV['READ_DATABASE_URL'] ? :read : :primary }
+  connects_to database: { writing: :primary, reading: ENV['DB_REPLICA_NAME'] || ENV['REPLICA_DATABASE_URL'] ? :replica : :primary }
 
   class << self
     def update_index(_type_name, *_args, &_block)

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,7 +15,7 @@ development:
     password: <%= (ENV['DB_PASS'] || '').to_json %>
     host: <%= ENV['DB_HOST'] %>
     port: <%= ENV['DB_PORT'] %>
-  read:
+  replica:
     <<: *default
     database: <%= ENV['DB_NAME'] || 'mastodon_development' %>
     username: <%= ENV['DB_USER'] %>
@@ -35,7 +35,7 @@ test:
     password: <%= (ENV['DB_PASS'] || '').to_json %>
     host: <%= ENV['DB_HOST'] %>
     port: <%= ENV['DB_PORT'] %>
-  read:
+  replica:
     <<: *default
     database: <%= ENV['DB_NAME'] || 'mastodon' %>_test<%= ENV['TEST_ENV_NUMBER'] %>
     username: <%= ENV['DB_USER'] %>
@@ -53,7 +53,7 @@ production:
     host: <%= ENV['DB_HOST'] || 'localhost' %>
     port: <%= ENV['DB_PORT'] || 5432 %>
     prepared_statements: <%= ENV['PREPARED_STATEMENTS'] || 'true' %>
-  read:
+  replica:
     <<: *default
     database: <%= ENV['DB_REPLICA_NAME'] ||ENV['DB_NAME'] || 'mastodon_production' %>
     username: <%= ENV['DB_REPLICA_USER'] ||ENV['DB_USER'] || 'mastodon' %>


### PR DESCRIPTION
This makes Rails read `REPLICA_DATABASE_URL` instead of `READ_DATABASE_URL`