### PR TITLE
Chewy / Elastic search version update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'addressable', '~> 2.8'
 gem 'bootsnap', '~> 1.18.0', require: false
 gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
-gem 'chewy', github: 'toptal/chewy'
+gem 'chewy', '8.0.0.pre.beta'
 gem 'devise', '~> 4.9'
 gem 'devise-two-factor'
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'addressable', '~> 2.8'
 gem 'bootsnap', '~> 1.18.0', require: false
 gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
-gem 'chewy', '~> 7.3'
+gem 'chewy', github: 'toptal/chewy', branch: 'es-8-0-upgrade-poc'
 gem 'devise', '~> 4.9'
 gem 'devise-two-factor'
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'addressable', '~> 2.8'
 gem 'bootsnap', '~> 1.18.0', require: false
 gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
-gem 'chewy', github: 'toptal/chewy', branch: 'es-8-0-upgrade-poc'
+gem 'chewy', github: 'ql/chewy', branch: 'es-8-0-upgrade-poc'
 gem 'devise', '~> 4.9'
 gem 'devise-two-factor'
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'addressable', '~> 2.8'
 gem 'bootsnap', '~> 1.18.0', require: false
 gem 'browser'
 gem 'charlock_holmes', '~> 0.7.7'
-gem 'chewy', github: 'ql/chewy', branch: 'es-8-0-upgrade-poc'
+gem 'chewy', github: 'toptal/chewy'
 gem 'devise', '~> 4.9'
 gem 'devise-two-factor'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,10 @@ GIT
       jwt (~> 2.0)
 
 GIT
-  remote: https://github.com/ql/chewy.git
-  revision: 545118fa11f0d18ef2bad06d88c70ca5b715fcfa
-  branch: es-8-0-upgrade-poc
+  remote: https://github.com/toptal/chewy.git
+  revision: 84c0eed871e835f55d560097ef141cd5fe504967
   specs:
-    chewy (8.0.0)
+    chewy (7.6.0)
       activesupport (>= 6.1)
       elasticsearch (>= 8.14, < 9.0)
       elasticsearch-dsl

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/ql/chewy.git
-  revision: d2129a8cf35f07cdcb651a669e130fd9417b3aab
+  revision: 545118fa11f0d18ef2bad06d88c70ca5b715fcfa
   branch: es-8-0-upgrade-poc
   specs:
-    chewy (7.6.0)
+    chewy (8.0.0)
       activesupport (>= 6.1)
       elasticsearch (>= 8.14, < 9.0)
       elasticsearch-dsl

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,13 @@ GIT
       jwt (~> 2.0)
 
 GIT
-  remote: https://github.com/toptal/chewy.git
-  revision: 5a1c4d540b3b3047b7f2fd104c107ff95f7cf667
+  remote: https://github.com/ql/chewy.git
+  revision: d2129a8cf35f07cdcb651a669e130fd9417b3aab
   branch: es-8-0-upgrade-poc
   specs:
-    chewy (7.4.0)
+    chewy (7.6.0)
       activesupport (>= 6.1)
-      elasticsearch (>= 8.11, < 9.0)
+      elasticsearch (>= 8.14, < 9.0)
       elasticsearch-dsl
 
 GEM
@@ -210,13 +210,13 @@ GEM
       railties (>= 5)
     dotenv (3.1.4)
     drb (2.2.1)
-    elastic-transport (8.3.2)
+    elastic-transport (8.3.5)
       faraday (< 3)
       multi_json
-    elasticsearch (8.13.0)
+    elasticsearch (8.15.0)
       elastic-transport (~> 8.3)
-      elasticsearch-api (= 8.13.0)
-    elasticsearch-api (8.13.0)
+      elasticsearch-api (= 8.15.0)
+    elasticsearch-api (8.15.0)
       multi_json
     elasticsearch-dsl (0.1.10)
     email_spec (2.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,16 @@ GIT
       hkdf (~> 0.2)
       jwt (~> 2.0)
 
+GIT
+  remote: https://github.com/toptal/chewy.git
+  revision: 5a1c4d540b3b3047b7f2fd104c107ff95f7cf667
+  branch: es-8-0-upgrade-poc
+  specs:
+    chewy (7.4.0)
+      activesupport (>= 6.1)
+      elasticsearch (>= 8.11, < 9.0)
+      elasticsearch-dsl
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -150,10 +160,6 @@ GEM
       activesupport
     cbor (0.5.9.8)
     charlock_holmes (0.7.9)
-    chewy (7.6.0)
-      activesupport (>= 5.2)
-      elasticsearch (>= 7.14.0, < 8)
-      elasticsearch-dsl
     childprocess (5.1.0)
       logger (~> 1.5)
     chunky_png (1.4.0)
@@ -204,16 +210,15 @@ GEM
       railties (>= 5)
     dotenv (3.1.4)
     drb (2.2.1)
-    elasticsearch (7.17.11)
-      elasticsearch-api (= 7.17.11)
-      elasticsearch-transport (= 7.17.11)
-    elasticsearch-api (7.17.11)
+    elastic-transport (8.3.2)
+      faraday (< 3)
+      multi_json
+    elasticsearch (8.12.2)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 8.12.2)
+    elasticsearch-api (8.12.2)
       multi_json
     elasticsearch-dsl (0.1.10)
