### PR TITLE
Add Elasticsearch cluster health check and indexes mismatch check to dashboard

### DIFF
--- a/app/chewy/instances_index.rb
+++ b/app/chewy/instances_index.rb
@@ -6,7 +6,7 @@ class InstancesIndex < Chewy::Index
   index_scope ::Instance.searchable
 
   root date_detection: false do
-    field :domain, type: 'text', index_prefixes: { min_chars: 1 }
+    field :domain, type: 'text', index_prefixes: { min_chars: 1, max_chars: 5 }
     field :accounts_count, type: 'long'
   end
 end

--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -16,6 +16,8 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
     return true unless Chewy.enabled?
 
     running_version.present? && compatible_version? && cluster_health['status'] == 'green' && indexes_match?
+  rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error
+    false
   end
 
   def message
@@ -40,6 +42,8 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
     else
       Admin::SystemCheck::Message.new(:elasticsearch_health_yellow)
     end
+  rescue Faraday::ConnectionFailed, Elasticsearch::Transport::Transport::Error
+    Admin::SystemCheck::Message.new(:elasticsearch_running_check)
   end
 
   private
@@ -69,6 +73,8 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
 
     Gem::Version.new(running_version) >= Gem::Version.new(required_version) ||
       Gem::Version.new(compatible_wire_version) >= Gem::Version.new(required_version)
+  rescue ArgumentError
+    false
   end
 
   def mismatched_indexes

--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -41,6 +41,8 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
       Admin::SystemCheck::Message.new(:elasticsearch_health_red)
     elsif cluster_health['number_of_nodes'] < 2 && ENV.fetch('ES_PRESET', 'single_node_cluster') != 'single_node_cluster'
       Admin::SystemCheck::Message.new(:elasticsearch_preset_single_node, nil, 'https://docs.joinmastodon.org/admin/optional/elasticsearch/#scaling')
+    elsif Chewy.client.indices.get_settings['chewy_specifications'].dig('settings', 'index', 'number_of_replicas')&.to_i&.positive? && ENV.fetch('ES_PRESET', 'single_node_cluster') == 'single_node_cluster'
+      Admin::SystemCheck::Message.new(:elasticsearch_reset_chewy)
     elsif cluster_health['status'] == 'yellow'
       Admin::SystemCheck::Message.new(:elasticsearch_health_yellow)
     else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -818,6 +818,8 @@ en:
         message_html: Elasticsearch cluster is unhealthy (red status), search features are unavailable
       elasticsearch_health_yellow:
         message_html: Elasticsearch cluster is unhealthy (yellow status), search features may be unavailable
+      elasticsearch_index_mismatch:
+        message_html: Elasticsearch indexes do not match current definitions. Please run <code>tootctl search deploy --only=%{value}</code>
       elasticsearch_running_check:
         message_html: Could not connect to Elasticsearch. Please check that it is running, or disable full-text search
       elasticsearch_version_check:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -817,9 +817,9 @@ en:
       elasticsearch_health_red:
         message_html: Elasticsearch cluster is unhealthy (red status), search features are unavailable
       elasticsearch_health_yellow:
-        message_html: Elasticsearch cluster is unhealthy (yellow status), search features may be unavailable
+        message_html: Elasticsearch cluster is unhealthy (yellow status), you may want to review your setup
       elasticsearch_index_mismatch:
-        message_html: Elasticsearch indexes do not match current definitions. Please run <code>tootctl search deploy --only=%{value}</code>
+        message_html: Elasticsearch index mappings are outdated. Please run <code>tootctl search deploy --only=%{value}</code>
       elasticsearch_running_check:
         message_html: Could not connect to Elasticsearch. Please check that it is running, or disable full-text search
       elasticsearch_version_check:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -820,6 +820,12 @@ en:
         message_html: Elasticsearch cluster is unhealthy (yellow status), you may want to review your setup
       elasticsearch_index_mismatch:
         message_html: Elasticsearch index mappings are outdated. Please run <code>tootctl search deploy --only=%{value}</code>
