### PR TITLE
Change DCT method used for JPEG encoding to float

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -172,7 +172,7 @@ class MediaAttachment < ApplicationRecord
   DEFAULT_STYLES = [:original].freeze
 
   GLOBAL_CONVERT_OPTIONS = {
-    all: '-quality 90 +profile "!icc,*" +set modify-date +set create-date',
+    all: '-quality 90 +profile "!icc,*" +set modify-date -define jpeg:dct-method=float +set create-date',
   }.freeze
 
   belongs_to :account,          inverse_of: :media_attachments, optional: true


### PR DESCRIPTION
Fix #26674

Adds jpeg:dct-method=float to the GLOBAL_CONVERT_OPTIONS to work around the poor quality associated with the current default method image-magick uses