-    elasticsearch-transport (7.17.11)
-      base64
-      faraday (>= 1, < 3)
-      multi_json
     email_spec (2.3.0)
       htmlentities (~> 4.3.3)
       launchy (>= 2.1, < 4.0)
@@ -893,7 +898,7 @@ DEPENDENCIES
   bundler-audit (~> 0.9)
   capybara (~> 3.39)
   charlock_holmes (~> 0.7.7)
-  chewy (~> 7.3)
+  chewy!
   climate_control
   cocoon (~> 1.2)
   color_diff (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,15 +7,6 @@ GIT
       hkdf (~> 0.2)
       jwt (~> 2.0)
 
-GIT
-  remote: https://github.com/toptal/chewy.git
-  revision: 84c0eed871e835f55d560097ef141cd5fe504967
-  specs:
-    chewy (7.6.0)
-      activesupport (>= 6.1)
-      elasticsearch (>= 8.14, < 9.0)
-      elasticsearch-dsl
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -159,6 +150,10 @@ GEM
       activesupport
     cbor (0.5.9.8)
     charlock_holmes (0.7.9)
+    chewy (8.0.0.pre.beta)
+      activesupport (>= 6.1)
+      elasticsearch (>= 8.14, < 9.0)
+      elasticsearch-dsl
     childprocess (5.1.0)
       logger (~> 1.5)
     chunky_png (1.4.0)
@@ -897,7 +892,7 @@ DEPENDENCIES
   bundler-audit (~> 0.9)
   capybara (~> 3.39)
   charlock_holmes (~> 0.7.7)
-  chewy!
+  chewy (= 8.0.0.pre.beta)
   climate_control
   cocoon (~> 1.2)
   color_diff (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,10 +213,10 @@ GEM
     elastic-transport (8.3.2)
       faraday (< 3)
       multi_json
-    elasticsearch (8.12.2)
+    elasticsearch (8.13.0)
       elastic-transport (~> 8.3)
-      elasticsearch-api (= 8.12.2)
-    elasticsearch-api (8.12.2)
+      elasticsearch-api (= 8.13.0)
+    elasticsearch-api (8.13.0)
       multi_json
     elasticsearch-dsl (0.1.10)
     email_spec (2.3.0)

--- a/app/lib/admin/metrics/dimension/software_versions_dimension.rb
+++ b/app/lib/admin/metrics/dimension/software_versions_dimension.rb
@@ -67,7 +67,7 @@ class Admin::Metrics::Dimension::SoftwareVersionsDimension < Admin::Metrics::Dim
       value: version,
       human_value: version,
     }
-  rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error
+  rescue Faraday::ConnectionFailed, Elastic::Transport::Transport::Error
     nil
   end
 

--- a/app/lib/admin/metrics/dimension/space_usage_dimension.rb
+++ b/app/lib/admin/metrics/dimension/space_usage_dimension.rb
@@ -80,7 +80,7 @@ class Admin::Metrics::Dimension::SpaceUsageDimension < Admin::Metrics::Dimension
       unit: 'bytes',
       human_value: number_to_human_size(value),
     }
-  rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error
+  rescue Faraday::ConnectionFailed, Elastic::Transport::Transport::Error
     nil
   end
 end

--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -17,7 +17,7 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
     return true unless Chewy.enabled?
 
     running_version.present? && compatible_version? && cluster_health['status'] == 'green' && indexes_match? && preset_matches?
-  rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error
+  rescue Faraday::ConnectionFailed, Elastic::Transport::Transport::Error
     false
   end
 
@@ -49,7 +49,7 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
     else
       Admin::SystemCheck::Message.new(:elasticsearch_preset, nil, 'https://docs.joinmastodon.org/admin/elasticsearch/#scaling')
     end
-  rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error
+  rescue Faraday::ConnectionFailed, Elastic::Transport::Transport::Error
     Admin::SystemCheck::Message.new(:elasticsearch_running_check)
   end
 
