### PR TITLE
Fix already initialized constant warning

### DIFF
--- a/lib/http_extensions.rb
+++ b/lib/http_extensions.rb
@@ -2,9 +2,7 @@
 
 # Monkey patching until https://github.com/httprb/http/pull/757 is merged
 unless HTTP::Request::METHODS.include?(:purge)
-  module HTTP
-    class Request
-      METHODS = METHODS.dup.push(:purge).freeze
-    end
-  end
+  methods = HTTP::Request::METHODS.dup
+  HTTP::Request.send(:remove_const, :METHODS)
+  HTTP::Request.const_set(:METHODS, methods.push(:purge).freeze)
 end


### PR DESCRIPTION
Fixes #26540

We purposefully redefine HTTP::Request::METHODS, so the warning is not useful in this case.