### PR TITLE
Fix "undefined method `indexable`" error when searching for remote accounts

### DIFF
--- a/app/services/activitypub/process_account_service.rb
+++ b/app/services/activitypub/process_account_service.rb
@@ -115,7 +115,7 @@ class ActivityPub::ProcessAccountService < BaseService
     @account.fields                  = property_values || {}
     @account.also_known_as           = as_array(@json['alsoKnownAs'] || []).map { |item| value_or_id(item) }
     @account.discoverable            = @json['discoverable'] || false
-    @account.indexable               = @json['indexable'] || false
+    @account.indexable               = @json['indexable'] if @json['indexable'].present? || false
   end
 
   def set_fetchable_key!


### PR DESCRIPTION
If you search for a remote account (@username@server) on a server equivalent to the latest Mastodon main branch, an error will be returned and you will not be able to search.
I also get the following error in the server console:

    bundle[****]: [****] NoMethodError (undefined method `indexable=' for #<Account id: **** ~>):
    bundle[****]: [****] app/services/activitypub/process_account_service.rb:119:in `set_immediate_attributes!'
    bundle[****]: [****] app/services/activitypub/process_account_service.rb:93:in `update_account'

This PR fix it.