+      elasticsearch_preset:
+        action: See documentation
+        message_html: Your Elastic Search cluster has more than one node, but is only using one.
+      elasticsearch_preset_single_node:
+        action: See documentation
+        message_html: Your Elastic Search cluster has only one node, <code>ES_PRESET</code> should be set to <code>single_node_cluster</code>.
       elasticsearch_running_check:
         message_html: Could not connect to Elasticsearch. Please check that it is running, or disable full-text search
       elasticsearch_version_check:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -814,6 +814,10 @@ en:
     system_checks:
       database_schema_check:
         message_html: There are pending database migrations. Please run them to ensure the application behaves as expected
+      elasticsearch_health_red:
+        message_html: Elasticsearch cluster is unhealthy (red status), search features are unavailable
+      elasticsearch_health_yellow:
+        message_html: Elasticsearch cluster is unhealthy (yellow status), search features may be unavailable
       elasticsearch_running_check:
         message_html: Could not connect to Elasticsearch. Please check that it is running, or disable full-text search
       elasticsearch_version_check:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -826,6 +826,8 @@ en:
       elasticsearch_preset_single_node:
         action: See documentation
         message_html: Your Elasticsearch cluster has only one node, <code>ES_PRESET</code> should be set to <code>single_node_cluster</code>.
+      elasticsearch_reset_chewy:
+        message_html: Your Elasticsearch system index is outdated due to a setting change. Please run <code>tootctl search deploy --reset-chewy</code> to update it.
       elasticsearch_running_check:
         message_html: Could not connect to Elasticsearch. Please check that it is running, or disable full-text search
       elasticsearch_version_check:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -817,15 +817,15 @@ en:
       elasticsearch_health_red:
         message_html: Elasticsearch cluster is unhealthy (red status), search features are unavailable
       elasticsearch_health_yellow:
-        message_html: Elasticsearch cluster is unhealthy (yellow status), you may want to review your setup
+        message_html: Elasticsearch cluster is unhealthy (yellow status), you may want to investigate the reason
       elasticsearch_index_mismatch:
         message_html: Elasticsearch index mappings are outdated. Please run <code>tootctl search deploy --only=%{value}</code>
       elasticsearch_preset:
         action: See documentation
-        message_html: Your Elastic Search cluster has more than one node, but is only using one.
+        message_html: Your Elasticsearch cluster has more than one node, but Mastodon is not configured to use them.
       elasticsearch_preset_single_node:
         action: See documentation
-        message_html: Your Elastic Search cluster has only one node, <code>ES_PRESET</code> should be set to <code>single_node_cluster</code>.
+        message_html: Your Elasticsearch cluster has only one node, <code>ES_PRESET</code> should be set to <code>single_node_cluster</code>.
       elasticsearch_running_check:
         message_html: Could not connect to Elasticsearch. Please check that it is running, or disable full-text search
       elasticsearch_version_check:

--- a/spec/lib/admin/system_check/elasticsearch_check_spec.rb
+++ b/spec/lib/admin/system_check/elasticsearch_check_spec.rb
@@ -11,7 +11,16 @@ describe Admin::SystemCheck::ElasticsearchCheck do
 
   describe 'pass?' do
     context 'when chewy is enabled' do
-      before { allow(Chewy).to receive(:enabled?).and_return(true) }
+      before do
+        allow(Chewy).to receive(:enabled?).and_return(true)
+        allow(Chewy.client.cluster).to receive(:health).and_return({ 'status' => 'green' })
+        allow(Chewy.client.indices).to receive(:get_mapping).and_return({
+          AccountsIndex.index_name => AccountsIndex.mappings_hash.deep_stringify_keys,
+          StatusesIndex.index_name => StatusesIndex.mappings_hash.deep_stringify_keys,
+          InstancesIndex.index_name => InstancesIndex.mappings_hash.deep_stringify_keys,
+          TagsIndex.index_name => TagsIndex.mappings_hash.deep_stringify_keys,
+        })
+      end
 
       context 'when running version is present and high enough' do
         before do
@@ -67,8 +76,19 @@ describe Admin::SystemCheck::ElasticsearchCheck do
   end
 
   describe 'message' do
