### PR TITLE
fix: stop the scrollable from scrolling to the top when in slow mode.

### DIFF
--- a/app/javascript/mastodon/components/load_more.tsx
+++ b/app/javascript/mastodon/components/load_more.tsx
@@ -1,12 +1,14 @@
 import { FormattedMessage } from 'react-intl';
 
 interface Props {
-  onClick: (event: React.MouseEvent) => void;
+  onMouseDown: (event: React.MouseEvent) => void;
+  onMouseUp: (event: React.MouseEvent) => void;
   disabled?: boolean;
   visible?: boolean;
 }
 export const LoadMore: React.FC<Props> = ({
-  onClick,
+  onMouseDown,
+  onMouseUp,
   disabled,
   visible = true,
 }) => {
@@ -16,7 +18,8 @@ export const LoadMore: React.FC<Props> = ({
       className='load-more'
       disabled={disabled || !visible}
       style={{ visibility: visible ? 'visible' : 'hidden' }}
-      onClick={onClick}
+      onMouseDown={onMouseDown}
+      onMouseUp={onMouseUp}
     >
       <FormattedMessage id='status.load_more' defaultMessage='Load more' />
     </button>

--- a/app/javascript/mastodon/components/load_pending.tsx
+++ b/app/javascript/mastodon/components/load_pending.tsx
@@ -1,13 +1,22 @@
 import { FormattedMessage } from 'react-intl';
 
 interface Props {
-  onClick: (event: React.MouseEvent) => void;
+  onMouseDown: (event: React.MouseEvent) => void;
+  onMouseUp: (event: React.MouseEvent) => void;
   count: number;
 }
 
-export const LoadPending: React.FC<Props> = ({ onClick, count }) => {
+export const LoadPending: React.FC<Props> = ({
+  onMouseDown,
+  onMouseUp,
+  count,
+}) => {
   return (
-    <button className='load-more load-gap' onClick={onClick}>
+    <button
+      className='load-more load-gap'
+      onMouseDown={onMouseDown}
+      onMouseUp={onMouseUp}
+    >
       <FormattedMessage
         id='load_pending'
         defaultMessage='{count, plural, one {# new item} other {# new items}}'

--- a/app/javascript/mastodon/components/scrollable_list.jsx
+++ b/app/javascript/mastodon/components/scrollable_list.jsx
@@ -7,7 +7,6 @@ import { useLocation } from 'react-router-dom';
 import { List as ImmutableList } from 'immutable';
 import { connect } from 'react-redux';
 
-import { supportsPassiveEvents } from 'detect-passive-events';
 import { throttle } from 'lodash';
 
 import ScrollContainer from 'mastodon/containers/scroll_container';
@@ -19,8 +18,6 @@ import IntersectionObserverWrapper from '../features/ui/util/intersection_observ
 import { LoadMore } from './load_more';
 import { LoadPending } from './load_pending';
 import { LoadingIndicator } from './loading_indicator';
-
-const listenerOptions = supportsPassiveEvents ? { passive: true } : false;
 
 /**
  *
@@ -218,20 +215,16 @@ class ScrollableList extends PureComponent {
   attachScrollListener () {
     if (this.props.bindToDocument) {
       document.addEventListener('scroll', this.handleScroll);
-      document.addEventListener('wheel', this.handleWheel,  listenerOptions);
     } else {
       this.node.addEventListener('scroll', this.handleScroll);
-      this.node.addEventListener('wheel', this.handleWheel, listenerOptions);
     }
   }
 
   detachScrollListener () {
     if (this.props.bindToDocument) {
       document.removeEventListener('scroll', this.handleScroll);
-      document.removeEventListener('wheel', this.handleWheel, listenerOptions);
     } else {
       this.node.removeEventListener('scroll', this.handleScroll);
-      this.node.removeEventListener('wheel', this.handleWheel, listenerOptions);
     }
   }
 

--- a/app/javascript/mastodon/components/scrollable_list.jsx
+++ b/app/javascript/mastodon/components/scrollable_list.jsx
@@ -90,7 +90,7 @@ class ScrollableList extends PureComponent {
   };
 
   intersectionObserverWrapper = new IntersectionObserverWrapper();
-  firstArticle = null;
+  firstSeenArticle = null;
 
   handleScroll = throttle(() => {
     if (this.node) {
@@ -260,19 +260,19 @@ class ScrollableList extends PureComponent {
     for (const article of articles) {
       const articleRect = article.getBoundingClientRect();
       if (articleRect.top > scrollableRect.top) {
-        this.firstArticle = article;
+        this.firstSeenArticle = article;
         break;
       }
     }
   }
 
   returnToFirstArticle () {
-    if (this.firstArticle !== null) {
-      // Scroll the firstArticle back into view once we're done with everything
-      // else.
+    if (this.firstSeenArticle !== null) {
+      // Scroll the firstSeenArticle back into view once we're done with
+      // everything else.
       setTimeout(() => {
-        firstArticle.scrollIntoView();
-        firstArticle.querySelector("div.status__wrapper").focus();
+        firstSeenArticle.scrollIntoView();
+        firstSeenArticle.querySelector("div.status__wrapper").focus();
       }, 0);
     }
   }

--- a/app/javascript/mastodon/components/scrollable_list.jsx
+++ b/app/javascript/mastodon/components/scrollable_list.jsx
@@ -90,6 +90,7 @@ class ScrollableList extends PureComponent {
   };
 
   intersectionObserverWrapper = new IntersectionObserverWrapper();
+  firstArticle = null;
 
   handleScroll = throttle(() => {
     if (this.node) {
@@ -251,14 +252,42 @@ class ScrollableList extends PureComponent {
     this.node = c;
   };
 
+  preLoad = () => {
+    // Here we record the first visible article so that when we mouseUp on
+    // the LoadX element, were able to scroll back to it.
+    const scrollableRect = this.node.getBoundingClientRect();
+    const articles = this.node.querySelectorAll("article");
+    for (const article of articles) {
+      const articleRect = article.getBoundingClientRect();
+      if (articleRect.top > scrollableRect.top) {
+        this.firstArticle = article;
+        break;
+      }
+    }
+  }
+
+  returnToFirstArticle () {
+    if (this.firstArticle !== null) {
+      // Scroll the firstArticle back into view once we're done with everything
+      // else.
+      setTimeout(() => {
+        firstArticle.scrollIntoView();
+        firstArticle.querySelector("div.status__wrapper").focus();
+      }, 0);
+    }
+  }
+
+
   handleLoadMore = e => {
     e.preventDefault();
     this.props.onLoadMore();
+    this.returnToFirstArticle();
   };
 
   handleLoadPending = e => {
     e.preventDefault();
     this.props.onLoadPending();
+    this.returnToFirstArticle();
   };
 
   render () {
@@ -266,8 +295,8 @@ class ScrollableList extends PureComponent {
     const { fullscreen } = this.state;
     const childrenCount = Children.count(children);
 
-    const loadMore     = (hasMore && onLoadMore) ? <LoadMore visible={!isLoading} onClick={this.handleLoadMore} /> : null;
-    const loadPending  = (numPending > 0) ? <LoadPending count={numPending} onClick={this.handleLoadPending} /> : null;
+    const loadMore     = (hasMore && onLoadMore) ? <LoadMore visible={!isLoading} onMouseDown={this.preLoad} onMouseUp={this.handleLoadMore} /> : null;
+    const loadPending  = (numPending > 0) ? <LoadPending count={numPending} onMouseDown={this.preLoad} onMouseUp={this.handleLoadPending} /> : null;
     let scrollableArea = null;
 
     if (showLoading) {


### PR DESCRIPTION
I've produced this patch against v4.1.6 which was the latest stable version at the time I produced the patch.

The problem I was trying to fix with this patch is that when I'm in slow mode, sometimes, the scrollable is updated correctly, but sometimes it is not. This is highly irritating. 

This need some sort of sanity check from someone before this is merged. Note that I'm running this code at:

https://mast.yourautisticlife.com/

Registration is currently closed, but if someone from the dev team wants an account there, you should just talk to me.

