### PR TITLE
Add new public status index

### DIFF
--- a/app/chewy/accounts_index.rb
+++ b/app/chewy/accounts_index.rb
@@ -62,6 +62,6 @@ class AccountsIndex < Chewy::Index
     field(:last_status_at, type: 'date', value: ->(account) { account.last_status_at || account.created_at })
     field(:display_name, type: 'text', analyzer: 'verbatim') { field :edge_ngram, type: 'text', analyzer: 'edge_ngram', search_analyzer: 'verbatim' }
     field(:username, type: 'text', analyzer: 'verbatim', value: ->(account) { [account.username, account.domain].compact.join('@') }) { field :edge_ngram, type: 'text', analyzer: 'edge_ngram', search_analyzer: 'verbatim' }
-    field(:text, type: 'text', value: ->(account) { account.searchable_text }) { field :stemmed, type: 'text', analyzer: 'natural' }
+    field(:text, type: 'text', analyzer: 'whitespace', value: ->(account) { account.searchable_text }) { field :stemmed, type: 'text', analyzer: 'natural' }
   end
 end

--- a/app/chewy/public_statuses_index.rb
+++ b/app/chewy/public_statuses_index.rb
@@ -43,31 +43,6 @@ class PublicStatusesIndex < Chewy::Index
                       .where(accounts: { discoverable: true })
                       .where(visibility: :public)
 
-  crutch :mentions do |collection|
-    data = ::Mention.where(status_id: collection.map(&:id)).where(account: Account.local, silent: false).pluck(:status_id, :account_id)
-    data.each.with_object({}) { |(id, name), result| (result[id] ||= []).push(name) }
-  end
-
-  crutch :favourites do |collection|
-    data = ::Favourite.where(status_id: collection.map(&:id)).where(account: Account.local).pluck(:status_id, :account_id)
-    data.each.with_object({}) { |(id, name), result| (result[id] ||= []).push(name) }
-  end
-
-  crutch :reblogs do |collection|
-    data = ::Status.where(reblog_of_id: collection.map(&:id)).where(account: Account.local).pluck(:reblog_of_id, :account_id)
-    data.each.with_object({}) { |(id, name), result| (result[id] ||= []).push(name) }
-  end
-
-  crutch :bookmarks do |collection|
-    data = ::Bookmark.where(status_id: collection.map(&:id)).where(account: Account.local).pluck(:status_id, :account_id)
-    data.each.with_object({}) { |(id, name), result| (result[id] ||= []).push(name) }
-  end
-
-  crutch :votes do |collection|
-    data = ::PollVote.joins(:poll).where(poll: { status_id: collection.map(&:id) }).where(account: Account.local).pluck(:status_id, :account_id)
-    data.each.with_object({}) { |(id, name), result| (result[id] ||= []).push(name) }
-  end
-
   root date_detection: false do
     field(:id, type: 'long')
     field(:account_id, type: 'long')

--- a/app/chewy/public_statuses_index.rb
+++ b/app/chewy/public_statuses_index.rb
@@ -43,8 +43,9 @@ class PublicStatusesIndex < Chewy::Index
                       .where(visibility: :public)
 
   root date_detection: false do
+    field(:id, type: 'keyword')
     field(:account_id, type: 'long')
-    field(:text, type: 'text', value: ->(status) { status.searchable_text }) { field(:stemmed, type: 'text', analyzer: 'content') }
+    field(:text, type: 'text', analyzer: 'whitespace', value: ->(status) { status.searchable_text }) { field(:stemmed, type: 'text', analyzer: 'content') }
     field(:language, type: 'keyword')
     field(:properties, type: 'keyword', value: ->(status) { status.searchable_properties })
     field(:created_at, type: 'date')

--- a/app/chewy/public_statuses_index.rb
+++ b/app/chewy/public_statuses_index.rb
@@ -1,23 +1,24 @@
 # frozen_string_literal: true
 
 class PublicStatusesIndex < Chewy::Index
