### PR TITLE
Fix incorrect call to `PublicStatusesIndex.import`

### DIFF
--- a/app/models/concerns/account_statuses_search.rb
+++ b/app/models/concerns/account_statuses_search.rb
@@ -32,7 +32,7 @@ module AccountStatusesSearch
     return unless Chewy.enabled?
 
     statuses.without_reblogs.where(visibility: :public).find_in_batches do |batch|
-      PublicStatusesIndex.import(query: batch)
+      PublicStatusesIndex.import(batch)
     end
   end
 


### PR DESCRIPTION
`query:` is not a supported argument for `PublicStatusesIndex.import`, which means it's equivalent to calling it without a collection at all, making it re-index everything