### PR TITLE
Allow setting a custom HTTP method in CacheBuster

### DIFF
--- a/app/lib/cache_buster.rb
+++ b/app/lib/cache_buster.rb
@@ -2,9 +2,12 @@
 
 class CacheBuster
   def initialize(options = {})
-    @secret_header = options[:secret_header] || nil
-    @secret        = options[:secret] || nil
-    @http_method   = options[:http_method] || 'GET'
+    @secret_header = options[:secret_header] ||
+                     (options[:http_method] ? nil : 'Secret-Header')
+    @secret = options[:secret] ||
+              (options[:http_method] ? nil : 'True')
+
+    @http_method = options[:http_method] || 'GET'
   end
 
   def bust(url)

--- a/app/lib/cache_buster.rb
+++ b/app/lib/cache_buster.rb
@@ -2,6 +2,8 @@
 
 class CacheBuster
   def initialize(options = {})
+    ActiveSupport::Deprecation.warn('Default values for the cache buster secret header name and values will be removed in Mastodon 4.3. Please set them explicitely if you rely on those.') unless options[:http_method] || (options[:secret] && options[:secret_header])
+
     @secret_header = options[:secret_header] ||
                      (options[:http_method] ? nil : 'Secret-Header')
     @secret = options[:secret] ||

--- a/app/lib/cache_buster.rb
+++ b/app/lib/cache_buster.rb
@@ -2,8 +2,9 @@
 
 class CacheBuster
   def initialize(options = {})
-    @secret_header = options[:secret_header] || 'Secret-Header'
-    @secret        = options[:secret] || 'True'
+    @secret_header = options[:secret_header] || nil
+    @secret        = options[:secret] || nil
+    @http_method   = options[:http_method] || 'GET'
   end
 
   def bust(url)
@@ -21,7 +22,8 @@ class CacheBuster
   end
 
   def build_request(url, http_client)
-    Request.new(:get, url, http_client: http_client).tap do |request|
+    request = Request.new(@http_method.to_sym, url, http_client: http_client)
+    if @secret_header && !@secret_header.empty? && @secret && !@secret.empty?
       request.add_headers(@secret_header => @secret)
     end
   end

--- a/app/lib/cache_buster.rb
+++ b/app/lib/cache_buster.rb
@@ -22,9 +22,9 @@ class CacheBuster
   end
 
   def build_request(url, http_client)
-    request = Request.new(@http_method.to_sym, url, http_client: http_client)
-    if @secret_header && !@secret_header.empty? && @secret && !@secret.empty?
-      request.add_headers(@secret_header => @secret)
-    end
+    request = Request.new(@http_method.downcase.to_sym, url, http_client: http_client)
+    request.add_headers(@secret_header => @secret) if @secret_header.present? && @secret && !@secret.empty?
+
+    request
   end
 end

--- a/app/lib/request.rb
+++ b/app/lib/request.rb
@@ -117,7 +117,7 @@ class Request
 
   def perform
     begin
-      response = http_client.public_send(@verb, @url.to_s, @options.merge(headers: headers))
+      response = http_client.request(@verb, @url.to_s, @options.merge(headers: headers))
     rescue => e
       raise e.class, "#{e.message} on #{@url}", e.backtrace[0]
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,7 @@ require_relative '../lib/rails/engine_extensions'
 require_relative '../lib/active_record/database_tasks_extensions'
 require_relative '../lib/active_record/batches'
 require_relative '../lib/simple_navigation/item_extensions'
+require_relative '../lib/http_extensions'
 
 Dotenv::Railtie.load
 

--- a/config/initializers/cache_buster.rb
+++ b/config/initializers/cache_buster.rb
@@ -6,5 +6,6 @@ Rails.application.configure do
   config.x.cache_buster = {
     secret_header: ENV['CACHE_BUSTER_SECRET_HEADER'],
     secret: ENV['CACHE_BUSTER_SECRET'],
+    http_method: ENV['CACHE_BUSTER_HTTP_METHOD'] || 'GET',
   }
 end

--- a/lib/http_extensions.rb
+++ b/lib/http_extensions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Monkey patching until https://github.com/httprb/http/pull/757 is merged
+unless HTTP::Request::METHODS.include?(:purge)
+  module HTTP
+    class Request
+      METHODS = METHODS.dup.push(:purge).freeze
+    end
+  end
+end

--- a/spec/lib/cache_buster_spec.rb
+++ b/spec/lib/cache_buster_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CacheBuster do
+  subject { described_class.new(secret_header: secret_header, secret: secret, http_method: http_method) }
+
+  let(:secret_header) { nil }
+  let(:secret) { nil }
+  let(:http_method) { nil }
+
+  let(:purge_url) { 'https://example.com/test_purge' }
+
+  describe '#bust' do
+    shared_examples 'makes_request' do
+      it 'makes an HTTP purging request' do
+        method = http_method&.to_sym || :get
+        stub_request(method, purge_url).to_return(status: 200)
+
+        subject.bust(purge_url)
+
+        test_request = a_request(method, purge_url)
+
+        test_request = test_request.with(headers: { secret_header => secret }) if secret && secret_header
+
+        expect(test_request).to have_been_made.once
+      end
+    end
+
+    context 'when using default options' do
+      include_examples 'makes_request'
+    end
+
+    context 'when specifying a secret header' do
+      let(:secret_header) { 'X-Purge-Secret' }
+      let(:secret) { SecureRandom.hex(20) }
+
+      include_examples 'makes_request'
+    end
+
+    context 'when specifying a PURGE method' do
+      let(:http_method) { 'purge' }
+
+      context 'when not using headers' do
+        include_examples 'makes_request'
+      end
+
+      context 'when specifying a secret header' do
+        let(:secret_header) { 'X-Purge-Secret' }
+        let(:secret) { SecureRandom.hex(20) }
+
+        include_examples 'makes_request'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is needed for some CDN providers, for example Fastly, as you need to use a custom `PURGE` HTTP method for purges.

In Fastly's case, you can use an API key scoped to your service and restricted to purging only in the headers.

HTTP.rb does not support the `PURGE` method, so we need to monkey-patch it (https://github.com/httprb/http/pull/757 for upstream change).

I also added a spec for the cache buster feature.

To maintain compatibility, you need to specify an HTTP method if you want to not send any headers. We should probably deprecate the default headers, and clean up this code in the next version.

Replaces #26224