### PR TITLE
fix: YouTube iframe being able to start at a defined time

### DIFF
--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -37,7 +37,7 @@ const getHostname = url => {
 
 const domParser = new DOMParser();
 
-const handleIframeUrl = (html, url) => {
+const handleIframeUrl = (html, url, providerName) => {
   const document = domParser.parseFromString(html, 'text/html').documentElement;
   const iframe = document.querySelector('iframe');
   const startTime = new URL(url).searchParams.get('t')
@@ -48,7 +48,7 @@ const handleIframeUrl = (html, url) => {
     iframeUrl.searchParams.set('autoplay', 1)
     iframeUrl.searchParams.set('auto_play', 1)
 
-    if (startTime) iframeUrl.searchParams.set('start', startTime)
+    if (startTime && providerName === "YouTube") iframeUrl.searchParams.set('start', startTime)
 
     iframe.src = iframeUrl.href
 
@@ -116,7 +116,7 @@ export default class Card extends PureComponent {
 
   renderVideo () {
     const { card } = this.props;
-    const content = { __html: handleIframeUrl(card.get('html'), card.get('url')) };
+    const content = { __html: handleIframeUrl(card.get('html'), card.get('url'), card.get('provider_name')) };
 
     return (
       <div

--- a/app/javascript/mastodon/features/status/components/card.jsx
+++ b/app/javascript/mastodon/features/status/components/card.jsx
@@ -37,18 +37,20 @@ const getHostname = url => {
 
 const domParser = new DOMParser();
 
-const addAutoPlay = html => {
+const handleIframeUrl = (html, url) => {
   const document = domParser.parseFromString(html, 'text/html').documentElement;
   const iframe = document.querySelector('iframe');
+  const startTime = new URL(url).searchParams.get('t')
 
   if (iframe) {
-    if (iframe.src.indexOf('?') !== -1) {
-      iframe.src += '&';
-    } else {
-      iframe.src += '?';
-    }
+    const iframeUrl = new URL(iframe.src)
 
-    iframe.src += 'autoplay=1&auto_play=1';
+    iframeUrl.searchParams.set('autoplay', 1)
+    iframeUrl.searchParams.set('auto_play', 1)
+
+    if (startTime) iframeUrl.searchParams.set('start', startTime)
+
+    iframe.src = iframeUrl.href
 
     // DOM parser creates html/body elements around original HTML fragment,
     // so we need to get innerHTML out of the body and not the entire document
@@ -114,7 +116,7 @@ export default class Card extends PureComponent {
 
   renderVideo () {
     const { card } = this.props;
-    const content = { __html: addAutoPlay(card.get('html')) };
+    const content = { __html: handleIframeUrl(card.get('html'), card.get('url')) };
 
     return (
       <div


### PR DESCRIPTION
Closes #9944, Closes #22238

This update addresses the issue where YouTube videos were not starting at the correct time when a parameter was passed in the URL.
Currently, I'm adding the parameter to the URL the same way autoplay is being added.