### PR TITLE
Fix Content Security Policy sometimes unnecessarily allowing hCaptcha scripts

### DIFF
--- a/app/controllers/concerns/captcha_concern.rb
+++ b/app/controllers/concerns/captcha_concern.rb
@@ -42,7 +42,7 @@ module CaptchaConcern
   end
 
   def extend_csp_for_captcha!
-    policy = request.content_security_policy
+    policy = request.content_security_policy&.clone
 
     return unless captcha_required? && policy.present?
 
@@ -54,6 +54,8 @@ module CaptchaConcern
 
       policy.send(directive, *values)
     end
+
+    request.content_security_policy = policy
   end
 
   def render_captcha


### PR DESCRIPTION
The CSP object is sometimes reused across requests.