### PR TITLE
Update ordering to use `id` from body of document instead of deprecated `_id`

### DIFF
--- a/app/services/statuses_search_service.rb
+++ b/app/services/statuses_search_service.rb
@@ -27,7 +27,7 @@ class StatusesSearchService < BaseService
       )
     )
 
-    results             = definition.collapse(field: :id).order(_id: { order: :desc }).limit(@limit).offset(@offset).objects.compact
+    results             = definition.collapse(field: :id).order(id: { order: :desc }).limit(@limit).offset(@offset).objects.compact
     account_ids         = results.map(&:account_id)
     account_domains     = results.map(&:account_domain)
     preloaded_relations = @account.relations_map(account_ids, account_domains)


### PR DESCRIPTION
This should fix:
```
Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled
```