### PR TITLE
Change design of hidden media overlay (again) in web UI

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4249,16 +4249,19 @@ a.status-card {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba($black, 0.5);
+    background: transparent;
     width: 100%;
     height: 100%;
     padding: 0;
     margin: 0;
     border: 0;
-    border-radius: 4px;
     color: $white;
 
     &__label {
+      background-color: rgba($black, 0.45);
+      backdrop-filter: blur(10px) saturate(180%) contrast(75%) brightness(70%);
+      border-radius: 6px;
+      padding: 10px 15px;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -4271,6 +4274,13 @@ a.status-card {
     &__action {
       font-weight: 400;
       font-size: 13px;
+    }
+
+    &:hover,
+    &:focus {
+      .spoiler-button__overlay__label {
+        background-color: rgba($black, 0.9);
+      }
     }
   }
 }


### PR DESCRIPTION
The desaturation of the blurred image through the overlay took away some of the joy.

![Screenshot 2023-08-03 at 00-57-50 Localhost](https://github.com/mastodon/mastodon/assets/184731/463fdc0a-f19d-4b8b-939f-d1d56ca968a7)
