### PR TITLE
Fix search queries with slash causing or-condition

### DIFF
--- a/app/lib/search_query_transformer.rb
+++ b/app/lib/search_query_transformer.rb
@@ -25,7 +25,7 @@ class SearchQueryTransformer < Parslet::Transform
     def clause_to_query(clause)
       case clause
       when TermClause
-        { multi_match: { type: 'most_fields', query: clause.term, fields: ['text', 'text.stemmed'] } }
+        { multi_match: { type: 'most_fields', query: clause.term, fields: ['text', 'text.stemmed'], operator: 'and' } }
       when PhraseClause
         { match_phrase: { text: { query: clause.phrase } } }
       else


### PR DESCRIPTION
Searching for `ios/android` would yield results with either `ios` or `android`. This is because our own parser tokenizes user input on spaces, and the resulting clauses are combined using "and". However the slash would cause both words to be treated as a single clause; the default operator of the `most_fields` query, which is "or", would then come into effect.