### PR TITLE
Fix missing cached preview cards attributes

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -162,7 +162,7 @@ class Status < ApplicationRecord
   REAL_TIME_WINDOW = 6.hours
 
   def cache_key
-    "v2:#{super}"
+    "v3:#{super}"
   end
 
   def searchable_by(preloaded = nil)


### PR DESCRIPTION
Fixes #26229, #26333

The updated cache key is on `Status` because that's what actually gets cached (with its loaded associations).