### PR TITLE
Re-publish status when preview card is updated

### DIFF
--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -67,6 +67,7 @@ class FetchLinkCardService < BaseService
       @status.preview_cards << @card
       Rails.cache.delete(@status)
       Trends.links.register(@status)
+      DistributionWorker.perform_async(@status.id)
     end
   end
 

--- a/app/services/fetch_link_card_service.rb
+++ b/app/services/fetch_link_card_service.rb
@@ -67,7 +67,7 @@ class FetchLinkCardService < BaseService
       @status.preview_cards << @card
       Rails.cache.delete(@status)
       Trends.links.register(@status)
-      DistributionWorker.perform_async(@status.id)
+      DistributionWorker.perform_async(@status.id, { update: true })
     end
   end
 

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe FetchLinkCardService, type: :service do
   end
 
   it 'redistributes status' do
-    expect(DistributionWorker).to have_received(:perform_async).with(status.id)
+    expect(DistributionWorker).to have_received(:perform_async).with(status.id, { update: true })
   end
 
   context 'with a local status' do

--- a/spec/services/fetch_link_card_service_spec.rb
+++ b/spec/services/fetch_link_card_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe FetchLinkCardService, type: :service do
   subject { described_class.new }
 
   let(:html) { '<!doctype html><title>Hello world</title>' }
+  let(:status) { Fabricate(:status, text: 'http://example.com/html') }
   let(:oembed_cache) { nil }
 
   before do
@@ -27,9 +28,20 @@ RSpec.describe FetchLinkCardService, type: :service do
     stub_request(:get, 'http://example.com/koi8-r').to_return(request_fixture('koi8-r.txt'))
     stub_request(:get, 'http://example.com/windows-1251').to_return(request_fixture('windows-1251.txt'))
 
+    allow(DistributionWorker).to receive(:perform_async)
+    allow(Trends.links).to receive(:register)
+
     Rails.cache.write('oembed_endpoint:example.com', oembed_cache) if oembed_cache
 
     subject.call(status)
+  end
+
+  it 'registers trends' do
+    expect(Trends.links).to have_received(:register).with(status)
+  end
+
+  it 'redistributes status' do
+    expect(DistributionWorker).to have_received(:perform_async).with(status.id)
   end
 
   context 'with a local status' do


### PR DESCRIPTION
When you create a post, a small _“Post published. [Open]”_ toast is displayed. If the post contains a link, and you click _Open_ very quickly, the preview card may not have been generated yet, i.e. your post doesn't “look right”. This makes you wonder whether you posted the wrong link, whether the server is down, etc.

Publish the updated status after attaching the preview card, so the preview card shows up even if the user already has clicked on _Open_.