-  include FormattingHelper
-
   settings index: { refresh_interval: '30s' }, analysis: {
     filter: {
       english_stop: {
         type: 'stop',
         stopwords: '_english_',
       },
+
       english_stemmer: {
         type: 'stemmer',
         language: 'english',
       },
+
       english_possessive_stemmer: {
         type: 'stemmer',
         language: 'possessive_english',
       },
     },
+
     analyzer: {
       content: {
         tokenizer: 'uax_url_email',
@@ -33,22 +34,19 @@ class PublicStatusesIndex < Chewy::Index
     },
   }
 
-  # We do not use delete_if option here because it would call a method that we
-  # expect to be called with crutches without crutches, causing n+1 queries
   index_scope ::Status.unscoped
                       .kept
                       .without_reblogs
-                      .includes(:media_attachments, :preloadable_poll)
+                      .includes(:media_attachments, :preloadable_poll, :preview_cards)
                       .joins(:account)
                       .where(accounts: { discoverable: true })
                       .where(visibility: :public)
 
   root date_detection: false do
-    field(:id, type: 'long')
     field(:account_id, type: 'long')
-
-    field(:text, type: 'text', value: ->(status) { status.searchable_text }) do
-      field(:stemmed, type: 'text', analyzer: 'content')
-    end
+    field(:text, type: 'text', value: ->(status) { status.searchable_text }) { field(:stemmed, type: 'text', analyzer: 'content') }
+    field(:language, type: 'keyword')
+    field(:properties, type: 'keyword', value: ->(status) { status.searchable_properties })
+    field(:created_at, type: 'date')
   end
 end

--- a/app/chewy/public_statuses_index.rb
+++ b/app/chewy/public_statuses_index.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PublicStatusesIndex < Chewy::Index
-  settings index: { refresh_interval: '30s' }, analysis: {
+  settings index: index_preset(refresh_interval: '30s', number_of_shards: 5), analysis: {
     filter: {
       english_stop: {
         type: 'stop',

--- a/app/chewy/public_statuses_index.rb
+++ b/app/chewy/public_statuses_index.rb
@@ -36,11 +36,8 @@ class PublicStatusesIndex < Chewy::Index
 
   index_scope ::Status.unscoped
                       .kept
-                      .without_reblogs
+                      .indexable
                       .includes(:media_attachments, :preloadable_poll, :preview_cards)
-                      .joins(:account)
-                      .where(accounts: { discoverable: true })
-                      .where(visibility: :public)
 
   root date_detection: false do
     field(:id, type: 'keyword')

--- a/app/chewy/statuses_index.rb
+++ b/app/chewy/statuses_index.rb
@@ -64,8 +64,9 @@ class StatusesIndex < Chewy::Index
   end
 
   root date_detection: false do
+    field(:id, type: 'keyword')
     field(:account_id, type: 'long')
-    field(:text, type: 'text', value: ->(status) { status.searchable_text }) { field(:stemmed, type: 'text', analyzer: 'content') }
+    field(:text, type: 'text', analyzer: 'whitespace', value: ->(status) { status.searchable_text }) { field(:stemmed, type: 'text', analyzer: 'content') }
     field(:searchable_by, type: 'long', value: ->(status, crutches) { status.searchable_by(crutches) })
     field(:language, type: 'keyword')
     field(:properties, type: 'keyword', value: ->(status) { status.searchable_properties })

--- a/app/chewy/statuses_index.rb
+++ b/app/chewy/statuses_index.rb
@@ -1,23 +1,24 @@
 # frozen_string_literal: true
 
 class StatusesIndex < Chewy::Index
-  include FormattingHelper
-
   settings index: index_preset(refresh_interval: '30s', number_of_shards: 5), analysis: {
     filter: {
       english_stop: {
         type: 'stop',
         stopwords: '_english_',
       },
+
       english_stemmer: {
         type: 'stemmer',
         language: 'english',
       },
+
       english_possessive_stemmer: {
         type: 'stemmer',
         language: 'possessive_english',
       },
     },
+
     analyzer: {
       content: {
         tokenizer: 'uax_url_email',
@@ -35,7 +36,7 @@ class StatusesIndex < Chewy::Index
 
   # We do not use delete_if option here because it would call a method that we
   # expect to be called with crutches without crutches, causing n+1 queries
-  index_scope ::Status.unscoped.kept.without_reblogs.includes(:media_attachments, :preloadable_poll)
+  index_scope ::Status.unscoped.kept.without_reblogs.includes(:media_attachments, :preloadable_poll, :preview_cards)
 
   crutch :mentions do |collection|
     data = ::Mention.where(status_id: collection.map(&:id)).where(account: Account.local, silent: false).pluck(:status_id, :account_id)
@@ -63,13 +64,11 @@ class StatusesIndex < Chewy::Index
   end
 
   root date_detection: false do
-    field(:id, type: 'long')
     field(:account_id, type: 'long')
-
-    field(:text, type: 'text', value: ->(status) { status.searchable_text }) do
-      field(:stemmed, type: 'text', analyzer: 'content')
-    end
-
+    field(:text, type: 'text', value: ->(status) { status.searchable_text }) { field(:stemmed, type: 'text', analyzer: 'content') }
     field(:searchable_by, type: 'long', value: ->(status, crutches) { status.searchable_by(crutches) })
+    field(:language, type: 'keyword')
+    field(:properties, type: 'keyword', value: ->(status) { status.searchable_properties })
+    field(:created_at, type: 'date')
   end
 end

--- a/app/controllers/api/v1/accounts/credentials_controller.rb
+++ b/app/controllers/api/v1/accounts/credentials_controller.rb
@@ -30,6 +30,7 @@ class Api::V1::Accounts::CredentialsController < Api::BaseController
       :bot,
       :discoverable,
       :hide_collections,
+      :indexable,
       fields_attributes: [:name, :value]
     )
   end

--- a/app/controllers/settings/privacy_controller.rb
+++ b/app/controllers/settings/privacy_controller.rb
@@ -18,7 +18,7 @@ class Settings::PrivacyController < Settings::BaseController
   private
 
   def account_params
-    params.require(:account).permit(:discoverable, :unlocked, :show_collections, settings: UserSettings.keys)
+    params.require(:account).permit(:discoverable, :unlocked, :indexable, :show_collections, settings: UserSettings.keys)
   end
 
   def set_account

--- a/app/lib/importer/public_statuses_index_importer.rb
+++ b/app/lib/importer/public_statuses_index_importer.rb
@@ -45,7 +45,7 @@ class Importer::PublicStatusesIndexImporter < Importer::BaseImporter
 
   def scopes
     [
-      local_statuses_scope
+      local_statuses_scope,
     ]
   end
 

--- a/app/lib/importer/public_statuses_index_importer.rb
+++ b/app/lib/importer/public_statuses_index_importer.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+class Importer::PublicStatusesIndexImporter < Importer::BaseImporter
+  def import!
+    # Similar to the StatusesIndexImporter, we will process different scopes
+    # to import data into the PublicStatusesIndex.
+    scopes.each do |scope|
+      scope.find_in_batches(batch_size: @batch_size) do |batch|
+        in_work_unit(batch.map(&:status_id)) do |status_ids|
+          bulk = ActiveRecord::Base.connection_pool.with_connection do
+            status_data = Status.includes(:media_attachments, :preloadable_poll)
+                                .joins(:account)
+                                .where(accounts: { discoverable: true })
+                                .where(id: status_ids)
+            Chewy::Index::Import::BulkBuilder.new(index, to_index: status_data).bulk_body
+          end
+
+          indexed = 0
+          deleted = 0
+
+          bulk.map! do |entry|
+            if entry[:index]
+              indexed += 1
+            else
+              deleted += 1
+            end
+            entry
+          end
+
+          Chewy::Index::Import::BulkRequest.new(index).perform(bulk)
+
+          [indexed, deleted]
+        end
+      end
+    end
+
+    wait!
+  end
+
+  private
+
+  def index
+    PublicStatusesIndex
+  end
+
+  def scopes
+    [
+      local_statuses_scope,
+      local_mentions_scope,
+      local_favourites_scope,
+      local_votes_scope,
+      local_bookmarks_scope,
+    ]
+  end
+
+  def local_mentions_scope
+    Mention.where(account: Account.local, silent: false)
+           .joins(status: :account)
+           .where(accounts: { discoverable: true })
+           .where(statuses: { visibility: :public })
+           .select('mentions.id, statuses.id AS status_id')
+  end
+
+  def local_favourites_scope
+    Favourite.where(account: Account.local)
+             .joins(status: :account)
+             .where(accounts: { discoverable: true })
+             .where(statuses: { visibility: :public })
+             .select('favourites.id, statuses.id AS status_id')
+  end
+
+  def local_bookmarks_scope
+    Bookmark.joins(status: :account)
+            .where(accounts: { discoverable: true })
+            .where(statuses: { visibility: :public })
+            .select('bookmarks.id, statuses.id AS status_id')
+  end
+
+  def local_votes_scope
+    local_account_ids = Account.where(discoverable: true).pluck(:id)
+
+    Poll.joins(:votes)
+        .where(poll_votes: { account_id: local_account_ids })
+        .where(status_id: Status.where(visibility: :public))
+  end
+
+  def local_statuses_scope
+    Status.local
+          .select('"statuses"."id", COALESCE("statuses"."reblog_of_id", "statuses"."id") AS status_id')
+          .joins(:account)
+          .where(accounts: { discoverable: true })
+          .where(visibility: :public)
+  end
+end

--- a/app/lib/importer/public_statuses_index_importer.rb
+++ b/app/lib/importer/public_statuses_index_importer.rb
@@ -45,43 +45,8 @@ class Importer::PublicStatusesIndexImporter < Importer::BaseImporter
 
   def scopes
     [
-      local_statuses_scope,
-      local_mentions_scope,
-      local_favourites_scope,
-      local_votes_scope,
-      local_bookmarks_scope,
+      local_statuses_scope
     ]
-  end
-
-  def local_mentions_scope
-    Mention.where(account: Account.local, silent: false)
-           .joins(status: :account)
-           .where(accounts: { discoverable: true })
-           .where(statuses: { visibility: :public })
-           .select('mentions.id, statuses.id AS status_id')
-  end
-
-  def local_favourites_scope
-    Favourite.where(account: Account.local)
-             .joins(status: :account)
-             .where(accounts: { discoverable: true })
-             .where(statuses: { visibility: :public })
-             .select('favourites.id, statuses.id AS status_id')
-  end
-
-  def local_bookmarks_scope
-    Bookmark.joins(status: :account)
-            .where(accounts: { discoverable: true })
-            .where(statuses: { visibility: :public })
-            .select('bookmarks.id, statuses.id AS status_id')
-  end
-
-  def local_votes_scope
-    local_account_ids = Account.where(discoverable: true).pluck(:id)
-
-    Poll.joins(:votes)
-        .where(poll_votes: { account_id: local_account_ids })
-        .where(status_id: Status.where(visibility: :public))
   end
 
   def local_statuses_scope

--- a/app/lib/importer/public_statuses_index_importer.rb
+++ b/app/lib/importer/public_statuses_index_importer.rb
@@ -2,35 +2,27 @@
 
 class Importer::PublicStatusesIndexImporter < Importer::BaseImporter
   def import!
-    # Similar to the StatusesIndexImporter, we will process different scopes
-    # to import data into the PublicStatusesIndex.
-    scopes.each do |scope|
-      scope.find_in_batches(batch_size: @batch_size) do |batch|
-        in_work_unit(batch.map(&:status_id)) do |status_ids|
-          bulk = ActiveRecord::Base.connection_pool.with_connection do
-            status_data = Status.includes(:media_attachments, :preloadable_poll)
-                                .joins(:account)
-                                .where(accounts: { discoverable: true })
-                                .where(id: status_ids)
-            Chewy::Index::Import::BulkBuilder.new(index, to_index: status_data).bulk_body
-          end
-
-          indexed = 0
-          deleted = 0
-
-          bulk.map! do |entry|
-            if entry[:index]
-              indexed += 1
-            else
-              deleted += 1
-            end
-            entry
-          end
-
-          Chewy::Index::Import::BulkRequest.new(index).perform(bulk)
-
-          [indexed, deleted]
+    indexable_statuses_scope.find_in_batches(batch_size: @batch_size) do |batch|
+      in_work_unit(batch.map(&:status_id)) do |status_ids|
+        bulk = ActiveRecord::Base.connection_pool.with_connection do
+          Chewy::Index::Import::BulkBuilder.new(index, to_index: Status.includes(:media_attachments, :preloadable_poll).where(id: status_ids)).bulk_body
         end
+
+        indexed = 0
+        deleted = 0
+
+        bulk.map! do |entry|
+          if entry[:index]
+            indexed += 1
+          else
+            deleted += 1
+          end
+          entry
+        end
+
+        Chewy::Index::Import::BulkRequest.new(index).perform(bulk)
+
+        [indexed, deleted]
       end
     end
 
@@ -43,17 +35,7 @@ class Importer::PublicStatusesIndexImporter < Importer::BaseImporter
     PublicStatusesIndex
   end
 
-  def scopes
-    [
-      local_statuses_scope,
-    ]
-  end
-
-  def local_statuses_scope
-    Status.local
-          .select('"statuses"."id", COALESCE("statuses"."reblog_of_id", "statuses"."id") AS status_id')
-          .joins(:account)
-          .where(accounts: { discoverable: true })
-          .where(visibility: :public)
+  def indexable_statuses_scope
+    Status.indexable.select('"statuses"."id", COALESCE("statuses"."reblog_of_id", "statuses"."id") AS status_id')
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -135,7 +135,7 @@ class Account < ApplicationRecord
   scope :not_domain_blocked_by_account, ->(account) { where(arel_table[:domain].eq(nil).or(arel_table[:domain].not_in(account.excluded_from_timeline_domains))) }
 
   after_update_commit :trigger_update_webhooks
-  after_update :enqueue_update_public_statuses_index, if: :saved_change_to_discoverable? and Chewy.enabled?
+  after_update_commit :enqueue_update_public_statuses_index, if: :saved_change_to_discoverable? and Chewy.enabled?
 
   delegate :email,
            :unconfirmed_email,
@@ -479,7 +479,7 @@ class Account < ApplicationRecord
   before_validation :prepare_username, on: :create
   before_create :generate_keys
   before_destroy :clean_feed_manager
-  after_commit :enqueue_remove_from_public_statuses_index, on: :destroy, if: -> { Chewy.enabled? && discoverable? }
+  after_destroy_commit :enqueue_remove_from_public_statuses_index, if: -> { Chewy.enabled? && discoverable? }
 
   def ensure_keys!
     return unless local? && private_key.blank? && public_key.blank?

--- a/app/models/concerns/account_statuses_search.rb
+++ b/app/models/concerns/account_statuses_search.rb
@@ -26,19 +26,11 @@ module AccountStatusesSearch
   def add_to_public_statuses_index!
     return unless Chewy.enabled?
 
-    batch_size = 1000
-    offset = 0
-
-    loop do
-      batch = Status.where(account_id: id).offset(offset).limit(batch_size)
-
-      break if batch.empty?
-
+    Status.where(account_id: id).find_in_batches(batch_size: 1_000) do |batch|
+      puts batch
       Chewy.strategy(:sidekiq) do
         PublicStatusesIndex.import(query: batch)
       end
-
-      offset += batch_size
     end
   end
 

--- a/app/models/concerns/account_statuses_search.rb
+++ b/app/models/concerns/account_statuses_search.rb
@@ -27,9 +27,7 @@ module AccountStatusesSearch
     return unless Chewy.enabled?
 
     Status.joins(:account).where(accounts: { discoverable: true }).where(visibility: :public).where(account_id: id).find_in_batches(batch_size: 1_000) do |batch|
-      Chewy.strategy(:sidekiq) do
-        PublicStatusesIndex.import(query: batch)
-      end
+      PublicStatusesIndex.import(query: batch)
     end
   end
 

--- a/app/models/concerns/account_statuses_search.rb
+++ b/app/models/concerns/account_statuses_search.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module AccountStatusesSearch
+  extend ActiveSupport::Concern
+
+  def enqueue_update_public_statuses_index
+    if discoverable?
+      enqueue_add_to_public_statuses_index
+    else
+      enqueue_remove_from_public_statuses_index
+    end
+  end
+
+  def enqueue_add_to_public_statuses_index
+    return unless Chewy.enabled?
+
+    AddToPublicStatusesIndexWorker.perform_async(id)
+  end
+
+  def enqueue_remove_from_public_statuses_index
+    return unless Chewy.enabled?
+
+    RemoveFromPublicStatusesIndexWorker.perform_async(id)
+  end
+
+  def add_to_public_statuses_index!
+    return unless Chewy.enabled?
+
+    batch_size = 1000
+    offset = 0
+
+    loop do
+      batch = Status.where(account_id: id).offset(offset).limit(batch_size)
+
+      break if batch.empty?
+
+      Chewy.strategy(:sidekiq) do
+        PublicStatusesIndex.import(query: batch)
+      end
+
+      offset += batch_size
+    end
+  end
+
+  def remove_from_public_statuses_index!
+    return unless Chewy.enabled?
+
+    PublicStatusesIndex.filter(term: { account_id: id }).delete_all
+  end
+end

--- a/app/models/concerns/account_statuses_search.rb
+++ b/app/models/concerns/account_statuses_search.rb
@@ -26,8 +26,7 @@ module AccountStatusesSearch
   def add_to_public_statuses_index!
     return unless Chewy.enabled?
 
-    Status.where(account_id: id).find_in_batches(batch_size: 1_000) do |batch|
-      puts batch
+    Status.joins(:account).where(accounts: { discoverable: true }).where(visibility: :public).where(account_id: id).find_in_batches(batch_size: 1_000) do |batch|
       Chewy.strategy(:sidekiq) do
         PublicStatusesIndex.import(query: batch)
       end

--- a/app/models/concerns/status_search_concern.rb
+++ b/app/models/concerns/status_search_concern.rb
@@ -3,6 +3,10 @@
 module StatusSearchConcern
   extend ActiveSupport::Concern
 
+  included do
+    scope :indexable, -> { without_reblogs.where(visibility: :public).joins(:account).where(account: { indexable: true }) }
+  end
+
   def searchable_by(preloaded = nil)
     ids = []
 

--- a/app/models/concerns/status_search_concern.rb
+++ b/app/models/concerns/status_search_concern.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module StatusSearchConcern
+  extend ActiveSupport::Concern
+
+  def searchable_by(preloaded = nil)
+    ids = []
+
+    ids << account_id if local?
+
+    if preloaded.nil?
+      ids += mentions.joins(:account).merge(Account.local).active.pluck(:account_id)
+      ids += favourites.joins(:account).merge(Account.local).pluck(:account_id)
+      ids += reblogs.joins(:account).merge(Account.local).pluck(:account_id)
+      ids += bookmarks.joins(:account).merge(Account.local).pluck(:account_id)
+      ids += poll.votes.joins(:account).merge(Account.local).pluck(:account_id) if poll.present?
+    else
+      ids += preloaded.mentions[id] || []
+      ids += preloaded.favourites[id] || []
+      ids += preloaded.reblogs[id] || []
+      ids += preloaded.bookmarks[id] || []
+      ids += preloaded.votes[id] || []
+    end
+
+    ids.uniq
+  end
+
+  def searchable_text
+    [
+      spoiler_text,
+      FormattingHelper.extract_status_plain_text(self),
+      preloadable_poll&.options&.join("\n\n"),
+      ordered_media_attachments.map(&:description).join("\n\n"),
+    ].compact.join("\n\n")
+  end
+
+  def searchable_properties
+    [].tap do |properties|
+      properties << 'image' if ordered_media_attachments.any?(&:image?)
+      properties << 'video' if ordered_media_attachments.any?(&:video?)
+      properties << 'audio' if ordered_media_attachments.any?(&:audio?)
+      properties << 'media' if with_media?
+      properties << 'poll' if with_poll?
+      properties << 'link' if with_preview_card?
+      properties << 'embed' if preview_cards.any?(&:video?)
+      properties << 'sensitive' if sensitive?
+      properties << 'reply' if reply?
+    end
+  end
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -47,6 +47,7 @@ class Status < ApplicationRecord
   attr_accessor :override_timestamps
 
   update_index('statuses', :proper)
+  update_index('publicStatuses', :proper)
 
   enum visibility: { public: 0, unlisted: 1, private: 2, direct: 3, limited: 4 }, _suffix: :visibility
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -37,6 +37,7 @@ class Status < ApplicationRecord
   include StatusSnapshotConcern
   include RateLimitable
   include StatusSafeReblogInsert
+  include StatusSearchConcern
 
   rate_limit by: :account, family: :statuses
 
@@ -166,37 +167,6 @@ class Status < ApplicationRecord
     "v3:#{super}"
   end
 
-  def searchable_by(preloaded = nil)
-    ids = []
-
-    ids << account_id if local?
-
-    if preloaded.nil?
-      ids += mentions.joins(:account).merge(Account.local).active.pluck(:account_id)
-      ids += favourites.joins(:account).merge(Account.local).pluck(:account_id)
-      ids += reblogs.joins(:account).merge(Account.local).pluck(:account_id)
-      ids += bookmarks.joins(:account).merge(Account.local).pluck(:account_id)
-      ids += poll.votes.joins(:account).merge(Account.local).pluck(:account_id) if poll.present?
-    else
-      ids += preloaded.mentions[id] || []
-      ids += preloaded.favourites[id] || []
-      ids += preloaded.reblogs[id] || []
-      ids += preloaded.bookmarks[id] || []
-      ids += preloaded.votes[id] || []
-    end
-
-    ids.uniq
-  end
-
-  def searchable_text
-    [
-      spoiler_text,
-      FormattingHelper.extract_status_plain_text(self),
-      preloadable_poll ? preloadable_poll.options.join("\n\n") : nil,
-      ordered_media_attachments.map(&:description).join("\n\n"),
-    ].compact.join("\n\n")
-  end
-
   def to_log_human_identifier
     account.acct
   end
@@ -269,6 +239,10 @@ class Status < ApplicationRecord
 
   def with_preview_card?
     preview_cards.any?
+  end
+
+  def with_poll?
+    preloadable_poll.present?
   end
 
   def non_sensitive_with_media?

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -47,7 +47,7 @@ class Status < ApplicationRecord
   attr_accessor :override_timestamps
 
   update_index('statuses', :proper)
-  update_index('publicStatuses', :proper)
+  update_index('public_statuses', :proper)
 
   enum visibility: { public: 0, unlisted: 1, private: 2, direct: 3, limited: 4 }, _suffix: :visibility
 

--- a/app/serializers/activitypub/actor_serializer.rb
+++ b/app/serializers/activitypub/actor_serializer.rb
@@ -8,13 +8,13 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
 
   context_extensions :manually_approves_followers, :featured, :also_known_as,
                      :moved_to, :property_value, :discoverable, :olm, :suspended,
-                     :memorial
+                     :memorial, :indexable
 
   attributes :id, :type, :following, :followers,
              :inbox, :outbox, :featured, :featured_tags,
              :preferred_username, :name, :summary,
              :url, :manually_approves_followers,
-             :discoverable, :published, :memorial
+             :discoverable, :indexable, :published, :memorial
 
   has_one :public_key, serializer: ActivityPub::PublicKeySerializer
 
@@ -97,6 +97,10 @@ class ActivityPub::ActorSerializer < ActivityPub::Serializer
 
   def discoverable
     object.suspended? ? false : (object.discoverable || false)
+  end
+
+  def indexable
+    object.suspended? ? false : (object.indexable || false)
   end
 
   def name

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -35,7 +35,7 @@ class BatchedRemoveStatusService < BaseService
 
     # Since we skipped all callbacks, we also need to manually
     # deindex the statuses
-    Chewy.strategy.current.update(StatusesIndex, statuses_and_reblogs) if Chewy.enabled?
+    Chewy::Index.update([StatusesIndex, PublicStatusesIndex], statuses_and_reblogs) if Chewy.enabled?
 
     return if options[:skip_side_effects]
 

--- a/app/services/batched_remove_status_service.rb
+++ b/app/services/batched_remove_status_service.rb
@@ -35,7 +35,10 @@ class BatchedRemoveStatusService < BaseService
 
     # Since we skipped all callbacks, we also need to manually
     # deindex the statuses
-    Chewy::Index.update([StatusesIndex, PublicStatusesIndex], statuses_and_reblogs) if Chewy.enabled?
+    if Chewy.enabled?
+      Chewy.strategy.current.update(StatusesIndex, statuses_and_reblogs)
+      Chewy.strategy.current.update(PublicStatusesIndex, statuses_and_reblogs)
+    end
 
     return if options[:skip_side_effects]
 

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -187,7 +187,7 @@ class DeleteAccountService < BaseService
     @account.favourites.in_batches do |favourites|
       ids = favourites.pluck(:status_id)
       StatusStat.where(status_id: ids).update_all('favourites_count = GREATEST(0, favourites_count - 1)')
-      Chewy::Index.update([StatusesIndex, PublicStatusesIndex], ids) if Chewy.enabled?
+      Chewy.strategy.current.update(StatusesIndex, ids) if Chewy.enabled?
       Rails.cache.delete_multi(ids.map { |id| "statuses/#{id}" })
       favourites.delete_all
     end
@@ -195,7 +195,7 @@ class DeleteAccountService < BaseService
 
   def purge_bookmarks!
     @account.bookmarks.in_batches do |bookmarks|
-      Chewy::Index.update([StatusesIndex, PublicStatusesIndex], bookmarks.pluck(:status_id)) if Chewy.enabled?
+      Chewy.strategy.current.update(StatusesIndex, bookmarks.pluck(:status_id)) if Chewy.enabled?
       bookmarks.delete_all
     end
   end

--- a/app/services/delete_account_service.rb
+++ b/app/services/delete_account_service.rb
@@ -187,7 +187,7 @@ class DeleteAccountService < BaseService
     @account.favourites.in_batches do |favourites|
       ids = favourites.pluck(:status_id)
       StatusStat.where(status_id: ids).update_all('favourites_count = GREATEST(0, favourites_count - 1)')
-      Chewy.strategy.current.update(StatusesIndex, ids) if Chewy.enabled?
+      Chewy::Index.update([StatusesIndex, PublicStatusesIndex], ids) if Chewy.enabled?
       Rails.cache.delete_multi(ids.map { |id| "statuses/#{id}" })
       favourites.delete_all
     end
@@ -195,7 +195,7 @@ class DeleteAccountService < BaseService
 
   def purge_bookmarks!
     @account.bookmarks.in_batches do |bookmarks|
-      Chewy.strategy.current.update(StatusesIndex, bookmarks.pluck(:status_id)) if Chewy.enabled?
+      Chewy::Index.update([StatusesIndex, PublicStatusesIndex], bookmarks.pluck(:status_id)) if Chewy.enabled?
       bookmarks.delete_all
     end
   end

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -39,25 +39,15 @@ class SearchService < BaseService
   end
 
   def perform_statuses_search!
-    definition = parsed_query.apply(StatusesIndex.filter(term: { searchable_by: @account.id }))
-
-    definition = definition.filter(term: { account_id: @options[:account_id] }) if @options[:account_id].present?
-
-    if @options[:min_id].present? || @options[:max_id].present?
-      range      = {}
-      range[:gt] = @options[:min_id].to_i if @options[:min_id].present?
-      range[:lt] = @options[:max_id].to_i if @options[:max_id].present?
-      definition = definition.filter(range: { id: range })
-    end
-
-    results             = definition.limit(@limit).offset(@offset).objects.compact
-    account_ids         = results.map(&:account_id)
-    account_domains     = results.map(&:account_domain)
-    preloaded_relations = @account.relations_map(account_ids, account_domains)
-
-    results.reject { |status| StatusFilter.new(status, @account, preloaded_relations).filtered? }
-  rescue Faraday::ConnectionFailed, Parslet::ParseFailed
-    []
+    StatusesSearchService.new.call(
+      @query,
+      @account,
+      limit: @limit,
+      offset: @offset,
+      account_id: @options[:account_id],
+      min_id: @options[:min_id],
+      max_id: @options[:max_id]
+    )
   end
 
   def perform_hashtags_search!
@@ -113,9 +103,5 @@ class SearchService < BaseService
 
   def statuses_search?
     @options[:type].blank? || @options[:type] == 'statuses'
-  end
-
-  def parsed_query
-    SearchQueryTransformer.new.apply(SearchQueryParser.new.parse(@query))
   end
 end

--- a/app/services/statuses_search_service.rb
+++ b/app/services/statuses_search_service.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class StatusesSearchService < BaseService
+  def call(query, account = nil, options = {})
+    @query   = query&.strip
+    @account = account
+    @options = options
+    @limit   = options[:limit].to_i
+    @offset  = options[:offset].to_i
+
+    status_search_results
+  end
+
+  private
+
+  def status_search_results
+    definition = parsed_query.apply(
+      StatusesIndex.filter(
+        bool: {
+          should: [
+            publicly_searchable,
+            non_publicly_searchable,
+          ],
+          minimum_should_match: 1,
+        }
+      )
+    )
+
+    definition = definition.filter(term: { account_id: @options[:account_id] }) if @options[:account_id].present?
+
+    if @options[:min_id].present? || @options[:max_id].present?
+      range      = {}
+      range[:gt] = @options[:min_id].to_i if @options[:min_id].present?
+      range[:lt] = @options[:max_id].to_i if @options[:max_id].present?
+      definition = definition.filter(range: { id: range })
+    end
+
+    definition.instance_variable_get(:@parameters)[:indices].value[:indices] << PublicStatusesIndex
+
+    results             = definition.limit(@limit).offset(@offset).objects.compact
+    account_ids         = results.map(&:account_id)
+    account_domains     = results.map(&:account_domain)
+    preloaded_relations = @account.relations_map(account_ids, account_domains)
+
+    results.reject { |status| StatusFilter.new(status, @account, preloaded_relations).filtered? }
+  rescue Faraday::ConnectionFailed, Parslet::ParseFailed
+    []
+  end
+
+  def publicly_searchable
+    {
+      bool: {
+        must_not: {
+          exists: {
+            field: 'searchable_by',
+          },
+        },
+      },
+    }
+  end
+
+  def non_publicly_searchable
+    {
+      bool: {
+        must: [
+          {
+            exists: {
+              field: 'searchable_by',
+            },
+          },
+          {
+            term: { searchable_by: @account.id },
+          },
+        ],
+      },
+    }
+  end
+
+  def parsed_query
+    SearchQueryTransformer.new.apply(SearchQueryParser.new.parse(@query))
+  end
+end

--- a/app/services/statuses_search_service.rb
+++ b/app/services/statuses_search_service.rb
@@ -35,6 +35,7 @@ class StatusesSearchService < BaseService
       definition = definition.filter(range: { id: range })
     end
 
+    # This is the best way to submit identical queries to multi-indexes though chewy
     definition.instance_variable_get(:@parameters)[:indices].value[:indices] << PublicStatusesIndex
 
     results             = definition.limit(@limit).offset(@offset).objects.compact

--- a/app/services/statuses_search_service.rb
+++ b/app/services/statuses_search_service.rb
@@ -30,7 +30,7 @@ class StatusesSearchService < BaseService
     # This is the best way to submit identical queries to multi-indexes though chewy
     definition.instance_variable_get(:@parameters)[:indices].value[:indices] << PublicStatusesIndex
 
-    results             = definition.order(_id: { order: :desc }).limit(@limit).offset(@offset).objects.compact
+    results             = definition.collapse(field: :id).order(_id: { order: :desc }).limit(@limit).offset(@offset).objects.compact
     account_ids         = results.map(&:account_id)
     account_domains     = results.map(&:account_domain)
     preloaded_relations = @account.relations_map(account_ids, account_domains)

--- a/app/views/settings/privacy/show.html.haml
+++ b/app/views/settings/privacy/show.html.haml
@@ -24,6 +24,9 @@
 
   %p.lead= t('privacy.search_hint_html')
 
+  .fields-group
+    = f.input :indexable, as: :boolean, wrapper: :with_label
+
   = f.simple_fields_for :settings, current_user.settings do |ff|
     .fields-group
       = ff.input :indexable, wrapper: :with_label

--- a/app/workers/add_to_public_statuses_index_worker.rb
+++ b/app/workers/add_to_public_statuses_index_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddToPublicStatusesIndexWorker
+  include Sidekiq::Worker
+
+  def perform(account_id)
+    account = Account.find(account_id)
+    return unless account&.discoverable?
+
+    account.add_to_public_statuses_index!
+  end
+end

--- a/app/workers/add_to_public_statuses_index_worker.rb
+++ b/app/workers/add_to_public_statuses_index_worker.rb
@@ -5,8 +5,11 @@ class AddToPublicStatusesIndexWorker
 
   def perform(account_id)
     account = Account.find(account_id)
-    return unless account&.discoverable?
+
+    return unless account.indexable?
 
     account.add_to_public_statuses_index!
+  rescue ActiveRecord::RecordNotFound
+    true
   end
 end

--- a/app/workers/remove_from_public_statuses_index_worker.rb
+++ b/app/workers/remove_from_public_statuses_index_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RemoveFromPublicStatusesIndexWorker
+  include Sidekiq::Worker
+
+  def perform(account_id)
+    account = Account.find(account_id)
+    return unless account&.undiscoverable?
+
+    account.remove_from_public_statuses_index!
+  end
+end

--- a/app/workers/remove_from_public_statuses_index_worker.rb
+++ b/app/workers/remove_from_public_statuses_index_worker.rb
@@ -5,8 +5,11 @@ class RemoveFromPublicStatusesIndexWorker
 
   def perform(account_id)
     account = Account.find(account_id)
-    return unless account&.undiscoverable?
+
+    return if account.indexable?
 
     account.remove_from_public_statuses_index!
+  rescue ActiveRecord::RecordNotFound
+    true
   end
 end

--- a/app/workers/scheduler/indexing_scheduler.rb
+++ b/app/workers/scheduler/indexing_scheduler.rb
@@ -23,6 +23,6 @@ class Scheduler::IndexingScheduler
   end
 
   def indexes
-    [AccountsIndex, TagsIndex, StatusesIndex]
+    [AccountsIndex, TagsIndex, PublicStatusesIndex, StatusesIndex]
   end
 end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -6,6 +6,7 @@ en:
         discoverable: Your public posts and profile may be featured or recommended in various areas of Mastodon and your profile may be suggested to other users.
         display_name: Your full name or your fun name.
         fields: Your homepage, pronouns, age, anything you want.
+        indexable: Your public posts may appear in search results on Mastodon. People who have interacted with your posts may be able to search them regardless.
         note: 'You can @mention other people or #hashtags.'
         show_collections: People will be able to browse through your follows and followers. People that you follow will see that you follow them regardless.
         unlocked: People will be able to follow you without requesting approval. Uncheck if you want to review follow requests and chose whether to accept or reject new followers.
@@ -143,6 +144,7 @@ en:
         fields:
           name: Label
           value: Content
+        indexable: Include public posts in search results
         show_collections: Show follows and followers on profile
         unlocked: Automatically accept new followers
       account_alias:

--- a/lib/mastodon/cli/search.rb
+++ b/lib/mastodon/cli/search.rb
@@ -10,6 +10,7 @@ module Mastodon::CLI
       InstancesIndex,
       AccountsIndex,
       TagsIndex,
+      PublicStatusesIndex,
       StatusesIndex,
     ].freeze
 

--- a/spec/chewy/public_statuses_index_spec.rb
+++ b/spec/chewy/public_statuses_index_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PublicStatusesIndex do
+  describe 'Searching the index' do
+    before do
+      mock_elasticsearch_response(described_class, raw_response)
+    end
+
+    it 'returns results from a query' do
+      results = described_class.query(match: { name: 'status' })
+
+      expect(results).to eq []
+    end
+  end
+
+  def raw_response
+    {
+      took: 3,
+      hits: {
+        hits: [
+          {
+            _id: '0',
+            _score: 1.6375021,
+          },
+        ],
+      },
+    }
+  end
+end

--- a/spec/lib/importer/public_statuses_index_importer_spec.rb
+++ b/spec/lib/importer/public_statuses_index_importer_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Importer::PublicStatusesIndexImporter do
+  describe 'import!' do
+    let(:pool) { Concurrent::FixedThreadPool.new(5) }
+    let(:importer) { described_class.new(batch_size: 123, executor: pool) }
+
+    before { Fabricate(:status) }
+
+    it 'indexes relevant statuses' do
+      expect { importer.import! }.to update_index(PublicStatusesIndex)
+    end
+  end
+end

--- a/spec/lib/importer/public_statuses_index_importer_spec.rb
+++ b/spec/lib/importer/public_statuses_index_importer_spec.rb
@@ -7,7 +7,7 @@ describe Importer::PublicStatusesIndexImporter do
     let(:pool) { Concurrent::FixedThreadPool.new(5) }
     let(:importer) { described_class.new(batch_size: 123, executor: pool) }
 
-    before { Fabricate(:status) }
+    before { Fabricate(:status, account: Fabricate(:account, indexable: true)) }
 
     it 'indexes relevant statuses' do
       expect { importer.import! }.to update_index(PublicStatusesIndex)

--- a/spec/lib/search_query_transformer_spec.rb
+++ b/spec/lib/search_query_transformer_spec.rb
@@ -9,8 +9,8 @@ describe SearchQueryTransformer do
     it 'sets attributes' do
       transformer = described_class.new.apply(parser)
 
-      expect(transformer.should_clauses.first).to be_a(SearchQueryTransformer::TermClause)
-      expect(transformer.must_clauses.first).to be_nil
+      expect(transformer.should_clauses.first).to be_nil
+      expect(transformer.must_clauses.first).to be_a(SearchQueryTransformer::TermClause)
       expect(transformer.must_not_clauses.first).to be_nil
       expect(transformer.filter_clauses.first).to be_nil
     end

--- a/spec/models/concerns/account_statuses_search_spec.rb
+++ b/spec/models/concerns/account_statuses_search_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe AccountStatusesSearch do
-  let(:account) { Fabricate(:account, discoverable: discoverable) }
+  let(:account) { Fabricate(:account, indexable: indexable) }
 
   before do
     allow(Chewy).to receive(:enabled?).and_return(true)
@@ -15,8 +15,8 @@ describe AccountStatusesSearch do
       allow(account).to receive(:enqueue_remove_from_public_statuses_index)
     end
 
-    context 'when account is discoverable' do
-      let(:discoverable) { true }
+    context 'when account is indexable' do
+      let(:indexable) { true }
 
       it 'enqueues add_to_public_statuses_index and not to remove_from_public_statuses_index' do
         account.enqueue_update_public_statuses_index
@@ -25,8 +25,8 @@ describe AccountStatusesSearch do
       end
     end
 
-    context 'when account is not discoverable' do
-      let(:discoverable) { false }
+    context 'when account is not indexable' do
+      let(:indexable) { false }
 
       it 'enqueues remove_from_public_statuses_index and not to add_to_public_statuses_index' do
         account.enqueue_update_public_statuses_index
@@ -37,7 +37,7 @@ describe AccountStatusesSearch do
   end
 
   describe '#enqueue_add_to_public_statuses_index' do
-    let(:discoverable) { nil }
+    let(:indexable) { true }
     let(:worker) { AddToPublicStatusesIndexWorker }
 
     before do
@@ -51,7 +51,7 @@ describe AccountStatusesSearch do
   end
 
   describe '#enqueue_remove_from_public_statuses_index' do
-    let(:discoverable) { nil }
+    let(:indexable) { false }
     let(:worker) { RemoveFromPublicStatusesIndexWorker }
 
     before do

--- a/spec/models/concerns/account_statuses_search_spec.rb
+++ b/spec/models/concerns/account_statuses_search_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AccountStatusesSearch do
+  let(:account) { Fabricate(:account, discoverable: discoverable) }
+
+  before do
+    allow(Chewy).to receive(:enabled?).and_return(true)
+  end
+
+  describe '#enqueue_update_public_statuses_index' do
+    before do
+      allow(account).to receive(:enqueue_add_to_public_statuses_index)
+      allow(account).to receive(:enqueue_remove_from_public_statuses_index)
+    end
+
+    context 'when account is discoverable' do
+      let(:discoverable) { true }
+
+      it 'enqueues add_to_public_statuses_index and not to remove_from_public_statuses_index' do
+        account.enqueue_update_public_statuses_index
+        expect(account).to have_received(:enqueue_add_to_public_statuses_index)
+        expect(account).to_not have_received(:enqueue_remove_from_public_statuses_index)
+      end
+    end
+
+    context 'when account is not discoverable' do
+      let(:discoverable) { false }
+
+      it 'enqueues remove_from_public_statuses_index and not to add_to_public_statuses_index' do
+        account.enqueue_update_public_statuses_index
+        expect(account).to have_received(:enqueue_remove_from_public_statuses_index)
+        expect(account).to_not have_received(:enqueue_add_to_public_statuses_index)
+      end
+    end
+  end
+
+  describe '#enqueue_add_to_public_statuses_index' do
+    let(:discoverable) { nil }
+    let(:worker) { AddToPublicStatusesIndexWorker }
+
+    before do
+      allow(worker).to receive(:perform_async)
+    end
+
+    it 'enqueues AddToPublicStatusesIndexWorker' do
+      account.enqueue_add_to_public_statuses_index
+      expect(worker).to have_received(:perform_async).with(account.id)
+    end
+  end
+
+  describe '#enqueue_remove_from_public_statuses_index' do
+    let(:discoverable) { nil }
+    let(:worker) { RemoveFromPublicStatusesIndexWorker }
+
+    before do
+      allow(worker).to receive(:perform_async)
+    end
+
+    it 'enqueues RemoveFromPublicStatusesIndexWorker' do
+      account.enqueue_remove_from_public_statuses_index
+      expect(worker).to have_received(:perform_async).with(account.id)
+    end
+  end
+end

--- a/spec/workers/add_to_public_statuses_index_worker_spec.rb
+++ b/spec/workers/add_to_public_statuses_index_worker_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AddToPublicStatusesIndexWorker do
+  describe '#perform' do
+    let(:account) { Fabricate(:account, discoverable: discoverable) }
+    let(:account_id) { account.id }
+
+    before do
+      allow(Account).to receive(:find).with(account_id).and_return(account)
+      allow(account).to receive(:add_to_public_statuses_index!)
+    end
+
+    context 'when account is discoverable' do
+      let(:discoverable) { true }
+
+      it 'adds the account to the public statuses index' do
+        subject.perform(account_id)
+        expect(account).to have_received(:add_to_public_statuses_index!)
+      end
+    end
+
+    context 'when account is undiscoverable' do
+      let(:discoverable) { false }
+
+      it 'does not add the account to public statuses index' do
+        subject.perform(account_id)
+        expect(account).to_not have_received(:add_to_public_statuses_index!)
+      end
+    end
+
+    context 'when account does not exist' do
+      let(:account_id) { 999 }
+      let(:discoverable) { nil }
+
+      it 'does not raise an error' do
+        expect { subject.perform(account_id) }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/workers/add_to_public_statuses_index_worker_spec.rb
+++ b/spec/workers/add_to_public_statuses_index_worker_spec.rb
@@ -4,16 +4,16 @@ require 'rails_helper'
 
 describe AddToPublicStatusesIndexWorker do
   describe '#perform' do
-    let(:account) { Fabricate(:account, discoverable: discoverable) }
+    let(:account) { Fabricate(:account, indexable: indexable) }
     let(:account_id) { account.id }
 
     before do
-      allow(Account).to receive(:find).with(account_id).and_return(account)
-      allow(account).to receive(:add_to_public_statuses_index!)
+      allow(Account).to receive(:find).with(account_id).and_return(account) unless account.nil?
+      allow(account).to receive(:add_to_public_statuses_index!) unless account.nil?
     end
 
-    context 'when account is discoverable' do
-      let(:discoverable) { true }
+    context 'when account is indexable' do
+      let(:indexable) { true }
 
       it 'adds the account to the public statuses index' do
         subject.perform(account_id)
@@ -21,8 +21,8 @@ describe AddToPublicStatusesIndexWorker do
       end
     end
 
-    context 'when account is undiscoverable' do
-      let(:discoverable) { false }
+    context 'when account is not indexable' do
+      let(:indexable) { false }
 
       it 'does not add the account to public statuses index' do
         subject.perform(account_id)
@@ -31,8 +31,8 @@ describe AddToPublicStatusesIndexWorker do
     end
 
     context 'when account does not exist' do
+      let(:account) { nil }
       let(:account_id) { 999 }
-      let(:discoverable) { nil }
 
       it 'does not raise an error' do
         expect { subject.perform(account_id) }.to_not raise_error

--- a/spec/workers/remove_from_public_statuses_index_worker_spec.rb
+++ b/spec/workers/remove_from_public_statuses_index_worker_spec.rb
@@ -4,16 +4,16 @@ require 'rails_helper'
 
 describe RemoveFromPublicStatusesIndexWorker do
   describe '#perform' do
-    let(:account) { Fabricate(:account, discoverable: discoverable) }
+    let(:account) { Fabricate(:account, indexable: indexable) }
     let(:account_id) { account.id }
 
     before do
-      allow(Account).to receive(:find).with(account_id).and_return(account)
-      allow(account).to receive(:remove_from_public_statuses_index!)
+      allow(Account).to receive(:find).with(account_id).and_return(account) unless account.nil?
+      allow(account).to receive(:remove_from_public_statuses_index!) unless account.nil?
     end
 
-    context 'when account is undiscoverable' do
-      let(:discoverable) { false }
+    context 'when account is not indexable' do
+      let(:indexable) { false }
 
       it 'removes the account from public statuses index' do
         subject.perform(account_id)
@@ -21,8 +21,8 @@ describe RemoveFromPublicStatusesIndexWorker do
       end
     end
 
-    context 'when account is discoverable' do
-      let(:discoverable) { true }
+    context 'when account is indexable' do
+      let(:indexable) { true }
 
       it 'does not remove the account from public statuses index' do
         subject.perform(account_id)
@@ -31,8 +31,8 @@ describe RemoveFromPublicStatusesIndexWorker do
     end
 
     context 'when account does not exist' do
+      let(:account) { nil }
       let(:account_id) { 999 }
-      let(:discoverable) { nil }
 
       it 'does not raise an error' do
         expect { subject.perform(account_id) }.to_not raise_error

--- a/spec/workers/remove_from_public_statuses_index_worker_spec.rb
+++ b/spec/workers/remove_from_public_statuses_index_worker_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RemoveFromPublicStatusesIndexWorker do
+  describe '#perform' do
+    let(:account) { Fabricate(:account, discoverable: discoverable) }
+    let(:account_id) { account.id }
+
+    before do
+      allow(Account).to receive(:find).with(account_id).and_return(account)
+      allow(account).to receive(:remove_from_public_statuses_index!)
+    end
+
+    context 'when account is undiscoverable' do
+      let(:discoverable) { false }
+
+      it 'removes the account from public statuses index' do
+        subject.perform(account_id)
+        expect(account).to have_received(:remove_from_public_statuses_index!)
+      end
+    end
+
+    context 'when account is discoverable' do
+      let(:discoverable) { true }
+
+      it 'does not remove the account from public statuses index' do
+        subject.perform(account_id)
+        expect(account).to_not have_received(:remove_from_public_statuses_index!)
+      end
+    end
+
+    context 'when account does not exist' do
+      let(:account_id) { 999 }
+      let(:discoverable) { nil }
+
+      it 'does not raise an error' do
+        expect { subject.perform(account_id) }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a follow up to https://github.com/mastodon/mastodon/pull/25951

The idea here is to allow `public` posts by `discoverable` users to show up in search results. This is done by adding a new Public Status Index to Elastic Search.

A status is added to the `PublicStatusesIndex` if the status's visibility is `public` and if the account is `discoverable`.

Note: This will only work on instances with Elastic Search enabled.

## Outstanding questions
1. I'm not really sure how to test the changes to the Mastodon CLI. How do I do that? Can someone point me in the right direction there?
2. I'm also not sure how to know if the vacuum changes are working.
3. I wanted to add a few more tests for the `AccountStatusesSearch` concern, but I think I might need to add a new gem to do that (`chewy_spec`). I'm not sure what the process is for adding new gems. Is that something I can just do, or perhaps if there is a conversation that should happen first.

## Examples
Two `public` posts were made. One from a `discoverable` account and one from a `non-discoverable` account. You can see both of these posts in the `StatusesIndex`
<img width="1196" alt="Screenshot 2023-08-04 at 11 18 08 AM" src="https://github.com/mastodon/mastodon/assets/15234688/2e9f0a02-2740-424e-aace-bb1d1ab535ee">

However, you can only see one of these posts, the one by the `discoverable` account, in the `PublicStatusesIndex`
<img width="1286" alt="Screenshot 2023-08-04 at 11 18 21 AM" src="https://github.com/mastodon/mastodon/assets/15234688/95bf8a7c-70a7-423d-8be9-11a32cd9c9b8">

Any random user can then search for the string `hello` and only the public post will be returned from that search query
<img width="893" alt="Screenshot 2023-08-04 at 11 20 27 AM" src="https://github.com/mastodon/mastodon/assets/15234688/55bf0756-f2e5-4d65-a312-8457662198f1">

## Account Deletion
An account creates a public post
<img width="1426" alt="Screenshot 2023-08-04 at 11 25 43 AM" src="https://github.com/mastodon/mastodon/assets/15234688/48935bd0-72e9-4613-a1a8-2ea3de678af3">

When/if that account is deleted, so are its posts.
<img width="1391" alt="Screenshot 2023-08-04 at 11 26 41 AM" src="https://github.com/mastodon/mastodon/assets/15234688/b469a9f8-3147-4fb3-b291-a52a2716ac91">

## Discoverable --> Non-discoverable
If a `discoverable` account posts something
<img width="1381" alt="Screenshot 2023-08-04 at 11 33 33 AM" src="https://github.com/mastodon/mastodon/assets/15234688/79c15ab5-e5ff-4238-9cd4-3c9886a16208">

And then switches the `discoverability` of their account, the posts are removed from the `public` index
<img width="1254" alt="Screenshot 2023-08-04 at 11 34 43 AM" src="https://github.com/mastodon/mastodon/assets/15234688/7f60ba28-7538-4b89-9ae3-a883e595502d">

## Non-discoverable --> Discoverable
But if they then post again and then switch back, all the posts are returned to the index
<img width="1397" alt="Screenshot 2023-08-04 at 11 37 25 AM" src="https://github.com/mastodon/mastodon/assets/15234688/646ddb9f-024f-4867-9d84-0d68ee4a37a4">

___

Fixes MAS-88
