### PR TITLE
Fix clicking “Explore” or “Live feeds” column headers to scroll in advanced mode

### DIFF
--- a/app/javascript/mastodon/components/column.jsx
+++ b/app/javascript/mastodon/components/column.jsx
@@ -16,7 +16,19 @@ export default class Column extends PureComponent {
   };
 
   scrollTop () {
-    const scrollable = this.props.bindToDocument ? document.scrollingElement : this.node.querySelector('.scrollable');
+    let scrollable = null;
+
+    if (this.props.bindToDocument) {
+      scrollable = document.scrollingElement;
+    } else {
+      scrollable = this.node.querySelector('.scrollable');
+
+      // Some columns have nested `.scrollable` containers, with the outer one
+      // being a wrapper while the actual scrollable content is deeper.
+      if (scrollable.classList.contains('scrollable--flex')) {
+        scrollable = scrollable?.querySelector('.scrollable') || scrollable;
+      }
+   }
 
     if (!scrollable) {
       return;


### PR DESCRIPTION
Fixes #26405

Expanded from https://github.com/glitch-soc/mastodon/issues/2382#issuecomment-1689844070 because a quick search revealed `.scrollable--flex` was used in more ways, but the original patch may have been enough.