### PR TITLE
Fix dashboard check for Elasticsearch suggested command including incorrect names

### DIFF
--- a/app/lib/admin/system_check/elasticsearch_check.rb
+++ b/app/lib/admin/system_check/elasticsearch_check.rb
@@ -86,7 +86,7 @@ class Admin::SystemCheck::ElasticsearchCheck < Admin::SystemCheck::BaseCheck
 
   def mismatched_indexes
     @mismatched_indexes ||= INDEXES.filter_map do |klass|
-      klass.index_name if Chewy.client.indices.get_mapping[klass.index_name]&.deep_symbolize_keys != klass.mappings_hash
+      klass.base_name if Chewy.client.indices.get_mapping[klass.index_name]&.deep_symbolize_keys != klass.mappings_hash
     end
   end
 


### PR DESCRIPTION
When `ES_PREFIX` is used, the dashboard warning would recommend running e.g. `tootctl search deploy --only=prefix_accounts` instead of `tootctl search deploy --only=accounts`