### PR TITLE
Better hashtag normalization when processing a post

### DIFF
--- a/app/javascript/mastodon/components/__tests__/hashtag_bar.tsx
+++ b/app/javascript/mastodon/components/__tests__/hashtag_bar.tsx
@@ -105,6 +105,21 @@ describe('computeHashtagBarForStatus', () => {
     );
   });
 
+  it('handles server-side normalized tags with accentuated characters', () => {
+    const status = createStatus(
+      '<p>Text</p><p><a href="test">#éaa</a> <a href="test">#Éaa</a></p>',
+      ['eaa'], // The server may normalize the hashtags in the `tags` attribute
+    );
+
+    const { hashtagsInBar, statusContentProps } =
+      computeHashtagBarForStatus(status);
+
+    expect(hashtagsInBar).toEqual(['Éaa']);
+    expect(statusContentProps.statusContent).toMatchInlineSnapshot(
+      `"<p>Text</p>"`,
+    );
+  });
+
   it('does not display in bar a hashtag in content with a case difference', () => {
     const status = createStatus(
       '<p>Text <a href="test">#Éaa</a></p><p><a href="test">#éaa</a></p>',


### PR DESCRIPTION
This should fix the hashtag issues with accentuated letters

- NKFC normalization, like in the Ruby code
- `sensitivity: 'base'` for Collator, so we compare base characters, to emulate ASCII folding made in Ruby (but efficiently?)

I hope that configuring the collator this way will work like the ASCII folding the Ruby does, otherwise we will need to do per-character processing of every hashtag, which does not feel efficient. Possible issues here are with non-latin languages.

The collator can accept an array of languages, so we could feed it with the post language, but I am not sure how much it would help. We need real examples to test this.