### PR TITLE
Improve error messages when DeepL quota is exceeded

### DIFF
--- a/app/controllers/api/v1/statuses/translations_controller.rb
+++ b/app/controllers/api/v1/statuses/translations_controller.rb
@@ -8,7 +8,15 @@ class Api::V1::Statuses::TranslationsController < Api::BaseController
   before_action :set_translation
 
   rescue_from TranslationService::NotConfiguredError, with: :not_found
-  rescue_from TranslationService::UnexpectedResponseError, TranslationService::QuotaExceededError, TranslationService::TooManyRequestsError, with: :service_unavailable
+  rescue_from TranslationService::UnexpectedResponseError, with: :service_unavailable
+
+  rescue_from TranslationService::QuotaExceededError do
+    render json: { error: I18n.t('translation.errors.quota_exceeded') }, status: 503
+  end
+
+  rescue_from TranslationService::TooManyRequestsError do
+    render json: { error: I18n.t('translation.errors.too_many_requests') }, status: 503
+  end
 
   def create
     render json: @translation, serializer: REST::TranslationSerializer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1709,6 +1709,10 @@ en:
       default: "%b %d, %Y, %H:%M"
       month: "%b %Y"
       time: "%H:%M"
+  translation:
+    errors:
+      quota_exceeded: The server-wide usage quota for the translation service has been exceeded.
+      too_many_requests: There have been too many requests to the translation service recently.
   two_factor_authentication:
     add: Add
     disable: Disable 2FA


### PR DESCRIPTION
The DeepL free tier has a quota of 500,000 translated characters per month which is relatively easy to hit on busier servers. Even with the DeepL pro tier, you can still run into this error when you have cost control enabled.

The current handling makes it look like the Mastodon server has an internal server error when the quota is exceeded. Back when we were still on the free tier we would often get reports from users about the server being broken towards the end of the month because of the nondescript error.

I'm not super happy with the wording of the messages though, so if someone has suggestions for that..

Before:

![image](https://github.com/mastodon/mastodon/assets/179393/2e4c0699-c603-4873-9dd1-22e09454b890)

After:

![image](https://github.com/mastodon/mastodon/assets/179393/344194a1-16b8-4cac-b4c8-cf256c90d069)

