### PR TITLE
Fix notification permissions being requested immediately after login

### DIFF
--- a/app/javascript/mastodon/actions/notifications.js
+++ b/app/javascript/mastodon/actions/notifications.js
@@ -18,6 +18,7 @@ import {
   importFetchedStatuses,
 } from './importer';
 import { submitMarkers } from './markers';
+import { register as registerPushNotifications } from './push_notifications';
 import { saveSettings } from './settings';
 
 export const NOTIFICATIONS_UPDATE      = 'NOTIFICATIONS_UPDATE';
@@ -293,6 +294,10 @@ export function requestBrowserPermission(callback = noOp) {
     requestNotificationPermission((permission) => {
       dispatch(setBrowserPermission(permission));
       callback(permission);
+
+      if (permission === 'granted') {
+        dispatch(registerPushNotifications());
+      }
     });
   };
 }

--- a/app/javascript/mastodon/main.jsx
+++ b/app/javascript/mastodon/main.jsx
@@ -33,7 +33,7 @@ function main() {
         console.error(err);
       }
 
-      if (registration) {
+      if (registration && 'Notification' in window && Notification.permission === 'granted') {
         const registerPushNotifications = await import('mastodon/actions/push_notifications');
 
         store.dispatch(registerPushNotifications.register());


### PR DESCRIPTION
Despite our intent to request notifications permission only on user action from the notification banner column, we missed the part where we were immediately registering push notifications through the service worker.

Only register push notifications at launch if the permission is already granted, otherwise, do that when the permission gets granted.