### PR TITLE
Change the hashtag column to not display the hashtag header on pinned columns

### DIFF
--- a/app/javascript/mastodon/features/hashtag_timeline/index.jsx
+++ b/app/javascript/mastodon/features/hashtag_timeline/index.jsx
@@ -203,7 +203,7 @@ class HashtagTimeline extends PureComponent {
         </ColumnHeader>
 
         <StatusListContainer
-          prepend={<HashtagHeader tag={tag} disabled={!signedIn} onClick={this.handleFollow} />}
+          prepend={pinned ? null : <HashtagHeader tag={tag} disabled={!signedIn} onClick={this.handleFollow} />}
           alwaysPrepend
           trackScroll={!pinned}
           scrollKey={`hashtag_timeline-${columnId}`}


### PR DESCRIPTION
#26362 added a header to hashtag timelines and moved the follow button there.

If someone has a pinned column for a hashtag In the advanced (multi-column) interface, they are probably not interested in following it (having the posts from this hashtag show up in their Home timeline).

This PR keeps the header in un-pinned columns so that following/unfollowing remains easy and discoverable.

![image](https://github.com/mastodon/mastodon/assets/384364/e0b75233-56e9-4a29-b8d3-7683ff211c8e)