### PR TITLE
Chore: Migrate from webpush gem to web-push gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem 'tty-prompt', '~> 0.23', require: false
 gem 'twitter-text', '~> 3.1.0'
 gem 'tzinfo-data', '~> 1.2023'
 gem 'webpacker', '~> 5.4'
-gem 'webpush', github: 'ClearlyClaire/webpush', ref: 'f14a4d52e201128b1b00245d11b6de80d6cfdcd9'
+gem 'web-push', '~> 3.0'
 gem 'webauthn', '~> 3.0'
 
 gem 'json-ld'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/ClearlyClaire/webpush.git
-  revision: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
-  ref: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
-  specs:
-    webpush (0.3.8)
-      hkdf (~> 0.2)
-      jwt (~> 2.0)
-
-GIT
   remote: https://github.com/jhawthorn/nsa.git
   revision: e020fcc3a54d993ab45b7194d89ab720296c111b
   ref: e020fcc3a54d993ab45b7194d89ab720296c111b
@@ -344,7 +335,7 @@ GEM
       json
     highline (2.1.0)
     hiredis (0.6.3)
-    hkdf (0.3.0)
+    hkdf (1.0.0)
     htmlentities (4.3.4)
     http (5.1.1)
       addressable (~> 2.8)
@@ -779,6 +770,10 @@ GEM
       public_suffix
     warden (1.2.9)
       rack (>= 2.0.9)
+    web-push (3.0.0)
+      hkdf (~> 1.0)
+      jwt (~> 2.0)
+      openssl (~> 3.0)
     webauthn (3.0.0)
       android_key_attestation (~> 0.3.0)
       awrence (~> 1.1)
@@ -939,10 +934,10 @@ DEPENDENCIES
   tty-prompt (~> 0.23)
   twitter-text (~> 3.1.0)
   tzinfo-data (~> 1.2023)
+  web-push (~> 3.0)
   webauthn (~> 3.0)
   webmock (~> 3.18)
   webpacker (~> 5.4)
-  webpush!
   xorcist (~> 1.1)
 
 RUBY VERSION

--- a/app/models/web/push_subscription.rb
+++ b/app/models/web/push_subscription.rb
@@ -28,7 +28,7 @@ class Web::PushSubscription < ApplicationRecord
   delegate :locale, to: :associated_user
 
   def encrypt(payload)
-    Webpush::Encryption.encrypt(payload, key_p256dh, key_auth)
+    WebPush::Encryption.encrypt(payload, key_p256dh, key_auth)
   end
 
   def audience
@@ -91,7 +91,7 @@ class Web::PushSubscription < ApplicationRecord
   end
 
   def vapid_key
-    @vapid_key ||= Webpush::VapidKey.from_keys(Rails.configuration.x.vapid_public_key, Rails.configuration.x.vapid_private_key)
+    @vapid_key ||= WebPush::VapidKey.from_keys(Rails.configuration.x.vapid_public_key, Rails.configuration.x.vapid_private_key)
   end
 
   def contact_email

--- a/app/workers/web/push_notification_worker.rb
+++ b/app/workers/web/push_notification_worker.rb
@@ -26,8 +26,8 @@ class Web::PushNotificationWorker
         'Ttl' => TTL,
         'Urgency' => URGENCY,
         'Content-Encoding' => 'aesgcm',
-        'Encryption' => "salt=#{Webpush.encode64(payload.fetch(:salt)).delete('=')}",
-        'Crypto-Key' => "dh=#{Webpush.encode64(payload.fetch(:server_public_key)).delete('=')};#{@subscription.crypto_key_header}",
+        'Encryption' => "salt=#{WebPush.encode64(payload.fetch(:salt)).delete('=')}",
+        'Crypto-Key' => "dh=#{WebPush.encode64(payload.fetch(:server_public_key)).delete('=')};#{@subscription.crypto_key_header}",
         'Authorization' => @subscription.authorization_header
       )
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   end
 
   # Generate random VAPID keys
