### PR TITLE
Fix hashtag bar sometimes including tags that appear in the post's body

### DIFF
--- a/app/javascript/mastodon/components/hashtag_bar.jsx
+++ b/app/javascript/mastodon/components/hashtag_bar.jsx
@@ -15,7 +15,7 @@ const VISIBLE_HASHTAGS = 7;
 export const HashtagBar = ({ hashtags, text }) => {
   const renderedHashtags = useMemo(() => {
     const body = domParser.parseFromString(text, 'text/html').documentElement;
-    return [].map.call(body.querySelectorAll('[rel=tag]'), node => node.textContent.toLowerCase());
+    return [].filter.call(body.querySelectorAll('a[href]'), link => link.textContent[0] === '#' || (link.previousSibling?.textContent?.[link.previousSibling.textContent.length - 1] === '#')).map(node => node.textContent.toLowerCase());
   }, [text]);
 
   const invisibleHashtags = useMemo(() => (

--- a/app/javascript/mastodon/components/hashtag_bar.jsx
+++ b/app/javascript/mastodon/components/hashtag_bar.jsx
@@ -19,7 +19,7 @@ export const HashtagBar = ({ hashtags, text }) => {
   }, [text]);
 
   const invisibleHashtags = useMemo(() => (
-    hashtags.filter(hashtag => !renderedHashtags.some(textContent => textContent === `#${hashtag.get('name')}` || textContent === hashtag.get('name')))
+    hashtags.filter(hashtag => !renderedHashtags.some(textContent => textContent === `#${hashtag.get('name').toLowerCase()}` || textContent === hashtag.get('name').toLowerCase()))
   ), [hashtags, renderedHashtags]);
 
   const [expanded, setExpanded] = useState(false);


### PR DESCRIPTION
This fixes the issue hashtags appearing in local posts also appearing in the hashtag bar if their “canonical” representation is not lowercase.

This also fixes the matching logic for remote tags not to rely on the `rel` attribute containing `tag`, as not all implementations output it, Mastodon is currently stripping it from incoming posts anyway, and we had another logic in place for a similar purpose.