### PR TITLE
Change hashtag bar tags to be de-emphasized

### DIFF
--- a/app/javascript/mastodon/components/hashtag_bar.tsx
+++ b/app/javascript/mastodon/components/hashtag_bar.tsx
@@ -204,7 +204,7 @@ const HashtagBar: React.FC<{
     <div className='hashtag-bar'>
       {revealedHashtags.map((hashtag) => (
         <Link key={hashtag} to={`/tags/${hashtag}`}>
-          #{hashtag}
+          #<span>{hashtag}</span>
         </Link>
       ))}
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -9305,16 +9305,15 @@ noscript {
 
   a {
     display: inline-flex;
-    border-radius: 4px;
-    background: rgba($highlight-text-color, 0.2);
-    color: $highlight-text-color;
-    padding: 0.4em 0.6em;
+    color: $dark-text-color;
     text-decoration: none;
 
-    &:hover,
-    &:focus,
-    &:active {
-      background: rgba($highlight-text-color, 0.3);
+    &:hover {
+      text-decoration: none;
+
+      span {
+        text-decoration: underline;
+      }
     }
   }
 }


### PR DESCRIPTION
The original reasoning for the change is in #26260:

> People will often put all of the hashtags relevant to the post at the end of the post, but it looks spammy. Others avoid using hashtags this way because it looks spammy, and therefore lose out on discoverability. Since hashtags on Mastodon are out-of-band on the protocol and API level anyway, we can continue to allow them to be input the usual way but render them out-of-band in a more clean manner.

However, the actual change made the hashtags more prominent, which I don't think matches the intent.

## Before this PR

![image](https://github.com/mastodon/mastodon/assets/384364/3e521160-e7b3-4fb6-aa1c-aa39cd839d73)

## After this PR

![image](https://github.com/mastodon/mastodon/assets/384364/3e343ca7-565e-41e9-a7c9-34baa16493c5)