### PR TITLE
Add avatar image to webfinger responses

### DIFF
--- a/app/serializers/webfinger_serializer.rb
+++ b/app/serializers/webfinger_serializer.rb
@@ -18,20 +18,22 @@ class WebfingerSerializer < ActiveModel::Serializer
   end
 
   def links
-    if object.instance_actor?
-      [
-        { rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: about_more_url(instance_actor: true) },
-        { rel: 'self', type: 'application/activity+json', href: instance_actor_url },
-        { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_interaction_url}?uri={uri}" },
-      ]
-    else
-      [
-        { rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: short_account_url(object) },
-        { rel: 'self', type: 'application/activity+json', href: account_url(object) },
-        { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_interaction_url}?uri={uri}" },
-      ].tap do |x|
-        x << { rel: 'http://webfinger.net/rel/avatar', type: object.avatar.content_type, href: full_asset_url(object.avatar_original_url) } if object.avatar.present? && object.avatar.content_type.present?
-      end
+    [
+      { rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: profile_page_href },
+      { rel: 'self', type: 'application/activity+json', href: self_href },
+      { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_interaction_url}?uri={uri}" },
+    ].tap do |x|
+      x << { rel: 'http://webfinger.net/rel/avatar', type: object.avatar.content_type, href: full_asset_url(object.avatar_original_url) } if object.avatar.present? && object.avatar.content_type.present?
     end
+  end
+
+  private
+
+  def profile_page_href
+    object.instance_actor? ? about_more_url(instance_actor: true) : short_account_url(object)
+  end
+
+  def self_href
+    object.instance_actor? ? instance_actor_url : account_url(object)
   end
 end

--- a/app/serializers/webfinger_serializer.rb
+++ b/app/serializers/webfinger_serializer.rb
@@ -25,11 +25,15 @@ class WebfingerSerializer < ActiveModel::Serializer
         { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_interaction_url}?uri={uri}" },
       ]
     else
-      [
+      resp = [
         { rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: short_account_url(object) },
         { rel: 'self', type: 'application/activity+json', href: account_url(object) },
         { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_interaction_url}?uri={uri}" },
       ]
+
+      resp << { rel: 'http://webfinger.net/rel/avatar', type: object.avatar.content_type, href: full_asset_url(object.avatar_original_url) } if object.avatar.present? && object.avatar.content_type.present?
+
+      resp
     end
   end
 end

--- a/app/serializers/webfinger_serializer.rb
+++ b/app/serializers/webfinger_serializer.rb
@@ -25,15 +25,13 @@ class WebfingerSerializer < ActiveModel::Serializer
         { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_interaction_url}?uri={uri}" },
       ]
     else
-      resp = [
+      [
         { rel: 'http://webfinger.net/rel/profile-page', type: 'text/html', href: short_account_url(object) },
         { rel: 'self', type: 'application/activity+json', href: account_url(object) },
         { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_interaction_url}?uri={uri}" },
-      ]
-
-      resp << { rel: 'http://webfinger.net/rel/avatar', type: object.avatar.content_type, href: full_asset_url(object.avatar_original_url) } if object.avatar.present? && object.avatar.content_type.present?
-
-      resp
+      ].tap do |x|
+        x << { rel: 'http://webfinger.net/rel/avatar', type: object.avatar.content_type, href: full_asset_url(object.avatar_original_url) } if object.avatar.present? && object.avatar.content_type.present?
+      end
     end
   end
 end

--- a/app/serializers/webfinger_serializer.rb
+++ b/app/serializers/webfinger_serializer.rb
@@ -23,11 +23,20 @@ class WebfingerSerializer < ActiveModel::Serializer
       { rel: 'self', type: 'application/activity+json', href: self_href },
       { rel: 'http://ostatus.org/schema/1.0/subscribe', template: "#{authorize_interaction_url}?uri={uri}" },
     ].tap do |x|
-      x << { rel: 'http://webfinger.net/rel/avatar', type: object.avatar.content_type, href: full_asset_url(object.avatar_original_url) } if object.avatar.present? && object.avatar.content_type.present?
+      x << { rel: 'http://webfinger.net/rel/avatar', type: object.avatar.content_type, href: full_asset_url(object.avatar_original_url) } if show_avatar?
     end
   end
 
   private
+
+  def show_avatar?
+    media_present = object.avatar.present? && object.avatar.content_type.present?
+
+    # Show avatar only if an instance shows profiles to logged out users
+    allowed_by_config = ENV['DISALLOW_UNAUTHENTICATED_API_ACCESS'] != 'true' && !Rails.configuration.x.limited_federation_mode
+
+    media_present && allowed_by_config
+  end
 
   def profile_page_href
     object.instance_actor? ? about_more_url(instance_actor: true) : short_account_url(object)

--- a/spec/controllers/well_known/webfinger_controller_spec.rb
+++ b/spec/controllers/well_known/webfinger_controller_spec.rb
@@ -196,7 +196,7 @@ describe WellKnown::WebfingerController do
         perform_show!
       end
 
-      it 'returns avatar in response' do
+      it 'does not return avatar in response' do
         json = body_as_json
 
         avatar_link = json[:links].find { |link| link[:rel] == 'http://webfinger.net/rel/avatar' }


### PR DESCRIPTION
Closes https://github.com/mastodon/mastodon/issues/26557

Adds an avatar link to webfinger responses. The avatar field is defined in the spec here https://webfinger.net/rel/

> `http://webfinger.net/rel/avatar`
> The link relation http://webfinger.net/rel/avatar identifies a person’s avatar and may be in any standard image format (e.g., PNG, JPEG, GIF).