@@ -62,7 +62,7 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
   def running_version
     @running_version ||= begin
       Chewy.client.info['version']['number']
-    rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error
+    rescue Faraday::ConnectionFailed, Elastic::Transport::Transport::Error
       nil
     end
   end

--- a/lib/elasticsearch/client_extensions.rb
+++ b/lib/elasticsearch/client_extensions.rb
@@ -2,7 +2,7 @@
 
 module Elasticsearch
   module ClientExtensions
-    def verify_elasticsearch
+    def verify_elasticsearch(*_args, &_block)
       @verified = true
     end
   end

--- a/lib/mastodon/cli/search.rb
+++ b/lib/mastodon/cli/search.rb
@@ -100,7 +100,7 @@ module Mastodon::CLI
       progress.finish
 
       say("Indexed #{added} records, de-indexed #{removed}", :green, true)
-    rescue Elasticsearch::Transport::Transport::ServerError => e
+    rescue Elastic::Transport::Transport::ServerError => e
       fail_with_message <<~ERROR
         There was an issue connecting to the search server. Make sure the
         server is configured and running correctly, and that the environment

--- a/spec/lib/admin/system_check/elasticsearch_check_spec.rb
+++ b/spec/lib/admin/system_check/elasticsearch_check_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Admin::SystemCheck::ElasticsearchCheck do
 
   def stub_elasticsearch_error
     client = instance_double(Elasticsearch::Client)
-    allow(client).to receive(:info).and_raise(Elasticsearch::Transport::Transport::Error)
+    allow(client).to receive(:info).and_raise(Elastic::Transport::Transport::Error)
     allow(Chewy).to receive(:client).and_return(client)
   end
 end

--- a/spec/lib/mastodon/cli/search_spec.rb
+++ b/spec/lib/mastodon/cli/search_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Mastodon::CLI::Search do
     context 'when server communication raises an error' do
       let(:options) { { reset_chewy: true } }
 
-      before { allow(Chewy::Stash::Specification).to receive(:reset!).and_raise(Elasticsearch::Transport::Transport::Errors::InternalServerError) }
+      before { allow(Chewy::Stash::Specification).to receive(:reset!).and_raise(Elastic::Transport::Transport::Errors::InternalServerError) }
 
       it 'Exits with error message' do
         expect { subject }


### PR DESCRIPTION
As discussed here - https://github.com/mastodon/mastodon/pull/24209#issuecomment-1648720866 - we are limited in our ability to update `omniauth_openid_connect` or anything else which wants to be on Faraday 2+, because chewy gem has dependency on older ES gems which are locked to Faraday 1.x.

Opening this as draft to just get it moving. For now I'm pointing to an experimental branch someone has linked from this issue - https://github.com/toptal/chewy/issues/847 - which has started on some basic class changes in Chewy to support changes made in the ES gems. With that alone and one small change on our side I was able to get things loading/running/passing, but there are a ton of caveats here (hence the draft status!):

- Similar to the omniauth changes, we don't have exhaustive chewy/ES integration coverage in the specs. Most of what we do have is just stubbing out ES responses with chewy mock helpers and verifying basic chewy behavior. Makes it hard to be confident about results here. We should almost definitely improve this situation before upgrading.
- How fully does this experimental chewy branch actually do all updates needed for the 8.x ES gems (split into transport and api gems) -- I don't know currently.
- There’s a warning from the gem during spec run because of error connecting to server and how server is not official supported version. I think this is actually fine to ignore, but in the few mins I looked it didn't seem to be disableable.
- ~~There's an insistence from the official 8.x server on secure/443/https connections, which our default config does not seem to do.~~ (not relevant: we wont update server to 8.x any time soon)
- ~~I suspect we have some specs which are not correctly stubbed out … I was able to get different spec output when running -vs- not running an actual ES server locally~~ (fixed in https://github.com/mastodon/mastodon/pull/26413)
- I did a quick console session to see if Chewy could just connect with both a 7.x and 8.x server running locally and this chewy gem update in place, and was able to at least get that connection established, but have done zero work yet to verify anything else works.
- ~~I know there are licensing changes on the server side of things either in server v7 or moving from 7 to 8 and have not at all contemplated whether that matters here yet (I think it does not narrowly matter, because we're not changing the packaged Docker ES distribution, but maybe its related).~~ (not relevant: we arent packaging server, and we will only update client libs here)

All that to say, this is currently focused merely on accomplishing the upgrade at all, and needs a lot more verification of behavior (which I’ll continue on) … just wanted to open this to clarify direction here and whether this is a good path to work on (as opposed to investigating a switch to OpenSearch, and/or any other ideas to open up our Faraday update Future).



