### PR TITLE
Avoid connecting to a running ES instance in ES search check spec

### DIFF
--- a/spec/lib/admin/system_check/elasticsearch_check_spec.rb
+++ b/spec/lib/admin/system_check/elasticsearch_check_spec.rb
@@ -49,11 +49,7 @@ describe Admin::SystemCheck::ElasticsearchCheck do
       end
 
       context 'when running version is missing' do
-        before do
-          client = instance_double(Elasticsearch::Transport::Client)
-          allow(client).to receive(:info).and_raise(Elasticsearch::Transport::Transport::Error)
-          allow(Chewy).to receive(:client).and_return(client)
-        end
+        before { stub_elasticsearch_error }
 
         it 'returns false' do
           expect(check.pass?).to be false
@@ -86,6 +82,8 @@ describe Admin::SystemCheck::ElasticsearchCheck do
     end
 
     context 'when running version is missing' do
+      before { stub_elasticsearch_error }
+
       it 'sends class name symbol to message instance' do
         allow(Admin::SystemCheck::Message).to receive(:new)
           .with(:elasticsearch_running_check)
@@ -96,5 +94,11 @@ describe Admin::SystemCheck::ElasticsearchCheck do
           .with(:elasticsearch_running_check)
       end
     end
+  end
+
+  def stub_elasticsearch_error
+    client = instance_double(Elasticsearch::Transport::Client)
+    allow(client).to receive(:info).and_raise(Elasticsearch::Transport::Transport::Error)
+    allow(Chewy).to receive(:client).and_return(client)
   end
 end


### PR DESCRIPTION
While working on https://github.com/mastodon/mastodon/pull/26399 I realized that of the two "missing version" examples in the system check spec, only one of them is actually stubbing out an ES response; the other is just relying on an ES server not running so it fails that way.

That means that if an ES server *is running* the spec will connect to it (and fail).

This changes the spec to fully stub out the ES connection in both of the "missing version" examples.