### PR TITLE
Change nightlies versioning from `v4.2.0+2023-08-23` to `v4.2.0-nightly.2023-08-23`

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           TZ: Etc/UTC
         run: |
-          echo mastodon_version_suffix=nightly-$(date +'%Y-%m-%d')>> $GITHUB_OUTPUT
+          echo mastodon_version_suffix=nightly.$(date +'%Y-%m-%d')>> $GITHUB_OUTPUT
     outputs:
       suffix: ${{ steps.version_vars.outputs.mastodon_version_suffix }}
 
@@ -29,8 +29,8 @@ jobs:
       push_to_images: |
         tootsuite/mastodon
         ghcr.io/mastodon/mastodon
-      # The `+` is important here, result will be v4.1.2+nightly-2022-03-05
-      version_suffix: +${{ needs.compute-suffix.outputs.suffix }}
+      # The `-` is important here, result will be v4.1.2-nightly.2022-03-05
+      version_suffix: -${{ needs.compute-suffix.outputs.suffix }}
       labels: |
         org.opencontainers.image.description=Nightly build image used for testing purposes
       flavor: |


### PR DESCRIPTION
This way, nightlies are proper pre-releases