### PR TITLE
Using Sidekiq concurrency for default db pool value

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter: postgresql
-  pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>
+  pool: <%= ENV["DB_POOL"] || (if Sidekiq.server? then Sidekiq[:concurrency] else ENV['MAX_THREADS'] end) || 5 %>
   timeout: 5000
   connect_timeout: 15
   encoding: unicode


### PR DESCRIPTION
This will make db pool default value to `Sidekiq[:concurrency]` or `SIDEKIQ_CONCURRENCY` in sidekiq process.

Like redis parts: https://github.com/mastodon/mastodon/blob/f5778caa3acde205e55df6a8ec00b28a691f8c19/lib/mastodon/redis_config.rb#L38
https://github.com/mastodon/mastodon/blob/f5778caa3acde205e55df6a8ec00b28a691f8c19/app/lib/redis_configuration.rb#L16-L23

And will helps
> [The database pool size is controlled with the DB_POOL environment variable and must be at least the same as the number of threads.](https://docs.joinmastodon.org/admin/scaling/#sidekiq-threads)

automatically.