-  Webpush.generate_key.tap do |vapid_key|
+  WebPush.generate_key.tap do |vapid_key|
     config.x.vapid_private_key = vapid_key.private_key
     config.x.vapid_public_key = vapid_key.public_key
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   config.x.otp_secret = '100c7faeef00caa29242f6b04156742bf76065771fd4117990c4282b8748ff3d99f8fdae97c982ab5bd2e6756a159121377cce4421f4a8ecd2d67bd7749a3fb4'
 
   # Generate random VAPID keys
-  vapid_key = Webpush.generate_key
+  vapid_key = WebPush.generate_key
   config.x.vapid_private_key = vapid_key.private_key
   config.x.vapid_public_key = vapid_key.public_key
 

--- a/lib/tasks/mastodon.rake
+++ b/lib/tasks/mastodon.rake
@@ -34,7 +34,7 @@ namespace :mastodon do
         env[key] = SecureRandom.hex(64)
       end
 
-      vapid_key = Webpush.generate_key
+      vapid_key = WebPush.generate_key
 
       env['VAPID_PRIVATE_KEY'] = vapid_key.private_key
       env['VAPID_PUBLIC_KEY']  = vapid_key.public_key
@@ -528,7 +528,7 @@ namespace :mastodon do
   namespace :webpush do
     desc 'Generate VAPID key'
     task :generate_vapid_key do
-      vapid_key = Webpush.generate_key
+      vapid_key = WebPush.generate_key
       puts "VAPID_PRIVATE_KEY=#{vapid_key.private_key}"
       puts "VAPID_PUBLIC_KEY=#{vapid_key.public_key}"
     end

--- a/spec/workers/web/push_notification_worker_spec.rb
+++ b/spec/workers/web/push_notification_worker_spec.rb
@@ -13,7 +13,7 @@ describe Web::PushNotificationWorker do
   let(:subscription) { Fabricate(:web_push_subscription, user_id: user.id, key_p256dh: p256dh, key_auth: auth, endpoint: endpoint, data: { alerts: { notification.type => true } }) }
   let(:vapid_public_key) { 'BB37UCyc8LLX4PNQSe-04vSFvpUWGrENubUaslVFM_l5TxcGVMY0C3RXPeUJAQHKYlcOM2P4vTYmkoo0VZGZTM4=' }
   let(:vapid_private_key) { 'OPrw1Sum3gRoL4-DXfSCC266r-qfFSRZrnj8MgIhRHg=' }
-  let(:vapid_key) { Webpush::VapidKey.from_keys(vapid_public_key, vapid_private_key) }
+  let(:vapid_key) { WebPush::VapidKey.from_keys(vapid_public_key, vapid_private_key) }
   let(:contact_email) { 'sender@example.com' }
   let(:ciphertext) { "+\xB8\xDBT}\x13\xB6\xDD.\xF9\xB0\xA7\xC8\xD2\x80\xFD\x99#\xF7\xAC\x83\xA4\xDB,\x1F\xB5\xB9w\x85>\xF7\xADr" }
   let(:salt) { "X\x97\x953\xE4X\xF8_w\xE7T\x95\xC51q\xFE" }
@@ -25,7 +25,7 @@ describe Web::PushNotificationWorker do
     before do
       allow_any_instance_of(subscription.class).to receive(:contact_email).and_return(contact_email)
       allow_any_instance_of(subscription.class).to receive(:vapid_key).and_return(vapid_key)
-      allow(Webpush::Encryption).to receive(:encrypt).and_return(payload)
+      allow(WebPush::Encryption).to receive(:encrypt).and_return(payload)
       allow(JWT).to receive(:encode).and_return('jwt.encoded.payload')
 
       stub_request(:post, endpoint).to_return(status: 201, body: '')


### PR DESCRIPTION
This removes the need for pulling the gem from a commit in a fork of the GitHub repository, in favour of using a gem that is maintained and published on rubygems. This may have similar issues to #18457 with regards to compatibility, however it does include the same OpenSSL 3 fix from Claire's fork.

The only thing that seems to have changed is the module name (`Webpush => WebPush`), everything else seems backwards compatible.