### PR TITLE
Throttle account deletions in `tootctl self-destruct` to avoid overwhelming Sidekiq/Redis

### DIFF
--- a/lib/mastodon/cli/main.rb
+++ b/lib/mastodon/cli/main.rb
@@ -130,7 +130,8 @@ module Mastodon::CLI
             [json, account.id, inbox_url]
           end
 
-          account.suspend!(block_email: false)
+          # Do not call `Account#suspend!` because we don't want to issue a deletion request
+          account.update!(suspended_at: Time.now.utc, suspension_origin: :local)
         end
 
         processed += 1


### PR DESCRIPTION
Currently, we enqueue every account deletion job at once, which means roughly `num_local_accounts * known_remote_inbox` jobs queued at once, which is very likely to overwhelm Sidekiq/Redis.

This PR pauses queuing new deletions every 50 accounts if the redis memory usage is over 50% of total available memory or if more than 5000 jobs are queued.