### PR TITLE
Don’t check for mentions in URLs

### DIFF
--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -25,6 +25,7 @@ class ProcessMentionsService < BaseService
   private
 
   def scan_text!
+    @status.text = @status.text.gsub(/http[^\s]+/,"")
     @status.text = @status.text.gsub(Account::MENTION_RE) do |match|
       username, domain = Regexp.last_match(1).split('@')
 

--- a/app/services/process_mentions_service.rb
+++ b/app/services/process_mentions_service.rb
@@ -25,7 +25,7 @@ class ProcessMentionsService < BaseService
   private
 
   def scan_text!
-    @status.text = @status.text.gsub(/http[^\s]+/,"")
+    @status.text = @status.text.gsub(/http[^\s]+/, '')
     @status.text = @status.text.gsub(Account::MENTION_RE) do |match|
       username, domain = Regexp.last_match(1).split('@')
 


### PR DESCRIPTION
URLs can contain things that look like @handles. Users shouldn’t be notified in this case.

#23275 