### PR TITLE
Add new Identity Context to supplement the deprecated context API

### DIFF
--- a/app/javascript/mastodon/containers/identity_context.tsx
+++ b/app/javascript/mastodon/containers/identity_context.tsx
@@ -29,5 +29,5 @@ export const createLegacyIdentityContext = (state: InitialState) => {
 };
 
 export const useIdentityContext = (): IdentityState => {
-  return useContext(Context);
+  return useContext(IdentityContext);
 };

--- a/app/javascript/mastodon/containers/identity_context.tsx
+++ b/app/javascript/mastodon/containers/identity_context.tsx
@@ -10,7 +10,7 @@ interface IdentityState {
   permissions: number;
 }
 
-export const Context = createContext<IdentityState>({
+export const IdentityContext = createContext<IdentityState>({
   signedIn: false,
   accountId: '',
   disabledAccountId: '',

--- a/app/javascript/mastodon/containers/identity_context.tsx
+++ b/app/javascript/mastodon/containers/identity_context.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext } from 'react';
+
+import type { InitialState } from 'mastodon/initial_state';
+
+interface IdentityState {
+  signedIn: boolean;
+  accountId: string;
+  disabledAccountId: string;
+  accessToken: string;
+  permissions: number;
+}
+
+export const Context = createContext<IdentityState>({
+  signedIn: false,
+  accountId: '',
+  disabledAccountId: '',
+  accessToken: '',
+  permissions: 0,
+});
+
+export const createLegacyIdentityContext = (state: InitialState) => {
+  return {
+    signedIn: !!state.meta.me,
+    accountId: state.meta.me,
+    disabledAccountId: state.meta.disabled_account_id,
+    accessToken: state.meta.access_token,
+    permissions: state.role?.permissions ?? 0,
+  };
+};
+
+export const useIdentityContext = (): IdentityState => {
+  return useContext(Context);
+};

--- a/app/javascript/mastodon/containers/identity_context.tsx
+++ b/app/javascript/mastodon/containers/identity_context.tsx
@@ -28,6 +28,6 @@ export const createLegacyIdentityContext = (state: InitialState) => {
   };
 };
 
-export const useIdentityContext = (): IdentityState => {
+export const useIdentity = (): IdentityState => {
   return useContext(IdentityContext);
 };

--- a/app/javascript/mastodon/containers/mastodon.jsx
+++ b/app/javascript/mastodon/containers/mastodon.jsx
@@ -18,7 +18,7 @@ import initialState, { title as siteTitle } from 'mastodon/initial_state';
 import { IntlProvider } from 'mastodon/locales';
 import { store } from 'mastodon/store';
 
-import { Context as IdentityContext, createLegacyIdentityContext } from './identity_context';
+import { IdentityContext, createLegacyIdentityContext } from './identity_context';
 
 const title = process.env.NODE_ENV === 'production' ? siteTitle : `${siteTitle} (Dev)`;
 

--- a/app/javascript/mastodon/containers/mastodon.jsx
+++ b/app/javascript/mastodon/containers/mastodon.jsx
@@ -18,6 +18,8 @@ import initialState, { title as siteTitle } from 'mastodon/initial_state';
 import { IntlProvider } from 'mastodon/locales';
 import { store } from 'mastodon/store';
 
+import { Context as IdentityContext, createLegacyIdentityContext } from './identity_context';
+
 const title = process.env.NODE_ENV === 'production' ? siteTitle : `${siteTitle} (Dev)`;
 
 const hydrateAction = hydrateStore(initialState);
@@ -27,16 +29,7 @@ if (initialState.meta.me) {
   store.dispatch(fetchCustomEmojis());
 }
 
-const createIdentityContext = state => ({
-  signedIn: !!state.meta.me,
-  accountId: state.meta.me,
-  disabledAccountId: state.meta.disabled_account_id,
-  accessToken: state.meta.access_token,
-  permissions: state.role ? state.role.permissions : 0,
-});
-
 export default class Mastodon extends PureComponent {
-
   static childContextTypes = {
     identity: PropTypes.shape({
       signedIn: PropTypes.bool.isRequired,
@@ -46,7 +39,7 @@ export default class Mastodon extends PureComponent {
     }).isRequired,
   };
 
-  identity = createIdentityContext(initialState);
+  identity = createLegacyIdentityContext(initialState);
 
   getChildContext() {
     return {
@@ -60,25 +53,27 @@ export default class Mastodon extends PureComponent {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     if (this.disconnect) {
       this.disconnect();
       this.disconnect = null;
     }
   }
 
-  shouldUpdateScroll (prevRouterProps, { location }) {
+  shouldUpdateScroll(prevRouterProps, { location }) {
     return !(location.state?.mastodonModalKey && location.state?.mastodonModalKey !== prevRouterProps?.location?.state?.mastodonModalKey);
   }
 
-  render () {
+  render() {
     return (
       <IntlProvider>
         <ReduxProvider store={store}>
           <ErrorBoundary>
             <Router>
               <ScrollContext shouldUpdateScroll={this.shouldUpdateScroll}>
-                <Route path='/' component={UI} />
+                <IdentityContext.Provider value={this.identity}>
+                  <Route path='/' component={UI} />
+                </IdentityContext.Provider>
               </ScrollContext>
             </Router>
 

--- a/app/javascript/mastodon/features/firehose/index.jsx
+++ b/app/javascript/mastodon/features/firehose/index.jsx
@@ -11,7 +11,8 @@ import { changeSetting } from 'mastodon/actions/settings';
 import { connectPublicStream, connectCommunityStream } from 'mastodon/actions/streaming';
 import { expandPublicTimeline, expandCommunityTimeline } from 'mastodon/actions/timelines';
 import { DismissableBanner } from 'mastodon/components/dismissable_banner';
-import initialState, { domain } from 'mastodon/initial_state';
+import { useIdentity } from 'mastodon/containers/identity_context';
+import { domain } from 'mastodon/initial_state';
 import { useAppDispatch, useAppSelector } from 'mastodon/store';
 
 import Column from '../../components/column';
@@ -19,17 +20,9 @@ import ColumnHeader from '../../components/column_header';
 import SettingToggle from '../notifications/components/setting_toggle';
 import StatusListContainer from '../ui/containers/status_list_container';
 
+
 const messages = defineMessages({
   title: { id: 'column.firehose', defaultMessage: 'Live feeds' },
-});
-
-// TODO: use a proper React context later on
-const useIdentity = () => ({
-  signedIn: !!initialState.meta.me,
-  accountId: initialState.meta.me,
-  disabledAccountId: initialState.meta.disabled_account_id,
-  accessToken: initialState.meta.access_token,
-  permissions: initialState.role ? initialState.role.permissions : 0,
 });
 
 const ColumnSettings = () => {

--- a/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
+++ b/app/javascript/mastodon/features/ui/components/navigation_panel.jsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 
 import { WordmarkLogo } from 'mastodon/components/logo';
 import NavigationPortal from 'mastodon/components/navigation_portal';
+import { IdentityContext } from 'mastodon/containers/identity_context';
 import { timelinePreview, trendsEnabled } from 'mastodon/initial_state';
 import { transientSingleColumn } from 'mastodon/is_mobile';
 
@@ -34,11 +35,7 @@ const messages = defineMessages({
 });
 
 class NavigationPanel extends Component {
-
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-    identity: PropTypes.object.isRequired,
-  };
+  static contextType = IdentityContext;
 
   static propTypes = {
     intl: PropTypes.object.isRequired,
@@ -48,9 +45,9 @@ class NavigationPanel extends Component {
     return match || location.pathname.startsWith('/public');
   };
 
-  render () {
+  render() {
     const { intl } = this.props;
-    const { signedIn, disabledAccountId } = this.context.identity;
+    const { signedIn, disabledAccountId } = this.context;
 
     return (
       <div className='navigation-panel'>
@@ -86,7 +83,7 @@ class NavigationPanel extends Component {
         {!signedIn && (
           <div className='navigation-panel__sign-in-banner'>
             <hr />
-            { disabledAccountId ? <DisabledAccountBanner /> : <SignInBanner /> }
+            {disabledAccountId ? <DisabledAccountBanner /> : <SignInBanner />}
           </div>
         )}
 

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -84,7 +84,7 @@
  */
 
 /**
- * @typedef Role
+ * @typedef InitialStateRole
  * @property {number} permissions
  */
 
@@ -93,7 +93,7 @@
  * @property {Record<string, Account>} accounts
  * @property {InitialStateLanguage[]} languages
  * @property {InitialStateMeta} meta
- * @property {Role} [role]
+ * @property {InitialStateRole} [role]
  */
 
 const element = document.getElementById('initial-state');

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -84,10 +84,16 @@
  */
 
 /**
+ * @typedef Role
+ * @property {number} permissions
+ */
+
+/**
  * @typedef InitialState
  * @property {Record<string, Account>} accounts
  * @property {InitialStateLanguage[]} languages
  * @property {InitialStateMeta} meta
+ * @property {Role} [role]
  */
 
 const element = document.getElementById('initial-state');


### PR DESCRIPTION
Throughout the codebase, there are 38 references to `this.context.identity`, which contains information about the current users identity. This contextual information is established in `mastodon.jsx` using `getChildContext()`.

`getChildContext()` was part of the legacy context API which was deprecated in [React 16.3](https://legacy.reactjs.org/docs/legacy-context.html) and there are no guarantees it will continue to work into the future.

* Typing this context is difficult using PropTypes, and each consumer of this context defines their own `contextTypes`, frequently declared as just `PropTypes.object`
* Typing the context in TypeScript requires specifying a third type parameter on `React.Component` for class components, or setting `contextType` with an actual context object.
* This context is inaccessible to functional components as functional components only support accessing context through the new API using `Context.Consumer` _or_ via `useContext()`.

This PR adds a context for the identity state information and constructs it within `mastodon.jsx`. It uses the same value as is provided to `getChildContext()`, which is stable, preventing the new context from causing additional renders.  The construction of the initial state is moved into this new file, and, in addition, a hook for accessing the identity information is exposed.

The goal of this change is to enable existing dependents of this information to be able to convert to functional components, and for legacy class components to benefit from the usage of `contextType` rather than the deprecated `contextTypes`.

Additionally included is an example usage.
