### PR TITLE
Fix hashtag bar display when status is in a thread

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1111,7 +1111,8 @@ body > [data-popper-placement] {
     .audio-player,
     .attachment-list,
     .picture-in-picture-placeholder,
-    .status-card {
+    .status-card,
+    .hashtag-bar {
       margin-inline-start: $thread-margin;
       width: calc(100% - ($thread-margin));
     }


### PR DESCRIPTION
This is related to the changes introduced in #26492. Currently, the hashtag bar in statuses which are part of a thread is covered by the thread line, when said status is not open/focused. I added `hashtag-bar` to the list of classes that when inside of a status in thread should have a margin. 

Before/After:
![beforeafterhashtagbar](https://github.com/mastodon/mastodon/assets/36609914/e2d9e151-1ab3-4d60-9693-4b1eb3713532)
