### PR TITLE
Merge duplicate Gemfile groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -186,9 +186,7 @@ group :development, :test do
   gem 'ruby-prof', require: false
   gem 'stackprof', require: false
   gem 'test-prof'
-end
 
-group :development, :test do
   # RSpec runner for rails
   gem 'rspec-rails', '~> 6.0'
 end


### PR DESCRIPTION
One off the newer version was crashing on a new rule Bundler/DuplicatedGroup. I think it was likely going to suggest this, so I just fixed this ahead of time