### PR TITLE
Fix blocking subdomains of an already-blocked domain

### DIFF
--- a/app/controllers/admin/domain_blocks_controller.rb
+++ b/app/controllers/admin/domain_blocks_controller.rb
@@ -37,7 +37,7 @@ module Admin
         @domain_block.errors.delete(:domain)
         render :new
       else
-        if existing_domain_block.present?
+        if existing_domain_block.present? && existing_domain_block.domain == resource_params[:domain]
           @domain_block = existing_domain_block
           @domain_block.update(resource_params)
         end


### PR DESCRIPTION
This should address #26374, but for the 4.1 branch.

(The issue probably exists in other branches as well, but I started by investigating on 4.1.6 as it's where it was reported and 4.2.0-beta1 has changed parts of this code)