### PR TITLE
Fix bad search type heuristic

### DIFF
--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -17,7 +17,7 @@ class SearchService < BaseService
         results.merge!(url_resource_results) unless url_resource.nil? || @offset.positive? || (@options[:type].present? && url_resource_symbol != @options[:type].to_sym)
       elsif @query.present?
         results[:accounts] = perform_accounts_search! if account_searchable?
-        results[:statuses] = perform_statuses_search! if full_text_searchable?
+        results[:statuses] = perform_statuses_search! if status_searchable?
         results[:hashtags] = perform_hashtags_search! if hashtag_searchable?
       end
     end
@@ -79,18 +79,16 @@ class SearchService < BaseService
     url_resource.class.name.downcase.pluralize.to_sym
   end
 
-  def full_text_searchable?
-    return false unless Chewy.enabled?
-
-    statuses_search? && !@account.nil? && !(@query.include?('@') && !@query.include?(' '))
+  def status_searchable?
+    Chewy.enabled? && status_search? && @account.present?
   end
 
   def account_searchable?
-    account_search? && !(@query.include?('@') && @query.include?(' '))
+    account_search?
   end
 
   def hashtag_searchable?
-    hashtag_search? && !@query.include?('@')
+    hashtag_search?
   end
 
   def account_search?
@@ -101,7 +99,7 @@ class SearchService < BaseService
     @options[:type].blank? || @options[:type] == 'hashtags'
   end
 
-  def statuses_search?
+  def status_search?
     @options[:type].blank? || @options[:type] == 'statuses'
   end
 end

--- a/spec/services/search_service_spec.rb
+++ b/spec/services/search_service_spec.rb
@@ -83,15 +83,6 @@ describe SearchService, type: :service do
           expect(Tag).to have_received(:search_for).with('tag', 10, 0, exclude_unreviewed: nil)
           expect(results).to eq empty_results.merge(hashtags: [tag])
         end
-
-        it 'does not include tag when starts with @ character' do
-          query = '@username'
-          allow(Tag).to receive(:search_for)
-
-          results = subject.call(query, nil, 10)
-          expect(Tag).to_not have_received(:search_for)
-          expect(results).to eq empty_results
-        end
       end
     end
   end


### PR DESCRIPTION
Previously, hashtags would not be searched if the query contained a `@` (which is fair enough, but far from the only invalid hashtag character!), accounts would not be searched if they contained both a `@` and a space (presumably because it indicates we're searching for status text?), and statuses would not be searched if the query contained a `@` and no spaces. What the last part meant is that e.g. `from:@username` would not give the expected results even though in combination with a space and any other segment, it would behave correctly. The idea was originally to save resources by only searching the sources that are likely intended, but I think that's not worth optimizing.