### PR TITLE
Fix "Create Account" button in interaction modal

### DIFF
--- a/app/javascript/mastodon/features/interaction_modal/index.jsx
+++ b/app/javascript/mastodon/features/interaction_modal/index.jsx
@@ -25,8 +25,11 @@ const mapStateToProps = (state, { accountId }) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   onSignupClick() {
-    dispatch(closeModal());
-    dispatch(openModal('CLOSED_REGISTRATIONS'));
+    dispatch(closeModal({
+        modalType: undefined,
+        ignoreFocus: false,
+      }));
+    dispatch(openModal({ modalType: 'CLOSED_REGISTRATIONS' }));
   },
 });
 

--- a/app/javascript/mastodon/features/interaction_modal/index.jsx
+++ b/app/javascript/mastodon/features/interaction_modal/index.jsx
@@ -21,6 +21,7 @@ const messages = defineMessages({
 
 const mapStateToProps = (state, { accountId }) => ({
   displayNameHtml: state.getIn(['accounts', accountId, 'display_name_html']),
+  signupUrl: state.getIn(['server', 'server', 'registrations', 'url'], null) || '/auth/sign_up',
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -297,6 +298,7 @@ class InteractionModal extends React.PureComponent {
     url: PropTypes.string,
     type: PropTypes.oneOf(['reply', 'reblog', 'favourite', 'follow']),
     onSignupClick: PropTypes.func.isRequired,
+    signupUrl: PropTypes.string.isRequired,
   };
 
   handleSignupClick = () => {
@@ -304,7 +306,7 @@ class InteractionModal extends React.PureComponent {
   };
 
   render () {
-    const { url, type, displayNameHtml } = this.props;
+    const { url, type, displayNameHtml, signupUrl } = this.props;
 
     const name = <bdi dangerouslySetInnerHTML={{ __html: displayNameHtml }} />;
 
@@ -343,7 +345,7 @@ class InteractionModal extends React.PureComponent {
       );
     } else if (registrationsOpen) {
       signupButton = (
-        <a href='/auth/sign_up' className='link-button'>
+        <a href={signupUrl} className='link-button'>
           <FormattedMessage id='sign_in_banner.create_account' defaultMessage='Create account' />
         </a>
       );


### PR DESCRIPTION
This fixes following issues:

1. In closed registrations, modal not changing by clicking on the button.
2. Custom signup URL configured in the `SSO_ACCOUNT_SIGN_UP` environment variable not overrides the button's link-to.

## Steps to reproduce the first one

1. Disable registrations in server settings
2. Logout from Mastodon
3. Click follow button on someone's profile
4. Click the "Create Account" button in the interaction modal

### Expected behavior

The interaction modal closing then the closed-registrations modal opening.

### Actual behavior

Nothing happens.

## Steps to reproduce the second one

1. Set custom signup URL with define `SSO_ACCOUNT_SIGN_UP` variable in .env
2. Open the interaction modal

### Expected behavior

The "Create Account" button linked to the customized signup URL.

### Actual behavior

The "Create Account" button linked to `/auth/sign_up` the default signup URL.
