### PR TITLE
Fix ES_PRESET not being applied to Chewy's internal index

### DIFF
--- a/config/initializers/chewy.rb
+++ b/config/initializers/chewy.rb
@@ -15,6 +15,9 @@ Chewy.settings = {
   journal: false,
   user: user,
   password: password,
+  index: {
+    number_of_replicas: ['single_node_cluster', nil].include?(ENV['ES_PRESET'].presence) ? 0 : 1,
+  },
 }
 
 # We use our own async strategy even outside the request-response

--- a/lib/mastodon/cli/search.rb
+++ b/lib/mastodon/cli/search.rb
@@ -18,6 +18,7 @@ module Mastodon::CLI
     option :only, type: :array, enum: %w(instances accounts tags statuses), desc: 'Only process these indices'
     option :import, type: :boolean, default: true, desc: 'Import data from the database to the index'
     option :clean, type: :boolean, default: true, desc: 'Remove outdated documents from the index'
+    option :reset_chewy, type: :boolean, default: false, desc: "Reset Chewy's internal index"
     desc 'deploy', 'Create or upgrade Elasticsearch indices and populate them'
     long_desc <<~LONG_DESC
       If Elasticsearch is empty, this command will create the necessary indices
@@ -41,6 +42,8 @@ module Mastodon::CLI
       pool      = Concurrent::FixedThreadPool.new(options[:concurrency], max_queue: options[:concurrency] * 10)
       importers = indices.index_with { |index| "Importer::#{index.name}Importer".constantize.new(batch_size: options[:batch_size], executor: pool) }
       progress  = ProgressBar.create(total: nil, format: '%t%c/%u |%b%i| %e (%r docs/s)', autofinish: false)
+
+      Chewy::Stash::Specification.reset! if options[:reset_chewy]
 
       # First, ensure all indices are created and have the correct
       # structure, so that live data can already be written


### PR DESCRIPTION
While #26483 added an environment variable to set the number of replicas, Chewy has its own internal index which did not make use of this.

This also adds a `--reset-chewy` flag to `tootctl search deploy` to reset that index, as `tootctl search deploy` will not currently reset it.