### PR TITLE
Fix unexpected audio stream transcoding when uploaded video is eligible to passthrough

### DIFF
--- a/lib/paperclip/transcoder.rb
+++ b/lib/paperclip/transcoder.rb
@@ -37,7 +37,7 @@ module Paperclip
         @output_options['f']       = 'image2'
         @output_options['vframes'] = 1
       when 'mp4'
-        if !eligible_to_passthrough?(metadata)
+        unless eligible_to_passthrough?(metadata)
           @output_options['acodec'] = 'aac'
           @output_options['strict'] = 'experimental'
 

--- a/lib/paperclip/transcoder.rb
+++ b/lib/paperclip/transcoder.rb
@@ -37,12 +37,14 @@ module Paperclip
         @output_options['f']       = 'image2'
         @output_options['vframes'] = 1
       when 'mp4'
-        @output_options['acodec'] = 'aac'
-        @output_options['strict'] = 'experimental'
+        if !eligible_to_passthrough?(metadata)
+          @output_options['acodec'] = 'aac'
+          @output_options['strict'] = 'experimental'
 
-        if high_vfr?(metadata) && !eligible_to_passthrough?(metadata)
-          @output_options['vsync'] = 'vfr'
-          @output_options['r'] = @vfr_threshold
+          if high_vfr?(metadata)
+            @output_options['vsync'] = 'vfr'
+            @output_options['r'] = @vfr_threshold
+          end
         end
       end
 


### PR DESCRIPTION
This commit fixes duplicated codec options incorrectly passed to ffmpeg.

When the uploaded video meets `eligible_to_passthrough?` conditions, the `-c:v copy -c:a copy` option is passed to avoid transcoding the video and audio streams. However, the `-c:a copy` option is ignored because it is overridden by the `-acodec aac`. As a result, the audio stream will be transcoded by the `aac` encoder, resulting in a loss of audio quality.

Before: 

```
mastodon-sidekiq-1  | Command :: ffmpeg -nostdin -i '/tmp/*****.mp4' -loglevel 'fatal' -map_metadata '-1' -c:v 'copy' -c:a 'copy' -acodec 'aac' -strict 'experimental' -y '/tmp/*****.mp4'
```

After:

```
mastodon-sidekiq-1  | Command :: ffmpeg -nostdin -i '/tmp/*****.mp4' -loglevel 'fatal' -map_metadata '-1' -c:v 'copy' -c:a 'copy' -y '/tmp/*****.mp4'
```

Difference in ffmpeg logs:

```diff
-$ ffmpeg -nostdin -i /tmp/aaa.mp4 -hide_banner -map_metadata '-1' -c:v 'copy' -c:a 'copy' -acodec 'aac' -strict 'experimental' -y /tmp/bbb.mp4
+$ ffmpeg -nostdin -i /tmp/aaa.mp4 -hide_banner -map_metadata '-1' -c:v 'copy' -c:a 'copy' -y /tmp/bbb.mp4
 Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/tmp/aaa.mp4':
   Metadata:
     major_brand     : isom
     minor_version   : 512
     compatible_brands: isomiso2avc1mp41
     encoder         : Lavf58.45.100
   Duration: 00:00:08.30, start: 0.000000, bitrate: 1498 kb/s
     Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1600x1200, 1360 kb/s, 60 fps, 60 tbr, 15360 tbn, 120 tbc (default)
     Metadata:
       handler_name    : VideoHandler
     Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 128 kb/s (default)
     Metadata:
       handler_name    : SoundHandler
-Multiple -c, -codec, -acodec, -vcodec, -scodec or -dcodec options specified for stream 1, only the last option '-c:a aac' will be used.
 Output #0, mp4, to '/tmp/bbb.mp4':
   Metadata:
     encoder         : Lavf58.45.100
     Stream #0:0: Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1600x1200, q=2-31, 1360 kb/s, 60 fps, 60 tbr, 15360 tbn, 15360 tbc (default)
     Stream #0:1: Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 128 kb/s (default)
-    Metadata:
-      encoder         : Lavc58.91.100 aac
 Stream mapping:
   Stream #0:0 -> #0:0 (copy)
-  Stream #0:1 -> #0:1 (aac (native) -> aac (native))
+  Stream #0:1 -> #0:1 (copy)
 Press [q] to stop, [?] for help
```