+    before do
+      allow(Chewy).to receive(:enabled?).and_return(true)
+      allow(Chewy.client.cluster).to receive(:health).and_return({ 'status' => 'green' })
+      allow(Chewy.client.indices).to receive(:get_mapping).and_return({
+        AccountsIndex.index_name => AccountsIndex.mappings_hash.deep_stringify_keys,
+        StatusesIndex.index_name => StatusesIndex.mappings_hash.deep_stringify_keys,
+        InstancesIndex.index_name => InstancesIndex.mappings_hash.deep_stringify_keys,
+        TagsIndex.index_name => TagsIndex.mappings_hash.deep_stringify_keys,
+      })
+    end
+
     context 'when running version is present' do
-      before { allow(Chewy.client).to receive(:info).and_return({ 'version' => { 'number' => '999.99.9' } }) }
+      before { allow(Chewy.client).to receive(:info).and_return({ 'version' => { 'number' => '1.2.3' } }) }
 
       it 'sends class name symbol to message instance' do
         allow(Admin::SystemCheck::Message).to receive(:new)
@@ -77,7 +97,7 @@ describe Admin::SystemCheck::ElasticsearchCheck do
         check.message
 
         expect(Admin::SystemCheck::Message).to have_received(:new)
-          .with(:elasticsearch_version_check, 'Elasticsearch 999.99.9 is running while 7.x is required')
+          .with(:elasticsearch_version_check, 'Elasticsearch 1.2.3 is running while 7.x is required')
       end
     end
 

--- a/spec/lib/admin/system_check/elasticsearch_check_spec.rb
+++ b/spec/lib/admin/system_check/elasticsearch_check_spec.rb
@@ -20,6 +20,15 @@ describe Admin::SystemCheck::ElasticsearchCheck do
           InstancesIndex.index_name => InstancesIndex.mappings_hash.deep_stringify_keys,
           TagsIndex.index_name => TagsIndex.mappings_hash.deep_stringify_keys,
         })
+        allow(Chewy.client.indices).to receive(:get_settings).and_return({
+          'chewy_specifications' => {
+            'settings' => {
+              'index' => {
+                'number_of_replicas' => 0,
+              },
+            },
+          },
+        })
       end
 
       context 'when running version is present and high enough' do

--- a/spec/lib/admin/system_check/elasticsearch_check_spec.rb
+++ b/spec/lib/admin/system_check/elasticsearch_check_spec.rb
@@ -13,7 +13,7 @@ describe Admin::SystemCheck::ElasticsearchCheck do
     context 'when chewy is enabled' do
       before do
         allow(Chewy).to receive(:enabled?).and_return(true)
-        allow(Chewy.client.cluster).to receive(:health).and_return({ 'status' => 'green' })
+        allow(Chewy.client.cluster).to receive(:health).and_return({ 'status' => 'green', 'number_of_nodes' => 1 })
         allow(Chewy.client.indices).to receive(:get_mapping).and_return({
           AccountsIndex.index_name => AccountsIndex.mappings_hash.deep_stringify_keys,
           StatusesIndex.index_name => StatusesIndex.mappings_hash.deep_stringify_keys,
@@ -78,7 +78,7 @@ describe Admin::SystemCheck::ElasticsearchCheck do
   describe 'message' do
     before do
       allow(Chewy).to receive(:enabled?).and_return(true)
-      allow(Chewy.client.cluster).to receive(:health).and_return({ 'status' => 'green' })
+      allow(Chewy.client.cluster).to receive(:health).and_return({ 'status' => 'green', 'number_of_nodes' => 1 })
       allow(Chewy.client.indices).to receive(:get_mapping).and_return({
         AccountsIndex.index_name => AccountsIndex.mappings_hash.deep_stringify_keys,
         StatusesIndex.index_name => StatusesIndex.mappings_hash.deep_stringify_keys,


### PR DESCRIPTION
Fixes #26417

Note that it should not be merged right away, because under current configuration, single-node Elasticsearch deployments will always have yellow health at best.

![image](https://github.com/mastodon/mastodon/assets/384364/1d9978ee-bc89-470a-be5b-eb8e7c4ba541)
![image](https://github.com/mastodon/mastodon/assets/384364/237965f6-ed11-470f-8499-9499cbefe6ef)