### PR TITLE
Fix list import concurrently creating lists of the same name

### DIFF
--- a/spec/services/bulk_import_row_service_spec.rb
+++ b/spec/services/bulk_import_row_service_spec.rb
@@ -161,6 +161,12 @@ RSpec.describe BulkImportRowService do
         end
 
         include_examples 'common behavior'
+
+        it 'does not create a new list' do
+          account.follow!(target_account)
+
+          expect { subject.call(import_row) }.to_not(change { List.where(title: 'my list').count })
+        end
       end
     end
   end


### PR DESCRIPTION
We unfortunately do not have any index (or even validation) preventing duplicate in list names, so we cannot completely avoid duplicates, and users may have legitimate duplicate lists already (though I think this is unlikely), so instead, avoid the race condition by creating lists before the background process populate them.

This should fix the issue, unless the user deletes a list after it is created, and before the background process tries to populate them, which should be fairly unlikely.