### PR TITLE
Allow filter form in profiles directory to wrap

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -2381,6 +2381,7 @@ $ui-header-height: 55px;
 
   .filter-form {
     display: flex;
+    flex-wrap: wrap;
   }
 
   .autosuggest-textarea__textarea {


### PR DESCRIPTION
This is a really dumb thingy but currently when browsing the profiles directory on mobile sometimes the filter form at the top doesn't fit on the screen, so I thought we could allow it to wrap if that's the case. It should still look the same for desktop, when there's enough space for it.

This is how it looks before and after:
![beforeaftermobilefilterform](https://github.com/mastodon/mastodon/assets/36609914/6fa538e0-d614-4796-b2ff-2dc00594c7c5)

