### PR TITLE
Fix selecting domains to forward reports to not passing the information correctly

### DIFF
--- a/app/javascript/mastodon/features/ui/components/report_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/report_modal.jsx
@@ -62,7 +62,7 @@ class ReportModal extends ImmutablePureComponent {
     dispatch(submitReport({
       account_id: accountId,
       status_ids: selectedStatusIds.toArray(),
-      selected_domains: selectedDomains.toArray(),
+      forward_to_domains: selectedDomains.toArray(),
       comment,
       forward: selectedDomains.size > 0,
       category,


### PR DESCRIPTION
It used `selected_domains` instead of `forward_to_domains`