### PR TITLE
update tab focus style on notification__filter-bar and account__section-headline

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -6791,15 +6791,22 @@ a.status-card {
 .notification__filter-bar,
 .account__section-headline {
   background: darken($ui-base-color, 4%);
-  border-bottom: 1px solid lighten($ui-base-color, 8%);
   cursor: default;
   display: flex;
   flex-shrink: 0;
 
-  button {
-    background: darken($ui-base-color, 4%);
+  button,
+  a {
     border: 0;
+    border-bottom: 2px solid lighten($ui-base-color, 8%);
+    background: darken($ui-base-color, 4%);
     margin: 0;
+    border-radius: 0;
+
+    &:focus-visible {
+      outline: none;
+      border-bottom: 2px solid $ui-button-focus-outline-color;
+    }
   }
 
   button,
@@ -6832,11 +6839,25 @@ a.status-card {
         border-style: solid;
         border-width: 0 10px 10px;
         border-color: transparent transparent lighten($ui-base-color, 8%);
+
+        &:focus-visible {
+          border-color: $ui-button-focus-outline-color;
+        }
       }
 
       &::after {
-        bottom: -1px;
+        bottom: -3px;
         border-color: transparent transparent $ui-base-color;
+      }
+
+      &:focus-visible {
+        &::before {
+          border-color: transparent transparent $ui-button-focus-outline-color;
+        }
+
+        &::after {
+          display: none;
+        }
       }
     }
   }


### PR DESCRIPTION
![2023-08-17 15 22 40](https://github.com/mastodon/mastodon/assets/17292/a7373e7a-3764-423f-b357-50adacbe41f9)

light theme.
<img width="355" alt="CleanShot 2023-08-17 at 15 14 29@2x" src="https://github.com/mastodon/mastodon/assets/17292/807c838e-6522-4c45-a256-5f5e350698cb">


dark ..account__section-headline 
<img width="337" alt="CleanShot 2023-08-17 at 17 18 25@2x" src="https://github.com/mastodon/mastodon/assets/17292/34696a93-f4d3-4ec0-886e-1669361d2324">



old style

<img width="361" alt="CleanShot 2023-08-17 at 15 14 58@2x" src="https://github.com/mastodon/mastodon/assets/17292/b0cb38c0-d78c-4ff3-8f2d-8b6fb75e1fb7">
<img width="357" alt="CleanShot 2023-08-17 at 15 15 07@2x" src="https://github.com/mastodon/mastodon/assets/17292/7f62e6f7-2957-4e23-9a4b-066c956850a6">

<img width="349" alt="CleanShot 2023-08-17 at 17 18 50@2x" src="https://github.com/mastodon/mastodon/assets/17292/c9a07d52-326f-422b-a77c-7f5ce2f33ae0">
