### PR TITLE
Add `data-nosnippet` attribute to remote posts and local posts with `noindex`

### DIFF
--- a/app/javascript/mastodon/components/status.jsx
+++ b/app/javascript/mastodon/components/status.jsx
@@ -550,7 +550,7 @@ class Status extends ImmutablePureComponent {
 
     return (
       <HotKeys handlers={handlers}>
-        <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), unread, focusable: !this.props.muted })} tabIndex={this.props.muted ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader(intl, status, rebloggedByText)} ref={this.handleRef}>
+        <div className={classNames('status__wrapper', `status__wrapper-${status.get('visibility')}`, { 'status__wrapper-reply': !!status.get('in_reply_to_id'), unread, focusable: !this.props.muted })} tabIndex={this.props.muted ? null : 0} data-featured={featured ? 'true' : null} aria-label={textForScreenReader(intl, status, rebloggedByText)} ref={this.handleRef} data-nosnippet={status.getIn(['account', 'noindex'], true) || undefined}>
           {prepend}
 
           <div className={classNames('status', `status-${status.get('visibility')}`, { 'status-reply': !!status.get('in_reply_to_id'), 'status--in-thread': !!rootId, 'status--first-in-thread': previousId && (!connectUp || connectToRoot), muted: this.props.muted })} data-id={status.get('id')}>


### PR DESCRIPTION
Currently, when opting out of “Include profile page in search engines”, `noindex` is set on pages that are “owned” by the account, but that does not affect pages that are “owned” by other accounts and can still include posts from the user who has opted out (e.g. replies, parent posts, or boosts in an account's profile).

As far as I know, search engines do not offer any capability to prevent indexing part of a page (e.g. you want to index a post, but not all of its replies), but `data-nosnippet` is the next best thing, as it should prevent the post content itself from appearing in the search result.

I am not sure how this affects indexing, if at all.

Other alternatives may be to make whole pages `noindex` if even a single post on it is from a `noindex` account (but that may severely hamper searchability of people who do want to be searchable), or omitting those posts altogether from logged-out pages, which risks being extremely confusing and detrimental to the user experience.