### PR TITLE
Add auto-refresh of accounts we get new messages/edits of

### DIFF
--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -4,6 +4,8 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   include FormattingHelper
 
   def perform
+    @account.schedule_refresh_if_stale!
+
     dereference_object!
 
     case @object['type']

--- a/app/lib/activitypub/activity/update.rb
+++ b/app/lib/activitypub/activity/update.rb
@@ -2,6 +2,8 @@
 
 class ActivityPub::Activity::Update < ActivityPub::Activity
   def perform
+    @account.schedule_refresh_if_stale!
+
     dereference_object!
 
     if equals_or_includes_any?(@object['type'], %w(Application Group Organization Person Service))

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -63,6 +63,8 @@ class Account < ApplicationRecord
     trust_level
   )
 
+  BACKGROUND_REFRESH_INTERVAL = 1.week.freeze
+
   USERNAME_RE   = /[a-z0-9_]+([a-z0-9_.-]+[a-z0-9_]+)?/i
   MENTION_RE    = %r{(?<=^|[^/[:word:]])@((#{USERNAME_RE})(?:@[[:word:].-]+[[:word:]]+)?)}i
   URL_PREFIX_RE = %r{\Ahttp(s?)://[^/]+}
@@ -207,6 +209,12 @@ class Account < ApplicationRecord
 
   def possibly_stale?
     last_webfingered_at.nil? || last_webfingered_at <= 1.day.ago
+  end
+
+  def schedule_refresh_if_stale!
+    return unless last_webfingered_at.present? && last_webfingered_at <= BACKGROUND_REFRESH_INTERVAL.ago
+
+    AccountRefreshWorker.perform_in(rand(6.hours.to_i), id)
   end
 
   def refresh!

--- a/app/workers/account_refresh_worker.rb
+++ b/app/workers/account_refresh_worker.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AccountRefreshWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'pull', retry: 3, dead: false, lock: :until_executed, lock_ttl: 1.day.to_i
+
+  def perform(account_id)
+    account = Account.find_by(id: account_id)
+    return if account.nil? || account.last_webfingered_at > Account::BACKGROUND_REFRESH_INTERVAL.ago
+
+    ResolveAccountService.new.call(account)
+  end
+end


### PR DESCRIPTION
Mastodon already refreshes accounts in various edge cases but otherwise relies on getting `Update` activities.

This PR schedules an update when processing a new or updated post from a remote account, but:
- updates are only scheduled if the account has not been refreshed in the last 7 days: this is to avoid too frequent updates
- updates are scheduled at random in a 6 hours interval: this is to avoid the thundering herd problem

This is motivated by a possible issue highlighted in https://github.com/mastodon/mastodon/pull/26344#pullrequestreview-1580465810

TODO: assess performance implications, and find if existing refresh paths could use this new pattern, although that last bit could be done in a different PR

EDIT: decreased refresh frequency as well as schedule jitter to reduce the number of queued tasks