### PR TITLE
Fix layout of the closed registrations modal

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8541,12 +8541,11 @@ noscript {
 
   &__choices {
     display: flex;
+    gap: 40px;
 
     &__choice {
-      flex: 0 0 auto;
-      width: 50%;
+      flex: 1;
       box-sizing: border-box;
-      padding: 20px;
 
       h3 {
         margin-bottom: 20px;
@@ -8555,6 +8554,7 @@ noscript {
       p {
         color: $darker-text-color;
         margin-bottom: 20px;
+        font-size: 15px;
       }
 
       .button {
@@ -8569,11 +8569,10 @@ noscript {
 
   @media screen and (max-width: $no-gap-breakpoint - 1px) {
     &__choices {
-      display: block;
+      flex-direction: column;
 
       &__choice {
-        width: auto;
-        margin-bottom: 20px;
+        margin-top: 40px;
       }
     }
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -8539,6 +8539,45 @@ noscript {
     }
   }
 
+  &__choices {
+    display: flex;
+
+    &__choice {
+      flex: 0 0 auto;
+      width: 50%;
+      box-sizing: border-box;
+      padding: 20px;
+
+      h3 {
+        margin-bottom: 20px;
+      }
+
+      p {
+        color: $darker-text-color;
+        margin-bottom: 20px;
+      }
+
+      .button {
+        margin-bottom: 10px;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
+
+  @media screen and (max-width: $no-gap-breakpoint - 1px) {
+    &__choices {
+      display: block;
+
+      &__choice {
+        width: auto;
+        margin-bottom: 20px;
+      }
+    }
+  }
+
   .link-button {
     font-size: inherit;
     display: inline;


### PR DESCRIPTION
Fixes a regression from #26075, which removed CSS classes that were in use by the old interaction modal, but also the closed registrations modal.

## Before #26075

![image](https://github.com/mastodon/mastodon/assets/384364/69eecc4f-d82b-4fa4-aa88-c8a0c4758f7a)

## After #26075 / Before this PR

![image](https://github.com/mastodon/mastodon/assets/384364/a7db5d71-7d79-4fd6-9c0a-1919acbdd4b1)

## After this PR

![image](https://github.com/mastodon/mastodon/assets/384364/306b86c8-0fcc-4425-b57a-7d40078103a2)