### PR TITLE
Fix cached posts including stale stats

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -379,8 +379,13 @@ class Status < ApplicationRecord
         item.account = accounts[item.account_id]
         item.reblog.account = accounts[item.reblog.account_id] if item.reblog?
 
-        status_stat = status_stats[item.id]
-        item.status_stat = status_stat if status_stat.present?
+        if item.reblog?
+          status_stat = status_stats[item.reblog.id]
+          item.reblog.status_stat = status_stat if status_stat.present?
+        else
+          status_stat = status_stats[item.id]
+          item.status_stat = status_stat if status_stat.present?
+        end
       end
     end
 

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -367,13 +367,20 @@ class Status < ApplicationRecord
 
       account_ids.uniq!
 
+      status_ids = cached_items.map { |item| item.reblog? ? item.reblog_of_id : item.id }.uniq
+
       return if account_ids.empty?
 
       accounts = Account.where(id: account_ids).includes(:account_stat, :user).index_by(&:id)
 
+      status_stats = StatusStat.where(status_id: status_ids).index_by(&:status_id)
+
       cached_items.each do |item|
         item.account = accounts[item.account_id]
         item.reblog.account = accounts[item.reblog.account_id] if item.reblog?
+
+        status_stat = status_stats[item.id]
+        item.status_stat = status_stat if status_stat.present?
       end
     end
 

--- a/spec/controllers/concerns/cache_concern_spec.rb
+++ b/spec/controllers/concerns/cache_concern_spec.rb
@@ -13,12 +13,17 @@ RSpec.describe CacheConcern do
     def empty_relation
       render plain: cache_collection(Status.none, Status).size
     end
+
+    def account_statuses_favourites
+      render plain: cache_collection(Status.where(account_id: params[:id]), Status).map(&:favourites_count)
+    end
   end
 
   before do
     routes.draw do
-      get  'empty_array' => 'anonymous#empty_array'
-      post 'empty_relation' => 'anonymous#empty_relation'
+      get 'empty_array' => 'anonymous#empty_array'
+      get 'empty_relation' => 'anonymous#empty_relation'
+      get 'account_statuses_favourites' => 'anonymous#account_statuses_favourites'
     end
   end
 
@@ -34,6 +39,21 @@ RSpec.describe CacheConcern do
       it 'returns an empty array' do
         get :empty_relation
         expect(response.body).to eq '0'
+      end
+    end
+
+    context 'when given a collection of statuses' do
+      let!(:account) { Fabricate(:account) }
+      let!(:status)  { Fabricate(:status, account: account) }
+
+      it 'correctly updates with new interactions' do
+        get :account_statuses_favourites, params: { id: account.id }
+        expect(response.body).to eq '[0]'
+
+        FavouriteService.new.call(account, status)
+
+        get :account_statuses_favourites, params: { id: account.id }
+        expect(response.body).to eq '[1]'
       end
     end
   end


### PR DESCRIPTION
This fixes the favorite/reblog/reply counts being out of date on cached posts.

Needs some tests as well as evaluating the performance impact.