### PR TITLE
Do not start LibreTranslate and Elasticsearch on GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,29 @@
-// For more details, see https://aka.ms/devcontainer.json.
 {
   "name": "Mastodon",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
-  // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {}
   },
 
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // This can be used to network with other containers or the host.
+  "runServices": ["app", "db", "redis"],
+
   "forwardPorts": [3000, 4000],
 
-  // Use 'postCreateCommand' to run commands after the container is created.
+  "containerEnv": {
+    "ES_ENABLED": "",
+    "LIBRE_TRANSLATE_ENDPOINT": ""
+  },
+
   "onCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
   "postCreateCommand": ".devcontainer/post-create.sh",
   "waitFor": "postCreateCommand",
 
-  // Configure tool-specific properties.
   "customizations": {
-    // Configure properties specific to VS Code.
     "vscode": {
-      // Set *default* container specific settings.json values on container create.
       "settings": {},
-      // Add the IDs of extensions you want installed when the container is created.
       "extensions": ["EditorConfig.EditorConfig", "webben.browserslist"]
     }
   }


### PR DESCRIPTION
The free tier on GitHub Codespaces only include 32 GB storage. It seems this is not enough to boot the full environment.

I'm not sure how it adds up to 32 GB, but on my local machine, the LibreTranslate volume alone uses 5 GB. AFAIK the language model is downloaded when the container first boots. The LibreTranslate image is another 600 MB.

With this PR LibreTranslate and Elasticsearch are not started automatically, so the development environment is able to boot. People with paid access to Codespaces can easily update devcontainer.json if they wish to start either of these services.

Fixes #25932.