### PR TITLE
Change: Block GPTBot

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,8 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 
+User-agent: GPTBot
+Disallow: /
+
 User-agent: *
 Disallow: /media_proxy/
 Disallow: /interact/


### PR DESCRIPTION
I saw OpenAI allow you to opt out of indexing by their model data crawler: https://platform.openai.com/docs/gptbot

Maybe we want this on by default? Maybe that's too opinionated? Thought I'd propose it at least 🙂