### PR TITLE
Change “privacy and reach” settings so that unchecking boxes always increase privacy and checking them always increase reach

### DIFF
--- a/app/controllers/settings/privacy_controller.rb
+++ b/app/controllers/settings/privacy_controller.rb
@@ -18,7 +18,7 @@ class Settings::PrivacyController < Settings::BaseController
   private
 
   def account_params
-    params.require(:account).permit(:discoverable, :locked, :hide_collections, settings: UserSettings.keys)
+    params.require(:account).permit(:discoverable, :unlocked, :show_collections, settings: UserSettings.keys)
   end
 
   def set_account

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -442,7 +442,20 @@ class Account < ApplicationRecord
         EntityCache.instance.mention(username, domain)
       end
     end
+
+    def inverse_alias(key, original_key)
+      define_method("#{key}=") do |value|
+        public_send("#{original_key}=", !ActiveModel::Type::Boolean.new.cast(value))
+      end
+
+      define_method(key) do
+        !public_send(original_key)
+      end
+    end
   end
+
+  inverse_alias :show_collections, :hide_collections
+  inverse_alias :unlocked, :locked
 
   def emojis
     @emojis ||= CustomEmoji.from_text(emojifiable_text, domain)

--- a/app/views/settings/privacy/show.html.haml
+++ b/app/views/settings/privacy/show.html.haml
@@ -18,7 +18,7 @@
     = f.input :discoverable, as: :boolean, wrapper: :with_label, recommended: true
 
   .fields-group
-    = f.input :locked, as: :boolean, wrapper: :with_label
+    = f.input :unlocked, as: :boolean, wrapper: :with_label
 
   %h4= t('privacy.search')
 
@@ -33,7 +33,7 @@
   %p.lead= t('privacy.privacy_hint_html')
 
   .fields-group
-    = f.input :hide_collections, as: :boolean, wrapper: :with_label
+    = f.input :show_collections, as: :boolean, wrapper: :with_label
 
   = f.simple_fields_for :settings, current_user.settings do |ff|
     .fields-group

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -6,9 +6,9 @@ en:
         discoverable: Your public posts and profile may be featured or recommended in various areas of Mastodon and your profile may be suggested to other users.
         display_name: Your full name or your fun name.
         fields: Your homepage, pronouns, age, anything you want.
-        hide_collections: People will not be able to browse through your follows and followers. People that you follow will see that you follow them regardless.
-        locked: People will request to follow you and you will be able to either accept or reject new followers.
         note: 'You can @mention other people or #hashtags.'
+        show_collections: People will be able to browse through your follows and followers. People that you follow will see that you follow them regardless.
+        unlocked: People will be able to follow you without requesting approval. Uncheck if you want to review follow requests and chose whether to accept or reject new followers.
       account_alias:
         acct: Specify the username@domain of the account you want to move from
       account_migration:
@@ -143,8 +143,8 @@ en:
         fields:
           name: Label
           value: Content
-        hide_collections: Hide follows and followers from profile
-        locked: Manually review new followers
+        show_collections: Show follows and followers on profile
+        unlocked: Automatically accept new followers
       account_alias:
         acct: Handle of the old account
       account_migration:


### PR DESCRIPTION
Fixes #26493 (with some wording changes)

## Before

![image](https://github.com/mastodon/mastodon/assets/384364/9e525e89-5556-4eab-8e02-985a7e1b12c9)

## After

![image](https://github.com/mastodon/mastodon/assets/384364/a76ddb17-e35f-4260-a9dd-694e4c7f57e1)