### PR TITLE
Use migration classes in migrations where current definition conflicts with older

### DIFF
--- a/db/migrate/20170105224407_add_shortcode_to_media_attachments.rb
+++ b/db/migrate/20170105224407_add_shortcode_to_media_attachments.rb
@@ -1,12 +1,19 @@
 # frozen_string_literal: true
 
 class AddShortcodeToMediaAttachments < ActiveRecord::Migration[5.0]
+  class MigrationMediaAttachment < ApplicationRecord
+    self.table_name = :media_attachments
+    scope :local, -> { where(remote_url: '') }
+  end
+
   def up
     add_column :media_attachments, :shortcode, :string, null: true, default: nil
     add_index :media_attachments, :shortcode, unique: true
 
+    MigrationMediaAttachment.reset_column_information
+
     # Migrate old links
-    MediaAttachment.local.update_all('shortcode = id')
+    MigrationMediaAttachment.local.update_all('shortcode = id')
   end
 
   def down

--- a/db/migrate/20170304202101_add_type_to_media_attachments.rb
+++ b/db/migrate/20170304202101_add_type_to_media_attachments.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
 class AddTypeToMediaAttachments < ActiveRecord::Migration[5.0]
+  class MigrationMediaAttachment < ApplicationRecord
+    self.table_name = :media_attachments
+    enum type: [:image, :gifv, :video]
+    IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif'].freeze
+    VIDEO_MIME_TYPES = ['video/webm', 'video/mp4'].freeze
+  end
+
   def up
     add_column :media_attachments, :type, :integer, default: 0, null: false
 
-    MediaAttachment.where(file_content_type: MediaAttachment::IMAGE_MIME_TYPES).update_all(type: MediaAttachment.types[:image])
-    MediaAttachment.where(file_content_type: MediaAttachment::VIDEO_MIME_TYPES).update_all(type: MediaAttachment.types[:video])
+    MigrationMediaAttachment.reset_column_information
+
+    MigrationMediaAttachment
+      .where(file_content_type: MigrationMediaAttachment::IMAGE_MIME_TYPES)
+      .update_all(type: MigrationMediaAttachment.types[:image])
+    MigrationMediaAttachment
+      .where(file_content_type: MigrationMediaAttachment::VIDEO_MIME_TYPES)
+      .update_all(type: MigrationMediaAttachment.types[:video])
   end
 
   def down

--- a/db/migrate/20181116173541_copy_account_stats.rb
+++ b/db/migrate/20181116173541_copy_account_stats.rb
@@ -3,6 +3,10 @@
 class CopyAccountStats < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
+  class MigrationAccount < ApplicationRecord
+    self.table_name = :accounts
+  end
+
   def up
     safety_assured do
       if supports_upsert?
@@ -27,7 +31,7 @@ class CopyAccountStats < ActiveRecord::Migration[5.2]
   def up_fast
     say 'Upsert is available, importing counters using the fast method'
 
-    Account.unscoped.select('id').find_in_batches(batch_size: 5_000) do |accounts|
+    MigrationAccount.unscoped.select('id').find_in_batches(batch_size: 5_000) do |accounts|
       execute <<-SQL.squish
         INSERT INTO account_stats (account_id, statuses_count, following_count, followers_count, created_at, updated_at)
         SELECT id, statuses_count, following_count, followers_count, created_at, updated_at
@@ -44,7 +48,7 @@ class CopyAccountStats < ActiveRecord::Migration[5.2]
 
     # We cannot use bulk INSERT or overarching transactions here because of possible
     # uniqueness violations that we need to skip over
-    Account.unscoped.select('id, statuses_count, following_count, followers_count, created_at, updated_at').find_each do |account|
+    MigrationAccount.unscoped.select('id, statuses_count, following_count, followers_count, created_at, updated_at').find_each do |account|
       params = [account.id, account[:statuses_count], account[:following_count], account[:followers_count], account.created_at, account.updated_at]
       exec_insert('INSERT INTO account_stats (account_id, statuses_count, following_count, followers_count, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6)', nil, params)
     rescue ActiveRecord::RecordNotUnique

--- a/db/post_migrate/20201017234926_fill_account_suspension_origin.rb
+++ b/db/post_migrate/20201017234926_fill_account_suspension_origin.rb
@@ -3,8 +3,15 @@
 class FillAccountSuspensionOrigin < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
+  class MigrationAccount < ApplicationRecord
+    self.table_name = :accounts
+    scope :suspended, -> { where.not(suspended_at: nil) }
+    enum suspension_origin: { local: 0, remote: 1 }, _prefix: true
+  end
+
   def up
-    Account.suspended.where(suspension_origin: nil).in_batches.update_all(suspension_origin: :local)
+    MigrationAccount.reset_column_information
+    MigrationAccount.suspended.where(suspension_origin: nil).in_batches.update_all(suspension_origin: :local)
   end
 
   def down; end


### PR DESCRIPTION
_Extracted from https://github.com/mastodon/mastodon/pull/25963_

As noted on that Rails 7.1 PR, there's a change in Rails main which leads to an `enum` declaration erroring out earlier than previously if a column does not exist. As a result, these migrations which run fine in main right now, throw up errors on the Rails 7.1 PR branch.

I generally dislike changing old migrations, but similar to - https://github.com/mastodon/mastodon/pull/26178 - these all strike me as so old that they are unlikely to ever actually be run in production? (presumably anyone upgrading is closer to current than these migrations, and any new instances or dev environments would just load the current schema and only ever apply newer migrations, so it seems safe). As far as I can tell, the generated sql and migration changes remain the same.

