### PR TITLE
Change emoji size in statuses when it only contains emoji

### DIFF
--- a/app/javascript/mastodon/components/__tests__/status_contains_only_emoji-test.ts
+++ b/app/javascript/mastodon/components/__tests__/status_contains_only_emoji-test.ts
@@ -1,0 +1,42 @@
+import { fromJS } from 'immutable';
+
+import { statusContainsOnlyEmoji } from '../status_content';
+
+function makeStatus(content: string) {
+  return fromJS({
+    search_index: content,
+    emojis: [{ shortcode: 'test' }],
+  });
+}
+
+describe('statusContainsOnlyEmoji', () => {
+  const validStatuses = [
+    '😃',
+    '😇🥲',
+    '😃:test:',
+    ':test:',
+    '😃 :test:',
+    '  😃 :test:',
+    '😃 :test:   ',
+  ];
+
+  const invalidStatuses = [
+    '😃 test',
+    'test',
+    '😃\n😃',
+    ':wrong:',
+    '😃:wrong:',
+    ':wrong: 😃 :test:',
+  ];
+
+  test.each(validStatuses)('status %j contains only emoji', (statusText) => {
+    expect(statusContainsOnlyEmoji(makeStatus(statusText))).toBe(true);
+  });
+
+  test.each(invalidStatuses)(
+    'status %j does not contains only emoji',
+    (statusText) => {
+      expect(statusContainsOnlyEmoji(makeStatus(statusText))).toBe(false);
+    },
+  );
+});

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -16,9 +16,9 @@ import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_s
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
 // Using SHORTCODE_RE_FRAGMENT from app/models/custom_emoji.rb
-const emojiRegexp = /^(?:\p{Extended_Pictographic}\s*|:([a-zA-Z0-9_]{2,}):\s*)+$/u;
+const emojiRegexp = /^(?:\p{Extended_Pictographic}[^\S\r\n]*|:([a-zA-Z0-9_]{2,}):[\S\r\n]*)+$/u;
 
-function containsOnlyEmoji(status) {
+export function statusContainsOnlyEmoji(status) {
   // We need to use `trim` here to avoid matching for leading spaces in the regexp above, as this might trigger a ReDoS vulnerability
   const matches = status.get('search_index')?.trim()?.match(emojiRegexp);
 
@@ -275,7 +275,7 @@ class StatusContent extends PureComponent {
       'status__content--with-action': this.props.onClick && this.context.router,
       'status__content--with-spoiler': status.get('spoiler_text').length > 0,
       'status__content--collapsed': renderReadMore,
-      'status__content--only-emoji': containsOnlyEmoji(status),
+      'status__content--only-emoji': statusContainsOnlyEmoji(status),
     });
 
     const readMoreButton = renderReadMore && (

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -15,6 +15,12 @@ import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_s
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
+const emojiRegexp = /^(\s*(?:\p{Extended_Pictographic}|:[a-zA-Z0-9]+:)+\s*)+$/u
+
+function containsOnlyEmoji(status) {
+  return emojiRegexp.test(status.get('search_index'))
+}
+
 /**
  *
  * @param {any} status
@@ -250,6 +256,7 @@ class StatusContent extends PureComponent {
       'status__content--with-action': this.props.onClick && this.context.router,
       'status__content--with-spoiler': status.get('spoiler_text').length > 0,
       'status__content--collapsed': renderReadMore,
+      'status__content--only-emoji': containsOnlyEmoji(status),
     });
 
     const readMoreButton = renderReadMore && (

--- a/app/javascript/mastodon/components/status_content.jsx
+++ b/app/javascript/mastodon/components/status_content.jsx
@@ -15,10 +15,11 @@ import { autoPlayGif, languages as preloadedLanguages } from 'mastodon/initial_s
 
 const MAX_HEIGHT = 706; // 22px * 32 (+ 2px padding at the top)
 
-const emojiRegexp = /^(?:\s*(?:\p{Extended_Pictographic}|:([a-zA-Z0-9]+):)+)+$/u;
+// Using SHORTCODE_RE_FRAGMENT from app/models/custom_emoji.rb
+const emojiRegexp = /^(?:\p{Extended_Pictographic}\s*|:([a-zA-Z0-9_]{2,}):\s*)+$/u;
 
 function containsOnlyEmoji(status) {
-  // We need to use `trim` here to avoid matching for trailing spaces in the regexp above, as this might trigger a ReDoS vulnerability
+  // We need to use `trim` here to avoid matching for leading spaces in the regexp above, as this might trigger a ReDoS vulnerability
   const matches = status.get('search_index')?.trim()?.match(emojiRegexp);
 
   if(matches) {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -810,6 +810,7 @@ body > [data-popper-placement] {
     img.emojione {
       width: 48px;
       height: 48px;
+      margin: 0;
     }
   }
 }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -805,6 +805,15 @@ body > [data-popper-placement] {
   clear: both;
 }
 
+.status__content--only-emoji {
+  .status__content__text {
+    img.emojione {
+      width: 48px;
+      height: 48px;
+    }
+  }
+}
+
 .status__content,
 .reply-indicator__content {
   position: relative;


### PR DESCRIPTION
<img width="597" alt="image" src="https://github.com/mastodon/mastodon/assets/42070/47a48427-bf25-4900-b279-ff0f7995254c">


I am not sure this is the best way to do it, but this regexp is supported in [every modern browser](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Unicode_character_class_escape).

To avoid recreating the regexp for each status (which can have perf impact), I extract every match between `:`, and then compare it with `status.emoji.shortcode`.

Maybe the `containsOnlyEmoji` function should be cached, based on the status ID + `edited_at`?

I also considered trying to parse `status.content`, but this seems very brittle.

Fixes #26456